### PR TITLE
feat(auth): record successful and failed logins in the audit trail

### DIFF
--- a/apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts
@@ -14,13 +14,15 @@ import { createHash } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCheckRateLimit = vi.fn();
-const mockCreateSession = vi.fn();
+const mockRotateSession = vi.fn();
+const mockAuditLoginSuccess = vi.fn();
 const mockGetUserByVerificationToken = vi.fn();
 const mockUpdateUser = vi.fn();
 
 vi.mock('@revealui/auth/server', () => ({
   checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
-  createSession: (...args: unknown[]) => mockCreateSession(...args),
+  rotateSession: (...args: unknown[]) => mockRotateSession(...args),
+  auditLoginSuccess: (...args: unknown[]) => mockAuditLoginSuccess(...args),
 }));
 
 vi.mock('@revealui/utils/logger', () => ({
@@ -113,6 +115,7 @@ describe('GET /api/auth/verify-email', () => {
       remaining: 9,
       resetAt: Date.now() + 60000,
     });
+    mockAuditLoginSuccess.mockResolvedValue(undefined);
   });
 
   async function loadRoute() {
@@ -124,7 +127,7 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest());
     expect((res as MockRes).url).toContain('error=missing_token');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
   });
 
   it('redirects with too_many_attempts when rate limited', async () => {
@@ -137,7 +140,7 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('some-token'));
     expect((res as MockRes).url).toContain('error=too_many_attempts');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
   });
 
   it('fails closed  -  redirects with error when rate limit check throws', async () => {
@@ -146,7 +149,7 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('some-token'));
     expect((res as MockRes).url).toContain('error=verification_failed');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
   });
 
   it('garbage token: redirects with invalid_token and creates no session', async () => {
@@ -155,7 +158,7 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('garbage-token'));
     expect((res as MockRes).url).toContain('error=invalid_token');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
   });
 
   it('expired token: getUserByVerificationToken finds no row, redirects with invalid_token and creates no session', async () => {
@@ -166,7 +169,7 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('expired-token'));
     expect((res as MockRes).url).toContain('error=invalid_token');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
   });
 
   it('reused token: the token column is nulled after first use, so a second attempt finds no row and creates no session', async () => {
@@ -175,7 +178,7 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('already-consumed-token'));
     expect((res as MockRes).url).toContain('error=invalid_token');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
   });
 
   it('redirects with already_verified when email already verified, and creates no session', async () => {
@@ -184,7 +187,7 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('valid-token'));
     expect((res as MockRes).url).toContain('message=already_verified');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
     expect(mockUpdateUser).not.toHaveBeenCalled();
   });
 
@@ -195,13 +198,13 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('valid-token'));
     expect((res as MockRes).url).toContain('error=verification_failed');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
   });
 
   it('valid token: establishes a session, sets cookies, and redirects to billing checkout with the upgrade param', async () => {
     mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
     mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
-    mockCreateSession.mockResolvedValue({
+    mockRotateSession.mockResolvedValue({
       token: 'session-token-abc',
       session: { id: 'sess1', userId: 'u1' },
     });
@@ -209,16 +212,59 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('valid-token', 'pro'));
 
-    expect(mockCreateSession).toHaveBeenCalledWith('u1', expect.any(Object));
+    expect(mockRotateSession).toHaveBeenCalledWith('u1', expect.any(Object));
     expect((res as MockRes).url).toContain('/account/billing?upgrade=pro');
     expect((res as MockRes).cookies.get('revealui-session')?.value).toBe('session-token-abc');
     expect((res as MockRes).cookies.get('revealui-role')?.value).toBe('viewer');
   });
 
+  it('valid token: mints the session via rotateSession (revoke-then-issue) for parity with sign-in', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
+    mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
+    mockRotateSession.mockResolvedValue({
+      token: 'session-token-abc',
+      session: { id: 'sess1', userId: 'u1' },
+    });
+
+    const GET = await loadRoute();
+    await GET(makeRequest('valid-token'));
+
+    // rotateSession revokes every prior session for the user before minting a
+    // fresh one (proven by @revealui/auth session tests); calling it with the
+    // verified user's id is the parity contract with the sign-in path.
+    expect(mockRotateSession).toHaveBeenCalledTimes(1);
+    expect(mockRotateSession).toHaveBeenCalledWith('u1', expect.any(Object));
+  });
+
+  it('valid token: lands exactly one login-success audit event with the actor id', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
+    mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
+    mockRotateSession.mockResolvedValue({
+      token: 'session-token-abc',
+      session: { id: 'sess1', userId: 'u1' },
+    });
+
+    const GET = await loadRoute();
+    await GET(makeRequest('valid-token'));
+
+    expect(mockAuditLoginSuccess).toHaveBeenCalledTimes(1);
+    expect(mockAuditLoginSuccess.mock.calls[0][0]).toBe('u1');
+  });
+
+  it('does not emit a login-success audit event when no session is created', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: true });
+
+    const GET = await loadRoute();
+    await GET(makeRequest('valid-token'));
+
+    expect(mockRotateSession).not.toHaveBeenCalled();
+    expect(mockAuditLoginSuccess).not.toHaveBeenCalled();
+  });
+
   it('valid token without an upgrade param: redirects a non-admin to /welcome', async () => {
     mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
     mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
-    mockCreateSession.mockResolvedValue({
+    mockRotateSession.mockResolvedValue({
       token: 'session-token-xyz',
       session: { id: 'sess2', userId: 'u1' },
     });
@@ -233,7 +279,7 @@ describe('GET /api/auth/verify-email', () => {
   it('valid token for an admin without an upgrade param: redirects to /', async () => {
     mockGetUserByVerificationToken.mockResolvedValue({ id: 'u2', emailVerified: false });
     mockUpdateUser.mockResolvedValue({ id: 'u2', role: 'admin', emailVerified: true });
-    mockCreateSession.mockResolvedValue({
+    mockRotateSession.mockResolvedValue({
       token: 'session-token-admin',
       session: { id: 'sess3', userId: 'u2' },
     });
@@ -248,7 +294,7 @@ describe('GET /api/auth/verify-email', () => {
   it('ignores an unrecognized upgrade value (no open redirect)', async () => {
     mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
     mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
-    mockCreateSession.mockResolvedValue({
+    mockRotateSession.mockResolvedValue({
       token: 'session-token-abc',
       session: { id: 'sess1', userId: 'u1' },
     });
@@ -266,7 +312,7 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('some-token'));
     expect((res as MockRes).url).toContain('error=verification_failed');
-    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockRotateSession).not.toHaveBeenCalled();
   });
 
   it('hashes the raw token with SHA-256 before the DB lookup, never passing it through verbatim', async () => {
@@ -284,7 +330,7 @@ describe('GET /api/auth/verify-email', () => {
   it('marks the email verified and consumes the token in a single update', async () => {
     mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
     mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
-    mockCreateSession.mockResolvedValue({
+    mockRotateSession.mockResolvedValue({
       token: 'session-token-abc',
       session: { id: 'sess1', userId: 'u1' },
     });

--- a/apps/admin/src/app/api/auth/verify-email/route.ts
+++ b/apps/admin/src/app/api/auth/verify-email/route.ts
@@ -14,7 +14,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { checkRateLimit, createSession } from '@revealui/auth/server';
+import { auditLoginSuccess, checkRateLimit, rotateSession } from '@revealui/auth/server';
 import { getClient } from '@revealui/db';
 import { getUserByVerificationToken, updateUser } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
@@ -95,18 +95,26 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return NextResponse.redirect(`${baseUrl}/login?error=verification_failed`);
     }
 
-    // Establish a session for this user, mirroring the session-creation
-    // mechanism sign-up uses for the auto-promoted first user.
+    // Establish a session for this user. Use rotateSession (revoke-then-issue)
+    // for parity with the sign-in path: it deletes any prior sessions for the
+    // user, then mints a fresh one. The signup-time session row is only ever
+    // handed to the client as a cookie once the email is verified (sign-up
+    // route sets the cookie behind `isVerified`), so for a verifying user it is
+    // an undelivered orphan row that rotate cleanly reclaims.
     const userAgent = request.headers.get('user-agent') || undefined;
     const ipAddress =
       request.headers.get('x-real-ip') ||
       request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
       undefined;
 
-    const { token: sessionToken } = await createSession(updatedUser.id, {
+    const { token: sessionToken } = await rotateSession(updatedUser.id, {
       userAgent,
       ipAddress,
     });
+
+    // First login on email verification: land a success receipt in the audit
+    // trail (best-effort; auditLoginSuccess never throws).
+    await auditLoginSuccess(updatedUser.id, ipAddress ?? 'unknown', userAgent ?? 'unknown');
 
     const dest = resolveAuthDest({
       upgrade,

--- a/packages/auth/src/server/__tests__/audit-bridge.test.ts
+++ b/packages/auth/src/server/__tests__/audit-bridge.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the auth → audit-trail bridge.
+ *
+ * The bridge is best-effort by contract: it emits structured audit events for
+ * auth operations, but a failure to persist an event must never propagate to
+ * the caller (a login must succeed even when its audit write fails).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockLog = vi.fn();
+
+vi.mock('@revealui/security/server', () => ({
+  audit: { log: (...args: unknown[]) => mockLog(...args) },
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { logger } from '@revealui/core/observability/logger';
+import { auditLoginFailure, auditLoginSuccess } from '../audit-bridge.js';
+
+describe('audit-bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLog.mockResolvedValue(undefined);
+  });
+
+  describe('auditLoginSuccess', () => {
+    it('emits exactly one auth.login success event carrying the actor id', async () => {
+      await auditLoginSuccess('user-42', '1.2.3.4', 'test-agent');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      const event = mockLog.mock.calls[0][0];
+      expect(event.type).toBe('auth.login');
+      expect(event.result).toBe('success');
+      expect(event.action).toBe('login');
+      expect(event.actor.id).toBe('user-42');
+      expect(event.actor.type).toBe('user');
+      expect(event.actor.ip).toBe('1.2.3.4');
+      expect(event.actor.userAgent).toBe('test-agent');
+    });
+
+    it('does not throw when the audit write fails, and logs the failure', async () => {
+      mockLog.mockRejectedValueOnce(new Error('audit storage down'));
+
+      await expect(auditLoginSuccess('user-42', '1.2.3.4', 'test-agent')).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('auditLoginFailure', () => {
+    it('emits an auth.failed_login event carrying the email actor and reason', async () => {
+      await auditLoginFailure('bad@example.com', '1.2.3.4', 'test-agent', 'invalid_credentials');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      const event = mockLog.mock.calls[0][0];
+      expect(event.type).toBe('auth.failed_login');
+      expect(event.result).toBe('failure');
+      expect(event.actor.id).toBe('bad@example.com');
+      expect(event.metadata.reason).toBe('invalid_credentials');
+    });
+
+    it('does not throw when the audit write fails', async () => {
+      mockLog.mockRejectedValueOnce(new Error('audit storage down'));
+
+      await expect(
+        auditLoginFailure('bad@example.com', '1.2.3.4', 'test-agent', 'invalid_credentials'),
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/auth/src/server/__tests__/auth.test.ts
+++ b/packages/auth/src/server/__tests__/auth.test.ts
@@ -49,6 +49,14 @@ vi.mock('../session.js', () => ({
   rotateSession: (...args: unknown[]) => mockRotateSession(...args),
 }));
 
+// Mock audit bridge
+const mockAuditLoginSuccess = vi.fn();
+const mockAuditLoginFailure = vi.fn();
+vi.mock('../audit-bridge.js', () => ({
+  auditLoginSuccess: (...args: unknown[]) => mockAuditLoginSuccess(...args),
+  auditLoginFailure: (...args: unknown[]) => mockAuditLoginFailure(...args),
+}));
+
 // Chain mocks for drizzle-orm query builder
 const mockReturning = vi.fn();
 const mockInsertValues = vi.fn().mockReturnValue({ returning: mockReturning });
@@ -129,6 +137,8 @@ describe('auth', () => {
     mockClearFailedAttempts.mockResolvedValue(undefined);
     mockCreateSession.mockResolvedValue({ token: 'session-token-abc', session: {} });
     mockRotateSession.mockResolvedValue({ token: 'session-token-abc', session: {} });
+    mockAuditLoginSuccess.mockResolvedValue(undefined);
+    mockAuditLoginFailure.mockResolvedValue(undefined);
     mockBcryptCompare.mockResolvedValue(true);
     mockBcryptHash.mockResolvedValue('$2a$12$newhashedpassword');
     mockValidatePasswordStrength.mockReturnValue({ valid: true, errors: [] });
@@ -350,6 +360,64 @@ describe('auth', () => {
       const result = await signIn('test@example.com', 'Password123');
       expect(result.success).toBe(true);
       expect(result.sessionToken).toBe('session-token-abc');
+    });
+
+    // =======================================================================
+    // Audit-trail wiring
+    // =======================================================================
+    it('lands exactly one login-success audit event with the actor id on success', async () => {
+      mockLimit.mockResolvedValueOnce([makeUser()]);
+      mockBcryptCompare.mockResolvedValueOnce(true);
+
+      const result = await signIn('test@example.com', 'Password123', {
+        ipAddress: '1.2.3.4',
+        userAgent: 'test-agent',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockAuditLoginSuccess).toHaveBeenCalledTimes(1);
+      expect(mockAuditLoginSuccess).toHaveBeenCalledWith('user-1', '1.2.3.4', 'test-agent');
+      expect(mockAuditLoginFailure).not.toHaveBeenCalled();
+    });
+
+    it('lands exactly one login-failure audit event on invalid password', async () => {
+      mockLimit.mockResolvedValueOnce([makeUser()]);
+      mockBcryptCompare.mockResolvedValueOnce(false);
+
+      const result = await signIn('test@example.com', 'WrongPass1', {
+        ipAddress: '1.2.3.4',
+        userAgent: 'test-agent',
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockAuditLoginFailure).toHaveBeenCalledTimes(1);
+      expect(mockAuditLoginFailure).toHaveBeenCalledWith(
+        'test@example.com',
+        '1.2.3.4',
+        'test-agent',
+        'invalid_credentials',
+      );
+      expect(mockAuditLoginSuccess).not.toHaveBeenCalled();
+    });
+
+    it('lands a login-failure audit event for a nonexistent user', async () => {
+      mockLimit.mockResolvedValueOnce([]);
+
+      await signIn('nobody@example.com', 'Password123');
+
+      expect(mockAuditLoginFailure).toHaveBeenCalledTimes(1);
+      expect(mockAuditLoginSuccess).not.toHaveBeenCalled();
+    });
+
+    it('does not emit a login-success event when MFA is still pending (no session yet)', async () => {
+      mockLimit.mockResolvedValueOnce([makeUser({ mfaEnabled: true })]);
+      mockBcryptCompare.mockResolvedValueOnce(true);
+
+      const result = await signIn('test@example.com', 'Password123');
+
+      expect(result.success).toBe(true);
+      expect(mockAuditLoginSuccess).not.toHaveBeenCalled();
+      expect(mockAuditLoginFailure).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/auth/src/server/audit-bridge.ts
+++ b/packages/auth/src/server/audit-bridge.ts
@@ -6,6 +6,7 @@
  * avoid circular dependency issues at module load time.
  */
 
+import { logger } from '@revealui/core/observability/logger';
 import type { AuditEvent, AuditSystem } from '@revealui/security/server';
 
 type AuditEventInput = Omit<AuditEvent, 'id' | 'timestamp'>;
@@ -25,15 +26,23 @@ async function getAudit(): Promise<AuditSystem | null> {
 }
 
 /**
- * Internal helper  -  logs an audit event, silently skipping if the
- * audit system is unavailable.
+ * Internal helper  -  logs an audit event best-effort. Silently skips when the
+ * audit system is unavailable, and swallows (but logs) a write failure so the
+ * operation being audited  -  e.g. a login  -  never fails because its audit
+ * record could not be persisted.
  */
 async function logAuditEvent(event: AuditEventInput): Promise<void> {
   const auditSystem = await getAudit();
   if (!auditSystem) {
     return;
   }
-  await auditSystem.log(event);
+  try {
+    await auditSystem.log(event);
+  } catch (error) {
+    logger.error('Failed to write audit event', error instanceof Error ? error : undefined, {
+      type: event.type,
+    });
+  }
 }
 
 /**

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -11,6 +11,7 @@ import { accountMemberships, accounts, oauthAccounts, users } from '@revealui/db
 import bcrypt from 'bcryptjs';
 import { and, eq, isNull } from 'drizzle-orm';
 import type { SignInResult, SignUpResult, User } from '../types.js';
+import { auditLoginFailure, auditLoginSuccess } from './audit-bridge.js';
 import { clearFailedAttempts, isAccountLocked, recordFailedAttempt } from './brute-force.js';
 import { validatePasswordStrength } from './password-validation.js';
 import { checkRateLimit } from './rate-limit.js';
@@ -103,23 +104,32 @@ export async function signIn(
     // Always return same error message to prevent user enumeration
     const invalidCredentialsMessage = 'Invalid email or password';
 
-    if (!user) {
+    // Record a failed credential attempt: bump the brute-force counter AND
+    // land a failed-login receipt in the audit trail. recordFailedAttempt only
+    // feeds lockout accounting; without the audit emit a failed sign-in leaves
+    // no receipt. auditLoginFailure is best-effort and never throws.
+    const failInvalidCredentials = async (): Promise<SignInResult> => {
       await recordFailedAttempt(email);
+      await auditLoginFailure(
+        email,
+        options?.ipAddress ?? 'unknown',
+        options?.userAgent ?? 'unknown',
+        'invalid_credentials',
+      );
       return {
         success: false,
         reason: 'invalid_credentials',
         error: invalidCredentialsMessage,
       };
+    };
+
+    if (!user) {
+      return failInvalidCredentials();
     }
 
     // Check if user has a password (not OAuth-only user)
     if (!user.password) {
-      await recordFailedAttempt(email);
-      return {
-        success: false,
-        reason: 'invalid_credentials',
-        error: invalidCredentialsMessage,
-      };
+      return failInvalidCredentials();
     }
 
     // Verify password hash
@@ -128,21 +138,11 @@ export async function signIn(
       isValid = await bcrypt.compare(password, user.password);
     } catch {
       logger.error('Error comparing password');
-      await recordFailedAttempt(email);
-      return {
-        success: false,
-        reason: 'invalid_credentials',
-        error: invalidCredentialsMessage,
-      };
+      return failInvalidCredentials();
     }
 
     if (!isValid) {
-      await recordFailedAttempt(email);
-      return {
-        success: false,
-        reason: 'invalid_credentials',
-        error: invalidCredentialsMessage,
-      };
+      return failInvalidCredentials();
     }
 
     // Successful login - clear failed attempts
@@ -187,6 +187,15 @@ export async function signIn(
         error: 'Failed to create session',
       };
     }
+
+    // A fresh session was minted: the login succeeded. Land a success receipt
+    // in the audit trail (best-effort; auditLoginSuccess never throws, so an
+    // audit-write failure cannot fail the login).
+    await auditLoginSuccess(
+      user.id,
+      options?.ipAddress ?? 'unknown',
+      options?.userAgent ?? 'unknown',
+    );
 
     // Check if password rotation is required (e.g., bootstrapped admin accounts)
     if (user.mustRotatePassword) {


### PR DESCRIPTION
## Why

A successful sign-in emitted **no audit event** anywhere in the fleet. For a receipts-first product, human authentication leaving no receipt is a coherence gap: the audit trail could not answer "who signed in when" from its own records.

## Call-site audit

- `auditLoginSuccess` (`packages/auth/src/server/audit-bridge.ts`) had **zero call sites** — only re-exports (`packages/auth/src/server/index.ts`, `packages/engines/src/users/index.ts`). Dead fleet-wide.
- `auditLoginFailure` — same: **zero call sites**. Dead too.
- `signIn` (`packages/auth/src/server/auth.ts`) → `rotateSession` minted a session on success but recorded nothing to the audit trail.
- The email-verification route (`apps/admin/src/app/api/auth/verify-email/route.ts`) minted via `createSession` and likewise recorded nothing.

## Both success emits wired (same PR, so they never diverge)

- **Sign-in:** `signIn()` emits `auditLoginSuccess(userId, ip, userAgent)` exactly once, right after a fresh session is minted. MFA-pending returns earlier (no session yet), so no premature receipt is written for a half-completed login.
- **Verify-email first login:** the route emits `auditLoginSuccess(userId, ip, userAgent)` exactly once after minting its session.

Both reuse the existing `auditLoginSuccess` primitive and its event shape (`type: auth.login`, `actor.id`, timestamp stamped by `AuditSystem.log`). No new audit pipeline.

## Failure-side finding

**Failures were also unrecorded in the audit trail.** `recordFailedAttempt` (`packages/auth/src/server/brute-force.ts`) only bumps the brute-force **lockout counter** (`brute_force:<email>` storage key); it never writes to the `AuditSystem`. So I wired `auditLoginFailure` on the credential-failure branch (consolidated into one helper alongside the existing `recordFailedAttempt` call). A failed sign-in now leaves a receipt too.

> Out of scope, noted for a follow-up: account-lockout (`auditAccountLocked`) and MFA-completion login success are still unwired — separate branches from the two paths this PR covers.

## Parity ruling: adopt `rotateSession` on verify-email

**Decision: switched verify-email from `createSession` to `rotateSession`** (revoke-then-issue), matching sign-in.

**Trace (why nothing depends on the signup-time session surviving):** for a user who goes through email verification, the signup-time session row is created at sign-up but its token is only ever handed to the client as a cookie **once the email is verified** — the sign-up route sets the `revealui-session` cookie behind an `isVerified` guard. So for an unverified-then-verifying user, that row is an **undelivered orphan** no device holds. Rotating on verification reclaims it and leaves the user with exactly one live session. (First users are auto-verified at signup and never traverse this route, so they are unaffected.)

## Non-blocking

The audit bridge now **swallows and logs** a write failure, so an audit-write error can never fail the operation it records. This is the single seam that makes every emit best-effort.

## Tests + prove-red

New regression tests:
- (a) successful sign-in lands exactly one success event with the actor id
- (b) successful verify-login lands exactly one success event with the actor id
- (c) invalid-credentials sign-in lands exactly one failure event (finding: failures were unrecorded, now wired)
- (d) an audit-write failure does not throw (bridge best-effort), so the login is unaffected
- (e) verify-email mints via `rotateSession` (revoke-then-issue), pinning the parity decision

**Prove-red:** stashing the wiring turns the new tests red (auth: 5 new tests fail; verify-email: the parity + emit tests fail); restoring the wiring returns them green.

Results:
- `pnpm --filter @revealui/auth exec vitest run` -> **528 passed, 19 skipped** (full suite green)
- admin auth route tests (`verify-email-route`, `sign-in-route`) -> **29 passed**
- `pnpm exec turbo build --filter=admin --filter=server` -> **21 tasks successful**

## Security checker verdict

`security-pr-review-check.js --diff origin/test` -> **SECURITY-SENSITIVE (HOLD)**, touching `packages/auth/` + `api/auth/`. This is expected and correct for an auth-surface change.

## Awaiting a non-author security verdict before merge

This PR touches the authentication surface. Per the review-before-merge convention it **must carry a recorded verdict from a non-author reviewer before it merges**. Do not self-merge; do not apply any `*approved` label as the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
