### PR TITLE
docs: reconcile provider-surface docs with GAP-360 reality

### DIFF
--- a/apps/admin/CONVERSATIONAL-DASHBOARD-GUIDE.md
+++ b/apps/admin/CONVERSATIONAL-DASHBOARD-GUIDE.md
@@ -206,14 +206,23 @@ Set up your AI provider credentials. `createLLMClientFromEnv` auto-detects the p
 # Inference Snaps (default; local, zero-config on Ubuntu)
 INFERENCE_SNAPS_BASE_URL=http://localhost:9090/v1
 
-# Groq
+# Groq (cloud, your own key)
 GROQ_API_KEY=gsk_your-key-here
 
 # Ollama (local)
 OLLAMA_BASE_URL=http://localhost:11434
 
-# Hugging Face
+# Anthropic (cloud, your own key)
+ANTHROPIC_API_KEY=your-key-here
+
+# OpenAI (cloud, your own key)
+OPENAI_API_KEY=your-key-here
+```
+
+Hugging Face also works as a cloud, bring-your-own-key provider, but it is not part of this auto-detect list. Set `LLM_PROVIDER=huggingface` explicitly, along with:
+```bash
 HF_TOKEN=your-token-here
+HF_MODEL_URL=https://your-model-endpoint.huggingface.cloud
 ```
 
 ### Agent seems confused

--- a/apps/docs/public/docs-pro/ai/index.md
+++ b/apps/docs/public/docs-pro/ai/index.md
@@ -8,7 +8,7 @@ AI agents, open-model inference, CRDT memory, and the A2A protocol — distribut
 
 - **Agents**  -  long-running task agents with persistent state
 - **Memory**  -  four-store cognitive memory (working, episodic, semantic, procedural)
-- **Open-model inference (default)**  -  Ollama, Canonical's Ubuntu Inference Snaps; Groq is a pluggable, opt-in cloud provider. HuggingFace and a generic OpenAI-compatible provider are declared but not yet wired up.
+- **Open-model inference (default)**  -  Ollama, Canonical's Ubuntu Inference Snaps. Groq, Anthropic, OpenAI, and HuggingFace are pluggable, opt-in cloud adapters. Each one is a thin wrapper that calls the vendor's OpenAI-compatible HTTP endpoint using your own API key. RevealUI never hosts a model and ships no proprietary vendor SDK.
 - **Orchestration**  -  multi-agent coordination with the A2A protocol
 - **MCP integration**  -  tool use via Model Context Protocol (`@revealui/mcp`, MIT)
 
@@ -38,7 +38,10 @@ import { createLLMClientFromEnv } from '@revealui/ai/llm/client'
 
 // Auto-detects from environment: explicit LLM_PROVIDER first, then
 // INFERENCE_SNAPS_BASE_URL, then GROQ_API_KEY, then OLLAMA_BASE_URL,
-// falling back to Inference Snaps if none are set
+// then ANTHROPIC_API_KEY, then OPENAI_API_KEY, falling back to
+// Inference Snaps if none are set. HuggingFace works too, but it is
+// not part of this auto-detect list. Set LLM_PROVIDER=huggingface
+// explicitly to use it.
 const llm = createLLMClientFromEnv()
 
 // Use the client directly
@@ -70,9 +73,10 @@ See `@revealui/ai/memory` for the store classes (`WorkingMemory`, `EpisodicMemor
 |------|------|-----------|-------|
 | **Ollama** (default local) | Yes | Yes | Any open source GGUF model (Gemma 4, Qwen, Mistral). `nomic-embed-text` is the default 768-dim embedding model. |
 | Ubuntu Inference Snaps (planned recommended) | Yes | Depends on snap | Canonical snap runtime — hardware-aware, single command install. Studio lifecycle pending. |
-| Groq | Yes | No | Cloud-compatible — opt-in via `GROQ_API_KEY`. |
-| HuggingFace | Not yet | Not yet | Declared provider type (`HF_TOKEN`), not yet wired to a working client. |
-| OpenAI-compatible | Not yet | Not yet | Config type exists, but no provider case is wired up yet. |
+| Groq | Yes | No | Cloud, bring your own key. Opt-in via `GROQ_API_KEY`. |
+| Anthropic | Yes | No | Cloud, bring your own key. Opt-in via `ANTHROPIC_API_KEY`. Calls Anthropic's OpenAI-compatible endpoint directly. No proprietary Anthropic SDK. |
+| OpenAI | Yes | Yes | Cloud, bring your own key. Opt-in via `OPENAI_API_KEY`. |
+| HuggingFace | Yes | Depends on model | Cloud, bring your own key. Set `HF_TOKEN` and `HF_MODEL_URL`, then select it explicitly with `LLM_PROVIDER=huggingface` (not part of auto-detect). Calls the HuggingFace OpenAI-compatible inference endpoint. |
 
 ## A2A protocol
 

--- a/apps/docs/public/docs-pro/inference/index.md
+++ b/apps/docs/public/docs-pro/inference/index.md
@@ -1,6 +1,6 @@
 # Open-Model Inference
 
-RevealUI AI defaults to open-model inference (Snaps, Ollama). Groq is a pluggable, opt-in cloud provider via `GROQ_API_KEY`. HuggingFace and generic OpenAI-compatible endpoints are declared provider types but are not yet wired to a working client.
+RevealUI AI defaults to open-model inference (Snaps, Ollama). Groq, Anthropic, OpenAI, and HuggingFace are pluggable, opt-in cloud adapters. Each one is a thin wrapper that calls the vendor's OpenAI-compatible HTTP endpoint using your own API key. RevealUI never hosts a model and ships no proprietary vendor SDK.
 
 ## Planned: Ubuntu Inference Snaps
 
@@ -53,7 +53,10 @@ When `INFERENCE_SNAPS_BASE_URL` is set, the LLM client auto-detects it as the pr
 |------|---------|------|----------|
 | **Ollama** (default) | Local GGUF models | Free (your hardware) | Flexible  -  any open source GGUF model (Gemma 4, Qwen, Mistral) |
 | **Ubuntu Inference Snaps** (planned) | Canonical snap runtime | Free (your hardware) | Local production  -  Gemma 3, Nemotron-Nano, DeepSeek-R1, Qwen-VL |
-| **HuggingFace** | Not yet wired | N/A | Declared provider type; no working client yet |
+| **Groq** | Cloud, your own key | Pay Groq directly | Fast cloud inference, opt-in via `GROQ_API_KEY` |
+| **Anthropic** | Cloud, your own key | Pay Anthropic directly | Bring your own key, opt-in via `ANTHROPIC_API_KEY` |
+| **OpenAI** | Cloud, your own key | Pay OpenAI directly | Bring your own key, opt-in via `OPENAI_API_KEY` |
+| **HuggingFace** | Cloud, your own key | Pay HuggingFace directly | Bring your own key, select explicitly via `LLM_PROVIDER=huggingface` |
 
 ## Ollama (Open Source Models)
 
@@ -70,12 +73,28 @@ Configure:
 OLLAMA_BASE_URL=http://localhost:11434/v1
 ```
 
-## HuggingFace (not yet wired)
+## HuggingFace
 
-`huggingface` is a declared provider type that reads `HF_TOKEN`, but the client factory does not yet instantiate a working provider for it. Setting `HF_TOKEN` and `LLM_PROVIDER=huggingface` will throw today.
+`huggingface` calls the HuggingFace OpenAI-compatible inference endpoint using your own token. It is not part of the auto-detect cascade, so select it explicitly with `LLM_PROVIDER=huggingface`.
 
 ```bash
+LLM_PROVIDER=huggingface
 HF_TOKEN=hf_xxxxx
+HF_MODEL_URL=https://your-model-endpoint.huggingface.cloud
+```
+
+## Anthropic and OpenAI
+
+`anthropic` and `openai` are bring-your-own-key cloud adapters. Each one is a thin wrapper that calls the vendor's own OpenAI-compatible HTTP endpoint with your key. RevealUI ships no proprietary Anthropic or OpenAI SDK.
+
+```bash
+# Anthropic
+ANTHROPIC_API_KEY=sk-ant-xxxxx
+# ANTHROPIC_BASE_URL defaults to https://api.anthropic.com/v1
+
+# OpenAI
+OPENAI_API_KEY=sk-xxxxx
+# OPENAI_BASE_URL defaults to https://api.openai.com/v1
 ```
 
 ## Auto-Detection
@@ -86,9 +105,11 @@ The LLM client factory auto-detects your inference path in this order:
 2. `INFERENCE_SNAPS_BASE_URL`
 3. `GROQ_API_KEY`
 4. `OLLAMA_BASE_URL`
-5. Falls back to Inference Snaps if none of the above are set
+5. `ANTHROPIC_API_KEY`
+6. `OPENAI_API_KEY`
+7. Falls back to Inference Snaps if none of the above are set
 
-`huggingface` and `openai-compat` are not part of this auto-detect cascade and are not currently wired up as `LLM_PROVIDER` values; setting either throws.
+`huggingface` works as an `LLM_PROVIDER` value, but it is not part of this auto-detect cascade. Set `LLM_PROVIDER=huggingface` explicitly to use it.
 
 ## Server-side Usage
 
@@ -106,6 +127,6 @@ const response = await llm.chat([
 ## Security
 
 - Local providers (snaps, Ollama): no API keys leave your infrastructure
-- Cloud providers (Groq, HuggingFace, OpenAI-compatible): data is sent to your chosen endpoint when API keys are configured. Picking only open-weights models is your choice; the package supports both.
-- Air-gap capability with Ollama (zero network required after model download). The default RevealUI deployment also depends on cloud services (Postgres / Stripe / Blob storage) — the local AI path is optional, not a guarantee that the whole stack runs offline.
+- Cloud providers (Groq, Anthropic, OpenAI, HuggingFace): data is sent to your chosen vendor endpoint using your own API key. Picking only open-weights models is your choice. The package supports both.
+- Air-gap capability with Ollama (zero network required after model download). The default RevealUI deployment also depends on cloud services (Postgres, Stripe, Blob storage). The local AI path is optional, not a guarantee that the whole stack runs offline.
 - Inference snaps are signed and verified by Canonical

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -926,7 +926,7 @@ All MCP servers are **completely free**:
 
 # Open-Model Inference
 
-RevealUI AI runs exclusively on open source models. No proprietary cloud APIs, no vendor lock-in, no API bills.
+RevealUI AI defaults to open source models running on your own hardware. It never hosts a model and ships no proprietary vendor SDK. Cloud providers are opt-in adapters that call the vendor's own OpenAI-compatible endpoint using your own API key.
 
 ## Inference Paths
 
@@ -935,7 +935,10 @@ RevealUI AI runs exclusively on open source models. No proprietary cloud APIs, n
 | Path | Runtime | Notes |
 |------|---------|-------|
 | **Ollama** | Local GGUF models | Any open source GGUF model. Default: `gemma4:e2b` |
-| **HuggingFace** | HuggingFace Inference API | Open models hosted on HuggingFace infrastructure |
+| **Groq** | Cloud, your own key | Bring your own key, opt-in via `GROQ_API_KEY` |
+| **Anthropic** | Cloud, your own key | Bring your own key, opt-in via `ANTHROPIC_API_KEY`. Calls Anthropic's OpenAI-compatible endpoint directly. No proprietary Anthropic SDK. |
+| **OpenAI** | Cloud, your own key | Bring your own key, opt-in via `OPENAI_API_KEY` |
+| **HuggingFace** | Cloud, your own key | Bring your own key. Calls the HuggingFace OpenAI-compatible inference endpoint. Select explicitly via `LLM_PROVIDER=huggingface` (not part of auto-detect). |
 
 ### Planned (roadmap)
 
@@ -949,9 +952,13 @@ RevealUI AI runs exclusively on open source models. No proprietary cloud APIs, n
 import { createLLMClientFromEnv } from "@revealui/ai/llm/client";
 
 // Auto-detects from environment in precedence order:
-//   INFERENCE_SNAPS_BASE_URL (if set — planned path, manual wiring)
+//   INFERENCE_SNAPS_BASE_URL (if set, planned path, manual wiring)
+//   GROQ_API_KEY
 //   OLLAMA_BASE_URL (default local runtime)
-//   HUGGINGFACE_API_KEY (hosted fallback)
+//   ANTHROPIC_API_KEY
+//   OPENAI_API_KEY
+// HuggingFace works too, but it is not part of this auto-detect list.
+// Set LLM_PROVIDER=huggingface explicitly to use it.
 const llm = createLLMClientFromEnv();
 
 const response = await llm.chat([{ role: "user", content: "Hello!" }]);
@@ -960,18 +967,28 @@ const response = await llm.chat([{ role: "user", content: "Hello!" }]);
 ## Environment configuration
 
 ```bash
-# Ubuntu inference snap — planned path; requires manual snap install + service
+# Ubuntu inference snap, planned path; requires manual snap install + service
 # (see Planned roadmap table above). Studio UI lifecycle not shipped.
 INFERENCE_SNAPS_BASE_URL=http://localhost:8080/v1
 
 # Ollama (any open source model)
 OLLAMA_BASE_URL=http://localhost:11434/v1
 
-# HuggingFace Inference API (open models)
-HUGGINGFACE_API_KEY=hf_xxxxx
+# Groq (cloud, your own key)
+GROQ_API_KEY=gsk_xxxxx
+
+# Anthropic (cloud, your own key)
+ANTHROPIC_API_KEY=sk-ant-xxxxx
+
+# OpenAI (cloud, your own key)
+OPENAI_API_KEY=sk-xxxxx
+
+# HuggingFace (cloud, your own key; not part of auto-detect, requires LLM_PROVIDER=huggingface below)
+HF_TOKEN=hf_xxxxx
+HF_MODEL_URL=https://your-model-endpoint.huggingface.cloud
 
 # Force specific inference path (overrides auto-detection)
-# Valid values: ollama, huggingface, inference-snaps (planned)
+# Valid values: ollama, groq, anthropic, openai, huggingface, inference-snaps (planned)
 LLM_PROVIDER=ollama
 ```
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -16,7 +16,7 @@ AI system for RevealUI - memory, LLM, orchestration, and tools.
 ## Features
 
 - **Memory System**: CRDT-based persistent memory (Working, Episodic, Semantic)
-- **LLM Integration**: Provider abstractions for Groq, Ollama, Canonical Inference Snaps, and other OpenAI-compatible endpoints. Anthropic-SDK-free.
+- **LLM Integration**: Provider abstractions for Ollama and Canonical Inference Snaps (open-model defaults), plus Groq, Anthropic, OpenAI, and HuggingFace as bring-your-own-key cloud adapters. Every adapter calls the vendor's OpenAI-compatible HTTP endpoint with your own key. No proprietary Anthropic or OpenAI SDK.
 - **Agent Orchestration**: Runtime and execution engine for AI agents
 - **Tool Calling**: Tool registry + standard-MCP-client integration (Stage 5.1a)
 - **Vector Search**: Semantic search with pgvector
@@ -64,8 +64,9 @@ const provider = new InferenceSnapsProvider({
 const client = new LLMClient({ provider })
 ```
 
-Groq remains supported as a pluggable cloud provider; the local
-inference path is the documented default for self-hosted deployments.
+Groq, Anthropic, OpenAI, and HuggingFace remain supported as pluggable,
+bring-your-own-key cloud providers. The local inference path is the
+documented default for self-hosted deployments.
 
 ## MCP tool integration
 
@@ -313,7 +314,7 @@ const state = await persistence.loadCRDTState(crdtId, 'lww_register')
 
 ### LLM Integration
 
-Provider abstractions and unified client for Groq, Ollama, and Canonical Inference Snaps.
+Provider abstractions and unified client for Ollama, Canonical Inference Snaps, Groq, Anthropic, OpenAI, and HuggingFace.
 
 ```typescript
 import { LLMClient, createLLMClientFromEnv } from '@revealui/ai/llm/client'


### PR DESCRIPTION
GAP-360 PR-1/PR-2 (merged) shipped working **Anthropic, OpenAI, and HuggingFace** providers plus `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` auto-detection. Each is a thin wrapper over the vendor's OpenAI-compatible HTTP endpoint (`packages/ai/src/llm/providers/anthropic.ts`: "No proprietary Anthropic SDK"). The docs still said these were "declared but not yet wired / throws", and `docs/PRO.md` claimed the runtime "runs exclusively on open source models, no proprietary cloud APIs" — flatly wrong given the shipped adapters.

Reconciled to the merged reality, framed to the foundation-layer positioning: **RevealUI hosts no model and ships no vendor SDK; the cloud providers are opt-in bring-your-own-key adapters** over the vendor's OpenAI-compatible endpoint. (This is the follow-up to the earlier doc-drift sweep #1893, which had correctly documented the *pre*-GAP-360 state.)

## Changed
- `apps/docs/public/docs-pro/{ai,inference}/index.md`: provider overviews, inference-path tables, HuggingFace sections, and the real 5-step auto-detect cascade (HuggingFace works but is not auto-detected; there is no `openai-compat` `LLM_PROVIDER` value).
- `packages/ai/README.md`: provider lists include Anthropic/OpenAI/HuggingFace, keeping the no-proprietary-SDK point.
- `apps/admin/CONVERSATIONAL-DASHBOARD-GUIDE.md`: env list adds `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`; HF needs explicit `LLM_PROVIDER=huggingface`.
- `docs/PRO.md`: open-model-default + BYO-cloud-adapter framing; `HF_TOKEN` not `HUGGINGFACE_API_KEY`; corrected `LLM_PROVIDER` valid values.

## Verification
All four doc gates green: `validate:claims` (0 mismatches), `validate:doc-currency` (0 new), `validate:docs-imports` (green), `validate:citations` (0 new). No em dashes added (counts held or dropped per file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)