### PR TITLE
feat(ai): GAP-360 PR-1 — provider surface (anthropic/openai), fail-loud defaults, CHECK widening

### DIFF
--- a/.changeset/gap-360-provider-surface.md
+++ b/.changeset/gap-360-provider-surface.md
@@ -1,0 +1,23 @@
+---
+"@revealui/ai": minor
+"@revealui/db": minor
+---
+
+Widen the LLM provider surface with Anthropic and OpenAI (no behavior change).
+
+`@revealui/ai`: `LLMProviderType` now includes `anthropic` and `openai`, added to
+the `createProvider` factory as OpenAI-compatible wrappers (Anthropic at
+`https://api.anthropic.com/v1`, OpenAI at `https://api.openai.com/v1`) with
+conservative default models. Fixes a latent defect where `huggingface` was
+accepted by the env factory but had no `createProvider` case and threw at first
+use. `createLLMClientFromEnv` auto-detects the two new providers after the
+existing checks so existing deployments resolve identically, and now emits the
+one-line boot warning it always documented when the zero-config localhost default
+is selected. The OpenAI-compatible client sets a 60s request timeout and one
+retry so an unreachable endpoint fails fast instead of burning the serverless
+duration. Exports a `hostedViable` classification for later resolver/UI wiring.
+
+`@revealui/db`: migration widening the provider CHECK constraints on
+`user_api_keys` and `workspace_inference_configs` (and the latter's key-pairing
+CHECK) to allow `anthropic` and `openai`. Constraint-widening only, idempotent,
+no backfill.

--- a/packages/ai/src/llm/__tests__/env-factory-warning.test.ts
+++ b/packages/ai/src/llm/__tests__/env-factory-warning.test.ts
@@ -1,0 +1,63 @@
+/**
+ * GAP-360 PR-1 §5.3 — the zero-config localhost-default boot warning.
+ *
+ * The docstring at client.ts promised a one-line stderr warning when the
+ * zero-config inference-snaps localhost default is selected, but nothing emitted
+ * it. This asserts it now fires — exactly once per process (module-level guard),
+ * only on the zero-config path.
+ *
+ * Isolated in its own file so the module-level once-guard starts fresh.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { warnSpy } = vi.hoisted(() => ({ warnSpy: vi.fn() }));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  createLogger: () => ({
+    warn: warnSpy,
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { createLLMClientFromEnv } from '../client.js';
+
+const PROVIDER_ENV_KEYS = [
+  'LLM_PROVIDER',
+  'INFERENCE_SNAPS_BASE_URL',
+  'GROQ_API_KEY',
+  'OLLAMA_BASE_URL',
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+] as const;
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of PROVIDER_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of PROVIDER_ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+});
+
+describe('zero-config localhost default warning', () => {
+  it('emits exactly once across repeated zero-config factory calls', () => {
+    createLLMClientFromEnv();
+    createLLMClientFromEnv();
+    createLLMClientFromEnv();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('inference-snaps');
+  });
+});

--- a/packages/ai/src/llm/__tests__/env-factory.test.ts
+++ b/packages/ai/src/llm/__tests__/env-factory.test.ts
@@ -1,0 +1,186 @@
+/**
+ * GAP-360 PR-1 — provider-surface widening for the env + client factories.
+ *
+ * Covers: createProvider branches for anthropic/openai, the huggingface factory
+ * fix (previously threw 'Unknown provider type'), createLLMClientFromEnv
+ * auto-detect priority (existing env combos must resolve identically), explicit
+ * LLM_PROVIDER selection, and the hostedViable classification.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Silence the real boot-warning logger (console.warn) — the once-only warning is
+// asserted separately in env-factory-warning.test.ts with a fresh module.
+vi.mock('@revealui/core/observability/logger', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import {
+  createLLMClientFromEnv,
+  hostedViable,
+  isHostedViable,
+  LLMClient,
+  type LLMProviderType,
+} from '../client.js';
+
+const PROVIDER_ENV_KEYS = [
+  'LLM_PROVIDER',
+  'INFERENCE_SNAPS_BASE_URL',
+  'GROQ_API_KEY',
+  'GROQ_BASE_URL',
+  'OLLAMA_BASE_URL',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_BASE_URL',
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'HF_TOKEN',
+  'HF_MODEL_URL',
+  'LLM_MODEL',
+  'LLM_TEMPERATURE',
+  'LLM_MAX_TOKENS',
+] as const;
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of PROVIDER_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of PROVIDER_ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = savedEnv[key];
+    }
+  }
+});
+
+/** The provider a constructed client is wired to (via the circuit-breaker name). */
+function providerOf(client: LLMClient): string {
+  return client.getCircuitBreakerStats().primary.name.replace('llm-', '');
+}
+
+describe('createProvider — new factory branches', () => {
+  it('constructs an anthropic provider without throwing', () => {
+    const client = new LLMClient({ provider: 'anthropic', apiKey: 'sk-ant-test' });
+    expect(providerOf(client)).toBe('anthropic');
+  });
+
+  it('constructs an openai provider without throwing', () => {
+    const client = new LLMClient({ provider: 'openai', apiKey: 'sk-test' });
+    expect(providerOf(client)).toBe('openai');
+  });
+
+  it('constructs a huggingface provider without throwing (regression: was Unknown provider type)', () => {
+    // Before the fix, createProvider had no 'huggingface' case and threw
+    // 'Unknown provider type: huggingface' inside the LLMClient constructor.
+    expect(
+      () =>
+        new LLMClient({
+          provider: 'huggingface',
+          apiKey: 'hf_test',
+          baseURL: 'http://hf.local/v1',
+        }),
+    ).not.toThrow();
+  });
+});
+
+describe('createLLMClientFromEnv — explicit LLM_PROVIDER', () => {
+  it('resolves anthropic from LLM_PROVIDER + ANTHROPIC_API_KEY', () => {
+    process.env.LLM_PROVIDER = 'anthropic';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('anthropic');
+  });
+
+  it('resolves openai from LLM_PROVIDER + OPENAI_API_KEY', () => {
+    process.env.LLM_PROVIDER = 'openai';
+    process.env.OPENAI_API_KEY = 'sk-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('openai');
+  });
+
+  it('throws a keyless error for anthropic without ANTHROPIC_API_KEY', () => {
+    process.env.LLM_PROVIDER = 'anthropic';
+    expect(() => createLLMClientFromEnv()).toThrow(/ANTHROPIC_API_KEY/);
+  });
+});
+
+describe('createLLMClientFromEnv — auto-detect priority order (unchanged for existing deployments)', () => {
+  it('INFERENCE_SNAPS wins over GROQ', () => {
+    process.env.INFERENCE_SNAPS_BASE_URL = 'http://localhost:9090/v1';
+    process.env.GROQ_API_KEY = 'gsk_test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('inference-snaps');
+  });
+
+  it('GROQ resolves when only GROQ_API_KEY is set', () => {
+    process.env.GROQ_API_KEY = 'gsk_test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('groq');
+  });
+
+  it('OLLAMA resolves when only OLLAMA_BASE_URL is set', () => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434';
+    expect(providerOf(createLLMClientFromEnv())).toBe('ollama');
+  });
+
+  it('GROQ still wins over a newly-added ANTHROPIC_API_KEY (priority unchanged)', () => {
+    process.env.GROQ_API_KEY = 'gsk_test';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('groq');
+  });
+});
+
+describe('createLLMClientFromEnv — auto-detect for new providers (appended after existing checks)', () => {
+  it('ANTHROPIC_API_KEY alone resolves to anthropic', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('anthropic');
+  });
+
+  it('OPENAI_API_KEY alone resolves to openai', () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('openai');
+  });
+
+  it('ANTHROPIC wins over OPENAI when both are set', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    process.env.OPENAI_API_KEY = 'sk-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('anthropic');
+  });
+
+  it('falls back to the inference-snaps localhost default with no provider env', () => {
+    expect(providerOf(createLLMClientFromEnv())).toBe('inference-snaps');
+  });
+});
+
+describe('hostedViable classification', () => {
+  it('marks cloud providers viable and localhost-only providers not viable', () => {
+    expect(hostedViable).toEqual({
+      anthropic: true,
+      openai: true,
+      groq: true,
+      huggingface: true,
+      ollama: false,
+      'inference-snaps': false,
+    });
+  });
+
+  it('isHostedViable agrees with the map for every provider', () => {
+    const providers: LLMProviderType[] = [
+      'anthropic',
+      'openai',
+      'groq',
+      'huggingface',
+      'ollama',
+      'inference-snaps',
+    ];
+    for (const p of providers) {
+      expect(isHostedViable(p)).toBe(hostedViable[p]);
+    }
+  });
+});

--- a/packages/ai/src/llm/__tests__/env-factory.test.ts
+++ b/packages/ai/src/llm/__tests__/env-factory.test.ts
@@ -108,7 +108,7 @@ describe('createLLMClientFromEnv — explicit LLM_PROVIDER', () => {
 
   it('throws a keyless error for anthropic without ANTHROPIC_API_KEY', () => {
     process.env.LLM_PROVIDER = 'anthropic';
-    expect(() => createLLMClientFromEnv()).toThrow(/ANTHROPIC_API_KEY/);
+    expect(() => createLLMClientFromEnv()).toThrow('ANTHROPIC_API_KEY');
   });
 });
 

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -7,6 +7,7 @@
 // Log redaction lives in @revealui/security — import `redactLogContext`
 // (recursive walker) or `redactLogField` (single key/value).
 
+import { createLogger } from '@revealui/core/observability/logger';
 import type { Database } from '@revealui/db/client';
 import { decryptApiKey } from '@revealui/db/crypto';
 import { tenantProviderConfigs, userApiKeys } from '@revealui/db/schema';
@@ -18,6 +19,7 @@ import {
 import { and, eq } from 'drizzle-orm';
 import type { AuditStore } from '../audit/store.js';
 import type { ProviderHealthMonitor } from './provider-health.js';
+import { AnthropicProvider, type AnthropicProviderConfig } from './providers/anthropic.js';
 import type {
   Embedding,
   LLMChatOptions,
@@ -34,7 +36,8 @@ import {
   type InferenceSnapsProviderConfig,
 } from './providers/inference-snaps.js';
 import { OllamaProvider, type OllamaProviderConfig } from './providers/ollama.js';
-import type { OpenAICompatConfig } from './providers/openai-compat.js';
+import { OpenAIProvider, type OpenAIProviderConfig } from './providers/openai.js';
+import { type OpenAICompatConfig, OpenAICompatProvider } from './providers/openai-compat.js';
 import { type CacheStats, ResponseCache, type ResponseCacheOptions } from './response-cache.js';
 import {
   SemanticCache,
@@ -43,7 +46,36 @@ import {
 } from './semantic-cache.js';
 import { estimateRequest as _estimateRequestTokens } from './token-counter.js';
 
-export type LLMProviderType = 'groq' | 'ollama' | 'huggingface' | 'inference-snaps';
+export type LLMProviderType =
+  | 'anthropic'
+  | 'openai'
+  | 'groq'
+  | 'huggingface'
+  | 'ollama'
+  | 'inference-snaps';
+
+/**
+ * Providers reachable from a hosted (serverless) deployment. Localhost-only
+ * providers are false. Consumed by PR-2/PR-3 (resolver + settings UI) to pick
+ * which providers a hosted account may configure; no runtime consumer yet.
+ */
+export const hostedViable: Record<LLMProviderType, boolean> = {
+  anthropic: true,
+  openai: true,
+  groq: true,
+  huggingface: true,
+  ollama: false,
+  'inference-snaps': false,
+};
+
+/** True when the provider can serve a hosted (serverless) deployment. */
+export function isHostedViable(provider: LLMProviderType): boolean {
+  return hostedViable[provider];
+}
+
+/** Emitted once per process when the zero-config localhost default is selected. */
+let warnedLocalhostDefault = false;
+const envFactoryLogger = createLogger({ component: 'createLLMClientFromEnv' });
 
 export interface LLMClientConfig {
   provider: LLMProviderType;
@@ -169,17 +201,29 @@ export class LLMClient {
     type: LLMProviderType,
     config:
       | OpenAICompatConfig
+      | AnthropicProviderConfig
+      | OpenAIProviderConfig
       | GroqProviderConfig
       | OllamaProviderConfig
       | InferenceSnapsProviderConfig,
   ): LLMProvider {
     switch (type) {
+      case 'anthropic':
+        return new AnthropicProvider(config as AnthropicProviderConfig);
+      case 'openai':
+        return new OpenAIProvider(config as OpenAIProviderConfig);
       case 'groq':
         return new GroqProvider(config as GroqProviderConfig);
       case 'ollama':
         return new OllamaProvider(config as OllamaProviderConfig);
       case 'inference-snaps':
         return new InferenceSnapsProvider(config as InferenceSnapsProviderConfig);
+      case 'huggingface':
+        // HuggingFace exposes an OpenAI-compatible inference endpoint; baseURL is
+        // per-model (HF_MODEL_URL), so it has no dedicated wrapper — the compat
+        // base serves it directly. Fixes the latent defect where the env factory
+        // accepted 'huggingface' but createProvider threw 'Unknown provider type'.
+        return new OpenAICompatProvider(config as OpenAICompatConfig);
       default:
         throw new Error(`Unknown provider type: ${String(type)}`);
     }
@@ -579,23 +623,29 @@ export class LLMClient {
  * Create an LLM client from environment variables.
  *
  * When LLM_PROVIDER is not set, auto-detects the provider by checking env vars
- * in priority order: INFERENCE_SNAPS → GROQ → OLLAMA. If none are set, defaults
- * to Inference Snaps at http://localhost:9090/v1 (Ubuntu local) and emits a
- * one-line stderr warning so the implicit default is discoverable in logs.
+ * in priority order: INFERENCE_SNAPS → GROQ → OLLAMA → ANTHROPIC_API_KEY →
+ * OPENAI_API_KEY. If none are set, defaults to Inference Snaps at
+ * http://localhost:9090/v1 (Ubuntu local) and emits a one-line stderr warning so
+ * the implicit localhost default is discoverable in logs.
  *
- * All providers use OpenAI-compatible APIs. No proprietary provider SDKs.
+ * All providers use OpenAI-compatible APIs. No proprietary provider SDKs
+ * (Anthropic + OpenAI ride their OpenAI-compatible endpoints).
  *
  * Canonical Inference Snaps is the reference local provider on Ubuntu — offline,
  * silicon-optimized, no API key required. See `providers/inference-snaps.ts` for
  * install docs (`sudo snap install gemma3`, etc.).
  *
  * Provider defaults:
- *   inference-snaps → gemma3       (base URL defaults to http://localhost:9090/v1)
+ *   inference-snaps → gemma3            (base URL defaults to http://localhost:9090/v1)
  *   groq            → qwen/qwen3-32b
- *   ollama          → gemma4:e2b   (base URL defaults to http://localhost:11434)
+ *   ollama          → gemma4:e2b        (base URL defaults to http://localhost:11434)
+ *   anthropic       → claude-sonnet-4-6 (base URL defaults to https://api.anthropic.com/v1)
+ *   openai          → gpt-4o            (base URL defaults to https://api.openai.com/v1)
  */
 export function createLLMClientFromEnv(): LLMClient {
-  // Auto-detect provider when LLM_PROVIDER is not explicitly set
+  // Auto-detect provider when LLM_PROVIDER is not explicitly set. The existing
+  // priority order (INFERENCE_SNAPS → GROQ → OLLAMA) is preserved so existing
+  // deployments resolve identically; the frontier providers are appended after.
   let provider: LLMProviderType;
   if (process.env.LLM_PROVIDER) {
     provider = process.env.LLM_PROVIDER as LLMProviderType;
@@ -605,17 +655,38 @@ export function createLLMClientFromEnv(): LLMClient {
     provider = 'groq';
   } else if (process.env.OLLAMA_BASE_URL) {
     provider = 'ollama';
+  } else if (process.env.ANTHROPIC_API_KEY) {
+    provider = 'anthropic';
+  } else if (process.env.OPENAI_API_KEY) {
+    provider = 'openai';
   } else {
-    // Zero-config Ubuntu default: assume Inference Snaps on the standard
-    // local port. Operator sees the warning once at boot.
+    // Zero-config Ubuntu default: assume Inference Snaps on the standard local
+    // port. This localhost default is unreachable inside a hosted serverless
+    // function, so warn once per process to make the implicit choice visible.
     provider = 'inference-snaps';
+    if (!warnedLocalhostDefault) {
+      warnedLocalhostDefault = true;
+      envFactoryLogger.warn(
+        'No LLM provider env var set — defaulting to inference-snaps at ' +
+          'http://localhost:9090/v1. This localhost endpoint is unreachable on a ' +
+          'hosted deployment; set LLM_PROVIDER or a provider key.',
+      );
+    }
   }
 
   let apiKey: string | undefined;
   let baseURL: string | undefined;
   let defaultModel: string | undefined;
 
-  if (provider === 'huggingface') {
+  if (provider === 'anthropic') {
+    apiKey = process.env.ANTHROPIC_API_KEY;
+    baseURL = process.env.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com/v1';
+    defaultModel = 'claude-sonnet-4-6';
+  } else if (provider === 'openai') {
+    apiKey = process.env.OPENAI_API_KEY;
+    baseURL = process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1';
+    defaultModel = 'gpt-4o';
+  } else if (provider === 'huggingface') {
     apiKey = process.env.HF_TOKEN;
     baseURL = process.env.HF_MODEL_URL;
   } else if (provider === 'groq') {
@@ -639,7 +710,8 @@ export function createLLMClientFromEnv(): LLMClient {
   if (!apiKey) {
     throw new Error(
       `API key not found for provider "${provider}". Set the corresponding env var ` +
-        `(INFERENCE_SNAPS_BASE_URL, GROQ_API_KEY, OLLAMA_BASE_URL, or HF_TOKEN).`,
+        `(INFERENCE_SNAPS_BASE_URL, GROQ_API_KEY, OLLAMA_BASE_URL, HF_TOKEN, ` +
+        `ANTHROPIC_API_KEY, or OPENAI_API_KEY).`,
     );
   }
 

--- a/packages/ai/src/llm/providers/anthropic.ts
+++ b/packages/ai/src/llm/providers/anthropic.ts
@@ -1,0 +1,74 @@
+/**
+ * Anthropic Provider
+ *
+ * Thin wrapper over OpenAICompatProvider using Anthropic's OpenAI-compatible
+ * surface at https://api.anthropic.com/v1. No proprietary Anthropic SDK — the
+ * fleet posture is "No proprietary provider SDKs" (see client.ts). Anthropic
+ * exposes an OpenAI-compatible chat/completions endpoint, so the same base
+ * implementation that serves Groq/Ollama/inference-snaps serves Anthropic too.
+ *
+ * Docs: https://docs.anthropic.com/en/api/openai-sdk
+ */
+
+import type {
+  Embedding,
+  LLMChatOptions,
+  LLMChunk,
+  LLMEmbedOptions,
+  LLMProvider,
+  LLMProviderConfig,
+  LLMResponse,
+  LLMStreamOptions,
+  Message,
+  ReasonerCapabilities,
+} from './base.js';
+import { OpenAICompatProvider } from './openai-compat.js';
+
+export interface AnthropicProviderConfig extends Omit<LLMProviderConfig, 'apiKey'> {
+  apiKey: string;
+  /** Defaults to https://api.anthropic.com/v1 */
+  baseURL?: string;
+  /** Defaults to claude-sonnet-4-6 (conservative documented default; overridable) */
+  model?: string;
+  timeout?: number;
+  maxRetries?: number;
+}
+
+export class AnthropicProvider implements LLMProvider {
+  private inner: OpenAICompatProvider;
+
+  constructor(config: AnthropicProviderConfig) {
+    this.inner = new OpenAICompatProvider({
+      ...config,
+      baseURL: config.baseURL ?? 'https://api.anthropic.com/v1',
+      model: config.model ?? 'claude-sonnet-4-6',
+    });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    return {
+      providerTag: 'anthropic',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      // Anthropic exposes no embeddings endpoint on its OpenAI-compat surface.
+      embeddings: false,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
+  }
+
+  chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {
+    return this.inner.chat(messages, options);
+  }
+
+  stream(messages: Message[], options?: LLMStreamOptions): AsyncIterable<LLMChunk> {
+    return this.inner.stream(messages, options);
+  }
+
+  embed(_text: string | string[], _options?: LLMEmbedOptions): Promise<Embedding | Embedding[]> {
+    throw new Error('Anthropic does not expose an embeddings endpoint. Use OpenAI or Ollama.');
+  }
+}

--- a/packages/ai/src/llm/providers/openai-compat.ts
+++ b/packages/ai/src/llm/providers/openai-compat.ts
@@ -21,7 +21,15 @@ import type {
   ToolCall,
 } from './base.js';
 
-export interface OpenAICompatConfig extends LLMProviderConfig {}
+export interface OpenAICompatConfig extends LLMProviderConfig {
+  /** Per-request timeout in ms applied to connection setup. Default 60_000. */
+  timeout?: number;
+  /** Retries on connection/timeout errors (not on HTTP error responses). Default 1. */
+  maxRetries?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000 as const;
+const DEFAULT_MAX_RETRIES = 1 as const;
 
 type OpenAIChatToolCall = {
   id: string;
@@ -77,6 +85,8 @@ const isFunctionToolCall = (call: unknown): call is OpenAIChatToolCall => {
 export class OpenAICompatProvider implements LLMProvider {
   private config: OpenAICompatConfig;
   private baseURL: string;
+  private timeoutMs: number;
+  private maxRetries: number;
 
   constructor(config: OpenAICompatConfig) {
     this.config = config;
@@ -86,6 +96,33 @@ export class OpenAICompatProvider implements LLMProvider {
       );
     }
     this.baseURL = config.baseURL;
+    this.timeoutMs = config.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+  }
+
+  /**
+   * fetch() with a connection-setup timeout and bounded retries. The timeout
+   * aborts a hung connection (the localhost-default failure mode that otherwise
+   * burns the whole serverless duration) and is cleared once headers arrive, so
+   * a legitimately long streaming body is not truncated. Retries fire only on a
+   * thrown fetch error (connection refused, DNS, timeout) — never on an HTTP
+   * error response, which the caller inspects — so a POST is re-sent only when
+   * no response was received.
+   */
+  private async fetchWithResilience(url: string, init: RequestInit): Promise<Response> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+      try {
+        return await fetch(url, { ...init, signal: controller.signal });
+      } catch (error) {
+        lastError = error;
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
   }
 
   capabilities(): ReasonerCapabilities {
@@ -105,7 +142,7 @@ export class OpenAICompatProvider implements LLMProvider {
   }
 
   async chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {
-    const response = await fetch(`${this.baseURL}/chat/completions`, {
+    const response = await this.fetchWithResilience(`${this.baseURL}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -188,7 +225,7 @@ export class OpenAICompatProvider implements LLMProvider {
     const texts = Array.isArray(text) ? text : [text];
     const model = options?.model || 'text-embedding-3-small';
 
-    const response = await fetch(`${this.baseURL}/embeddings`, {
+    const response = await this.fetchWithResilience(`${this.baseURL}/embeddings`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -226,7 +263,7 @@ export class OpenAICompatProvider implements LLMProvider {
   }
 
   async *stream(messages: Message[], options?: LLMStreamOptions): AsyncIterable<LLMChunk> {
-    const response = await fetch(`${this.baseURL}/chat/completions`, {
+    const response = await this.fetchWithResilience(`${this.baseURL}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/ai/src/llm/providers/openai.ts
+++ b/packages/ai/src/llm/providers/openai.ts
@@ -1,0 +1,70 @@
+/**
+ * OpenAI Provider
+ *
+ * Thin wrapper over OpenAICompatProvider targeting OpenAI's native
+ * chat/completions + embeddings API at https://api.openai.com/v1. OpenAI is the
+ * reference OpenAI-compatible surface, so the shared base implementation serves
+ * it directly — no proprietary SDK (fleet posture in client.ts).
+ */
+
+import type {
+  Embedding,
+  LLMChatOptions,
+  LLMChunk,
+  LLMEmbedOptions,
+  LLMProvider,
+  LLMProviderConfig,
+  LLMResponse,
+  LLMStreamOptions,
+  Message,
+  ReasonerCapabilities,
+} from './base.js';
+import { OpenAICompatProvider } from './openai-compat.js';
+
+export interface OpenAIProviderConfig extends Omit<LLMProviderConfig, 'apiKey'> {
+  apiKey: string;
+  /** Defaults to https://api.openai.com/v1 */
+  baseURL?: string;
+  /** Defaults to gpt-4o (conservative documented default; overridable) */
+  model?: string;
+  timeout?: number;
+  maxRetries?: number;
+}
+
+export class OpenAIProvider implements LLMProvider {
+  private inner: OpenAICompatProvider;
+
+  constructor(config: OpenAIProviderConfig) {
+    this.inner = new OpenAICompatProvider({
+      ...config,
+      baseURL: config.baseURL ?? 'https://api.openai.com/v1',
+      model: config.model ?? 'gpt-4o',
+    });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    return {
+      providerTag: 'openai',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      embeddings: true,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
+  }
+
+  chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {
+    return this.inner.chat(messages, options);
+  }
+
+  stream(messages: Message[], options?: LLMStreamOptions): AsyncIterable<LLMChunk> {
+    return this.inner.stream(messages, options);
+  }
+
+  embed(text: string | string[], options?: LLMEmbedOptions): Promise<Embedding | Embedding[]> {
+    return this.inner.embed(text, options);
+  }
+}

--- a/packages/db/migrations/0024_widen_provider_check_anthropic_openai.sql
+++ b/packages/db/migrations/0024_widen_provider_check_anthropic_openai.sql
@@ -1,0 +1,47 @@
+-- Migration: widen the provider CHECK constraints to allow 'anthropic' and
+-- 'openai' as BYOK / site-level providers.
+--
+-- WHY: GAP-360 PR-1 adds Anthropic + OpenAI to LLMProviderType and the
+-- createProvider factory (as OpenAI-compatible wrappers). The provider surface
+-- is gated in the DB at two CHECK constraints that predate those providers:
+--   - user_api_keys_provider_check                 (per-user BYOK keys)
+--   - workspace_inference_configs_provider_check   (site-level infra config)
+-- Both would reject an 'anthropic'/'openai' row. This widens them. The
+-- workspace_inference_configs key-pairing CHECK is also widened so that the two
+-- new (keyed, cloud) providers land in the non-NULL-encrypted-key branch,
+-- matching groq/huggingface.
+--
+-- NOT WIDENED: tenant_provider_configs has no provider CHECK constraint in the
+-- schema (packages/db/src/schema/api-keys.ts:68-94 declares only an index), so
+-- there is nothing to widen there — 'anthropic'/'openai' are already accepted.
+-- The design's "widen tenant_provider_configs" step does not apply to code
+-- reality (code-over-docs). Recorded in the PR body.
+--
+-- SCOPE: constraint-widening only. No backfill, no data migration.
+--
+-- IDEMPOTENCY: DROP CONSTRAINT IF EXISTS + DO $$ ADD CONSTRAINT ... EXCEPTION
+-- WHEN duplicate_object make this safe to re-run against a DB that already has
+-- the widened constraints (0014/0015/0023 precedent).
+
+ALTER TABLE "user_api_keys" DROP CONSTRAINT IF EXISTS "user_api_keys_provider_check";--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_api_keys" ADD CONSTRAINT "user_api_keys_provider_check" CHECK (provider IN ('anthropic', 'openai', 'groq', 'huggingface', 'inference-snaps', 'ollama'));
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+ALTER TABLE "workspace_inference_configs" DROP CONSTRAINT IF EXISTS "workspace_inference_configs_provider_check";--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspace_inference_configs" ADD CONSTRAINT "workspace_inference_configs_provider_check" CHECK (provider IN ('anthropic', 'openai', 'groq', 'huggingface', 'inference-snaps', 'ollama'));
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+ALTER TABLE "workspace_inference_configs" DROP CONSTRAINT IF EXISTS "workspace_inference_configs_key_pairing_check";--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspace_inference_configs" ADD CONSTRAINT "workspace_inference_configs_key_pairing_check" CHECK (
+  (provider IN ('inference-snaps', 'ollama') AND encrypted_api_key IS NULL)
+  OR
+  (provider IN ('anthropic', 'openai', 'groq', 'huggingface') AND encrypted_api_key IS NOT NULL)
+ );
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -56,6 +56,12 @@
       "rationale": "GAP-356 revenue blocker: widens account_entitlements_status_check to allow 'trialing' (the customer.subscription.created handler writes raw subscription.status into the entitlement upsert, so every trial checkout's entitlement INSERT threw a check violation and paying trial customers got no entitlement row) and adds nullable last_event_at to account_subscriptions + account_entitlements for the event-to-event staleness guard. Hand-written because a CHECK-constraint widening needs an idempotent drop/re-add: DROP CONSTRAINT IF EXISTS + DO $$ ADD CONSTRAINT ... EXCEPTION WHEN duplicate_object + ADD COLUMN IF NOT EXISTS, following the 0014/0015 precedent. Companion Drizzle schema change at packages/db/src/schema/accounts.ts widens the check() and adds the lastEventAt columns.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. The Drizzle schema at accounts.ts already reflects the widened constraint and lastEventAt columns at the type level; webhooks.ts queries via Drizzle."
+    },
+    {
+      "tag": "0024_widen_provider_check_anthropic_openai",
+      "rationale": "GAP-360 PR-1 provider-surface widening: adds 'anthropic' and 'openai' to the provider CHECK on user_api_keys and workspace_inference_configs (and to the workspace_inference_configs key-pairing CHECK, in the keyed/non-NULL branch alongside groq/huggingface). Hand-written because a CHECK-constraint widening needs an idempotent drop/re-add: DROP CONSTRAINT IF EXISTS + DO $$ ADD CONSTRAINT ... EXCEPTION WHEN duplicate_object, following the 0014/0015/0023 precedent. Constraint-widening only, no backfill. tenant_provider_configs is intentionally untouched — it has no provider CHECK in the schema, so there is nothing to widen. Companion Drizzle schema changes at packages/db/src/schema/api-keys.ts and inference-configs.ts widen the check() calls.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. The Drizzle schema at api-keys.ts + inference-configs.ts already reflects the widened constraints at the type level; consumers query via Drizzle."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1784000000000,
       "tag": "0023_entitlement_trialing_last_event",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1784100000000,
+      "tag": "0024_widen_provider_check_anthropic_openai",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/api-keys.ts
+++ b/packages/db/src/schema/api-keys.ts
@@ -25,7 +25,8 @@ export const userApiKeys = pgTable(
       .references(() => users.id, { onDelete: 'cascade' }),
 
     // Which LLM provider this key belongs to
-    provider: text('provider').notNull(), // 'groq' | 'huggingface' | 'inference-snaps' | 'ollama'
+    // 'anthropic' | 'openai' | 'groq' | 'huggingface' | 'inference-snaps' | 'ollama'
+    provider: text('provider').notNull(),
 
     // AES-256-GCM envelope-encrypted API key
     // Format: <base64(iv)>.<base64(authTag)>.<base64(ciphertext)>
@@ -53,7 +54,7 @@ export const userApiKeys = pgTable(
     index('user_api_keys_deleted_at_idx').on(table.deletedAt),
     check(
       'user_api_keys_provider_check',
-      sql`provider IN ('groq', 'huggingface', 'inference-snaps', 'ollama')`,
+      sql`provider IN ('anthropic', 'openai', 'groq', 'huggingface', 'inference-snaps', 'ollama')`,
     ),
   ],
 );

--- a/packages/db/src/schema/inference-configs.ts
+++ b/packages/db/src/schema/inference-configs.ts
@@ -55,13 +55,12 @@ export const workspaceInferenceConfigs = pgTable(
     // One config per site
     uniqueIndex('workspace_inference_configs_workspace_id_uidx').on(table.workspaceId),
 
-    // Provider must be one of the 4 LLMProviderType values. Vultr was
-    // removed in this same PR (bespoke provider with no differentiation
-    // vs. Groq/HF). Inference Snaps + Ollama are local; Groq + HF are
-    // cloud BYOK.
+    // Provider must be one of the LLMProviderType values. Inference Snaps +
+    // Ollama are local (keyless); Groq, HuggingFace, Anthropic, and OpenAI are
+    // cloud BYOK (keyed). Anthropic + OpenAI added in GAP-360 PR-1.
     check(
       'workspace_inference_configs_provider_check',
-      sql`provider IN ('groq', 'huggingface', 'inference-snaps', 'ollama')`,
+      sql`provider IN ('anthropic', 'openai', 'groq', 'huggingface', 'inference-snaps', 'ollama')`,
     ),
 
     // Pairing: keyless providers MUST have NULL encrypted_api_key;
@@ -71,7 +70,7 @@ export const workspaceInferenceConfigs = pgTable(
       sql`(
         (provider IN ('inference-snaps', 'ollama') AND encrypted_api_key IS NULL)
         OR
-        (provider IN ('groq', 'huggingface') AND encrypted_api_key IS NOT NULL)
+        (provider IN ('anthropic', 'openai', 'groq', 'huggingface') AND encrypted_api_key IS NOT NULL)
       )`,
     ),
   ],


### PR DESCRIPTION
Part 1/3 of GAP-360; PR-2 wires the resolver.

Scope per the ratified design spec [`docs/gap-specs/GAP-360-hosted-agent-execution-design.md`](https://github.com/RevealUIStudio/revealui-jv) §5.1 (provider surface) + §5.3 (fail-loud + missing warning), i.e. spec §7 "PR-1 (no behavior change)". PR-2 (resolver wiring) and PR-3 (UI) are out of scope — `createLLMClientForUser` is not wired anywhere here.

## What changed

**`@revealui/ai`**
- `LLMProviderType` widened to `anthropic | openai | groq | huggingface | ollama | inference-snaps`.
- `createProvider` gains `anthropic` and `openai` cases as OpenAI-compatible wrappers over the existing `openai-compat` base (no proprietary SDKs — spec §4-C posture). Default base URLs: Anthropic `https://api.anthropic.com/v1`, OpenAI `https://api.openai.com/v1`.
- **Latent defect fixed:** `huggingface` was accepted by `createLLMClientFromEnv` but had no `createProvider` case, so it threw `Unknown provider type` at first use. It now constructs an `OpenAICompatProvider` directly (HuggingFace's base URL is per-model via `HF_MODEL_URL`, so no dedicated wrapper).
- `createLLMClientFromEnv`: explicit `LLM_PROVIDER=anthropic|openai` support plus auto-detect **appended after** the existing checks. Priority order for existing deployments is unchanged: `INFERENCE_SNAPS → GROQ → OLLAMA → ANTHROPIC_API_KEY → OPENAI_API_KEY → zero-config localhost default`. Keys: `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`. No keys added to validate-startup/required-env (spec §6.6).
- **Boot warning (§5.3):** implemented the one-line stderr warning the docstring promised but never emitted — one warning, once per process (module-level guard), only on the zero-config localhost default. Uses the sanctioned `createLogger(...).warn` (respects the no-console Biome rule).
- **Timeouts (§5.3):** the OpenAI-compatible client now sets a 60s request timeout (via `AbortController`, cleared once headers arrive so long streams aren't truncated) and `maxRetries: 1` on connection/timeout errors (never on HTTP error responses). Overridable via `timeout` / `maxRetries` on `OpenAICompatConfig`.
- `hostedViable` classification exported (const map + `isHostedViable`): anthropic/openai/groq/huggingface `true`; ollama/inference-snaps `false`. Typed; no consumer wired yet (for PR-2/PR-3).

**`@revealui/db`**
- Migration `0024_widen_provider_check_anthropic_openai.sql` widens the provider CHECK on `user_api_keys` and `workspace_inference_configs`, and the `workspace_inference_configs` key-pairing CHECK (anthropic/openai land in the keyed / non-NULL branch alongside groq/huggingface). Constraint-widening only, idempotent (DROP IF EXISTS + `DO $$ ... EXCEPTION WHEN duplicate_object`), no backfill — same class as migration 0023. Schema source (`api-keys.ts`, `inference-configs.ts`) + drizzle journal/custom manifest updated to match.

## Default models (conservative, documented, overridable)

Anthropic's OpenAI-compat surface and OpenAI's native API both accept model ids as-is. Defaults chosen for stability/GA breadth, overridable via `tenant_provider_configs.model` / `LLM_MODEL`:
- anthropic → `claude-sonnet-4-6` (stable, GA; the spec's "claude-sonnet-5 alias" note — I picked the previous-generation Sonnet as the conservative choice).
- openai → `gpt-4o`.

## Red-proof (huggingface fix)

Per the required protocol: restored `packages/ai/src/llm/client.ts` from `origin/test` (`git checkout origin/test -- ...`, no stash of the fix), ran the new huggingface regression test, and it **failed red**:

```
AssertionError: expected [Function] to not throw an error but
'Error: Unknown provider type: huggingface' was thrown
```

Restored the fix → the same test passes green. The test proves the defect, not just guards the fix.

## Gate results (from the worktree)

- `pnpm --filter @revealui/ai test` → **985 passed | 5 skipped** (66 files).
- `pnpm --filter @revealui/db test` → **1184 passed | 5 skipped** (55 files).
- `pnpm --filter @revealui/ai --filter @revealui/db typecheck` → **clean** (`tsc --noEmit` Done for both).
- `biome check` on all 8 changed source files → **clean** (1 import-ordering autofix applied).
- migration-journal validator → `25 SQL files, 25 journal entries, all checks passed`.

## Security checker

```
$ node ~/revfleet/.jv/scripts/security-pr-review-check.js --diff origin/test
Current branch vs origin/test: no security-sensitive files — no coordinator gate.
```

(The changed `packages/db/src/schema/api-keys.ts` is a schema file; the checker's sensitive-path list targets `routes/api-keys` and middleware, not the schema. PR-2, which handles per-account key decryption at dispatch, is on the guardrail-2 sensitive-path list.)

## Spec deviation (recorded, code-over-docs)

The spec §5.1/§7 says to widen the provider CHECK on `user_api_keys`, `tenant_provider_configs`, **and** `inference_configs`. In code reality, `tenant_provider_configs` has **no** provider CHECK constraint ([`packages/db/src/schema/api-keys.ts`](../blob/feat/gap-360-provider-surface/packages/db/src/schema/api-keys.ts) declares only an index) — so there is nothing to widen there, and `anthropic`/`openai` are already accepted. Adding a new constraint would be a tightening (a behavior change) that contradicts PR-1's no-behavior-change mandate, so it was intentionally not added. This is recorded in the migration header and the `_custom.json` rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
