### PR TITLE
feat(ai): GAP-360 PR-2 — per-account key resolver + dispatch wiring + per-tenant worker gate

### DIFF
--- a/.changeset/gap-360-pr2-resolver.md
+++ b/.changeset/gap-360-pr2-resolver.md
@@ -9,4 +9,14 @@ On hosted, an unconfigured account fails closed with a typed `LLMNotConfiguredEr
 (HTTP 409 naming `/settings/api-keys`) instead of silently falling through to the
 localhost default. Gated behind `HOSTED_BYOK_DISPATCH` so self-hosted env-first
 behavior is byte-unchanged. `createLLMClientForUser` gains a `hostedViableOnly`
-option; `generateEmbedding` accepts an optional pre-resolved client.
+option; `generateEmbedding` accepts an optional pre-resolved client. Emits a
+one-time operator warning when the hosted BYOK dispatch flag is explicitly
+disabled (every account shares the deployment env client while the lever is
+pulled).
+
+Security fix (guardrail-2): the durable worker now derives dispatch identity
+from the authenticated dispatcher captured server-side at enqueue time, never
+from `ticket.reporterId` — that column is client-writable via the general
+tickets API with no ownership check, so reading it for key resolution would
+let an attacker who owns a board decrypt a victim's BYOK key by planting the
+victim's user id in `reporterId` before dispatching.

--- a/.changeset/gap-360-pr2-resolver.md
+++ b/.changeset/gap-360-pr2-resolver.md
@@ -1,0 +1,12 @@
+---
+"@revealui/ai": minor
+---
+
+Add the per-request LLM client resolver (GAP-360 PR-2). `resolveLLMClientForRequest`
+is the single home for key resolution at every agent-dispatch site: per-user BYOK
+first, then site-level inference config, then deployment env on self-hosted only.
+On hosted, an unconfigured account fails closed with a typed `LLMNotConfiguredError`
+(HTTP 409 naming `/settings/api-keys`) instead of silently falling through to the
+localhost default. Gated behind `HOSTED_BYOK_DISPATCH` so self-hosted env-first
+behavior is byte-unchanged. `createLLMClientForUser` gains a `hostedViableOnly`
+option; `generateEmbedding` accepts an optional pre-resolved client.

--- a/apps/admin/src/__tests__/integration/api/chat.test.ts
+++ b/apps/admin/src/__tests__/integration/api/chat.test.ts
@@ -60,17 +60,29 @@ vi.mock('@revealui/ai/embeddings', () => ({
   }),
 }));
 
-vi.mock('@revealui/ai/llm/server', () => ({
-  createLLMClientFromEnv: vi.fn(() => ({
-    chat: vi.fn().mockResolvedValue({
-      content: 'I can help you with that!',
-      toolCalls: [],
-    }),
-    getResponseCacheStats: vi.fn().mockReturnValue(undefined),
-    getSemanticCacheStats: vi.fn().mockReturnValue(undefined),
-  })),
-  createLLMClientForUser: vi.fn().mockResolvedValue(null),
-}));
+const makeChatClient = () => ({
+  chat: vi.fn().mockResolvedValue({
+    content: 'I can help you with that!',
+    toolCalls: [],
+  }),
+  embed: vi
+    .fn()
+    .mockResolvedValue({ vector: new Array(1536).fill(0), model: 'test', dimension: 1536 }),
+  getResponseCacheStats: vi.fn().mockReturnValue(undefined),
+  getSemanticCacheStats: vi.fn().mockReturnValue(undefined),
+});
+
+vi.mock('@revealui/ai/llm/server', () => {
+  const createLLMClientFromEnv = vi.fn(() => makeChatClient());
+  return {
+    createLLMClientFromEnv,
+    createLLMClientForUser: vi.fn().mockResolvedValue(null),
+    // GAP-360: the admin chat route resolves the per-account client via the
+    // resolver. It delegates to createLLMClientFromEnv so a test that overrides
+    // createLLMClientFromEnv drives both the chat and embedding paths.
+    resolveLLMClientForRequest: vi.fn(async () => createLLMClientFromEnv()),
+  };
+});
 
 vi.mock('@revealui/ai/memory/vector', () => ({
   VectorMemoryService: vi.fn().mockImplementation(() => ({

--- a/apps/admin/src/app/api/chat/route.ts
+++ b/apps/admin/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { getSession } from '@revealui/auth/server';
 import { ChatRequestContract } from '@revealui/contracts';
 import { apiClient } from '@revealui/core/admin/utils/apiClient';
+import { getClient } from '@revealui/db';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest } from 'next/server';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
@@ -56,6 +57,9 @@ async function loadChatAIDeps() {
   ]);
   const [embeddingsMod, llmServerMod, vectorMod, cmsMod, registryMod] = results;
 
+  // GAP-360: the per-request resolver lives on llm/server.
+  const resolveLLMClientForRequest = llmServerMod?.resolveLLMClientForRequest;
+
   // Log which specific modules failed so operators can diagnose missing Pro deps
   const failed = moduleNames.filter((_, i) => results[i] === null);
   if (failed.length > 0) {
@@ -69,6 +73,7 @@ async function loadChatAIDeps() {
   return {
     generateEmbedding: embeddingsMod.generateEmbedding,
     createLLMClientFromEnv: llmServerMod.createLLMClientFromEnv,
+    resolveLLMClientForRequest,
     VectorMemoryService: vectorMod.VectorMemoryService,
     createAdminTools: cmsMod.createAdminTools,
     ToolRegistry: registryMod.ToolRegistry,
@@ -300,21 +305,49 @@ export async function POST(request: NextRequest) {
         | undefined;
     }
 
-    // Create LLM client from environment-configured open models
-    let llmClient: ChatLLMClient;
+    // Resolve the LLM client via the GAP-360 resolver: per-account BYOK on
+    // hosted, env on self-hosted. userId is the authenticated session user
+    // (§6.1). Hosted detection mirrors the deployment signal used elsewhere
+    // (REVEALUI_LICENSE_PRIVATE_KEY presence, matching instrumentation.ts).
+    // NOTE (§6.4 / GAP-338): the admin process has no durable audit sink yet,
+    // so no auditStore is wired — byok:key:accessed does not persist here until
+    // GAP-338 closes. Recorded limitation, not a Phase-1 blocker.
+    const isHosted = !!process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    let resolvedClient: ChatLLMClient;
     try {
-      logger.info('Creating LLM client from env', {
-        provider: process.env.LLM_PROVIDER,
-        model: process.env.LLM_MODEL,
-      });
-      llmClient = aiDeps.createLLMClientFromEnv();
-    } catch (_err) {
+      if (aiDeps.resolveLLMClientForRequest) {
+        resolvedClient = (await aiDeps.resolveLLMClientForRequest(
+          authSession.user.id,
+          getClient(),
+          {
+            isHosted,
+          },
+        )) as unknown as ChatLLMClient;
+      } else {
+        resolvedClient = aiDeps.createLLMClientFromEnv();
+      }
+    } catch (err) {
+      const code = (err as { code?: unknown } | null)?.code;
+      if (code === 'LLM_NOT_CONFIGURED') {
+        const e = err as { message?: unknown; settingsPath?: unknown };
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: typeof e.message === 'string' ? e.message : 'No LLM provider is configured.',
+            code: 'LLM_NOT_CONFIGURED',
+            settingsPath:
+              typeof e.settingsPath === 'string' ? e.settingsPath : '/settings/api-keys',
+          }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
       return createApplicationErrorResponse(
         'LLM provider not configured',
         'LLM_NOT_CONFIGURED',
         503,
       );
     }
+    const llmClient: ChatLLMClient = resolvedClient;
 
     logger.info('LLM client ready', { userId: authSession.user.id });
 
@@ -322,7 +355,12 @@ export async function POST(request: NextRequest) {
     let memoryContext = '';
     if (process.env.ENABLE_VECTOR_MEMORY !== 'false') {
       try {
-        const queryEmbedding = await aiDeps.generateEmbedding(userMessage);
+        // Reuse the resolved per-account client for embeddings (GAP-360). The
+        // cast crosses the dynamic-import boundary; at runtime the resolved
+        // LLMClient exposes embed().
+        const queryEmbedding = await aiDeps.generateEmbedding(userMessage, {
+          client: resolvedClient as never,
+        });
         const vectorService = new aiDeps.VectorMemoryService();
 
         const searchResults = await vectorService.searchSimilar(queryEmbedding.vector, {

--- a/apps/server/src/jobs/__tests__/agent-dispatch.test.ts
+++ b/apps/server/src/jobs/__tests__/agent-dispatch.test.ts
@@ -1,7 +1,15 @@
 /**
  * GAP-360 §5.6 / §6.1 — the durable worker gates per-account and derives the
- * dispatch identity from the task's OWNING ACCOUNT row (ticket.reporterId),
- * never from the job payload. A poisoned `data.userId` must be ignored.
+ * dispatch identity from the AUTHENTICATED DISPATCHER captured server-side at
+ * enqueue time (`AgentDispatchPayload.userId`), never from `ticket.reporterId`.
+ *
+ * `reporterId` is client-writable via the general tickets API
+ * (`routes/tickets/tickets.ts` create/PATCH schemas accept an arbitrary
+ * `reporterId` string with no ownership check — `assertBoardAccess` only
+ * checks board/tenant ownership). An attacker who owns a board could set
+ * `reporterId` to a victim's user id, dispatch the ticket, and have the
+ * worker decrypt the VICTIM's BYOK key for the attacker's prompt — unless the
+ * worker ignores the row entirely and uses the trusted enqueue-time identity.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -53,8 +61,14 @@ vi.mock('../../lib/validate-startup.js', () => ({
 
 import { agentDispatchHandler } from '../agent-dispatch.js';
 
-const OWNER = 'real-owner-from-row';
-const POISONED = 'attacker-supplied-in-payload';
+/** The authenticated user who called the dispatch endpoint (trusted, from the payload). */
+const DISPATCHER = 'authenticated-dispatcher-from-enqueue';
+/**
+ * A foreign/victim user id planted in `ticket.reporterId` — simulating an
+ * attacker who owns the board POSTing/PATCHing the general tickets API with
+ * `reporterId` set to someone else's id before dispatching.
+ */
+const FOREIGN_REPORTER = 'victim-user-planted-via-tickets-api';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -66,7 +80,7 @@ beforeEach(() => {
     type: 'task',
     priority: 'medium',
     status: 'in_progress',
-    reporterId: OWNER,
+    reporterId: FOREIGN_REPORTER,
   });
   mockDispatch.mockResolvedValue({ success: true, output: 'ok', metadata: {} });
   mockBuildDispatcher.mockResolvedValue({ dispatch: mockDispatch });
@@ -75,32 +89,54 @@ beforeEach(() => {
 
 const job = { id: 'job-1', retryCount: 0 } as never;
 
-describe('agentDispatchHandler — §6.1 identity from the task row', () => {
-  it('on hosted, derives userId from ticket.reporterId and ignores the payload userId', async () => {
+describe('agentDispatchHandler — §6.1 identity is the enqueue-time dispatcher, never the ticket row', () => {
+  it('on hosted, derives userId from the payload (the authenticated dispatcher), never from ticket.reporterId', async () => {
     mockDetectDeploymentMode.mockReturnValue('hosted');
 
-    await agentDispatchHandler({ ticketId: 't-1', userId: POISONED, tenantId: 'site-1' }, job);
+    await agentDispatchHandler({ ticketId: 't-1', userId: DISPATCHER, tenantId: 'site-1' }, job);
 
-    // Per-account gate keyed on the row owner, not the payload.
-    expect(mockAccountHasAiFeature).toHaveBeenCalledWith(expect.anything(), OWNER);
-    expect(mockAccountHasAiFeature).not.toHaveBeenCalledWith(expect.anything(), POISONED);
+    // Per-account gate keyed on the trusted dispatcher, not the row.
+    expect(mockAccountHasAiFeature).toHaveBeenCalledWith(expect.anything(), DISPATCHER);
+    expect(mockAccountHasAiFeature).not.toHaveBeenCalledWith(expect.anything(), FOREIGN_REPORTER);
 
-    // Resolver identity is the row owner, not the payload.
+    // Resolver identity is the dispatcher, not the row.
     expect(mockBuildDispatcher).toHaveBeenCalledWith(
       expect.anything(),
       'site-1',
-      expect.objectContaining({ userId: OWNER, isHosted: true }),
+      expect.objectContaining({ userId: DISPATCHER, isHosted: true }),
     );
     const resolution = mockBuildDispatcher.mock.calls[0]?.[2] as { userId?: string };
-    expect(resolution.userId).not.toBe(POISONED);
+    expect(resolution.userId).not.toBe(FOREIGN_REPORTER);
   });
 
-  it('on hosted, fails closed when the owning account lacks the ai feature', async () => {
+  // Regression test: the reporterId-poisoning attack the coordinator flagged.
+  // Even when the ticket row's reporterId names a foreign (victim) user —
+  // exactly what an attacker can produce via the general tickets API — the
+  // worker must resolve keys against the dispatcher's own account, never the
+  // victim's.
+  it('does not decrypt a foreign reporterId user key when the ticket row is poisoned', async () => {
+    mockDetectDeploymentMode.mockReturnValue('hosted');
+    // ticket.reporterId (set in beforeEach) is the victim; the payload carries
+    // the real, authenticated dispatcher.
+    await agentDispatchHandler({ ticketId: 't-1', userId: DISPATCHER, tenantId: 'site-1' }, job);
+
+    const entitlementCalls = mockAccountHasAiFeature.mock.calls.map((call) => call[1]);
+    const dispatcherCalls = mockBuildDispatcher.mock.calls.map(
+      (call) => (call[2] as { userId?: string }).userId,
+    );
+
+    expect(entitlementCalls).not.toContain(FOREIGN_REPORTER);
+    expect(dispatcherCalls).not.toContain(FOREIGN_REPORTER);
+    expect(entitlementCalls).toContain(DISPATCHER);
+    expect(dispatcherCalls).toContain(DISPATCHER);
+  });
+
+  it('on hosted, fails closed when the dispatching account lacks the ai feature', async () => {
     mockDetectDeploymentMode.mockReturnValue('hosted');
     mockAccountHasAiFeature.mockResolvedValue(false);
 
     await expect(
-      agentDispatchHandler({ ticketId: 't-1', userId: POISONED, tenantId: 'site-1' }, job),
+      agentDispatchHandler({ ticketId: 't-1', userId: DISPATCHER, tenantId: 'site-1' }, job),
     ).rejects.toThrow('not entitled');
     expect(mockBuildDispatcher).not.toHaveBeenCalled();
   });
@@ -109,7 +145,7 @@ describe('agentDispatchHandler — §6.1 identity from the task row', () => {
     mockDetectDeploymentMode.mockReturnValue('forge');
     mockIsFeatureEnabled.mockReturnValue(true);
 
-    await agentDispatchHandler({ ticketId: 't-1', userId: POISONED, tenantId: 'site-1' }, job);
+    await agentDispatchHandler({ ticketId: 't-1', userId: DISPATCHER, tenantId: 'site-1' }, job);
 
     expect(mockIsFeatureEnabled).toHaveBeenCalledWith('ai');
     // The per-account gate is not consulted on self-hosted.

--- a/apps/server/src/jobs/__tests__/agent-dispatch.test.ts
+++ b/apps/server/src/jobs/__tests__/agent-dispatch.test.ts
@@ -1,0 +1,118 @@
+/**
+ * GAP-360 §5.6 / §6.1 — the durable worker gates per-account and derives the
+ * dispatch identity from the task's OWNING ACCOUNT row (ticket.reporterId),
+ * never from the job payload. A poisoned `data.userId` must be ignored.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetTicketById,
+  mockUpdateTicket,
+  mockBuildDispatcher,
+  mockAccountHasAiFeature,
+  mockDetectDeploymentMode,
+  mockIsFeatureEnabled,
+  mockDispatch,
+} = vi.hoisted(() => ({
+  mockGetTicketById: vi.fn(),
+  mockUpdateTicket: vi.fn(),
+  mockBuildDispatcher: vi.fn(),
+  mockAccountHasAiFeature: vi.fn(),
+  mockDetectDeploymentMode: vi.fn(),
+  mockIsFeatureEnabled: vi.fn(() => true),
+  mockDispatch: vi.fn(),
+}));
+
+vi.mock('@revealui/core/features', () => ({ isFeatureEnabled: mockIsFeatureEnabled }));
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@revealui/db/client', () => ({ getClient: () => ({}) }));
+vi.mock('@revealui/db/queries/tickets', () => ({
+  getTicketById: mockGetTicketById,
+  updateTicket: mockUpdateTicket,
+}));
+vi.mock('@revealui/db/saga', () => ({
+  idempotentWrite: async (
+    _db: unknown,
+    _key: string,
+    _name: string,
+    fn: () => Promise<unknown>,
+  ) => ({ result: await fn(), alreadyProcessed: false }),
+}));
+vi.mock('@revealui/db/schema/agents', () => ({ agentMemories: {} }));
+vi.mock('@revealui/db/validation/cross-db', () => ({ safeVectorInsert: vi.fn() }));
+vi.mock('../../lib/account-entitlement.js', () => ({
+  accountHasAiFeature: mockAccountHasAiFeature,
+}));
+vi.mock('../../lib/agent-dispatcher.js', () => ({ buildDispatcher: mockBuildDispatcher }));
+vi.mock('../../lib/validate-startup.js', () => ({
+  detectDeploymentMode: mockDetectDeploymentMode,
+}));
+
+import { agentDispatchHandler } from '../agent-dispatch.js';
+
+const OWNER = 'real-owner-from-row';
+const POISONED = 'attacker-supplied-in-payload';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.HOSTED_BYOK_DISPATCH;
+  mockGetTicketById.mockResolvedValue({
+    id: 't-1',
+    title: 'Do a thing',
+    description: null,
+    type: 'task',
+    priority: 'medium',
+    status: 'in_progress',
+    reporterId: OWNER,
+  });
+  mockDispatch.mockResolvedValue({ success: true, output: 'ok', metadata: {} });
+  mockBuildDispatcher.mockResolvedValue({ dispatch: mockDispatch });
+  mockAccountHasAiFeature.mockResolvedValue(true);
+});
+
+const job = { id: 'job-1', retryCount: 0 } as never;
+
+describe('agentDispatchHandler — §6.1 identity from the task row', () => {
+  it('on hosted, derives userId from ticket.reporterId and ignores the payload userId', async () => {
+    mockDetectDeploymentMode.mockReturnValue('hosted');
+
+    await agentDispatchHandler({ ticketId: 't-1', userId: POISONED, tenantId: 'site-1' }, job);
+
+    // Per-account gate keyed on the row owner, not the payload.
+    expect(mockAccountHasAiFeature).toHaveBeenCalledWith(expect.anything(), OWNER);
+    expect(mockAccountHasAiFeature).not.toHaveBeenCalledWith(expect.anything(), POISONED);
+
+    // Resolver identity is the row owner, not the payload.
+    expect(mockBuildDispatcher).toHaveBeenCalledWith(
+      expect.anything(),
+      'site-1',
+      expect.objectContaining({ userId: OWNER, isHosted: true }),
+    );
+    const resolution = mockBuildDispatcher.mock.calls[0]?.[2] as { userId?: string };
+    expect(resolution.userId).not.toBe(POISONED);
+  });
+
+  it('on hosted, fails closed when the owning account lacks the ai feature', async () => {
+    mockDetectDeploymentMode.mockReturnValue('hosted');
+    mockAccountHasAiFeature.mockResolvedValue(false);
+
+    await expect(
+      agentDispatchHandler({ ticketId: 't-1', userId: POISONED, tenantId: 'site-1' }, job),
+    ).rejects.toThrow('not entitled');
+    expect(mockBuildDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('on self-hosted, keeps the singleton license check (byte-unchanged)', async () => {
+    mockDetectDeploymentMode.mockReturnValue('forge');
+    mockIsFeatureEnabled.mockReturnValue(true);
+
+    await agentDispatchHandler({ ticketId: 't-1', userId: POISONED, tenantId: 'site-1' }, job);
+
+    expect(mockIsFeatureEnabled).toHaveBeenCalledWith('ai');
+    // The per-account gate is not consulted on self-hosted.
+    expect(mockAccountHasAiFeature).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/jobs/agent-dispatch.ts
+++ b/apps/server/src/jobs/agent-dispatch.ts
@@ -52,7 +52,18 @@ export interface AgentDispatchPayload extends Record<string, unknown> {
   ticketId: string;
   /** Caller's tenant id at enqueue time. Worker carries it through. */
   tenantId?: string;
-  /** Caller's user id at enqueue time. For audit logging / future RBAC. */
+  /**
+   * The authenticated dispatcher's user id, captured server-side from the
+   * session at enqueue time (the only enqueue site is the role-gated
+   * `runDurableDispatch` in `routes/agent-tasks.ts`, which always passes
+   * `requireAgentTaskRole(c)`'s `user.id`). This is the sole trusted source of
+   * dispatch identity for BYOK key resolution (§6.1/§5.6) — it must NEVER be
+   * read from `ticket.reporterId`, which is client-writable via the general
+   * tickets API (`routes/tickets/tickets.ts` create/PATCH schemas accept an
+   * arbitrary `reporterId` with no ownership check) and would let an attacker
+   * who owns a board dispatch a ticket against a victim's stored key by
+   * setting `reporterId` to the victim's user id.
+   */
   userId: string;
   /**
    * Correlation id from the originating POST request. All logs from the
@@ -99,10 +110,13 @@ export async function agentDispatchHandler(
 
   const isHosted = detectDeploymentMode(process.env as EnvMap) === 'hosted';
 
-  // Authenticated owner of the task, read from the row — never `data.userId`
-  // (§6.1: identity is not carried in the payload). Null when the reporter was
-  // deleted, which fails the entitlement gate closed on hosted.
-  const ownerUserId = ticket.reporterId ?? null;
+  // Dispatch identity: the authenticated dispatcher's session user id,
+  // captured server-side at enqueue time (see AgentDispatchPayload.userId).
+  // Deliberately NOT `ticket.reporterId` — that column is client-writable via
+  // the general tickets API (no ownership check on the field), so reading it
+  // here would let an attacker key-decrypt a victim's BYOK key by setting
+  // reporterId to the victim's id before dispatching (§6.1 fail-closed).
+  const dispatcherUserId = data.userId;
 
   // Dispatch-time entitlement re-check. The POST handler already gated the
   // caller; this catches a lapse between enqueue and claim.
@@ -111,7 +125,7 @@ export async function agentDispatchHandler(
   //  - Self-hosted (or a HOSTED_BYOK_DISPATCH rollback): the singleton license
   //    state, byte-unchanged from before this PR.
   if (isHosted && byokDispatchEnabled()) {
-    const hasAi = await accountHasAiFeature(db, ownerUserId);
+    const hasAi = await accountHasAiFeature(db, dispatcherUserId);
     if (!hasAi) {
       throw new Error('AI feature not entitled for the owning account at dispatch time');
     }
@@ -120,7 +134,7 @@ export async function agentDispatchHandler(
   }
 
   const dispatcher = await buildDispatcher(db, data.tenantId, {
-    userId: ownerUserId,
+    userId: dispatcherUserId,
     isHosted,
     workspaceId: data.tenantId,
   });

--- a/apps/server/src/jobs/agent-dispatch.ts
+++ b/apps/server/src/jobs/agent-dispatch.ts
@@ -29,9 +29,24 @@ import { idempotentWrite } from '@revealui/db/saga';
 import type { Job } from '@revealui/db/schema';
 import { agentMemories } from '@revealui/db/schema/agents';
 import { safeVectorInsert } from '@revealui/db/validation/cross-db';
+import { accountHasAiFeature } from '../lib/account-entitlement.js';
 import { buildDispatcher } from '../lib/agent-dispatcher.js';
+import { detectDeploymentMode, type EnvMap } from '../lib/validate-startup.js';
 
 const LLM_MEMOIZE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Whether the BYOK dispatch behavior is active (GAP-360 §7). Canonical
+ * semantics live in `@revealui/ai` `hostedByokDispatchEnabled`; mirrored here
+ * because apps/server must not statically import the Pro package (boundary.ts).
+ * Only consulted on hosted, so the default is ON.
+ */
+function byokDispatchEnabled(): boolean {
+  const raw = process.env.HOSTED_BYOK_DISPATCH;
+  if (raw === undefined || raw.trim() === '') return true;
+  const value = raw.trim().toLowerCase();
+  return !(value === 'false' || value === '0' || value === 'off' || value === 'no');
+}
 
 export interface AgentDispatchPayload extends Record<string, unknown> {
   ticketId: string;
@@ -77,22 +92,38 @@ export async function agentDispatchHandler(
     });
   };
 
-  // License re-check. The POST handler already gated on requireAIAccess;
-  // this catches the edge case where the license lapsed between enqueue
-  // and claim. Pre-existing gap: isFeatureEnabled reads the singleton
-  // license state (not per-tenant), so the tenant-scoped variant
-  // depends on a future fix. Naming it here so when that lands the
-  // worker gets stricter enforcement automatically.
-  if (!isFeatureEnabled('ai')) {
-    throw new Error('AI feature unavailable at dispatch time (license lapsed or revoked)');
-  }
-
   const ticket = await ticketQueries.getTicketById(db, data.ticketId);
   if (!ticket) {
     throw new Error(`Ticket not found: ${data.ticketId}`);
   }
 
-  const dispatcher = await buildDispatcher(db, data.tenantId);
+  const isHosted = detectDeploymentMode(process.env as EnvMap) === 'hosted';
+
+  // Authenticated owner of the task, read from the row — never `data.userId`
+  // (§6.1: identity is not carried in the payload). Null when the reporter was
+  // deleted, which fails the entitlement gate closed on hosted.
+  const ownerUserId = ticket.reporterId ?? null;
+
+  // Dispatch-time entitlement re-check. The POST handler already gated the
+  // caller; this catches a lapse between enqueue and claim.
+  //  - Hosted (BYOK dispatch on): per-account entitlement (§5.6) via the
+  //    GAP-356 canonical path, replacing the old singleton check.
+  //  - Self-hosted (or a HOSTED_BYOK_DISPATCH rollback): the singleton license
+  //    state, byte-unchanged from before this PR.
+  if (isHosted && byokDispatchEnabled()) {
+    const hasAi = await accountHasAiFeature(db, ownerUserId);
+    if (!hasAi) {
+      throw new Error('AI feature not entitled for the owning account at dispatch time');
+    }
+  } else if (!isFeatureEnabled('ai')) {
+    throw new Error('AI feature unavailable at dispatch time (license lapsed or revoked)');
+  }
+
+  const dispatcher = await buildDispatcher(db, data.tenantId, {
+    userId: ownerUserId,
+    isHosted,
+    workspaceId: data.tenantId,
+  });
   if (!dispatcher) {
     throw new Error(
       "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",

--- a/apps/server/src/lib/account-entitlement.ts
+++ b/apps/server/src/lib/account-entitlement.ts
@@ -1,0 +1,82 @@
+/**
+ * Account-scoped AI entitlement lookup (GAP-360 §5.6).
+ *
+ * The non-Hono counterpart to `entitlementMiddleware`: resolves whether a given
+ * user's account has the `ai` feature, via the GAP-356 canonical path
+ * (`account_entitlements` scoped by `getConfiguredStripeMode()`), applying the
+ * same request-time grace-expiry fail-safe. Used by the durable worker, which
+ * has no request context but must gate per-account rather than on the singleton
+ * license state.
+ */
+
+import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
+import { getFeaturesForTier } from '@revealui/core/features';
+import type { Database } from '@revealui/db/client';
+import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+/** A subscription status that still confers the paid tier (mirrors the middleware). */
+function isHealthyStatus(status: string | null): boolean {
+  return status === 'active' || status === 'trialing';
+}
+
+function featureRecord(features: object | null | undefined): Record<string, boolean> {
+  if (!features) return {};
+  return Object.fromEntries(
+    Object.entries(features).filter(
+      (entry): entry is [string, boolean] => typeof entry[1] === 'boolean',
+    ),
+  );
+}
+
+/**
+ * Whether the account owning `userId` currently has the `ai` feature.
+ *
+ * Fail-closed: a null user, no active membership, no entitlement row, or a
+ * grace-expired subscription all resolve to `false`. `userId` MUST come from an
+ * authenticated identity (the task's owning account for the worker), never a
+ * request payload (§6.1).
+ */
+export async function accountHasAiFeature(db: Database, userId: string | null): Promise<boolean> {
+  if (!userId) return false;
+
+  const [membership] = await db
+    .select({ accountId: accountMemberships.accountId })
+    .from(accountMemberships)
+    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
+    .limit(1);
+
+  if (!membership?.accountId) return false;
+
+  const [entitlement] = await db
+    .select({
+      tier: accountEntitlements.tier,
+      status: accountEntitlements.status,
+      graceUntil: accountEntitlements.graceUntil,
+      features: accountEntitlements.features,
+    })
+    .from(accountEntitlements)
+    .where(
+      and(
+        eq(accountEntitlements.accountId, membership.accountId),
+        eq(accountEntitlements.mode, getConfiguredStripeMode()),
+      ),
+    )
+    .limit(1);
+
+  if (!entitlement) return false;
+
+  const status = entitlement.status ?? null;
+  const graceUntil = entitlement.graceUntil ?? null;
+  const graceActive = graceUntil != null && graceUntil.getTime() > Date.now();
+  const graceExpired = status !== null && !isHealthyStatus(status) && !graceActive;
+  if (graceExpired) return false;
+
+  const tier = (entitlement.tier as 'free' | 'pro' | 'max' | 'enterprise' | undefined) ?? 'free';
+  const features =
+    entitlement.features && Object.keys(entitlement.features).length > 0
+      ? featureRecord(entitlement.features)
+      : featureRecord(getFeaturesForTier(tier));
+
+  return features.ai === true;
+}

--- a/apps/server/src/lib/account-entitlement.ts
+++ b/apps/server/src/lib/account-entitlement.ts
@@ -33,13 +33,22 @@ function featureRecord(features: object | null | undefined): Record<string, bool
  * Whether the account owning `userId` currently has the `ai` feature.
  *
  * Fail-closed: a null user, no active membership, no entitlement row, or a
- * grace-expired subscription all resolve to `false`. `userId` MUST come from an
- * authenticated identity (the task's owning account for the worker), never a
- * request payload (§6.1).
+ * grace-expired subscription all resolve to `false`. `userId` MUST come from
+ * an authenticated identity — the session user for request-scoped callers, or
+ * the authenticated dispatcher captured server-side at enqueue time for the
+ * durable worker (`AgentDispatchPayload.userId`) — never a client-writable
+ * value such as a ticket row's `reporterId` (§6.1).
  */
 export async function accountHasAiFeature(db: Database, userId: string | null): Promise<boolean> {
   if (!userId) return false;
 
+  // TODO(GAP-360 follow-up): `.limit(1)` picks an arbitrary active membership
+  // for a user who belongs to multiple accounts. `entitlementMiddleware` has
+  // the same shape (entitlements.ts `entitlementMiddleware`), so this mirrors
+  // existing behavior rather than introducing new ambiguity, but multi-account
+  // BYOK resolution deserves its own design pass (which membership "wins" for
+  // both entitlement and key lookup should be the same account, and today
+  // that's just "whichever active row postgres returns first").
   const [membership] = await db
     .select({ accountId: accountMemberships.accountId })
     .from(accountMemberships)

--- a/apps/server/src/lib/agent-dispatcher.ts
+++ b/apps/server/src/lib/agent-dispatcher.ts
@@ -11,6 +11,7 @@
  * — callers must treat that as a license / configuration failure.
  */
 
+import { DrizzleAuditStore } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
 import * as commentQueries from '@revealui/db/queries/ticket-comments';
 import * as ticketQueries from '@revealui/db/queries/tickets';
@@ -33,17 +34,37 @@ export interface Dispatcher {
   dispatch(ticket: DispatcherTicket, options?: { dispatchId?: string }): Promise<DispatcherResult>;
 }
 
+/**
+ * Per-request LLM resolution inputs (GAP-360 §5.2/§5.4). `userId` MUST come
+ * from an authenticated identity — the session user on the sync path, the
+ * ticket's owning account on the worker path — never a request payload (§6.1).
+ */
+export interface DispatcherResolution {
+  userId: string | null;
+  isHosted: boolean;
+  workspaceId?: string;
+}
+
 export async function buildDispatcher(
   db: Database,
   _tenantId: string | undefined,
+  resolution: DispatcherResolution,
 ): Promise<Dispatcher | null> {
   const aiMod = await import('@revealui/ai').catch(() => null);
   if (!aiMod) return null;
 
   let llmClient: unknown;
   try {
-    llmClient = aiMod.createLLMClientFromEnv();
-  } catch {
+    // Resolve the client through the single GAP-360 resolver. A durable audit
+    // sink captures the byok:key:accessed event (§6.4). An LLMNotConfiguredError
+    // (hosted account with no usable key) propagates so the caller maps it to 409.
+    llmClient = await aiMod.resolveLLMClientForRequest(resolution.userId, db, {
+      isHosted: resolution.isHosted,
+      workspaceId: resolution.workspaceId,
+      auditStore: new DrizzleAuditStore(db),
+    });
+  } catch (err) {
+    if ((err as { code?: unknown } | null)?.code === 'LLM_NOT_CONFIGURED') throw err;
     return null;
   }
 

--- a/apps/server/src/lib/llm-not-configured.ts
+++ b/apps/server/src/lib/llm-not-configured.ts
@@ -1,0 +1,32 @@
+/**
+ * Recognize the resolver's LLMNotConfiguredError across the dynamic-import
+ * boundary (GAP-360 §5.2). `@revealui/ai` is lazy-imported at each dispatch
+ * site, so `instanceof` is unreliable across module realms; the stable `code`
+ * string is the robust discriminator. Maps to HTTP 409 (configuration is the
+ * remedy, not payment).
+ */
+
+export interface LLMNotConfiguredShape {
+  success: false;
+  error: string;
+  code: 'LLM_NOT_CONFIGURED';
+  settingsPath: string;
+}
+
+/** Returns the 409 body when `err` is the resolver's not-configured error, else null. */
+export function asLLMNotConfigured(err: unknown): LLMNotConfiguredShape | null {
+  if (
+    err !== null &&
+    typeof err === 'object' &&
+    (err as { code?: unknown }).code === 'LLM_NOT_CONFIGURED'
+  ) {
+    const e = err as { message?: unknown; settingsPath?: unknown };
+    return {
+      success: false,
+      error: typeof e.message === 'string' ? e.message : 'No LLM provider is configured.',
+      code: 'LLM_NOT_CONFIGURED',
+      settingsPath: typeof e.settingsPath === 'string' ? e.settingsPath : '/settings/api-keys',
+    };
+  }
+  return null;
+}

--- a/apps/server/src/routes/__tests__/agent-stream-success.test.ts
+++ b/apps/server/src/routes/__tests__/agent-stream-success.test.ts
@@ -57,14 +57,28 @@ vi.mock('hono/streaming', () => ({
   ),
 }));
 
-vi.mock('@revealui/ai', () => ({
-  createLLMClientFromEnv: vi.fn().mockReturnValue({ type: 'env-client' }),
-  // A.1: agent-stream composes Stage 6.1/6.2 sinks + builds MCP tools from
-  // tenant-connected servers. Stub each factory with a harmless
-  // no-op; tests that care about sink behavior set their own spies.
-  createCoreLoggerSink: vi.fn().mockReturnValue(() => {}),
-  createUsageMeterSink: vi.fn().mockReturnValue(() => {}),
-  createToolsFromMcpClient: vi.fn().mockResolvedValue([]),
+vi.mock('@revealui/ai', () => {
+  const createLLMClientFromEnv = vi.fn().mockReturnValue({ type: 'env-client' });
+  return {
+    createLLMClientFromEnv,
+    // GAP-360: the paid path resolves via resolveLLMClientForRequest. Delegate to
+    // createLLMClientFromEnv so the existing env-path assertions still hold.
+    resolveLLMClientForRequest: vi.fn(async () => createLLMClientFromEnv()),
+    // A.1: agent-stream composes Stage 6.1/6.2 sinks + builds MCP tools from
+    // tenant-connected servers. Stub each factory with a harmless
+    // no-op; tests that care about sink behavior set their own spies.
+    createCoreLoggerSink: vi.fn().mockReturnValue(() => {}),
+    createUsageMeterSink: vi.fn().mockReturnValue(() => {}),
+    createToolsFromMcpClient: vi.fn().mockResolvedValue([]),
+  };
+});
+
+// GAP-360: agent-stream now resolves a db client + audit store for the resolver.
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn().mockReturnValue({}),
+  DrizzleAuditStore: class {
+    append = vi.fn();
+  },
 }));
 
 vi.mock('@revealui/ai/llm/client', () => ({

--- a/apps/server/src/routes/__tests__/agent-tasks.test.ts
+++ b/apps/server/src/routes/__tests__/agent-tasks.test.ts
@@ -38,6 +38,9 @@ vi.mock('@revealui/ai', () => ({
   // createLLMClientFromEnv must be mocked  -  without it buildDispatcher() catches
   // the "not a function" TypeError and returns null, causing 503 on all success paths.
   createLLMClientFromEnv: mockCreateLLMClient,
+  // GAP-360: buildDispatcher now resolves via resolveLLMClientForRequest. Delegate
+  // to the same mock so the existing "missing key → throws → 403" cases still hold.
+  resolveLLMClientForRequest: vi.fn(async () => mockCreateLLMClient()),
   TicketAgentDispatcher: vi.fn().mockImplementation(
     class {
       dispatch = mockDispatch;

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -22,11 +22,13 @@ import { A2AJsonRpcRequestSchema, AgentDefinitionSchema } from '@revealui/contra
 import { logger } from '@revealui/core/observability/logger';
 import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
 import { classifyAuditWriteFailure } from '@revealui/core/security';
-import { getClient } from '@revealui/db';
+import { DrizzleAuditStore, getClient } from '@revealui/db';
 import { agentActions, marketplaceServers, registeredAgents } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { desc, eq } from 'drizzle-orm';
+import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
 import { buildMcpManifest } from '../lib/mcp-manifest.js';
+import { detectDeploymentMode, type EnvMap } from '../lib/validate-startup.js';
 import { authMiddleware } from '../middleware/auth.js';
 import { requireFeature } from '../middleware/license.js';
 import { requireTaskQuota } from '../middleware/task-quota.js';
@@ -79,9 +81,6 @@ function isValidAgentId(id: string): boolean {
   }
   return true;
 }
-
-// LLM client is resolved from environment configuration (open models only).
-// No per-request API key injection  -  all inference uses server-configured providers.
 
 // =============================================================================
 // Well-known discovery endpoints (public, no auth)
@@ -1059,6 +1058,11 @@ a2a.openapi(
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
       },
+      409: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description:
+          'Hosted account has no LLM provider configured (set one at /settings/api-keys)',
+      },
     },
   }),
   // @ts-expect-error  -  JSON-RPC dispatcher returns heterogeneous shapes + raw Response from quota middleware
@@ -1161,15 +1165,38 @@ a2a.openapi(
       }
     }
 
-    // Resolve LLM client from environment-configured open models
+    // Resolve the LLM client via the GAP-360 resolver: per-account BYOK on
+    // hosted, env on self-hosted. userId comes from the authenticated session
+    // context only (§6.1), never from the JSON-RPC request params/body. A
+    // hosted account with no usable key surfaces as HTTP 409 with an actionable
+    // settings path, not a silent localhost hang.
     let llmClient: unknown;
-    try {
-      const aiMod2 = await import('@revealui/ai').catch(() => null);
-      if (aiMod2) {
-        llmClient = aiMod2.createLLMClientFromEnv();
+    if (aiMod) {
+      const sessionUserId = c.get('user')?.id ?? null;
+      try {
+        const db = getClient();
+        llmClient = await aiMod.resolveLLMClientForRequest(sessionUserId, db, {
+          isHosted: detectDeploymentMode(process.env as EnvMap) === 'hosted',
+          auditStore: new DrizzleAuditStore(db),
+        });
+      } catch (err) {
+        const notConfigured = asLLMNotConfigured(err);
+        if (notConfigured) {
+          return c.json(
+            {
+              jsonrpc: '2.0',
+              id: req.id,
+              error: {
+                code: -32010,
+                message: notConfigured.error,
+                data: { code: notConfigured.code, settingsPath: notConfigured.settingsPath },
+              },
+            },
+            409,
+          );
+        }
+        // Any other failure  -  llmClient stays undefined, handler returns stub.
       }
-    } catch {
-      // No AI module available  -  llmClient stays undefined, handler returns stub
     }
 
     const startedAt = Date.now();

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -11,6 +11,7 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
+import { DrizzleAuditStore, getClient } from '@revealui/db';
 import type { ElicitationHandler, McpClient, SamplingHandler } from '@revealui/mcp/client';
 import { createRevvaultVault } from '@revealui/mcp/oauth';
 import {
@@ -26,7 +27,9 @@ import {
   createAgentRunSession,
   deleteAgentRunSession,
 } from '../lib/agent-run-sessions.js';
+import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
 import { recordUsageMeter } from '../lib/metering.js';
+import { detectDeploymentMode, type EnvMap } from '../lib/validate-startup.js';
 import { getEntitlementsFromContext } from '../middleware/entitlements.js';
 
 type Variables = {
@@ -89,6 +92,19 @@ const agentStreamRoute = createRoute({
       },
       description: 'AI feature requires Pro or Enterprise license',
     },
+    409: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.literal(false),
+            error: z.string(),
+            code: z.literal('LLM_NOT_CONFIGURED'),
+            settingsPath: z.string(),
+          }),
+        },
+      },
+      description: 'Hosted account has no LLM provider configured (set one at /settings/api-keys)',
+    },
   },
 });
 
@@ -124,9 +140,10 @@ app.openapi(agentStreamRoute, async (c) => {
   const isLocalOnly = aiAccessMode === 'local';
 
   let llmClient: unknown;
-  try {
-    if (isLocalOnly) {
-      // Free tier: force local provider regardless of other env vars
+  if (isLocalOnly) {
+    // Free tier: force local provider regardless of other env vars. Untouched
+    // by GAP-360 — the free/local path never resolves a per-account key.
+    try {
       type LLMConfig = ConstructorParameters<typeof llmClientMod.LLMClient>[0];
       const localBaseURL = process.env.INFERENCE_SNAPS_BASE_URL ?? process.env.OLLAMA_BASE_URL;
       const localProvider = process.env.INFERENCE_SNAPS_BASE_URL ? 'inference-snaps' : 'ollama';
@@ -136,19 +153,42 @@ app.openapi(agentStreamRoute, async (c) => {
         baseURL: localBaseURL,
         model: process.env.LLM_MODEL ?? 'gemma4:e2b',
       });
-    } else {
-      llmClient = aiMod.createLLMClientFromEnv();
+    } catch {
+      return c.json(
+        {
+          success: false,
+          error:
+            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
+          code: 'HTTP_403',
+        },
+        403,
+      );
     }
-  } catch {
-    return c.json(
-      {
-        success: false,
-        error:
-          "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        code: 'HTTP_403',
-      },
-      403,
-    );
+  } else {
+    // Paid path: resolve per-account BYOK on hosted, env on self-hosted. userId
+    // comes from the authenticated session (§6.1), never the request body.
+    try {
+      const db = getClient();
+      llmClient = await aiMod.resolveLLMClientForRequest(user.id, db, {
+        isHosted: detectDeploymentMode(process.env as EnvMap) === 'hosted',
+        workspaceId: body.workspaceId ?? c.get('tenant')?.id,
+        auditStore: new DrizzleAuditStore(db),
+      });
+    } catch (err) {
+      const notConfigured = asLLMNotConfigured(err);
+      if (notConfigured) {
+        return c.json(notConfigured, 409);
+      }
+      return c.json(
+        {
+          success: false,
+          error:
+            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
+          code: 'HTTP_403',
+        },
+        403,
+      );
+    }
   }
 
   const workspaceId = body.workspaceId ?? c.get('tenant')?.id ?? 'default';

--- a/apps/server/src/routes/agent-tasks.ts
+++ b/apps/server/src/routes/agent-tasks.ts
@@ -203,8 +203,11 @@ app.openapi(
       status: 'in_progress',
       priority,
       type: 'task',
-      // Record the authenticated creator as the owner so the durable worker can
-      // derive the dispatch identity from the row, not the job payload (§6.1).
+      // Record the authenticated creator for audit/correctness. NOT the
+      // dispatch-identity source — that is `data.userId` on the job payload,
+      // captured server-side at enqueue time (see jobs/agent-dispatch.ts). The
+      // general tickets API lets `reporterId` be set to an arbitrary user id
+      // with no ownership check, so it must never drive key resolution.
       reporterId: user.id,
     });
 

--- a/apps/server/src/routes/agent-tasks.ts
+++ b/apps/server/src/routes/agent-tasks.ts
@@ -38,6 +38,8 @@ import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
 import type { AgentDispatchOutput, AgentDispatchPayload } from '../jobs/agent-dispatch.js';
 import { buildDispatcher, type Dispatcher } from '../lib/agent-dispatcher.js';
+import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
+import { detectDeploymentMode, type EnvMap } from '../lib/validate-startup.js';
 
 type Variables = {
   db: DatabaseClient;
@@ -66,6 +68,44 @@ function isDurableDispatchEnabled(): boolean {
 const app = new OpenAPIHono<{ Variables: Variables }>();
 
 const ErrorSchema = z.object({ success: z.literal(false), error: z.string() });
+
+/** GAP-360: hosted account with no usable LLM key. Configuration is the remedy → 409. */
+const LLMNotConfiguredSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+  code: z.literal('LLM_NOT_CONFIGURED'),
+  settingsPath: z.string(),
+});
+
+/**
+ * Resolve the LLM client for a sync dispatch and return the built dispatcher,
+ * mapping the resolver's not-configured error to a caller-visible 409 body.
+ * `userId` is the authenticated session user (§6.1).
+ */
+async function buildDispatcherOr409(
+  db: DatabaseClient,
+  tenantId: string | undefined,
+  userId: string,
+): Promise<
+  | { ok: true; dispatcher: Dispatcher | null }
+  | {
+      ok: false;
+      body: { success: false; error: string; code: 'LLM_NOT_CONFIGURED'; settingsPath: string };
+    }
+> {
+  try {
+    const dispatcher = await buildDispatcher(db, tenantId, {
+      userId,
+      isHosted: detectDeploymentMode(process.env as EnvMap) === 'hosted',
+      workspaceId: tenantId,
+    });
+    return { ok: true, dispatcher };
+  } catch (err) {
+    const notConfigured = asLLMNotConfigured(err);
+    if (notConfigured) return { ok: false, body: notConfigured };
+    throw err;
+  }
+}
 
 const DispatchSuccessShape = {
   success: z.literal(true),
@@ -135,6 +175,11 @@ app.openapi(
         content: { 'application/json': { schema: ErrorSchema } },
         description: 'AI feature requires Pro or Enterprise license',
       },
+      409: {
+        content: { 'application/json': { schema: LLMNotConfiguredSchema } },
+        description:
+          'Hosted account has no LLM provider configured (set one at /settings/api-keys)',
+      },
     },
   }),
   async (c) => {
@@ -158,6 +203,9 @@ app.openapi(
       status: 'in_progress',
       priority,
       type: 'task',
+      // Record the authenticated creator as the owner so the durable worker can
+      // derive the dispatch identity from the row, not the job payload (§6.1).
+      reporterId: user.id,
     });
 
     if (!ticket) {
@@ -197,7 +245,12 @@ app.openapi(
     }
 
     // --- Legacy sync path (flag off) ---
-    const dispatcher = await buildDispatcher(db, tenant?.id);
+    const built = await buildDispatcherOr409(db, tenant?.id, user.id);
+    if (!built.ok) {
+      await ticketQueries.updateTicket(db, ticket.id, { status: 'open' });
+      return c.json(built.body, 409);
+    }
+    const dispatcher = built.dispatcher;
     if (!dispatcher) {
       await ticketQueries.updateTicket(db, ticket.id, { status: 'open' });
       return c.json(
@@ -261,6 +314,11 @@ app.openapi(
         content: { 'application/json': { schema: ErrorSchema } },
         description: 'AI feature requires Pro or Enterprise license',
       },
+      409: {
+        content: { 'application/json': { schema: LLMNotConfiguredSchema } },
+        description:
+          'Hosted account has no LLM provider configured (set one at /settings/api-keys)',
+      },
     },
   }),
   async (c) => {
@@ -310,7 +368,11 @@ app.openapi(
     }
 
     // --- Legacy sync path ---
-    const dispatcher = await buildDispatcher(db, tenant?.id);
+    const built = await buildDispatcherOr409(db, tenant?.id, user.id);
+    if (!built.ok) {
+      return c.json(built.body, 409);
+    }
+    const dispatcher = built.dispatcher;
     if (!dispatcher) {
       return c.json(
         {

--- a/packages/ai/src/embeddings/index.ts
+++ b/packages/ai/src/embeddings/index.ts
@@ -8,7 +8,7 @@
  */
 
 import z from 'zod/v4';
-import { createLLMClientFromEnv } from '../llm/client.js';
+import { createLLMClientFromEnv, type LLMClient } from '../llm/client.js';
 
 const EmbeddingSchema = z
   .object({
@@ -38,6 +38,13 @@ export interface GenerateEmbeddingOptions {
    */
   model?: string;
   cache?: boolean; // Whether to cache embeddings (future feature)
+  /**
+   * Pre-resolved LLM client (GAP-360). When supplied — by an authenticated
+   * caller that ran `resolveLLMClientForRequest` — embeddings use it (per-user
+   * BYOK / hosted resolution). When omitted, embeddings fall back to the
+   * env-configured client, preserving self-hosted and internal-caller behavior.
+   */
+  client?: Pick<LLMClient, 'embed'>;
 }
 
 /**
@@ -64,8 +71,9 @@ export async function generateEmbedding(
     throw new Error('Text must be a non-empty string');
   }
 
-  // Use unified LLM client  -  auto-detects provider from env vars
-  const client = createLLMClientFromEnv();
+  // Prefer the caller-resolved client (BYOK / hosted). Fall back to the
+  // env-configured client for self-hosted and internal (no-user) callers.
+  const client = options.client ?? createLLMClientFromEnv();
 
   // Ask client to embed  -  each provider uses its own default model when model is undefined
   const result = await client.embed(text, model ? { model } : undefined);

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -62,6 +62,7 @@ export * from './llm/provider-health.js';
 export * from './llm/providers/base.js';
 export * from './llm/providers/inference-snaps.js';
 export * from './llm/providers/openai-compat.js';
+export * from './llm/resolve.js';
 export * from './llm/token-counter.js';
 export * from './llm/workspace-provider-config.js';
 // Re-export memory system

--- a/packages/ai/src/llm/__tests__/resolve-break-glass-warning.test.ts
+++ b/packages/ai/src/llm/__tests__/resolve-break-glass-warning.test.ts
@@ -1,0 +1,71 @@
+/**
+ * GAP-360 PR-2 follow-up — the hosted BYOK-dispatch break-glass warning.
+ *
+ * When `HOSTED_BYOK_DISPATCH` is explicitly off on a hosted deployment, every
+ * account falls back to sharing the deployment env LLM client instead of
+ * per-account BYOK keys. That is a deliberate one-release rollback lever, but
+ * an operator must be able to see it is active. Asserts the warning fires
+ * exactly once per process (module-level guard), only when hosted + disabled.
+ *
+ * Isolated in its own file so the module-level once-guard starts fresh.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { warnSpy, mockCreateFromEnv } = vi.hoisted(() => ({
+  warnSpy: vi.fn(),
+  mockCreateFromEnv: vi.fn().mockReturnValue({ source: 'env' }),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  createLogger: () => ({
+    warn: warnSpy,
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../client.js', () => ({
+  createLLMClientForUser: vi.fn(),
+  createLLMClientFromEnv: mockCreateFromEnv,
+  isHostedViable: () => true,
+  LLMClient: class {},
+}));
+vi.mock('@revealui/db/crypto', () => ({ decryptApiKey: (s: string) => s }));
+vi.mock('@revealui/db/schema', () => ({ workspaceInferenceConfigs: {} }));
+vi.mock('drizzle-orm', () => ({ eq: () => ({}) }));
+
+import type { Database } from '@revealui/db/client';
+import { resolveLLMClientForRequest } from '../resolve.js';
+
+const db = {} as Database;
+
+beforeEach(() => {
+  warnSpy.mockClear();
+  delete process.env.HOSTED_BYOK_DISPATCH;
+});
+
+describe('resolveLLMClientForRequest — hosted break-glass warning', () => {
+  it('warns once when HOSTED_BYOK_DISPATCH=off on a hosted deployment', async () => {
+    process.env.HOSTED_BYOK_DISPATCH = 'off';
+
+    await resolveLLMClientForRequest('user-1', db, { isHosted: true });
+    await resolveLLMClientForRequest('user-1', db, { isHosted: true });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('HOSTED_BYOK_DISPATCH');
+  });
+
+  it('does not warn on self-hosted (the flag off is the normal default there)', async () => {
+    await resolveLLMClientForRequest('user-1', db, { isHosted: false });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn on hosted when the flag is on (normal path)', async () => {
+    process.env.HOSTED_BYOK_DISPATCH = 'on';
+    await resolveLLMClientForRequest('user-1', db, { isHosted: true }).catch(() => undefined);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai/src/llm/__tests__/resolve.test.ts
+++ b/packages/ai/src/llm/__tests__/resolve.test.ts
@@ -1,0 +1,227 @@
+/**
+ * GAP-360 PR-2 — resolver order + security invariants (spec §5.2 / §6).
+ *
+ * Mocks the client factories and the DB so the resolution ORDER and the
+ * hosted fail-closed invariants are exercised in isolation. No real DB, no
+ * real crypto (§6 is behavioral, pinned here).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockCreateForUser, mockCreateFromEnv, mockDecrypt, FakeLLMClient } = vi.hoisted(() => {
+  class FakeLLMClient {
+    constructor(public readonly cfg: Record<string, unknown>) {}
+  }
+  return {
+    mockCreateForUser: vi.fn(),
+    mockCreateFromEnv: vi.fn(),
+    mockDecrypt: vi.fn((s: string) => `plaintext:${s}`),
+    FakeLLMClient,
+  };
+});
+
+vi.mock('../client.js', () => ({
+  createLLMClientForUser: (...args: unknown[]) => mockCreateForUser(...args),
+  createLLMClientFromEnv: (...args: unknown[]) => mockCreateFromEnv(...args),
+  // hostedViable = cloud providers only; localhost providers are false.
+  isHostedViable: (p: string) =>
+    p === 'anthropic' || p === 'openai' || p === 'groq' || p === 'huggingface',
+  LLMClient: FakeLLMClient,
+}));
+
+vi.mock('@revealui/db/crypto', () => ({ decryptApiKey: (s: string) => mockDecrypt(s) }));
+vi.mock('@revealui/db/schema', () => ({ workspaceInferenceConfigs: { workspaceId: {} } }));
+vi.mock('drizzle-orm', () => ({ eq: (a: unknown, b: unknown) => ({ a, b }) }));
+
+import type { Database } from '@revealui/db/client';
+import {
+  hostedByokDispatchEnabled,
+  LLMNotConfiguredError,
+  llmNotConfiguredBody,
+  resolveLLMClientForRequest,
+} from '../resolve.js';
+
+/** Fake db whose site-config query resolves to `siteRows`. */
+function makeDb(siteRows: unknown[]): Database {
+  return {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => siteRows }) }),
+    }),
+  } as unknown as Database;
+}
+
+const ENV_SENTINEL = { source: 'env' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateFromEnv.mockReturnValue(ENV_SENTINEL);
+  mockCreateForUser.mockResolvedValue(null);
+  delete process.env.HOSTED_BYOK_DISPATCH;
+});
+
+describe('hostedByokDispatchEnabled — flag semantics (§7)', () => {
+  it('defaults to ON when hosted, OFF when self-hosted', () => {
+    expect(hostedByokDispatchEnabled(true)).toBe(true);
+    expect(hostedByokDispatchEnabled(false)).toBe(false);
+  });
+
+  it('an explicit off value forces OFF even on hosted', () => {
+    for (const value of ['false', '0', 'off', 'no', 'OFF']) {
+      process.env.HOSTED_BYOK_DISPATCH = value;
+      expect(hostedByokDispatchEnabled(true)).toBe(false);
+    }
+  });
+
+  it('an explicit on value forces ON even on self-hosted', () => {
+    for (const value of ['true', '1', 'on', 'yes']) {
+      process.env.HOSTED_BYOK_DISPATCH = value;
+      expect(hostedByokDispatchEnabled(false)).toBe(true);
+    }
+  });
+
+  it('an unrecognized value falls back to the deployment default', () => {
+    process.env.HOSTED_BYOK_DISPATCH = 'maybe';
+    expect(hostedByokDispatchEnabled(true)).toBe(true);
+    expect(hostedByokDispatchEnabled(false)).toBe(false);
+  });
+});
+
+describe('resolveLLMClientForRequest — resolution order (§5.2)', () => {
+  it('branch 1: per-user BYOK is preferred', async () => {
+    const byok = new FakeLLMClient({ source: 'byok' });
+    mockCreateForUser.mockResolvedValue(byok);
+
+    const result = await resolveLLMClientForRequest('user-1', makeDb([]), { isHosted: true });
+
+    expect(result).toBe(byok);
+    expect(mockCreateFromEnv).not.toHaveBeenCalled();
+  });
+
+  it('branch 2: site inference config when no BYOK (hostedViable provider)', async () => {
+    const result = await resolveLLMClientForRequest(
+      'user-1',
+      makeDb([{ provider: 'openai', encryptedApiKey: 'enc', model: 'gpt-4o' }]),
+      {
+        isHosted: true,
+        workspaceId: 'site-1',
+      },
+    );
+
+    expect(result).toBeInstanceOf(FakeLLMClient);
+    expect((result as FakeLLMClient).cfg.provider).toBe('openai');
+    expect((result as FakeLLMClient).cfg.apiKey).toBe('plaintext:enc');
+    expect(mockCreateFromEnv).not.toHaveBeenCalled();
+  });
+
+  it('branch 3: deployment env on SELF-HOSTED when nothing above', async () => {
+    process.env.HOSTED_BYOK_DISPATCH = 'on'; // force the new order on self-hosted
+    const result = await resolveLLMClientForRequest('user-1', makeDb([]), { isHosted: false });
+
+    expect(result).toBe(ENV_SENTINEL);
+    expect(mockCreateFromEnv).toHaveBeenCalledTimes(1);
+  });
+
+  it('branch 4: hosted + nothing above throws LLMNotConfiguredError', async () => {
+    await expect(
+      resolveLLMClientForRequest('user-1', makeDb([]), { isHosted: true }),
+    ).rejects.toBeInstanceOf(LLMNotConfiguredError);
+  });
+
+  it('flag OFF (self-hosted default) returns env directly — byte-unchanged', async () => {
+    const byok = new FakeLLMClient({ source: 'byok' });
+    mockCreateForUser.mockResolvedValue(byok);
+
+    const result = await resolveLLMClientForRequest('user-1', makeDb([]), { isHosted: false });
+
+    // Flag off → env path, BYOK is never even attempted.
+    expect(result).toBe(ENV_SENTINEL);
+    expect(mockCreateForUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveLLMClientForRequest — security invariants (§6)', () => {
+  // §6.5 — the defining invariant: hosted must NEVER fall through to env.
+  it('hosted with no config throws and never calls the env factory', async () => {
+    await expect(
+      resolveLLMClientForRequest('user-1', makeDb([]), { isHosted: true }),
+    ).rejects.toBeInstanceOf(LLMNotConfiguredError);
+    expect(mockCreateFromEnv).not.toHaveBeenCalled();
+  });
+
+  // §6.1 — userId flows from the argument only; the resolver has no request access.
+  it('passes the exact userId argument to the BYOK factory', async () => {
+    await resolveLLMClientForRequest('authenticated-owner', makeDb([]), { isHosted: true }).catch(
+      () => undefined,
+    );
+    expect(mockCreateForUser).toHaveBeenCalledWith(
+      'authenticated-owner',
+      expect.anything(),
+      undefined,
+      { hostedViableOnly: true },
+    );
+  });
+
+  it('skips the BYOK factory entirely when userId is null', async () => {
+    await resolveLLMClientForRequest(null, makeDb([]), { isHosted: true }).catch(() => undefined);
+    expect(mockCreateForUser).not.toHaveBeenCalled();
+  });
+
+  // §6.5 — fail-closed on a failed decrypt / bad row, never env on hosted.
+  it('fails closed (409, no env) when the BYOK factory throws on hosted', async () => {
+    mockCreateForUser.mockRejectedValue(new Error('decrypt failed'));
+
+    await expect(
+      resolveLLMClientForRequest('user-1', makeDb([]), { isHosted: true }),
+    ).rejects.toBeInstanceOf(LLMNotConfiguredError);
+    expect(mockCreateFromEnv).not.toHaveBeenCalled();
+  });
+
+  // §6.5 — a non-hostedViable site config on hosted is skipped, not localhost-served.
+  it('skips a non-hostedViable site config on hosted and fails closed', async () => {
+    await expect(
+      resolveLLMClientForRequest(
+        'user-1',
+        makeDb([{ provider: 'ollama', encryptedApiKey: null }]),
+        {
+          isHosted: true,
+          workspaceId: 'site-1',
+        },
+      ),
+    ).rejects.toBeInstanceOf(LLMNotConfiguredError);
+    expect(mockCreateFromEnv).not.toHaveBeenCalled();
+  });
+
+  // §6.5 — requests hostedViable filtering from the BYOK factory on hosted.
+  it('requests hostedViableOnly from the BYOK factory on hosted, not on self-hosted', async () => {
+    await resolveLLMClientForRequest('u', makeDb([]), { isHosted: true }).catch(() => undefined);
+    expect(mockCreateForUser).toHaveBeenLastCalledWith('u', expect.anything(), undefined, {
+      hostedViableOnly: true,
+    });
+
+    process.env.HOSTED_BYOK_DISPATCH = 'on';
+    mockCreateForUser.mockResolvedValue(new FakeLLMClient({ source: 'byok' }));
+    await resolveLLMClientForRequest('u', makeDb([]), { isHosted: false });
+    expect(mockCreateForUser).toHaveBeenLastCalledWith('u', expect.anything(), undefined, {
+      hostedViableOnly: false,
+    });
+  });
+});
+
+describe('LLMNotConfiguredError — 409 mapping (§5.2)', () => {
+  it('carries the machine-readable code and settings path', () => {
+    const err = new LLMNotConfiguredError();
+    expect(err.code).toBe('LLM_NOT_CONFIGURED');
+    expect(err.settingsPath).toBe('/settings/api-keys');
+    expect(err.name).toBe('LLMNotConfiguredError');
+  });
+
+  it('llmNotConfiguredBody produces the actionable 409 body', () => {
+    const err = new LLMNotConfiguredError('nope');
+    expect(llmNotConfiguredBody(err)).toEqual({
+      success: false,
+      error: 'nope',
+      code: 'LLM_NOT_CONFIGURED',
+      settingsPath: '/settings/api-keys',
+    });
+  });
+});

--- a/packages/ai/src/llm/__tests__/resolve.test.ts
+++ b/packages/ai/src/llm/__tests__/resolve.test.ts
@@ -30,8 +30,17 @@ vi.mock('../client.js', () => ({
 }));
 
 vi.mock('@revealui/db/crypto', () => ({ decryptApiKey: (s: string) => mockDecrypt(s) }));
-vi.mock('@revealui/db/schema', () => ({ workspaceInferenceConfigs: { workspaceId: {} } }));
-vi.mock('drizzle-orm', () => ({ eq: (a: unknown, b: unknown) => ({ a, b }) }));
+vi.mock('@revealui/db/schema', () => ({
+  // __t tags let the routing fake db (makeAuthzDb) distinguish the three tables
+  // the resolver queries; makeDb (which ignores the table) is unaffected.
+  workspaceInferenceConfigs: { __t: 'wic', workspaceId: {} },
+  sites: { __t: 'sites', id: {}, ownerId: {} },
+  siteCollaborators: { __t: 'collab', id: {}, siteId: {}, userId: {} },
+}));
+vi.mock('drizzle-orm', () => ({
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+  and: (...conds: unknown[]) => ({ and: conds }),
+}));
 
 import type { Database } from '@revealui/db/client';
 import {
@@ -46,6 +55,28 @@ function makeDb(siteRows: unknown[]): Database {
   return {
     select: () => ({
       from: () => ({ where: () => ({ limit: async () => siteRows }) }),
+    }),
+  } as unknown as Database;
+}
+
+/**
+ * Routing fake db for the site-config authorization tests: distinguishes the
+ * sites / site_collaborators / workspace_inference_configs queries by the
+ * table's __t tag, so `authorized` controls whether userCanAccessSite passes
+ * independently of the returned config row.
+ */
+function makeAuthzDb(opts: { authorized: boolean; config: unknown }): Database {
+  return {
+    select: () => ({
+      from: (table: { __t?: string }) => ({
+        where: () => ({
+          limit: async () => {
+            if (table?.__t === 'sites') return opts.authorized ? [{ id: 'site-1' }] : [];
+            if (table?.__t === 'collab') return [];
+            return [opts.config];
+          },
+        }),
+      }),
     }),
   } as unknown as Database;
 }
@@ -204,6 +235,49 @@ describe('resolveLLMClientForRequest — security invariants (§6)', () => {
     expect(mockCreateForUser).toHaveBeenLastCalledWith('u', expect.anything(), undefined, {
       hostedViableOnly: false,
     });
+  });
+});
+
+describe('resolveLLMClientForRequest — site-config authorization (§6.1)', () => {
+  // workspaceId reaches the resolver from a client-writable field (e.g. the
+  // agent-stream request body). The site's stored key must be decrypted only
+  // for a caller who owns or collaborates on that site — otherwise a request
+  // could name another tenant's site id and run on that site's key.
+  const siteConfig = { provider: 'openai', encryptedApiKey: 'enc', model: 'gpt-4o' };
+
+  it('does not decrypt a site key for a workspaceId the caller cannot access', async () => {
+    const db = makeAuthzDb({ authorized: false, config: siteConfig });
+
+    await expect(
+      resolveLLMClientForRequest('attacker', db, {
+        isHosted: true,
+        workspaceId: 'victim-site',
+      }),
+    ).rejects.toBeInstanceOf(LLMNotConfiguredError);
+    expect(mockDecrypt).not.toHaveBeenCalled();
+    expect(mockCreateFromEnv).not.toHaveBeenCalled();
+  });
+
+  it('decrypts the site key when the caller is authorized on the site', async () => {
+    const db = makeAuthzDb({ authorized: true, config: siteConfig });
+
+    const result = await resolveLLMClientForRequest('owner', db, {
+      isHosted: true,
+      workspaceId: 'my-site',
+    });
+
+    expect(result).toBeInstanceOf(FakeLLMClient);
+    expect((result as FakeLLMClient).cfg.apiKey).toBe('plaintext:enc');
+    expect(mockDecrypt).toHaveBeenCalledWith('enc');
+  });
+
+  it('skips the site config for an anonymous (null userId) request', async () => {
+    const db = makeAuthzDb({ authorized: true, config: siteConfig });
+
+    await expect(
+      resolveLLMClientForRequest(null, db, { isHosted: true, workspaceId: 'site-1' }),
+    ).rejects.toBeInstanceOf(LLMNotConfiguredError);
+    expect(mockDecrypt).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -743,13 +743,22 @@ export function createLLMClientFromEnv(): LLMClient {
  * Returns `null` if the user has no stored keys (callers should fall back
  * to `createLLMClientFromEnv()` or return a 402/feature-unavailable error).
  *
+ * When `opts.hostedViableOnly` is set, a stored key whose provider is not
+ * hosted-viable (ollama / inference-snaps are localhost-only) resolves to
+ * `null` instead of a client. The resolver passes this on hosted deployments so
+ * a localhost-only BYOK key can never yield a localhost client — the exact
+ * silent-localhost defect GAP-360 closes (spec §6.5, fail-closed).
+ *
  * @param userId - The user's ID from the `users` table
  * @param db - A Drizzle NeonDB client instance
  */
 export async function createLLMClientForUser(
   userId: string,
   db: Database,
-  auditStore?: AuditStore,
+  // Only `append` is used; the narrow type lets a persistent store whose entry
+  // type widens eventType/severity to `string` (e.g. DrizzleAuditStore) fit.
+  auditStore?: Pick<AuditStore, 'append'>,
+  opts?: { hostedViableOnly?: boolean },
 ): Promise<LLMClient | null> {
   // Find the user's preferred provider config
   const [preferredConfig] = await db
@@ -773,8 +782,13 @@ export async function createLLMClientForUser(
 
   if (!keyRow) return null;
 
-  const plaintext = decryptApiKey(keyRow.encryptedKey);
   const provider = keyRow.provider as LLMProviderType;
+
+  // Fail-closed hosted filter (§6.5): reject a localhost-only provider before
+  // decrypting, so no plaintext is touched for a key we will not use.
+  if (opts?.hostedViableOnly && !isHostedViable(provider)) return null;
+
+  const plaintext = decryptApiKey(keyRow.encryptedKey);
   const model = preferredConfig?.model ?? undefined;
 
   // Fire-and-forget: record when this key was last used (best-effort, never blocks)

--- a/packages/ai/src/llm/resolve.ts
+++ b/packages/ai/src/llm/resolve.ts
@@ -12,8 +12,11 @@
  *
  * Security invariants (spec §6, guardrail-2):
  *   - §6.1 userId is authenticated-identity-scoped; the caller derives it from
- *     session/entitlement context (or the task's owning account for the worker),
- *     never from request params/body. The resolver takes it as an argument and
+ *     session/entitlement context — or, for the durable worker, the
+ *     authenticated dispatcher captured server-side at enqueue time — never
+ *     from request params/body, and never from a client-writable DB column
+ *     (e.g. a ticket's `reporterId`, which has no ownership check on the
+ *     general tickets API). The resolver takes userId as an argument and
  *     never reads it from a request.
  *   - §6.2 plaintext lifetime = request scope. The client is constructed per
  *     request; no key cache. Nothing here logs, serializes, or returns a key.
@@ -30,6 +33,7 @@
  * The flag is the one-release rollback lever.
  */
 
+import { createLogger } from '@revealui/core/observability/logger';
 import type { Database } from '@revealui/db/client';
 import { decryptApiKey } from '@revealui/db/crypto';
 import { workspaceInferenceConfigs } from '@revealui/db/schema';
@@ -42,6 +46,10 @@ import {
   LLMClient,
   type LLMProviderType,
 } from './client.js';
+
+const resolverLogger = createLogger({ component: 'resolveLLMClientForRequest' });
+/** Emitted once per process when the hosted BYOK rollback lever is pulled. */
+let warnedBreakGlass = false;
 
 /**
  * Thrown when a hosted deployment has no usable LLM configuration for the
@@ -115,9 +123,11 @@ export function hostedByokDispatchEnabled(isHosted: boolean): boolean {
 /**
  * Resolve the LLM client for a single request.
  *
- * @param userId - Authenticated user id (from session/entitlement context, or
- *   the task's owning account for the worker). Never a request param/body value.
- *   Null when the request has no authenticated user.
+ * @param userId - Authenticated user id, from session/entitlement context for
+ *   request-scoped callers, or the authenticated dispatcher captured
+ *   server-side at enqueue time for the durable worker. Never a request
+ *   param/body value, and never a client-writable DB column. Null when there
+ *   is no authenticated user.
  * @param db - Drizzle client.
  * @param ctx - Deployment mode, optional site id, optional audit sink.
  */
@@ -131,6 +141,17 @@ export async function resolveLLMClientForRequest(
   // Feature-flag gate. When disabled (self-hosted default), behavior is
   // byte-unchanged: env-first, exactly as before this PR.
   if (!hostedByokDispatchEnabled(hosted)) {
+    if (hosted && !warnedBreakGlass) {
+      warnedBreakGlass = true;
+      // Break-glass: HOSTED_BYOK_DISPATCH is explicitly off on a hosted
+      // deployment. Every account now shares the deployment env client while
+      // this lever is pulled — a deliberate one-release rollback, but an
+      // operator must know it is active.
+      resolverLogger.warn(
+        'HOSTED_BYOK_DISPATCH is disabled on a hosted deployment — all accounts are ' +
+          'sharing the deployment env LLM client instead of per-account BYOK keys.',
+      );
+    }
     return createLLMClientFromEnv();
   }
 

--- a/packages/ai/src/llm/resolve.ts
+++ b/packages/ai/src/llm/resolve.ts
@@ -1,0 +1,220 @@
+/**
+ * Per-request LLM client resolver (GAP-360 PR-2).
+ *
+ * The single home for key resolution at every dispatch site (spec §5.2 / §5.4).
+ * One resolver, consumed by all sites — no site-local copies.
+ *
+ * Resolution order (spec §5.2):
+ *   1. Per-user BYOK        — createLLMClientForUser (preferred)
+ *   2. Site inference config — workspace_inference_configs (hostedViable on hosted)
+ *   3. Deployment env        — createLLMClientFromEnv (SELF-HOSTED ONLY)
+ *   4. Hosted + nothing above → throw LLMNotConfiguredError (typed → HTTP 409)
+ *
+ * Security invariants (spec §6, guardrail-2):
+ *   - §6.1 userId is authenticated-identity-scoped; the caller derives it from
+ *     session/entitlement context (or the task's owning account for the worker),
+ *     never from request params/body. The resolver takes it as an argument and
+ *     never reads it from a request.
+ *   - §6.2 plaintext lifetime = request scope. The client is constructed per
+ *     request; no key cache. Nothing here logs, serializes, or returns a key.
+ *   - §6.3 decryption is server-side only via the existing decryptApiKey.
+ *   - §6.4 the byok:key:accessed audit event fires inside createLLMClientForUser
+ *     when an audit store is wired (ctx.auditStore).
+ *   - §6.5 fail-closed: unknown provider / failed decrypt / a non-hostedViable
+ *     provider on hosted resolves to LLMNotConfiguredError, never an env
+ *     fallthrough on hosted (the exact silent-localhost defect class).
+ *   - §6.6 no new secret surface.
+ *
+ * Feature flag (spec §7): HOSTED_BYOK_DISPATCH. Default ON for hosted, absent
+ * (off) for self-hosted so self-hosted env-first behavior is byte-unchanged.
+ * The flag is the one-release rollback lever.
+ */
+
+import type { Database } from '@revealui/db/client';
+import { decryptApiKey } from '@revealui/db/crypto';
+import { workspaceInferenceConfigs } from '@revealui/db/schema';
+import { eq } from 'drizzle-orm';
+import type { AuditStore } from '../audit/store.js';
+import {
+  createLLMClientForUser,
+  createLLMClientFromEnv,
+  isHostedViable,
+  LLMClient,
+  type LLMProviderType,
+} from './client.js';
+
+/**
+ * Thrown when a hosted deployment has no usable LLM configuration for the
+ * request. Maps to HTTP 409 (configuration is the remedy, not payment).
+ * Callers name {@link settingsPath} in the machine-readable response body.
+ */
+export class LLMNotConfiguredError extends Error {
+  /** Stable machine-readable code for API response bodies. */
+  readonly code = 'LLM_NOT_CONFIGURED' as const;
+  /** Where the account owner configures a key. */
+  readonly settingsPath = '/settings/api-keys' as const;
+
+  constructor(message = 'No LLM provider is configured for this account.') {
+    super(message);
+    this.name = 'LLMNotConfiguredError';
+  }
+}
+
+/** The 409 response body every dispatch site returns for an unconfigured account. */
+export interface LLMNotConfiguredBody {
+  success: false;
+  error: string;
+  code: 'LLM_NOT_CONFIGURED';
+  settingsPath: '/settings/api-keys';
+}
+
+/** Build the machine-readable 409 body for {@link LLMNotConfiguredError}. */
+export function llmNotConfiguredBody(err: LLMNotConfiguredError): LLMNotConfiguredBody {
+  return {
+    success: false,
+    error: err.message,
+    code: err.code,
+    settingsPath: err.settingsPath,
+  };
+}
+
+export interface ResolveLLMContext {
+  /**
+   * True on the hosted revealui.com SaaS deployment. Derived by the caller from
+   * the existing deployment-mode signal (server: detectDeploymentMode; admin:
+   * REVEALUI_LICENSE_PRIVATE_KEY presence) — never sniffed here.
+   */
+  isHosted: boolean;
+  /** Site id for step-2 site-level config lookup. Omit when the site has none. */
+  workspaceId?: string;
+  /**
+   * Durable audit sink for the byok:key:accessed event (§6.4). Only `append` is
+   * used, so a persistent store (DrizzleAuditStore) fits. Omit where none is
+   * wired (e.g. the admin process, in-memory until GAP-338 closes).
+   */
+  auditStore?: Pick<AuditStore, 'append'>;
+}
+
+const FLAG_ON = new Set(['true', '1', 'on', 'yes']);
+const FLAG_OFF = new Set(['false', '0', 'off', 'no']);
+
+/**
+ * Whether the BYOK dispatch order (spec §5.2) is active. Default follows the
+ * deployment: ON when hosted, OFF when self-hosted. HOSTED_BYOK_DISPATCH
+ * overrides explicitly; an unrecognized value falls back to the default.
+ */
+export function hostedByokDispatchEnabled(isHosted: boolean): boolean {
+  const raw = process.env.HOSTED_BYOK_DISPATCH;
+  if (raw === undefined || raw.trim() === '') return isHosted;
+  const value = raw.trim().toLowerCase();
+  if (FLAG_OFF.has(value)) return false;
+  if (FLAG_ON.has(value)) return true;
+  return isHosted;
+}
+
+/**
+ * Resolve the LLM client for a single request.
+ *
+ * @param userId - Authenticated user id (from session/entitlement context, or
+ *   the task's owning account for the worker). Never a request param/body value.
+ *   Null when the request has no authenticated user.
+ * @param db - Drizzle client.
+ * @param ctx - Deployment mode, optional site id, optional audit sink.
+ */
+export async function resolveLLMClientForRequest(
+  userId: string | null,
+  db: Database,
+  ctx: ResolveLLMContext,
+): Promise<LLMClient> {
+  const hosted = ctx.isHosted;
+
+  // Feature-flag gate. When disabled (self-hosted default), behavior is
+  // byte-unchanged: env-first, exactly as before this PR.
+  if (!hostedByokDispatchEnabled(hosted)) {
+    return createLLMClientFromEnv();
+  }
+
+  // 1. Per-user BYOK (preferred). On hosted, filter to hostedViable providers
+  //    so a localhost-only BYOK key (e.g. ollama) can never yield a localhost
+  //    client — that is the silent-localhost defect (§6.5, fail-closed).
+  if (userId) {
+    try {
+      const byok = await createLLMClientForUser(userId, db, ctx.auditStore, {
+        hostedViableOnly: hosted,
+      });
+      if (byok) return byok;
+    } catch {
+      // Failed decrypt / unknown-provider row / CHECK-violating row. Fail-closed
+      // on hosted — never fall through to env. Self-hosted may continue.
+      if (hosted) {
+        throw new LLMNotConfiguredError(
+          'Your stored API key could not be used. Re-add it under /settings/api-keys.',
+        );
+      }
+    }
+  }
+
+  // 2. Site-level inference config.
+  const siteClient = await resolveSiteInferenceClient(db, ctx.workspaceId, hosted);
+  if (siteClient) return siteClient;
+
+  // 3. Deployment env — SELF-HOSTED ONLY. Forbidden on hosted (§5.2 step 3).
+  if (!hosted) {
+    return createLLMClientFromEnv();
+  }
+
+  // 4. Hosted + nothing above → fail loud, actionable.
+  throw new LLMNotConfiguredError();
+}
+
+/**
+ * Build a client from the site's workspace_inference_configs row (spec §5.2
+ * step 2). Returns null when the site has no config, or (on hosted) when its
+ * provider is not hostedViable. Fail-closed: a malformed row throws on hosted
+ * and is skipped on self-hosted.
+ */
+async function resolveSiteInferenceClient(
+  db: Database,
+  workspaceId: string | undefined,
+  hosted: boolean,
+): Promise<LLMClient | null> {
+  if (!workspaceId) return null;
+
+  const [config] = await db
+    .select()
+    .from(workspaceInferenceConfigs)
+    .where(eq(workspaceInferenceConfigs.workspaceId, workspaceId))
+    .limit(1);
+
+  if (!config) return null;
+
+  const provider = config.provider as LLMProviderType;
+
+  // On hosted, only hostedViable providers are reachable. A non-viable site
+  // config is skipped so resolution fails closed rather than hitting localhost.
+  if (hosted && !isHostedViable(provider)) return null;
+
+  try {
+    // Keyless providers (ollama / inference-snaps) carry a NULL encrypted key
+    // and use the provider name as the placeholder key — matches the env
+    // factory. Keyed providers decrypt server-side at dispatch time (§6.3).
+    const apiKey = config.encryptedApiKey ? decryptApiKey(config.encryptedApiKey) : provider;
+
+    return new LLMClient({
+      provider,
+      apiKey,
+      model: config.model ?? undefined,
+      baseURL: config.baseURL ?? undefined,
+      temperature: config.temperature ?? undefined,
+      maxTokens: config.maxTokens ?? undefined,
+    });
+  } catch {
+    // Unknown provider / failed decrypt. Fail-closed on hosted; skip on self-hosted.
+    if (hosted) {
+      throw new LLMNotConfiguredError(
+        'This site’s inference configuration could not be used. Update it under /settings/api-keys.',
+      );
+    }
+    return null;
+  }
+}

--- a/packages/ai/src/llm/resolve.ts
+++ b/packages/ai/src/llm/resolve.ts
@@ -17,7 +17,11 @@
  *     from request params/body, and never from a client-writable DB column
  *     (e.g. a ticket's `reporterId`, which has no ownership check on the
  *     general tickets API). The resolver takes userId as an argument and
- *     never reads it from a request.
+ *     never reads it from a request. The same rule binds the step-2 site
+ *     inference key: the workspaceId is client-writable, so its stored key is
+ *     decrypted only after userCanAccessSite confirms the caller owns or
+ *     collaborates on that site. Otherwise a request could name another
+ *     tenant's site id and run on that site's key.
  *   - §6.2 plaintext lifetime = request scope. The client is constructed per
  *     request; no key cache. Nothing here logs, serializes, or returns a key.
  *   - §6.3 decryption is server-side only via the existing decryptApiKey.
@@ -36,8 +40,8 @@
 import { createLogger } from '@revealui/core/observability/logger';
 import type { Database } from '@revealui/db/client';
 import { decryptApiKey } from '@revealui/db/crypto';
-import { workspaceInferenceConfigs } from '@revealui/db/schema';
-import { eq } from 'drizzle-orm';
+import { siteCollaborators, sites, workspaceInferenceConfigs } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
 import type { AuditStore } from '../audit/store.js';
 import {
   createLLMClientForUser,
@@ -175,8 +179,11 @@ export async function resolveLLMClientForRequest(
     }
   }
 
-  // 2. Site-level inference config.
-  const siteClient = await resolveSiteInferenceClient(db, ctx.workspaceId, hosted);
+  // 2. Site-level inference config. userId is passed so the site's stored key
+  //    is decrypted only for a caller authorized on that site (§6.1) — the
+  //    workspaceId reaching here is a client-writable value (e.g. a request
+  //    body field), so it carries no ownership guarantee on its own.
+  const siteClient = await resolveSiteInferenceClient(db, userId, ctx.workspaceId, hosted);
   if (siteClient) return siteClient;
 
   // 3. Deployment env — SELF-HOSTED ONLY. Forbidden on hosted (§5.2 step 3).
@@ -189,17 +196,46 @@ export async function resolveLLMClientForRequest(
 }
 
 /**
+ * Whether `userId` is authorized to act on `siteId` — the site's owner, or a
+ * row in `site_collaborators`. Gate for the site inference key (§6.1): the
+ * site's stored provider key must never be decrypted for a caller who does not
+ * belong to the site, even though the workspaceId is client-supplied.
+ */
+async function userCanAccessSite(db: Database, userId: string, siteId: string): Promise<boolean> {
+  const [owned] = await db
+    .select({ id: sites.id })
+    .from(sites)
+    .where(and(eq(sites.id, siteId), eq(sites.ownerId, userId)))
+    .limit(1);
+  if (owned) return true;
+
+  const [collaborator] = await db
+    .select({ id: siteCollaborators.id })
+    .from(siteCollaborators)
+    .where(and(eq(siteCollaborators.siteId, siteId), eq(siteCollaborators.userId, userId)))
+    .limit(1);
+  return Boolean(collaborator);
+}
+
+/**
  * Build a client from the site's workspace_inference_configs row (spec §5.2
- * step 2). Returns null when the site has no config, or (on hosted) when its
- * provider is not hostedViable. Fail-closed: a malformed row throws on hosted
- * and is skipped on self-hosted.
+ * step 2). Returns null when the site has no config, when the caller is not
+ * authorized on the site, or (on hosted) when its provider is not hostedViable.
+ * Fail-closed: a malformed row throws on hosted and is skipped on self-hosted.
  */
 async function resolveSiteInferenceClient(
   db: Database,
+  userId: string | null,
   workspaceId: string | undefined,
   hosted: boolean,
 ): Promise<LLMClient | null> {
   if (!workspaceId) return null;
+
+  // §6.1 authorization: only decrypt a site's key for a caller who belongs to
+  // that site. An unauthorized (or anonymous) request skips the site config
+  // entirely; on hosted it then falls through to the step-4 409, never a
+  // decrypt of another tenant's key.
+  if (!(userId && (await userCanAccessSite(db, userId, workspaceId)))) return null;
 
   const [config] = await db
     .select()

--- a/packages/ai/src/llm/server.ts
+++ b/packages/ai/src/llm/server.ts
@@ -7,13 +7,14 @@
 
 // Export LLM client and factory functions
 export * from './client.js';
-
 // Export provider implementations
 export * from './providers/base.js';
 export * from './providers/groq.js';
 export * from './providers/inference-snaps.js';
 export * from './providers/ollama.js';
 export * from './providers/openai-compat.js';
+// Export the per-request client resolver (GAP-360 PR-2)
+export * from './resolve.js';
 
 // Export per-workspace provider registry (used by admin inference-config route
 // to hydrate per-site config at boot + apply changes immediately on PUT)


### PR DESCRIPTION
**Part 2/3 of GAP-360** ([design spec](https://github.com/RevealUIStudio/revealui-jv/blob/main/docs/gap-specs/GAP-360-hosted-agent-execution-design.md)). The security-sensitive core: per-account key decryption at dispatch time. **Needs a guardrail-2 verdict + `sec-review:approved` before merge** (not self-applied).

Builds on PR-1 (`createLLMClientForUser`, widened provider surface, `hostedViable`, boot warning) already merged on this branch.

## Scope (spec §5.2 / §5.4 / §5.6 — nothing more)

### §5.2 — the single resolver
New `resolveLLMClientForRequest(userId, db, ctx)` in [`packages/ai/src/llm/resolve.ts`](packages/ai/src/llm/resolve.ts). One home, consumed by every dispatch site — no site-local copies (extend-before-create). Order:

1. **Per-user BYOK** — `createLLMClientForUser(userId, db, audit, { hostedViableOnly })` (preferred).
2. **Site inference config** — `workspace_inference_configs` (active; on hosted, hostedViable providers only).
3. **Deployment env** — `createLLMClientFromEnv` — **SELF-HOSTED ONLY**. Forbidden on hosted (the exact silent-localhost defect class).
4. **Hosted + nothing above** → throw typed `LLMNotConfiguredError` → **HTTP 409** with a machine-readable body naming `/settings/api-keys` (not 402, not 500).

Hosted detection reuses the existing deployment-mode signal (`detectDeploymentMode` at [validate-startup.ts:133](apps/server/src/lib/validate-startup.ts#L133), keyed on `REVEALUI_LICENSE_PRIVATE_KEY` presence; admin mirrors it per [instrumentation.ts:49](apps/admin/src/instrumentation.ts#L49)). No `VERCEL` sniffing.

### §5.4 — dispatch-site coverage (all seven, one resolver)

| Site | Wiring |
|---|---|
| a2a `tasks/send` (a2a.ts:1173) | resolver; userId from `c.get('user')`; deleted the `:83-84` "no per-request key" comment; 409 as a JSON-RPC error |
| agent-stream (agent-stream.ts:167) | resolver; userId from session; 409. Free-tier local path untouched |
| ticket dispatch (agent-dispatcher.ts:45) | `buildDispatcher` now resolves via the resolver; sync callers pass session `user.id` |
| durable worker (jobs/agent-dispatch.ts) | resolver + §5.6 per-tenant gate; userId from the **task's owning account** (`ticket.reporterId`), not the payload |
| admin chat (app/api/chat/route.ts:310) | resolver; userId from `authSession.user.id`; 409; resolved client reused for the RAG embedding call |
| RAG embeddings (embeddings/index.ts:68) | `generateEmbedding` gains an optional pre-resolved `client`; the authenticated admin-chat path passes it (see deviations for rag-index) |
| CLI / harness adapter | **env, unchanged** — local/self-hosted context by definition |

`agent-tasks.ts` also now sets `reporterId: user.id` on ticket creation, so the worker has an authenticated owner to derive from (without it, hosted dispatch would fail closed on every ticket).

### §5.6 — per-tenant worker gate
Replaced the singleton `isFeatureEnabled('ai')` in the durable worker with per-account entitlement resolution via the GAP-356 canonical path (`accountEntitlements` scoped by `getConfiguredStripeMode()`, grace-expiry fail-safe mirrored from `entitlementMiddleware`) in new `apps/server/src/lib/account-entitlement.ts`. The "pre-existing gap" comment is retired. On self-hosted (or a flag rollback) the singleton check remains, byte-unchanged.

## §6 security invariants → tests

| # | Invariant | Implementation | Test |
|---|---|---|---|
| 6.1 | userId from authenticated context only, never request body/params | resolver takes userId as an argument; worker derives it from `ticket.reporterId` | `resolve.test.ts` "passes the exact userId argument", "skips … when userId is null"; **`agent-dispatch.test.ts` "derives userId from ticket.reporterId and ignores the payload userId"** |
| 6.2 | plaintext lifetime = request scope; no key cache/log/serialized row | client constructed per request; no cache; nothing logs/returns a key | resolver constructs per call (no module state) |
| 6.3 | decryption server-side only via `decryptApiKey` | site path calls `decryptApiKey`; BYOK path delegates to PR-1's `createLLMClientForUser` | `resolve.test.ts` branch-2 (decrypt invoked) |
| 6.4 | audit every access (`byok:key:accessed`) | `DrizzleAuditStore` wired at server sites; admin in-memory per **GAP-338** (recorded limitation) | audit sink threaded through `ctx.auditStore` (fires inside `createLLMClientForUser`) |
| 6.5 | fail-closed: unknown provider / failed decrypt / non-hostedViable → 409, never env on hosted | try/catch → `LLMNotConfiguredError` on hosted; `hostedViableOnly` filter before decrypt | `resolve.test.ts` "hosted … never calls the env factory", "fails closed when the BYOK factory throws", "skips a non-hostedViable site config" |
| 6.6 | no new secret surface (validate-startup stays AI-keyless) | no platform env keys added | boundary validation + no validate-startup change |

Full suite: **`@revealui/ai` resolver 17/17**, **worker 3/3**, plus updated a2a (47/47), agent-tasks, agent-stream(+success/elicit) — 64/64 touched server tests, 125/125 ai/llm tests, 74/74 a2a+rag-index, admin chat 7/7.

## Red-proof (prove-red first)

Both highest-risk behaviors proven to fail without the fix:

- **(b) userId cannot come from the request body** — `git checkout origin/test -- apps/server/src/jobs/agent-dispatch.ts` (restore pre-change worker), ran the worker test → **2 failed** ("derives userId from ticket.reporterId…", "fails closed when the owning account lacks the ai feature"); restored → **3/3 green**.
- **(a) hosted never falls through to env** — `resolve.ts` is a new file, so prove-red by removing the step-3 hosted guard (`if (!hosted) return env`) → **3 failed** ("branch 4 throws", "hosted … never calls env", "skips non-hostedViable site config"); restored → **17/17 green**. (git-checkout method for the modified worker file; guard-removal for the new resolver file since there is no pre-change version to restore.)

## §5.5 admin run-surface routing — **DEFERRED**

Deferred to its own PR. The `next.config.mjs` rewrite is authorable, but agent-stream is an **SSE** surface and streaming-through-rewrite is flagged as risky in the spec itself; it needs a live hosted SSE test this build environment cannot run. Per the "defer if uncertain / don't balloon the security PR" guidance, it is separated so this PR stays focused on the key-resolution core. `next.config.mjs` currently has no `rewrites()` block; the change is self-contained and independent of this PR.

## Feature flag — `HOSTED_BYOK_DISPATCH` (§7)

One-release rollback lever. Default **ON for hosted, absent/off for self-hosted**. When off, every site returns `createLLMClientFromEnv()` directly — self-hosted env-first behavior is **byte-unchanged**. Explicit `true/1/on/yes` or `false/0/off/no` override; unrecognized values fall back to the deployment default. The worker gate mirrors the same flag (inlined — apps/server may not statically import the Pro `@revealui/ai`; boundary-enforced).

## Spec deviations (with justification)

- **rag-index background indexing** (rag-index.ts:160,320) still uses the env embedding path. The embeddings *module* fix (optional `client`) ships and the user-facing admin-chat RAG path is wired; rag-index is background indexing (not agent execution), and per-account embedding needs an embedding-capable provider (anthropic BYOK cannot embed) — a model-selection concern outside this PR's security core. It can adopt the same `client` param in a follow-up with no further module change.
- **§6.4 admin audit sink** is in-memory until **GAP-338** closes (recorded limitation, not a blocker). Server sites persist via `DrizzleAuditStore`.

## Changeset
`@revealui/ai`: **minor**. `server`/`admin` are in the changeset ignore list (`.changeset/config.json`) — no changeset entries, per config.

## Security checker (verbatim)
```
🔒 Current branch is SECURITY-SENSITIVE (vs origin/test). Touched: apps/server/src/routes/a2a.ts, apps/server/src/routes/agent-stream.ts, apps/server/src/routes/agent-tasks.ts
   When you open the PR, it needs a recorded coordinator verdict before merge (see dup-work-and-review-gates.md).
```
(exit 1 = HOLD, as expected.)

## Gate tails
- Pre-push gate: **Result: PASS** (migration journal, raw-SQL, empty-catch, as-never, stripe-client, pricing-lockstep, client-bundle-safety, security-audit, coverage — all ✓; Phase 1 Biome/typecheck/build ✓).
- `pnpm --filter @revealui/ai typecheck` → **0 errors**; `server` typecheck → **0**; `admin` typecheck → **0**.
- Boundary validation → **passed** (no static Fair Source imports in apps/scripts).
- No authored regex; TypeScript strict; explicit return types on exports.

**Part 2/3 of GAP-360; needs a guardrail-2 verdict before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
