### PR TITLE
feat(marketing): add Agent Receipts Audit lead magnet

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -16,6 +16,7 @@ import { PhilosophyPage } from './routes/PhilosophyPage';
 import { PricingPage } from './routes/PricingPage';
 import { PrivacyPage } from './routes/PrivacyPage';
 import { ProductsPage } from './routes/ProductsPage';
+import { ReceiptsAuditPage } from './routes/ReceiptsAuditPage';
 import { RoadmapPage } from './routes/RoadmapPage';
 import { SecurityPage } from './routes/SecurityPage';
 import { ServicesPage } from './routes/ServicesPage';
@@ -51,6 +52,11 @@ export function App() {
         meta: { title: 'Provable agent governance | RevealUI' },
       },
       { path: '/pricing', component: PricingPage, meta: { title: 'Pricing | RevealUI' } },
+      {
+        path: '/receipts-audit',
+        component: ReceiptsAuditPage,
+        meta: { title: 'The Agent Receipts Audit | RevealUI' },
+      },
       {
         path: '/services',
         component: ServicesPage,

--- a/apps/marketing/app/__tests__/receipts-audit.test.ts
+++ b/apps/marketing/app/__tests__/receipts-audit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { RECEIPTS_AUDIT_BANDS, RECEIPTS_AUDIT_QUESTIONS } from '../content/receipts-audit';
+import { type AuditAnswer, bandForScore, countReceipts } from '../lib/receipts-audit';
+
+// The scoring is the load-bearing logic of the audit: it turns twelve yes/no
+// answers into a receipt count and a band, and the band drives the CTAs. These
+// tests pin the band boundaries and the one reverse-scored question (Q5).
+
+const ALL_YES: readonly AuditAnswer[] = RECEIPTS_AUDIT_QUESTIONS.map(() => 'yes');
+const ALL_NO: readonly AuditAnswer[] = RECEIPTS_AUDIT_QUESTIONS.map(() => 'no');
+
+describe('receipts-audit scoring', () => {
+  it('has exactly twelve questions', () => {
+    expect(RECEIPTS_AUDIT_QUESTIONS).toHaveLength(12);
+  });
+
+  it('reverse-scores only question 5 (unbounded spend)', () => {
+    const reversed = RECEIPTS_AUDIT_QUESTIONS.filter((q) => q.positiveAnswer === 'no');
+    expect(reversed).toHaveLength(1);
+    expect(reversed[0]?.id).toBe(5);
+  });
+
+  describe('countReceipts', () => {
+    it('scores 11 when every answer is yes (Q5 yes is the one gap)', () => {
+      expect(countReceipts(RECEIPTS_AUDIT_QUESTIONS, ALL_YES)).toBe(11);
+    });
+
+    it('scores 1 when every answer is no (Q5 no is the one receipt)', () => {
+      expect(countReceipts(RECEIPTS_AUDIT_QUESTIONS, ALL_NO)).toBe(1);
+    });
+
+    it('never counts unanswered questions', () => {
+      const none = RECEIPTS_AUDIT_QUESTIONS.map(() => null);
+      expect(countReceipts(RECEIPTS_AUDIT_QUESTIONS, none)).toBe(0);
+    });
+
+    it('counts a single receipt-positive answer', () => {
+      const answers: (AuditAnswer | null)[] = RECEIPTS_AUDIT_QUESTIONS.map(() => null);
+      answers[0] = 'yes'; // Q1 positive is 'yes'
+      expect(countReceipts(RECEIPTS_AUDIT_QUESTIONS, answers)).toBe(1);
+      answers[0] = 'no';
+      expect(countReceipts(RECEIPTS_AUDIT_QUESTIONS, answers)).toBe(0);
+    });
+  });
+
+  describe('bandForScore', () => {
+    it('bands 10 through 12 as strong', () => {
+      expect(bandForScore(12)).toBe('strong');
+      expect(bandForScore(10)).toBe('strong');
+    });
+
+    it('bands 5 through 9 as partial', () => {
+      expect(bandForScore(9)).toBe('partial');
+      expect(bandForScore(5)).toBe('partial');
+    });
+
+    it('bands 0 through 4 as trust', () => {
+      expect(bandForScore(4)).toBe('trust');
+      expect(bandForScore(0)).toBe('trust');
+    });
+  });
+
+  describe('band content', () => {
+    it('gives the strong band a single (start-free) CTA', () => {
+      const strong = RECEIPTS_AUDIT_BANDS.strong;
+      expect(strong.primaryCta.label).toBe('Start free');
+      expect(strong.secondaryCta).toBeUndefined();
+    });
+
+    it('leads the trust band with the Architecture Review', () => {
+      const trust = RECEIPTS_AUDIT_BANDS.trust;
+      expect(trust.primaryCta.label).toBe('Book the Architecture Review');
+      expect(trust.primaryCta.href).toContain('cal.com');
+      expect(trust.secondaryCta?.label).toBe('Start free');
+    });
+
+    it('offers both paths in the partial band', () => {
+      const partial = RECEIPTS_AUDIT_BANDS.partial;
+      expect(partial.primaryCta.label).toBe('Start free');
+      expect(partial.secondaryCta?.label).toBe('Book the Architecture Review');
+    });
+  });
+});

--- a/apps/marketing/app/__tests__/routes.test.ts
+++ b/apps/marketing/app/__tests__/routes.test.ts
@@ -11,6 +11,7 @@ import { NotFoundPage } from '../routes/NotFoundPage';
 import { PricingPage } from '../routes/PricingPage';
 import { PrivacyPage } from '../routes/PrivacyPage';
 import { ProductsPage } from '../routes/ProductsPage';
+import { ReceiptsAuditPage } from '../routes/ReceiptsAuditPage';
 import { RoadmapPage } from '../routes/RoadmapPage';
 import { TermsPage } from '../routes/TermsPage';
 
@@ -21,6 +22,7 @@ describe('marketing route registry', () => {
       { path: '/', component: HomePage },
       { path: '/products', component: ProductsPage },
       { path: '/pricing', component: PricingPage },
+      { path: '/receipts-audit', component: ReceiptsAuditPage },
       { path: '/blog', component: BlogIndexPage },
       { path: '/blog/:slug', component: BlogPostPage },
       { path: '/contact', component: ContactPage },
@@ -38,6 +40,7 @@ describe('marketing route registry', () => {
       '/',
       '/products',
       '/pricing',
+      '/receipts-audit',
       '/blog',
       '/blog/getting-started',
       '/blog/ui-of-the-future',

--- a/apps/marketing/app/components/__tests__/ReceiptsAudit.test.tsx
+++ b/apps/marketing/app/components/__tests__/ReceiptsAudit.test.tsx
@@ -1,0 +1,90 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the API layer so the form submit never hits the network. The component
+// only depends on submitReceiptsAudit resolving to null (success) or a string
+// (error message).
+vi.mock('../../lib/api', () => ({
+  submitReceiptsAudit: vi.fn().mockResolvedValue(null),
+}));
+
+import { submitReceiptsAudit } from '../../lib/api';
+import { ReceiptsAudit } from '../receipts-audit/ReceiptsAudit';
+
+const mockedSubmit = vi.mocked(submitReceiptsAudit);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+/** Answer every question 'yes' by clicking each group's Yes button. */
+function answerAllYes(): void {
+  const yesButtons = screen.getAllByRole('button', { name: 'Yes' });
+  for (const btn of yesButtons) fireEvent.click(btn);
+}
+
+describe('ReceiptsAudit', () => {
+  it('renders twelve yes/no questions', () => {
+    render(<ReceiptsAudit />);
+    expect(screen.getAllByRole('button', { name: 'Yes' })).toHaveLength(12);
+    expect(screen.getAllByRole('button', { name: 'No' })).toHaveLength(12);
+  });
+
+  it('hides the result band until every question is answered', () => {
+    render(<ReceiptsAudit />);
+    // Answer only the first question.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Yes' })[0] as HTMLElement);
+    expect(screen.queryByText('Your score')).not.toBeInTheDocument();
+  });
+
+  it('reveals the score band once all twelve are answered', () => {
+    render(<ReceiptsAudit />);
+    answerAllYes();
+    // All 'yes' scores 11 (Q5 yes is the one gap) → strong band.
+    expect(screen.getByText('Your score')).toBeInTheDocument();
+    expect(screen.getByText('You have receipts.')).toBeInTheDocument();
+    expect(screen.getByText(/11 \/ 12/)).toBeInTheDocument();
+  });
+
+  it('submits the email against the receipts-audit source and reveals the guide', async () => {
+    render(<ReceiptsAudit />);
+    answerAllYes();
+
+    // The remediation guide is hidden before submit.
+    expect(screen.queryByTestId('remediation-guide')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'operator@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send it' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('remediation-guide')).toBeInTheDocument();
+    });
+
+    expect(mockedSubmit).toHaveBeenCalledTimes(1);
+    expect(mockedSubmit).toHaveBeenCalledWith({ email: 'operator@example.com', website: '' });
+
+    // All twelve remediation items are rendered.
+    const guide = screen.getByTestId('remediation-guide');
+    expect(guide.querySelectorAll('li')).toHaveLength(12);
+  });
+
+  it('shows an error message when the submit fails and keeps the guide hidden', async () => {
+    mockedSubmit.mockResolvedValueOnce('Signup failed: 500');
+    render(<ReceiptsAudit />);
+    answerAllYes();
+
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'operator@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send it' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Signup failed: 500')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('remediation-guide')).not.toBeInTheDocument();
+  });
+});

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -88,6 +88,16 @@ export function Problem() {
         <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-muted-foreground">
           {HOME_PROBLEM.footnote}
         </p>
+
+        <p className="mx-auto mt-4 max-w-3xl text-center text-sm text-muted-foreground">
+          {HOME_PROBLEM.receiptsAudit.prefix}{' '}
+          <a
+            href={HOME_PROBLEM.receiptsAudit.href}
+            className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+          >
+            {HOME_PROBLEM.receiptsAudit.label}
+          </a>
+        </p>
       </div>
     </section>
   );

--- a/apps/marketing/app/components/receipts-audit/ReceiptsAudit.tsx
+++ b/apps/marketing/app/components/receipts-audit/ReceiptsAudit.tsx
@@ -1,0 +1,264 @@
+import { ButtonCVA as Button, Input } from '@revealui/presentation';
+import type { FormEvent } from 'react';
+import { useMemo, useState } from 'react';
+import {
+  RECEIPTS_AUDIT_BANDS,
+  RECEIPTS_AUDIT_FORM,
+  RECEIPTS_AUDIT_PROGRESS,
+  RECEIPTS_AUDIT_QUESTIONS,
+  RECEIPTS_AUDIT_REMEDIATION,
+  RECEIPTS_AUDIT_SCORE,
+} from '../../content/receipts-audit';
+import { submitReceiptsAudit } from '../../lib/api';
+import { type AuditAnswer, bandForScore, countReceipts } from '../../lib/receipts-audit';
+
+const TOTAL = RECEIPTS_AUDIT_QUESTIONS.length;
+
+function AnswerButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={`min-w-[4.5rem] rounded-full px-5 py-2 text-sm font-medium transition ${
+        active
+          ? 'bg-primary text-primary-foreground'
+          : 'bg-secondary text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ReceiptsAudit() {
+  const [answers, setAnswers] = useState<readonly (AuditAnswer | null)[]>(() =>
+    RECEIPTS_AUDIT_QUESTIONS.map(() => null),
+  );
+  const [email, setEmail] = useState('');
+  const [website, setWebsite] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+  const [revealed, setRevealed] = useState(false);
+
+  const answeredCount = useMemo(() => answers.filter((a) => a !== null).length, [answers]);
+  const complete = answeredCount === TOTAL;
+  const score = useMemo(() => countReceipts(RECEIPTS_AUDIT_QUESTIONS, answers), [answers]);
+  const band = RECEIPTS_AUDIT_BANDS[bandForScore(score)];
+
+  function answer(index: number, value: AuditAnswer) {
+    setAnswers((prev) => prev.map((a, i) => (i === index ? value : a)));
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!email || status === 'loading') return;
+
+    setStatus('loading');
+    const error = await submitReceiptsAudit({ email, website });
+    if (error === null) {
+      setStatus('idle');
+      setRevealed(true);
+    } else {
+      setStatus('error');
+      setMessage(error);
+    }
+  }
+
+  return (
+    <>
+      {/* Questions */}
+      <section className="px-6 py-16 sm:py-20 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          <p
+            className="text-sm text-muted-foreground"
+            aria-live="polite"
+            data-testid="audit-progress"
+          >
+            {RECEIPTS_AUDIT_PROGRESS.prefix} {answeredCount} {RECEIPTS_AUDIT_PROGRESS.suffix}
+          </p>
+
+          <ol className="mt-8 space-y-10 list-none p-0">
+            {RECEIPTS_AUDIT_QUESTIONS.map((q, index) => (
+              <li key={q.id}>
+                <fieldset className="flex flex-col gap-4">
+                  <legend className="text-base leading-7 text-foreground">
+                    <span className="mr-2 font-mono text-sm text-muted-foreground">
+                      {String(q.id).padStart(2, '0')}
+                    </span>
+                    {q.text}
+                  </legend>
+                  <div className="flex gap-3">
+                    <AnswerButton
+                      active={answers[index] === 'yes'}
+                      onClick={() => answer(index, 'yes')}
+                    >
+                      {RECEIPTS_AUDIT_PROGRESS.yesLabel}
+                    </AnswerButton>
+                    <AnswerButton
+                      active={answers[index] === 'no'}
+                      onClick={() => answer(index, 'no')}
+                    >
+                      {RECEIPTS_AUDIT_PROGRESS.noLabel}
+                    </AnswerButton>
+                  </div>
+                </fieldset>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      {/* Result band + email capture, revealed once all twelve are answered. */}
+      {complete && (
+        <section className="border-t border-border bg-card px-6 py-16 sm:py-20 lg:px-8">
+          <div className="mx-auto max-w-2xl">
+            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+              {RECEIPTS_AUDIT_SCORE.scoreLabel}
+            </p>
+            <p className="mt-2 text-4xl font-bold tracking-tight text-foreground">
+              {score} / {TOTAL}{' '}
+              <span className="text-2xl font-medium text-muted-foreground">
+                {RECEIPTS_AUDIT_SCORE.suffix}
+              </span>
+            </p>
+
+            <h2 className="mt-8 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+              {band.headline}
+            </h2>
+            <p className="mt-4 text-lg leading-8 text-muted-foreground">{band.body}</p>
+
+            <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row">
+              <Button asChild size="lg" variant="primary">
+                <a
+                  href={band.primaryCta.href}
+                  {...(band.primaryCta.external
+                    ? { target: '_blank', rel: 'noopener noreferrer' }
+                    : {})}
+                >
+                  {band.primaryCta.label}
+                </a>
+              </Button>
+              {band.secondaryCta && (
+                <Button asChild size="lg" variant="outline">
+                  <a
+                    href={band.secondaryCta.href}
+                    {...(band.secondaryCta.external
+                      ? { target: '_blank', rel: 'noopener noreferrer' }
+                      : {})}
+                  >
+                    {band.secondaryCta.label}
+                  </a>
+                </Button>
+              )}
+            </div>
+
+            {/* Email capture. Revealing the remediation guide is the payoff. */}
+            {!revealed && (
+              <div className="mt-16 border-t border-border pt-10">
+                <h3 className="text-xl font-semibold text-foreground">
+                  {RECEIPTS_AUDIT_FORM.heading}
+                </h3>
+                <p className="mt-1 text-base text-muted-foreground">
+                  {RECEIPTS_AUDIT_FORM.subheading}
+                </p>
+                <p className="mt-4 text-base leading-7 text-muted-foreground">
+                  {RECEIPTS_AUDIT_FORM.body}
+                </p>
+
+                <form onSubmit={handleSubmit} className="mt-6 flex max-w-sm flex-col gap-3">
+                  <label htmlFor="receipts-audit-email" className="sr-only">
+                    {RECEIPTS_AUDIT_FORM.emailLabel}
+                  </label>
+                  <Input
+                    id="receipts-audit-email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder={RECEIPTS_AUDIT_FORM.emailPlaceholder}
+                    required
+                  />
+
+                  {/* Honeypot: hidden from humans, tempting to bots. The server
+                      silently 200s any submission that fills it. */}
+                  <div
+                    className="absolute left-[-9999px] h-px w-px overflow-hidden"
+                    aria-hidden="true"
+                  >
+                    <label htmlFor="receipts-audit-website">Website</label>
+                    <input
+                      id="receipts-audit-website"
+                      type="text"
+                      tabIndex={-1}
+                      autoComplete="off"
+                      value={website}
+                      onChange={(e) => setWebsite(e.target.value)}
+                    />
+                  </div>
+
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    isLoading={status === 'loading'}
+                    disabled={status === 'loading'}
+                  >
+                    {status === 'loading'
+                      ? RECEIPTS_AUDIT_FORM.buttonLoadingLabel
+                      : RECEIPTS_AUDIT_FORM.buttonLabel}
+                  </Button>
+                  {status === 'error' && <p className="text-xs text-destructive">{message}</p>}
+                </form>
+              </div>
+            )}
+
+            {revealed && (
+              <p className="mt-16 border-t border-border pt-10 text-base font-medium text-primary">
+                {RECEIPTS_AUDIT_FORM.successMessage}
+              </p>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* Remediation checklist, revealed only after a successful submit. */}
+      {revealed && (
+        <section className="px-6 py-16 sm:py-20 lg:px-8" data-testid="remediation-guide">
+          <div className="mx-auto max-w-2xl">
+            <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+              {RECEIPTS_AUDIT_REMEDIATION.heading}
+            </h2>
+            <p className="mt-4 text-base leading-7 text-muted-foreground">
+              {RECEIPTS_AUDIT_REMEDIATION.intro}
+            </p>
+
+            <ol className="mt-10 space-y-8 list-none p-0">
+              {RECEIPTS_AUDIT_REMEDIATION.items.map((item) => (
+                <li key={item.id} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+                  <div className="flex items-center gap-3">
+                    <span className="font-mono text-sm text-muted-foreground">
+                      {String(item.id).padStart(2, '0')}
+                    </span>
+                    <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+                      {item.primitive}
+                    </span>
+                  </div>
+                  <h3 className="mt-4 text-lg font-semibold text-foreground">{item.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">{item.gap}</p>
+                  <p className="mt-3 text-sm leading-6 text-foreground">{item.fix}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -109,6 +109,13 @@ export const HOME_PROBLEM = {
   ] as readonly ProblemRow[],
   footnote:
     'Capability comparison only; a monthly cost estimate lives on the pricing page. RevealUI Pro is $49/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.',
+  // Quiet contextual link back to the receipt foil, near the audit-log row of
+  // the comparison. Not a section, not a CTA button: one calm inline link.
+  receiptsAudit: {
+    prefix: 'Not sure you could prove what your agents did?',
+    label: 'Take the Agent Receipts Audit.',
+    href: '/receipts-audit',
+  },
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -31,6 +31,7 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
       { label: 'Services', href: '/services' },
       { label: 'Local AI', href: '/local-ai' },
       { label: 'Governance', href: '/governance' },
+      { label: 'Agent Receipts Audit', href: '/receipts-audit' },
       { label: 'Pricing', href: '/pricing' },
       { label: 'Documentation', href: SITE.urls.docs },
       { label: 'Blog', href: '/blog' },

--- a/apps/marketing/app/content/receipts-audit.ts
+++ b/apps/marketing/app/content/receipts-audit.ts
@@ -1,0 +1,259 @@
+// Content for the Agent Receipts Audit lead magnet (/receipts-audit).
+//
+// A twelve-question yes/no self-assessment that scores as the visitor answers,
+// bands the result, and captures an email against the waitlist (source
+// 'receipts-audit', a LEAD source). After a successful submit the remediation
+// checklist below is revealed inline.
+//
+// Copy is owner-authored verbatim for the title, subhead, questions, and score
+// bands. The remediation checklist is written in the same voice, mapping each
+// gap to a runtime primitive (People / Content / Offers / Payments / Agents)
+// and a concrete mechanism. No em dashes (owner style); voice-and-headline
+// rules apply (validated by scripts/validate/marketing-voice.ts).
+
+import type { AuditAnswer, BandId } from '../lib/receipts-audit';
+import { SITE } from './site';
+import type { Cta } from './types';
+
+/** External booking link for the Architecture Review call. */
+const ARCHITECTURE_REVIEW_URL = 'https://cal.com/revealuistudio/discovery' as const;
+
+const START_FREE: Cta = { label: 'Start free', href: SITE.urls.signup };
+const BOOK_REVIEW: Cta = {
+  label: 'Book the Architecture Review',
+  href: ARCHITECTURE_REVIEW_URL,
+  external: true,
+};
+
+export interface AuditQuestion {
+  readonly id: number;
+  readonly text: string;
+  /** The answer that scores as a receipt. Defaults to 'yes' for all but Q5. */
+  readonly positiveAnswer: AuditAnswer;
+}
+
+export const RECEIPTS_AUDIT_QUESTIONS: readonly AuditQuestion[] = [
+  {
+    id: 1,
+    text: 'Can you list every action an AI agent took in your business last week?',
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 2,
+    text: "Does every agent act as its own user with its own identity, or do your agents share a human's credentials?",
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 3,
+    text: "Could you revoke one agent's access right now without breaking anything else?",
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 4,
+    text: 'When an agent changes content, can you see exactly what changed and roll it back?',
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 5,
+    text: 'Can an agent spend money today without hitting a limit you set?',
+    // A "yes" here means there is no ceiling, which is the gap. "No" is the receipt.
+    positiveAnswer: 'no',
+  },
+  {
+    id: 6,
+    text: 'Do you know which AI provider processed your customer data this month?',
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 7,
+    text: 'If a customer asked "did a human or an agent send this?", could you answer with evidence?',
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 8,
+    text: 'Are your agent prompts and policies written down and versioned where a reviewer could read them?',
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 9,
+    text: 'Could you pause every agent from one place in under a minute?',
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 10,
+    text: 'Do your agents run on infrastructure you control?',
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 11,
+    text: 'When an agent fails, does something alert a human before a customer notices?',
+    positiveAnswer: 'yes',
+  },
+  {
+    id: 12,
+    text: 'If you were audited tomorrow, could you produce a log of agent activity in minutes rather than days?',
+    positiveAnswer: 'yes',
+  },
+] as const;
+
+export const RECEIPTS_AUDIT_HERO = {
+  eyebrow: 'Self-assessment',
+  title: 'The Agent Receipts Audit',
+  subhead:
+    "If an agent did it, there's a receipt. Twelve questions that show whether that is true for your business. Five minutes, scored as you go.",
+} as const;
+
+export const RECEIPTS_AUDIT_PROGRESS = {
+  /** Rendered as `Answered {n} of 12`. */
+  prefix: 'Answered',
+  suffix: 'of 12',
+  yesLabel: 'Yes',
+  noLabel: 'No',
+} as const;
+
+export interface AuditBand {
+  readonly headline: string;
+  readonly body: string;
+  readonly primaryCta: Cta;
+  readonly secondaryCta?: Cta;
+}
+
+export const RECEIPTS_AUDIT_BANDS: Readonly<Record<BandId, AuditBand>> = {
+  strong: {
+    headline: 'You have receipts.',
+    body: 'You are ahead of nearly every team running agents today. See how far the runtime takes the rest.',
+    primaryCta: START_FREE,
+  },
+  partial: {
+    headline: 'You have partial receipts.',
+    body: 'Your agents work, but you could not prove everything they did. The gaps you just found are exactly what a governed runtime closes.',
+    primaryCta: START_FREE,
+    secondaryCta: BOOK_REVIEW,
+  },
+  trust: {
+    headline: 'You are running on trust.',
+    body: 'Nothing here is unusual, but none of it survives an audit or an incident. Fixing this is a two week project, not a rewrite.',
+    primaryCta: BOOK_REVIEW,
+    secondaryCta: START_FREE,
+  },
+} as const;
+
+/** The score band shown as a fraction, e.g. "8 / 12 receipts". */
+export const RECEIPTS_AUDIT_SCORE = {
+  suffix: 'receipts',
+  scoreLabel: 'Your score',
+} as const;
+
+export const RECEIPTS_AUDIT_FORM = {
+  heading: 'Get the full checklist',
+  subheading: 'The fix for every gap you found.',
+  body: 'Enter your email and we will show the remediation guide for all twelve receipts, and send you a copy.',
+  emailLabel: 'Email address',
+  emailPlaceholder: 'you@company.com',
+  buttonLabel: 'Send it',
+  buttonLoadingLabel: 'Sending…',
+  successMessage: 'Here is the remediation guide. A copy is on its way to your inbox.',
+} as const;
+
+export type RuntimePrimitive = 'People' | 'Content' | 'Offers' | 'Payments' | 'Agents';
+
+export interface RemediationItem {
+  /** Maps 1:1 to the question of the same id. */
+  readonly id: number;
+  readonly primitive: RuntimePrimitive;
+  readonly title: string;
+  readonly gap: string;
+  readonly fix: string;
+}
+
+export const RECEIPTS_AUDIT_REMEDIATION = {
+  heading: 'The remediation guide',
+  intro:
+    'One fix per receipt, mapped to the runtime primitive that closes it. Read it here, and check your inbox for a copy.',
+  items: [
+    {
+      id: 1,
+      primitive: 'Agents',
+      title: 'List every action from last week',
+      gap: 'You cannot reconstruct last week because agent actions were never written to one durable place.',
+      fix: 'Every agent action signs into a tamper-evident audit log, so a full week of activity is one query away.',
+    },
+    {
+      id: 2,
+      primitive: 'People',
+      title: 'Give every agent its own identity',
+      gap: 'Agents that borrow a human login are invisible in your records and impossible to tell apart.',
+      fix: 'Each agent becomes its own governed user with its own identity, so every action traces back to the exact actor.',
+    },
+    {
+      id: 3,
+      primitive: 'People',
+      title: 'Revoke one agent without collateral damage',
+      gap: 'Shared credentials mean pulling one agent breaks the humans and agents sitting next to it.',
+      fix: 'Per-agent identity lets you revoke one agent in a click, with no collateral outage.',
+    },
+    {
+      id: 4,
+      primitive: 'Content',
+      title: 'See and undo what an agent changed',
+      gap: 'A content change with no history is a change you can neither review nor undo.',
+      fix: 'Content edits are versioned, so you see the exact diff an agent made and roll it back.',
+    },
+    {
+      id: 5,
+      primitive: 'Payments',
+      title: 'Cap what an agent can spend',
+      gap: 'An agent that can spend without a ceiling is an incident waiting to bill you.',
+      fix: 'A spend limit caps each agent, and the runtime blocks the transaction that would cross it.',
+    },
+    {
+      id: 6,
+      primitive: 'Agents',
+      title: 'Know which provider saw your data',
+      gap: 'If you cannot name the provider that saw your customer data, you cannot answer for where it went.',
+      fix: 'You choose the AI provider per workload, and the runtime records which one handled each request.',
+    },
+    {
+      id: 7,
+      primitive: 'Agents',
+      title: 'Prove who sent it',
+      gap: 'Without a record of who acted, human versus agent is a guess.',
+      fix: 'Every message carries the identity that produced it, so you answer a customer with the record, not a hunch.',
+    },
+    {
+      id: 8,
+      primitive: 'Content',
+      title: 'Version your prompts and policies',
+      gap: "Prompts and policies kept in someone's head cannot be reviewed or rolled back.",
+      fix: 'Prompts and policies live as versioned records a reviewer can read, compare, and revert.',
+    },
+    {
+      id: 9,
+      primitive: 'Agents',
+      title: 'Pause everything at once',
+      gap: 'If pausing agents means chasing processes, you cannot stop an incident fast enough.',
+      fix: 'One kill switch pauses every agent at once, in seconds, from a single screen.',
+    },
+    {
+      id: 10,
+      primitive: 'Agents',
+      title: 'Run agents on your own infrastructure',
+      gap: "Agents on someone else's infrastructure put your data and your controls outside your reach.",
+      fix: 'The runtime is self-hosted, so agents run on infrastructure you control and the data stays with you.',
+    },
+    {
+      id: 11,
+      primitive: 'Agents',
+      title: 'Hear about a failure before your customer does',
+      gap: 'A silent failure is one your customer reports before you do.',
+      fix: 'A failed agent action raises an alert to a human first, so you reach the customer before the complaint does.',
+    },
+    {
+      id: 12,
+      primitive: 'Agents',
+      title: 'Produce the log in minutes',
+      gap: 'An audit that takes days of log-digging is an audit you are not ready for.',
+      fix: 'A hash-chained activity log exports in minutes, so an auditor gets a clean record on the day they ask.',
+    },
+  ] as readonly RemediationItem[],
+} as const;

--- a/apps/marketing/app/lib/api.ts
+++ b/apps/marketing/app/lib/api.ts
@@ -26,7 +26,13 @@ export interface WaitlistPayload {
    * Segmentation key — matches the server's WAITLIST_SOURCES enum.
    * e.g. 'managed-cloud' (RevealUI Cloud waitlist), 'newsletter'.
    */
-  source: 'managed-cloud' | 'newsletter' | 'landing-page' | 'blog';
+  source: 'managed-cloud' | 'newsletter' | 'landing-page' | 'blog' | 'receipts-audit';
+  /**
+   * Honeypot — the server silently 200s any submission with a non-empty value
+   * (packages/../waitlist.ts). Forms render it hidden via CSS; humans leave it
+   * empty, bots fill it. Omitted from the request body when empty.
+   */
+  website?: string;
 }
 
 export interface BlogPost {
@@ -68,10 +74,15 @@ export async function submitContact(payload: ContactPayload): Promise<string | n
  */
 export async function submitWaitlist(payload: WaitlistPayload): Promise<string | null> {
   try {
+    const body: { email: string; source: WaitlistPayload['source']; website?: string } = {
+      email: payload.email,
+      source: payload.source,
+    };
+    if (payload.website) body.website = payload.website;
     const res = await fetch(`${API_URL}/api/waitlist`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: payload.email, source: payload.source }),
+      body: JSON.stringify(body),
     });
     if (res.ok) return null;
     // empty-catch-ok: malformed JSON from apps/server shouldn't crash the form; falls back to a generic status-coded message below.
@@ -92,6 +103,23 @@ export async function submitWaitlist(payload: WaitlistPayload): Promise<string |
  */
 export async function submitNewsletter(payload: NewsletterPayload): Promise<string | null> {
   return submitWaitlist({ email: payload.email, source: 'newsletter' });
+}
+
+/**
+ * Capture a lead from the Agent Receipts Audit lead magnet
+ * (revealui.com/receipts-audit). A thin wrapper over submitWaitlist that pins
+ * the source to 'receipts-audit' (a LEAD source: the server fires a team alert
+ * + a confirmation email). `website` is the honeypot the form passes through.
+ */
+export async function submitReceiptsAudit(payload: {
+  email: string;
+  website?: string;
+}): Promise<string | null> {
+  return submitWaitlist({
+    email: payload.email,
+    source: 'receipts-audit',
+    website: payload.website,
+  });
 }
 
 /**

--- a/apps/marketing/app/lib/receipts-audit.ts
+++ b/apps/marketing/app/lib/receipts-audit.ts
@@ -1,0 +1,44 @@
+// Pure scoring logic for the Agent Receipts Audit (/receipts-audit). Kept out
+// of the React component so the score-band boundaries are unit-testable in
+// isolation. The question copy + band copy live in content/receipts-audit.ts;
+// this module only knows how a set of yes/no answers maps to a receipt count
+// and a band.
+
+export type AuditAnswer = 'yes' | 'no';
+
+/** The scoreable shape of a question: which answer counts as a receipt. */
+export interface ScoredQuestion {
+  /** The answer that means "you have a receipt" for this question. Most
+   *  questions score a 'yes'; question 5 (unbounded spend) scores a 'no'. */
+  readonly positiveAnswer: AuditAnswer;
+}
+
+export type BandId = 'strong' | 'partial' | 'trust';
+
+/**
+ * Count receipt-positive answers. Unanswered questions (null) never count.
+ * `answers[i]` corresponds to `questions[i]`.
+ */
+export function countReceipts(
+  questions: readonly ScoredQuestion[],
+  answers: readonly (AuditAnswer | null)[],
+): number {
+  let count = 0;
+  for (let i = 0; i < questions.length; i++) {
+    const answer = answers[i];
+    if (answer !== null && answer === questions[i]?.positiveAnswer) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Map a receipt count to a score band. Boundaries (owner copy):
+ *   10-12 → strong  ("You have receipts.")
+ *    5-9  → partial ("You have partial receipts.")
+ *    0-4  → trust   ("You are running on trust.")
+ */
+export function bandForScore(score: number): BandId {
+  if (score >= 10) return 'strong';
+  if (score >= 5) return 'partial';
+  return 'trust';
+}

--- a/apps/marketing/app/routes/ReceiptsAuditPage.tsx
+++ b/apps/marketing/app/routes/ReceiptsAuditPage.tsx
@@ -1,0 +1,38 @@
+import { Footer } from '../components/Footer';
+import { ReceiptsAudit } from '../components/receipts-audit/ReceiptsAudit';
+import { RECEIPTS_AUDIT_HERO } from '../content/receipts-audit';
+
+/**
+ * /receipts-audit — the Agent Receipts Audit lead magnet. A twelve-question
+ * yes/no self-assessment that scores inline, bands the result, and captures an
+ * email against the waitlist (source 'receipts-audit') in exchange for the
+ * remediation guide, which is revealed on the page after a successful submit.
+ *
+ * Design direction (owner ruling 2026-07-10): the calmest page in the room.
+ * Subtraction-first, generous whitespace, at most one CTA per viewport, Cobalt
+ * brand tokens. No banners, no popups, no homepage sections beyond the two
+ * quiet placements (footer nav + Problem-section contextual link).
+ */
+export function ReceiptsAuditPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <section className="px-6 pt-24 pb-8 sm:pt-32 lg:px-8">
+        <div className="mx-auto max-w-2xl">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {RECEIPTS_AUDIT_HERO.eyebrow}
+          </p>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+            {RECEIPTS_AUDIT_HERO.title}
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            {RECEIPTS_AUDIT_HERO.subhead}
+          </p>
+        </div>
+      </section>
+
+      <ReceiptsAudit />
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -21,6 +21,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://revealui.com/receipts-audit</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://revealui.com/blog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>

--- a/apps/server/src/routes/__tests__/waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/waitlist.test.ts
@@ -166,6 +166,24 @@ describe('waitlist route', () => {
     );
   });
 
+  it('emails the team + confirms the lead for a receipts-audit signup', async () => {
+    const { db } = makeDb(vi.fn().mockResolvedValue(undefined));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    mockedGetClient.mockReturnValue(db as any);
+
+    const res = await post(createApp(), { email: 'audit@example.com', source: 'receipts-audit' });
+
+    expect(res.status).toBe(200);
+    // receipts-audit is a LEAD source: one operator alert + one confirmation.
+    expect(mockedSendEmail).toHaveBeenCalledTimes(2);
+    expect(mockedSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ replyTo: 'audit@example.com' }),
+    );
+    expect(mockedSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'audit@example.com' }),
+    );
+  });
+
   it('does not email for a newsletter signup (subscription, not a lead)', async () => {
     const { db } = makeDb(vi.fn().mockResolvedValue(undefined));
     // biome-ignore lint/suspicious/noExplicitAny: test mock

--- a/apps/server/src/routes/waitlist.ts
+++ b/apps/server/src/routes/waitlist.ts
@@ -18,10 +18,13 @@
  * Used by:
  *   - revealui.com /for-operators/managed — RevealUI Cloud waitlist
  *     (source: 'managed-cloud')
+ *   - revealui.com /receipts-audit         — Agent Receipts Audit lead magnet
+ *     (source: 'receipts-audit')
  *   - revealui.com footer + GetStarted     — newsletter capture
  *     (source: 'newsletter')
  *
- * Notifications (LEAD sources only — 'managed-cloud', 'landing-page'):
+ * Notifications (LEAD sources only — 'managed-cloud', 'landing-page',
+ * 'receipts-audit'):
  *   - the operator team gets an alert email (Reply-To the lead) so a
  *     high-intent signup is acted on immediately, not left sitting in a table;
  *   - the lead gets a confirmation email closing the loop.
@@ -53,12 +56,20 @@ import { escapeHtml } from '../lib/html.js';
 // Closed enum keeps the segmentation column clean + queryable. Add a source
 // here when a new capture surface ships — a one-line API change, deliberate
 // so the `source` dimension never accumulates free-text drift.
-const WAITLIST_SOURCES = ['managed-cloud', 'newsletter', 'landing-page', 'blog'] as const;
+const WAITLIST_SOURCES = [
+  'managed-cloud',
+  'newsletter',
+  'landing-page',
+  'blog',
+  'receipts-audit',
+] as const;
 
 // Sources that represent a product LEAD (vs. a newsletter subscription). Only
 // these trigger a team alert + subscriber confirmation; newsletter/blog are
-// list subscriptions handled separately.
-const LEAD_SOURCES = new Set<string>(['managed-cloud', 'landing-page']);
+// list subscriptions handled separately. 'receipts-audit' is a high-intent
+// self-assessment lead: the operator team should act on it like a managed-cloud
+// signup, and the submitter gets the confirmation that closes the loop.
+const LEAD_SOURCES = new Set<string>(['managed-cloud', 'landing-page', 'receipts-audit']);
 
 // Operator inbox for new-lead alerts. Validated at startup
 // (lib/validate-startup.ts); the founder fallback matches the other server


### PR DESCRIPTION
## What this adds

The **Agent Receipts Audit** lead magnet on the marketing site: a new `/receipts-audit` page that turns the "if an agent did it, there's a receipt" foil into an interactive self-assessment, and captures leads through the existing waitlist endpoint.

### The page (`/receipts-audit`)
- Twelve yes/no questions answered inline (client state), scored as you go.
- A score band (10-12 / 5-9 / 0-4) with tailored copy and CTAs (`Start free` and, on the lower bands, `Book the Architecture Review`).
- An email capture form that posts to `/api/waitlist` with `source: 'receipts-audit'` (honeypot `website` field included, hidden via CSS like the server expects).
- After a successful submit, the full remediation checklist is revealed inline. No new email-sending infrastructure: each of the twelve fixes maps to a runtime primitive (People / Content / Offers / Payments / Agents) and names a concrete mechanism.
- Design direction: the calmest page in the room. Subtraction-first, one CTA per viewport, Cobalt tokens.

### Email capture
- Server: `receipts-audit` added to `WAITLIST_SOURCES` **and** `LEAD_SOURCES`, so a submission fires the operator alert + subscriber confirmation like a managed-cloud lead. Route doc comment and `waitlist.test.ts` updated. Confirmation copy is generic, so no per-source variant was added.
- Client: `submitReceiptsAudit` in `app/lib/api.ts`, a thin wrapper over `submitWaitlist` that pins the source and forwards the honeypot.

### Placements (minimal, calm)
- Footer nav: an "Agent Receipts Audit" link (Product column).
- One quiet contextual link in the homepage Problem section, near the receipt foil. No banners, popups, or new homepage sections.

## Tests
- Score-band logic unit tests (`app/__tests__/receipts-audit.test.ts`), including the one reverse-scored question (Q5). Proven to fail without the fix by flipping a band boundary.
- Form submit test with a mocked API (`app/components/__tests__/ReceiptsAudit.test.tsx`): reveals the band, submits with the tagged source, reveals the guide, and handles error state.
- Server: new receipts-audit lead-notification test in `waitlist.test.ts`.
- Route registry test updated with the new path.

Marketing suite: 90 passed. Server waitlist suite: 11 passed. `marketing-voice` validator: 0 new violations. Biome + marketing typecheck clean. (Server typecheck has pre-existing `@revealui/ai` module-resolution errors from the gitignored Pro package, none in the changed file.)

## Copy notes
Used the owner copy verbatim for the title, subhead, twelve questions, and score bands. The remediation checklist and the two placement lines were written in the same voice (no em dashes, full clauses, "your"). Question 5 ("Can an agent spend money today without hitting a limit you set?") is reverse-scored: a "yes" counts as a gap, per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
