### PR TITLE
feat(mcp): revealui-mcp bin launcher + mcpName + server.json for MCP Registry listing

### DIFF
--- a/.changeset/mcp-registry-listing.md
+++ b/.changeset/mcp-registry-listing.md
@@ -1,0 +1,5 @@
+---
+"@revealui/mcp": patch
+---
+
+Add a `revealui-mcp` bin launcher, the `mcpName` field, and `server.json` so the package is listable on the MCP Registry (registry.modelcontextprotocol.io) and runnable straight from npm: `npx @revealui/mcp <server>`. The launcher is a static allowlist over the servers already shipped in `dist/servers/`; no behavior change to any server.

--- a/.changeset/mcp-registry-listing.md
+++ b/.changeset/mcp-registry-listing.md
@@ -1,5 +1,5 @@
 ---
-"@revealui/mcp": patch
+"@revealui/mcp": minor
 ---
 
 Add a `revealui-mcp` bin launcher, the `mcpName` field, and `server.json` so the package is listable on the MCP Registry (registry.modelcontextprotocol.io) and runnable straight from npm: `npx @revealui/mcp <server>`. The launcher is a static allowlist over the servers already shipped in `dist/servers/`; no behavior change to any server.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,6 +8,10 @@
     "directory": "packages/mcp"
   },
   "license": "FSL-1.1-MIT",
+  "bin": {
+    "revealui-mcp": "./dist/cli.js"
+  },
+  "mcpName": "io.github.revealuistudio/revealui",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@revealui/config": "workspace:*",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.revealuistudio/revealui",
-  "description": "First-party MCP servers for the RevealUI runtime: content, email, memory, and Stripe servers for RevealUI apps, plus adapters for Stripe, Supabase, Vercel, Neon, Playwright, and Next.js devtools. Launch one server per process: revealui-mcp <server>.",
+  "description": "MCP servers for the RevealUI runtime. First-party: contracts, docs, revealui-content, revealui-email, revealui-memory, revealui-stripe. Adapters (require pnpm on PATH; they launch the upstream MCP package): stripe, supabase, vercel, neon, playwright, next-devtools. Launch one server per process: revealui-mcp <server>.",
   "repository": {
     "url": "https://github.com/RevealUIStudio/revealui",
     "source": "github"
   },
-  "version": "0.7.2",
+  "version": "0.7.1",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@revealui/mcp",
-      "version": "0.7.2",
+      "version": "0.7.1",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.revealuistudio/revealui",
+  "description": "First-party MCP servers for the RevealUI runtime: content, email, memory, and Stripe servers for RevealUI apps, plus adapters for Stripe, Supabase, Vercel, Neon, Playwright, and Next.js devtools. Launch one server per process: revealui-mcp <server>.",
+  "repository": {
+    "url": "https://github.com/RevealUIStudio/revealui",
+    "source": "github"
+  },
+  "version": "0.7.2",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@revealui/mcp",
+      "version": "0.7.2",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "package_arguments": [
+        {
+          "type": "positional",
+          "value_hint": "server",
+          "description": "Which server to launch: contracts, docs, neon, next-devtools, playwright, revealui-content, revealui-email, revealui-memory, revealui-stripe, stripe, supabase, or vercel.",
+          "is_required": true
+        }
+      ]
+    }
+  ]
+}

--- a/packages/mcp/src/__tests__/server-json.test.ts
+++ b/packages/mcp/src/__tests__/server-json.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
+const serverJson = JSON.parse(readFileSync(new URL('../../server.json', import.meta.url), 'utf8'));
+
+// The MCP Registry rejects a server.json whose version differs from the
+// published npm version, and nothing bumps server.json automatically
+// (changesets only touches package.json). These assertions force the
+// version-bump PR to update server.json in lockstep.
+describe('server.json registry metadata', () => {
+  it('tracks package.json version at top level', () => {
+    expect(serverJson.version).toBe(pkg.version);
+  });
+
+  it('tracks package.json version in the npm package entry', () => {
+    expect(serverJson.packages[0].version).toBe(pkg.version);
+  });
+
+  it('has a name matching package.json mcpName (registry ownership check)', () => {
+    expect(serverJson.name).toBe(pkg.mcpName);
+  });
+
+  it('points at this package on npm', () => {
+    expect(serverJson.packages[0].identifier).toBe(pkg.name);
+  });
+});

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * revealui-mcp — launch a first-party RevealUI MCP server by name.
+ *
+ * Usage:
+ *   revealui-mcp <server>
+ *   npx @revealui/mcp <server>
+ *
+ * Each server module self-starts on import (its own main() runs). The
+ * allowlist below is static so no user input ever reaches an import path.
+ * code-validator is repo-only (tsx, excluded from the build) and is not
+ * listed here.
+ */
+
+const SERVERS: Record<string, () => Promise<unknown>> = {
+  contracts: () => import('./servers/contracts.js'),
+  docs: () => import('./servers/docs.js'),
+  neon: () => import('./servers/neon.js'),
+  'next-devtools': () => import('./servers/next-devtools.js'),
+  playwright: () => import('./servers/playwright.js'),
+  'revealui-content': () => import('./servers/revealui-content.js'),
+  'revealui-email': () => import('./servers/revealui-email.js'),
+  'revealui-memory': () => import('./servers/revealui-memory.js'),
+  'revealui-stripe': () => import('./servers/revealui-stripe.js'),
+  stripe: () => import('./servers/stripe.js'),
+  supabase: () => import('./servers/supabase.js'),
+  vercel: () => import('./servers/vercel.js'),
+};
+
+const requested = process.argv[2];
+const launch = requested ? SERVERS[requested] : undefined;
+
+if (!launch) {
+  const list = Object.keys(SERVERS).join('\n  ');
+  process.stderr.write(`Usage: revealui-mcp <server>\n\nAvailable servers:\n  ${list}\n`);
+  process.exit(2);
+}
+
+launch().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`revealui-mcp: failed to start ${requested}: ${message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Makes `@revealui/mcp` listable on the MCP Registry (registry.modelcontextprotocol.io) and runnable straight from npm:

- `packages/mcp/src/cli.ts`: a `revealui-mcp` bin that launches one first-party server per process (`npx @revealui/mcp <server>`). Static allowlist over the 12 servers already shipped in `dist/servers/`; no user input reaches an import path; no behavior change to any server. `code-validator` stays repo-only (it is excluded from the build at `packages/mcp/tsconfig.json`).
- `packages/mcp/package.json`: adds `bin` and `mcpName: io.github.revealuistudio/revealui` (the registry requires `mcpName` in the published package to match `server.json`'s `name`).
- `packages/mcp/server.json`: registry metadata (schema 2025-12-11), npm package entry with stdio transport and the required positional server argument.
- Changeset: patch bump.

## Why

First zero-gate ecosystem listing from the cert/partner roadmap (`.jv/docs/anthropic-certs/partner-programs.md` has the publish runbook). The package is already public on npm (0.7.1) but had no runnable entrypoint, so a registry listing would have been broken without the bin.

## Audit

Pre-change audit confirmed: no existing bin or CLI in the package to extend (servers run via repo-local `tsx`/`pnpm` scripts only, per `packages/mcp/configs/README.md`); each server module self-starts on import (e.g. `src/servers/stripe.ts` runs `main()`), which the launcher relies on.

## Verification

- Build, typecheck, lint, tests green (423 passed, 5 skipped).
- Live protocol smoke: `node dist/cli.js docs` answered an MCP `initialize` with a valid JSON-RPC response from `revealui-docs`; no-arg and unknown-name paths exit 2 with usage.
- Fleet security checker (`security-pr-review-check.js --diff origin/test`): no security-sensitive files, no coordinator gate.

## Post-merge (owner, from the runbook)

After the changeset release publishes 0.7.2: `mcp-publisher init/login github/publish` per `.jv/docs/anthropic-certs/partner-programs.md`. Note the namespace assumption: `io.github.revealuistudio` requires the GitHub login used for `mcp-publisher login github` to control the RevealUIStudio account; if publishing as joshua-v-dev instead, flip `mcpName` + `server.json` name to `io.github.joshua-v-dev/revealui` (or use the domain-verified `com.revealui/*` path) before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)