### PR TITLE
feat(core): honor draft param, write _status, add snapshot ops

### DIFF
--- a/packages/core/src/collections/CollectionOperations.ts
+++ b/packages/core/src/collections/CollectionOperations.ts
@@ -28,6 +28,12 @@ import { deleteDocument } from './operations/delete.js';
 import { deleteMany } from './operations/deleteMany.js';
 import { find } from './operations/find.js';
 import { findByID } from './operations/findById.js';
+import {
+  createSnapshot,
+  type RestoreOptions,
+  restoreSnapshot,
+  type SnapshotOptions,
+} from './operations/snapshot.js';
 import { update } from './operations/update.js';
 import { updateMany } from './operations/updateMany.js';
 
@@ -55,6 +61,8 @@ export class RevealUICollection {
     depth?: number;
     req?: RevealRequest;
     populate?: PopulateType;
+    overrideAccess?: boolean;
+    draft?: boolean;
   }): Promise<RevealDocument | null> {
     return findByID(this.config, this.db, options);
   }
@@ -81,5 +89,13 @@ export class RevealUICollection {
 
   async deleteMany(options: BatchDeleteOptions): Promise<BatchResult<RevealDocument>> {
     return deleteMany(this.config, this.db, options);
+  }
+
+  async snapshot(options: SnapshotOptions): Promise<RevealDocument> {
+    return createSnapshot(this.config, this.db, options);
+  }
+
+  async restore(options: RestoreOptions): Promise<RevealDocument> {
+    return restoreSnapshot(this.config, this.db, options);
   }
 }

--- a/packages/core/src/collections/operations/__tests__/drafts.test.ts
+++ b/packages/core/src/collections/operations/__tests__/drafts.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Draft read/write + snapshot enforcement tests
+ *
+ * Proves the draft boundary that keeps unpublished content from leaking:
+ *   - find()/findByID() honor the `draft` param, but ONLY relax the
+ *     published-only default — never the access.read clause.
+ *   - THE CRITICAL INVARIANT: an unauthenticated read with `draft=true` still
+ *     returns published content only.
+ *   - update() persists `_status` transitions, gated by access.update.
+ *   - createSnapshot()/restoreSnapshot() are gated by access.update and
+ *     delegate to the typed storage seam.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  DatabaseResult,
+  RevealCollectionConfig,
+  RevealRequest,
+} from '../../../types/index.js';
+import { find } from '../find.js';
+import { findByID } from '../findById.js';
+import { createSnapshot, restoreSnapshot } from '../snapshot.js';
+import { update } from '../update.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockRequest(overrides: Partial<RevealRequest> = {}): RevealRequest {
+  return {
+    transactionID: 'test-tx',
+    context: {},
+    user: { id: 'user-1', email: 'test@example.com', roles: ['editor'] },
+    ...overrides,
+  };
+}
+
+/** Minimal in-memory WhereClause matcher (and/or + equals/not_equals/in). */
+function matchesWhere(doc: Record<string, unknown>, where: unknown): boolean {
+  if (!where || typeof where !== 'object') return true;
+  const w = where as Record<string, unknown>;
+  if (Array.isArray(w.and)) return w.and.every((sub) => matchesWhere(doc, sub));
+  if (Array.isArray(w.or)) return w.or.some((sub) => matchesWhere(doc, sub));
+  return Object.entries(w).every(([field, cond]) => {
+    if (field === 'and' || field === 'or') return true;
+    if (!cond || typeof cond !== 'object') return true;
+    const c = cond as Record<string, unknown>;
+    const actual = doc[field];
+    if ('equals' in c) return actual === c.equals;
+    if ('not_equals' in c) return actual !== c.not_equals;
+    if ('in' in c && Array.isArray(c.in)) return c.in.includes(actual);
+    return true;
+  });
+}
+
+/**
+ * Mock storage whose find() scopes by the merged where, and whose findByID()
+ * returns the raw row UNSCOPED. The unscoped findByID is deliberate: if the
+ * operation layer fails to apply the draft/access filter, an unpublished row
+ * leaks through — and the test catches it.
+ */
+function mockDb(docs: Record<string, unknown>[] = []) {
+  return {
+    query: vi.fn(),
+    collectionStorage: {
+      find: vi
+        .fn()
+        .mockImplementation((_c: RevealCollectionConfig, opts: { where?: unknown } = {}) => {
+          const filtered = docs.filter((d) => matchesWhere(d, opts.where));
+          return Promise.resolve({
+            docs: filtered,
+            totalDocs: filtered.length,
+            limit: 10,
+            totalPages: filtered.length > 0 ? 1 : 0,
+            page: 1,
+            pagingCounter: filtered.length > 0 ? 1 : 0,
+            hasPrevPage: false,
+            hasNextPage: false,
+            prevPage: null,
+            nextPage: null,
+          });
+        }),
+      findByID: vi
+        .fn()
+        .mockImplementation((_c: RevealCollectionConfig, opts: { id: string | number }) =>
+          Promise.resolve(docs.find((d) => d.id === String(opts.id)) ?? null),
+        ),
+    },
+  };
+}
+
+const draftDocs = [
+  { id: '1', title: 'Published Page', _status: 'published' },
+  { id: '2', title: 'Draft Page', _status: 'draft' },
+];
+
+/** Drafts-enabled collection (mirrors the admin Pages `versions.drafts` config). */
+const draftConfig: RevealCollectionConfig = {
+  slug: 'pages',
+  fields: [{ name: 'title', type: 'text' }],
+  versions: { drafts: { autosave: { interval: 100 } }, maxPerDoc: 50 },
+} as RevealCollectionConfig;
+
+/** Public/anon access rule: a user-bearing req is admin (allow all); a
+ *  user-less req is scoped to published (mirrors authenticatedOrPublished). */
+const publicOrPublished = ({ req }: { req: RevealRequest }) =>
+  req.user ? true : { _status: { equals: 'published' } };
+
+// ---------------------------------------------------------------------------
+// find() — draft read semantics
+// ---------------------------------------------------------------------------
+
+describe('find() draft semantics', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('drafts-enabled + no draft param + admin access.read=true → published only', async () => {
+    const config = { ...draftConfig, access: { read: () => true } };
+    const result = await find(config, mockDb(draftDocs) as never, { req: mockRequest() });
+    expect(result.docs.map((d) => d.id)).toEqual(['1']);
+  });
+
+  it('drafts-enabled + draft=true + admin access.read=true → includes drafts', async () => {
+    const config = { ...draftConfig, access: { read: () => true } };
+    const result = await find(config, mockDb(draftDocs) as never, {
+      req: mockRequest(),
+      draft: true,
+    });
+    expect(result.docs.map((d) => d.id).sort()).toEqual(['1', '2']);
+  });
+
+  // THE INVARIANT: draft=true must NOT override access.read for a public reader.
+  it('INVARIANT: drafts-enabled + draft=true + public (user-less req) → published only', async () => {
+    const config = { ...draftConfig, access: { read: publicOrPublished } };
+    const result = await find(config, mockDb(draftDocs) as never, {
+      req: mockRequest({ user: undefined }),
+      draft: true,
+    });
+    expect(result.docs.map((d) => d.id)).toEqual(['1']);
+    expect(result.docs.some((d) => d._status === 'draft')).toBe(false);
+  });
+
+  it('non-drafts collection + draft=true → no _status filtering (backward compatible)', async () => {
+    const config: RevealCollectionConfig = {
+      slug: 'posts',
+      fields: [{ name: 'title', type: 'text' }],
+      access: { read: () => true },
+    };
+    const result = await find(config, mockDb(draftDocs) as never, {
+      req: mockRequest(),
+      draft: true,
+    });
+    expect(result.docs).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findByID() — draft read semantics
+// ---------------------------------------------------------------------------
+
+describe('findByID() draft semantics', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('drafts-enabled + draft=false + admin access.read=true → draft doc returns null', async () => {
+    const config = { ...draftConfig, access: { read: () => true } };
+    const doc = await findByID(config, mockDb(draftDocs) as never, { id: '2', req: mockRequest() });
+    expect(doc).toBeNull();
+  });
+
+  it('drafts-enabled + draft=true + admin access.read=true → draft doc returned', async () => {
+    const config = { ...draftConfig, access: { read: () => true } };
+    const doc = await findByID(config, mockDb(draftDocs) as never, {
+      id: '2',
+      req: mockRequest(),
+      draft: true,
+    });
+    expect(doc?.id).toBe('2');
+  });
+
+  // THE INVARIANT (single-doc): a public reader cannot fetch a draft by id
+  // even with draft=true.
+  it('INVARIANT: drafts-enabled + draft=true + public → draft doc returns null', async () => {
+    const config = { ...draftConfig, access: { read: publicOrPublished } };
+    const doc = await findByID(config, mockDb(draftDocs) as never, {
+      id: '2',
+      req: mockRequest({ user: undefined }),
+      draft: true,
+    });
+    expect(doc).toBeNull();
+  });
+
+  it('drafts-enabled + draft=true + public → published doc still returned', async () => {
+    const config = { ...draftConfig, access: { read: publicOrPublished } };
+    const doc = await findByID(config, mockDb(draftDocs) as never, {
+      id: '1',
+      req: mockRequest({ user: undefined }),
+      draft: true,
+    });
+    expect(doc?.id).toBe('1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update() — _status writes
+// ---------------------------------------------------------------------------
+
+describe('update() _status writes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const writeConfig: RevealCollectionConfig = {
+    slug: 'pages',
+    fields: [{ name: 'title', type: 'text' }],
+  };
+
+  it('persists an _status transition to the dynamic-SQL UPDATE', async () => {
+    const db = {
+      query: vi
+        .fn()
+        // checkExistsByIdQuery
+        .mockResolvedValueOnce({ rows: [{ id: 'p1' }] } as DatabaseResult)
+        // UPDATE
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 } as DatabaseResult)
+        // findByID read-back (dynamic path)
+        .mockResolvedValueOnce({
+          rows: [{ id: 'p1', title: 'T', _status: 'published' }],
+        } as DatabaseResult),
+    };
+
+    await update(writeConfig, db as never, {
+      id: 'p1',
+      data: { title: 'T', _status: 'published' },
+    });
+
+    const updateCall = db.query.mock.calls[1];
+    expect(updateCall[0]).toContain('UPDATE');
+    expect(updateCall[0]).toContain('_status');
+    expect(updateCall[1]).toContain('published');
+  });
+
+  it('rejects an _status transition when access.update denies', async () => {
+    const config: RevealCollectionConfig = {
+      ...writeConfig,
+      access: { update: () => false },
+    };
+    const db = { query: vi.fn() };
+
+    await expect(
+      update(config, db as never, {
+        id: 'p1',
+        data: { _status: 'published' },
+        req: mockRequest(),
+      }),
+    ).rejects.toThrow('Access denied');
+    expect(db.query).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshot / restore
+// ---------------------------------------------------------------------------
+
+describe('createSnapshot() / restoreSnapshot()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function snapshotDb() {
+    return {
+      query: vi.fn(),
+      collectionStorage: {
+        snapshot: vi.fn().mockResolvedValue({ id: 'rev-1', revisionNumber: 1, pageId: 'p1' }),
+        restore: vi.fn().mockResolvedValue({ id: 'p1', title: 'restored' }),
+      },
+    };
+  }
+
+  it('createSnapshot delegates to the storage seam when access.update allows', async () => {
+    const config: RevealCollectionConfig = {
+      slug: 'pages',
+      fields: [],
+      access: { update: () => true },
+    };
+    const db = snapshotDb();
+    const rev = await createSnapshot(config, db as never, {
+      id: 'p1',
+      req: mockRequest(),
+      changeDescription: 'edit',
+    });
+    expect(rev.id).toBe('rev-1');
+    expect(db.collectionStorage.snapshot).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ id: 'p1', changeDescription: 'edit' }),
+    );
+  });
+
+  it('createSnapshot is denied when access.update returns false', async () => {
+    const config: RevealCollectionConfig = {
+      slug: 'pages',
+      fields: [],
+      access: { update: () => false },
+    };
+    const db = snapshotDb();
+    await expect(
+      createSnapshot(config, db as never, { id: 'p1', req: mockRequest() }),
+    ).rejects.toThrow('Access denied');
+    expect(db.collectionStorage.snapshot).not.toHaveBeenCalled();
+  });
+
+  it('createSnapshot throws when no typed storage seam is registered', async () => {
+    const config: RevealCollectionConfig = { slug: 'pages', fields: [] };
+    const db = { query: vi.fn(), collectionStorage: {} };
+    await expect(createSnapshot(config, db as never, { id: 'p1' })).rejects.toThrow(
+      'Snapshots are not supported',
+    );
+  });
+
+  it('restoreSnapshot delegates to the storage seam when access.update allows', async () => {
+    const config: RevealCollectionConfig = {
+      slug: 'pages',
+      fields: [],
+      access: { update: () => true },
+    };
+    const db = snapshotDb();
+    const doc = await restoreSnapshot(config, db as never, {
+      id: 'p1',
+      revisionId: 'rev-1',
+      req: mockRequest(),
+    });
+    expect(doc.title).toBe('restored');
+    expect(db.collectionStorage.restore).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ id: 'p1', revisionId: 'rev-1' }),
+    );
+  });
+
+  it('restoreSnapshot is denied when access.update returns false', async () => {
+    const config: RevealCollectionConfig = {
+      slug: 'pages',
+      fields: [],
+      access: { update: () => false },
+    };
+    const db = snapshotDb();
+    await expect(
+      restoreSnapshot(config, db as never, { id: 'p1', revisionId: 'rev-1', req: mockRequest() }),
+    ).rejects.toThrow('Access denied');
+    expect(db.collectionStorage.restore).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/collections/operations/drafts.ts
+++ b/packages/core/src/collections/operations/drafts.ts
@@ -1,0 +1,47 @@
+/**
+ * Draft read semantics
+ *
+ * A collection opts into drafts via `versions.drafts` (see the admin
+ * `VersionsConfigSchema`). When drafts are enabled, a document's `_status`
+ * column distinguishes `'draft'` from `'published'` state in a single row.
+ *
+ * These helpers centralize the ONE rule that keeps unpublished content from
+ * leaking to readers who should not see it: a read of a drafts-enabled
+ * collection is published-only by default, and `draft=true` relaxes ONLY that
+ * default. It never touches the `access.read` clause, which find()/findByID()
+ * AND-merge separately — so a caller scoped to published content by
+ * `access.read` stays published-only even when it asks for `draft=true`.
+ */
+
+import type { RevealCollectionConfig, RevealWhere } from '../../types/index.js';
+
+/**
+ * True when the collection enables drafts via `versions.drafts`.
+ *
+ * `versions: true` (version history without drafts) does NOT enable drafts —
+ * there is no `_status` lifecycle to gate, so reads are not filtered.
+ */
+export function collectionHasDrafts(config: RevealCollectionConfig): boolean {
+  const versions = (config as { versions?: unknown }).versions;
+  if (!versions || typeof versions !== 'object') return false;
+  const drafts = (versions as { drafts?: unknown }).drafts;
+  return drafts === true || (typeof drafts === 'object' && drafts !== null);
+}
+
+/**
+ * The additional published-only read filter for a drafts-enabled collection
+ * when draft mode is NOT requested. Returns `undefined` when no filter applies
+ * (collection has no drafts, or `draft=true` was passed).
+ *
+ * SECURITY: this is layered ON TOP of `access.read`, never a replacement.
+ * `draft=true` removes only this filter; the access clause is AND-merged by the
+ * caller and always wins.
+ */
+export function publishedOnlyReadFilter(
+  config: RevealCollectionConfig,
+  draft: boolean,
+): RevealWhere | undefined {
+  if (draft) return undefined;
+  if (!collectionHasDrafts(config)) return undefined;
+  return { _status: { equals: 'published' } };
+}

--- a/packages/core/src/collections/operations/find.ts
+++ b/packages/core/src/collections/operations/find.ts
@@ -17,6 +17,7 @@ import type {
   SanitizedCollectionConfig,
 } from '../../types/index.js';
 import { deserializeJsonFields } from '../../utils/json-parsing.js';
+import { publishedOnlyReadFilter } from './drafts.js';
 import { countDocumentsQuery, escapeIdentifier, listDocumentsQuery } from './sqlAdapter.js';
 
 /**
@@ -53,7 +54,16 @@ export async function find(
   db: QueryableDatabaseAdapter | null,
   options: RevealFindOptions,
 ): Promise<RevealPaginatedResult> {
-  const { where, limit = 10, page = 1, sort, depth = 0, req, populate: populateOption } = options;
+  const {
+    where,
+    limit = 10,
+    page = 1,
+    sort,
+    depth = 0,
+    req,
+    populate: populateOption,
+    draft = false,
+  } = options;
 
   // Validate depth
   if (depth < 0 || depth > 3) {
@@ -79,9 +89,23 @@ export async function find(
     };
   }
 
-  // Merge access-control WhereClause with user-provided where filter
-  const mergedWhere =
-    accessResult === true ? where : where ? { and: [where, accessResult] } : accessResult;
+  // Merge, with AND, three independent restrictions:
+  //   1. the user-provided where filter,
+  //   2. the access.read WhereClause (when access returned a clause, not `true`),
+  //   3. the drafts published-only filter (drafts-enabled collection, draft!==true).
+  // draft=true relaxes ONLY (3); it never removes (2), so a caller scoped to
+  // published content by access.read stays published-only even with draft=true.
+  const statusFilter = publishedOnlyReadFilter(config, draft);
+  const andClauses: RevealWhere[] = [];
+  if (where) andClauses.push(where);
+  if (accessResult !== true) andClauses.push(accessResult);
+  if (statusFilter) andClauses.push(statusFilter);
+  const mergedWhere: RevealWhere | undefined =
+    andClauses.length === 0
+      ? undefined
+      : andClauses.length === 1
+        ? andClauses[0]
+        : { and: andClauses };
 
   // Replace where in options for downstream use.
   // When access returned a WhereClause (not just boolean true), set overrideAccess: true
@@ -110,7 +134,7 @@ export async function find(
               currentDepth: 1,
               depth,
               doc,
-              draft: false,
+              draft,
               fallbackLocale: req.fallbackLocale || 'en',
               findMany: true,
               flattenLocales: true,
@@ -247,7 +271,7 @@ export async function find(
             currentDepth: 1,
             depth,
             doc,
-            draft: false,
+            draft,
             fallbackLocale: req.fallbackLocale || 'en',
             findMany: true,
             flattenLocales: true,

--- a/packages/core/src/collections/operations/findById.ts
+++ b/packages/core/src/collections/operations/findById.ts
@@ -15,6 +15,7 @@ import type {
   SanitizedCollectionConfig,
 } from '../../types/index.js';
 import { deserializeJsonFields } from '../../utils/json-parsing.js';
+import { publishedOnlyReadFilter } from './drafts.js';
 import { find } from './find.js';
 import { selectByIdQuery } from './sqlAdapter.js';
 
@@ -27,16 +28,17 @@ export async function findByID(
     req?: RevealRequest;
     populate?: PopulateType;
     overrideAccess?: boolean;
+    draft?: boolean;
   },
 ): Promise<RevealDocument | null> {
-  const { id, depth = 0, req, populate: populateOption } = options;
+  const { id, depth = 0, req, populate: populateOption, draft = false } = options;
 
   // Validate depth
   if (depth < 0 || depth > 3) {
     throw new Error(`Depth must be between 0 and 3, got ${depth}`);
   }
 
-  // --- Access control enforcement ---
+  // --- Access control + draft enforcement ---
   if (!options.overrideAccess) {
     const accessConfig = (
       config as {
@@ -45,6 +47,7 @@ export async function findByID(
     ).access;
     const readAccess = accessConfig?.read;
 
+    let accessWhere: RevealWhere | undefined;
     if (readAccess) {
       if (!req) return null; // No request context = deny
 
@@ -52,23 +55,34 @@ export async function findByID(
 
       if (result === false) return null;
 
-      if (result !== true) {
-        // Row-level access: a WhereClause means "allowed only for rows matching
-        // this filter". Confirm THIS row matches before returning it — otherwise
-        // findByID hands back rows the ownership rule was meant to scope out
-        // (cross-tenant / unpublished-draft leakage). Reuse find()'s AND-merge so
-        // the filter runs through the same proven path the list view uses (both
-        // storage adapters); overrideAccess skips re-evaluating the rule.
-        const scoped = await find(config, db, {
-          where: { and: [{ id: { equals: id } }, result as RevealWhere] },
-          limit: 1,
-          depth,
-          req,
-          ...(populateOption !== undefined ? { populate: populateOption } : {}),
-          overrideAccess: true,
-        });
-        return scoped.docs[0] ?? null;
-      }
+      if (result !== true) accessWhere = result as RevealWhere;
+    }
+
+    // For a drafts-enabled collection read without draft mode, the row must also
+    // be published. draft=true drops THIS filter only — accessWhere still stands.
+    const statusFilter = publishedOnlyReadFilter(config, draft);
+
+    if (accessWhere || statusFilter) {
+      // Row-level access and/or the published-only filter apply. Route through
+      // find()'s AND-merge — the same proven path the list view uses on both
+      // storage adapters — so findByID cannot hand back a row the ownership rule
+      // or draft state was meant to scope out (cross-tenant / draft leakage).
+      // overrideAccess skips re-evaluating access.read; find() re-derives the
+      // published-only filter itself from `draft`, so only accessWhere is merged
+      // in here.
+      const where: RevealWhere = accessWhere
+        ? { and: [{ id: { equals: id } }, accessWhere] }
+        : { id: { equals: id } };
+      const scoped = await find(config, db, {
+        where,
+        limit: 1,
+        depth,
+        req,
+        draft,
+        ...(populateOption !== undefined ? { populate: populateOption } : {}),
+        overrideAccess: true,
+      });
+      return scoped.docs[0] ?? null;
     }
   }
 
@@ -91,7 +105,7 @@ export async function findByID(
           currentDepth: 1,
           depth,
           doc,
-          draft: false,
+          draft,
           fallbackLocale: req.fallbackLocale || 'en',
           findMany: false,
           flattenLocales: true,
@@ -144,7 +158,7 @@ export async function findByID(
         currentDepth: 1,
         depth,
         doc,
-        draft: false,
+        draft,
         fallbackLocale: req.fallbackLocale || 'en',
         findMany: false,
         flattenLocales: true,

--- a/packages/core/src/collections/operations/snapshot.ts
+++ b/packages/core/src/collections/operations/snapshot.ts
@@ -1,0 +1,123 @@
+/**
+ * Snapshot Operations
+ *
+ * Point-in-time revisions of a document, modeled on the `page_revisions`
+ * pattern (per-doc revision number, content snapshot, createdBy,
+ * changeDescription).
+ *
+ * Persistence lives behind the `collectionStorage` seam so the typed store owns
+ * the revision table — the same seam `create`/`update`/`delete` already use.
+ * Core owns the access gate. This deliberately does NOT introduce a parallel
+ * dynamic revisions table: snapshots require a registered typed storage
+ * adapter, keeping core drafts thin (the edit-session layer owns its own
+ * snapshot path and does not route through here).
+ */
+
+import type {
+  QueryableDatabaseAdapter,
+  RevealCollectionConfig,
+  RevealDocument,
+  RevealRequest,
+  RevealWhere,
+} from '../../types/index.js';
+import { find } from './find.js';
+
+function accessDenied(): Error {
+  return new Error('Access denied: insufficient permissions to snapshot this document');
+}
+
+function snapshotUnsupported(slug: string): Error {
+  const err = new Error(
+    `Snapshots are not supported for collection '${slug}': no typed storage adapter is registered.`,
+  );
+  (err as Error & { statusCode: number }).statusCode = 501;
+  return err;
+}
+
+/**
+ * Confirm the caller may write the target document — snapshotting and restoring
+ * are part of the edit lifecycle. Reuses `access.update` and the same row-level
+ * scoping `update()` uses, so a caller cannot snapshot or restore a row outside
+ * its scope.
+ */
+async function assertWriteAccess(
+  config: RevealCollectionConfig,
+  db: QueryableDatabaseAdapter | null,
+  id: string | number,
+  req: RevealRequest | undefined,
+  overrideAccess: boolean | undefined,
+): Promise<void> {
+  if (overrideAccess) return;
+  const updateAccess = (
+    config as {
+      access?: { update?: (args: { req: RevealRequest; id?: string | number }) => unknown };
+    }
+  ).access?.update;
+  if (!updateAccess) return;
+  if (!req) throw accessDenied();
+  const result = await updateAccess({ req, id });
+  if (result === false) throw accessDenied();
+  if (result !== true) {
+    const scoped = await find(config, db, {
+      where: { and: [{ id: { equals: id } }, result as RevealWhere] },
+      limit: 1,
+      req,
+      overrideAccess: true,
+    });
+    if (scoped.docs.length === 0) throw accessDenied();
+  }
+}
+
+export interface SnapshotOptions {
+  id: string | number;
+  req?: RevealRequest;
+  changeDescription?: string;
+  overrideAccess?: boolean;
+}
+
+export interface RestoreOptions {
+  id: string | number;
+  revisionId: string | number;
+  req?: RevealRequest;
+  overrideAccess?: boolean;
+}
+
+export async function createSnapshot(
+  config: RevealCollectionConfig,
+  db: QueryableDatabaseAdapter | null,
+  options: SnapshotOptions,
+): Promise<RevealDocument> {
+  const { id, req, changeDescription } = options;
+  await assertWriteAccess(config, db, id, req, options.overrideAccess);
+
+  const seam = db?.collectionStorage?.snapshot;
+  if (!seam) throw snapshotUnsupported(config.slug);
+
+  const revision = await seam(config, {
+    id,
+    ...(req ? { req } : {}),
+    ...(changeDescription !== undefined ? { changeDescription } : {}),
+  });
+  if (revision === undefined) throw snapshotUnsupported(config.slug);
+  return revision;
+}
+
+export async function restoreSnapshot(
+  config: RevealCollectionConfig,
+  db: QueryableDatabaseAdapter | null,
+  options: RestoreOptions,
+): Promise<RevealDocument> {
+  const { id, revisionId, req } = options;
+  await assertWriteAccess(config, db, id, req, options.overrideAccess);
+
+  const seam = db?.collectionStorage?.restore;
+  if (!seam) throw snapshotUnsupported(config.slug);
+
+  const restored = await seam(config, {
+    id,
+    revisionId,
+    ...(req ? { req } : {}),
+  });
+  if (restored === undefined) throw snapshotUnsupported(config.slug);
+  return restored;
+}

--- a/packages/core/src/collections/operations/update.ts
+++ b/packages/core/src/collections/operations/update.ts
@@ -213,6 +213,7 @@ export async function update(
       'created_at',
       'updated_at',
       '_json',
+      '_status',
       'password',
     ]);
     if (config.fields) {

--- a/packages/core/src/instance/RevealUIInstance.ts
+++ b/packages/core/src/instance/RevealUIInstance.ts
@@ -139,6 +139,8 @@ export async function createRevealUIInstance(config: RevealConfig): Promise<Reve
       id: string | number;
       depth?: number;
       req?: import('../types/index.js').RevealRequest;
+      draft?: boolean;
+      overrideAccess?: boolean;
     }): Promise<RevealDocument | null> {
       return findByID(revealUIInstance, ensureDbConnected, options);
     },

--- a/packages/core/src/instance/methods/findById.ts
+++ b/packages/core/src/instance/methods/findById.ts
@@ -15,6 +15,8 @@ export async function findByID(
     id: string | number;
     depth?: number;
     req?: RevealRequest;
+    draft?: boolean;
+    overrideAccess?: boolean;
   },
 ): Promise<RevealDocument | null> {
   await ensureDbConnected();

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -295,6 +295,26 @@ export interface CollectionStorageAdapter {
     collection: RevealCollectionConfig,
     options: { id: string | number; req?: RevealRequest },
   ) => Promise<RevealDocument | undefined>;
+  /**
+   * Capture a point-in-time revision of a document (the `page_revisions`
+   * pattern: per-doc revision number, content snapshot, createdBy,
+   * changeDescription). `undefined` = not handled — snapshots require a typed
+   * revision store, so there is no dynamic-SQL fallback. The created revision =
+   * success. Throw for handled-but-not-found.
+   */
+  snapshot?: (
+    collection: RevealCollectionConfig,
+    options: { id: string | number; req?: RevealRequest; changeDescription?: string },
+  ) => Promise<RevealDocument | undefined>;
+  /**
+   * Restore a document to a stored revision, writing the revision's content back
+   * over the live document. `undefined` = not handled. The restored document =
+   * success. Throw for handled-but-not-found (document or revision).
+   */
+  restore?: (
+    collection: RevealCollectionConfig,
+    options: { id: string | number; revisionId: string | number; req?: RevealRequest },
+  ) => Promise<RevealDocument | undefined>;
 }
 
 export interface QueryableDatabaseAdapter {


### PR DESCRIPTION
## Summary

Makes drafts work end-to-end through the `@revealui/core` collection operations layer, per foundation item F4 of the internal visual-edit-sessions spec (the edit-path keystone). Extends the existing operations — no parallel path. References the internal CMS content-surfaces audit (finding B5: REST accepts `draft` but `find()` hard-codes `draft:false`; nothing writes `_status`; snapshots unimplemented).

Three changes:
1. `find()`/`findByID()` honor the REST `draft` query param.
2. `update()` persists `_status` transitions (they were silently dropped).
3. New `createSnapshot()`/`restoreSnapshot()` operations modeled on the revisions pattern.

## ⚠️ Awaiting security verdict — DO NOT MERGE

This branch touches `collections/operations`, a security-sensitive surface (the draft-leak boundary). Per the review-before-merge convention it requires a **recorded coordinator verdict from a non-author** before merge. This PR is proposal-shaped only; the author does not self-clear. Do not merge and do not apply any `sec-review:*` label without an independent review.

## Access-control statement for drafts (the invariant)

`draft=true` **never** widens what a caller may read. For every read:

- `access.read` is evaluated exactly as before and AND-merged into the query (unchanged path).
- Independently, a drafts-enabled collection (`versions.drafts`) gets a published-only filter `{_status: {equals: 'published'}}` **by default**. `draft=true` removes **only** this default filter.
- Because the two filters are independent and AND-merged, a caller scoped to published content by `access.read` (an unauthenticated / non-admin reader, via `authenticatedOrPublished`) stays published-only **even when it passes `draft=true`**. Draft content is returned only to a caller whose `access.read` returns `true` (or a clause that admits the row) **and** who asked for `draft=true`.

## File:line map

**Ignored before / fixed:**
- `packages/core/src/api/rest.ts:49,93-97` — parses `draft` (already correct).
- `packages/core/src/collections/operations/find.ts:56` — `draft` was never destructured; `draft:false` hard-coded into `afterRead` (was lines 113,250). Now destructured, published-only filter layered into the AND-merge, real `draft` passed to `afterRead`.
- `packages/core/src/collections/operations/findById.ts` — routed through `find()`'s AND-merge whenever an access clause **or** the published-only filter applies (previously only for a row-level access clause), so an admin without draft mode and a public caller with `draft=true` both get published-only; real `draft` passed to `afterRead`.
- `packages/core/src/collections/operations/update.ts:209-218` — added `_status` to the dynamic-SQL column allowlist (it was dropped, so `_status` never persisted). Gated by the pre-existing `access.update` enforcement.

**New:**
- `packages/core/src/collections/operations/drafts.ts` — `collectionHasDrafts()` + `publishedOnlyReadFilter()` (shared by find/findById; the one place the published-only rule lives).
- `packages/core/src/collections/operations/snapshot.ts` — `createSnapshot()`/`restoreSnapshot()`, gated by `access.update`, delegating to a new optional `collectionStorage` seam. Persistence is owned by the typed store; this PR adds no dynamic revisions table (the typed adapter lands with the typed-storage write bridge, a separate foundation item).
- `packages/core/src/types/runtime.ts` — optional `snapshot`/`restore` on `CollectionStorageAdapter`; `draft` threaded onto the `findByID` option types.
- `packages/core/src/collections/CollectionOperations.ts`, `instance/RevealUIInstance.ts`, `instance/methods/findById.ts` — thread `draft` through the findByID chain; expose `snapshot`/`restore` on the collection surface.

## Tests

New suite `packages/core/src/collections/operations/__tests__/drafts.test.ts` (15 tests) covering draft read semantics on both `find()` and `findByID()`, `_status` writes + access-gated denial, and snapshot/restore delegation + access gating. Two tests are the explicit draft-leak regression guards (an unauthenticated `draft=true` read returns published content only, on both operations).

- `@revealui/core` full suite: **2787 passed** (111 files).
- Operations suite incl. new tests: **156 passed**.
- Biome clean on all changed files.
- `turbo build --filter=@revealui/core --filter=server`: success.

## Prove-red

Reverted the three behavioral files (`find.ts`, `findById.ts`, `update.ts`) to `origin/test`, kept the new tests, and re-ran — **3 tests went red**, matching the three new behaviors:

- `find() … no draft param + admin → published only` (old code returned drafts too)
- `findByID() … draft=false + admin → draft doc returns null` (old code returned the draft)
- `update() persists an _status transition` (old code dropped `_status`)

The two draft-leak invariant guards stayed **green** with the fix reverted — as expected: the boundary is enforced by the `access.read` AND-merge, which `draft=true` cannot bypass. The regression tests lock that a future change cannot make `draft=true` bypass access.

## Checker verdict

```
$ node security-pr-review-check.js --diff origin/test
🔒 Current branch is SECURITY-SENSITIVE (vs origin/test).
   When you open the PR, it needs a recorded coordinator verdict before merge.
```

HOLD is expected. This PR waits for a non-author security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
