### PR TITLE
fix(ai): authorize the site-config decrypt against the caller (GAP-360 §6.1)

### DIFF
--- a/packages/ai/src/llm/__tests__/resolve.test.ts
+++ b/packages/ai/src/llm/__tests__/resolve.test.ts
@@ -30,8 +30,17 @@ vi.mock('../client.js', () => ({
 }));
 
 vi.mock('@revealui/db/crypto', () => ({ decryptApiKey: (s: string) => mockDecrypt(s) }));
-vi.mock('@revealui/db/schema', () => ({ workspaceInferenceConfigs: { workspaceId: {} } }));
-vi.mock('drizzle-orm', () => ({ eq: (a: unknown, b: unknown) => ({ a, b }) }));
+vi.mock('@revealui/db/schema', () => ({
+  // __t tags let the routing fake db (makeAuthzDb) distinguish the three tables
+  // the resolver queries; makeDb (which ignores the table) is unaffected.
+  workspaceInferenceConfigs: { __t: 'wic', workspaceId: {} },
+  sites: { __t: 'sites', id: {}, ownerId: {} },
+  siteCollaborators: { __t: 'collab', id: {}, siteId: {}, userId: {} },
+}));
+vi.mock('drizzle-orm', () => ({
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+  and: (...conds: unknown[]) => ({ and: conds }),
+}));
 
 import type { Database } from '@revealui/db/client';
 import {
@@ -46,6 +55,28 @@ function makeDb(siteRows: unknown[]): Database {
   return {
     select: () => ({
       from: () => ({ where: () => ({ limit: async () => siteRows }) }),
+    }),
+  } as unknown as Database;
+}
+
+/**
+ * Routing fake db for the site-config authorization tests: distinguishes the
+ * sites / site_collaborators / workspace_inference_configs queries by the
+ * table's __t tag, so `authorized` controls whether userCanAccessSite passes
+ * independently of the returned config row.
+ */
+function makeAuthzDb(opts: { authorized: boolean; config: unknown }): Database {
+  return {
+    select: () => ({
+      from: (table: { __t?: string }) => ({
+        where: () => ({
+          limit: async () => {
+            if (table?.__t === 'sites') return opts.authorized ? [{ id: 'site-1' }] : [];
+            if (table?.__t === 'collab') return [];
+            return [opts.config];
+          },
+        }),
+      }),
     }),
   } as unknown as Database;
 }
@@ -204,6 +235,49 @@ describe('resolveLLMClientForRequest — security invariants (§6)', () => {
     expect(mockCreateForUser).toHaveBeenLastCalledWith('u', expect.anything(), undefined, {
       hostedViableOnly: false,
     });
+  });
+});
+
+describe('resolveLLMClientForRequest — site-config authorization (§6.1)', () => {
+  // workspaceId reaches the resolver from a client-writable field (e.g. the
+  // agent-stream request body). The site's stored key must be decrypted only
+  // for a caller who owns or collaborates on that site — otherwise a request
+  // could name another tenant's site id and run on that site's key.
+  const siteConfig = { provider: 'openai', encryptedApiKey: 'enc', model: 'gpt-4o' };
+
+  it('does not decrypt a site key for a workspaceId the caller cannot access', async () => {
+    const db = makeAuthzDb({ authorized: false, config: siteConfig });
+
+    await expect(
+      resolveLLMClientForRequest('attacker', db, {
+        isHosted: true,
+        workspaceId: 'victim-site',
+      }),
+    ).rejects.toBeInstanceOf(LLMNotConfiguredError);
+    expect(mockDecrypt).not.toHaveBeenCalled();
+    expect(mockCreateFromEnv).not.toHaveBeenCalled();
+  });
+
+  it('decrypts the site key when the caller is authorized on the site', async () => {
+    const db = makeAuthzDb({ authorized: true, config: siteConfig });
+
+    const result = await resolveLLMClientForRequest('owner', db, {
+      isHosted: true,
+      workspaceId: 'my-site',
+    });
+
+    expect(result).toBeInstanceOf(FakeLLMClient);
+    expect((result as FakeLLMClient).cfg.apiKey).toBe('plaintext:enc');
+    expect(mockDecrypt).toHaveBeenCalledWith('enc');
+  });
+
+  it('skips the site config for an anonymous (null userId) request', async () => {
+    const db = makeAuthzDb({ authorized: true, config: siteConfig });
+
+    await expect(
+      resolveLLMClientForRequest(null, db, { isHosted: true, workspaceId: 'site-1' }),
+    ).rejects.toBeInstanceOf(LLMNotConfiguredError);
+    expect(mockDecrypt).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ai/src/llm/resolve.ts
+++ b/packages/ai/src/llm/resolve.ts
@@ -17,7 +17,11 @@
  *     from request params/body, and never from a client-writable DB column
  *     (e.g. a ticket's `reporterId`, which has no ownership check on the
  *     general tickets API). The resolver takes userId as an argument and
- *     never reads it from a request.
+ *     never reads it from a request. The same rule binds the step-2 site
+ *     inference key: the workspaceId is client-writable, so its stored key is
+ *     decrypted only after userCanAccessSite confirms the caller owns or
+ *     collaborates on that site. Otherwise a request could name another
+ *     tenant's site id and run on that site's key.
  *   - §6.2 plaintext lifetime = request scope. The client is constructed per
  *     request; no key cache. Nothing here logs, serializes, or returns a key.
  *   - §6.3 decryption is server-side only via the existing decryptApiKey.
@@ -36,8 +40,8 @@
 import { createLogger } from '@revealui/core/observability/logger';
 import type { Database } from '@revealui/db/client';
 import { decryptApiKey } from '@revealui/db/crypto';
-import { workspaceInferenceConfigs } from '@revealui/db/schema';
-import { eq } from 'drizzle-orm';
+import { siteCollaborators, sites, workspaceInferenceConfigs } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
 import type { AuditStore } from '../audit/store.js';
 import {
   createLLMClientForUser,
@@ -175,8 +179,11 @@ export async function resolveLLMClientForRequest(
     }
   }
 
-  // 2. Site-level inference config.
-  const siteClient = await resolveSiteInferenceClient(db, ctx.workspaceId, hosted);
+  // 2. Site-level inference config. userId is passed so the site's stored key
+  //    is decrypted only for a caller authorized on that site (§6.1) — the
+  //    workspaceId reaching here is a client-writable value (e.g. a request
+  //    body field), so it carries no ownership guarantee on its own.
+  const siteClient = await resolveSiteInferenceClient(db, userId, ctx.workspaceId, hosted);
   if (siteClient) return siteClient;
 
   // 3. Deployment env — SELF-HOSTED ONLY. Forbidden on hosted (§5.2 step 3).
@@ -189,17 +196,46 @@ export async function resolveLLMClientForRequest(
 }
 
 /**
+ * Whether `userId` is authorized to act on `siteId` — the site's owner, or a
+ * row in `site_collaborators`. Gate for the site inference key (§6.1): the
+ * site's stored provider key must never be decrypted for a caller who does not
+ * belong to the site, even though the workspaceId is client-supplied.
+ */
+async function userCanAccessSite(db: Database, userId: string, siteId: string): Promise<boolean> {
+  const [owned] = await db
+    .select({ id: sites.id })
+    .from(sites)
+    .where(and(eq(sites.id, siteId), eq(sites.ownerId, userId)))
+    .limit(1);
+  if (owned) return true;
+
+  const [collaborator] = await db
+    .select({ id: siteCollaborators.id })
+    .from(siteCollaborators)
+    .where(and(eq(siteCollaborators.siteId, siteId), eq(siteCollaborators.userId, userId)))
+    .limit(1);
+  return Boolean(collaborator);
+}
+
+/**
  * Build a client from the site's workspace_inference_configs row (spec §5.2
- * step 2). Returns null when the site has no config, or (on hosted) when its
- * provider is not hostedViable. Fail-closed: a malformed row throws on hosted
- * and is skipped on self-hosted.
+ * step 2). Returns null when the site has no config, when the caller is not
+ * authorized on the site, or (on hosted) when its provider is not hostedViable.
+ * Fail-closed: a malformed row throws on hosted and is skipped on self-hosted.
  */
 async function resolveSiteInferenceClient(
   db: Database,
+  userId: string | null,
   workspaceId: string | undefined,
   hosted: boolean,
 ): Promise<LLMClient | null> {
   if (!workspaceId) return null;
+
+  // §6.1 authorization: only decrypt a site's key for a caller who belongs to
+  // that site. An unauthorized (or anonymous) request skips the site config
+  // entirely; on hosted it then falls through to the step-4 409, never a
+  // decrypt of another tenant's key.
+  if (!(userId && (await userCanAccessSite(db, userId, workspaceId)))) return null;
 
   const [config] = await db
     .select()


### PR DESCRIPTION
Closes the blocker from the guardrail-2 verdict on #1896 (https://github.com/RevealUIStudio/revealui/pull/1896#issuecomment-4995960826). Targets the PR branch so it merges into #1896.

## The hole

The resolver's step-2 site path decrypted `workspace_inference_configs[workspaceId].encryptedApiKey` with **no check that the requester belongs to that site**. `agent-stream.ts:174` feeds `workspaceId` from `body.workspaceId` (which overrides the membership-validated `c.get('tenant')`), so on hosted an authenticated AI-entitled account that configures **no** BYOK key of its own can post `body.workspaceId = <victim site id>` and run agents on the victim's decrypted provider key. Same §6.1 class the resolver already guards for `userId`, applied to `workspaceId`.

## The fix

`resolveSiteInferenceClient` now takes `userId` and gates the lookup on `userCanAccessSite` — `sites.ownerId === userId` OR a `site_collaborators` row. An unauthorized or anonymous request skips the site config entirely, so on hosted it falls through to the step-4 409 and **never decrypts**. Centralized in the resolver, so every current and future dispatch site inherits it.

## Tests (+3, proven red)

- a `workspaceId` the caller cannot access → 409, no decrypt, no env fallthrough;
- an authorized owner → decrypts as before;
- a null-userId request → skips the site config.

Proven red against the pre-fix resolver: both negative cases fail without the gate; the authorized case stays green. Full `resolve.test.ts` 20/20; `@revealui/ai` typecheck + Biome clean.

Once merged into #1896, the guardrail-2 blocker is cleared (the MEDIUM admin-chat audit-gap note stands separately for the author to accept or wire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)