### PR TITLE
refactor(setup,mcp): extract shared revvault CLI client

### DIFF
--- a/.changeset/revvault-shared-client.md
+++ b/.changeset/revvault-shared-client.md
@@ -1,0 +1,14 @@
+---
+"@revealui/setup": minor
+"@revealui/mcp": patch
+---
+
+Add a shared `revvault` CLI client at `@revealui/setup/revvault`, consolidating
+the six hand-rolled `revvault` spawn implementations across the MCP OAuth
+provider and the setup/admin/probe scripts into one module. Adds a fail-fast
+`requireRevvaultSecret` helper that throws naming the exact vault path when a
+secret is missing, alongside tolerant (`readRevvaultSecret`) and write
+(`writeRevvaultSecret`, `revvaultSecretExists`) variants for scripts that
+previously reimplemented their own spawn + error handling. `@revealui/mcp`'s
+OAuth provider now consumes the shared client with no change to its public
+API or behavior.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@playwright/test": "catalog:",
     "@revealui/core": "workspace:*",
     "@revealui/services": "workspace:*",
+    "@revealui/setup": "workspace:*",
     "@size-limit/file": "^12.1.0",
     "@size-limit/webpack": "^12.1.0",
     "@stripe/mcp": "^0.3.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -16,6 +16,7 @@
     "@revealui/db": "workspace:*",
     "@revealui/knowledge-graph": "workspace:*",
     "@revealui/security": "workspace:*",
+    "@revealui/setup": "workspace:*",
     "dotenv": "catalog:",
     "jose": "catalog:"
   },

--- a/packages/mcp/src/oauth.ts
+++ b/packages/mcp/src/oauth.ts
@@ -38,9 +38,6 @@
  *      `saveTokens` verbatim.
  */
 
-import { spawn } from 'node:child_process';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 import type {
   OAuthClientInformation,
@@ -49,198 +46,21 @@ import type {
   OAuthClientMetadata,
   OAuthTokens,
 } from '@modelcontextprotocol/sdk/shared/auth.js';
+import {
+  createMemoryVault,
+  createRevvaultVault,
+  RevvaultError,
+  type RevvaultVaultOptions,
+  type Vault,
+} from '@revealui/setup/revvault';
 
-// ---------------------------------------------------------------------------
-// Vault interface (pluggable KV for provider state)
-// ---------------------------------------------------------------------------
-
-/**
- * Minimal key/value interface the provider needs from its backing store.
- *
- * Keys are revvault-style slash-delimited paths (e.g. `mcp/acme/linear/tokens`).
- * Values are opaque strings; the provider JSON-encodes structured values
- * before calling `set`.
- */
-export interface Vault {
-  /** Returns the value at `path`, or `undefined` if not present. */
-  get(path: string): Promise<string | undefined>;
-  /** Stores `value` at `path`, overwriting any prior value. */
-  set(path: string, value: string): Promise<void>;
-  /** Deletes the value at `path`. No-op if not present. */
-  delete(path: string): Promise<void>;
-  /**
-   * Lists every path that starts with `prefix`. Returns an empty array when
-   * no matches exist. The return order is implementation-defined.
-   *
-   * Used by admin catalog tooling to enumerate configured servers without
-   * requiring an out-of-band registry.
-   */
-  list(prefix: string): Promise<string[]>;
-}
-
-// ---------------------------------------------------------------------------
-// Revvault-backed vault (default)
-// ---------------------------------------------------------------------------
-
-export interface RevvaultVaultOptions {
-  /** Path to the `revvault` binary. Defaults to `~/.local/bin/revvault`. */
-  binPath?: string;
-  /**
-   * Age identity path. Passed via `REVVAULT_IDENTITY` env var. Defaults to
-   * `~/.config/age/keys.txt`, matching revvault's own default.
-   */
-  identityPath?: string;
-  /** Spawn timeout in ms. Defaults to 10_000. */
-  timeoutMs?: number;
-}
-
-/**
- * Creates a {@link Vault} backed by the `revvault` CLI. Requires `revvault` to
- * be installed on the host and the age identity to be readable.
- *
- * Production default for RevealUI deployments. In CI or test environments
- * without revvault, prefer {@link createMemoryVault}.
- */
-export function createRevvaultVault(options: RevvaultVaultOptions = {}): Vault {
-  const binPath = options.binPath ?? join(homedir(), '.local/bin/revvault');
-  const identityPath =
-    options.identityPath ??
-    process.env.REVVAULT_IDENTITY ??
-    join(homedir(), '.config/age/keys.txt');
-  const timeoutMs = options.timeoutMs ?? 10_000;
-
-  const env = { ...process.env, REVVAULT_IDENTITY: identityPath };
-
-  const run = (
-    args: string[],
-    stdin?: string,
-  ): Promise<{ code: number | null; stdout: string; stderr: string }> =>
-    new Promise((resolve, reject) => {
-      const child = spawn(binPath, args, { env, timeout: timeoutMs });
-      let stdout = '';
-      let stderr = '';
-      child.stdout.setEncoding('utf8');
-      child.stderr.setEncoding('utf8');
-      child.stdout.on('data', (chunk: string) => {
-        stdout += chunk;
-      });
-      child.stderr.on('data', (chunk: string) => {
-        stderr += chunk;
-      });
-      child.on('error', reject);
-      child.on('close', (code) => {
-        resolve({ code, stdout, stderr });
-      });
-      if (stdin !== undefined) {
-        child.stdin.end(stdin);
-      } else {
-        child.stdin.end();
-      }
-    });
-
-  return {
-    async get(path) {
-      assertSafePath(path);
-      const { code, stdout, stderr } = await run(['get', '--full', path]);
-      if (code !== 0) {
-        throw new RevvaultError(`revvault get exited ${code}: ${stderr.trim()}`);
-      }
-      if (stdout.length === 0 && /not found/i.test(stderr)) {
-        return undefined;
-      }
-      if (stdout.length === 0) {
-        throw new RevvaultError(`revvault get returned empty output: ${stderr.trim()}`);
-      }
-      return stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
-    },
-    async set(path, value) {
-      assertSafePath(path);
-      const { code, stderr } = await run(['set', '--force', path], value);
-      if (code !== 0) {
-        throw new RevvaultError(`revvault set exited ${code}: ${stderr.trim()}`);
-      }
-    },
-    async delete(path) {
-      assertSafePath(path);
-      const { code, stderr } = await run(['delete', '--force', path]);
-      if (code !== 0 && !/not found/i.test(stderr)) {
-        throw new RevvaultError(`revvault delete exited ${code}: ${stderr.trim()}`);
-      }
-    },
-    async list(prefix) {
-      assertSafePrefix(prefix);
-      const { code, stdout, stderr } = await run(['list', prefix]);
-      if (code !== 0) {
-        throw new RevvaultError(`revvault list exited ${code}: ${stderr.trim()}`);
-      }
-      // `revvault list` emits one path per line. Empty / informational output
-      // (e.g. `No secrets found.`) returns an empty array.
-      return stdout
-        .split('\n')
-        .map((line) => line.trim())
-        .filter((line) => line.length > 0 && line.startsWith(prefix));
-    },
-  };
-}
-
-/** Reject shell-metacharacter and traversal patterns in vault paths. */
-function assertSafePath(path: string): void {
-  if (!/^[A-Za-z0-9/_\-.]+$/.test(path)) {
-    throw new RevvaultError(`Vault path contains disallowed characters: ${path}`);
-  }
-  if (path.includes('..') || path.startsWith('/') || path.endsWith('/')) {
-    throw new RevvaultError(`Vault path is not well-formed: ${path}`);
-  }
-}
-
-/** Same rules as {@link assertSafePath} but allows the trailing slash of a prefix. */
-function assertSafePrefix(prefix: string): void {
-  if (!/^[A-Za-z0-9/_\-.]+$/.test(prefix)) {
-    throw new RevvaultError(`Vault prefix contains disallowed characters: ${prefix}`);
-  }
-  if (prefix.includes('..') || prefix.startsWith('/')) {
-    throw new RevvaultError(`Vault prefix is not well-formed: ${prefix}`);
-  }
-}
-
-export class RevvaultError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'RevvaultError';
-  }
-}
-
-// ---------------------------------------------------------------------------
-// In-memory vault (tests / ephemeral flows)
-// ---------------------------------------------------------------------------
-
-/**
- * Creates an in-memory {@link Vault} backed by a `Map`. Intended for tests and
- * for short-lived processes where persistence is not required.
- *
- * An optional `seed` object prepopulates the map.
- */
-export function createMemoryVault(seed?: Record<string, string>): Vault {
-  const store = new Map<string, string>(seed ? Object.entries(seed) : undefined);
-  return {
-    async get(path) {
-      return store.get(path);
-    },
-    async set(path, value) {
-      store.set(path, value);
-    },
-    async delete(path) {
-      store.delete(path);
-    },
-    async list(prefix) {
-      const out: string[] = [];
-      for (const key of store.keys()) {
-        if (key.startsWith(prefix)) out.push(key);
-      }
-      return out;
-    },
-  };
-}
+export {
+  createMemoryVault,
+  createRevvaultVault,
+  RevvaultError,
+  type RevvaultVaultOptions,
+  type Vault,
+};
 
 // ---------------------------------------------------------------------------
 // Path layout

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -58,6 +58,10 @@
     "./system-tune": {
       "types": "./dist/system-tune/index.d.ts",
       "import": "./dist/system-tune/index.js"
+    },
+    "./revvault": {
+      "types": "./dist/revvault/index.d.ts",
+      "import": "./dist/revvault/index.js"
     }
   },
   "files": [

--- a/packages/setup/src/__tests__/revvault.test.ts
+++ b/packages/setup/src/__tests__/revvault.test.ts
@@ -89,6 +89,11 @@ describe('assertSafePath / assertSafePrefix', () => {
     expect(() => assertSafePrefix('mcp/acme/')).not.toThrow();
     expect(() => assertSafePrefix('/mcp/acme')).toThrow(RevvaultError);
   });
+
+  it('rejects empty strings (the pre-extraction anchored pattern required 1+ chars; an empty prefix would list the whole vault)', () => {
+    expect(() => assertSafePath('')).toThrow(RevvaultError);
+    expect(() => assertSafePrefix('')).toThrow(RevvaultError);
+  });
 });
 
 describe('readRevvaultSecret', () => {

--- a/packages/setup/src/__tests__/revvault.test.ts
+++ b/packages/setup/src/__tests__/revvault.test.ts
@@ -1,0 +1,219 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnSyncMock = vi.fn();
+const spawnMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+import {
+  assertSafePath,
+  assertSafePrefix,
+  createMemoryVault,
+  createRevvaultVault,
+  RevvaultError,
+  readRevvaultSecret,
+  requireRevvaultSecret,
+  revvaultSecretExists,
+  writeRevvaultSecret,
+} from '../revvault/index.js';
+
+function fakeSpawnSyncResult(overrides: {
+  status?: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: Error;
+}): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+} {
+  return {
+    status: overrides.status ?? 0,
+    stdout: overrides.stdout ?? '',
+    stderr: overrides.stderr ?? '',
+    error: overrides.error,
+  };
+}
+
+/** Minimal stand-in for a Readable stream: just enough for `spawn`'s usage. */
+class FakeReadable extends EventEmitter {
+  setEncoding = vi.fn();
+}
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new FakeReadable();
+  stderr = new FakeReadable();
+  stdin = { end: vi.fn() };
+
+  emitStdout(chunk: string): void {
+    this.stdout.emit('data', chunk);
+  }
+
+  emitStderr(chunk: string): void {
+    this.stderr.emit('data', chunk);
+  }
+
+  close(code: number | null): void {
+    this.emit('close', code);
+  }
+}
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+  spawnMock.mockReset();
+});
+
+describe('assertSafePath / assertSafePrefix', () => {
+  it('accepts well-formed slash-delimited paths', () => {
+    expect(() => assertSafePath('mcp/acme/linear/tokens')).not.toThrow();
+    expect(() => assertSafePrefix('mcp/acme/')).not.toThrow();
+  });
+
+  it('rejects disallowed characters', () => {
+    expect(() => assertSafePath('mcp/acme/$(rm -rf)')).toThrow(RevvaultError);
+    expect(() => assertSafePath('mcp/acme; ls')).toThrow(RevvaultError);
+  });
+
+  it('rejects traversal and leading/trailing slashes', () => {
+    expect(() => assertSafePath('mcp/../etc/passwd')).toThrow(RevvaultError);
+    expect(() => assertSafePath('/mcp/acme')).toThrow(RevvaultError);
+    expect(() => assertSafePath('mcp/acme/')).toThrow(RevvaultError);
+  });
+
+  it('assertSafePrefix allows a trailing slash', () => {
+    expect(() => assertSafePrefix('mcp/acme/')).not.toThrow();
+    expect(() => assertSafePrefix('/mcp/acme')).toThrow(RevvaultError);
+  });
+});
+
+describe('readRevvaultSecret', () => {
+  it('returns the value on success, stripping one trailing newline', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 0, stdout: 'sekret\n' }));
+    expect(readRevvaultSecret('revealui/dev/foo')).toBe('sekret');
+  });
+
+  it('returns undefined on nonzero exit', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 1, stderr: 'not found' }));
+    expect(readRevvaultSecret('revealui/dev/missing')).toBeUndefined();
+  });
+
+  it('returns undefined on empty output', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 0, stdout: '   \n' }));
+    expect(readRevvaultSecret('revealui/dev/empty')).toBeUndefined();
+  });
+
+  it('returns undefined when the binary itself fails to spawn', () => {
+    spawnSyncMock.mockReturnValue(
+      fakeSpawnSyncResult({ status: null, error: new Error('ENOENT') }),
+    );
+    expect(readRevvaultSecret('revealui/dev/foo')).toBeUndefined();
+  });
+});
+
+describe('requireRevvaultSecret', () => {
+  it('returns the value on success', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 0, stdout: 'sekret\n' }));
+    expect(requireRevvaultSecret('revealui/prod/foo')).toBe('sekret');
+  });
+
+  it('throws a RevvaultError naming the exact path when missing', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 1, stderr: 'not found' }));
+    expect(() => requireRevvaultSecret('revealui/prod/missing-thing')).toThrow(RevvaultError);
+    try {
+      requireRevvaultSecret('revealui/prod/missing-thing');
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(RevvaultError);
+      expect((err as Error).message).toContain('revealui/prod/missing-thing');
+      expect((err as Error).message).toContain('revvault set revealui/prod/missing-thing');
+    }
+  });
+});
+
+describe('writeRevvaultSecret', () => {
+  it('succeeds on exit code 0', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 0 }));
+    expect(() => writeRevvaultSecret('revealui/prod/foo', 'value')).not.toThrow();
+  });
+
+  it('throws RevvaultError on nonzero exit', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 1, stderr: 'locked store' }));
+    expect(() => writeRevvaultSecret('revealui/prod/foo', 'value')).toThrow(RevvaultError);
+  });
+});
+
+describe('revvaultSecretExists', () => {
+  it('is true on exit code 0, false otherwise', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 0 }));
+    expect(revvaultSecretExists('revealui/staging/kek')).toBe(true);
+
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 1 }));
+    expect(revvaultSecretExists('revealui/staging/kek')).toBe(false);
+  });
+
+  it('calls `get` without `--full`, matching the existence-check convention', () => {
+    spawnSyncMock.mockReturnValue(fakeSpawnSyncResult({ status: 0 }));
+    revvaultSecretExists('revealui/staging/kek');
+    const [, args] = spawnSyncMock.mock.calls[0] as [string, string[]];
+    expect(args).toEqual(['get', 'revealui/staging/kek']);
+  });
+});
+
+describe('createRevvaultVault', () => {
+  function nextChild(): FakeChildProcess {
+    const child = new FakeChildProcess();
+    spawnMock.mockReturnValueOnce(child);
+    return child;
+  }
+
+  it('get() returns the stored value', async () => {
+    const vault = createRevvaultVault();
+    const child = nextChild();
+    const promise = vault.get('mcp/acme/linear/tokens');
+    child.emitStdout('{"access":"tok"}\n');
+    child.close(0);
+    await expect(promise).resolves.toBe('{"access":"tok"}');
+  });
+
+  it('get() returns undefined when revvault reports not found (exit 0, empty stdout)', async () => {
+    const vault = createRevvaultVault();
+    const child = nextChild();
+    const promise = vault.get('mcp/acme/linear/tokens');
+    child.emitStderr('secret not found');
+    child.close(0);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('set() rejects on nonzero exit', async () => {
+    const vault = createRevvaultVault();
+    const child = nextChild();
+    const promise = vault.set('mcp/acme/linear/tokens', 'value');
+    child.emitStderr('locked');
+    child.close(1);
+    await expect(promise).rejects.toThrow(RevvaultError);
+  });
+
+  it('rejects an unsafe path before ever spawning', async () => {
+    const vault = createRevvaultVault();
+    await expect(vault.get('../etc/passwd')).rejects.toThrow(RevvaultError);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('createMemoryVault', () => {
+  it('supports get/set/delete/list round-trip', async () => {
+    const vault = createMemoryVault({ 'mcp/acme/linear/tokens': 'seed' });
+    expect(await vault.get('mcp/acme/linear/tokens')).toBe('seed');
+    await vault.set('mcp/acme/linear/client', 'client-info');
+    expect(await vault.list('mcp/acme/linear/')).toEqual(
+      expect.arrayContaining(['mcp/acme/linear/tokens', 'mcp/acme/linear/client']),
+    );
+    await vault.delete('mcp/acme/linear/tokens');
+    expect(await vault.get('mcp/acme/linear/tokens')).toBeUndefined();
+  });
+});

--- a/packages/setup/src/index.ts
+++ b/packages/setup/src/index.ts
@@ -12,6 +12,8 @@
 export * from './bootstrap/index.js';
 // Environment setup
 export * from './environment/index.js';
+// Shared revvault CLI client
+export * from './revvault/index.js';
 // System Tune (hardware-aware auto-config)
 export * from './system-tune/index.js';
 // Utilities

--- a/packages/setup/src/revvault/index.ts
+++ b/packages/setup/src/revvault/index.ts
@@ -1,0 +1,332 @@
+/**
+ * Shared `revvault` CLI client.
+ *
+ * Consolidates the revvault-invocation logic that used to be hand-rolled at
+ * every call site (an async `Vault` for long-lived processes like the MCP
+ * OAuth provider, plus sync helpers for one-shot CLI scripts). Every caller
+ * gets the same path-safety guard, the same default binary/identity
+ * resolution, and the same `RevvaultError` shape.
+ *
+ * Two API surfaces, because the two consumer shapes are genuinely different:
+ *   - {@link createRevvaultVault} — an async `Vault` (get/set/delete/list),
+ *     for long-lived processes that need the full CRUD surface (e.g. the MCP
+ *     OAuth provider's token storage).
+ *   - {@link readRevvaultSecret} / {@link requireRevvaultSecret} /
+ *     {@link writeRevvaultSecret} / {@link revvaultSecretExists} — sync
+ *     one-shot lookups, for CLI scripts that read a handful of secrets and
+ *     exit. Sync matches how every script call site already used
+ *     `spawnSync`/`execFileSync`.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Shared constants + errors
+// ---------------------------------------------------------------------------
+
+const DEFAULT_BIN_PATH = join(homedir(), '.local/bin/revvault');
+const DEFAULT_IDENTITY_PATH = join(homedir(), '.config/age/keys.txt');
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export class RevvaultError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RevvaultError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path safety (no-regex: explicit charset walk instead of a pattern test)
+// ---------------------------------------------------------------------------
+
+const SAFE_PATH_CHARS = new Set(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/_-.'.split(''),
+);
+
+function hasOnlySafePathChars(value: string): boolean {
+  for (const char of value) {
+    if (!SAFE_PATH_CHARS.has(char)) return false;
+  }
+  return true;
+}
+
+/** Reject shell-metacharacter and traversal patterns in vault paths. */
+export function assertSafePath(path: string): void {
+  if (!hasOnlySafePathChars(path)) {
+    throw new RevvaultError(`Vault path contains disallowed characters: ${path}`);
+  }
+  if (path.includes('..') || path.startsWith('/') || path.endsWith('/')) {
+    throw new RevvaultError(`Vault path is not well-formed: ${path}`);
+  }
+}
+
+/** Same rules as {@link assertSafePath} but allows the trailing slash of a prefix. */
+export function assertSafePrefix(prefix: string): void {
+  if (!hasOnlySafePathChars(prefix)) {
+    throw new RevvaultError(`Vault prefix contains disallowed characters: ${prefix}`);
+  }
+  if (prefix.includes('..') || prefix.startsWith('/')) {
+    throw new RevvaultError(`Vault prefix is not well-formed: ${prefix}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Async Vault (long-lived processes, e.g. MCP OAuth token storage)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal key/value interface a caller needs from its backing store.
+ *
+ * Keys are revvault-style slash-delimited paths (e.g. `mcp/acme/linear/tokens`).
+ * Values are opaque strings; callers JSON-encode structured values before
+ * calling `set`.
+ */
+export interface Vault {
+  /** Returns the value at `path`, or `undefined` if not present. */
+  get(path: string): Promise<string | undefined>;
+  /** Stores `value` at `path`, overwriting any prior value. */
+  set(path: string, value: string): Promise<void>;
+  /** Deletes the value at `path`. No-op if not present. */
+  delete(path: string): Promise<void>;
+  /**
+   * Lists every path that starts with `prefix`. Returns an empty array when
+   * no matches exist. The return order is implementation-defined.
+   */
+  list(prefix: string): Promise<string[]>;
+}
+
+export interface RevvaultVaultOptions {
+  /** Path to the `revvault` binary. Defaults to `~/.local/bin/revvault`. */
+  binPath?: string;
+  /**
+   * Age identity path. Passed via `REVVAULT_IDENTITY` env var. Defaults to
+   * `~/.config/age/keys.txt`, matching revvault's own default.
+   */
+  identityPath?: string;
+  /** Spawn timeout in ms. Defaults to 10_000. */
+  timeoutMs?: number;
+}
+
+/**
+ * Creates a {@link Vault} backed by the `revvault` CLI. Requires `revvault` to
+ * be installed on the host and the age identity to be readable.
+ *
+ * Production default for RevealUI deployments. In CI or test environments
+ * without revvault, prefer {@link createMemoryVault}.
+ */
+export function createRevvaultVault(options: RevvaultVaultOptions = {}): Vault {
+  const binPath = options.binPath ?? DEFAULT_BIN_PATH;
+  const identityPath =
+    options.identityPath ?? process.env.REVVAULT_IDENTITY ?? DEFAULT_IDENTITY_PATH;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const env = { ...process.env, REVVAULT_IDENTITY: identityPath };
+
+  const run = (
+    args: string[],
+    stdin?: string,
+  ): Promise<{ code: number | null; stdout: string; stderr: string }> =>
+    new Promise((resolve, reject) => {
+      const child = spawn(binPath, args, { env, timeout: timeoutMs });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        resolve({ code, stdout, stderr });
+      });
+      if (stdin !== undefined) {
+        child.stdin.end(stdin);
+      } else {
+        child.stdin.end();
+      }
+    });
+
+  return {
+    async get(path) {
+      assertSafePath(path);
+      const { code, stdout, stderr } = await run(['get', '--full', path]);
+      if (code !== 0) {
+        throw new RevvaultError(`revvault get exited ${code}: ${stderr.trim()}`);
+      }
+      if (stdout.length === 0 && stderr.toLowerCase().includes('not found')) {
+        return undefined;
+      }
+      if (stdout.length === 0) {
+        throw new RevvaultError(`revvault get returned empty output: ${stderr.trim()}`);
+      }
+      return stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
+    },
+    async set(path, value) {
+      assertSafePath(path);
+      const { code, stderr } = await run(['set', '--force', path], value);
+      if (code !== 0) {
+        throw new RevvaultError(`revvault set exited ${code}: ${stderr.trim()}`);
+      }
+    },
+    async delete(path) {
+      assertSafePath(path);
+      const { code, stderr } = await run(['delete', '--force', path]);
+      if (code !== 0 && !stderr.toLowerCase().includes('not found')) {
+        throw new RevvaultError(`revvault delete exited ${code}: ${stderr.trim()}`);
+      }
+    },
+    async list(prefix) {
+      assertSafePrefix(prefix);
+      const { code, stdout, stderr } = await run(['list', prefix]);
+      if (code !== 0) {
+        throw new RevvaultError(`revvault list exited ${code}: ${stderr.trim()}`);
+      }
+      // `revvault list` emits one path per line. Empty / informational output
+      // (e.g. `No secrets found.`) returns an empty array.
+      return stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && line.startsWith(prefix));
+    },
+  };
+}
+
+/**
+ * Creates an in-memory {@link Vault} backed by a `Map`. Intended for tests and
+ * for short-lived processes where persistence is not required.
+ *
+ * An optional `seed` object prepopulates the map.
+ */
+export function createMemoryVault(seed?: Record<string, string>): Vault {
+  const store = new Map<string, string>(seed ? Object.entries(seed) : undefined);
+  return {
+    async get(path) {
+      return store.get(path);
+    },
+    async set(path, value) {
+      store.set(path, value);
+    },
+    async delete(path) {
+      store.delete(path);
+    },
+    async list(prefix) {
+      const out: string[] = [];
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) out.push(key);
+      }
+      return out;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sync one-shot lookups (CLI scripts)
+// ---------------------------------------------------------------------------
+
+export interface RevvaultLookupOptions {
+  /** Path to the `revvault` binary. Defaults to `~/.local/bin/revvault`. */
+  binPath?: string;
+  /** Age identity path, passed via `REVVAULT_IDENTITY`. Defaults to `~/.config/age/keys.txt`. */
+  identityPath?: string;
+  /** Spawn timeout in ms. Defaults to 10_000. */
+  timeoutMs?: number;
+}
+
+interface SyncRunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runRevvaultSync(
+  args: string[],
+  input: string | undefined,
+  options: RevvaultLookupOptions,
+): SyncRunResult {
+  const binPath = options.binPath ?? DEFAULT_BIN_PATH;
+  const identityPath =
+    options.identityPath ?? process.env.REVVAULT_IDENTITY ?? DEFAULT_IDENTITY_PATH;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const env = { ...process.env, REVVAULT_IDENTITY: identityPath };
+
+  const result = spawnSync(binPath, args, {
+    env,
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    input,
+  });
+
+  if (result.error) {
+    return { code: null, stdout: '', stderr: result.error.message };
+  }
+  return {
+    code: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function stripTrailingNewline(value: string): string {
+  return value.endsWith('\n') ? value.slice(0, -1) : value;
+}
+
+/**
+ * Reads a secret at `path`, tolerating absence. Returns `undefined` when the
+ * secret is missing, the CLI is unavailable, or the lookup otherwise fails —
+ * callers that must not proceed without the value should use
+ * {@link requireRevvaultSecret} instead.
+ */
+export function readRevvaultSecret(
+  path: string,
+  options: RevvaultLookupOptions = {},
+): string | undefined {
+  assertSafePath(path);
+  const { code, stdout } = runRevvaultSync(['get', '--full', path], undefined, options);
+  if (code !== 0) return undefined;
+  const value = stripTrailingNewline(stdout);
+  return value.trim().length > 0 ? value : undefined;
+}
+
+/**
+ * Reads a secret at `path`, throwing a {@link RevvaultError} naming the exact
+ * path when the secret is missing (per the fleet secrets rule: a missing
+ * secret must fail loud and name the path to set).
+ */
+export function requireRevvaultSecret(path: string, options: RevvaultLookupOptions = {}): string {
+  assertSafePath(path);
+  const { code, stdout, stderr } = runRevvaultSync(['get', '--full', path], undefined, options);
+  const value = stripTrailingNewline(stdout);
+  if (code === 0 && value.trim().length > 0) return value;
+  const detail = stderr.trim().length > 0 ? stderr.trim() : 'not found';
+  throw new RevvaultError(
+    `Missing revvault secret at "${path}" (${detail}). Set it with: revvault set ${path}`,
+  );
+}
+
+/** Writes `value` to `path` via `revvault set --force`. */
+export function writeRevvaultSecret(
+  path: string,
+  value: string,
+  options: RevvaultLookupOptions = {},
+): void {
+  assertSafePath(path);
+  const { code, stderr } = runRevvaultSync(['set', '--force', path], value, options);
+  if (code !== 0) {
+    throw new RevvaultError(`revvault set exited ${code}: ${stderr.trim()}`);
+  }
+}
+
+/**
+ * Checks whether a value exists at `path` without reading it. Uses `revvault
+ * get` (no `--full`) since the caller only needs the exit code.
+ */
+export function revvaultSecretExists(path: string, options: RevvaultLookupOptions = {}): boolean {
+  assertSafePath(path);
+  const { code } = runRevvaultSync(['get', path], undefined, options);
+  return code === 0;
+}

--- a/packages/setup/src/revvault/index.ts
+++ b/packages/setup/src/revvault/index.ts
@@ -54,6 +54,9 @@ function hasOnlySafePathChars(value: string): boolean {
 
 /** Reject shell-metacharacter and traversal patterns in vault paths. */
 export function assertSafePath(path: string): void {
+  if (path.length === 0) {
+    throw new RevvaultError('Vault path must not be empty');
+  }
   if (!hasOnlySafePathChars(path)) {
     throw new RevvaultError(`Vault path contains disallowed characters: ${path}`);
   }
@@ -64,6 +67,9 @@ export function assertSafePath(path: string): void {
 
 /** Same rules as {@link assertSafePath} but allows the trailing slash of a prefix. */
 export function assertSafePrefix(prefix: string): void {
+  if (prefix.length === 0) {
+    throw new RevvaultError('Vault prefix must not be empty');
+  }
   if (!hasOnlySafePathChars(prefix)) {
     throw new RevvaultError(`Vault prefix contains disallowed characters: ${prefix}`);
   }

--- a/packages/setup/tsup.config.ts
+++ b/packages/setup/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     'validators/index': 'src/validators/index.ts',
     'bootstrap/index': 'src/bootstrap/index.ts',
     'system-tune/index': 'src/system-tune/index.ts',
+    'revvault/index': 'src/revvault/index.ts',
   },
   format: ['esm'],
   dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@revealui/services':
         specifier: workspace:*
         version: link:packages/services
+      '@revealui/setup':
+        specifier: workspace:*
+        version: link:packages/setup
       '@size-limit/file':
         specifier: ^12.1.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
@@ -1251,6 +1254,9 @@ importers:
       '@revealui/security':
         specifier: workspace:*
         version: link:../security
+      '@revealui/setup':
+        specifier: workspace:*
+        version: link:../setup
       dotenv:
         specifier: 'catalog:'
         version: 17.4.2

--- a/scripts/admin/bootstrap.ts
+++ b/scripts/admin/bootstrap.ts
@@ -21,9 +21,9 @@
  *   revealui/{env}/admin/bootstrap/force-rotate   (optional, default: true)
  */
 
-import { execFileSync } from 'node:child_process';
 import { randomFillSync, randomUUID } from 'node:crypto';
 import { hostname } from 'node:os';
+import { readRevvaultSecret, requireRevvaultSecret } from '@revealui/setup/revvault';
 
 // ---------------------------------------------------------------------------
 // Environment resolution
@@ -45,28 +45,6 @@ function resolveEnv(args: string[]): string {
 }
 
 // ---------------------------------------------------------------------------
-// Revvault integration
-// ---------------------------------------------------------------------------
-
-function revvaultGet(path: string, opts: { optional?: boolean } = {}): string | null {
-  try {
-    const result = execFileSync('revvault', ['get', '--full', path], {
-      encoding: 'utf-8',
-      timeout: 10_000,
-      // Lookups are non-interactive (stdin ignored). For optional secrets,
-      // discard revvault's stderr so a legitimately-absent secret does not
-      // print a misleading "secret not found" line. Required secrets keep
-      // stderr visible so a genuine vault failure (locked store, missing age
-      // identity) surfaces alongside this script's own guidance below.
-      stdio: ['ignore', 'pipe', opts.optional ? 'ignore' : 'inherit'],
-    });
-    return result.trim() || null;
-  } catch {
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -84,30 +62,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Read credentials from revvault
-  const email = revvaultGet(`revealui/${env}/admin/bootstrap/email`);
-  if (!email) {
-    console.error(
-      `[bootstrap] revvault path not found: revealui/${env}/admin/bootstrap/email\n` +
-        `Set it with: revvault set revealui/${env}/admin/bootstrap/email`,
-    );
-    process.exit(1);
-  }
+  // Read credentials from revvault. Required lookups throw (naming the exact
+  // path + how to set it); the top-level main().catch below prints + exits 1.
+  const email = requireRevvaultSecret(`revealui/${env}/admin/bootstrap/email`);
+  const password = requireRevvaultSecret(`revealui/${env}/admin/bootstrap/password`);
 
-  const password = revvaultGet(`revealui/${env}/admin/bootstrap/password`);
-  if (!password) {
-    console.error(
-      `[bootstrap] revvault path not found: revealui/${env}/admin/bootstrap/password\n` +
-        `Set it with: revvault set revealui/${env}/admin/bootstrap/password`,
-    );
-    process.exit(1);
-  }
-
-  const name =
-    revvaultGet(`revealui/${env}/admin/bootstrap/name`, { optional: true }) ?? 'Super Admin';
-  const forceRotateRaw = revvaultGet(`revealui/${env}/admin/bootstrap/force-rotate`, {
-    optional: true,
-  });
+  const name = readRevvaultSecret(`revealui/${env}/admin/bootstrap/name`) ?? 'Super Admin';
+  const forceRotateRaw = readRevvaultSecret(`revealui/${env}/admin/bootstrap/force-rotate`);
   const forceRotate = forceRotateRaw !== 'false'; // default true
 
   // Import bootstrap (deferred to avoid top-level DB connection)

--- a/scripts/electric-latency-probe/probe.ts
+++ b/scripts/electric-latency-probe/probe.ts
@@ -14,51 +14,34 @@
  *     pnpm exec tsx scripts/electric-latency-probe/probe.ts
  */
 
-import { spawnSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readRevvaultSecret, requireRevvaultSecret } from '@revealui/setup/revvault';
 
 // ---------------------------------------------------------------------------
 // Config — revvault is the single source of truth. No env fallback.
 // See ~/.claude/rules/secrets.md for the hard rule.
 // ---------------------------------------------------------------------------
 
-const REVVAULT_BIN =
-  process.env.REVVAULT ?? `${process.env.HOME}/suite/revvault/target/release/revvault`;
-
-interface SecretOptions {
-  optional?: boolean;
-}
-
-function revvault(path: string): string;
-function revvault(path: string, options: { optional: true }): string | null;
-function revvault(path: string, options: SecretOptions = {}): string | null {
-  const result = spawnSync(REVVAULT_BIN, ['get', '--full', path], { encoding: 'utf8' });
-  if (result.status === 0) {
-    const value = result.stdout.trimEnd();
-    if (value.length > 0) return value;
-  }
-
-  if (options.optional) return null;
-
-  console.error(`
-FAIL: revvault path not found or empty.
-  path:   '${path}'
-  binary: ${REVVAULT_BIN}
-
-Set it:
-  echo "<value>" | revvault set ${path}
+/** Required lookup with this probe's own formatted failure message + exit(1). */
+function revvault(path: string): string {
+  try {
+    return requireRevvaultSecret(path);
+  } catch (err) {
+    console.error(`
+FAIL: ${err instanceof Error ? err.message : String(err)}
 
 See scripts/electric-latency-probe/README.md for the full path list.
 `);
-  process.exit(1);
+    process.exit(1);
+  }
 }
 
 const ADMIN_BASE_URL = revvault('revealui/dev/admin-base-url');
 const ELECTRIC_SERVICE_URL = revvault('revealui/dev/electric/service-url');
 // Cookie is either pre-stored in revvault or obtained via auto-sign-in below.
-let sessionCookie = revvault('revealui/dev/admin-session-cookie', { optional: true }) ?? '';
+let sessionCookie = readRevvaultSecret('revealui/dev/admin-session-cookie') ?? '';
 
 const sessionCookieName = 'revealui-session';
 
@@ -92,9 +75,9 @@ async function autoSignIn(): Promise<string> {
   // Sign in with revvault credentials
   const adminEmail =
     process.env.PROBE_ADMIN_EMAIL ??
-    revvault('revealui/dev/admin-email', { optional: true }) ??
+    readRevvaultSecret('revealui/dev/admin-email') ??
     'founder@revealui.com';
-  const adminPassword = revvault('revealui/dev/admin-password', { optional: true });
+  const adminPassword = readRevvaultSecret('revealui/dev/admin-password');
   if (!adminPassword) {
     console.error(`
 FAIL: No valid session cookie and no admin password in revvault.

--- a/scripts/setup/credentials.ts
+++ b/scripts/setup/credentials.ts
@@ -20,16 +20,16 @@
  *   3. Environment variables already in process.env
  *
  * @dependencies
- *   node:child_process   -  spawnSync (runs revvault CLI)
- *   node:fs/promises     -  read .env fallback
- *   node:os              -  home dir for ~/.npmrc
- *   node:path            -  path joins
+ *   @revealui/setup/revvault  -  shared revvault CLI client
+ *   node:fs/promises         -  read .env fallback
+ *   node:os                  -  home dir for ~/.npmrc
+ *   node:path                -  path joins
  */
 
-import { spawnSync } from 'node:child_process';
 import { readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { readRevvaultSecret } from '@revealui/setup/revvault';
 
 // ---------------------------------------------------------------------------
 // Logger (inline  -  avoids pulling in @revealui/core/monitoring via scripts/lib)
@@ -48,8 +48,6 @@ const log = {
 // Revvault reader
 // ---------------------------------------------------------------------------
 
-const REVVAULT_BIN = join(homedir(), '.local/bin/revvault');
-const REVVAULT_IDENTITY = process.env.REVVAULT_IDENTITY ?? join(homedir(), '.config/age/keys.txt');
 const REVVAULT_SECRET_PATH = 'revealui/env/reveal-saas-dev-secrets';
 
 /**
@@ -71,16 +69,9 @@ function parseRevvaultOutput(raw: string): Record<string, string> {
 }
 
 function readFromRevvault(): Record<string, string> | null {
-  const result = spawnSync(REVVAULT_BIN, ['get', '--full', REVVAULT_SECRET_PATH], {
-    env: { ...process.env, REVVAULT_IDENTITY },
-    encoding: 'utf-8',
-    timeout: 10_000,
-  });
-
-  if (result.error || result.status !== 0) return null;
-  if (!result.stdout?.trim()) return null;
-
-  return parseRevvaultOutput(result.stdout);
+  const raw = readRevvaultSecret(REVVAULT_SECRET_PATH);
+  if (raw === undefined) return null;
+  return parseRevvaultOutput(raw);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/setup/gen-staging-secrets.ts
+++ b/scripts/setup/gen-staging-secrets.ts
@@ -54,9 +54,9 @@
  * No regex (M2): every check here is string-method / Set-based.
  */
 
-import { execFileSync, spawnSync } from 'node:child_process';
 import { generateKeyPairSync, randomBytes } from 'node:crypto';
 import { selfVerifyLicenseKeypair } from '@revealui/core/license';
+import { revvaultSecretExists, writeRevvaultSecret } from '@revealui/setup/revvault';
 
 // ─── The staging.revealui.com subtree (lane plan §The URL decision) ──────────
 const STAGING_ROOT_DOMAIN = 'staging.revealui.com';
@@ -174,15 +174,10 @@ export async function buildEntries(): Promise<SecretEntry[]> {
 export type VaultExists = (path: string) => boolean;
 export type VaultWrite = (path: string, value: string) => void;
 
-const defaultVaultExists: VaultExists = (path) => {
-  const result = spawnSync('revvault', ['get', path], { encoding: 'utf-8', timeout: 10_000 });
-  return result.status === 0;
-};
+const defaultVaultExists: VaultExists = (path) => revvaultSecretExists(path);
 
-/** Pipes `value` into `revvault set --force <path>` via stdin (never argv). */
-const defaultVaultWrite: VaultWrite = (path, value) => {
-  execFileSync('revvault', ['set', '--force', path], { input: value, encoding: 'utf-8' });
-};
+/** Writes `value` to `path` via the shared revvault client (never argv). */
+const defaultVaultWrite: VaultWrite = (path, value) => writeRevvaultSecret(path, value);
 
 export interface RunOptions {
   dryRun: boolean;

--- a/scripts/setup/stripe-revvault-sync.ts
+++ b/scripts/setup/stripe-revvault-sync.ts
@@ -21,8 +21,8 @@
  * No regex (M2): the manifest is parsed with string operations only.
  */
 
-import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { writeRevvaultSecret } from '@revealui/setup/revvault';
 
 export interface SyncLog {
   info: (message: string) => void;
@@ -41,12 +41,7 @@ const defaultLog: SyncLog = {
 /** Pipe a single value into `revvault set --force <path>` via stdin. */
 export type RevvaultSetter = (vaultPath: string, value: string) => void;
 
-const defaultSetter: RevvaultSetter = (vaultPath, value) => {
-  execFileSync('revvault', ['set', '--force', vaultPath], {
-    input: value,
-    encoding: 'utf-8',
-  });
-};
+const defaultSetter: RevvaultSetter = (vaultPath, value) => writeRevvaultSecret(vaultPath, value);
 
 /**
  * Parse `KEY = "revealui/..."` lines from a revvault-vercel manifest into an

--- a/scripts/validate/as-never-values-allowlist.json
+++ b/scripts/validate/as-never-values-allowlist.json
@@ -9,8 +9,8 @@
     },
     {
       "path": "scripts/admin/bootstrap.ts",
-      "line": 205,
-      "reason": "Stage 1 fixes the event/actor/meta -> event_type/agent_id/payload column mapping; Stage 0 only makes the write's failure loud (classified console.warn) instead of silently swallowing it."
+      "line": 166,
+      "reason": "Stage 1 fixes the event/actor/meta -> event_type/agent_id/payload column mapping; Stage 0 only makes the write's failure loud (classified console.warn) instead of silently swallowing it. Line shifted down from 205 after the revvault client extraction removed the inline revvaultGet() helper."
     }
   ]
 }


### PR DESCRIPTION
## Summary

The fleet secrets rule anticipates exactly one shared TypeScript client for invoking the `revvault` secrets CLI. Today six call sites each hand-rolled the spawn: the MCP OAuth provider (the one fully-featured implementation, with a `RevvaultError` class and a path-safety guard) plus five setup/admin/probe scripts with divergent, partial reimplementations.

This PR extracts the shared client to `@revealui/setup/revvault` and migrates all six call sites onto it.

- New module `packages/setup/src/revvault/index.ts`:
  - `createRevvaultVault()` / `createMemoryVault()` — the async `Vault` (get/set/delete/list), moved verbatim from the MCP OAuth provider for its long-lived token-storage use case.
  - `readRevvaultSecret()` — tolerant sync lookup, returns `undefined` on any failure.
  - `requireRevvaultSecret()` — fail-fast sync lookup; throws a `RevvaultError` naming the exact vault path and the `revvault set <path>` command to fix it, per the fleet secrets rule ("missing secrets must be loud and name the path to set").
  - `writeRevvaultSecret()` / `revvaultSecretExists()` — the write and existence-check halves used by the guarded generators.
  - `assertSafePath()` / `assertSafePrefix()` — the same traversal/shell-metacharacter guard the MCP provider already had, now applied uniformly (previously only two of the six call sites validated their paths at all).
- `packages/mcp/src/oauth.ts` now imports and re-exports from the shared module; its own public exports (`Vault`, `RevvaultError`, `createRevvaultVault`, `createMemoryVault`, `RevvaultVaultOptions`) are unchanged, so `remote-client.ts` and `index.ts` need no changes.
- Five script call sites migrated, each keeping its original tolerance/strictness:
  - `scripts/setup/credentials.ts` — tolerant multi-key YAML-ish lookup (unchanged parsing, now backed by `readRevvaultSecret`).
  - `scripts/setup/gen-staging-secrets.ts` — its existing injectable `VaultExists`/`VaultWrite` test seams now delegate their default implementations to the shared client.
  - `scripts/setup/stripe-revvault-sync.ts` — its injectable `RevvaultSetter` default now delegates to `writeRevvaultSecret`.
  - `scripts/admin/bootstrap.ts` — required lookups (email/password) now throw via `requireRevvaultSecret` instead of a hand-rolled not-found branch; optional lookups (name, force-rotate) use `readRevvaultSecret`.
  - `scripts/electric-latency-probe/probe.ts` — required lookups keep the probe's own formatted failure message via a thin wrapper around `requireRevvaultSecret`; optional lookups use `readRevvaultSecret`. This also fixes a stale fallback binary path (`~/suite/revvault/...`, a retired location) picked up as a side effect of removing the local spawn wrapper.

## Home chosen: `@revealui/setup`, not `@revealui/utils`

Per extend-before-create, I audited both existing OSS packages before adding a new subpath anywhere:

- `@revealui/utils` (logger, db ssl-config, validation) has zero `child_process` precedent and is consumed broadly by admin API routes; nothing in it currently owns "invoke an external tool."
- `@revealui/setup` already targets `node24` explicitly, its own package description already says "secrets validation," it already spawns a child process (`execSync` in `system-tune/detect.ts`), and one of the five migrated call sites (`scripts/admin/bootstrap.ts`) already depended on it (`@revealui/setup/bootstrap`).

Both packages resolve identically for the monorepo's two consumption paths (workspace `package.json` + built `dist/` exports for real packages; the root `tsconfig.json` `@revealui/setup/*` wildcard for the `scripts/` tsx call sites), so there was no bundling-safety tiebreaker — the tiebreaker was which package already owns this kind of tooling. `@revealui/setup` was the better fit on the merits, not just the fallback.

`@revealui/mcp` (Fair Source) depending on `@revealui/setup` (MIT) is the allowed Pro→OSS direction; the reverse would not have been.

## Test plan

- [x] `pnpm --filter @revealui/setup build` — new `revvault` tsup entry builds clean
- [x] `pnpm --filter @revealui/setup typecheck` — clean
- [x] `pnpm --filter @revealui/setup test` — 98/98 pass (19 new tests for the extracted client, mocking `node:child_process`)
- [x] `pnpm --filter @revealui/mcp typecheck` / `build` — clean after building its dependency graph
- [x] `pnpm --filter @revealui/mcp test` — 423 passed, 5 skipped (unchanged; no existing test targets `oauth.ts` directly, so this confirms no regression elsewhere in the package)
- [x] `pnpm exec vitest run scripts/setup/__tests__/gen-staging-secrets.test.ts scripts/setup/__tests__/stripe-revvault-sync.test.ts` — 20/20 pass (their existing injectable-dependency tests don't exercise the default implementations directly, so this only confirms no import/wiring break)
- [x] Runtime smoke test of `credentials.ts` and `gen-staging-secrets.ts --dry-run` via `tsx` (no live revvault installed in this environment; both degrade the same way they did before — tolerant fallback / dry-run)
- [x] `biome check` clean on all touched files
- [x] Grepped for remaining direct `spawnSync`/`execFileSync`/`spawn(` of the revvault binary outside the shared client — none found
- [x] `pnpm validate:changesets` — clean

## Security note

This PR touches `packages/mcp` (Fair Source), which is a security-review-gated surface. Per the review-before-merge convention, this must not merge without a recorded coordinator verdict (`sec-review:approved` label or equivalent). I have not applied that label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
