### PR TITLE
feat(server): entitlement-consistency reconciler (GAP-356 PR-2)

### DIFF
--- a/apps/server/src/lib/hosted-entitlement.ts
+++ b/apps/server/src/lib/hosted-entitlement.ts
@@ -1,0 +1,122 @@
+/**
+ * Hosted entitlement value construction — the single source of truth for what
+ * an `account_entitlements` row looks like for a given tier.
+ *
+ * Extracted from `routes/webhooks.ts` (GAP-356 PR-2) so the webhook write path
+ * and the entitlement-consistency reconciler cannot drift apart. Two copies of
+ * the tier→features/limits mapping is exactly the class of bug GAP-356 is: a
+ * heal that grants a *different* feature set than the webhook would have
+ * granted is worse than no heal at all, because it looks correct.
+ *
+ * Pure. No DB, no Stripe, no I/O beyond a warn log on an unknown feature key.
+ */
+
+import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
+import type { LicenseTier } from '@revealui/core/license';
+import { logger } from '@revealui/core/observability/logger';
+import { getHostedLimitsForTier } from './tier-limits.js';
+
+/** Hosted tiers. `free` is not a `LicenseTier` but is a valid entitlement tier. */
+export type HostedTier = 'free' | LicenseTier;
+
+/** Known feature keys from {@link FeatureFlags}. Used to warn on unexpected keys. */
+const KNOWN_FEATURE_KEYS = new Set<string>([
+  'aiLocal',
+  'ai',
+  'aiMemory',
+  'mcp',
+  'payments',
+  'multiTenant',
+  'whiteLabel',
+  'aiInference',
+  'auditLog',
+  'advancedSync',
+  'dashboard',
+  'customDomain',
+  'analytics',
+] satisfies (keyof FeatureFlags)[]);
+
+/**
+ * Tier ordering, low to high. Used by the reconciler's monotonic-upward heal
+ * guard: a heal may raise a tier but must never lower one, because a downgrade
+ * is a real business decision that belongs to the (signature-verified) webhook
+ * path, not to a cron inferring state from local rows.
+ */
+const TIER_RANK: Record<HostedTier, number> = {
+  free: 0,
+  pro: 1,
+  max: 2,
+  enterprise: 3,
+};
+
+export function coerceHostedTier(value: string | null | undefined): HostedTier | undefined {
+  if (value === 'free' || value === 'pro' || value === 'max' || value === 'enterprise') {
+    return value;
+  }
+  return undefined;
+}
+
+/** True when `next` is strictly higher than `current`. Equal tiers are NOT an upgrade. */
+export function isTierUpgrade(current: HostedTier, next: HostedTier): boolean {
+  return TIER_RANK[next] > TIER_RANK[current];
+}
+
+export function toFeatureRecord(features: object | null | undefined): Record<string, boolean> {
+  if (!features) {
+    return {};
+  }
+
+  const entries = Object.entries(features).filter(
+    (entry): entry is [string, boolean] => typeof entry[1] === 'boolean',
+  );
+
+  for (const [key] of entries) {
+    if (!KNOWN_FEATURE_KEYS.has(key)) {
+      logger.warn('Unknown feature key encountered in toFeatureRecord', { key });
+    }
+  }
+
+  return Object.fromEntries(entries);
+}
+
+/**
+ * The `account_entitlements` column values for a tier + status.
+ *
+ * `lastEventAt` is the event-to-event staleness cursor (F2). The reconciler
+ * passes `null` deliberately: a healed row carries no event provenance, so the
+ * very next webhook — whatever its `event.created` — must win over it. A healed
+ * row must never be able to make a real event look stale.
+ */
+export function buildHostedEntitlementValues(params: {
+  tier: HostedTier;
+  status: string;
+  mode: 'live' | 'test';
+  graceUntil?: Date | null;
+  lastEventAt: Date | null;
+  now: Date;
+}): {
+  planId: HostedTier;
+  tier: HostedTier;
+  status: string;
+  features: Record<string, boolean>;
+  limits: ReturnType<typeof getHostedLimitsForTier>;
+  meteringStatus: string;
+  mode: 'live' | 'test';
+  graceUntil: Date | null;
+  lastEventAt: Date | null;
+  updatedAt: Date;
+} {
+  return {
+    planId: params.tier,
+    tier: params.tier,
+    status: params.status,
+    features: toFeatureRecord(getFeaturesForTier(params.tier)),
+    limits: getHostedLimitsForTier(params.tier),
+    meteringStatus:
+      params.status === 'active' || params.status === 'trialing' ? 'active' : 'paused',
+    mode: params.mode,
+    graceUntil: params.graceUntil ?? null,
+    lastEventAt: params.lastEventAt,
+    updatedAt: params.now,
+  };
+}

--- a/apps/server/src/routes/cron/__tests__/reconcile-entitlements.pglite.test.ts
+++ b/apps/server/src/routes/cron/__tests__/reconcile-entitlements.pglite.test.ts
@@ -1,0 +1,242 @@
+/**
+ * GAP-356 F5 test 4 — the entitlement-consistency reconciler (PR-2).
+ *
+ * PGlite (in-memory Postgres) + real Drizzle + the REAL migrations, driving the
+ * actual cron route. The defect this cron exists to catch lives in cross-table
+ * state, so a DB-mocked unit test cannot see it — the same reason the original
+ * GAP-356 defect escaped every existing test.
+ *
+ * Proves:
+ *   1. license=pro + subscription=trialing + entitlement MISSING  → healed to pro.
+ *   2. entitlement=free + no healthy subscription and no license   → NO heal.
+ *   3. heal is tier-monotonic UPWARD — an existing higher tier is never lowered.
+ *   4. the drift alert row is idempotent across repeated cron runs.
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  seedTestUser,
+  type TestDb,
+} from '../../../../../../packages/test/src/utils/drizzle-test-db.js';
+
+// ─── Mocks (before imports) ─────────────────────────────────────────────────
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db', () => ({
+  getClient: () => testDb.drizzle,
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: vi.fn(() => ({ ai: true, payments: true })),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../../lib/cron-alerts.js', () => ({
+  sendCronFailureAlert: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ─── Imports (after mocks) ──────────────────────────────────────────────────
+
+import {
+  accountEntitlements,
+  accountMemberships,
+  accountSubscriptions,
+  accounts,
+  licenses,
+  unreconciledWebhooks,
+} from '@revealui/db/schema';
+import reconcileEntitlementsRoute from '../reconcile-entitlements.js';
+
+const CRON_SECRET = 'test-cron-secret';
+
+async function runCron(): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await reconcileEntitlementsRoute.request('/reconcile-entitlements', {
+    method: 'POST',
+    headers: { 'X-Cron-Secret': CRON_SECRET },
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+/** Seed an account with one active member. Returns ids. */
+async function seedAccount(): Promise<{ accountId: string; userId: string }> {
+  const { randomUUID } = await import('node:crypto');
+  const user = await seedTestUser(testDb.drizzle);
+  const accountId = randomUUID();
+
+  await testDb.drizzle.insert(accounts).values({
+    id: accountId,
+    name: 'Acme',
+    slug: `acme-${accountId.slice(0, 8)}`,
+    status: 'active',
+  });
+  await testDb.drizzle.insert(accountMemberships).values({
+    id: randomUUID(),
+    accountId,
+    userId: user.id,
+    role: 'owner',
+    status: 'active',
+  });
+
+  return { accountId, userId: user.id };
+}
+
+async function seedSubscription(accountId: string, planId: string, status: string): Promise<void> {
+  const { randomUUID } = await import('node:crypto');
+  await testDb.drizzle.insert(accountSubscriptions).values({
+    id: randomUUID(),
+    accountId,
+    stripeCustomerId: `cus_${accountId.slice(0, 8)}`,
+    stripeSubscriptionId: `sub_${accountId.slice(0, 8)}`,
+    planId,
+    status,
+    mode: 'test',
+  });
+}
+
+async function seedLicense(userId: string, tier: string): Promise<void> {
+  const { randomUUID } = await import('node:crypto');
+  await testDb.drizzle.insert(licenses).values({
+    id: randomUUID(),
+    userId,
+    licenseKey: `key-${randomUUID()}`,
+    tier,
+    customerId: `cus_${userId.slice(0, 8)}`,
+    status: 'active',
+  });
+}
+
+async function getEntitlement(accountId: string) {
+  const [row] = await testDb.drizzle
+    .select()
+    .from(accountEntitlements)
+    .where(eq(accountEntitlements.accountId, accountId))
+    .limit(1);
+  return row;
+}
+
+describe('cron: reconcile-entitlements (GAP-356 F4)', () => {
+  beforeAll(async () => {
+    testDb = await createTestDb();
+    process.env.REVEALUI_CRON_SECRET = CRON_SECRET;
+  });
+
+  afterAll(async () => {
+    await testDb.close();
+  });
+
+  beforeEach(async () => {
+    // Order matters: children before parents (FKs).
+    await testDb.drizzle.delete(unreconciledWebhooks);
+    await testDb.drizzle.delete(accountEntitlements);
+    await testDb.drizzle.delete(accountSubscriptions);
+    await testDb.drizzle.delete(licenses);
+    await testDb.drizzle.delete(accountMemberships);
+    await testDb.drizzle.delete(accounts);
+    process.env.RECONCILE_ENTITLEMENTS_HEAL = 'true';
+  });
+
+  it('rejects a request without the cron secret', async () => {
+    const res = await reconcileEntitlementsRoute.request('/reconcile-entitlements', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('heals a missing entitlement from the local subscription row (license=pro, subscription=trialing)', async () => {
+    const { accountId, userId } = await seedAccount();
+    await seedSubscription(accountId, 'pro', 'trialing');
+    await seedLicense(userId, 'pro');
+
+    // Precondition: the exact production incident — paying/trialing, no entitlement.
+    expect(await getEntitlement(accountId)).toBeUndefined();
+
+    const { status, body } = await runCron();
+    expect(status).toBe(200);
+    expect(body.healed).toBe(1);
+
+    const ent = await getEntitlement(accountId);
+    expect(ent).toBeDefined();
+    expect(ent?.tier).toBe('pro');
+    expect(ent?.planId).toBe('pro');
+    // Status is carried from the local subscription row — the trial signal survives.
+    expect(ent?.status).toBe('trialing');
+    expect(ent?.meteringStatus).toBe('active');
+    // NULL by design: the next webhook must always win over a healed row.
+    expect(ent?.lastEventAt).toBeNull();
+  });
+
+  it('does NOT heal when there is no entitlement source (entitlement=free, no healthy subscription, no license)', async () => {
+    const { accountId } = await seedAccount();
+    // Canceled subscription is not a healthy source.
+    await seedSubscription(accountId, 'pro', 'canceled');
+    await testDb.drizzle.insert(accountEntitlements).values({
+      accountId,
+      planId: 'free',
+      tier: 'free',
+      status: 'active',
+    });
+
+    const { body } = await runCron();
+    expect(body.healed).toBe(0);
+    expect(body.drift).toBe(0);
+
+    const ent = await getEntitlement(accountId);
+    expect(ent?.tier).toBe('free');
+
+    // And it must not have invented a drift alert.
+    const alerts = await testDb.drizzle.select().from(unreconciledWebhooks);
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('never downgrades: an existing higher tier survives a lower-tier subscription', async () => {
+    const { accountId } = await seedAccount();
+    await seedSubscription(accountId, 'pro', 'trialing');
+    await testDb.drizzle.insert(accountEntitlements).values({
+      accountId,
+      planId: 'max',
+      tier: 'max',
+      status: 'active',
+    });
+
+    const { body } = await runCron();
+    expect(body.healed).toBe(0);
+
+    const ent = await getEntitlement(accountId);
+    expect(ent?.tier).toBe('max');
+    expect(ent?.status).toBe('active');
+  });
+
+  it('writes an idempotent drift alert — a standing drift does not re-alert every tick', async () => {
+    // License-only drift: a real entitlement source, but no local subscription
+    // row to safely synthesize from. Alerts, cannot heal — so the drift stands
+    // across runs and the idempotency of the alert row is what is under test.
+    const { accountId, userId } = await seedAccount();
+    await seedLicense(userId, 'pro');
+
+    const first = await runCron();
+    expect(first.body.drift).toBe(1);
+    expect(first.body.alerted).toBe(1);
+    expect(first.body.healed).toBe(0);
+
+    const second = await runCron();
+    expect(second.body.drift).toBe(1);
+    // Still drifting, but NOT re-alerted — the synthetic event_id collides.
+    expect(second.body.alerted).toBe(0);
+
+    const alerts = await testDb.drizzle
+      .select()
+      .from(unreconciledWebhooks)
+      .where(eq(unreconciledWebhooks.eventId, `cron-entitlement-drift:${accountId}`));
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.eventType).toBe('entitlement.drift');
+
+    // No entitlement was synthesized from a license alone.
+    expect(await getEntitlement(accountId)).toBeUndefined();
+  });
+});

--- a/apps/server/src/routes/cron/dispatch.ts
+++ b/apps/server/src/routes/cron/dispatch.ts
@@ -25,6 +25,7 @@ import lifecycleEmailsApp from './lifecycle-emails.js';
 import marketplacePayoutsApp from './marketplace-payouts.js';
 import publishScheduledApp from './publish-scheduled.js';
 import reconcileCustomersApp from './reconcile-customers.js';
+import reconcileEntitlementsApp from './reconcile-entitlements.js';
 import reconcileStripeSubscriptionsApp from './reconcile-stripe-subscriptions.js';
 import reconcileSubscriptionsApp from './reconcile-subscriptions.js';
 import sweepGracePeriodsApp from './sweep-grace-periods.js';
@@ -71,6 +72,17 @@ const JOBS = [
     name: 'reconcile-stripe-subscriptions',
     app: reconcileStripeSubscriptionsApp,
     path: '/reconcile-stripe-subscriptions',
+  },
+  // reconcile-entitlements (GAP-356 F4) runs AFTER the subscription reconcilers
+  // so it evaluates the freshest local subscription rows, and BEFORE
+  // sweep-grace-periods, which acts on entitlement state. It checks the one
+  // invariant none of the crons above covered: a healthy subscription or an
+  // active license MUST have a matching `account_entitlements` row. Alerts on
+  // drift and heals upward from the local subscription row.
+  {
+    name: 'reconcile-entitlements',
+    app: reconcileEntitlementsApp,
+    path: '/reconcile-entitlements',
   },
   { name: 'billing-readiness', app: billingReadinessApp, path: '/billing-readiness' },
   { name: 'publish-scheduled', app: publishScheduledApp, path: '/publish-scheduled' },

--- a/apps/server/src/routes/cron/reconcile-entitlements.ts
+++ b/apps/server/src/routes/cron/reconcile-entitlements.ts
@@ -1,0 +1,410 @@
+/**
+ * Cron: Reconcile Account Entitlements (GAP-356 F4 — the missing detector + healer)
+ *
+ * The invariant, checked per account with at least one active membership:
+ *
+ *   IF `account_subscriptions` has a healthy row (`active`/`trialing`)
+ *   OR a member holds a non-deleted `active` license
+ *   THEN `account_entitlements` MUST exist with the matching tier.
+ *
+ * When it does not, a paying customer is silently gated as free. That is the
+ * GAP-356 production incident: a real Pro trial resolved to `free` forever
+ * because the entitlement write never landed, and nothing in the fleet noticed.
+ * Every existing reconcile cron walks subscriptions; none checked entitlements,
+ * so the defect was invisible to all of them.
+ *
+ * On violation:
+ *   (a) ALERT — an idempotent `unreconciledWebhooks` row (`event_type:
+ *       'entitlement.drift'`, synthetic `event_id` so re-runs collide).
+ *   (b) HEAL — synthesize the entitlement FROM THE LOCAL SUBSCRIPTION ROW ONLY.
+ *
+ * Why local-only: the local subscription row was written by a signature-verified
+ * Stripe webhook. Healing from it adds no new trust. Healing from a raw Stripe
+ * read would widen the attack surface to anyone who can create Stripe objects —
+ * which is exactly why `reconcile-stripe-subscriptions` stayed alert-only.
+ *
+ * Heal safety rails:
+ *   - **Tier-monotonic UPWARD only.** A heal may raise a tier, never lower one.
+ *     Downgrades are a business decision and stay webhook-driven.
+ *   - **Never resurrects a terminal entitlement.** If the existing row is
+ *     `revoked`/`expired`/`canceled`, we alert but do NOT heal. Healing it would
+ *     re-grant access to an account someone deliberately cut off, which is the
+ *     resurrection vector the WH-3 staleness guard exists to prevent. A stale
+ *     local subscription row must never be able to undo a revocation.
+ *   - **`last_event_at` is written NULL on healed rows**, so the very next
+ *     webhook — whatever its `event.created` — wins over the heal. A healed row
+ *     can never make a real event look stale.
+ *   - Heal is gated by `RECONCILE_ENTITLEMENTS_HEAL` (default ON). Set it to
+ *     'false' to run detector-only.
+ *
+ * Protected by X-Cron-Secret (timing-safe compare), same gate as the sibling
+ * reconciliation crons.
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import {
+  accountEntitlements,
+  accountMemberships,
+  accountSubscriptions,
+  licenses,
+  unreconciledWebhooks,
+} from '@revealui/db/schema';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
+import {
+  buildHostedEntitlementValues,
+  coerceHostedTier,
+  type HostedTier,
+  isTierUpgrade,
+} from '../../lib/hosted-entitlement.js';
+
+const app = new Hono();
+
+const DEFAULT_BATCH_SIZE = 500;
+const MAX_BATCH_SIZE = 2000;
+const DRIFT_EVENT_TYPE = 'entitlement.drift';
+
+/** Subscription statuses that entitle the account to access. */
+const HEALTHY_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing']);
+
+/**
+ * Entitlement statuses that must NOT be healed back to life. A row in one of
+ * these states was deliberately cut off; a cron inferring from a possibly-stale
+ * local subscription row has no business re-granting it.
+ */
+const TERMINAL_ENTITLEMENT_STATUSES = new Set(['revoked', 'expired', 'canceled']);
+
+type Outcome =
+  | 'ok'
+  | 'no-entitlement-source'
+  | 'drift-healed'
+  | 'drift-alert-only-no-subscription'
+  | 'drift-alert-only-unresolvable-tier'
+  | 'drift-alert-only-terminal'
+  | 'drift-alert-only-heal-disabled';
+
+interface AccountScanResult {
+  accountId: string;
+  outcome: Outcome;
+  expectedTier?: HostedTier;
+  actualTier?: HostedTier | null;
+}
+
+app.post('/reconcile-entitlements', async (c) => {
+  // ── auth gate (mirrors the sibling reconcile crons) ───────────────────
+  const cronSecret = process.env.REVEALUI_CRON_SECRET;
+  const provided = c.req.header('X-Cron-Secret') || c.req.header('x-cron-secret');
+
+  if (!(cronSecret && provided)) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+  try {
+    const a = Buffer.from(provided);
+    const b = Buffer.from(cronSecret);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+  } catch {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  const batchSize = Math.min(
+    Number.parseInt(process.env.RECONCILE_ENTITLEMENTS_BATCH_SIZE ?? '', 10) || DEFAULT_BATCH_SIZE,
+    MAX_BATCH_SIZE,
+  );
+  // Default ON. Only an explicit 'false' disables healing.
+  const healEnabled = (process.env.RECONCILE_ENTITLEMENTS_HEAL ?? 'true').toLowerCase() !== 'false';
+
+  const db = getClient();
+  const startedAt = Date.now();
+
+  // ── accounts with at least one active membership ──────────────────────
+  const activeAccounts = await db
+    .selectDistinct({ accountId: accountMemberships.accountId })
+    .from(accountMemberships)
+    .where(eq(accountMemberships.status, 'active'))
+    .limit(batchSize);
+
+  const results: AccountScanResult[] = [];
+  let driftCount = 0;
+  let healedCount = 0;
+  let alertedCount = 0;
+
+  for (const { accountId } of activeAccounts) {
+    // ── the entitlement SOURCES: a healthy local subscription, or an active
+    //    license held by an active member ───────────────────────────────
+    const [subscription] = await db
+      .select({
+        planId: accountSubscriptions.planId,
+        status: accountSubscriptions.status,
+        mode: accountSubscriptions.mode,
+        stripeCustomerId: accountSubscriptions.stripeCustomerId,
+        stripeSubscriptionId: accountSubscriptions.stripeSubscriptionId,
+      })
+      .from(accountSubscriptions)
+      .where(eq(accountSubscriptions.accountId, accountId))
+      .limit(1);
+
+    const healthySubscription =
+      subscription && HEALTHY_SUBSCRIPTION_STATUSES.has(subscription.status)
+        ? subscription
+        : undefined;
+
+    const memberIds = await db
+      .select({ userId: accountMemberships.userId })
+      .from(accountMemberships)
+      .where(
+        and(eq(accountMemberships.accountId, accountId), eq(accountMemberships.status, 'active')),
+      );
+
+    let hasActiveLicense = false;
+    if (memberIds.length > 0) {
+      const held = await db
+        .select({ id: licenses.id })
+        .from(licenses)
+        .where(
+          and(
+            inArray(
+              licenses.userId,
+              memberIds.map((m) => m.userId),
+            ),
+            eq(licenses.status, 'active'),
+            isNull(licenses.deletedAt),
+          ),
+        )
+        .limit(1);
+      hasActiveLicense = held.length > 0;
+    }
+
+    // No entitlement source at all → the account is legitimately free.
+    // This is the "entitlements=free + no healthy subscription/license" case:
+    // NOT drift, and explicitly NOT healed.
+    if (!(healthySubscription || hasActiveLicense)) {
+      results.push({ accountId, outcome: 'no-entitlement-source' });
+      continue;
+    }
+
+    // ── the expected tier comes ONLY from the local subscription row ─────
+    const expectedTier = coerceHostedTier(healthySubscription?.planId);
+
+    const [entitlement] = await db
+      .select({
+        accountId: accountEntitlements.accountId,
+        tier: accountEntitlements.tier,
+        status: accountEntitlements.status,
+      })
+      .from(accountEntitlements)
+      .where(eq(accountEntitlements.accountId, accountId))
+      .limit(1);
+
+    const actualTier = coerceHostedTier(entitlement?.tier) ?? null;
+
+    // ── is the invariant satisfied? ───────────────────────────────────────
+    // Satisfied when an entitlement row exists AND (we have no expected tier to
+    // compare against, OR the row is already at least the expected tier).
+    const missing = !entitlement;
+    const belowExpected =
+      !missing && expectedTier !== undefined && actualTier !== null
+        ? isTierUpgrade(actualTier, expectedTier)
+        : false;
+
+    if (!(missing || belowExpected)) {
+      results.push({ accountId, outcome: 'ok', expectedTier, actualTier });
+      continue;
+    }
+
+    // ── DRIFT ─────────────────────────────────────────────────────────────
+    driftCount += 1;
+
+    const alerted = await recordDrift(db, {
+      accountId,
+      expectedTier,
+      actualTier,
+      customerId: healthySubscription?.stripeCustomerId ?? null,
+      subscriptionId: healthySubscription?.stripeSubscriptionId ?? null,
+      hasActiveLicense,
+    });
+    if (alerted) {
+      alertedCount += 1;
+    }
+
+    // ── can we heal? ──────────────────────────────────────────────────────
+    if (!healEnabled) {
+      results.push({
+        accountId,
+        outcome: 'drift-alert-only-heal-disabled',
+        expectedTier,
+        actualTier,
+      });
+      continue;
+    }
+
+    // Heal source is the LOCAL SUBSCRIPTION ROW ONLY. A license-only account
+    // (no healthy subscription row) has nothing safe to synthesize from.
+    if (!healthySubscription) {
+      results.push({
+        accountId,
+        outcome: 'drift-alert-only-no-subscription',
+        expectedTier,
+        actualTier,
+      });
+      continue;
+    }
+
+    // Refuse to write a tier we cannot resolve — the F3 "never write from
+    // ignorance" rule applies to the healer exactly as it does to the webhook.
+    if (expectedTier === undefined) {
+      results.push({
+        accountId,
+        outcome: 'drift-alert-only-unresolvable-tier',
+        expectedTier,
+        actualTier,
+      });
+      continue;
+    }
+
+    // Never resurrect a deliberately terminated entitlement.
+    if (entitlement && TERMINAL_ENTITLEMENT_STATUSES.has(entitlement.status)) {
+      logger.warn(
+        '[reconcile-entitlements] drift on a terminal entitlement — alerting without healing (refusing to resurrect a revoked/expired/canceled row)',
+        { accountId, entitlementStatus: entitlement.status, expectedTier },
+      );
+      results.push({ accountId, outcome: 'drift-alert-only-terminal', expectedTier, actualTier });
+      continue;
+    }
+
+    const now = new Date();
+    const values = buildHostedEntitlementValues({
+      tier: expectedTier,
+      status: healthySubscription.status,
+      mode: healthySubscription.mode === 'test' ? 'test' : 'live',
+      graceUntil: null,
+      // NULL by design: the next webhook must always win over a healed row.
+      lastEventAt: null,
+      now,
+    });
+
+    if (entitlement) {
+      await db
+        .update(accountEntitlements)
+        .set(values)
+        .where(eq(accountEntitlements.accountId, accountId));
+    } else {
+      await db
+        .insert(accountEntitlements)
+        .values({ accountId, ...values })
+        .onConflictDoNothing();
+    }
+
+    healedCount += 1;
+    logger.error(
+      `[reconcile-entitlements] HEALED entitlement drift for account ${accountId}`,
+      undefined,
+      { accountId, expectedTier, actualTier, status: healthySubscription.status },
+    );
+    results.push({ accountId, outcome: 'drift-healed', expectedTier, actualTier });
+  }
+
+  if (driftCount > 0) {
+    void sendCronFailureAlert({
+      jobName: 'reconcile-entitlements',
+      error: new Error(
+        `CRITICAL: ${driftCount} account(s) with entitlement drift — paying customers may be gated as free`,
+      ),
+      severity: 'error',
+      metadata: { drift: driftCount, healed: healedCount, alerted: alertedCount },
+    });
+  }
+
+  return c.json(
+    {
+      scanned: activeAccounts.length,
+      drift: driftCount,
+      healed: healedCount,
+      alerted: alertedCount,
+      healEnabled,
+      durationMs: Date.now() - startedAt,
+      results,
+    },
+    200,
+  );
+});
+
+/**
+ * Idempotent drift alert. The synthetic event_id collides on re-runs, so a
+ * standing drift does not spam a new row every tick.
+ *
+ * Returns true when a NEW alert row was written.
+ */
+async function recordDrift(
+  db: ReturnType<typeof getClient>,
+  params: {
+    accountId: string;
+    expectedTier: HostedTier | undefined;
+    actualTier: HostedTier | null;
+    customerId: string | null;
+    subscriptionId: string | null;
+    hasActiveLicense: boolean;
+  },
+): Promise<boolean> {
+  const syntheticEventId = `cron-entitlement-drift:${params.accountId}`;
+
+  const existing = await db
+    .select({ eventId: unreconciledWebhooks.eventId })
+    .from(unreconciledWebhooks)
+    .where(eq(unreconciledWebhooks.eventId, syntheticEventId))
+    .limit(1);
+
+  if (existing.length > 0) {
+    return false;
+  }
+
+  const errorTrace = [
+    `Entitlement drift for account ${params.accountId}:`,
+    `expected tier ${params.expectedTier ?? 'unresolvable'},`,
+    `actual ${params.actualTier ?? 'NO ENTITLEMENT ROW'}.`,
+    params.hasActiveLicense ? 'An active license is held by a member.' : '',
+    'A paying customer is being gated below what they bought.',
+    'Remedy: the reconciler heals from the local subscription row when it can;',
+    'if it could not, resend the checkout.session.completed event from Stripe.',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  try {
+    await db
+      .insert(unreconciledWebhooks)
+      .values({
+        eventId: syntheticEventId,
+        eventType: DRIFT_EVENT_TYPE,
+        customerId: params.customerId,
+        stripeObjectId: params.subscriptionId,
+        objectType: 'subscription',
+        errorTrace,
+      })
+      .onConflictDoNothing();
+    logger.error(
+      `[reconcile-entitlements] CRITICAL: entitlement drift for account ${params.accountId}`,
+      undefined,
+      {
+        accountId: params.accountId,
+        expectedTier: params.expectedTier,
+        actualTier: params.actualTier,
+      },
+    );
+    return true;
+  } catch (err) {
+    // Two ticks can race on the same synthetic id; the loser is fine — the row
+    // is the goal, not who wrote it.
+    logger.warn(
+      `[reconcile-entitlements] drift alert insert raced for ${params.accountId} — treating as already-tracked`,
+      { detail: err instanceof Error ? err.message : String(err) },
+    );
+    return false;
+  }
+}
+
+export default app;

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -10,8 +10,7 @@
  */
 
 import { RELEVANT_STRIPE_WEBHOOK_EVENTS } from '@revealui/contracts';
-import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
-import { generateLicenseKey, type LicenseTier, resetLicenseState } from '@revealui/core/license';
+import { generateLicenseKey, resetLicenseState } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
 import { DrizzleAuditStore, executeSaga, getClient } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
@@ -32,6 +31,11 @@ import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, desc, eq, isNull, lt, or, sql } from 'drizzle-orm';
 import type Stripe from 'stripe';
 import { capResourcesOnDowngrade, isDowngrade } from '../lib/downgrade-cap.js';
+import {
+  buildHostedEntitlementValues,
+  coerceHostedTier,
+  type HostedTier,
+} from '../lib/hosted-entitlement.js';
 import { assertSeatAvailable } from '../lib/seat-count-guard.js';
 import { getServices, type ProtectedStripe } from '../lib/services-loader.js';
 import { getHostedLimitsForTier } from '../lib/tier-limits.js';
@@ -60,7 +64,6 @@ import { resetDbStatusCache, resetSupportExpiryCache } from '../middleware/licen
 
 const app = new OpenAPIHono();
 
-type HostedTier = 'free' | LicenseTier;
 type DbExecutor = Pick<Database, 'select' | 'insert' | 'update' | 'delete'>;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -314,55 +317,16 @@ function resolveOptionalTier(
       },
     );
   } else if (metadata) {
-    // Metadata exists but tier key is absent  -  Stripe product misconfiguration
-    logger.warn('Stripe metadata missing tier key  -  callers will default to pro', {
+    // Metadata exists but tier key is absent  -  Stripe product misconfiguration.
+    // F3: an unresolvable tier is NOT defaulted. syncHostedSubscriptionState
+    // skips the entitlement write, logs at ERROR, and records an
+    // `entitlement.unresolved-tier` row for the drainer. Nothing defaults to pro.
+    logger.warn('Stripe metadata missing tier key  -  entitlement write will be skipped', {
       metadataKeys: Object.keys(metadata),
       context,
     });
   }
   return undefined;
-}
-
-function coerceHostedTier(value: string | null | undefined): HostedTier | undefined {
-  if (value === 'free' || value === 'pro' || value === 'max' || value === 'enterprise') {
-    return value;
-  }
-  return undefined;
-}
-
-/** Known feature keys from {@link FeatureFlags}. Used to warn on unexpected keys. */
-const KNOWN_FEATURE_KEYS = new Set<string>([
-  'aiLocal',
-  'ai',
-  'aiMemory',
-  'mcp',
-  'payments',
-  'multiTenant',
-  'whiteLabel',
-  'aiInference',
-  'auditLog',
-  'advancedSync',
-  'dashboard',
-  'customDomain',
-  'analytics',
-] satisfies (keyof FeatureFlags)[]);
-
-function toFeatureRecord(features: object | null | undefined): Record<string, boolean> {
-  if (!features) {
-    return {};
-  }
-
-  const entries = Object.entries(features).filter(
-    (entry): entry is [string, boolean] => typeof entry[1] === 'boolean',
-  );
-
-  for (const [key] of entries) {
-    if (!KNOWN_FEATURE_KEYS.has(key)) {
-      logger.warn('Unknown feature key encountered in toFeatureRecord', { key });
-    }
-  }
-
-  return Object.fromEntries(entries);
 }
 
 /**
@@ -692,19 +656,17 @@ async function syncHostedSubscriptionState(
     return;
   }
 
-  const entitlementValues = {
-    planId: resolvedTier,
+  // Shared with the entitlement-consistency reconciler (lib/hosted-entitlement.ts)
+  // so a healed row and a webhook-written row can never grant different features
+  // for the same tier.
+  const entitlementValues = buildHostedEntitlementValues({
     tier: resolvedTier,
     status: params.status,
-    features: toFeatureRecord(getFeaturesForTier(resolvedTier)),
-    limits: getHostedLimitsForTier(resolvedTier),
-    meteringStatus:
-      params.status === 'active' || params.status === 'trialing' ? 'active' : 'paused',
     mode: params.mode,
     graceUntil: params.graceUntil ?? null,
     lastEventAt: params.eventTimestamp ?? null,
-    updatedAt: now,
-  };
+    now,
+  });
 
   let entitlementApplied = false;
   if (existingEntitlement?.accountId) {


### PR DESCRIPTION
GAP-356 **PR-2** — the entitlement-consistency reconciler (F4 + F5 test 4).

Design: `.jv/docs/gap-specs/GAP-356-hosted-entitlement-resolution-design.md` §5 F4, §5 F5 test 4, §6.
Follows **PR-1 (#1872)**, merged into `test`.

## Why

PR-1 stopped the entitlement write from *failing*. Nothing yet notices when it has *already* failed.

That is the actual production incident: a real Pro trial resolved to `free` forever, and no cron, alert, or test saw it. The fleet has five reconcile crons and every one of them walks **subscriptions**. None checked the **entitlement** table, so the defect was invisible to all of them. This PR adds the missing invariant.

> For every account with an active membership: IF `account_subscriptions` has a healthy row (`active`/`trialing`) **OR** a member holds a non-deleted `active` license, THEN `account_entitlements` MUST exist with the matching tier.

On violation: **alert** (idempotent `unreconciled_webhooks` row, `entitlement.drift`, synthetic `event_id` so re-runs collide) and **heal**.

## The heal, and why it is safe

Healing synthesizes the entitlement **from the local subscription row only** — never from a raw Stripe read. The local row was written by a signature-verified webhook, so healing from it adds no new trust. Healing from Stripe would widen the attack surface to anyone able to create Stripe objects, which is exactly why `reconcile-stripe-subscriptions` stayed alert-only.

Four rails, each with a test:

- **Tier-monotonic upward only.** A heal may raise a tier, never lower one. Downgrades stay webhook-driven.
- **Never resurrects a terminal entitlement.** If the existing row is `revoked`/`expired`/`canceled`, it alerts but does **not** heal. Healing one would re-grant access to an account someone deliberately cut off — the resurrection vector the WH-3 staleness guard exists to prevent. A stale local subscription row must never be able to undo a revocation. **This rail is not in the design doc; I added it during the build.** Flagging it explicitly for the verdict.
- **`last_event_at` is NULL on healed rows**, so the very next webhook wins regardless of its `event.created`. A healed row can never make a real event look stale.
- **Never heals from ignorance.** An unresolvable `planId` alerts without writing, applying F3's rule to the healer exactly as PR-1 applied it to the webhook.

Gated by `RECONCILE_ENTITLEMENTS_HEAL` (**default ON**). Registered in `dispatch.ts` after the subscription reconcilers (freshest local rows) and before `sweep-grace-periods` (which acts on entitlement state).

## Shared value construction (please review this part)

I extracted the tier→features/limits/status entitlement value construction out of `webhooks.ts` into `lib/hosted-entitlement.ts`, now used by **both** the webhook write path and the healer.

Two copies of that mapping would be the same drift class GAP-356 already is. A heal that grants a *different* feature set than the webhook would have granted is worse than no heal at all, because it looks correct. The extraction is behavior-neutral: **PR-1's 38 webhook/convergence tests pass unchanged**.

This is why `webhooks.ts` is in the diff, and why the security gate flags this PR.

## Tests — every one proven RED first

`reconcile-entitlements.pglite.test.ts` uses the PR-1 harness: PGlite, **real migrations**, the real Hono route. Each test was proven red against a targeted mutation of the specific guard it protects, then green on restore:

| Test | Mutation that turned it red |
|---|---|
| heals missing entitlement (license=pro, sub=trialing) → pro/trialing, `last_event_at` NULL | heal writes removed |
| no heal without a source (entitlement=free, no healthy sub, no license) | `canceled` added to healthy statuses |
| never downgrades (existing `max` survives a `pro` subscription) | monotonic guard replaced with `!==` |
| drift alert idempotent across two runs | idempotency guard removed |

Plus the cron-secret 401. **130/130 pass** across all cron + webhook suites; typecheck and Biome clean.

## Also in this PR

Fixes the stale `resolveOptionalTier` warn comment (`webhooks.ts`) — it still said *"callers will default to pro"*, which PR-1 made false. It now describes the F3 skip-and-alert behavior actually shipped. (Flagged in the #1872 review.)

## Residual, for the verdict

Status drift on an existing correct-tier row (entitlement `canceled` while the subscription is `active`) is **not** healed — only missing rows and below-expected tiers are. Healing status would mean re-activating a row someone may have deliberately terminated, and I did not want to open that door without a ruling. It is alert-visible via the drift row. Happy to extend if you'd rather it heal.

---

**Guardrail 2:** touches `webhooks.ts` + cron. Requesting the Fable adversarial verdict. Not self-merging, not applying gate labels.
