### PR TITLE
feat(ci): security-audit label guard — auto-revoke a premature sec-review:approved

### DIFF
--- a/.github/workflows/sec-audit-label-guard.yml
+++ b/.github/workflows/sec-audit-label-guard.yml
@@ -1,0 +1,106 @@
+# Security-audit label guard — server-side companion to the harness
+# sec-review audit gate.
+#
+# The clearance label `sec-review:approved` may only stand while the PR's
+# security audit is green. The harness hook withholds the label at APPLY time
+# for commands run through a session; this catches the out-of-band case — the
+# label applied from a terminal, or an audit that goes RED after the label was
+# added — by REVOKING a premature label and commenting why.
+#
+# CONSERVATIVE: revokes only on a definitive audit FAILURE (never pending /
+# missing / cancelled), so it cannot false-revoke during the audit's in-flight
+# window. Deterministic (check conclusions only, no model) — keeps ADR
+# 2026-07-10-automated-security-review-eval condition 4 (additive-to-CI) intact.
+#
+# Overrides (ADR condition 9): repo variable SEC_AUDIT_GATE_DISABLED='true' is
+# the kill switch; the per-PR label `sec-audit-override` exempts one PR.
+
+name: Security Audit Label Guard
+
+on:
+  pull_request:
+    branches: [test, main]
+    types: [labeled]
+  check_suite:
+    types: [completed]
+
+concurrency:
+  group: sec-audit-label-guard-${{ github.event.pull_request.number || github.event.check_suite.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: write
+
+jobs:
+  guard:
+    name: Security audit label guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            scripts/validate/sec-audit-label-decision.cjs
+          sparse-checkout-cone-mode: false
+
+      - name: Guard the clearance label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          KILL_SWITCH: ${{ vars.SEC_AUDIT_GATE_DISABLED }}
+        run: |
+          set -euo pipefail
+          KILL=false
+          if [ "${KILL_SWITCH:-}" = "true" ]; then KILL=true; fi
+
+          # PR numbers from whichever event fired, read from the event payload
+          # (a labeled event carries .pull_request; a check_suite carries
+          # .check_suite.pull_requests[]). De-duplicated, blanks dropped.
+          prs=$(jq -r '(.pull_request.number // empty), (.check_suite.pull_requests[]?.number // empty)' \
+            "$GITHUB_EVENT_PATH" | grep -E '^[0-9]+$' | sort -u || true)
+          if [ -z "$prs" ]; then
+            echo "No associated PR — nothing to guard."
+            exit 0
+          fi
+
+          for pr in $prs; do
+            echo "::group::PR #$pr"
+            state=$(gh pr view "$pr" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "")
+            if [ "$state" != "OPEN" ]; then
+              echo "PR #$pr is not open ($state) — skip."; echo "::endgroup::"; continue
+            fi
+
+            sha=$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq '.headRefOid')
+            labels=$(gh pr view "$pr" --repo "$REPO" --json labels --jq '[.labels[].name]')
+            checks=$(gh api "repos/$REPO/commits/$sha/check-runs" --paginate \
+              --jq '[.check_runs[] | {name: .name, conclusion: .conclusion, status: .status}]' \
+              | jq -s 'add // []')
+
+            payload=$(jq -n \
+              --argjson checkRuns "$checks" \
+              --argjson labels "$labels" \
+              --argjson killSwitch "$KILL" \
+              '{checkRuns: $checkRuns, labels: $labels, killSwitch: $killSwitch}')
+
+            decision=$(printf '%s' "$payload" | node scripts/validate/sec-audit-label-decision.cjs)
+            action=$(printf '%s' "$decision" | awk '{print $1}')
+            reason=$(printf '%s' "$decision" | cut -d' ' -f2-)
+            echo "decision: $action — $reason"
+
+            if [ "$action" = "revoke" ]; then
+              gh pr edit "$pr" --repo "$REPO" --remove-label "sec-review:approved"
+              body=$(printf '%s\n' \
+                "🔒 **sec-review:approved was removed by the security-audit label guard.**" \
+                "" \
+                "Reason: $reason" \
+                "" \
+                "The clearance label may only stand while the security audit is green on the current head. Re-apply it once the failing check(s) pass. It is deterministic (check conclusions only) and additive — never merges around a required check, only withholds a premature approval." \
+                "" \
+                "Overrides: apply the \`sec-audit-override\` label to exempt this PR, or set the repo variable \`SEC_AUDIT_GATE_DISABLED=true\` as a kill switch.")
+              gh pr comment "$pr" --repo "$REPO" --body "$body"
+              echo "Removed sec-review:approved from PR #$pr."
+            fi
+            echo "::endgroup::"
+          done

--- a/scripts/validate/__tests__/sec-audit-label-decision.test.ts
+++ b/scripts/validate/__tests__/sec-audit-label-decision.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+const {
+  decide,
+  checkState,
+  CLEAR_LABEL,
+  OVERRIDE_LABEL,
+} = require('../sec-audit-label-decision.cjs');
+
+const green = (name: string) => ({ name, conclusion: 'SUCCESS', status: 'COMPLETED' });
+const red = (name: string) => ({ name, conclusion: 'FAILURE', status: 'COMPLETED' });
+const pending = (name: string) => ({ name, conclusion: null, status: 'IN_PROGRESS' });
+const cancelled = (name: string) => ({ name, conclusion: 'CANCELLED', status: 'COMPLETED' });
+
+const ALL = ['Security Gate', 'CodeQL', 'Secret Scanning (Gitleaks)', 'Dependency Review'];
+const allGreen = () => ALL.map(green);
+
+describe('checkState', () => {
+  it('green when a SUCCESS entry exists', () => {
+    expect(checkState([green('CodeQL')], 'CodeQL')).toBe('ok');
+  });
+  it('failing on a definitive failure', () => {
+    expect(checkState([red('CodeQL')], 'CodeQL')).toBe('failing');
+  });
+  it('missing when the check is absent', () => {
+    expect(checkState([green('Other')], 'CodeQL')).toBe('missing');
+  });
+  it('pending when in progress', () => {
+    expect(checkState([pending('CodeQL')], 'CodeQL')).toBe('pending');
+  });
+  it('cancelled-alongside-success is ok, not failing (fleet superseded rule)', () => {
+    expect(checkState([cancelled('CodeQL'), green('CodeQL')], 'CodeQL')).toBe('ok');
+  });
+  it('failure-alongside-success still fails', () => {
+    expect(checkState([green('CodeQL'), red('CodeQL')], 'CodeQL')).toBe('failing');
+  });
+});
+
+describe('decide', () => {
+  it('REVOKES when the label is present and an audit check is failing', () => {
+    const r = decide({
+      checkRuns: [...allGreen().slice(0, 3), red('Dependency Review')],
+      labels: [CLEAR_LABEL],
+    });
+    expect(r.action).toBe('revoke');
+    expect(r.reason).toContain('Dependency Review');
+  });
+  it('SKIPS (never revokes) when the audit is fully green', () => {
+    expect(decide({ checkRuns: allGreen(), labels: [CLEAR_LABEL] }).action).toBe('skip');
+  });
+  it('SKIPS a pending audit — no false revoke during the in-flight window', () => {
+    const runs = [...allGreen().slice(0, 3), pending('Dependency Review')];
+    expect(decide({ checkRuns: runs, labels: [CLEAR_LABEL] }).action).toBe('skip');
+  });
+  it('SKIPS a missing audit check (conservative)', () => {
+    expect(decide({ checkRuns: allGreen().slice(0, 3), labels: [CLEAR_LABEL] }).action).toBe(
+      'skip',
+    );
+  });
+  it('SKIPS when the clearance label is not present', () => {
+    expect(decide({ checkRuns: [red('CodeQL')], labels: ['bug'] }).action).toBe('skip');
+  });
+  it('SKIPS when the per-PR override label is present, even with a red audit', () => {
+    const r = decide({ checkRuns: [red('CodeQL')], labels: [CLEAR_LABEL, OVERRIDE_LABEL] });
+    expect(r.action).toBe('skip');
+    expect(r.reason).toContain('override');
+  });
+  it('SKIPS when the kill switch is set, even with a red audit', () => {
+    expect(
+      decide({ checkRuns: [red('CodeQL')], labels: [CLEAR_LABEL], killSwitch: true }).action,
+    ).toBe('skip');
+  });
+  it('accepts GitHub label objects, not just strings', () => {
+    const r = decide({ checkRuns: [red('CodeQL')], labels: [{ name: CLEAR_LABEL }] });
+    expect(r.action).toBe('revoke');
+  });
+});

--- a/scripts/validate/sec-audit-label-decision.cjs
+++ b/scripts/validate/sec-audit-label-decision.cjs
@@ -1,0 +1,105 @@
+"use strict";
+// sec-audit-label-decision.cjs — decides whether a PR's `sec-review:approved`
+// clearance label must be REVOKED because the security audit is failing.
+//
+// The server-side companion to the harness sec-review audit gate: the harness
+// gate withholds the label at apply time for commands run through a session;
+// this catches the out-of-band case (label applied from a terminal, or an audit
+// that goes red AFTER the label was added). Together they make the approval
+// sign-off mean "the audit passed".
+//
+// CONSERVATIVE BY DESIGN: revokes ONLY on a definitive audit FAILURE, never on
+// pending / missing / cancelled — so it cannot false-revoke a legitimate label
+// during the audit's in-flight window (and merge is already blocked by the
+// required checks in those states anyway). Deterministic: check conclusions
+// only, no model (keeps ADR 2026-07-10 condition 4 — additive-to-CI — intact).
+//
+// Pure `decide()` / `checkState()` are unit-tested; the thin CLI reads a JSON
+// { checkRuns, labels, killSwitch } from stdin and prints "revoke <reason>" or
+// "skip <reason>" for the workflow to act on. Zero deps, zero authored regex.
+
+const REQUIRED_AUDIT_CHECKS = [
+  "Security Gate",
+  "CodeQL",
+  "Secret Scanning (Gitleaks)",
+  "Dependency Review",
+];
+const CLEAR_LABEL = "sec-review:approved";
+const OVERRIDE_LABEL = "sec-audit-override";
+
+// Definitive failures only. CANCELLED / SKIPPED / null are NOT here — a
+// cancelled run is usually a superseded duplicate (fleet rule), and treating it
+// as a failure would false-revoke.
+const FAILING = new Set([
+  "FAILURE",
+  "TIMED_OUT",
+  "ACTION_REQUIRED",
+  "STARTUP_FAILURE",
+  "ERROR",
+]);
+
+// checkRuns: array of { name, conclusion, status } (GitHub check-run shape).
+// Returns "missing" | "failing" | "ok" | "pending" for one required check name.
+function checkState(checkRuns, name) {
+  const entries = (checkRuns || []).filter((c) => c && c.name === name);
+  if (entries.length === 0) return "missing";
+  if (entries.some((c) => FAILING.has(c.conclusion))) return "failing";
+  if (entries.some((c) => c.conclusion === "SUCCESS")) return "ok";
+  return "pending";
+}
+
+// Returns { action: "revoke" | "skip", reason: string }.
+function decide(input) {
+  const checkRuns = (input && input.checkRuns) || [];
+  const labels = ((input && input.labels) || []).map((l) =>
+    typeof l === "string" ? l : (l && l.name) || ""
+  );
+  const killSwitch = Boolean(input && input.killSwitch);
+
+  if (killSwitch) {
+    return { action: "skip", reason: "kill switch set (SEC_AUDIT_GATE_DISABLED)" };
+  }
+  const labelSet = new Set(labels);
+  if (!labelSet.has(CLEAR_LABEL)) {
+    return { action: "skip", reason: "no clearance label present" };
+  }
+  if (labelSet.has(OVERRIDE_LABEL)) {
+    return { action: "skip", reason: `per-PR override label '${OVERRIDE_LABEL}' present` };
+  }
+  const failing = REQUIRED_AUDIT_CHECKS.filter(
+    (n) => checkState(checkRuns, n) === "failing"
+  );
+  if (failing.length > 0) {
+    return { action: "revoke", reason: `security audit failing: ${failing.join(", ")}` };
+  }
+  return { action: "skip", reason: "audit not failing (green or in-flight)" };
+}
+
+module.exports = {
+  decide,
+  checkState,
+  REQUIRED_AUDIT_CHECKS,
+  CLEAR_LABEL,
+  OVERRIDE_LABEL,
+};
+
+// CLI: node sec-audit-label-decision.cjs  <  {"checkRuns":[...],"labels":[...],"killSwitch":false}
+if (require.main === module) {
+  let raw = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (d) => {
+    raw += d;
+  });
+  process.stdin.on("end", () => {
+    let input;
+    try {
+      input = JSON.parse(raw || "{}");
+    } catch {
+      // Fail-safe for the ACTION: on unparseable input, do NOT revoke.
+      process.stdout.write("skip could-not-parse-input\n");
+      return;
+    }
+    const { action, reason } = decide(input);
+    process.stdout.write(`${action} ${reason}\n`);
+  });
+}


### PR DESCRIPTION
Server-side companion to the harness sec-review audit gate (owner directive 2026-07-16, "proceed as recommended"). Closes the one bypass the harness hook cannot see: a `sec-review:approved` label applied from a terminal, or an audit that goes red *after* the label was added.

## What it does
A GitHub Action on `pull_request: [labeled]` (catches label-added-while-red) and `check_suite: [completed]` (catches audit-goes-red-after-label). For each affected open PR it reads the required audit checks (`Security Gate`, `CodeQL`, `Secret Scanning (Gitleaks)`, `Dependency Review`) on the current head and, if any is **definitively failing**, removes `sec-review:approved` and comments why.

## Design
- **Conservative — revokes ONLY on a definitive FAILURE**, never on pending / missing / cancelled, so it cannot false-revoke during the audit's in-flight window (and merge is already blocked by the required checks in those states). Cancelled-alongside-success is treated as green (fleet superseded rule).
- **Deterministic** (check conclusions only, no model) — keeps ADR `2026-07-10-automated-security-review-eval` condition 4 (additive-to-CI) intact; it can only *withhold* a premature approval, never merge around a check.
- **Overrides (ADR condition 9):** repo variable `SEC_AUDIT_GATE_DISABLED=true` (kill switch); per-PR label `sec-audit-override` (exempt one PR).
- Pure `decide()` / `checkState()` in `scripts/validate/sec-audit-label-decision.cjs` (zero deps, zero authored regex, matches the `security-review-gate.cjs` pattern); side effects live in the workflow. **14/14 unit tests** incl. cancelled-alongside-success, override, kill-switch, and fail-safe-on-bad-input (bad input → skip, never a spurious revoke).

## Notes for the reviewer/owner
- The fleet `security-pr-review-check.js` reports this PR as **not** security-sensitive — because `.github/workflows/` and `scripts/validate/` are absent from `SECURITY_PATHS`. That means **changes to the security enforcement machinery itself currently bypass guardrail-2** — a real classification gap worth widening (separate item; flagged here so it's not lost). I labeled this `area:security` manually.
- Companion to the harness gate shipped in claude-config; design recorded in `.jv` lane `automated-security-review-eval` (Addendum 2026-07-16).
- Blast radius of a bug is a false-revoke (UX annoyance), never an insecure merge — it only removes clearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)