### PR TITLE
fix(tokens): verify deployed font assets are reachable, not just named

### DIFF
--- a/packages/tokens/scripts/verify-deployed-tokens.cjs
+++ b/packages/tokens/scripts/verify-deployed-tokens.cjs
@@ -27,7 +27,7 @@
  *
  * Exit 0 when every URL passes; exit 1 with a per-failure report otherwise.
  *
- * Two checks per URL:
+ * Three checks per URL:
  *   1. TOKEN PARITY — every canonical --rvui-* token is present in the
  *      deployed CSS with a numerically-identical value (minifier formatting
  *      normalized away). A deployed token may carry EXTRA values only when
@@ -40,6 +40,16 @@
  *      cascade means only the effective value renders — an app override that
  *      redeclares --rvui-font-sans leaves the canonical stack in the bundle
  *      but it never paints, so flagging it would be a false positive.
+ *   3. FONT ASSET REACHABILITY — a name match against an @font-face rule
+ *      (check 2) proves the CSS TEXT is self-consistent; it proves nothing
+ *      about whether the browser can actually download the face. A deploy
+ *      can ship a byte-perfect @font-face rule whose `src: url(...)` 404s
+ *      (stale build hash, purged CDN, broken asset pipeline) and still pass
+ *      check 2 while rendering system fonts — the identical visual defect
+ *      check 2 exists to catch, invisible to a text-only comparison. This
+ *      check fetches the font asset for every family a stack names and that
+ *      an @font-face rule claims to register, and fails the token if none of
+ *      that family's declared files are reachable.
  */
 
 const { readFileSync } = require('node:fs');
@@ -131,6 +141,37 @@ function stripQuotes(s) {
     return t.slice(1, -1);
   }
   return t;
+}
+
+// Family names (lowercased) -> the raw src url(...) tokens their @font-face
+// rules declare, in source order. A name appearing in extractFontFaceFamilies
+// with no entry (or an empty array) here means the rule had no parseable
+// src url — that's a CSS authoring gap, not an asset-reachability failure, so
+// callers should treat "no urls" as "nothing to verify," not as a failure.
+function extractFontFaceSrcUrls(css) {
+  const clean = stripComments(css);
+  const map = new Map();
+  // regex-ok: locate @font-face blocks, then their font-family + src descriptors.
+  const blockRe = /@font-face\s*\{([^}]*)\}/gi;
+  let block;
+  while ((block = blockRe.exec(clean)) !== null) {
+    const body = block[1];
+    const fam = /font-family\s*:\s*([^;]+)/i.exec(body);
+    if (!fam) continue;
+    const family = stripQuotes(fam[1].trim()).toLowerCase();
+    const src = /src\s*:\s*([^;]+)/i.exec(body);
+    if (!src) continue;
+    // regex-ok: extract each url(...) token from a (possibly comma-separated,
+    // multi-format) src descriptor already isolated to one @font-face block.
+    const urlRe = /url\(\s*["']?([^"')]+)["']?\s*\)/gi;
+    let um;
+    const urls = [];
+    while ((um = urlRe.exec(src[1])) !== null) urls.push(um[1]);
+    if (urls.length === 0) continue;
+    if (!map.has(family)) map.set(family, []);
+    map.get(family).push(...urls);
+  }
+  return map;
 }
 
 const GENERIC_FAMILIES = new Set([
@@ -259,6 +300,69 @@ function checkFontResolvability(fontDecls, fontFaceFamilies, csp, externalFontRe
   return failures;
 }
 
+// Default reachability probe: HEAD (falling back to GET on 405, since some
+// CDNs/dev servers reject HEAD) and treat any 2xx as reachable. A data: URI
+// is embedded in the CSS itself — no network round-trip needed to resolve it.
+async function defaultFetchAsset(absUrl) {
+  if (absUrl.startsWith('data:')) return true;
+  try {
+    const res = await fetch(absUrl, { method: 'HEAD', redirect: 'follow' });
+    if (res.ok) return true;
+    if (res.status !== 405) return false;
+  } catch {
+    return false;
+  }
+  try {
+    const res = await fetch(absUrl, { method: 'GET', redirect: 'follow' });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/* ── font asset reachability ──────────────────────────────────────────
+ * A name match against fontFaceFamilies (checkFontResolvability's job)
+ * proves the CSS text is internally consistent; it says nothing about
+ * whether the browser can actually download the face. This walks every
+ * family a font token's stack names AND an @font-face rule claims to
+ * register, and fetches that family's declared src urls (relative to
+ * pageOrigin — the deployed font paths in this fleet are root-relative).
+ * A family with zero declared urls is skipped (nothing to verify, not a
+ * failure — see extractFontFaceSrcUrls). Returns one failure per
+ * (token, family) pair where every declared url is unreachable. */
+async function checkFontAssetReachability(fontDecls, fontFaceFamilies, fontFaceSrcUrls, pageOrigin, fetchAsset = defaultFetchAsset) {
+  const cache = new Map();
+  const failures = [];
+  for (const [tokenName, stacks] of fontDecls) {
+    const checkedFamilies = new Set();
+    for (const stack of stacks) {
+      for (const fam of namedFamilies(stack)) {
+        const key = fam.toLowerCase();
+        if (!fontFaceFamilies.has(key) || checkedFamilies.has(key)) continue;
+        checkedFamilies.add(key);
+        const urls = fontFaceSrcUrls.get(key) || [];
+        if (urls.length === 0) continue;
+        let reachable = false;
+        for (const rel of urls) {
+          let abs;
+          try {
+            abs = new URL(rel, pageOrigin).href;
+          } catch {
+            continue;
+          }
+          if (!cache.has(abs)) cache.set(abs, await fetchAsset(abs));
+          if (cache.get(abs)) {
+            reachable = true;
+            break;
+          }
+        }
+        if (!reachable) failures.push({ token: tokenName, family: fam, urls });
+      }
+    }
+  }
+  return failures;
+}
+
 /* ── HTML / CSS discovery ─────────────────────────────────────────────── */
 function discoverFromHtml(html, pageUrl) {
   const pageOrigin = new URL(pageUrl).origin;
@@ -376,19 +480,27 @@ function loadAllowlist(path, host) {
 /* ── per-URL verification ─────────────────────────────────────────────── */
 async function verifyUrl(pageUrl, canonicalTokens, canonicalFontNames, allowlistPath) {
   const host = new URL(pageUrl).hostname;
+  const pageOrigin = new URL(pageUrl).origin;
   const { css, csp, externalFontRefs, cssBundleCount } = await fetchDeployed(pageUrl);
   const deployedTokens = extractTokenDecls(css);
   const deployedFonts = extractFontDecls(css);
   const fontFaceFamilies = extractFontFaceFamilies(css);
+  const fontFaceSrcUrls = extractFontFaceSrcUrls(css);
   const allowlist = loadAllowlist(allowlistPath, host);
 
   const parity = compareTokens(canonicalTokens, deployedTokens, allowlist);
   const fontFailures = checkFontResolvability(deployedFonts, fontFaceFamilies, csp, externalFontRefs);
+  const assetFailures = await checkFontAssetReachability(deployedFonts, fontFaceFamilies, fontFaceSrcUrls, pageOrigin);
 
-  // Only assert resolvability on canonical font tokens (ignore any app-only ones).
+  // Only assert resolvability/reachability on canonical font tokens (ignore any app-only ones).
   const relevantFontFailures = fontFailures.filter((f) => canonicalFontNames.has(f.token));
+  const relevantAssetFailures = assetFailures.filter((f) => canonicalFontNames.has(f.token));
 
-  const ok = parity.missing.length === 0 && parity.extra.length === 0 && relevantFontFailures.length === 0;
+  const ok =
+    parity.missing.length === 0 &&
+    parity.extra.length === 0 &&
+    relevantFontFailures.length === 0 &&
+    relevantAssetFailures.length === 0;
   return {
     url: pageUrl,
     ok,
@@ -397,6 +509,7 @@ async function verifyUrl(pageUrl, canonicalTokens, canonicalFontNames, allowlist
     externalFontRefs,
     parity,
     fontFailures: relevantFontFailures,
+    assetFailures: relevantAssetFailures,
   };
 }
 
@@ -440,6 +553,10 @@ function reportHuman(results) {
       }
       console.error(`    @font-face registers: ${f.fontFaceRegistered.join(', ') || '(none)'}`);
     }
+    for (const a of r.assetFailures) {
+      console.error(`  FONT ASSET ${a.token} — "${a.family}" is registered but unreachable:`);
+      console.error(`    tried: ${a.urls.join(', ')}`);
+    }
   }
 }
 
@@ -467,7 +584,14 @@ async function main() {
       r.parityCount = canonicalTokens.size;
       results.push(r);
     } catch (err) {
-      results.push({ url, ok: false, error: String(err && err.message ? err.message : err), parity: { missing: [], extra: [] }, fontFailures: [] });
+      results.push({
+        url,
+        ok: false,
+        error: String(err && err.message ? err.message : err),
+        parity: { missing: [], extra: [] },
+        fontFailures: [],
+        assetFailures: [],
+      });
     }
   }
 
@@ -496,6 +620,8 @@ module.exports = {
   cspAllows,
   compareTokens,
   checkFontResolvability,
+  extractFontFaceSrcUrls,
+  checkFontAssetReachability,
   discoverFromHtml,
   discoverCssImports,
   loadAllowlist,

--- a/packages/tokens/src/__tests__/verify-deployed-tokens.test.ts
+++ b/packages/tokens/src/__tests__/verify-deployed-tokens.test.ts
@@ -24,6 +24,14 @@ const verify = require('../../scripts/verify-deployed-tokens.cjs') as {
     csp: Map<string, string[]> | null,
     externalFontRefs: Array<{ host: string; kind: string }>,
   ) => Array<{ token: string; stacks: unknown[] }>;
+  extractFontFaceSrcUrls: (css: string) => Map<string, string[]>;
+  checkFontAssetReachability: (
+    fontDecls: Map<string, string[]>,
+    fontFaceFamilies: Set<string>,
+    fontFaceSrcUrls: Map<string, string[]>,
+    pageOrigin: string,
+    fetchAsset?: (absUrl: string) => Promise<boolean>,
+  ) => Promise<Array<{ token: string; family: string; urls: string[] }>>;
 };
 
 describe('normalizeValue', () => {
@@ -205,5 +213,144 @@ describe('checkFontResolvability', () => {
     ];
     const failures = verify.checkFontResolvability(fontDecls, new Set(), csp, externalRefs);
     expect(failures).toHaveLength(0);
+  });
+});
+
+describe('extractFontFaceSrcUrls', () => {
+  it('collects url(...) tokens per family, lowercased key, source order preserved', () => {
+    const css =
+      "@font-face{font-family:'Inter Variable';src:url(/a.woff2) format('woff2-variations')}" +
+      "@font-face{font-family:'Inter Variable';src:url(/b.woff2) format('woff2-variations')}";
+    const map = verify.extractFontFaceSrcUrls(css);
+    expect(map.get('inter variable')).toEqual(['/a.woff2', '/b.woff2']);
+  });
+
+  it('omits a family whose @font-face rule has no url() (nothing to verify)', () => {
+    const css = "@font-face{font-family:'Local Only';src:local('Local Only')}";
+    const map = verify.extractFontFaceSrcUrls(css);
+    expect(map.has('local only')).toBe(false);
+  });
+});
+
+describe('checkFontAssetReachability', () => {
+  // Reproduces the marketing false pass: the deployed CSS is the exact
+  // shape apps/marketing ships after its app-level override (fix/marketing
+  // PR #1801) — the stack leads with 'Inter Variable', and an @font-face
+  // rule registers that exact family name. checkFontResolvability (the
+  // name-match check) would call this resolved. But the font FILE the rule
+  // points to 404s in production (stale build hash, purged CDN, broken
+  // asset pipeline) — the browser falls through the stack and system fonts
+  // render, the identical visual defect docs.revealui.com failed on. A
+  // text-only name match can never see this; only a live fetch can.
+  it('reproduces the marketing false pass: name-matched @font-face whose file 404s still fails', async () => {
+    const fontDecls = verify.extractFontDecls(
+      ":root{--rvui-font-sans:'Inter Variable', 'Inter', system-ui, sans-serif}",
+    );
+    const fontFaceCss =
+      "@font-face{font-family:'Inter Variable';src:url(/assets/inter-latin-BROKEN.woff2) format('woff2-variations')}";
+    const fontFaceFamilies = verify.extractFontFaceFamilies(fontFaceCss);
+    const fontFaceSrcUrls = verify.extractFontFaceSrcUrls(fontFaceCss);
+
+    // Sanity check: the name-match check alone sees no problem here — this
+    // is precisely why marketing passed while docs correctly failed.
+    const nameMatchFailures = verify.checkFontResolvability(fontDecls, fontFaceFamilies, null, []);
+    expect(nameMatchFailures).toHaveLength(0);
+
+    const fetchAsset = async () => false; // every asset 404s
+    const failures = await verify.checkFontAssetReachability(
+      fontDecls,
+      fontFaceFamilies,
+      fontFaceSrcUrls,
+      'https://www.revealui.com',
+      fetchAsset,
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      token: '--rvui-font-sans',
+      family: 'Inter Variable',
+      urls: ['/assets/inter-latin-BROKEN.woff2'],
+    });
+  });
+
+  it('passes when the registered font file is actually reachable', async () => {
+    const fontDecls = verify.extractFontDecls(
+      ":root{--rvui-font-sans:'Inter Variable', 'Inter', system-ui, sans-serif}",
+    );
+    const fontFaceCss =
+      "@font-face{font-family:'Inter Variable';src:url(/assets/inter-latin-OK.woff2) format('woff2-variations')}";
+    const fontFaceFamilies = verify.extractFontFaceFamilies(fontFaceCss);
+    const fontFaceSrcUrls = verify.extractFontFaceSrcUrls(fontFaceCss);
+
+    const fetchAsset = async (absUrl: string) => absUrl.endsWith('inter-latin-OK.woff2');
+    const failures = await verify.checkFontAssetReachability(
+      fontDecls,
+      fontFaceFamilies,
+      fontFaceSrcUrls,
+      'https://www.revealui.com',
+      fetchAsset,
+    );
+    expect(failures).toHaveLength(0);
+  });
+
+  it('resolves the url against pageOrigin (root-relative deployed font paths)', async () => {
+    const fontDecls = verify.extractFontDecls(":root{--rvui-font-sans:'Inter Variable'}");
+    const fontFaceCss = "@font-face{font-family:'Inter Variable';src:url(/f.woff2)}";
+    const fontFaceFamilies = verify.extractFontFaceFamilies(fontFaceCss);
+    const fontFaceSrcUrls = verify.extractFontFaceSrcUrls(fontFaceCss);
+
+    const seen: string[] = [];
+    const fetchAsset = async (absUrl: string) => {
+      seen.push(absUrl);
+      return true;
+    };
+    await verify.checkFontAssetReachability(
+      fontDecls,
+      fontFaceFamilies,
+      fontFaceSrcUrls,
+      'https://docs.revealui.com',
+      fetchAsset,
+    );
+    expect(seen).toEqual(['https://docs.revealui.com/f.woff2']);
+  });
+
+  it('treats a family with no parseable src url as nothing-to-verify, not a failure', async () => {
+    const fontDecls = verify.extractFontDecls(":root{--rvui-font-sans:'Local Only'}");
+    const fontFaceFamilies = verify.extractFontFaceFamilies(
+      "@font-face{font-family:'Local Only';src:local('Local Only')}",
+    );
+    const fontFaceSrcUrls = new Map<string, string[]>(); // no urls captured for it
+    const fetchAsset = async () => false;
+    const failures = await verify.checkFontAssetReachability(
+      fontDecls,
+      fontFaceFamilies,
+      fontFaceSrcUrls,
+      'https://docs.revealui.com',
+      fetchAsset,
+    );
+    expect(failures).toHaveLength(0);
+  });
+
+  it('checks each distinct family at most once per token (dedup across repeated urls)', async () => {
+    const fontDecls = verify.extractFontDecls(
+      ":root{--rvui-font-sans:'Inter Variable', 'Inter', system-ui, sans-serif}" +
+        ":root{--rvui-font-sans:'Inter Variable', system-ui, sans-serif}",
+    );
+    const fontFaceCss = "@font-face{font-family:'Inter Variable';src:url(/f.woff2)}";
+    const fontFaceFamilies = verify.extractFontFaceFamilies(fontFaceCss);
+    const fontFaceSrcUrls = verify.extractFontFaceSrcUrls(fontFaceCss);
+
+    let calls = 0;
+    const fetchAsset = async () => {
+      calls += 1;
+      return true;
+    };
+    await verify.checkFontAssetReachability(
+      fontDecls,
+      fontFaceFamilies,
+      fontFaceSrcUrls,
+      'https://www.revealui.com',
+      fetchAsset,
+    );
+    expect(calls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

The post-deploy design-system verifier (#1802) checks that a font token's leading family is *named* by a matching `@font-face` rule in the deployed CSS. It never checks whether the browser can actually download the file that rule points to. On 2026-07-13, the deploy verifier failed `docs.revealui.com` red on the Inter/Inter-Variable font-resolution defect (correct) but passed `www.revealui.com` with the same visual symptom (system fonts rendering) — a gate that passes one site and fails another on the same class of defect is not trustworthy.

## Root cause

[`checkFontResolvability`](packages/tokens/scripts/verify-deployed-tokens.cjs) marks a font token "resolved" purely on a family-name string match against `@font-face` blocks found in the deployed CSS text ([verify-deployed-tokens.cjs:236-260](packages/tokens/scripts/verify-deployed-tokens.cjs#L236-L260), specifically the `viaFontFace = families.filter((f) => fontFaceFamilies.has(f.toLowerCase()))` check). `extractFontFaceFamilies` only ever captures the family *name*, never whether the `src: url(...)` it points to is reachable.

Root-caused with a real build: on the current `test` branch, `apps/marketing/app/index.css` already redeclares `--rvui-font-sans` etc. with `'Inter Variable'` leading (PR #1801), and `docs`'s equivalent fix (#1854, GAP-324) only redeclares Tailwind's `--font-sans`, never the `--rvui-font-sans` design token itself — which is why the *current* checker correctly fails docs and correctly passes marketing for a pure text/name comparison. But that comparison proves nothing about whether the font asset the browser needs is actually fetchable. A deploy can carry a byte-perfect `@font-face` rule whose `src` 404s (stale build hash, purged CDN, broken asset pipeline) and the checker has no way to see it — exactly the class of drift that would let the July 13 symptom recur invisibly on either site.

## Fix

Add a third, independent check: `checkFontAssetReachability` + `extractFontFaceSrcUrls`. For every family a font token's stack names *and* a matching `@font-face` rule claims to register, fetch that family's declared `src` URL(s) (resolved against the page origin — deployed font paths in this fleet are root-relative) and fail the token if none of them are reachable. Wired into `verifyUrl` alongside the existing parity + name-resolvability checks; a token now only passes when all three agree.

Ruled out other hypotheses against code before landing on this one: marketing IS in the CI `--url` list ([deploy.yml:627](.github/workflows/deploy.yml#L627)); CSS-bundle discovery correctly finds marketing's single built CSS file; the per-host allowlist only affects token-parity "extra" values, never `checkFontResolvability`; no error-swallowing path produces a silent pass (the swallowed-fetch paths in `fetchDeployed` instead cause a loud "missing token" failure).

## Test plan

- [x] New tests in `packages/tokens/src/__tests__/verify-deployed-tokens.test.ts` reproduce the marketing false pass with a mocked `fetchAsset` (CSS shaped exactly like marketing's real override: stack leads with `'Inter Variable'`, `@font-face` registers `'Inter Variable'`, but the asset 404s) — asserts the existing `checkFontResolvability` alone sees no problem (documenting the gap), then asserts the new `checkFontAssetReachability` catches it.
- [x] Proved red: `git checkout origin/test -- packages/tokens/scripts/verify-deployed-tokens.cjs` (pre-fix script, new tests kept) → all 7 new tests fail with `TypeError: verify.extractFontFaceSrcUrls is not a function` / `checkFontAssetReachability is not a function`. Re-applied the fix → 57/57 pass.
- [x] `pnpm --filter @revealui/tokens test` — 57 passed
- [x] `pnpm --filter @revealui/tokens typecheck` — clean
- [x] `pnpm --filter @revealui/tokens lint` (Biome) — clean
- [x] Pre-push gate (phase 1 + full CI gate) — PASS

Does not touch `packages/tokens/src/tokens.css` (a peer is fixing the underlying token defect there in a separate worktree/PR) and the new tests are self-contained CSS fixtures, independent of that fix.
