### PR TITLE
chore(dev): refresh dev-shell banner; fix doc-currency and biome local-gate breakages

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
             # session that enters this dev environment.
             db-start() {
               if [ ! -d "$PGDATA" ]; then
-                echo "❌ PostgreSQL not initialized. Run 'revealui db init' first."
+                echo "❌ PostgreSQL not initialized. Run 'db-init' first."
                 return 1
               fi
               if pg_ctl status -D "$PGDATA" &>/dev/null; then
@@ -168,7 +168,7 @@ host    all             all             127.0.0.1/32            trust
 host    all             all             ::1/128                 trust
 PGHBA
               echo "✅ PostgreSQL initialized at $PGDATA"
-              echo "   Run 'revealui db start' to start the server"
+              echo "   Run 'db-start' to start the server"
             }
 
             db-reset() {
@@ -180,7 +180,7 @@ PGHBA
 
             db-psql() {
               if ! pg_ctl status -D "$PGDATA" &>/dev/null; then
-                echo "❌ PostgreSQL is not running. Run 'revealui db start' first."
+                echo "❌ PostgreSQL is not running. Run 'db-start' first."
                 return 1
               fi
               psql -h "$PGHOST" -U postgres -d postgres "$@"
@@ -227,7 +227,7 @@ PGHBA
             [ "$_ENV" = "production"  ] && _ENV="prod"
 
             # ── Boxed header ───────────────────────────────────────────────────
-            _TITLE="  RevealUI  ·  Business OS  ·  $_ENV  "
+            _TITLE="  RevealUI  ·  Agentic Business Runtime  ·  $_ENV  "
             _W=''${#_TITLE}
             _LINE=$(printf '─%.0s' $(seq 1 "$_W"))
             echo ""
@@ -251,11 +251,11 @@ PGHBA
             _warn() { _WARNS="$_WARNS   ''${_AMBER}⚠  $1''${_NC}\n"; }
 
             if [ ! -d "$PGDATA" ]; then
-              _warn "postgres  ''${_DIM}→''${_NC}  ''${_CYAN}revealui db init''${_NC}"
+              _warn "postgres  ''${_DIM}→''${_NC}  ''${_CYAN}db-init''${_NC}"
             elif pg_ctl status -D "$PGDATA" &>/dev/null; then
               _ok "''${_GREEN}✓ postgres''${_NC}"; _PG_READY=1
             else
-              _warn "postgres  ''${_DIM}→''${_NC}  ''${_CYAN}revealui db start''${_NC}"
+              _warn "postgres  ''${_DIM}→''${_NC}  ''${_CYAN}db-start''${_NC}"
             fi
 
             if [ -d "node_modules" ]; then
@@ -268,22 +268,22 @@ PGHBA
               && _ok "''${_GREEN}✓ docker''${_NC}" \
               || _warn "docker  ''${_DIM}→''${_NC}  start Docker Desktop"
 
-            { [ -n "''${VERCEL_API_KEY:-}" ] || [ -n "''${STRIPE_SECRET_KEY:-}" ]; } \
-              && _ok "''${_GREEN}✓ mcp''${_NC}" \
-              || _warn "mcp  ''${_DIM}→''${_NC}  ''${_CYAN}dev up --include mcp''${_NC}"
+            # Secrets are revvault-first: check the vault store, not env vars.
+            [ -d "''${REVVAULT_STORE:-$HOME/.revealui/passage-store}" ] \
+              && _ok "''${_GREEN}✓ vault''${_NC}" \
+              || _warn "vault  ''${_DIM}→''${_NC}  ''${_CYAN}revvault init''${_NC}"
 
-            [ "''${TERM_PROGRAM:-}" = "zed" ] \
-              && _ok "''${_GREEN}✓ acp''${_NC}" \
-              || _warn "acp  ''${_DIM}→''${_NC}  open Zed + connect"
+            # ACP only applies inside Zed — a plain terminal is not degraded.
+            [ "''${TERM_PROGRAM:-}" = "zed" ] && _ok "''${_GREEN}✓ acp''${_NC}"
 
             echo ""
             [ -n "$_OK"    ] && echo -e "   $_OK"
             [ -n "$_WARNS" ] && printf "\n%b" "$_WARNS"
 
             # ── Quick commands ─────────────────────────────────────────────────
-            _CMDS="''${_CYAN}dev''${_NC}  ''${_DIM}·''${_NC}  ''${_CYAN}wb''${_NC}"
+            _CMDS="''${_CYAN}pnpm dev''${_NC}  ''${_DIM}·''${_NC}  ''${_CYAN}wb''${_NC}"
             [ "$_PG_READY"   = 1 ] && _CMDS="$_CMDS  ''${_DIM}·''${_NC}  ''${_CYAN}db-psql''${_NC}"
-            [ "$_DEPS_READY" = 1 ] && _CMDS="$_CMDS  ''${_DIM}·''${_NC}  ''${_CYAN}gate:quick''${_NC}"
+            [ "$_DEPS_READY" = 1 ] && _CMDS="$_CMDS  ''${_DIM}·''${_NC}  ''${_CYAN}pnpm gate:quick''${_NC}"
             echo -e "\n   $_CMDS\n"
 
             unset _B _AMBER _GREEN _CYAN _DIM _NC
@@ -291,9 +291,14 @@ PGHBA
             unset _OK _WARNS _PG_READY _DEPS_READY _CMDS
             unset -f _ok _warn
 
-            # Live workboard watcher — renders .claude/workboard.md every 3 s
+            # Live workboard watcher — renders the workboard every 3 s.
+            # The in-repo .claude/workboard.md may be a redirect stub; set
+            # REVEALUI_WORKBOARD (e.g. in .envrc.local) to watch the real one.
             # Usage: wb
-            wb() { watch -n3 "glow '$PWD/.claude/workboard.md' 2>/dev/null || cat '$PWD/.claude/workboard.md'"; }
+            wb() {
+              local _wb="''${REVEALUI_WORKBOARD:-$PWD/.claude/workboard.md}"
+              watch -n3 "glow '$_wb' 2>/dev/null || cat '$_wb'"
+            }
             export -f wb
 
             # opensrc — fetch package source for agent context

--- a/scripts/validate/__tests__/doc-currency.test.ts
+++ b/scripts/validate/__tests__/doc-currency.test.ts
@@ -1,9 +1,11 @@
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   COMMON_EXON,
+  collectMarkdownFiles,
   extractStringLiterals,
   type Hit,
   hitKey,
@@ -239,6 +241,35 @@ describe('shouldSkipFile — historical exemptions', () => {
     const abs = path.join(tmpRoot, 'current.md');
     fs.writeFileSync(abs, '# Current\n\nWe use Neon and ElectricSQL.');
     expect(shouldSkipFile('docs/current.md', abs)).toBe(false);
+  });
+});
+
+describe('collectMarkdownFiles — gitignored generated files', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-currency-gitignore-'));
+    fs.mkdirSync(path.join(tmpRoot, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, 'docs', 'current.md'), '# Current\n');
+    fs.writeFileSync(path.join(tmpRoot, 'docs', 'generated.md'), '# Generated\n');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('drops gitignored files inside a git repo (generated mirrors are not scanned)', () => {
+    execFileSync('git', ['-C', tmpRoot, 'init', '--quiet']);
+    fs.writeFileSync(path.join(tmpRoot, '.gitignore'), 'docs/generated.md\n');
+    const files = collectMarkdownFiles(tmpRoot);
+    expect(files.some((f) => f.endsWith('current.md'))).toBe(true);
+    expect(files.some((f) => f.endsWith('generated.md'))).toBe(false);
+  });
+
+  it('passes everything through outside a git repo (unit-test temp dirs)', () => {
+    const files = collectMarkdownFiles(tmpRoot);
+    expect(files.some((f) => f.endsWith('current.md'))).toBe(true);
+    expect(files.some((f) => f.endsWith('generated.md'))).toBe(true);
   });
 });
 

--- a/scripts/validate/doc-currency.ts
+++ b/scripts/validate/doc-currency.ts
@@ -10,7 +10,7 @@
  *   1. Markdown prose across the repo's reader-facing surfaces (line-based
  *      substring scan, mirroring the fenced-import scanner style already used
  *      by `docs-import-drift.ts`): the whole `docs/**` tree (including the
- *      public `docs/blog` posts and `apps/docs/public` mirror via `apps/**`),
+ *      public `docs/blog` posts) plus `apps/**` markdown,
  *      every package `README.md`, and the root-level docs
  *      (README/CLAUDE/AGENTS/SECURITY/…). CHANGELOGs and archived/handoff
  *      records are skipped as inherently historical.
@@ -48,6 +48,7 @@
  * Exit 0 = clean (or report mode). Exit 1 = new drift (ci mode). Exit 2 = bad arg.
  */
 
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import ts from 'typescript';
@@ -408,6 +409,34 @@ function walkMarkdownFiles(dir: string, acc: string[], accept: (name: string) =>
   }
 }
 
+/**
+ * Drop gitignored files from a collected list. Gitignored markdown is
+ * generated output (e.g. the `apps/docs/public` mirror that `copy-docs.sh`
+ * regenerates from `docs/`): its sources are already scanned directly, its
+ * paths are absent from the baseline, and CI checkouts never contain it —
+ * so scanning it yields only machine-dependent duplicate findings.
+ * Outside a git repo (unit-test temp dirs), the list passes through as-is.
+ */
+function filterGitignored(root: string, files: string[]): string[] {
+  if (files.length === 0) return files;
+  let out: string;
+  try {
+    out = execFileSync('git', ['-C', root, 'check-ignore', '--stdin'], {
+      input: files.join('\n'),
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err) {
+    const e = err as { status?: number | null; stdout?: unknown };
+    // Exit code 1 means "no paths are ignored"; anything else (128 = not a
+    // git repo, ENOENT = no git binary) falls back to scanning everything.
+    if (e.status !== 1) return files;
+    out = typeof e.stdout === 'string' ? e.stdout : '';
+  }
+  const ignored = new Set(out.split('\n').filter((line) => line.length > 0));
+  return files.filter((f) => !ignored.has(f));
+}
+
 export function collectMarkdownFiles(root: string): string[] {
   const acc: string[] = [];
   for (const rel of MARKDOWN_ROOTS) walkMarkdownFiles(path.join(root, rel), acc, isMarkdown);
@@ -425,7 +454,7 @@ export function collectMarkdownFiles(root: string): string[] {
   for (const e of entries) {
     if (e.isFile() && isMarkdown(e.name)) acc.push(path.join(root, e.name));
   }
-  return acc;
+  return filterGitignored(root, acc);
 }
 
 export function scanMarkdownFile(root: string, abs: string): Hit[] {
@@ -484,7 +513,7 @@ function walkContentFiles(dir: string, acc: string[]): void {
 export function collectContentFiles(root: string): string[] {
   const acc: string[] = [];
   walkContentFiles(path.join(root, CONTENT_ROOT_REL), acc);
-  return acc;
+  return filterGitignored(root, acc);
 }
 
 export interface StringLiteralSpan {


### PR DESCRIPTION
## Why

The dev-shell banner had drifted from both the product messaging and the actual tooling, and pushing the fix surfaced two unrelated local-gate breakages that are fixed here too (they blocked any push from a machine that had run the docs app).

## Commit 1 — banner refresh (`flake.nix`)

- "Business OS" title replaced with the current positioning, "Agentic Business Runtime".
- `revealui db init` / `revealui db start` hints replaced with the `db-init` / `db-start` shell functions that exist; the installed `revealui` binary is the tmux workspace launcher and has no `db` subcommand.
- The mcp readiness check keyed off `VERCEL_API_KEY` / `STRIPE_SECRET_KEY` env vars, contradicting the revvault-first secrets posture (M4). Replaced with a `vault` check on the revvault store directory, hinting `revvault init`.
- The acp warning fired in every non-Zed terminal; it now shows a green check inside Zed and stays silent elsewhere.
- Quick commands are now runnable as written: `pnpm dev`, `wb`, `pnpm gate:quick`.
- `wb` watched the in-repo `.claude/workboard.md` redirect stub forever; it now honors a `REVEALUI_WORKBOARD` override (set in the gitignored `.envrc.local`) with the in-repo file as fallback, keeping the private hub path out of the public repo.

Verified by re-entering the dev shell: banner renders, vault check goes green, postgres hint points at `db-start`.

## Commit 2 — doc-currency scanner false failures (`scripts/validate/doc-currency.ts`)

The scanner walked `apps/**` from the filesystem, pulling in the gitignored `apps/docs/public` mirror that `copy-docs.sh` regenerates from `docs/`. Those copies duplicate already-scanned sources at paths the baseline does not carry and CI checkouts never contain, so any machine that had ever run the docs app failed the pre-push doc-currency gate on findings unrelated to its diff. Collected files now pass through `git check-ignore` (via `execFileSync`, no shell); outside a git repo or without git the list passes through unchanged, so CI and unit-test behavior for tracked files is identical. New tests cover both paths; the in-repo case was proven red against the previous scanner.

## Commit 3 — biome.json schema bump

The catalog bump to `@biomejs/biome` 2.5.2 landed without updating `biome.json`'s `$schema` (still 2.5.0), which made every local `biome check` emit a hard deserialize error and fail the gate's lint phase. Bumped to 2.5.2.

## Verification

- `pnpm validate:doc-currency --mode=ci`: OK (116 baselined, 0 new)
- `pnpm vitest run scripts/validate/__tests__/doc-currency.test.ts`: 44/44
- `pnpm lint`: 0 errors (9 pre-existing warnings unchanged)
- Full pre-push gate passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
