### PR TITLE
fix(server): harden the entitlement reconciler (GAP-356 PR-2 review)

### DIFF
--- a/apps/server/src/lib/downgrade-cap.ts
+++ b/apps/server/src/lib/downgrade-cap.ts
@@ -34,6 +34,19 @@ export function isDowngrade(oldTier: LicenseTierId, newTier: LicenseTierId): boo
   return TIER_RANK[newTier] < TIER_RANK[oldTier];
 }
 
+/**
+ * Returns true if newTier has strictly higher rank than oldTier. Equal tiers are
+ * NOT an upgrade.
+ *
+ * The entitlement reconciler's monotonic-upward heal guard uses this. It lives
+ * here, beside `isDowngrade` and sharing the one `TIER_RANK`, rather than in a
+ * second copy of the map — a duplicated tier ordering is exactly the drift class
+ * GAP-356 already is.
+ */
+export function isUpgrade(oldTier: LicenseTierId, newTier: LicenseTierId): boolean {
+  return TIER_RANK[newTier] > TIER_RANK[oldTier];
+}
+
 // =============================================================================
 // Capping Result
 // =============================================================================

--- a/apps/server/src/lib/hosted-entitlement.ts
+++ b/apps/server/src/lib/hosted-entitlement.ts
@@ -36,29 +36,11 @@ const KNOWN_FEATURE_KEYS = new Set<string>([
   'analytics',
 ] satisfies (keyof FeatureFlags)[]);
 
-/**
- * Tier ordering, low to high. Used by the reconciler's monotonic-upward heal
- * guard: a heal may raise a tier but must never lower one, because a downgrade
- * is a real business decision that belongs to the (signature-verified) webhook
- * path, not to a cron inferring state from local rows.
- */
-const TIER_RANK: Record<HostedTier, number> = {
-  free: 0,
-  pro: 1,
-  max: 2,
-  enterprise: 3,
-};
-
 export function coerceHostedTier(value: string | null | undefined): HostedTier | undefined {
   if (value === 'free' || value === 'pro' || value === 'max' || value === 'enterprise') {
     return value;
   }
   return undefined;
-}
-
-/** True when `next` is strictly higher than `current`. Equal tiers are NOT an upgrade. */
-export function isTierUpgrade(current: HostedTier, next: HostedTier): boolean {
-  return TIER_RANK[next] > TIER_RANK[current];
 }
 
 export function toFeatureRecord(features: object | null | undefined): Record<string, boolean> {
@@ -82,10 +64,16 @@ export function toFeatureRecord(features: object | null | undefined): Record<str
 /**
  * The `account_entitlements` column values for a tier + status.
  *
- * `lastEventAt` is the event-to-event staleness cursor (F2). The reconciler
- * passes `null` deliberately: a healed row carries no event provenance, so the
- * very next webhook — whatever its `event.created` — must win over it. A healed
- * row must never be able to make a real event look stale.
+ * `lastEventAt` is the event-to-event staleness cursor (F2).
+ *
+ * The webhook path passes `event.created`. The reconciler passes `null` **only
+ * when INSERTing** a brand-new row, so the next webhook wins over a synthesized
+ * one. It must NOT null the cursor on an UPDATE: the guard is
+ * `last_event_at IS NULL OR last_event_at < event.created`, so NULL lets *any*
+ * event win — including a stale one. `drain-unreconciled` replays old events
+ * with their original `created`, so nulling an existing cursor would re-open the
+ * out-of-order window PR-1 closed. On an update the caller preserves the
+ * existing cursor.
  */
 export function buildHostedEntitlementValues(params: {
   tier: HostedTier;

--- a/apps/server/src/lib/synthetic-events.ts
+++ b/apps/server/src/lib/synthetic-events.ts
@@ -1,0 +1,49 @@
+/**
+ * Synthetic `unreconciled_webhooks.event_id` prefixes.
+ *
+ * Several crons record ops-visible alerts by writing a row into
+ * `unreconciled_webhooks` with a MADE-UP `event_id` (so re-runs collide and the
+ * alert is idempotent). Those ids are not Stripe events and can never be
+ * replayed.
+ *
+ * This matters because `drain-unreconciled` selects EVERY unresolved row and
+ * hands `event_id` to `stripe.events.retrieve()`. Stripe 404s on a synthetic id,
+ * the drainer classifies it `event-missing`, and **marks the row resolved**.
+ *
+ * The consequence, found in review of GAP-356 PR-2: the drainer runs every 15
+ * minutes (the GAP-142 external scheduler) while the reconcilers run once a day
+ * (Vercel Hobby allows one cron). So a synthetic alert is auto-closed long
+ * before the cron that raised it looks again, and because the raising crons
+ * check "does a row with this event_id exist" WITHOUT filtering on
+ * `resolved_at`, they then never raise it again. The alert channel silently
+ * closes itself after the first firing.
+ *
+ * Fix: the drainer skips synthetic ids entirely (they stay unresolved until a
+ * human or the raising cron resolves them), and the raising crons scope their
+ * existence check to unresolved rows.
+ */
+
+/** Every synthetic `event_id` prefix in use. Add new ones here, not inline. */
+export const SYNTHETIC_EVENT_ID_PREFIXES = [
+  /** reconcile-entitlements — entitlement drift (GAP-356 F4) */
+  'cron-entitlement-drift:',
+  /** reconcile-stripe-subscriptions — a live Stripe sub with no local row */
+  'cron-sub-orphan:',
+  /** reconcile-customers — a Stripe customer with no local user */
+  'cron-orphan:',
+  /** webhooks.ts — entitlement tier unresolvable (GAP-356 F3) */
+  'entitlement-unresolved-tier:',
+] as const;
+
+/**
+ * True when `eventId` is a cron-authored alert marker rather than a real Stripe
+ * event id. Substring check only — no regex (fleet no-regex posture).
+ */
+export function isSyntheticEventId(eventId: string): boolean {
+  for (const prefix of SYNTHETIC_EVENT_ID_PREFIXES) {
+    if (eventId.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/apps/server/src/routes/cron/__tests__/reconcile-entitlements.pglite.test.ts
+++ b/apps/server/src/routes/cron/__tests__/reconcile-entitlements.pglite.test.ts
@@ -1,16 +1,17 @@
 /**
- * GAP-356 F5 test 4 — the entitlement-consistency reconciler (PR-2).
+ * GAP-356 F5 test 4 — the entitlement-consistency reconciler.
  *
- * PGlite (in-memory Postgres) + real Drizzle + the REAL migrations, driving the
- * actual cron route. The defect this cron exists to catch lives in cross-table
- * state, so a DB-mocked unit test cannot see it — the same reason the original
- * GAP-356 defect escaped every existing test.
+ * PGlite + REAL migrations + the real Hono route. The defects this cron guards
+ * live in cross-table state, so a DB-mocked unit test cannot see them.
  *
- * Proves:
- *   1. license=pro + subscription=trialing + entitlement MISSING  → healed to pro.
- *   2. entitlement=free + no healthy subscription and no license   → NO heal.
- *   3. heal is tier-monotonic UPWARD — an existing higher tier is never lowered.
- *   4. the drift alert row is idempotent across repeated cron runs.
+ * Covers the hardening from the PR-2 adversarial review:
+ *   B1  a STALE subscription (period ended) is never healed from
+ *   B3  a resolved drift alert does NOT suppress the next genuine drift
+ *   B4  a RESUBSCRIBED customer over a terminal entitlement IS healed
+ *   S1  mode scoping — a test-mode row never touches a live entitlement
+ *   S2  `last_event_at` is preserved on UPDATE, nulled only on INSERT
+ *   S4  the previously-untested rails: unresolvable tier, heal disabled, and
+ *       the healed row's features/limits
  */
 
 import { eq } from 'drizzle-orm';
@@ -29,8 +30,14 @@ vi.mock('@revealui/db', () => ({
   getClient: () => testDb.drizzle,
 }));
 
+vi.mock('@revealui/config/stripe-mode', () => ({
+  getConfiguredStripeMode: () => 'live',
+}));
+
 vi.mock('@revealui/core/features', () => ({
-  getFeaturesForTier: vi.fn(() => ({ ai: true, payments: true })),
+  getFeaturesForTier: vi.fn((tier: string) =>
+    tier === 'pro' ? { ai: true, payments: true } : { ai: false, payments: false },
+  ),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({
@@ -51,51 +58,47 @@ import {
   licenses,
   unreconciledWebhooks,
 } from '@revealui/db/schema';
+import { getHostedLimitsForTier } from '../../../lib/tier-limits.js';
 import reconcileEntitlementsRoute from '../reconcile-entitlements.js';
 
 const CRON_SECRET = 'test-cron-secret';
+const HOUR = 60 * 60 * 1000;
 
-async function runCron(): Promise<{ status: number; body: Record<string, unknown> }> {
+async function runCron(): Promise<Record<string, unknown>> {
   const res = await reconcileEntitlementsRoute.request('/reconcile-entitlements', {
     method: 'POST',
     headers: { 'X-Cron-Secret': CRON_SECRET },
   });
-  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+  return (await res.json()) as Record<string, unknown>;
 }
 
-/** Seed an account with one active member. Returns ids. */
 async function seedAccount(): Promise<{ accountId: string; userId: string }> {
   const { randomUUID } = await import('node:crypto');
   const user = await seedTestUser(testDb.drizzle);
   const accountId = randomUUID();
-
-  await testDb.drizzle.insert(accounts).values({
-    id: accountId,
-    name: 'Acme',
-    slug: `acme-${accountId.slice(0, 8)}`,
-    status: 'active',
-  });
-  await testDb.drizzle.insert(accountMemberships).values({
-    id: randomUUID(),
-    accountId,
-    userId: user.id,
-    role: 'owner',
-    status: 'active',
-  });
-
+  await testDb.drizzle
+    .insert(accounts)
+    .values({ id: accountId, name: 'Acme', slug: `acme-${accountId.slice(0, 8)}` });
+  await testDb.drizzle
+    .insert(accountMemberships)
+    .values({ id: randomUUID(), accountId, userId: user.id, role: 'owner', status: 'active' });
   return { accountId, userId: user.id };
 }
 
-async function seedSubscription(accountId: string, planId: string, status: string): Promise<void> {
+async function seedSubscription(
+  accountId: string,
+  opts: { planId: string; status: string; periodEnd?: Date | null; mode?: 'live' | 'test' },
+): Promise<void> {
   const { randomUUID } = await import('node:crypto');
   await testDb.drizzle.insert(accountSubscriptions).values({
     id: randomUUID(),
     accountId,
     stripeCustomerId: `cus_${accountId.slice(0, 8)}`,
     stripeSubscriptionId: `sub_${accountId.slice(0, 8)}`,
-    planId,
-    status,
-    mode: 'test',
+    planId: opts.planId,
+    status: opts.status,
+    currentPeriodEnd: opts.periodEnd ?? new Date(Date.now() + 24 * HOUR),
+    mode: opts.mode ?? 'live',
   });
 }
 
@@ -108,6 +111,7 @@ async function seedLicense(userId: string, tier: string): Promise<void> {
     tier,
     customerId: `cus_${userId.slice(0, 8)}`,
     status: 'active',
+    mode: 'live',
   });
 }
 
@@ -120,7 +124,16 @@ async function getEntitlement(accountId: string) {
   return row;
 }
 
-describe('cron: reconcile-entitlements (GAP-356 F4)', () => {
+async function getAlert(accountId: string) {
+  const [row] = await testDb.drizzle
+    .select()
+    .from(unreconciledWebhooks)
+    .where(eq(unreconciledWebhooks.eventId, `cron-entitlement-drift:${accountId}`))
+    .limit(1);
+  return row;
+}
+
+describe('cron: reconcile-entitlements (GAP-356 F4, hardened)', () => {
   beforeAll(async () => {
     testDb = await createTestDb();
     process.env.REVEALUI_CRON_SECRET = CRON_SECRET;
@@ -131,7 +144,6 @@ describe('cron: reconcile-entitlements (GAP-356 F4)', () => {
   });
 
   beforeEach(async () => {
-    // Order matters: children before parents (FKs).
     await testDb.drizzle.delete(unreconciledWebhooks);
     await testDb.drizzle.delete(accountEntitlements);
     await testDb.drizzle.delete(accountSubscriptions);
@@ -148,95 +160,196 @@ describe('cron: reconcile-entitlements (GAP-356 F4)', () => {
     expect(res.status).toBe(401);
   });
 
-  it('heals a missing entitlement from the local subscription row (license=pro, subscription=trialing)', async () => {
+  it('heals a missing entitlement from a fresh subscription, with the correct feature set', async () => {
     const { accountId, userId } = await seedAccount();
-    await seedSubscription(accountId, 'pro', 'trialing');
+    await seedSubscription(accountId, { planId: 'pro', status: 'trialing' });
     await seedLicense(userId, 'pro');
 
-    // Precondition: the exact production incident — paying/trialing, no entitlement.
-    expect(await getEntitlement(accountId)).toBeUndefined();
-
-    const { status, body } = await runCron();
-    expect(status).toBe(200);
+    const body = await runCron();
     expect(body.healed).toBe(1);
 
     const ent = await getEntitlement(accountId);
-    expect(ent).toBeDefined();
     expect(ent?.tier).toBe('pro');
-    expect(ent?.planId).toBe('pro');
-    // Status is carried from the local subscription row — the trial signal survives.
     expect(ent?.status).toBe('trialing');
     expect(ent?.meteringStatus).toBe('active');
-    // NULL by design: the next webhook must always win over a healed row.
+    expect(ent?.mode).toBe('live');
+    // INSERT: cursor NULL so the next webhook wins.
     expect(ent?.lastEventAt).toBeNull();
+    // S4 — a heal must grant the SAME features/limits the webhook path would.
+    expect(ent?.features).toEqual({ ai: true, payments: true });
+    expect(ent?.limits).toEqual(getHostedLimitsForTier('pro'));
   });
 
-  it('does NOT heal when there is no entitlement source (entitlement=free, no healthy subscription, no license)', async () => {
+  // ── B1: the over-grant the review found ──────────────────────────────────
+  it('does NOT heal from a STALE subscription — an expired trial is not a licence to grant', async () => {
     const { accountId } = await seedAccount();
-    // Canceled subscription is not a healthy source.
-    await seedSubscription(accountId, 'pro', 'canceled');
-    await testDb.drizzle.insert(accountEntitlements).values({
-      accountId,
-      planId: 'free',
-      tier: 'free',
-      status: 'active',
+    // Still says `trialing` because the expiry webhook never landed — the exact
+    // failure class this cron exists to backstop. The period ended a day ago.
+    await seedSubscription(accountId, {
+      planId: 'pro',
+      status: 'trialing',
+      periodEnd: new Date(Date.now() - 24 * HOUR),
     });
 
-    const { body } = await runCron();
+    const body = await runCron();
+    expect(body.healed).toBe(0);
+    expect(body.drift).toBe(1);
+
+    // No free Pro, forever.
+    expect(await getEntitlement(accountId)).toBeUndefined();
+    expect((await getAlert(accountId))?.errorTrace).toContain('STALE');
+  });
+
+  it('does NOT heal when there is no entitlement source at all', async () => {
+    const { accountId } = await seedAccount();
+    await seedSubscription(accountId, { planId: 'pro', status: 'canceled' });
+    await testDb.drizzle
+      .insert(accountEntitlements)
+      .values({ accountId, planId: 'free', tier: 'free', status: 'active', mode: 'live' });
+
+    const body = await runCron();
     expect(body.healed).toBe(0);
     expect(body.drift).toBe(0);
-
-    const ent = await getEntitlement(accountId);
-    expect(ent?.tier).toBe('free');
-
-    // And it must not have invented a drift alert.
-    const alerts = await testDb.drizzle.select().from(unreconciledWebhooks);
-    expect(alerts).toHaveLength(0);
+    expect((await getEntitlement(accountId))?.tier).toBe('free');
+    expect(await getAlert(accountId)).toBeUndefined();
   });
 
   it('never downgrades: an existing higher tier survives a lower-tier subscription', async () => {
     const { accountId } = await seedAccount();
-    await seedSubscription(accountId, 'pro', 'trialing');
-    await testDb.drizzle.insert(accountEntitlements).values({
-      accountId,
-      planId: 'max',
-      tier: 'max',
-      status: 'active',
-    });
+    await seedSubscription(accountId, { planId: 'pro', status: 'trialing' });
+    await testDb.drizzle
+      .insert(accountEntitlements)
+      .values({ accountId, planId: 'max', tier: 'max', status: 'active', mode: 'live' });
 
-    const { body } = await runCron();
+    const body = await runCron();
     expect(body.healed).toBe(0);
+    expect((await getEntitlement(accountId))?.tier).toBe('max');
+  });
+
+  // ── B4: the rail the review found backwards ──────────────────────────────
+  it('HEALS a resubscribed customer whose entitlement is terminal (the old rail denied this)', async () => {
+    const { accountId } = await seedAccount();
+    // They resubscribed — fresh, healthy Pro subscription…
+    await seedSubscription(accountId, { planId: 'pro', status: 'active' });
+    // …but the entitlement still sits expired from the previous cycle because its
+    // write failed. The earlier terminal-status rail refused to heal exactly this
+    // person, while letting a deleted row be resurrected.
+    await testDb.drizzle
+      .insert(accountEntitlements)
+      .values({ accountId, planId: 'free', tier: 'free', status: 'expired', mode: 'live' });
+
+    const body = await runCron();
+    expect(body.healed).toBe(1);
 
     const ent = await getEntitlement(accountId);
-    expect(ent?.tier).toBe('max');
+    expect(ent?.tier).toBe('pro');
     expect(ent?.status).toBe('active');
   });
 
-  it('writes an idempotent drift alert — a standing drift does not re-alert every tick', async () => {
-    // License-only drift: a real entitlement source, but no local subscription
-    // row to safely synthesize from. Alerts, cannot heal — so the drift stands
-    // across runs and the idempotency of the alert row is what is under test.
+  // ── S2: the WH-3 window must stay closed ─────────────────────────────────
+  it('preserves last_event_at on an UPDATE heal (nulling it would let a stale replay win)', async () => {
+    const { accountId } = await seedAccount();
+    const cursor = new Date(Date.now() - 10 * HOUR);
+    await seedSubscription(accountId, { planId: 'max', status: 'active' });
+    await testDb.drizzle.insert(accountEntitlements).values({
+      accountId,
+      planId: 'pro',
+      tier: 'pro',
+      status: 'active',
+      mode: 'live',
+      lastEventAt: cursor,
+    });
+
+    const body = await runCron();
+    expect(body.healed).toBe(1);
+
+    const ent = await getEntitlement(accountId);
+    expect(ent?.tier).toBe('max');
+    // Cursor survives the heal — a stale replayed event must still lose.
+    expect(ent?.lastEventAt?.toISOString()).toBe(cursor.toISOString());
+  });
+
+  // ── S1: mode scoping ─────────────────────────────────────────────────────
+  it('ignores a test-mode subscription when running in live mode', async () => {
+    const { accountId } = await seedAccount();
+    await seedSubscription(accountId, { planId: 'pro', status: 'active', mode: 'test' });
+
+    const body = await runCron();
+    expect(body.healed).toBe(0);
+    expect(body.drift).toBe(0);
+    // A test-mode row must never mint a live entitlement.
+    expect(await getEntitlement(accountId)).toBeUndefined();
+  });
+
+  // ── rails the review found untested ──────────────────────────────────────
+  it('alerts without writing when the tier is unresolvable (never writes from ignorance)', async () => {
+    const { accountId } = await seedAccount();
+    await seedSubscription(accountId, { planId: 'mystery-plan', status: 'active' });
+
+    const body = await runCron();
+    expect(body.drift).toBe(1);
+    expect(body.healed).toBe(0);
+    expect(await getEntitlement(accountId)).toBeUndefined();
+    expect((await getAlert(accountId))?.eventType).toBe('entitlement.drift');
+  });
+
+  it('alerts without healing when RECONCILE_ENTITLEMENTS_HEAL=false', async () => {
+    process.env.RECONCILE_ENTITLEMENTS_HEAL = 'false';
+    const { accountId } = await seedAccount();
+    await seedSubscription(accountId, { planId: 'pro', status: 'active' });
+
+    const body = await runCron();
+    expect(body.healEnabled).toBe(false);
+    expect(body.drift).toBe(1);
+    expect(body.healed).toBe(0);
+    expect(await getEntitlement(accountId)).toBeUndefined();
+    expect(await getAlert(accountId)).toBeDefined();
+  });
+
+  // ── B3: the alert channel must not close itself ──────────────────────────
+  it('re-alerts after a previous drift row was resolved (the drainer must not silence us)', async () => {
     const { accountId, userId } = await seedAccount();
+    await seedLicense(userId, 'pro'); // license-only → alert, unhealable
+
+    const first = await runCron();
+    expect(first.alerted).toBe(1);
+
+    // Simulate what `drain-unreconciled` did to our synthetic row: Stripe 404s,
+    // so it stamped resolvedAt. (It now skips synthetic ids — but the reconciler
+    // must be robust to a resolved row regardless, since an operator can resolve
+    // one by hand.)
+    await testDb.drizzle
+      .update(unreconciledWebhooks)
+      .set({ resolvedAt: new Date(), resolvedBy: 'cron:event-missing' })
+      .where(eq(unreconciledWebhooks.eventId, `cron-entitlement-drift:${accountId}`));
+
+    const second = await runCron();
+    // The drift is still real, so it MUST be raised again.
+    expect(second.drift).toBe(1);
+    expect(second.alerted).toBe(1);
+    expect((await getAlert(accountId))?.resolvedAt).toBeNull();
+  });
+
+  it('does not re-alert while the drift row is still open', async () => {
+    const { userId } = await seedAccount();
     await seedLicense(userId, 'pro');
 
     const first = await runCron();
-    expect(first.body.drift).toBe(1);
-    expect(first.body.alerted).toBe(1);
-    expect(first.body.healed).toBe(0);
-
+    expect(first.alerted).toBe(1);
     const second = await runCron();
-    expect(second.body.drift).toBe(1);
-    // Still drifting, but NOT re-alerted — the synthetic event_id collides.
-    expect(second.body.alerted).toBe(0);
+    expect(second.drift).toBe(1);
+    expect(second.alerted).toBe(0); // still open — no duplicate
+  });
 
-    const alerts = await testDb.drizzle
-      .select()
-      .from(unreconciledWebhooks)
-      .where(eq(unreconciledWebhooks.eventId, `cron-entitlement-drift:${accountId}`));
-    expect(alerts).toHaveLength(1);
-    expect(alerts[0]?.eventType).toBe('entitlement.drift');
+  it('closes its own alert once the drift is healed', async () => {
+    const { accountId } = await seedAccount();
+    await seedSubscription(accountId, { planId: 'pro', status: 'active' });
 
-    // No entitlement was synthesized from a license alone.
-    expect(await getEntitlement(accountId)).toBeUndefined();
+    const body = await runCron();
+    expect(body.healed).toBe(1);
+
+    const alert = await getAlert(accountId);
+    expect(alert?.resolvedAt).not.toBeNull();
+    expect(alert?.resolvedBy).toBe('cron:reconcile-entitlements');
   });
 });

--- a/apps/server/src/routes/cron/dispatch.ts
+++ b/apps/server/src/routes/cron/dispatch.ts
@@ -73,20 +73,29 @@ const JOBS = [
     app: reconcileStripeSubscriptionsApp,
     path: '/reconcile-stripe-subscriptions',
   },
-  // reconcile-entitlements (GAP-356 F4) runs AFTER the subscription reconcilers
-  // so it evaluates the freshest local subscription rows, and BEFORE
-  // sweep-grace-periods, which acts on entitlement state. It checks the one
-  // invariant none of the crons above covered: a healthy subscription or an
-  // active license MUST have a matching `account_entitlements` row. Alerts on
-  // drift and heals upward from the local subscription row.
+  { name: 'billing-readiness', app: billingReadinessApp, path: '/billing-readiness' },
+  { name: 'publish-scheduled', app: publishScheduledApp, path: '/publish-scheduled' },
+  { name: 'sweep-grace-periods', app: sweepGracePeriodsApp, path: '/sweep-grace-periods' },
+  // reconcile-entitlements (GAP-356 F4) checks the one invariant none of the
+  // crons above cover: a healthy, FRESH subscription (or an active license) MUST
+  // have a matching `account_entitlements` row. Alerts on drift; heals upward
+  // from the local subscription row.
+  //
+  // It runs AFTER sweep-grace-periods on purpose. All ~13 jobs share ONE 30s
+  // function (Vercel Hobby allows a single daily cron), so a job that overruns
+  // starves every job behind it. sweep-grace-periods is the cron that EXPIRES
+  // access for non-payers; letting a healer that GRANTS access run ahead of the
+  // revoker means a bad day for the healer becomes a free-access day for
+  // everyone who stopped paying. Revoke first, then heal.
+  //
+  // Running after the sweep also means this job sees the sweep's own
+  // expirations, so it will not re-grant what was just expired: the sweep sets
+  // account_subscriptions.status = 'expired', which fails the healthy check.
   {
     name: 'reconcile-entitlements',
     app: reconcileEntitlementsApp,
     path: '/reconcile-entitlements',
   },
-  { name: 'billing-readiness', app: billingReadinessApp, path: '/billing-readiness' },
-  { name: 'publish-scheduled', app: publishScheduledApp, path: '/publish-scheduled' },
-  { name: 'sweep-grace-periods', app: sweepGracePeriodsApp, path: '/sweep-grace-periods' },
   { name: 'marketplace-payouts', app: marketplacePayoutsApp, path: '/marketplace-payouts' },
   { name: 'cleanup', app: cleanupApp, path: '/cleanup' },
   // lifecycle-emails evaluates onboarding day-0/day-1/day-7 sends. Disarmed by

--- a/apps/server/src/routes/cron/drain-unreconciled.ts
+++ b/apps/server/src/routes/cron/drain-unreconciled.ts
@@ -38,6 +38,7 @@ import { and, asc, eq, isNull } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
 import { getServices } from '../../lib/services-loader.js';
+import { isSyntheticEventId } from '../../lib/synthetic-events.js';
 import { replayStripeEvent } from '../../lib/webhook-replay.js';
 import webhooksApp from '../webhooks.js';
 
@@ -53,7 +54,9 @@ type Outcome =
   | 'event-missing'
   | 'stripe-error'
   | 'handler-error'
-  | 'timeout';
+  | 'timeout'
+  /** A cron-authored alert marker, not a Stripe event. Left unresolved on purpose. */
+  | 'skipped-synthetic';
 
 interface Result {
   eventId: string;
@@ -136,6 +139,24 @@ app.post('/drain-unreconciled', async (c) => {
     const ageMs = Date.now() - row.createdAt.getTime();
     const critical = ageMs >= CRITICAL_AGE_MS;
     if (critical) criticalCount += 1;
+
+    // Synthetic ids are cron-authored alert markers, not Stripe events. Passing
+    // one to stripe.events.retrieve() 404s, which this drainer classifies as
+    // `event-missing` and RESOLVES — silently closing an open alert that no
+    // human has acted on. Worse, the raising cron then never re-raises it,
+    // because its idempotency check keys on event_id alone. Skip them: they stay
+    // unresolved until the raising cron heals the underlying drift (and resolves
+    // its own row) or an operator does. See lib/synthetic-events.ts.
+    if (isSyntheticEventId(row.eventId)) {
+      results.push({
+        eventId: row.eventId,
+        eventType: row.eventType,
+        outcome: 'skipped-synthetic',
+        ageMs,
+        critical,
+      });
+      continue;
+    }
 
     if (Date.now() - startedAt >= durationBudgetMs) {
       results.push({

--- a/apps/server/src/routes/cron/reconcile-entitlements.ts
+++ b/apps/server/src/routes/cron/reconcile-entitlements.ts
@@ -1,47 +1,67 @@
 /**
  * Cron: Reconcile Account Entitlements (GAP-356 F4 — the missing detector + healer)
  *
- * The invariant, checked per account with at least one active membership:
+ * The invariant, per account with an active membership:
  *
- *   IF `account_subscriptions` has a healthy row (`active`/`trialing`)
+ *   IF the local `account_subscriptions` row is HEALTHY AND FRESH
  *   OR a member holds a non-deleted `active` license
- *   THEN `account_entitlements` MUST exist with the matching tier.
+ *   THEN `account_entitlements` MUST exist with at least the matching tier.
  *
- * When it does not, a paying customer is silently gated as free. That is the
- * GAP-356 production incident: a real Pro trial resolved to `free` forever
- * because the entitlement write never landed, and nothing in the fleet noticed.
- * Every existing reconcile cron walks subscriptions; none checked entitlements,
- * so the defect was invisible to all of them.
+ * When it does not, a paying customer is silently gated as free — the GAP-356
+ * production incident. Every other reconcile cron walks subscriptions; none
+ * checked entitlements, so the defect was invisible to all of them.
  *
- * On violation:
- *   (a) ALERT — an idempotent `unreconciledWebhooks` row (`event_type:
- *       'entitlement.drift'`, synthetic `event_id` so re-runs collide).
- *   (b) HEAL — synthesize the entitlement FROM THE LOCAL SUBSCRIPTION ROW ONLY.
+ * ─── Authority model (read this before changing the heal) ───────────────────
  *
- * Why local-only: the local subscription row was written by a signature-verified
- * Stripe webhook. Healing from it adds no new trust. Healing from a raw Stripe
- * read would widen the attack surface to anyone who can create Stripe objects —
- * which is exactly why `reconcile-stripe-subscriptions` stayed alert-only.
+ * The **local subscription row is the only heal source**, and it is authoritative
+ * *only while it is fresh*. It was written by a signature-verified Stripe
+ * webhook, so healing from it adds no new trust — but provenance is not
+ * currency. A row frozen at `trialing` because the trial-expiry webhook failed
+ * (exactly the failure class this cron backstops) would otherwise re-grant Pro
+ * forever, for free. So:
  *
- * Heal safety rails:
- *   - **Tier-monotonic UPWARD only.** A heal may raise a tier, never lower one.
- *     Downgrades are a business decision and stay webhook-driven.
- *   - **Never resurrects a terminal entitlement.** If the existing row is
- *     `revoked`/`expired`/`canceled`, we alert but do NOT heal. Healing it would
- *     re-grant access to an account someone deliberately cut off, which is the
- *     resurrection vector the WH-3 staleness guard exists to prevent. A stale
- *     local subscription row must never be able to undo a revocation.
- *   - **`last_event_at` is written NULL on healed rows**, so the very next
- *     webhook — whatever its `event.created` — wins over the heal. A healed row
- *     can never make a real event look stale.
- *   - Heal is gated by `RECONCILE_ENTITLEMENTS_HEAL` (default ON). Set it to
- *     'false' to run detector-only.
+ *   healthy = status IN ('active','trialing')
+ *             AND (current_period_end IS NULL OR current_period_end > now)
  *
- * Protected by X-Cron-Secret (timing-safe compare), same gate as the sibling
- * reconciliation crons.
+ * An expired period means the row is STALE, not that the customer is entitled.
+ * A stale row alerts and is never healed from.
+ *
+ * **Stripe is the cut-off mechanism, not the database.** To revoke access, cancel
+ * the subscription in Stripe: the webhook flips the local row to a non-healthy
+ * status and this cron stops healing. Hand-editing `account_entitlements`
+ * (setting tier to free, or deleting the row) is NOT a supported revocation — it
+ * will be healed back within a day, correctly, because a fresh healthy
+ * subscription says the customer is paying.
+ *
+ * There is deliberately NO entitlement-status rail here. An earlier draft refused
+ * to heal `revoked`/`expired`/`canceled` entitlements. That was backwards: those
+ * statuses are unreachable while a subscription is healthy, and the one case the
+ * rail did catch was a customer who RESUBSCRIBED after expiry and whose
+ * entitlement write failed — it denied exactly the person it should have healed.
+ *
+ * ─── Heal rails ─────────────────────────────────────────────────────────────
+ *   - Tier-monotonic UPWARD only (`isUpgrade`, sharing the single TIER_RANK in
+ *     lib/downgrade-cap.ts). Downgrades stay webhook-driven.
+ *   - Never heals from an unresolvable tier (F3, applied to the healer).
+ *   - `last_event_at` is NULL only on INSERT, never nulled on UPDATE — NULL lets
+ *     *any* event win, including a stale replay from `drain-unreconciled`.
+ *   - Mode-scoped throughout: a test-mode row must never touch live entitlements.
+ *   - Gated by `RECONCILE_ENTITLEMENTS_HEAL` (default ON).
+ *
+ * ─── Cost ───────────────────────────────────────────────────────────────────
+ * Vercel Hobby allows ONE cron/day, and `dispatch.ts` runs all ~13 jobs
+ * sequentially inside a single 30s function. So this job is **set-based**: one
+ * scan query covering every account, then writes only for the (small) drift set.
+ * An earlier draft did 4 queries per account under a 500-row cap, which both ate
+ * the shared budget and silently never reconciled account 501+. It is registered
+ * AFTER `sweep-grace-periods` so that even if it exhausts its budget it cannot
+ * starve the cron that REVOKES access for non-payers.
+ *
+ * Protected by X-Cron-Secret (timing-safe compare).
  */
 
 import { timingSafeEqual } from 'node:crypto';
+import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import {
@@ -51,42 +71,36 @@ import {
   licenses,
   unreconciledWebhooks,
 } from '@revealui/db/schema';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
+import { isUpgrade } from '../../lib/downgrade-cap.js';
 import {
   buildHostedEntitlementValues,
   coerceHostedTier,
   type HostedTier,
-  isTierUpgrade,
 } from '../../lib/hosted-entitlement.js';
 
 const app = new Hono();
 
-const DEFAULT_BATCH_SIZE = 500;
-const MAX_BATCH_SIZE = 2000;
 const DRIFT_EVENT_TYPE = 'entitlement.drift';
+const DRIFT_EVENT_ID_PREFIX = 'cron-entitlement-drift:';
+/** Headroom inside dispatch's shared 30s budget. */
+const DEFAULT_DURATION_BUDGET_MS = 8000;
 
-/** Subscription statuses that entitle the account to access. */
 const HEALTHY_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing']);
-
-/**
- * Entitlement statuses that must NOT be healed back to life. A row in one of
- * these states was deliberately cut off; a cron inferring from a possibly-stale
- * local subscription row has no business re-granting it.
- */
-const TERMINAL_ENTITLEMENT_STATUSES = new Set(['revoked', 'expired', 'canceled']);
 
 type Outcome =
   | 'ok'
   | 'no-entitlement-source'
   | 'drift-healed'
+  | 'drift-alert-only-stale-subscription'
   | 'drift-alert-only-no-subscription'
   | 'drift-alert-only-unresolvable-tier'
-  | 'drift-alert-only-terminal'
-  | 'drift-alert-only-heal-disabled';
+  | 'drift-alert-only-heal-disabled'
+  | 'drift-alert-only-budget-exhausted';
 
-interface AccountScanResult {
+interface ScanResult {
   accountId: string;
   outcome: Outcome;
   expectedTier?: HostedTier;
@@ -94,7 +108,6 @@ interface AccountScanResult {
 }
 
 app.post('/reconcile-entitlements', async (c) => {
-  // ── auth gate (mirrors the sibling reconcile crons) ───────────────────
   const cronSecret = process.env.REVEALUI_CRON_SECRET;
   const provided = c.req.header('X-Cron-Secret') || c.req.header('x-cron-secret');
 
@@ -111,104 +124,84 @@ app.post('/reconcile-entitlements', async (c) => {
     return c.json({ error: 'Unauthorized' }, 401);
   }
 
-  const batchSize = Math.min(
-    Number.parseInt(process.env.RECONCILE_ENTITLEMENTS_BATCH_SIZE ?? '', 10) || DEFAULT_BATCH_SIZE,
-    MAX_BATCH_SIZE,
-  );
-  // Default ON. Only an explicit 'false' disables healing.
   const healEnabled = (process.env.RECONCILE_ENTITLEMENTS_HEAL ?? 'true').toLowerCase() !== 'false';
+  const durationBudgetMs =
+    Number.parseInt(process.env.RECONCILE_ENTITLEMENTS_BUDGET_MS ?? '', 10) ||
+    DEFAULT_DURATION_BUDGET_MS;
 
   const db = getClient();
+  const mode = getConfiguredStripeMode();
   const startedAt = Date.now();
+  const now = new Date();
 
-  // ── accounts with at least one active membership ──────────────────────
-  const activeAccounts = await db
-    .selectDistinct({ accountId: accountMemberships.accountId })
+  // ── ONE scan query for every account with an active membership ────────────
+  // Subscription and entitlement are at most one row per account (mode-scoped),
+  // so the join fans out only on membership count; the license probe is folded
+  // in as a correlated EXISTS rather than an N+1.
+  const scanned = await db
+    .selectDistinct({
+      accountId: accountMemberships.accountId,
+      subPlanId: accountSubscriptions.planId,
+      subStatus: accountSubscriptions.status,
+      subPeriodEnd: accountSubscriptions.currentPeriodEnd,
+      subCustomerId: accountSubscriptions.stripeCustomerId,
+      subSubscriptionId: accountSubscriptions.stripeSubscriptionId,
+      entAccountId: accountEntitlements.accountId,
+      entTier: accountEntitlements.tier,
+      entLastEventAt: accountEntitlements.lastEventAt,
+      hasActiveLicense: sql<boolean>`EXISTS (
+        SELECT 1 FROM ${licenses} l
+        JOIN ${accountMemberships} m2 ON m2.user_id = l.user_id
+        WHERE m2.account_id = ${accountMemberships.accountId}
+          AND m2.status = 'active'
+          AND l.status = 'active'
+          AND l.deleted_at IS NULL
+          AND l.mode = ${mode}
+      )`.as('has_active_license'),
+    })
     .from(accountMemberships)
-    .where(eq(accountMemberships.status, 'active'))
-    .limit(batchSize);
+    .leftJoin(
+      accountSubscriptions,
+      and(
+        eq(accountSubscriptions.accountId, accountMemberships.accountId),
+        eq(accountSubscriptions.mode, mode),
+      ),
+    )
+    .leftJoin(
+      accountEntitlements,
+      and(
+        eq(accountEntitlements.accountId, accountMemberships.accountId),
+        eq(accountEntitlements.mode, mode),
+      ),
+    )
+    .where(eq(accountMemberships.status, 'active'));
 
-  const results: AccountScanResult[] = [];
+  const results: ScanResult[] = [];
   let driftCount = 0;
   let healedCount = 0;
   let alertedCount = 0;
 
-  for (const { accountId } of activeAccounts) {
-    // ── the entitlement SOURCES: a healthy local subscription, or an active
-    //    license held by an active member ───────────────────────────────
-    const [subscription] = await db
-      .select({
-        planId: accountSubscriptions.planId,
-        status: accountSubscriptions.status,
-        mode: accountSubscriptions.mode,
-        stripeCustomerId: accountSubscriptions.stripeCustomerId,
-        stripeSubscriptionId: accountSubscriptions.stripeSubscriptionId,
-      })
-      .from(accountSubscriptions)
-      .where(eq(accountSubscriptions.accountId, accountId))
-      .limit(1);
+  for (const row of scanned) {
+    const accountId = row.accountId;
 
-    const healthySubscription =
-      subscription && HEALTHY_SUBSCRIPTION_STATUSES.has(subscription.status)
-        ? subscription
-        : undefined;
+    // A subscription is an entitlement source only while HEALTHY *and* FRESH.
+    const statusHealthy = row.subStatus ? HEALTHY_SUBSCRIPTION_STATUSES.has(row.subStatus) : false;
+    const periodFresh = !row.subPeriodEnd || row.subPeriodEnd.getTime() > now.getTime();
+    const subscriptionUsable = statusHealthy && periodFresh;
+    const subscriptionStale = statusHealthy && !periodFresh;
+    const hasActiveLicense = row.hasActiveLicense === true;
 
-    const memberIds = await db
-      .select({ userId: accountMemberships.userId })
-      .from(accountMemberships)
-      .where(
-        and(eq(accountMemberships.accountId, accountId), eq(accountMemberships.status, 'active')),
-      );
-
-    let hasActiveLicense = false;
-    if (memberIds.length > 0) {
-      const held = await db
-        .select({ id: licenses.id })
-        .from(licenses)
-        .where(
-          and(
-            inArray(
-              licenses.userId,
-              memberIds.map((m) => m.userId),
-            ),
-            eq(licenses.status, 'active'),
-            isNull(licenses.deletedAt),
-          ),
-        )
-        .limit(1);
-      hasActiveLicense = held.length > 0;
-    }
-
-    // No entitlement source at all → the account is legitimately free.
-    // This is the "entitlements=free + no healthy subscription/license" case:
-    // NOT drift, and explicitly NOT healed.
-    if (!(healthySubscription || hasActiveLicense)) {
+    if (!(subscriptionUsable || subscriptionStale || hasActiveLicense)) {
       results.push({ accountId, outcome: 'no-entitlement-source' });
       continue;
     }
 
-    // ── the expected tier comes ONLY from the local subscription row ─────
-    const expectedTier = coerceHostedTier(healthySubscription?.planId);
-
-    const [entitlement] = await db
-      .select({
-        accountId: accountEntitlements.accountId,
-        tier: accountEntitlements.tier,
-        status: accountEntitlements.status,
-      })
-      .from(accountEntitlements)
-      .where(eq(accountEntitlements.accountId, accountId))
-      .limit(1);
-
-    const actualTier = coerceHostedTier(entitlement?.tier) ?? null;
-
-    // ── is the invariant satisfied? ───────────────────────────────────────
-    // Satisfied when an entitlement row exists AND (we have no expected tier to
-    // compare against, OR the row is already at least the expected tier).
-    const missing = !entitlement;
+    const expectedTier = subscriptionUsable ? coerceHostedTier(row.subPlanId) : undefined;
+    const actualTier = coerceHostedTier(row.entTier) ?? null;
+    const missing = !row.entAccountId;
     const belowExpected =
       !missing && expectedTier !== undefined && actualTier !== null
-        ? isTierUpgrade(actualTier, expectedTier)
+        ? isUpgrade(actualTier, expectedTier)
         : false;
 
     if (!(missing || belowExpected)) {
@@ -216,128 +209,136 @@ app.post('/reconcile-entitlements', async (c) => {
       continue;
     }
 
-    // ── DRIFT ─────────────────────────────────────────────────────────────
     driftCount += 1;
 
     const alerted = await recordDrift(db, {
       accountId,
       expectedTier,
       actualTier,
-      customerId: healthySubscription?.stripeCustomerId ?? null,
-      subscriptionId: healthySubscription?.stripeSubscriptionId ?? null,
+      customerId: row.subCustomerId ?? null,
+      subscriptionId: row.subSubscriptionId ?? null,
       hasActiveLicense,
+      subscriptionStale,
     });
     if (alerted) {
       alertedCount += 1;
     }
 
-    // ── can we heal? ──────────────────────────────────────────────────────
+    const alertOnly = (outcome: Outcome): void => {
+      results.push({ accountId, outcome, expectedTier, actualTier });
+    };
+
     if (!healEnabled) {
-      results.push({
-        accountId,
-        outcome: 'drift-alert-only-heal-disabled',
-        expectedTier,
-        actualTier,
-      });
+      alertOnly('drift-alert-only-heal-disabled');
       continue;
     }
-
-    // Heal source is the LOCAL SUBSCRIPTION ROW ONLY. A license-only account
-    // (no healthy subscription row) has nothing safe to synthesize from.
-    if (!healthySubscription) {
-      results.push({
-        accountId,
-        outcome: 'drift-alert-only-no-subscription',
-        expectedTier,
-        actualTier,
-      });
+    // A stale row is NOT a licence to grant. Alert; never heal from it.
+    if (subscriptionStale) {
+      alertOnly('drift-alert-only-stale-subscription');
       continue;
     }
-
-    // Refuse to write a tier we cannot resolve — the F3 "never write from
-    // ignorance" rule applies to the healer exactly as it does to the webhook.
+    // License-only: nothing safe to synthesize from. An operator resends the event.
+    if (!subscriptionUsable) {
+      alertOnly('drift-alert-only-no-subscription');
+      continue;
+    }
+    // F3: never write a tier we cannot resolve.
     if (expectedTier === undefined) {
-      results.push({
-        accountId,
-        outcome: 'drift-alert-only-unresolvable-tier',
-        expectedTier,
-        actualTier,
-      });
+      alertOnly('drift-alert-only-unresolvable-tier');
+      continue;
+    }
+    if (Date.now() - startedAt >= durationBudgetMs) {
+      alertOnly('drift-alert-only-budget-exhausted');
       continue;
     }
 
-    // Never resurrect a deliberately terminated entitlement.
-    if (entitlement && TERMINAL_ENTITLEMENT_STATUSES.has(entitlement.status)) {
-      logger.warn(
-        '[reconcile-entitlements] drift on a terminal entitlement — alerting without healing (refusing to resurrect a revoked/expired/canceled row)',
-        { accountId, entitlementStatus: entitlement.status, expectedTier },
-      );
-      results.push({ accountId, outcome: 'drift-alert-only-terminal', expectedTier, actualTier });
-      continue;
-    }
-
-    const now = new Date();
     const values = buildHostedEntitlementValues({
       tier: expectedTier,
-      status: healthySubscription.status,
-      mode: healthySubscription.mode === 'test' ? 'test' : 'live',
+      status: row.subStatus ?? 'active',
+      mode,
       graceUntil: null,
-      // NULL by design: the next webhook must always win over a healed row.
-      lastEventAt: null,
+      // INSERT: NULL, so the next webhook wins over a synthesized row.
+      // UPDATE: preserve the cursor — nulling it would let a STALE replayed
+      // event win and re-open the WH-3 window PR-1 closed.
+      lastEventAt: missing ? null : (row.entLastEventAt ?? null),
       now,
     });
 
-    if (entitlement) {
-      await db
-        .update(accountEntitlements)
-        .set(values)
-        .where(eq(accountEntitlements.accountId, accountId));
-    } else {
+    if (missing) {
       await db
         .insert(accountEntitlements)
         .values({ accountId, ...values })
         .onConflictDoNothing();
+    } else {
+      await db
+        .update(accountEntitlements)
+        .set(values)
+        .where(
+          and(eq(accountEntitlements.accountId, accountId), eq(accountEntitlements.mode, mode)),
+        );
     }
+
+    // The drift is gone — close our own alert row, so a FUTURE drift on this
+    // account can raise a fresh one (recordDrift only suppresses on an UNRESOLVED row).
+    await db
+      .update(unreconciledWebhooks)
+      .set({ resolvedAt: new Date(), resolvedBy: 'cron:reconcile-entitlements' })
+      .where(
+        and(
+          eq(unreconciledWebhooks.eventId, `${DRIFT_EVENT_ID_PREFIX}${accountId}`),
+          isNull(unreconciledWebhooks.resolvedAt),
+        ),
+      );
 
     healedCount += 1;
     logger.error(
       `[reconcile-entitlements] HEALED entitlement drift for account ${accountId}`,
       undefined,
-      { accountId, expectedTier, actualTier, status: healthySubscription.status },
+      { accountId, expectedTier, actualTier, status: row.subStatus },
     );
     results.push({ accountId, outcome: 'drift-healed', expectedTier, actualTier });
   }
 
-  if (driftCount > 0) {
+  // Page ops only for drift we could NOT fix. A fully-healed run is a success,
+  // not an incident.
+  const unhealed = driftCount - healedCount;
+  if (unhealed > 0) {
     void sendCronFailureAlert({
       jobName: 'reconcile-entitlements',
       error: new Error(
-        `CRITICAL: ${driftCount} account(s) with entitlement drift — paying customers may be gated as free`,
+        `${unhealed} account(s) with UNHEALED entitlement drift — paying customers may be gated as free`,
       ),
       severity: 'error',
-      metadata: { drift: driftCount, healed: healedCount, alerted: alertedCount },
+      metadata: { drift: driftCount, healed: healedCount, unhealed, alerted: alertedCount },
     });
   }
 
   return c.json(
     {
-      scanned: activeAccounts.length,
+      scanned: scanned.length,
       drift: driftCount,
       healed: healedCount,
+      unhealed,
       alerted: alertedCount,
       healEnabled,
+      mode,
       durationMs: Date.now() - startedAt,
-      results,
+      // Exceptions only — echoing every account id would be a payload and
+      // log-noise problem at scale.
+      results: results.filter((r) => r.outcome !== 'ok' && r.outcome !== 'no-entitlement-source'),
     },
     200,
   );
 });
 
 /**
- * Idempotent drift alert. The synthetic event_id collides on re-runs, so a
- * standing drift does not spam a new row every tick.
+ * Idempotent drift alert.
  *
- * Returns true when a NEW alert row was written.
+ * The existence check is scoped to UNRESOLVED rows. A previously-resolved row
+ * must not suppress a fresh alert — that is the bug that let the alert channel
+ * close itself permanently after a single firing (see lib/synthetic-events.ts).
+ *
+ * Returns true when a new alert was raised.
  */
 async function recordDrift(
   db: ReturnType<typeof getClient>,
@@ -348,17 +349,18 @@ async function recordDrift(
     customerId: string | null;
     subscriptionId: string | null;
     hasActiveLicense: boolean;
+    subscriptionStale: boolean;
   },
 ): Promise<boolean> {
-  const syntheticEventId = `cron-entitlement-drift:${params.accountId}`;
+  const eventId = `${DRIFT_EVENT_ID_PREFIX}${params.accountId}`;
 
-  const existing = await db
+  const open = await db
     .select({ eventId: unreconciledWebhooks.eventId })
     .from(unreconciledWebhooks)
-    .where(eq(unreconciledWebhooks.eventId, syntheticEventId))
+    .where(and(eq(unreconciledWebhooks.eventId, eventId), isNull(unreconciledWebhooks.resolvedAt)))
     .limit(1);
 
-  if (existing.length > 0) {
+  if (open.length > 0) {
     return false;
   }
 
@@ -366,39 +368,44 @@ async function recordDrift(
     `Entitlement drift for account ${params.accountId}:`,
     `expected tier ${params.expectedTier ?? 'unresolvable'},`,
     `actual ${params.actualTier ?? 'NO ENTITLEMENT ROW'}.`,
+    params.subscriptionStale
+      ? 'The local subscription row is STALE (current_period_end has passed) and was NOT healed from — the period likely expired and the expiry webhook never landed.'
+      : '',
     params.hasActiveLicense ? 'An active license is held by a member.' : '',
-    'A paying customer is being gated below what they bought.',
-    'Remedy: the reconciler heals from the local subscription row when it can;',
-    'if it could not, resend the checkout.session.completed event from Stripe.',
+    'Remedy: resend the relevant Stripe event, or cancel the subscription in Stripe if the customer is no longer entitled.',
   ]
     .filter(Boolean)
     .join(' ');
 
   try {
+    // A RESOLVED row with this id may already exist (an earlier, since-healed
+    // drift). Re-open it rather than letting the PK conflict swallow the alert.
     await db
       .insert(unreconciledWebhooks)
       .values({
-        eventId: syntheticEventId,
+        eventId,
         eventType: DRIFT_EVENT_TYPE,
         customerId: params.customerId,
         stripeObjectId: params.subscriptionId,
         objectType: 'subscription',
         errorTrace,
       })
-      .onConflictDoNothing();
+      .onConflictDoUpdate({
+        target: unreconciledWebhooks.eventId,
+        set: { resolvedAt: null, resolvedBy: null, errorTrace, createdAt: new Date() },
+      });
     logger.error(
-      `[reconcile-entitlements] CRITICAL: entitlement drift for account ${params.accountId}`,
+      `[reconcile-entitlements] entitlement drift for account ${params.accountId}`,
       undefined,
       {
         accountId: params.accountId,
         expectedTier: params.expectedTier,
         actualTier: params.actualTier,
+        subscriptionStale: params.subscriptionStale,
       },
     );
     return true;
   } catch (err) {
-    // Two ticks can race on the same synthetic id; the loser is fine — the row
-    // is the goal, not who wrote it.
     logger.warn(
       `[reconcile-entitlements] drift alert insert raced for ${params.accountId} — treating as already-tracked`,
       { detail: err instanceof Error ? err.message : String(err) },


### PR DESCRIPTION
Addresses the **REQUEST-CHANGES** verdict on #1873 ([verdict comment](https://github.com/RevealUIStudio/revealui/pull/1873#issuecomment-4953543688)).

#1873 shipped a cron that **writes paid entitlements in production**. An independent adversarial review found four defects that each either over-grant access, disable the alert channel the cron exists to provide, or starve the cron that revokes access. **None of it reached production** — #1873 is on `test` only, and the promote was held. But `test` cannot promote until this lands, because any promote carries that cron to `main`.

I wrote the code under review. Everything below is a fix to my own defect.

## B1 — Over-grant: no freshness bound (the worst one)

The healer never read `currentPeriodEnd`. `HEALTHY_SUBSCRIPTION_STATUSES` was a bare string check on `status`, and `isHealthyStatus` grants full tier for `trialing` with no expiry comparison.

So: a trial ends → Stripe's expiry webhook **fails** (the exact failure class this cron backstops) → the local row stays frozen at `trialing`/`pro` → **every tick, my cron re-granted Pro. Forever. Free.** I created a path that converts a stale local row into granted access with no Stripe event behind it. That capability did not exist before.

A subscription is now an entitlement source only while `status` is healthy **AND** `current_period_end` is null or in the future. Provenance is not currency: a signature-verified webhook wrote the row, but that says nothing about whether it's still true. A stale row alerts and is **never** healed from.

## B3 — The alert channel closed itself (proven)

`drain-unreconciled` selects **every** unresolved row and hands `event_id` to `stripe.events.retrieve()`. A synthetic id 404s → it classifies `event-missing` → **it marks the row resolved.** The drainer runs every 15 minutes (the GAP-142 external scheduler); this cron runs daily (Vercel Hobby allows one cron). So the alert was auto-closed within 15 minutes — and because `recordDrift` keyed idempotency on `event_id` alone, **that account could never raise a drift alert again.**

The original idempotency test passed only because no drainer ran between its two ticks. Production has one.

Fixed on both sides:
- `lib/synthetic-events.ts` — the drainer now skips cron-authored ids. This also protects the **two pre-existing callers** with the same latent bug (`cron-sub-orphan:`, `entitlement-unresolved-tier:`), which were silently being auto-resolved too.
- `recordDrift` scopes its check to **unresolved** rows, and re-opens a resolved one rather than losing the alert to a PK conflict.
- A successful heal now **closes its own alert**, so the row doesn't linger unresolved forever.

## B2 / B4 — The terminal rail was backwards

I added a rail refusing to heal `revoked`/`expired`/`canceled` entitlements, and flagged it for the verdict. The review traced every reachable status and showed it is **unreachable in practice** — `revoked` is never written to entitlements (all 14 sites target `licenses`), and `expired`/`canceled` always accompany a non-healthy subscription, which bails earlier.

The one case it *did* catch: a customer who **resubscribed** after expiry and whose entitlement write failed. My rail denied exactly the person it should have healed. Meanwhile the real resurrection vector — a manually **deleted** row — sailed straight through, because the check required the row to exist.

Removed, and replaced with an explicit, documented authority model:

> **Stripe is the cut-off mechanism, not the database.** Cancel the subscription and the local row stops being healthy, so the cron stops healing. Hand-editing `account_entitlements` (tier→free, or deleting the row) is **not** a supported revocation — it will be healed back within a day, *correctly*, because a fresh healthy subscription says the customer is paying.

With B1's freshness bound in place, that model is safe: a dead trial no longer looks healthy.

## B5 — Cost, and the dangerous ordering

Vercel Hobby allows **one cron/day**, and `dispatch.ts` runs all ~13 jobs sequentially inside a single 30s function.

- I had 4 queries per account under a 500-row cap. Past 500 accounts the remainder was **silently never reconciled** — the cap was a scan limit masquerading as a batch. A keyset cursor doesn't fix that under a daily tick (account #501 waits a day, #1001 two days), so the job is now **set-based**: one scan query for all accounts, with the license probe folded in as a correlated `EXISTS`. Writes happen only for the (small) drift set.
- I registered it **before `sweep-grace-periods`** — the cron that **expires** access for non-payers. If my job ate the shared budget, revocation wouldn't run that day. It now runs **after** the sweep. A healer that grants access must never starve the revoker. (Running after the sweep also means it sees the sweep's own expirations and won't re-grant what was just expired.)

## Also fixed

- **Mode scoping** on every read and write. `account_id` is the entitlement PK, so a heal driven by a **test-mode** subscription would have flipped the account's single row to `mode: 'test'` — making it invisible to the live consumer. Textbook "paying customer gated as free."
- **`last_event_at` is no longer nulled on UPDATE.** NULL means *any* event wins — including a **stale** one replayed by the drainer with its original `created`. That re-opened the WH-3 out-of-order window PR-1 just closed. NULL on INSERT only.
- **`TIER_RANK` de-duplicated** — now reuses the single map in `downgrade-cap.ts` via a new `isUpgrade` beside `isDowngrade`. Shipping a third copy in a PR whose thesis is *"duplicate mappings are the bug"* was self-defeating.
- Ops is paged only for **unhealed** drift (a fully-healed run is a success, not an incident), and the response returns exceptions rather than every account id.

## Tests: 5 → 13, and the two critical ones proven red

Each new rail has a test, including the four the review found **untested**:

| Test | Guards |
|---|---|
| stale subscription is never healed from | **B1** |
| re-alerts after a resolved drift row | **B3** |
| resubscribed customer over a terminal entitlement **is** healed | **B4** |
| test-mode row never touches a live entitlement | mode scoping |
| `last_event_at` preserved on UPDATE | WH-3 window |
| unresolvable tier → alert, no write | F3 rail |
| `RECONCILE_ENTITLEMENTS_HEAL=false` → alert, no heal | kill switch |
| healed row carries the right features/limits | shared builder |

The two blocker fixes were **proven red** by mutation: removing the freshness bound fails the stale-subscription test (the expired trial gets free Pro); removing the unresolved-scope fails the re-alert test.

**433/433 pass** across cron + webhook + lib suites. Typecheck and Biome clean.

---

**Guardrail 2:** touches cron + entitlement write paths. **Requesting an independent adversarial verdict — I am the author of both the original defect and this fix, and I am not clearing my own work.** Not self-merging, not applying gate labels.
