### PR TITLE
feat(marketing): messaging rewrite with a per-sentence claims-evidence index

### DIFF
--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -1,0 +1,720 @@
+// Claims-evidence index: every prose sentence in the covered marketing
+// content files maps to the artifacts that prove it (owner directive
+// 2026-07-12; spec: .jv docs/lanes/frontend-excellence/messaging-rewrite-2026-07-12.md).
+//
+// claim-drift.ts pins the NUMBERS marketing quotes; this index pins the
+// SENTENCES. scripts/validate/claims-evidence.ts hard-fails the gate when a
+// covered file gains prose with no entry here, when an entry's text no longer
+// matches the copy, or when a cited code path stops existing.
+//
+// Granularity: one entry per copy FIELD (a field may hold more than one
+// sentence); the evidence array carries one ref per distinct claim in the
+// field, with the claim named in `note`. Line numbers never appear in `ref`
+// (they drift); put them in `note` when helpful.
+//
+// Generalizes the existing pattern in capabilities.ts, where every capability
+// card already cites its source file (checked by content.test.ts).
+
+export type EvidenceKind = 'code' | 'command' | 'url' | 'metric';
+
+export interface EvidenceRef {
+  /** What kind of artifact proves the claim. */
+  readonly kind: EvidenceKind;
+  /** Repo-relative path (code/metric), runnable command, or public URL. */
+  readonly ref: string;
+  /** Which claim in the field this ref proves, and any caveat. */
+  readonly note?: string;
+}
+
+export interface ClaimEntry {
+  /** Content module, relative to app/content/. */
+  readonly file: string;
+  /** Dot path of the export the copy lives under (documentation aid). */
+  readonly exportPath: string;
+  /**
+   * The exact runtime copy string. With `match: 'path'` (interpolated
+   * template literals) the validator resolves `exportPath` instead and
+   * `text` is documentation only.
+   */
+  readonly text: string;
+  readonly match?: 'text' | 'path';
+  readonly evidence: readonly EvidenceRef[];
+}
+
+/** Files whose prose the validator requires to be fully indexed. */
+export interface CoveredFile {
+  readonly file: string;
+  /** When set, only exports whose name starts with this prefix are covered. */
+  readonly exportPrefix?: string;
+}
+
+export const COVERED_FILES: readonly CoveredFile[] = [
+  { file: 'home.ts' },
+  { file: 'primitives.ts', exportPrefix: 'HOME_' },
+  { file: 'proof.ts' },
+  { file: 'pricing-teaser.ts' },
+  { file: 'site.ts' },
+] as const;
+
+const AUTH_SESSIONS: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/auth/src/server/auth.ts',
+  note: 'session creation + sign-in/sign-up flows',
+};
+const RBAC_ABAC: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/security/src/authorization.ts',
+  note: 'RBAC + ABAC policy engine; enforcement tests at packages/core/src/__tests__/auth/',
+};
+const COLLECTIONS: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/admin/src/lib/collections',
+  note: 'collection definitions drive the admin UI + REST API; engine at packages/core/src/collections',
+};
+const BILLING: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/routes/billing.ts',
+  note: 'Stripe checkout, subscription, portal routes',
+};
+const WEBHOOKS: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/routes/webhooks.ts',
+  note: 'signature-verified Stripe webhook processing',
+};
+const RECONCILE: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/routes/cron/reconcile-subscriptions.ts',
+  note: 'reconciliation crons; siblings reconcile-stripe-subscriptions.ts + drain-unreconciled.ts',
+};
+const MCP_CONTENT: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/mcp/src/servers/factories/revealui-content.ts',
+  note: 'generic content tools + opt-in mcpResource collection introspection',
+};
+const TIER_GATES: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/middleware/entitlements.ts',
+  note: 'per-account tier resolution; AI routes gated in entitlements mode in apps/server/src/index.ts',
+};
+const OPEN_WEIGHT: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/middleware/license.ts',
+  note: 'requireAIAccess free-tier local-inference path (OLLAMA_BASE_URL / INFERENCE_SNAPS_BASE_URL)',
+};
+const PROVIDERS: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/ai/src/llm/providers',
+  note: 'provider adapters; open-weight default via ollama.ts + inference/',
+};
+const CLI_CREATE: EvidenceRef = {
+  kind: 'command',
+  ref: 'npx create-revealui@latest my-app',
+  note: 'scaffolder at packages/cli; the 60-second figure is a timed claim, re-verify per release',
+};
+const LICENSE_MIT: EvidenceRef = {
+  kind: 'code',
+  ref: 'LICENSE',
+  note: 'root MIT license; per-package FSL-1.1-MIT files in the 5 Pro packages',
+};
+const LICENSE_SPLIT: EvidenceRef = {
+  kind: 'metric',
+  ref: 'scripts/validate/claim-drift.ts',
+  note: 'licenseSplit 22 MIT + 5 FSL + 1 internal, pinned by the claim-drift gate',
+};
+const SELF_HOST: EvidenceRef = {
+  kind: 'code',
+  ref: 'docs/guides/deployment.md',
+  note: 'self-host deployment guide; plain Node bundle, no vendor edge runtime',
+};
+const REPO: EvidenceRef = {
+  kind: 'url',
+  ref: 'https://github.com/RevealUIStudio/revealui',
+  note: 'the entire runtime is in the public repo',
+};
+const CI_GATE: EvidenceRef = {
+  kind: 'code',
+  ref: 'scripts/gates/ci-gate.ts',
+  note: '3-phase gate: Biome, typecheck, Vitest, build; CodeQL + Gitleaks in .github/workflows',
+};
+const TRIAL: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/routes/billing.ts',
+  note: 'default trial period for new subscriptions (DEFAULT_TRIAL_DAYS)',
+};
+const TIER_LIMITS: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/lib/tier-limits.ts',
+  note: 'pro maxAgentTasks 10_000; free 1_000',
+};
+const X402: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/middleware/x402.ts',
+  note: 'HTTP 402 payment middleware; rails in development per the roadmap',
+};
+const MEMORY: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/ai/src/memory',
+  note: 'CRDT agent memory',
+};
+const AGENT_ROUTES: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/routes/agent-tasks.ts',
+  note: 'agent surfaces mounted behind the same auth + entitlement middleware as user routes',
+};
+const OPEN_STANDARDS: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/openapi/src',
+  note: 'OpenAPI spec generation; MCP + Stripe webhooks + OAuth are the other open surfaces',
+};
+const POSTGRES: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/db/src/schema',
+  note: 'plain Postgres via Drizzle; no proprietary database',
+};
+const THIS_SITE: EvidenceRef = {
+  kind: 'url',
+  ref: 'https://revealui.com',
+  note: 'this site (apps/marketing) and revealuistudio.com run on RevealUI in production',
+};
+const PRICING_FALLBACKS: EvidenceRef = {
+  kind: 'metric',
+  ref: 'apps/marketing/app/lib/pricing-fallbacks.ts',
+  note: 'display prices pinned in lockstep with scripts/setup/stripe-catalog.ts by validate:pricing-lockstep',
+};
+const NO_TELEMETRY: EvidenceRef = {
+  kind: 'url',
+  ref: 'https://github.com/RevealUIStudio/revealui/search?q=telemetry',
+  note: 'negative claim: no telemetry client ships in the runtime; verify by repo search',
+};
+const DEPLOY_TARGETS: EvidenceRef = {
+  kind: 'code',
+  ref: 'docs/guides/deployment.md',
+  note: 'Vercel, Cloudflare, Fly, Hetzner, self-host deploy paths',
+};
+const DOCS: EvidenceRef = { kind: 'url', ref: 'https://docs.revealui.com' };
+
+export const CLAIMS: readonly ClaimEntry[] = [
+  // ── site.ts ───────────────────────────────────────────────────────────────
+  {
+    file: 'site.ts',
+    exportPath: 'SITE.brandTagline',
+    text: 'The open runtime for businesses that run their own AI.',
+    evidence: [LICENSE_MIT, OPEN_WEIGHT, SELF_HOST],
+  },
+
+  // ── home.ts — hero ───────────────────────────────────────────────────────
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_HERO.eyebrow',
+    text: 'Open source. Self-hostable.',
+    evidence: [LICENSE_MIT, SELF_HOST],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_HERO.h1',
+    text: 'Run your whole business on one runtime you own.',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'packages',
+        note: 'auth, content, billing, agents in one monorepo runtime',
+      },
+      LICENSE_MIT,
+      SELF_HOST,
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_HERO.subtitle.sentence1',
+    text: 'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof.',
+    evidence: [SELF_HOST, AGENT_ROUTES, TIER_GATES],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_HERO.subtitle.support',
+    text: 'It runs on any AI provider you choose.',
+    evidence: [PROVIDERS, OPEN_WEIGHT],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_HERO_FOUNDATION.h1',
+    text: 'The foundation your business runs on.',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'packages',
+        note: 'sanctioned A/B variant of HOME_HERO.h1; same grounding',
+      },
+    ],
+  },
+
+  // ── home.ts — problem ────────────────────────────────────────────────────
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.heading',
+    text: 'Vendor sprawl, or framework-only. Pick neither.',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'packages',
+        note: 'framing sentence; the table below carries the claims',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.body',
+    text: 'You either glue together an auth vendor, a headless CMS, Stripe code, and a job runner, or you pick an agent framework and rebuild all four underneath it. RevealUI is the third option: the whole set arrives wired into one runtime that you own.',
+    evidence: [AUTH_SESSIONS, COLLECTIONS, BILLING, LICENSE_MIT],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.rows[0].sprawl',
+    text: 'A separate auth vendor, per seat',
+    evidence: [
+      {
+        kind: 'url',
+        ref: 'https://revealui.com/pricing',
+        note: 'competitor-column framing; cost detail lives on the pricing page',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.rows[0].revealui',
+    text: 'Sessions with RBAC and ABAC, built in',
+    evidence: [AUTH_SESSIONS, RBAC_ABAC],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.rows[1].sprawl',
+    text: 'A headless CMS, plus a team to wire it',
+    evidence: [
+      {
+        kind: 'url',
+        ref: 'https://revealui.com/pricing',
+        note: 'competitor-column framing; cost detail lives on the pricing page',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.rows[1].revealui',
+    text: 'Collections with an admin UI and REST API',
+    evidence: [COLLECTIONS, OPEN_STANDARDS],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.rows[2].revealui',
+    text: 'Checkout, webhooks, and reconciliation crons',
+    evidence: [BILLING, WEBHOOKS, RECONCILE],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.rows[3].revealui',
+    text: 'Content tools over MCP, plus collections you opt in',
+    evidence: [MCP_CONTENT],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.footnote',
+    text: 'Capability comparison only; a monthly cost estimate lives on the pricing page. (interpolated: Pro price from pricing-fallbacks)',
+    match: 'path',
+    evidence: [PRICING_FALLBACKS, DEPLOY_TARGETS],
+  },
+
+  // ── home.ts — demo ───────────────────────────────────────────────────────
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_DEMO.heading',
+    text: 'From one command to a working stack in 60 seconds.',
+    evidence: [CLI_CREATE],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_DEMO.body',
+    text: 'The stack runs locally in 60 seconds, Stripe starts in test mode, and agents connect over MCP.',
+    evidence: [CLI_CREATE, BILLING, MCP_CONTENT],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_DEMO.mockupCaption.prefix',
+    text: 'Local screenshot from a fresh',
+    evidence: [CLI_CREATE],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_DEMO.mockupCaption.suffix',
+    text: '. The three beats below describe the steps.',
+    evidence: [CLI_CREATE],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_DEMO.beats[0].body',
+    text: 'One command. Auth, content, admin UI, the Stripe webhook handler, and MCP server scaffolding all running locally in 60 seconds.',
+    evidence: [CLI_CREATE, AUTH_SESSIONS, WEBHOOKS, MCP_CONTENT],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_DEMO.beats[1].title',
+    text: 'Customer flow, end to end.',
+    evidence: [BILLING],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_DEMO.beats[1].body',
+    text: 'A user signs up, picks a plan, and Stripe test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
+    evidence: [
+      AUTH_SESSIONS,
+      BILLING,
+      {
+        kind: 'code',
+        ref: 'apps/server/src/lib/validate-startup.ts',
+        note: 'STRIPE_LIVE_MODE flip validated at boot',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_DEMO.beats[2].body',
+    text: 'Wire an LLM provider and your agents read your sites, users, and content over MCP, with every call passing the same auth and tier gates your human users pass.',
+    evidence: [PROVIDERS, MCP_CONTENT, TIER_GATES],
+  },
+
+  // ── home.ts — FAQ ────────────────────────────────────────────────────────
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[0].answer',
+    text: 'No. Open standards end-to-end: OAuth, JWT, Stripe webhooks, MCP, and OpenAPI, over plain Postgres. Deploy anywhere Node runs, and take your data, your code, and your infrastructure with you. RevealUI is the runtime, not the prison.',
+    evidence: [OPEN_STANDARDS, POSTGRES, SELF_HOST],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[1].answer',
+    text: 'Every PR clears a 3-phase gate before it lands: Biome, Vitest unit and integration tests, Playwright end-to-end tests, CodeQL, and Gitleaks. This site and the agency site at revealuistudio.com both run on RevealUI in production.',
+    evidence: [CI_GATE, THIS_SITE],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[2].question',
+    text: 'How is this different from stitching together separate auth, database, CMS, and background-job services?',
+    evidence: [
+      { kind: 'code', ref: 'packages', note: 'question copy; the answer carries the claims' },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[2].answer',
+    text: 'Each of those covers one slice: a real-time database, a Postgres-plus-auth backend, a session service, a jobs runner. RevealUI is the whole runtime: auth, content, billing, admin UI, and an agent layer, self-hosted at every tier. (Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.)',
+    evidence: [AUTH_SESSIONS, COLLECTIONS, BILLING, AGENT_ROUTES, DEPLOY_TARGETS],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[3].answer',
+    text: 'Yes. 22 of 28 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
+    evidence: [LICENSE_SPLIT, LICENSE_MIT, SELF_HOST, POSTGRES],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[4].question',
+    text: 'What does "agent-native" actually mean in code?',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'packages/mcp/src',
+        note: 'question copy; the answer carries the claims',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[4].answer',
+    text: 'Agents authenticate like users and pass the same tier gates your customers pass. The content MCP server ships discovery and read tools, any collection becomes a discoverable MCP resource with one flag, and writes go through the same REST API your app uses.',
+    evidence: [TIER_GATES, MCP_CONTENT, OPEN_STANDARDS],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[5].question',
+    text: 'How does AI inference work?',
+    evidence: [OPEN_WEIGHT],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[5].answer',
+    text: 'Agents run on an open-weight model on your own infrastructure by default, with Claude, GPT, or any other provider one config line away. See the local AI docs at revealui.com/local-ai for the full pathway.',
+    evidence: [OPEN_WEIGHT, PROVIDERS],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[6].question',
+    text: 'How do agent payments work?',
+    evidence: [X402],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_FAQ.items[6].answer',
+    text: 'RevealUI implements the HTTP 402 payment protocol so agents can pay each other over standard HTTP, with the payment rails still in development. See the agents section of the pricing page for the current status.',
+    evidence: [X402],
+  },
+
+  // ── home.ts — get started ────────────────────────────────────────────────
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_GET_STARTED.heading',
+    text: 'Your stack is one command away.',
+    evidence: [CLI_CREATE],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_GET_STARTED.body',
+    text: 'Spin it up on your machine in minutes. Flip to live mode when you are ready to charge real customers.',
+    evidence: [
+      CLI_CREATE,
+      {
+        kind: 'code',
+        ref: 'apps/server/src/lib/validate-startup.ts',
+        note: 'live-mode flip validated at boot',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_GET_STARTED.cli.caption',
+    text: 'Local dev stack in 60 seconds. No credit card.',
+    evidence: [
+      CLI_CREATE,
+      {
+        kind: 'code',
+        ref: 'apps/admin/src/app/api/auth/sign-up/route.ts',
+        note: 'signup takes no payment method',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_GET_STARTED.newsletter.label',
+    text: 'Not ready to start? Get product updates and engineering insights.',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'apps/server/src/routes/waitlist.ts',
+        note: 'newsletter capture endpoint',
+      },
+    ],
+  },
+
+  // ── primitives.ts (HOME_ exports) ────────────────────────────────────────
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES_SECTION.eyebrow',
+    text: 'Five primitives. One login.',
+    evidence: [
+      AUTH_SESSIONS,
+      {
+        kind: 'code',
+        ref: 'packages/engines/src',
+        note: 'the five business primitives behind one session',
+      },
+    ],
+  },
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES_SECTION.heading',
+    text: 'The five things every business runs on.',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'packages/engines/src',
+        note: 'people, content, offers, payments, agents',
+      },
+    ],
+  },
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES_SECTION.body',
+    text: 'Each primitive ships as an API and an admin surface, and your agents work the same objects your team does.',
+    evidence: [OPEN_STANDARDS, COLLECTIONS, AGENT_ROUTES],
+  },
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES_SECTION.docsLink.label',
+    text: 'See the primitive reference →',
+    evidence: [DOCS],
+  },
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES[0].body',
+    text: 'Your team signs in with sessions and works under RBAC and ABAC policies.',
+    evidence: [AUTH_SESSIONS, RBAC_ABAC],
+  },
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES[1].body',
+    text: 'Collections give you a CMS, rich text, and media, with an admin UI generated from your schema.',
+    evidence: [
+      COLLECTIONS,
+      { kind: 'code', ref: 'packages/core/src/richtext', note: 'Lexical rich text' },
+    ],
+  },
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES[2].body',
+    text: 'Catalogs and feature gates decide what each tier can do, for your people and your agents.',
+    evidence: [
+      TIER_GATES,
+      TIER_LIMITS,
+      { kind: 'code', ref: 'packages/core/src/features.ts', note: 'tier feature matrix' },
+    ],
+  },
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES[3].body',
+    text: 'Stripe checkout, subscriptions, and webhook reconciliation come pre-wired.',
+    evidence: [BILLING, WEBHOOKS, RECONCILE],
+  },
+  {
+    file: 'primitives.ts',
+    exportPath: 'HOME_PRIMITIVES[4].body',
+    text: 'Agents run on an open-weight model you host, with any provider one config line away.',
+    evidence: [OPEN_WEIGHT, PROVIDERS],
+  },
+
+  // ── proof.ts ─────────────────────────────────────────────────────────────
+  {
+    file: 'proof.ts',
+    exportPath: 'PROOF_SECTION.heading',
+    text: 'Inspect the code before you commit to it.',
+    evidence: [REPO],
+  },
+  {
+    file: 'proof.ts',
+    exportPath: 'PROOF_SECTION.body',
+    text: 'The entire runtime sits in the public repo under an open license. Read it, run it, or fork it before you build on it.',
+    evidence: [REPO, LICENSE_MIT],
+  },
+  {
+    file: 'proof.ts',
+    exportPath: 'PROOF_TRUST.body',
+    text: 'Your security team can read every line. The whole runtime is open source, MIT or Fair Source, sitting in the repo. There is no closed binary to explain away when procurement comes asking.',
+    evidence: [REPO, LICENSE_SPLIT],
+  },
+  {
+    file: 'proof.ts',
+    exportPath: 'PROOF_TRUST.changelogCta.label',
+    text: 'See what shipped this month →',
+    evidence: [
+      { kind: 'url', ref: 'https://github.com/RevealUIStudio/revealui/blob/main/CHANGELOG.md' },
+    ],
+  },
+  {
+    file: 'proof.ts',
+    exportPath: 'LIVE_METRICS.heading',
+    text: 'Every number here is pinned to the codebase.',
+    evidence: [LICENSE_SPLIT],
+  },
+  {
+    file: 'proof.ts',
+    exportPath: 'LIVE_METRICS.body',
+    text: 'These counts are validated on every PR by the claim-drift gate. If the code changes and a number drifts, the build fails before it can ship.',
+    evidence: [LICENSE_SPLIT, CI_GATE],
+  },
+
+  // ── pricing-teaser.ts ────────────────────────────────────────────────────
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_SECTION.heading',
+    text: 'Start free. Pay when you scale.',
+    evidence: [LICENSE_MIT, TIER_LIMITS],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_SECTION.body',
+    text: 'Self-host the open-source stack at no cost. Pro, Max, and Enterprise add runtime entitlements and an agent task allowance. Pro and Max include a 7-day free trial.',
+    evidence: [LICENSE_MIT, TIER_GATES, TIER_LIMITS, TRIAL],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_TIERS[0].description',
+    text: '22 of 28 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
+    evidence: [LICENSE_SPLIT, NO_TELEMETRY],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_TIERS[0].features[3]',
+    text: 'Bring your own model (open-weight default)',
+    evidence: [OPEN_WEIGHT, PROVIDERS],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_TIERS[1].description',
+    text: 'Pro adds the AI primitives, an agent task allowance, and priority support.',
+    evidence: [TIER_GATES, TIER_LIMITS],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_TIERS[1].features[1]',
+    text: '10,000 agent tasks / month included',
+    evidence: [TIER_LIMITS],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_TIERS[1].features[2]',
+    text: 'Pro AI features (agents, MCP, memory), beta in production',
+    evidence: [
+      TIER_GATES,
+      MEMORY,
+      { kind: 'code', ref: 'packages/mcp/src', note: 'MCP hypervisor + servers' },
+    ],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_LINKS[0].description',
+    text: 'Max adds AI memory, advanced inference, and compliance tooling.',
+    evidence: [
+      MEMORY,
+      { kind: 'code', ref: 'packages/ai/src/inference', note: 'inference layer' },
+      RBAC_ABAC,
+    ],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_LINKS[1].description',
+    text: 'Enterprise adds scale and compliance controls.',
+    evidence: [TIER_LIMITS, RBAC_ABAC],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_FOOTER.caption.prefix',
+    text: 'Deploys to Vercel, Cloudflare, Fly, Hetzner, or self-host.',
+    evidence: [DEPLOY_TARGETS],
+  },
+  {
+    file: 'pricing-teaser.ts',
+    exportPath: 'PRICING_TEASER_FOOTER.caption.suffix',
+    text: 'produces a standard Node bundle.',
+    evidence: [{ kind: 'command', ref: 'pnpm build', note: 'turbo build to a plain Node bundle' }],
+  },
+] as const;
+
+/**
+ * Field names whose string values are never prose claims (icons, colors,
+ * routes, ids). The validator skips them when computing coverage.
+ */
+export const NON_COPY_KEYS: readonly string[] = [
+  'iconPath',
+  'icon',
+  'color',
+  'bgColor',
+  'ringColor',
+  'href',
+  'moreHref',
+  'linkHref',
+  'validatorHref',
+  'code',
+  'command',
+  'id',
+  'n',
+  'key',
+  'tableAriaLabel',
+  'create',
+] as const;

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -12,6 +12,10 @@
 // removed (thin vocabulary/pull-quote content, no longer rendered anywhere);
 // HOME_HERO's agency CTAs moved to the footer, its CLI block moved into
 // HOME_GET_STARTED.cli.
+// 2026-07-12: messaging rewrite (frontend-excellence Phase 1b spec in .jv).
+// Every prose sentence in this file is indexed in ./claims-evidence.ts with
+// the code that proves it (owner directive); the collections-over-MCP claims
+// are corrected to the shipped opt-in resource mechanism.
 
 import { SUBSCRIPTION_PRICE_FALLBACKS } from '../lib/pricing-fallbacks';
 import { SITE } from './site';
@@ -66,7 +70,7 @@ export interface ProblemRow {
 export const HOME_PROBLEM = {
   eyebrow: 'The problem',
   heading: 'Vendor sprawl, or framework-only. Pick neither.',
-  body: 'Most AI teams glue together a half-dozen SaaS backends. Some pick a thin agent framework and rebuild auth, billing, and content from scratch. RevealUI is the third option: everything wired in, governed by one policy, owned by you.',
+  body: 'You either glue together an auth vendor, a headless CMS, Stripe code, and a job runner, or you pick an agent framework and rebuild all four underneath it. RevealUI is the third option: the whole set arrives wired into one runtime that you own.',
   tableAriaLabel: 'Vendor sprawl vs agent-framework vs RevealUI comparison',
   columns: {
     capability: 'Capability',
@@ -79,25 +83,25 @@ export const HOME_PROBLEM = {
       capability: 'Auth + RBAC + sessions',
       sprawl: 'A separate auth vendor, per seat',
       agentOnly: 'Bring your own',
-      revealui: 'Built in',
+      revealui: 'Sessions with RBAC and ABAC, built in',
     },
     {
       capability: 'CMS + admin UI',
       sprawl: 'A headless CMS, plus a team to wire it',
       agentOnly: 'Bring your own',
-      revealui: 'Built in',
+      revealui: 'Collections with an admin UI and REST API',
     },
     {
       capability: 'Stripe billing + webhooks',
       sprawl: 'Stripe + your code',
       agentOnly: 'Bring your own',
-      revealui: 'Built in (with reconciliation)',
+      revealui: 'Checkout, webhooks, and reconciliation crons',
     },
     {
-      capability: 'MCP tools for every API',
-      sprawl: 'Per-collection plugin',
+      capability: 'Agent access to your data',
+      sprawl: 'One-off integrations',
       agentOnly: 'Tool registry only',
-      revealui: 'Auto-exposed',
+      revealui: 'Content tools over MCP, plus collections you opt in',
     },
   ] as readonly ProblemRow[],
   footnote: `Capability comparison only; a monthly cost estimate lives on the pricing page. RevealUI Pro is ${SUBSCRIPTION_PRICE_FALLBACKS.pro.price}/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.`,
@@ -115,8 +119,8 @@ export interface DemoBeat {
 
 export const HOME_DEMO = {
   eyebrow: 'Watch it work',
-  heading: 'From CLI to a working stack in 90 seconds.',
-  body: 'Three beats. Local in 60 seconds. Test-mode Stripe by default. Agents wired in via MCP.',
+  heading: 'From one command to a working stack in 60 seconds.',
+  body: 'The stack runs locally in 60 seconds, Stripe starts in test mode, and agents connect over MCP.',
   mockupCaption: {
     prefix: 'Local screenshot from a fresh',
     code: 'npx create-revealui',
@@ -136,7 +140,7 @@ export const HOME_DEMO = {
     {
       n: '03',
       title: 'Agent-native, by default.',
-      body: 'Every primitive ships with a matching MCP server. Wire an LLM provider and your agents read customers, refund subscriptions, and write content through the same APIs your app uses.',
+      body: 'Wire an LLM provider and your agents read your sites, users, and content over MCP, with every call passing the same auth and tier gates your human users pass.',
     },
   ] as readonly DemoBeat[],
 } as const;
@@ -178,7 +182,7 @@ export const HOME_FAQ = {
     {
       question: 'What does "agent-native" actually mean in code?',
       answer:
-        'Every collection is an MCP tool AND a REST endpoint AND a typed SDK call. The runtime is the contract, not a glue layer.',
+        'Agents authenticate like users and pass the same tier gates your customers pass. The content MCP server ships discovery and read tools, any collection becomes a discoverable MCP resource with one flag, and writes go through the same REST API your app uses.',
     },
     {
       question: 'How does AI inference work?',
@@ -198,8 +202,8 @@ export const HOME_FAQ = {
 // ---------------------------------------------------------------------------
 
 export const HOME_GET_STARTED = {
-  heading: 'Build your business today.',
-  body: 'The business logic, pre-wired. Spin up on your machine in minutes, then flip to live mode when you’re ready to charge real customers.',
+  heading: 'Your stack is one command away.',
+  body: 'Spin it up on your machine in minutes. Flip to live mode when you are ready to charge real customers.',
   cta: {
     primary: { label: 'Start free', href: SITE.urls.signup } satisfies Cta,
     secondary: { label: 'Read the docs', href: SITE.urls.docs } satisfies Cta,

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -29,7 +29,7 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
     id: 'free',
     name: 'Free',
     description:
-      '22 of 28 packages MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. No telemetry.',
+      '22 of 28 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
     features: [
       'Full primitive stack',
       'Admin dashboard + API',
@@ -43,7 +43,7 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
   {
     id: 'pro',
     name: 'Pro',
-    description: 'Pro AI primitives, agent task allowance, and priority support.',
+    description: 'Pro adds the AI primitives, an agent task allowance, and priority support.',
     features: [
       'Everything in Free',
       '10,000 agent tasks / month included',
@@ -67,13 +67,13 @@ export const PRICING_TEASER_LINKS: readonly TeaserLink[] = [
   {
     id: 'max',
     name: 'Max',
-    description: 'AI memory, advanced inference, and compliance tooling.',
+    description: 'Max adds AI memory, advanced inference, and compliance tooling.',
     href: '/pricing',
   },
   {
     id: 'enterprise',
     name: 'Enterprise',
-    description: 'Scale, compliance, and agent payments.',
+    description: 'Enterprise adds scale and compliance controls.',
     href: '/pricing',
   },
 ] as const;

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -22,43 +22,43 @@ export interface HomePrimitive {
 
 export const HOME_PRIMITIVES_SECTION = {
   eyebrow: 'Five primitives. One login.',
-  heading: "Everything a business needs. Nothing you don't.",
-  body: 'People, content, offers, payments, and agents: the five things every product needs.',
+  heading: 'The five things every business runs on.',
+  body: 'Each primitive ships as an API and an admin surface, and your agents work the same objects your team does.',
   docsLink: { label: 'See the primitive reference →', href: SITE.urls.docs },
 } as const;
 
 export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
   {
     label: 'People',
-    body: 'Auth, sessions, RBAC + ABAC for your team.',
+    body: 'Your team signs in with sessions and works under RBAC and ABAC policies.',
     color: 'emerald',
     iconPath:
       'M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z',
   },
   {
     label: 'Content',
-    body: 'Headless CMS, rich text, media. Auto-exposed as MCP tools.',
+    body: 'Collections give you a CMS, rich text, and media, with an admin UI generated from your schema.',
     color: 'blue',
     iconPath:
       'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z',
   },
   {
     label: 'Offers',
-    body: 'Catalogs, entitlements, feature flags. Gates govern agent capabilities.',
+    body: 'Catalogs and feature gates decide what each tier can do, for your people and your agents.',
     color: 'amber',
     iconPath:
       'M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
   },
   {
     label: 'Payments',
-    body: 'Stripe billing, subscriptions, webhook reconciliation. x402-native agent payments.',
+    body: 'Stripe checkout, subscriptions, and webhook reconciliation come pre-wired.',
     color: 'cyan',
     iconPath:
       'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z',
   },
   {
     label: 'Agents',
-    body: 'Agents, MCP servers, persistent memory. Bring-your-own-model with an open-weight default.',
+    body: 'Agents run on an open-weight model you host, with any provider one config line away.',
     color: 'violet',
     iconPath:
       'M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z',
@@ -128,14 +128,14 @@ export const PRODUCTS_PRIMITIVES: readonly ProductsPrimitive[] = [
         'Rich text editing with Lexical, media management, draft/live publishing, and a full REST API with OpenAPI spec. Define your data model once and the admin dashboard and API generate automatically.',
     },
     forAgents: {
-      headline: 'Collections become discoverable tools via MCP',
+      headline: 'Collections become discoverable resources over MCP',
       description:
-        'Every collection you define is automatically exposed as an MCP tool. Agents create, query, and update content through the same API humans use. No separate integration layer.',
+        'The content MCP server ships discovery and read tools, and any collection you flag with mcpResource: true becomes a discoverable MCP resource. Agents write through the same REST API your app uses.',
     },
     together: {
-      headline: 'Define your data model. Agents immediately operate on it.',
+      headline: 'Define your data model once. Choose what agents can discover.',
       description:
-        'Add a collection. The admin UI, REST API, and MCP tool all appear simultaneously. No integration step between what humans see and what agents can do.',
+        'Add a collection and the admin UI and REST API appear with it. Flag it as an MCP resource and agents can discover and read it too.',
     },
     features: [
       'Schema-first collection definitions',

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -31,7 +31,7 @@ export const PROOF_SECTION = {
 // answers is whether their security team can read the code, not what
 // framework it runs on.
 export const PROOF_TRUST = {
-  body: 'Their security team can read every line. The whole runtime is open source, MIT or Fair Source, sitting in the repo. No closed binary to explain away when procurement comes asking.',
+  body: 'Your security team can read every line. The whole runtime is open source, MIT or Fair Source, sitting in the repo. There is no closed binary to explain away when procurement comes asking.',
   linkLabel: 'Read the LICENSE',
   linkHref: SITE.urls.repoLicense,
   changelogCta: {

--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
     "validate:structure": "tsx scripts/validate/structure.ts",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
+    "validate:claims-evidence": "tsx scripts/validate/claims-evidence.ts",
     "validate:marketing-voice": "tsx scripts/validate/marketing-voice.ts",
     "validate:client-safety": "tsx scripts/validate/client-safety.ts",
     "validate:design-context": "tsx scripts/validate/design-context-drift.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -315,6 +315,15 @@ async function gate(): Promise<void> {
         args: ['validate:claims'],
       },
       {
+        // Every prose sentence in covered marketing content files must carry
+        // a claims-evidence entry citing the code that proves it; cited paths
+        // must exist. Sibling of claim-drift: that gate pins the numbers,
+        // this one pins the sentences.
+        name: 'Claims evidence (hard fail)',
+        command: 'pnpm',
+        args: ['validate:claims-evidence'],
+      },
+      {
         name: 'Marketing voice (hard fail)',
         command: 'pnpm',
         args: ['validate:marketing-voice'],

--- a/scripts/validate/claims-evidence.ts
+++ b/scripts/validate/claims-evidence.ts
@@ -65,7 +65,9 @@ function collectStrings(
     return;
   }
   if (Array.isArray(node)) {
-    node.forEach((item, i) => collectStrings(file, item, `${path}[${i}]`, key, out));
+    for (let i = 0; i < node.length; i++) {
+      collectStrings(file, node[i], `${path}[${i}]`, key, out);
+    }
     return;
   }
   if (node !== null && typeof node === 'object') {

--- a/scripts/validate/claims-evidence.ts
+++ b/scripts/validate/claims-evidence.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env tsx
+/**
+ * Claims-evidence gate — every prose sentence in the covered marketing
+ * content files must carry an entry in claims-evidence.ts citing the code
+ * that proves it (owner directive 2026-07-12; spec in the coordination hub:
+ * lanes/frontend-excellence/messaging-rewrite-2026-07-12.md).
+ *
+ * Complements claim-drift.ts: that gate pins the NUMBERS marketing quotes;
+ * this one pins the SENTENCES. Checks, in both directions:
+ *   1. coverage — every qualifying string in a covered content module has an
+ *      index entry (exact text match, or a `match: 'path'` entry for
+ *      interpolated template literals);
+ *   2. staleness — every index entry still matches the copy it indexes;
+ *   3. evidence — every `code`/`metric` evidence ref resolves to a real
+ *      repo path.
+ *
+ * A string qualifies as prose when its field name is not in NON_COPY_KEYS,
+ * it is longer than 25 characters, contains a space, and is not a URL or
+ * route. Zero authored regex (fleet no-regex rule): substring predicates and
+ * Set lookups only.
+ *
+ * Usage:
+ *   tsx scripts/validate/claims-evidence.ts          # exit 1 on violations
+ *   tsx scripts/validate/claims-evidence.ts --warn   # warn-only (exit 0)
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  CLAIMS,
+  COVERED_FILES,
+  NON_COPY_KEYS,
+} from '../../apps/marketing/app/content/claims-evidence.js';
+
+const warnOnly = process.argv.includes('--warn');
+const repoRoot = join(import.meta.dirname, '..', '..');
+const contentDir = join(repoRoot, 'apps', 'marketing', 'app', 'content');
+
+const nonCopyKeys = new Set<string>(NON_COPY_KEYS);
+const MIN_PROSE_LENGTH = 26;
+
+interface CollectedString {
+  readonly file: string;
+  readonly path: string;
+  readonly value: string;
+}
+
+function isProse(key: string, value: string): boolean {
+  if (nonCopyKeys.has(key)) return false;
+  if (value.length < MIN_PROSE_LENGTH) return false;
+  if (!value.includes(' ')) return false;
+  if (value.startsWith('http') || value.startsWith('/')) return false;
+  return true;
+}
+
+function collectStrings(
+  file: string,
+  node: unknown,
+  path: string,
+  key: string,
+  out: CollectedString[],
+): void {
+  if (typeof node === 'string') {
+    if (isProse(key, node)) out.push({ file, path, value: node });
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => collectStrings(file, item, `${path}[${i}]`, key, out));
+    return;
+  }
+  if (node !== null && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) {
+      collectStrings(file, v, path ? `${path}.${k}` : k, k, out);
+    }
+  }
+}
+
+const violations: string[] = [];
+
+for (const covered of COVERED_FILES) {
+  const modulePath = join(contentDir, covered.file);
+  if (!existsSync(modulePath)) {
+    violations.push(`covered file missing: apps/marketing/app/content/${covered.file}`);
+    continue;
+  }
+  const mod = (await import(modulePath)) as Record<string, unknown>;
+
+  const collected: CollectedString[] = [];
+  for (const [exportName, value] of Object.entries(mod)) {
+    if (covered.exportPrefix && !exportName.startsWith(covered.exportPrefix)) continue;
+    collectStrings(covered.file, value, exportName, exportName, collected);
+  }
+
+  const fileClaims = CLAIMS.filter((c) => c.file === covered.file);
+  const textEntries = new Set(
+    fileClaims.filter((c) => (c.match ?? 'text') === 'text').map((c) => c.text),
+  );
+  const pathEntries = new Set(
+    fileClaims.filter((c) => c.match === 'path').map((c) => c.exportPath),
+  );
+
+  // 1. Coverage: every collected prose string is indexed.
+  for (const s of collected) {
+    if (textEntries.has(s.value)) continue;
+    if (pathEntries.has(s.path)) continue;
+    violations.push(
+      `${covered.file} :: ${s.path} — prose with no claims-evidence entry: "${s.value.slice(0, 80)}"`,
+    );
+  }
+
+  // 2. Staleness: every index entry still matches the module.
+  const collectedValues = new Set(collected.map((s) => s.value));
+  const collectedPaths = new Set(collected.map((s) => s.path));
+  for (const claim of fileClaims) {
+    if (claim.match === 'path') {
+      if (!collectedPaths.has(claim.exportPath)) {
+        violations.push(
+          `${covered.file} :: ${claim.exportPath} — path-matched entry resolves to no prose string (copy moved or field renamed)`,
+        );
+      }
+      continue;
+    }
+    if (!collectedValues.has(claim.text)) {
+      violations.push(
+        `${covered.file} :: ${claim.exportPath} — entry text no longer matches the copy: "${claim.text.slice(0, 80)}"`,
+      );
+    }
+  }
+}
+
+// 3. Evidence: cited repo paths exist.
+for (const claim of CLAIMS) {
+  for (const ev of claim.evidence) {
+    if (ev.kind === 'code' || ev.kind === 'metric') {
+      if (!existsSync(join(repoRoot, ev.ref))) {
+        violations.push(`${claim.file} :: ${claim.exportPath} — evidence path missing: ${ev.ref}`);
+      }
+    } else if (ev.ref.trim() === '') {
+      violations.push(`${claim.file} :: ${claim.exportPath} — empty evidence ref`);
+    }
+  }
+}
+
+const coveredCount = CLAIMS.length;
+if (violations.length === 0) {
+  console.log(
+    `claims-evidence: ${coveredCount} indexed claims across ${COVERED_FILES.length} covered files, all matched, all evidence paths present.`,
+  );
+  process.exit(0);
+}
+
+console.error(`claims-evidence: ${violations.length} violation(s):`);
+for (const v of violations) {
+  console.error(`  ✗ ${v}`);
+}
+console.error(
+  '\nFix: index the sentence in apps/marketing/app/content/claims-evidence.ts with the code that proves it, update the stale entry, or restore the cited path. Copy with no proof does not ship.',
+);
+process.exit(warnOnly ? 0 : 1);


### PR DESCRIPTION
## Messaging rewrite + per-sentence claims-evidence index

Executes the frontend-excellence Phase 1b messaging rewrite (spec: `.jv` `docs/lanes/frontend-excellence/messaging-rewrite-2026-07-12.md`, PR alongside) with the owner's 2026-07-12 directive built in as infrastructure: **every prose sentence in covered marketing content files carries an index entry citing the code that proves it**, enforced by a new hard-fail gate.

### The mechanism

- `apps/marketing/app/content/claims-evidence.ts` — 64 indexed claims across 5 covered files (home, primitives `HOME_*`, proof, pricing-teaser, site), each mapping the exact copy string to `code` / `command` / `url` / `metric` evidence refs. Generalizes the existing `capabilities.ts` per-card source citations.
- `scripts/validate/claims-evidence.ts` + gate wiring (`validate:claims-evidence`, hard fail in phase 1) — checks three directions: every qualifying prose string is indexed, every index entry still matches the live copy, every cited repo path exists. Zero authored regex. Sibling of claim-drift: that pins the numbers, this pins the sentences.
- Coverage is a ratchet: `COVERED_FILES` grows file-by-file (products, for-operators, pricing next — routed per the spec §6).

The validator caught two real defects during its own authoring: a surviving false capability claim (below) and a stale path (collections live at `apps/admin/src/lib/collections`, not the `apps/admin/src/collections` CLAUDE.md documents — doc fix rides the ratchet PR).

### The copy changes (before → after highlights)

| Where | Before | After | Why |
|---|---|---|---|
| Problem body | "Most AI teams glue together a half-dozen SaaS backends…" | "You either glue together an auth vendor, a headless CMS, Stripe code, and a job runner…" | names the reader's stack (voice rule 3) |
| Problem table | "Built in" ×3 | "Sessions with RBAC and ABAC, built in" / "Collections with an admin UI and REST API" / "Checkout, webhooks, and reconciliation crons" | specifics over labels (voice rule 2) |
| Problem row 4 | "MCP tools for every API — Auto-exposed" | "Agent access to your data — Content tools over MCP, plus collections you opt in" | **truth fix**: shipped mechanism is generic tools + opt-in `mcpResource` introspection |
| Demo heading | "…in 90 seconds." (beats said 60) | "…in 60 seconds." | self-contradiction |
| Demo beat 03 | "agents read customers, refund subscriptions, and write content" | "agents read your sites, users, and content over MCP, with every call passing the same auth and tier gates your human users pass" | matches the actual tool surface; adds the true differentiator |
| Primitives heading | "Everything a business needs. Nothing you don't." | "The five things every business runs on." | cliché out |
| Primitives cards | verbless fragments ("Auth, sessions, RBAC + ABAC for your team.") | full clauses ("Your team signs in with sessions and works under RBAC and ABAC policies.") | copy-voice.md rule 1 |
| Payments card | "x402-native agent payments" | removed from the card (keeps its qualified FAQ entry) | **truth fix**: x402 rails are in development |
| Products Content forAgents | "Every collection you define is automatically exposed as an MCP tool." | "…any collection you flag with mcpResource: true becomes a discoverable MCP resource." | **truth fix** (GAP-354 class) |
| Proof | "Their security team can read every line." | "Your security team can read every line." | wrong person |
| Get started | "Build your business today." | "Your stack is one command away." | filler out, concrete in |
| Enterprise teaser | "Scale, compliance, and agent payments." | "Enterprise adds scale and compliance controls." | drops the unshipped agent-payments claim |

Hero is untouched: H1, canonical sentence, support line, and CTAs are locked canon (ADR 2026-07-09 + copy-voice.md). The receipt foil stays embargoed until GAP-355; the re-arm layer is staged in the spec, not in this repo.

### Verification

- `validate:claims-evidence`: 64 claims, all matched, all evidence paths present
- `pnpm gate:quick`: PASS (all 26 phase-1 checks incl. marketing-voice, claim-drift, doc-currency)
- `pnpm --filter marketing test`: 11 files, 75/75 pass

Not security-sensitive (content + validator only). Owner merges (agent-authored this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
