### PR TITLE
fix(knowledge-graph,db): GAP-349 scan-hardening batch

### DIFF
--- a/packages/db/src/__tests__/pool-statement-timeout.test.ts
+++ b/packages/db/src/__tests__/pool-statement-timeout.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression tests for the pool `onPoolConnect` SET-statement bug (GAP-349
+ * fleet scan incident): `SET statement_timeout TO $1` fails on every pool
+ * connection with "syntax error at or near $1" because Postgres' `SET`
+ * command does not accept bind parameters. The fix validates the timeout
+ * value and interpolates it as a literal instead.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPoolInstance = {
+  on: vi.fn(),
+  connect: vi.fn(),
+  end: vi.fn(),
+  query: vi.fn(),
+  totalCount: 10,
+  idleCount: 5,
+  waitingCount: 0,
+};
+
+vi.mock('pg', () => {
+  class MockPool {
+    on = mockPoolInstance.on;
+    connect = mockPoolInstance.connect;
+    end = mockPoolInstance.end;
+    query = mockPoolInstance.query;
+    totalCount = mockPoolInstance.totalCount;
+    idleCount = mockPoolInstance.idleCount;
+    waitingCount = mockPoolInstance.waitingCount;
+  }
+  return { Pool: MockPool };
+});
+
+vi.mock('@revealui/utils/database', () => ({
+  getSSLConfig: vi.fn(() => false),
+}));
+
+vi.mock('@revealui/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+let originalEnv: NodeJS.ProcessEnv;
+
+describe('formatValidatedStatementTimeoutMs', () => {
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    process.env.NODE_ENV = 'test';
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it('formats a finite positive integer as a bare numeric string', async () => {
+    const { formatValidatedStatementTimeoutMs } = await import('../pool.js');
+    expect(formatValidatedStatementTimeoutMs(10000)).toBe('10000');
+    expect(formatValidatedStatementTimeoutMs(1)).toBe('1');
+  });
+
+  it('accepts a numeric string and formats it as a bare numeric string', async () => {
+    const { formatValidatedStatementTimeoutMs } = await import('../pool.js');
+    expect(formatValidatedStatementTimeoutMs('300000')).toBe('300000');
+  });
+
+  it('rejects non-finite values', async () => {
+    const { formatValidatedStatementTimeoutMs } = await import('../pool.js');
+    expect(() => formatValidatedStatementTimeoutMs(Number.NaN)).toThrow(
+      'invalid statement_timeout value',
+    );
+    expect(() => formatValidatedStatementTimeoutMs(Number.POSITIVE_INFINITY)).toThrow(
+      'invalid statement_timeout value',
+    );
+  });
+
+  it('rejects non-integer values', async () => {
+    const { formatValidatedStatementTimeoutMs } = await import('../pool.js');
+    expect(() => formatValidatedStatementTimeoutMs(10.5)).toThrow(
+      'invalid statement_timeout value',
+    );
+  });
+
+  it('rejects zero and negative values', async () => {
+    const { formatValidatedStatementTimeoutMs } = await import('../pool.js');
+    expect(() => formatValidatedStatementTimeoutMs(0)).toThrow('invalid statement_timeout value');
+    expect(() => formatValidatedStatementTimeoutMs(-1)).toThrow('invalid statement_timeout value');
+  });
+
+  it('rejects a non-numeric string', async () => {
+    const { formatValidatedStatementTimeoutMs } = await import('../pool.js');
+    expect(() => formatValidatedStatementTimeoutMs('not-a-number')).toThrow(
+      'invalid statement_timeout value',
+    );
+  });
+});
+
+describe('onPoolConnect setup query', () => {
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    process.env.NODE_ENV = 'test';
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it('issues one multi-statement SET query with the timeout interpolated as a literal, never a $1 placeholder', async () => {
+    const { getPool } = await import('../pool.js');
+    void getPool().totalCount;
+
+    const connectCall = mockPoolInstance.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === 'connect',
+    );
+    expect(connectCall).toBeDefined();
+    const onConnect = connectCall?.[1] as (client: unknown) => void;
+
+    const fakeClient = { query: vi.fn().mockResolvedValue({ rows: [] }), processID: 1 };
+    onConnect(fakeClient);
+    // The setup query runs in a detached (fire-and-forget) async flow off the
+    // synchronous 'connect' event handler; flush microtasks so it lands.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fakeClient.query).toHaveBeenCalledTimes(1);
+    const [sql] = fakeClient.query.mock.calls[0] as [string];
+    expect(sql).not.toContain('$1');
+    expect(sql).toContain("SET timezone TO 'UTC'");
+    expect(sql).toContain('SET statement_timeout TO 10000');
+    expect(sql).toContain('SET track_io_timing = on');
+  });
+});

--- a/packages/db/src/pool.ts
+++ b/packages/db/src/pool.ts
@@ -140,6 +140,41 @@ export function getPool(): Pool {
   return _pool;
 }
 
+export interface CreatePoolOptions {
+  connectionTimeoutMillis?: number;
+  queryTimeoutMillis?: number;
+  statementTimeoutMillis?: number;
+  max?: number;
+}
+
+/**
+ * Create a standalone pool for a caller whose workload doesn't fit the
+ * shared app pool's server-tuned defaults (5s connect, 10s query/statement)
+ * -- e.g. a long-running CLI ingest against a cold Neon compute. Reuses the
+ * same connection-identity + SSL resolution as `getPool()`, but does NOT
+ * attach the shared `onPoolConnect` setup handler: that handler's `SET
+ * statement_timeout` is pinned to the shared pool's own budget
+ * (`poolConfig.statement_timeout`) and would silently override a caller's
+ * longer override on every connection. `statement_timeout`/`query_timeout`
+ * passed here are instead applied by the pg driver itself as connection
+ * startup parameters (see `Client#getStartupConf` in `pg`), so no manual
+ * `SET` round trip is needed for a pool that isn't the shared one. This is
+ * the only sanctioned way for non-`packages/db` code to obtain a `pg.Pool`
+ * (the raw-SQL `direct-import` gate blocks importing `pg` elsewhere).
+ */
+export function createPool(options: CreatePoolOptions = {}): Pool {
+  const pool = new Pool({
+    ...getConnectionIdentity(),
+    ssl: getPoolSSLConfig(),
+    connectionTimeoutMillis: options.connectionTimeoutMillis,
+    query_timeout: options.queryTimeoutMillis,
+    statement_timeout: options.statementTimeoutMillis,
+    max: options.max,
+  });
+  pool.on('error', onPoolError);
+  return pool;
+}
+
 // ===========================================================================
 // ERROR HANDLING
 // ===========================================================================

--- a/packages/db/src/pool.ts
+++ b/packages/db/src/pool.ts
@@ -186,27 +186,44 @@ function onPoolError(err: Error) {
   );
 }
 
+/**
+ * Validate `value` is a finite, positive, safe integer and format it as a
+ * bare numeric literal for interpolation into a `SET` statement. Postgres'
+ * `SET` command does not accept bind parameters ("syntax error at or near
+ * $1" on every connection — the defect this replaces), so the value must be
+ * interpolated directly into the query text. `value` is always the already
+ * `parseInt`-ed `poolConfig.statement_timeout`, never user input, and this
+ * validator only ever emits digits, so there is no injection surface.
+ */
+export function formatValidatedStatementTimeoutMs(value: unknown): string {
+  const ms = typeof value === 'number' ? value : Number(value);
+  if (!(Number.isFinite(ms) && Number.isInteger(ms)) || ms <= 0) {
+    throw new Error(`invalid statement_timeout value: ${String(value)}`);
+  }
+  return String(ms);
+}
+
+async function initializeConnection(client: PoolClient): Promise<void> {
+  const timeoutMs = formatValidatedStatementTimeoutMs(poolConfig.statement_timeout || 10000);
+  // One multi-statement round trip (simple query protocol) so the three
+  // setup statements execute as a single sequential flow on this client
+  // instead of three separate awaited `client.query()` calls racing for
+  // the connection.
+  await client.query(
+    `SET timezone TO 'UTC'; SET statement_timeout TO ${timeoutMs}; SET track_io_timing = on`,
+  );
+}
+
 function onPoolConnect(client: PoolClient) {
   const pid = (client as PoolClientWithPID).processID;
   logger.info(`Database connection established (PID: ${pid})`);
 
-  void (async () => {
-    try {
-      // Set timezone
-      await client.query("SET timezone TO 'UTC'");
-
-      // Set statement timeout (parameterized to prevent injection)
-      await client.query('SET statement_timeout TO $1', [poolConfig.statement_timeout || 10000]);
-
-      // Enable query statistics
-      await client.query('SET track_io_timing = on');
-    } catch (error) {
-      logger.error(
-        'Error initializing database client',
-        error instanceof Error ? error : new Error(String(error)),
-      );
-    }
-  })();
+  void initializeConnection(client).catch((error) => {
+    logger.error(
+      'Error initializing database client',
+      error instanceof Error ? error : new Error(String(error)),
+    );
+  });
 }
 
 function onPoolAcquire(client: PoolClient) {

--- a/packages/knowledge-graph/src/cli/revkg.ts
+++ b/packages/knowledge-graph/src/cli/revkg.ts
@@ -8,10 +8,20 @@
  *   revkg neighbors <naturalKey> [--depth <n>] [--at <iso>]
  *   revkg at <naturalKey> <iso>
  *
- * Connects to Neon via `@revealui/db` (POSTGRES_URL / DATABASE_URL). Embeddings,
- * when a local model is available, come from `@revealui/ai` — loaded lazily so
- * the graph still ingests (with NULL embeddings, deferred backfill) when it is
- * absent or Ollama is down.
+ * Connects to Neon via its own pool (`@revealui/db`'s `createPool`, DATABASE_URL
+ * / POSTGRES_URL resolved by `getConnectionIdentity`) rather than the shared
+ * app pool: the shared pool's server-tuned defaults (5s connect timeout, 10s
+ * query/statement timeout) are wrong for a long-running ingest — they killed
+ * real fleet scans against a cold Neon compute (a connect timeout, then a
+ * mid-scan "Query read timeout" on the largest repo). This pool uses a much
+ * longer connect timeout and a 5-minute query/statement budget, and a small
+ * `max` since a CLI scan is a single-threaded ingest, not a request-serving
+ * pool. `createPool` (not a direct `pg` import — the raw-SQL `direct-import`
+ * gate only allows `pg` inside `packages/db/src/`) is the sanctioned way for
+ * this package to get a `pg.Pool`. Embeddings, when a local model is
+ * available, come from `@revealui/ai` — loaded lazily so the graph still
+ * ingests (with NULL embeddings, deferred backfill) when it is absent or
+ * Ollama is down.
  */
 
 import { hostname } from 'node:os';
@@ -24,6 +34,25 @@ import { resolveNaturalKey } from '../ingest/resolve.js';
 import type { NodeKind } from '../ontology/index.js';
 import { kgAtTime, kgNeighbors, kgSearch } from '../search/index.js';
 import type { Embedder, KgExecutor } from '../types.js';
+
+/** Long-running-ingest pool tuning (spec: cold Neon compute + big-repo scans). */
+const CLI_POOL_CONNECT_TIMEOUT_MS = 30_000;
+const CLI_POOL_QUERY_TIMEOUT_MS = 300_000;
+const CLI_POOL_MAX_CLIENTS = 5;
+
+/** Target host to surface on a connection error, without ever printing the full URL/credentials. */
+let lastTargetHost: string | undefined;
+
+function describeTargetHost(identity: { connectionString?: string; host?: string }): string {
+  if (identity.connectionString) {
+    try {
+      return new URL(identity.connectionString).hostname;
+    } catch {
+      return '(unparseable connection string)';
+    }
+  }
+  return identity.host ?? 'localhost';
+}
 
 function out(line: string): void {
   process.stdout.write(`${line}\n`);
@@ -67,11 +96,25 @@ function parseArgs(argv: string[]): ParsedArgs {
 }
 
 async function getExecutor(): Promise<{ exec: KgExecutor; close: () => Promise<void> }> {
-  const pool = await import('@revealui/db/pool');
-  const client = pool.getPool();
+  const { createPool, getConnectionIdentity } = await import('@revealui/db/pool');
+  const identity = getConnectionIdentity();
+  lastTargetHost = describeTargetHost(identity);
+
+  const pool = createPool({
+    connectionTimeoutMillis: CLI_POOL_CONNECT_TIMEOUT_MS,
+    queryTimeoutMillis: CLI_POOL_QUERY_TIMEOUT_MS,
+    statementTimeoutMillis: CLI_POOL_QUERY_TIMEOUT_MS,
+    max: CLI_POOL_MAX_CLIENTS,
+  });
+  pool.on('error', (error) => {
+    process.stderr.write(
+      `revkg: pool error (host: ${lastTargetHost}): ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+  });
+
   return {
-    exec: makePoolExecutor(client),
-    close: () => client.end(),
+    exec: makePoolExecutor(pool),
+    close: () => pool.end(),
   };
 }
 
@@ -271,5 +314,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((error: unknown) => {
-  fail(error instanceof Error ? error.message : String(error));
+  const hostSuffix = lastTargetHost ? ` (target host: ${lastTargetHost})` : '';
+  fail(`${error instanceof Error ? error.message : String(error)}${hostSuffix}`);
 });

--- a/packages/knowledge-graph/src/extractors/__tests__/single-package-repo.test.ts
+++ b/packages/knowledge-graph/src/extractors/__tests__/single-package-repo.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Fleet scan hardening (GAP-349): coverage for non-pnpm-monorepo fleet repos.
+ *
+ * Before this fix, `workspaceExtractor`/`tsProjectExtractor` only discovered
+ * scan targets via `pnpm-workspace.yaml` membership, so a fleet repo with no
+ * workspace file (e.g. a bare Vite SPA checkout like `agency`) produced only
+ * the bare repo node and zero file/symbol coverage ("agency: 1 nodes, 0
+ * edges" from the first `revkg scan --fleet` run). These fixtures exercise
+ * the three shapes observed across the fleet: a single-package repo with a
+ * real TS `src` tree, a repo with a `package.json` but no TS, and a bare
+ * directory with neither.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { deriveNodeId } from '../../ids.js';
+import { packageKey, repoKey } from '../shared.js';
+import { tsProjectExtractor } from '../ts-project.js';
+import type { ExtractorContext } from '../types.js';
+import { workspaceExtractor } from '../workspace.js';
+
+const tempDirs: string[] = [];
+
+async function makeTempRepo(files: Record<string, string>): Promise<string> {
+  const root = mkdtempSync(join(tmpdir(), 'revkg-single-pkg-'));
+  tempDirs.push(root);
+  for (const [relPath, content] of Object.entries(files)) {
+    const full = join(root, relPath);
+    await mkdir(dirname(full), { recursive: true });
+    writeFileSync(full, content, 'utf-8');
+  }
+  return root;
+}
+
+function ctxFor(repoRoot: string, repo: string): ExtractorContext {
+  return { repoRoot, repo, siteId: 'site-test', now: new Date('2026-07-11T00:00:00Z') };
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('single-package (non-monorepo) repo fallback', () => {
+  it('extracts file + symbol nodes for a single-package repo with a tsconfig and src tree', async () => {
+    const repoRoot = await makeTempRepo({
+      'package.json': JSON.stringify({ name: 'agency', version: '0.1.0' }),
+      'tsconfig.json': JSON.stringify({ compilerOptions: { strict: true } }),
+      'src/index.ts': "export const greeting = 'hello';\n",
+    });
+    const ctx = ctxFor(repoRoot, 'agency');
+
+    const [wsProduct] = await workspaceExtractor.extract(ctx);
+    expect(wsProduct).toBeDefined();
+    const wsKinds = wsProduct?.nodes.map((n) => `${n.kind}:${n.naturalKey}`) ?? [];
+    expect(wsKinds).toContain(`repo:${repoKey('agency')}`);
+    expect(wsKinds).toContain(`package:${packageKey('agency', 'agency')}`);
+    expect(wsProduct?.edges).toEqual([
+      expect.objectContaining({
+        source: { kind: 'repo', naturalKey: repoKey('agency') },
+        target: { kind: 'package', naturalKey: packageKey('agency', 'agency') },
+        relation: 'contains',
+      }),
+    ]);
+
+    const [tsProduct] = await tsProjectExtractor.extract(ctx);
+    expect(tsProduct).toBeDefined();
+    const fileNode = tsProduct?.nodes.find((n) => n.kind === 'file');
+    expect(fileNode?.naturalKey).toBe('agency/src/index.ts');
+    const symbolNode = tsProduct?.nodes.find((n) => n.kind === 'symbol');
+    expect(symbolNode?.name).toBe('greeting');
+    expect(symbolNode?.naturalKey).toBe('agency/src/index.ts#greeting');
+
+    // The ts-project `contains` edge must originate from the SAME package
+    // natural key the workspace extractor emitted, so the two Tier-1
+    // extractors converge on one deterministic node id for the package.
+    const containsEdge = tsProduct?.edges.find((e) => e.relation === 'contains');
+    expect(containsEdge?.source).toEqual({
+      kind: 'package',
+      naturalKey: packageKey('agency', 'agency'),
+    });
+  });
+
+  it('yields the repo + implicit package node but zero file/symbol nodes for a repo with package.json and no TS', async () => {
+    const repoRoot = await makeTempRepo({
+      'package.json': JSON.stringify({ name: 'status', version: '0.1.0' }),
+      'README.md': '# status\n',
+    });
+    const ctx = ctxFor(repoRoot, 'status');
+
+    const [wsProduct] = await workspaceExtractor.extract(ctx);
+    const wsKinds = wsProduct?.nodes.map((n) => `${n.kind}:${n.naturalKey}`) ?? [];
+    expect(wsKinds).toContain(`repo:${repoKey('status')}`);
+    expect(wsKinds).toContain(`package:${packageKey('status', 'status')}`);
+
+    const tsProducts = await tsProjectExtractor.extract(ctx);
+    expect(tsProducts).toEqual([]);
+  });
+
+  it('does not error on a bare directory with neither package.json nor TS, and still yields the repo node', async () => {
+    const repoRoot = await makeTempRepo({
+      '.gitkeep': '',
+    });
+    const ctx = ctxFor(repoRoot, 'scripts');
+
+    const [wsProduct] = await workspaceExtractor.extract(ctx);
+    expect(wsProduct).toBeDefined();
+    const repoNode = wsProduct?.nodes.find((n) => n.kind === 'repo');
+    expect(repoNode?.naturalKey).toBe(repoKey('scripts'));
+
+    await expect(tsProjectExtractor.extract(ctx)).resolves.toEqual([]);
+  });
+
+  it('derives distinct node ids for implicit single-package repos with the same package name in different repos', async () => {
+    const repoA = await makeTempRepo({ 'package.json': JSON.stringify({ name: 'shared-name' }) });
+    const repoB = await makeTempRepo({ 'package.json': JSON.stringify({ name: 'shared-name' }) });
+
+    const [productA] = await workspaceExtractor.extract(ctxFor(repoA, 'repo-a'));
+    const [productB] = await workspaceExtractor.extract(ctxFor(repoB, 'repo-b'));
+
+    const pkgNodeA = productA?.nodes.find((n) => n.kind === 'package');
+    const pkgNodeB = productB?.nodes.find((n) => n.kind === 'package');
+    expect(pkgNodeA?.naturalKey).not.toBe(pkgNodeB?.naturalKey);
+
+    const idA = deriveNodeId('package', pkgNodeA?.naturalKey ?? '');
+    const idB = deriveNodeId('package', pkgNodeB?.naturalKey ?? '');
+    expect(idA).not.toBe(idB);
+  });
+
+  it('never emits an implicit package when the repo declares a pnpm workspace', async () => {
+    const repoRoot = await makeTempRepo({
+      'pnpm-workspace.yaml': 'packages:\n  - packages/*\n',
+      'packages/core/package.json': JSON.stringify({ name: 'core' }),
+    });
+    const ctx = ctxFor(repoRoot, 'revealui');
+
+    const [wsProduct] = await workspaceExtractor.extract(ctx);
+    const packageNodes = wsProduct?.nodes.filter((n) => n.kind === 'package') ?? [];
+    expect(packageNodes).toHaveLength(1);
+    expect(packageNodes[0]?.naturalKey).toBe(packageKey('revealui', 'core'));
+    // The implicit-package fallback name (`revealui`, the repo dir basename)
+    // must never appear alongside the real workspace-derived package.
+    expect(packageNodes.some((n) => n.naturalKey === packageKey('revealui', 'revealui'))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/knowledge-graph/src/extractors/shared.ts
+++ b/packages/knowledge-graph/src/extractors/shared.ts
@@ -7,7 +7,7 @@
  */
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { basename, join, relative } from 'node:path';
 import type { EpisodeInput } from '../types.js';
 
 // =============================================================================
@@ -110,6 +110,28 @@ export function listDir(path: string): string[] {
   } catch {
     return [];
   }
+}
+
+// =============================================================================
+// Single-package (non-monorepo) repo fallback
+// =============================================================================
+
+/** True when `repoRoot` declares a pnpm workspace (has a readable `pnpm-workspace.yaml`). */
+export function hasPnpmWorkspace(repoRoot: string): boolean {
+  return readTextFile(join(repoRoot, 'pnpm-workspace.yaml')) !== null;
+}
+
+/**
+ * Name for the implicit single-package fallback used when a repo has no
+ * `pnpm-workspace.yaml` (e.g. a bare Vite SPA checkout): the repo root's own
+ * `package.json` name, or the repo root directory's basename when no
+ * `package.json` exists. Shared by the `workspace` and `ts-project`
+ * extractors so both derive the identical `packageKey`, keeping their
+ * natural keys (and therefore deterministic node ids) convergent.
+ */
+export function implicitPackageName(repoRoot: string): string {
+  const pkgJson = readJsonFile<{ name?: string }>(join(repoRoot, 'package.json'));
+  return pkgJson?.name ?? basename(repoRoot);
 }
 
 const DEFAULT_IGNORE = new Set(['node_modules', 'dist', '.git', '.turbo', 'coverage', '.next']);

--- a/packages/knowledge-graph/src/extractors/ts-project.ts
+++ b/packages/knowledge-graph/src/extractors/ts-project.ts
@@ -7,6 +7,10 @@
  * edges (to another file for relative specifiers, to a `dependency` node for
  * bare specifiers). One combined `ScanProduct` per repo so re-scan diffing
  * stays correct across the whole `ts-project` scope.
+ *
+ * When the repo has no `pnpm-workspace.yaml`, the repo root itself is walked
+ * as a single implicit package (its `src` directory), matching the fallback
+ * the `workspace` extractor uses so both derive the identical `packageKey`.
  */
 
 import { dirname, join, relative } from 'node:path';
@@ -15,6 +19,8 @@ import type { EdgeInput, NodeInput } from '../types.js';
 import {
   dependencyKey,
   fileKey,
+  hasPnpmWorkspace,
+  implicitPackageName,
   isDir,
   listDir,
   packageKey,
@@ -43,6 +49,9 @@ function mapKey(kind: string, naturalKey: string): string {
 }
 
 function discoverPackages(repoRoot: string): DiscoveredPackage[] {
+  if (!hasPnpmWorkspace(repoRoot)) {
+    return [{ dir: '', kind: 'package', name: implicitPackageName(repoRoot) }];
+  }
   const out: DiscoveredPackage[] = [];
   for (const [topDir, kind] of [
     ['packages', 'package'],

--- a/packages/knowledge-graph/src/extractors/workspace.ts
+++ b/packages/knowledge-graph/src/extractors/workspace.ts
@@ -5,6 +5,11 @@
  * form is handled) and each discovered package/app's `package.json`. Emits the
  * repo node, one package/app node per workspace member, one dependency node
  * per distinct external dependency, and `contains` / `depends-on` edges.
+ *
+ * When the repo has no `pnpm-workspace.yaml` (a non-monorepo fleet checkout,
+ * e.g. a bare Vite SPA), the repo root itself is treated as a single implicit
+ * package so the `ts-project` extractor still has a package to scope its
+ * `src` walk under (see `implicitPackageName` in shared.ts).
  */
 
 import { join } from 'node:path';
@@ -12,6 +17,8 @@ import { parse } from 'yaml';
 import type { EdgeInput, NodeInput } from '../types.js';
 import {
   dependencyKey,
+  hasPnpmWorkspace,
+  implicitPackageName,
   isDir,
   listDir,
   packageKey,
@@ -82,7 +89,8 @@ function discoverWorkspaceDirs(repoRoot: string): string[] {
 export const workspaceExtractor: Extractor = {
   name: 'workspace',
   async extract(ctx: ExtractorContext): Promise<ScanProduct[]> {
-    const dirs = discoverWorkspaceDirs(ctx.repoRoot);
+    const isWorkspace = hasPnpmWorkspace(ctx.repoRoot);
+    const dirs = isWorkspace ? discoverWorkspaceDirs(ctx.repoRoot) : [];
     const nodes = new Map<string, NodeInput>();
     const edges: EdgeInput[] = [];
 
@@ -100,6 +108,16 @@ export const workspaceExtractor: Extractor = {
       if (!pkgJson?.name) continue;
       const kind: 'package' | 'app' = dir.startsWith('apps/') ? 'app' : 'package';
       discovered.push({ dir, kind, name: pkgJson.name, pkgJson });
+    }
+
+    if (!isWorkspace) {
+      const pkgJson = readJsonFile<PackageJsonShape>(join(ctx.repoRoot, 'package.json')) ?? {};
+      discovered.push({
+        dir: '',
+        kind: 'package',
+        name: implicitPackageName(ctx.repoRoot),
+        pkgJson,
+      });
     }
 
     const packageKindByName = new Map<string, 'package' | 'app'>();


### PR DESCRIPTION
Part of GAP-349.

Three defects discovered during the first fleet-wide `revkg scan --fleet` run, fixed in three logically separate commits.

## Fix 1: single-package repo extractor coverage

The `ts-project`/`workspace` extractors only discovered scan targets via pnpm workspace membership, so non-pnpm-monorepo fleet repos produced almost nothing (observed: "agency: 1 nodes, 0 edges" for a whole Vite SPA).

When a repo has no `pnpm-workspace.yaml`, the repo root is now treated as a single implicit package (name from `package.json`, or the directory name), scanned the same way a workspace package's `src` tree is scanned. Repos with no TS still yield their repo node and don't error. Both extractors share `hasPnpmWorkspace`/`implicitPackageName` from `shared.ts` so their derived `packageKey` stays identical — no natural-key drift between the two Tier-1 extractors for the same repo.

New fixture tests: single-package repo with a real `src` tree, repo with `package.json` and no TS, and a bare directory with neither. **Prove-red performed**: reverted the three extractor files to `origin/test` via `git checkout origin/test -- <files>`, ran the new test file — 3 of 5 tests failed against the old discovery logic — then restored from the committed fix via `git checkout HEAD -- <files>` and confirmed green again.

## Fix 2: revkg CLI connection settings

The CLI borrowed `@revealui/db`'s shared pool, whose server-tuned defaults (5s connect timeout, 10s query/statement timeout) killed real fleet scans against a cold Neon compute — a connect timeout on the first run, then a mid-scan "Query read timeout" on the largest repo.

`revkg` now opens its own pool sized for a long-running ingest (30s connect timeout, 5-minute query/statement timeout, `max: 5`). This required adding `createPool` to `@revealui/db/pool` rather than importing `pg` directly in the CLI — the repo's `raw-SQL` `direct-import` gate (`scripts/validate/raw-sql.ts`, enforced in the pre-push gate) only allows a direct `pg` import inside `packages/db/src/`. `createPool` reuses `getConnectionIdentity` (exported since #1859) for the URL-vs-discrete resolution, and deliberately skips the shared pool's `onPoolConnect` setup handler — that handler's `SET statement_timeout` is pinned to the shared pool's 10s budget and would silently override a longer override on every connection. `statement_timeout`/`query_timeout` passed to `createPool` are applied by the `pg` driver itself as connection startup parameters (`Client#getStartupConf`), so no manual `SET` is needed for a non-shared pool.

Also fixed: the header comment's env-var precedence (`DATABASE_URL` wins over `POSTGRES_URL`, not the reverse — it said the opposite), and connection errors now print the target hostname (parsed via `new URL`, never the full connection string or credentials) so the next person can tell localhost from Neon at a glance.

## Fix 3: shared pool SET bug (pre-existing, `packages/db/src/pool.ts`)

`SET statement_timeout TO $1` failed on **every** pool connection with "syntax error at or near $1" — Postgres' `SET` command does not accept bind parameters. The intended 10s statement timeout has never actually applied anywhere, and every connect logged the error.

Extracted `formatValidatedStatementTimeoutMs`, which validates the value is a finite positive integer (it is always the already `parseInt`'d `poolConfig.statement_timeout`, never user input) before interpolating it as a literal — no injection surface. The three setup statements (timezone, statement_timeout, track_io_timing) now run as one multi-statement query on a single `await`, instead of three separate sequential `client.query()` calls on the same client. Unit tests cover the validator's edge cases (non-finite, non-integer, zero/negative, non-numeric string) plus a test that drives the pool's `'connect'` handler through a mock client and asserts the emitted SQL never contains `$1`.

## Verification actually run

- `pnpm --filter @revealui/knowledge-graph test` — 9 files / 38 tests passed
- `pnpm --filter @revealui/db test` — 54 files / 1182 passed, 5 skipped
- `pnpm --filter @revealui/knowledge-graph typecheck` — clean
- `pnpm --filter @revealui/db typecheck` — clean
- `pnpm --filter "@revealui/knowledge-graph..." build` — full dependency chain builds clean
- `pnpm --filter "server..." build` + `pnpm --filter server typecheck` — clean
- `pnpm --filter admin typecheck` (after `apps/admin` Next.js build) — clean
- `npx biome check` (scoped to changed files) — clean
- `npx tsx scripts/validate/raw-sql.ts` — PASS (0 violations)
- Internal fleet security-review checker, run against this diff — no security-sensitive files touched, no coordinator gate required
- Full pre-push gate (24 checks including Raw-SQL, Boundary validation, Security audit) — PASS

## Escalations for Fable

None required for merge. Two notes for awareness, out of scope for this batch:

1. **Implicit-package node kind is always `'package'`**, never `'app'`, since there's no reliable non-speculative signal (no `apps/`-prefix convention exists for a single-package repo). If ontology-precision on this matters for downstream graph consumers, a follow-up could add an app-detection heuristic (e.g. presence of `index.html` / `vite.config.*` at repo root) — deliberately not attempted here to avoid inventing untested heuristics beyond the stated fix scope.
2. Unrelated pre-existing drift noticed in passing: `packages/knowledge-graph/package.json`'s `author` field still carries a retired email address from a prior identity migration. This is repo-wide (likely every `package.json`), not scoped to this PR, and left untouched.

## Note on a stale worktree

A stale local worktree from the now-merged #1859 (`getConnectionIdentity`/pool connectionString fix, referenced above) was found still checked out. It appears not to have been cleaned up after merge. Flagging for owner cleanup since worktree removal is a disposition action outside agent scope.
