### PR TITLE
chore(core,contracts): remove dead sso feature flag (GAP-300 P2-11)

### DIFF
--- a/apps/server/src/routes/__tests__/billing-feature-matrix.test.ts
+++ b/apps/server/src/routes/__tests__/billing-feature-matrix.test.ts
@@ -5,7 +5,7 @@
  * and blocked at lower tiers. This is the "promise-to-delivery" verification layer.
  *
  * Tests:
- * 1. requireFeature() enforcement for all 15 features × 4 tiers
+ * 1. requireFeature() enforcement for all 13 features × 4 tiers
  * 2. Error response format (upgrade URL, required tier name)
  * 3. Resource limits match documented tier definitions
  */
@@ -31,7 +31,6 @@ vi.mock('@revealui/core/features', () => ({
       auditLog: 'max',
       multiTenant: 'enterprise',
       whiteLabel: 'enterprise',
-      sso: 'enterprise',
     };
     return map[feature] ?? 'enterprise';
   }),
@@ -52,7 +51,6 @@ vi.mock('@revealui/core/features', () => ({
       auditLog: 'max',
       multiTenant: 'enterprise',
       whiteLabel: 'enterprise',
-      sso: 'enterprise',
     };
     const flags: Record<string, boolean> = {};
     for (const [feature, requiredTier] of Object.entries(map)) {
@@ -104,7 +102,6 @@ const ALL_FEATURES = [
   'auditLog',
   'multiTenant',
   'whiteLabel',
-  'sso',
 ] as const;
 type Feature = (typeof ALL_FEATURES)[number];
 
@@ -123,7 +120,6 @@ const FEATURE_TIER_MAP: Record<Feature, Tier> = {
   auditLog: 'max',
   multiTenant: 'enterprise',
   whiteLabel: 'enterprise',
-  sso: 'enterprise',
 };
 
 /** Documented resource limits per tier */
@@ -238,7 +234,6 @@ describe('Feature Gate Error Response Format', () => {
     ['multiTenant', 'free', 'enterprise'],
     ['multiTenant', 'pro', 'enterprise'],
     ['multiTenant', 'max', 'enterprise'],
-    ['sso', 'free', 'enterprise'],
   ];
 
   it.each(
@@ -318,16 +313,15 @@ describe('Resource Limits Match Tier Definitions', () => {
     expect(enabledFeatures).toContain('auditLog');
   });
 
-  it('enterprise tier gets all 14 features', () => {
+  it('enterprise tier gets all 13 features', () => {
     const features = getFeaturesForTier('enterprise') as Record<string, boolean>;
     const enabledFeatures = Object.entries(features)
       .filter(([, v]) => v)
       .map(([k]) => k);
 
-    expect(enabledFeatures).toHaveLength(14);
+    expect(enabledFeatures).toHaveLength(13);
     expect(enabledFeatures).toContain('multiTenant');
     expect(enabledFeatures).toContain('whiteLabel');
-    expect(enabledFeatures).toContain('sso');
   });
 
   it('documented resource limits match hosted tier definitions', () => {
@@ -383,7 +377,7 @@ describe('Feature Tier Boundary Precision', () => {
   });
 
   it('enterprise features are blocked on max but allowed on enterprise', async () => {
-    const enterpriseFeatures: Feature[] = ['multiTenant', 'whiteLabel', 'sso'];
+    const enterpriseFeatures: Feature[] = ['multiTenant', 'whiteLabel'];
 
     for (const feature of enterpriseFeatures) {
       const blocked = await makeFeatureRequest(createFeatureGatedApp(feature).app, feature, 'max');

--- a/apps/server/src/routes/__tests__/checkout-to-feature-e2e.test.ts
+++ b/apps/server/src/routes/__tests__/checkout-to-feature-e2e.test.ts
@@ -34,7 +34,6 @@ vi.mock('@revealui/core/features', () => ({
       auditLog: 'max',
       multiTenant: 'enterprise',
       whiteLabel: 'enterprise',
-      sso: 'enterprise',
     };
     return map[feature] ?? 'enterprise';
   }),
@@ -55,7 +54,6 @@ vi.mock('@revealui/core/features', () => ({
       auditLog: 'max',
       multiTenant: 'enterprise',
       whiteLabel: 'enterprise',
-      sso: 'enterprise',
     };
     const flags: Record<string, boolean> = {};
     for (const [f, req] of Object.entries(map)) {
@@ -103,7 +101,7 @@ const PRO_FEATURES = [
   'analytics',
 ] as const;
 const MAX_FEATURES = ['aiMemory', 'aiInference', 'auditLog'] as const;
-const ENTERPRISE_FEATURES = ['multiTenant', 'whiteLabel', 'sso'] as const;
+const ENTERPRISE_FEATURES = ['multiTenant', 'whiteLabel'] as const;
 
 /** Hosted tier limits (must match getHostedLimitsForTier in apps/server/src/lib/tier-limits.ts) */
 const HOSTED_LIMITS: Record<Tier, { maxSites: number; maxUsers: number; maxAgentTasks: number }> = {
@@ -266,22 +264,18 @@ describe('Checkout-to-Feature E2E Flow', () => {
       expect(await testFeatureAccess('free', 'aiLocal')).toBe(200);
       expect(await testFeatureAccess('free', 'ai')).toBe(403);
       expect(await testFeatureAccess('free', 'aiMemory')).toBe(403);
-      expect(await testFeatureAccess('free', 'sso')).toBe(403);
 
       // At pro: ai unlocked, aiMemory still blocked
       expect(await testFeatureAccess('pro', 'ai')).toBe(200);
       expect(await testFeatureAccess('pro', 'aiMemory')).toBe(403);
-      expect(await testFeatureAccess('pro', 'sso')).toBe(403);
 
-      // At max: aiMemory unlocked, sso still blocked
+      // At max: aiMemory unlocked
       expect(await testFeatureAccess('max', 'ai')).toBe(200);
       expect(await testFeatureAccess('max', 'aiMemory')).toBe(200);
-      expect(await testFeatureAccess('max', 'sso')).toBe(403);
 
       // At enterprise: everything unlocked
       expect(await testFeatureAccess('enterprise', 'ai')).toBe(200);
       expect(await testFeatureAccess('enterprise', 'aiMemory')).toBe(200);
-      expect(await testFeatureAccess('enterprise', 'sso')).toBe(200);
     });
   });
 

--- a/apps/server/src/routes/__tests__/pricing-accuracy.test.ts
+++ b/apps/server/src/routes/__tests__/pricing-accuracy.test.ts
@@ -43,7 +43,6 @@ const EXPECTED_FEATURE_TIER_MAP: Record<FeatureFlagKey, LicenseTierId> = {
   auditLog: 'max',
   multiTenant: 'enterprise',
   whiteLabel: 'enterprise',
-  sso: 'enterprise',
 };
 
 /** Must match getHostedLimitsForTier in apps/server/src/lib/tier-limits.ts */
@@ -145,9 +144,9 @@ describe('Pricing Accuracy  -  Contracts vs Code Enforcement', () => {
   });
 
   describe('Feature flag consistency', () => {
-    it('all 14 feature flags have tier assignments', () => {
+    it('all 13 feature flags have tier assignments', () => {
       const featureKeys = Object.keys(EXPECTED_FEATURE_TIER_MAP);
-      expect(featureKeys).toHaveLength(14);
+      expect(featureKeys).toHaveLength(13);
     });
 
     it('aiLocal is the only free-tier feature', () => {
@@ -179,14 +178,14 @@ describe('Pricing Accuracy  -  Contracts vs Code Enforcement', () => {
       expect(maxFeatures).toContain('auditLog');
     });
 
-    it('enterprise-tier has 3 features', () => {
+    it('enterprise-tier has 2 features', () => {
       const enterpriseFeatures = Object.entries(EXPECTED_FEATURE_TIER_MAP)
         .filter(([, tier]) => tier === 'enterprise')
         .map(([feature]) => feature);
 
-      expect(enterpriseFeatures).toHaveLength(3);
+      expect(enterpriseFeatures).toHaveLength(2);
       expect(enterpriseFeatures).toContain('multiTenant');
-      expect(enterpriseFeatures).toContain('sso');
+      expect(enterpriseFeatures).toContain('whiteLabel');
     });
   });
 

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -339,7 +339,6 @@ const KNOWN_FEATURE_KEYS = new Set<string>([
   'payments',
   'multiTenant',
   'whiteLabel',
-  'sso',
   'aiInference',
   'auditLog',
   'advancedSync',

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -42,7 +42,6 @@ export type FeatureFlagKey =
   | 'auditLog'
   | 'multiTenant'
   | 'whiteLabel'
-  | 'sso'
   | 'vaultDesktop'
   | 'vaultRotation'
   | 'devkitProfiles';
@@ -83,7 +82,6 @@ export const FEATURE_LABELS: Record<FeatureFlagKey, string> = {
   auditLog: 'Audit Logging',
   multiTenant: 'Multi-site Content Management',
   whiteLabel: 'White-label Branding (managed setup via revforge)',
-  sso: 'SSO/SAML Authentication (Coming Soon)',
   vaultDesktop: 'RevVault Desktop App',
   vaultRotation: 'RevVault Rotation Engine',
   devkitProfiles: 'RevKit Environment Provisioning',

--- a/packages/core/src/__tests__/features.test.ts
+++ b/packages/core/src/__tests__/features.test.ts
@@ -43,7 +43,6 @@ const ALL_FEATURES: (keyof FeatureFlags)[] = [
   'payments',
   'multiTenant',
   'whiteLabel',
-  'sso',
   'aiInference',
   'auditLog',
   'advancedSync',
@@ -80,14 +79,14 @@ const MAX_FEATURES: (keyof FeatureFlags)[] = [
 ];
 
 /** Features that require Enterprise tier */
-const ENTERPRISE_FEATURES: (keyof FeatureFlags)[] = ['multiTenant', 'whiteLabel', 'sso'];
+const ENTERPRISE_FEATURES: (keyof FeatureFlags)[] = ['multiTenant', 'whiteLabel'];
 
 /**
  * Features hardcoded to false (B-02: unimplemented, unsafe to expose).
- * whiteLabel and sso exist in the tier map but getFeatures/isFeatureEnabled/
- * getFeaturesForTier force them off until the implementations ship.
+ * whiteLabel exists in the tier map but getFeatures/isFeatureEnabled/
+ * getFeaturesForTier force it off until the implementation ships.
  */
-const DISABLED_FEATURES: (keyof FeatureFlags)[] = ['whiteLabel', 'sso'];
+const DISABLED_FEATURES: (keyof FeatureFlags)[] = ['whiteLabel'];
 
 /** All features that can actually be enabled (excludes hardcoded-off) */
 const ENABLEABLE_FEATURES = ALL_FEATURES.filter((f) => !DISABLED_FEATURES.includes(f));
@@ -189,16 +188,16 @@ describe('getFeatures', () => {
     for (const feature of ENABLEABLE_FEATURES) {
       expect(features[feature]).toBe(true);
     }
-    // B-02: whiteLabel and sso are hardcoded off (unimplemented)
+    // B-02: whiteLabel is hardcoded off (unimplemented)
     for (const feature of DISABLED_FEATURES) {
       expect(features[feature]).toBe(false);
     }
   });
 
-  it('returns a FeatureFlags object with exactly 17 keys', () => {
+  it('returns a FeatureFlags object with exactly 16 keys', () => {
     simulateTier('free');
     const features = getFeatures();
-    expect(Object.keys(features)).toHaveLength(17);
+    expect(Object.keys(features)).toHaveLength(16);
   });
 
   it('calls isLicensed for each feature', () => {
@@ -262,7 +261,7 @@ describe('isFeatureEnabled', () => {
       expect(isFeatureEnabled(feature)).toBe(true);
     });
 
-    // B-02: whiteLabel and sso are hardcoded off
+    // B-02: whiteLabel is hardcoded off
     it.each(DISABLED_FEATURES)('returns false for %s (hardcoded off)', (feature) => {
       expect(isFeatureEnabled(feature)).toBe(false);
     });
@@ -278,7 +277,7 @@ describe('isFeatureEnabled', () => {
     isFeatureEnabled('aiMemory');
     expect(mockIsLicensed).toHaveBeenCalledWith('max');
 
-    // B-02: sso is hardcoded off, so isFeatureEnabled short-circuits before
+    // B-02: whiteLabel is hardcoded off, so isFeatureEnabled short-circuits before
     // calling isLicensed. Use multiTenant to verify enterprise tier delegation.
     mockIsLicensed.mockClear();
     isFeatureEnabled('multiTenant');
@@ -336,7 +335,7 @@ describe('getFeaturesForTier', () => {
     for (const feature of ENABLEABLE_FEATURES) {
       expect(features[feature]).toBe(true);
     }
-    // B-02: whiteLabel and sso are hardcoded off
+    // B-02: whiteLabel is hardcoded off
     for (const feature of DISABLED_FEATURES) {
       expect(features[feature]).toBe(false);
     }
@@ -355,7 +354,7 @@ describe('getFeaturesForTier', () => {
     for (const feature of ENABLEABLE_FEATURES) {
       expect(enterpriseFeatures[feature]).toBe(true);
     }
-    // B-02: whiteLabel and sso remain off regardless of tier
+    // B-02: whiteLabel remains off regardless of tier
     for (const feature of DISABLED_FEATURES) {
       expect(enterpriseFeatures[feature]).toBe(false);
     }
@@ -419,10 +418,6 @@ describe('getRequiredTier', () => {
     expect(getRequiredTier('whiteLabel')).toBe('enterprise');
   });
 
-  it('returns enterprise for sso feature', () => {
-    expect(getRequiredTier('sso')).toBe('enterprise');
-  });
-
   it('returns pro for vaultDesktop feature', () => {
     expect(getRequiredTier('vaultDesktop')).toBe('pro');
   });
@@ -446,7 +441,7 @@ describe('tier progression', () => {
     free: 1, // aiLocal
     pro: 10, // 1 free + 9 pro features (incl. vaultDesktop, vaultRotation)
     max: 14, // 1 free + 9 pro + 4 max features (incl. devkitProfiles)
-    enterprise: 15, // 17 total minus 2 hardcoded-off (whiteLabel, sso)
+    enterprise: 15, // 16 total minus 1 hardcoded-off (whiteLabel)
   };
 
   it.each(tiers)('%s tier enables exactly %i features', (tier) => {
@@ -496,10 +491,6 @@ describe('feature blocking  -  free tier restrictions', () => {
 
   it('blocks multi-tenancy', () => {
     expect(isFeatureEnabled('multiTenant')).toBe(false);
-  });
-
-  it('blocks SSO/SAML authentication', () => {
-    expect(isFeatureEnabled('sso')).toBe(false);
   });
 
   it('blocks white-label dashboard', () => {

--- a/packages/core/src/features.ts
+++ b/packages/core/src/features.ts
@@ -27,8 +27,6 @@ export interface FeatureFlags {
   multiTenant: boolean;
   /** White-label admin dashboard (planned  -  not yet implemented) */
   whiteLabel: boolean;
-  /** SSO/SAML authentication (planned  -  not yet implemented) */
-  sso: boolean;
   /** Open-model inference configuration  -  snaps, Ollama, harness (Max+) */
   aiInference: boolean;
   /** Audit logging and compliance trail */
@@ -63,11 +61,10 @@ const featureTierMap: Record<keyof FeatureFlags, LicenseTier> = {
   aiInference: 'max',
   auditLog: 'max',
   multiTenant: 'enterprise',
-  // NOTE: whiteLabel and sso are planned but not yet implemented.
+  // NOTE: whiteLabel is planned but not yet implemented.
   // Forced to false below in getFeatures/getFeaturesForTier/isFeatureEnabled
   // to avoid advertising features that don't exist. Re-enable when implemented.
   whiteLabel: 'enterprise',
-  sso: 'enterprise',
   vaultDesktop: 'pro',
   vaultRotation: 'pro',
   devkitProfiles: 'max',
@@ -95,7 +92,6 @@ export function getFeatures(): FeatureFlags {
 
   // Planned but not yet implemented  -  force false to avoid false advertising
   flags.whiteLabel = false;
-  flags.sso = false;
 
   return flags;
 }
@@ -114,7 +110,7 @@ export function getFeatures(): FeatureFlags {
  */
 export function isFeatureEnabled(feature: keyof FeatureFlags): boolean {
   // Planned but not yet implemented  -  always return false
-  if (feature === 'whiteLabel' || feature === 'sso') return false;
+  if (feature === 'whiteLabel') return false;
 
   const requiredTier = featureTierMap[feature];
   return isLicensed(requiredTier);
@@ -139,7 +135,6 @@ export function getFeaturesForTier(tier: LicenseTier): FeatureFlags {
 
   // Planned but not yet implemented  -  force false to avoid false advertising
   flags.whiteLabel = false;
-  flags.sso = false;
 
   return flags;
 }

--- a/packages/paywall/src/core/__tests__/paywall.test.ts
+++ b/packages/paywall/src/core/__tests__/paywall.test.ts
@@ -60,7 +60,6 @@ describe('createPaywall  -  zero-config (defaults)', () => {
       expect(paywall.isFeatureEnabled('enterprise', 'ai')).toBe(true);
       expect(paywall.isFeatureEnabled('enterprise', 'multiTenant')).toBe(true);
       expect(paywall.isFeatureEnabled('enterprise', 'whiteLabel')).toBe(false); // planned
-      expect(paywall.isFeatureEnabled('enterprise', 'sso')).toBe(false); // planned
     });
   });
 

--- a/packages/paywall/src/core/defaults.ts
+++ b/packages/paywall/src/core/defaults.ts
@@ -36,7 +36,6 @@ export const DEFAULT_FEATURES: Record<string, FeatureDefinition<DefaultTier>> = 
   // --- Enterprise tier ---
   multiTenant: { tier: 'enterprise', label: 'Multi-Tenant' },
   whiteLabel: { tier: 'enterprise', label: 'White Label', planned: true },
-  sso: { tier: 'enterprise', label: 'SSO / SAML', planned: true },
 };
 
 /** Standard resource limits. */

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -1217,7 +1217,7 @@ const BLOCKLIST: BlocklistEntry[] = [
   {
     token: /\b(SSO|single sign-on)\b/i,
     label: 'SSO',
-    why: 'sso marked planned in packages/core/src/features.ts',
+    why: 'SSO/SAML is roadmap-only (designed, not built) per apps/marketing/app/content/roadmap.ts',
   },
   {
     token: /\bSCIM\b/i,


### PR DESCRIPTION
## Summary

Owner-ruled dead-flag removal (GAP-300 P2 item 11 follow-up, ruled 2026-07-11): `sso` was a forced-false FeatureFlag key with **no behavioral consumer** anywhere in the codebase. `whiteLabel` is deliberately **left entirely untouched** — it is a wired badge-suppression hook consumed by `PoweredByRevealUI`, unlike `sso`.

- `packages/core/src/features.ts`: removed `sso` from `FeatureFlags`, `featureTierMap`, `getFeatures()`, `isFeatureEnabled()`, `getFeaturesForTier()`. Updated the stale NOTE comment to reference `whiteLabel` only.
- `packages/contracts/src/pricing.ts`: removed `sso` from `FeatureFlagKey` and `FEATURE_LABELS`.
- `packages/paywall/src/core/defaults.ts`: removed the `sso` entry from `DEFAULT_FEATURES` (verified first — it was purely a `planned: true` data marker, same generic mechanism as `whiteLabel`, no special-cased behavioral consumer in the paywall package).
- Audit-first turned up real consumers outside the four grounded files that were NOT in original scope but would have broken the build/tests if left: `apps/server/src/routes/webhooks.ts` (`KNOWN_FEATURE_KEYS satisfies (keyof FeatureFlags)[]`), and three server test files (`pricing-accuracy.test.ts`, `checkout-to-feature-e2e.test.ts`, `billing-feature-matrix.test.ts`) that mirrored the tier map / enterprise-feature list including `sso`. All updated to drop `sso` and adjust affected counts.
- `scripts/validate/claim-drift.ts`: the SSO blocklist entry's `why` citation pointed at "`sso` marked planned in `packages/core/src/features.ts`" — now stale since that entry no longer exists. Updated the citation to point at the roadmap entry (`apps/marketing/app/content/roadmap.ts`, "Planned: designed, not built") — the blocklist rule itself (blocking unqualified SSO claims in docs) is untouched and still correct.
- `apps/marketing/app/content/roadmap.ts` "Enterprise SSO / SAML" entry is **untouched** — SSO stays honestly on the public roadmap; only the dead code-level flag is removed.

## Contract-change note

`getFeaturesForTier()` (consumed by `apps/server/src/routes/webhooks.ts`, `license.ts`, and `middleware/entitlements.ts`) no longer returns an `sso` key in its output object. Since `sso` was always hardcoded to `false` and had no behavioral consumer, this is safe — but it **is** a shape change on the license/verify response payload.

## Verification performed

- `pnpm --filter @revealui/core build`, `pnpm --filter @revealui/contracts build`, `pnpm --filter @revealui/paywall build` — all clean (built via `turbo run build` to resolve the full workspace dependency graph in this fresh worktree).
- `pnpm --filter @revealui/core exec vitest run src/__tests__/features.test.ts` — 123/123 passed.
- `pnpm --filter @revealui/core exec tsc --noEmit`, `pnpm --filter @revealui/contracts exec tsc --noEmit`, `pnpm --filter @revealui/paywall exec tsc --noEmit` — clean, zero errors.
- `pnpm --filter server exec tsc --noEmit` — 24 pre-existing `@revealui/ai` (gitignored Pro package) module-not-found errors only, none related to this change.
- `pnpm --filter server exec vitest run` on the three affected server test files — 136/136 passed.
- `pnpm --filter @revealui/paywall exec vitest run` (full suite) — 129/129 passed.
- Biome check on all 10 touched files — clean.
- Full pre-push CI gate (`pnpm gate` phase 1 + phase 2, including hard-fail "Pricing lockstep" and "Claim drift" checks) — PASS.
- Grep proof: `grep -rn "\bsso\b" packages/core/src packages/contracts/src packages/paywall/src --include=*.ts | grep -v __tests__` → zero matches.
- `whiteLabel` untouched: occurrence count in the three edited production files is unchanged (9 → 9 vs `origin/test`), and a line-level diff confirms no `whiteLabel` line was removed, only `sso` was stripped from shared lines/comments.

## SECURITY SURFACE (entitlements)

This touches feature-gating/entitlements code. **Requires a non-author guardrail-2 verdict before merge. Do NOT self-merge. Owner disposes.**

Closes: GAP-300 P2-11 (dead `sso` flag removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
