### PR TITLE
fix(ci): sec-audit label guard survives transient gh-API failures

### DIFF
--- a/.github/workflows/sec-audit-label-guard.yml
+++ b/.github/workflows/sec-audit-label-guard.yml
@@ -72,11 +72,32 @@ jobs:
               echo "PR #$pr is not open ($state) — skip."; echo "::endgroup::"; continue
             fi
 
-            sha=$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq '.headRefOid')
-            labels=$(gh pr view "$pr" --repo "$REPO" --json labels --jq '[.labels[].name]')
-            checks=$(gh api "repos/$REPO/commits/$sha/check-runs" --paginate \
-              --jq '[.check_runs[] | {name: .name, conclusion: .conclusion, status: .status}]' \
-              | jq -s 'add // []')
+            sha=$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
+            labels=$(gh pr view "$pr" --repo "$REPO" --json labels --jq '[.labels[].name]' 2>/dev/null || true)
+            if [ -z "$sha" ] || [ -z "$labels" ]; then
+              echo "::warning::PR #$pr — could not read PR metadata (transient API error?); skipping."
+              echo "::endgroup::"; continue
+            fi
+
+            # Fetch check-runs resiliently. A transient gh-API 5xx can return an
+            # HTML body, which crashes jq ("invalid character '<'"). Fetch RAW
+            # (no gh --jq so gh's own jq pass can't crash), retry a few times,
+            # then SKIP — never error the workflow. Fail-safe: a skip performs
+            # no revoke, and the next check_suite event re-evaluates the PR.
+            checks=""
+            for attempt in 1 2 3; do
+              raw=$(gh api "repos/$REPO/commits/$sha/check-runs" --paginate 2>/dev/null || true)
+              if [ -n "$raw" ]; then
+                parsed=$(printf '%s' "$raw" \
+                  | jq -s '[.[].check_runs[]? | {name: .name, conclusion: .conclusion, status: .status}]' 2>/dev/null || true)
+                if [ -n "$parsed" ]; then checks="$parsed"; break; fi
+              fi
+              sleep 2
+            done
+            if [ -z "$checks" ]; then
+              echo "::warning::PR #$pr — check-runs API unavailable or non-JSON after retries; skipping (fail-safe, no revoke). The next check_suite event re-evaluates."
+              echo "::endgroup::"; continue
+            fi
 
             payload=$(jq -n \
               --argjson checkRuns "$checks" \


### PR DESCRIPTION
Hardens the Security Audit Label Guard (shipped in #1899) against transient GitHub-API failures.

## The bug
The guard ran `gh api … | jq` under `set -euo pipefail` with no error handling on the `sha` / `labels` / `check-runs` fetches. A transient gh-API 5xx returns an HTML body, which crashes `jq` ("invalid character '<'") and errors the whole workflow — a **spurious red check on any PR** whenever the API hiccups, fleet-wide (the guard runs on every `check_suite:completed`). Surfaced by a 503 flake on #1906, which carries no clearance label for the guard to act on.

## The fix
- `sha` / `labels` fetches: skip the PR on failure (warning, not error).
- `check-runs`: fetched RAW (no `gh --jq`, so gh's own jq pass can't crash on HTML), JSON-validated, with a 3× retry, then the PR is skipped if still unavailable.
- **Fail-safe unchanged**: a skip performs no revoke; the next `check_suite` event re-evaluates. No change to the gate logic or the decision script.

Verified: YAML + `bash -n` clean; the jq flattening produces the same `[{name,conclusion,status}]` shape on a normal paginated response and falls through to a fail-safe skip on an HTML body.

Note: this touches security-enforcement machinery (`.github/workflows/security*`), which the fleet `SECURITY_PATHS` list does NOT currently classify as sensitive — flagged separately as a classification gap. Labeled `area:security` manually. Resilience-only; no gate-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)