### PR TITLE
feat(mcp): agent surfaces for the fleet knowledge graph

### DIFF
--- a/packages/mcp/__tests__/knowledge-graph-factory.test.ts
+++ b/packages/mcp/__tests__/knowledge-graph-factory.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Vitest coverage for the `knowledge-graph` MCP server factory (GAP-349 P2).
+ *
+ * Exercises: tool-schema validation (Zod), kg_add_episode ontology
+ * validation, the read tools (kg_search/kg_get_node/kg_neighbors/kg_path/
+ * kg_at_time) against a PGlite-backed KgExecutor seeded via the P1 additive
+ * ingest path, and kg_context budget enforcement (spec §8.4).
+ *
+ * The PGlite harness mirrors `@revealui/knowledge-graph`'s own
+ * `src/__tests__/test-db.ts`, built only from that package's PUBLIC export
+ * surface (`kgDdlStatements` + `makeExecutor`) since the internal test
+ * helper isn't exported. NEVER touches a real database.
+ */
+
+import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { PGlite } from '@electric-sql/pglite';
+import {
+  type EdgeInput,
+  type EpisodeInput,
+  ingestEpisode,
+  type KgExecutor,
+  kgDdlStatements,
+  makeExecutor,
+  type NodeInput,
+} from '@revealui/knowledge-graph';
+import { afterEach, describe, expect, it } from 'vitest';
+import { McpClient } from '../src/client.js';
+import {
+  createKnowledgeGraphServer,
+  KgAddEpisodeArgsSchema,
+  KgAtTimeArgsSchema,
+  KgContextArgsSchema,
+  KgGetNodeArgsSchema,
+  KgNeighborsArgsSchema,
+  KgPathArgsSchema,
+  KgSearchArgsSchema,
+} from '../src/servers/factories/knowledge-graph.js';
+import { createNodeStreamableHttpHandler } from '../src/streamable-http.js';
+
+// ---------------------------------------------------------------------------
+// PGlite test db
+// ---------------------------------------------------------------------------
+
+interface TestDb {
+  exec: KgExecutor;
+  close: () => Promise<void>;
+}
+
+async function createTestDb(): Promise<TestDb> {
+  const pglite = new PGlite();
+  for (const statement of kgDdlStatements({ variant: 'portable' })) {
+    await pglite.exec(statement);
+  }
+  return { exec: makeExecutor(pglite), close: () => pglite.close() };
+}
+
+const REPO = 'revealui';
+const FILE_KEY = 'revealui/packages/ai/src/llm/client.ts';
+const SYMBOL_KEY = `${FILE_KEY}#getClient`;
+const T = new Date('2026-07-01T00:00:00Z');
+
+async function seed(exec: KgExecutor): Promise<void> {
+  const episode: EpisodeInput = {
+    episodeType: 'code-scan',
+    source: 'test',
+    siteId: 'test-site',
+    referenceTime: T,
+    contentRef: { repo: REPO },
+  };
+  const nodes: NodeInput[] = [
+    {
+      kind: 'file',
+      name: 'client.ts',
+      naturalKey: FILE_KEY,
+      repo: REPO,
+      summary: 'the LLM client factory',
+    },
+    {
+      kind: 'symbol',
+      name: 'getClient',
+      naturalKey: SYMBOL_KEY,
+      repo: REPO,
+      summary: 'creates an LLM client',
+    },
+    { kind: 'dependency', name: 'zod', naturalKey: 'npm:zod' },
+  ];
+  const edges: EdgeInput[] = [
+    {
+      source: { kind: 'file', naturalKey: FILE_KEY },
+      target: { kind: 'symbol', naturalKey: SYMBOL_KEY },
+      relation: 'exports',
+      fact: 'client.ts exports getClient',
+      repo: REPO,
+      validAt: T,
+    },
+    {
+      source: { kind: 'file', naturalKey: FILE_KEY },
+      target: { kind: 'dependency', naturalKey: 'npm:zod' },
+      relation: 'imports',
+      fact: 'client.ts imports zod',
+      repo: REPO,
+      validAt: T,
+    },
+  ];
+  await ingestEpisode(exec, { episode, nodes, edges });
+}
+
+// ---------------------------------------------------------------------------
+// HTTP harness (mirrors revealui-content-factory.integration.test.ts)
+// ---------------------------------------------------------------------------
+
+type McpHandle = { url: string; close: () => Promise<void> };
+
+async function startMcpHttp(exec: KgExecutor): Promise<McpHandle> {
+  const handler = createNodeStreamableHttpHandler({
+    createServer: () => createKnowledgeGraphServer({ executor: exec }),
+    enableJsonResponse: true,
+  });
+  const httpServer: NodeHttpServer = createHttpServer((req, res) => {
+    void handler(req, res).catch(() => {
+      if (!res.headersSent) res.statusCode = 500;
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        httpServer.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+interface SdkCallToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+interface SdkClient {
+  callTool(args: { name: string; arguments?: Record<string, unknown> }): Promise<SdkCallToolResult>;
+}
+
+const teardowns: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (teardowns.length > 0) {
+    const t = teardowns.pop();
+    if (t) await t().catch(() => undefined);
+  }
+});
+
+async function connectedClient(exec: KgExecutor): Promise<{ client: McpClient; sdk: SdkClient }> {
+  const mcp = await startMcpHttp(exec);
+  teardowns.push(mcp.close);
+  const client = new McpClient({
+    clientInfo: { name: 'kg-test', version: '0.0.1' },
+    transport: { kind: 'streamable-http', url: mcp.url },
+  });
+  await client.connect();
+  teardowns.push(async () => {
+    await client.close();
+  });
+  // Tool invocation isn't yet surfaced on McpClient's own facade (same gap
+  // noted in revealui-content-factory.integration.test.ts) — reach into the
+  // internal SDK client, matching that test's established workaround.
+  // biome-ignore lint/suspicious/noExplicitAny: reaching into private SDK field for coverage
+  const sdk = (client as any).sdk as SdkClient;
+  return { client, sdk };
+}
+
+function parseToolJson<T>(result: SdkCallToolResult): T {
+  const first = result.content[0];
+  if (first?.type !== 'text') throw new Error('expected text content');
+  return JSON.parse(first.text) as T;
+}
+
+// ---------------------------------------------------------------------------
+// Tool-schema validation
+// ---------------------------------------------------------------------------
+
+describe('knowledge-graph tool schemas', () => {
+  it('kg_search accepts a bare query', () => {
+    expect(KgSearchArgsSchema.safeParse({ query: 'client' }).success).toBe(true);
+  });
+
+  it('kg_search rejects an unrecognized field (strict — never raw SQL/table names)', () => {
+    expect(
+      KgSearchArgsSchema.safeParse({ query: 'client', sql: 'DROP TABLE kg_nodes' }).success,
+    ).toBe(false);
+  });
+
+  it('kg_search rejects an unknown node kind', () => {
+    expect(KgSearchArgsSchema.safeParse({ query: 'client', kinds: ['not-a-kind'] }).success).toBe(
+      false,
+    );
+  });
+
+  it('kg_get_node requires naturalKey', () => {
+    expect(KgGetNodeArgsSchema.safeParse({}).success).toBe(false);
+    expect(KgGetNodeArgsSchema.safeParse({ naturalKey: FILE_KEY }).success).toBe(true);
+  });
+
+  it('kg_neighbors rejects an unknown edge relation', () => {
+    expect(
+      KgNeighborsArgsSchema.safeParse({ naturalKey: FILE_KEY, relations: ['drops'] }).success,
+    ).toBe(false);
+  });
+
+  it('kg_path requires both endpoints', () => {
+    expect(KgPathArgsSchema.safeParse({ fromNaturalKey: 'a' }).success).toBe(false);
+    expect(KgPathArgsSchema.safeParse({ fromNaturalKey: 'a', toNaturalKey: 'b' }).success).toBe(
+      true,
+    );
+  });
+
+  it('kg_at_time requires an ISO-8601 `at`', () => {
+    expect(KgAtTimeArgsSchema.safeParse({ naturalKey: FILE_KEY, at: 'not-a-date' }).success).toBe(
+      false,
+    );
+    expect(
+      KgAtTimeArgsSchema.safeParse({ naturalKey: FILE_KEY, at: T.toISOString() }).success,
+    ).toBe(true);
+  });
+
+  it('kg_context accepts a charBudget override', () => {
+    expect(KgContextArgsSchema.safeParse({ naturalKey: FILE_KEY, charBudget: 500 }).success).toBe(
+      true,
+    );
+  });
+});
+
+describe('kg_add_episode ontology validation', () => {
+  it('rejects an unknown episodeType', () => {
+    const parsed = KgAddEpisodeArgsSchema.safeParse({
+      episodeType: 'not-a-real-type',
+      source: 'test',
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an unknown node kind in the nodes array', () => {
+    const parsed = KgAddEpisodeArgsSchema.safeParse({
+      episodeType: 'agent-fact',
+      source: 'test',
+      nodes: [{ kind: 'not-a-kind', name: 'x', naturalKey: 'x' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an unknown edge relation in the edges array', () => {
+    const parsed = KgAddEpisodeArgsSchema.safeParse({
+      episodeType: 'agent-fact',
+      source: 'test',
+      edges: [
+        {
+          source: { kind: 'file', naturalKey: 'a' },
+          target: { kind: 'file', naturalKey: 'b' },
+          relation: 'not-a-relation',
+          fact: 'a relates to b',
+        },
+      ],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts a minimal valid agent-fact episode', () => {
+    const parsed = KgAddEpisodeArgsSchema.safeParse({
+      episodeType: 'agent-fact',
+      source: 'claude-session',
+      content: 'discovered a race condition',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an unrecognized top-level field (strict — never raw SQL/table names)', () => {
+    const parsed = KgAddEpisodeArgsSchema.safeParse({
+      episodeType: 'agent-fact',
+      source: 'test',
+      sql: 'DROP TABLE kg_nodes',
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read tools against a PGlite-backed KgExecutor
+// ---------------------------------------------------------------------------
+
+describe('knowledge-graph MCP tools (PGlite)', () => {
+  it('lists all 7 tools', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    const { client } = await connectedClient(db.exec);
+    const tools = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(
+      [
+        'kg_add_episode',
+        'kg_at_time',
+        'kg_context',
+        'kg_get_node',
+        'kg_neighbors',
+        'kg_path',
+        'kg_search',
+      ].sort(),
+    );
+  });
+
+  it('kg_search finds a seeded node via the FTS channel with no embedder configured', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({ name: 'kg_search', arguments: { query: 'client' } });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{ nodes: Array<{ naturalKey: string }> }>(result);
+    expect(parsed.nodes.some((n) => n.naturalKey === FILE_KEY)).toBe(true);
+  });
+
+  it('kg_get_node fetches a seeded node by natural key with its current facts', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_get_node',
+      arguments: { naturalKey: FILE_KEY },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{
+      node: { natural_key: string };
+      facts: Array<{ relation: string }>;
+    }>(result);
+    expect(parsed.node.natural_key).toBe(FILE_KEY);
+    expect(parsed.facts.some((f) => f.relation === 'exports')).toBe(true);
+  });
+
+  it('kg_get_node returns an MCP tool error for an unknown natural key', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_get_node',
+      arguments: { naturalKey: 'does-not-exist' },
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('kg_neighbors reaches connected nodes', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_neighbors',
+      arguments: { naturalKey: FILE_KEY, depth: 2 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{ nodes: Array<{ naturalKey: string; distance: number }> }>(
+      result,
+    );
+    const zod = parsed.nodes.find((n) => n.naturalKey === 'npm:zod');
+    expect(zod).toBeDefined();
+    expect(zod?.distance).toBe(1);
+  });
+
+  it('kg_path finds the shortest path between two nodes', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_path',
+      arguments: { fromNaturalKey: FILE_KEY, toNaturalKey: 'npm:zod' },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{ path: Array<{ natural_key: string }> | null }>(result);
+    expect(parsed.path).not.toBeNull();
+    expect(parsed.path?.at(-1)?.natural_key).toBe('npm:zod');
+  });
+
+  it('kg_path returns null when no path exists', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    // getClient is only connected to client.ts (1-hop), never to zod directly
+    // without traversing through client.ts's other edges is fine — instead
+    // seed an isolated node with no edges to prove the null path.
+    const nodes: NodeInput[] = [{ kind: 'concept', name: 'orphan', naturalKey: 'concept:orphan' }];
+    await ingestEpisode(db.exec, {
+      episode: {
+        episodeType: 'manual',
+        source: 'test',
+        siteId: 'test-site',
+        referenceTime: T,
+      },
+      nodes,
+      edges: [],
+    });
+    const result = await sdk.callTool({
+      name: 'kg_path',
+      arguments: { fromNaturalKey: FILE_KEY, toNaturalKey: 'concept:orphan' },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{ path: unknown }>(result);
+    expect(parsed.path).toBeNull();
+  });
+
+  it('kg_at_time returns the facts valid at the seeded reference time', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_at_time',
+      arguments: { naturalKey: FILE_KEY, at: new Date(T.getTime() + 1000).toISOString() },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{ facts: Array<{ relation: string }> }>(result);
+    expect(parsed.facts.some((f) => f.relation === 'exports')).toBe(true);
+  });
+
+  it('kg_add_episode is the only write path and its result is durably visible to reads', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_add_episode',
+      arguments: {
+        episodeType: 'agent-fact',
+        source: 'claude-session',
+        content: 'the electric proxy retries with backoff',
+        nodes: [
+          {
+            kind: 'concept',
+            name: 'electric proxy retries',
+            naturalKey: 'concept:electric-proxy-retries',
+          },
+        ],
+        edges: [],
+      },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{ episodeId: string; nodeCount: number; edgeCount: number }>(
+      result,
+    );
+    expect(parsed.nodeCount).toBe(1);
+    expect(typeof parsed.episodeId).toBe('string');
+
+    const getResult = await sdk.callTool({
+      name: 'kg_get_node',
+      arguments: { naturalKey: 'concept:electric-proxy-retries' },
+    });
+    expect(getResult.isError).not.toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// kg_context — budget enforcement (spec §8.4)
+// ---------------------------------------------------------------------------
+
+describe('kg_context budget enforcement', () => {
+  it('packs the full neighborhood within a generous budget', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_context',
+      arguments: { naturalKey: FILE_KEY, depth: 2, charBudget: 16_000 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{
+      truncated: boolean;
+      nodeCount: number;
+      charsUsed: number;
+      charBudget: number;
+    }>(result);
+    expect(parsed.truncated).toBe(false);
+    expect(parsed.nodeCount).toBeGreaterThanOrEqual(3);
+    expect(parsed.charsUsed).toBeLessThanOrEqual(parsed.charBudget);
+  });
+
+  it('truncates and never exceeds charBudget under a tight budget', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_context',
+      arguments: { naturalKey: FILE_KEY, depth: 2, charBudget: 80 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseToolJson<{
+      truncated: boolean;
+      charsUsed: number;
+      charBudget: number;
+      context: string;
+    }>(result);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.charsUsed).toBeLessThanOrEqual(80);
+    expect(parsed.context.length).toBeLessThanOrEqual(80);
+  });
+
+  it('includes provenance episode ids for facts in the packed context', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({
+      name: 'kg_context',
+      arguments: { naturalKey: FILE_KEY, depth: 2, charBudget: 16_000 },
+    });
+    const parsed = parseToolJson<{ context: string }>(result);
+    expect(parsed.context).toContain('[episodes:');
+    expect(parsed.context).not.toContain('[episodes: none]');
+  });
+
+  it('defaults charBudget to 16000 when omitted', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    await seed(db.exec);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({ name: 'kg_context', arguments: { naturalKey: FILE_KEY } });
+    const parsed = parseToolJson<{ charBudget: number }>(result);
+    expect(parsed.charBudget).toBe(16_000);
+  });
+
+  it('returns an MCP tool error for an unknown anchor natural key', async () => {
+    const db = await createTestDb();
+    teardowns.push(db.close);
+    const { sdk } = await connectedClient(db.exec);
+    const result = await sdk.callTool({ name: 'kg_context', arguments: { naturalKey: 'nope' } });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -13,9 +13,14 @@
     "@revealui/config": "workspace:*",
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
+    "@revealui/db": "workspace:*",
+    "@revealui/knowledge-graph": "workspace:*",
     "@revealui/security": "workspace:*",
     "dotenv": "catalog:",
     "jose": "catalog:"
+  },
+  "optionalDependencies": {
+    "@revealui/ai": "workspace:*"
   },
   "devDependencies": {
     "@electric-sql/pglite": "catalog:",
@@ -62,6 +67,10 @@
     "./docs-server": {
       "types": "./dist/servers/factories/docs.d.ts",
       "import": "./dist/servers/factories/docs.js"
+    },
+    "./kg-server": {
+      "types": "./dist/servers/factories/knowledge-graph.d.ts",
+      "import": "./dist/servers/factories/knowledge-graph.js"
     },
     "./hypervisor": {
       "types": "./dist/hypervisor.d.ts",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -177,6 +177,13 @@ export {
   type ResolveResult,
   resolveLibrary,
 } from './servers/factories/docs.js';
+// Knowledge graph server (GAP-349 P2 — kg_search/kg_get_node/kg_neighbors/
+// kg_add_episode/kg_path/kg_at_time/kg_context over @revealui/knowledge-graph)
+export {
+  type AssembledContext,
+  type CreateKnowledgeGraphServerOptions,
+  createKnowledgeGraphServer,
+} from './servers/factories/knowledge-graph.js';
 // First-party server factories (Stage 1 PR-1.2 — dual-mode template)
 export {
   createRevealuiContentServer,

--- a/packages/mcp/src/servers/factories/knowledge-graph.ts
+++ b/packages/mcp/src/servers/factories/knowledge-graph.ts
@@ -1,0 +1,819 @@
+/**
+ * Factory for the `knowledge-graph` MCP server (GAP-349 P2 — agent surfaces for
+ * the fleet knowledge graph; P1 shipped the schema + `@revealui/knowledge-graph`
+ * core in revealui#1858).
+ *
+ * Tools exposed:
+ *   kg_search       — hybrid retrieval (vector + FTS + BFS traversal, RRF-fused)
+ *   kg_get_node     — fetch a node + its current facts by natural key
+ *   kg_neighbors    — BFS neighbors of a node (current or point-in-time)
+ *   kg_add_episode  — THE ONLY WRITE TOOL. Additive ingestion (never a rescan).
+ *   kg_path         — shortest path between two nodes
+ *   kg_at_time      — a node's facts as of a point-in-time timestamp
+ *   kg_context      — budgeted context assembly (design spec §8.4): BFS from an
+ *                      anchor, rerank by node-distance + episode-mentions, pack
+ *                      node summaries + edge facts (with provenance episode ids)
+ *                      into a text block capped at `charBudget` characters.
+ *
+ * All tools operate over a `KgExecutor` (the driver-agnostic query interface
+ * `@revealui/knowledge-graph` already exposes for Neon-in-prod / PGlite-in-tests
+ * parity). Production resolves a pooled executor lazily from `@revealui/db/pool`
+ * (the same connection pattern `revkg`'s CLI uses — extend, not duplicate); tests
+ * inject a PGlite-backed executor via `CreateKnowledgeGraphServerOptions.executor`.
+ *
+ * Read tools degrade gracefully with no pgvector and no embeddings present:
+ * `kgSearch`'s vector channel is skipped whenever no query embedding is
+ * supplied, and query-embedding generation here is best-effort — an
+ * `@revealui/ai` import failure or an Ollama-down `generateEmbedding()` call
+ * both fall back to FTS + BFS only, never a hard failure.
+ *
+ * `kg_add_episode` is the only write tool. It always calls the additive
+ * `ingestEpisode` (never `applyScan`, which is the deterministic-rescan path
+ * reserved for `revkg scan`), Zod-validates `episodeType` plus every node kind
+ * and edge relation against the ontology enums, and accepts no raw SQL or
+ * table-name input of any kind.
+ */
+
+import { hostname } from 'node:os';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  type CallToolRequest,
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+import {
+  EDGE_RELATIONS,
+  type EdgeInput,
+  type EdgeRelation,
+  type Embedder,
+  ingestEpisode,
+  type KgExecutor,
+  kgAtTime,
+  kgNeighbors,
+  kgPath,
+  kgSearch,
+  makePoolExecutor,
+  NODE_KINDS,
+  type NodeInput,
+  type NodeKind,
+} from '@revealui/knowledge-graph';
+import { resolveNaturalKey } from '@revealui/knowledge-graph/ingest';
+import { z } from 'zod/v4';
+import { validateToolArgs } from '../../validate-tool-args.js';
+
+const SERVER_NAME = 'knowledge-graph';
+const SERVER_VERSION = '0.1.0';
+
+/** Text block budget for `kg_context` — chars, not tokens, per GAP-349 P2 scope. */
+const DEFAULT_CONTEXT_CHAR_BUDGET = 16_000;
+
+/**
+ * Mirrors `EpisodeType` in `@revealui/knowledge-graph/src/types.ts`. That union
+ * is a compile-time type only (not exported as a runtime array by P1), so the
+ * literal list is duplicated here for Zod enum validation — keep it in
+ * lockstep with `types.ts` on any future P3 change.
+ */
+const EPISODE_TYPES = [
+  'code-scan',
+  'git-commit',
+  'doc',
+  'agent-fact',
+  'memory',
+  'json',
+  'manual',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Tool argument schemas (Zod 4)
+// ---------------------------------------------------------------------------
+
+export const KgSearchArgsSchema = z
+  .object({
+    query: z.string().min(1),
+    anchor: z.string().min(1).optional(),
+    kinds: z.array(z.enum(NODE_KINDS)).optional(),
+    relations: z.array(z.enum(EDGE_RELATIONS)).optional(),
+    at: z.string().datetime().optional(),
+    limit: z.number().int().positive().max(100).optional(),
+    bfsDepth: z.number().int().min(1).max(6).optional(),
+  })
+  .strict();
+
+export const KgGetNodeArgsSchema = z
+  .object({
+    naturalKey: z.string().min(1),
+  })
+  .strict();
+
+export const KgNeighborsArgsSchema = z
+  .object({
+    naturalKey: z.string().min(1),
+    depth: z.number().int().min(1).max(6).optional(),
+    relations: z.array(z.enum(EDGE_RELATIONS)).optional(),
+    at: z.string().datetime().optional(),
+  })
+  .strict();
+
+const NodeRefArgsSchema = z
+  .object({
+    kind: z.enum(NODE_KINDS),
+    naturalKey: z.string().min(1),
+  })
+  .strict();
+
+const NodeInputArgsSchema = z
+  .object({
+    kind: z.enum(NODE_KINDS),
+    name: z.string().min(1),
+    naturalKey: z.string().min(1),
+    repo: z.string().min(1).optional(),
+    summary: z.string().optional(),
+    attributes: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+const EdgeInputArgsSchema = z
+  .object({
+    source: NodeRefArgsSchema,
+    target: NodeRefArgsSchema,
+    relation: z.enum(EDGE_RELATIONS),
+    fact: z.string().min(1),
+    repo: z.string().min(1).optional(),
+    validAt: z.string().datetime().optional(),
+    attributes: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export const KgAddEpisodeArgsSchema = z
+  .object({
+    episodeType: z.enum(EPISODE_TYPES),
+    source: z.string().min(1),
+    content: z.string().optional(),
+    contentRef: z.record(z.string(), z.unknown()).optional(),
+    referenceTime: z.string().datetime().optional(),
+    siteId: z.string().min(1).optional(),
+    nodes: z.array(NodeInputArgsSchema).default([]),
+    edges: z.array(EdgeInputArgsSchema).default([]),
+  })
+  .strict();
+
+export const KgPathArgsSchema = z
+  .object({
+    fromNaturalKey: z.string().min(1),
+    toNaturalKey: z.string().min(1),
+    at: z.string().datetime().optional(),
+    maxDepth: z.number().int().min(1).max(12).optional(),
+  })
+  .strict();
+
+export const KgAtTimeArgsSchema = z
+  .object({
+    naturalKey: z.string().min(1),
+    at: z.string().datetime(),
+  })
+  .strict();
+
+export const KgContextArgsSchema = z
+  .object({
+    naturalKey: z.string().min(1),
+    charBudget: z.number().int().positive().max(200_000).optional(),
+    depth: z.number().int().min(1).max(6).optional(),
+    at: z.string().datetime().optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// Tool definitions (MCP SDK JSON Schema)
+// ---------------------------------------------------------------------------
+
+const NODE_KIND_ENUM = [...NODE_KINDS];
+const EDGE_RELATION_ENUM = [...EDGE_RELATIONS];
+
+const NODE_REF_SCHEMA = {
+  type: 'object',
+  properties: {
+    kind: { type: 'string', enum: NODE_KIND_ENUM },
+    naturalKey: { type: 'string' },
+  },
+  required: ['kind', 'naturalKey'],
+} as const;
+
+const TOOLS: Tool[] = [
+  {
+    name: 'kg_search',
+    description:
+      'Hybrid search over the fleet knowledge graph: vector + full-text + BFS ' +
+      'traversal, RRF-fused, reranked by node-distance and episode-mentions. ' +
+      'Returns nodes AND facts (edges) with provenance episode ids. Prefer ' +
+      'kg_context for "what do I need to know before touching X" — this tool ' +
+      'is for open-ended queries.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Free-text query.' },
+        anchor: {
+          type: 'string',
+          description: 'Anchor node id for the BFS traversal channel + node-distance reranker.',
+        },
+        kinds: {
+          type: 'array',
+          items: { type: 'string', enum: NODE_KIND_ENUM },
+          description: 'Restrict results to these node kinds.',
+        },
+        relations: {
+          type: 'array',
+          items: { type: 'string', enum: EDGE_RELATION_ENUM },
+          description: 'Restrict fact results to these edge relations.',
+        },
+        at: { type: 'string', description: 'ISO-8601 point-in-time; omit for the current graph.' },
+        limit: { type: 'number', description: 'Max results per list (default 20).' },
+        bfsDepth: {
+          type: 'number',
+          description: 'Max BFS depth for the traversal channel (default 3).',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'kg_get_node',
+    description: 'Fetch a node and its current facts by natural key.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        naturalKey: {
+          type: 'string',
+          description: 'e.g. "revealui/packages/ai/src/llm/client.ts#getClient"',
+        },
+      },
+      required: ['naturalKey'],
+    },
+  },
+  {
+    name: 'kg_neighbors',
+    description: 'BFS neighbors of a node (current graph, or as of a point-in-time timestamp).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        naturalKey: { type: 'string' },
+        depth: { type: 'number', description: 'Max hops (default 1).' },
+        relations: {
+          type: 'array',
+          items: { type: 'string', enum: EDGE_RELATION_ENUM },
+          description: 'Restrict traversal to these edge relations.',
+        },
+        at: { type: 'string', description: 'ISO-8601 point-in-time; omit for the current graph.' },
+      },
+      required: ['naturalKey'],
+    },
+  },
+  {
+    name: 'kg_add_episode',
+    description:
+      'Publish an episode (provenance unit) plus candidate nodes/edges into the ' +
+      'graph. The ONLY write tool. Always additive (never a rescan) — use this ' +
+      'to durably record an agent discovery (episodeType "agent-fact") or any ' +
+      'other unstructured fact, extending the shared_facts / end-of-session ' +
+      'publishing flow.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        episodeType: { type: 'string', enum: [...EPISODE_TYPES] },
+        source: {
+          type: 'string',
+          description: 'e.g. "claude-session", "shared_facts:coord-abc123"',
+        },
+        content: { type: 'string', description: 'Raw payload or pointer summary.' },
+        contentRef: { type: 'object', description: 'e.g. { repo, path, sha, factId }' },
+        referenceTime: {
+          type: 'string',
+          description: 'ISO-8601; when the described state was true. Defaults to now.',
+        },
+        siteId: {
+          type: 'string',
+          description: 'Origin machine/replica id. Defaults to hostname().',
+        },
+        nodes: {
+          type: 'array',
+          description:
+            'Candidate nodes to upsert (deterministic ids derived from kind+naturalKey).',
+          items: {
+            type: 'object',
+            properties: {
+              kind: { type: 'string', enum: NODE_KIND_ENUM },
+              name: { type: 'string' },
+              naturalKey: { type: 'string' },
+              repo: { type: 'string' },
+              summary: { type: 'string' },
+              attributes: { type: 'object' },
+            },
+            required: ['kind', 'name', 'naturalKey'],
+          },
+        },
+        edges: {
+          type: 'array',
+          description: 'Candidate facts between nodes referenced by kind+naturalKey.',
+          items: {
+            type: 'object',
+            properties: {
+              source: NODE_REF_SCHEMA,
+              target: NODE_REF_SCHEMA,
+              relation: { type: 'string', enum: EDGE_RELATION_ENUM },
+              fact: { type: 'string' },
+              repo: { type: 'string' },
+              validAt: { type: 'string', description: 'ISO-8601; defaults to referenceTime.' },
+              attributes: { type: 'object' },
+            },
+            required: ['source', 'target', 'relation', 'fact'],
+          },
+        },
+      },
+      required: ['episodeType', 'source'],
+    },
+  },
+  {
+    name: 'kg_path',
+    description: 'Shortest path (node list) between two nodes, current or as of a point-in-time.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        fromNaturalKey: { type: 'string' },
+        toNaturalKey: { type: 'string' },
+        at: { type: 'string', description: 'ISO-8601 point-in-time; omit for the current graph.' },
+        maxDepth: { type: 'number', description: 'Max hops to search (default 6).' },
+      },
+      required: ['fromNaturalKey', 'toNaturalKey'],
+    },
+  },
+  {
+    name: 'kg_at_time',
+    description: "A node's facts as of a point-in-time timestamp.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        naturalKey: { type: 'string' },
+        at: { type: 'string', description: 'ISO-8601 timestamp.' },
+      },
+      required: ['naturalKey', 'at'],
+    },
+  },
+  {
+    name: 'kg_context',
+    description:
+      'Budgeted context assembly (design spec §8.4): BFS from an anchor node, ' +
+      'rerank by node-distance + episode-mentions, pack node summaries and edge ' +
+      'facts (with provenance episode ids) into a text block capped at ' +
+      'charBudget characters. The default entry point for "what do I need to ' +
+      'know before touching X" — prefer this over kg_search for that use case.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        naturalKey: { type: 'string', description: 'Anchor node natural key.' },
+        charBudget: {
+          type: 'number',
+          description: `Max characters in the packed context block (default ${DEFAULT_CONTEXT_CHAR_BUDGET}).`,
+        },
+        depth: { type: 'number', description: 'Max BFS depth from the anchor (default 3).' },
+        at: { type: 'string', description: 'ISO-8601 point-in-time; omit for the current graph.' },
+      },
+      required: ['naturalKey'],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Result helpers
+// ---------------------------------------------------------------------------
+
+function textResult(data: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  } as CallToolResult;
+}
+
+function errorResult(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: `Error: ${message}` }],
+    isError: true,
+  } as CallToolResult;
+}
+
+// ---------------------------------------------------------------------------
+// kg_context — budgeted context assembly (spec §8.4)
+// ---------------------------------------------------------------------------
+
+interface ContextNode {
+  id: string;
+  kind: string;
+  name: string;
+  naturalKey: string;
+  summary: string | null;
+  distance: number;
+}
+
+interface ContextFact {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  relation: string;
+  fact: string;
+  mentions: number;
+  episodeIds: string[];
+}
+
+export interface AssembledContext {
+  context: string;
+  anchor: { id: string; naturalKey: string };
+  nodeCount: number;
+  factCount: number;
+  charBudget: number;
+  charsUsed: number;
+  truncated: boolean;
+}
+
+async function assembleContext(
+  exec: KgExecutor,
+  anchorId: string,
+  opts: { charBudget: number; depth: number; at?: Date },
+): Promise<AssembledContext> {
+  const neighbors = await kgNeighbors(exec, anchorId, { depth: opts.depth, at: opts.at });
+
+  const nodeIds = neighbors.nodes.map((n): string => n.id);
+  const summaryRows = nodeIds.length
+    ? await exec.query<{ id: string; summary: string | null }>(
+        `SELECT id, summary FROM kg_nodes WHERE id = ANY($1::text[])`,
+        [nodeIds],
+      )
+    : [];
+  const summaryById = new Map<string, string | null>(summaryRows.map((r) => [r.id, r.summary]));
+
+  const rankedNodes: ContextNode[] = neighbors.nodes
+    .map(
+      (n): ContextNode => ({
+        id: n.id,
+        kind: n.kind,
+        name: n.name,
+        naturalKey: n.naturalKey,
+        summary: summaryById.get(n.id) ?? null,
+        distance: n.distance,
+      }),
+    )
+    .sort((a, b) =>
+      a.distance - b.distance !== 0
+        ? a.distance - b.distance
+        : a.naturalKey < b.naturalKey
+          ? -1
+          : 1,
+    );
+  const distanceById = new Map<string, number>(rankedNodes.map((n) => [n.id, n.distance]));
+
+  const edgeIds = neighbors.edges.map((e): string => e.id);
+  const mentionRows = edgeIds.length
+    ? await exec.query<{ id: string; mentions: number; episode_ids: string[] | null }>(
+        `SELECT e.id, count(ee.episode_id)::int AS mentions,
+                coalesce(array_agg(ee.episode_id) FILTER (WHERE ee.episode_id IS NOT NULL), '{}') AS episode_ids
+         FROM kg_edges e
+         LEFT JOIN kg_edge_episodes ee ON ee.edge_id = e.id
+         WHERE e.id = ANY($1::text[])
+         GROUP BY e.id`,
+        [edgeIds],
+      )
+    : [];
+  const mentionById = new Map<string, { mentions: number; episodeIds: string[] }>(
+    mentionRows.map((r) => [
+      r.id,
+      { mentions: Number(r.mentions), episodeIds: r.episode_ids ?? [] },
+    ]),
+  );
+
+  interface RankedFactCandidate extends ContextFact {
+    rankDistance: number;
+  }
+
+  const rankedFacts: ContextFact[] = neighbors.edges
+    .map((e): RankedFactCandidate => {
+      const m = mentionById.get(e.id) ?? { mentions: 0, episodeIds: [] };
+      const nearDistance = Math.min(
+        distanceById.get(e.sourceId) ?? Number.POSITIVE_INFINITY,
+        distanceById.get(e.targetId) ?? Number.POSITIVE_INFINITY,
+      );
+      return {
+        id: e.id,
+        sourceId: e.sourceId,
+        targetId: e.targetId,
+        relation: e.relation,
+        fact: e.fact,
+        mentions: m.mentions,
+        episodeIds: m.episodeIds,
+        rankDistance: nearDistance,
+      };
+    })
+    .sort((a, b) => {
+      if (b.mentions - a.mentions !== 0) return b.mentions - a.mentions;
+      if (a.rankDistance - b.rankDistance !== 0) return a.rankDistance - b.rankDistance;
+      return a.id < b.id ? -1 : 1;
+    })
+    .map(({ rankDistance: _rankDistance, ...fact }): ContextFact => fact);
+
+  const lines: string[] = [`# Context for ${anchorId} (depth=${opts.depth})`, '', '## Nodes'];
+  for (const n of rankedNodes) {
+    const summaryPart = n.summary ? ` — ${n.summary}` : '';
+    lines.push(`- [${n.kind}] ${n.naturalKey} (${n.distance} hop)${summaryPart}`);
+  }
+  lines.push('', '## Facts');
+  for (const f of rankedFacts) {
+    const provenance = f.episodeIds.length > 0 ? f.episodeIds.join(', ') : 'none';
+    lines.push(`- (${f.relation}) ${f.fact} [episodes: ${provenance}]`);
+  }
+
+  let charsUsed = 0;
+  let truncated = false;
+  const packed: string[] = [];
+  for (const line of lines) {
+    const addedLength = line.length + 1; // + newline
+    if (charsUsed + addedLength > opts.charBudget) {
+      truncated = true;
+      break;
+    }
+    packed.push(line);
+    charsUsed += addedLength;
+  }
+
+  return {
+    context: packed.join('\n'),
+    anchor: {
+      id: anchorId,
+      naturalKey: rankedNodes.find((n) => n.id === anchorId)?.naturalKey ?? anchorId,
+    },
+    nodeCount: rankedNodes.length,
+    factCount: rankedFacts.length,
+    charBudget: opts.charBudget,
+    charsUsed,
+    truncated,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface CreateKnowledgeGraphServerOptions {
+  /** Injected executor. Tests pass a PGlite-backed `KgExecutor`; production omits this and resolves lazily from `@revealui/db/pool`. */
+  executor?: KgExecutor;
+  /** Injected embedder. Tests can stub; production omits this and resolves lazily from `@revealui/ai/embeddings`, degrading to `undefined` (no vector channel) when unavailable. */
+  embedder?: Embedder;
+  /** siteId stamped on episodes ingested via `kg_add_episode`. Defaults to `os.hostname()`. */
+  siteId?: string;
+}
+
+/**
+ * Create a fresh `knowledge-graph` MCP Server instance. Safe to call multiple
+ * times — each call returns an independent Server with its own request
+ * handlers and its own lazily-resolved executor/embedder cache.
+ */
+export function createKnowledgeGraphServer(options?: CreateKnowledgeGraphServerOptions): Server {
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } },
+  );
+
+  const defaultSiteId = options?.siteId ?? hostname();
+
+  let cachedExecutor: KgExecutor | undefined = options?.executor;
+  async function resolveExecutor(): Promise<KgExecutor> {
+    if (cachedExecutor) return cachedExecutor;
+    const poolModule = await import('@revealui/db/pool');
+    cachedExecutor = makePoolExecutor(poolModule.getPool());
+    return cachedExecutor;
+  }
+
+  // Tri-state: `undefined` = not yet resolved, `null` = resolved-unavailable.
+  let cachedEmbedder: Embedder | null | undefined = options?.embedder;
+  async function resolveEmbedder(): Promise<Embedder | undefined> {
+    if (cachedEmbedder !== undefined) return cachedEmbedder ?? undefined;
+    try {
+      // Non-literal specifier: `@revealui/ai` is an optional (Pro) dependency,
+      // so this package must not carry a hard type/import edge to it.
+      const specifier = '@revealui/ai/embeddings';
+      const ai = (await import(specifier)) as {
+        generateEmbedding(text: string): Promise<{ vector: number[] }>;
+      };
+      cachedEmbedder = async (text: string): Promise<number[]> => {
+        const result = await ai.generateEmbedding(text);
+        return result.vector;
+      };
+    } catch {
+      cachedEmbedder = null;
+    }
+    return cachedEmbedder ?? undefined;
+  }
+
+  /** Best-effort query embedding: Ollama-down or no embedder both fall back to `undefined` (FTS + BFS only). */
+  async function tryEmbed(text: string): Promise<number[] | undefined> {
+    const embedder = await resolveEmbedder();
+    if (!embedder) return undefined;
+    try {
+      return await embedder(text);
+    } catch {
+      return undefined;
+    }
+  }
+
+  interface NodeDetailRow {
+    id: string;
+    kind: string;
+    name: string;
+    natural_key: string;
+    repo: string | null;
+    summary: string | null;
+    attributes: Record<string, unknown>;
+    first_seen_at: string;
+    last_confirmed_at: string;
+  }
+
+  async function hydratePath(exec: KgExecutor, path: string[]): Promise<NodeDetailRow[]> {
+    if (path.length === 0) return [];
+    const rows = await exec.query<NodeDetailRow>(
+      `SELECT id, kind, name, natural_key, repo, summary, attributes, first_seen_at, last_confirmed_at
+       FROM kg_nodes WHERE id = ANY($1::text[])`,
+      [path],
+    );
+    const byId = new Map<string, NodeDetailRow>(rows.map((r) => [r.id, r]));
+    return path.flatMap((id): NodeDetailRow[] => {
+      const row = byId.get(id);
+      return row ? [row] : [];
+    });
+  }
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+    const toolName = request.params.name;
+
+    let exec: KgExecutor;
+    try {
+      exec = await resolveExecutor();
+    } catch (err) {
+      return errorResult(
+        `knowledge graph database unavailable: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    try {
+      switch (toolName) {
+        case 'kg_search': {
+          const parsed = validateToolArgs(KgSearchArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error as unknown as CallToolResult;
+          const { query, anchor, kinds, relations, at, limit, bfsDepth } = parsed.value;
+          const queryEmbedding = await tryEmbed(query);
+          const result = await kgSearch(exec, {
+            query,
+            anchor,
+            kinds: kinds as NodeKind[] | undefined,
+            relations: relations as EdgeRelation[] | undefined,
+            at: at ? new Date(at) : undefined,
+            limit,
+            bfsDepth,
+            queryEmbedding,
+          });
+          return textResult(result);
+        }
+
+        case 'kg_get_node': {
+          const parsed = validateToolArgs(KgGetNodeArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error as unknown as CallToolResult;
+          const { naturalKey } = parsed.value;
+          const id = await resolveNaturalKey(exec, naturalKey);
+          if (!id) return errorResult(`no node with natural key: ${naturalKey}`);
+          const rows = await exec.query<NodeDetailRow>(
+            `SELECT id, kind, name, natural_key, repo, summary, attributes, first_seen_at, last_confirmed_at
+             FROM kg_nodes WHERE id = $1`,
+            [id],
+          );
+          const node = rows[0];
+          if (!node) return errorResult(`node ${id} vanished`);
+          const facts = await kgAtTime(exec, id, new Date());
+          return textResult({ node, facts });
+        }
+
+        case 'kg_neighbors': {
+          const parsed = validateToolArgs(
+            KgNeighborsArgsSchema,
+            request.params.arguments,
+            toolName,
+          );
+          if (!parsed.ok) return parsed.error as unknown as CallToolResult;
+          const { naturalKey, depth, relations, at } = parsed.value;
+          const id = await resolveNaturalKey(exec, naturalKey);
+          if (!id) return errorResult(`no node with natural key: ${naturalKey}`);
+          const result = await kgNeighbors(exec, id, {
+            depth,
+            relations: relations as EdgeRelation[] | undefined,
+            at: at ? new Date(at) : undefined,
+          });
+          return textResult(result);
+        }
+
+        case 'kg_add_episode': {
+          const parsed = validateToolArgs(
+            KgAddEpisodeArgsSchema,
+            request.params.arguments,
+            toolName,
+          );
+          if (!parsed.ok) return parsed.error as unknown as CallToolResult;
+          const v = parsed.value;
+          const referenceTime = v.referenceTime ? new Date(v.referenceTime) : new Date();
+          const nodes: NodeInput[] = v.nodes.map((n) => ({
+            kind: n.kind,
+            name: n.name,
+            naturalKey: n.naturalKey,
+            repo: n.repo,
+            summary: n.summary,
+            attributes: n.attributes,
+          }));
+          const edges: EdgeInput[] = v.edges.map((e) => ({
+            source: e.source,
+            target: e.target,
+            relation: e.relation,
+            fact: e.fact,
+            repo: e.repo,
+            validAt: e.validAt ? new Date(e.validAt) : undefined,
+            attributes: e.attributes,
+          }));
+          const embedder = await resolveEmbedder();
+          const result = await ingestEpisode(
+            exec,
+            {
+              episode: {
+                episodeType: v.episodeType,
+                source: v.source,
+                siteId: v.siteId ?? defaultSiteId,
+                content: v.content,
+                contentRef: v.contentRef,
+                referenceTime,
+              },
+              nodes,
+              edges,
+            },
+            { embedder, recordOutbox: true },
+          );
+          return textResult({
+            episodeId: result.episodeId,
+            nodeCount: result.nodeCount,
+            edgeCount: result.edgeCount,
+          });
+        }
+
+        case 'kg_path': {
+          const parsed = validateToolArgs(KgPathArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error as unknown as CallToolResult;
+          const { fromNaturalKey, toNaturalKey, at, maxDepth } = parsed.value;
+          const fromId = await resolveNaturalKey(exec, fromNaturalKey);
+          if (!fromId) return errorResult(`no node with natural key: ${fromNaturalKey}`);
+          const toId = await resolveNaturalKey(exec, toNaturalKey);
+          if (!toId) return errorResult(`no node with natural key: ${toNaturalKey}`);
+          const path = await kgPath(exec, fromId, toId, {
+            at: at ? new Date(at) : undefined,
+            maxDepth,
+          });
+          if (!path) return textResult({ path: null });
+          const detail = await hydratePath(exec, path);
+          return textResult({ path: detail });
+        }
+
+        case 'kg_at_time': {
+          const parsed = validateToolArgs(KgAtTimeArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error as unknown as CallToolResult;
+          const { naturalKey, at } = parsed.value;
+          const id = await resolveNaturalKey(exec, naturalKey);
+          if (!id) return errorResult(`no node with natural key: ${naturalKey}`);
+          const facts = await kgAtTime(exec, id, new Date(at));
+          return textResult({ facts });
+        }
+
+        case 'kg_context': {
+          const parsed = validateToolArgs(KgContextArgsSchema, request.params.arguments, toolName);
+          if (!parsed.ok) return parsed.error as unknown as CallToolResult;
+          const { naturalKey, charBudget, depth, at } = parsed.value;
+          const id = await resolveNaturalKey(exec, naturalKey);
+          if (!id) return errorResult(`no node with natural key: ${naturalKey}`);
+          const assembled = await assembleContext(exec, id, {
+            charBudget: charBudget ?? DEFAULT_CONTEXT_CHAR_BUDGET,
+            depth: depth ?? 3,
+            at: at ? new Date(at) : undefined,
+          });
+          return textResult(assembled);
+        }
+
+        default:
+          return errorResult(`Unknown tool: ${toolName}`);
+      }
+    } catch (err) {
+      return errorResult(err instanceof Error ? err.message : String(err));
+    }
+  });
+
+  return server;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1236,6 +1236,12 @@ importers:
       '@revealui/core':
         specifier: workspace:*
         version: link:../core
+      '@revealui/db':
+        specifier: workspace:*
+        version: link:../db
+      '@revealui/knowledge-graph':
+        specifier: workspace:*
+        version: link:../knowledge-graph
       '@revealui/security':
         specifier: workspace:*
         version: link:../security
@@ -1258,6 +1264,10 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@revealui/ai':
+        specifier: workspace:*
+        version: link:../ai
 
   packages/openapi:
     devDependencies:


### PR DESCRIPTION
## Summary

GAP-349 P2 deliverable A: MCP tools in `@revealui/mcp` exposing the fleet
knowledge graph (`@revealui/knowledge-graph`, P1 shipped in #1858) to agents.

New factory `packages/mcp/src/servers/factories/knowledge-graph.ts`
(`createKnowledgeGraphServer`, exported at `@revealui/mcp` root and via a new
`./kg-server` subpath), following the exact `createXServer` factory pattern
established by `revealui-content.ts` / `docs.ts` — Tool[] + Zod arg schemas
+ `CallToolRequestSchema` switch handler.

Seven tools, keyed to design spec sections:
- `kg_search` — hybrid retrieval (vector + FTS + BFS, RRF-fused) — spec §7
- `kg_get_node`, `kg_neighbors`, `kg_path`, `kg_at_time` — read/traversal wrappers over the P1 search API
- `kg_add_episode` — **the only write tool**. Always calls the additive
  `ingestEpisode` (never `applyScan`, the deterministic-rescan path reserved
  for `revkg scan`). Zod-validates `episodeType` and every node kind / edge
  relation against the ontology enums; `.strict()` schemas throughout so no
  raw SQL or table names can be smuggled through any tool input.
- `kg_context` — spec §8.4 budgeted context assembly: BFS from an anchor,
  rerank by node-distance + episode-mentions, pack node summaries + edge
  facts (with provenance episode ids) into a text block capped at
  `charBudget` characters (default 16000; chars not tokens, per task scope).

**DB connection pattern (extend, not duplicate):** production resolves a
pooled `KgExecutor` lazily via dynamic `import('@revealui/db/pool')` +
`makePoolExecutor` — the same connection pattern `revkg`'s own CLI already
uses (`packages/knowledge-graph/src/cli/revkg.ts`). Tests inject a
PGlite-backed executor via `CreateKnowledgeGraphServerOptions.executor`.

**Graceful degradation:** read tools work with no pgvector and no
embeddings present — `kgSearch`'s vector channel is skipped whenever no
query embedding is supplied. Query-embedding generation is lazy + optional
(`@revealui/ai/embeddings` via a non-literal dynamic import specifier, same
technique `revkg` uses to avoid a hard type/import edge to the optional Pro
package) and wrapped in try/catch per-call, so an Ollama-down
`generateEmbedding()` call falls back to FTS + BFS only, never a hard tool
failure.

## Escalations for Fable

- **MCP SDK `CallToolResult` union assignability.** The SDK's
  `CallToolRequestSchema` handler return type is a union that includes a
  `task`-shaped member (async/background tool results). Returning a value
  through a named helper function (rather than an inline fresh object
  literal) loses TypeScript's literal-freshness exemption for the
  index-signature/task-union check, so `textResult`/`errorResult`/
  `parsed.error` (from the shared `validate-tool-args.ts` `McpToolError`
  type) needed `as CallToolResult` / `as unknown as CallToolResult` casts to
  typecheck. Verified safe at runtime (all 27 new tests pass, including
  explicit error-path assertions), but it's a structural-typing wart worth a
  second look — a cleaner fix might be adding an index signature to the
  shared `McpToolError` interface itself so every factory using
  `validateToolArgs` benefits, rather than casting at each of my 7 call
  sites. Left as-is (additive-only local change) rather than touching a
  shared file used by every other MCP factory in this PR.
- **`EpisodeType` duplication.** `@revealui/knowledge-graph`'s `EpisodeType`
  union (`types.ts`) isn't exported as a runtime array by P1, so the Zod
  enum for `kg_add_episode`'s `episodeType` field duplicates the 7-value
  literal list locally with a comment flagging the lockstep requirement.
  Low-risk (P3 would need to touch this factory anyway on any ontology
  change) but flagging since it's the one place this PR carries knowledge
  that could drift from its source of truth.

## Deferred: bridge exposure (deliverable C)

**Not built.** Audited whether `@revdev/bridge` (separate `revdev` repo/
pnpm workspace) can consume `@revealui/knowledge-graph` today:

- `@revealui/knowledge-graph` is at `0.1.0` in the `revealui` workspace and
  is **not published to npm** (`npm view @revealui/knowledge-graph versions`
  → 404).
- `@revdev/bridge`'s existing `@revealui/*` consumption precedent
  (`packages/daemon/package.json`) is via published semver ranges
  (`"@revealui/contracts": "^1.4.0"`, etc.) — never a path or git dependency
  across the two repos' separate pnpm workspaces.
- Per the task's hard constraint (no path deps across repos, no git deps),
  building C now would require inventing a new, unprecedented cross-repo
  dependency mechanism — out of scope for a P2 agent-surfaces PR.

**Unblock:** publish `@revealui/knowledge-graph` to npm (it already carries
`publishConfig: { access: "public", registry: "https://registry.npmjs.org" }`
and ships via the existing changesets pipeline — `pnpm changeset` →
`pnpm changeset:version` → `release.yml` `workflow_dispatch`, or lands
automatically via `release-canary.yml` on the next push to `test` if a
changeset is present). Once published, `@revdev/bridge`'s change is
mechanical: add `"@revealui/knowledge-graph": "^0.1.0"` to
`packages/bridge/package.json` dependencies and mirror the same seven
tool definitions through its existing MCP tool registration pattern
(`packages/bridge/src/index.ts`), reusing this PR's Zod schemas as the
reference shape.

## Test plan

- [x] `pnpm --filter @revealui/mcp test` — 423 passed, 5 skipped (23 files, incl. 27 new tests)
- [x] `pnpm --filter @revealui/mcp typecheck` — clean
- [x] `pnpm exec biome check` on all changed files — clean
- [x] `pnpm --filter "@revealui/mcp..." build` — clean (full dependency chain)
- [x] `pnpm --filter server typecheck` — clean (consumer of `@revealui/mcp`)
- [x] `pnpm --filter admin typecheck` — clean (consumer of `@revealui/mcp`)
- [x] New tests never touch a real database — PGlite only, built from
      `@revealui/knowledge-graph`'s public export surface
      (`kgDdlStatements` + `makeExecutor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)