### PR TITLE
fix(docs): self-host fonts + add CSP/security headers (GAP-324)

### DIFF
--- a/apps/docs/app/__tests__/brand-fonts.test.ts
+++ b/apps/docs/app/__tests__/brand-fonts.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Production font regression gate (GAP-324).
+ *
+ * docs.revealui.com previously rendered fonts ONLY because it shipped no CSP and
+ * linked Inter / Inter Tight / JetBrains Mono from fonts.googleapis.com. GAP-324
+ * self-hosts the fonts (@fontsource-variable/*) and adds a CSP whose
+ * font-src 'self' data: blocks third-party font hosts. Fontsource registers the
+ * "* Variable" family names, so each --font-* stack must lead with those or it
+ * resolves to no self-hosted face (the exact bug the marketing site hit first).
+ *
+ * Asserted here:
+ *   (a) index.html references no third-party font host.
+ *   (b) app/index.css leads each --font-* stack with a fontsource "* Variable" family.
+ *   (c) each declared "* Variable" family is one the installed fontsource package
+ *       actually registers, and every package is imported in entry.client.tsx.
+ */
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const APP_DIR = join(import.meta.dirname, '..');
+
+const INDEX_HTML = readFileSync(join(APP_DIR, '..', 'index.html'), 'utf8');
+const INDEX_CSS = readFileSync(join(APP_DIR, 'index.css'), 'utf8');
+const ENTRY_CLIENT = readFileSync(join(APP_DIR, 'entry.client.tsx'), 'utf8');
+
+// Tailwind @theme token → fontsource package + the family it registers via @font-face.
+const FONT_MAP = [
+  {
+    token: '--font-sans',
+    fontsourcePackage: '@fontsource-variable/inter',
+    variableFamily: '"Inter Variable"',
+  },
+  {
+    token: '--font-display',
+    fontsourcePackage: '@fontsource-variable/inter-tight',
+    variableFamily: '"Inter Tight Variable"',
+  },
+  {
+    token: '--font-mono',
+    fontsourcePackage: '@fontsource-variable/jetbrains-mono',
+    variableFamily: '"JetBrains Mono Variable"',
+  },
+] as const;
+
+describe('docs brand fonts', () => {
+  it('index.html references no CSP-blocked third-party font host', () => {
+    expect(INDEX_HTML).not.toContain('fonts.googleapis.com');
+    expect(INDEX_HTML).not.toContain('fonts.gstatic.com');
+  });
+
+  it('app CSS leads each --font-* stack with a self-hosted variable family', () => {
+    for (const { token, variableFamily } of FONT_MAP) {
+      expect(INDEX_CSS).toContain(`${token}: ${variableFamily}`);
+    }
+  });
+
+  it('each declared variable family is registered by the installed fontsource package', () => {
+    for (const { fontsourcePackage, variableFamily } of FONT_MAP) {
+      const packageCss = readFileSync(require.resolve(`${fontsourcePackage}/index.css`), 'utf8');
+      // fontsource declares @font-face { font-family: "Inter Variable"; ... }
+      // (its own CSS uses single quotes, so compare on the unquoted family name).
+      const bareFamily = variableFamily.slice(1, -1);
+      expect(packageCss).toContain(bareFamily);
+    }
+  });
+
+  it('every fontsource package is imported in the client entry', () => {
+    for (const { fontsourcePackage } of FONT_MAP) {
+      expect(ENTRY_CLIENT).toContain(`import '${fontsourcePackage}'`);
+    }
+  });
+});

--- a/apps/docs/app/entry.client.tsx
+++ b/apps/docs/app/entry.client.tsx
@@ -1,3 +1,6 @@
+import '@fontsource-variable/inter';
+import '@fontsource-variable/inter-tight';
+import '@fontsource-variable/jetbrains-mono';
 import { Router, RouterProvider } from '@revealui/router';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/apps/docs/app/index.css
+++ b/apps/docs/app/index.css
@@ -31,9 +31,14 @@
   --color-code-block: var(--rvui-midnight, oklch(0.16 0.03 260)); /* midnight; --rvui-midnight not yet a token, fallback = surface-0 dark value */
   --color-ink: var(--rvui-text-0);
 
-  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  --font-display: "Inter Tight", "Inter", sans-serif;
+  /* Self-hosted variable fonts (@fontsource-variable/*, imported in
+   * app/entry.client.tsx) register under the "* Variable" family names, so each
+   * stack leads with those; the original Google names stay as fallbacks. The CSP
+   * in vercel.json blocks third-party font hosts (font-src 'self' data:), so the
+   * self-hosted faces are the only ones that resolve. GAP-324, mirrors marketing. */
+  --font-sans: "Inter Variable", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono Variable", "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --font-display: "Inter Tight Variable", "Inter Tight", "Inter", sans-serif;
 
   --width-sidebar: 272px;
   --width-content: 820px;

--- a/apps/docs/app/types.d.ts
+++ b/apps/docs/app/types.d.ts
@@ -1,0 +1,6 @@
+// Side-effect font imports have no runtime API; declare the @fontsource-variable
+// CSS-only modules so TS doesn't complain about missing type declarations.
+// Self-hosted fonts imported in app/entry.client.tsx (GAP-324, mirrors marketing).
+declare module '@fontsource-variable/inter';
+declare module '@fontsource-variable/inter-tight';
+declare module '@fontsource-variable/jetbrains-mono';

--- a/apps/docs/index.html
+++ b/apps/docs/index.html
@@ -24,9 +24,7 @@
     <!-- SEO -->
     <link rel="canonical" href="https://docs.revealui.com" />
     <meta name="keywords" content="revealui, typescript, react, cms, saas, ai agents, open source, business runtime, stripe, authentication" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Inter+Tight:wght@700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+    <!-- Fonts are self-hosted via @fontsource-variable/* (imported in app/entry.client.tsx); no third-party font hosts. GAP-324. -->
   </head>
   <body>
     <div id="root"></div>

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,6 +4,9 @@
   "description": "Documentation site for RevealUI",
   "private": true,
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.5",
+    "@fontsource-variable/inter-tight": "^5.2.5",
+    "@fontsource-variable/jetbrains-mono": "^5.2.5",
     "@revealui/core": "workspace:*",
     "@revealui/presentation": "workspace:*",
     "@revealui/router": "workspace:*",

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -5,6 +5,23 @@
   "outputDirectory": "dist",
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.revealui.com https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'"
+        }
+      ]
+    },
+    {
       "source": "/(.*).md",
       "headers": [{ "key": "Content-Type", "value": "text/markdown; charset=utf-8" }]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,6 +436,15 @@ importers:
 
   apps/docs:
     dependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.2.5
+        version: 5.2.8
+      '@fontsource-variable/inter-tight':
+        specifier: ^5.2.5
+        version: 5.2.7
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.5
+        version: 5.2.8
       '@revealui/core':
         specifier: workspace:*
         version: link:../../packages/core


### PR DESCRIPTION
## Self-host docs fonts + add CSP/security-header parity (GAP-324)

`docs.revealui.com` shipped **no** Content-Security-Policy and loaded Inter / Inter Tight / JetBrains Mono from `fonts.googleapis.com` (verified live 2026-07-10). This brings docs to security-header + self-hosted-font parity with marketing (the merged fix #1801).

### Changes (apps/docs)

- **Self-host fonts** via `@fontsource-variable/{inter,inter-tight,jetbrains-mono}` — imported in `app/entry.client.tsx`, each `--font-*` `@theme` stack re-led with the `"* Variable"` families (fallbacks intact), Google `<link>`/preconnects dropped from `index.html`, module type shim added. Mirrors the merged marketing pattern (`apps/marketing/app/index.css:35-37`).
- **CSP + security headers** added to `apps/docs/vercel.json` (previously none): X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, HSTS, and a CSP with `font-src 'self' data:` — the exact marketing block. Docs' `fetch()` calls are all same-origin, so `connect-src` mirrors marketing's (superset, safe).
- **Regression guard test** (`app/__tests__/brand-fonts.test.ts`) mirrors marketing's: asserts no third-party font host, each stack leads with a fontsource family that the installed package registers, and every package is imported.

### Verification (local)

- `pnpm --filter docs... build` → **19 self-hosted woff2 emitted**, **zero `fonts.googleapis.com`/`fonts.gstatic.com` in `dist`**, the three `"* Variable"` `@font-face` families register. Fonts resolve to self-hosted faces under the new CSP.
- `brand-fonts` test **4/4**. Full pre-push gate green (doc-currency, boundary, security, client-bundle, all hard-fails).
- Post-deploy verification already covers `docs.revealui.com` (`verify-deployed-tokens.cjs` via `deploy.yml`), so font/CSP resolvability is enforced on deploy.

### Admin finding (GAP-324 work item 3 — recorded, fix deferred)

Admin is **not** parity: its **public** login surface (`proxy.ts` `PUBLIC_PATHS`: `/login`, `/signup`, `/mfa`, `/rotate-password`, `/reset-password`, `/setup`) renders Google font `<link>`s (`apps/admin/src/app/(frontend)/layout.tsx:57-66`), and its per-request CSP explicitly allows the Google hosts (`apps/admin/src/lib/security/csp.ts:122` style-src, `:124` font-src). The fix (self-host fontsource + a `--rvui-font` Variable override in `styles.css` + drop the Google hosts from `csp.ts`) is **deferred to a focused follow-up**: admin is a Next.js app and `csp.ts` is a security file, so it warrants its own Next-build/render verification and an arm's-length security review rather than riding this Vite-docs change. Until it lands, acceptance criterion "no app links googleapis" holds for marketing + docs; admin is tracked.

### Review gate

Adds a Content-Security-Policy (security surface) → **guardrail-2 non-author verdict** before merge. Not self-merging. Design record / gap: `revealui-jv` GAP-324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
