### PR TITLE
fix(ci): classify security-enforcement machinery as security-sensitive

### DIFF
--- a/scripts/validate/__tests__/security-review-gate.test.ts
+++ b/scripts/validate/__tests__/security-review-gate.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+const { SECURITY_PATHS, classifyFiles } = require('../security-review-gate.cjs');
+
+// The enforcement-machinery markers this gate must self-protect. A PR editing
+// any of these files has to carry a recorded guardrail-2 verdict before merge.
+const ENFORCEMENT_MACHINERY_FILES = [
+  'scripts/validate/security-review-gate.cjs',
+  'scripts/validate/sec-audit-label-decision.cjs',
+  '.github/workflows/security-review-gate.yml',
+  '.github/workflows/sec-audit-label-guard.yml',
+  '.github/workflows/security.yml',
+];
+
+describe('classifyFiles — enforcement-machinery self-protection', () => {
+  it.each(ENFORCEMENT_MACHINERY_FILES)('flags %s as security-sensitive', (file) => {
+    expect(classifyFiles([file])).toContain(file);
+  });
+
+  it('flags a whole changeset when only a machinery file is touched', () => {
+    const changed = ['README.md', 'scripts/validate/sec-audit-label-decision.cjs'];
+    expect(classifyFiles(changed)).toEqual(['scripts/validate/sec-audit-label-decision.cjs']);
+  });
+
+  it('does NOT flag an unrelated file (red-proof for the new markers)', () => {
+    // This benign path contains none of the machinery markers. If the markers
+    // were removed, ENFORCEMENT_MACHINERY_FILES above would stop being flagged;
+    // this line guarantees the markers are not so broad they catch everything.
+    expect(classifyFiles(['apps/marketing/app/components/Hero.tsx'])).toEqual([]);
+  });
+});
+
+describe('SECURITY_PATHS — machinery markers present', () => {
+  const MACHINERY_MARKERS = [
+    'scripts/validate/security-review-gate',
+    'scripts/validate/sec-audit-label-decision',
+    '.github/workflows/security-review-gate',
+    '.github/workflows/sec-audit-label-guard',
+    '.github/workflows/security.yml',
+  ];
+
+  it.each(MACHINERY_MARKERS)('includes the %s marker', (marker) => {
+    expect(SECURITY_PATHS).toContain(marker);
+  });
+});

--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -75,6 +75,17 @@ const SECURITY_PATHS = [
   // unflagged. Keep in lockstep with .jv scripts/security-pr-review-check.js.
   'api/shapes/',
   'api/sync/',
+  // Self-protection: changes to the security-enforcement machinery must
+  // themselves carry a guardrail-2 verdict. Surfaced 2026-07-16 when the
+  // sec-audit-label-guard work bypassed this gate — a PR editing the gate/guard
+  // scripts or their workflows classified as NOT security-sensitive, so the
+  // machinery that decides what is security-sensitive was itself unguarded.
+  // Keep in lockstep with the fleet checker (separate .jv PR).
+  'scripts/validate/security-review-gate',
+  'scripts/validate/sec-audit-label-decision',
+  '.github/workflows/security-review-gate',
+  '.github/workflows/sec-audit-label-guard',
+  '.github/workflows/security.yml',
 ];
 
 // A recorded reviewer verdict = an approving GH review OR one of these labels.
@@ -187,4 +198,11 @@ function main() {
   runDiffMode(base);
 }
 
-main();
+// Export the surface list + classifier so the unit test can assert the
+// classification without spawning the CLI. Guarding main() behind
+// require.main === module keeps the CLI behavior identical when run directly.
+module.exports = { SECURITY_PATHS, SEC_REVIEW_LABELS, classifyFiles };
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## The gap

The `security-review-gate.cjs` `SECURITY_PATHS` list decides whether a PR is security-sensitive (and thus needs a recorded review verdict before merge). It covered auth, license, payment, and content surfaces but **not the security-enforcement machinery itself**. So a PR editing the gate script, the audit-guard decision script, or their workflows classified as NOT security-sensitive and bypassed the review gate. Surfaced 2026-07-16 when the sec-audit-label-guard work went in without a recorded verdict.

## The change

Add self-protection markers to `SECURITY_PATHS` (exact substrings):

- `scripts/validate/security-review-gate`
- `scripts/validate/sec-audit-label-decision`
- `.github/workflows/security-review-gate`
- `.github/workflows/sec-audit-label-guard`
- `.github/workflows/security.yml`

Now any PR touching the machinery that decides what is security-sensitive is itself classified security-sensitive and must carry a recorded verdict.

Also exports `SECURITY_PATHS` + `classifyFiles` and guards `main()` behind `require.main === module` so the new unit test asserts classification without spawning the CLI (matches `sec-audit-label-decision.cjs`). Behavior when run directly is unchanged.

## Test

New `scripts/validate/__tests__/security-review-gate.test.ts` (12 cases): each new marker's file classifies as sensitive, a machinery-only changeset is flagged, and an unrelated file (`apps/marketing/app/components/Hero.tsx`) is NOT flagged. Red-proof: with the markers removed, 11 cases fail while the unrelated-file case still passes — isolating the markers. All 12 pass with the fix; the full pre-push gate passes.

## Self-trigger (intended)

Because the in-repo gate runs the branch's OWN `security-review-gate.cjs`, adding the `scripts/validate/security-review-gate` marker means **this PR classifies itself as security-sensitive** and requires the `sec-review:approved` label before merge. That is correct and intended — the gate self-protects immediately. Confirmed locally: `node scripts/validate/security-review-gate.cjs --diff origin/test` now HOLDs (exit 1) on this branch. The owner applies the label after review.

## Lockstep

The fleet checker carries an identical `SECURITY_PATHS` list and is being widened with the same five markers in lockstep (separate change). Keep the two lists in lockstep on every future widening.
