### PR TITLE
feat(marketing): add SLA and refund policy pages

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -15,9 +15,11 @@ import { PhilosophyPage } from './routes/PhilosophyPage';
 import { PricingPage } from './routes/PricingPage';
 import { PrivacyPage } from './routes/PrivacyPage';
 import { ProductsPage } from './routes/ProductsPage';
+import { RefundPolicyPage } from './routes/RefundPolicyPage';
 import { RoadmapPage } from './routes/RoadmapPage';
 import { SecurityPage } from './routes/SecurityPage';
 import { ServicesPage } from './routes/ServicesPage';
+import { SlaPage } from './routes/SlaPage';
 import { StatusPage } from './routes/StatusPage';
 import { SubprocessorsPage } from './routes/SubprocessorsPage';
 import { SupportPage } from './routes/SupportPage';
@@ -73,6 +75,12 @@ export function App() {
       { path: '/terms', component: TermsPage, meta: { title: 'Terms of Service | RevealUI' } },
       { path: '/security', component: SecurityPage, meta: { title: 'Security | RevealUI' } },
       { path: '/support', component: SupportPage, meta: { title: 'Support | RevealUI' } },
+      { path: '/sla', component: SlaPage, meta: { title: 'Service Level Commitments | RevealUI' } },
+      {
+        path: '/refund-policy',
+        component: RefundPolicyPage,
+        meta: { title: 'Refund Policy | RevealUI' },
+      },
       { path: '/status', component: StatusPage, meta: { title: 'Status | RevealUI' } },
       {
         path: '/legal/subprocessors',

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -228,6 +228,11 @@ const FAIR_SOURCE_PAGE: EvidenceRef = {
   kind: 'code',
   ref: 'apps/marketing/app/routes/FairSourcePage.tsx',
 };
+const SLA_PAGE: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/marketing/app/routes/SlaPage.tsx',
+  note: 'published support-response and infrastructure-uptime commitments',
+};
 const INFRA_COST_ESTIMATE: EvidenceRef = {
   kind: 'url',
   ref: 'https://revealui.com/pricing',
@@ -2145,9 +2150,9 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'pricing-faq.ts',
     exportPath: 'PRICING_FAQS[8].answer',
-    text: 'Yes. If you need more than what the Enterprise tier offers, contact us to discuss custom pricing and SLAs. (interpolated: SITE.emails.support)',
+    text: 'Yes. If you need more than what the Enterprise tier offers, contact us to discuss custom pricing. See /sla for our standard support and uptime commitments. (interpolated: SITE.emails.support)',
     match: 'path',
-    evidence: [COMMERCIAL_POLICY],
+    evidence: [COMMERCIAL_POLICY, SLA_PAGE],
   },
   {
     file: 'pricing-faq.ts',

--- a/apps/marketing/app/content/legal/refund-policy.ts
+++ b/apps/marketing/app/content/legal/refund-policy.ts
@@ -1,0 +1,54 @@
+// Refund policy page content. Schema reused from LegalSection for layout
+// consistency with Terms, Privacy, Security, Support, and the SLA page.
+//
+// The refund window and its conditions are sourced verbatim from the
+// owner-decided ADR at .jv:docs/decisions/refund-window.md (Option A,
+// confirmed 2026-04-16). Do not change the window or its conditions here
+// without first changing the ADR; this file is the public restatement of
+// that decision, not an independent source.
+
+import { SITE } from '../site';
+import type { LegalSection } from './privacy';
+
+export const REFUND_POLICY_META = {
+  title: 'Refund Policy',
+  lastUpdated: 'July 12, 2026',
+  intro:
+    'This page describes when you can get your money back from RevealUI Studio and how to ask for it. It applies to purchases made directly through revealui.com and admin.revealui.com.',
+} as const;
+
+export const REFUND_POLICY_SECTIONS: readonly LegalSection[] = [
+  {
+    heading: '1. Perpetual licenses (Pro, Agency, and Enterprise Perpetual)',
+    paragraphs: [
+      'You may request a full refund within 14 days of purchase, for any reason, no questions asked. Refunds are processed within 5 business days. Your license key is revoked once the refund is issued.',
+      'After the 14-day window, refunds are available only for documented product defects, at our discretion.',
+    ],
+  },
+  {
+    heading: '2. Subscriptions (Pro, Max, and Enterprise plans)',
+    paragraphs: [
+      'You can cancel a subscription at any time. Cancellation takes effect at the end of your current billing period, and there is no pro-rated refund for the unused portion of a billing cycle.',
+      'Your first month is refundable in full if you request it within 14 days of your initial paid charge.',
+    ],
+  },
+  {
+    heading: '3. Services engagements',
+    paragraphs: [
+      'Architecture Review, Fleet deployment, Custom Build, and other services sold by invoice are governed by the Master Service Agreement and Statement of Work for that engagement, not by this policy.',
+    ],
+  },
+  {
+    heading: '4. How to request a refund',
+    listItems: [
+      `Email ${SITE.emails.founder} with your order number.`,
+      'We process eligible refunds within 5 business days of your request.',
+      'For a perpetual license, your license key is revoked once the refund is issued.',
+    ],
+  },
+  {
+    heading: '5. Contact',
+    paragraphs: [`Questions about a specific order or refund go to ${SITE.emails.founder}.`],
+    contactEmail: SITE.emails.founder,
+  },
+];

--- a/apps/marketing/app/content/legal/sla.ts
+++ b/apps/marketing/app/content/legal/sla.ts
@@ -1,0 +1,69 @@
+// Service level commitments page content. Schema reused from LegalSection for
+// layout consistency with Terms, Privacy, Security, and Support.
+//
+// Every number on this page is sourced verbatim from the owner-decided ADR at
+// .jv:docs/decisions/sla-target.md (Option B, confirmed 2026-04-16). Do not
+// change these numbers here without first changing the ADR; this file is the
+// public restatement of that decision, not an independent source.
+
+import { SITE } from '../site';
+import type { LegalSection } from './privacy';
+
+export const SLA_META = {
+  title: 'Service Level Commitments',
+  lastUpdated: 'July 12, 2026',
+  intro:
+    'RevealUI Studio is a solo-operated company. We would rather commit to numbers we can hit on our worst week than promise something impressive and miss it. This page states exactly what we commit to today, for whom, and what those commitments do not cover.',
+} as const;
+
+export const SLA_SECTIONS: readonly LegalSection[] = [
+  {
+    heading: '1. Support response times',
+    listItems: [
+      'Business hours: we respond within 24 hours, Monday through Friday, 9am to 5pm U.S. Central Time. This excludes weekends and U.S. federal holidays.',
+      'Critical issues: we respond within 4 hours, any day of the week. A critical issue is one where your data is at risk or you are completely unable to use the product you purchased.',
+    ],
+    paragraphs: [
+      `These targets apply to email sent to ${SITE.emails.support}. They are the same for every paid tier today. We often beat them, and we would rather you notice us beating a promise than missing one.`,
+    ],
+  },
+  {
+    heading: '2. Infrastructure uptime',
+    paragraphs: [
+      'For the license validation endpoint and the download and release endpoint, we target 99% uptime, measured monthly. That works out to as much as 7.3 hours of downtime in a month before we would consider ourselves out of this commitment. It is a generous floor on purpose: a solo operator needs room for a bad week without breaking a promise, and our actual uptime is typically well above this floor.',
+      'If you self-host RevealUI, this uptime commitment covers our infrastructure (license validation, downloads, and updates), not your infrastructure. Your deployment runs on servers you control, and its uptime is your responsibility.',
+      'A hosted RevealUI product beyond license and download infrastructure does not yet carry a published uptime commitment. When that changes, this page will say so.',
+    ],
+  },
+  {
+    heading: '3. Planned maintenance',
+    paragraphs: [
+      'When we need to take infrastructure down for planned maintenance, we give at least 48 hours of advance notice by email to affected customers and on our status page.',
+    ],
+  },
+  {
+    heading: '4. What happens if our license service is down',
+    paragraphs: [
+      'If a self-hosted installation cannot reach our license validation service, your previously validated license keeps working for 7 days while we fix the outage. Full detail on every license grace period lives in our Terms of Service.',
+    ],
+  },
+  {
+    heading: '5. Why these numbers and not bigger ones',
+    paragraphs: [
+      'We are one person. There is no on-call rotation and no second engineer to page. A 24-hour response and a 99% uptime floor are numbers we can hold even through a sick week or a vacation. As the team grows, these commitments tighten, not the other way around. Being the solo-operated version of a promise you can trust is worth more to us than the impressive-sounding version we might quietly miss.',
+    ],
+  },
+  {
+    heading: '6. Status and live updates',
+    paragraphs: [
+      'Real-time status for revealui.com, admin.revealui.com, api.revealui.com, and docs.revealui.com is published at https://revealui.com/status.',
+    ],
+  },
+  {
+    heading: '7. Contact',
+    paragraphs: [
+      `Questions about these commitments, or about a specific incident, go to ${SITE.emails.support}.`,
+    ],
+    contactEmail: SITE.emails.support,
+  },
+];

--- a/apps/marketing/app/content/legal/support.ts
+++ b/apps/marketing/app/content/legal/support.ts
@@ -16,7 +16,7 @@ export const SUPPORT_SECTIONS: readonly LegalSection[] = [
     heading: '1. Choose your channel',
     listPreamble: 'Different questions land best in different places. In rough order of speed:',
     listItems: [
-      `**Documentation** at https://docs.revealui.com: covers setup, configuration, the API surface, and most "how do I do X with RevealUI" questions. Always check here first; if the answer is there, you have it now instead of in 48 hours.`,
+      `**Documentation** at https://docs.revealui.com: covers setup, configuration, the API surface, and most "how do I do X with RevealUI" questions. Always check here first; if the answer is there, you have it now instead of waiting on an email reply.`,
       `**GitHub Discussions** at https://github.com/RevealUIStudio/revealui/discussions: community-friendly format for design questions, "is there a better way to do X", and ideas. Other users and the maintainer both watch this. Best for questions where a public answer benefits more than just you.`,
       `**GitHub Issues** at https://github.com/RevealUIStudio/revealui/issues: for confirmed bugs and feature requests. Include reproduction steps. See §5 below for "bug vs support" guidance.`,
       `**Email** at ${SITE.emails.support}: for account-specific issues (billing, license keys, your data), security concerns, and questions you cannot ask in public.`,
@@ -25,9 +25,9 @@ export const SUPPORT_SECTIONS: readonly LegalSection[] = [
   {
     heading: '2. Response SLA',
     paragraphs: [
-      `Email to ${SITE.emails.support}: we aim for a substantive response within **48 business hours** (Monday through Friday, U.S. Central Time, excluding U.S. federal holidays). Acknowledgement is usually faster, within one business day, and complex issues may require multiple rounds of correspondence.`,
+      `Email to ${SITE.emails.support}: we respond within **24 hours** during business hours (Monday through Friday, 9am to 5pm U.S. Central Time, excluding U.S. federal holidays), and within **4 hours** any day for a critical issue (your data is at risk, or you cannot use the product you purchased at all). Complex issues may need multiple rounds of correspondence after that first response. Full detail is on our SLA page at https://revealui.com/sla.`,
       'GitHub Issues and Discussions: best-effort. We read them, but we may not respond instantly. If something is urgent, email is the right channel.',
-      'Security reports: see the dedicated security policy at https://revealui.com/security. Those go to a separate address with separate SLAs.',
+      'Security reports: see the dedicated security policy at https://revealui.com/security. Those go to a separate address with a separate response commitment.',
     ],
   },
   {
@@ -75,7 +75,7 @@ export const SUPPORT_SECTIONS: readonly LegalSection[] = [
   {
     heading: '7. Premium support',
     paragraphs: [
-      'The published pricing page describes the response targets for the Pro tier (48 business hours), Max tier (24 business hours), and Enterprise tier (4-hour Slack SLA). These targets are aspirational at launch and we will publish the actual achieved response times once we have data. We would rather measure honestly than over-promise.',
+      'Today, every paid tier gets the same response commitment described in §2 and on our SLA page: 24 hours during business hours, 4 hours for a critical issue. We do not yet offer a faster tiered SLA, and we would rather tell you that plainly than promise a tier we cannot staff as a solo operator.',
       'Enterprise customers who need a dedicated Slack channel, a named technical contact, or scheduled architecture reviews should contact us before purchase to confirm scope and timeline.',
     ],
   },

--- a/apps/marketing/app/content/legal/terms.ts
+++ b/apps/marketing/app/content/legal/terms.ts
@@ -55,7 +55,7 @@ export const TERMS_SECTIONS: readonly LegalSection[] = [
       },
       {
         heading: 'Refunds',
-        paragraph: `We offer a full refund if requested within 14 days of your first paid charge (not including the trial period). After 14 days, no refunds are issued for partial billing periods. Contact ${SITE.emails.support} for refund requests.`,
+        paragraph: `We offer a full refund if requested within 14 days of your first paid charge (not including the trial period). After 14 days, no refunds are issued for partial billing periods. Contact ${SITE.emails.support} for refund requests. Perpetual licenses follow a separate window; see our full Refund Policy at /refund-policy.`,
       },
       {
         heading: 'License continuity and grace periods',

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -49,6 +49,7 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
     links: [
       { label: 'Status', href: '/status' },
       { label: 'Support', href: '/support' },
+      { label: 'SLA', href: '/sla' },
       { label: 'Security', href: '/security' },
       { label: 'Subprocessors', href: '/legal/subprocessors' },
     ],
@@ -59,7 +60,7 @@ export const FOOTER_TAGLINE =
   'Agentic business runtime. People, content, offers, payments, and agents, pre-wired, open source, and ready to deploy.' as const;
 
 export const FOOTER_SOLO_OPERATOR_NOTE =
-  'Built by one engineer in Tennessee. See Support for response SLAs.' as const;
+  'Built by one engineer in Tennessee. See our SLA for response times.' as const;
 
 export interface FooterServiceLink {
   readonly prefix: string;
@@ -85,6 +86,8 @@ export const FOOTER_LEGAL = {
 export const FOOTER_LEGAL_LINKS: readonly NavLink[] = [
   { label: 'Privacy', href: '/privacy' },
   { label: 'Terms', href: '/terms' },
+  { label: 'Refund Policy', href: '/refund-policy' },
+  { label: 'SLA', href: '/sla' },
   { label: 'Security', href: '/security' },
   { label: 'Subprocessors', href: '/legal/subprocessors' },
 ] as const;

--- a/apps/marketing/app/content/pricing-faq.ts
+++ b/apps/marketing/app/content/pricing-faq.ts
@@ -51,7 +51,7 @@ export const PRICING_FAQS: readonly FaqItem[] = [
   },
   {
     question: 'Do you offer custom pricing for large teams?',
-    answer: `Yes. If you need more than what the Enterprise tier offers, contact us at ${SITE.emails.support} to discuss custom pricing and SLAs.`,
+    answer: `Yes. If you need more than what the Enterprise tier offers, contact us at ${SITE.emails.support} to discuss custom pricing. See /sla for our standard support and uptime commitments.`,
   },
   {
     question: 'What is RevFleet?',

--- a/apps/marketing/app/routes/RefundPolicyPage.tsx
+++ b/apps/marketing/app/routes/RefundPolicyPage.tsx
@@ -1,36 +1,26 @@
 import { Callout } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
-import { SUPPORT_META, SUPPORT_SECTIONS } from '../content/legal/support';
-import { SITE } from '../content/site';
+import { REFUND_POLICY_META, REFUND_POLICY_SECTIONS } from '../content/legal/refund-policy';
 
-export function SupportPage() {
+export function RefundPolicyPage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-3xl px-6 pt-24 lg:px-8">
-        <Callout variant="info" title="One channel for direct support, three for community + docs">
-          The fastest path is to check{' '}
-          <a className="underline" href={SITE.urls.docs} target="_blank" rel="noopener noreferrer">
-            the documentation
-          </a>{' '}
-          first. For account-specific issues, billing, or anything sensitive, email{' '}
-          <a className="underline" href={`mailto:${SITE.emails.support}`}>
-            {SITE.emails.support}
-          </a>
-          . We reply within 24 hours during business hours (Mon-Fri, U.S. Central), and within 4
-          hours any day for a critical issue. Full detail is on our{' '}
-          <a className="underline" href="/sla">
-            SLA page
-          </a>
-          .
+        <Callout variant="info" title="The short version">
+          Perpetual licenses get a full refund within 14 days of purchase, no questions asked.
+          Subscriptions get a full refund on your first month if you cancel within 14 days of your
+          first charge. Details below.
         </Callout>
       </div>
       <article className="mx-auto max-w-3xl px-6 pb-24 pt-12 lg:px-8 prose prose-gray">
-        <h1>{SUPPORT_META.title}</h1>
-        <p className="text-sm text-muted-foreground">Last updated: {SUPPORT_META.lastUpdated}</p>
+        <h1>{REFUND_POLICY_META.title}</h1>
+        <p className="text-sm text-muted-foreground">
+          Last updated: {REFUND_POLICY_META.lastUpdated}
+        </p>
 
-        <p>{SUPPORT_META.intro}</p>
+        <p>{REFUND_POLICY_META.intro}</p>
 
-        {SUPPORT_SECTIONS.map((section) => (
+        {REFUND_POLICY_SECTIONS.map((section) => (
           <div key={section.heading}>
             <h2>{section.heading}</h2>
 
@@ -61,7 +51,7 @@ export function SupportPage() {
             {section.paragraphs?.map((para) =>
               section.contactEmail ? (
                 <p key={para}>
-                  For support questions, email{' '}
+                  For questions about a specific order or refund, email{' '}
                   <a href={`mailto:${section.contactEmail}`}>{section.contactEmail}</a>.
                 </p>
               ) : (

--- a/apps/marketing/app/routes/SlaPage.tsx
+++ b/apps/marketing/app/routes/SlaPage.tsx
@@ -1,36 +1,28 @@
 import { Callout } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
-import { SUPPORT_META, SUPPORT_SECTIONS } from '../content/legal/support';
-import { SITE } from '../content/site';
+import { SLA_META, SLA_SECTIONS } from '../content/legal/sla';
 
-export function SupportPage() {
+export function SlaPage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-3xl px-6 pt-24 lg:px-8">
-        <Callout variant="info" title="One channel for direct support, three for community + docs">
-          The fastest path is to check{' '}
-          <a className="underline" href={SITE.urls.docs} target="_blank" rel="noopener noreferrer">
-            the documentation
-          </a>{' '}
-          first. For account-specific issues, billing, or anything sensitive, email{' '}
-          <a className="underline" href={`mailto:${SITE.emails.support}`}>
-            {SITE.emails.support}
-          </a>
-          . We reply within 24 hours during business hours (Mon-Fri, U.S. Central), and within 4
-          hours any day for a critical issue. Full detail is on our{' '}
-          <a className="underline" href="/sla">
-            SLA page
+        <Callout variant="info" title="The short version">
+          We respond within 24 hours during U.S. business hours, and within 4 hours for anything
+          critical. Our license and download infrastructure targets 99% monthly uptime. Live status
+          is always at{' '}
+          <a className="underline" href="/status">
+            revealui.com/status
           </a>
           .
         </Callout>
       </div>
       <article className="mx-auto max-w-3xl px-6 pb-24 pt-12 lg:px-8 prose prose-gray">
-        <h1>{SUPPORT_META.title}</h1>
-        <p className="text-sm text-muted-foreground">Last updated: {SUPPORT_META.lastUpdated}</p>
+        <h1>{SLA_META.title}</h1>
+        <p className="text-sm text-muted-foreground">Last updated: {SLA_META.lastUpdated}</p>
 
-        <p>{SUPPORT_META.intro}</p>
+        <p>{SLA_META.intro}</p>
 
-        {SUPPORT_SECTIONS.map((section) => (
+        {SLA_SECTIONS.map((section) => (
           <div key={section.heading}>
             <h2>{section.heading}</h2>
 
@@ -61,7 +53,7 @@ export function SupportPage() {
             {section.paragraphs?.map((para) =>
               section.contactEmail ? (
                 <p key={para}>
-                  For support questions, email{' '}
+                  For questions about these commitments, email{' '}
                   <a href={`mailto:${section.contactEmail}`}>{section.contactEmail}</a>.
                 </p>
               ) : (


### PR DESCRIPTION
## Summary

- Adds two public marketing pages required before first sale: `/sla` (service level commitments) and `/refund-policy`. Neither existed; the pricing FAQ referenced "SLAs" and license refunds with no artifact backing either claim.
- Every number on both pages is sourced verbatim from the owner-decided ADRs: `.jv:docs/decisions/sla-target.md` (Option B, confirmed 2026-04-16) and `.jv:docs/decisions/refund-window.md` (Option A, confirmed 2026-04-16). No number was invented; nothing more generous or vaguer than what was decided.
- Links the new pages from the footer Trust column, the footer legal-links row, and the pricing FAQ's SLA answer.
- Fixes a pre-existing drift discovered during the audit: `content/legal/support.ts` and `SupportPage.tsx` promised a **48-hour** response, which contradicts the decided **24-hour** commitment now published on `/sla`. Corrected both call sites plus the stale tiered-SLA claim in support.ts §7 (which cited a "pricing page" table that does not exist in `pricing.ts`).
- Indexes the SLA-related FAQ claim in `content/claims-evidence.ts` (485 → still 485 claims, `SLA_PAGE` evidence ref added citing the new route). `sla.ts` / `refund-policy.ts` themselves are intentionally **not** added to `COVERED_FILES` — consistent with the existing exclusion of `terms.ts` / `privacy.ts` / `security.ts` / `support.ts` / `subprocessors.ts` (legal/policy pages are the source of truth, not something requiring separate evidence).

## Test plan

- [x] `pnpm --filter marketing typecheck` — clean
- [x] `pnpm --filter marketing test` (vitest) — 75/75 passed
- [x] `npx turbo run build --filter=marketing` — green
- [x] `tsx scripts/validate/claims-evidence.ts` — 485 indexed claims across 17 covered files, all matched
- [x] `tsx scripts/validate/marketing-voice.ts` — 0 new violations
- [x] `tsx scripts/validate/claim-drift.ts` — 0 mismatches
- [x] `npx biome check apps/marketing` — clean (5 pre-existing unrelated warnings in other files)
- [x] Push-gate (`pnpm gate`-equivalent pre-push hook) — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
