### PR TITLE
feat(sync): staging Vercel manifest + secret-path lockstep (GAP-343 Phase 3)

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -79,6 +79,12 @@ These paths are the canonical source for the Vercel + Fly sync manifests
 CI secret mirrors. The table below is a DERIVED VIEW of the machine spec at
 `scripts/sync/secret-paths.ts` - do not hand-edit it (see the marker note).
 
+The `revealui/staging/*` rows below (GAP-343) are synced by a SEPARATE
+manifest, `scripts/sync/revvault-vercel-staging.toml`, deliberately never the
+prod one - see that file's header for the `git_branch` preview-scoping
+mechanics and `scripts/setup/gen-staging-secrets.ts` for the owner-run
+generator that fills the "fresh value" paths.
+
 <!-- BEGIN GENERATED:secret-paths -->
 
 _Machine-generated from [`scripts/sync/secret-paths.ts`](../scripts/sync/secret-paths.ts) by
@@ -87,7 +93,7 @@ _Machine-generated from [`scripts/sync/secret-paths.ts`](../scripts/sync/secret-
 spec, the Vercel/Fly sync manifests, or their sensitivity markers. Change `secret-paths.ts`
 and re-run the renderer._
 
-Production runtime paths synced to Vercel + Fly (60 paths). `sensitive` = the
+Production runtime paths synced to Vercel + Fly (108 paths). `sensitive` = the
 value is never UI/API-revealable after write (credentials + private signing keys).
 
 | Path | Kind | Sensitive | Consumers | Notes |
@@ -106,10 +112,10 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/db/postgres-url` | credential | yes | vercel:api, vercel:admin, fly:worker | required@boot; canonical Neon pooled url - feeds POSTGRES_URL + DATABASE_URL |
 | `revealui/prod/electric/secret` | credential | yes | vercel:api, vercel:admin, fly:worker | currently empty in the vault (GAP-230/231); the worker does not require it |
 | `revealui/prod/electric/service-url` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
-| `revealui/prod/email/from` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
-| `revealui/prod/email/reply-to` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
-| `revealui/prod/google/private-key` | credential | yes | vercel:api, vercel:admin, fly:worker | PKCS8 PEM - Gmail SA domain-wide delegation |
-| `revealui/prod/google/service-account-email` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
+| `revealui/prod/email/from` | public-config | no | vercel:api, vercel:admin, fly:worker, vercel:api-staging, vercel:admin-staging |  |
+| `revealui/prod/email/reply-to` | public-config | no | vercel:api, vercel:admin, fly:worker, vercel:api-staging, vercel:admin-staging |  |
+| `revealui/prod/google/private-key` | credential | yes | vercel:api, vercel:admin, fly:worker, vercel:api-staging, vercel:admin-staging | PKCS8 PEM - Gmail SA domain-wide delegation; also read by staging (GAP-343) |
+| `revealui/prod/google/service-account-email` | public-config | no | vercel:api, vercel:admin, fly:worker, vercel:api-staging, vercel:admin-staging |  |
 | `revealui/prod/kek` | credential | yes | vercel:api, vercel:admin, fly:worker | REVEALUI_KEK - AES-256-GCM envelope key; has a NEXT dual-slot rotation story |
 | `revealui/prod/marketplace-connect-return-url` | public-config | no | vercel:api, fly:worker |  |
 | `revealui/prod/passkey/origin` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
@@ -130,7 +136,7 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/sentry/org` | public-config | no | vercel:admin |  |
 | `revealui/prod/sentry/project-admin` | public-config | no | vercel:admin |  |
 | `revealui/prod/session-cookie-domain` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
-| `revealui/prod/stripe/agent-meter-event-name` | public-config | no | vercel:api, fly:worker |  |
+| `revealui/prod/stripe/agent-meter-event-name` | public-config | no | vercel:api, fly:worker, vercel:api-staging |  |
 | `revealui/prod/stripe/agent-overage-price-id` | price-id | no | vercel:api, fly:worker |  |
 | `revealui/prod/stripe/billing-portal-config-id` | public-config | no | vercel:api | canonical billing-portal config id (Vercel api) |
 | `revealui/prod/stripe/credits-scale-price-id` | price-id | no | vercel:api, fly:worker |  |
@@ -152,6 +158,54 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/stripe/secret-key` | credential | yes | vercel:api, vercel:admin | sk_live_* - set Fly-direct (mode-gated), not synced to the worker |
 | `revealui/prod/stripe/webhook-secret` | credential | yes | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/stripe/webhook-secret-live` | credential | yes | vercel:api, fly:worker |  |
+| `revealui/staging/admin/api-key` | credential | yes | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/admin/email` | public-config | no | vercel:admin-staging | owner sets by hand - fresh staging bootstrap admin user |
+| `revealui/staging/admin/password` | credential | yes | vercel:admin-staging | owner sets by hand - fresh staging bootstrap admin user |
+| `revealui/staging/alert-email` | public-config | no | vercel:api-staging | owner sets by hand - not derivable, not generated by gen-staging-secrets.ts |
+| `revealui/staging/audit-hmac-secret` | credential | yes | vercel:api-staging |  |
+| `revealui/staging/cors-origin` | public-config | no | vercel:api-staging |  |
+| `revealui/staging/cron-secret` | credential | yes | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/db/postgres-url` | credential | yes | vercel:api-staging, vercel:admin-staging | Phase 1 (owner-run empty Neon branch + full migrate) fills this |
+| `revealui/staging/kek` | credential | yes | vercel:api-staging, vercel:admin-staging | fresh staging value (scripts/setup/gen-staging-secrets.ts) |
+| `revealui/staging/license/private-key` | signing-private | yes | vercel:api-staging, vercel:admin-staging | fresh Ed25519 pair, isolated from revdev/license-signing-* (GAP-343 decision 1) |
+| `revealui/staging/license/public-key` | signing-public | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/passkey/origin` | public-config | no | vercel:api-staging, vercel:admin-staging | the admin app origin, https://admin.staging.revealui.com |
+| `revealui/staging/passkey/rp-id` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/passkey/rp-name` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/public/api-url` | public-config | no | vercel:admin-staging, vercel:marketing-staging | the api own origin; also VITE_API_URL on marketing (the anti-cross-wire fix, GAP-343) |
+| `revealui/staging/public/server-url` | public-config | no | vercel:api-staging, vercel:admin-staging, vercel:marketing-staging | the admin app own origin (parity with the prod server-url leaf) |
+| `revealui/staging/r2/access-key-id` | credential | yes | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/r2/account-id` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/r2/bucket` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/r2/public-base-url` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/r2/secret-access-key` | credential | yes | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/secret` | credential | yes | vercel:api-staging, vercel:admin-staging | must match across api + admin - CSRF tokens are cross-verified |
+| `revealui/staging/sentry/auth-token` | credential | yes | vercel:admin-staging |  |
+| `revealui/staging/sentry/dsn` | public-config | no | vercel:api-staging | separate staging Sentry project - prod error budget stays clean |
+| `revealui/staging/sentry/dsn-admin` | public-config | no | vercel:admin-staging |  |
+| `revealui/staging/sentry/org` | public-config | no | vercel:admin-staging |  |
+| `revealui/staging/sentry/project-admin` | public-config | no | vercel:admin-staging |  |
+| `revealui/staging/session-cookie-domain` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/agent-overage-price-id` | price-id | no | vercel:api-staging |  |
+| `revealui/staging/stripe/billing-portal-config-id` | public-config | no | vercel:api-staging |  |
+| `revealui/staging/stripe/credits-scale-price-id` | price-id | no | vercel:api-staging |  |
+| `revealui/staging/stripe/credits-standard-price-id` | price-id | no | vercel:api-staging |  |
+| `revealui/staging/stripe/credits-starter-price-id` | price-id | no | vercel:api-staging |  |
+| `revealui/staging/stripe/enterprise-annual-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/enterprise-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/max-annual-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/max-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/perpetual-enterprise-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/perpetual-max-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/perpetual-pro-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/pro-annual-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/pro-price-id` | price-id | no | vercel:api-staging, vercel:admin-staging |  |
+| `revealui/staging/stripe/publishable-key` | public-config | no | vercel:admin-staging | pk_test_* |
+| `revealui/staging/stripe/renewal-enterprise-price-id` | price-id | no | vercel:api-staging |  |
+| `revealui/staging/stripe/renewal-max-price-id` | price-id | no | vercel:api-staging |  |
+| `revealui/staging/stripe/renewal-pro-price-id` | price-id | no | vercel:api-staging |  |
+| `revealui/staging/stripe/secret-key` | credential | yes | vercel:api-staging, vercel:admin-staging | sk_test_* - isolated staging Stripe test account (Phase 2) |
+| `revealui/staging/stripe/webhook-secret` | credential | yes | vercel:api-staging, vercel:admin-staging |  |
 
 <!-- END GENERATED:secret-paths -->
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@electric-sql/pglite": "catalog:",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "catalog:",
+    "@revealui/core": "workspace:*",
     "@revealui/services": "workspace:*",
     "@size-limit/file": "^12.1.0",
     "@size-limit/webpack": "^12.1.0",
@@ -198,6 +199,7 @@
     "scripts": "tsx scripts/cli/scripts.ts",
     "secrets:scan": "tsx scripts/secrets/scan.ts",
     "setup:mcp": "tsx scripts/setup/setup-mcp.ts",
+    "setup:staging-secrets": "tsx scripts/setup/gen-staging-secrets.ts",
     "stripe:seed": "tsx scripts/setup/seed-stripe.ts",
     "stripe:catalog:check": "tsx scripts/setup/seed-stripe.ts --check",
     "studio:build": "cd apps/studio/src-tauri && cargo tauri build",
@@ -240,7 +242,9 @@
     "kek:rotate": "tsx scripts/security/rotate-kek.ts",
     "vercel:sync": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml",
     "vercel:sync:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply",
-    "vercel:drift-check": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --json"
+    "vercel:drift-check": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --json",
+    "vercel:sync:staging": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel-staging.toml",
+    "vercel:sync:staging:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel-staging.toml --apply"
   },
   "type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.61.1
+      '@revealui/core':
+        specifier: workspace:*
+        version: link:packages/core
       '@revealui/services':
         specifier: workspace:*
         version: link:packages/services

--- a/scripts/setup/__tests__/gen-staging-secrets.test.ts
+++ b/scripts/setup/__tests__/gen-staging-secrets.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildEntries,
+  describeShape,
+  generateVerifiedLicenseKeypair,
+  parseCliFlags,
+  runGenerator,
+  type SecretEntry,
+} from '../gen-staging-secrets.js';
+
+describe('parseCliFlags', () => {
+  it('defaults everything off with no args', () => {
+    expect(parseCliFlags([])).toEqual({ dryRun: false, force: false, help: false });
+  });
+
+  it('reads --dry-run, --force, --help independently', () => {
+    expect(parseCliFlags(['--dry-run'])).toEqual({ dryRun: true, force: false, help: false });
+    expect(parseCliFlags(['--force'])).toEqual({ dryRun: false, force: true, help: false });
+    expect(parseCliFlags(['--dry-run', '--force'])).toEqual({
+      dryRun: true,
+      force: true,
+      help: false,
+    });
+    expect(parseCliFlags(['-h'])).toEqual({ dryRun: false, force: false, help: true });
+  });
+});
+
+describe('describeShape', () => {
+  it('never echoes the value - only length/kind', () => {
+    const entry: SecretEntry = { path: 'x', shape: 'hex-64', value: 'a'.repeat(64) };
+    const shape = describeShape(entry);
+    expect(shape).not.toContain('a'.repeat(64));
+    expect(shape).toContain('64');
+  });
+
+  it('describes each shape kind distinctly', () => {
+    expect(describeShape({ shape: 'hex-64', value: 'f'.repeat(64) })).toBe(
+      '64 lowercase hex chars',
+    );
+    expect(describeShape({ shape: 'hex-random', value: 'f'.repeat(48) })).toBe(
+      '48 lowercase hex chars',
+    );
+    expect(describeShape({ shape: 'literal', value: 'staging.revealui.com' })).toBe(
+      'literal string, 20 chars',
+    );
+    expect(describeShape({ shape: 'pem-private-ed25519', value: 'line1\nline2\nline3' })).toBe(
+      'PKCS8 Ed25519 private key PEM (3 lines)',
+    );
+    expect(describeShape({ shape: 'pem-public-ed25519', value: 'line1\nline2\nline3' })).toBe(
+      'SPKI Ed25519 public key PEM (3 lines)',
+    );
+  });
+});
+
+describe('generateVerifiedLicenseKeypair', () => {
+  it('produces a PKCS8 private PEM + SPKI public PEM that self-verify', async () => {
+    const { privateKey, publicKey } = await generateVerifiedLicenseKeypair();
+    expect(privateKey).toContain('BEGIN PRIVATE KEY');
+    expect(publicKey).toContain('BEGIN PUBLIC KEY');
+  });
+
+  it('two calls produce two DIFFERENT keypairs (fresh each time)', async () => {
+    const first = await generateVerifiedLicenseKeypair();
+    const second = await generateVerifiedLicenseKeypair();
+    expect(first.privateKey).not.toBe(second.privateKey);
+    expect(first.publicKey).not.toBe(second.publicKey);
+  });
+});
+
+describe('buildEntries', () => {
+  it('includes the full generate-fresh bucket under revealui/staging/*, no duplicate paths', async () => {
+    const entries = await buildEntries();
+    const paths = entries.map((e) => e.path);
+    expect(new Set(paths).size).toBe(paths.length);
+    expect(paths.length).toBeGreaterThan(10);
+    for (const path of paths) {
+      expect(path.startsWith('revealui/staging/')).toBe(true);
+    }
+    expect(paths).toContain('revealui/staging/kek');
+    expect(paths).toContain('revealui/staging/secret');
+    expect(paths).toContain('revealui/staging/cron-secret');
+    expect(paths).toContain('revealui/staging/audit-hmac-secret');
+    expect(paths).toContain('revealui/staging/admin/api-key');
+    expect(paths).toContain('revealui/staging/license/private-key');
+    expect(paths).toContain('revealui/staging/license/public-key');
+    expect(paths).toContain('revealui/staging/session-cookie-domain');
+    expect(paths).toContain('revealui/staging/passkey/rp-id');
+    expect(paths).toContain('revealui/staging/passkey/origin');
+    expect(paths).toContain('revealui/staging/passkey/rp-name');
+    expect(paths).toContain('revealui/staging/cors-origin');
+    expect(paths).toContain('revealui/staging/public/server-url');
+    expect(paths).toContain('revealui/staging/public/api-url');
+  });
+
+  it('never includes the owner-set-by-hand paths (alert-email, admin email/password)', async () => {
+    const paths = (await buildEntries()).map((e) => e.path);
+    expect(paths).not.toContain('revealui/staging/alert-email');
+    expect(paths).not.toContain('revealui/staging/admin/email');
+    expect(paths).not.toContain('revealui/staging/admin/password');
+  });
+
+  it('REVEALUI_KEK-shaped value is exactly 64 hex chars (validate-startup.ts format)', async () => {
+    const kek = (await buildEntries()).find((e) => e.path === 'revealui/staging/kek');
+    expect(kek?.value).toHaveLength(64);
+    expect(kek?.value).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('the >=32-char secrets meet the validate-startup.ts minimum length', async () => {
+    const entries = await buildEntries();
+    for (const path of [
+      'revealui/staging/secret',
+      'revealui/staging/cron-secret',
+      'revealui/staging/audit-hmac-secret',
+    ]) {
+      const entry = entries.find((e) => e.path === path);
+      expect(entry?.value.length ?? 0, path).toBeGreaterThanOrEqual(32);
+    }
+  });
+
+  it('the deterministic URL values honor the amended-B staging.revealui.com subtree', async () => {
+    const entries = await buildEntries();
+    const byPath = new Map(entries.map((e) => [e.path, e.value]));
+    expect(byPath.get('revealui/staging/session-cookie-domain')).toBe('staging.revealui.com');
+    expect(byPath.get('revealui/staging/passkey/rp-id')).toBe('staging.revealui.com');
+    expect(byPath.get('revealui/staging/passkey/origin')).toBe(
+      'https://admin.staging.revealui.com',
+    );
+    // server-url == passkey/origin (both the admin app's own origin) per the
+    // fleet convention this script's header documents.
+    expect(byPath.get('revealui/staging/public/server-url')).toBe(
+      byPath.get('revealui/staging/passkey/origin'),
+    );
+    expect(byPath.get('revealui/staging/public/api-url')).toBe('https://api.staging.revealui.com');
+    expect(byPath.get('revealui/staging/cors-origin')).toBe(
+      'https://staging.revealui.com,https://admin.staging.revealui.com',
+    );
+  });
+});
+
+describe('runGenerator', () => {
+  const entries: SecretEntry[] = [
+    { path: 'revealui/staging/a', shape: 'hex-random', value: 'secretvalue-a' },
+    { path: 'revealui/staging/b', shape: 'literal', value: 'secretvalue-b' },
+  ];
+
+  it('dry-run makes zero calls to exists/write and never logs a value', () => {
+    const exists = vi.fn(() => true);
+    const write = vi.fn();
+    const lines: string[] = [];
+    const result = runGenerator(entries, {
+      dryRun: true,
+      force: false,
+      exists,
+      write,
+      log: (line) => lines.push(line),
+    });
+    expect(exists).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+    expect(result.written).toEqual(['revealui/staging/a', 'revealui/staging/b']);
+    for (const line of lines) {
+      expect(line).not.toContain('secretvalue-a');
+      expect(line).not.toContain('secretvalue-b');
+    }
+  });
+
+  it('skips an existing path without --force, writes it with --force', () => {
+    const exists = vi.fn(() => true);
+    const write = vi.fn();
+    const skipped = runGenerator(entries, {
+      dryRun: false,
+      force: false,
+      exists,
+      write,
+      log: () => {},
+    });
+    expect(skipped.skipped).toEqual(['revealui/staging/a', 'revealui/staging/b']);
+    expect(write).not.toHaveBeenCalled();
+
+    const forced = runGenerator(entries, {
+      dryRun: false,
+      force: true,
+      exists,
+      write,
+      log: () => {},
+    });
+    expect(forced.written).toEqual(['revealui/staging/a', 'revealui/staging/b']);
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(write).toHaveBeenCalledWith('revealui/staging/a', 'secretvalue-a');
+  });
+
+  it('writes a fresh (non-existing) path without needing --force', () => {
+    const exists = vi.fn(() => false);
+    const write = vi.fn();
+    const result = runGenerator(entries, {
+      dryRun: false,
+      force: false,
+      exists,
+      write,
+      log: () => {},
+    });
+    expect(result.written).toEqual(['revealui/staging/a', 'revealui/staging/b']);
+    expect(write).toHaveBeenCalledTimes(2);
+  });
+
+  it('collects a per-path write failure instead of throwing', () => {
+    const exists = vi.fn(() => false);
+    const write = vi.fn(() => {
+      throw new Error('revvault set failed');
+    });
+    const result = runGenerator(entries, {
+      dryRun: false,
+      force: false,
+      exists,
+      write,
+      log: () => {},
+    });
+    expect(result.failed).toEqual(['revealui/staging/a', 'revealui/staging/b']);
+    expect(result.written).toEqual([]);
+  });
+});

--- a/scripts/setup/gen-staging-secrets.ts
+++ b/scripts/setup/gen-staging-secrets.ts
@@ -1,0 +1,309 @@
+#!/usr/bin/env tsx
+/**
+ * Owner-run generator for the staging environment's "generate fresh" secret
+ * bucket (GAP-343 Phase 3, docs/lanes/staging-environment/plan.md). Writes
+ * directly to revvault under revealui/staging/* - the manifest
+ * (scripts/sync/revvault-vercel-staging.toml) then syncs these vault values
+ * into Vercel via `pnpm vercel:sync:staging:apply`.
+ *
+ * What this writes:
+ *   - A fresh Ed25519 license-signing keypair, self-verified at generation
+ *     time (sign + verify a throwaway token) before being queued for write.
+ *     Staging runs no worker, so the usual boot-time canary
+ *     (apps/server/src/lib/license-canary.ts, wired from worker.ts) never
+ *     runs here - this script is the only check this keypair ever gets.
+ *   - REVEALUI_KEK, REVEALUI_SECRET, REVEALUI_CRON_SECRET,
+ *     REVEALUI_AUDIT_HMAC_SECRET, REVEALUI_ADMIN_API_KEY - fresh random values,
+ *     format-compatible with apps/server/src/lib/validate-startup.ts's checks
+ *     (REVEALUI_KEK: 64 hex chars; the rest: >=32 chars).
+ *   - The deterministic staging URL config derived from the amended-B
+ *     staging.revealui.com subtree (SESSION_COOKIE_DOMAIN, PASSKEY_RP_ID,
+ *     PASSKEY_ORIGIN, PASSKEY_RP_NAME, CORS_ORIGIN, and the two "server url"
+ *     concepts the fleet already tracks as separate vault leaves: the admin
+ *     app's own origin and the api's own origin).
+ *
+ * What this deliberately does NOT write (owner sets these by hand, they are
+ * not derivable): revealui/staging/alert-email (an inbox, not a secret) and
+ * the admin bootstrap REVEALUI_ADMIN_EMAIL / REVEALUI_ADMIN_PASSWORD pair.
+ * Stripe test-mode credentials come from Phase 2 (`pnpm stripe:seed`), and
+ * POSTGRES_URL from Phase 1 (the owner-run empty Neon branch) - neither is
+ * generated here.
+ *
+ * Safety:
+ *   - `--dry-run` runs the full generation + self-verification path (so a
+ *     bug in keygen still surfaces) but makes NO revvault calls at all - not
+ *     even a read. It prints each path with a value SHAPE (length + kind),
+ *     never the value.
+ *   - Without `--dry-run`, each path is checked against the live vault first;
+ *     an existing value is left untouched (skipped) unless `--force` is
+ *     passed. There is no bulk "wipe and regenerate."
+ *   - A secret value is NEVER printed or logged, in any mode. Failures print
+ *     the vault PATH and the error message only.
+ *
+ * This script is authored, not run, by the session that wrote it - GAP-343
+ * Phase 3 explicitly excludes running it against the real vault from that
+ * session's scope. The owner runs it as part of the before-Phase-4 sequence:
+ * gen-staging-secrets -> Phase 1 (Neon) -> Phase 2 (Stripe seed) ->
+ * `vercel:sync:staging:apply`.
+ *
+ * Usage:
+ *   pnpm tsx scripts/setup/gen-staging-secrets.ts --dry-run
+ *   pnpm tsx scripts/setup/gen-staging-secrets.ts
+ *   pnpm tsx scripts/setup/gen-staging-secrets.ts --force
+ *
+ * No regex (M2): every check here is string-method / Set-based.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { generateKeyPairSync, randomBytes } from 'node:crypto';
+import { selfVerifyLicenseKeypair } from '@revealui/core/license';
+
+// ─── The staging.revealui.com subtree (lane plan §The URL decision) ──────────
+const STAGING_ROOT_DOMAIN = 'staging.revealui.com';
+const STAGING_ADMIN_ORIGIN = 'https://admin.staging.revealui.com';
+const STAGING_API_ORIGIN = 'https://api.staging.revealui.com';
+
+export type SecretShape =
+  | 'hex-64' // REVEALUI_KEK - exactly 64 hex chars
+  | 'hex-random' // >=32-char random secret (cron/audit/admin-api-key/session)
+  | 'pem-private-ed25519'
+  | 'pem-public-ed25519'
+  | 'literal'; // deterministic public config, not secret
+
+export interface SecretEntry {
+  /** Canonical revvault path this value is written to. */
+  path: string;
+  shape: SecretShape;
+  /** The actual value - NEVER printed; only `describeShape` output is. */
+  value: string;
+}
+
+function randomHex(byteLength: number): string {
+  return randomBytes(byteLength).toString('hex');
+}
+
+/** Describe a value's SHAPE only - length + kind, never the content. */
+export function describeShape(entry: Pick<SecretEntry, 'shape' | 'value'>): string {
+  switch (entry.shape) {
+    case 'hex-64':
+    case 'hex-random':
+      return `${entry.value.length} lowercase hex chars`;
+    case 'pem-private-ed25519':
+      return `PKCS8 Ed25519 private key PEM (${entry.value.split('\n').length} lines)`;
+    case 'pem-public-ed25519':
+      return `SPKI Ed25519 public key PEM (${entry.value.split('\n').length} lines)`;
+    case 'literal':
+      return `literal string, ${entry.value.length} chars`;
+  }
+}
+
+/**
+ * Generate the fresh Ed25519 license keypair and self-verify it BEFORE
+ * returning it - a keypair that fails its own canary is a generation bug,
+ * never queued for write. Mirrors the sign/verify path
+ * apps/server/src/lib/license-canary.ts runs at hosted boot (which staging,
+ * running no worker, never exercises).
+ */
+export async function generateVerifiedLicenseKeypair(): Promise<{
+  privateKey: string;
+  publicKey: string;
+}> {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  });
+  const canary = await selfVerifyLicenseKeypair(privateKey, [publicKey]);
+  if (canary.status !== 'ok') {
+    const reason = 'reason' in canary ? canary.reason : undefined;
+    throw new Error(
+      `freshly generated staging license keypair failed self-verification ` +
+        `(status=${canary.status}${reason ? `, reason=${reason}` : ''}). ` +
+        'This is a generation bug, not a real-world risk - refusing to queue it for write.',
+    );
+  }
+  return { privateKey, publicKey };
+}
+
+/** The full "generate fresh" bucket, in write order. Pure aside from keygen. */
+export async function buildEntries(): Promise<SecretEntry[]> {
+  const entries: SecretEntry[] = [
+    { path: 'revealui/staging/kek', shape: 'hex-64', value: randomHex(32) },
+    { path: 'revealui/staging/secret', shape: 'hex-random', value: randomHex(32) },
+    { path: 'revealui/staging/cron-secret', shape: 'hex-random', value: randomHex(32) },
+    { path: 'revealui/staging/audit-hmac-secret', shape: 'hex-random', value: randomHex(32) },
+    { path: 'revealui/staging/admin/api-key', shape: 'hex-random', value: randomHex(32) },
+  ];
+
+  const { privateKey, publicKey } = await generateVerifiedLicenseKeypair();
+  entries.push(
+    {
+      path: 'revealui/staging/license/private-key',
+      shape: 'pem-private-ed25519',
+      value: privateKey,
+    },
+    { path: 'revealui/staging/license/public-key', shape: 'pem-public-ed25519', value: publicKey },
+  );
+
+  entries.push(
+    {
+      path: 'revealui/staging/session-cookie-domain',
+      shape: 'literal',
+      value: STAGING_ROOT_DOMAIN,
+    },
+    { path: 'revealui/staging/passkey/rp-id', shape: 'literal', value: STAGING_ROOT_DOMAIN },
+    { path: 'revealui/staging/passkey/origin', shape: 'literal', value: STAGING_ADMIN_ORIGIN },
+    { path: 'revealui/staging/passkey/rp-name', shape: 'literal', value: 'RevealUI Staging' },
+    {
+      path: 'revealui/staging/cors-origin',
+      shape: 'literal',
+      value: `https://${STAGING_ROOT_DOMAIN},${STAGING_ADMIN_ORIGIN}`,
+    },
+    // Fleet convention (mirrors revealui/prod/public/server-url): the "server
+    // url" leaf is the ADMIN app's own origin, consumed by apps/admin (self-
+    // referential) and apps/server (license domain binding, ADMIN_URL links
+    // in billing emails). The api's own origin is the separate "api-url" leaf.
+    { path: 'revealui/staging/public/server-url', shape: 'literal', value: STAGING_ADMIN_ORIGIN },
+    { path: 'revealui/staging/public/api-url', shape: 'literal', value: STAGING_API_ORIGIN },
+  );
+
+  return entries;
+}
+
+// ─── Injectable vault I/O (tests supply fakes; never touch real revvault) ────
+
+export type VaultExists = (path: string) => boolean;
+export type VaultWrite = (path: string, value: string) => void;
+
+const defaultVaultExists: VaultExists = (path) => {
+  const result = spawnSync('revvault', ['get', path], { encoding: 'utf-8', timeout: 10_000 });
+  return result.status === 0;
+};
+
+/** Pipes `value` into `revvault set --force <path>` via stdin (never argv). */
+const defaultVaultWrite: VaultWrite = (path, value) => {
+  execFileSync('revvault', ['set', '--force', path], { input: value, encoding: 'utf-8' });
+};
+
+export interface RunOptions {
+  dryRun: boolean;
+  force: boolean;
+  exists?: VaultExists;
+  write?: VaultWrite;
+  log?: (line: string) => void;
+}
+
+export interface RunResult {
+  written: string[];
+  skipped: string[];
+  failed: string[];
+}
+
+/**
+ * Write every entry, guarded by the existing-value check unless `--force`.
+ * `--dry-run` makes no vault calls at all (not even `exists`) - it only
+ * reports the shape of what WOULD be written.
+ */
+export function runGenerator(entries: readonly SecretEntry[], options: RunOptions): RunResult {
+  const { dryRun, force, exists = defaultVaultExists, write = defaultVaultWrite } = options;
+  const log = options.log ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const result: RunResult = { written: [], skipped: [], failed: [] };
+
+  for (const entry of entries) {
+    const shape = describeShape(entry);
+    if (dryRun) {
+      log(`  [dry-run] ${entry.path} -> ${shape}`);
+      result.written.push(entry.path);
+      continue;
+    }
+    if (!force && exists(entry.path)) {
+      log(`  SKIP ${entry.path} (already set in revvault; pass --force to overwrite)`);
+      result.skipped.push(entry.path);
+      continue;
+    }
+    try {
+      write(entry.path, entry.value);
+      log(`  wrote ${entry.path} (${shape})`);
+      result.written.push(entry.path);
+    } catch (err) {
+      log(`  FAILED ${entry.path}: ${err instanceof Error ? err.message : String(err)}`);
+      result.failed.push(entry.path);
+    }
+  }
+
+  return result;
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+
+interface CliFlags {
+  dryRun: boolean;
+  force: boolean;
+  help: boolean;
+}
+
+export function parseCliFlags(argv: readonly string[]): CliFlags {
+  const set = new Set(argv);
+  return {
+    dryRun: set.has('--dry-run'),
+    force: set.has('--force'),
+    help: set.has('--help') || set.has('-h'),
+  };
+}
+
+function printUsage(): void {
+  process.stdout.write(`Usage: tsx scripts/setup/gen-staging-secrets.ts [--dry-run] [--force]
+
+  --dry-run   Generate + self-verify everything, print vault paths and value
+              SHAPES only. Makes no revvault calls (not even a read).
+  --force     Overwrite a path that already has a value in revvault. Without
+              it, an existing value is left untouched (skipped).
+  -h, --help  Show this help.
+`);
+}
+
+async function main(): Promise<void> {
+  const flags = parseCliFlags(process.argv.slice(2));
+  if (flags.help) {
+    printUsage();
+    return;
+  }
+
+  const entries = await buildEntries();
+
+  process.stdout.write('── gen-staging-secrets (GAP-343 Phase 3) ──\n');
+  process.stdout.write(
+    `${entries.length} paths to ${flags.dryRun ? 'simulate' : 'write'}${flags.force ? ' (--force)' : ''}\n\n`,
+  );
+
+  const result = runGenerator(entries, { dryRun: flags.dryRun, force: flags.force });
+
+  process.stdout.write('\n');
+  if (flags.dryRun) {
+    process.stdout.write(
+      `dry-run complete - ${result.written.length} paths simulated, nothing written.\n`,
+    );
+    return;
+  }
+  process.stdout.write(
+    `${result.written.length} written, ${result.skipped.length} skipped, ${result.failed.length} failed.\n`,
+  );
+  if (result.failed.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    return import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/sync/__tests__/secret-paths-lockstep.test.ts
+++ b/scripts/sync/__tests__/secret-paths-lockstep.test.ts
@@ -41,10 +41,15 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const VERCEL_MANIFEST = resolve(HERE, '../revvault-vercel.toml');
 const FLY_MANIFEST = resolve(HERE, '../revvault-fly.toml');
+const STAGING_MANIFEST = resolve(HERE, '../revvault-vercel-staging.toml');
 
 const vercelVars = collectVars(readFileSync(VERCEL_MANIFEST, 'utf8'), 'projects', 'vercel');
 const flyVars = collectVars(readFileSync(FLY_MANIFEST, 'utf8'), 'fly-apps', 'fly');
-const allManifestPaths = [...vercelVars, ...flyVars].map((v) => v.path);
+// The staging manifest (GAP-343 Phase 3) is a SEPARATE file from the prod
+// Vercel manifest by design, but must get the same declared/synced/
+// sensitivity/kebab lockstep coverage - fed into the same predicates below.
+const stagingVars = collectVars(readFileSync(STAGING_MANIFEST, 'utf8'), 'projects', 'vercel');
+const allManifestPaths = [...vercelVars, ...flyVars, ...stagingVars].map((v) => v.path);
 const secretsMd = readFileSync(SECRETS_MD_PATH, 'utf8');
 const docPaths = extractGeneratedPaths(secretsMd);
 
@@ -68,6 +73,10 @@ describe('manifest ↔ spec lockstep', () => {
     expect(flyVars.length).toBeGreaterThan(20);
   });
 
+  it('parses the staging manifest to a non-trivial var set (GAP-343)', () => {
+    expect(stagingVars.length).toBeGreaterThan(40);
+  });
+
   it('no undeclared manifest path and every synced spec path is explicitly listed', () => {
     expect(findManifestDrift(allManifestPaths)).toEqual([]);
   });
@@ -80,11 +89,49 @@ describe('manifest ↔ spec lockstep', () => {
     expect(findSensitivityGaps(vercelVars)).toEqual([]);
   });
 
+  it('sensitivity-completeness holds for the staging manifest too (GAP-343)', () => {
+    expect(findSensitivityGaps(stagingVars)).toEqual([]);
+  });
+
   it('the license private key is sensitive and the public key is bare in the Vercel manifest', () => {
     const priv = vercelVars.find((v) => v.name === 'REVEALUI_LICENSE_PRIVATE_KEY');
     const pub = vercelVars.find((v) => v.name === 'REVEALUI_LICENSE_PUBLIC_KEY');
     expect(priv?.sensitive).toBe(true);
     expect(pub?.sensitive).toBe(false);
+  });
+
+  it('the staging license private key is sensitive and the public key is bare', () => {
+    const priv = stagingVars.find((v) => v.name === 'REVEALUI_LICENSE_PRIVATE_KEY');
+    const pub = stagingVars.find((v) => v.name === 'REVEALUI_LICENSE_PUBLIC_KEY');
+    expect(priv?.sensitive).toBe(true);
+    expect(pub?.sensitive).toBe(false);
+  });
+
+  it('the staging license keypair path is isolated from the prod revdev/* pair', () => {
+    const priv = stagingVars.find((v) => v.name === 'REVEALUI_LICENSE_PRIVATE_KEY');
+    const pub = stagingVars.find((v) => v.name === 'REVEALUI_LICENSE_PUBLIC_KEY');
+    expect(priv?.path).toBe('revealui/staging/license/private-key');
+    expect(pub?.path).toBe('revealui/staging/license/public-key');
+  });
+
+  // GAP-343: the staging manifest reuses exactly five prod paths on purpose
+  // (Gmail SA transport + one Stripe meter-event name - see the manifest
+  // header + the consumers additions on those prod SECRET_PATHS entries).
+  // Any OTHER revealui/prod/* reference in the staging manifest is an
+  // accidental leak, not a deliberate reuse - this is the machine-checked
+  // form of the PR's "grep the diff for revealui/prod/ paths" instruction.
+  it('the staging manifest references revealui/prod/* only for the documented reuse set', () => {
+    const allowedProdReuse: ReadonlySet<string> = new Set([
+      'revealui/prod/stripe/agent-meter-event-name',
+      'revealui/prod/google/service-account-email',
+      'revealui/prod/google/private-key',
+      'revealui/prod/email/from',
+      'revealui/prod/email/reply-to',
+    ]);
+    const unexpectedProdPaths = stagingVars
+      .map((v) => v.path)
+      .filter((path) => path.startsWith('revealui/prod/') && !allowedProdReuse.has(path));
+    expect(unexpectedProdPaths).toEqual([]);
   });
 });
 

--- a/scripts/sync/revvault-vercel-staging.toml
+++ b/scripts/sync/revvault-vercel-staging.toml
@@ -1,0 +1,263 @@
+# revvault → Vercel STAGING sync manifest (GAP-343 Phase 3)
+#
+# Drives `revvault sync vercel --manifest scripts/sync/revvault-vercel-staging.toml
+# [--apply]` — a SEPARATE manifest from revvault-vercel.toml, deliberately, so a
+# routine `pnpm vercel:sync:apply` (prod) can never touch staging, and
+# `pnpm vercel:sync:staging:apply` can never touch production. Same schema as
+# the prod manifest (see its header docblock for the full field reference);
+# this header only documents what is DIFFERENT here.
+#
+# Requires revvault >= the build that ships `git_branch` support (revvault#127
+# / GAP-346, landed on revvault `test`, NOT `main` as of this writing — the
+# owner's installed revvault binary must be built from `test` before running
+# this manifest). Older binaries reject the `git_branch` key at parse time.
+#
+# git_branch semantics (see revvault crates/core/src/sync/vercel.rs):
+#   - Every var in every block below is created with `targets = ["preview"]`
+#     and `git_branch = "staging"`, so it is exposed ONLY to the `staging`
+#     branch's preview deployments, not every branch's previews. Vercel
+#     rejects `git_branch` unless `targets` includes `"preview"` — revvault
+#     enforces this client-side and fails loudly rather than a bare Vercel 400.
+#   - `git_branch` is applied on CREATE only. Update (PATCH) sends `value` only
+#     and Vercel preserves the existing row's `gitBranch` as-is. If a `preview`
+#     row for one of these keys already exists on the project (e.g. from an
+#     earlier ad-hoc `deploy-test.yml` dispatch) with no branch scope, the
+#     first sync will PATCH its value but leave it branch-UNSCOPED — visible to
+#     every branch's previews. Delete any pre-existing unscoped preview row for
+#     these keys before the first `--apply`, or `git_branch` never takes effect
+#     for it.
+#
+# Three project blocks, one per app that gets a staging.revealui.com subtree
+# host (docs is excluded — not deployed to staging, see the lane plan Phase 4).
+# Same Vercel project IDs as the prod manifest (same projects, different env
+# target + branch scope) — vault_prefix is staging-namespaced so an unmatched
+# var falls back under revealui/staging/vercel/<app>/<VAR_NAME> rather than
+# ever defaulting into a revealui/prod/* fallback path.
+#
+# Var buckets (full rationale: .jv docs/lanes/staging-environment/plan.md
+# §Phase 3 bucket table):
+#   - Vaulted fresh under revealui/staging/*        — new staging-only values
+#   - Vaulted but reusing the SAME prod path         — explicitly marked below
+#     ("reuse prod" comment); low-risk shared config (transactional email
+#     transport, one Stripe meter-event name), not per-environment secrets.
+#   - Dropped entirely (not in this file)            — STRIPE_LIVE_MODE,
+#     STRIPE_WEBHOOK_SECRET_LIVE (handler falls back to STRIPE_WEBHOOK_SECRET;
+#     unset flag + livemode:false test events pass the gate), NEON_API_KEY,
+#     MARKETPLACE_CONNECT_RETURN_URL, NEXT_PUBLIC_IS_LIVE (true orphan,
+#     GAP-345), ELECTRIC_* (no walked UI consumes shapes on staging).
+
+# ── revealui-api-staging ────────────────────────────────────────────────────
+[projects.revealui-api-staging]
+project_id = "prj_zk6EQijYXwd9L7BccuBssi436ktM"
+vault_prefix = "revealui/staging/api"
+targets = ["preview"]
+git_branch = "staging"
+skip = [
+  "NODE_ENV",
+  # Deliberately never synced: staying unset keeps Stripe in test mode and
+  # the webhook handler on the STRIPE_WEBHOOK_SECRET fallback (see header).
+  "STRIPE_LIVE_MODE",
+]
+
+[projects.revealui-api-staging.vars]
+# Stripe — keys + secrets. Phase 3 declares the paths; Phase 2 (owner-run
+# `stripe:seed` against the isolated staging Stripe test account) fills them.
+STRIPE_SECRET_KEY     = { path = "revealui/staging/stripe/secret-key", sensitive = true }
+STRIPE_WEBHOOK_SECRET = { path = "revealui/staging/stripe/webhook-secret", sensitive = true }
+# reuse prod: Vercel-side Stripe meter event name is not secret and identical
+# across environments; no reason to fork it.
+STRIPE_AGENT_METER_EVENT_NAME = "revealui/prod/stripe/agent-meter-event-name"
+
+# Stripe — price ids (literal, low-secrecy; Phase 2 fills after test-mode catalog seed)
+STRIPE_PRO_PRICE_ID                  = "revealui/staging/stripe/pro-price-id"
+STRIPE_MAX_PRICE_ID                  = "revealui/staging/stripe/max-price-id"
+STRIPE_ENTERPRISE_PRICE_ID           = "revealui/staging/stripe/enterprise-price-id"
+STRIPE_PERPETUAL_PRO_PRICE_ID        = "revealui/staging/stripe/perpetual-pro-price-id"
+STRIPE_PERPETUAL_MAX_PRICE_ID        = "revealui/staging/stripe/perpetual-max-price-id"
+STRIPE_PERPETUAL_ENTERPRISE_PRICE_ID = "revealui/staging/stripe/perpetual-enterprise-price-id"
+STRIPE_RENEWAL_PRO_PRICE_ID          = "revealui/staging/stripe/renewal-pro-price-id"
+STRIPE_RENEWAL_MAX_PRICE_ID          = "revealui/staging/stripe/renewal-max-price-id"
+STRIPE_RENEWAL_ENTERPRISE_PRICE_ID   = "revealui/staging/stripe/renewal-enterprise-price-id"
+STRIPE_CREDITS_STARTER_PRICE_ID      = "revealui/staging/stripe/credits-starter-price-id"
+STRIPE_CREDITS_STANDARD_PRICE_ID     = "revealui/staging/stripe/credits-standard-price-id"
+STRIPE_CREDITS_SCALE_PRICE_ID        = "revealui/staging/stripe/credits-scale-price-id"
+STRIPE_AGENT_OVERAGE_PRICE_ID        = "revealui/staging/stripe/agent-overage-price-id"
+STRIPE_PRO_ANNUAL_PRICE_ID           = "revealui/staging/stripe/pro-annual-price-id"
+STRIPE_MAX_ANNUAL_PRICE_ID           = "revealui/staging/stripe/max-annual-price-id"
+STRIPE_ENTERPRISE_ANNUAL_PRICE_ID    = "revealui/staging/stripe/enterprise-annual-price-id"
+
+# Observability — Sentry. Separate STAGING Sentry project (not prod's DSN) so
+# staging errors never pollute the prod error budget.
+SENTRY_DSN = "revealui/staging/sentry/dsn"
+
+# Admin API key (parity with admin) — fresh staging value
+REVEALUI_ADMIN_API_KEY = { path = "revealui/staging/admin/api-key", sensitive = true }
+
+# Database — Phase 1 (owner-run, empty Neon branch + full migrate) fills this
+POSTGRES_URL = { path = "revealui/staging/db/postgres-url", sensitive = true }
+DATABASE_URL = { path = "revealui/staging/db/postgres-url", sensitive = true }
+
+# Encryption + signing — all FRESH staging values (gen-staging-secrets.ts fills)
+REVEALUI_KEK                = { path = "revealui/staging/kek", sensitive = true }
+# Fresh staging Ed25519 pair — deliberately NOT the prod revdev/license-signing-*
+# pair (isolation: a staging-minted license JWT must never verify against prod).
+REVEALUI_LICENSE_PRIVATE_KEY = { path = "revealui/staging/license/private-key", sensitive = true }
+REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/staging/license/public-key"
+REVEALUI_AUDIT_HMAC_SECRET   = { path = "revealui/staging/audit-hmac-secret", sensitive = true }
+# Must resolve to the SAME path as admin's REVEALUI_SECRET below — CSRF tokens
+# are cross-verified between the two apps.
+REVEALUI_SECRET              = { path = "revealui/staging/secret", sensitive = true }
+
+# Cron + alerting
+REVEALUI_CRON_SECRET = { path = "revealui/staging/cron-secret", sensitive = true }
+REVEALUI_ALERT_EMAIL = "revealui/staging/alert-email"
+
+# Storage — Cloudflare R2. Staging-scoped bucket + token, not the prod bucket
+# (prod is a write-capable credential; the 9-path walk never uploads, but a
+# staging-scoped bucket costs nothing and removes the shared-blast-radius risk).
+R2_ACCOUNT_ID         = "revealui/staging/r2/account-id"
+R2_ACCESS_KEY_ID      = { path = "revealui/staging/r2/access-key-id", sensitive = true }
+R2_SECRET_ACCESS_KEY  = { path = "revealui/staging/r2/secret-access-key", sensitive = true }
+R2_BUCKET             = "revealui/staging/r2/bucket"
+R2_PUBLIC_BASE_URL    = "revealui/staging/r2/public-base-url"
+
+# Email transport (Gmail SA) — reuse prod: real verification/receipt/license
+# mail must land in a real inbox for the walk; forking transport credentials
+# buys no isolation the walk needs.
+GOOGLE_SERVICE_ACCOUNT_EMAIL = "revealui/prod/google/service-account-email"
+GOOGLE_PRIVATE_KEY            = { path = "revealui/prod/google/private-key", sensitive = true }
+EMAIL_FROM                    = "revealui/prod/email/from"
+EMAIL_REPLY_TO                = "revealui/prod/email/reply-to"
+
+# Auth + session — staging.revealui.com subtree (gen-staging-secrets.ts fills
+# with the deterministic values; see the lane plan §The URL decision)
+PASSKEY_ORIGIN         = "revealui/staging/passkey/origin"
+PASSKEY_RP_ID          = "revealui/staging/passkey/rp-id"
+PASSKEY_RP_NAME        = "revealui/staging/passkey/rp-name"
+SESSION_COOKIE_DOMAIN  = "revealui/staging/session-cookie-domain"
+CORS_ORIGIN            = "revealui/staging/cors-origin"
+
+# Billing (Stripe customer-portal config id) — Phase 2 fills after the
+# test-mode billing portal config is created
+REVEALUI_BILLING_PORTAL_CONFIG_ID = "revealui/staging/stripe/billing-portal-config-id"
+
+# Public (bundled into client; not secret, kept canonical for reproducibility).
+# server-url == the admin app's own origin (https://admin.staging.revealui.com);
+# see apps/admin/src/proxy.ts + apps/server validate-startup license domain
+# binding, both of which treat NEXT_PUBLIC_SERVER_URL as the admin origin.
+NEXT_PUBLIC_SERVER_URL     = "revealui/staging/public/server-url"
+REVEALUI_PUBLIC_SERVER_URL = "revealui/staging/public/server-url"
+
+
+# ── revealui-admin-staging ──────────────────────────────────────────────────
+[projects.revealui-admin-staging]
+project_id = "prj_7sEFDg4MH6C26nJPjrukK86QdwfG"
+vault_prefix = "revealui/staging/admin"
+targets = ["preview"]
+git_branch = "staging"
+skip = [
+  "NODE_ENV",
+  "NEXT_TELEMETRY_DISABLED",
+]
+
+[projects.revealui-admin-staging.vars]
+# Stripe — keys (parity with api; same staging paths as the api block above)
+STRIPE_SECRET_KEY     = { path = "revealui/staging/stripe/secret-key", sensitive = true }
+STRIPE_WEBHOOK_SECRET = { path = "revealui/staging/stripe/webhook-secret", sensitive = true }
+
+# Stripe — publishable key (admin-side client SDK)
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "revealui/staging/stripe/publishable-key"
+
+# Stripe — price IDs (parity twins; same staging canonical paths as api)
+NEXT_PUBLIC_STRIPE_PRO_PRICE_ID        = "revealui/staging/stripe/pro-price-id"
+NEXT_PUBLIC_STRIPE_MAX_PRICE_ID        = "revealui/staging/stripe/max-price-id"
+NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID = "revealui/staging/stripe/enterprise-price-id"
+NEXT_PUBLIC_STRIPE_PRO_ANNUAL_PRICE_ID        = "revealui/staging/stripe/pro-annual-price-id"
+NEXT_PUBLIC_STRIPE_MAX_ANNUAL_PRICE_ID        = "revealui/staging/stripe/max-annual-price-id"
+NEXT_PUBLIC_STRIPE_ENTERPRISE_ANNUAL_PRICE_ID = "revealui/staging/stripe/enterprise-annual-price-id"
+NEXT_PUBLIC_STRIPE_PRO_PERPETUAL_PRICE_ID        = "revealui/staging/stripe/perpetual-pro-price-id"
+NEXT_PUBLIC_STRIPE_MAX_PERPETUAL_PRICE_ID        = "revealui/staging/stripe/perpetual-max-price-id"
+NEXT_PUBLIC_STRIPE_ENTERPRISE_PERPETUAL_PRICE_ID = "revealui/staging/stripe/perpetual-enterprise-price-id"
+# Bare versions on admin (server-side reads in Next.js api routes; same values)
+STRIPE_MAX_PRICE_ID        = "revealui/staging/stripe/max-price-id"
+STRIPE_PRO_ANNUAL_PRICE_ID        = "revealui/staging/stripe/pro-annual-price-id"
+STRIPE_MAX_ANNUAL_PRICE_ID        = "revealui/staging/stripe/max-annual-price-id"
+STRIPE_ENTERPRISE_ANNUAL_PRICE_ID = "revealui/staging/stripe/enterprise-annual-price-id"
+
+# Database — same staging Neon branch as api
+POSTGRES_URL = { path = "revealui/staging/db/postgres-url", sensitive = true }
+# NEON_API_KEY intentionally excluded — real consumer is the Neon MCP server,
+# not exercised by the 9-path conversion walk.
+
+# Encryption + signing (parity with api — same staging KEK/license/secret)
+REVEALUI_KEK                 = { path = "revealui/staging/kek", sensitive = true }
+REVEALUI_LICENSE_PRIVATE_KEY = { path = "revealui/staging/license/private-key", sensitive = true }
+REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/staging/license/public-key"
+REVEALUI_SECRET              = { path = "revealui/staging/secret", sensitive = true }
+
+# Auth — passkey / WebAuthn (admin serves the passkey ceremony at
+# admin.staging.revealui.com; rp-id=staging.revealui.com is its registrable parent)
+PASSKEY_ORIGIN         = "revealui/staging/passkey/origin"
+PASSKEY_RP_ID          = "revealui/staging/passkey/rp-id"
+PASSKEY_RP_NAME        = "revealui/staging/passkey/rp-name"
+
+# Cron + alerting (parity with api)
+REVEALUI_CRON_SECRET = { path = "revealui/staging/cron-secret", sensitive = true }
+
+# Storage — Cloudflare R2 (staging-scoped bucket; parity with api)
+R2_ACCOUNT_ID         = "revealui/staging/r2/account-id"
+R2_ACCESS_KEY_ID      = { path = "revealui/staging/r2/access-key-id", sensitive = true }
+R2_SECRET_ACCESS_KEY  = { path = "revealui/staging/r2/secret-access-key", sensitive = true }
+R2_BUCKET             = "revealui/staging/r2/bucket"
+R2_PUBLIC_BASE_URL    = "revealui/staging/r2/public-base-url"
+
+# Email transport (parity with api — reuse prod, see api block comment)
+EMAIL_FROM                   = "revealui/prod/email/from"
+EMAIL_REPLY_TO               = "revealui/prod/email/reply-to"
+GOOGLE_PRIVATE_KEY           = { path = "revealui/prod/google/private-key", sensitive = true }
+GOOGLE_SERVICE_ACCOUNT_EMAIL = "revealui/prod/google/service-account-email"
+
+# Auth + session (parity with api)
+SESSION_COOKIE_DOMAIN = "revealui/staging/session-cookie-domain"
+
+# Public URLs (parity twins across api/admin/marketing)
+NEXT_PUBLIC_API_URL        = "revealui/staging/public/api-url"
+REVEALUI_API_URL           = "revealui/staging/public/api-url"
+NEXT_PUBLIC_SERVER_URL     = "revealui/staging/public/server-url"
+REVEALUI_PUBLIC_SERVER_URL = "revealui/staging/public/server-url"
+
+# Observability — Sentry (separate STAGING Sentry project; parity with api block)
+NEXT_PUBLIC_SENTRY_DSN = "revealui/staging/sentry/dsn-admin"
+SENTRY_AUTH_TOKEN      = { path = "revealui/staging/sentry/auth-token", sensitive = true }
+SENTRY_ORG             = "revealui/staging/sentry/org"
+SENTRY_PROJECT         = "revealui/staging/sentry/project-admin"
+
+# Admin-specific — fresh staging bootstrap credentials so the owner can sign in
+REVEALUI_ADMIN_EMAIL         = "revealui/staging/admin/email"
+REVEALUI_ADMIN_PASSWORD      = { path = "revealui/staging/admin/password", sensitive = true }
+REVEALUI_ADMIN_API_KEY       = { path = "revealui/staging/admin/api-key", sensitive = true }
+
+
+# ── revealui-marketing-staging ──────────────────────────────────────────────
+[projects.revealui-marketing-staging]
+project_id = "prj_frTIYlnONVPLNIjKnQpINiGb5lm0"
+vault_prefix = "revealui/staging/marketing"
+targets = ["preview"]
+git_branch = "staging"
+skip = [
+  "NODE_ENV",
+]
+
+[projects.revealui-marketing-staging.vars]
+# THE anti-cross-wire var this whole manifest exists to set explicitly: prod
+# marketing has NO VITE_API_URL today and hard-falls-back to the LIVE
+# api.revealui.com in every PROD build (apps/marketing/app/lib/api.ts:8-10).
+# Without this line, staging marketing would silently call the live api.
+VITE_API_URL               = "revealui/staging/public/api-url"
+NEXT_PUBLIC_API_URL        = "revealui/staging/public/api-url"
+REVEALUI_API_URL           = "revealui/staging/public/api-url"
+NEXT_PUBLIC_SERVER_URL     = "revealui/staging/public/server-url"
+REVEALUI_PUBLIC_SERVER_URL = "revealui/staging/public/server-url"
+# NEXT_PUBLIC_IS_LIVE intentionally excluded — genuine orphan, no code reader
+# (GAP-345), and dropping it for staging removes one class of confusion this
+# environment exists to avoid.

--- a/scripts/sync/revvault-vercel-staging.toml
+++ b/scripts/sync/revvault-vercel-staging.toml
@@ -40,9 +40,13 @@
 #   - Vaulted but reusing the SAME prod path         — explicitly marked below
 #     ("reuse prod" comment); low-risk shared config (transactional email
 #     transport, one Stripe meter-event name), not per-environment secrets.
-#   - Dropped entirely (not in this file)            — STRIPE_LIVE_MODE,
-#     STRIPE_WEBHOOK_SECRET_LIVE (handler falls back to STRIPE_WEBHOOK_SECRET;
-#     unset flag + livemode:false test events pass the gate), NEON_API_KEY,
+#   - Listed in `skip` (name known, never synced)    — STRIPE_LIVE_MODE. Kept
+#     in `skip` rather than omitted so sync explicitly refuses to manage it
+#     instead of reporting it as an untracked Vercel orphan. Staying unset is
+#     what keeps staging in Stripe test mode.
+#   - Dropped entirely (absent from this file)       — STRIPE_WEBHOOK_SECRET_LIVE
+#     (handler falls back to STRIPE_WEBHOOK_SECRET; unset flag +
+#     livemode:false test events pass the gate), NEON_API_KEY,
 #     MARKETPLACE_CONNECT_RETURN_URL, NEXT_PUBLIC_IS_LIVE (true orphan,
 #     GAP-345), ELECTRIC_* (no walked UI consumes shapes on staging).
 

--- a/scripts/sync/secret-path-drift.ts
+++ b/scripts/sync/secret-path-drift.ts
@@ -30,6 +30,10 @@ import { DECLARED_PATHS } from './secret-paths.js';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const VERCEL_MANIFEST = resolve(HERE, 'revvault-vercel.toml');
 const FLY_MANIFEST = resolve(HERE, 'revvault-fly.toml');
+// Separate staging manifest (GAP-343 Phase 3) - project slugs already
+// disambiguate (e.g. "vercel:revealui-api-staging"), so it shares the same
+// 'vercel' sourceLabel as the prod manifest rather than inventing a new one.
+const STAGING_MANIFEST = resolve(HERE, 'revvault-vercel-staging.toml');
 
 export type DriftCategory = 'orphan' | 'missing' | 'shape-violation';
 
@@ -118,6 +122,7 @@ function manifestNamePathIndex(): Map<string, Map<string, string>> {
   };
   add(VERCEL_MANIFEST, 'projects', 'vercel');
   add(FLY_MANIFEST, 'fly-apps', 'fly');
+  add(STAGING_MANIFEST, 'projects', 'vercel');
   return index;
 }
 

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -41,7 +41,7 @@ export type SecretKind =
   | 'price-id'; // Stripe price/product ids (low-secrecy identifiers)          → NOT sensitive
 
 /** Secrecy tier (by secrecy, not by vault namespace). */
-export type SecretTier = 'prod' | 'dev' | 'env' | 'credentials' | 'agents' | 'forge';
+export type SecretTier = 'prod' | 'staging' | 'dev' | 'env' | 'credentials' | 'agents' | 'forge';
 
 export interface SecretPathDef {
   /** Canonical revvault path, lower-kebab, a leaf XOR a directory prefix (never both). */
@@ -119,7 +119,9 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'public-config',
     sensitive: false,
     tier: 'prod',
-    consumers: ['vercel:api', 'fly:worker'],
+    // Also read by the staging api project (revvault-vercel-staging.toml) -
+    // not secret, not per-environment, deliberately shared (GAP-343 Phase 3).
+    consumers: ['vercel:api', 'fly:worker', 'vercel:api-staging'],
   },
   {
     path: 'revealui/prod/stripe/billing-portal-config-id',
@@ -323,29 +325,56 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'public-config',
     sensitive: false,
     tier: 'prod',
-    consumers: ['vercel:api', 'vercel:admin', 'fly:worker'],
+    // Reused as-is by staging (revvault-vercel-staging.toml) - real
+    // verification/receipt/license mail must land in a real inbox during the
+    // 9-path walk; forking transport credentials buys no isolation (GAP-343).
+    consumers: [
+      'vercel:api',
+      'vercel:admin',
+      'fly:worker',
+      'vercel:api-staging',
+      'vercel:admin-staging',
+    ],
   },
   {
     path: 'revealui/prod/google/private-key',
     kind: 'credential',
     sensitive: true,
     tier: 'prod',
-    consumers: ['vercel:api', 'vercel:admin', 'fly:worker'],
-    note: 'PKCS8 PEM - Gmail SA domain-wide delegation',
+    consumers: [
+      'vercel:api',
+      'vercel:admin',
+      'fly:worker',
+      'vercel:api-staging',
+      'vercel:admin-staging',
+    ],
+    note: 'PKCS8 PEM - Gmail SA domain-wide delegation; also read by staging (GAP-343)',
   },
   {
     path: 'revealui/prod/email/from',
     kind: 'public-config',
     sensitive: false,
     tier: 'prod',
-    consumers: ['vercel:api', 'vercel:admin', 'fly:worker'],
+    consumers: [
+      'vercel:api',
+      'vercel:admin',
+      'fly:worker',
+      'vercel:api-staging',
+      'vercel:admin-staging',
+    ],
   },
   {
     path: 'revealui/prod/email/reply-to',
     kind: 'public-config',
     sensitive: false,
     tier: 'prod',
-    consumers: ['vercel:api', 'vercel:admin', 'fly:worker'],
+    consumers: [
+      'vercel:api',
+      'vercel:admin',
+      'fly:worker',
+      'vercel:api-staging',
+      'vercel:admin-staging',
+    ],
   },
   // ── Auth / session ────────────────────────────────────────────────────────
   {
@@ -470,6 +499,301 @@ export const SECRET_PATHS: SecretPathDef[] = [
     consumers: ['vercel:admin', 'vercel:marketing'],
     note: 'NEXT_PUBLIC_IS_LIVE - Stripe live-mode feature flag',
   },
+  // ── STAGING (GAP-343 Phase 3) ──────────────────────────────────────────────
+  // The revealui/staging/* surface synced by scripts/sync/revvault-vercel-staging.toml
+  // (a SEPARATE manifest from the prod one - see its header). Same subsystem
+  // grouping as the prod entries above; consumers use the *-staging tokens
+  // (vercel:api-staging / vercel:admin-staging / vercel:marketing-staging) so
+  // "which manifest reads this" stays visible without inventing a new field.
+  // Reused-from-prod values (Gmail SA, one Stripe meter-event name) are NOT
+  // duplicated here - see the consumers additions on the prod entries above.
+  {
+    path: 'revealui/staging/stripe/secret-key',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+    note: 'sk_test_* - isolated staging Stripe test account (Phase 2)',
+  },
+  {
+    path: 'revealui/staging/stripe/webhook-secret',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/stripe/publishable-key',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:admin-staging'],
+    note: 'pk_test_*',
+  },
+  {
+    path: 'revealui/staging/stripe/billing-portal-config-id',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging'],
+  },
+  ...(
+    [
+      ['revealui/staging/stripe/pro-price-id', ['vercel:api-staging', 'vercel:admin-staging']],
+      ['revealui/staging/stripe/max-price-id', ['vercel:api-staging', 'vercel:admin-staging']],
+      [
+        'revealui/staging/stripe/enterprise-price-id',
+        ['vercel:api-staging', 'vercel:admin-staging'],
+      ],
+      [
+        'revealui/staging/stripe/pro-annual-price-id',
+        ['vercel:api-staging', 'vercel:admin-staging'],
+      ],
+      [
+        'revealui/staging/stripe/max-annual-price-id',
+        ['vercel:api-staging', 'vercel:admin-staging'],
+      ],
+      [
+        'revealui/staging/stripe/enterprise-annual-price-id',
+        ['vercel:api-staging', 'vercel:admin-staging'],
+      ],
+      [
+        'revealui/staging/stripe/perpetual-pro-price-id',
+        ['vercel:api-staging', 'vercel:admin-staging'],
+      ],
+      [
+        'revealui/staging/stripe/perpetual-max-price-id',
+        ['vercel:api-staging', 'vercel:admin-staging'],
+      ],
+      [
+        'revealui/staging/stripe/perpetual-enterprise-price-id',
+        ['vercel:api-staging', 'vercel:admin-staging'],
+      ],
+      ['revealui/staging/stripe/renewal-pro-price-id', ['vercel:api-staging']],
+      ['revealui/staging/stripe/renewal-max-price-id', ['vercel:api-staging']],
+      ['revealui/staging/stripe/renewal-enterprise-price-id', ['vercel:api-staging']],
+      ['revealui/staging/stripe/credits-starter-price-id', ['vercel:api-staging']],
+      ['revealui/staging/stripe/credits-standard-price-id', ['vercel:api-staging']],
+      ['revealui/staging/stripe/credits-scale-price-id', ['vercel:api-staging']],
+      ['revealui/staging/stripe/agent-overage-price-id', ['vercel:api-staging']],
+    ] as const
+  ).map(
+    ([path, consumers]): SecretPathDef => ({
+      path,
+      kind: 'price-id',
+      sensitive: false,
+      tier: 'staging',
+      consumers: [...consumers],
+    }),
+  ),
+  {
+    path: 'revealui/staging/db/postgres-url',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+    note: 'Phase 1 (owner-run empty Neon branch + full migrate) fills this',
+  },
+  {
+    path: 'revealui/staging/kek',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+    note: 'fresh staging value (scripts/setup/gen-staging-secrets.ts)',
+  },
+  {
+    path: 'revealui/staging/secret',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+    note: 'must match across api + admin - CSRF tokens are cross-verified',
+  },
+  {
+    path: 'revealui/staging/audit-hmac-secret',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging'],
+  },
+  {
+    path: 'revealui/staging/license/private-key',
+    kind: 'signing-private',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+    note: 'fresh Ed25519 pair, isolated from revdev/license-signing-* (GAP-343 decision 1)',
+  },
+  {
+    path: 'revealui/staging/license/public-key',
+    kind: 'signing-public',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/cron-secret',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/alert-email',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging'],
+    note: 'owner sets by hand - not derivable, not generated by gen-staging-secrets.ts',
+  },
+  {
+    path: 'revealui/staging/admin/api-key',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/admin/email',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:admin-staging'],
+    note: 'owner sets by hand - fresh staging bootstrap admin user',
+  },
+  {
+    path: 'revealui/staging/admin/password',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:admin-staging'],
+    note: 'owner sets by hand - fresh staging bootstrap admin user',
+  },
+  {
+    path: 'revealui/staging/r2/account-id',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/r2/access-key-id',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/r2/secret-access-key',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/r2/bucket',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/r2/public-base-url',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/passkey/origin',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+    note: 'the admin app origin, https://admin.staging.revealui.com',
+  },
+  {
+    path: 'revealui/staging/passkey/rp-id',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/passkey/rp-name',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/session-cookie-domain',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/cors-origin',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging'],
+  },
+  {
+    path: 'revealui/staging/sentry/dsn',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging'],
+    note: 'separate staging Sentry project - prod error budget stays clean',
+  },
+  {
+    path: 'revealui/staging/sentry/dsn-admin',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/sentry/auth-token',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'staging',
+    consumers: ['vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/sentry/org',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/sentry/project-admin',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:admin-staging'],
+  },
+  {
+    path: 'revealui/staging/public/server-url',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging', 'vercel:marketing-staging'],
+    note: 'the admin app own origin (parity with the prod server-url leaf)',
+  },
+  {
+    path: 'revealui/staging/public/api-url',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'staging',
+    consumers: ['vercel:admin-staging', 'vercel:marketing-staging'],
+    note: 'the api own origin; also VITE_API_URL on marketing (the anti-cross-wire fix, GAP-343)',
+  },
+
   // ── Env bundle (derived, verify-only - NOT synced to any platform) ────────
   // Tracked here to enforce the R8 invariant: with-secrets loads the license
   // keypair from a SEPARATE bundle path. intentionallyUnsynced excludes it from


### PR DESCRIPTION
## Summary

- Adds `scripts/sync/revvault-vercel-staging.toml`, a **separate** manifest from `scripts/sync/revvault-vercel.toml`, covering the three staging projects (`revealui-api-staging`, `revealui-admin-staging`, `revealui-marketing-staging`) with `targets = ["preview"]` and `git_branch = "staging"` on every var.
- Adds `scripts/setup/gen-staging-secrets.ts`, an owner-run generator for the "generate fresh" bucket (KEK, secret, cron-secret, audit-HMAC-secret, admin-API-key, a self-verified fresh Ed25519 license keypair, and the deterministic `staging.revealui.com` subtree URL config). Never run against the real vault by this session; ships with a `--dry-run` mode (shape-only output, zero revvault calls) and a `--force` overwrite guard.
- Wires the new `revealui/staging/*` paths into `scripts/sync/secret-paths.ts` (48 new entries + a new `staging` `SecretTier`), the lockstep test, and `scripts/sync/secret-path-drift.ts`, so staging gets the same declared/synced/sensitivity/kebab coverage as prod. Re-rendered `docs/SECRETS.md`.
- Adds `pnpm vercel:sync:staging` / `vercel:sync:staging:apply` (mirrors the existing prod scripts, same `VERCEL_TOKEN` source, staging manifest instead).

## Important context for the reviewer / before applying

**(a) revvault version requirement.** `git_branch` is only supported by revvault's Vercel sync as of revvault PR #127 (GAP-346), which landed on revvault's `test` branch, **not** `main`. Before running `vercel:sync:staging` or `:apply`, the owner's installed `revvault` binary must be built from `revvault:test` — an older binary rejects the `git_branch` manifest key at parse time.

**(b) `git_branch` is CREATE-only.** Per `revvault crates/core/src/sync/vercel.rs::create_env_var`, `gitBranch` is only sent on the POST (create) call; `update_env_var` PATCHes `value` only and Vercel preserves whatever `gitBranch` (or lack thereof) the row already has. **If any of these projects already has a `preview`-target row for one of these keys (e.g. from an earlier ad-hoc `deploy-test.yml` dispatch), delete it before the first `--apply`** — otherwise the row gets its value updated but stays branch-unscoped, visible to every branch's previews, silently defeating the isolation this manifest exists to provide.

**(c) Owner-run ordering before `vercel:sync:staging:apply`.** This manifest only declares vault *paths* — most of them are empty until populated in this order:
1. `pnpm setup:staging-secrets` (this PR's generator) — fills the fresh-value bucket (KEK, secret, license keypair, etc.) and the deterministic URL config.
2. Phase 1 (owner-run, not this PR) — empty Neon branch + full `db:migrate` chain → `revealui/staging/db/postgres-url`.
3. Phase 2 (owner-run, not this PR) — `pnpm stripe:seed` against an isolated staging Stripe test account → `revealui/staging/stripe/*`.
4. Only then does `pnpm vercel:sync:staging:apply` have anything real to sync — running it earlier means every Stripe/DB var syncs as missing/empty.

**(d) Deliberately excluded vars (not in the staging manifest):** `STRIPE_LIVE_MODE` and `STRIPE_WEBHOOK_SECRET_LIVE` (the webhook handler falls back to `STRIPE_WEBHOOK_SECRET`; leaving the live flag unset plus `livemode:false` test events pass the gate cleanly), `NEON_API_KEY` (real consumer is the Neon MCP server, not exercised by the 9-path walk), `MARKETPLACE_CONNECT_RETURN_URL` (real consumer is marketplace Connect, not walked), `NEXT_PUBLIC_IS_LIVE` (a genuine code-dead orphan, GAP-345), and `ELECTRIC_*` (no walked UI consumes shapes on staging).

**(e) The anti-cross-wire fix this manifest exists for.** Today, prod marketing has **no** `VITE_API_URL` set at all and hard-falls-back to the **live** `https://api.revealui.com` in every production build (`apps/marketing/app/lib/api.ts:8-10`). Without an explicit `VITE_API_URL` in the staging marketing project, a staging marketing deploy would silently call the live api. This manifest sets it explicitly to `revealui/staging/public/api-url`.

## Not in scope for this PR (owner dispositions)

- Running `gen-staging-secrets.ts` against the real vault.
- Applying the sync (`vercel:sync:staging:apply`).
- Merging this PR — it's a secret-sync surface change; per the fleet's disposition-actions convention this needs an explicit owner merge decision, not an agent one.

## Test plan

- [x] `pnpm validate:secret-paths` — 20/20 passing (lockstep test, including new staging coverage: manifest parses to 98 var entries / 53 unique paths, sensitivity-completeness, kebab, leaf-or-dir, no accidental `revealui/prod/*` references beyond the 5 documented reuse paths, doc/spec bijection).
- [x] `scripts/setup/__tests__/gen-staging-secrets.test.ts` — 15/15 passing (fresh keypair self-verifies via `@revealui/core/license`'s `selfVerifyLicenseKeypair`, dry-run makes zero revvault calls and never logs a value, force/skip semantics, KEK/secret format compliance with `validate-startup.ts`).
- [x] Full `scripts/sync` + `scripts/setup` suite — 88/88 passing.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npx biome check` — clean on every touched file.
- [x] `docs/SECRETS.md` re-rendered and idempotency-checked.
- [x] Manually grepped the diff for secret-shaped values (none found) and for undocumented `revealui/prod/*` references (none beyond the 5 documented reuse paths, machine-checked by a new lockstep test case).