### PR TITLE
fix(docker): copy every workspace manifest the Forge images actually build

### DIFF
--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -24,6 +24,7 @@ COPY packages/core/package.json          ./packages/core/
 COPY packages/create-revealui/package.json ./packages/create-revealui/
 COPY packages/db/package.json            ./packages/db/
 COPY packages/dev/package.json           ./packages/dev/
+COPY packages/knowledge-graph/package.json ./packages/knowledge-graph/
 COPY packages/mcp/package.json           ./packages/mcp/
 COPY packages/paywall/package.json       ./packages/paywall/
 COPY packages/presentation/package.json  ./packages/presentation/
@@ -34,6 +35,7 @@ COPY packages/services/package.json      ./packages/services/
 COPY packages/setup/package.json         ./packages/setup/
 COPY packages/sync/package.json          ./packages/sync/
 COPY packages/test/package.json          ./packages/test/
+COPY packages/tokens/package.json        ./packages/tokens/
 COPY packages/utils/package.json         ./packages/utils/
 COPY apps/admin/package.json             ./apps/admin/
 

--- a/apps/server/Dockerfile.forge
+++ b/apps/server/Dockerfile.forge
@@ -20,8 +20,10 @@ COPY packages/contracts/package.json  ./packages/contracts/
 COPY packages/core/package.json       ./packages/core/
 COPY packages/db/package.json         ./packages/db/
 COPY packages/dev/package.json        ./packages/dev/
+COPY packages/knowledge-graph/package.json ./packages/knowledge-graph/
 COPY packages/mcp/package.json        ./packages/mcp/
 COPY packages/openapi/package.json    ./packages/openapi/
+COPY packages/paywall/package.json    ./packages/paywall/
 COPY packages/resilience/package.json ./packages/resilience/
 COPY packages/security/package.json   ./packages/security/
 COPY packages/services/package.json   ./packages/services/


### PR DESCRIPTION
## The bug

The Forge image build has been red on `test` all day with:

```
@revealui/paywall:build: sh: tsup: not found
```

This blocks the `test` → `main` promotion, because **"Build migrate" is a required check**.

## Root cause

Both Forge Dockerfiles copy a **hand-maintained list** of `package.json` files into the install stage, then run `pnpm install --filter <app>...`. That list had drifted behind the real dependency graph:

| image | workspace packages in its graph | manifests copied | missing |
|---|---|---|---|
| server | 16 | 14 | `paywall`, `knowledge-graph` |
| admin | 19 | 17 | `knowledge-graph`, `tokens` |

pnpm resolves `--filter` against the manifests **present at install time**. A package whose manifest is absent simply isn't part of the workspace, so its devDependencies (here `tsup`) are never installed. The later `COPY packages ./packages` then drags the package in anyway, and turbo tries to build it with a toolchain that was never installed.

`knowledge-graph` is new — it entered both graphs with the GAP-349 knowledge-graph work that merged today. That's why this went red today and not earlier.

## Verification

Built the previously-failing target locally:

```
docker build -f apps/server/Dockerfile.forge --target migrate .
```

Red before the change (reproduces the CI error exactly), green after — the image builds and exports.

## Note on the class

This is a hand-maintained list that must stay in lockstep with a computed graph, with no check keeping them honest. It will drift again the next time a package joins an app's graph. Worth a follow-up that either generates the COPY list or asserts it against `pnpm ls --filter <app>...` in CI.
