### PR TITLE
fix(admin): guard mock.calls index in verify-email test (TS2532)

### DIFF
--- a/apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts
@@ -248,7 +248,7 @@ describe('GET /api/auth/verify-email', () => {
     await GET(makeRequest('valid-token'));
 
     expect(mockAuditLoginSuccess).toHaveBeenCalledTimes(1);
-    expect(mockAuditLoginSuccess.mock.calls[0][0]).toBe('u1');
+    expect(mockAuditLoginSuccess.mock.calls[0]?.[0]).toBe('u1');
   });
 
   it('does not emit a login-success audit event when no session is created', async () => {


### PR DESCRIPTION
## Problem

`test` HEAD carries a strict-index type error in `apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts:251`:

```
error TS2532: Object is possibly 'undefined'.
```

`mockAuditLoginSuccess.mock.calls[0][0]` indexes `calls[0]` which is possibly undefined under `noUncheckedIndexedAccess`. The PR-only "Typecheck affected packages (PRs — hard fail)" job typechecks the PR-merge result, so **every** open PR merging into test inherits this failure (surfaced on #1830). The push-triggered gate on test does not run the same hard-fail affected-typecheck, which is how it slipped onto test.

## Fix

Guard the first-call access with optional chaining: `mock.calls[0]?.[0]`. The preceding `toHaveBeenCalledTimes(1)` assertion guarantees the call exists at runtime, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)