### PR TITLE
feat(knowledge-graph): GAP-349 P4 electric sync + explorer + drift

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -13,6 +13,7 @@
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
     "@revealui/db": "workspace:*",
+    "@revealui/knowledge-graph": "workspace:*",
     "@revealui/mcp": "workspace:*",
     "@revealui/paywall": "workspace:*",
     "@revealui/presentation": "workspace:*",

--- a/apps/admin/src/app/(backend)/knowledge-graph/page.tsx
+++ b/apps/admin/src/app/(backend)/knowledge-graph/page.tsx
@@ -1,0 +1,460 @@
+'use client';
+
+import type { NodeKind } from '@revealui/knowledge-graph/ontology';
+import { NODE_KINDS } from '@revealui/knowledge-graph/ontology';
+import {
+  Badge,
+  Button,
+  Card,
+  EmptyState,
+  Input,
+  Select,
+  Skeleton,
+  Textarea,
+} from '@revealui/presentation';
+import type { KgEdgeRecord, KgNodeRecord } from '@revealui/sync';
+import { useKgViewDocument, useKnowledgeGraph } from '@revealui/sync';
+import { useEffect, useMemo, useState } from 'react';
+import { LicenseGate } from '@/lib/components/LicenseGate';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const SLUG_CHARS = new Set('abcdefghijklmnopqrstuvwxyz0123456789-');
+
+/** Map a repo name (e.g. `.jv`, `revealui`) to a valid kg-view slug. No authored regex. */
+function toViewSlug(repo: string | undefined): string {
+  if (!repo) return 'fleet';
+  const mapped = Array.from(repo.toLowerCase())
+    .map((c) => (SLUG_CHARS.has(c) ? c : '-'))
+    .join('');
+  const trimmed = mapped
+    .split('-')
+    .filter((part) => part.length > 0)
+    .join('-');
+  return trimmed.length > 0 ? trimmed.slice(0, 64) : 'fleet';
+}
+
+function isEdgeLiveAt(edge: KgEdgeRecord, at: Date | null): boolean {
+  if (!at) return edge.invalid_at === null;
+  const validAt = new Date(edge.valid_at);
+  if (validAt > at) return false;
+  if (edge.invalid_at && new Date(edge.invalid_at) <= at) return false;
+  return true;
+}
+
+function formatTimestamp(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString();
+}
+
+// =============================================================================
+// Page
+// =============================================================================
+
+export default function KnowledgeGraphPage() {
+  return (
+    <LicenseGate feature="ai">
+      <KnowledgeGraphExplorer />
+    </LicenseGate>
+  );
+}
+
+function KnowledgeGraphExplorer() {
+  const [availableRepos, setAvailableRepos] = useState<string[]>([]);
+  const [reposLoading, setReposLoading] = useState(true);
+  const [selectedRepo, setSelectedRepo] = useState<string>('');
+  const [kindFilter, setKindFilter] = useState<'all' | NodeKind>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [pointInTime, setPointInTime] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/kg/repos', { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : { repos: [] }))
+      .then((data: { repos?: string[] }) => {
+        if (!cancelled) setAvailableRepos(data.repos ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setAvailableRepos([]);
+      })
+      .finally(() => {
+        if (!cancelled) setReposLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const { nodes, edges, edgeEpisodes, isLoading, error } = useKnowledgeGraph(
+    selectedRepo || undefined,
+  );
+
+  const at = pointInTime ? new Date(pointInTime) : null;
+
+  const filteredNodes = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return nodes
+      .filter((n) => kindFilter === 'all' || n.kind === kindFilter)
+      .filter(
+        (n) =>
+          q.length === 0 ||
+          n.name.toLowerCase().includes(q) ||
+          n.natural_key.toLowerCase().includes(q),
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [nodes, kindFilter, searchQuery]);
+
+  const nodeById = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes]);
+  const selectedNode = selectedNodeId ? (nodeById.get(selectedNodeId) ?? null) : null;
+
+  return (
+    <div className="min-h-screen">
+      <div className="border-b border-border bg-card px-6 py-4">
+        <h1 className="text-xl font-semibold text-foreground">Knowledge Graph</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Read-only, canonical-state view of the fleet knowledge graph (GAP-349). Curation
+          annotations and pins are ephemeral until flushed to an episode; the graph itself is never
+          written from this screen.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 border-b border-border bg-muted px-6 py-3">
+        <div className="w-48">
+          <Select
+            aria-label="Repo"
+            value={selectedRepo}
+            onChange={(e) => {
+              setSelectedRepo(e.target.value);
+              setSelectedNodeId(null);
+            }}
+            disabled={reposLoading}
+          >
+            <option value="">All repos</option>
+            {availableRepos.map((repo) => (
+              <option key={repo} value={repo}>
+                {repo}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="w-40">
+          <Select
+            aria-label="Node kind"
+            value={kindFilter}
+            onChange={(e) => setKindFilter(e.target.value as 'all' | NodeKind)}
+          >
+            <option value="all">All kinds</option>
+            {NODE_KINDS.map((kind) => (
+              <option key={kind} value={kind}>
+                {kind}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="w-64">
+          <Input
+            aria-label="Search by name"
+            placeholder="Search by name or natural key"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label htmlFor="kg-point-in-time" className="text-xs text-muted-foreground">
+            Point in time
+          </label>
+          <input
+            id="kg-point-in-time"
+            type="date"
+            value={pointInTime}
+            onChange={(e) => setPointInTime(e.target.value)}
+            className="rounded-lg border border-input bg-transparent px-2 py-1 text-sm text-foreground"
+          />
+          {pointInTime && (
+            <Button plain onClick={() => setPointInTime('')}>
+              Clear
+            </Button>
+          )}
+        </div>
+
+        <span className="ml-auto text-xs text-muted-foreground">
+          {filteredNodes.length} of {nodes.length} nodes
+          {selectedRepo ? ` in ${selectedRepo}` : ' (all repos)'}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-0 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+        <div className="border-r border-border p-4">
+          {isLoading && nodes.length === 0 ? (
+            <div className="flex flex-col gap-2" role="status" aria-label="Loading nodes">
+              {Array.from({ length: 4 }).map((_, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+                <Skeleton key={i} className="h-10 w-full rounded-lg" />
+              ))}
+            </div>
+          ) : error ? (
+            <div
+              role="alert"
+              className="rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error"
+            >
+              {error.message}
+            </div>
+          ) : filteredNodes.length === 0 ? (
+            <EmptyState
+              title={selectedRepo ? 'No nodes match' : 'Pick a repo or search'}
+              description={
+                selectedRepo
+                  ? 'No nodes match the current filter in this repo.'
+                  : 'Select a repo above, or search across the whole fleet graph.'
+              }
+            />
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {filteredNodes.map((node) => (
+                <li key={node.id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedNodeId(node.id)}
+                    aria-current={selectedNodeId === node.id}
+                    className={`w-full rounded-lg border px-3 py-2 text-left transition-colors ${
+                      selectedNodeId === node.id
+                        ? 'border-ring bg-card'
+                        : 'border-transparent hover:border-border hover:bg-card'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <Badge color="muted">{node.kind}</Badge>
+                      <span className="truncate text-sm text-foreground">{node.name}</span>
+                    </div>
+                    <div className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                      {node.natural_key}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="p-4">
+          {selectedNode ? (
+            <NodeDetailPane
+              node={selectedNode}
+              edges={edges}
+              edgeEpisodes={edgeEpisodes}
+              nodeById={nodeById}
+              at={at}
+              viewSlug={toViewSlug(selectedRepo || undefined)}
+            />
+          ) : (
+            <EmptyState
+              title="No node selected"
+              description="Select a node from the list to see its detail."
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Node detail pane
+// =============================================================================
+
+interface NodeDetailPaneProps {
+  node: KgNodeRecord;
+  edges: KgEdgeRecord[];
+  edgeEpisodes: Array<{ edge_id: string; episode_id: string }>;
+  nodeById: Map<string, KgNodeRecord>;
+  at: Date | null;
+  viewSlug: string;
+}
+
+function NodeDetailPane({
+  node,
+  edges,
+  edgeEpisodes,
+  nodeById,
+  at,
+  viewSlug,
+}: NodeDetailPaneProps) {
+  const overlay = useKgViewDocument(viewSlug);
+  const [annotationDraft, setAnnotationDraft] = useState('');
+  const [flushStatus, setFlushStatus] = useState<'idle' | 'flushing' | 'flushed' | 'error'>('idle');
+
+  useEffect(() => {
+    setAnnotationDraft(overlay.state.annotations.get(node.id)?.text ?? '');
+    setFlushStatus('idle');
+  }, [node.id, overlay.state.annotations]);
+
+  const facts = useMemo(() => {
+    return edges
+      .filter((e) => e.source_id === node.id || e.target_id === node.id)
+      .filter((e) => isEdgeLiveAt(e, at))
+      .map((e) => {
+        const otherId = e.source_id === node.id ? e.target_id : e.source_id;
+        const other = nodeById.get(otherId);
+        const provenance = edgeEpisodes
+          .filter((ee) => ee.edge_id === e.id)
+          .map((ee) => ee.episode_id);
+        return { edge: e, other, provenance };
+      })
+      .sort((a, b) => b.edge.valid_at.localeCompare(a.edge.valid_at));
+  }, [edges, node.id, at, nodeById, edgeEpisodes]);
+
+  const isPinned = overlay.state.pins.has(node.id);
+
+  async function handleAnnotate() {
+    await overlay.annotate(node.id, annotationDraft, 'admin-explorer');
+  }
+
+  async function handleTogglePin() {
+    await overlay.setPinned(node.id, !isPinned);
+  }
+
+  async function handleFlush() {
+    setFlushStatus('flushing');
+    try {
+      const response = await fetch('/api/sync/kg-episodes', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          viewSlug,
+          source: `kg-curation:${viewSlug}`,
+          content: annotationDraft,
+          nodes: [
+            { kind: 'agent', name: 'admin-explorer', naturalKey: 'agent:admin-explorer' },
+            {
+              kind: node.kind,
+              name: node.name,
+              naturalKey: node.natural_key,
+              repo: node.repo ?? undefined,
+            },
+          ],
+          edges: [
+            {
+              source: { kind: 'agent', naturalKey: 'agent:admin-explorer' },
+              target: { kind: node.kind, naturalKey: node.natural_key },
+              relation: 'discovered',
+              fact: annotationDraft,
+              repo: node.repo ?? undefined,
+            },
+          ],
+        }),
+      });
+      setFlushStatus(response.ok ? 'flushed' : 'error');
+    } catch {
+      setFlushStatus('error');
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <div className="p-4">
+          <div className="flex items-center gap-2">
+            <Badge color="muted">{node.kind}</Badge>
+            <h2 className="text-lg font-semibold text-foreground">{node.name}</h2>
+            {isPinned && <Badge color="warning">pinned</Badge>}
+          </div>
+          <div className="mt-1 font-mono text-xs text-muted-foreground">{node.natural_key}</div>
+          {node.repo && <div className="mt-1 text-xs text-muted-foreground">repo: {node.repo}</div>}
+          {node.summary && <p className="mt-3 text-sm text-foreground">{node.summary}</p>}
+          <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+            <span>First seen: {formatTimestamp(node.first_seen_at)}</span>
+            <span>Last confirmed: {formatTimestamp(node.last_confirmed_at)}</span>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="p-4">
+          <h3 className="text-sm font-medium text-foreground">Attributes</h3>
+          {Object.keys(node.attributes ?? {}).length === 0 ? (
+            <p className="mt-1 text-xs text-muted-foreground">No attributes.</p>
+          ) : (
+            <pre className="mt-2 overflow-x-auto rounded-lg bg-muted p-3 text-xs text-foreground">
+              {JSON.stringify(node.attributes, null, 2)}
+            </pre>
+          )}
+        </div>
+      </Card>
+
+      <Card>
+        <div className="p-4">
+          <h3 className="text-sm font-medium text-foreground">
+            Facts {at ? `as of ${at.toLocaleDateString()}` : '(current)'}
+          </h3>
+          {facts.length === 0 ? (
+            <p className="mt-1 text-xs text-muted-foreground">No facts.</p>
+          ) : (
+            <ul className="mt-2 flex flex-col gap-2">
+              {facts.map(({ edge, other, provenance }) => (
+                <li key={edge.id} className="rounded-lg border border-border p-2 text-sm">
+                  <div>
+                    <Badge color="muted">{edge.relation}</Badge>{' '}
+                    <span className="text-foreground">{edge.fact}</span>
+                  </div>
+                  <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    {other && (
+                      <span>
+                        {edge.source_id === node.id ? '→' : '←'} {other.name}
+                      </span>
+                    )}
+                    <span>valid: {formatTimestamp(edge.valid_at)}</span>
+                    <span>episodes: {provenance.length > 0 ? provenance.join(', ') : 'none'}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </Card>
+
+      <Card>
+        <div className="p-4">
+          <h3 className="text-sm font-medium text-foreground">Curation (view: {viewSlug})</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Ephemeral until flushed. Never writes the graph directly.
+          </p>
+          <Textarea
+            className="mt-2"
+            rows={3}
+            placeholder="Annotate this node…"
+            value={annotationDraft}
+            onChange={(e) => setAnnotationDraft(e.target.value)}
+          />
+          <div className="mt-2 flex flex-wrap gap-2">
+            <Button onClick={handleAnnotate} disabled={!annotationDraft.trim()}>
+              Save annotation
+            </Button>
+            <Button plain onClick={handleTogglePin}>
+              {isPinned ? 'Unpin' : 'Pin'}
+            </Button>
+            <Button
+              outline
+              onClick={handleFlush}
+              disabled={!annotationDraft.trim() || flushStatus === 'flushing'}
+            >
+              {flushStatus === 'flushing' ? 'Flushing…' : 'Flush to episode'}
+            </Button>
+          </div>
+          {flushStatus === 'flushed' && (
+            <p className="mt-2 text-xs text-success">Flushed as a manual episode.</p>
+          )}
+          {flushStatus === 'error' && (
+            <p className="mt-2 text-xs text-error">Flush failed — try again.</p>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/admin/src/app/api/kg/repos/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/kg/repos/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Knowledge Graph Repos Route Tests
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn().mockReturnValue(true),
+}));
+
+const mockOrderBy = vi.fn();
+const mockWhere = vi.fn(() => ({ orderBy: mockOrderBy }));
+const mockFrom = vi.fn(() => ({ where: mockWhere }));
+const mockSelectDistinct = vi.fn(() => ({ from: mockFrom }));
+
+vi.mock('@revealui/db/client', () => ({
+  getClient: vi.fn(() => ({ selectDistinct: mockSelectDistinct })),
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  kgNodes: { repo: 'repo-column' },
+}));
+
+const { GET } = await import('../route');
+
+const mockSession = {
+  session: {
+    id: 'session-abc-123',
+    userId: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    tokenHash: 'token-hash',
+    expiresAt: new Date(Date.now() + 86400000),
+    userAgent: 'test-agent',
+    ipAddress: '127.0.0.1',
+    persistent: false,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    metadata: null,
+  },
+  user: {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    type: 'human',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatarUrl: null,
+    password: null,
+    role: 'viewer',
+    status: 'active',
+    emailVerified: false,
+    emailVerificationToken: null,
+    emailVerifiedAt: null,
+    mfaEnabled: false,
+    mfaVerifiedAt: null,
+    agentModel: null,
+    agentCapabilities: null,
+    agentConfig: null,
+    preferences: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActiveAt: null,
+  },
+};
+
+describe('GET /api/kg/repos', () => {
+  const mockGetSession = vi.mocked(authServer.getSession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOrderBy.mockResolvedValue([{ repo: 'revealui' }, { repo: 'revdev' }, { repo: null }]);
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const response = await GET(new NextRequest('http://localhost:3000/api/kg/repos'));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns the distinct repo list, dropping nulls', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const response = await GET(new NextRequest('http://localhost:3000/api/kg/repos'));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.repos).toEqual(['revealui', 'revdev']);
+  });
+
+  it('handles errors gracefully', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockOrderBy.mockRejectedValue(new Error('db down'));
+
+    const response = await GET(new NextRequest('http://localhost:3000/api/kg/repos'));
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/apps/admin/src/app/api/kg/repos/route.ts
+++ b/apps/admin/src/app/api/kg/repos/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Knowledge Graph Repos Route
+ *
+ * GET /api/kg/repos
+ *
+ * Authenticated, read-only list of distinct `repo` values present in
+ * `kg_nodes`. Backs the explorer's repo picker (GAP-349 P4 deliverable B).
+ *
+ * Deliberately NOT an Electric shape: the design spec (§8.2) has the
+ * explorer subscribe only to the repos actually in view, never the whole
+ * fleet graph unfiltered (50-150k nodes per §12). This tiny, fixed,
+ * parameterless query gives the picker real data without ever syncing an
+ * unfiltered `kg_nodes` shape just to discover repo names.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db/client';
+import { kgNodes } from '@revealui/db/schema';
+import { logger } from '@revealui/utils/logger';
+import { isNotNull } from 'drizzle-orm';
+import { type NextRequest, NextResponse } from 'next/server';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const db = getClient();
+    const rows = await db
+      .selectDistinct({ repo: kgNodes.repo })
+      .from(kgNodes)
+      .where(isNotNull(kgNodes.repo))
+      .orderBy(kgNodes.repo);
+
+    const repos = rows.flatMap((r) => (r.repo ? [r.repo] : []));
+
+    return NextResponse.json({ repos });
+  } catch (error) {
+    logger.error('Error listing kg repos', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/kg/repos',
+      operation: 'kg_repos_list',
+    });
+  }
+}

--- a/apps/admin/src/app/api/shapes/__tests__/kg-edge-episodes.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-edge-episodes.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Knowledge Graph Edge-Episode Provenance Shape Proxy Route Tests
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '../kg-edge-episodes/route';
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@/lib/api/electric-proxy', () => ({
+  prepareElectricUrl: vi.fn((_url: string) => new URL('http://localhost:5133/v1/shape')),
+  proxyElectricRequest: vi.fn(async () => {
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }),
+}));
+
+const mockSession = {
+  session: {
+    id: 'session-abc-123',
+    userId: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    tokenHash: 'token-hash',
+    expiresAt: new Date(Date.now() + 86400000),
+    userAgent: 'test-agent',
+    ipAddress: '127.0.0.1',
+    persistent: false,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    metadata: null,
+  },
+  user: {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    type: 'human',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatarUrl: null,
+    password: null,
+    role: 'viewer',
+    status: 'active',
+    emailVerified: false,
+    emailVerificationToken: null,
+    emailVerifiedAt: null,
+    mfaEnabled: false,
+    mfaVerifiedAt: null,
+    agentModel: null,
+    agentCapabilities: null,
+    agentConfig: null,
+    preferences: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActiveAt: null,
+  },
+};
+
+describe('GET /api/shapes/kg-edge-episodes', () => {
+  const mockGetSession = vi.mocked(authServer.getSession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-edge-episodes');
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('proxies the full join table with no where clause', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-edge-episodes');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const originUrl = vi.mocked(prepareElectricUrl).mock.results[0]?.value as URL;
+    expect(originUrl.searchParams.get('table')).toBe('kg_edge_episodes');
+    expect(originUrl.searchParams.has('where')).toBe(false);
+    expect(proxyElectricRequest).toHaveBeenCalled();
+  });
+
+  it('handles errors gracefully', async () => {
+    mockGetSession.mockRejectedValue(new Error('Database error'));
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-edge-episodes');
+    const response = await GET(request);
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/apps/admin/src/app/api/shapes/__tests__/kg-edges.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-edges.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Knowledge Graph Edges Shape Proxy Route Tests
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '../kg-edges/route';
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@/lib/api/electric-proxy', () => ({
+  prepareElectricUrl: vi.fn((_url: string) => new URL('http://localhost:5133/v1/shape')),
+  proxyElectricRequest: vi.fn(async () => {
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }),
+}));
+
+const mockSession = {
+  session: {
+    id: 'session-abc-123',
+    userId: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    tokenHash: 'token-hash',
+    expiresAt: new Date(Date.now() + 86400000),
+    userAgent: 'test-agent',
+    ipAddress: '127.0.0.1',
+    persistent: false,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    metadata: null,
+  },
+  user: {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    type: 'human',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatarUrl: null,
+    password: null,
+    role: 'viewer',
+    status: 'active',
+    emailVerified: false,
+    emailVerificationToken: null,
+    emailVerifiedAt: null,
+    mfaEnabled: false,
+    mfaVerifiedAt: null,
+    agentModel: null,
+    agentCapabilities: null,
+    agentConfig: null,
+    preferences: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActiveAt: null,
+  },
+};
+
+describe('GET /api/shapes/kg-edges', () => {
+  const mockGetSession = vi.mocked(authServer.getSession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-edges');
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('proxies with no where clause when repo is omitted', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    const { prepareElectricUrl } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-edges');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const originUrl = vi.mocked(prepareElectricUrl).mock.results[0]?.value as URL;
+    expect(originUrl.searchParams.get('table')).toBe('kg_edges');
+    expect(originUrl.searchParams.has('where')).toBe(false);
+  });
+
+  it('proxies filtered by repo when a valid repo is supplied', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    const { prepareElectricUrl } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-edges?repo=revdev');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const originUrl = vi.mocked(prepareElectricUrl).mock.results[0]?.value as URL;
+    expect(originUrl.searchParams.get('where')).toBe(`repo = 'revdev'`);
+  });
+
+  it('rejects an invalid repo value', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/shapes/kg-edges?repo=' +
+        encodeURIComponent("a'; DROP TABLE kg_edges;--"),
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('handles errors gracefully', async () => {
+    mockGetSession.mockRejectedValue(new Error('Database error'));
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-edges');
+    const response = await GET(request);
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/apps/admin/src/app/api/shapes/__tests__/kg-nodes.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-nodes.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Knowledge Graph Nodes Shape Proxy Route Tests
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '../kg-nodes/route';
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@/lib/api/electric-proxy', () => ({
+  prepareElectricUrl: vi.fn((_url: string) => {
+    const electricUrl = new URL('http://localhost:5133/v1/shape');
+    return electricUrl;
+  }),
+  proxyElectricRequest: vi.fn(async () => {
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }),
+}));
+
+const mockSession = {
+  session: {
+    id: 'session-abc-123',
+    userId: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    tokenHash: 'token-hash',
+    expiresAt: new Date(Date.now() + 86400000),
+    userAgent: 'test-agent',
+    ipAddress: '127.0.0.1',
+    persistent: false,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    metadata: null,
+  },
+  user: {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    type: 'human',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatarUrl: null,
+    password: null,
+    role: 'viewer',
+    status: 'active',
+    emailVerified: false,
+    emailVerificationToken: null,
+    emailVerifiedAt: null,
+    mfaEnabled: false,
+    mfaVerifiedAt: null,
+    agentModel: null,
+    agentCapabilities: null,
+    agentConfig: null,
+    preferences: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActiveAt: null,
+  },
+};
+
+describe('GET /api/shapes/kg-nodes', () => {
+  const mockGetSession = vi.mocked(authServer.getSession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-nodes');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('UNAUTHORIZED');
+  });
+
+  it('proxies with no where clause when repo is omitted', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-nodes');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(prepareElectricUrl).toHaveBeenCalled();
+    const originUrl = vi.mocked(prepareElectricUrl).mock.results[0]?.value as URL;
+    expect(originUrl.searchParams.get('table')).toBe('kg_nodes');
+    expect(originUrl.searchParams.has('where')).toBe(false);
+    expect(proxyElectricRequest).toHaveBeenCalled();
+  });
+
+  it('proxies filtered by repo when a valid repo is supplied', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    const { prepareElectricUrl } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-nodes?repo=revealui');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const originUrl = vi.mocked(prepareElectricUrl).mock.results[0]?.value as URL;
+    expect(originUrl.searchParams.get('where')).toBe(`repo = 'revealui'`);
+  });
+
+  it('accepts dotted repo names like .jv', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    const { prepareElectricUrl } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-nodes?repo=.jv');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const originUrl = vi.mocked(prepareElectricUrl).mock.results[0]?.value as URL;
+    expect(originUrl.searchParams.get('where')).toBe(`repo = '.jv'`);
+  });
+
+  it('rejects a repo value carrying a quote (injection attempt)', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/shapes/kg-nodes?repo=revealui' OR '1'='1",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects a repo value with whitespace or slashes', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/shapes/kg-nodes?repo=${encodeURIComponent('reveal/ui')}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it('handles errors gracefully', async () => {
+    mockGetSession.mockRejectedValue(new Error('Database error'));
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-nodes');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('INTERNAL_ERROR');
+  });
+});

--- a/apps/admin/src/app/api/shapes/__tests__/kg-views.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-views.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Knowledge Graph Curation-View Shape Proxy Route Tests
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '../kg-views/route';
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@/lib/api/electric-proxy', () => ({
+  prepareElectricUrl: vi.fn((_url: string) => new URL('http://localhost:5133/v1/shape')),
+  proxyElectricRequest: vi.fn(async () => {
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }),
+}));
+
+const mockSession = {
+  session: {
+    id: 'session-abc-123',
+    userId: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    tokenHash: 'token-hash',
+    expiresAt: new Date(Date.now() + 86400000),
+    userAgent: 'test-agent',
+    ipAddress: '127.0.0.1',
+    persistent: false,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    metadata: null,
+  },
+  user: {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    type: 'human',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatarUrl: null,
+    password: null,
+    role: 'viewer',
+    status: 'active',
+    emailVerified: false,
+    emailVerificationToken: null,
+    emailVerifiedAt: null,
+    mfaEnabled: false,
+    mfaVerifiedAt: null,
+    agentModel: null,
+    agentCapabilities: null,
+    agentConfig: null,
+    preferences: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActiveAt: null,
+  },
+};
+
+describe('GET /api/shapes/kg-views', () => {
+  const mockGetSession = vi.mocked(authServer.getSession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/shapes/kg-views?document_id=kg-view-my-view',
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 400 when document_id is missing', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-views');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for a UUID (not a kg-view id)', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/shapes/kg-views?document_id=0b9f2a4e-1c3d-4e5f-8a7b-9c0d1e2f3a4b',
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 for an injection attempt in the slug', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/shapes/kg-views?document_id=' +
+        encodeURIComponent("kg-view-x'; DROP TABLE yjs_documents;--"),
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it('proxies filtered by document_id for a valid kg-view id', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/shapes/kg-views?document_id=kg-view-my-view',
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const originUrl = vi.mocked(prepareElectricUrl).mock.results[0]?.value as URL;
+    expect(originUrl.searchParams.get('table')).toBe('yjs_documents');
+    expect(originUrl.searchParams.get('where')).toBe(`id = 'kg-view-my-view'`);
+    expect(proxyElectricRequest).toHaveBeenCalled();
+  });
+
+  it('handles errors gracefully', async () => {
+    mockGetSession.mockRejectedValue(new Error('Database error'));
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/shapes/kg-views?document_id=kg-view-my-view',
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/apps/admin/src/app/api/shapes/kg-edge-episodes/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-edge-episodes/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Knowledge Graph Edge-Episode Provenance Shape Proxy Route
+ *
+ * GET /api/shapes/kg-edge-episodes
+ *
+ * Authenticated, read-only proxy for the ElectricSQL `kg_edge_episodes` shape
+ * (GAP-349 P4, design spec §8.2/§9): the provenance join between `kg_edges`
+ * and `kg_episodes` (composite PK `edge_id, episode_id`, no other columns).
+ *
+ * NOT repo-partitioned, unlike `kg-nodes`/`kg-edges`: `kg_edge_episodes` has
+ * no `repo` column (see `packages/db/src/schema/knowledge-graph.ts`) and
+ * Electric shape `where` clauses are single-table (design spec §8.2), so a
+ * join-based repo filter is not available here without a schema change. This
+ * route syncs the full provenance join table. Flagged for the Fable review:
+ * if this needs partitioning as the graph grows, it requires either
+ * denormalizing `repo` onto `kg_edge_episodes` or dropping this shape in
+ * favor of REST-fetched provenance (e.g. via the existing `kgAtTime` /
+ * `kgNeighbors` query helpers, which already return `episodeIds` per fact).
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'kg_edge_episodes');
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying kg-edge-episodes shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/kg-edge-episodes',
+      operation: 'kg_edge_episodes_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/shapes/kg-edges/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-edges/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Knowledge Graph Edges Shape Proxy Route
+ *
+ * GET /api/shapes/kg-edges[?repo=<repo>]
+ *
+ * Authenticated, read-only proxy for the ElectricSQL `kg_edges` shape
+ * (GAP-349 P4, design spec §8.2/§9). Same repo-partition and validation
+ * contract as `kg-nodes` — see that route's header comment.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { isRepoIdentifier } from '@/lib/utils/identifier-validation';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const repo = new URL(request.url).searchParams.get('repo');
+    if (repo !== null && !isRepoIdentifier(repo)) {
+      return createValidationErrorResponse(
+        'repo must be a non-empty string of alphanumeric characters, hyphens, underscores, or dots (max 128 chars)',
+        'repo',
+        repo,
+      );
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'kg_edges');
+    if (repo !== null) {
+      originUrl.searchParams.set('where', `repo = '${repo}'`);
+    }
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying kg-edges shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/kg-edges',
+      operation: 'kg_edges_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/shapes/kg-nodes/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-nodes/route.ts
@@ -1,0 +1,68 @@
+/**
+ * Knowledge Graph Nodes Shape Proxy Route
+ *
+ * GET /api/shapes/kg-nodes[?repo=<repo>]
+ *
+ * Authenticated, read-only proxy for the ElectricSQL `kg_nodes` shape
+ * (GAP-349 P4, design spec §8.2/§9). Partitioned by the denormalized `repo`
+ * column: an omitted `repo` param syncs the whole fleet graph; a supplied
+ * one is validated against {@link isRepoIdentifier} (character-set only, no
+ * authored regex) before being inlined into the Electric `where` clause —
+ * Electric's shape API takes `where` as a literal SQL predicate string, so
+ * an unvalidated value here would be a SQL injection surface.
+ *
+ * Electric sync is read-only by design: this route (and its kg-edges /
+ * kg-edge-episodes siblings) never accepts a write. The only write path into
+ * `kg_*` tables is `POST /api/sync/kg-episodes` (additive `ingestEpisode`).
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { isRepoIdentifier } from '@/lib/utils/identifier-validation';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const repo = new URL(request.url).searchParams.get('repo');
+    if (repo !== null && !isRepoIdentifier(repo)) {
+      return createValidationErrorResponse(
+        'repo must be a non-empty string of alphanumeric characters, hyphens, underscores, or dots (max 128 chars)',
+        'repo',
+        repo,
+      );
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'kg_nodes');
+    if (repo !== null) {
+      originUrl.searchParams.set('where', `repo = '${repo}'`);
+    }
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying kg-nodes shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/kg-nodes',
+      operation: 'kg_nodes_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/shapes/kg-views/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-views/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Knowledge Graph Curation-View Shape Proxy Route
+ *
+ * GET /api/shapes/kg-views?document_id=kg-view-<slug>
+ *
+ * Authenticated proxy for the ElectricSQL `yjs_documents` shape, scoped to
+ * kg-view curation-overlay documents (design spec §8.3). Reuses the EXISTING
+ * `yjs_documents` table (extend, never a new table) but is a separate route
+ * from `/api/shapes/yjs-documents`, whose entire validation contract is
+ * "UUID or refuse" — kg-view document ids are `kg-view-<slug>`, never a
+ * UUID. Keeping this route narrowly scoped to that one id shape, rather than
+ * broadening the existing UUID-only route's accepted id space, keeps the
+ * already-shipped route's review surface untouched. Flagged for the Fable
+ * review as a trade-off worth a second opinion (documented in the PR body):
+ * a small amount of route duplication (~40 lines, same shape as the sibling
+ * route) versus reopening a security-reviewed route's validation contract.
+ *
+ * `document_id` is validated via {@link isKgViewDocumentId} (character-set
+ * check on the `kg-view-` prefix + slug, no authored regex) before being
+ * inlined into the Electric `where` clause.
+ */
+
+import { getSession } from '@revealui/auth/server';
+import { isKgViewDocumentId } from '@revealui/sync/collab/server';
+import { logger } from '@revealui/utils/logger';
+import type { NextRequest, NextResponse } from 'next/server';
+import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const documentId = new URL(request.url).searchParams.get('document_id');
+    if (!(documentId && isKgViewDocumentId(documentId))) {
+      return createApplicationErrorResponse(
+        'Missing or invalid document_id: must be a kg-view-<slug> id',
+        'VALIDATION_ERROR',
+        400,
+      );
+    }
+
+    const originUrl = prepareElectricUrl(request.url);
+    originUrl.searchParams.set('table', 'yjs_documents');
+    originUrl.searchParams.set('where', `id = '${documentId}'`);
+
+    return proxyElectricRequest(originUrl);
+  } catch (error) {
+    logger.error('Error proxying kg-views shape', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/shapes/kg-views',
+      operation: 'kg_views_proxy',
+    });
+  }
+}

--- a/apps/admin/src/app/api/sync/kg-episodes/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/sync/kg-episodes/__tests__/route.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Knowledge Graph Episode Flush Route Tests
+ *
+ * The only write path into `kg_*` tables from the admin app — verifies auth
+ * gating, ontology-enum validation (rejects an unknown node kind / edge
+ * relation), the "at least one node or edge" guard, and that a valid body
+ * reaches `ingestEpisode` with `episodeType` forced to `manual`.
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/auth/server', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@revealui/db/pool', () => ({
+  getPool: vi.fn(() => ({})),
+}));
+
+const mockIngestEpisode = vi.fn();
+
+vi.mock('@revealui/knowledge-graph', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@revealui/knowledge-graph')>();
+  return {
+    ...actual,
+    ingestEpisode: (...args: unknown[]) => mockIngestEpisode(...args),
+    makePoolExecutor: vi.fn(() => ({})),
+  };
+});
+
+const { POST } = await import('../route');
+
+const mockSession = {
+  session: {
+    id: 'session-abc-123',
+    userId: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    tokenHash: 'token-hash',
+    expiresAt: new Date(Date.now() + 86400000),
+    userAgent: 'test-agent',
+    ipAddress: '127.0.0.1',
+    persistent: false,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    metadata: null,
+  },
+  user: {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    schemaVersion: '1',
+    type: 'human',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatarUrl: null,
+    password: null,
+    role: 'viewer',
+    status: 'active',
+    emailVerified: false,
+    emailVerificationToken: null,
+    emailVerifiedAt: null,
+    mfaEnabled: false,
+    mfaVerifiedAt: null,
+    agentModel: null,
+    agentCapabilities: null,
+    agentConfig: null,
+    preferences: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActiveAt: null,
+  },
+};
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/sync/kg-episodes', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/sync/kg-episodes', () => {
+  const mockGetSession = vi.mocked(authServer.getSession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIngestEpisode.mockResolvedValue({ episodeId: 'ep-1', nodeCount: 1, edgeCount: 0 });
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const response = await POST(
+      postRequest({ viewSlug: 'my-view', source: 'kg-curation:my-view', nodes: [], edges: [] }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects a body with an invalid viewSlug', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const response = await POST(
+      postRequest({
+        viewSlug: 'My View',
+        source: 'kg-curation:my-view',
+        nodes: [{ kind: 'file', name: 'x.ts', naturalKey: 'revealui/x.ts' }],
+        edges: [],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockIngestEpisode).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body with an unknown node kind (ontology enum validation)', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const response = await POST(
+      postRequest({
+        viewSlug: 'my-view',
+        source: 'kg-curation:my-view',
+        nodes: [{ kind: 'not-a-real-kind', name: 'x.ts', naturalKey: 'revealui/x.ts' }],
+        edges: [],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockIngestEpisode).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body with an unknown edge relation (ontology enum validation)', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const response = await POST(
+      postRequest({
+        viewSlug: 'my-view',
+        source: 'kg-curation:my-view',
+        nodes: [],
+        edges: [
+          {
+            source: { kind: 'file', naturalKey: 'a' },
+            target: { kind: 'file', naturalKey: 'b' },
+            relation: 'made-up-relation',
+            fact: 'a relates to b',
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockIngestEpisode).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body with neither nodes nor edges', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const response = await POST(
+      postRequest({ viewSlug: 'my-view', source: 'kg-curation:my-view', nodes: [], edges: [] }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockIngestEpisode).not.toHaveBeenCalled();
+  });
+
+  it('rejects extra/unknown top-level fields (strict schema)', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const response = await POST(
+      postRequest({
+        viewSlug: 'my-view',
+        source: 'kg-curation:my-view',
+        nodes: [{ kind: 'file', name: 'x.ts', naturalKey: 'revealui/x.ts' }],
+        edges: [],
+        episodeType: 'code-scan', // must not be attacker-controllable
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockIngestEpisode).not.toHaveBeenCalled();
+  });
+
+  it('ingests a valid flush body as a manual episode', async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+
+    const response = await POST(
+      postRequest({
+        viewSlug: 'my-view',
+        source: 'kg-curation:my-view',
+        content: 'curator note',
+        nodes: [{ kind: 'file', name: 'x.ts', naturalKey: 'revealui/x.ts', repo: 'revealui' }],
+        edges: [],
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.episodeId).toBe('ep-1');
+    expect(mockIngestEpisode).toHaveBeenCalledTimes(1);
+    const [, input] = mockIngestEpisode.mock.calls[0] ?? [];
+    expect(input.episode.episodeType).toBe('manual');
+    expect(input.episode.source).toBe('kg-curation:my-view');
+    expect(input.episode.contentRef.viewSlug).toBe('my-view');
+    expect(input.nodes).toHaveLength(1);
+  });
+});

--- a/apps/admin/src/app/api/sync/kg-episodes/route.ts
+++ b/apps/admin/src/app/api/sync/kg-episodes/route.ts
@@ -1,0 +1,165 @@
+/**
+ * Knowledge Graph Episode Flush Route
+ *
+ * POST /api/sync/kg-episodes
+ *
+ * The ONLY write path into `kg_*` tables from the admin app (design spec
+ * §8.3 hard invariant: "the only bridge is an explicit 'flush to episode'
+ * action"). The Yjs curation overlay (`packages/sync/src/collab/kg-view.ts`)
+ * never writes `kg_nodes` / `kg_edges` directly; the explorer's "flush to
+ * episode" action POSTs selected annotations/facts here, which validates the
+ * body and calls the additive `ingestEpisode` (episodeType always `manual`,
+ * never a rescan) server-side — the same write path `kg_add_episode` uses in
+ * `@revealui/mcp`'s knowledge-graph MCP server factory.
+ *
+ * `nodes`/`edges` reuse `KgAddEpisodeArgsSchema`'s exact node/edge shapes
+ * from `@revealui/mcp/kg-server` (Zod-validated against the ontology enums —
+ * `NODE_KINDS`/`EDGE_RELATIONS` — exactly like `kg_add_episode`), rather than
+ * duplicating that schema here. `episodeType` is not client-supplied: this
+ * route always ingests as `manual`.
+ */
+
+import { hostname } from 'node:os';
+import { getSession } from '@revealui/auth/server';
+import { getPool } from '@revealui/db/pool';
+import {
+  type EdgeInput,
+  ingestEpisode,
+  makePoolExecutor,
+  type NodeInput,
+} from '@revealui/knowledge-graph';
+import { KgAddEpisodeArgsSchema } from '@revealui/mcp/kg-server';
+import { isValidKgViewSlug } from '@revealui/sync/collab/server';
+import { logger } from '@revealui/utils/logger';
+import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
+import {
+  createApplicationErrorResponse,
+  createErrorResponse,
+  createValidationErrorResponse,
+} from '@/lib/utils/error-response';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const KgFlushArgsSchema = z
+  .object({
+    viewSlug: z.string().min(1),
+    source: z.string().min(1),
+    content: z.string().max(20_000).optional(),
+    contentRef: z.record(z.string(), z.unknown()).optional(),
+    nodes: KgAddEpisodeArgsSchema.shape.nodes,
+    edges: KgAddEpisodeArgsSchema.shape.edges,
+  })
+  .strict();
+
+interface EmbeddingModule {
+  generateEmbedding(text: string): Promise<{ vector: number[] }>;
+}
+
+/** Best-effort embedder, mirroring `revkg`'s CLI and the MCP factory's `resolveEmbedder` (`@revealui/ai` is optional). */
+async function loadEmbedder(): Promise<((text: string) => Promise<number[]>) | undefined> {
+  try {
+    const specifier = '@revealui/ai/embeddings';
+    const ai = (await import(specifier)) as EmbeddingModule;
+    return async (text: string): Promise<number[]> => {
+      const result = await ai.generateEmbedding(text);
+      return result.vector;
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const aiGate = checkAIFeatureGate();
+  if (aiGate) return aiGate;
+
+  try {
+    const session = await getSession(request.headers, extractRequestContext(request));
+    if (!session) {
+      return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const body: unknown = await request.json();
+    const parsed = KgFlushArgsSchema.safeParse(body);
+    if (!parsed.success) {
+      return createValidationErrorResponse('Invalid kg episode flush body', 'body', undefined, {
+        issues: parsed.error.issues,
+      });
+    }
+    const v = parsed.data;
+
+    if (!isValidKgViewSlug(v.viewSlug)) {
+      return createValidationErrorResponse(
+        'viewSlug must be lowercase alphanumeric and hyphens only (max 64 chars)',
+        'viewSlug',
+        v.viewSlug,
+      );
+    }
+
+    if (v.nodes.length === 0 && v.edges.length === 0) {
+      return createValidationErrorResponse(
+        'at least one node or edge is required',
+        'nodes/edges',
+        undefined,
+      );
+    }
+
+    const nodes: NodeInput[] = v.nodes.map((n) => ({
+      kind: n.kind,
+      name: n.name,
+      naturalKey: n.naturalKey,
+      repo: n.repo,
+      summary: n.summary,
+      attributes: n.attributes,
+    }));
+    const edges: EdgeInput[] = v.edges.map((e) => ({
+      source: e.source,
+      target: e.target,
+      relation: e.relation,
+      fact: e.fact,
+      repo: e.repo,
+      validAt: e.validAt ? new Date(e.validAt) : undefined,
+      attributes: e.attributes,
+    }));
+
+    const exec = makePoolExecutor(getPool());
+    const embedder = await loadEmbedder();
+    const referenceTime = new Date();
+
+    const result = await ingestEpisode(
+      exec,
+      {
+        episode: {
+          episodeType: 'manual',
+          source: v.source,
+          siteId: `admin-explorer:${hostname()}`,
+          content: v.content ?? null,
+          contentRef: { ...v.contentRef, viewSlug: v.viewSlug },
+          referenceTime,
+        },
+        nodes,
+        edges,
+      },
+      { embedder, recordOutbox: true },
+    );
+
+    return NextResponse.json(
+      {
+        episodeId: result.episodeId,
+        nodeCount: result.nodeCount,
+        edgeCount: result.edgeCount,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    logger.error('Error flushing kg episode', { error });
+    return createErrorResponse(error, {
+      endpoint: '/api/sync/kg-episodes',
+      operation: 'kg_episode_flush',
+    });
+  }
+}

--- a/apps/admin/src/lib/utils/__tests__/identifier-validation.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/identifier-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isSyncIdentifier, isUuid } from '../identifier-validation';
+import { isRepoIdentifier, isSyncIdentifier, isUuid } from '../identifier-validation';
 
 describe('isUuid', () => {
   it('accepts lowercase UUIDs', () => {
@@ -58,5 +58,38 @@ describe('isSyncIdentifier', () => {
 
   it('rejects non-ASCII characters', () => {
     expect(isSyncIdentifier('agént')).toBe(false);
+  });
+});
+
+describe('isRepoIdentifier', () => {
+  it('accepts plain repo names', () => {
+    expect(isRepoIdentifier('revealui')).toBe(true);
+    expect(isRepoIdentifier('revdev')).toBe(true);
+    expect(isRepoIdentifier('agent-system-2')).toBe(true);
+  });
+
+  it('accepts dotted repo names', () => {
+    expect(isRepoIdentifier('.jv')).toBe(true);
+    expect(isRepoIdentifier('revealui-jv')).toBe(true);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isRepoIdentifier('')).toBe(false);
+  });
+
+  it('rejects whitespace, slashes, and quoting attempts', () => {
+    expect(isRepoIdentifier('reveal ui')).toBe(false);
+    expect(isRepoIdentifier('reveal/ui')).toBe(false);
+    expect(isRepoIdentifier("'; DROP TABLE kg_nodes;--")).toBe(false);
+    expect(isRepoIdentifier("revealui' OR '1'='1")).toBe(false);
+  });
+
+  it('rejects non-ASCII characters', () => {
+    expect(isRepoIdentifier('révealui')).toBe(false);
+  });
+
+  it('rejects values over the length bound', () => {
+    expect(isRepoIdentifier('a'.repeat(128))).toBe(true);
+    expect(isRepoIdentifier('a'.repeat(129))).toBe(false);
   });
 });

--- a/apps/admin/src/lib/utils/identifier-validation.ts
+++ b/apps/admin/src/lib/utils/identifier-validation.ts
@@ -32,3 +32,23 @@ const IDENTIFIER_CHARS = new Set(
 export function isSyncIdentifier(value: string): boolean {
   return value.length > 0 && Array.from(value).every((c) => IDENTIFIER_CHARS.has(c));
 }
+
+const REPO_IDENTIFIER_CHARS = new Set(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.',
+);
+const MAX_REPO_IDENTIFIER_LENGTH = 128;
+
+/**
+ * Fleet repo identifier: non-empty, alphanumeric plus hyphen/underscore/dot,
+ * bounded length. Superset of {@link isSyncIdentifier}'s charset (adds `.`)
+ * to cover repo names like `.jv`. Used to validate the `repo` denormalized
+ * partition column (design spec §8.2) before it is inlined into an Electric
+ * shape `where` clause — never accept an unvalidated value there.
+ */
+export function isRepoIdentifier(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= MAX_REPO_IDENTIFIER_LENGTH &&
+    Array.from(value).every((c) => REPO_IDENTIFIER_CHARS.has(c))
+  );
+}

--- a/packages/knowledge-graph/src/__tests__/drift.test.ts
+++ b/packages/knowledge-graph/src/__tests__/drift.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Doc-currency drift detection (design spec §8.5): `kgDrift` walks CURRENT
+ * `documents` edges (doc node -> code node, per the direction convention
+ * documented in `search/drift.ts`) and reports the ones where the code node's
+ * `last_confirmed_at` is newer than the doc's, sorted by staleness delta.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { scanEpisode } from '../extractors/shared.js';
+import { ingestEpisode } from '../ingest/index.js';
+import { kgDrift } from '../search/drift.js';
+import type { EdgeInput, NodeInput } from '../types.js';
+import { createKgTestDb, type KgTestDb } from './test-db.js';
+
+let db: KgTestDb;
+beforeEach(async () => {
+  db = await createKgTestDb();
+});
+afterEach(async () => {
+  await db.close();
+});
+
+const REPO = 'revealui';
+const DOC_KEY = 'revealui/docs/architecture/electric-sync.md';
+const CODE_KEY = 'revealui/packages/sync/src/collab/kg-view.ts';
+const OTHER_CODE_KEY = 'revealui/packages/sync/src/collab/use-kg-view-document.ts';
+
+async function seedDoc(docConfirmedAt: Date, codeConfirmedAt: Date): Promise<void> {
+  const nodes: NodeInput[] = [
+    { kind: 'adr', name: 'electric-sync.md', naturalKey: DOC_KEY, repo: REPO },
+    { kind: 'file', name: 'kg-view.ts', naturalKey: CODE_KEY, repo: REPO },
+  ];
+  const edge: EdgeInput = {
+    source: { kind: 'adr', naturalKey: DOC_KEY },
+    target: { kind: 'file', naturalKey: CODE_KEY },
+    relation: 'documents',
+    fact: 'electric-sync.md documents kg-view.ts',
+    repo: REPO,
+    validAt: docConfirmedAt,
+  };
+
+  // First episode establishes both nodes at the doc's confirmation time.
+  await ingestEpisode(db.exec, {
+    episode: scanEpisode({ repo: REPO, siteId: 's', now: docConfirmedAt }, 'docs-frontmatter'),
+    nodes,
+    edges: [edge],
+  });
+
+  // A later episode re-confirms only the code node (simulating a code scan
+  // after the doc was last touched) — bump its last_confirmed_at without
+  // touching the doc node or the edge.
+  if (codeConfirmedAt.getTime() !== docConfirmedAt.getTime()) {
+    await ingestEpisode(db.exec, {
+      episode: scanEpisode({ repo: REPO, siteId: 's', now: codeConfirmedAt }, 'ts-project'),
+      nodes: [{ kind: 'file', name: 'kg-view.ts', naturalKey: CODE_KEY, repo: REPO }],
+      edges: [],
+    });
+  }
+}
+
+describe('kgDrift', () => {
+  it('reports a doc whose documented code node was confirmed later', async () => {
+    const docAt = new Date('2026-07-01T00:00:00Z');
+    const codeAt = new Date('2026-07-10T00:00:00Z');
+    await seedDoc(docAt, codeAt);
+
+    const candidates = await kgDrift(db.exec);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.docNaturalKey).toBe(DOC_KEY);
+    expect(candidates[0]?.codeNaturalKey).toBe(CODE_KEY);
+    expect(candidates[0]?.deltaSeconds).toBeCloseTo(9 * 24 * 60 * 60, 0);
+    expect(candidates[0]?.episodeIds.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('omits a doc that is at least as fresh as its documented code', async () => {
+    const at = new Date('2026-07-01T00:00:00Z');
+    await seedDoc(at, at);
+
+    const candidates = await kgDrift(db.exec);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('sorts multiple candidates by staleness delta descending', async () => {
+    await seedDoc(new Date('2026-07-01T00:00:00Z'), new Date('2026-07-03T00:00:00Z'));
+
+    const secondDocKey = 'revealui/docs/architecture/other.md';
+    const nodes: NodeInput[] = [
+      { kind: 'adr', name: 'other.md', naturalKey: secondDocKey, repo: REPO },
+      { kind: 'file', name: 'use-kg-view-document.ts', naturalKey: OTHER_CODE_KEY, repo: REPO },
+    ];
+    const edge: EdgeInput = {
+      source: { kind: 'adr', naturalKey: secondDocKey },
+      target: { kind: 'file', naturalKey: OTHER_CODE_KEY },
+      relation: 'documents',
+      fact: 'other.md documents use-kg-view-document.ts',
+      repo: REPO,
+      validAt: new Date('2026-07-01T00:00:00Z'),
+    };
+    await ingestEpisode(db.exec, {
+      episode: scanEpisode(
+        { repo: REPO, siteId: 's', now: new Date('2026-07-01T00:00:00Z') },
+        'docs-frontmatter',
+        { doc: 'other' },
+      ),
+      nodes,
+      edges: [edge],
+    });
+    await ingestEpisode(db.exec, {
+      episode: scanEpisode(
+        { repo: REPO, siteId: 's', now: new Date('2026-07-20T00:00:00Z') },
+        'ts-project',
+        { doc: 'other' },
+      ),
+      nodes: [
+        { kind: 'file', name: 'use-kg-view-document.ts', naturalKey: OTHER_CODE_KEY, repo: REPO },
+      ],
+      edges: [],
+    });
+
+    const candidates = await kgDrift(db.exec);
+    expect(candidates).toHaveLength(2);
+    // The second (19-day delta) candidate ranks before the first (2-day delta).
+    expect(candidates[0]?.docNaturalKey).toBe(secondDocKey);
+    expect(candidates[1]?.docNaturalKey).toBe(DOC_KEY);
+    expect(candidates[0]?.deltaSeconds).toBeGreaterThan(candidates[1]?.deltaSeconds ?? 0);
+  });
+
+  it('filters by repo when requested', async () => {
+    await seedDoc(new Date('2026-07-01T00:00:00Z'), new Date('2026-07-10T00:00:00Z'));
+
+    const inRepo = await kgDrift(db.exec, { repo: REPO });
+    expect(inRepo).toHaveLength(1);
+
+    const otherRepo = await kgDrift(db.exec, { repo: 'revdev' });
+    expect(otherRepo).toHaveLength(0);
+  });
+});

--- a/packages/knowledge-graph/src/cli/revkg.ts
+++ b/packages/knowledge-graph/src/cli/revkg.ts
@@ -7,6 +7,7 @@
  *   revkg node <naturalKey>
  *   revkg neighbors <naturalKey> [--depth <n>] [--at <iso>]
  *   revkg at <naturalKey> <iso>
+ *   revkg drift [--repo <name>] [--json]                   doc-currency drift report (spec §8.5)
  *
  * Connects to Neon via its own pool (`@revealui/db`'s `createPool`, DATABASE_URL
  * / POSTGRES_URL resolved by `getConnectionIdentity`) rather than the shared
@@ -32,7 +33,7 @@ import { isDir, readJsonFile, readTextFile } from '../extractors/shared.js';
 import { applyScan, ingestEpisode } from '../ingest/index.js';
 import { resolveNaturalKey } from '../ingest/resolve.js';
 import type { NodeKind } from '../ontology/index.js';
-import { kgAtTime, kgNeighbors, kgSearch } from '../search/index.js';
+import { type DriftCandidate, kgAtTime, kgDrift, kgNeighbors, kgSearch } from '../search/index.js';
 import type { Embedder, KgExecutor } from '../types.js';
 
 /** Long-running-ingest pool tuning (spec: cold Neon compute + big-repo scans). */
@@ -73,7 +74,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   const positionals: string[] = [];
   const flags = new Map<string, string>();
   const bools = new Set<string>();
-  const boolFlags = new Set(['fleet']);
+  const boolFlags = new Set(['fleet', 'json']);
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === undefined) continue;
@@ -288,6 +289,28 @@ async function cmdAt(args: ParsedArgs): Promise<void> {
   }
 }
 
+function formatDriftRow(c: DriftCandidate): string {
+  const days = (c.deltaSeconds / 86_400).toFixed(1);
+  const episodes = c.episodeIds.length > 0 ? c.episodeIds.join(',') : 'none';
+  return `  +${days}d  doc=[${c.docKind}] ${c.docNaturalKey}  code=[${c.codeKind}] ${c.codeNaturalKey}  episodes=${episodes}`;
+}
+
+async function cmdDrift(args: ParsedArgs): Promise<void> {
+  const repo = args.flags.get('repo');
+  const { exec, close } = await getExecutor();
+  try {
+    const candidates = await kgDrift(exec, { repo });
+    if (args.bools.has('json')) {
+      out(JSON.stringify(candidates, null, 2));
+      return;
+    }
+    out(`drift candidates (${candidates.length}):`);
+    for (const c of candidates) out(formatDriftRow(c));
+  } finally {
+    await close();
+  }
+}
+
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
   const args = parseArgs(rest);
@@ -307,8 +330,11 @@ async function main(): Promise<void> {
     case 'at':
       await cmdAt(args);
       break;
+    case 'drift':
+      await cmdDrift(args);
+      break;
     default:
-      out('usage: revkg <scan|search|node|neighbors|at> [...]');
+      out('usage: revkg <scan|search|node|neighbors|at|drift> [...]');
       process.exit(command ? 1 : 0);
   }
 }

--- a/packages/knowledge-graph/src/index.ts
+++ b/packages/knowledge-graph/src/index.ts
@@ -40,9 +40,12 @@ export {
   validateNodeAttributes,
 } from './ontology/index.js';
 export {
+  type DriftCandidate,
+  type KgDriftOptions,
   type KgSearchQuery,
   type KgSearchResult,
   kgAtTime,
+  kgDrift,
   kgNeighbors,
   kgPath,
   kgSearch,

--- a/packages/knowledge-graph/src/search/drift.ts
+++ b/packages/knowledge-graph/src/search/drift.ts
@@ -1,0 +1,104 @@
+/**
+ * Doc-currency drift detection (design spec §8.5).
+ *
+ * `documents` edges make the code-over-docs rule (`~/.claude/rules/code-over-docs.md`)
+ * queryable: a doc node that documents a code node is drifting when the code node
+ * was confirmed by a scan AFTER the doc node's own last confirmation. `kgDrift`
+ * walks every CURRENT `documents` edge and reports the ones where that holds,
+ * sorted by staleness delta (largest first) so the worst drift surfaces first.
+ *
+ * Direction convention (no extractor emits `documents` edges yet as of P4 —
+ * this is Tier-2/manual-episode territory per spec §6 Tier 2 and the P3 rider
+ * list — so this is a documented assumption, not an empirically-observed
+ * convention): `source` is the DOC node, `target` is the CODE node, matching
+ * the spec's literal wording ("any doc node whose `documents` edge TARGETS a
+ * code node"). `kgAddEpisode` / `kg_add_episode` callers that emit `documents`
+ * edges must follow this direction for `revkg drift` to report them correctly.
+ *
+ * Read-only: no writes, no invalidation. Feeds the `doc-code-reconciliation`
+ * lane and the doc-currency stale-fact scanner with grounded, per-claim
+ * candidates instead of full-file heuristics.
+ */
+
+import type { KgExecutor } from '../types.js';
+
+export interface DriftCandidate {
+  edgeId: string;
+  docNaturalKey: string;
+  docKind: string;
+  docLastConfirmedAt: string;
+  codeNaturalKey: string;
+  codeKind: string;
+  codeLastConfirmedAt: string;
+  /** Seconds by which the code node's last confirmation is newer than the doc's. */
+  deltaSeconds: number;
+  episodeIds: string[];
+}
+
+export interface KgDriftOptions {
+  /** Restrict to `documents` edges stamped with this repo (edge.repo). Omit for fleet-wide. */
+  repo?: string;
+}
+
+interface DriftRow {
+  edge_id: string;
+  doc_natural_key: string;
+  doc_kind: string;
+  doc_last_confirmed_at: string;
+  code_natural_key: string;
+  code_kind: string;
+  code_last_confirmed_at: string;
+  delta_seconds: number;
+  episode_ids: string[] | null;
+}
+
+/**
+ * Doc-currency drift candidates from current `documents` edges, sorted by
+ * staleness delta descending. A candidate exists only when the code node's
+ * `last_confirmed_at` is strictly newer than the doc node's (the `HAVING`
+ * clause) — a doc confirmed at or after its code is not drifting.
+ */
+export async function kgDrift(
+  exec: KgExecutor,
+  options: KgDriftOptions = {},
+): Promise<DriftCandidate[]> {
+  const params: unknown[] = options.repo ? [options.repo] : [];
+  const repoClause = options.repo ? `AND e.repo = $1` : '';
+
+  const rows = await exec.query<DriftRow>(
+    `SELECT
+       e.id AS edge_id,
+       doc.natural_key AS doc_natural_key,
+       doc.kind AS doc_kind,
+       doc.last_confirmed_at AS doc_last_confirmed_at,
+       code.natural_key AS code_natural_key,
+       code.kind AS code_kind,
+       code.last_confirmed_at AS code_last_confirmed_at,
+       EXTRACT(EPOCH FROM (code.last_confirmed_at - doc.last_confirmed_at)) AS delta_seconds,
+       coalesce(array_agg(ee.episode_id) FILTER (WHERE ee.episode_id IS NOT NULL), '{}') AS episode_ids
+     FROM kg_edges e
+     JOIN kg_nodes doc ON doc.id = e.source_id
+     JOIN kg_nodes code ON code.id = e.target_id
+     LEFT JOIN kg_edge_episodes ee ON ee.edge_id = e.id
+     WHERE e.relation = 'documents'
+       AND e.invalid_at IS NULL AND e.expired_at IS NULL
+       ${repoClause}
+     GROUP BY e.id, doc.natural_key, doc.kind, doc.last_confirmed_at,
+              code.natural_key, code.kind, code.last_confirmed_at
+     HAVING code.last_confirmed_at > doc.last_confirmed_at
+     ORDER BY delta_seconds DESC, e.id`,
+    params,
+  );
+
+  return rows.map((r) => ({
+    edgeId: r.edge_id,
+    docNaturalKey: r.doc_natural_key,
+    docKind: r.doc_kind,
+    docLastConfirmedAt: r.doc_last_confirmed_at,
+    codeNaturalKey: r.code_natural_key,
+    codeKind: r.code_kind,
+    codeLastConfirmedAt: r.code_last_confirmed_at,
+    deltaSeconds: Number(r.delta_seconds),
+    episodeIds: r.episode_ids ?? [],
+  }));
+}

--- a/packages/knowledge-graph/src/search/index.ts
+++ b/packages/knowledge-graph/src/search/index.ts
@@ -17,6 +17,9 @@ import type { EdgeRelation, NodeKind } from '../ontology/index.js';
 import type { KgExecutor } from '../types.js';
 import { applyEpisodeMentions, applyNodeDistance, rankByScore, rrfFuse } from './rrf.js';
 
+export type { DriftCandidate, KgDriftOptions } from './drift.js';
+export { kgDrift } from './drift.js';
+
 export interface KgSearchQuery {
   query: string;
   /** Anchor node id for the traversal channel + node-distance reranker. */

--- a/packages/sync/src/collab/__tests__/kg-view.test.ts
+++ b/packages/sync/src/collab/__tests__/kg-view.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Knowledge graph curation overlay (design spec §8.3). Round-trips
+ * `buildAnnotationPatch`/`buildPinPatch`/`buildLayoutPatch`/`buildPresencePatch`
+ * through the REAL `applyPatch` + `readScratchpad` Yjs machinery (not just
+ * unit-testing `parseKgViewState` against fabricated objects) — this is the
+ * "verify the existing structured-patch REST path works for these docs"
+ * requirement from the P4 checklist.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import {
+  buildAnnotationPatch,
+  buildKgViewDocumentId,
+  buildLayoutPatch,
+  buildPinPatch,
+  buildPresencePatch,
+  isKgViewDocumentId,
+  isPresenceStale,
+  isValidKgViewSlug,
+  KG_VIEW_ID_PREFIX,
+  PRESENCE_STALE_MS,
+  parseKgViewState,
+} from '../kg-view.js';
+import {
+  applyPatch,
+  applyPatches,
+  readScratchpad,
+  type ScratchpadPatch,
+} from '../scratchpad-patch-applier.js';
+
+describe('isValidKgViewSlug', () => {
+  it('accepts lowercase alphanumeric and hyphens', () => {
+    expect(isValidKgViewSlug('electric-sync-map')).toBe(true);
+    expect(isValidKgViewSlug('view1')).toBe(true);
+  });
+
+  it('rejects the empty string, uppercase, and non-charset characters', () => {
+    expect(isValidKgViewSlug('')).toBe(false);
+    expect(isValidKgViewSlug('View')).toBe(false);
+    expect(isValidKgViewSlug('view_1')).toBe(false);
+    expect(isValidKgViewSlug('view/1')).toBe(false);
+    expect(isValidKgViewSlug("view'; DROP TABLE--")).toBe(false);
+  });
+
+  it('rejects slugs over the length bound', () => {
+    expect(isValidKgViewSlug('a'.repeat(64))).toBe(true);
+    expect(isValidKgViewSlug('a'.repeat(65))).toBe(false);
+  });
+});
+
+describe('buildKgViewDocumentId / isKgViewDocumentId', () => {
+  it('builds a prefixed document id from a valid slug', () => {
+    expect(buildKgViewDocumentId('my-view')).toBe(`${KG_VIEW_ID_PREFIX}my-view`);
+  });
+
+  it('throws on an invalid slug', () => {
+    expect(() => buildKgViewDocumentId('My View')).toThrow();
+  });
+
+  it('round-trips through isKgViewDocumentId', () => {
+    const id = buildKgViewDocumentId('my-view');
+    expect(isKgViewDocumentId(id)).toBe(true);
+    expect(isKgViewDocumentId('0b9f2a4e-1c3d-4e5f-8a7b-9c0d1e2f3a4b')).toBe(false);
+    expect(isKgViewDocumentId('kg-view-')).toBe(false);
+  });
+
+  it('is compatible with the existing yjs-document-patches DOCUMENT_ID_RE charset', () => {
+    // apps/admin/.../api/sync/yjs-document-patches/route.ts: /^[a-zA-Z0-9_-]+$/
+    const allowedChars = new Set(
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-',
+    );
+    const id = buildKgViewDocumentId('electric-sync-map');
+    expect(Array.from(id).every((c) => allowedChars.has(c))).toBe(true);
+  });
+});
+
+describe('kg-view patch round trip through real Yjs', () => {
+  const nodeId = '0b9f2a4e-1c3d-4e5f-8a7b-9c0d1e2f3a4b';
+
+  it('annotate then read back via readScratchpad + parseKgViewState', () => {
+    const now = new Date('2026-07-11T12:00:00Z');
+    const patch = buildAnnotationPatch(
+      nodeId,
+      'looks stale, verify against code',
+      'claude-session',
+      now,
+    );
+    const { state } = applyPatches(null, [patch]);
+    const root = readScratchpad(state);
+    const parsed = parseKgViewState(root);
+
+    const annotation = parsed.annotations.get(nodeId);
+    expect(annotation?.text).toBe('looks stale, verify against code');
+    expect(annotation?.authorAgentId).toBe('claude-session');
+    expect(annotation?.updatedAt).toBe(now.toISOString());
+  });
+
+  it('pin then unpin, applying patches sequentially to the same doc', () => {
+    const doc = new Y.Doc();
+    applyPatch(doc, buildPinPatch(nodeId, true));
+    let parsed = parseKgViewState(readScratchpad(Y.encodeStateAsUpdate(doc)));
+    expect(parsed.pins.has(nodeId)).toBe(true);
+
+    applyPatch(doc, buildPinPatch(nodeId, false));
+    parsed = parseKgViewState(readScratchpad(Y.encodeStateAsUpdate(doc)));
+    expect(parsed.pins.has(nodeId)).toBe(false);
+    doc.destroy();
+  });
+
+  it('sets a layout position', () => {
+    const patch = buildLayoutPatch(nodeId, 120, -40);
+    const { state } = applyPatches(null, [patch]);
+    const parsed = parseKgViewState(readScratchpad(state));
+    expect(parsed.layout.get(nodeId)).toEqual({ x: 120, y: -40 });
+  });
+
+  it('records a presence heartbeat', () => {
+    const now = new Date('2026-07-11T12:00:00Z');
+    const patch = buildPresencePatch('client-abc', 'Joshua', nodeId, now);
+    const { state } = applyPatches(null, [patch]);
+    const parsed = parseKgViewState(readScratchpad(state));
+    expect(parsed.presence.get('client-abc')).toEqual({
+      name: 'Joshua',
+      nodeId,
+      updatedAt: now.toISOString(),
+    });
+  });
+
+  it('applies multiple overlay kinds together and reads them all back', () => {
+    const patches: ScratchpadPatch[] = [
+      buildAnnotationPatch(nodeId, 'note', 'agent-a'),
+      buildPinPatch(nodeId, true),
+      buildLayoutPatch(nodeId, 1, 2),
+      buildPresencePatch('client-1', 'Agent A', nodeId),
+    ];
+    const { state } = applyPatches(null, patches);
+    const parsed = parseKgViewState(readScratchpad(state));
+
+    expect(parsed.annotations.has(nodeId)).toBe(true);
+    expect(parsed.pins.has(nodeId)).toBe(true);
+    expect(parsed.layout.has(nodeId)).toBe(true);
+    expect(parsed.presence.has('client-1')).toBe(true);
+  });
+
+  it('drops malformed entries instead of throwing', () => {
+    const parsed = parseKgViewState({
+      'annotation:n1': 'not json',
+      'layout:n2': JSON.stringify({ x: 'nope', y: 2 }),
+      'pin:n3': 'yes', // not literally 'true'
+      'presence:c1': JSON.stringify({ name: 42 }),
+      unrelated_key: 'ignored',
+    });
+    expect(parsed.annotations.size).toBe(0);
+    expect(parsed.layout.size).toBe(0);
+    expect(parsed.pins.has('n3')).toBe(false);
+    expect(parsed.presence.size).toBe(0);
+  });
+});
+
+describe('isPresenceStale', () => {
+  it('is not stale just under the threshold', () => {
+    const now = new Date('2026-07-11T12:00:00Z');
+    const entry = {
+      name: 'a',
+      nodeId: null,
+      updatedAt: new Date(now.getTime() - (PRESENCE_STALE_MS - 1000)).toISOString(),
+    };
+    expect(isPresenceStale(entry, now)).toBe(false);
+  });
+
+  it('is stale past the threshold', () => {
+    const now = new Date('2026-07-11T12:00:00Z');
+    const entry = {
+      name: 'a',
+      nodeId: null,
+      updatedAt: new Date(now.getTime() - (PRESENCE_STALE_MS + 1000)).toISOString(),
+    };
+    expect(isPresenceStale(entry, now)).toBe(true);
+  });
+
+  it('treats an unparseable timestamp as stale', () => {
+    expect(isPresenceStale({ name: 'a', nodeId: null, updatedAt: 'not-a-date' })).toBe(true);
+  });
+});

--- a/packages/sync/src/collab/index.ts
+++ b/packages/sync/src/collab/index.ts
@@ -1,3 +1,22 @@
+export type {
+  KgViewAnnotation,
+  KgViewLayoutPosition,
+  KgViewPresenceEntry,
+  KgViewState,
+} from './kg-view.js';
+export {
+  buildAnnotationPatch,
+  buildKgViewDocumentId,
+  buildLayoutPatch,
+  buildPinPatch,
+  buildPresencePatch,
+  isKgViewDocumentId,
+  isPresenceStale,
+  isValidKgViewSlug,
+  KG_VIEW_ID_PREFIX,
+  PRESENCE_STALE_MS,
+  parseKgViewState,
+} from './kg-view.js';
 export { MESSAGE_AWARENESS, MESSAGE_SYNC } from './protocol-constants.js';
 export type { ApplyResult, PatchType, ScratchpadPatch } from './scratchpad-patch-applier.js';
 export { applyPatch, applyPatches, readScratchpad } from './scratchpad-patch-applier.js';
@@ -9,5 +28,7 @@ export type {
   UseCollaborationResult,
 } from './use-collaboration.js';
 export { useCollaboration } from './use-collaboration.js';
+export type { UseKgViewDocumentResult } from './use-kg-view-document.js';
+export { useKgViewDocument } from './use-kg-view-document.js';
 export type { UserPresence } from './yjs-websocket-provider.js';
 export { CollabProvider } from './yjs-websocket-provider.js';

--- a/packages/sync/src/collab/kg-view.ts
+++ b/packages/sync/src/collab/kg-view.ts
@@ -1,0 +1,253 @@
+/**
+ * Knowledge graph curation overlay — per-view Y.Doc shape (design spec §8.3).
+ *
+ * Extends the EXISTING `yjs_documents` + `yjs_document_patches` infra (never
+ * a new table): a "graph view" document is keyed `kg-view-<slug>` and holds
+ * three kinds of ephemeral overlay state on top of the canonical graph —
+ * annotations, pins, and layout positions — plus a small polled presence
+ * overlay (see below). The Yjs state is NEVER written into `kg_*` tables
+ * directly; the only bridge is the explicit "flush to episode" action
+ * (`POST /api/sync/kg-episodes`), which reads selected annotations out of
+ * this shape and durably records them as a `manual` episode via
+ * `ingestEpisode`. Boundary rule, verbatim from the spec: "Yjs co-edits
+ * ephemeral working state; the Postgres CRDT classes hold canonical truth;
+ * episodes are the only bridge between them."
+ *
+ * ## Document id
+ *
+ * `kg-view-<slug>` (hyphen, not the spec's illustrative `kg-view:<slug>` —
+ * see the PR body escalation: the existing `/api/sync/yjs-document-patches`
+ * write route's `DOCUMENT_ID_RE` already accepts `[a-zA-Z0-9_-]+`, so a
+ * hyphen-delimited id reuses that route UNCHANGED; a colon would not have
+ * matched it). Validate the slug with {@link isValidKgViewSlug} before
+ * building an id with {@link buildKgViewDocumentId}.
+ *
+ * ## Patch shapes (structured-patch REST path, Layer 2 of multi-agent-memory)
+ *
+ * All four overlay kinds ride the EXISTING `set_key` patch type — root-level
+ * key set to a string value (`packages/sync/src/collab/scratchpad-patch-applier.ts`).
+ * No new patch type was added; each kind is a distinct root-key PREFIX with a
+ * JSON- or boolean-encoded string value:
+ *
+ * | Kind        | Root key                | Content                                    |
+ * |-------------|--------------------------|---------------------------------------------|
+ * | annotation  | `annotation:<nodeId>`    | `JSON.stringify(KgViewAnnotation)`           |
+ * | pin         | `pin:<nodeId>`           | `'true'` or `'false'`                        |
+ * | layout      | `layout:<nodeId>`        | `JSON.stringify(KgViewLayoutPosition)`       |
+ * | presence    | `presence:<clientId>`    | `JSON.stringify(KgViewPresenceEntry)`        |
+ *
+ * `nodeId` is a `kg_nodes.id` (deterministic UUID-shaped id — already a safe
+ * character set). `clientId` is a per-tab `crypto.randomUUID()`. Both CLI
+ * agents (via `POST /api/sync/yjs-document-patches`, unmodified) and browser
+ * agents (via the same REST path today; a live websocket path is deferred —
+ * see `use-kg-view-document.ts`) write through this exact shape.
+ *
+ * ## Presence (awareness deferred)
+ *
+ * `apps/admin` has no live Yjs websocket wired (`useCollaboration` /
+ * `CollabProvider` have zero admin consumers as of GAP-349 P4). Rather than
+ * standing up a new websocket server, presence is a small POLLED overlay:
+ * viewers periodically POST a `presence:<clientId>` patch (a heartbeat); the
+ * READ side is still fully live via the Electric shape subscription (any
+ * patch from any agent propagates to every subscriber in real time), so
+ * presence freshness is bounded by the write-side poll interval, not the
+ * read side. A stale entry (older than {@link PRESENCE_STALE_MS}) is treated
+ * as gone by {@link isPresenceStale} — there is no delete patch type, so
+ * presence rows are never removed, only aged out client-side.
+ */
+
+import type { ScratchpadPatch } from './scratchpad-patch-applier.js';
+
+export const KG_VIEW_ID_PREFIX = 'kg-view-';
+
+const SLUG_CHARS = new Set('abcdefghijklmnopqrstuvwxyz0123456789-');
+const MAX_SLUG_LENGTH = 64;
+
+const ANNOTATION_PREFIX = 'annotation:';
+const PIN_PREFIX = 'pin:';
+const LAYOUT_PREFIX = 'layout:';
+const PRESENCE_PREFIX = 'presence:';
+
+/** Presence entries older than this are treated as stale (client-side only; never deleted server-side). */
+export const PRESENCE_STALE_MS = 60_000;
+
+/** Lowercase alphanumeric + hyphen, 1-64 chars. No authored regex — character-set check. */
+export function isValidKgViewSlug(slug: string): boolean {
+  return (
+    slug.length > 0 &&
+    slug.length <= MAX_SLUG_LENGTH &&
+    Array.from(slug).every((c) => SLUG_CHARS.has(c))
+  );
+}
+
+/** Build the `yjs_documents.id` for a validated view slug. Throws on an invalid slug. */
+export function buildKgViewDocumentId(slug: string): string {
+  if (!isValidKgViewSlug(slug)) {
+    throw new Error(`invalid kg-view slug: ${slug}`);
+  }
+  return `${KG_VIEW_ID_PREFIX}${slug}`;
+}
+
+/** True when `documentId` is a well-formed kg-view document id. */
+export function isKgViewDocumentId(documentId: string): boolean {
+  if (!documentId.startsWith(KG_VIEW_ID_PREFIX)) return false;
+  return isValidKgViewSlug(documentId.slice(KG_VIEW_ID_PREFIX.length));
+}
+
+export interface KgViewAnnotation {
+  text: string;
+  updatedAt: string;
+  authorAgentId: string;
+}
+
+export interface KgViewLayoutPosition {
+  x: number;
+  y: number;
+}
+
+export interface KgViewPresenceEntry {
+  name: string;
+  nodeId: string | null;
+  updatedAt: string;
+}
+
+export interface KgViewState {
+  annotations: Map<string, KgViewAnnotation>;
+  pins: Set<string>;
+  layout: Map<string, KgViewLayoutPosition>;
+  presence: Map<string, KgViewPresenceEntry>;
+}
+
+function emptyState(): KgViewState {
+  return { annotations: new Map(), pins: new Set(), layout: new Map(), presence: new Map() };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseJsonString(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function asAnnotation(raw: Record<string, unknown>): KgViewAnnotation | null {
+  if (typeof raw.text !== 'string' || typeof raw.updatedAt !== 'string') return null;
+  return {
+    text: raw.text,
+    updatedAt: raw.updatedAt,
+    authorAgentId: typeof raw.authorAgentId === 'string' ? raw.authorAgentId : 'unknown',
+  };
+}
+
+function asLayoutPosition(raw: Record<string, unknown>): KgViewLayoutPosition | null {
+  if (typeof raw.x !== 'number' || typeof raw.y !== 'number') return null;
+  return { x: raw.x, y: raw.y };
+}
+
+function asPresenceEntry(raw: Record<string, unknown>): KgViewPresenceEntry | null {
+  if (typeof raw.name !== 'string' || typeof raw.updatedAt !== 'string') return null;
+  return {
+    name: raw.name,
+    nodeId: typeof raw.nodeId === 'string' ? raw.nodeId : null,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+/**
+ * Parse the flat root map produced by `readScratchpad(state)` into the
+ * typed kg-view overlay shape. Malformed entries (unparseable JSON, a
+ * shape mismatch) are silently dropped rather than throwing — the overlay
+ * is ephemeral working state, not a durable contract.
+ */
+export function parseKgViewState(root: Record<string, unknown>): KgViewState {
+  const state = emptyState();
+
+  for (const [key, value] of Object.entries(root)) {
+    if (key.startsWith(ANNOTATION_PREFIX)) {
+      const nodeId = key.slice(ANNOTATION_PREFIX.length);
+      const raw = parseJsonString(value);
+      const annotation = raw ? asAnnotation(raw) : null;
+      if (annotation) state.annotations.set(nodeId, annotation);
+      continue;
+    }
+    if (key.startsWith(PIN_PREFIX)) {
+      const nodeId = key.slice(PIN_PREFIX.length);
+      if (value === 'true') state.pins.add(nodeId);
+      else state.pins.delete(nodeId);
+      continue;
+    }
+    if (key.startsWith(LAYOUT_PREFIX)) {
+      const nodeId = key.slice(LAYOUT_PREFIX.length);
+      const raw = parseJsonString(value);
+      const position = raw ? asLayoutPosition(raw) : null;
+      if (position) state.layout.set(nodeId, position);
+      continue;
+    }
+    if (key.startsWith(PRESENCE_PREFIX)) {
+      const clientId = key.slice(PRESENCE_PREFIX.length);
+      const raw = parseJsonString(value);
+      const entry = raw ? asPresenceEntry(raw) : null;
+      if (entry) state.presence.set(clientId, entry);
+    }
+  }
+
+  return state;
+}
+
+/** True when a presence entry's `updatedAt` is older than {@link PRESENCE_STALE_MS}. */
+export function isPresenceStale(entry: KgViewPresenceEntry, now: Date = new Date()): boolean {
+  const updatedAt = Date.parse(entry.updatedAt);
+  if (Number.isNaN(updatedAt)) return true;
+  return now.getTime() - updatedAt > PRESENCE_STALE_MS;
+}
+
+export function buildAnnotationPatch(
+  nodeId: string,
+  text: string,
+  authorAgentId: string,
+  now: Date = new Date(),
+): ScratchpadPatch {
+  const annotation: KgViewAnnotation = { text, authorAgentId, updatedAt: now.toISOString() };
+  return {
+    patchType: 'set_key',
+    path: `${ANNOTATION_PREFIX}${nodeId}`,
+    content: JSON.stringify(annotation),
+  };
+}
+
+export function buildPinPatch(nodeId: string, pinned: boolean): ScratchpadPatch {
+  return {
+    patchType: 'set_key',
+    path: `${PIN_PREFIX}${nodeId}`,
+    content: pinned ? 'true' : 'false',
+  };
+}
+
+export function buildLayoutPatch(nodeId: string, x: number, y: number): ScratchpadPatch {
+  const position: KgViewLayoutPosition = { x, y };
+  return {
+    patchType: 'set_key',
+    path: `${LAYOUT_PREFIX}${nodeId}`,
+    content: JSON.stringify(position),
+  };
+}
+
+export function buildPresencePatch(
+  clientId: string,
+  name: string,
+  nodeId: string | null,
+  now: Date = new Date(),
+): ScratchpadPatch {
+  const entry: KgViewPresenceEntry = { name, nodeId, updatedAt: now.toISOString() };
+  return {
+    patchType: 'set_key',
+    path: `${PRESENCE_PREFIX}${clientId}`,
+    content: JSON.stringify(entry),
+  };
+}

--- a/packages/sync/src/collab/server-index.ts
+++ b/packages/sync/src/collab/server-index.ts
@@ -2,6 +2,25 @@ export type { AgentCollabClientOptions, AgentIdentity } from './agent-client.js'
 export { AgentCollabClient } from './agent-client.js';
 export type { CreateAgentClientOptions } from './agent-client-factory.js';
 export { createAgentClient, createAndConnectAgentClient } from './agent-client-factory.js';
+export type {
+  KgViewAnnotation,
+  KgViewLayoutPosition,
+  KgViewPresenceEntry,
+  KgViewState,
+} from './kg-view.js';
+export {
+  buildAnnotationPatch,
+  buildKgViewDocumentId,
+  buildLayoutPatch,
+  buildPinPatch,
+  buildPresencePatch,
+  isKgViewDocumentId,
+  isPresenceStale,
+  isValidKgViewSlug,
+  KG_VIEW_ID_PREFIX,
+  PRESENCE_STALE_MS,
+  parseKgViewState,
+} from './kg-view.js';
 export { MESSAGE_AWARENESS, MESSAGE_SYNC } from './protocol-constants.js';
 export type { ApplyResult, PatchType, ScratchpadPatch } from './scratchpad-patch-applier.js';
 export { applyPatch, applyPatches, readScratchpad } from './scratchpad-patch-applier.js';

--- a/packages/sync/src/collab/use-kg-view-document.ts
+++ b/packages/sync/src/collab/use-kg-view-document.ts
@@ -1,0 +1,169 @@
+'use client';
+
+import { useShape } from '@electric-sql/react';
+import { useCallback, useMemo, useRef } from 'react';
+import { csrfHeaders } from '../csrf.js';
+import { fetchWithTimeout } from '../fetch-with-timeout.js';
+import { useElectricConfig } from '../provider/index.js';
+import {
+  buildAnnotationPatch,
+  buildKgViewDocumentId,
+  buildLayoutPatch,
+  buildPinPatch,
+  buildPresencePatch,
+  isValidKgViewSlug,
+  type KgViewState,
+  parseKgViewState,
+} from './kg-view.js';
+import { readScratchpad, type ScratchpadPatch } from './scratchpad-patch-applier.js';
+
+const EMPTY_STATE: KgViewState = {
+  annotations: new Map(),
+  pins: new Set(),
+  layout: new Map(),
+  presence: new Map(),
+};
+
+/** Default timeout for a curation-overlay patch POST (milliseconds). */
+const PATCH_FETCH_TIMEOUT_MS = 10_000;
+
+export interface UseKgViewDocumentResult {
+  documentId: string | null;
+  state: KgViewState;
+  connectedClients: number;
+  isLoading: boolean;
+  error: Error | null;
+  /** Annotate a node with free text. Overwrites any prior annotation for that node. */
+  annotate: (nodeId: string, text: string, authorAgentId: string) => Promise<boolean>;
+  /** Pin or unpin a node in this view. */
+  setPinned: (nodeId: string, pinned: boolean) => Promise<boolean>;
+  /** Set a node's layout position in this view. */
+  setLayout: (nodeId: string, x: number, y: number) => Promise<boolean>;
+  /** Presence heartbeat — see kg-view.ts header comment ("Presence (awareness deferred)"). */
+  touchPresence: (clientId: string, name: string, nodeId: string | null) => Promise<boolean>;
+}
+
+function decodeBase64State(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Curation overlay for one graph view (design spec §8.3). Reads the
+ * `kg-view-<slug>` Y.Doc via the dedicated `/api/shapes/kg-views` shape
+ * (repo-agnostic; see that route's header comment for why it is separate
+ * from `/api/shapes/yjs-documents`), and writes through the EXISTING,
+ * unmodified `/api/sync/yjs-document-patches` route.
+ */
+export function useKgViewDocument(slug: string): UseKgViewDocumentResult {
+  const { proxyBaseUrl } = useElectricConfig();
+  const isValid = isValidKgViewSlug(slug);
+  const documentId = isValid ? buildKgViewDocumentId(slug) : null;
+
+  // Hook must always be called (Rules of Hooks). Pass an impossible id when
+  // the slug is invalid so the shape returns no rows but the hook still runs.
+  const { data, isLoading, error } = useShape({
+    url: `${proxyBaseUrl}/api/shapes/kg-views`,
+    params: { document_id: documentId ?? '__invalid__' },
+    fetchClient: fetchWithTimeout,
+  });
+
+  const patchUrlRef = useRef<string>('');
+  patchUrlRef.current = `${proxyBaseUrl}/api/sync/yjs-document-patches`;
+
+  const { state, connectedClients } = useMemo(() => {
+    if (!(documentId && data) || data.length === 0) {
+      return { state: EMPTY_STATE, connectedClients: 0 };
+    }
+    const row = data[0] as Record<string, unknown>;
+    const rawState = row.state;
+    if (typeof rawState !== 'string' || rawState.length === 0) {
+      return { state: EMPTY_STATE, connectedClients: (row.connected_clients as number) ?? 0 };
+    }
+    const bytes = decodeBase64State(rawState);
+    const root = readScratchpad(bytes);
+    return {
+      state: parseKgViewState(root),
+      connectedClients: (row.connected_clients as number) ?? 0,
+    };
+  }, [documentId, data]);
+
+  const submitPatch = useCallback(
+    async (patch: ScratchpadPatch): Promise<boolean> => {
+      if (!documentId) return false;
+      const url = patchUrlRef.current;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), PATCH_FETCH_TIMEOUT_MS);
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          credentials: 'include',
+          signal: controller.signal,
+          headers: { 'Content-Type': 'application/json', ...csrfHeaders(url) },
+          body: JSON.stringify({
+            document_id: documentId,
+            agent_id: 'admin-explorer',
+            patch_type: patch.patchType,
+            path: patch.path,
+            content: patch.content,
+          }),
+        });
+        return response.ok;
+      } catch {
+        return false;
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+    [documentId],
+  );
+
+  const annotate = useCallback(
+    (nodeId: string, text: string, authorAgentId: string) =>
+      submitPatch(buildAnnotationPatch(nodeId, text, authorAgentId)),
+    [submitPatch],
+  );
+  const setPinned = useCallback(
+    (nodeId: string, pinned: boolean) => submitPatch(buildPinPatch(nodeId, pinned)),
+    [submitPatch],
+  );
+  const setLayout = useCallback(
+    (nodeId: string, x: number, y: number) => submitPatch(buildLayoutPatch(nodeId, x, y)),
+    [submitPatch],
+  );
+  const touchPresence = useCallback(
+    (clientId: string, name: string, nodeId: string | null) =>
+      submitPatch(buildPresencePatch(clientId, name, nodeId)),
+    [submitPatch],
+  );
+
+  if (!isValid) {
+    return {
+      documentId: null,
+      state: EMPTY_STATE,
+      connectedClients: 0,
+      isLoading: false,
+      error: new Error(
+        'Invalid kg-view slug: lowercase alphanumeric and hyphens only, max 64 chars',
+      ),
+      annotate,
+      setPinned,
+      setLayout,
+      touchPresence,
+    };
+  }
+
+  return {
+    documentId,
+    state,
+    connectedClients,
+    isLoading,
+    error: error || null,
+    annotate,
+    setPinned,
+    setLayout,
+    touchPresence,
+  };
+}

--- a/packages/sync/src/hooks/__tests__/useKnowledgeGraph.test.ts
+++ b/packages/sync/src/hooks/__tests__/useKnowledgeGraph.test.ts
@@ -1,0 +1,140 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useKgEdgeEpisodes,
+  useKgEdges,
+  useKgNodes,
+  useKnowledgeGraph,
+} from '../useKnowledgeGraph.js';
+
+vi.mock('@electric-sql/react', () => ({
+  useShape: vi.fn(),
+}));
+
+import { useShape } from '@electric-sql/react';
+
+const mockUseShape = useShape as ReturnType<typeof vi.fn>;
+
+describe('useKgNodes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty array when there is no data', () => {
+    mockUseShape.mockReturnValue({ data: null, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useKgNodes());
+
+    expect(result.current.nodes).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls useShape with no repo param when repo is omitted', () => {
+    mockUseShape.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderHook(() => useKgNodes());
+
+    expect(mockUseShape).toHaveBeenCalledWith({
+      url: '/api/shapes/kg-nodes',
+      params: {},
+      fetchClient: expect.any(Function),
+    });
+  });
+
+  it('calls useShape with the repo param when supplied', () => {
+    mockUseShape.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderHook(() => useKgNodes('revealui'));
+
+    expect(mockUseShape).toHaveBeenCalledWith({
+      url: '/api/shapes/kg-nodes',
+      params: { repo: 'revealui' },
+      fetchClient: expect.any(Function),
+    });
+  });
+
+  it('propagates loading and error state', () => {
+    const mockError = new Error('shape error');
+    mockUseShape.mockReturnValue({ data: null, isLoading: true, error: mockError });
+
+    const { result } = renderHook(() => useKgNodes('revealui'));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe(mockError);
+  });
+
+  it('exposes no mutation functions (Electric sync is read-only for the graph)', () => {
+    mockUseShape.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    const { result } = renderHook(() => useKgNodes());
+
+    expect(result.current).not.toHaveProperty('create');
+    expect(result.current).not.toHaveProperty('update');
+    expect(result.current).not.toHaveProperty('remove');
+  });
+});
+
+describe('useKgEdges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('transforms shape data into edge records', () => {
+    const mockData = [
+      { id: 'e1', source_id: 'n1', target_id: 'n2', relation: 'contains', fact: 'a contains b' },
+    ];
+    mockUseShape.mockReturnValue({ data: mockData, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useKgEdges('revdev'));
+
+    expect(result.current.edges).toEqual(mockData);
+    expect(mockUseShape).toHaveBeenCalledWith({
+      url: '/api/shapes/kg-edges',
+      params: { repo: 'revdev' },
+      fetchClient: expect.any(Function),
+    });
+  });
+});
+
+describe('useKgEdgeEpisodes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls useShape with no params (not repo-partitioned)', () => {
+    mockUseShape.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderHook(() => useKgEdgeEpisodes());
+
+    expect(mockUseShape).toHaveBeenCalledWith({
+      url: '/api/shapes/kg-edge-episodes',
+      fetchClient: expect.any(Function),
+    });
+  });
+});
+
+describe('useKnowledgeGraph', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('composes nodes, edges, and edge-episodes with combined loading/error state', () => {
+    mockUseShape
+      .mockReturnValueOnce({ data: [{ id: 'n1' }], isLoading: false, error: null }) // nodes
+      .mockReturnValueOnce({ data: [{ id: 'e1' }], isLoading: true, error: null }) // edges
+      .mockReturnValueOnce({
+        data: [{ edge_id: 'e1', episode_id: 'ep1' }],
+        isLoading: false,
+        error: null,
+      }); // edge-episodes
+
+    const { result } = renderHook(() => useKnowledgeGraph('revealui'));
+
+    expect(result.current.nodes).toEqual([{ id: 'n1' }]);
+    expect(result.current.edges).toEqual([{ id: 'e1' }]);
+    expect(result.current.edgeEpisodes).toEqual([{ edge_id: 'e1', episode_id: 'ep1' }]);
+    // edges hook was loading -> composite reflects it
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/packages/sync/src/hooks/useKnowledgeGraph.ts
+++ b/packages/sync/src/hooks/useKnowledgeGraph.ts
@@ -1,0 +1,149 @@
+'use client';
+
+import { useShape } from '@electric-sql/react';
+import { fetchWithTimeout } from '../fetch-with-timeout.js';
+import { useElectricConfig } from '../provider/index.js';
+import { toRecords } from '../shape-utils.js';
+
+/**
+ * `useKnowledgeGraph` — read-only Electric shapes over the fleet knowledge
+ * graph (GAP-349 P4, design spec §8.2/§9). Backs `/api/shapes/kg-nodes`,
+ * `/api/shapes/kg-edges`, and `/api/shapes/kg-edge-episodes`.
+ *
+ * Deliberately NO mutation functions: Electric sync is read-only for this
+ * graph. Writes go through the additive `POST /api/sync/kg-episodes` route
+ * (`ingestEpisode`), never through a direct table mutation — see the design
+ * spec §8.2 "Down: Electric shapes... Up: write-through API".
+ */
+
+export interface KgNodeRecord {
+  id: string;
+  kind: string;
+  name: string;
+  natural_key: string;
+  repo: string | null;
+  summary: string | null;
+  attributes: Record<string, unknown>;
+  attributes_clock: Record<string, unknown>;
+  embedding: number[] | null;
+  first_seen_at: string;
+  last_confirmed_at: string;
+  deleted_at: string | null;
+  created_at: string;
+}
+
+export interface KgEdgeRecord {
+  id: string;
+  source_id: string;
+  target_id: string;
+  relation: string;
+  fact: string;
+  repo: string | null;
+  attributes: Record<string, unknown>;
+  embedding: number[] | null;
+  valid_at: string;
+  invalid_at: string | null;
+  created_at: string;
+  expired_at: string | null;
+}
+
+export interface KgEdgeEpisodeRecord {
+  edge_id: string;
+  episode_id: string;
+}
+
+export interface UseKgNodesResult {
+  nodes: KgNodeRecord[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export interface UseKgEdgesResult {
+  edges: KgEdgeRecord[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export interface UseKgEdgeEpisodesResult {
+  edgeEpisodes: KgEdgeEpisodeRecord[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export interface UseKnowledgeGraphResult {
+  nodes: KgNodeRecord[];
+  edges: KgEdgeRecord[];
+  edgeEpisodes: KgEdgeEpisodeRecord[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/** Nodes in the fleet graph, optionally partitioned by `repo`. Omit `repo` to sync the whole fleet. */
+export function useKgNodes(repo?: string): UseKgNodesResult {
+  const { proxyBaseUrl } = useElectricConfig();
+  const { data, isLoading, error } = useShape({
+    url: `${proxyBaseUrl}/api/shapes/kg-nodes`,
+    params: repo ? { repo } : {},
+    fetchClient: fetchWithTimeout,
+  });
+
+  return {
+    nodes: toRecords<KgNodeRecord>(data),
+    isLoading,
+    error: error || null,
+  };
+}
+
+/** Edges (bi-temporal facts) in the fleet graph, optionally partitioned by `repo`. */
+export function useKgEdges(repo?: string): UseKgEdgesResult {
+  const { proxyBaseUrl } = useElectricConfig();
+  const { data, isLoading, error } = useShape({
+    url: `${proxyBaseUrl}/api/shapes/kg-edges`,
+    params: repo ? { repo } : {},
+    fetchClient: fetchWithTimeout,
+  });
+
+  return {
+    edges: toRecords<KgEdgeRecord>(data),
+    isLoading,
+    error: error || null,
+  };
+}
+
+/**
+ * The edge -> episode provenance join. Not repo-partitioned — the join
+ * table carries no `repo` column (see the `kg-edge-episodes` shape route's
+ * header comment for why).
+ */
+export function useKgEdgeEpisodes(): UseKgEdgeEpisodesResult {
+  const { proxyBaseUrl } = useElectricConfig();
+  const { data, isLoading, error } = useShape({
+    url: `${proxyBaseUrl}/api/shapes/kg-edge-episodes`,
+    fetchClient: fetchWithTimeout,
+  });
+
+  return {
+    edgeEpisodes: toRecords<KgEdgeEpisodeRecord>(data),
+    isLoading,
+    error: error || null,
+  };
+}
+
+/** Composite convenience hook: nodes + edges + edge-episode provenance for one `repo` (or the whole fleet). */
+export function useKnowledgeGraph(repo?: string): UseKnowledgeGraphResult {
+  const { nodes, isLoading: nodesLoading, error: nodesError } = useKgNodes(repo);
+  const { edges, isLoading: edgesLoading, error: edgesError } = useKgEdges(repo);
+  const {
+    edgeEpisodes,
+    isLoading: edgeEpisodesLoading,
+    error: edgeEpisodesError,
+  } = useKgEdgeEpisodes();
+
+  return {
+    nodes,
+    edges,
+    edgeEpisodes,
+    isLoading: nodesLoading || edgesLoading || edgeEpisodesLoading,
+    error: nodesError || edgesError || edgeEpisodesError,
+  };
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -12,13 +12,30 @@
 
 export type {
   CollabDocumentState,
+  KgViewAnnotation,
+  KgViewLayoutPosition,
+  KgViewPresenceEntry,
+  KgViewState,
   UseCollaborationOptions,
   UseCollaborationResult,
+  UseKgViewDocumentResult,
 } from './collab/index.js';
 export {
+  buildAnnotationPatch,
+  buildKgViewDocumentId,
+  buildLayoutPatch,
+  buildPinPatch,
+  buildPresencePatch,
   CollabProvider,
+  isKgViewDocumentId,
+  isPresenceStale,
+  isValidKgViewSlug,
+  KG_VIEW_ID_PREFIX,
+  PRESENCE_STALE_MS,
+  parseKgViewState,
   useCollabDocument,
   useCollaboration,
+  useKgViewDocument,
 } from './collab/index.js';
 export type {
   ConflictInfo,
@@ -66,6 +83,21 @@ export type {
   UseCoordinationWorkItemsResult,
 } from './hooks/useCoordinationWorkItems.js';
 export { useCoordinationWorkItems } from './hooks/useCoordinationWorkItems.js';
+export type {
+  KgEdgeEpisodeRecord,
+  KgEdgeRecord,
+  KgNodeRecord,
+  UseKgEdgeEpisodesResult,
+  UseKgEdgesResult,
+  UseKgNodesResult,
+  UseKnowledgeGraphResult,
+} from './hooks/useKnowledgeGraph.js';
+export {
+  useKgEdgeEpisodes,
+  useKgEdges,
+  useKgNodes,
+  useKnowledgeGraph,
+} from './hooks/useKnowledgeGraph.js';
 export { useOfflineCache } from './hooks/useOfflineCache.js';
 export type { OnlineStatusResult } from './hooks/useOnlineStatus.js';
 export { useOnlineStatus } from './hooks/useOnlineStatus.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@revealui/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@revealui/knowledge-graph':
+        specifier: workspace:*
+        version: link:../../packages/knowledge-graph
       '@revealui/mcp':
         specifier: workspace:*
         version: link:../../packages/mcp


### PR DESCRIPTION
Part of GAP-349.

## A. Electric shape routes + hooks

- `apps/admin/src/app/api/shapes/{kg-nodes,kg-edges,kg-edge-episodes}/route.ts` — copied the `coordination-sessions` template exactly (getSession auth gate, `checkAIFeatureGate`, `prepareElectricUrl`, `runtime = 'nodejs'`, `dynamic = 'force-dynamic'`).
- `repo` query param partitioning: a new `isRepoIdentifier` char-set validator in `apps/admin/src/lib/utils/identifier-validation.ts` (extends the existing `isSyncIdentifier`/`isUuid` module rather than duplicating it — the repo charset needs `.` for repo names like `.jv`, which the existing sync-identifier charset excludes). No authored regex anywhere in the new validation path.
- `kg-edge-episodes` is **not** repo-partitioned — see the escalation below.
- `useKgNodes`/`useKgEdges`/`useKgEdgeEpisodes` + a `useKnowledgeGraph` composite in `packages/sync/src/hooks/useKnowledgeGraph.ts`, exported from the package root. Deliberately **no mutation functions** — Electric sync stays read-only for this graph (tested explicitly).

## B. Read-only graph explorer

- `apps/admin/src/app/(backend)/knowledge-graph/page.tsx`, gated `feature="ai"` (same tier as the other AI-adjacent admin surfaces).
- Repo picker (backed by a tiny new `GET /api/kg/repos` distinct-query route — deliberately *not* an Electric shape, so the picker never has to sync the whole unfiltered fleet graph just to discover repo names), kind filter, name/natural-key search, node detail pane (summary, attributes, current facts with provenance episode ids), and a date-input point-in-time toggle that filters the already-synced edges client-side (`valid_at`/`invalid_at` predicate).
- No writes to `kg_*` from the UI. No graph canvas (list/detail only, per the P4 scope note).

## C. Yjs curation overlay

- `packages/sync/src/collab/kg-view.ts`: per-view `kg-view-<slug>` documents on the **existing** `yjs_documents`/`yjs_document_patches` tables. Annotations, pins, and layout positions all ride the **existing** `set_key` patch type (no new patch type) — see the file's header comment for the exact patch-shape table.
- `apps/admin/src/app/api/shapes/kg-views/route.ts` — a **new, narrowly-scoped** shape route rather than broadening the existing `yjs-documents` route's UUID-only validation contract. Trade-off documented below.
- The existing `POST /api/sync/yjs-document-patches` route needed **zero changes** — its `DOCUMENT_ID_RE`/path validation already accepts the `kg-view-<slug>` id shape.
- `POST /api/sync/kg-episodes` — the **only** write path into `kg_*` from the admin app. Reuses `KgAddEpisodeArgsSchema`'s node/edge shapes from `@revealui/mcp/kg-server` directly (so ontology-enum validation is identical to `kg_add_episode`, not re-derived), forces `episodeType: 'manual'`, calls `ingestEpisode`.
- Presence: a small polled heartbeat (`presence:<clientId>` patch), **not** a live websocket — `apps/admin` has zero `useCollaboration`/`CollabProvider` consumers today, and the task scope said not to stand up a new websocket server for this. The read side is still fully live via Electric.

## D. `revkg drift`

- `kgDrift()` in `packages/knowledge-graph/src/search/drift.ts` (re-exported from the package root), PGlite-tested in `src/__tests__/drift.test.ts`.
- `revkg drift [--repo <name>] [--json]` CLI subcommand.
- **Direction assumption, not yet empirically observed**: no Tier-1 extractor emits `documents` edges yet (it's Tier-2/manual-episode territory), so I took the spec's literal wording ("a doc node whose `documents` edge targets a code node") as `source = doc`, `target = code`, and documented it in the file header for whoever writes the first `documents`-emitting extractor.

## Escalations for Fable

1. **`kg-edge-episodes` has no `repo` column.** The join table (`edge_id`, `episode_id` composite PK) can't be repo-filtered without a join, and Electric `where` clauses are single-table. This shape route syncs the full provenance join table, unfiltered. Options if this needs partitioning later: denormalize `repo` onto the table, or drop the shape in favor of REST-fetched provenance (`kgAtTime`/`kgNeighbors` already return `episodeIds`).
2. **`kg-views` is a separate route from `yjs-documents`, not an extension of it.** The existing route's entire contract is "UUID or refuse" (used by the generic scratchpad/collab machinery elsewhere); I chose not to broaden that contract for kg-view ids and instead added a second, narrowly-scoped route with its own validator (`isKgViewDocumentId`). Costs ~40 lines of duplication; keeps the already-shipped route's review surface untouched. Worth a second opinion on whether consolidating is preferred.
3. **Document-id charset deviation from the spec's illustrative example.** The spec text says `kg-view:<slug>` (colon); I used `kg-view-<slug>` (hyphen) so the id stays inside the *existing* `yjs-document-patches` route's accepted charset (`[a-zA-Z0-9_-]+`) with zero changes to that route. Flagging in case the colon form was intended to be load-bearing somewhere I didn't find.
4. **`security-pr-review-check.js --diff origin/test` reports "no security-sensitive files"** for this diff — its `SECURITY_PATHS` list doesn't currently cover `apps/admin/src/app/api/shapes/**` or the new `packages/knowledge-graph/**`. Per the task brief these are new data-exposure/write surfaces regardless of what the automated checker says. **Not merging this myself; requesting the Fable review explicitly.**
5. **Flush-route write semantics**: the explorer's "flush to episode" button encodes a curator annotation as a `discovered` edge from a synthetic `agent:admin-explorer` node to the annotated node (the ontology's prescribed relation for "agent-fact edges"), rather than inventing a new relation. Wanted a second opinion that this is the right ontology mapping.

## Verification actually run

- `pnpm --filter @revealui/knowledge-graph exec vitest run` — 10 files / 42 tests pass (incl. 5 new `drift.test.ts`).
- `pnpm --filter @revealui/sync exec vitest run` — 19 files / 253 tests pass (incl. new `useKnowledgeGraph.test.ts` and `kg-view.test.ts`).
- `pnpm --filter admin exec vitest run` — 150 files / 1996 tests pass (incl. all new shape/flush/repos route tests).
- `pnpm --filter @revealui/knowledge-graph typecheck`, `pnpm --filter @revealui/sync typecheck`, `pnpm --filter admin typecheck`, `pnpm --filter server typecheck` — all clean.
- `pnpm --filter admin build` — production build succeeds; `/knowledge-graph`, `/api/kg/repos`, `/api/shapes/kg-*`, `/api/sync/kg-episodes` all compile as routes.
- `node_modules/.bin/biome check .` — 0 errors (only 2 pre-existing warnings in files I never touched: `apps/marketing/app/routes/PhilosophyPage.tsx`, `e2e/billing-paid-path.e2e.ts`).
- `pnpm gate` (full) — every phase passes except `@revealui/ai#test`, which failed on one wall-clock-timing assertion (`packages/ai/src/__tests__/performance.test.ts`, "10 create operations at reasonable average latency", 38ms vs a 30ms threshold) under the load of a fully concurrent gate run. Confirmed unrelated: zero diff in `packages/ai` on this branch, and the same test passes cleanly in isolation (8/8).
- the internal fleet security-review checker (`--diff origin/test`) → "no security-sensitive files — no coordinator gate" (see escalation 4).
- Pre-push gate (phase 1, changed-only) ran automatically on `git push` and passed.

## Deferred (with unblock steps)

- Live Yjs websocket awareness for presence — unblock: wire `useCollaboration`/`CollabProvider` into `apps/admin` against `apps/server`'s collab websocket endpoint (out of scope here; no admin websocket infra exists today).
- `kg-edge-episodes` repo partitioning — unblock: a schema migration denormalizing `repo` onto `kg_edge_episodes` (owner/Fable call, see escalation 1).
- A visual graph canvas — explicitly out of scope for P4 per the task brief; the Yjs `layout:<nodeId>` patch shape already exists for whenever a canvas view is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

