### PR TITLE
fix(marketing): repair pricing and offer copy/link drift

### DIFF
--- a/apps/marketing/app/__tests__/agency-engagement-ladder.test.ts
+++ b/apps/marketing/app/__tests__/agency-engagement-ladder.test.ts
@@ -1,10 +1,10 @@
 /**
  * Drift gate: asserts that the agency engagement ladder
  * (`AGENCY_ENGAGEMENT_LADDER` in `app/content/for-operators.ts`) is the
- * single source of truth for the three published "from" anchors —
- * Architecture Review, Fleet deployment, Custom Build — and that every
- * marketing surface that displays them derives from it instead of
- * authoring the literals inline.
+ * single source of truth for the four published engagement anchors —
+ * Architecture Review, Launch Package, Fleet deployment, Custom Build —
+ * and that every marketing surface that displays them derives from it
+ * instead of authoring the literals inline.
  *
  * Failure mode the gate forbids: a future edit that re-introduces a
  * hand-typed "$25,000" or "$50,000" in any marketing content/* module
@@ -50,19 +50,21 @@ function countOccurrencesInCode(source: string, needle: string): number {
 }
 
 describe('AGENCY_ENGAGEMENT_LADDER — canonical anchors', () => {
-  it('pins the three published "from" anchors', () => {
+  it('pins the four published anchors, Launch Package between Architecture Review and Fleet deployment', () => {
     expect(AGENCY_ENGAGEMENT_LADDER.map((e) => [e.id, e.name, e.price, e.startsFrom])).toEqual([
       ['architecture-review', 'Architecture Review', '$3,500', false],
+      ['launch-package', 'Launch Package', '$7,500', false],
       ['fleet-deployment', 'Fleet deployment', '$25,000', true],
       ['custom-build', 'Custom Build', '$50,000', true],
     ]);
   });
 
-  it('renders Architecture Review as a flat price and the rest with a "from" prefix', () => {
+  it('renders Architecture Review and Launch Package as flat prices, and the rest with a "from" prefix', () => {
     const display = Object.fromEntries(
       AGENCY_ENGAGEMENT_LADDER.map((e) => [e.id, agencyEngagementPriceDisplay(e)]),
     );
     expect(display['architecture-review']).toBe('$3,500');
+    expect(display['launch-package']).toBe('$7,500');
     expect(display['fleet-deployment']).toBe('from $25,000');
     expect(display['custom-build']).toBe('from $50,000');
   });
@@ -116,7 +118,7 @@ describe('single ownership of agency-only price anchors', () => {
   }
 });
 
-describe('FOUNDER_SERVICE_OFFERINGS — founder-led services, NOT the agency ladder', () => {
+describe('FOUNDER_SERVICE_OFFERINGS — founder-led services menu', () => {
   it('does not include Fleet deployment or Custom Build', () => {
     const names = FOUNDER_SERVICE_OFFERINGS.map((s) => s.name);
     expect(names).not.toContain('Fleet deployment');
@@ -129,20 +131,23 @@ describe('FOUNDER_SERVICE_OFFERINGS — founder-led services, NOT the agency lad
     expect(review?.price).toBe(ladderReview?.price);
   });
 
-  // $7,500 is the Launch Package price — founder-led services only. It must
-  // not leak into the agency-tier marketing surfaces (the analog of the
-  // $25,000 / $50,000 single-ownership rules above, in the opposite
-  // direction).
-  it('Launch Package price ($7,500) is owned exclusively by FOUNDER_SERVICE_OFFERINGS', () => {
+  // Launch Package is the second rung shared between the founder-led menu
+  // and the agency ladder (same pattern as Architecture Review above): both
+  // surfaces import LAUNCH_PACKAGE_PRICE from @revealui/contracts/pricing
+  // rather than re-authoring "$7,500", so this checks the two stay equal
+  // instead of asserting the literal never appears anywhere else.
+  it('agrees with the ladder on the shared Launch Package price', () => {
     const launch = FOUNDER_SERVICE_OFFERINGS.find((s) => s.id === 'launch-package');
+    const ladderLaunch = AGENCY_ENGAGEMENT_LADDER.find((e) => e.id === 'launch-package');
     expect(launch?.price).toBe('$7,500');
+    expect(launch?.price).toBe(ladderLaunch?.price);
   });
 
-  it('$7,500 does not appear in content/for-operators.ts code', () => {
+  it('$7,500 does not appear as a hand-typed literal in content/for-operators.ts code (imports LAUNCH_PACKAGE_PRICE instead)', () => {
     expect(countOccurrencesInCode(FOR_OPERATORS_SRC, '$7,500')).toBe(0);
   });
 
-  it('$7,500 does not appear in content/pricing.ts code', () => {
+  it('$7,500 does not appear as a hand-typed literal in content/pricing.ts code (band derives via import)', () => {
     expect(countOccurrencesInCode(PRICING_SRC, '$7,500')).toBe(0);
   });
 });

--- a/apps/marketing/app/content/for-operators.ts
+++ b/apps/marketing/app/content/for-operators.ts
@@ -7,7 +7,7 @@
 // The future managed offering is named "RevealUI Cloud" (OQ-1) — referenced
 // only via the inline link to /for-operators/managed (Page 3, not this PR).
 
-import { ARCHITECTURE_REVIEW_PRICE } from '@revealui/contracts/pricing';
+import { ARCHITECTURE_REVIEW_PRICE, LAUNCH_PACKAGE_PRICE } from '@revealui/contracts/pricing';
 import { SITE } from './site';
 import type { Cta, FaqItem } from './types';
 
@@ -92,10 +92,12 @@ export const FOR_OPERATORS_HOW_WE_DELIVER = {
 
 // ---------------------------------------------------------------------------
 // Agency engagement ladder — single source of truth for the agency-only "from"
-// anchors RevealUI Studio offers (Fleet deployment, Custom Build). The shared
-// Architecture Review rung imports its price from @revealui/contracts/pricing
-// (`ARCHITECTURE_REVIEW_PRICE`) so the agency surface cannot drift from the
-// self-serve FOUNDER_SERVICE_OFFERINGS menu that also lists it.
+// anchors RevealUI Studio offers (Fleet deployment, Custom Build), plus the two
+// fixed-price entry rungs it shares with the self-serve founder-led menu
+// (Architecture Review, Launch Package). The shared rungs import their price
+// from @revealui/contracts/pricing (`ARCHITECTURE_REVIEW_PRICE`,
+// `LAUNCH_PACKAGE_PRICE`) so the agency surface cannot drift from the
+// self-serve FOUNDER_SERVICE_OFFERINGS menu that also lists them.
 //
 // Two surfaces consume the ladder: this file's FOR_OPERATORS_PRICING (the
 // agency page at /for-operators) and content/pricing.ts's PRICING_DONE_FOR_YOU
@@ -110,7 +112,11 @@ export const FOR_OPERATORS_HOW_WE_DELIVER = {
 // __tests__/agency-engagement-ladder.test.ts.
 // ---------------------------------------------------------------------------
 
-export type AgencyEngagementId = 'architecture-review' | 'fleet-deployment' | 'custom-build';
+export type AgencyEngagementId =
+  | 'architecture-review'
+  | 'launch-package'
+  | 'fleet-deployment'
+  | 'custom-build';
 
 export interface AgencyEngagement {
   readonly id: AgencyEngagementId;
@@ -124,6 +130,12 @@ export const AGENCY_ENGAGEMENT_LADDER: readonly AgencyEngagement[] = [
     id: 'architecture-review',
     name: 'Architecture Review',
     price: ARCHITECTURE_REVIEW_PRICE,
+    startsFrom: false,
+  },
+  {
+    id: 'launch-package',
+    name: 'Launch Package',
+    price: LAUNCH_PACKAGE_PRICE,
     startsFrom: false,
   },
   { id: 'fleet-deployment', name: 'Fleet deployment', price: '$25,000', startsFrom: true },
@@ -142,6 +154,7 @@ function findEngagement(id: AgencyEngagementId): AgencyEngagement {
 }
 
 const ARCHITECTURE_REVIEW = findEngagement('architecture-review');
+const LAUNCH_PACKAGE = findEngagement('launch-package');
 const FLEET_DEPLOYMENT = findEngagement('fleet-deployment');
 const CUSTOM_BUILD = findEngagement('custom-build');
 
@@ -169,6 +182,12 @@ export const FOR_OPERATORS_PRICING = {
       price: agencyEngagementPriceDisplay(ARCHITECTURE_REVIEW),
       body: 'A two-week, fixed-bid plan for a self-hosted, audited product your clients own: a reference architecture, a data-flow and audit map, a model plan, and a priced path to launch. Credited toward a Fleet deployment if you start one within 30 days.',
       cta: { label: 'Book the scoping call', href: AGENCY_CONTACT, external: true },
+    },
+    {
+      title: LAUNCH_PACKAGE.name,
+      price: agencyEngagementPriceDisplay(LAUNCH_PACKAGE),
+      body: 'A fixed-bid setup, live in two to four weeks: we configure your RevealUI instance, deploy it to production, and hand you the keys with a full handoff session. The fastest path from a signed engagement to a live product you operate yourself.',
+      cta: { label: 'Book a build call', href: AGENCY_CONTACT, external: true },
     },
     {
       title: FLEET_DEPLOYMENT.name,
@@ -235,7 +254,7 @@ export const FOR_OPERATORS_FAQ = {
     },
     {
       question: 'How much does it cost?',
-      answer: `The discovery call scopes the engagement. A ${ARCHITECTURE_REVIEW.price} fixed-bid ${ARCHITECTURE_REVIEW.name} is the written-assessment starting point, and it credits toward what you build next. From there, ${FLEET_DEPLOYMENT.name}s start at ${FLEET_DEPLOYMENT.price} and ${CUSTOM_BUILD.name}s at ${CUSTOM_BUILD.price}; the discovery call scopes the final number.`,
+      answer: `The discovery call scopes the engagement. A ${ARCHITECTURE_REVIEW.price} fixed-bid ${ARCHITECTURE_REVIEW.name} is the written-assessment starting point, and it credits toward what you build next. A ${LAUNCH_PACKAGE.price} ${LAUNCH_PACKAGE.name} takes you from that plan to a live product in two to four weeks. From there, ${FLEET_DEPLOYMENT.name}s start at ${FLEET_DEPLOYMENT.price} and ${CUSTOM_BUILD.name}s at ${CUSTOM_BUILD.price}; the discovery call scopes the final number.`,
     },
     {
       question: 'How long does it take?',

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -13,6 +13,7 @@
 // HOME_HERO's agency CTAs moved to the footer, its CLI block moved into
 // HOME_GET_STARTED.cli.
 
+import { SUBSCRIPTION_PRICE_FALLBACKS } from '../lib/pricing-fallbacks';
 import { SITE } from './site';
 import type { Cta, FaqItem } from './types';
 
@@ -107,8 +108,7 @@ export const HOME_PROBLEM = {
       revealui: 'Hash-chained, in DB',
     },
   ] as readonly ProblemRow[],
-  footnote:
-    'Capability comparison only; a monthly cost estimate lives on the pricing page. RevealUI Pro is $49/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.',
+  footnote: `Capability comparison only; a monthly cost estimate lives on the pricing page. RevealUI Pro is ${SUBSCRIPTION_PRICE_FALLBACKS.pro.price}/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.`,
   // Quiet contextual link back to the receipt foil, near the audit-log row of
   // the comparison. Not a section, not a CTA button: one calm inline link.
   receiptsAudit: {

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -13,6 +13,7 @@ export {
   SUBSCRIPTION_TIERS,
 } from '@revealui/contracts/pricing';
 
+import { SUBSCRIPTION_PRICE_FALLBACKS } from '../lib/pricing-fallbacks';
 import {
   AGENCY_ENGAGEMENT_LADDER,
   type AgencyEngagement,
@@ -114,7 +115,11 @@ export const PRICING_COST_CALCULATOR = {
     },
   ] as const satisfies readonly CostTier[],
   rentedLabel: 'The rented stack',
-  revealui: { label: 'RevealUI', value: '$49 / month', sub: '+ your own Postgres and compute' },
+  revealui: {
+    label: 'RevealUI',
+    value: `${SUBSCRIPTION_PRICE_FALLBACKS.pro.price} / month`,
+    sub: '+ your own Postgres and compute',
+  },
   footnote:
     'A sourced estimate from current 2026 published pricing, time-sensitive. It excludes payment processing, and RevealUI is self-hosted, so you still pay for your own Postgres and compute. Figures are ranges, not a quote.',
 } as const;
@@ -195,7 +200,7 @@ export const PRICING_AGENT_CTA_LINKS = {
 // Done-for-you rung: surfaces the agency engagement ladder where the buying
 // decision happens, instead of a bare link out. Name + price derive from
 // content/for-operators.ts AGENCY_ENGAGEMENT_LADDER, the single source of
-// truth for the three published "from" anchors. Per-rung `note` copy is
+// truth for the published engagement anchors. Per-rung `note` copy is
 // surface-specific (band-voice, shorter than the agency-page rung body), so
 // only the name + price are reused. The discovery call doubles as the
 // mid-funnel capture for buyers who are not ready to self-serve (06-10
@@ -203,6 +208,8 @@ export const PRICING_AGENT_CTA_LINKS = {
 const DONE_FOR_YOU_RUNG_NOTES: Record<AgencyEngagementId, string> = {
   'architecture-review':
     'Fixed-bid written assessment of your project, schema, deployment, and security posture. Credited toward a Fleet deployment if you proceed within 30 days.',
+  'launch-package':
+    'Your RevealUI instance is set up, configured, and deployed to production, with a full handoff session included.',
   'fleet-deployment':
     'A branded, self-hosted RevealUI deployment for your business or your clients. Starting point, scoped in discovery.',
   'custom-build':

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -39,7 +39,7 @@ import type { Cta } from './types';
 export const PRODUCTS_PAGE_HERO = {
   h1: 'The RevFleet product family',
   subtitle:
-    'Start with the runtime, add the rest as you grow. Eight products on one foundation, all built and operated by RevealUI Studio, every one shipping today except the agent marketplace, which is on the way.',
+    'Start with the runtime, add the rest as you grow. Seven products on one foundation, all built and operated by RevealUI Studio, every one shipping today except the agent marketplace, which is on the way.',
 } as const;
 
 export type ProductStatus = 'Beta' | 'Alpha' | 'Active (MIT)' | 'Planned';

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -101,6 +101,7 @@ export function PricingPage() {
       price: tier.price ?? fallback?.price,
       priceNote: tier.priceNote ?? fallback?.priceNote,
       renewal: tier.renewal ?? fallback?.renewal,
+      ctaHref: tier.ctaHref.startsWith('/') ? `${ADMIN_URL}${tier.ctaHref}` : tier.ctaHref,
     };
   });
 
@@ -587,7 +588,13 @@ export function PricingPage() {
           </p>
           <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <ButtonCVA asChild size="lg" className="w-full sm:w-auto">
-              <a href={`${ADMIN_URL}${PRICING_FINAL_CTA_LINKS.getStarted.href}`}>
+              <a
+                href={
+                  PRICING_FINAL_CTA_LINKS.getStarted.href.startsWith('/')
+                    ? `${ADMIN_URL}${PRICING_FINAL_CTA_LINKS.getStarted.href}`
+                    : PRICING_FINAL_CTA_LINKS.getStarted.href
+                }
+              >
                 {PRICING_FINAL_CTA_LINKS.getStarted.label}
               </a>
             </ButtonCVA>

--- a/apps/marketing/app/routes/__tests__/PricingPage.test.tsx
+++ b/apps/marketing/app/routes/__tests__/PricingPage.test.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PricingPage } from '../PricingPage';
+
+afterEach(cleanup);
+
+describe('PricingPage final CTA', () => {
+  beforeEach(() => {
+    // The page fetches live pricing on mount; force the fallback content path
+    // so the test only exercises the static CTA hrefs under test.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve(null) }),
+    );
+  });
+
+  it('links the final "Get Started Free" CTA straight to the absolute signup URL', async () => {
+    render(<PricingPage />);
+    const cta = await screen.findByRole('link', { name: 'Get Started Free' });
+    // PRICING_FINAL_CTA_LINKS.getStarted.href is already absolute
+    // (SITE.urls.signup); it must not be re-prefixed with ADMIN_URL.
+    expect(cta).toHaveAttribute('href', 'https://admin.revealui.com/signup');
+  });
+
+  it('points the Pro Perpetual CTA at the self-serve checkout, prefixed with ADMIN_URL', async () => {
+    render(<PricingPage />);
+    const cta = await screen.findByRole('link', { name: 'Buy Pro Perpetual' });
+    // PERPETUAL_TIERS ships a relative ctaHref ('/account/license'); the
+    // perpetual tier map must apply the same ADMIN_URL guard as the
+    // subscription tier map so it resolves off-site correctly.
+    expect(cta).toHaveAttribute('href', 'https://admin.revealui.com/account/license');
+  });
+});

--- a/apps/server/src/routes/__tests__/pricing.test.ts
+++ b/apps/server/src/routes/__tests__/pricing.test.ts
@@ -223,7 +223,30 @@ describe('GET /api/pricing', () => {
     const free = data.subscriptions.find((t: { id: string }) => t.id === 'free');
     expect(free.name).toBe('Free (OSS)');
     expect(free.features.length).toBeGreaterThan(0);
-    expect(free.cta).toBe('Get Started');
+    expect(free.cta).toBe('Start free');
+  });
+
+  it('includes the enterprise annual price once the annual price-ID guard is set, matching the marketing fallback', async () => {
+    vi.stubEnv('STRIPE_SECRET_KEY', '');
+    vi.stubEnv('STRIPE_ENTERPRISE_ANNUAL_PRICE_ID', 'price_test_enterprise_annual');
+    const res = await app.request('/');
+    const data = await res.json();
+
+    // Must match apps/marketing/app/lib/pricing-fallbacks.ts
+    // ANNUAL_SUBSCRIPTION_PRICE_FALLBACKS.enterprise ($14,390 / Save $3,598/yr).
+    const enterprise = data.subscriptions.find((t: { id: string }) => t.id === 'enterprise');
+    expect(enterprise.annualPrice).toBe('$14,390');
+    expect(enterprise.annualPeriod).toBe('/year');
+  });
+
+  it('omits the enterprise annual price when the annual price-ID guard is unset', async () => {
+    vi.stubEnv('STRIPE_SECRET_KEY', '');
+    const res = await app.request('/');
+    const data = await res.json();
+
+    const enterprise = data.subscriptions.find((t: { id: string }) => t.id === 'enterprise');
+    expect(enterprise.annualPrice).toBeUndefined();
+    expect(enterprise.annualPeriod).toBeUndefined();
   });
 
   it('sets cache headers', async () => {

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -140,8 +140,8 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Community support',
       'Full source code access',
     ],
-    cta: 'Get Started',
-    ctaHref: 'https://docs.revealui.com',
+    cta: 'Start free',
+    ctaHref: '/signup',
     highlighted: false,
   },
   {
@@ -274,9 +274,10 @@ export interface PerpetualTier {
 // (Architecture Review, Launch Package, Migration Assist, Consulting Hour).
 // These are NOT the agency-tier offerings — the Fleet deployment ($25K+) and
 // Custom Build ($50K+) tiers live in apps/marketing/app/content/pricing.ts
-// under PRICING_DONE_FOR_YOU.rungs (agency segment, different buyer). The two
-// surfaces share only the Architecture Review entry-point, whose canonical
-// price is owned here; marketing imports it rather than re-authoring.
+// under PRICING_DONE_FOR_YOU.rungs (agency segment, different buyer). The
+// two surfaces also share the Architecture Review and Launch Package entry
+// points, whose canonical prices are owned here; marketing imports them
+// rather than re-authoring.
 // =============================================================================
 
 export interface ServiceOffering {
@@ -300,6 +301,16 @@ export interface ServiceOffering {
  */
 export const ARCHITECTURE_REVIEW_PRICE = '$3,500' as const;
 
+/**
+ * Canonical price of the Launch Package. Owned here for the same reason as
+ * `ARCHITECTURE_REVIEW_PRICE`: `AGENCY_ENGAGEMENT_LADDER` in
+ * `apps/marketing/app/content/for-operators.ts` imports it rather than
+ * re-authoring the literal, so the Launch Package rung on /pricing and
+ * /for-operators cannot drift from this menu. Same cross-package guard in
+ * `apps/marketing/app/__tests__/agency-engagement-ladder.test.ts`.
+ */
+export const LAUNCH_PACKAGE_PRICE = '$7,500' as const;
+
 export const FOUNDER_SERVICE_OFFERINGS: ServiceOffering[] = [
   {
     id: 'architecture-review',
@@ -322,7 +333,7 @@ export const FOUNDER_SERVICE_OFFERINGS: ServiceOffering[] = [
   {
     id: 'launch-package',
     name: 'Launch Package',
-    price: '$7,500',
+    price: LAUNCH_PACKAGE_PRICE,
     description:
       'Go from zero to production. I set up your RevealUI instance, configure your content model, deploy to Vercel, and hand you the keys with a full handoff session.',
     includes: [
@@ -395,8 +406,8 @@ export const PERPETUAL_TIERS: PerpetualTier[] = [
       'All Pro updates released during support period',
       'Private GitHub repo access',
     ],
-    cta: 'Contact Sales',
-    ctaHref: 'mailto:support@revealui.com?subject=Pro%20Perpetual%20License',
+    cta: 'Buy Pro Perpetual',
+    ctaHref: '/account/license',
     comingSoon: false,
   },
   {


### PR DESCRIPTION
## Summary

Seven independent, verified defects on the marketing pricing/offer surfaces, bundled into one branch per the audit brief:

1. **Dead final CTA on /pricing** — `PricingPage.tsx:590` prefixed an already-absolute signup URL with `ADMIN_URL`, producing `https://admin.revealui.comhttps://admin.revealui.com/signup`. Fixed with the same relative-href guard already used at `PricingPage.tsx:83`. Added a failing-first regression test (`PricingPage.test.tsx`) — confirmed red against the bug, green after the fix.
2. **Free-tier CTA mismatch** — Free tier said "Get Started" → docs.revealui.com while every other free CTA on the site says "Start free" → signup. Changed `SUBSCRIPTION_TIERS.free` in contracts to `cta: 'Start free'`, `ctaHref: '/signup'` (relative, consistent with the Pro/Max tiers in the same array — `/signup` has no `plan` query param since `free` isn't a recognized plan value in the admin signup form). Updated the one test asserting the old label (`apps/server/src/routes/__tests__/pricing.test.ts`).
3. **Product-count contradiction** — `/products` said "Eight products" while `/pricing` FAQ said "seven products". The rendered roster (flagship + `PRODUCTS_SISTERS`) is 7. Fixed `/products` to say "Seven products" to match.
4. **Hardcoded Pro price strings** — `$49 / month` in `PRICING_COST_CALCULATOR` and `$49/mo` in the homepage footnote are now both derived from `SUBSCRIPTION_PRICE_FALLBACKS.pro.price` (the canonical fallback already used elsewhere) instead of separate literals that could drift.
5. **Enterprise annual price server-side** — audit flagged this as missing; on inspection the entry (and its `STRIPE_ENTERPRISE_ANNUAL_PRICE_ID` env guard) was already added in a prior commit (`15eba9d31`). No code change needed. Added two tests that were missing: one proving the enterprise annual price/period match the marketing fallback when the guard env var is set, one proving they're omitted when it's unset.
6. **Self-serve Pro Perpetual CTA** — changed from "Contact Sales" (mailto) to "Buy Pro Perpetual" → `/account/license`, which already posts to the existing `/api/billing/checkout-perpetual` endpoint. Verified the admin license page redirects unauthenticated visitors to `/login?redirect=...` (both client-side via `useSession` and server-side via `proxy.ts`'s auth gate) rather than erroring, so this is safe. Also discovered and fixed a related gap: the perpetual-tier CTA map in `PricingPage.tsx` never applied the ADMIN_URL relative-href rewrite that the subscription-tier map does, so the new relative `/account/license` href would have resolved against revealui.com instead of admin.revealui.com. Added the same guard there.
7. **Launch Package never rendered** — `FOUNDER_SERVICE_OFFERINGS` defines a $7,500 Launch Package that had no render surface. Exported a new `LAUNCH_PACKAGE_PRICE` constant from contracts (same pattern as `ARCHITECTURE_REVIEW_PRICE`) and added it as a shared rung to `AGENCY_ENGAGEMENT_LADDER` in `for-operators.ts`, positioned between Architecture Review ($3,500) and Fleet deployment (from $25,000). It now renders automatically in the /pricing "Done for you" band (which maps over the ladder) and was added explicitly to the `/for-operators` engagement pricing rungs and FAQ answer. Updated `agency-engagement-ladder.test.ts`, whose prior assertions explicitly locked Launch Package OUT of both surfaces — updated those to the new shared-ownership pattern (same as how Architecture Review's price is already shared, not duplicated).

## Test plan

- [x] `pnpm --filter @revealui/contracts test` — 965/965 passing
- [x] `pnpm --filter marketing test` — 75/75 passing (includes 2 new PricingPage tests + updated agency-engagement-ladder tests)
- [x] `pnpm --filter server test` — 2852/2852 passing (1 pre-existing skip), includes 2 new enterprise-annual-price tests
- [x] `pnpm --filter @revealui/contracts typecheck`, `pnpm --filter marketing typecheck`, `pnpm --filter server typecheck` — all clean
- [x] `pnpm --filter marketing build`, `pnpm --filter server build`, `pnpm --filter @revealui/contracts build` — all clean; spot-checked the marketing build output confirms the double-URL bug is gone and "Launch Package" / "Seven products" / "Buy Pro Perpetual" all render
- [x] Biome check clean on every touched file
- [x] Item 1 proven red-then-green: stashed the fix, re-ran the new test (failed with the exact malformed URL from the bug report), restored the fix, re-ran (passed)
- [x] Pre-push gate (`pnpm gate`, incl. the repo's "Pricing lockstep" hard-fail check) passed

## Deviations from the brief

- Item 5 required no code change (already fixed server-side in a prior commit); backfilled the missing test coverage instead.
- Item 6: went with the marketing-side ADMIN_URL guard fix (not called out explicitly in the brief) because it was necessary for the new relative CTA href to resolve correctly — without it the Pro Perpetual button would have pointed at a nonexistent path on revealui.com instead of admin.revealui.com.
- Item 7: this required loosening `agency-engagement-ladder.test.ts`'s prior "Launch Package must not appear on agency surfaces" assertions, which were an intentional architectural boundary (founder-led vs agency-tier buyer segments). Following the brief's explicit instruction to surface it on both bands. Flagging this trade-off for review since it's a policy change, not just a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)