### PR TITLE
fix(admin): proxy /api/agent-stream to the API host (GAP-360 §5.5)

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -155,6 +155,28 @@ const nextConfig = {
       },
     ]
   },
+  async rewrites() {
+    // GAP-360 §5.5: the admin Run / Watch-live UI POSTs same-origin to
+    // /api/agent-stream and /api/agent-stream/elicit, but those handlers live
+    // on the API host, not the admin app, so the calls 404 without a proxy.
+    // Rewrite them to the API host so the request stays same-origin (the
+    // CSRF/cookie/CORS posture is untouched) and the SSE stream is proxied
+    // through. When NEXT_PUBLIC_SERVER_URL is unset (single-origin dev), no
+    // rewrite is added so nothing loops back on itself.
+    let serverUrl = process.env.NEXT_PUBLIC_SERVER_URL
+    if (!serverUrl) return []
+    while (serverUrl.endsWith('/')) serverUrl = serverUrl.slice(0, -1)
+    return [
+      {
+        source: '/api/agent-stream',
+        destination: `${serverUrl}/api/agent-stream`,
+      },
+      {
+        source: '/api/agent-stream/:path*',
+        destination: `${serverUrl}/api/agent-stream/:path*`,
+      },
+    ]
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
Fixes the guaranteed 404 that GAP-360 §5.5 identified and PR-2 deferred. The admin **Run / Watch-live** UI POSTs same-origin to `/api/agent-stream` and `/api/agent-stream/elicit` (`useAgentStream.ts:182,275`), but those handlers live only on the API host (`apps/server/src/index.ts:864-867`). The admin app has no such route, so hosted agent runs 404 today. This is the piece that makes the per-account execution built in PR-1/PR-2 actually reachable from the admin UI.

## Change
Adds `next.config.mjs` rewrites for `/api/agent-stream` and `/api/agent-stream/:path*` to `NEXT_PUBLIC_SERVER_URL`. Per the spec (§5.5): a **rewrite** (not a client-side `apiBase` change) keeps the calls same-origin, so the existing CSRF/cookie/CORS posture is untouched and Vercel proxies the SSE stream through. No rewrite is added when `NEXT_PUBLIC_SERVER_URL` is unset (single-origin dev). Trailing-slash strip is no-regex per repo policy. Verified no admin `/api/agent-stream` route exists to shadow.

## Verification
- `node --check` + Biome clean; no regex, no em dashes.
- **Needs a live check before merge:** streaming-through-rewrite (SSE) behavior can only be confirmed on a real hosted origin. Deploy a Vercel preview and confirm a Run / Watch-live agent stream actually flows end-to-end. Spec fallback if it misbehaves: thread the API base into `useAgentStream` via the public API-URL config + CORS (bigger diff, only if the rewrite fails the live test).

Companion: GAP-360 PR-3 (settings UI listing the BYO providers) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)