### PR TITLE
feat(harnesses): register opencode roadmap profile and detection data

### DIFF
--- a/.changeset/opencode-roadmap-profile.md
+++ b/.changeset/opencode-roadmap-profile.md
@@ -1,0 +1,8 @@
+---
+"@revealui/harnesses": minor
+---
+
+Register OpenCode as a roadmap capability profile (data only): capability
+declaration, process-detection pattern, config paths, degradation row, and
+`SessionType`. No adapter class ships in this change — `TOOL_PROFILES` and
+`auto-detector.ts` are unchanged, so there is no new runtime behavior.

--- a/packages/harnesses/src/__tests__/harness-config-paths.test.ts
+++ b/packages/harnesses/src/__tests__/harness-config-paths.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   getConfigurableHarnesses,
@@ -11,6 +12,7 @@ describe('harness-config-paths', () => {
     expect(ids).toContain('claude-code');
     expect(ids).toContain('cursor');
     expect(ids).toContain('copilot');
+    expect(ids).toContain('opencode');
   });
 
   it('returns local config path for claude-code', () => {
@@ -25,6 +27,12 @@ describe('harness-config-paths', () => {
     expect(p).toMatch(/\.cursor\/settings\.json$/);
   });
 
+  it('returns local config path for opencode', () => {
+    const p = getLocalConfigPath('opencode');
+    expect(p).toBeDefined();
+    expect(p?.endsWith(join('.config', 'opencode', 'opencode.json'))).toBe(true);
+  });
+
   it('returns undefined for unknown harness', () => {
     expect(getLocalConfigPath('unknown-tool')).toBeUndefined();
   });
@@ -34,6 +42,13 @@ describe('harness-config-paths', () => {
     expect(p).toBeDefined();
     expect(p).toContain('harness-configs/claude-code');
     expect(p).toContain('settings.json');
+  });
+
+  it('returns root config path for opencode', () => {
+    const p = getRootConfigPath('opencode', '/mnt/e/.revealui');
+    expect(p).toBeDefined();
+    expect(p).toContain('harness-configs/opencode');
+    expect(p).toContain('opencode.json');
   });
 
   it('returns undefined root path for unknown harness', () => {

--- a/packages/harnesses/src/__tests__/protocol-types.test.ts
+++ b/packages/harnesses/src/__tests__/protocol-types.test.ts
@@ -61,8 +61,13 @@ describe('TOOL_PROFILES (shipped adapters)', () => {
 });
 
 describe('ROADMAP_PROFILES (declared, no adapter)', () => {
-  it('contains the three spec-declared tools', () => {
-    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex', 'cursor']);
+  it('contains the four spec-declared tools', () => {
+    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual([
+      'claude-code',
+      'codex',
+      'cursor',
+      'opencode',
+    ]);
   });
 
   it('claude-code has no dispatch capabilities (interactive tool)', () => {
@@ -85,6 +90,19 @@ describe('ROADMAP_PROFILES (declared, no adapter)', () => {
     expect(caps.lifecycleEvents).toEqual([]);
   });
 
+  it('opencode is headless/resumable/forkable/backgroundable but has no hooks', () => {
+    const caps = ROADMAP_PROFILES.opencode;
+    expect(caps.headless).toBe(true);
+    expect(caps.resumable).toBe(true);
+    expect(caps.forkable).toBe(true);
+    expect(caps.backgroundable).toBe(true);
+    expect(caps.hooks.supported).toBe(false);
+    expect(caps.hooks.canBlock).toBe(false);
+    expect(caps.supportsSkills).toBe(true);
+    expect(caps.supportsMcp).toBe(true);
+    expect(caps.supportsWorktrees).toBe(false);
+  });
+
   it('does not overlap with TOOL_PROFILES', () => {
     for (const id of Object.keys(ROADMAP_PROFILES)) {
       expect(TOOL_PROFILES[id]).toBeUndefined();
@@ -93,11 +111,12 @@ describe('ROADMAP_PROFILES (declared, no adapter)', () => {
 });
 
 describe('ALL_KNOWN_PROFILES (merged view)', () => {
-  it('contains all four declared tools', () => {
+  it('contains all five declared tools', () => {
     expect(Object.keys(ALL_KNOWN_PROFILES).sort()).toEqual([
       'claude-code',
       'codex',
       'cursor',
+      'opencode',
       'revealui-agent',
     ]);
   });
@@ -215,6 +234,14 @@ describe('degradation strategies', () => {
 
   it('returns absent for unknown tools', () => {
     expect(getDegradationStrategy('unknown-tool', 'session.start')).toBe('absent');
+  });
+
+  it('returns absent for opencode per-tool events (no hooks) and polyfill for lifecycle events', () => {
+    expect(getDegradationStrategy('opencode', 'tool.before')).toBe('absent');
+    expect(getDegradationStrategy('opencode', 'tool.after')).toBe('absent');
+    expect(getDegradationStrategy('opencode', 'tool.blocked')).toBe('absent');
+    expect(getDegradationStrategy('opencode', 'session.start')).toBe('polyfill');
+    expect(getDegradationStrategy('opencode', 'agent.heartbeat')).toBe('polyfill');
   });
 
   it('revealui-agent has no degradation for any event', () => {

--- a/packages/harnesses/src/__tests__/session-identity.test.ts
+++ b/packages/harnesses/src/__tests__/session-identity.test.ts
@@ -31,4 +31,9 @@ describe('deriveSessionId', () => {
     expect(deriveSessionId('codex', [])).toBe('codex-1');
     expect(deriveSessionId('codex', ['codex-1', 'codex-2'])).toBe('codex-3');
   });
+
+  it('supports opencode session type', () => {
+    expect(deriveSessionId('opencode', [])).toBe('opencode-1');
+    expect(deriveSessionId('opencode', ['opencode-1'])).toBe('opencode-2');
+  });
 });

--- a/packages/harnesses/src/config/harness-config-paths.ts
+++ b/packages/harnesses/src/config/harness-config-paths.ts
@@ -16,12 +16,14 @@ const LOCAL_CONFIG_PATHS: Record<string, string> = {
   'claude-code': join(HOME, '.claude', 'settings.json'),
   cursor: join(HOME, '.cursor', 'settings.json'),
   copilot: join(HOME, '.config', 'github-copilot', 'hosts.json'),
+  opencode: join(HOME, '.config', 'opencode', 'opencode.json'),
 };
 
 const ROOT_CONFIG_FILES: Record<string, string> = {
   'claude-code': 'settings.json',
   cursor: 'settings.json',
   copilot: 'hosts.json',
+  opencode: 'opencode.json',
 };
 
 /** Returns the local config file path for a given harness id, or undefined if unknown. */

--- a/packages/harnesses/src/detection/process-detector.ts
+++ b/packages/harnesses/src/detection/process-detector.ts
@@ -29,6 +29,7 @@ const HARNESS_PROCESS_PATTERNS: Record<string, string[]> = {
   'claude-code': ['claude'],
   cursor: ['cursor', 'Cursor'],
   copilot: ['copilot'],
+  opencode: ['opencode'],
 };
 
 /** Finds running process instances for a specific harness. */

--- a/packages/harnesses/src/protocol/degradation-strategies.ts
+++ b/packages/harnesses/src/protocol/degradation-strategies.ts
@@ -51,6 +51,22 @@ const DEGRADATION_TABLE: Record<string, Partial<Record<ProtocolEvent, Degradatio
   'revealui-agent': {
     // RevealUI Agent natively supports all 10 events; no degradation needed.
   },
+  // No working adapter yet (GAP-371 Phase 0: data only). No hook system
+  // (canBlock: false), so per-tool events have no source to polyfill from;
+  // session/task/heartbeat events are synthesizable from process lifecycle
+  // (headless + backgroundable via `opencode serve`).
+  opencode: {
+    'session.start': 'polyfill',
+    'session.stop': 'polyfill',
+    'session.crash': 'polyfill',
+    'prompt.submit': 'polyfill',
+    'tool.before': 'absent',
+    'tool.after': 'absent',
+    'tool.blocked': 'absent',
+    'task.claimed': 'polyfill',
+    'task.completed': 'polyfill',
+    'agent.heartbeat': 'polyfill',
+  },
 };
 
 /**

--- a/packages/harnesses/src/protocol/roadmap-profiles.ts
+++ b/packages/harnesses/src/protocol/roadmap-profiles.ts
@@ -111,6 +111,33 @@ export const ROADMAP_PROFILES: Record<string, ProtocolCapabilities> = {
     maxContextTokens: 128_000,
     lifecycleEvents: [],
   },
+
+  // No working adapter yet (GAP-371 Phase 0: data only). Plugins exist in
+  // OpenCode but no adapter wiring ships, so hooks stay honestly unsupported.
+  opencode: {
+    dispatch: {
+      generateCode: true,
+      analyzeCode: true,
+      applyEdit: false,
+      executeCommand: true,
+    },
+    readWorkboard: false,
+    writeWorkboard: false,
+    claimTasks: false,
+    reportConflicts: false,
+    headless: true,
+    resumable: true,
+    forkable: true,
+    backgroundable: true,
+    hooks: { supported: false, granularity: 'none', canBlock: false },
+    sandbox: { supported: false, modes: [] },
+    supportsWorktrees: false,
+    supportsSkills: true,
+    supportsMcp: true,
+    memory: { supported: false, backend: 'none' },
+    maxContextTokens: 0,
+    lifecycleEvents: [],
+  },
 } as const;
 
 /**

--- a/packages/harnesses/src/workboard/session-identity.ts
+++ b/packages/harnesses/src/workboard/session-identity.ts
@@ -6,7 +6,7 @@ import { readFileSync } from 'node:fs';
  * Supports tool-prefixed identifiers ('claude', 'codex') alongside
  * IDE-based types ('zed', 'cursor') and a generic 'terminal' fallback.
  */
-export type SessionType = 'claude' | 'codex' | 'zed' | 'cursor' | 'terminal';
+export type SessionType = 'claude' | 'codex' | 'zed' | 'cursor' | 'opencode' | 'terminal';
 
 /**
  * Detects the session type using a 7-tier identity cascade.
@@ -30,6 +30,7 @@ export function detectSessionType(): SessionType {
     if (tool === 'codex') return 'codex';
     if (tool === 'cursor') return 'cursor';
     if (tool === 'zed') return 'zed';
+    if (tool === 'opencode') return 'opencode';
     return 'terminal';
   }
 
@@ -40,7 +41,13 @@ export function detectSessionType(): SessionType {
   try {
     const cachePath = `/tmp/protocol-session-${process.ppid}.id`;
     const cached = readFileSync(cachePath, 'utf8').trim();
-    if (cached === 'claude' || cached === 'codex' || cached === 'zed' || cached === 'cursor') {
+    if (
+      cached === 'claude' ||
+      cached === 'codex' ||
+      cached === 'zed' ||
+      cached === 'cursor' ||
+      cached === 'opencode'
+    ) {
       return cached;
     }
   } catch {
@@ -59,6 +66,7 @@ export function detectSessionType(): SessionType {
       if (cmdline.includes('codex')) return 'codex';
       if (cmdline.includes('zed')) return 'zed';
       if (cmdline.includes('cursor')) return 'cursor';
+      if (cmdline.includes('opencode')) return 'opencode';
       const status = readFileSync(`/proc/${pid}/status`, 'utf8');
       const m = status.match(/PPid:\s+(\d+)/);
       if (!m) break;


### PR DESCRIPTION
## Summary

Phase 0 (data-only) of the OpenCode harness integration: registers OpenCode as a
**roadmap capability profile** in `@revealui/harnesses`, alongside the existing
`claude-code`, `codex`, and `cursor` roadmap entries.

- No adapter class, no behavior change.
- `ROADMAP_PROFILES.opencode` — honest capability declaration (headless,
  resumable, forkable, backgroundable; no hooks/sandbox/worktrees/memory support
  yet; skills + MCP supported).
- Process-detection pattern (`opencode`), local + root config paths
  (`~/.config/opencode/opencode.json`), a degradation-table row, and a new
  `SessionType` value (`opencode`) with `/proc` cmdline detection.
- `TOOL_PROFILES`, `auto-detector.ts`, and `capabilities.ts` are untouched —
  this is a **roadmap profile**, not a working adapter. It gets promoted to
  `TOOL_PROFILES` when the adapter ships (see the internal design doc for the
  phased build plan).
- Pinned tests updated: `protocol-types.test.ts`, `harness-config-paths.test.ts`,
  `session-identity.test.ts`.
- Changeset: `@revealui/harnesses` minor.

## Test plan

- [x] `pnpm --filter @revealui/harnesses test` — 275/275 passing
- [x] `pnpm --filter @revealui/harnesses typecheck` — clean
- [x] `pnpm --filter @revealui/harnesses build` — clean
- [x] Biome clean on all touched files
- [x] Confirmed `TOOL_PROFILES`, `auto-detector.ts` byte-unchanged (no new
      adapter registered, no runtime behavior change)
