### PR TITLE
chore: claims-ratchet hygiene follow-ups (CLAUDE.md, marketing-voice exemption)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 | @revealui/engines | Unified entry point for the five business primitives (private workspace package) |
 | @revealui/harnesses | AI harness adapters, workboard coordination, JSON-RPC |
 | @revealui/mcp | MCP hypervisor, adapter framework, tool discovery |
-| @revealui/services | Stripe (billing + circuit breaker), Vercel (deploy + DNS) |
+| @revealui/services | Stripe (payment processing + circuit breaker), email (Gmail API delivery) |
 
 ### Internal Package (no license, build tooling) — 1
 | Package | Purpose |
@@ -178,7 +178,7 @@ pnpm --filter admin dev                # Dev one app
 ```
 
 ### admin Collections
-Collections are defined in `apps/admin/src/collections/` with access control, hooks, and field definitions. Use `@revealui/contracts` for type schemas.
+Collections are defined in `apps/admin/src/lib/collections/` with access control, hooks, and field definitions. Use `@revealui/contracts` for type schemas.
 
 ### Feature Gating
 Pro features use `isLicensed('pro')` and `isFeatureEnabled('ai')` from `@revealui/core`. Tiers: free, pro, max, enterprise.

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/services",
   "version": "0.7.4",
-  "description": "External service integrations — Stripe (billing + circuit breaker), Vercel (deploy + DNS). Ships with RevealUI.",
+  "description": "External service integrations, Stripe (payment processing + circuit breaker) and email (Gmail API delivery). Ships with RevealUI.",
   "repository": {
     "type": "git",
     "url": "https://github.com/RevealUIStudio/revealui.git",

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -3,6 +3,7 @@
  *
  * Provides service integrations:
  * - Stripe payment processing
+ * - Email delivery (Gmail API)
  *
  * ## Usage
  *

--- a/scripts/validate/__tests__/marketing-voice.test.ts
+++ b/scripts/validate/__tests__/marketing-voice.test.ts
@@ -4,10 +4,12 @@ import {
   hasEmDash,
   hasEmoji,
   hasSentenceExclamation,
+  isClaimsEvidenceIndex,
   isContentFile,
   isVoiceExempt,
   type LineScanOptions,
   matchesSequence,
+  scanAll,
   scanLine,
   tokenize,
 } from '../marketing-voice.js';
@@ -132,6 +134,20 @@ describe('scanLine — skips imports and comments', () => {
     expect(scanLine('  // a powerful, cutting-edge comment', CONTENT)).toEqual([]);
     expect(scanLine('   * jsdoc powerful line', CONTENT)).toEqual([]);
     expect(scanLine('  // product roster — em dashes fine in comments', CONTENT)).toEqual([]);
+  });
+});
+
+describe('claims-evidence index exemption', () => {
+  it('isClaimsEvidenceIndex matches only the index file', () => {
+    expect(isClaimsEvidenceIndex('apps/marketing/app/content/claims-evidence.ts')).toBe(true);
+    expect(isClaimsEvidenceIndex('apps/marketing/app/content/home.ts')).toBe(false);
+    expect(isClaimsEvidenceIndex('apps/marketing/app/content/for-operators.ts')).toBe(false);
+  });
+  it('scanAll produces zero findings attributed to the claims-evidence index file', () => {
+    const findings = scanAll();
+    expect(findings.some((f) => f.file === 'apps/marketing/app/content/claims-evidence.ts')).toBe(
+      false,
+    );
   });
 });
 

--- a/scripts/validate/marketing-voice.ts
+++ b/scripts/validate/marketing-voice.ts
@@ -29,6 +29,12 @@
  *     with class names.
  *   - em-dash: every marketing file — the character never appears in class
  *     names, and comment lines (including JSX comments) are skipped.
+ *   - `content/claims-evidence.ts` is exempt from every rule above (see
+ *     `isClaimsEvidenceIndex`): it is the claims registry, not copy — it
+ *     quotes other content files' prose verbatim so the register rules would
+ *     double-count real (or already-baselined) findings at the index's own
+ *     file:line. The copy it quotes still runs through the normal scan via
+ *     the content file it was copied from.
  *
  * A baseline (`marketing-voice-baseline.json`) grandfathers the current
  * corpus; CI fails only on NEW `(file::ruleId::token)` triples. Shrinking the
@@ -320,6 +326,25 @@ export function scanLine(line: string, opts: LineScanOptions): RawFinding[] {
 const MARKETING_APP = 'apps/marketing/app';
 const SCAN_SUBDIRS = ['content', 'components', 'routes', 'layouts'];
 
+/**
+ * The claims-evidence index (`content/claims-evidence.ts`) quotes copy
+ * verbatim from the files it indexes — that is the entire point of
+ * exact-text pinning (see claims-evidence.ts's own header comment). It is
+ * not customer-facing copy itself, so running the register rules over it is
+ * a false-positive generator: a quoted sentence trips hype/codename/voice
+ * findings at the INDEX's file:line in addition to the real finding (or
+ * baseline entry) at the copy's own file:line, and the only way to silence
+ * the duplicate was to paraphrase the pin away from the exact text it exists
+ * to preserve. The copy it indexes still goes through the normal scan via
+ * `COVERED_FILES` in claims-evidence.ts, so exempting this one file does not
+ * reduce voice coverage of the site.
+ */
+const CLAIMS_EVIDENCE_INDEX_REL = 'apps/marketing/app/content/claims-evidence.ts';
+
+export function isClaimsEvidenceIndex(rel: string): boolean {
+  return rel === CLAIMS_EVIDENCE_INDEX_REL;
+}
+
 /** `for-operators/*` + blog surfaces speak in the studio's first-person voice
  *  by design (corpus §2.1) — exempt from the fleet-voice register rule. */
 export function isVoiceExempt(rel: string): boolean {
@@ -372,6 +397,7 @@ export function baselineKey(f: Pick<Finding, 'file' | 'ruleId' | 'token'>): stri
 
 function scanFile(absPath: string): Finding[] {
   const rel = path.relative(ROOT, absPath).split(path.sep).join('/');
+  if (isClaimsEvidenceIndex(rel)) return [];
   const content = fs.readFileSync(absPath, 'utf8');
   const lines = content.split('\n');
   const content_ = isContentFile(rel);


### PR DESCRIPTION
## Summary

Three hygiene follow-ups from the 2026-07-13 marketing claims-ratchet work
(`agent-system (fable)` workboard log entry
`.jv/.claude/workboard.d/log/2026-07-13T01-29-34-277Z-agent-system-fable.md`).

1. **Stale CLAUDE.md claims**, verified against the code:
   - admin collections actually live at `apps/admin/src/lib/collections/`,
     not `apps/admin/src/collections/` (that path does not exist).
   - `@revealui/services` only ships Stripe payment processing (with a DB
     circuit breaker, `src/stripe/db-circuit-breaker.ts`) and Gmail-API email
     delivery (`src/email/`). There is no Vercel deploy/DNS service anywhere
     in `src/` — the only Vercel reference is a comment excluding Vercel's
     serverless path from a warm-cache optimization. Also fixed the same
     phantom-Vercel description in `packages/services/package.json` (public
     npm description) and filled in the missing email line in the module doc
     comment, since it's the same root cause and a one-line fix.

2. **Stale versioning-rule note — NOT in this repo, see below.**

3. **marketing-voice exemption for the claims-evidence index**
   (`content/claims-evidence.ts`, 485 entries / 17 files): the index quotes
   other content files' prose verbatim to pin exact text against evidence.
   Scanning it under the same hype/codename/voice/em-dash register rules as
   real copy double-counts findings at the index's own file:line, and the
   documented workaround (per the fable log) was to paraphrase 13 operator
   entries' `text` fields to dodge the scanner — which defeats exact-text
   pinning. Fixed by exempting only `content/claims-evidence.ts` from the
   marketing-voice scan (`isClaimsEvidenceIndex`), with a comment explaining
   why. The copy it quotes is unaffected — it still runs through the normal
   scan via its own content file, so voice coverage of the site doesn't
   shrink. Added test coverage in `marketing-voice.test.ts`
   (`isClaimsEvidenceIndex` predicate + a `scanAll()` integration check that
   the index produces zero findings). `marketing-voice-baseline.json` is
   untouched (still 0 keys).

### Item 2 is a separate PR, not in this repo

`.claude/rules/versioning.md` is **gitignored in this repo**
(`.gitignore:91,170`) and, in the main checkout, is a symlink to
`~/revfleet/revcon/profiles/revealui/claude/rules/versioning.md` — a
distribution copy that lives in `RevealUIStudio/revcon`, not here. Editing it
inside this worktree would produce a change git can't track. Filed and fixed
at the real location: **RevealUIStudio/revcon#79**. Verified stale claim: the
note said Pro packages (ai, harnesses) "are ignored, they're gitignored in
the public repo" — false on both counts (`packages/ai/package.json` etc. are
tracked in git; `.gitignore`'s Pro-packages block is a comment header with no
ignore pattern; `.changeset/config.json`'s `ignore` list is `server`,
`admin`, `docs`, `marketing`, `@revealui/test`, `@revealui/scripts`,
`@revealui/dev`, no Pro package in it; `packages/ai/CHANGELOG.md` shows
normal changeset-generated version history).

### The 13 paraphrased entries: not recoverable, flagging instead of guessing

I could not identify which 13 operator entries the fable log refers to, or
recover their pre-paraphrase text. Audit performed:
- `git log -p` (full history) on `apps/marketing/app/content/claims-evidence.ts`
  and on `for-operators.ts` / `for-operators-how-it-works.ts` /
  `for-operators-managed.ts` across all four PRs (#1874, #1877, #1878,
  #1880) — only 3 `text:` field edits exist in the file's entire history,
  none are hype-word paraphrases and none touch an operator file.
- Empirically re-scanned the live `claims-evidence.ts` with every
  marketing-voice rule forced on: 0 findings, confirming there is no
  currently-flaggable trace left in the file.
- `git reflog --all` + `git fsck --unreachable`: no dangling/amended commit
  from the 2026-07-12 ratchet session touches this file or the operator
  content files.
- The originating fable log entry names the count (13) but not the entries
  or their original wording — that detail lived only in the authoring
  session's working state, not in git or in the `.jv` lane docs I could
  find (`docs/lanes/frontend-excellence/`).

Restoring text I can't verify against a real prior version would violate the
exact-text-pinning principle worse than the paraphrase does. The exemption
in this PR removes the scanner pressure that caused the paraphrasing, so a
session with the original context (a fresh Fable pass, most likely) can now
safely restore the 13 entries without CI fighting it. Recommend re-flagging
this specific sub-item rather than treating it as done.

## Coordination note

`.wt/refund-sla-pages` is concurrently *adding* new claims-evidence entries
(new marketing pages). This PR only *touches the validator* and does
unrelated doc/description fixes elsewhere — it does not edit
`claims-evidence.ts` content, so there's no line-level conflict. Order
shouldn't matter, but merging this one first gets the exemption landed
before any new operator-adjacent entries in that PR risk hitting the same
scanner pressure.

## Test plan

- [x] `pnpm --filter @revealui/services typecheck` — clean
- [x] `pnpm --filter @revealui/services lint` — clean
- [x] `node_modules/.bin/vitest run scripts/validate/__tests__/marketing-voice.test.ts` — 28/28 pass (26 existing + 2 new)
- [x] `node_modules/.bin/tsx scripts/validate/marketing-voice.ts` — 0 occurrences, 0 new
- [x] `node_modules/.bin/tsx scripts/validate/claims-evidence.ts` — 485/485 matched, all evidence paths present
- [x] `pnpm --filter marketing test` — 75/75 pass (matches the ratchet-3 commit's own count)
- [x] `pnpm --filter marketing typecheck` — clean
- [x] `node_modules/.bin/tsx scripts/validate/doc-currency.ts` — 0 new drift
- [x] Full pre-push `pnpm gate` (phase 1 + CI gate incl. Marketing voice / Claims evidence hard-fail checks) — PASS
- [ ] 13 paraphrased entries restored — **not done, see above**; needs the original authoring context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
