### PR TITLE
docs: reconcile db + stack docs with single-neon retired-infra state

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -2,7 +2,7 @@
 visibility: public
 status: verified
 title: "Database Management Guide"
-description: "Drizzle ORM schema, migrations, NeonDB setup (with optional legacy Supabase RAG sidecar), and seeding"
+description: "Drizzle ORM schema, migrations, single Neon-primary setup (vector and RAG tables included via pgvector), and seeding"
 category: guide
 audience: developer
 ---
@@ -197,7 +197,7 @@ CI=true pnpm db:migrate
 - `--no-backup` - Skip backup creation
 - `--seed` - Seed sample data after reset
 - `--database=rest` - Reset only REST database (Neon)
-- `--database=vector` - Reset only the vector database (optional Supabase RAG sidecar)
+- `--database=vector` - Legacy dual-database holdover. The separate Supabase vector store was removed per the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md); vector and RAG tables now live in the single Neon database via pgvector.
 - `--force` - Allow in CI environment
 
 **Safety Features:**
@@ -322,8 +322,8 @@ postgresql://user:password@host:port/database
 # Neon (serverless)
 postgresql://user:password@host.neon.tech/database?sslmode=require
 
-# Supabase (optional RAG sidecar — legacy, being retired; connection pooling)
-postgresql://postgres:password@db.project.supabase.co:5432/postgres
+# Supabase Postgres via the legacy SUPABASE_DATABASE_URI alias (being retired; treated as a generic Postgres host, not a RAG sidecar)
+postgresql://postgres:password@db.project.supabase.co:5432/postgres  # legacy alias, being retired
 ```
 
 ### Optional Variables

--- a/docs/guides/technology-stack.md
+++ b/docs/guides/technology-stack.md
@@ -74,7 +74,7 @@ The runtime is provider-agnostic by contract and ships with no default AI vendor
 | Target | Role |
 |---|---|
 | **Vercel** | HTTP layer (`apps/marketing`, `apps/docs`, `apps/admin`, `apps/server` functions). |
-| **Fly** | Long-running services (ElectricSQL sync, optional dedicated `apps/server` machine) per ADR `2026-05-18-drop-railway-migrate-to-vercel-fly`. |
+| **Fly** | Long-running services (ElectricSQL sync, optional dedicated `apps/server` worker) configured via `apps/server/fly.toml` + `apps/server/Dockerfile.worker`. Railway was dropped as a target. |
 | **Self-host** | Any infrastructure that runs Node 24 + Postgres + Hono. The runtime is portable by contract. |
 
 ## License posture


### PR DESCRIPTION
## What

Doc-truth sweep over the retired-infra cluster: reconcile the database and stack docs against what the **code** actually does, so Supabase's retired vector/RAG-sidecar role reads as retired rather than current. Scope was `docs/DATABASE.md` and `docs/guides/technology-stack.md`; `packages/db/README.md`, `packages/db/docs/migrations-discipline.md`, and `docs/guides/deployment.md` were audited and already matched.

Ground truth: the dual-database architecture was removed. Vector and RAG tables now live in the single Neon database via pgvector; `SUPABASE_DATABASE_URI` survives only as a legacy connection alias the setup scripts still read as a fallback.

- `packages/db/src/schema/vector.ts:5-13` — "the 'vector' name refers to pgvector embeddings, not a separate vector database ... lives in the single Neon (Postgres) database"
- `packages/db/src/schema/rag.ts:3-4` — "Stored on Neon (Postgres) because rag_chunks uses the pgvector extension"
- `packages/db/src/client/index.ts:9-11,68` — single `'rest'` database type; the legacy `'vector'` alias "was removed per GAP-129 PR-C"
- `docs/decisions/2026-05-01-supabase-removal.md` — the Supabase-removal ADR
- `scripts/setup/database.ts:47`, `scripts/setup/reset-database.ts:85`, `packages/core/src/database/universal-postgres.ts:241` — `SUPABASE_DATABASE_URI` still read as a legacy fallback
- `apps/server/fly.toml`, `apps/server/Dockerfile.worker` — the Fly target's real artifacts

## Reconciliation table

| Claim (doc) | Code truth | Verdict | Action |
|---|---|---|---|
| `docs/DATABASE.md:5` frontmatter "optional legacy Supabase RAG sidecar" | RAG lives in Neon via pgvector (`packages/db/src/schema/rag.ts:3-4`) | DOC-DRIFT | Rewrote to "single Neon-primary setup (vector and RAG tables included via pgvector)" |
| `docs/DATABASE.md:200` `--database=vector` "the vector database (optional Supabase RAG sidecar)" | Separate vector store removed; tables in Neon (`packages/db/src/client/index.ts:9-11`, Supabase-removal ADR) | DOC-DRIFT | Reframed as a legacy dual-database holdover; vector + RAG now in Neon; linked the ADR |
| `docs/DATABASE.md:325-326` connection example "Supabase (optional RAG sidecar)" + bare `.supabase.co` URL | `SUPABASE_DATABASE_URI` is a legacy Postgres connection alias, not a RAG sidecar (`scripts/setup/reset-database.ts:85`) | DOC-DRIFT | Reframed as the legacy alias, treated as a generic Postgres host; marked the URL line "legacy alias, being retired" |
| `docs/DATABASE.md:66,133,314` `SUPABASE_DATABASE_URI` "legacy, being retired" | Still read as a fallback in setup scripts | MATCHES | none |
| `docs/DATABASE.md:118,297` provider detection lists "Neon, Supabase, Vercel, Generic" | `scripts/setup/database.ts:60-61` genuinely detects a `.supabase.co` host | MATCHES | none (customer-adapter-style detection) |
| `docs/guides/technology-stack.md:77` Fly "per ADR `2026-05-18-drop-railway-migrate-to-vercel-fly`" | No such ADR file exists; Fly is configured by `apps/server/fly.toml` + `Dockerfile.worker` | DOC-DRIFT | Replaced the dangling citation with the real artifacts; stated the Railway drop plainly |
| `docs/guides/technology-stack.md:27` Vercel Blob "legacy ... being retired per GAP-208" | R2 canonical (`packages/core/src/storage/types.ts:11-13`, `r2.ts`) | MATCHES | none |
| `docs/guides/technology-stack.md:25` data layer "NeonDB (Postgres) ... pgvector supported" (no Supabase) | Single Neon-primary with pgvector | MATCHES | none |
| `docs/guides/deployment.md:11` "Railway was dropped ... a `fly.toml` ships at `apps/server/fly.toml`" | `apps/server/fly.toml` exists; R2 env throughout | MATCHES | none |
| `packages/db/README.md:85` vectors "all live in NeonDB" | Confirmed | MATCHES | none |

## Supabase-adapter carve-out

The customer-facing Supabase MCP adapter (`packages/mcp/src/servers/supabase.ts`) is intentionally retained per the Supabase-removal ADR: it is an adapter for customers who use Supabase, distinct from any internal RevealUI usage. None of these edits touch that carve-out. Provider detection recognizing a `.supabase.co` host (a valid generic Postgres target) is left as MATCHES for the same reason.

## Validator results

`pnpm validate:doc-currency --mode=ci`:
- Before: `99 non-exonerated occurrence(s) — 99 baselined, 0 NEW`
- After: `98 non-exonerated occurrence(s) — 98 baselined, 0 NEW` — **OK, no new stale-fact drift**

The removed occurrence is the bare `.supabase.co` connection URL that was the sole live hit behind the `docs/DATABASE.md::supabase-as-current` baseline key. That key now has zero live occurrences, so the baseline can shrink by one at the next `--update-baseline` regen. Per convention the baseline is not regenerated here; shrinking it is deferred to a regen pass.

`pnpm exec turbo build --filter=docs`: 13/13 tasks successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
