### PR TITLE
feat(server): add globals content endpoint and reconcile callers

### DIFF
--- a/apps/admin/src/__tests__/api/proxy-routes.test.ts
+++ b/apps/admin/src/__tests__/api/proxy-routes.test.ts
@@ -78,13 +78,16 @@ function makeUpstreamError(status: number, text = 'upstream error') {
 describe('GET /api/globals/[slug]', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('proxies a 200 response from the API', async () => {
-    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ title: 'Home' }));
-    const req = new NextRequest('http://localhost/api/globals/home');
-    const res = await globalsGet(req, { params: Promise.resolve({ slug: 'home' }) });
+  it('forwards to /api/content/globals and unwraps { success, data } to { doc }', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeUpstreamOk({ success: true, data: { id: '1', schemaVersion: '1' } }),
+    );
+    const req = new NextRequest('http://localhost/api/globals/header');
+    const res = await globalsGet(req, { params: Promise.resolve({ slug: 'header' }) });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.title).toBe('Home');
+    expect(body.doc).toEqual({ id: '1', schemaVersion: '1' });
+    expect(String(mockFetch.mock.calls[0]?.[0])).toContain('/api/content/globals/header');
   });
 
   it('returns sanitized 404 when upstream returns 404', async () => {
@@ -122,17 +125,22 @@ describe('GET /api/globals/[slug]', () => {
 describe('POST /api/globals/[slug]', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('proxies a 200 POST response', async () => {
-    mockFetch.mockResolvedValueOnce(makeUpstreamOk({ updated: true }));
-    const req = new NextRequest('http://localhost/api/globals/nav', {
+  it('forwards as PATCH to /api/content/globals and unwraps to { doc }', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeUpstreamOk({ success: true, data: { id: '1', schemaVersion: '1' } }),
+    );
+    const req = new NextRequest('http://localhost/api/globals/header', {
       method: 'POST',
-      body: JSON.stringify({ links: [] }),
+      body: JSON.stringify({ logoId: 'logo-1' }),
       headers: { 'Content-Type': 'application/json' },
     });
-    const res = await globalsPost(req, { params: Promise.resolve({ slug: 'nav' }) });
+    const res = await globalsPost(req, { params: Promise.resolve({ slug: 'header' }) });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.updated).toBe(true);
+    expect(body.doc).toEqual({ id: '1', schemaVersion: '1' });
+    const [url, init] = mockFetch.mock.calls[0] ?? [];
+    expect(String(url)).toContain('/api/content/globals/header');
+    expect((init as RequestInit).method).toBe('PATCH');
   });
 
   it('returns sanitized 403 for forbidden POST', async () => {

--- a/apps/admin/src/app/api/globals/[slug]/route.ts
+++ b/apps/admin/src/app/api/globals/[slug]/route.ts
@@ -28,13 +28,25 @@ function sanitizeErrorResponse(status: number): string {
   }
 }
 
+/**
+ * The canonical content endpoint returns `{ success, data }`; the admin client
+ * (packages/core client apiClient) consumes the engine-REST `{ doc }` shape.
+ * Adapt here so the dashboard global editor keeps its expected response.
+ */
+function unwrapGlobal(payload: unknown): unknown {
+  if (payload !== null && typeof payload === 'object' && 'data' in payload) {
+    return (payload as { data: unknown }).data;
+  }
+  return payload;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ): Promise<NextResponse> {
-  // Fail-closed session gate, mirroring the collections list proxy. The api
-  // server enforces per-global permissions on the forwarded cookie, but this
-  // proxy must not forward at all without a validated session.
+  // Fail-closed session gate, mirroring the collections list proxy. The read
+  // side of the canonical endpoint is public, but this admin proxy only serves
+  // authenticated dashboard sessions, so it must not forward without one.
   const session = await getSession(request.headers, extractRequestContext(request));
   if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -43,9 +55,12 @@ export async function GET(
   const { slug } = await params;
   const { searchParams } = new URL(request.url);
 
-  const apiResponse = await fetch(`${API_URL}/api/globals/${slug}?${searchParams.toString()}`, {
-    headers: await apiForwardHeaders(request),
-  });
+  const apiResponse = await fetch(
+    `${API_URL}/api/content/globals/${slug}?${searchParams.toString()}`,
+    {
+      headers: await apiForwardHeaders(request),
+    },
+  );
 
   if (!apiResponse.ok) {
     return NextResponse.json(
@@ -55,7 +70,7 @@ export async function GET(
   }
 
   const data = await apiResponse.json();
-  return NextResponse.json(data, { status: apiResponse.status });
+  return NextResponse.json({ doc: unwrapGlobal(data) }, { status: apiResponse.status });
 }
 
 export async function POST(
@@ -70,8 +85,8 @@ export async function POST(
   const { slug } = await params;
   const body = await request.json();
 
-  const apiResponse = await fetch(`${API_URL}/api/globals/${slug}`, {
-    method: 'POST',
+  const apiResponse = await fetch(`${API_URL}/api/content/globals/${slug}`, {
+    method: 'PATCH',
     headers: await apiForwardHeaders(request, { 'Content-Type': 'application/json' }),
     body: JSON.stringify(body),
   });
@@ -84,5 +99,5 @@ export async function POST(
   }
 
   const data = await apiResponse.json();
-  return NextResponse.json(data, { status: apiResponse.status });
+  return NextResponse.json({ doc: unwrapGlobal(data) }, { status: apiResponse.status });
 }

--- a/apps/server/src/routes/__tests__/content-globals.test.ts
+++ b/apps/server/src/routes/__tests__/content-globals.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Content Globals Route Tests
+ *
+ * Covers GET /globals/:slug (public, published read) and PATCH /globals/:slug
+ * (RBAC content:update). The PATCH gate is the production `/api/content/*`
+ * mount middleware (requirePermission('content','update')), replicated here so
+ * the unauthenticated + under-privileged rejections are proven, not assumed.
+ */
+
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockGlobalQueries } = vi.hoisted(() => ({
+  mockGlobalQueries: {
+    getGlobalHeader: vi.fn(),
+    getGlobalFooter: vi.fn(),
+    getGlobalSettings: vi.fn(),
+    updateGlobalHeader: vi.fn(),
+    updateGlobalFooter: vi.fn(),
+    updateGlobalSettings: vi.fn(),
+    isGlobalSlug: (v: string) => v === 'header' || v === 'footer' || v === 'settings',
+    GLOBAL_SLUGS: ['header', 'footer', 'settings'] as const,
+  },
+}));
+
+vi.mock('@revealui/db/queries/globals', () => mockGlobalQueries);
+
+// ─── Import under test ────────────────────────────────────────────────────────
+
+import { requirePermission } from '../../middleware/authorization.js';
+import contentApp from '../content/index.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface UserCtx {
+  id: string;
+  role: string;
+}
+
+const EDITOR: UserCtx = { id: 'editor-1', role: 'editor' };
+const AGENT: UserCtx = { id: 'agent-1', role: 'agent' };
+
+/**
+ * Mount contentApp behind the same content-mutation RBAC middleware the server
+ * applies at `/api/content/*`, so PATCH auth is exercised end to end.
+ */
+function createApp(user: UserCtx | null) {
+  const app = new Hono<{ Variables: { user: UserCtx | undefined; db: unknown } }>();
+  app.use('*', async (c, next) => {
+    if (user) c.set('user', user);
+    c.set('db', {});
+    await next();
+  });
+  app.patch('*', requirePermission('content', 'update'));
+  app.route('/', contentApp);
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) return c.json({ error: err.message }, err.status);
+    return c.json({ error: 'Internal server error' }, 500);
+  });
+  return app;
+}
+
+function makeHeader(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '1',
+    schemaVersion: '1',
+    navItems: [{ label: 'Home', url: '/' }],
+    logoId: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '1',
+    schemaVersion: '1',
+    siteName: 'RevealUI',
+    siteDescription: null,
+    defaultMeta: null,
+    contactEmail: null,
+    contactPhone: null,
+    socialProfiles: null,
+    analyticsId: null,
+    features: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function patch(app: ReturnType<typeof createApp>, slug: string, body: unknown) {
+  return app.request(`/globals/${slug}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+// ─── GET (public, published) ────────────────────────────────────────────────
+
+describe('GET /globals/:slug', () => {
+  it('returns the header global to an unauthenticated caller', async () => {
+    mockGlobalQueries.getGlobalHeader.mockResolvedValue(makeHeader());
+    const res = await createApp(null).request('/globals/header');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe('1');
+    expect(body.data.navItems).toEqual([{ label: 'Home', url: '/' }]);
+    expect(body.data.createdAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('404s for an unknown slug', async () => {
+    const res = await createApp(null).request('/globals/nope');
+    expect(res.status).toBe(404);
+    expect(mockGlobalQueries.getGlobalHeader).not.toHaveBeenCalled();
+  });
+
+  it('404s when the singleton row does not exist yet', async () => {
+    mockGlobalQueries.getGlobalSettings.mockResolvedValue(undefined);
+    const res = await createApp(null).request('/globals/settings');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── PATCH (RBAC content:update) ────────────────────────────────────────────
+
+describe('PATCH /globals/:slug', () => {
+  it('rejects an unauthenticated PATCH with 401 and never writes', async () => {
+    const res = await patch(createApp(null), 'header', { logoId: 'logo-1' });
+    expect(res.status).toBe(401);
+    expect(mockGlobalQueries.updateGlobalHeader).not.toHaveBeenCalled();
+  });
+
+  it('rejects a read-only agent role with 403 and never writes', async () => {
+    const res = await patch(createApp(AGENT), 'header', { logoId: 'logo-1' });
+    expect(res.status).toBe(403);
+    expect(mockGlobalQueries.updateGlobalHeader).not.toHaveBeenCalled();
+  });
+
+  it('lets an editor update the header and returns the serialized row', async () => {
+    mockGlobalQueries.updateGlobalHeader.mockResolvedValue(makeHeader({ logoId: 'logo-1' }));
+    const res = await patch(createApp(EDITOR), 'header', { logoId: 'logo-1' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.logoId).toBe('logo-1');
+    expect(mockGlobalQueries.updateGlobalHeader).toHaveBeenCalledWith(expect.anything(), {
+      logoId: 'logo-1',
+    });
+  });
+
+  it('lets an editor update settings', async () => {
+    mockGlobalQueries.updateGlobalSettings.mockResolvedValue(makeSettings({ siteName: 'Renamed' }));
+    const res = await patch(createApp(EDITOR), 'settings', { siteName: 'Renamed' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.siteName).toBe('Renamed');
+  });
+
+  it('rejects a field that does not belong to the slug (strict validation) with 400', async () => {
+    const res = await patch(createApp(EDITOR), 'header', { siteName: 'wrong-global' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(mockGlobalQueries.updateGlobalHeader).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/routes/content/globals.ts
+++ b/apps/server/src/routes/content/globals.ts
@@ -1,0 +1,304 @@
+/**
+ * Global CRUD routes
+ *
+ * GET   /globals/:slug   public  -  returns the published global config
+ * PATCH /globals/:slug   auth'd  -  mutates the global (RBAC content:update)
+ *
+ * Globals are single-row site configuration (header, footer, settings). The
+ * read path is public because these render on every public page; the write
+ * path inherits the content-mutation middleware chain mounted at
+ * `/api/content/*` in index.ts (requirePermission('content','update') +
+ * CSRF + rejectRecovery), so no auth is re-implemented here.
+ */
+
+import {
+  getGlobalFooter,
+  getGlobalHeader,
+  getGlobalSettings,
+  isGlobalSlug,
+  updateGlobalFooter,
+  updateGlobalHeader,
+  updateGlobalSettings,
+} from '@revealui/db/queries/globals';
+import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
+import { HTTPException } from 'hono/http-exception';
+import { SlugParam, ValidationErrorSchema } from '../_helpers/content-schemas.js';
+import { dateToString } from '../_helpers/serialize.js';
+import type { ContentVariables } from './index.js';
+
+const app = new OpenAPIHono<{ Variables: ContentVariables }>();
+
+// =============================================================================
+// Response Schemas
+// =============================================================================
+
+const DateTime = z.string().openapi({ type: 'string', format: 'date-time' });
+
+const GlobalHeaderSchema = z
+  .object({
+    id: z.string(),
+    schemaVersion: z.string(),
+    navItems: z.unknown().nullable(),
+    logoId: z.string().nullable(),
+    createdAt: DateTime,
+    updatedAt: DateTime,
+  })
+  .openapi('GlobalHeader');
+
+const GlobalFooterSchema = z
+  .object({
+    id: z.string(),
+    schemaVersion: z.string(),
+    columns: z.unknown().nullable(),
+    copyright: z.string().nullable(),
+    socialLinks: z.unknown().nullable(),
+    createdAt: DateTime,
+    updatedAt: DateTime,
+  })
+  .openapi('GlobalFooter');
+
+const GlobalSettingsSchema = z
+  .object({
+    id: z.string(),
+    schemaVersion: z.string(),
+    siteName: z.string().nullable(),
+    siteDescription: z.string().nullable(),
+    defaultMeta: z.unknown().nullable(),
+    contactEmail: z.string().nullable(),
+    contactPhone: z.string().nullable(),
+    socialProfiles: z.unknown().nullable(),
+    analyticsId: z.string().nullable(),
+    features: z.unknown().nullable(),
+    createdAt: DateTime,
+    updatedAt: DateTime,
+  })
+  .openapi('GlobalSettings');
+
+const GlobalSchema = z.union([GlobalHeaderSchema, GlobalFooterSchema, GlobalSettingsSchema]);
+
+const GlobalResponse = z.object({ success: z.literal(true), data: GlobalSchema });
+const NotFoundSchema = z.object({ success: z.literal(false), error: z.string() });
+
+// =============================================================================
+// Request Schemas (per-slug, strict  -  unknown/wrong-slug fields are rejected)
+// =============================================================================
+
+const NavItemSchema = z.object({
+  label: z.string(),
+  url: z.string(),
+  newTab: z.boolean().optional(),
+  children: z
+    .array(z.object({ label: z.string(), url: z.string(), newTab: z.boolean().optional() }))
+    .optional(),
+});
+
+const HeaderUpdateSchema = z
+  .object({
+    schemaVersion: z.string().optional(),
+    navItems: z.array(NavItemSchema).optional(),
+    logoId: z.string().nullable().optional(),
+  })
+  .strict();
+
+const FooterUpdateSchema = z
+  .object({
+    schemaVersion: z.string().optional(),
+    columns: z
+      .array(
+        z.object({
+          label: z.string(),
+          links: z.array(
+            z.object({ label: z.string(), url: z.string(), newTab: z.boolean().optional() }),
+          ),
+        }),
+      )
+      .optional(),
+    copyright: z.string().nullable().optional(),
+    socialLinks: z.array(z.object({ platform: z.string(), url: z.string() })).optional(),
+  })
+  .strict();
+
+const SettingsUpdateSchema = z
+  .object({
+    schemaVersion: z.string().optional(),
+    siteName: z.string().nullable().optional(),
+    siteDescription: z.string().nullable().optional(),
+    defaultMeta: z.record(z.string(), z.unknown()).nullable().optional(),
+    contactEmail: z.string().nullable().optional(),
+    contactPhone: z.string().nullable().optional(),
+    socialProfiles: z.record(z.string(), z.unknown()).nullable().optional(),
+    analyticsId: z.string().nullable().optional(),
+    features: z.record(z.string(), z.unknown()).nullable().optional(),
+  })
+  .strict();
+
+// The OpenAPI body is permissive; the strict per-slug schema above runs in the
+// handler once the slug is known, so wrong-slug fields fail with a 400.
+const GlobalPatchBody = z.record(z.string(), z.unknown());
+
+// =============================================================================
+// Serializers
+// =============================================================================
+
+function serializeHeader(
+  row: NonNullable<Awaited<ReturnType<typeof getGlobalHeader>>>,
+): z.infer<typeof GlobalHeaderSchema> {
+  return {
+    id: row.id,
+    schemaVersion: row.schemaVersion,
+    navItems: row.navItems ?? null,
+    logoId: row.logoId ?? null,
+    createdAt: dateToString(row.createdAt),
+    updatedAt: dateToString(row.updatedAt),
+  };
+}
+
+function serializeFooter(
+  row: NonNullable<Awaited<ReturnType<typeof getGlobalFooter>>>,
+): z.infer<typeof GlobalFooterSchema> {
+  return {
+    id: row.id,
+    schemaVersion: row.schemaVersion,
+    columns: row.columns ?? null,
+    copyright: row.copyright ?? null,
+    socialLinks: row.socialLinks ?? null,
+    createdAt: dateToString(row.createdAt),
+    updatedAt: dateToString(row.updatedAt),
+  };
+}
+
+function serializeSettings(
+  row: NonNullable<Awaited<ReturnType<typeof getGlobalSettings>>>,
+): z.infer<typeof GlobalSettingsSchema> {
+  return {
+    id: row.id,
+    schemaVersion: row.schemaVersion,
+    siteName: row.siteName ?? null,
+    siteDescription: row.siteDescription ?? null,
+    defaultMeta: row.defaultMeta ?? null,
+    contactEmail: row.contactEmail ?? null,
+    contactPhone: row.contactPhone ?? null,
+    socialProfiles: row.socialProfiles ?? null,
+    analyticsId: row.analyticsId ?? null,
+    features: row.features ?? null,
+    createdAt: dateToString(row.createdAt),
+    updatedAt: dateToString(row.updatedAt),
+  };
+}
+
+// =============================================================================
+// Routes
+// =============================================================================
+
+// GET /globals/:slug  -  public read of the published global
+app.openapi(
+  createRoute({
+    method: 'get',
+    path: '/globals/{slug}',
+    tags: ['content'],
+    summary: 'Get a global by slug',
+    request: { params: SlugParam },
+    responses: {
+      200: {
+        content: { 'application/json': { schema: GlobalResponse } },
+        description: 'Global found',
+      },
+      404: {
+        content: { 'application/json': { schema: NotFoundSchema } },
+        description: 'Not found',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const { slug } = c.req.valid('param');
+
+    if (slug === 'header') {
+      const row = await getGlobalHeader(db);
+      if (!row) throw new HTTPException(404, { message: 'Global not found' });
+      return c.json({ success: true as const, data: serializeHeader(row) }, 200);
+    }
+    if (slug === 'footer') {
+      const row = await getGlobalFooter(db);
+      if (!row) throw new HTTPException(404, { message: 'Global not found' });
+      return c.json({ success: true as const, data: serializeFooter(row) }, 200);
+    }
+    if (slug === 'settings') {
+      const row = await getGlobalSettings(db);
+      if (!row) throw new HTTPException(404, { message: 'Global not found' });
+      return c.json({ success: true as const, data: serializeSettings(row) }, 200);
+    }
+    throw new HTTPException(404, { message: 'Global not found' });
+  },
+);
+
+// PATCH /globals/:slug  -  RBAC content:update enforced at the /api/content/* mount
+app.openapi(
+  createRoute({
+    method: 'patch',
+    path: '/globals/{slug}',
+    tags: ['content'],
+    summary: 'Update a global',
+    request: {
+      params: SlugParam,
+      body: { content: { 'application/json': { schema: GlobalPatchBody } } },
+    },
+    responses: {
+      200: {
+        content: { 'application/json': { schema: GlobalResponse } },
+        description: 'Global updated',
+      },
+      400: {
+        content: { 'application/json': { schema: ValidationErrorSchema } },
+        description: 'Validation failed',
+      },
+      404: {
+        content: { 'application/json': { schema: NotFoundSchema } },
+        description: 'Not found',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const { slug } = c.req.valid('param');
+    const body = c.req.valid('json');
+
+    if (!isGlobalSlug(slug)) {
+      throw new HTTPException(404, { message: 'Global not found' });
+    }
+
+    if (slug === 'header') {
+      const parsed = HeaderUpdateSchema.safeParse(body);
+      if (!parsed.success) {
+        return c.json(
+          { success: false as const, errors: parsed.error.issues.map((i) => i.message) },
+          400,
+        );
+      }
+      const row = await updateGlobalHeader(db, parsed.data);
+      return c.json({ success: true as const, data: serializeHeader(row) }, 200);
+    }
+    if (slug === 'footer') {
+      const parsed = FooterUpdateSchema.safeParse(body);
+      if (!parsed.success) {
+        return c.json(
+          { success: false as const, errors: parsed.error.issues.map((i) => i.message) },
+          400,
+        );
+      }
+      const row = await updateGlobalFooter(db, parsed.data);
+      return c.json({ success: true as const, data: serializeFooter(row) }, 200);
+    }
+    const parsed = SettingsUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(
+        { success: false as const, errors: parsed.error.issues.map((i) => i.message) },
+        400,
+      );
+    }
+    const row = await updateGlobalSettings(db, parsed.data);
+    return c.json({ success: true as const, data: serializeSettings(row) }, 200);
+  },
+);
+
+export default app;

--- a/apps/server/src/routes/content/index.ts
+++ b/apps/server/src/routes/content/index.ts
@@ -17,6 +17,9 @@
  * Pages:     GET|POST /api/content/sites/:siteId/pages
  *            GET|PATCH|DELETE /api/content/pages/:id
  *
+ * Globals:   GET /api/content/globals/:slug (public)
+ *            PATCH /api/content/globals/:slug (content:update)
+ *
  * Users:     GET /api/content/users (admin-only, paginated)
  *            GET|PATCH|DELETE /api/content/users/:id
  *
@@ -35,6 +38,7 @@ import type { DatabaseClient } from '@revealui/db/client';
 import { OpenAPIHono } from '@revealui/openapi';
 import batchRoutes from './batch.js';
 import exportRoutes from './export.js';
+import globalsRoutes from './globals.js';
 import mediaRoutes from './media.js';
 import ordersRoutes from './orders.js';
 import pagesRoutes from './pages.js';
@@ -55,6 +59,7 @@ app.route('/', postsRoutes);
 app.route('/', mediaRoutes);
 app.route('/', sitesRoutes);
 app.route('/', pagesRoutes);
+app.route('/', globalsRoutes);
 app.route('/', searchRoutes);
 app.route('/', usersRoutes);
 app.route('/', productsRoutes);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -162,6 +162,10 @@
       "types": "./dist/queries/posts.d.ts",
       "import": "./dist/queries/posts.js"
     },
+    "./queries/globals": {
+      "types": "./dist/queries/globals.d.ts",
+      "import": "./dist/queries/globals.js"
+    },
     "./queries/media": {
       "types": "./dist/queries/media.d.ts",
       "import": "./dist/queries/media.js"

--- a/packages/db/src/queries/globals.ts
+++ b/packages/db/src/queries/globals.ts
@@ -1,0 +1,115 @@
+/**
+ * Global database queries
+ *
+ * Globals are single-row configuration tables (`global_header`,
+ * `global_footer`, `global_settings`). Each holds exactly one row; the get
+ * helpers read it and the update helpers upsert it. Typed Drizzle access keeps
+ * these off the engine's dynamic-SQL path.
+ */
+
+import { eq } from 'drizzle-orm';
+import type { Database } from '../client/index.js';
+import {
+  type GlobalFooter,
+  type GlobalHeader,
+  type GlobalSettings,
+  globalFooter,
+  globalHeader,
+  globalSettings,
+  type NewGlobalFooter,
+  type NewGlobalHeader,
+  type NewGlobalSettings,
+} from '../schema/admin.js';
+
+/** The globals exposed over the content API, in URL-slug form. */
+export const GLOBAL_SLUGS = ['header', 'footer', 'settings'] as const;
+export type GlobalSlug = (typeof GLOBAL_SLUGS)[number];
+
+/** Type guard for the closed set of global slugs. */
+export function isGlobalSlug(value: string): value is GlobalSlug {
+  return (GLOBAL_SLUGS as readonly string[]).includes(value);
+}
+
+/** Default id for the singleton rows (schema default is '1'). */
+const SINGLETON_ID = '1';
+
+export async function getGlobalHeader(db: Database): Promise<GlobalHeader | undefined> {
+  const rows = await db.select().from(globalHeader).limit(1);
+  return rows[0];
+}
+
+export async function getGlobalFooter(db: Database): Promise<GlobalFooter | undefined> {
+  const rows = await db.select().from(globalFooter).limit(1);
+  return rows[0];
+}
+
+export async function getGlobalSettings(db: Database): Promise<GlobalSettings | undefined> {
+  const rows = await db.select().from(globalSettings).limit(1);
+  return rows[0];
+}
+
+export async function updateGlobalHeader(
+  db: Database,
+  data: Partial<Omit<NewGlobalHeader, 'id' | 'createdAt' | 'updatedAt'>>,
+): Promise<GlobalHeader> {
+  const existing = await getGlobalHeader(db);
+  if (existing) {
+    const rows = await db
+      .update(globalHeader)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(globalHeader.id, existing.id))
+      .returning();
+    // biome-ignore lint/style/noNonNullAssertion: update of an existing row returns it
+    return rows[0]!;
+  }
+  const rows = await db
+    .insert(globalHeader)
+    .values({ id: SINGLETON_ID, ...data })
+    .returning();
+  // biome-ignore lint/style/noNonNullAssertion: insert always returns the created row
+  return rows[0]!;
+}
+
+export async function updateGlobalFooter(
+  db: Database,
+  data: Partial<Omit<NewGlobalFooter, 'id' | 'createdAt' | 'updatedAt'>>,
+): Promise<GlobalFooter> {
+  const existing = await getGlobalFooter(db);
+  if (existing) {
+    const rows = await db
+      .update(globalFooter)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(globalFooter.id, existing.id))
+      .returning();
+    // biome-ignore lint/style/noNonNullAssertion: update of an existing row returns it
+    return rows[0]!;
+  }
+  const rows = await db
+    .insert(globalFooter)
+    .values({ id: SINGLETON_ID, ...data })
+    .returning();
+  // biome-ignore lint/style/noNonNullAssertion: insert always returns the created row
+  return rows[0]!;
+}
+
+export async function updateGlobalSettings(
+  db: Database,
+  data: Partial<Omit<NewGlobalSettings, 'id' | 'createdAt' | 'updatedAt'>>,
+): Promise<GlobalSettings> {
+  const existing = await getGlobalSettings(db);
+  if (existing) {
+    const rows = await db
+      .update(globalSettings)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(globalSettings.id, existing.id))
+      .returning();
+    // biome-ignore lint/style/noNonNullAssertion: update of an existing row returns it
+    return rows[0]!;
+  }
+  const rows = await db
+    .insert(globalSettings)
+    .values({ id: SINGLETON_ID, ...data })
+    .returning();
+  // biome-ignore lint/style/noNonNullAssertion: insert always returns the created row
+  return rows[0]!;
+}


### PR DESCRIPTION
## Summary

Adds the missing canonical globals HTTP endpoint on the Hono server and reconciles the divergent globals callers onto it. Foundation item from the internal visual-edit-sessions spec; grounded in the internal CMS content-surfaces audit (finding B3: "no `/api/globals` or `/api/content/globals` route exists anywhere in apps/server", with three live callers pointing at drifted paths).

## Endpoint contract

`/api/content/globals/:slug` where `slug` is one of `header`, `footer`, `settings` (the three single-row global config tables; unknown slugs 404).

| Method | Auth | Behavior |
|---|---|---|
| `GET` | public | Returns the published global as `{ success: true, data }`. Globals render on every public page, so the read path is public (same posture as published blog posts). 404 when the singleton row does not exist yet. |
| `PATCH` | content RBAC | Upserts the singleton row and returns the serialized result. Per-slug **strict** validation rejects fields that do not belong to the slug (400), keeping writes on the typed Drizzle path rather than dynamic SQL. |

Data access is a new typed query module (`@revealui/db/queries/globals`) that extends the existing per-entity queries pattern (posts/sites/pages/media) with `getGlobal*` / `updateGlobal*` over the typed `global_header` / `global_footer` / `global_settings` tables. This deliberately avoids the engine's dynamic-SQL global path (and its documented camelCase-column trap).

## RBAC statement

No parallel auth is introduced. `PATCH` inherits the existing content-mutation middleware chain already mounted at `/api/content/*` in `apps/server/src/index.ts`:

- `requirePermission('content', 'update')` — editor/admin/owner may write; the read-only agent role is denied.
- `writeProtected` (CSRF) + `rejectRecovery`.

An unauthenticated `PATCH` is rejected at that mount (401) before reaching the handler; an under-privileged role is rejected (403). Both are proven by tests that replicate the production wiring, not assumed.

## Three-caller reconciliation (audit-first)

1. **Admin proxy** — [apps/admin/src/app/api/globals/[slug]/route.ts:46](apps/admin/src/app/api/globals/[slug]/route.ts) (GET) and [:73](apps/admin/src/app/api/globals/[slug]/route.ts) (POST) forwarded to `${API_URL}/api/globals/${slug}` (no `/content`, and POST for the mutation). **Changed:** forwards to `/api/content/globals/${slug}`, translates the mutation to `PATCH`, and adapts the content-API `{ success, data }` response into the `{ doc }` shape the dashboard client (`packages/core` `apiClient`) consumes. Inbound GET/POST stay stable so the admin dashboard editor keeps working.
2. **Internal admin client** — [apps/server/src/lib/internal-admin-client.ts:105](apps/server/src/lib/internal-admin-client.ts) (GET) and [:109](apps/server/src/lib/internal-admin-client.ts) (PATCH) already target the canonical `/api/content/globals/${slug}` with the correct verbs against the API origin. **No change needed** — it self-404'd only because the route did not exist; it now resolves.
3. **Ticket dispatcher client** — [apps/server/src/lib/agent-dispatcher.ts:176](apps/server/src/lib/agent-dispatcher.ts) (GET) and [:184](apps/server/src/lib/agent-dispatcher.ts) (POST/updateGlobal) call `${ADMIN_URL}/api/globals/${slug}`. That path is admin-app-relative and correct for its host; it reaches the canonical endpoint through the now-corrected admin proxy (caller 1). **No change needed** — transitively fixed. (Its `ADMIN_URL`/bearer auth model is a separate, pre-existing concern out of this scope.)

Net: the "with vs without `/content`" drift the audit flagged is resolved. The canonical path is `/api/content/globals` on the API; the admin proxy at `/api/globals` bridges admin-relative callers to it; all callers now converge on the same data.

## Tests

- New `apps/server/src/routes/__tests__/content-globals.test.ts` (8 tests): GET published-public + unknown-slug/missing-row 404s; PATCH unauthenticated → 401 (no write), read-only agent → 403 (no write), editor updates header + settings, strict-validation wrong-slug field → 400. Verified these go red when the route is unmounted (genuine coverage, not regression guards).
- Updated `apps/admin/src/__tests__/api/proxy-routes.test.ts` for the new forward path, `PATCH` verb, and `{ doc }` unwrap.

Full suites, all green after the change:

- `@revealui/db`: 1170 passed / 5 skipped
- `server` (apps/server): 2858 passed / 1 skipped
- `admin` (apps/admin): 1933 passed / 13 skipped
- `turbo build --filter=server --filter=admin`: 21/21 successful (typecheck included)

## Security checker verdict

`security-pr-review-check.js --diff origin/test` → **"no security-sensitive files — no coordinator gate."** The content-route + db-query files are not on the fleet sensitive-path list. Flagging for awareness regardless: this PR adds a content-mutation surface that leans on the existing content RBAC, so a review of the auth inheritance is welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
