### PR TITLE
fix(docs): correct license key format and soften daemon key copy

### DIFF
--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -312,8 +312,8 @@ export default function LicensePage() {
                 </p>
                 <div className="space-y-1.5 text-sm text-zinc-600 dark:text-zinc-400">
                   <p>
-                    The RevDev daemon also needs the vendor public key to verify your license.
-                    Without it, a valid Pro license silently runs as Free. Set it as{' '}
+                    The RevDev daemon can also verify your license against the vendor public key.
+                    Set it as{' '}
                     <code className="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-900">
                       REVDEV_LICENSE_PUBLIC_KEY
                     </code>

--- a/docs/ENVIRONMENT-VARIABLES-GUIDE.md
+++ b/docs/ENVIRONMENT-VARIABLES-GUIDE.md
@@ -279,7 +279,7 @@ Enterprise tier feature. Controls the look and feel of admin UI and transactiona
 
 | Variable | Required | Default | Description | Security | Used By |
 |----------|----------|---------|-------------|----------|---------|
-| `REVEALUI_LICENSE_KEY` | No | None | RevealUI Pro/Enterprise license key. Unlocks commercial features. Format: `rui_live_...`. | MEDIUM | admin, api |
+| `REVEALUI_LICENSE_KEY` | No | None | RevealUI Pro/Enterprise license key. Unlocks commercial features. Format: an EdDSA-signed JWT (`eyJhbGciOiJFZERTQSIs...`). | MEDIUM | admin, api |
 | `REVEALUI_LICENSE_ENCRYPTION_KEY` | No | None | AES-256-GCM encryption key for license keys at rest. 32-byte hex (64 chars). Generate with `bash scripts/generate-secret.sh`. | HIGH (server-only) | api |
 | `LICENSE_CACHE_TTL_MS` | No | `15000` | License cache TTL in milliseconds. Lower values detect revocations faster; higher values reduce DB pressure. | LOW | api |
 

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -34,7 +34,7 @@ Fleet sits beside, not underneath, the hosted pricing model:
 ## Prerequisites
 
 - Docker Engine 24+ and Docker Compose v2
-- A Fleet license key (issued at checkout once live billing is enabled — `rui_forge_...`)
+- A Fleet license key, an EdDSA-signed JWT issued at checkout once live billing is enabled
 - A domain you control (e.g. `admin.acme.com`)
 - Stripe keys for billing (if you want to use the billing stack)
 - A NeonDB or PostgreSQL 16 database URL
@@ -68,7 +68,7 @@ POSTGRES_URL=postgresql://user:pass@db:5432/revealui
 REVEALUI_SECRET=<32+ char random string>
 
 # Fleet license
-REVFORGE_LICENSE_KEY=rui_forge_...
+REVFORGE_LICENSE_KEY=eyJhbGciOiJFZERTQSIs...
 REVFORGE_LICENSED_DOMAIN=admin.acme.com
 
 # Admin URL (used by API for redirects)
@@ -113,7 +113,7 @@ All Fleet-specific variables. See [Environment Variables Guide](./ENVIRONMENT-VA
 
 | Variable | Required | Description |
 |---|---|---|
-| `REVFORGE_LICENSE_KEY` | Yes | Your Fleet license JWT (`rui_forge_...`) |
+| `REVFORGE_LICENSE_KEY` | Yes | Your Fleet license JWT (`eyJhbGciOiJFZERTQSIs...`) |
 | `REVFORGE_LICENSED_DOMAIN` | Yes | The domain this instance is locked to |
 | `POSTGRES_URL` | Yes | PostgreSQL 16 connection URL |
 | `REVEALUI_SECRET` | Yes | 32+ char application secret (session signing, CSRF, HMAC operations) |

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -1332,13 +1332,13 @@ After the 12-month update period, the license continues to work indefinitely on 
 
 ## License key format
 
-Perpetual license keys are JWT-signed:
+Perpetual license keys are EdDSA-signed JWTs, the same format as subscription keys:
 
 ```
-rui_perpetual_<base64-payload>.<signature>
+eyJhbGciOiJFZERTQSIs... // gitleaks:allow
 ```
 
-The payload encodes: `domain`, `issuedAt`, `expiresAt` (update window end), and `tier`.
+The payload encodes: `customerId`, `tier`, `perpetual: true` (the `exp` claim is omitted), and optional `domains`/`maxSites`/`maxUsers` limits.
 
 ## Validating a license
 
@@ -1346,7 +1346,7 @@ The payload encodes: `domain`, `issuedAt`, `expiresAt` (update window end), and 
 POST /api/license/verify
 Content-Type: application/json
 
-{ "licenseKey": "rui_perpetual_..." }
+{ "licenseKey": "eyJhbGciOiJFZERTQSIs..." } // gitleaks:allow
 ```
 
 ```json
@@ -1407,7 +1407,7 @@ Customers buy the Enterprise tier of RevealUI ($1,499/mo); the RevealUI Fleet ki
 - **Hosted Enterprise** — RevealUI Studio manages infrastructure. You get a dedicated instance on `revealui.com` infrastructure, domain-configured for your organization.
 - **Self-hosted Fleet** — You deploy the Docker Compose stack (API + admin + PostgreSQL) on your own infrastructure, domain-locked via `REVFORGE_LICENSED_DOMAIN`.
 
-Both paths use the same Enterprise license tier and the same `REVFORGE_LICENSE_KEY` format (`rui_forge_...`). The difference is where the stack runs.
+Both paths use the same Enterprise license tier and the same EdDSA-signed JWT format for `REVFORGE_LICENSE_KEY`. The difference is where the stack runs.
 
 ## RevealUI Fleet — Self-Hosted Deployment
 


### PR DESCRIPTION
## Summary

- Normalizes the license key format shown in `docs/PRO.md`, `docs/ENVIRONMENT-VARIABLES-GUIDE.md`, and `docs/FLEET.md` from the fictional `rui_live_...`/`rui_forge_...`/`rui_perpetual_...` shapes to the real EdDSA-signed JWT format (`eyJhbGciOiJFZERTQSIs...`) that the framework's `validateLicenseKey` (packages/core/src/license.ts) and the RevDev daemon actually verify.
- Softens the license page's "daemon public key" copy string (apps/admin) to drop the overstated "a valid Pro license silently runs as Free" claim, aligning it with the correct optional/rotation-only note already on the same page.

## Finding: paywall license format (eyJ vs rui_)

Per the task instructions, I verified against the actual verify code before editing rather than guessing:

- [`packages/core/src/license.ts`](packages/core/src/license.ts) `validateLicenseKey()` imports the public key with `jose.importSPKI(candidate, 'EdDSA')` and verifies with `jose.jwtVerify(licenseKey, key, { algorithms: ['EdDSA'], ... })` — a standard three-part JWT, not a `rui_*`-prefixed wrapper.
- [`packages/core/src/revforge-license.ts`](packages/core/src/revforge-license.ts) `issueRevForgeLicense()` (used for `REVFORGE_LICENSE_KEY`, the Fleet/Enterprise variable) calls the same `generateLicenseKey()` and documents the return value as "Signed EdDSA JWT — the license key the customer installs." No separate `rui_forge_...` wrapper format exists anywhere in the codebase.
- [`apps/server/src/routes/license.ts`](apps/server/src/routes/license.ts) `POST /api/license/verify` route description: "Validates a JWT license key."
- `docs/blog/05-five-primitives.md:280` already showed the correct format (`eyJhbGciOiJFZERTQSIs...`), so the four files fixed here were the outliers.

Conclusion: `rui_live_...` / `rui_forge_...` / `rui_perpetual_...` never existed in the framework. They were doc-only fiction. Normalized all four occurrences to the real JWT format; also corrected the adjacent "payload encodes" description in `PRO.md` (was listing `domain`/`issuedAt`/`expiresAt`, actual schema is `customerId`/`tier`/`perpetual`/optional `domains`/`maxSites`/`maxUsers` per `LicensePayload` in `packages/core/src/license.ts`).

## Per-item changes

1. **`apps/admin/src/app/(frontend)/account/license/page.tsx`** (copy only, no logic touched) — replaced "The RevDev daemon also needs the vendor public key to verify your license. Without it, a valid Pro license silently runs as Free." with "The RevDev daemon can also verify your license against the vendor public key." The existing note two paragraphs down ("Newer daemon builds bake this key in, so this step is only needed for older builds or after a key rotation") already correctly scopes this as optional/rotation-only — this file is on the guardrail-2 sensitive path (`license`) and needs a non-author verdict before merge.
2. **`docs/PRO.md`** — license key format block, JSON verify example, and the RevForge tier-parity sentence all normalized to the real JWT format.
3. **`docs/ENVIRONMENT-VARIABLES-GUIDE.md`** — `REVEALUI_LICENSE_KEY` format description corrected.
4. **`docs/FLEET.md`** — prerequisites bullet, `.env.forge` example, and the Fleet env var table entry all normalized.

## Test plan

- [x] `pnpm biome check` on the changed `.tsx` file — clean, no fixes needed.
- [x] `pnpm turbo run typecheck --filter=admin` — 16/17 tasks passed; `admin#typecheck` itself surfaced ~30 pre-existing `TS2307 Cannot find module '@revealui/ai/...'` / `'@revealui/services'` errors, none referencing the edited file. Confirmed root cause: `@revealui/ai` and `@revealui/services` are `peerDependenciesMeta.optional` in `apps/admin/package.json`, so turbo's `^build` graph for `--filter=admin` doesn't build them in a fresh worktree — unrelated to this change (a JSX text-string edit cannot cause module resolution failures elsewhere).
- [x] `git push` ran the full local CI gate (phase 1: biome, boundary, claim-drift, doc-currency, security gate, etc.) — all passed.
- [ ] Non-author verdict on the license page copy change (guardrail-2 sensitive path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)