### PR TITLE
feat(admin): GAP-360 PR-3 — Anthropic/OpenAI provider settings + honest onboarding

### DIFF
--- a/.changeset/gap-360-pr3-settings-ui.md
+++ b/.changeset/gap-360-pr3-settings-ui.md
@@ -1,0 +1,10 @@
+---
+"@revealui/contracts": minor
+---
+
+Widen `LLM_PROVIDERS` to include `anthropic` and `openai` (GAP-360 PR-3). PR-1
+(`@revealui/ai`, `@revealui/db`) already widened `LLMProviderType` and the DB
+provider CHECK constraints to six providers, but left this canonical list at
+four — so the two BYOK routes that import it (`apps/server/src/routes/api-keys.ts`,
+`packages/mcp/src/servers/factories/contracts.ts`) still rejected a saved
+Anthropic/OpenAI key. This closes that gap; no other behavior changes.

--- a/apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseLicense = vi.fn();
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: (...args: Parameters<typeof fetch>) => fetch(...args),
+}));
+
+import { ALL_PROVIDERS, visibleProviders } from '@/lib/settings/api-key-providers';
+import ApiKeysPageClient from '../api-keys-client';
+
+function mockFetchOnce(body: unknown, ok = true) {
+  return vi.fn().mockResolvedValue({ ok, json: () => Promise.resolve(body) });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseLicense.mockReturnValue({ features: { ai: true }, isLoading: false });
+});
+
+describe('ApiKeysPageClient', () => {
+  it('offers Anthropic and OpenAI alongside the open-model providers on self-hosted', () => {
+    vi.stubGlobal('fetch', mockFetchOnce(null));
+    render(<ApiKeysPageClient providers={ALL_PROVIDERS} isHosted={false} />);
+
+    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Ollama/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Inference Snaps/ })).toBeInTheDocument();
+    expect(screen.queryByText(/hosted deployment/)).not.toBeInTheDocument();
+  });
+
+  it('hides local-only providers and shows the hosted hint on a hosted deployment', () => {
+    vi.stubGlobal('fetch', mockFetchOnce(null));
+    const hostedProviders = visibleProviders(true, {
+      anthropic: true,
+      openai: true,
+      groq: true,
+      huggingface: true,
+      ollama: false,
+      'inference-snaps': false,
+    });
+    render(<ApiKeysPageClient providers={hostedProviders} isHosted={true} />);
+
+    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Ollama/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Inference Snaps/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/hosted deployment/)).toBeInTheDocument();
+  });
+
+  it('shows the get-key link pointing at the active provider docs', () => {
+    vi.stubGlobal('fetch', mockFetchOnce(null));
+    render(<ApiKeysPageClient providers={ALL_PROVIDERS} isHosted={false} />);
+
+    const link = screen.getByRole('link', { name: /Get key/ });
+    expect(link).toHaveAttribute('href', 'https://console.anthropic.com/settings/keys');
+
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    expect(screen.getByRole('link', { name: /Get key/ })).toHaveAttribute(
+      'href',
+      'https://platform.openai.com/api-keys',
+    );
+  });
+
+  it('renders the honest "will use it" banner once a key is configured', async () => {
+    vi.stubGlobal('fetch', mockFetchOnce({ provider: 'anthropic', keyHint: 'sk-ant-...abcd' }));
+    render(<ApiKeysPageClient providers={ALL_PROVIDERS} isHosted={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Agent tasks will use it\./)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Anthropic key configured \(sk-ant-...abcd\)/)).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/app/(backend)/settings/api-keys/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/__tests__/page.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseLicense = vi.fn();
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: (...args: Parameters<typeof fetch>) => fetch(...args),
+}));
+
+import ApiKeysPage from '../page';
+
+const ORIGINAL_LICENSE_KEY = process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  if (ORIGINAL_LICENSE_KEY === undefined) {
+    delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+  } else {
+    process.env.REVEALUI_LICENSE_PRIVATE_KEY = ORIGINAL_LICENSE_KEY;
+  }
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseLicense.mockReturnValue({ features: { ai: true }, isLoading: false });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(null) }),
+  );
+});
+
+describe('ApiKeysPage (server shell)', () => {
+  it('offers all six providers when REVEALUI_LICENSE_PRIVATE_KEY is unset (self-hosted)', async () => {
+    delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+
+    const element = await ApiKeysPage();
+    render(element);
+
+    expect(screen.getByRole('option', { name: /Ollama/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Inference Snaps/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
+  });
+
+  it('hides localhost-only providers when REVEALUI_LICENSE_PRIVATE_KEY is set (hosted)', async () => {
+    process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'test-private-key';
+
+    const element = await ApiKeysPage();
+    render(element);
+
+    expect(screen.queryByRole('option', { name: /Ollama/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Inference Snaps/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+const SAVED_FEEDBACK_MS = 2_000;
+
+import { Input, Select } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
+import { useEffect, useState } from 'react';
+import { LicenseGate } from '@/lib/components/LicenseGate';
+import type { Provider, ProviderInfo } from '@/lib/settings/api-key-providers';
+import { apiFetch } from '@/lib/utils/csrf';
+
+interface ApiKeysPageClientProps {
+  /** Providers to offer — already filtered for this deployment (server-resolved). */
+  providers: ProviderInfo[];
+  /** True on a hosted (serverless) deployment; false on self-hosted. */
+  isHosted: boolean;
+}
+
+export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageClientProps) {
+  const [provider, setProvider] = useState<Provider>(providers[0]?.id ?? 'anthropic');
+  const [apiKey, setApiKey] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [currentProvider, setCurrentProvider] = useState<string | null>(null);
+  const [currentKeyHint, setCurrentKeyHint] = useState<string | null>(null);
+
+  // Load existing key metadata from server on mount
+  useEffect(() => {
+    fetch('/api/user/api-keys')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { provider: string; keyHint: string | null } | null) => {
+        if (data) {
+          setCurrentProvider(data.provider);
+          setCurrentKeyHint(data.keyHint);
+        }
+      })
+      .catch(() => {
+        // Swallow fetch errors  -  API key metadata is non-critical
+      });
+  }, []);
+
+  async function handleSave() {
+    if (!apiKey.trim()) return;
+    setSaveError(null);
+    try {
+      const res = await apiFetch('/api/user/api-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider, key: apiKey.trim() }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { provider: string; keyHint: string };
+        setCurrentProvider(data.provider);
+        setCurrentKeyHint(data.keyHint);
+        setApiKey('');
+        setSaved(true);
+        setTimeout(() => setSaved(false), SAVED_FEEDBACK_MS);
+      } else {
+        // empty-catch-ok: JSON-parse fallback for an error-response body; `{}` is the safe shape so `data.error` evaluates to undefined and the UI falls back to the generic error text below.
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setSaveError(
+          data.error ?? 'Failed to save key. Contact support@revealui.com if this persists.',
+        );
+      }
+    } catch {
+      setSaveError('Unable to reach the server. Please check your connection and try again.');
+    }
+  }
+
+  async function handleClear() {
+    setSaveError(null);
+    try {
+      await apiFetch('/api/user/api-keys', { method: 'DELETE' });
+      setApiKey('');
+      setCurrentProvider(null);
+      setCurrentKeyHint(null);
+      setSaved(false);
+    } catch {
+      setSaveError('Unable to reach the server. Please check your connection and try again.');
+    }
+  }
+
+  const activeProviderInfo = providers.find((p) => p.id === provider);
+
+  return (
+    <LicenseGate feature="ai">
+      <div className="min-h-screen">
+        <div className="p-4 sm:p-6 max-w-lg">
+          {/* Status banner */}
+          {currentProvider && (
+            <div className="mb-6 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
+              <span className="h-2 w-2 rounded-full bg-success" />
+              {providers.find((p) => p.id === currentProvider)?.label ?? currentProvider} key
+              configured{currentKeyHint ? ` (${currentKeyHint})` : ''}. Agent tasks will use it.
+            </div>
+          )}
+
+          {/* Error banner */}
+          {saveError && (
+            <div
+              role="alert"
+              className="mb-6 rounded-lg border border-error/30 bg-error/10 px-4 py-3 text-sm text-error"
+            >
+              {saveError}
+            </div>
+          )}
+
+          <div className="rounded-xl border border-border bg-card p-5">
+            <h1 className="text-base font-semibold text-foreground">AI Provider</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Connect the AI provider your agents run on. We store your key encrypted on RevealUI's
+              servers and only use it server-side when an agent task runs.
+            </p>
+            {isHosted && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                This is a hosted deployment, so local-only providers like Ollama and Inference Snaps
+                aren't listed below.
+              </p>
+            )}
+
+            <div className="mt-5 flex flex-col gap-4">
+              {/* Provider selector */}
+              <Field>
+                <Label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                  Provider
+                </Label>
+                <Select value={provider} onChange={(e) => setProvider(e.target.value as Provider)}>
+                  {providers.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.label}
+                    </option>
+                  ))}
+                </Select>
+              </Field>
+
+              {/* API key input */}
+              <Field>
+                <Label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                  API Key
+                  {activeProviderInfo && (
+                    <a
+                      href={activeProviderInfo.docsUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="ml-2 text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Get key ↗
+                    </a>
+                  )}
+                </Label>
+                <div className="relative">
+                  <Input
+                    type={showKey ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={activeProviderInfo?.placeholder ?? ''}
+                    className="pr-16 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowKey((v) => !v)}
+                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    {showKey ? 'hide' : 'show'}
+                  </button>
+                </div>
+              </Field>
+
+              {/* Actions */}
+              <div className="flex items-center gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!apiKey.trim()}
+                  className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {saved ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="3"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                      Saved
+                    </span>
+                  ) : (
+                    'Save Key'
+                  )}
+                </button>
+                {currentProvider && (
+                  <button
+                    type="button"
+                    onClick={handleClear}
+                    className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </LicenseGate>
+  );
+}

--- a/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
@@ -1,238 +1,25 @@
-'use client';
+/**
+ * Settings, API Keys — server shell.
+ *
+ * Resolves the GAP-360 hosted flag server-side (same signal as
+ * `app/api/chat/route.ts:315` — `REVEALUI_LICENSE_PRIVATE_KEY` presence)
+ * and the provider list to offer, then hands both down to the client page.
+ * The boolean crosses the server/client boundary; the env var itself never
+ * does.
+ */
 
-const SAVED_FEEDBACK_MS = 2_000;
+import { visibleProviders } from '@/lib/settings/api-key-providers';
+import ApiKeysPageClient from './api-keys-client';
 
-import { Input, Select } from '@revealui/presentation';
-import { Field, Label } from '@revealui/presentation/client';
-import { useEffect, useState } from 'react';
-import { LicenseGate } from '@/lib/components/LicenseGate';
-import { apiFetch } from '@/lib/utils/csrf';
+export default async function ApiKeysPage() {
+  const isHosted = !!process.env.REVEALUI_LICENSE_PRIVATE_KEY;
 
-type Provider = 'groq' | 'huggingface' | 'inference-snaps' | 'ollama';
+  // @revealui/ai is an optional Pro peer dependency of apps/admin — dynamic
+  // import + catch, matching every other consumer (src/lib/ai/pro-stub.ts).
+  const aiClientMod = await import('@revealui/ai/llm/client').catch(() => null);
+  const hostedViable = aiClientMod?.hostedViable ?? null;
 
-interface ProviderInfo {
-  id: Provider;
-  label: string;
-  placeholder: string;
-  docsUrl: string;
-}
+  const providers = visibleProviders(isHosted, hostedViable);
 
-const PROVIDERS: ProviderInfo[] = [
-  {
-    id: 'inference-snaps',
-    label: 'Inference Snaps (Ubuntu, canonical default)',
-    placeholder: 'leave blank — runs locally',
-    docsUrl: 'https://snapcraft.io/search?q=inference',
-  },
-  {
-    id: 'ollama',
-    label: 'Ollama (local)',
-    placeholder: 'leave blank — runs locally',
-    docsUrl: 'https://ollama.com/docs',
-  },
-  {
-    id: 'groq',
-    label: 'Groq (cloud, LPU silicon)',
-    placeholder: 'gsk_...',
-    docsUrl: 'https://console.groq.com/keys',
-  },
-  {
-    id: 'huggingface',
-    label: 'Hugging Face (cloud)',
-    placeholder: 'hf_...',
-    docsUrl: 'https://huggingface.co/settings/tokens',
-  },
-];
-
-export default function ApiKeysPage() {
-  const [provider, setProvider] = useState<Provider>('inference-snaps');
-  const [apiKey, setApiKey] = useState('');
-  const [showKey, setShowKey] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [currentProvider, setCurrentProvider] = useState<string | null>(null);
-  const [currentKeyHint, setCurrentKeyHint] = useState<string | null>(null);
-
-  // Load existing key metadata from server on mount
-  useEffect(() => {
-    fetch('/api/user/api-keys')
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data: { provider: string; keyHint: string | null } | null) => {
-        if (data) {
-          setCurrentProvider(data.provider as Provider);
-          setCurrentKeyHint(data.keyHint);
-        }
-      })
-      .catch(() => {
-        // Swallow fetch errors  -  API key metadata is non-critical
-      });
-  }, []);
-
-  async function handleSave() {
-    if (!apiKey.trim()) return;
-    setSaveError(null);
-    try {
-      const res = await apiFetch('/api/user/api-keys', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider, key: apiKey.trim() }),
-      });
-      if (res.ok) {
-        const data = (await res.json()) as { provider: string; keyHint: string };
-        setCurrentProvider(data.provider);
-        setCurrentKeyHint(data.keyHint);
-        setApiKey('');
-        setSaved(true);
-        setTimeout(() => setSaved(false), SAVED_FEEDBACK_MS);
-      } else {
-        // empty-catch-ok: JSON-parse fallback for an error-response body; `{}` is the safe shape so `data.error` evaluates to undefined and the UI falls back to the generic error text below.
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
-        setSaveError(
-          data.error ?? 'Failed to save key. Contact support@revealui.com if this persists.',
-        );
-      }
-    } catch {
-      setSaveError('Unable to reach the server. Please check your connection and try again.');
-    }
-  }
-
-  async function handleClear() {
-    setSaveError(null);
-    try {
-      await apiFetch('/api/user/api-keys', { method: 'DELETE' });
-      setApiKey('');
-      setCurrentProvider(null);
-      setCurrentKeyHint(null);
-      setSaved(false);
-    } catch {
-      setSaveError('Unable to reach the server. Please check your connection and try again.');
-    }
-  }
-
-  const activeProviderInfo = PROVIDERS.find((p) => p.id === provider);
-
-  return (
-    <LicenseGate feature="ai">
-      <div className="min-h-screen">
-        <div className="p-4 sm:p-6 max-w-lg">
-          {/* Status banner */}
-          {currentProvider && (
-            <div className="mb-6 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
-              <span className="h-2 w-2 rounded-full bg-success" />
-              {PROVIDERS.find((p) => p.id === currentProvider)?.label ?? currentProvider} key
-              configured{currentKeyHint ? ` (${currentKeyHint})` : ''} - tasks will use your key
-            </div>
-          )}
-
-          {/* Error banner */}
-          {saveError && (
-            <div
-              role="alert"
-              className="mb-6 rounded-lg border border-error/30 bg-error/10 px-4 py-3 text-sm text-error"
-            >
-              {saveError}
-            </div>
-          )}
-
-          <div className="rounded-xl border border-border bg-card p-5">
-            <h1 className="text-base font-semibold text-foreground">Inference Endpoint</h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Configure your open-model inference endpoint. Keys are stored encrypted on RevealUI
-              servers and only used server-side for agent tasks.
-            </p>
-
-            <div className="mt-5 flex flex-col gap-4">
-              {/* Provider selector */}
-              <Field>
-                <Label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                  Provider
-                </Label>
-                <Select value={provider} onChange={(e) => setProvider(e.target.value as Provider)}>
-                  {PROVIDERS.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.label}
-                    </option>
-                  ))}
-                </Select>
-              </Field>
-
-              {/* API key input */}
-              <Field>
-                <Label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                  API Key
-                  {activeProviderInfo && (
-                    <a
-                      href={activeProviderInfo.docsUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="ml-2 text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      Get key ↗
-                    </a>
-                  )}
-                </Label>
-                <div className="relative">
-                  <Input
-                    type={showKey ? 'text' : 'password'}
-                    value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
-                    placeholder={activeProviderInfo?.placeholder ?? ''}
-                    className="pr-16 font-mono"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowKey((v) => !v)}
-                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground"
-                  >
-                    {showKey ? 'hide' : 'show'}
-                  </button>
-                </div>
-              </Field>
-
-              {/* Actions */}
-              <div className="flex items-center gap-2 pt-1">
-                <button
-                  type="button"
-                  onClick={handleSave}
-                  disabled={!apiKey.trim()}
-                  className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {saved ? (
-                    <span className="inline-flex items-center gap-1.5">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="3"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        aria-hidden="true"
-                      >
-                        <polyline points="20 6 9 17 4 12" />
-                      </svg>
-                      Saved
-                    </span>
-                  ) : (
-                    'Save Key'
-                  )}
-                </button>
-                {currentProvider && (
-                  <button
-                    type="button"
-                    onClick={handleClear}
-                    className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-                  >
-                    Clear
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </LicenseGate>
-  );
+  return <ApiKeysPageClient providers={providers} isHosted={isHosted} />;
 }

--- a/apps/admin/src/app/api/user/api-keys/route.ts
+++ b/apps/admin/src/app/api/user/api-keys/route.ts
@@ -1,6 +1,7 @@
 export const runtime = 'nodejs';
 
 import { getSession } from '@revealui/auth/server';
+import { LLM_PROVIDERS } from '@revealui/contracts';
 import { getClient } from '@revealui/db';
 import { encryptApiKey, redactApiKey } from '@revealui/db/crypto';
 import { deleteApiKeys, getApiKeyMetadata, upsertApiKey } from '@revealui/db/queries/user-api-keys';
@@ -9,7 +10,7 @@ import { z } from 'zod';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 const ApiKeySchema = z.object({
-  provider: z.enum(['groq', 'huggingface', 'inference-snaps', 'ollama']),
+  provider: z.enum(LLM_PROVIDERS),
   key: z.string().min(1).max(4096),
 });
 

--- a/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
+++ b/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
@@ -1,16 +1,31 @@
-import { hostedViable } from '@revealui/ai/llm/client';
 import { describe, expect, it } from 'vitest';
+import type { Provider } from '../api-key-providers';
 import { ALL_PROVIDERS, visibleProviders } from '../api-key-providers';
 
+/**
+ * Loads the real `hostedViable` map from `@revealui/ai/llm/client` so this
+ * suite proves alignment with PR-1's classification rather than a
+ * hand-copied duplicate. A dynamic import, not a static one: apps/admin
+ * treats @revealui/ai as an optional Pro peer dependency everywhere,
+ * including test files (`scripts/validate/boundary.ts` Check 4 enforces
+ * this — a static import here would hard-require the Pro package).
+ */
+async function loadHostedViable(): Promise<Record<Provider, boolean>> {
+  const mod = await import('@revealui/ai/llm/client');
+  return mod.hostedViable;
+}
+
 describe('visibleProviders', () => {
-  it('offers all six providers on self-hosted, regardless of the hosted map', () => {
+  it('offers all six providers on self-hosted, regardless of the hosted map', async () => {
+    const hostedViable = await loadHostedViable();
     expect(visibleProviders(false, hostedViable).map((p) => p.id)).toEqual(
       ALL_PROVIDERS.map((p) => p.id),
     );
     expect(visibleProviders(false, null).map((p) => p.id)).toEqual(ALL_PROVIDERS.map((p) => p.id));
   });
 
-  it('hides localhost-only providers on hosted (GAP-360 defect 5)', () => {
+  it('hides localhost-only providers on hosted (GAP-360 defect 5)', async () => {
+    const hostedViable = await loadHostedViable();
     const ids = visibleProviders(true, hostedViable).map((p) => p.id);
     expect(ids).toEqual(['anthropic', 'openai', 'groq', 'huggingface']);
     expect(ids).not.toContain('ollama');

--- a/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
+++ b/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
@@ -1,0 +1,25 @@
+import { hostedViable } from '@revealui/ai/llm/client';
+import { describe, expect, it } from 'vitest';
+import { ALL_PROVIDERS, visibleProviders } from '../api-key-providers';
+
+describe('visibleProviders', () => {
+  it('offers all six providers on self-hosted, regardless of the hosted map', () => {
+    expect(visibleProviders(false, hostedViable).map((p) => p.id)).toEqual(
+      ALL_PROVIDERS.map((p) => p.id),
+    );
+    expect(visibleProviders(false, null).map((p) => p.id)).toEqual(ALL_PROVIDERS.map((p) => p.id));
+  });
+
+  it('hides localhost-only providers on hosted (GAP-360 defect 5)', () => {
+    const ids = visibleProviders(true, hostedViable).map((p) => p.id);
+    expect(ids).toEqual(['anthropic', 'openai', 'groq', 'huggingface']);
+    expect(ids).not.toContain('ollama');
+    expect(ids).not.toContain('inference-snaps');
+  });
+
+  it('fails open to the full list on hosted when the hosted map is unavailable', () => {
+    // e.g. @revealui/ai absent (Pro package stripped) — a display-only
+    // fallback; execution-time enforcement lives in the resolver, not here.
+    expect(visibleProviders(true, null).map((p) => p.id)).toEqual(ALL_PROVIDERS.map((p) => p.id));
+  });
+});

--- a/apps/admin/src/lib/settings/api-key-providers.ts
+++ b/apps/admin/src/lib/settings/api-key-providers.ts
@@ -1,0 +1,85 @@
+/**
+ * Provider catalog for the Settings, API Keys page (GAP-360 §5.7).
+ *
+ * Mirrors the six providers @revealui/ai's `LLMProviderType` supports
+ * (`packages/ai/src/llm/client.ts:49`). Kept as a local string union rather
+ * than importing that type: `@revealui/ai` is an optional Pro peer
+ * dependency for `apps/admin` (`package.json:67`) and every existing
+ * consumer only ever value-imports it dynamically with a `.catch(() =>
+ * null)` fallback (see `src/lib/ai/pro-stub.ts`) — this keeps the same
+ * contract for the display metadata below.
+ */
+
+export type Provider =
+  | 'anthropic'
+  | 'openai'
+  | 'groq'
+  | 'huggingface'
+  | 'ollama'
+  | 'inference-snaps';
+
+export interface ProviderInfo {
+  id: Provider;
+  label: string;
+  placeholder: string;
+  docsUrl: string;
+}
+
+/** All six providers, hosted-viable and localhost-only alike. */
+export const ALL_PROVIDERS: ProviderInfo[] = [
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    placeholder: 'sk-ant-...',
+    docsUrl: 'https://console.anthropic.com/settings/keys',
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    placeholder: 'sk-...',
+    docsUrl: 'https://platform.openai.com/api-keys',
+  },
+  {
+    id: 'groq',
+    label: 'Groq (cloud, LPU silicon)',
+    placeholder: 'gsk_...',
+    docsUrl: 'https://console.groq.com/keys',
+  },
+  {
+    id: 'huggingface',
+    label: 'Hugging Face (cloud)',
+    placeholder: 'hf_...',
+    docsUrl: 'https://huggingface.co/settings/tokens',
+  },
+  {
+    id: 'inference-snaps',
+    label: 'Inference Snaps (Ubuntu, canonical default)',
+    placeholder: 'leave blank — runs locally',
+    docsUrl: 'https://snapcraft.io/search?q=inference',
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama (local)',
+    placeholder: 'leave blank — runs locally',
+    docsUrl: 'https://ollama.com/docs',
+  },
+];
+
+/**
+ * Resolve which providers the Settings, API Keys page should offer.
+ *
+ * Self-hosted: all six. Hosted: only the ones `@revealui/ai`'s
+ * `hostedViable` map marks reachable from a serverless deployment
+ * (anthropic/openai/groq/huggingface) — `ollama`/`inference-snaps` are
+ * localhost-only and useless on hosted (GAP-360 defect 5). When the hosted
+ * map can't be resolved (Pro package absent), fail open to the full list —
+ * this only affects what the page DISPLAYS; execution-time provider choice
+ * is enforced independently by the resolver (GAP-360 PR-2).
+ */
+export function visibleProviders(
+  isHosted: boolean,
+  hostedViable: Record<Provider, boolean> | null,
+): ProviderInfo[] {
+  if (!(isHosted && hostedViable)) return ALL_PROVIDERS;
+  return ALL_PROVIDERS.filter((provider) => hostedViable[provider.id]);
+}

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -1,9 +1,18 @@
 /**
  * Supported LLM providers across the platform. Single source of truth.
- * Open models only — no proprietary providers (OpenAI, Anthropic).
  *
  * Two local (no API key required): inference-snaps (Ubuntu, default), ollama.
- * Two cloud (BYOK): groq (LPU silicon), huggingface (model variety).
+ * Four cloud (BYOK): groq (LPU silicon), huggingface (model variety),
+ * anthropic, openai (frontier providers, added GAP-360 — OpenAI-compatible
+ * endpoint configs per the ratified design's provider posture, no proprietary
+ * SDKs).
  */
-export const LLM_PROVIDERS = ['groq', 'huggingface', 'inference-snaps', 'ollama'] as const;
+export const LLM_PROVIDERS = [
+  'anthropic',
+  'openai',
+  'groq',
+  'huggingface',
+  'inference-snaps',
+  'ollama',
+] as const;
 export type LLMProvider = (typeof LLM_PROVIDERS)[number];


### PR DESCRIPTION
## Scope

GAP-360 PR-3, the onboarding-honesty scope of the internal design spec §5.7 only. Not §5.1/§5.2/§5.4/§5.6 (PR-1/PR-2, already merged) and not §5.5 (admin agent-stream 404 rewrite, a separate follow-up PR, out of scope here).

Fixes gap defect 5 (`docs/gaps/GAP-360.yml`): the Settings, API Keys page offered only inference-snaps/ollama/groq/huggingface (no Anthropic, no OpenAI), and its "tasks will use your key" banner was false before PR-2 wired `createLLMClientForUser` into dispatch.

## What changed

**A. Anthropic + OpenAI on the settings page** — `apps/admin/src/lib/settings/api-key-providers.ts` (new) adds both to the provider catalog with display labels, key placeholders (`sk-ant-...`, `sk-...`), and docs links (`console.anthropic.com/settings/keys`, `platform.openai.com/api-keys`). These ride the existing BYOK save path (`/api/user/api-keys`, `user_api_keys` table) unchanged — no storage/crypto path was touched.

**B. Hosted filtering** — the page is now a server/client split:
- `apps/admin/src/app/(backend)/settings/api-keys/page.tsx` is a server component. It resolves `isHosted = !!process.env.REVEALUI_LICENSE_PRIVATE_KEY` (same signal as `app/api/chat/route.ts:315`) and dynamically imports `@revealui/ai/llm/client` to read the real `hostedViable` classification PR-1 shipped — reused, not re-derived. Only the resulting boolean + filtered provider list cross into the client component; the env var itself never does.
- `apps/admin/src/lib/settings/api-key-providers.ts` exports the pure `visibleProviders(isHosted, hostedViable)` helper: self-hosted → all 6, hosted → only the 4 `hostedViable` ones (anthropic/openai/groq/huggingface), hiding ollama/inference-snaps (useless on hosted, GAP-360 defect 5). If `@revealui/ai` can't be resolved (Pro package absent), it fails open to the full list — display-only fallback; execution-time enforcement is the PR-2 resolver, not this page.
- `apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx` (new) is the client component — the prior page's logic, now taking `providers`/`isHosted` as props.

**Necessary plumbing fix (not scope creep):** `packages/contracts/src/providers.ts`'s `LLM_PROVIDERS` — its own doc comment calls it "single source of truth" — was left at 4 providers by PR-1 (which only widened `@revealui/ai`'s `LLMProviderType` and the DB CHECK constraints). Two other BYOK validation paths import it (`apps/server/src/routes/api-keys.ts`, `packages/mcp/src/servers/factories/contracts.ts`), and `apps/admin`'s own `/api/user/api-keys` route had a *third*, independently hardcoded 4-provider Zod enum. Without widening these, a saved Anthropic/OpenAI key would 400 at every one of these validation boundaries — the settings-page addition would be inert. Fixed by widening `LLM_PROVIDERS` to 6 (changeset: `@revealui/contracts` minor) and switching the admin route's Zod schema to `z.enum(LLM_PROVIDERS)` instead of its own duplicate literal (extend-before-create: one less duplicate list).

**Is this a duplicate of `@revealui/ai`'s `LLMProviderType`/`hostedViable`?** No — checked explicitly. `LLM_PROVIDERS` is a plain string-literal validation contract consumed by packages that must NOT depend on `@revealui/ai` (an optional Fair Source peer dependency); `hostedViable` is runtime classification logic that only `@revealui/ai` owns and that this PR reuses via dynamic import rather than re-deriving. The two unions (`LLMProviderType` in `@revealui/ai`, `LLMProvider` in `@revealui/contracts`) predate this PR and were already independently maintained with identical literal values — PR-1 widened one and not the other, which is exactly the drift this PR closes. Consolidating them into a single export (`@revealui/ai` importing its union from `@revealui/contracts`, the correct dependency direction since `ai` already depends on `contracts`) is a real, separate architectural cleanup — out of scope for a settings-UI PR and not requested here.

**C. Honest copy** — verified against copy-voice.md (no em dashes, full clauses, possessive/concrete):
- Header: "Inference Endpoint" → "AI Provider" (no longer open-model-only).
- Description: "Configure your open-model inference endpoint..." → "Connect the AI provider your agents run on. We store your key encrypted on RevealUI's servers and only use it server-side when an agent task runs." (drops the now-false "open-model" framing).
- Success banner: kept per the brief ("tasks will use your key" is true now that PR-2 wires the resolver into dispatch) but reworded to two real sentences: "{Provider} key configured (hint). Agent tasks will use it."
- New: a one-line hosted-only hint ("This is a hosted deployment, so local-only providers like Ollama and Inference Snaps aren't listed below.") shown only when `isHosted`, so the shorter list on hosted doesn't read as a bug.

**D. `inference-prerequisite.ts`** — left untouched. Its copy is provider-neutral already (doesn't claim open-model-only), and `inference-prerequisite.test.ts` asserts it names no proprietary vendor — touching it would risk that test for no copy-accuracy gain.

## Out of scope (per brief)

- Optional key-verify probe (§5.7 P2).
- MCP-servers empty-state hosted copy (§5.7 P2).
- §5.5 admin agent-stream 404 rewrite (separate follow-up PR).

## Tests

- `apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts` (3 tests) — the pure `visibleProviders` helper: self-hosted → 6 providers regardless of the hosted map, hosted → exactly `['anthropic','openai','groq','huggingface']`, hosted + unresolvable hosted map → fails open to 6. Uses the real `hostedViable` from `@revealui/ai/llm/client` (dynamically imported inside the test — a static import there would violate `scripts/validate/boundary.ts` Check 4's optional-Pro-dependency boundary, which treats apps/admin test files the same as production code).
- `apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx` (4 tests) — renders with hosted vs self-hosted provider props, get-key link per active provider, and the honest "will use it" banner once a key is configured.
- `apps/admin/src/app/(backend)/settings/api-keys/__tests__/page.test.tsx` (2 tests) — the server shell resolving `REVEALUI_LICENSE_PRIVATE_KEY` presence/absence into the right provider list end to end.
- Proved red first: temporarily reverted `visibleProviders` to always return the full list and confirmed all three test files failed on the hosted-filtering assertions, then restored the real implementation and confirmed green.

## Gate results

- `pnpm --filter admin test`: **2005 passed, 13 skipped, 0 failed** (153 files).
- `pnpm -r typecheck`: **32/32 workspace projects clean**, zero errors.
- `pnpm lint`: clean (0 errors; 9 pre-existing warnings elsewhere — marketing `PhilosophyPage.tsx` array-index keys, an e2e undeclared-env-var lint — untouched by this PR).
- Pre-push gate (feature-branch quality-only phase, per this repo's branch pipeline): **Security Gate PASS** (2 pre-existing warn-only findings, unrelated files) + **CI Gate PASS**, all 26 checks including Boundary validation, Biome lint, RSC CVE floor, and the hard-fail doc/claim/pricing/security checks.

## Security-checker output

```
$ (fleet security-pr-review checker) --diff origin/test
Current branch vs origin/test: no security-sensitive files — no coordinator gate.
```

Checked against the full changed-file list (`.changeset/`, the settings/api-keys page + new client/test files, `apps/admin/src/app/api/user/api-keys/route.ts`, `apps/admin/src/lib/settings/`, `packages/contracts/src/providers.ts`) — none match the checker's sensitive-path substrings (`routes/api-keys`, `middleware/*`, `packages/security/`, etc.). This tracks: no storage/crypto/auth path changed, only display filtering + a validation-enum widening. Not adding `area:security` since the tool didn't flag it.

---

Part 3/3 of GAP-360. §5.5 (admin agent-stream 404 rewrite) is a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

