### PR TITLE
fix(security): audit stage 0 — make failures loud, prove bugs red

### DIFF
--- a/apps/admin/src/app/api/setup/route.ts
+++ b/apps/admin/src/app/api/setup/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { type BootstrapResult, bootstrap, type RevealUILike } from '@revealui/setup/bootstrap';
 import { logger } from '@revealui/utils/logger';
 import { NextResponse } from 'next/server';
@@ -95,19 +96,51 @@ export async function POST(request: Request): Promise<NextResponse<BootstrapResu
       try {
         const { hostname } = await import('node:os');
         const { auditLog } = await import('@revealui/db/schema');
-        await db.insert(auditLog).values({
-          event: 'admin.bootstrap.completed',
-          actor: 'web',
-          severity: 'info',
-          meta: {
+        const { classifyAuditWriteFailure, recordAuditWriteResult } = await import(
+          '@revealui/core/security'
+        );
+        const eventId = crypto.randomUUID();
+        try {
+          await db.insert(auditLog).values({
+            event: 'admin.bootstrap.completed',
+            actor: 'web',
+            severity: 'info',
+            meta: {
+              email: parsed.data.email,
+              source: 'web',
+              hostname: hostname(),
+              seeded: parsed.data.seed ?? true,
+            },
+          } as never);
+          recordAuditWriteResult({ ok: true, eventId, eventType: 'admin.bootstrap.completed' });
+        } catch (auditError) {
+          const reason = classifyAuditWriteFailure(auditError);
+          recordAuditWriteResult({
+            ok: false,
+            reason,
+            eventId,
+            eventType: 'admin.bootstrap.completed',
+          });
+          // Non-fatal — the admin account was already created above. Loud,
+          // classified log instead of a silent catch: this writer targets
+          // columns (`event`/`actor`/`meta`) that do not exist on audit_log
+          // (real columns are `event_type`/`agent_id`/`payload`) and has
+          // never successfully persisted a row in any environment. Stage 1
+          // fixes the column mapping; Stage 0 only makes the failure visible.
+          logger.error('Bootstrap audit log write failed', {
             email: parsed.data.email,
-            source: 'web',
-            hostname: hostname(),
-            seeded: parsed.data.seed ?? true,
-          },
-        } as never);
-      } catch {
-        // Non-fatal — audit log may not be available in all environments
+            eventId,
+            reason,
+            error: auditError instanceof Error ? auditError.message : String(auditError),
+          });
+        }
+      } catch (auditSetupError) {
+        // Non-fatal — audit log subsystem may not be available in all environments
+        logger.error('Bootstrap audit log setup failed', {
+          email: parsed.data.email,
+          error:
+            auditSetupError instanceof Error ? auditSetupError.message : String(auditSetupError),
+        });
       }
     } catch (dbError) {
       // DB client unavailable — the admin was still created by bootstrap(), but

--- a/apps/server/src/lib/__tests__/postgres-audit-storage.pglite.test.ts
+++ b/apps/server/src/lib/__tests__/postgres-audit-storage.pglite.test.ts
@@ -7,17 +7,34 @@
  *
  * `packages/db/src/__tests__/audit-store.integration.test.ts` covers the
  * severity-vocabulary CHECK-constraint bug at the schema level (owned by
- * packages/db). The three bugs here are specific to THIS class's private
- * module state (the HMAC signing chain, `lastSignature`) and live in
- * apps/server, so they're tested here rather than from packages/db — testing
- * them from packages/db would require packages/db to import apps/server
- * source, an illegal reverse dependency in this monorepo.
+ * packages/db). The bugs here are specific to THIS class's private module
+ * state (the HMAC signing chain, `lastSignature`) and live in apps/server, so
+ * they're tested here rather than from packages/db — testing them from
+ * packages/db would require packages/db to import apps/server source, an
+ * illegal reverse dependency in this monorepo.
  *
- * RevealUI audit-remediation Stage 0: these are red-first tests documenting
- * bugs Stage 1 fixes. Wrapped in `it.fails()` (Vitest's native
- * "expected to fail" API) so CI stays green until Stage 1 removes the
- * wrapper — see the sibling packages/db test for the same convention
- * decision.
+ * RevealUI audit-remediation Stage 0. Each test below pins an exact,
+ * falsifiable fact about TODAY's behavior — a Postgres error code + a named
+ * constraint, an exact row count, a byte-level canonical-form mismatch, or a
+ * signature identity — not merely "something threw". `it.fails()` was tried
+ * first and rejected: it passes on ANY throw, including a broken harness
+ * (unbuilt package, missing schema import, migrations that never applied),
+ * so it proves nothing. Plain `it()` with a specific `expect(...)` cannot be
+ * satisfied by an unrelated failure, and a harness that cannot reach the
+ * assertion fails loudly instead of reporting green.
+ *
+ * The severity-rejection and severity-persistence tests below currently
+ * PASS: they pin the real, current (broken) behavior with enough specificity
+ * that nothing except the actual documented defect can satisfy them. Stage 1
+ * fixing the severity vocabulary will make these assertions false — at that
+ * point they FAIL, forcing Stage 1's author to consciously rewrite them to
+ * the new correct behavior. That failure-on-fix is the acceptance-criteria
+ * mechanism; it is not a bug in these tests.
+ *
+ * The chain-head test asserts a standing invariant (previous_signature must
+ * point at the last row that actually persisted) that should hold both
+ * before and after Stage 1. It FAILS today for real — no wrapper, no
+ * inversion — and should keep passing unmodified once Stage 1 lands.
  */
 import { randomUUID } from 'node:crypto';
 import type { AuditEvent } from '@revealui/security';
@@ -34,6 +51,11 @@ vi.mock('@revealui/db', async () => {
   const actual = await vi.importActual<typeof import('@revealui/db')>('@revealui/db');
   return { ...actual, getClient: () => testDb.drizzle };
 });
+
+/** SQLSTATE + constraint name asserted throughout — see packages/db/src/schema/audit-log.ts:57. */
+const SEVERITY_CHECK_VIOLATION = {
+  cause: { code: '23514', constraint: 'audit_log_severity_check' },
+} as const;
 
 function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
   return {
@@ -66,73 +88,155 @@ describe('PostgresAuditStorage — real PGlite schema, not a vi.fn() mock', () =
     delete process.env.REVEALUI_AUDIT_HMAC_SECRET;
   });
 
-  it.fails('persists every severity apps/server/src/middleware/audit.ts emits (Stage 1)', async () => {
+  // ── Harness sanity ─────────────────────────────────────────────────────
+  // Must run (and pass) before any of the bug-specific tests below are
+  // trusted. If this fails, the harness itself is broken (unbuilt package,
+  // missing @revealui/db/schema export, migrations that didn't apply, the
+  // getClient() mock not wired) and every other result in this file is
+  // meaningless until this is green again.
+
+  it('harness sanity: a valid severity persists and signs', async () => {
+    const store = new PostgresAuditStorage();
+    const { auditLog } = await import('@revealui/db/schema');
+
+    const event = makeEvent({ severity: 'critical' });
+    await store.write(event);
+
+    const rows = await testDb.drizzle.select().from(auditLog).where(eq(auditLog.id, event.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.signature).not.toBeNull();
+  });
+
+  // ── Severity vocabulary vs the CHECK constraint ─────────────────────────
+
+  it('every severity apps/server/src/middleware/audit.ts emits is rejected by the CHECK constraint — 0 of 3 rows land (Stage 1 must change this)', async () => {
     const store = new PostgresAuditStorage();
     const { auditLog } = await import('@revealui/db/schema');
 
     // The request middleware emits exactly these three severities
-    // (apps/server/src/middleware/audit.ts:59). Mirror the middleware's own
-    // catch-and-swallow (apps/server/src/middleware/audit.ts:80) so this test
-    // observes what production actually persists, not an unhandled rejection.
+    // (apps/server/src/middleware/audit.ts:59). Capture each outcome
+    // individually — do not swallow-and-count, or an unrelated failure
+    // (wrong error, different cause) would be indistinguishable from the
+    // real defect.
+    const outcomes: Array<{ severity: 'low' | 'medium' | 'high'; error: unknown }> = [];
     for (const severity of ['low', 'medium', 'high'] as const) {
-      await store.write(makeEvent({ severity })).catch(() => {});
+      try {
+        await store.write(makeEvent({ severity }));
+        outcomes.push({ severity, error: undefined });
+      } catch (error) {
+        outcomes.push({ severity, error });
+      }
+    }
+
+    for (const { severity, error } of outcomes) {
+      expect(error, `severity '${severity}' should have thrown a check_violation`).toMatchObject(
+        SEVERITY_CHECK_VIOLATION,
+      );
     }
 
     const rows = await testDb.drizzle.select().from(auditLog);
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(0);
   });
 
-  it.fails('round-trips a payload through jsonb without breaking the signature (Stage 1)', async () => {
+  // ── jsonb round-trip vs the HMAC signature ──────────────────────────────
+
+  it('the recomputed signature does not match because jsonb reorders payload.metadata keys, not because any value changed (Stage 1 must fix this)', async () => {
     const store = new PostgresAuditStorage();
     const { auditLog } = await import('@revealui/db/schema');
 
     // 'z' then 'a' (same length) — Postgres jsonb normalizes object key
-    // order on storage, so the keys come back in a different order than
-    // they were written in. Severity 'critical' is valid in both the
-    // security package's vocabulary AND the DB CHECK constraint, so this
-    // write succeeds and isolates the jsonb round-trip bug specifically.
+    // order on storage (same-length keys sort lexically), so the keys come
+    // back in a different order than they were written in. Severity
+    // 'critical' is valid in both the security package's vocabulary AND the
+    // DB CHECK constraint, so this write succeeds and isolates the jsonb
+    // round-trip bug specifically — nothing else about the write can be the
+    // cause of what follows.
     const event = makeEvent({ metadata: { z: 1, a: 2 } });
     await store.write(event);
 
     const [row] = await testDb.drizzle.select().from(auditLog).where(eq(auditLog.id, event.id));
     expect(row).toBeDefined();
-    expect(row?.signature).not.toBeNull();
+    if (!row) throw new Error('unreachable: guarded by the assertion above');
+    expect(row.signature).not.toBeNull();
+
+    // Every OTHER signed field round-trips identically — isolates the
+    // mismatch below to payload.metadata specifically, not some other drift.
+    expect(row.timestamp.toISOString()).toBe(event.timestamp);
+    expect(row.eventType).toBe(event.type);
+    expect(row.severity).toBe(event.severity);
+    expect(row.agentId).toBe(event.actor.id);
+
+    const roundTrippedMetadata = (row.payload as { metadata?: unknown } | null)?.metadata;
+    // The VALUE is unchanged (same keys, same values) ...
+    expect(roundTrippedMetadata).toEqual(event.metadata);
+    // ... but the canonical (JSON.stringify) representation is NOT
+    // byte-identical, because jsonb reordered the keys. This is exactly why
+    // verifyAuditSignature — which recomputes the HMAC over
+    // JSON.stringify(payload) — cannot reproduce the original signature at
+    // read time: the bytes it hashes are provably different even though the
+    // data is semantically identical.
+    expect(JSON.stringify(roundTrippedMetadata)).not.toBe(JSON.stringify(event.metadata));
 
     const verified = verifyAuditSignature(
       {
-        timestamp: row?.timestamp.toISOString() ?? '',
-        eventType: row?.eventType ?? '',
-        severity: row?.severity ?? '',
-        agentId: row?.agentId ?? '',
-        payload: row?.payload,
+        timestamp: row.timestamp.toISOString(),
+        eventType: row.eventType,
+        severity: row.severity,
+        agentId: row.agentId,
+        payload: row.payload,
       },
-      row?.signature ?? '',
-      row?.previousSignature ?? null,
+      row.signature ?? '',
+      row.previousSignature,
     );
-    expect(verified).toBe(true);
+    expect(verified).toBe(false);
   });
 
-  it.fails('does not advance the chain head on a rejected insert (Stage 1)', async () => {
+  // ── Hash-chain head vs a rejected insert ─────────────────────────────────
+
+  it('does not advance the chain head on a rejected insert — previous_signature must point at the last row that actually PERSISTED (Stage 1 must fix this)', async () => {
     const store = new PostgresAuditStorage();
     const { auditLog } = await import('@revealui/db/schema');
 
-    // Rejected insert: 'low' is not in the audit_log CHECK vocabulary.
-    await store.write(makeEvent({ severity: 'low' })).catch(() => {});
-
-    // Immediately follow with a valid insert.
-    const validEvent = makeEvent({ severity: 'critical' });
-    await store.write(validEvent);
-
-    const [row] = await testDb.drizzle
+    // Establish a known-good baseline: one row that genuinely persists.
+    const firstValid = makeEvent({ severity: 'critical' });
+    await store.write(firstValid);
+    const [firstRow] = await testDb.drizzle
       .select()
       .from(auditLog)
-      .where(eq(auditLog.id, validEvent.id));
+      .where(eq(auditLog.id, firstValid.id));
+    expect(firstRow).toBeDefined();
+    if (!firstRow) throw new Error('unreachable: guarded by the assertion above');
+    expect(firstRow.signature).not.toBeNull();
 
-    // Nothing was ever actually persisted before this row (the rejected
-    // write never landed), so its previous_signature must be null. Today it
-    // isn't: postgres-audit-storage.ts assigns `lastSignature` from the
-    // rejected write's computed signature BEFORE the insert that throws, so
-    // the module-level chain head advances on a write that never landed.
-    expect(row?.previousSignature).toBeNull();
+    // Rejected insert: 'low' is not in the audit_log CHECK vocabulary.
+    // Confirm both the specific rejection reason AND that it truly never
+    // landed — the invariant below is meaningless if this write silently
+    // persisted after all.
+    const rejected = makeEvent({ severity: 'low' });
+    await expect(store.write(rejected)).rejects.toMatchObject(SEVERITY_CHECK_VIOLATION);
+    const rejectedRows = await testDb.drizzle
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.id, rejected.id));
+    expect(rejectedRows).toHaveLength(0);
+
+    // Immediately follow with a second valid insert.
+    const secondValid = makeEvent({ severity: 'critical' });
+    await store.write(secondValid);
+    const [secondRow] = await testDb.drizzle
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.id, secondValid.id));
+    expect(secondRow).toBeDefined();
+    if (!secondRow) throw new Error('unreachable: guarded by the assertion above');
+
+    // The chain head must point at the last PERSISTED row (firstRow), never
+    // at the rejected write that never landed. Today it doesn't:
+    // postgres-audit-storage.ts assigns the module-level `lastSignature` from
+    // the rejected write's COMPUTED signature BEFORE the insert that throws,
+    // so the chain head advances on a write that never made it into the
+    // table. This assertion fails today and should keep passing, unmodified,
+    // once Stage 1 fixes the ordering.
+    expect(secondRow.previousSignature).toBe(firstRow.signature);
   });
 });

--- a/apps/server/src/lib/__tests__/postgres-audit-storage.pglite.test.ts
+++ b/apps/server/src/lib/__tests__/postgres-audit-storage.pglite.test.ts
@@ -13,28 +13,35 @@
  * packages/db would require packages/db to import apps/server source, an
  * illegal reverse dependency in this monorepo.
  *
- * RevealUI audit-remediation Stage 0. Each test below pins an exact,
- * falsifiable fact about TODAY's behavior — a Postgres error code + a named
- * constraint, an exact row count, a byte-level canonical-form mismatch, or a
- * signature identity — not merely "something threw". `it.fails()` was tried
- * first and rejected: it passes on ANY throw, including a broken harness
- * (unbuilt package, missing schema import, migrations that never applied),
- * so it proves nothing. Plain `it()` with a specific `expect(...)` cannot be
- * satisfied by an unrelated failure, and a harness that cannot reach the
- * assertion fails loudly instead of reporting green.
+ * RevealUI audit-remediation Stage 0. Every test below is a CHARACTERIZATION
+ * test: it pins an exact, falsifiable fact about TODAY's actual (broken)
+ * behavior — a Postgres error code + a named constraint, an exact row
+ * count, a byte-level canonical-form mismatch, or a specific chained
+ * signature identity — not merely "something threw". All four PASS today,
+ * on purpose, with no wrapper and no inversion: `pnpm --filter server test`
+ * must be fully green.
  *
- * The severity-rejection and severity-persistence tests below currently
- * PASS: they pin the real, current (broken) behavior with enough specificity
- * that nothing except the actual documented defect can satisfy them. Stage 1
- * fixing the severity vocabulary will make these assertions false — at that
- * point they FAIL, forcing Stage 1's author to consciously rewrite them to
- * the new correct behavior. That failure-on-fix is the acceptance-criteria
- * mechanism; it is not a bug in these tests.
+ * `it.fails()` was tried first here and rejected: it passes on ANY throw,
+ * including a broken harness (unbuilt package, missing schema import,
+ * migrations that never applied), so it proves nothing — and an earlier cut
+ * of the chain-head test asserted the DESIRED correct behavior instead of
+ * the defect, so it genuinely failed today, which would have put the CI
+ * `test` job (a shared-branch build every other PR depends on) permanently
+ * red until Stage 1 lands. Neither is acceptable. A plain `it()` with a
+ * specific `expect(...)` that asserts the CURRENT (buggy) behavior cannot be
+ * satisfied by an unrelated failure, a broken harness fails it loudly
+ * instead of reporting green, and it stays green in CI because it is true
+ * today.
  *
- * The chain-head test asserts a standing invariant (previous_signature must
- * point at the last row that actually persisted) that should hold both
- * before and after Stage 1. It FAILS today for real — no wrapper, no
- * inversion — and should keep passing unmodified once Stage 1 lands.
+ * Every test here pins real, current, verified behavior with enough
+ * specificity that nothing except the actual documented defect can satisfy
+ * it. Stage 1 fixing the underlying bug makes the pinned assertion FALSE —
+ * at that point the test fails, forcing Stage 1's author to consciously
+ * rewrite it to the new correct behavior. That failure-on-fix is the
+ * acceptance-criteria mechanism this whole file exists to provide; it is not
+ * a bug in these tests, and it is not something that happens by accident —
+ * it only happens when someone deliberately changes the behavior being
+ * pinned.
  */
 import { randomUUID } from 'node:crypto';
 import type { AuditEvent } from '@revealui/security';
@@ -193,7 +200,7 @@ describe('PostgresAuditStorage — real PGlite schema, not a vi.fn() mock', () =
 
   // ── Hash-chain head vs a rejected insert ─────────────────────────────────
 
-  it('does not advance the chain head on a rejected insert — previous_signature must point at the last row that actually PERSISTED (Stage 1 must fix this)', async () => {
+  it('DEFECT: the chain head advances on a rejected insert, so previous_signature points at a row that was never persisted (Stage 1 must fix this)', async () => {
     const store = new PostgresAuditStorage();
     const { auditLog } = await import('@revealui/db/schema');
 
@@ -210,7 +217,7 @@ describe('PostgresAuditStorage — real PGlite schema, not a vi.fn() mock', () =
 
     // Rejected insert: 'low' is not in the audit_log CHECK vocabulary.
     // Confirm both the specific rejection reason AND that it truly never
-    // landed — the invariant below is meaningless if this write silently
+    // landed — everything below is meaningless if this write silently
     // persisted after all.
     const rejected = makeEvent({ severity: 'low' });
     await expect(store.write(rejected)).rejects.toMatchObject(SEVERITY_CHECK_VIOLATION);
@@ -230,13 +237,37 @@ describe('PostgresAuditStorage — real PGlite schema, not a vi.fn() mock', () =
     expect(secondRow).toBeDefined();
     if (!secondRow) throw new Error('unreachable: guarded by the assertion above');
 
-    // The chain head must point at the last PERSISTED row (firstRow), never
-    // at the rejected write that never landed. Today it doesn't:
-    // postgres-audit-storage.ts assigns the module-level `lastSignature` from
-    // the rejected write's COMPUTED signature BEFORE the insert that throws,
-    // so the chain head advances on a write that never made it into the
-    // table. This assertion fails today and should keep passing, unmodified,
-    // once Stage 1 fixes the ordering.
-    expect(secondRow.previousSignature).toBe(firstRow.signature);
+    // THIS PASSES TODAY BECAUSE THE CODE IS WRONG. postgres-audit-storage.ts
+    // (:102-108) assigns the module-level `lastSignature` from the rejected
+    // write's COMPUTED signature BEFORE the insert that throws, so the chain
+    // head advances on a write that never made it into the table.
+    // secondRow.previousSignature therefore does NOT point at the last row
+    // that actually persisted (firstRow) ...
+    expect(secondRow.previousSignature).not.toBe(firstRow.signature);
+    // ... it points at exactly the signature that was computed for the
+    // REJECTED event, chained from firstRow — a row that does not exist in
+    // this table. Confirmed via verifyAuditSignature (which recomputes the
+    // HMAC and compares) rather than a hardcoded hash, since the rejected
+    // write's signature was never persisted anywhere to read back directly.
+    const previousSignatureIsTheRejectedWrites = verifyAuditSignature(
+      {
+        timestamp: rejected.timestamp,
+        eventType: rejected.type,
+        severity: rejected.severity,
+        agentId: rejected.actor.id,
+        payload: rejected,
+      },
+      secondRow.previousSignature ?? '',
+      firstRow.signature,
+    );
+    expect(previousSignatureIsTheRejectedWrites).toBe(true);
+
+    // When Stage 1 moves the `lastSignature` assignment to after a
+    // successful insert, secondRow.previousSignature will equal
+    // firstRow.signature and BOTH assertions above will flip — this test
+    // will FAIL, forcing its author to consciously rewrite it to assert the
+    // correct invariant (previous_signature always points at the last row
+    // that actually persisted) instead. That failure is the acceptance
+    // signal, not a regression in this test.
   });
 });

--- a/apps/server/src/lib/__tests__/postgres-audit-storage.pglite.test.ts
+++ b/apps/server/src/lib/__tests__/postgres-audit-storage.pglite.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Integration coverage for `PostgresAuditStorage` against a REAL, migrated
+ * schema (PGlite), not a `vi.fn()` mock. Follows the same
+ * `vi.mock('@revealui/db', () => ({ getClient: () => testDb.drizzle }))`
+ * pattern already used by `webhook-pglite.test.ts` /
+ * `dunning-lifecycle.pglite.test.ts` in this repo.
+ *
+ * `packages/db/src/__tests__/audit-store.integration.test.ts` covers the
+ * severity-vocabulary CHECK-constraint bug at the schema level (owned by
+ * packages/db). The three bugs here are specific to THIS class's private
+ * module state (the HMAC signing chain, `lastSignature`) and live in
+ * apps/server, so they're tested here rather than from packages/db — testing
+ * them from packages/db would require packages/db to import apps/server
+ * source, an illegal reverse dependency in this monorepo.
+ *
+ * RevealUI audit-remediation Stage 0: these are red-first tests documenting
+ * bugs Stage 1 fixes. Wrapped in `it.fails()` (Vitest's native
+ * "expected to fail" API) so CI stays green until Stage 1 removes the
+ * wrapper — see the sibling packages/db test for the same convention
+ * decision.
+ */
+import { randomUUID } from 'node:crypto';
+import type { AuditEvent } from '@revealui/security';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/db')>('@revealui/db');
+  return { ...actual, getClient: () => testDb.drizzle };
+});
+
+function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    type: 'data.read',
+    severity: 'critical',
+    actor: { id: 'agent-1', type: 'system' },
+    action: 'test',
+    result: 'success',
+    ...overrides,
+  };
+}
+
+describe('PostgresAuditStorage — real PGlite schema, not a vi.fn() mock', () => {
+  let PostgresAuditStorage: typeof import('../postgres-audit-storage.js').PostgresAuditStorage;
+  let verifyAuditSignature: typeof import('../postgres-audit-storage.js').verifyAuditSignature;
+
+  beforeEach(async () => {
+    process.env.REVEALUI_AUDIT_HMAC_SECRET = 'a'.repeat(32);
+    testDb = await createTestDb();
+    vi.resetModules();
+    const mod = await import('../postgres-audit-storage.js');
+    PostgresAuditStorage = mod.PostgresAuditStorage;
+    verifyAuditSignature = mod.verifyAuditSignature;
+  });
+
+  afterEach(async () => {
+    await testDb.close();
+    delete process.env.REVEALUI_AUDIT_HMAC_SECRET;
+  });
+
+  it.fails('persists every severity apps/server/src/middleware/audit.ts emits (Stage 1)', async () => {
+    const store = new PostgresAuditStorage();
+    const { auditLog } = await import('@revealui/db/schema');
+
+    // The request middleware emits exactly these three severities
+    // (apps/server/src/middleware/audit.ts:59). Mirror the middleware's own
+    // catch-and-swallow (apps/server/src/middleware/audit.ts:80) so this test
+    // observes what production actually persists, not an unhandled rejection.
+    for (const severity of ['low', 'medium', 'high'] as const) {
+      await store.write(makeEvent({ severity })).catch(() => {});
+    }
+
+    const rows = await testDb.drizzle.select().from(auditLog);
+    expect(rows).toHaveLength(3);
+  });
+
+  it.fails('round-trips a payload through jsonb without breaking the signature (Stage 1)', async () => {
+    const store = new PostgresAuditStorage();
+    const { auditLog } = await import('@revealui/db/schema');
+
+    // 'z' then 'a' (same length) — Postgres jsonb normalizes object key
+    // order on storage, so the keys come back in a different order than
+    // they were written in. Severity 'critical' is valid in both the
+    // security package's vocabulary AND the DB CHECK constraint, so this
+    // write succeeds and isolates the jsonb round-trip bug specifically.
+    const event = makeEvent({ metadata: { z: 1, a: 2 } });
+    await store.write(event);
+
+    const [row] = await testDb.drizzle.select().from(auditLog).where(eq(auditLog.id, event.id));
+    expect(row).toBeDefined();
+    expect(row?.signature).not.toBeNull();
+
+    const verified = verifyAuditSignature(
+      {
+        timestamp: row?.timestamp.toISOString() ?? '',
+        eventType: row?.eventType ?? '',
+        severity: row?.severity ?? '',
+        agentId: row?.agentId ?? '',
+        payload: row?.payload,
+      },
+      row?.signature ?? '',
+      row?.previousSignature ?? null,
+    );
+    expect(verified).toBe(true);
+  });
+
+  it.fails('does not advance the chain head on a rejected insert (Stage 1)', async () => {
+    const store = new PostgresAuditStorage();
+    const { auditLog } = await import('@revealui/db/schema');
+
+    // Rejected insert: 'low' is not in the audit_log CHECK vocabulary.
+    await store.write(makeEvent({ severity: 'low' })).catch(() => {});
+
+    // Immediately follow with a valid insert.
+    const validEvent = makeEvent({ severity: 'critical' });
+    await store.write(validEvent);
+
+    const [row] = await testDb.drizzle
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.id, validEvent.id));
+
+    // Nothing was ever actually persisted before this row (the rejected
+    // write never landed), so its previous_signature must be null. Today it
+    // isn't: postgres-audit-storage.ts assigns `lastSignature` from the
+    // rejected write's computed signature BEFORE the insert that throws, so
+    // the module-level chain head advances on a write that never landed.
+    expect(row?.previousSignature).toBeNull();
+  });
+});

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -138,6 +138,26 @@ describe('validateStartup — production presence', () => {
   });
 });
 
+describe('validateStartup — audit HMAC secret (both modes)', () => {
+  it('rejects a too-short REVEALUI_AUDIT_HMAC_SECRET override even when REVEALUI_SECRET is valid', () => {
+    expect(() =>
+      validateStartup(validLiveProdEnv({ REVEALUI_AUDIT_HMAC_SECRET: 'short' })),
+    ).toThrow(/REVEALUI_AUDIT_HMAC_SECRET/);
+  });
+
+  it('accepts a valid REVEALUI_AUDIT_HMAC_SECRET override', () => {
+    expect(() =>
+      validateStartup(validLiveProdEnv({ REVEALUI_AUDIT_HMAC_SECRET: 'z'.repeat(32) })),
+    ).not.toThrow();
+  });
+
+  it('falls back to REVEALUI_SECRET when REVEALUI_AUDIT_HMAC_SECRET is unset', () => {
+    // validLiveProdEnv() ships REVEALUI_SECRET (32 chars) and no override —
+    // the fallback alone must satisfy the check.
+    expect(() => validateStartup(validLiveProdEnv())).not.toThrow();
+  });
+});
+
 describe('validateStartup — production format checks (live mode)', () => {
   it('rejects STRIPE_SECRET_KEY without sk_live_ prefix', () => {
     expect(() => validateStartup(validLiveProdEnv({ STRIPE_SECRET_KEY: 'sk_test_abc' }))).toThrow(
@@ -673,6 +693,21 @@ describe('validateStartup — forge mode', () => {
     expect(() => validateStartup(validForgeProdEnv({ REVEALUI_SECRET: 'short' }))).toThrow(
       /REVEALUI_SECRET/,
     );
+  });
+
+  it('rejects a too-short REVEALUI_AUDIT_HMAC_SECRET override in forge mode even when REVEALUI_SECRET is valid', () => {
+    // REVEALUI_AUDIT_HMAC_SECRET takes priority over the REVEALUI_SECRET
+    // fallback (mirrors getAuditSecret()'s `??` chain) — a short override was
+    // never validated anywhere before this check existed.
+    expect(() =>
+      validateStartup(validForgeProdEnv({ REVEALUI_AUDIT_HMAC_SECRET: 'short' })),
+    ).toThrow(/REVEALUI_AUDIT_HMAC_SECRET/);
+  });
+
+  it('accepts a valid REVEALUI_AUDIT_HMAC_SECRET override in forge mode', () => {
+    expect(() =>
+      validateStartup(validForgeProdEnv({ REVEALUI_AUDIT_HMAC_SECRET: 'y'.repeat(32) })),
+    ).not.toThrow();
   });
 
   it('still enforces URL parity when both URLs are set in forge mode', () => {

--- a/apps/server/src/lib/postgres-audit-storage.ts
+++ b/apps/server/src/lib/postgres-audit-storage.ts
@@ -16,6 +16,7 @@
 
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { AuditEvent, AuditQuery, AuditStorage } from '@revealui/core/security';
+import { classifyAuditWriteFailure, recordAuditWriteResult } from '@revealui/core/security';
 import { getClient } from '@revealui/db';
 import { auditLog } from '@revealui/db/schema';
 import { and, count, desc, eq, gte, lte, sql } from 'drizzle-orm';
@@ -90,24 +91,29 @@ export function verifyAuditSignature(
 
 export class PostgresAuditStorage implements AuditStorage {
   async write(event: AuditEvent): Promise<void> {
-    const db = getClient();
-    const ts = event.timestamp;
-    const entry = {
-      timestamp: ts,
-      eventType: event.type,
-      severity: event.severity,
-      agentId: event.actor.id,
-      payload: event as unknown,
-    };
-    const previousSig = lastSignature;
-    const signature = computeSignature(entry, previousSig);
-    if (signature) {
-      lastSignature = signature;
-    }
+    try {
+      const db = getClient();
+      const ts = event.timestamp;
+      const entry = {
+        timestamp: ts,
+        eventType: event.type,
+        severity: event.severity,
+        agentId: event.actor.id,
+        payload: event as unknown,
+      };
+      const previousSig = lastSignature;
+      const signature = computeSignature(entry, previousSig);
+      if (signature) {
+        lastSignature = signature;
+      }
 
-    await db
-      .insert(auditLog)
-      .values({
+      // No .onConflictDoNothing(): event.id is a fresh crypto.randomUUID()
+      // minted once per AuditSystem.log() call (packages/security/src/audit.ts),
+      // never a caller-supplied idempotency key. A duplicate id can only mean
+      // the same already-constructed event was submitted twice, which is a bug
+      // — silently dropping that row would also leave a gap in the hash chain
+      // that Stage 1 depends on, which is worse than a loud failure.
+      await db.insert(auditLog).values({
         id: event.id,
         timestamp: new Date(ts),
         eventType: event.type,
@@ -119,8 +125,18 @@ export class PostgresAuditStorage implements AuditStorage {
         policyViolations: [],
         signature: signature || null,
         previousSignature: previousSig,
-      })
-      .onConflictDoNothing();
+      });
+
+      recordAuditWriteResult({ ok: true, eventId: event.id, eventType: event.type });
+    } catch (err) {
+      recordAuditWriteResult({
+        ok: false,
+        reason: classifyAuditWriteFailure(err),
+        eventId: event.id,
+        eventType: event.type,
+      });
+      throw err;
+    }
   }
 
   async query(query: AuditQuery): Promise<AuditEvent[]> {

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -258,6 +258,33 @@ export function validateStartup(
     errors.push('REVEALUI_SECRET must be at least 32 characters.');
   }
 
+  // Audit HMAC signing secret — required in both modes. Mirrors the fallback
+  // getAuditSecret() uses at write time (postgres-audit-storage.ts):
+  // REVEALUI_AUDIT_HMAC_SECRET, falling back to REVEALUI_SECRET. That runtime
+  // check throws per-write into a swallowing `.catch()`, so a misconfigured
+  // deploy served traffic for however long it took someone to notice the
+  // audit trail was silent. Checking the same effective value here means a
+  // server that cannot sign the audit log refuses to boot instead — this
+  // duplicates (does not replace) getAuditSecret()'s own defense-in-depth
+  // throw. REVEALUI_SECRET is already REQUIRED_IN_PRODUCTION_{HOSTED,FORGE}
+  // above, so in a correctly configured deploy this branch is unreachable;
+  // it exists to catch the same impossible states getAuditSecret() guards
+  // against (env tampering mid-run) at boot instead of at the first write.
+  const auditHmacSecret = env.REVEALUI_AUDIT_HMAC_SECRET ?? env.REVEALUI_SECRET ?? '';
+  if (!skipFormat(auditHmacSecret)) {
+    if (!auditHmacSecret) {
+      errors.push(
+        'REVEALUI_AUDIT_HMAC_SECRET (or REVEALUI_SECRET fallback) is required — ' +
+          'a server that cannot sign the audit log must not serve traffic. ' +
+          'See docs/SECRETS.md.',
+      );
+    } else if (auditHmacSecret.length < 32) {
+      errors.push(
+        'REVEALUI_AUDIT_HMAC_SECRET (or REVEALUI_SECRET fallback) must be at least 32 characters.',
+      );
+    }
+  }
+
   // URL parity — if both are set, they must match. Applies in both modes.
   const publicUrl = env.REVEALUI_PUBLIC_SERVER_URL ?? '';
   const nextPublicUrl = env.NEXT_PUBLIC_SERVER_URL ?? '';

--- a/apps/server/src/middleware/audit.ts
+++ b/apps/server/src/middleware/audit.ts
@@ -9,6 +9,7 @@
 
 import { logger } from '@revealui/core/observability/logger';
 import type { AuditEventType, AuditSystem } from '@revealui/core/security';
+import { AuditWriteError, classifyAuditWriteFailure } from '@revealui/core/security';
 import type { MiddlewareHandler } from 'hono';
 
 /** Tracks consecutive audit write failures for observability. */
@@ -79,10 +80,18 @@ export const auditMiddleware = (audit: AuditSystem): MiddlewareHandler => {
       })
       .catch((err: unknown) => {
         auditWriteFailures++;
+        // The write itself is already counted (success and failure) inside
+        // PostgresAuditStorage.write() — the single point every AuditSystem
+        // consumer's write funnels through. This catch classifies + logs the
+        // failure for THIS request's context; it does not double-count it.
+        const cause = err instanceof AuditWriteError ? err.cause : err;
         if (auditWriteFailures % FAILURE_LOG_INTERVAL === 1) {
           logger.warn('Audit log write failed', {
             consecutiveFailures: auditWriteFailures,
-            error: err instanceof Error ? err.message : String(err),
+            eventId: err instanceof AuditWriteError ? err.event.id : undefined,
+            eventType: err instanceof AuditWriteError ? err.event.type : undefined,
+            reason: classifyAuditWriteFailure(cause),
+            error: cause instanceof Error ? cause.message : String(cause),
           });
         }
       });

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -21,6 +21,7 @@ import type { A2AJsonRpcRequest } from '@revealui/contracts';
 import { A2AJsonRpcRequestSchema, AgentDefinitionSchema } from '@revealui/contracts';
 import { logger } from '@revealui/core/observability/logger';
 import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
+import { classifyAuditWriteFailure } from '@revealui/core/security';
 import { getClient } from '@revealui/db';
 import { agentActions, marketplaceServers, registeredAgents } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
@@ -1208,11 +1209,12 @@ a2a.openapi(
     // Fire-and-forget: persist task execution record to agentActions
     if (executionMethods.has(req.method)) {
       const status = taskState === 'failed' ? 'failed' : 'completed';
+      const actionId = crypto.randomUUID();
       void (async () => {
         try {
           const db = getClient();
           await db.insert(agentActions).values({
-            id: crypto.randomUUID(),
+            id: actionId,
             agentId: agentId ?? 'revealui-creator',
             tool: req.method,
             params: (req.params ?? null) as Record<string, unknown> | null,
@@ -1222,8 +1224,14 @@ a2a.openapi(
             completedAt: new Date(completedAt),
             durationMs: completedAt - startedAt,
           });
-        } catch {
+        } catch (err) {
           // Non-fatal  -  in-memory task store remains authoritative for active tasks
+          logger.warn('agentActions write failed', {
+            eventId: actionId,
+            eventType: req.method,
+            reason: classifyAuditWriteFailure(err),
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
       })();
     }

--- a/apps/server/src/routes/api-keys.ts
+++ b/apps/server/src/routes/api-keys.ts
@@ -11,6 +11,8 @@
 
 import crypto from 'node:crypto';
 import { LLM_PROVIDERS } from '@revealui/contracts';
+import { logger } from '@revealui/core/observability/logger';
+import { classifyAuditWriteFailure, recordAuditWriteResult } from '@revealui/core/security';
 import { getClient, withTransaction } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
 import { encryptApiKey, redactApiKey } from '@revealui/db/crypto';
@@ -37,16 +39,26 @@ async function recordCredentialEvent(
     label?: string | null;
   },
 ): Promise<void> {
+  const eventId = crypto.randomUUID();
   try {
     await db.insert(auditLog).values({
-      id: crypto.randomUUID(),
+      id: eventId,
       eventType,
       severity: 'info',
       agentId: userId,
       payload,
       policyViolations: [],
     });
-  } catch {
+    recordAuditWriteResult({ ok: true, eventId, eventType });
+  } catch (err) {
+    const reason = classifyAuditWriteFailure(err);
+    recordAuditWriteResult({ ok: false, reason, eventId, eventType });
+    logger.error('Credential audit write failed', {
+      eventId,
+      eventType,
+      reason,
+      error: err instanceof Error ? err.message : String(err),
+    });
     // best-effort; never block the caller on audit-write failure
   }
 }

--- a/apps/server/src/routes/cron/uptime-check.ts
+++ b/apps/server/src/routes/cron/uptime-check.ts
@@ -9,6 +9,7 @@
 
 import { healthCheck } from '@revealui/core/observability';
 import { logger } from '@revealui/core/observability/logger';
+import { AuditWriteError, classifyAuditWriteFailure } from '@revealui/core/security';
 import { Hono } from 'hono';
 
 const app = new Hono();
@@ -52,8 +53,17 @@ app.get('/', async (c) => {
         uptimeSeconds: health.uptime,
       },
     });
-  } catch {
-    // Audit system unavailable; health check data still logged to stdout
+  } catch (err) {
+    // Audit write failed (or the write path itself threw before reaching
+    // storage) — health check data is still on stdout above, but a failed
+    // SLA-tracking write must not vanish silently.
+    const cause = err instanceof AuditWriteError ? err.cause : err;
+    logger.warn('Uptime-check audit write failed', {
+      eventId: err instanceof AuditWriteError ? err.event.id : undefined,
+      eventType: err instanceof AuditWriteError ? err.event.type : undefined,
+      reason: classifyAuditWriteFailure(cause),
+      error: cause instanceof Error ? cause.message : String(cause),
+    });
   }
 
   return c.json(result, health.status === 'healthy' ? 200 : 503);

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "validate:changesets": "tsx scripts/validate/mixed-changesets.ts",
     "validate:changelogs": "tsx scripts/validate/changelog-format.ts",
     "validate:empty-catch": "tsx scripts/validate/empty-catch.ts",
+    "validate:as-never-values": "tsx scripts/validate/as-never-values.ts",
     "validate:kek-rotation": "vitest run scripts/security/__tests__/rotate-kek.test.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
     "validate:prod-env": "tsx scripts/validate/prod-env.ts",

--- a/packages/db/src/__tests__/audit-store.integration.test.ts
+++ b/packages/db/src/__tests__/audit-store.integration.test.ts
@@ -28,7 +28,12 @@
  * severity vocabulary reaches this table). Once Stage 1 lands, this exact
  * assertion becomes false and the test FAILS — forcing Stage 1's author to
  * consciously rewrite it to the new correct behavior. That failure-on-fix is
- * the acceptance-criteria mechanism, not a bug in this test.
+ * the acceptance-criteria mechanism, not a bug in this test. Both tests in
+ * this file pass today with no wrapper and no inversion — `pnpm vitest run
+ * packages/db` is part of the shared CI `test` job every other PR in this
+ * repo depends on, so a red test here is never acceptable, on this branch or
+ * any other, until someone consciously decides the pinned behavior should
+ * change.
  */
 import { randomUUID } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/packages/db/src/__tests__/audit-store.integration.test.ts
+++ b/packages/db/src/__tests__/audit-store.integration.test.ts
@@ -7,44 +7,79 @@
  * migration from packages/db/migrations applied), so the constraint really
  * fires.
  *
- * RevealUI audit-remediation Stage 0: an audit write can fail for several
- * distinct reasons and today they all produce identical silence. This test
- * documents one of them at the schema level — Stage 1 fixes it.
+ * RevealUI audit-remediation Stage 0. `it.fails()` was tried first here and
+ * rejected: it passes whenever the test body throws, for ANY reason — a
+ * demonstrated false-green exists where `createTestDb()` itself fails
+ * (e.g. `@revealui/db/schema` unresolved in an unbuilt workspace) and
+ * `it.fails()` still reports "expected fail", without the insert — let alone
+ * the CHECK constraint — ever being reached. Plain `it()` with a specific
+ * `expect(...).rejects.toMatchObject({ cause: { code: '23514', ... } })`
+ * cannot be satisfied by a missing import, an unbuilt package, or a typo; it
+ * can only pass if the insert is actually attempted and Postgres actually
+ * rejects it with exactly this SQLSTATE and constraint name.
  *
- * Wrapped in `it.fails()` (Vitest's native "expected to fail" API — the repo
- * has no existing red-first-test convention to match, so this was the
- * closest built-in fit): the assertion states the DESIRED post-Stage-1
- * behavior (a value from @revealui/security's severity vocabulary can be
- * persisted). Today that insert throws with Postgres 23514, so the plain
- * assertion fails — that failure is the proof this test exists to capture.
- * `it.fails()` inverts pass/fail so CI stays green until Stage 1 removes the
- * wrapper (at which point the bare assertion becomes the acceptance test).
+ * The harness-sanity test below must pass before the CHECK-constraint test
+ * is trusted — if it doesn't, the harness itself is broken and every other
+ * result here is meaningless.
+ *
+ * The CHECK-constraint test documents TODAY's real, current behavior and
+ * currently PASSES: a value from @revealui/security's severity vocabulary is
+ * rejected by the DB. That is the defect (Stage 1 must change how the
+ * severity vocabulary reaches this table). Once Stage 1 lands, this exact
+ * assertion becomes false and the test FAILS — forcing Stage 1's author to
+ * consciously rewrite it to the new correct behavior. That failure-on-fix is
+ * the acceptance-criteria mechanism, not a bug in this test.
  */
 import { randomUUID } from 'node:crypto';
-import { describe, it } from 'vitest';
-import { createTestDb } from '../../../test/src/utils/drizzle-test-db.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestDb, type TestDb } from '../../../test/src/utils/drizzle-test-db.js';
 import { auditLog } from '../schema/audit-log.js';
 
+function makeRow(overrides: Partial<{ severity: string }> = {}) {
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    eventType: 'data.read',
+    severity: 'info',
+    agentId: 'agent-1',
+    payload: {},
+    policyViolations: [],
+    ...overrides,
+  };
+}
+
 describe('audit_log CHECK constraint — real schema (PGlite), not the vi.fn() mock', () => {
-  it.fails('accepts the severity vocabulary @revealui/security/audit.ts emits (Stage 1)', async () => {
-    const db = await createTestDb();
-    try {
-      // AuditSeverity ('low' | 'medium' | 'high' | 'critical') is what every
-      // request-level event carries — apps/server/src/middleware/audit.ts:59.
-      // The audit_log CHECK constraint (packages/db/src/schema/audit-log.ts:57,
-      // migration 0001_special_logan.sql:15) only allows
-      // 'info' | 'warn' | 'critical'. This insert throws Postgres 23514 today.
-      await db.drizzle.insert(auditLog).values({
-        id: randomUUID(),
-        timestamp: new Date(),
-        eventType: 'data.read',
-        severity: 'low',
-        agentId: 'agent-1',
-        payload: {},
-        policyViolations: [],
-      });
-    } finally {
-      await db.close();
-    }
+  let db: TestDb;
+
+  // createTestDb() applies every real migration and has observed 9-19s
+  // bootstrap time (see packages/test/src/utils/drizzle-test-db.ts) — done
+  // in beforeEach/afterEach (not inside each `it()` body) so it's covered by
+  // this package's vitest.config.ts `hookTimeout: 30000` rather than the
+  // default 5000ms test timeout.
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it('harness sanity: createTestDb() applies real migrations and a valid severity persists', async () => {
+    await db.drizzle.insert(auditLog).values(makeRow({ severity: 'info' }));
+    const rows = await db.drizzle.select().from(auditLog);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('rejects the severity vocabulary @revealui/security/audit.ts emits with Postgres check_violation 23514 (Stage 1 must change this)', async () => {
+    // AuditSeverity ('low' | 'medium' | 'high' | 'critical') is what every
+    // request-level event carries — apps/server/src/middleware/audit.ts:59.
+    // The audit_log CHECK constraint (packages/db/src/schema/audit-log.ts:57,
+    // migration 0001_special_logan.sql) only allows
+    // 'info' | 'warn' | 'critical'.
+    await expect(
+      db.drizzle.insert(auditLog).values(makeRow({ severity: 'low' })),
+    ).rejects.toMatchObject({
+      cause: { code: '23514', constraint: 'audit_log_severity_check' },
+    });
   });
 });

--- a/packages/db/src/__tests__/audit-store.integration.test.ts
+++ b/packages/db/src/__tests__/audit-store.integration.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Integration coverage for the REAL `audit_log` CHECK constraint.
+ *
+ * `audit-store.test.ts` (the sibling in this directory) builds its db from
+ * `vi.fn()` — a mock can never enforce a CHECK constraint, so it cannot see
+ * this bug. This file runs against `createTestDb()` (PGlite with every real
+ * migration from packages/db/migrations applied), so the constraint really
+ * fires.
+ *
+ * RevealUI audit-remediation Stage 0: an audit write can fail for several
+ * distinct reasons and today they all produce identical silence. This test
+ * documents one of them at the schema level — Stage 1 fixes it.
+ *
+ * Wrapped in `it.fails()` (Vitest's native "expected to fail" API — the repo
+ * has no existing red-first-test convention to match, so this was the
+ * closest built-in fit): the assertion states the DESIRED post-Stage-1
+ * behavior (a value from @revealui/security's severity vocabulary can be
+ * persisted). Today that insert throws with Postgres 23514, so the plain
+ * assertion fails — that failure is the proof this test exists to capture.
+ * `it.fails()` inverts pass/fail so CI stays green until Stage 1 removes the
+ * wrapper (at which point the bare assertion becomes the acceptance test).
+ */
+import { randomUUID } from 'node:crypto';
+import { describe, it } from 'vitest';
+import { createTestDb } from '../../../test/src/utils/drizzle-test-db.js';
+import { auditLog } from '../schema/audit-log.js';
+
+describe('audit_log CHECK constraint — real schema (PGlite), not the vi.fn() mock', () => {
+  it.fails('accepts the severity vocabulary @revealui/security/audit.ts emits (Stage 1)', async () => {
+    const db = await createTestDb();
+    try {
+      // AuditSeverity ('low' | 'medium' | 'high' | 'critical') is what every
+      // request-level event carries — apps/server/src/middleware/audit.ts:59.
+      // The audit_log CHECK constraint (packages/db/src/schema/audit-log.ts:57,
+      // migration 0001_special_logan.sql:15) only allows
+      // 'info' | 'warn' | 'critical'. This insert throws Postgres 23514 today.
+      await db.drizzle.insert(auditLog).values({
+        id: randomUUID(),
+        timestamp: new Date(),
+        eventType: 'data.read',
+        severity: 'low',
+        agentId: 'agent-1',
+        payload: {},
+        policyViolations: [],
+      });
+    } finally {
+      await db.close();
+    }
+  });
+});

--- a/packages/security/src/__tests__/audit-write-failures.test.ts
+++ b/packages/security/src/__tests__/audit-write-failures.test.ts
@@ -1,3 +1,4 @@
+import { logger } from '@revealui/utils/logger';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   classifyAuditWriteFailure,
@@ -97,5 +98,90 @@ describe('recordAuditWriteResult — ratio tracking', () => {
     const stats = getAuditWriteFailureStatsForTest();
     expect(stats.attempted).toBe(1);
     expect(stats.failed).toBe(0);
+  });
+
+  // B2: this module must never log per-attempt or per-failure — every call
+  // site already owns its own event-level logging at its own cadence (e.g.
+  // middleware/audit.ts's 1-in-10 throttle). A per-failure log here would sit
+  // underneath that throttle and multiply log volume during exactly the
+  // near-100%-failure condition this module exists to catch.
+  it('never logs on an individual failure, no matter how many are recorded', () => {
+    for (let i = 0; i < 50; i++) {
+      recordAuditWriteResult({ ok: false, reason: 'constraint_violation' });
+    }
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('never logs on an individual success', () => {
+    for (let i = 0; i < 50; i++) {
+      recordAuditWriteResult({ ok: true });
+    }
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('escalates via logger.error exactly once while the ratio stays above threshold', () => {
+    for (let i = 0; i < 30; i++) {
+      recordAuditWriteResult({ ok: false, reason: 'constraint_violation' });
+    }
+    // Escalation fires the moment the window first reaches MIN_SAMPLE_SIZE
+    // (20) with 100% failures, not after all 30 have been recorded — the
+    // alarm latches at that point and the remaining 10 calls in this loop
+    // don't re-fire it.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Audit write failure ratio exceeded threshold',
+      expect.objectContaining({
+        ratio: 1,
+        windowSize: 20,
+        byReason: expect.objectContaining({ constraint_violation: 20 }),
+      }),
+    );
+
+    // More failures while still above threshold: no repeat escalation.
+    for (let i = 0; i < 10; i++) {
+      recordAuditWriteResult({ ok: false, reason: 'constraint_violation' });
+    }
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not escalate below the 1% threshold', () => {
+    // Establish a large pool of successes FIRST so the single failure below
+    // is already diluted the instant it's recorded — the ratio is checked on
+    // every call, so a failure recorded while the window is still small
+    // would transiently exceed 1% even if the eventual steady-state ratio is
+    // fine. This ordering is what "below threshold, never escalates" means
+    // in a rolling-window check.
+    for (let i = 0; i < 200; i++) {
+      recordAuditWriteResult({ ok: true });
+    }
+    recordAuditWriteResult({ ok: false, reason: 'db_error' });
+    // 1 failure / 201 attempts ≈ 0.5%, below the 1% threshold.
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  // S1: the ratio must be windowed (rolling), not a lifetime cumulative
+  // count, so the alarm can re-arm after a recovery and fire again on a
+  // later, independent failure spike.
+  it('re-arms and re-fires after the ratio recovers below threshold and spikes again', () => {
+    for (let i = 0; i < 30; i++) {
+      recordAuditWriteResult({ ok: false, reason: 'constraint_violation' });
+    }
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    // Recover: enough successes to age every failure out of the rolling
+    // window and push the ratio back under 1%.
+    for (let i = 0; i < 500; i++) {
+      recordAuditWriteResult({ ok: true });
+    }
+    const recovered = getAuditWriteFailureStatsForTest();
+    expect(recovered.failed).toBe(0);
+
+    // A second, independent spike must escalate again — proves the alarm
+    // did not latch permanently after the first escalation.
+    for (let i = 0; i < 30; i++) {
+      recordAuditWriteResult({ ok: false, reason: 'schema_mismatch' });
+    }
+    expect(logger.error).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/security/src/__tests__/audit-write-failures.test.ts
+++ b/packages/security/src/__tests__/audit-write-failures.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  classifyAuditWriteFailure,
+  getAuditWriteFailureStatsForTest,
+  recordAuditWriteResult,
+  resetAuditWriteFailureStatsForTest,
+} from '../audit-write-failures.js';
+
+vi.mock('@revealui/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+describe('classifyAuditWriteFailure', () => {
+  it('classifies the getAuditSecret() message as missing_secret', () => {
+    const err = new Error(
+      'Audit HMAC signing requires REVEALUI_AUDIT_HMAC_SECRET (or REVEALUI_SECRET fallback) to be set.',
+    );
+    expect(classifyAuditWriteFailure(err)).toBe('missing_secret');
+  });
+
+  it('classifies Postgres check_violation (23514) as constraint_violation', () => {
+    expect(classifyAuditWriteFailure({ code: '23514' })).toBe('constraint_violation');
+  });
+
+  it('classifies Postgres unique_violation (23505) as constraint_violation', () => {
+    expect(classifyAuditWriteFailure({ code: '23505' })).toBe('constraint_violation');
+  });
+
+  it('classifies Postgres undefined_column (42703) as schema_mismatch', () => {
+    expect(classifyAuditWriteFailure({ code: '42703' })).toBe('schema_mismatch');
+  });
+
+  it('classifies Postgres undefined_table (42P01) as schema_mismatch', () => {
+    expect(classifyAuditWriteFailure({ code: '42P01' })).toBe('schema_mismatch');
+  });
+
+  it('falls back to db_error for an unrecognized code', () => {
+    expect(classifyAuditWriteFailure({ code: '08006' })).toBe('db_error');
+  });
+
+  it('classifies a code nested under .cause (drizzle-orm wraps every driver error this way)', () => {
+    const wrapped = new Error('Failed query: insert into "audit_log" ...');
+    wrapped.cause = { code: '23514' };
+    expect(classifyAuditWriteFailure(wrapped)).toBe('constraint_violation');
+  });
+
+  it('prefers a top-level code over a nested .cause code', () => {
+    const wrapped = new Error('boom') as Error & { code?: string };
+    wrapped.code = '42703';
+    wrapped.cause = { code: '23514' };
+    expect(classifyAuditWriteFailure(wrapped)).toBe('schema_mismatch');
+  });
+
+  it('falls back to db_error for a plain Error with no code', () => {
+    expect(classifyAuditWriteFailure(new Error('connection reset'))).toBe('db_error');
+  });
+
+  it('falls back to db_error for a non-object throw', () => {
+    expect(classifyAuditWriteFailure('boom')).toBe('db_error');
+  });
+});
+
+describe('recordAuditWriteResult — ratio tracking', () => {
+  beforeEach(() => {
+    resetAuditWriteFailureStatsForTest();
+  });
+
+  afterEach(() => {
+    resetAuditWriteFailureStatsForTest();
+    vi.clearAllMocks();
+  });
+
+  it('does not escalate below the minimum sample size, even at 100% failure', () => {
+    for (let i = 0; i < 19; i++) {
+      recordAuditWriteResult({ ok: false, reason: 'constraint_violation' });
+    }
+    const stats = getAuditWriteFailureStatsForTest();
+    expect(stats.attempted).toBe(19);
+    expect(stats.failed).toBe(19);
+  });
+
+  it('tallies failures by reason', () => {
+    recordAuditWriteResult({ ok: false, reason: 'constraint_violation' });
+    recordAuditWriteResult({ ok: false, reason: 'constraint_violation' });
+    recordAuditWriteResult({ ok: false, reason: 'missing_secret' });
+    recordAuditWriteResult({ ok: true });
+
+    const stats = getAuditWriteFailureStatsForTest();
+    expect(stats.attempted).toBe(4);
+    expect(stats.failed).toBe(3);
+    expect(stats.byReason.constraint_violation).toBe(2);
+    expect(stats.byReason.missing_secret).toBe(1);
+  });
+
+  it('does not count a successful write as a failure', () => {
+    recordAuditWriteResult({ ok: true });
+    const stats = getAuditWriteFailureStatsForTest();
+    expect(stats.attempted).toBe(1);
+    expect(stats.failed).toBe(0);
+  });
+});

--- a/packages/security/src/audit-write-failures.ts
+++ b/packages/security/src/audit-write-failures.ts
@@ -39,14 +39,6 @@ const CONSTRAINT_VIOLATION_CODES = new Set([CHECK_VIOLATION, UNIQUE_VIOLATION, N
 const SCHEMA_MISMATCH_CODES = new Set([UNDEFINED_COLUMN, UNDEFINED_TABLE]);
 
 /**
- * Classify a thrown/rejected audit-write error into one of the four Stage 0
- * failure modes. Checks the `getAuditSecret()` message first (that path
- * throws before any query ever reaches Postgres, so it has no `.code`), then
- * the Postgres SQLSTATE (`.code`) surfaced by both `pg` and
- * `@neondatabase/serverless`, and falls back to `db_error` for anything else
- * (connection failures, timeouts, driver errors).
- */
-/**
  * Extract a Postgres SQLSTATE `.code` from an error, checking the error
  * itself and then one level of `.cause` — drizzle-orm wraps every driver
  * error in a `DrizzleQueryError` whose own `.code` is undefined; the real
@@ -67,6 +59,14 @@ function extractPgErrorCode(error: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * Classify a thrown/rejected audit-write error into one of the four Stage 0
+ * failure modes. Checks the `getAuditSecret()` message first (that path
+ * throws before any query ever reaches Postgres, so it has no `.code`), then
+ * the Postgres SQLSTATE (`.code`) surfaced by both `pg` and
+ * `@neondatabase/serverless`, and falls back to `db_error` for anything else
+ * (connection failures, timeouts, driver errors).
+ */
 export function classifyAuditWriteFailure(error: unknown): AuditWriteFailureReason {
   if (error instanceof Error && error.message.startsWith('Audit HMAC signing requires')) {
     return 'missing_secret';

--- a/packages/security/src/audit-write-failures.ts
+++ b/packages/security/src/audit-write-failures.ts
@@ -1,5 +1,5 @@
 /**
- * Audit write failure classification + ratio tracking.
+ * Audit write failure classification + rolling-ratio tracking.
  *
  * Stage 0 finding: an audit write can fail for four distinct reasons
  * (a rejected severity value, a missing signing secret, a schema mismatch in
@@ -10,12 +10,27 @@
  * place, and a failure ratio that would otherwise mean "the audit trail has
  * gone silent" gets escalated loudly instead.
  *
+ * This module counts SILENTLY. It never logs per attempt or per failure —
+ * each call site already owns its own event-level logging at whatever
+ * cadence makes sense for that call site (e.g. `middleware/audit.ts`'s
+ * existing 1-in-10 throttle). The only thing this module ever emits is the
+ * rolling-ratio escalation below. Emitting a log line here on every failure
+ * would sit underneath every call site's own throttle and multiply log
+ * volume during exactly the condition (near-100% failure) this module
+ * exists to catch — that was tried and reverted.
+ *
  * There is no metrics/counter primitive (StatsD, prom-client, Sentry metrics)
- * anywhere in this repo today — see the Stage 0 PR description. This module
- * is deliberately just a structured-logger-backed counter, not a new metrics
- * system: `audit_write_failures_total` is a stable log event name intended
- * for log-based counting (Vercel Logs / Datadog / Sentry breadcrumbs), not a
- * Prometheus counter.
+ * anywhere in this repo today — see the Stage 0 PR description. This is an
+ * in-process counter, not a new metrics system.
+ *
+ * The ratio is computed over a fixed-size ROLLING WINDOW of the last
+ * `WINDOW_SIZE` attempts, not a lifetime cumulative count. A cumulative
+ * count never decays: once enough failures accrue to cross the threshold,
+ * diluting it back down would require roughly 100x as many subsequent
+ * successes, so in practice the alarm could fire at most once per process
+ * and could never re-arm for a second, later failure spike. The rolling
+ * window ages failures out as new attempts come in, so the ratio reflects
+ * recent behavior and the alarm can legitimately re-fire after a recovery.
  */
 
 import { logger } from '@revealui/utils/logger';
@@ -79,10 +94,20 @@ export function classifyAuditWriteFailure(error: unknown): AuditWriteFailureReas
   return 'db_error';
 }
 
-/** Minimum sample size before the ratio alarm can fire — avoids noise on cold start. */
+/** Number of most-recent attempts the rolling ratio is computed over. */
+const WINDOW_SIZE = 500;
+/** Minimum attempts IN THE WINDOW before the ratio alarm can fire — avoids noise on cold start. */
 const MIN_SAMPLE_SIZE = 20;
 /** Failure ratio above which the whole audit trail is suspect. */
 const FAILURE_RATIO_THRESHOLD = 0.01;
+
+export interface AuditWriteOutcome {
+  ok: boolean;
+  reason?: AuditWriteFailureReason;
+  /** The failed/succeeded event's id, when known — surfaced only in the ratio-escalation log, never per-attempt. */
+  eventId?: string;
+  eventType?: string;
+}
 
 interface FailureCounters {
   attempted: number;
@@ -90,28 +115,24 @@ interface FailureCounters {
   byReason: Record<AuditWriteFailureReason, number>;
 }
 
-function emptyCounters(): FailureCounters {
-  return {
-    attempted: 0,
-    failed: 0,
-    byReason: {
-      constraint_violation: 0,
-      missing_secret: 0,
-      schema_mismatch: 0,
-      db_error: 0,
-    },
-  };
+function emptyByReason(): Record<AuditWriteFailureReason, number> {
+  return { constraint_violation: 0, missing_secret: 0, schema_mismatch: 0, db_error: 0 };
 }
 
-let counters = emptyCounters();
+let window: AuditWriteOutcome[] = [];
 let ratioAlarmFired = false;
+let lastFailure: AuditWriteOutcome | undefined;
 
-export interface AuditWriteOutcome {
-  ok: boolean;
-  reason?: AuditWriteFailureReason;
-  /** The failed/succeeded event's id, when known — for correlating the log line to a record. */
-  eventId?: string;
-  eventType?: string;
+function computeCounters(): FailureCounters {
+  const byReason = emptyByReason();
+  let failed = 0;
+  for (const outcome of window) {
+    if (!outcome.ok) {
+      failed++;
+      if (outcome.reason) byReason[outcome.reason]++;
+    }
+  }
+  return { attempted: window.length, failed, byReason };
 }
 
 /**
@@ -119,26 +140,21 @@ export interface AuditWriteOutcome {
  * every audit write path (success AND failure) so the ratio reflects the
  * whole system rather than one call site's private view of it.
  *
- * Emits `audit_write_failures_total` on every failure (the log-based counter
- * this module stands in for a real metrics backend), and escalates to
- * `logger.error` once the rolling failure ratio crosses 1% — the signal that
- * would have caught every Stage 0 bug on day one.
+ * Counts silently. Escalates to `logger.error` once the rolling failure
+ * ratio (over the last `WINDOW_SIZE` attempts) crosses 1% — the signal that
+ * would have caught every Stage 0 bug on day one — and stays quiet while the
+ * ratio remains above threshold so the escalation itself doesn't spam.
  */
 export function recordAuditWriteResult(outcome: AuditWriteOutcome): void {
-  counters.attempted++;
-
+  window.push(outcome);
+  if (window.length > WINDOW_SIZE) {
+    window.shift();
+  }
   if (!outcome.ok) {
-    counters.failed++;
-    if (outcome.reason) {
-      counters.byReason[outcome.reason]++;
-    }
-    logger.warn('audit_write_failures_total', {
-      reason: outcome.reason,
-      eventId: outcome.eventId,
-      eventType: outcome.eventType,
-    });
+    lastFailure = outcome;
   }
 
+  const counters = computeCounters();
   if (counters.attempted < MIN_SAMPLE_SIZE) return;
 
   const ratio = counters.failed / counters.attempted;
@@ -146,11 +162,13 @@ export function recordAuditWriteResult(outcome: AuditWriteOutcome): void {
     if (!ratioAlarmFired) {
       ratioAlarmFired = true;
       logger.error('Audit write failure ratio exceeded threshold', {
-        attempted: counters.attempted,
+        windowSize: counters.attempted,
         failed: counters.failed,
         ratio,
         threshold: FAILURE_RATIO_THRESHOLD,
         byReason: { ...counters.byReason },
+        lastFailureEventId: lastFailure?.eventId,
+        lastFailureEventType: lastFailure?.eventType,
       });
     }
   } else {
@@ -160,11 +178,12 @@ export function recordAuditWriteResult(outcome: AuditWriteOutcome): void {
 
 /** Test-only accessor — never call from production code. */
 export function getAuditWriteFailureStatsForTest(): FailureCounters {
-  return { ...counters, byReason: { ...counters.byReason } };
+  return computeCounters();
 }
 
 /** Test-only reset — never call from production code. */
 export function resetAuditWriteFailureStatsForTest(): void {
-  counters = emptyCounters();
+  window = [];
   ratioAlarmFired = false;
+  lastFailure = undefined;
 }

--- a/packages/security/src/audit-write-failures.ts
+++ b/packages/security/src/audit-write-failures.ts
@@ -1,0 +1,170 @@
+/**
+ * Audit write failure classification + ratio tracking.
+ *
+ * Stage 0 finding: an audit write can fail for four distinct reasons
+ * (a rejected severity value, a missing signing secret, a schema mismatch in
+ * a hand-rolled writer, or a generic DB error) and every one of them produced
+ * identical silence — the failure vanished into a `.catch()` with no log line
+ * and no counter. Every audit write path funnels its outcome through
+ * `recordAuditWriteResult()` so failures are classified and counted in one
+ * place, and a failure ratio that would otherwise mean "the audit trail has
+ * gone silent" gets escalated loudly instead.
+ *
+ * There is no metrics/counter primitive (StatsD, prom-client, Sentry metrics)
+ * anywhere in this repo today — see the Stage 0 PR description. This module
+ * is deliberately just a structured-logger-backed counter, not a new metrics
+ * system: `audit_write_failures_total` is a stable log event name intended
+ * for log-based counting (Vercel Logs / Datadog / Sentry breadcrumbs), not a
+ * Prometheus counter.
+ */
+
+import { logger } from '@revealui/utils/logger';
+
+export type AuditWriteFailureReason =
+  | 'constraint_violation'
+  | 'missing_secret'
+  | 'schema_mismatch'
+  | 'db_error';
+
+// Postgres SQLSTATE codes relevant to audit_log writes. Not authored regex —
+// plain string constants matched against the driver's `.code` property.
+// Reference: https://www.postgresql.org/docs/current/errcodes-appendix.html
+const CHECK_VIOLATION = '23514';
+const UNIQUE_VIOLATION = '23505';
+const NOT_NULL_VIOLATION = '23502';
+const UNDEFINED_COLUMN = '42703';
+const UNDEFINED_TABLE = '42P01';
+
+const CONSTRAINT_VIOLATION_CODES = new Set([CHECK_VIOLATION, UNIQUE_VIOLATION, NOT_NULL_VIOLATION]);
+const SCHEMA_MISMATCH_CODES = new Set([UNDEFINED_COLUMN, UNDEFINED_TABLE]);
+
+/**
+ * Classify a thrown/rejected audit-write error into one of the four Stage 0
+ * failure modes. Checks the `getAuditSecret()` message first (that path
+ * throws before any query ever reaches Postgres, so it has no `.code`), then
+ * the Postgres SQLSTATE (`.code`) surfaced by both `pg` and
+ * `@neondatabase/serverless`, and falls back to `db_error` for anything else
+ * (connection failures, timeouts, driver errors).
+ */
+/**
+ * Extract a Postgres SQLSTATE `.code` from an error, checking the error
+ * itself and then one level of `.cause` — drizzle-orm wraps every driver
+ * error in a `DrizzleQueryError` whose own `.code` is undefined; the real
+ * `pg`/`@neondatabase/serverless` error (and its `.code`) lives at
+ * `error.cause`.
+ */
+function extractPgErrorCode(error: unknown): string | undefined {
+  for (const candidate of [error, error instanceof Error ? error.cause : undefined]) {
+    if (
+      candidate &&
+      typeof candidate === 'object' &&
+      'code' in candidate &&
+      typeof candidate.code === 'string'
+    ) {
+      return candidate.code;
+    }
+  }
+  return undefined;
+}
+
+export function classifyAuditWriteFailure(error: unknown): AuditWriteFailureReason {
+  if (error instanceof Error && error.message.startsWith('Audit HMAC signing requires')) {
+    return 'missing_secret';
+  }
+  const code = extractPgErrorCode(error);
+  if (code) {
+    if (CONSTRAINT_VIOLATION_CODES.has(code)) return 'constraint_violation';
+    if (SCHEMA_MISMATCH_CODES.has(code)) return 'schema_mismatch';
+  }
+  return 'db_error';
+}
+
+/** Minimum sample size before the ratio alarm can fire — avoids noise on cold start. */
+const MIN_SAMPLE_SIZE = 20;
+/** Failure ratio above which the whole audit trail is suspect. */
+const FAILURE_RATIO_THRESHOLD = 0.01;
+
+interface FailureCounters {
+  attempted: number;
+  failed: number;
+  byReason: Record<AuditWriteFailureReason, number>;
+}
+
+function emptyCounters(): FailureCounters {
+  return {
+    attempted: 0,
+    failed: 0,
+    byReason: {
+      constraint_violation: 0,
+      missing_secret: 0,
+      schema_mismatch: 0,
+      db_error: 0,
+    },
+  };
+}
+
+let counters = emptyCounters();
+let ratioAlarmFired = false;
+
+export interface AuditWriteOutcome {
+  ok: boolean;
+  reason?: AuditWriteFailureReason;
+  /** The failed/succeeded event's id, when known — for correlating the log line to a record. */
+  eventId?: string;
+  eventType?: string;
+}
+
+/**
+ * Record the outcome of a single audit-log write attempt. Call this from
+ * every audit write path (success AND failure) so the ratio reflects the
+ * whole system rather than one call site's private view of it.
+ *
+ * Emits `audit_write_failures_total` on every failure (the log-based counter
+ * this module stands in for a real metrics backend), and escalates to
+ * `logger.error` once the rolling failure ratio crosses 1% — the signal that
+ * would have caught every Stage 0 bug on day one.
+ */
+export function recordAuditWriteResult(outcome: AuditWriteOutcome): void {
+  counters.attempted++;
+
+  if (!outcome.ok) {
+    counters.failed++;
+    if (outcome.reason) {
+      counters.byReason[outcome.reason]++;
+    }
+    logger.warn('audit_write_failures_total', {
+      reason: outcome.reason,
+      eventId: outcome.eventId,
+      eventType: outcome.eventType,
+    });
+  }
+
+  if (counters.attempted < MIN_SAMPLE_SIZE) return;
+
+  const ratio = counters.failed / counters.attempted;
+  if (ratio > FAILURE_RATIO_THRESHOLD) {
+    if (!ratioAlarmFired) {
+      ratioAlarmFired = true;
+      logger.error('Audit write failure ratio exceeded threshold', {
+        attempted: counters.attempted,
+        failed: counters.failed,
+        ratio,
+        threshold: FAILURE_RATIO_THRESHOLD,
+        byReason: { ...counters.byReason },
+      });
+    }
+  } else {
+    ratioAlarmFired = false;
+  }
+}
+
+/** Test-only accessor — never call from production code. */
+export function getAuditWriteFailureStatsForTest(): FailureCounters {
+  return { ...counters, byReason: { ...counters.byReason } };
+}
+
+/** Test-only reset — never call from production code. */
+export function resetAuditWriteFailureStatsForTest(): void {
+  counters = emptyCounters();
+  ratioAlarmFired = false;
+}

--- a/packages/security/src/audit.ts
+++ b/packages/security/src/audit.ts
@@ -84,6 +84,24 @@ export interface AuditStorage {
 }
 
 /**
+ * Thrown when `AuditSystem.log()` fails to persist an event. Carries the full
+ * constructed event (including the generated `id`) so any catch site can
+ * correlate the failure with exactly which event was dropped and classify
+ * the underlying cause — without this, a `.catch()` only sees a raw
+ * storage-layer error with no way to say which audit record never landed.
+ */
+export class AuditWriteError extends Error {
+  constructor(
+    public readonly event: AuditEvent,
+    public readonly cause: unknown,
+  ) {
+    const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    super(`Audit write failed for event ${event.id} (${event.type}): ${causeMessage}`);
+    this.name = 'AuditWriteError';
+  }
+}
+
+/**
  * Audit logging system
  */
 export class AuditSystem {
@@ -103,9 +121,12 @@ export class AuditSystem {
   }
 
   /**
-   * Log audit event
+   * Log audit event. Returns the full constructed event (including the
+   * generated `id`/`timestamp`) so callers can correlate it with later
+   * failures; throws `AuditWriteError` (wrapping the storage-layer cause) on
+   * a failed persist so the event that was lost is never anonymous.
    */
-  async log(event: Omit<AuditEvent, 'id' | 'timestamp'>): Promise<void> {
+  async log(event: Omit<AuditEvent, 'id' | 'timestamp'>): Promise<AuditEvent> {
     const fullEvent: AuditEvent = {
       ...event,
       id: crypto.randomUUID(),
@@ -116,10 +137,16 @@ export class AuditSystem {
     const shouldLog = this.filters.every((filter) => filter(fullEvent));
 
     if (!shouldLog) {
-      return;
+      return fullEvent;
     }
 
-    await this.storage.write(fullEvent);
+    try {
+      await this.storage.write(fullEvent);
+    } catch (cause) {
+      throw new AuditWriteError(fullEvent, cause);
+    }
+
+    return fullEvent;
   }
 
   /**

--- a/packages/security/src/server.ts
+++ b/packages/security/src/server.ts
@@ -28,12 +28,18 @@ export {
   AuditReportGenerator,
   AuditSystem,
   AuditTrail,
+  AuditWriteError,
   audit,
   createAuditMiddleware,
   InMemoryAuditStorage,
   signAuditEntry,
   verifyAuditEntry,
 } from './audit.js';
+export type { AuditWriteFailureReason } from './audit-write-failures.js';
+export {
+  classifyAuditWriteFailure,
+  recordAuditWriteResult,
+} from './audit-write-failures.js';
 export type {
   OAuthConfig,
   User,

--- a/scripts/admin/bootstrap.ts
+++ b/scripts/admin/bootstrap.ts
@@ -22,7 +22,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { randomFillSync } from 'node:crypto';
+import { randomFillSync, randomUUID } from 'node:crypto';
 import { hostname } from 'node:os';
 
 // ---------------------------------------------------------------------------
@@ -195,24 +195,47 @@ async function main(): Promise<void> {
   }
 
   // Audit log entry
-  try {
+  {
     const { auditLog } = await import('@revealui/db/schema');
-    await db.insert(auditLog).values({
-      event: 'admin.bootstrap.completed',
-      actor: 'cli',
-      severity: 'info',
-      meta: {
-        email,
-        env,
-        source: 'revvault',
-        hostname: hostname(),
-        forceRotate,
-        seeded: result.seeded ?? false,
-      },
-    } as never);
-  } catch {
-    // Non-fatal — audit log may not be available in all environments
-    console.warn('[bootstrap] audit log entry skipped (table may not exist)');
+    const { classifyAuditWriteFailure, recordAuditWriteResult } = await import(
+      '@revealui/core/security'
+    );
+    const eventId = randomUUID();
+    try {
+      await db.insert(auditLog).values({
+        event: 'admin.bootstrap.completed',
+        actor: 'cli',
+        severity: 'info',
+        meta: {
+          email,
+          env,
+          source: 'revvault',
+          hostname: hostname(),
+          forceRotate,
+          seeded: result.seeded ?? false,
+        },
+      } as never);
+      recordAuditWriteResult({ ok: true, eventId, eventType: 'admin.bootstrap.completed' });
+      console.log('[bootstrap] recorded audit log entry');
+    } catch (err) {
+      const reason = classifyAuditWriteFailure(err);
+      recordAuditWriteResult({
+        ok: false,
+        reason,
+        eventId,
+        eventType: 'admin.bootstrap.completed',
+      });
+      // Non-fatal — the admin account was already created above. This writer
+      // targets columns (`event`/`actor`/`meta`) that do not exist on
+      // audit_log (real columns are `event_type`/`agent_id`/`payload`) and
+      // has never successfully persisted a row in any environment. Stage 1
+      // fixes the column mapping; Stage 0 only makes the failure visible —
+      // previously this printed a misleading "table may not exist" guess
+      // without the real error.
+      console.warn(
+        `[bootstrap] audit log entry failed (reason: ${reason}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   console.log(`[bootstrap] ${result.message}`);

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -356,6 +356,11 @@ async function gate(): Promise<void> {
         args: ['validate:empty-catch'],
       },
       {
+        name: 'as-never on drizzle .values() (hard fail)',
+        command: 'pnpm',
+        args: ['validate:as-never-values'],
+      },
+      {
         name: 'Stripe-client consolidation (hard fail)',
         command: 'pnpm',
         args: ['validate:stripe-client'],

--- a/scripts/validate/__tests__/as-never-values.test.ts
+++ b/scripts/validate/__tests__/as-never-values.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { findAsNeverValuesCalls } from '../as-never-values.js';
+
+describe('findAsNeverValuesCalls', () => {
+  it('flags `as never` on a single-object .values() argument', () => {
+    const src = `
+      await db.insert(auditLog).values({
+        event: 'x',
+      } as never);
+    `;
+    const hits = findAsNeverValuesCalls(src, 'fixture.ts');
+    expect(hits).toHaveLength(1);
+  });
+
+  it('flags `as never` on an element inside an array-literal .values() argument', () => {
+    const src = `
+      await db.insert(t).values([
+        { a: 1 } as never,
+        { a: 2 },
+      ]);
+    `;
+    const hits = findAsNeverValuesCalls(src, 'fixture.ts');
+    expect(hits).toHaveLength(1);
+  });
+
+  it('does not flag a correctly-typed .values() call', () => {
+    const src = `
+      await db.insert(auditLog).values({
+        eventType: 'x',
+        agentId: 'y',
+        severity: 'info',
+        payload: {},
+        policyViolations: [],
+      });
+    `;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('does not flag `as never` used elsewhere in the same file (e.g. casting a mock client)', () => {
+    const src = `
+      const result = await capResourcesOnDowngrade(db as never, 'acct-1', 'free', 'pro');
+    `;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('does not flag a zero-argument .values() call (e.g. Map.values())', () => {
+    const src = `
+      for (const v of someMap.values()) {
+        console.log(v);
+      }
+    `;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('does not flag `as never` on a non-values() call', () => {
+    const src = `
+      mockedGetRestClient.mockReturnValue({} as never);
+    `;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('reports the 1-indexed line of the call expression', () => {
+    const src = ['', '', 'await db.insert(t).values({', '  a: 1,', '} as never);'].join('\n');
+    const hits = findAsNeverValuesCalls(src, 'fixture.ts');
+    expect(hits).toEqual([{ line: 3 }]);
+  });
+});

--- a/scripts/validate/__tests__/as-never-values.test.ts
+++ b/scripts/validate/__tests__/as-never-values.test.ts
@@ -64,4 +64,54 @@ describe('findAsNeverValuesCalls', () => {
     const hits = findAsNeverValuesCalls(src, 'fixture.ts');
     expect(hits).toEqual([{ line: 3 }]);
   });
+
+  // The bypasses an adversarial review demonstrated against the first cut of
+  // this matcher. Four are now caught; two remain uncaught by design — see
+  // the function's own doc comment for why (a spread requires data-flow
+  // analysis this syntactic check doesn't do, and `as any` is a different,
+  // broader pattern this check does not police).
+
+  it('follows a SINGLE hop through a hoisted local variable (the bypass that matters most)', () => {
+    const src = `
+      const p = { a: 1 } as never;
+      await db.insert(t).values(p);
+    `;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(1);
+  });
+
+  it('does not flag a hoisted variable that was never cast `as never`', () => {
+    const src = `
+      const p = { a: 1 };
+      await db.insert(t).values(p);
+    `;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('flags the angle-bracket cast syntax `<never>expr`', () => {
+    const src = `await db.insert(t).values(<never>{ a: 1 });`;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(1);
+  });
+
+  it('flags `as never` wrapped in an extra layer of parentheses', () => {
+    const src = `await db.insert(t).values(({ a: 1 } as never));`;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(1);
+  });
+
+  it('flags `as never` in either branch of a ternary argument', () => {
+    const src = `await db.insert(t).values(c ? (x as never) : y);`;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(1);
+  });
+
+  it('does NOT flag a spread of an array cast/assembled elsewhere (known gap — no data-flow analysis)', () => {
+    const src = `
+      const rowsCastElsewhere = build() as never;
+      await db.insert(t).values([...rowsCastElsewhere]);
+    `;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('does NOT flag `as any` (a different, broader pattern this check does not police)', () => {
+    const src = `await db.insert(t).values({ a: 1 } as any);`;
+    expect(findAsNeverValuesCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
 });

--- a/scripts/validate/as-never-values-allowlist.json
+++ b/scripts/validate/as-never-values-allowlist.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "RevealUI audit-remediation Stage 0 as-never-values validator allowlist. Both entries are the two pre-existing broken audit_log writers (event/actor/meta columns that do not exist on the table; real columns are event_type/agent_id/payload) that Stage 0 deliberately does NOT fix — only makes their failure loud (see apps/admin/src/app/api/setup/route.ts and scripts/admin/bootstrap.ts catch blocks). Stage 1 fixes the column mapping and removes both entries.",
+  "version": 1,
+  "entries": [
+    {
+      "path": "apps/admin/src/app/api/setup/route.ts",
+      "line": 104,
+      "reason": "Stage 1 fixes the event/actor/meta -> event_type/agent_id/payload column mapping; Stage 0 only makes the write's failure loud (structured log + classified reason) instead of silently swallowing it."
+    },
+    {
+      "path": "scripts/admin/bootstrap.ts",
+      "line": 205,
+      "reason": "Stage 1 fixes the event/actor/meta -> event_type/agent_id/payload column mapping; Stage 0 only makes the write's failure loud (classified console.warn) instead of silently swallowing it."
+    }
+  ]
+}

--- a/scripts/validate/as-never-values.ts
+++ b/scripts/validate/as-never-values.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env tsx
+// console-allowed
+
+/**
+ * `as never` on a drizzle `.values()` call — CI validator.
+ *
+ * RevealUI audit-remediation Stage 0 finding: two audit-log writers
+ * (apps/admin/src/app/api/setup/route.ts, scripts/admin/bootstrap.ts) insert
+ * columns that do not exist on the `audit_log` table (`event`/`actor`/`meta`
+ * instead of the real `event_type`/`agent_id`/`payload`), silenced with
+ * `as never` on the `.values()` argument. Both writers have NEVER succeeded
+ * in any environment — `as never` is exactly the mechanism that let a
+ * permanently-broken insert pass typecheck, CI, and code review.
+ *
+ * This validator makes that specific pattern un-mergeable going forward:
+ * `as never` used to cast the argument of any `.values(...)` call (the
+ * drizzle insert/update payload shape). Uses the TypeScript compiler API
+ * (mirrors `scripts/validate/doc-currency.ts`'s `extractStringLiterals` —
+ * `ts.createSourceFile` + `ts.forEachChild`) rather than authored regex, per
+ * the fleet's no-regex rule.
+ *
+ * This is a syntactic check (no type-checker/Program construction), so it
+ * cannot confirm the receiver is actually a drizzle query builder rather
+ * than some unrelated `.values(...)` method — the same trade-off
+ * doc-currency.ts's literal-extraction walk already accepts for its own
+ * scan. In practice `.values(` called WITH an argument is a drizzle-only
+ * shape in this codebase (Map/Set/FormData/URLSearchParams `.values()` take
+ * no arguments; `Object.values(x)` takes an argument but casting it
+ * `as never` would be equally suspicious).
+ *
+ * Pre-existing violations are enumerated in as-never-values-allowlist.json
+ * with reasons (mirrors raw-sql.ts / empty-catch.ts); new violations fail
+ * CI unless explicitly allowlisted.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+
+const ALLOWLIST_PATH = join(REPO_ROOT, 'scripts/validate/as-never-values-allowlist.json');
+
+const SCAN_ROOTS = ['apps', 'packages', 'scripts'];
+
+const SOURCE_EXTS = new Set(['.ts', '.tsx', '.mts', '.cts']);
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.turbo',
+  '.next',
+  'coverage',
+  'playwright-report',
+  'test-results',
+  'opensrc',
+]);
+
+// Test files routinely cast mock clients `as never` for reasons unrelated to
+// this rule (see e.g. apps/server/src/lib/__tests__/downgrade-cap.test.ts —
+// `db as never` casts a mock DB CLIENT, not a `.values()` payload). Excluded
+// the same way empty-catch.ts excludes test files from its scan.
+const EXCLUDED_PATH_SEGMENTS = [
+  '__tests__/',
+  '__mocks__/',
+  '.test.ts',
+  '.test.tsx',
+  '.spec.ts',
+  '.spec.tsx',
+  '.integration.test.ts',
+  '.integration.test.tsx',
+  '.e2e.ts',
+  '.e2e.tsx',
+  'scripts/validate/',
+  '/generated/',
+];
+
+// =============================================================================
+// Allowlist loading
+// =============================================================================
+
+interface AllowlistEntry {
+  path: string;
+  line?: number;
+  reason: string;
+}
+
+interface AllowlistFile {
+  version: number;
+  entries?: AllowlistEntry[];
+}
+
+interface AllowlistMatcher {
+  byPath: Map<string, AllowlistEntry[]>;
+}
+
+function loadAllowlist(): AllowlistMatcher {
+  if (!existsSync(ALLOWLIST_PATH)) {
+    return { byPath: new Map() };
+  }
+  const raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8')) as AllowlistFile;
+  const byPath = new Map<string, AllowlistEntry[]>();
+  for (const entry of raw.entries ?? []) {
+    if (!entry.reason?.trim()) {
+      throw new Error(
+        `as-never-values-allowlist.json: entry "${entry.path}${entry.line ? `:${entry.line}` : ''}" is missing a non-empty reason.`,
+      );
+    }
+    const list = byPath.get(entry.path) ?? [];
+    list.push(entry);
+    byPath.set(entry.path, list);
+  }
+  return { byPath };
+}
+
+function isAllowlisted(allow: AllowlistMatcher, relPath: string, line: number): boolean {
+  const normalized = relPath.split('\\').join('/');
+  const entries = allow.byPath.get(normalized);
+  if (!entries) return false;
+  for (const entry of entries) {
+    if (entry.line === undefined) return true;
+    if (entry.line === line) return true;
+  }
+  return false;
+}
+
+// =============================================================================
+// File collection
+// =============================================================================
+
+interface FoundFile {
+  abs: string;
+  rel: string;
+}
+
+function collectFiles(dir: string, acc: FoundFile[] = []): FoundFile[] {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      collectFiles(abs, acc);
+      continue;
+    }
+    if (!SOURCE_EXTS.has(extname(entry.name))) continue;
+    acc.push({ abs, rel: relative(REPO_ROOT, abs).split('\\').join('/') });
+  }
+  return acc;
+}
+
+function includesAnyPathSegment(path: string, segments: readonly string[]): boolean {
+  return segments.some((seg) => path.includes(seg));
+}
+
+// =============================================================================
+// AST rule
+// =============================================================================
+
+export interface AsNeverValuesHit {
+  line: number;
+}
+
+/**
+ * Walk a source file's AST for `<expr>.values(...)` calls whose argument
+ * (or an element of an array-literal argument) is `as never`.
+ */
+export function findAsNeverValuesCalls(sourceText: string, fileName: string): AsNeverValuesHit[] {
+  const sourceFile = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+  const hits: AsNeverValuesHit[] = [];
+
+  function isAsNever(node: ts.Node): boolean {
+    return ts.isAsExpression(node) && node.type.kind === ts.SyntaxKind.NeverKeyword;
+  }
+
+  function argHasAsNever(arg: ts.Expression): boolean {
+    if (isAsNever(arg)) return true;
+    if (ts.isArrayLiteralExpression(arg)) {
+      return arg.elements.some((el) => isAsNever(el));
+    }
+    return false;
+  }
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'values' &&
+      node.arguments.some(argHasAsNever)
+    ) {
+      const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      hits.push({ line: line + 1 });
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return hits;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+const Sep = '='.repeat(72);
+
+function main(): void {
+  out(Sep);
+  out('`as never` on drizzle .values() — CI validator');
+  out(Sep);
+
+  const allow = loadAllowlist();
+  out(`Allowlist entries: ${[...allow.byPath.values()].reduce((n, v) => n + v.length, 0)}`);
+
+  const files: FoundFile[] = [];
+  for (const root of SCAN_ROOTS) {
+    const abs = join(REPO_ROOT, root);
+    if (!existsSync(abs)) continue;
+    if (!statSync(abs).isDirectory()) continue;
+    collectFiles(abs, files);
+  }
+
+  out(`Scanning ${files.length} source files...`);
+  out('\n→ as-never-on-values-call');
+
+  const violations: string[] = [];
+  for (const file of files) {
+    if (includesAnyPathSegment(file.rel, EXCLUDED_PATH_SEGMENTS)) continue;
+    const content = readFileSync(file.abs, 'utf8');
+    for (const hit of findAsNeverValuesCalls(content, file.abs)) {
+      if (isAllowlisted(allow, file.rel, hit.line)) continue;
+      violations.push(
+        `  ${file.rel}:${hit.line}  \`as never\` on a .values() call — this is the exact ` +
+          'mechanism that let a wrong-shaped drizzle insert/update pass typecheck ' +
+          'silently. Fix the value shape or add an allowlist entry with a reason.',
+      );
+    }
+  }
+
+  if (violations.length === 0) {
+    out('  ✓ clean');
+  } else {
+    for (const v of violations) console.log(v);
+  }
+
+  out(`\n${Sep}`);
+  if (violations.length === 0) {
+    out('Result: PASS (0 violations)');
+    out(Sep);
+    process.exit(0);
+  }
+  out(`Result: FAIL (${violations.length} new violation${violations.length === 1 ? '' : 's'})`);
+  out('');
+  out('  Fix options:');
+  out('    1. Fix the value shape so it matches the real column set (preferred).');
+  out('    2. Add an entry to scripts/validate/as-never-values-allowlist.json');
+  out('       with the file path (and optionally a line number) plus a reason.');
+  out(Sep);
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/validate/as-never-values.ts
+++ b/scripts/validate/as-never-values.ts
@@ -171,21 +171,84 @@ export interface AsNeverValuesHit {
 }
 
 /**
- * Walk a source file's AST for `<expr>.values(...)` calls whose argument
- * (or an element of an array-literal argument) is `as never`.
+ * Walk a source file's AST for `<expr>.values(...)` calls whose argument is
+ * `as never` (or `<never>expr`), including through one level of
+ * parentheses, an array-literal element, a conditional (ternary) branch, or
+ * a hoisted local variable's own declaration.
+ *
+ * This is a SYNTACTIC check with no type-checker/Program construction (same
+ * trade-off `doc-currency.ts`'s literal-extraction walk already accepts), so
+ * it is a speed bump against the SPECIFIC pattern that shipped two broken
+ * audit_log writers — not a comprehensive guarantee. It catches the direct
+ * cast, `as unknown as never`, an array element, a ternary branch, and a
+ * SINGLE hop through a local `const`/`let` declaration (the single most
+ * natural way to write this — hoisting the cast object to a variable before
+ * passing it). It does NOT catch: a value threaded through more than one
+ * variable, a spread of an array assembled/cast elsewhere, or `as any`
+ * (a different, broader pattern this check does not attempt to police). The
+ * variable lookup is also NOT scope-aware — it matches by name across the
+ * whole file, so it can misidentify which declaration feeds a given call in
+ * a large or shadowed-name file. See scripts/validate/__tests__/as-never-values.test.ts
+ * for the exact set of variants this does and does not catch.
  */
 export function findAsNeverValuesCalls(sourceText: string, fileName: string): AsNeverValuesHit[] {
   const sourceFile = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
   const hits: AsNeverValuesHit[] = [];
 
-  function isAsNever(node: ts.Node): boolean {
-    return ts.isAsExpression(node) && node.type.kind === ts.SyntaxKind.NeverKeyword;
+  // Best-effort, whole-file, name-based index of `const`/`let` declarations
+  // with an initializer — used only to follow the single most common
+  // bypass (hoisting the cast to a variable) one hop back to its
+  // declaration. Not scope-aware; last declaration with a given name wins.
+  const declarationsByName = new Map<string, ts.Expression>();
+  function indexDeclarations(node: ts.Node): void {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      declarationsByName.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, indexDeclarations);
+  }
+  indexDeclarations(sourceFile);
+
+  function unwrapParens(node: ts.Expression): ts.Expression {
+    let current = node;
+    while (ts.isParenthesizedExpression(current)) {
+      current = current.expression;
+    }
+    return current;
+  }
+
+  function isAsNever(node: ts.Expression): boolean {
+    const unwrapped = unwrapParens(node);
+    if (ts.isAsExpression(unwrapped)) {
+      return unwrapped.type.kind === ts.SyntaxKind.NeverKeyword;
+    }
+    // Angle-bracket cast syntax: `<never>expr`.
+    if (ts.isTypeAssertionExpression(unwrapped)) {
+      return unwrapped.type.kind === ts.SyntaxKind.NeverKeyword;
+    }
+    return false;
+  }
+
+  function exprHasAsNever(expr: ts.Expression, hops: number): boolean {
+    const unwrapped = unwrapParens(expr);
+    if (isAsNever(unwrapped)) return true;
+    if (ts.isConditionalExpression(unwrapped)) {
+      return exprHasAsNever(unwrapped.whenTrue, hops) || exprHasAsNever(unwrapped.whenFalse, hops);
+    }
+    // Follow a SINGLE hop through a local variable's own declaration —
+    // the "hoist to a variable" bypass. Bounded to one hop so this can't
+    // loop on a cyclic/self-referential name index.
+    if (hops > 0 && ts.isIdentifier(unwrapped)) {
+      const declared = declarationsByName.get(unwrapped.text);
+      if (declared) return exprHasAsNever(declared, hops - 1);
+    }
+    return false;
   }
 
   function argHasAsNever(arg: ts.Expression): boolean {
-    if (isAsNever(arg)) return true;
-    if (ts.isArrayLiteralExpression(arg)) {
-      return arg.elements.some((el) => isAsNever(el));
+    if (exprHasAsNever(arg, 1)) return true;
+    const unwrapped = unwrapParens(arg);
+    if (ts.isArrayLiteralExpression(unwrapped)) {
+      return unwrapped.elements.some((el) => exprHasAsNever(el, 1));
     }
     return false;
   }


### PR DESCRIPTION
## Summary

Stage 0 of the approved audit-remediation design. Fixes NO behavior — makes audit write failures impossible to miss, and writes red-first tests that prove today's bugs, so Stage 1's fixes are independently verifiable.

**Updated twice after independent adversarial review** ([first verdict](https://github.com/RevealUIStudio/revealui/pull/1867#issuecomment-4949994129), [my response](https://github.com/RevealUIStudio/revealui/pull/1867#issuecomment-4950054305)). See "Response to review" below for the full history.

**Part 1 — Red-first tests, all four now CHARACTERIZATION tests (real migrated PGlite schema, not the existing `vi.fn()` mock):**

Every one of the four tests below is a characterization test: it pins an exact, falsifiable fact about TODAY's actual (broken) behavior — a Postgres error code + a named constraint, an exact row count, a byte-level canonical-form mismatch, or a specific chained-signature identity — and **all four currently PASS, with zero `it.fails()` anywhere.** `pnpm vitest run packages/db` and `pnpm --filter server test` (the real CI commands) are both fully green.

- `packages/db/src/__tests__/audit-store.integration.test.ts` — a harness-sanity test (a valid insert must persist), then an explicit assertion that the `audit_log` CHECK constraint rejects `@revealui/security`'s severity vocabulary (`low`/`medium`/`high`) with Postgres `code: '23514'` and `constraint: 'audit_log_severity_check'`.
- `apps/server/src/lib/__tests__/postgres-audit-storage.pglite.test.ts` — a harness-sanity test, then: (a) each of the three middleware severities fails with that same specific cause and 0 rows land; (b) the jsonb payload/signature round-trip breaks specifically because Postgres reorders jsonb object keys (asserted by comparing canonical `JSON.stringify` forms of the round-tripped vs. original payload, after confirming every other signed field round-trips identically); (c) **DEFECT: the chain head advances on a rejected insert** — after a valid→rejected→valid sequence, the second valid row's `previousSignature` is asserted to NOT equal the first valid row's signature, and IS asserted (via `verifyAuditSignature`, since the rejected write's signature was never persisted anywhere to read back) to be exactly the signature that would have been computed for the rejected, never-persisted event.

Why characterization, not "assert the fix and let it fail red": `pnpm --filter server test` is the actual CI `Unit Tests` job every other PR in this repo shares. A test that asserts the desired-but-not-yet-true behavior would leave that job permanently red until Stage 1 lands, which is not an acceptance criterion, it's a broken shared build. Stage 1 fixing each underlying bug makes its pinned assertion FALSE — at that point the specific test fails, forcing Stage 1's author to consciously rewrite it to the new correct behavior. That failure-on-fix is the acceptance-criteria mechanism; a red test on a shared branch today is not.

**Part 2 — Make failure loud:**
- `AuditSystem.log()` now returns the full event and throws `AuditWriteError` (event + cause) on a failed write.
- New `packages/security/src/audit-write-failures.ts`: classifies failures (`constraint_violation` / `missing_secret` / `schema_mismatch` / `db_error`) and tracks a failure ratio over a rolling window of the last 500 attempts, escalating to `logger.error` past 1%. Counts SILENTLY — no per-attempt or per-failure log line; every call site already owns its own event-level logging at its own cadence (e.g. `middleware/audit.ts`'s existing 1-in-10 throttle).
- Fixed five silent catches: `middleware/audit.ts`, `api-keys.ts`, `a2a.ts`, admin's setup route, `scripts/admin/bootstrap.ts`, and a fifth found via grep on the same path family, `cron/uptime-check.ts`.
- Removed `PostgresAuditStorage`'s `onConflictDoNothing()` — event ids are fresh `crypto.randomUUID()`s, never idempotency keys, so a duplicate can only mean a bug.
- `validateStartup()` now validates the effective audit HMAC secret at boot (both hosted and forge production modes), duplicating (not replacing) `getAuditSecret()`'s existing per-write defense-in-depth throw.

**Part 3 — the `as never` validator (a speed bump, not a class killer — see below):**
- New CI check `scripts/validate/as-never-values.ts` (TypeScript compiler API, zero authored regex): flags `as never` casting a drizzle `.values()` argument. Wired into `pnpm gate` phase 1 (covered by `gate:quick`).
- Hardened against four of six bypasses an adversarial review demonstrated: parenthesized casts, angle-bracket `<never>` casts, ternary branches, and a single hop through a hoisted local variable (the bypass most likely to occur naturally). Two remain uncaught by design, documented in the function's own doc comment: a spread of a value assembled/cast elsewhere (needs real data-flow analysis) and `as any` (a different, broader pattern this check does not police).
- Repo-wide grep found exactly two genuine instances, both pre-existing, neither fixed here (Stage 1 territory): `apps/admin/src/app/api/setup/route.ts:104` and `scripts/admin/bootstrap.ts:205` — both allowlisted with a reason.

## Response to review (full history)

**Round 1** — independent non-author review ([comment](https://github.com/RevealUIStudio/revealui/pull/1867#issuecomment-4949994129)) returned REQUEST-CHANGES with two blockers:
- **B1** — the four red tests proved nothing specific (`it.fails()` passes on any throw, including a broken harness — demonstrated with a reproducible false-green in an unbuilt workspace). Fixed by dropping `it.fails()` for plain `it()` + specific `expect(...).rejects.toMatchObject({ cause: { code, constraint } })` assertions, harness-sanity tests, and `toBeDefined()` guards.
- **B2** — the new counter logged every failure, defeating `middleware/audit.ts`'s existing 1-in-10 throttle, shipping an ~11x log-volume increase into a path that fails 100% of the time in production today. Fixed: the counter is silent; only the rolling-ratio escalation logs.
- Also fixed: **S1** (ratio was a lifetime cumulative count and could only ever escalate once — now a rolling window that re-arms) and **S3** (the `as never` validator over-claimed "kills the class" — hardened against 4/6 demonstrated bypasses, downgraded the claim to match reality for the other 2).

**Round 2** — after Round 1, the chain-head test asserted the DESIRED correct behavior and genuinely failed today (by design, mirroring what B1's fix pattern implied for the OTHER three tests but not this one). That's wrong for a test inside the actual shared CI `Unit Tests` job: a knowingly-red test there blocks every other PR's test run, not just this one, until Stage 1 lands. Fixed by inverting it to a characterization test like the other three — see Part 1 above. `pnpm vitest run packages/db` and `pnpm --filter server test` are both now fully green with zero `it.fails()`.

Two review suggestions (S2 — the `missing_secret` classification couples to a string literal authored in a different package; S5 — a failed audit write's error message can carry request PII, pre-existing behavior this PR's edited line doesn't change) were not in the fix-now set across either round and are left for the owner to decide whether to fold into this PR or track separately. S4 (the new startup secret-length check) was owner-checked against revvault and cleared.

## Deviations from the literal task spec (and why)

- The task asked for all 4 red-first tests in one file at `packages/db/src/__tests__/audit-store.integration.test.ts`. Split instead: the severity/CHECK-constraint bug (schema-level, owned by packages/db) stayed there; the bugs specific to `PostgresAuditStorage`'s private HMAC-chain state moved to `apps/server/src/lib/__tests__/postgres-audit-storage.pglite.test.ts`, because testing them from packages/db would require packages/db to import apps/server source — an illegal reverse dependency in this monorepo.
- "Prod uses in-memory storage" (from the original task context) is true for the Vercel serverless surface (`apps/server/src/index.ts`'s production branch never calls `audit.setStorage(new PostgresAuditStorage())`), but the Fly worker (`apps/server/src/worker.ts`, the actual long-running production entry) DOES wire Postgres storage unconditionally. Noted for accuracy; doesn't change Stage 0 scope.
- Classifier bug found and fixed during red-proving: drizzle-orm wraps every driver error in a `DrizzleQueryError` whose own `.code` is `undefined` — the real Postgres error (and its `.code`) lives one level down at `.cause`. `classifyAuditWriteFailure` checks both.

## Test results (real numbers, current head)

- `pnpm vitest run packages/db`: 55 files, **1184 passed, 5 skipped, 0 failed**.
- `pnpm --filter server test` (apps/server's own configured command — the actual CI `Unit Tests` job): 156 files, **2893 passed, 0 failed, 1 skipped**.
- **GitHub Actions on this PR head:** `Unit Tests` — pass. `Typecheck` — pass. `Build`, `Integration Tests`, `Integration Tests (extended)`, `Quality`, `Security Gate`, `CodeQL`, `Drizzle Migrations`, `Secret Scanning`, `Dependency Review`, `Submodule Audit` — all pass. `Security review gate` — **fail, expected**: gated on the owner applying `sec-review:approved`, not a code problem.
- `pnpm --filter @revealui/security typecheck`, `pnpm --filter admin typecheck`, `pnpm --filter @revealui/db typecheck`: all clean.
- `pnpm gate:quick`: **PASS** (all phase-1 checks including the `as-never on drizzle .values()` check).
- Full-repo `tsc --noEmit -p tsconfig.json` OOMs/times out in this sandbox regardless of heap size — infeasible to run directly; verified per-package instead (matches how CI's `pnpm -r typecheck` actually gates).

## Not merging

Security-sensitive surface — needs a recorded non-author verdict before merge per the fleet's review-gate convention. Do not merge without `sec-review:approved`. All four Stage-0 tests are green today; Stage 1 should expect specific, individual test failures as it lands each fix, and should treat that failure as its acceptance signal to rewrite the pinned assertion to the new correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
