### PR TITLE
fix(db): pool honors DATABASE_URL/POSTGRES_URL as connectionString

### DIFF
--- a/packages/db/src/__tests__/pool-connection-identity.test.ts
+++ b/packages/db/src/__tests__/pool-connection-identity.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression tests for the pool connection identity (GAP-349 fleet scan
+ * incident): with a URL set, the pool config must carry ONLY connectionString.
+ * Any discrete host/port field alongside it wins over the URL parts in pg and
+ * silently redirects the connection to localhost while SSL (derived from the
+ * URL) stays on, producing "The server does not support SSL connections"
+ * against the local dev Postgres.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getConnectionIdentity } from '../pool.js';
+
+const NEON_URL =
+  'postgresql://user:pw@ep-example-123.us-east-2.aws.neon.tech/neondb?sslmode=require';
+
+describe('getConnectionIdentity', () => {
+  it('uses connectionString alone when DATABASE_URL is set', () => {
+    const identity = getConnectionIdentity({ DATABASE_URL: NEON_URL });
+    expect(identity).toEqual({ connectionString: NEON_URL });
+    expect(Object.keys(identity)).toEqual(['connectionString']);
+  });
+
+  it('uses connectionString alone when only POSTGRES_URL is set', () => {
+    const identity = getConnectionIdentity({ POSTGRES_URL: NEON_URL });
+    expect(identity).toEqual({ connectionString: NEON_URL });
+  });
+
+  it('prefers DATABASE_URL over POSTGRES_URL', () => {
+    const identity = getConnectionIdentity({
+      DATABASE_URL: NEON_URL,
+      POSTGRES_URL: 'postgresql://other@other-host:5432/other',
+    });
+    expect(identity.connectionString).toBe(NEON_URL);
+  });
+
+  it('never mixes discrete host fields into URL mode, even when both are set', () => {
+    const identity = getConnectionIdentity({
+      DATABASE_URL: NEON_URL,
+      DATABASE_HOST: 'localhost',
+      DATABASE_PORT: '5432',
+    });
+    expect(identity.host).toBeUndefined();
+    expect(identity.port).toBeUndefined();
+    expect(identity.connectionString).toBe(NEON_URL);
+  });
+
+  it('falls back to discrete vars with localhost defaults when no URL is set', () => {
+    const identity = getConnectionIdentity({
+      DATABASE_NAME: 'revealui',
+      DATABASE_USER: 'postgres',
+    });
+    expect(identity.connectionString).toBeUndefined();
+    expect(identity.host).toBe('localhost');
+    expect(identity.port).toBe(5432);
+    expect(identity.database).toBe('revealui');
+    expect(identity.user).toBe('postgres');
+  });
+});

--- a/packages/db/src/pool.ts
+++ b/packages/db/src/pool.ts
@@ -44,13 +44,34 @@ function assertProductionConfig(): void {
   }
 }
 
+/**
+ * Connection identity: a URL (DATABASE_URL, then POSTGRES_URL) wins when
+ * present; discrete DATABASE_* vars are the fallback. The two forms must not
+ * be mixed in one config object: pg gives explicitly-set fields precedence
+ * over connectionString parts, so a `host: 'localhost'` default alongside a
+ * URL silently redirects the URL's host to localhost. That was the defect
+ * this replaced (the URL was consulted only for SSL while host/port stayed on
+ * the discrete defaults, and assertProductionConfig accepted a URL it then
+ * ignored).
+ */
+export function getConnectionIdentity(
+  env: NodeJS.ProcessEnv = process.env,
+): Pick<PoolConfig, 'connectionString' | 'host' | 'port' | 'database' | 'user' | 'password'> {
+  const url = env.DATABASE_URL || env.POSTGRES_URL;
+  if (url) {
+    return { connectionString: url };
+  }
+  return {
+    host: env.DATABASE_HOST || 'localhost',
+    port: parseInt(env.DATABASE_PORT || '5432', 10),
+    database: env.DATABASE_NAME,
+    user: env.DATABASE_USER,
+    password: env.DATABASE_PASSWORD,
+  };
+}
+
 const poolConfig: PoolConfig = {
-  // Connection details
-  host: process.env.DATABASE_HOST || 'localhost',
-  port: parseInt(process.env.DATABASE_PORT || '5432', 10),
-  database: process.env.DATABASE_NAME,
-  user: process.env.DATABASE_USER,
-  password: process.env.DATABASE_PASSWORD,
+  ...getConnectionIdentity(),
 
   // SSL configuration (auto-detected from connection string if available)
   ssl: getPoolSSLConfig(),


### PR DESCRIPTION
Part of GAP-349 (fleet knowledge graph).

## Defect

`packages/db/src/pool.ts` consulted `DATABASE_URL`/`POSTGRES_URL` only to derive the SSL setting, then connected with discrete `DATABASE_*` vars defaulting to `localhost:5432`. Any consumer configured by URL (the `revkg scan --fleet` first run, found live 2026-07-11) therefore dialed the local dev Postgres with SSL enabled and failed with "The server does not support SSL connections". `assertProductionConfig` also accepted a URL as valid production config and then ignored it.

## Fix

Connection identity is now a single choice: when a URL is present it is passed as `connectionString` alone, never mixed with discrete fields (pg gives explicitly-set fields precedence over connectionString parts, which is exactly how the localhost default was overriding the URL host). Discrete `DATABASE_*` vars remain the fallback, unchanged.

## Verification

- New `pool-connection-identity.test.ts`: 5 tests covering URL-only mode, POSTGRES_URL fallback, DATABASE_URL precedence, the no-mixing regression property, and the discrete-var fallback.
- Prove-red performed: with the old pool.ts restored, all 5 tests fail; green with the fix.
- `@revealui/db`: 1175 tests + 5 new pass, typecheck clean, Biome clean.

Reviewed-by: Fable (authored during the GAP-349 P1 incident triage).