### PR TITLE
fix(scripts): accept restricted stripe keys in catalog check mode

### DIFF
--- a/scripts/setup/__tests__/stripe-catalog.test.ts
+++ b/scripts/setup/__tests__/stripe-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   findOrphanProducts,
   isManagedProduct,
   type ManagedProductView,
+  validateStripeSecretKeyPrefix,
 } from '../stripe-catalog.js';
 
 /**
@@ -184,5 +185,55 @@ describe('findCatalogDrift', () => {
         (i) => i.kind === 'missing' && i.productKey === 'revealui_enterprise',
       ),
     ).toBe(true);
+  });
+});
+
+describe('validateStripeSecretKeyPrefix', () => {
+  it('accepts a full secret key in check mode', () => {
+    expect(validateStripeSecretKeyPrefix('sk_test_abc', true)).toEqual({
+      ok: true,
+      isLive: false,
+    });
+    expect(validateStripeSecretKeyPrefix('sk_live_abc', true)).toEqual({
+      ok: true,
+      isLive: true,
+    });
+  });
+
+  it('accepts a full secret key in seed/mutating mode', () => {
+    expect(validateStripeSecretKeyPrefix('sk_test_abc', false)).toEqual({
+      ok: true,
+      isLive: false,
+    });
+    expect(validateStripeSecretKeyPrefix('sk_live_abc', false)).toEqual({
+      ok: true,
+      isLive: true,
+    });
+  });
+
+  it('accepts a restricted key in check mode (least-privilege read-only gate)', () => {
+    expect(validateStripeSecretKeyPrefix('rk_test_abc', true)).toEqual({
+      ok: true,
+      isLive: false,
+    });
+    expect(validateStripeSecretKeyPrefix('rk_live_abc', true)).toEqual({
+      ok: true,
+      isLive: true,
+    });
+  });
+
+  it('rejects a restricted key in seed/mutating mode (can create/archive products)', () => {
+    const testResult = validateStripeSecretKeyPrefix('rk_test_abc', false);
+    expect(testResult.ok).toBe(false);
+    expect(testResult.message).toContain('restricted rk_ keys are not permitted');
+
+    const liveResult = validateStripeSecretKeyPrefix('rk_live_abc', false);
+    expect(liveResult.ok).toBe(false);
+    expect(liveResult.isLive).toBe(true);
+  });
+
+  it('rejects a garbage prefix in either mode', () => {
+    expect(validateStripeSecretKeyPrefix('pk_test_abc', true).ok).toBe(false);
+    expect(validateStripeSecretKeyPrefix('pk_test_abc', false).ok).toBe(false);
   });
 });

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -38,6 +38,7 @@ import {
   type ManagedProductView,
   PRICE_ENV_KEYS,
   PRICE_SERVER_ENV_KEYS,
+  validateStripeSecretKeyPrefix,
 } from './stripe-catalog.js';
 import { LOCAL_STRIPE_ENV_CACHE_PATH } from './stripe-env-cache-path.js';
 import { priceMatchesDefinition, priceSharesHandle } from './stripe-price-match.js';
@@ -764,12 +765,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  if (!(secretKey.startsWith('sk_test_') || secretKey.startsWith('sk_live_'))) {
-    log.error('STRIPE_SECRET_KEY must start with sk_test_ or sk_live_');
+  const keyValidation = validateStripeSecretKeyPrefix(secretKey, checkMode);
+  if (!keyValidation.ok) {
+    log.error(keyValidation.message ?? 'STRIPE_SECRET_KEY has an invalid prefix');
     process.exit(1);
   }
 
-  if (secretKey.startsWith('sk_live_')) {
+  if (keyValidation.isLive) {
     log.warn('Using LIVE Stripe key  -  resources will be created in production!');
     log.info('Press Ctrl+C within 5 seconds to abort...');
     await new Promise((r) => setTimeout(r, 5000));

--- a/scripts/setup/stripe-catalog.ts
+++ b/scripts/setup/stripe-catalog.ts
@@ -419,3 +419,44 @@ export function findCatalogDrift(active: readonly ManagedProductView[]): Catalog
 
   return issues;
 }
+
+export interface StripeKeyPrefixValidation {
+  ok: boolean;
+  /** Error message to log when ok is false. */
+  message?: string;
+  /** True when the accepted key targets Stripe live mode (sk_live_ or rk_live_). */
+  isLive: boolean;
+}
+
+/**
+ * Validates STRIPE_SECRET_KEY's prefix against the operation mode.
+ *
+ * --check (the scheduled read-only drift gate, see
+ * .github/workflows/stripe-catalog-check.yml) only ever reads the catalog, so
+ * a least-privilege Stripe RESTRICTED key (rk_test_/rk_live_) is the correct
+ * credential there and must be accepted.
+ *
+ * Seeding/mutating runs (the default `pnpm stripe:seed` -- no --check) can
+ * create or archive products, so a restricted key must never be accepted for
+ * them -- only a full secret key (sk_test_/sk_live_) may run them.
+ */
+export function validateStripeSecretKeyPrefix(
+  secretKey: string,
+  checkMode: boolean,
+): StripeKeyPrefixValidation {
+  const validPrefixes = checkMode
+    ? ['sk_test_', 'sk_live_', 'rk_test_', 'rk_live_']
+    : ['sk_test_', 'sk_live_'];
+  const ok = validPrefixes.some((prefix) => secretKey.startsWith(prefix));
+  const isLive = secretKey.startsWith('sk_live_') || secretKey.startsWith('rk_live_');
+  if (ok) {
+    return { ok, isLive };
+  }
+  return {
+    ok,
+    isLive,
+    message: checkMode
+      ? 'STRIPE_SECRET_KEY must start with sk_test_, sk_live_, rk_test_, or rk_live_'
+      : 'STRIPE_SECRET_KEY must start with sk_test_ or sk_live_ (restricted rk_ keys are not permitted for seeding/mutating runs)',
+  };
+}


### PR DESCRIPTION
## Summary
- `seed-stripe.ts`'s `STRIPE_SECRET_KEY` prefix guard only accepted `sk_test_`/`sk_live_`, but the scheduled read-only drift check (`stripe-catalog-check.yml`) maps a least-privilege Stripe RESTRICTED key (`rk_live_`, correctly least-privilege for a read-only job) into `STRIPE_SECRET_KEY`, so `--check` runs were rejected.
- `--check` (read-only) now also accepts `rk_test_`/`rk_live_`. Seeding/mutating runs (no `--check`) still require a full `sk_` key since they can create/archive products; a restricted key is rejected there.
- The live-key confirmation prompt/logic now treats `rk_live_` as live too, alongside `sk_live_`.
- Extracted the prefix guard into a pure, testable `validateStripeSecretKeyPrefix()` in `stripe-catalog.ts`, matching the existing pattern for logic pulled out of `seed-stripe.ts` (which runs `main()` on import, so it can't be imported directly by tests).

## Test plan
- [x] New tests in `scripts/setup/__tests__/stripe-catalog.test.ts` pin: `rk_` accepted in check mode, `rk_` rejected in seed mode, `sk_` accepted in both, garbage prefix rejected in both.
- [x] Proved red: reverted `stripe-catalog.ts` to the pre-fix `HEAD` version and confirmed the new tests failed (`validateStripeSecretKeyPrefix is not a function`), then restored the fix and confirmed all 5 new tests pass.
- [x] `pnpm vitest run scripts/setup/__tests__/` — 5 test files, 43 tests, all pass.
- [x] `biome check` on the 3 changed files — clean.
- [x] Local pre-push gate (`ci-gate.ts --phase=1 --changed`) passed, including Biome, boundary, claim-drift, and security-audit checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
