### PR TITLE
feat(mcp): governed authenticated MCP endpoint at /api/mcp

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -112,6 +112,7 @@ import licenseRoute from './routes/license.js';
 import logsRoute from './routes/logs.js';
 import maintenanceRoute from './routes/maintenance.js';
 import marketplaceRoute from './routes/marketplace.js';
+import { mountMcpEndpoint } from './routes/mcp-endpoint.js';
 import mcpUsageRoute from './routes/mcp-usage.js';
 import ogRoute from './routes/og.js';
 import pricingRoute from './routes/pricing.js';
@@ -1175,6 +1176,10 @@ app.route('/api/agent-stream/elicit', agentStreamElicitRoute);
 app.route('/api/agent-stream', agentStreamRoute);
 // A.3: Usage aggregation endpoint for the /admin/mcp Usage tab.
 app.route('/api/mcp/usage', mcpUsageRoute);
+// GAP-371 Phase 1: governed MCP endpoint. Bound to the EXACT path /api/mcp
+// (auth → entitlements → requireFeature('mcp') → Streamable HTTP), so it does
+// not shadow the /api/mcp/usage route mounted above.
+mountMcpEndpoint(app);
 app.route('/api/content', contentRoute);
 app.route('/api/rag', ragIndexRoute);
 app.route('/api/admin', adminObservabilityRoute);

--- a/apps/server/src/lib/mcp-audit.ts
+++ b/apps/server/src/lib/mcp-audit.ts
@@ -1,0 +1,162 @@
+/**
+ * Governed-MCP audit writer (GAP-371 Phase 1).
+ *
+ * Writes one hash-chained receipt to `audit_log` for every `tools/call` on the
+ * `/api/mcp` endpoint. Reuses the failure classifier + rolling-ratio tracker
+ * that every other audit write path funnels through
+ * (`classifyAuditWriteFailure` / `recordAuditWriteResult`).
+ *
+ * `recordMcpToolAudit` THROWS when the write does not land, so the caller (the
+ * content factory's audit sink) can fail closed for mutating tools and degrade
+ * for reads — the factory owns that policy split, not this module.
+ *
+ * Hash chain. Each receipt is signed HMAC-SHA256 over its immutable fields plus
+ * the previous receipt's signature, so tampering with any row invalidates every
+ * later signature. The MCP receipt stream keeps its OWN per-process chain head
+ * (`lastMcpSignature`), independent of the security-event chain in
+ * `postgres-audit-storage.ts`. This is INTENTIONAL duplication, not drift: the
+ * two are distinct append streams interleaved in one table (exactly as the
+ * unsigned credential-event rows already coexist there), each independently
+ * verifiable by walking its own eventType stream. Consolidating both onto a
+ * single shared chain head is a deliberate future refactor, not a Phase-1
+ * concern (audit-first §Mindfulness: classified INTENTIONAL).
+ */
+
+import { createHmac, randomUUID } from 'node:crypto';
+import { classifyAuditWriteFailure, recordAuditWriteResult } from '@revealui/core/security';
+import { getClient } from '@revealui/db';
+import { auditLog } from '@revealui/db/schema';
+
+export type McpAuditOutcome = 'invoked' | 'denied' | 'failed';
+
+const OUTCOME_TO_EVENT_TYPE: Readonly<Record<McpAuditOutcome, string>> = {
+  invoked: 'mcp:tool:invoked',
+  denied: 'mcp:tool:denied',
+  failed: 'mcp:tool:failed',
+};
+
+export interface McpAuditInput {
+  outcome: McpAuditOutcome;
+  /** MCP client name from the `initialize` handshake (e.g. `opencode`). */
+  clientName: string;
+  /** MCP session id the call routed through. */
+  sessionId?: string;
+  /** The user resolved from the verified bearer token (never client input). */
+  userId: string;
+  /** Server-derived account, or null when the caller has no account. */
+  accountId: string | null;
+  tool: string;
+  /** sha256 (hex) of the canonical JSON of the raw args. Raw args never stored. */
+  argsDigest: string;
+  /** Allowlisted non-secret scalars (collection, site_id). */
+  scalars: Record<string, string>;
+  durationMs: number;
+  httpStatus?: number;
+}
+
+/** Per-process hash-chain head for the MCP receipt stream. */
+let lastMcpSignature: string | null = null;
+
+/** Test-only reset of the chain head. */
+export function __resetMcpAuditChainForTest(): void {
+  lastMcpSignature = null;
+}
+
+function getAuditSecret(): string {
+  const secret = process.env.REVEALUI_AUDIT_HMAC_SECRET ?? process.env.REVEALUI_SECRET;
+  if (!secret) {
+    throw new Error(
+      'Audit HMAC signing requires REVEALUI_AUDIT_HMAC_SECRET (or REVEALUI_SECRET fallback) ' +
+        'to be set. MCP receipts are non-optional; a missing key fails loud rather than ' +
+        'silently writing an unsigned row.',
+    );
+  }
+  return secret;
+}
+
+/**
+ * HMAC-SHA256 over the receipt's immutable fields chained to the previous
+ * signature. Mirrors the canonical form used by the security-event chain so
+ * both streams verify the same way.
+ */
+function signChained(
+  entry: {
+    timestamp: string;
+    eventType: string;
+    severity: string;
+    agentId: string;
+    payload: unknown;
+  },
+  previousSig: string | null,
+  secret: string,
+): string {
+  const canonical = JSON.stringify({
+    timestamp: entry.timestamp,
+    eventType: entry.eventType,
+    severity: entry.severity,
+    agentId: entry.agentId,
+    payload: entry.payload,
+    previousSignature: previousSig ?? '',
+  });
+  return createHmac('sha256', secret).update(canonical).digest('hex');
+}
+
+/**
+ * Append one governed-MCP receipt. Throws on a failed write (already classified
+ * + counted) so the caller can fail closed. The chain head only advances on a
+ * durable write, so a failed write leaves no gap.
+ */
+export async function recordMcpToolAudit(input: McpAuditInput): Promise<void> {
+  const id = randomUUID();
+  const timestamp = new Date();
+  const eventType = OUTCOME_TO_EVENT_TYPE[input.outcome];
+  const severity = input.outcome === 'invoked' ? 'info' : 'warn';
+  const agentId = `mcp:${input.clientName}`;
+
+  const payload: Record<string, unknown> = {
+    userId: input.userId,
+    accountId: input.accountId,
+    tool: input.tool,
+    argsDigest: input.argsDigest,
+    outcome: input.outcome,
+    durationMs: input.durationMs,
+    ...input.scalars,
+  };
+  if (input.httpStatus !== undefined) payload.httpStatus = input.httpStatus;
+
+  const secret = getAuditSecret();
+  const previousSignature = lastMcpSignature;
+  const signature = signChained(
+    { timestamp: timestamp.toISOString(), eventType, severity, agentId, payload },
+    previousSignature,
+    secret,
+  );
+
+  try {
+    await getClient()
+      .insert(auditLog)
+      .values({
+        id,
+        timestamp,
+        eventType,
+        severity,
+        agentId,
+        taskId: null,
+        sessionId: input.sessionId ?? null,
+        payload,
+        policyViolations: [],
+        signature,
+        previousSignature,
+      });
+    lastMcpSignature = signature;
+    recordAuditWriteResult({ ok: true, eventId: id, eventType });
+  } catch (err) {
+    recordAuditWriteResult({
+      ok: false,
+      reason: classifyAuditWriteFailure(err),
+      eventId: id,
+      eventType,
+    });
+    throw err;
+  }
+}

--- a/apps/server/src/lib/mcp-manifest.ts
+++ b/apps/server/src/lib/mcp-manifest.ts
@@ -55,6 +55,26 @@ export interface McpServerEntry {
   requiresCredentials: boolean;
 }
 
+/**
+ * A remotely-reachable (Streamable HTTP) MCP endpoint. Distinct from the stdio
+ * `servers` list: a remote endpoint is authenticated per request with a bearer
+ * token and enforces the same RBAC/ABAC + audit the REST API uses (GAP-371).
+ */
+export interface McpRemoteEndpoint {
+  /** Stable identifier of the server surfaced at this endpoint. */
+  id: string;
+  /** Human-readable name. */
+  name: string;
+  /** Relative path of the endpoint on this deployment. */
+  path: string;
+  /** Transport mechanism. */
+  transport: 'remote';
+  /** How a client authenticates. `bearer` = an `rvui_dev_` device token. */
+  auth: 'bearer';
+  /** Whether the endpoint gates on a Pro/Enterprise entitlement. */
+  proGated: boolean;
+}
+
 export interface McpDiscoveryManifest {
   /** Manifest schema version */
   version: '1.0';
@@ -62,8 +82,10 @@ export interface McpDiscoveryManifest {
   platform: 'revealui';
   /** Catalog documentation URL (the @revealui/mcp README) */
   documentationUrl: string;
-  /** List of MCP servers exposed by this deployment */
+  /** List of MCP servers exposed by this deployment (stdio) */
   servers: McpServerEntry[];
+  /** Remotely-reachable (Streamable HTTP) endpoints (GAP-371) */
+  remote: McpRemoteEndpoint[];
 }
 
 /**
@@ -243,6 +265,22 @@ export const MCP_SERVERS: readonly McpServerEntry[] = [
 const DOC_URL = 'https://github.com/RevealUIStudio/revealui/blob/main/packages/mcp/README.md';
 
 /**
+ * Governed Streamable HTTP endpoints. Phase 1 exposes the read-oriented
+ * `revealui-content` tools; a client authenticates with an `rvui_dev_` device
+ * token and every call is enforced + audited as that user.
+ */
+const MCP_REMOTE_ENDPOINTS: readonly McpRemoteEndpoint[] = [
+  {
+    id: 'revealui-content',
+    name: 'RevealUI Content (governed)',
+    path: '/api/mcp',
+    transport: 'remote',
+    auth: 'bearer',
+    proGated: true,
+  },
+];
+
+/**
  * Build the MCP discovery manifest for `/.well-known/mcp.json`.
  *
  * Pure function — no I/O, no side effects. Safe to call per-request;
@@ -254,5 +292,6 @@ export function buildMcpManifest(): McpDiscoveryManifest {
     platform: 'revealui',
     documentationUrl: DOC_URL,
     servers: [...MCP_SERVERS],
+    remote: [...MCP_REMOTE_ENDPOINTS],
   };
 }

--- a/apps/server/src/routes/__tests__/mcp-endpoint.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/mcp-endpoint.pglite.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Governed MCP endpoint — end-to-end invariant tests against a REAL migrated
+ * schema (PGlite), a real `@hono/node-server` served on an ephemeral port, and
+ * the real `@modelcontextprotocol/sdk` client (GAP-371 Phase 1).
+ *
+ * Device tokens (`rvui_dev_…`) are minted into `user_devices`; the forwarded
+ * REST calls hit a stub backend that maps a token → user and enforces site
+ * ownership, standing in for the collection-access layer. This proves the MCP
+ * layer FORWARDS the caller's identity and honors the REST verdict — the
+ * Phase-1 enforcement contract (decision B).
+ *
+ * Covers:
+ *   full acceptance  initialize → tools/list → tools/call with a minted token,
+ *                    landing a hash-chained `mcp:tool:invoked` receipt (I-5,
+ *                    plus the positive I-3 "A's token on A's session → 200")
+ *   I-2  a foreign / nonexistent site_id yields the same empty shape (no oracle)
+ *   I-3  the session id is never authority (no-token replay → 401; B's token →
+ *        401 + session terminated)
+ *   I-4  an unauthenticated request 401s even with REVEALUI_API_KEY set
+ *   I-6  revocation / expiry honored per request, mid-session
+ *   gate requireFeature('mcp') denies a free-tier caller
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { serve } from '@hono/node-server';
+import * as schema from '@revealui/db/schema';
+import { McpClient } from '@revealui/mcp/client';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+import { createMcpEndpointApp } from '../mcp-endpoint.js';
+
+let testDb: TestDb;
+
+// `vi.mock` is hoisted above the imports; the factory reads `testDb` lazily so
+// the client resolves to the PGlite instance created in beforeAll.
+vi.mock('@revealui/db', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/db')>('@revealui/db');
+  return { ...actual, getClient: () => testDb.drizzle };
+});
+vi.mock('@revealui/auth/server', () => ({ getSession: async () => null }));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+const TOKEN_A = `rvui_dev_${'a'.repeat(64)}`;
+const TOKEN_B = `rvui_dev_${'b'.repeat(64)}`;
+const TOKEN_FREE = `rvui_dev_${'c'.repeat(64)}`;
+
+// Site ownership the stub backend enforces.
+const SITE_OWNERS: Record<string, string> = { 'site-A': 'user-A', 'site-B': 'user-B' };
+const CONTENT_BY_SITE: Record<string, Array<{ id: string }>> = {
+  'site-A': [{ id: 'post-a1' }],
+  'site-B': [{ id: 'post-b1' }],
+};
+
+let stubBackend: NodeHttpServer;
+let stubUrl: string;
+let served: ReturnType<typeof serve>;
+let endpointUrl: string;
+
+async function seed(): Promise<void> {
+  const db = testDb.drizzle;
+  const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+  await db.insert(schema.users).values([
+    { id: 'user-A', name: 'A', email: 'a@example.com', role: 'editor' },
+    { id: 'user-B', name: 'B', email: 'b@example.com', role: 'editor' },
+    { id: 'user-free', name: 'Free', email: 'free@example.com', role: 'viewer' },
+  ]);
+
+  await db.insert(schema.userDevices).values([
+    {
+      id: 'dev-A',
+      userId: 'user-A',
+      deviceId: 'device-A',
+      deviceType: 'cli',
+      tokenHash: tokenHash(TOKEN_A),
+      tokenExpiresAt: future,
+      isActive: true,
+    },
+    {
+      id: 'dev-B',
+      userId: 'user-B',
+      deviceId: 'device-B',
+      deviceType: 'cli',
+      tokenHash: tokenHash(TOKEN_B),
+      tokenExpiresAt: future,
+      isActive: true,
+    },
+    {
+      id: 'dev-free',
+      userId: 'user-free',
+      deviceId: 'device-free',
+      deviceType: 'cli',
+      tokenHash: tokenHash(TOKEN_FREE),
+      tokenExpiresAt: future,
+      isActive: true,
+    },
+  ]);
+
+  // Accounts + memberships + entitlements. A and B are Pro (mcp enabled);
+  // the free user has no account (falls to the free tier → no mcp feature).
+  await db.insert(schema.accounts).values([
+    { id: 'acct-A', name: 'Acct A', slug: 'acct-a' },
+    { id: 'acct-B', name: 'Acct B', slug: 'acct-b' },
+  ]);
+  await db.insert(schema.accountMemberships).values([
+    { id: 'mem-A', accountId: 'acct-A', userId: 'user-A', role: 'owner', status: 'active' },
+    { id: 'mem-B', accountId: 'acct-B', userId: 'user-B', role: 'owner', status: 'active' },
+  ]);
+  await db.insert(schema.accountEntitlements).values([
+    {
+      id: 'ent-A',
+      accountId: 'acct-A',
+      planId: 'plan-pro',
+      tier: 'pro',
+      status: 'active',
+      features: { mcp: true },
+      mode: 'test',
+    },
+    {
+      id: 'ent-B',
+      accountId: 'acct-B',
+      planId: 'plan-pro',
+      tier: 'pro',
+      status: 'active',
+      features: { mcp: true },
+      mode: 'test',
+    },
+  ]);
+}
+
+/** Stub REST backend: token → user, then site-ownership-scoped reads. */
+function startStubBackend(): Promise<void> {
+  const tokenToUser: Record<string, string> = {
+    [`Bearer ${TOKEN_A}`]: 'user-A',
+    [`Bearer ${TOKEN_B}`]: 'user-B',
+  };
+  stubBackend = createHttpServer((req, res) => {
+    const user = tokenToUser[req.headers.authorization ?? ''];
+    const url = new URL(req.url ?? '/', 'http://stub');
+    res.setHeader('content-type', 'application/json');
+    if (!user) {
+      res.statusCode = 401;
+      res.end(JSON.stringify({ error: 'unauthorized' }));
+      return;
+    }
+    if (url.pathname === '/api/sites') {
+      const owned = Object.entries(SITE_OWNERS)
+        .filter(([, owner]) => owner === user)
+        .map(([id]) => ({ id }));
+      res.statusCode = 200;
+      res.end(JSON.stringify({ docs: owned }));
+      return;
+    }
+    // /api/<collection> with a siteId → only rows the caller owns; any foreign
+    // or unknown site returns the same empty shape (no existence oracle).
+    if (url.pathname.startsWith('/api/')) {
+      const siteId = url.searchParams.get('siteId') ?? '';
+      const owns = SITE_OWNERS[siteId] === user;
+      res.statusCode = 200;
+      res.end(JSON.stringify({ docs: owns ? (CONTENT_BY_SITE[siteId] ?? []) : [] }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+  return new Promise<void>((resolve) => {
+    stubBackend.listen(0, '127.0.0.1', () => {
+      const { port } = stubBackend.address() as AddressInfo;
+      stubUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+}
+
+beforeAll(async () => {
+  process.env.REVEALUI_SECRET = 'test-secret-value-at-least-32-chars-long!!';
+  process.env.REVEALUI_API_KEY = 'ambient-admin-key-should-never-grant-access';
+  testDb = await createTestDb();
+  await seed();
+  await startStubBackend();
+
+  const app = createMcpEndpointApp({ selfApiBaseUrl: stubUrl });
+  await new Promise<void>((resolve) => {
+    served = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) => {
+      endpointUrl = `http://127.0.0.1:${info.port}/`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  served?.close();
+  stubBackend?.close();
+});
+
+function client(token: string): McpClient {
+  return new McpClient({
+    clientInfo: { name: 'e2e', version: '0.0.1' },
+    transport: {
+      kind: 'streamable-http',
+      url: endpointUrl,
+      requestInit: { headers: { Authorization: `Bearer ${token}` } },
+    },
+  });
+}
+
+function parseToolData(result: { content: Array<{ type: string; text?: string }> }): {
+  data?: { docs?: Array<{ id: string }> };
+} {
+  const text = result.content.find((c) => c.type === 'text')?.text ?? '{}';
+  return JSON.parse(text);
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance + I-5 receipt + I-3 positive
+// ---------------------------------------------------------------------------
+
+describe('acceptance: full governed session', () => {
+  it('initialize → tools/list → tools/call with a minted token, landing a hash-chained receipt', async () => {
+    const c = client(TOKEN_A);
+    await c.connect();
+
+    const tools = await c.listTools();
+    expect(tools.map((t) => t.name)).toContain('revealui_list_sites');
+
+    const result = (await c.callTool('revealui_list_sites', {})) as {
+      isError?: boolean;
+      content: Array<{ type: string; text?: string }>;
+    };
+    await c.close();
+
+    expect(result.isError).toBeFalsy();
+    expect(parseToolData(result).data?.docs).toEqual([{ id: 'site-A' }]);
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(schema.auditLog)
+      .where(eq(schema.auditLog.eventType, 'mcp:tool:invoked'));
+    const row = rows.find((r) => (r.payload as { tool?: string }).tool === 'revealui_list_sites');
+    expect(row).toBeDefined();
+    expect(row?.signature).toBeTruthy();
+    expect((row?.payload as { userId?: string }).userId).toBe('user-A');
+    expect(row?.agentId).toBe('mcp:e2e');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-2 — client-supplied scope needs an ownership check (no existence oracle)
+// ---------------------------------------------------------------------------
+
+describe('I-2 no client-supplied scope without ownership', () => {
+  it("A gets an empty, shape-identical response for B's site and for a random UUID", async () => {
+    const c = client(TOKEN_A);
+    await c.connect();
+
+    const own = parseToolData(
+      (await c.callTool('revealui_list_content', {
+        collection: 'posts',
+        site_id: 'site-A',
+      })) as never,
+    );
+    const foreign = parseToolData(
+      (await c.callTool('revealui_list_content', {
+        collection: 'posts',
+        site_id: 'site-B',
+      })) as never,
+    );
+    const nonexistent = parseToolData(
+      (await c.callTool('revealui_list_content', {
+        collection: 'posts',
+        site_id: randomUUID(),
+      })) as never,
+    );
+    await c.close();
+
+    // A sees its own content...
+    expect(own.data?.docs).toEqual([{ id: 'post-a1' }]);
+    // ...but B's site and a random id are byte-identical empty responses.
+    expect(foreign.data?.docs).toEqual([]);
+    expect(JSON.stringify(foreign.data)).toBe(JSON.stringify(nonexistent.data));
+    // None of B's content leaked.
+    expect(JSON.stringify(foreign)).not.toContain('post-b1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-3 — the session id is never authority
+// ---------------------------------------------------------------------------
+
+describe('I-3 the session id is never authority', () => {
+  async function rawInitialize(token: string): Promise<string> {
+    const res = await fetch(endpointUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'raw', version: '0.0.1' },
+        },
+      }),
+    });
+    const sid = res.headers.get('mcp-session-id');
+    if (!sid) throw new Error('no session id issued');
+    return sid;
+  }
+
+  function rawRequest(sessionId: string, token?: string): Promise<Response> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      'Mcp-Session-Id': sessionId,
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return fetch(endpointUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+    });
+  }
+
+  it('rejects a replayed session id with no token (401)', async () => {
+    const sid = await rawInitialize(TOKEN_A);
+    const res = await rawRequest(sid);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects another user's token on the session and terminates it (401)", async () => {
+    const sid = await rawInitialize(TOKEN_A);
+
+    const mismatch = await rawRequest(sid, TOKEN_B);
+    expect(mismatch.status).toBe(401);
+
+    // The session was terminated: even A's own token can no longer use it.
+    const afterTermination = await rawRequest(sid, TOKEN_A);
+    expect(afterTermination.status).not.toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-4 — no ambient service credential on the governed path
+// ---------------------------------------------------------------------------
+
+describe('I-4 no ambient service credential', () => {
+  it('401s an unauthenticated request even with REVEALUI_API_KEY set', async () => {
+    expect(process.env.REVEALUI_API_KEY).toBeTruthy();
+    const res = await fetch(endpointUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'x', version: '0' },
+        },
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-6 — expiry / revocation honored per request, mid-session
+// ---------------------------------------------------------------------------
+
+describe('I-6 revocation honored mid-session', () => {
+  it('a request fails once the device is deactivated', async () => {
+    const c = client(TOKEN_B);
+    await c.connect();
+    // Works while active.
+    const first = (await c.callTool('revealui_list_sites', {})) as { isError?: boolean };
+    expect(first.isError).toBeFalsy();
+
+    // Revoke the device mid-session.
+    await testDb.drizzle
+      .update(schema.userDevices)
+      .set({ isActive: false })
+      .where(eq(schema.userDevices.id, 'dev-B'));
+
+    // The next call on the same session must fail — the token no longer resolves.
+    await expect(c.callTool('revealui_list_sites', {})).rejects.toThrow();
+    await c.close().catch(() => undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireFeature('mcp') gate
+// ---------------------------------------------------------------------------
+
+describe('entitlement gate', () => {
+  it('denies a free-tier caller (no mcp feature)', async () => {
+    const res = await fetch(endpointUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN_FREE}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'x', version: '0' },
+        },
+      }),
+    });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).not.toBe(200);
+  });
+});

--- a/apps/server/src/routes/mcp-endpoint.ts
+++ b/apps/server/src/routes/mcp-endpoint.ts
@@ -1,0 +1,308 @@
+/**
+ * Governed MCP endpoint — `POST/GET/DELETE /api/mcp` (GAP-371 Phase 1).
+ *
+ * Mounts the existing `revealui-content` MCP server over Streamable HTTP behind
+ * the same auth the rest of the API uses. An OpenCode (or any) MCP client is an
+ * UNTRUSTED network caller: the only authority is the `rvui_dev_` bearer token
+ * it presents, re-verified on every request by `authMiddleware`.
+ *
+ * Chain (in order):
+ *   authMiddleware (bearer-first) → entitlementMiddleware → requireFeature('mcp')
+ *   → session⇢user binding check → MCP Streamable HTTP handler.
+ *
+ * Identity threading (I-1 / I-4). The content factory is constructed with a
+ * `credentialsProvider` that returns the CALLER's own token, forwarded to the
+ * REST API so collection `access.read` enforces against the real user. There is
+ * NO env-key fallback on this path: the provider throws if no per-request
+ * credential exists, so an ambient `REVEALUI_API_KEY` can never grant access.
+ *
+ * Session binding (I-3). The MCP session id is routing state, never authority.
+ * Each session id is bound to the user that created it; every later request
+ * re-validates the token AND asserts it resolves to the bound user. A mismatch
+ * is a 401 and terminates the session.
+ *
+ * Audit (I-5). Every tool call writes a hash-chained receipt via
+ * `recordMcpToolAudit`. Mutating tools fail closed on an audit-write failure;
+ * reads degrade. Phase 1 exposes read tools only, but the fail-closed branch is
+ * wired so Phase 2 writes inherit it.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { RESPONSE_ALREADY_SENT } from '@hono/node-server/utils/response';
+import { logger } from '@revealui/core/observability/logger';
+import {
+  createRevealuiContentServer,
+  type McpToolAuditRecord,
+  type McpToolAuditSink,
+  type McpToolCallContext,
+  type ResolvedApiCredentials,
+} from '@revealui/mcp/revealui-content-factory';
+import {
+  createNodeStreamableHttpHandler,
+  type StreamableHttpControl,
+} from '@revealui/mcp/streamable-http';
+import type { Handler, MiddlewareHandler } from 'hono';
+import { Hono } from 'hono';
+import { recordMcpToolAudit } from '../lib/mcp-audit.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { entitlementMiddleware, getEntitlementsFromContext } from '../middleware/entitlements.js';
+import { requireFeature } from '../middleware/license.js';
+
+/**
+ * Minimal structural mirror of the MCP SDK's `AuthInfo`. Defined locally so
+ * apps/server does not take a direct dependency on `@modelcontextprotocol/sdk`
+ * (a transitive-only dep under pnpm's strict layout). The transport reads
+ * `req.auth` and threads it verbatim to the tool handler's `extra.authInfo`.
+ */
+interface McpAuthInfo {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  extra?: Record<string, unknown>;
+}
+
+/** The per-request identity we thread through the MCP `AuthInfo.extra`. */
+interface McpAuthExtra extends Record<string, unknown> {
+  userId: string;
+  accountId: string | null;
+}
+
+export interface McpEndpointConfig {
+  /**
+   * Base URL the governed tools call back into (this same API). The forwarded
+   * REST request carries the caller's token, so identity reaches enforcement.
+   * Defaults to `REVEALUI_API_URL`.
+   */
+  selfApiBaseUrl?: string;
+  /** DNS-rebinding guard: allowed `Host` headers. Defaults from env. */
+  allowedHosts?: string[];
+  /** DNS-rebinding guard: allowed `Origin` headers. Defaults from env. */
+  allowedOrigins?: string[];
+}
+
+function splitEnvList(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const parts = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return parts.length > 0 ? parts : undefined;
+}
+
+function bearerFromHeader(header: string | undefined): string | undefined {
+  if (!(header && header.startsWith('Bearer '))) return undefined;
+  const token = header.slice(7);
+  return token.startsWith('rvui_dev_') ? token : undefined;
+}
+
+/** Pull the identity we threaded onto `AuthInfo.extra` back out of a call ctx. */
+function extraFromContext(ctx: McpToolCallContext): McpAuthExtra | undefined {
+  const info = ctx.authInfo as McpAuthInfo | undefined;
+  const extra = info?.extra as Partial<McpAuthExtra> | undefined;
+  if (!extra || typeof extra.userId !== 'string') return undefined;
+  return { userId: extra.userId, accountId: extra.accountId ?? null };
+}
+
+export interface McpEndpointParts {
+  /** Chain to run before the handler: auth → entitlements → mcp feature gate. */
+  middlewares: MiddlewareHandler[];
+  /** The Streamable-HTTP bridge handler (session binding + identity threading). */
+  handle: Handler;
+}
+
+/**
+ * Build the governed endpoint's middleware chain + handler. Kept separate from
+ * mounting so it can be bound to an EXACT path (`/api/mcp`) on the main app
+ * without shadowing the sibling `/api/mcp/usage` route.
+ */
+export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointParts {
+  const selfApiBaseUrl = config.selfApiBaseUrl ?? process.env.REVEALUI_API_URL ?? '';
+  const allowedHosts = config.allowedHosts ?? splitEnvList(process.env.REVEALUI_MCP_ALLOWED_HOSTS);
+  const allowedOrigins =
+    config.allowedOrigins ?? splitEnvList(process.env.REVEALUI_MCP_ALLOWED_ORIGINS);
+
+  // sessionId → the identity that created the session (I-3).
+  const sessionBindings = new Map<string, McpAuthExtra>();
+
+  // The credentialsProvider is the SOLE credential source on this path (I-4).
+  const credentialsProvider = (ctx: McpToolCallContext): ResolvedApiCredentials => {
+    const info = ctx.authInfo as McpAuthInfo | undefined;
+    const token = info?.token;
+    if (!token) {
+      throw new Error('governed MCP endpoint: no per-request credential — refusing tool call');
+    }
+    if (!selfApiBaseUrl) {
+      throw new Error('governed MCP endpoint: REVEALUI_API_URL is not configured');
+    }
+    return { apiUrl: selfApiBaseUrl, apiKey: token };
+  };
+
+  const auditSink: McpToolAuditSink = async (record: McpToolAuditRecord): Promise<void> => {
+    const identity = extraFromContext(record.context);
+    if (!identity) {
+      // Only reachable if the mount failed to thread identity — treat as a
+      // hard audit failure so a mutating tool fails closed.
+      throw new Error('governed MCP audit: request identity missing');
+    }
+    await recordMcpToolAudit({
+      outcome: record.outcome,
+      clientName: record.clientInfo?.name ?? 'unknown',
+      sessionId: record.context.sessionId,
+      userId: identity.userId,
+      accountId: identity.accountId,
+      tool: record.tool,
+      argsDigest: record.argsDigest,
+      scalars: record.scalars,
+      durationMs: record.durationMs,
+      httpStatus: record.httpStatus,
+    });
+  };
+
+  let control: StreamableHttpControl | null = null;
+  const handler = createNodeStreamableHttpHandler({
+    createServer: () =>
+      createRevealuiContentServer({
+        credentialsProvider,
+        auditSink,
+        // Phase 1 exposes read tools only. The set is empty in production; the
+        // fail-closed branch it feeds is exercised by the invariant tests.
+        mutatingTools: new Set<string>(),
+      }),
+    enableJsonResponse: true,
+    allowedHosts,
+    allowedOrigins,
+    onControl: (c) => {
+      control = c;
+    },
+    onSessionInitialized: (id, req) => {
+      // Bind the new session to the identity of the request that created it,
+      // read off the AuthInfo the mount threaded onto `req.auth` (I-3). Tied to
+      // this exact request, so it is race-free under concurrent initializes.
+      const auth = (req as { auth?: McpAuthInfo }).auth;
+      const extra = auth?.extra as Partial<McpAuthExtra> | undefined;
+      if (extra && typeof extra.userId === 'string') {
+        sessionBindings.set(id, { userId: extra.userId, accountId: extra.accountId ?? null });
+      }
+    },
+    onSessionClosed: (id) => {
+      sessionBindings.delete(id);
+    },
+  });
+
+  // Self-contained chain: authMiddleware (required) sets the user, then
+  // entitlements are re-resolved against that user, then the mcp feature gate.
+  const middlewares: MiddlewareHandler[] = [
+    authMiddleware({ required: true }),
+    entitlementMiddleware(),
+    requireFeature('mcp', { mode: 'entitlements' }),
+  ];
+
+  const handle: Handler = async (c) => {
+    const bindings = c.env as { incoming?: IncomingMessage; outgoing?: ServerResponse };
+    const incoming = bindings.incoming;
+    const outgoing = bindings.outgoing;
+    if (!(incoming && outgoing)) {
+      return c.json(
+        {
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'MCP endpoint requires a Node HTTP server' },
+          id: null,
+        },
+        500,
+      );
+    }
+
+    const user = c.get('user') as { id: string } | undefined;
+    const token = bearerFromHeader(c.req.header('Authorization'));
+    if (!(user && token)) {
+      // authMiddleware(required) should have 401'd already; belt-and-braces.
+      return c.json(
+        { jsonrpc: '2.0', error: { code: -32001, message: 'Authentication required' }, id: null },
+        401,
+      );
+    }
+    const accountId = getEntitlementsFromContext(c).accountId;
+    const identity: McpAuthExtra = { userId: user.id, accountId };
+
+    const sessionId = c.req.header('Mcp-Session-Id');
+    if (sessionId) {
+      const bound = sessionBindings.get(sessionId);
+      if (bound && bound.userId !== user.id) {
+        // I-3: a valid token for a DIFFERENT user on an existing session. The
+        // session id is not authority — reject and terminate it.
+        sessionBindings.delete(sessionId);
+        if (control?.hasSession(sessionId)) {
+          await control.terminateSession(sessionId).catch(() => undefined);
+        }
+        return c.json(
+          {
+            jsonrpc: '2.0',
+            error: { code: -32001, message: 'Session identity mismatch' },
+            id: null,
+          },
+          401,
+        );
+      }
+    }
+
+    // Thread the verified identity to the MCP tool handler via AuthInfo.
+    const authInfo: McpAuthInfo = {
+      token,
+      clientId: user.id,
+      scopes: [],
+      extra: identity satisfies McpAuthExtra,
+    };
+    (incoming as IncomingMessage & { auth?: McpAuthInfo }).auth = authInfo;
+
+    try {
+      await handler(incoming, outgoing);
+    } catch (err) {
+      logger.error('[/api/mcp] handler error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      if (!outgoing.headersSent) {
+        outgoing.statusCode = 500;
+        outgoing.setHeader('content-type', 'application/json');
+        outgoing.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: { code: -32000, message: 'Internal error' },
+            id: null,
+          }),
+        );
+      }
+      return RESPONSE_ALREADY_SENT;
+    }
+
+    // The session⇢user binding for a freshly-created session is set in the
+    // handler's `onSessionInitialized` callback above (race-free, tied to this
+    // request). Nothing to do here on the success path.
+    return RESPONSE_ALREADY_SENT;
+  };
+
+  return { middlewares, handle };
+}
+
+/**
+ * Mount the governed endpoint on the main app at the EXACT path `/api/mcp`
+ * (POST for JSON-RPC, GET for SSE, DELETE to end a session). Binding the exact
+ * path leaves the sibling `/api/mcp/usage` route untouched.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: accept any Hono/OpenAPIHono instance regardless of its Env/Schema generics
+export function mountMcpEndpoint(app: Hono<any, any, any>, config: McpEndpointConfig = {}): void {
+  const { middlewares, handle } = buildMcpEndpoint(config);
+  for (const mw of middlewares) app.use('/api/mcp', mw);
+  app.all('/api/mcp', handle);
+}
+
+/**
+ * Standalone Hono app whose root path IS the governed endpoint. Used by tests
+ * that serve the endpoint directly on an ephemeral port.
+ */
+export function createMcpEndpointApp(config: McpEndpointConfig = {}): Hono {
+  const { middlewares, handle } = buildMcpEndpoint(config);
+  const app = new Hono();
+  for (const mw of middlewares) app.use('/', mw);
+  app.all('/', handle);
+  return app;
+}

--- a/packages/mcp/__tests__/revealui-content-governed.test.ts
+++ b/packages/mcp/__tests__/revealui-content-governed.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Governed-path invariant tests for the `revealui-content` factory seams
+ * (GAP-371 Phase 1). Drives a real MCP client over Streamable HTTP against the
+ * factory, threading a per-request `AuthInfo` onto `req.auth` exactly as the
+ * `/api/mcp` mount does, with a fake REST backend standing in for the app so
+ * these stay fast and DB-free.
+ *
+ * Covers, at the factory/transport seam:
+ *   I-1  identity comes only from the verified credential (args cannot change it)
+ *   I-4  no ambient service credential on the governed path
+ *   I-5  a receipt per call; fail-closed for mutations, degrade for reads;
+ *        raw args never stored (digest + allowlisted scalars only)
+ *
+ * I-2 / I-3 / I-6 (which need the DB-backed middleware chain) live in the
+ * server-side pglite test.
+ */
+
+import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { McpClient } from '../src/client.js';
+import {
+  createRevealuiContentServer,
+  type McpToolAuditRecord,
+} from '../src/servers/factories/revealui-content.js';
+import { createNodeStreamableHttpHandler } from '../src/streamable-http.js';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const teardowns: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (teardowns.length > 0) {
+    const t = teardowns.pop();
+    if (t) await t().catch(() => undefined);
+  }
+});
+
+interface BackendCall {
+  authorization: string | undefined;
+  url: string;
+}
+
+/** Fake REST backend the governed tools forward to. Records every call. */
+async function startFakeBackend(
+  respond: (call: BackendCall) => { status: number; body: unknown },
+): Promise<{ url: string; calls: BackendCall[] }> {
+  const calls: BackendCall[] = [];
+  const server = createHttpServer((req, res) => {
+    const call: BackendCall = { authorization: req.headers.authorization, url: req.url ?? '' };
+    calls.push(call);
+    const { status, body } = respond(call);
+    res.statusCode = status;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const { port } = server.address() as AddressInfo;
+  teardowns.push(() => new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res()))));
+  return { url: `http://127.0.0.1:${port}`, calls };
+}
+
+interface GovernedServer {
+  url: string;
+  audits: McpToolAuditRecord[];
+}
+
+/**
+ * Start the governed MCP handler over HTTP. `authInfo` is a getter so a test
+ * can decide, per-connection, what identity (if any) is threaded onto
+ * `req.auth` — mirroring the real mount.
+ */
+async function startGoverned(opts: {
+  backendUrl: string;
+  authInfo: () => unknown;
+  mutatingTools?: Set<string>;
+  auditFails?: boolean;
+}): Promise<GovernedServer> {
+  const audits: McpToolAuditRecord[] = [];
+  const handler = createNodeStreamableHttpHandler({
+    enableJsonResponse: true,
+    createServer: () =>
+      createRevealuiContentServer({
+        mutatingTools: opts.mutatingTools ?? new Set<string>(),
+        credentialsProvider: (ctx) => {
+          const info = ctx.authInfo as { token?: string } | undefined;
+          if (!info?.token) throw new Error('no per-request credential');
+          return { apiUrl: opts.backendUrl, apiKey: info.token };
+        },
+        auditSink: async (record) => {
+          audits.push(record);
+          if (opts.auditFails) throw new Error('audit store down');
+        },
+      }),
+  });
+
+  const server: NodeHttpServer = createHttpServer((req, res) => {
+    (req as { auth?: unknown }).auth = opts.authInfo();
+    void handler(req, res).catch((err) => {
+      if (!res.headersSent) res.statusCode = 500;
+      res.end(JSON.stringify({ error: String(err) }));
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const { port } = server.address() as AddressInfo;
+  teardowns.push(() => new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res()))));
+  return { url: `http://127.0.0.1:${port}/`, audits };
+}
+
+function connectClient(url: string): Promise<McpClient> {
+  const client = new McpClient({
+    clientInfo: { name: 'governed-test', version: '0.0.1' },
+    transport: { kind: 'streamable-http', url },
+  });
+  return client.connect().then(() => client);
+}
+
+const okBackend = () => ({ status: 200, body: { docs: [{ id: 'row-1' }] } });
+
+// ---------------------------------------------------------------------------
+// I-1 — identity comes only from the verified credential
+// ---------------------------------------------------------------------------
+
+describe('I-1 identity comes only from the verified credential', () => {
+  it('forwards the token from AuthInfo and audits that identity, not any arg', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+
+    await client.callTool('revealui_list_content', { collection: 'posts', site_id: 'site-A' });
+    await client.close();
+
+    // The forwarded REST call carried A's token, sourced from AuthInfo.
+    expect(backend.calls.length).toBeGreaterThan(0);
+    for (const call of backend.calls) {
+      expect(call.authorization).toBe('Bearer tokenA');
+    }
+    // The receipt's identity is A, taken from AuthInfo — never from a request arg.
+    expect(governed.audits).toHaveLength(1);
+    const extra = (governed.audits[0]?.context.authInfo as { extra?: { userId?: string } }).extra;
+    expect(extra?.userId).toBe('A');
+  });
+
+  it('rejects an identity-shaped arg outright — args cannot smuggle a userId', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+
+    // The strict schemas admit no userId field; injecting one is denied before
+    // any REST call, so an arg can never become the acting identity.
+    const result = await client.callTool('revealui_list_sites', { userId: 'B' });
+    await client.close();
+
+    expect(result.isError).toBe(true);
+    expect(backend.calls).toHaveLength(0);
+    expect(governed.audits[0]?.outcome).toBe('denied');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-4 — no ambient service credential on the governed path
+// ---------------------------------------------------------------------------
+
+describe('I-4 no ambient service credential on the governed path', () => {
+  it('refuses the call when no per-request credential exists, even with REVEALUI_API_KEY set', async () => {
+    const prev = process.env.REVEALUI_API_KEY;
+    const prevUrl = process.env.REVEALUI_API_URL;
+    process.env.REVEALUI_API_KEY = 'ambient-admin-key';
+    process.env.REVEALUI_API_URL = 'http://should-never-be-called.invalid';
+    try {
+      const backend = await startFakeBackend(okBackend);
+      const governed = await startGoverned({
+        backendUrl: backend.url,
+        // No AuthInfo threaded — governed provider has no credential.
+        authInfo: () => undefined,
+      });
+      const client = await connectClient(governed.url);
+
+      const result = await client.callTool('revealui_list_sites', {});
+      await client.close();
+
+      expect(result.isError).toBe(true);
+      // The ambient env key was never used to reach any backend.
+      expect(backend.calls).toHaveLength(0);
+    } finally {
+      if (prev === undefined) delete process.env.REVEALUI_API_KEY;
+      else process.env.REVEALUI_API_KEY = prev;
+      if (prevUrl === undefined) delete process.env.REVEALUI_API_URL;
+      else process.env.REVEALUI_API_URL = prevUrl;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-5 — a receipt per call
+// ---------------------------------------------------------------------------
+
+describe('I-5 a receipt per call', () => {
+  it('records one invoked receipt on success with only a digest + allowlisted scalars', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+
+    const secret = 'sk_live_super_secret_value';
+    await client.callTool('revealui_list_content', {
+      collection: 'posts',
+      site_id: 'site-A',
+      status: secret,
+    });
+    await client.close();
+
+    expect(governed.audits).toHaveLength(1);
+    const rec = governed.audits[0]!;
+    expect(rec.outcome).toBe('invoked');
+    expect(rec.tool).toBe('revealui_list_content');
+    // Digest is a 64-char lowercase-hex sha256; raw args are NOT present.
+    expect(rec.argsDigest).toHaveLength(64);
+    expect([...rec.argsDigest].every((ch) => '0123456789abcdef'.includes(ch))).toBe(true);
+    // Allowlisted scalars only: collection + site_id, never the secret-shaped status.
+    expect(rec.scalars).toEqual({ collection: 'posts', site_id: 'site-A' });
+    const serialized = JSON.stringify(rec);
+    expect(serialized).not.toContain(secret);
+  });
+
+  it('records a denied receipt for an unknown tool', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+
+    await client.callTool('revealui_delete_everything', {});
+    await client.close();
+
+    expect(governed.audits).toHaveLength(1);
+    expect(governed.audits[0]?.outcome).toBe('denied');
+  });
+
+  it('records a failed receipt with httpStatus when the backend errors', async () => {
+    const backend = await startFakeBackend(() => ({ status: 503, body: { error: 'down' } }));
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+
+    const result = await client.callTool('revealui_list_sites', {});
+    await client.close();
+
+    expect(result.isError).toBe(true);
+    expect(governed.audits).toHaveLength(1);
+    expect(governed.audits[0]?.outcome).toBe('failed');
+    expect(governed.audits[0]?.httpStatus).toBe(503);
+  });
+
+  it('fails a mutating tool closed when the audit write fails, and never executes it', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+      mutatingTools: new Set(['revealui_list_sites']),
+      auditFails: true,
+    });
+    const client = await connectClient(governed.url);
+
+    const result = await client.callTool('revealui_list_sites', {});
+    await client.close();
+
+    expect(result.isError).toBe(true);
+    // Fail-closed: the tool never reached the backend, so nothing "mutated".
+    expect(backend.calls).toHaveLength(0);
+  });
+
+  it('degrades a read tool when the audit write fails, still returning data', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+      mutatingTools: new Set<string>(),
+      auditFails: true,
+    });
+    const client = await connectClient(governed.url);
+
+    const result = await client.callTool('revealui_list_sites', {});
+    await client.close();
+
+    expect(result.isError).toBeFalsy();
+    // The read executed despite the audit failure (degrade, not fail-closed).
+    expect(backend.calls.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/mcp/__tests__/revealui-content-governed.test.ts
+++ b/packages/mcp/__tests__/revealui-content-governed.test.ts
@@ -173,10 +173,12 @@ describe('I-4 no ambient service credential on the governed path', () => {
   it('refuses the call when no per-request credential exists, even with REVEALUI_API_KEY set', async () => {
     const prev = process.env.REVEALUI_API_KEY;
     const prevUrl = process.env.REVEALUI_API_URL;
-    process.env.REVEALUI_API_KEY = 'ambient-admin-key';
-    process.env.REVEALUI_API_URL = 'http://should-never-be-called.invalid';
     try {
       const backend = await startFakeBackend(okBackend);
+      // Point the ambient env credentials at the REAL backend, so an env
+      // fallback would be observable as a backend call with the ambient key.
+      process.env.REVEALUI_API_KEY = 'ambient-admin-key';
+      process.env.REVEALUI_API_URL = backend.url;
       const governed = await startGoverned({
         backendUrl: backend.url,
         // No AuthInfo threaded — governed provider has no credential.
@@ -188,7 +190,7 @@ describe('I-4 no ambient service credential on the governed path', () => {
       await client.close();
 
       expect(result.isError).toBe(true);
-      // The ambient env key was never used to reach any backend.
+      // No env fallback: the ambient key never reached the backend.
       expect(backend.calls).toHaveLength(0);
     } finally {
       if (prev === undefined) delete process.env.REVEALUI_API_KEY;

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -69,6 +69,10 @@
       "types": "./dist/servers/factories/contracts.d.ts",
       "import": "./dist/servers/factories/contracts.js"
     },
+    "./revealui-content-factory": {
+      "types": "./dist/servers/factories/revealui-content.d.ts",
+      "import": "./dist/servers/factories/revealui-content.js"
+    },
     "./docs-server": {
       "types": "./dist/servers/factories/docs.d.ts",
       "import": "./dist/servers/factories/docs.js"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -186,7 +186,14 @@ export {
 } from './servers/factories/knowledge-graph.js';
 // First-party server factories (Stage 1 PR-1.2 — dual-mode template)
 export {
+  type CreateRevealuiContentServerOptions,
+  type CredentialsProvider,
   createRevealuiContentServer,
+  type McpToolAuditOutcome,
+  type McpToolAuditRecord,
+  type McpToolAuditSink,
+  type McpToolCallContext,
+  type ResolvedApiCredentials,
   setCredentials as setRevealuiContentCredentials,
 } from './servers/factories/revealui-content.js';
 // Server launchers
@@ -199,6 +206,7 @@ export { launchVercelMcp } from './servers/vercel.js';
 // Streamable HTTP server-side helper (Stage 1 PR-1.1)
 export {
   createNodeStreamableHttpHandler,
+  type StreamableHttpControl,
   type StreamableHttpHandler,
   type StreamableHttpHandlerOptions,
 } from './streamable-http.js';

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -32,6 +32,7 @@
  * `REVEALUI_API_KEY` env vars when no override is set.
  */
 
+import { createHash } from 'node:crypto';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   type CallToolRequest,
@@ -44,7 +45,108 @@ import {
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod/v4';
-import { validateToolArgs } from '../../validate-tool-args.js';
+import { type McpToolError, validateToolArgs } from '../../validate-tool-args.js';
+
+// ---------------------------------------------------------------------------
+// Governed-path seams (GAP-371 Phase 1)
+// ---------------------------------------------------------------------------
+//
+// The stdio launcher constructs this factory with NO options and keeps the
+// process-global `resolveCredentials()` (env / setCredentials) model — correct
+// for a single-operator laptop. The governed HTTP mount (`/api/mcp`) instead
+// injects a per-request `credentialsProvider` (returns the CALLER's own bearer
+// token) and an `auditSink` (a receipt per tool call). When a
+// `credentialsProvider` is present it is the SOLE credential source: the env
+// fallback is never consulted on the governed path (invariant I-4).
+
+/** Resolved REST credentials for one tool call. */
+export interface ResolvedApiCredentials {
+  apiUrl: string;
+  apiKey: string;
+}
+
+/**
+ * Per-request context handed to the governed seams. Derived from the MCP
+ * request handler's `extra` (the transport threads `authInfo` from the
+ * authenticated HTTP request; `sessionId` is the routing key). `undefined`
+ * on the stdio path.
+ */
+export interface McpToolCallContext {
+  authInfo?: unknown;
+  sessionId?: string;
+}
+
+/**
+ * Governed-path credential resolver. Returns the credentials to forward for a
+ * single tool call — on the governed path, the caller's own bearer token so
+ * the REST layer enforces `access.read` against the real user. May throw /
+ * reject when no per-request credential exists; the call then fails closed.
+ */
+export type CredentialsProvider = (
+  ctx: McpToolCallContext,
+) => Promise<ResolvedApiCredentials> | ResolvedApiCredentials;
+
+/** Terminal outcome of a governed tool call, as recorded in the receipt. */
+export type McpToolAuditOutcome = 'invoked' | 'denied' | 'failed';
+
+/**
+ * A governed tool-call receipt. Raw arguments are NEVER included — only a
+ * sha256 digest of the canonical JSON plus an allowlisted scalar subset
+ * (`collection`, `site_id`) that is safe to store in the clear.
+ */
+export interface McpToolAuditRecord {
+  outcome: McpToolAuditOutcome;
+  tool: string;
+  /** sha256 (hex) of the canonical JSON of the raw arguments. */
+  argsDigest: string;
+  /** Allowlisted non-secret identifiers pulled from the validated args. */
+  scalars: Record<string, string>;
+  durationMs: number;
+  httpStatus?: number;
+  /** The MCP client that connected (from the `initialize` handshake). */
+  clientInfo?: { name: string; version: string };
+  context: McpToolCallContext;
+}
+
+/**
+ * Governed-path audit sink. Resolves when the receipt is durably written;
+ * rejects when the write failed. For a mutating tool a rejection fails the
+ * call (fail-closed); for a read tool it degrades to log-and-continue.
+ */
+export type McpToolAuditSink = (record: McpToolAuditRecord) => Promise<void>;
+
+/** sha256 (hex) of the canonical JSON of an arbitrary argument object. */
+function digestArgs(args: unknown): string {
+  return createHash('sha256').update(canonicalJson(args)).digest('hex');
+}
+
+/**
+ * Deterministic JSON with object keys sorted, so the digest of the same
+ * logical arguments is stable regardless of key order. No regex; a manual
+ * recursive serializer over the parsed value.
+ */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>).sort((a, b) =>
+    a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0,
+  );
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(',')}}`;
+}
+
+/** Allowlisted, non-secret scalars safe to store in a receipt in the clear. */
+const AUDIT_SCALAR_ALLOWLIST = ['collection', 'site_id'] as const;
+
+function pickAuditScalars(args: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!args || typeof args !== 'object') return out;
+  const record = args as Record<string, unknown>;
+  for (const key of AUDIT_SCALAR_ALLOWLIST) {
+    const raw = record[key];
+    if (typeof raw === 'string' && raw.length > 0) out[key] = raw;
+  }
+  return out;
+}
 
 // ---------------------------------------------------------------------------
 // Credential overrides (set by hypervisor / HTTP launcher)
@@ -101,10 +203,11 @@ async function apiGet(
   const res = await fetch(url.toString(), { headers: apiHeaders(apiKey) });
   const body = await res.json();
   if (!res.ok) {
-    throw new Error(
+    throw new ApiRequestError(
       (body as { error?: string; message?: string }).error ??
         (body as { message?: string }).message ??
         `API ${res.status}`,
+      res.status,
     );
   }
   return body;
@@ -269,6 +372,40 @@ export interface CreateRevealuiContentServerOptions {
    * directly; out-of-process subprocess consumers leave it unset.
    */
   collectionsProvider?: CollectionsProvider;
+
+  /**
+   * Governed-path (GAP-371) per-request credential resolver. When set, it is
+   * the SOLE source of tool-call credentials — the `REVEALUI_API_KEY` /
+   * `setCredentials()` fallback is never consulted (invariant I-4). Leave
+   * unset for the stdio launcher to keep the process-global env-key model.
+   */
+  credentialsProvider?: CredentialsProvider;
+
+  /**
+   * Governed-path audit sink. When set, every `tools/call` produces a receipt
+   * (invariant I-5). Mutating tools (see `mutatingTools`) fail closed if the
+   * receipt cannot be written; read tools degrade to log-and-continue.
+   */
+  auditSink?: McpToolAuditSink;
+
+  /**
+   * Names of tools that mutate state and therefore require a durable receipt
+   * BEFORE they run. Phase 1 exposes read tools only, so this is empty in
+   * production; it exists so Phase 2 write tools inherit the fail-closed path
+   * (and so the branch is testable now with a simulated mutating tool).
+   */
+  mutatingTools?: ReadonlySet<string>;
+}
+
+/** Error carrying the upstream HTTP status, for audit `httpStatus`. */
+class ApiRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'ApiRequestError';
+  }
 }
 
 /**
@@ -511,19 +648,97 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
     };
   });
 
-  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest, extra) => {
     const startTime = Date.now();
     const toolName = request.params.name;
+    const rawArgs = request.params.arguments;
+    const ctx: McpToolCallContext = {
+      authInfo: (extra as { authInfo?: unknown } | undefined)?.authInfo,
+      sessionId: (extra as { sessionId?: string } | undefined)?.sessionId,
+    };
+    const auditSink = options?.auditSink;
+    const mutating = options?.mutatingTools?.has(toolName) ?? false;
 
-    const { apiUrl, apiKey } = resolveCredentials();
+    // Write a receipt for this call. Returns whether the write succeeded; the
+    // sink itself classifies + logs a failure, so callers only decide between
+    // fail-closed (mutations) and degrade (reads). No-op when no sink is wired
+    // (the stdio path).
+    async function writeReceipt(
+      outcome: McpToolAuditOutcome,
+      httpStatus?: number,
+    ): Promise<boolean> {
+      if (!auditSink) return true;
+      const client = server.getClientVersion();
+      const record: McpToolAuditRecord = {
+        outcome,
+        tool: toolName,
+        argsDigest: digestArgs(rawArgs ?? null),
+        scalars: pickAuditScalars(rawArgs),
+        durationMs: Date.now() - startTime,
+        httpStatus,
+        clientInfo: client ? { name: client.name, version: client.version } : undefined,
+        context: ctx,
+      };
+      try {
+        await auditSink(record);
+        return true;
+      } catch {
+        return false;
+      }
+    }
 
-    if (!(apiUrl && apiKey)) {
+    // A call rejected before it executes (unknown tool, invalid args). Records
+    // a `denied` receipt (best-effort — a denial that mutates nothing degrades
+    // like a read) and returns the client-facing error.
+    async function denied(response: McpToolError): Promise<McpToolError> {
+      await writeReceipt('denied');
+      return response;
+    }
+
+    // Resolve credentials. Governed path: the injected provider is the sole
+    // source and may throw when no per-request credential exists (I-4). Env
+    // path is unchanged for stdio.
+    let apiUrl: string;
+    let apiKey: string;
+    try {
+      if (options?.credentialsProvider) {
+        const resolved = await options.credentialsProvider(ctx);
+        apiUrl = resolved.apiUrl;
+        apiKey = resolved.apiKey;
+      } else {
+        const resolved = resolveCredentials();
+        if (!(resolved.apiUrl && resolved.apiKey)) {
+          return {
+            content: [
+              { type: 'text', text: 'Error: REVEALUI_API_URL and REVEALUI_API_KEY must be set' },
+            ],
+            isError: true,
+          };
+        }
+        apiUrl = resolved.apiUrl;
+        apiKey = resolved.apiKey;
+      }
+    } catch (err) {
+      await writeReceipt('failed');
       return {
         content: [
-          { type: 'text', text: 'Error: REVEALUI_API_URL and REVEALUI_API_KEY must be set' },
+          { type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` },
         ],
         isError: true,
       };
+    }
+
+    // Fail-closed for mutations: the receipt is written BEFORE the tool runs,
+    // so a state change can never happen without a durable record of it. If
+    // the write fails, refuse the call — nothing executes.
+    if (mutating) {
+      const recorded = await writeReceipt('invoked');
+      if (!recorded) {
+        return {
+          content: [{ type: 'text', text: 'Error: audit log unavailable; mutating tool refused' }],
+          isError: true,
+        };
+      }
     }
 
     try {
@@ -531,8 +746,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
 
       switch (toolName) {
         case 'revealui_list_sites': {
-          const parsed = validateToolArgs(ListSitesArgsSchema, request.params.arguments, toolName);
-          if (!parsed.ok) return parsed.error;
+          const parsed = validateToolArgs(ListSitesArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
           const { limit = 20, page = 1 } = parsed.value;
           data = await apiGet(apiUrl, apiKey, '/api/sites', {
             limit: String(limit),
@@ -542,12 +757,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         }
 
         case 'revealui_list_content': {
-          const parsed = validateToolArgs(
-            ListContentArgsSchema,
-            request.params.arguments,
-            toolName,
-          );
-          if (!parsed.ok) return parsed.error;
+          const parsed = validateToolArgs(ListContentArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
           const { site_id, collection, limit = 20, page = 1, status } = parsed.value;
           const params: Record<string, string> = {
             limit: String(limit),
@@ -561,16 +772,16 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         }
 
         case 'revealui_get_content': {
-          const parsed = validateToolArgs(GetContentArgsSchema, request.params.arguments, toolName);
-          if (!parsed.ok) return parsed.error;
+          const parsed = validateToolArgs(GetContentArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
           const { collection, id } = parsed.value;
           data = await apiGet(apiUrl, apiKey, `/api/${collection}/${id}`);
           break;
         }
 
         case 'revealui_list_users': {
-          const parsed = validateToolArgs(ListUsersArgsSchema, request.params.arguments, toolName);
-          if (!parsed.ok) return parsed.error;
+          const parsed = validateToolArgs(ListUsersArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
           const { site_id, limit = 20, page = 1 } = parsed.value;
           const params: Record<string, string> = {
             limit: String(limit),
@@ -583,8 +794,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         }
 
         case 'revealui_site_stats': {
-          const parsed = validateToolArgs(SiteStatsArgsSchema, request.params.arguments, toolName);
-          if (!parsed.ok) return parsed.error;
+          const parsed = validateToolArgs(SiteStatsArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
           const { site_id } = parsed.value;
           const params: Record<string, string> = {};
           if (site_id) params.siteId = site_id;
@@ -594,11 +805,16 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         }
 
         default:
-          return {
+          return denied({
             content: [{ type: 'text', text: `Error: Unknown tool: ${toolName}` }],
             isError: true,
-          };
+          });
       }
+
+      // Read tools record the receipt AFTER a successful call and degrade on a
+      // write failure (the data is already fetched; the sink logs + marks the
+      // degraded write). Mutations already recorded their receipt above.
+      if (!mutating) await writeReceipt('invoked');
 
       return {
         content: [
@@ -621,6 +837,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         ],
       };
     } catch (err) {
+      const httpStatus = err instanceof ApiRequestError ? err.status : undefined;
+      await writeReceipt('failed', httpStatus);
       return {
         content: [
           { type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` },

--- a/packages/mcp/src/streamable-http.ts
+++ b/packages/mcp/src/streamable-http.ts
@@ -43,8 +43,13 @@ export type StreamableHttpHandlerOptions = {
   /** Generate session IDs. Default: `crypto.randomUUID()`. */
   sessionIdGenerator?: () => string;
 
-  /** Called when a new session is initialized. */
-  onSessionInitialized?: (sessionId: string) => void | Promise<void>;
+  /**
+   * Called when a new session is initialized, with the initializing request so
+   * a caller can bind the session to that request's authenticated identity
+   * (GAP-371 I-3). Fires synchronously within the initialize request's own
+   * handling — the `req` is exactly the request that created the session.
+   */
+  onSessionInitialized?: (sessionId: string, req: IncomingMessage) => void | Promise<void>;
 
   /** Called when a session is terminated (DELETE or transport close). */
   onSessionClosed?: (sessionId: string) => void | Promise<void>;
@@ -67,9 +72,29 @@ export type StreamableHttpHandlerOptions = {
    * serverless request/response platforms). Default: false.
    */
   enableJsonResponse?: boolean;
+
+  /**
+   * Called once, synchronously, during handler construction with a control
+   * surface for the handler's session map. A governed mount uses it to
+   * terminate a session whose bound identity no longer matches the presented
+   * credential (GAP-371 I-3). Optional — stdio / unauthenticated callers omit it.
+   */
+  onControl?: (control: StreamableHttpControl) => void;
 };
 
 export type StreamableHttpHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+
+/** Control surface over a handler's live session map. */
+export interface StreamableHttpControl {
+  /** Whether a session id currently has a live transport. */
+  hasSession(sessionId: string): boolean;
+  /**
+   * Close and forget a session. The transport's own `onsessionclosed` fires,
+   * so any external binding keyed on the id is cleaned up through the normal
+   * path. Idempotent — a no-op for an unknown id.
+   */
+  terminateSession(sessionId: string): Promise<void>;
+}
 
 type SessionEntry = {
   server: Server;
@@ -102,6 +127,21 @@ export function createNodeStreamableHttpHandler(
 ): StreamableHttpHandler {
   const sessions = new Map<string, SessionEntry>();
   const generateSessionId = options.sessionIdGenerator ?? (() => randomUUID());
+
+  options.onControl?.({
+    hasSession(sessionId) {
+      return sessions.has(sessionId);
+    },
+    async terminateSession(sessionId) {
+      const entry = sessions.get(sessionId);
+      if (!entry) return;
+      // Removing the entry first makes termination idempotent even if close()
+      // re-enters via onsessionclosed.
+      sessions.delete(sessionId);
+      await entry.transport.close();
+      await options.onSessionClosed?.(sessionId);
+    },
+  });
 
   return async function mcpStreamableHttpHandler(req, res) {
     const body = req.method === 'POST' ? await readJsonBody(req) : undefined;
@@ -139,7 +179,7 @@ export function createNodeStreamableHttpHandler(
         allowedOrigins: options.allowedOrigins,
         onsessioninitialized: async (id: string) => {
           sessions.set(id, { server, transport });
-          await options.onSessionInitialized?.(id);
+          await options.onSessionInitialized?.(id, req);
         },
         onsessionclosed: async (id: string) => {
           sessions.delete(id);


### PR DESCRIPTION
## Governed, authenticated, audited MCP endpoint at `/api/mcp`

Phase 1 of connecting external MCP clients (e.g. OpenCode) to RevealUI as governed, audited users. Mounts the existing (previously unmounted) `revealui-content` MCP server over Streamable HTTP behind the same auth the rest of the API uses. An external MCP client is treated as an **untrusted network caller**: the only authority is the `rvui_dev_` device token it presents, re-verified on every request.

### What this does

- **Mounts `/api/mcp`** (POST/GET/DELETE) on the Hono API, chain in order: `authMiddleware` (bearer-first) → `entitlementMiddleware` → `requireFeature('mcp')` → session⇢user binding → Streamable HTTP handler. DNS-rebinding guards (`allowedHosts`/`allowedOrigins`) configurable from deployment env. Bound to the exact path so it does not shadow `/api/mcp/usage`.
- **Per-request identity threading.** The content factory gains a `credentialsProvider(callContext)` seam that, on the governed path, returns the **caller's own token**, which the tools forward to the REST API so collection `access.read` enforces against the real user. The env-key fallback is structurally absent on this path (the provider throws with no per-request credential). The stdio launcher keeps its env-key model unchanged.
- **Session⇢user binding.** The MCP session id is routing state, never authority. Each session is bound to the user that created it (race-free, at `onSessionInitialized`); every later request re-validates the token and asserts it resolves to the bound user. A mismatch is a 401 and terminates the session.
- **A receipt per tool call** to `audit_log` (`mcp:tool:invoked | denied | failed`), hash-chained, with `payload` carrying `{ userId, accountId, tool, argsDigest, collection?, site_id?, outcome, durationMs, httpStatus? }`. Raw arguments are never stored — only a sha256 digest plus an allowlisted non-secret scalar subset. Mutating tools fail closed if the receipt cannot be written; reads degrade to log-and-continue. Phase 1 exposes read tools only, but the fail-closed branch is wired so future write tools inherit it.
- Adds a `remote` entry to the discovery manifest.

Payments/Stripe tools are deliberately out of scope for this endpoint.

### Security invariants (tested red-first, then green)

I-1 identity comes only from the verified token; I-2 no client-supplied scope without an ownership check (foreign/nonexistent `site_id` returns a byte-identical empty shape — no existence oracle); I-3 the session id is never authority; I-4 no ambient service credential on the governed path; I-5 a receipt per call (fail-closed for mutations, degrade for reads, secret-shaped args never stored raw); I-6 expiry/revocation honored per request, mid-session.

Each invariant was proven by removing its guard and watching the corresponding test go red, then restoring. New tests:
- `packages/mcp/__tests__/revealui-content-governed.test.ts` (factory/transport seam: I-1, I-4, I-5)
- `apps/server/src/routes/__tests__/mcp-endpoint.pglite.test.ts` (full E2E with a real MCP SDK client + PGlite + minted device tokens: acceptance, I-2, I-3, I-4, I-6, entitlement gate)

### Verification

- New suites green; full `@revealui/mcp` (435) and `server` (2916) suites green (no regressions). Typecheck + Biome clean on touched files.
- A real `@modelcontextprotocol/sdk` client completes initialize → tools/list → tools/call against `/api/mcp` with a minted `rvui_dev_` token, landing a hash-chained receipt.
- The governed-path suite runs with `REVEALUI_API_KEY` unset; a separate test proves an unauthenticated request 401s even with it set.

### Review note

This touches auth middleware and the MCP package, so it is **security-sensitive** and needs an **independent, non-author security verdict** (`sec-review:approved`) before merge. The authoring session does not self-clear. The fleet security checker flags the branch as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
