### PR TITLE
feat(harnesses): add OpenCodeAdapter, the first external-CLI harness

### DIFF
--- a/.changeset/opencode-adapter.md
+++ b/.changeset/opencode-adapter.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+add OpenCodeAdapter, the first external-CLI harness adapter: detects and drives the `opencode` CLI (headless run, config apply/sync/diff, running-instance discovery), promotes the `opencode` capability profile from roadmap to shipped, registers an OpenCode content generator (commands + agents), and adds `protocolConfigToOpencodeConfig` for wiring the governed RevealUI MCP endpoint into `opencode.json` via env-var token substitution (never a literal token).

--- a/packages/harnesses/src/__tests__/opencode-adapter.test.ts
+++ b/packages/harnesses/src/__tests__/opencode-adapter.test.ts
@@ -1,0 +1,277 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  describeOpenCodeExecError,
+  OpenCodeAdapter,
+  parseOpenCodeRunOutput,
+} from '../adapters/opencode-adapter.js';
+import { HarnessRegistry } from '../registry/harness-registry.js';
+import type { HarnessCommand, HarnessEvent } from '../types/core.js';
+
+describe('OpenCodeAdapter', () => {
+  let projectRoot: string;
+  let adapter: OpenCodeAdapter;
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), 'opencode-adapter-test-'));
+    adapter = new OpenCodeAdapter({ projectRoot });
+  });
+
+  afterEach(async () => {
+    await adapter.dispose();
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it('has id opencode and a display name', () => {
+    expect(adapter.id).toBe('opencode');
+    expect(adapter.name).toBe('OpenCode');
+  });
+
+  describe('getCapabilities', () => {
+    it('declares generate/analyze/config support but not edit or workboard', () => {
+      const caps = adapter.getCapabilities();
+      expect(caps).toEqual({
+        generateCode: true,
+        analyzeCode: true,
+        applyEdit: false,
+        applyConfig: true,
+        readWorkboard: false,
+        writeWorkboard: false,
+      });
+    });
+  });
+
+  describe('isAvailable / getInfo -- graceful no-binary failure', () => {
+    // `opencode` is not installed in this build environment (verified via
+    // `which opencode` during the audit for this PR). These assertions
+    // exercise the REAL execFile ENOENT path, not a mock.
+    it('isAvailable returns false when the opencode binary is missing', async () => {
+      const missing = new OpenCodeAdapter({ binaryPath: 'opencode-binary-that-does-not-exist' });
+      await expect(missing.isAvailable()).resolves.toBe(false);
+    });
+
+    it('getInfo reports an undefined version when the binary is missing', async () => {
+      const missing = new OpenCodeAdapter({ binaryPath: 'opencode-binary-that-does-not-exist' });
+      const info = await missing.getInfo();
+      expect(info.id).toBe('opencode');
+      expect(info.version).toBeUndefined();
+    });
+
+    it('execute(headless-prompt) fails gracefully with a helpful message when unavailable', async () => {
+      const missing = new OpenCodeAdapter({
+        projectRoot,
+        binaryPath: 'opencode-binary-that-does-not-exist',
+      });
+      const result = await missing.execute({ type: 'headless-prompt', prompt: 'hello' });
+      expect(result.success).toBe(false);
+      expect(result.command).toBe('headless-prompt');
+      expect(result.message).toContain('opencode CLI not found on PATH');
+    });
+
+    it('emits a generation-started event even when the run ultimately fails', async () => {
+      const missing = new OpenCodeAdapter({
+        projectRoot,
+        binaryPath: 'opencode-binary-that-does-not-exist',
+      });
+      const events: HarnessEvent[] = [];
+      missing.onEvent((e) => events.push(e));
+      await missing.execute({ type: 'generate-code', prompt: 'write a function' });
+      expect(events.some((e) => e.type === 'generation-started')).toBe(true);
+      expect(events.some((e) => e.type === 'generation-completed')).toBe(false);
+    });
+  });
+
+  describe('execute -- command mapping', () => {
+    it('get-status reports availability and config', async () => {
+      const result = await adapter.execute({ type: 'get-status' });
+      expect(result.success).toBe(true);
+      expect(result.command).toBe('get-status');
+      const data = result.data as { available: boolean; projectRoot: string };
+      expect(data.available).toBe(false); // opencode not installed in this env
+      expect(data.projectRoot).toBe(projectRoot);
+    });
+
+    it('apply-edit is explicitly unsupported', async () => {
+      const result = await adapter.execute({
+        type: 'apply-edit',
+        filePath: 'foo.ts',
+        diff: 'x',
+      });
+      expect(result.success).toBe(false);
+      expect(result.command).toBe('apply-edit');
+      expect(result.message).toContain('not supported');
+    });
+
+    it('read-workboard and update-workboard report the not-wired posture', async () => {
+      const read = await adapter.execute({ type: 'read-workboard' });
+      expect(read.success).toBe(false);
+      expect(read.message).toContain('not yet wired');
+
+      const update = await adapter.execute({
+        type: 'update-workboard',
+        sessionId: 'opencode-1',
+      });
+      expect(update.success).toBe(false);
+      expect(update.message).toContain('not yet wired');
+    });
+
+    it('get-running-instances succeeds even with zero running processes', async () => {
+      const result = await adapter.execute({ type: 'get-running-instances' });
+      expect(result.success).toBe(true);
+      const data = result.data as { instances: unknown[] };
+      expect(Array.isArray(data.instances)).toBe(true);
+    });
+
+    it('apply-config writes content under the project root', async () => {
+      const result = await adapter.execute({
+        type: 'apply-config',
+        configPath: 'opencode.json',
+        content: '{"mcp":{}}',
+      });
+      expect(result.success).toBe(true);
+      const written = await readFile(join(projectRoot, 'opencode.json'), 'utf8');
+      expect(written).toBe('{"mcp":{}}');
+    });
+
+    it('apply-config creates nested directories', async () => {
+      const result = await adapter.execute({
+        type: 'apply-config',
+        configPath: '.opencode/agents/reviewer.md',
+        content: '---\ndescription: x\n---\n',
+      });
+      expect(result.success).toBe(true);
+      const written = await readFile(
+        join(projectRoot, '.opencode', 'agents', 'reviewer.md'),
+        'utf8',
+      );
+      expect(written).toContain('description: x');
+    });
+
+    it('apply-config refuses to write outside the project root', async () => {
+      const result = await adapter.execute({
+        type: 'apply-config',
+        configPath: '../../etc/passwd',
+        content: 'malicious',
+      });
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('outside the project root');
+    });
+
+    it('diff-config reports both sides missing when nothing is configured locally', async () => {
+      const result = await adapter.execute({ type: 'diff-config' });
+      expect(result.success).toBe(true);
+      expect(result.command).toBe('diff-config');
+    });
+
+    it('an unknown command type is reported as unsupported', async () => {
+      const bogus = { type: 'not-a-real-command' } as unknown as HarnessCommand;
+      const result = await adapter.execute(bogus);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('registry lifecycle', () => {
+    let registry: HarnessRegistry;
+
+    beforeEach(() => {
+      registry = new HarnessRegistry();
+    });
+
+    afterEach(async () => {
+      await registry.disposeAll();
+    });
+
+    it('registers the adapter', () => {
+      registry.register(adapter);
+      expect(registry.get('opencode')).toBe(adapter);
+    });
+
+    it('throws on duplicate registration', () => {
+      registry.register(adapter);
+      expect(() => registry.register(new OpenCodeAdapter())).toThrow('already registered');
+    });
+
+    it('unregisters and disposes the adapter', async () => {
+      registry.register(adapter);
+      await registry.unregister('opencode');
+      expect(registry.get('opencode')).toBeUndefined();
+    });
+
+    it('reports unavailable in listAvailable() when the binary is missing', async () => {
+      const missing = new OpenCodeAdapter({ binaryPath: 'opencode-binary-that-does-not-exist' });
+      registry.register(missing);
+      const available = await registry.listAvailable();
+      expect(available).not.toContain('opencode');
+    });
+  });
+
+  describe('notifyRegistered / notifyUnregistering', () => {
+    it('emits harness-connected and harness-disconnected', () => {
+      const events: HarnessEvent[] = [];
+      adapter.onEvent((e) => events.push(e));
+      adapter.notifyRegistered();
+      adapter.notifyUnregistering();
+      expect(events).toEqual([
+        { type: 'harness-connected', harnessId: 'opencode' },
+        { type: 'harness-disconnected', harnessId: 'opencode' },
+      ]);
+    });
+  });
+});
+
+describe('parseOpenCodeRunOutput', () => {
+  it('returns empty string for empty stdout', () => {
+    expect(parseOpenCodeRunOutput('')).toBe('');
+    expect(parseOpenCodeRunOutput('   \n  ')).toBe('');
+  });
+
+  it('extracts a known text-bearing key from a JSON object', () => {
+    expect(parseOpenCodeRunOutput(JSON.stringify({ output: 'hello' }))).toBe('hello');
+    expect(parseOpenCodeRunOutput(JSON.stringify({ text: 'hi' }))).toBe('hi');
+    expect(parseOpenCodeRunOutput(JSON.stringify({ message: 'hey' }))).toBe('hey');
+    expect(parseOpenCodeRunOutput(JSON.stringify({ content: 'yo' }))).toBe('yo');
+  });
+
+  it('prefers the first matching key in priority order', () => {
+    expect(parseOpenCodeRunOutput(JSON.stringify({ output: 'first', text: 'second' }))).toBe(
+      'first',
+    );
+  });
+
+  it('falls back to the raw JSON text for an unrecognized object shape', () => {
+    const raw = JSON.stringify({ unknownField: 'value' });
+    expect(parseOpenCodeRunOutput(raw)).toBe(raw);
+  });
+
+  it('unwraps a bare JSON string', () => {
+    expect(parseOpenCodeRunOutput(JSON.stringify('plain string result'))).toBe(
+      'plain string result',
+    );
+  });
+
+  it('treats non-JSON stdout as plain text', () => {
+    expect(parseOpenCodeRunOutput('just plain text, not json')).toBe('just plain text, not json');
+  });
+});
+
+describe('describeOpenCodeExecError', () => {
+  it('gives a helpful message for ENOENT (binary not on PATH)', () => {
+    const err = Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' });
+    expect(describeOpenCodeExecError(err)).toContain('opencode CLI not found on PATH');
+  });
+
+  it('includes stderr when present', () => {
+    const err = Object.assign(new Error('Command failed'), { stderr: 'boom' });
+    expect(describeOpenCodeExecError(err)).toBe('Command failed\nboom');
+  });
+
+  it('falls back to the error message alone when there is no stderr', () => {
+    expect(describeOpenCodeExecError(new Error('plain failure'))).toBe('plain failure');
+  });
+
+  it('stringifies non-Error throwables', () => {
+    expect(describeOpenCodeExecError('a string error')).toBe('a string error');
+  });
+});

--- a/packages/harnesses/src/__tests__/opencode-config.test.ts
+++ b/packages/harnesses/src/__tests__/opencode-config.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { ProtocolConfig } from '../protocol/adapter.js';
+import { protocolConfigToOpencodeConfig } from '../protocol/config-normalizer.js';
+
+function createTestConfig(overrides: Partial<ProtocolConfig> = {}): ProtocolConfig {
+  return {
+    identity: { name: 'Test Agent', email: 'test@example.com', role: 'builder' },
+    permissions: { autoApprove: ['Read', 'Glob'], deny: ['Write'] },
+    environment: { variables: {}, mcpServers: [] },
+    rules: [],
+    skills: [],
+    commands: [],
+    ...overrides,
+  };
+}
+
+describe('protocolConfigToOpencodeConfig', () => {
+  it('emits the design-doc §5.7 remote MCP block', () => {
+    const config = createTestConfig();
+    const result = protocolConfigToOpencodeConfig(config, {
+      mcpUrl: 'https://your-host/api/mcp',
+    });
+
+    expect(result.mcp?.revealui).toEqual({
+      type: 'remote',
+      url: 'https://your-host/api/mcp',
+      headers: { Authorization: 'Bearer {env:REVEALUI_MCP_TOKEN}' },
+      oauth: false,
+      enabled: true,
+    });
+    expect(result.tools).toEqual({ 'revealui*': true });
+  });
+
+  it('respects a custom token env var name', () => {
+    const config = createTestConfig();
+    const result = protocolConfigToOpencodeConfig(config, {
+      mcpUrl: 'https://your-host/api/mcp',
+      tokenEnvVar: 'CUSTOM_TOKEN_VAR',
+    });
+    expect(result.mcp?.revealui.headers.Authorization).toBe('Bearer {env:CUSTOM_TOKEN_VAR}');
+  });
+
+  it('maps autoApprove/deny permissions to opencode allow/deny, dropping unsafe keys', () => {
+    const config = createTestConfig({
+      permissions: {
+        autoApprove: ['Read', 'Glob', '__proto__', 'constructor'],
+        deny: ['Write', 'prototype'],
+      },
+    });
+    const result = protocolConfigToOpencodeConfig(config, { mcpUrl: 'https://host/api/mcp' });
+
+    expect(result.permission).toEqual({ Read: 'allow', Glob: 'allow', Write: 'deny' });
+    expect(result.permission).not.toHaveProperty('__proto__');
+    expect(result.permission).not.toHaveProperty('constructor');
+    expect(result.permission).not.toHaveProperty('prototype');
+  });
+
+  it('omits the permission block entirely when there is nothing to declare', () => {
+    const config = createTestConfig({ permissions: { autoApprove: [], deny: [] } });
+    const result = protocolConfigToOpencodeConfig(config, { mcpUrl: 'https://host/api/mcp' });
+    expect(result.permission).toBeUndefined();
+  });
+
+  describe('SECURITY: never emits a literal bearer token', () => {
+    it('does not leak a token planted in config.environment.variables', () => {
+      const config = createTestConfig({
+        environment: {
+          variables: { REVEALUI_MCP_TOKEN: 'rvui_dev_should_never_appear_in_output' },
+          mcpServers: [],
+        },
+      });
+      const result = protocolConfigToOpencodeConfig(config, { mcpUrl: 'https://host/api/mcp' });
+      const serialized = JSON.stringify(result);
+
+      expect(serialized).not.toContain('rvui_dev_should_never_appear_in_output');
+      expect(result.mcp?.revealui.headers.Authorization).toBe('Bearer {env:REVEALUI_MCP_TOKEN}');
+    });
+
+    it('never emits any token-shaped literal regardless of what environment.variables contains', () => {
+      const config = createTestConfig({
+        environment: {
+          variables: {
+            REVEALUI_MCP_TOKEN: 'sk-should-not-leak',
+            ANOTHER_SECRET: 'also-should-not-leak',
+          },
+          mcpServers: [],
+        },
+      });
+      const result = protocolConfigToOpencodeConfig(config, {
+        mcpUrl: 'https://host/api/mcp',
+        tokenEnvVar: 'REVEALUI_MCP_TOKEN',
+      });
+      const serialized = JSON.stringify(result);
+
+      // The only string containing "REVEALUI_MCP_TOKEN" allowed in the
+      // output is the `{env:...}` substitution placeholder -- never a
+      // resolved literal value.
+      expect(serialized).not.toContain('sk-should-not-leak');
+      expect(serialized).not.toContain('also-should-not-leak');
+      expect(serialized).toContain('{env:REVEALUI_MCP_TOKEN}');
+    });
+  });
+});

--- a/packages/harnesses/src/__tests__/opencode-content-generator.test.ts
+++ b/packages/harnesses/src/__tests__/opencode-content-generator.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { OpenCodeGenerator } from '../content/generators/opencode.js';
+import { buildManifest, generateContent, getGenerator, listGenerators } from '../content/index.js';
+import type { Agent, Command, Rule, Skill } from '../content/schemas/index.js';
+
+const ctx = { projectRoot: '/test' };
+
+describe('OpenCodeGenerator', () => {
+  it('is auto-registered in the content generator registry', () => {
+    expect(listGenerators()).toContain('opencode');
+    expect(getGenerator('opencode')).toBeInstanceOf(OpenCodeGenerator);
+  });
+
+  it('declares its output directory', () => {
+    const generator = new OpenCodeGenerator();
+    expect(generator.id).toBe('opencode');
+    expect(generator.outputDir).toBe('.opencode');
+  });
+
+  describe('generateCommand', () => {
+    it('writes a frontmatter markdown file under .opencode/commands/', () => {
+      const cmd: Command = {
+        id: 'gate',
+        name: 'Gate',
+        description: 'Run the quality gate',
+        tier: 'oss',
+        disableModelInvocation: false,
+        content: 'Run lint, typecheck, and tests.',
+      };
+      const files = new OpenCodeGenerator().generateCommand(cmd, ctx);
+      expect(files).toHaveLength(1);
+      expect(files[0]?.relativePath).toBe('.opencode/commands/gate.md');
+      expect(files[0]?.content).toContain('description: Run the quality gate');
+      expect(files[0]?.content).toContain('Run lint, typecheck, and tests.');
+    });
+
+    it('includes argument-hint and disable-model-invocation when set', () => {
+      const cmd: Command = {
+        id: 'deploy',
+        name: 'Deploy',
+        description: 'Deploy the app',
+        tier: 'oss',
+        disableModelInvocation: true,
+        argumentHint: '[environment]',
+        content: 'Deploy steps.',
+      };
+      const [file] = new OpenCodeGenerator().generateCommand(cmd, ctx);
+      expect(file?.content).toContain('argument-hint: [environment]');
+      expect(file?.content).toContain('disable-model-invocation: true');
+    });
+  });
+
+  describe('generateAgent', () => {
+    it('writes a frontmatter markdown file under .opencode/agents/', () => {
+      const agent: Agent = {
+        id: 'reviewer',
+        name: 'Reviewer',
+        description: 'Reviews code',
+        tier: 'oss',
+        isolation: 'none',
+        tools: ['Read', 'Grep'],
+        content: 'You review code for quality.',
+      };
+      const [file] = new OpenCodeGenerator().generateAgent(agent, ctx);
+      expect(file?.relativePath).toBe('.opencode/agents/reviewer.md');
+      expect(file?.content).toContain('description: Reviews code');
+      expect(file?.content).toContain('tools: Read, Grep');
+      expect(file?.content).toContain('You review code for quality.');
+    });
+  });
+
+  describe('generateRule / generateSkill -- no native OpenCode surface', () => {
+    it('generateRule returns no files (folded into AGENTS.md by a different generator)', () => {
+      const rule: Rule = {
+        id: 'biome',
+        name: 'Biome',
+        description: 'Use biome',
+        scope: 'project',
+        preambleTier: 2,
+        tier: 'oss',
+        tags: [],
+        content: 'Format with biome.',
+      };
+      expect(new OpenCodeGenerator().generateRule(rule, ctx)).toEqual([]);
+    });
+
+    it('generateSkill returns no files (no documented native OpenCode skills surface)', () => {
+      const skill: Skill = {
+        id: 'tdd',
+        name: 'TDD',
+        description: 'Test-driven development',
+        tier: 'oss',
+        disableModelInvocation: false,
+        skipFrontmatter: false,
+        filePatterns: [],
+        bashPatterns: [],
+        references: {},
+        content: 'Write tests first.',
+      };
+      expect(new OpenCodeGenerator().generateSkill(skill, ctx)).toEqual([]);
+    });
+  });
+
+  describe('generateAll / generateContent over the real manifest', () => {
+    it('emits exactly one file per command and one per agent, nothing for rules/skills', () => {
+      const manifest = buildManifest();
+      const files = generateContent('opencode', manifest, ctx);
+
+      expect(files).toHaveLength(manifest.commands.length + manifest.agents.length);
+      for (const cmd of manifest.commands) {
+        expect(files.some((f) => f.relativePath === `.opencode/commands/${cmd.id}.md`)).toBe(true);
+      }
+      for (const agent of manifest.agents) {
+        expect(files.some((f) => f.relativePath === `.opencode/agents/${agent.id}.md`)).toBe(true);
+      }
+      expect(files.some((f) => f.relativePath.startsWith('.opencode/rules/'))).toBe(false);
+      expect(files.some((f) => f.relativePath.startsWith('.opencode/skills/'))).toBe(false);
+    });
+  });
+});

--- a/packages/harnesses/src/__tests__/protocol-types.test.ts
+++ b/packages/harnesses/src/__tests__/protocol-types.test.ts
@@ -35,8 +35,8 @@ describe('protocol capabilities', () => {
 });
 
 describe('TOOL_PROFILES (shipped adapters)', () => {
-  it('contains revealui-agent only', () => {
-    expect(Object.keys(TOOL_PROFILES)).toEqual(['revealui-agent']);
+  it('contains opencode and revealui-agent', () => {
+    expect(Object.keys(TOOL_PROFILES).sort()).toEqual(['opencode', 'revealui-agent']);
   });
 
   it('revealui-agent has full dispatch capabilities', () => {
@@ -53,6 +53,27 @@ describe('TOOL_PROFILES (shipped adapters)', () => {
     expect(caps.lifecycleEvents).toHaveLength(10);
   });
 
+  it('opencode is headless/resumable/forkable/backgroundable but has no hooks', () => {
+    const caps = TOOL_PROFILES.opencode;
+    expect(caps).toBeDefined();
+    expect(caps.dispatch.generateCode).toBe(true);
+    expect(caps.dispatch.analyzeCode).toBe(true);
+    expect(caps.dispatch.applyEdit).toBe(false);
+    expect(caps.dispatch.executeCommand).toBe(true);
+    expect(caps.headless).toBe(true);
+    expect(caps.resumable).toBe(true);
+    expect(caps.forkable).toBe(true);
+    expect(caps.backgroundable).toBe(true);
+    expect(caps.hooks.supported).toBe(false);
+    expect(caps.hooks.canBlock).toBe(false);
+    expect(caps.supportsSkills).toBe(true);
+    expect(caps.supportsMcp).toBe(true);
+    expect(caps.supportsWorktrees).toBe(false);
+    // 0 is the documented BYO-model sentinel for opencode (see the
+    // maxContextTokens doc comment on ProtocolCapabilities), not a defect.
+    expect(caps.maxContextTokens).toBe(0);
+  });
+
   it('does not contain entries for tools without adapters', () => {
     expect(TOOL_PROFILES['claude-code']).toBeUndefined();
     expect(TOOL_PROFILES.codex).toBeUndefined();
@@ -61,13 +82,8 @@ describe('TOOL_PROFILES (shipped adapters)', () => {
 });
 
 describe('ROADMAP_PROFILES (declared, no adapter)', () => {
-  it('contains the four spec-declared tools', () => {
-    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual([
-      'claude-code',
-      'codex',
-      'cursor',
-      'opencode',
-    ]);
+  it('contains the three remaining spec-declared tools (opencode graduated to TOOL_PROFILES)', () => {
+    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex', 'cursor']);
   });
 
   it('claude-code has no dispatch capabilities (interactive tool)', () => {
@@ -90,19 +106,6 @@ describe('ROADMAP_PROFILES (declared, no adapter)', () => {
     expect(caps.lifecycleEvents).toEqual([]);
   });
 
-  it('opencode is headless/resumable/forkable/backgroundable but has no hooks', () => {
-    const caps = ROADMAP_PROFILES.opencode;
-    expect(caps.headless).toBe(true);
-    expect(caps.resumable).toBe(true);
-    expect(caps.forkable).toBe(true);
-    expect(caps.backgroundable).toBe(true);
-    expect(caps.hooks.supported).toBe(false);
-    expect(caps.hooks.canBlock).toBe(false);
-    expect(caps.supportsSkills).toBe(true);
-    expect(caps.supportsMcp).toBe(true);
-    expect(caps.supportsWorktrees).toBe(false);
-  });
-
   it('does not overlap with TOOL_PROFILES', () => {
     for (const id of Object.keys(ROADMAP_PROFILES)) {
       expect(TOOL_PROFILES[id]).toBeUndefined();
@@ -122,11 +125,12 @@ describe('ALL_KNOWN_PROFILES (merged view)', () => {
   });
 
   it('shipped entries take precedence over roadmap entries on key collision', () => {
-    // No collision today (the four IDs are disjoint), but the spread order
+    // No collision today (the five IDs are disjoint), but the spread order
     // (...ROADMAP_PROFILES first, then ...TOOL_PROFILES) guarantees that
     // a future shipped adapter overrides any roadmap declaration with the
-    // same ID. Verify the shape of revealui-agent matches TOOL_PROFILES.
+    // same ID. Verify the shape of the shipped profiles matches TOOL_PROFILES.
     expect(ALL_KNOWN_PROFILES['revealui-agent']).toEqual(TOOL_PROFILES['revealui-agent']);
+    expect(ALL_KNOWN_PROFILES.opencode).toEqual(TOOL_PROFILES.opencode);
   });
 });
 

--- a/packages/harnesses/src/adapters/opencode-adapter.ts
+++ b/packages/harnesses/src/adapters/opencode-adapter.ts
@@ -1,0 +1,402 @@
+/**
+ * OpenCode Adapter
+ *
+ * Wraps the external `opencode` CLI (execFile), following the CLI-wrapping
+ * pattern in `translation-layer.ts`. Unlike `RevealUIAgentAdapter` (which IS
+ * the runtime), this adapter is a thin control-plane wrapper: it detects,
+ * drives, and observes a locally-installed `opencode` binary. It grants no
+ * RevealUI data-plane authority -- that flows through the governed MCP
+ * endpoint with its own bearer token (design doc §3, "bridging rule B-1").
+ *
+ * `opencode run <prompt> --format json` output shape is UNVERIFIED against a
+ * real binary (design doc §2.4) -- `parseRunOutput` below is defensive and
+ * documents exactly what it assumes.
+ */
+
+import { execFile } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve, sep } from 'node:path';
+import { promisify } from 'node:util';
+import { diffConfig, syncConfig } from '../config/config-sync.js';
+import { findHarnessProcesses } from '../detection/process-detector.js';
+import type { ProtocolCapabilities } from '../protocol/capabilities.js';
+import { TOOL_PROFILES } from '../protocol/capabilities.js';
+import type { ProtocolEventEnvelope } from '../protocol/event-envelope.js';
+import { EventNormalizer } from '../protocol/event-normalizer.js';
+import type { HarnessAdapter } from '../types/adapter.js';
+import type {
+  HarnessCapabilities,
+  HarnessCommand,
+  HarnessCommandResult,
+  HarnessEvent,
+  HarnessInfo,
+} from '../types/core.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Default timeout for a one-shot `opencode run` invocation (2 minutes). */
+const DEFAULT_RUN_TIMEOUT_MS = 120_000;
+/** Timeout for availability/version checks -- these must be fast (3s). */
+const AVAILABILITY_TIMEOUT_MS = 3_000;
+/** Cap stdout/stderr buffering for `opencode run` (10 MB). */
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Configuration for the OpenCode adapter. All fields are optional -- sensible
+ * defaults are applied.
+ */
+export interface OpenCodeAdapterConfig {
+  /** Project root the `opencode` CLI runs against (default: cwd) */
+  projectRoot?: string;
+  /** Model override passed as `--model` (default: OpenCode's own default) */
+  model?: string;
+  /** Agent override passed as `--agent` */
+  agent?: string;
+  /** Timeout for `opencode run` invocations in ms (default: 120000) */
+  timeoutMs?: number;
+  /** Path/name of the `opencode` executable (default: 'opencode', resolved via PATH) */
+  binaryPath?: string;
+}
+
+const DEFAULT_CONFIG: Required<Pick<OpenCodeAdapterConfig, 'timeoutMs' | 'binaryPath'>> = {
+  timeoutMs: DEFAULT_RUN_TIMEOUT_MS,
+  binaryPath: 'opencode',
+};
+
+/**
+ * Parse `opencode run --format json` stdout into a plain-text output string.
+ * The exact shape is UNVERIFIED against a real binary (design doc §2.4) --
+ * this deliberately degrades gracefully:
+ *   1. Valid JSON object with a known text-bearing key (`output`, `text`,
+ *      `message`, `content`) -- return that string.
+ *   2. Valid JSON of any other shape -- return the raw JSON text so no
+ *      information is lost.
+ *   3. Not JSON at all -- treat stdout as plain text (opencode's non-JSON
+ *      `run` mode is plain text; `--format json` failing silently to emit
+ *      JSON should not throw away the response).
+ *
+ * Exported (rather than a private method) so the parsing logic is directly
+ * unit-testable against the documented-but-unverified shape without
+ * mocking `execFile`.
+ */
+export function parseOpenCodeRunOutput(stdout: string): string {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) return '';
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === 'string') return parsed;
+    if (parsed && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>;
+      for (const key of ['output', 'text', 'message', 'content']) {
+        const value = obj[key];
+        if (typeof value === 'string') return value;
+      }
+    }
+    return trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * Turn an `execFile` rejection into a helpful message, special-casing the
+ * "binary not on PATH" case. Exported for direct unit testing.
+ */
+export function describeOpenCodeExecError(err: unknown): string {
+  if (
+    err &&
+    typeof err === 'object' &&
+    'code' in err &&
+    (err as { code?: string }).code === 'ENOENT'
+  ) {
+    return 'opencode CLI not found on PATH. Install via the curl script, `npm install -g opencode-ai`, or brew, then retry.';
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  const stderr =
+    err && typeof err === 'object' && 'stderr' in err
+      ? String((err as { stderr: unknown }).stderr)
+      : '';
+  return stderr ? `${message}\n${stderr}`.trim() : message;
+}
+
+/**
+ * OpenCode harness adapter -- the first external-CLI adapter in this package
+ * (`RevealUIAgentAdapter` IS the runtime; `translation-layer.ts` shows the
+ * `execFile` pattern this adapter follows).
+ */
+export class OpenCodeAdapter implements HarnessAdapter {
+  readonly id = 'opencode';
+  readonly name = 'OpenCode';
+
+  private readonly config: OpenCodeAdapterConfig;
+  private readonly binary: string;
+  private readonly eventHandlers = new Set<(event: HarnessEvent) => void>();
+  private readonly protocolEventHandlers = new Set<(event: ProtocolEventEnvelope) => void>();
+  private protocolNormalizer: EventNormalizer | null = null;
+
+  constructor(config?: OpenCodeAdapterConfig) {
+    this.config = { ...config };
+    this.binary = config?.binaryPath ?? DEFAULT_CONFIG.binaryPath;
+  }
+
+  getCapabilities(): HarnessCapabilities {
+    return {
+      generateCode: true,
+      analyzeCode: true,
+      // `opencode run` applies edits itself during generation; there is no
+      // clean CLI surface for the adapter to apply an externally-supplied
+      // diff (design doc §8.2).
+      applyEdit: false,
+      applyConfig: true,
+      // Workboard support is not wired -- same honest posture as
+      // RevealUIAgentAdapter (`execute()` below returns success:false for
+      // both read-workboard and update-workboard).
+      readWorkboard: false,
+      writeWorkboard: false,
+    };
+  }
+
+  async getInfo(): Promise<HarnessInfo> {
+    return {
+      id: this.id,
+      name: this.name,
+      version: await this.getVersion(),
+      capabilities: this.getCapabilities(),
+    };
+  }
+
+  /** Get the Harness Protocol capability profile for this adapter. */
+  getProtocolCapabilities(): ProtocolCapabilities {
+    // opencode is always defined in TOOL_PROFILES (promoted from
+    // ROADMAP_PROFILES when this adapter shipped).
+    return TOOL_PROFILES.opencode as ProtocolCapabilities;
+  }
+
+  /** Subscribe to protocol-normalized events. */
+  onProtocolEvent(handler: (event: ProtocolEventEnvelope) => void): () => void {
+    this.protocolEventHandlers.add(handler);
+    if (!this.protocolNormalizer) {
+      this.protocolNormalizer = new EventNormalizer('opencode', this.id, `session-${Date.now()}`);
+    }
+    return () => this.protocolEventHandlers.delete(handler);
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await execFileAsync(this.binary, ['--version'], { timeout: AVAILABILITY_TIMEOUT_MS });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  notifyRegistered(): void {
+    this.emit({ type: 'harness-connected', harnessId: this.id });
+  }
+
+  notifyUnregistering(): void {
+    this.emit({ type: 'harness-disconnected', harnessId: this.id });
+  }
+
+  async execute(command: HarnessCommand): Promise<HarnessCommandResult> {
+    try {
+      return await this.executeInner(command);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit({ type: 'error', harnessId: this.id, message });
+      return { success: false, command: command.type, message };
+    }
+  }
+
+  private async executeInner(command: HarnessCommand): Promise<HarnessCommandResult> {
+    switch (command.type) {
+      case 'get-status': {
+        const available = await this.isAvailable();
+        return {
+          success: true,
+          command: command.type,
+          data: {
+            available,
+            model: this.config.model ?? 'auto',
+            agent: this.config.agent ?? 'auto',
+            projectRoot: this.config.projectRoot ?? process.cwd(),
+          },
+        };
+      }
+
+      case 'headless-prompt': {
+        return this.runOpenCodeRun(command.type, command.prompt, { timeoutMs: command.timeoutMs });
+      }
+
+      case 'generate-code': {
+        const prompt = `Generate code: ${command.prompt}${command.language ? ` (language: ${command.language})` : ''}${command.context ? `\n\nContext:\n${command.context}` : ''}`;
+        return this.runOpenCodeRun(command.type, prompt);
+      }
+
+      case 'analyze-code': {
+        const question = command.question ?? 'Analyze this file and explain what it does.';
+        const prompt = `Read the file at ${command.filePath} and answer: ${question}`;
+        return this.runOpenCodeRun(command.type, prompt);
+      }
+
+      case 'apply-edit': {
+        return {
+          success: false,
+          command: command.type,
+          message:
+            'apply-edit is not supported by the OpenCode adapter -- opencode applies edits itself during `run`; there is no clean CLI surface for an externally-supplied diff.',
+        };
+      }
+
+      case 'apply-config': {
+        return this.applyConfig(command.configPath, command.content);
+      }
+
+      case 'sync-config': {
+        const result = syncConfig(this.id, command.direction);
+        return { success: result.success, command: command.type, message: result.message };
+      }
+
+      case 'diff-config': {
+        const diff = diffConfig(this.id);
+        return { success: true, command: command.type, data: diff };
+      }
+
+      case 'read-workboard':
+      case 'update-workboard': {
+        // Workboard support delegated to WorkboardManager (same posture as
+        // revealui-agent-adapter.ts) -- not wired at the adapter level.
+        return {
+          success: false,
+          command: command.type,
+          message: 'Workboard support not yet wired  -  use WorkboardManager directly',
+        };
+      }
+
+      case 'get-running-instances': {
+        const instances = await findHarnessProcesses(this.id);
+        return { success: true, command: command.type, data: { instances } };
+      }
+
+      default: {
+        return {
+          success: false,
+          command: (command as HarnessCommand).type,
+          message: `Command not supported by ${this.name}`,
+        };
+      }
+    }
+  }
+
+  /** Write `content` to `configPath`, resolved under the configured project root. */
+  private async applyConfig(configPath: string, content: string): Promise<HarnessCommandResult> {
+    const projectRoot = resolve(this.config.projectRoot ?? process.cwd());
+    const resolved = resolve(projectRoot, configPath);
+    const rootWithSep = projectRoot.endsWith(sep) ? projectRoot : projectRoot + sep;
+
+    if (!(resolved === projectRoot || resolved.startsWith(rootWithSep))) {
+      return {
+        success: false,
+        command: 'apply-config',
+        message: `Refusing to write outside the project root: ${configPath}`,
+      };
+    }
+
+    try {
+      await mkdir(dirname(resolved), { recursive: true });
+      await writeFile(resolved, content, 'utf8');
+      return { success: true, command: 'apply-config', data: { path: resolved } };
+    } catch (err) {
+      return {
+        success: false,
+        command: 'apply-config',
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
+   * Run a one-shot `opencode run` invocation and normalize its output.
+   * Emits `generation-started` / `generation-completed` around the call,
+   * mirroring `revealui-agent-adapter.ts`'s event pattern.
+   */
+  private async runOpenCodeRun(
+    commandType: HarnessCommand['type'],
+    prompt: string,
+    opts?: { timeoutMs?: number },
+  ): Promise<HarnessCommandResult> {
+    const taskId = `task-${Date.now()}`;
+    this.emit({ type: 'generation-started', taskId });
+
+    const args = ['run', prompt, '--format', 'json'];
+    if (this.config.model) args.push('--model', this.config.model);
+    if (this.config.agent) args.push('--agent', this.config.agent);
+
+    try {
+      const { stdout } = await execFileAsync(this.binary, args, {
+        cwd: this.config.projectRoot ?? process.cwd(),
+        timeout: opts?.timeoutMs ?? this.config.timeoutMs ?? DEFAULT_CONFIG.timeoutMs,
+        maxBuffer: MAX_BUFFER_BYTES,
+      });
+
+      const output = parseOpenCodeRunOutput(stdout);
+      this.emit({ type: 'generation-completed', taskId, output });
+
+      return {
+        success: true,
+        command: commandType,
+        message: output,
+        data: { taskId, output },
+      };
+    } catch (err) {
+      return { success: false, command: commandType, message: describeOpenCodeExecError(err) };
+    }
+  }
+
+  private async getVersion(): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFileAsync(this.binary, ['--version'], {
+        timeout: AVAILABILITY_TIMEOUT_MS,
+      });
+      const version = stdout.trim();
+      return version.length > 0 ? version : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  onEvent(handler: (event: HarnessEvent) => void): () => void {
+    this.eventHandlers.add(handler);
+    return () => this.eventHandlers.delete(handler);
+  }
+
+  async dispose(): Promise<void> {
+    this.eventHandlers.clear();
+    this.protocolEventHandlers.clear();
+    this.protocolNormalizer = null;
+  }
+
+  private emit(event: HarnessEvent): void {
+    for (const handler of this.eventHandlers) {
+      try {
+        handler(event);
+      } catch {
+        // Swallow subscriber errors
+      }
+    }
+
+    if (this.protocolNormalizer && this.protocolEventHandlers.size > 0) {
+      const envelope = this.protocolNormalizer.normalizeToEnvelope(event);
+      if (envelope) {
+        for (const handler of this.protocolEventHandlers) {
+          try {
+            handler(envelope);
+          } catch {
+            // Swallow subscriber errors
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/harnesses/src/content/generators/index.ts
+++ b/packages/harnesses/src/content/generators/index.ts
@@ -1,5 +1,7 @@
+import { OpenCodeGenerator } from './opencode.js';
 import type { ContentGenerator } from './types.js';
 
+export { OpenCodeGenerator } from './opencode.js';
 export type { ContentGenerator, DiffEntry, GeneratedFile } from './types.js';
 
 const generators = new Map<string, ContentGenerator>();
@@ -18,3 +20,8 @@ export function registerGenerator(generator: ContentGenerator): void {
 export function listGenerators(): string[] {
   return [...generators.keys()];
 }
+
+// Built-in generators, registered eagerly so `generateContent()` /
+// `diffContent()` (content/index.ts) work out of the box for any importer
+// of this module -- no manual registration call required.
+registerGenerator(new OpenCodeGenerator());

--- a/packages/harnesses/src/content/generators/opencode.ts
+++ b/packages/harnesses/src/content/generators/opencode.ts
@@ -3,7 +3,7 @@
  *
  * Renders the canonical content definitions (rules, commands, agents, skills)
  * into OpenCode-native output. OpenCode's documented writable surfaces
- * (GAP-371 design §2.4, audited 2026-07-16) are narrower than Claude Code's:
+ * (audited 2026-07-16) are narrower than Claude Code's:
  *   - agents: markdown + frontmatter under `.opencode/agents/<id>.md`
  *   - commands: markdown + frontmatter under `.opencode/commands/<id>.md`
  *   - AGENTS.md at the project root (natively read by OpenCode)

--- a/packages/harnesses/src/content/generators/opencode.ts
+++ b/packages/harnesses/src/content/generators/opencode.ts
@@ -1,0 +1,76 @@
+/**
+ * OpenCode Content Generator
+ *
+ * Renders the canonical content definitions (rules, commands, agents, skills)
+ * into OpenCode-native output. OpenCode's documented writable surfaces
+ * (GAP-371 design §2.4, audited 2026-07-16) are narrower than Claude Code's:
+ *   - agents: markdown + frontmatter under `.opencode/agents/<id>.md`
+ *   - commands: markdown + frontmatter under `.opencode/commands/<id>.md`
+ *   - AGENTS.md at the project root (natively read by OpenCode)
+ *
+ * There is no documented native surface for standalone rule or skill files.
+ * AGENTS.md is already emitted by the separate, existing
+ * `protocolConfigToAgentsMd` generator (`../../protocol/config-normalizer.ts`,
+ * operating over `ProtocolConfig` rather than the `Manifest` this generator
+ * consumes) -- this generator does not duplicate that output. Skills reach
+ * OpenCode only through its `CLAUDE.md` / `~/.claude/skills/` fallback (a
+ * read of ANOTHER tool's files), which this generator does not own.
+ * `generateRule`/`generateSkill` therefore return no files -- a scoping
+ * decision, not an oversight. Revisit if OpenCode ships a documented native
+ * rules/skills directory.
+ */
+
+import type { ResolverContext } from '../resolvers/types.js';
+import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
+import type { ContentGenerator, GeneratedFile } from './types.js';
+
+export class OpenCodeGenerator implements ContentGenerator {
+  readonly id = 'opencode';
+  readonly outputDir = '.opencode';
+
+  generateRule(_rule: Rule, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateCommand(cmd: Command, _ctx: ResolverContext): GeneratedFile[] {
+    const frontmatter = ['---', `description: ${cmd.description}`];
+    if (cmd.argumentHint) frontmatter.push(`argument-hint: ${cmd.argumentHint}`);
+    if (cmd.disableModelInvocation) frontmatter.push('disable-model-invocation: true');
+    frontmatter.push('---');
+
+    return [
+      {
+        relativePath: `.opencode/commands/${cmd.id}.md`,
+        content: `${frontmatter.join('\n')}\n\n${cmd.content}\n`,
+      },
+    ];
+  }
+
+  generateAgent(agent: Agent, _ctx: ResolverContext): GeneratedFile[] {
+    const frontmatter = ['---', `description: ${agent.description}`];
+    if (agent.tools.length > 0) frontmatter.push(`tools: ${agent.tools.join(', ')}`);
+    frontmatter.push('---');
+
+    return [
+      {
+        relativePath: `.opencode/agents/${agent.id}.md`,
+        content: `${frontmatter.join('\n')}\n\n${agent.content}\n`,
+      },
+    ];
+  }
+
+  generateSkill(_skill: Skill, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateAll(manifest: Manifest, ctx: ResolverContext): GeneratedFile[] {
+    const files: GeneratedFile[] = [];
+    for (const cmd of manifest.commands) {
+      files.push(...this.generateCommand(cmd, ctx));
+    }
+    for (const agent of manifest.agents) {
+      files.push(...this.generateAgent(agent, ctx));
+    }
+    return files;
+  }
+}

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -2,7 +2,10 @@
  * @revealui/harnesses/content  -  Canonical Content Layer
  *
  * Tool-agnostic definitions for AI guidance content (rules, commands, agents, skills).
- * Generators produce tool-specific output (Claude Code, Cursor, etc.) from canonical definitions.
+ * Generators produce tool-specific output from canonical definitions. `opencode`
+ * is the only registered generator today (`./generators/opencode.ts`) -- Claude
+ * Code / Cursor generators are not implemented, matching the adapter layer
+ * (`../adapters/`), which likewise ships only `revealui-agent` and `opencode`.
  *
  * @example
  * ```ts
@@ -10,7 +13,7 @@
  *
  * const manifest = buildManifest();
  * const validation = validateManifest(manifest);
- * const files = generateContent('claude-code', manifest, { projectRoot: '/path/to/project' });
+ * const files = generateContent('opencode', manifest, { projectRoot: '/path/to/project' });
  * ```
  */
 
@@ -23,7 +26,12 @@ import type { ResolverContext } from './resolvers/types.js';
 import { type Manifest, ManifestSchema } from './schemas/manifest.js';
 
 export { buildManifest } from './definitions/index.js';
-export { getGenerator, listGenerators, registerGenerator } from './generators/index.js';
+export {
+  getGenerator,
+  listGenerators,
+  OpenCodeGenerator,
+  registerGenerator,
+} from './generators/index.js';
 export type { ContentGenerator, DiffEntry, GeneratedFile } from './generators/types.js';
 export { listResolvers, registerResolver, resolveTemplate } from './resolvers/index.js';
 export type { ResolverContext, ResolverFn } from './resolvers/types.js';

--- a/packages/harnesses/src/detection/auto-detector.ts
+++ b/packages/harnesses/src/detection/auto-detector.ts
@@ -1,3 +1,4 @@
+import { OpenCodeAdapter } from '../adapters/opencode-adapter.js';
 import { RevealUIAgentAdapter } from '../adapters/revealui-agent-adapter.js';
 import type { HarnessRegistry } from '../registry/harness-registry.js';
 
@@ -8,7 +9,7 @@ import type { HarnessRegistry } from '../registry/harness-registry.js';
  * and registers those that respond. Unavailable adapters are disposed.
  */
 export async function autoDetectHarnesses(registry: HarnessRegistry): Promise<string[]> {
-  const candidates = [new RevealUIAgentAdapter()];
+  const candidates = [new RevealUIAgentAdapter(), new OpenCodeAdapter()];
 
   const registered: string[] = [];
 

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -40,6 +40,7 @@ export {
   diffContent,
   generateContent,
   listContent,
+  OpenCodeGenerator,
   validateManifest,
 } from './content/index.js';
 export type { CoordinatorOptions } from './coordinator.js';
@@ -88,6 +89,9 @@ export type {
   McpServerConfig,
   MemoryBackend,
   NormalizedEvent,
+  OpenCodeConfig,
+  OpenCodeMcpOptions,
+  OpenCodeMcpServerConfig,
   ProtocolAdapter,
   ProtocolAdapterInfo,
   ProtocolCapabilities,
@@ -114,6 +118,7 @@ export {
   protocolConfigToAgentsMd,
   protocolConfigToClaudeSettings,
   protocolConfigToCursorrules,
+  protocolConfigToOpencodeConfig,
   protocolEventEnvelopeSchema,
   protocolEventSchema,
   TOOL_PROFILES,

--- a/packages/harnesses/src/protocol/capabilities.ts
+++ b/packages/harnesses/src/protocol/capabilities.ts
@@ -66,6 +66,17 @@ export interface ProtocolCapabilities {
     supported: boolean;
     backend: MemoryBackend;
   };
+  /**
+   * Maximum context window the tool exposes, in tokens.
+   *
+   * `0` has two distinct meanings depending on context: `createDefaultCapabilities()`
+   * uses it as the "everything disabled" default, and BYO-model tools (e.g.
+   * `opencode`, which brings the user's own provider/model rather than a fixed
+   * one) also declare `0` because the effective window depends on whichever
+   * model the user configured, not a fixed capability of the tool. Do not treat
+   * `0` as "unsupported" when the tool's other dispatch capabilities are `true`
+   * -- check `dispatch`/`headless` instead.
+   */
   maxContextTokens: number;
 
   /** Which lifecycle events the tool emits natively */
@@ -103,16 +114,46 @@ export function createDefaultCapabilities(): ProtocolCapabilities {
 /**
  * Capability profiles for tools that have working adapters in this package.
  *
- * Only `revealui-agent` ships an adapter today. Profile data for tools
- * that are spec'd but have no adapter implementation lives in
- * `./roadmap-profiles.ts` to make the spec-vs-shipped gap structurally
- * visible.
+ * `revealui-agent` and `opencode` ship adapters today (`OpenCodeAdapter`,
+ * `src/adapters/opencode-adapter.ts`). Profile data for tools that are
+ * spec'd but have no adapter implementation lives in `./roadmap-profiles.ts`
+ * to make the spec-vs-shipped gap structurally visible.
  *
  * If you're looking for the previous full set (claude-code, codex,
- * cursor, revealui-agent), import `ALL_KNOWN_PROFILES` from
+ * cursor, revealui-agent, opencode), import `ALL_KNOWN_PROFILES` from
  * `./roadmap-profiles.ts` which merges both.
  */
 export const TOOL_PROFILES: Record<string, ProtocolCapabilities> = {
+  // OpenCode brings its own model (BYO via models.dev/AI-SDK) and has no
+  // in-loop hook system today -- an OpenCode plugin could add one later
+  // (GAP-371 §8.3), but until a plugin ships, `hooks.supported` stays
+  // honestly false. `maxContextTokens: 0` is the BYO sentinel documented on
+  // the interface field above, not a capability defect.
+  opencode: {
+    dispatch: {
+      generateCode: true,
+      analyzeCode: true,
+      applyEdit: false,
+      executeCommand: true,
+    },
+    readWorkboard: false,
+    writeWorkboard: false,
+    claimTasks: false,
+    reportConflicts: false,
+    headless: true,
+    resumable: true,
+    forkable: true,
+    backgroundable: true,
+    hooks: { supported: false, granularity: 'none', canBlock: false },
+    sandbox: { supported: false, modes: [] },
+    supportsWorktrees: false,
+    supportsSkills: true,
+    supportsMcp: true,
+    memory: { supported: false, backend: 'none' },
+    maxContextTokens: 0,
+    lifecycleEvents: [],
+  },
+
   'revealui-agent': {
     dispatch: {
       generateCode: true,

--- a/packages/harnesses/src/protocol/capabilities.ts
+++ b/packages/harnesses/src/protocol/capabilities.ts
@@ -125,10 +125,10 @@ export function createDefaultCapabilities(): ProtocolCapabilities {
  */
 export const TOOL_PROFILES: Record<string, ProtocolCapabilities> = {
   // OpenCode brings its own model (BYO via models.dev/AI-SDK) and has no
-  // in-loop hook system today -- an OpenCode plugin could add one later
-  // (GAP-371 §8.3), but until a plugin ships, `hooks.supported` stays
-  // honestly false. `maxContextTokens: 0` is the BYO sentinel documented on
-  // the interface field above, not a capability defect.
+  // in-loop hook system today -- an OpenCode plugin could add one later,
+  // but until a plugin ships, `hooks.supported` stays honestly false.
+  // `maxContextTokens: 0` is the BYO sentinel documented on the interface
+  // field above, not a capability defect.
   opencode: {
     dispatch: {
       generateCode: true,

--- a/packages/harnesses/src/protocol/config-normalizer.ts
+++ b/packages/harnesses/src/protocol/config-normalizer.ts
@@ -280,6 +280,85 @@ export function generateAllConfigs(config: ProtocolConfig): ConfigGenerationResu
   return { files };
 }
 
+// -- opencode.json (write-only) --------------------------------------------------
+
+/** OpenCode remote MCP server entry (opencode.json `mcp.<name>`, design doc §5.7). */
+export interface OpenCodeMcpServerConfig {
+  type: 'remote';
+  url: string;
+  headers: Record<string, string>;
+  oauth: boolean;
+  enabled: boolean;
+}
+
+/** Subset of opencode.json this module writes. */
+export interface OpenCodeConfig {
+  mcp?: Record<string, OpenCodeMcpServerConfig>;
+  tools?: Record<string, boolean>;
+  permission?: Record<string, 'allow' | 'ask' | 'deny'>;
+}
+
+/** Options for wiring the RevealUI governed MCP endpoint into an OpenCode config. */
+export interface OpenCodeMcpOptions {
+  /** RevealUI governed MCP endpoint, e.g. `https://your-host/api/mcp`. */
+  mcpUrl: string;
+  /**
+   * Name of the environment variable OpenCode resolves via its `{env:VAR}`
+   * substitution at runtime (default `REVEALUI_MCP_TOKEN`). Only the
+   * variable NAME is ever emitted -- see `protocolConfigToOpencodeConfig`.
+   */
+  tokenEnvVar?: string;
+}
+
+const DEFAULT_OPENCODE_TOKEN_ENV_VAR = 'REVEALUI_MCP_TOKEN';
+
+/**
+ * Convert a ProtocolConfig to an opencode.json fragment wiring the RevealUI
+ * governed MCP endpoint (design doc §5.7).
+ *
+ * SECURITY-CRITICAL: this function must never emit a literal bearer token,
+ * only the `{env:VAR}` substitution syntax OpenCode resolves at runtime. It
+ * deliberately does NOT read `config.environment.variables` for a token
+ * value -- the Authorization header is built exclusively from the
+ * `tokenEnvVar` NAME, so no caller can smuggle a literal secret into the
+ * emitted config by placing one in `environment.variables`.
+ */
+export function protocolConfigToOpencodeConfig(
+  config: ProtocolConfig,
+  opts: OpenCodeMcpOptions,
+): OpenCodeConfig {
+  const tokenEnvVar = opts.tokenEnvVar ?? DEFAULT_OPENCODE_TOKEN_ENV_VAR;
+
+  const opencodeConfig: OpenCodeConfig = {
+    mcp: {
+      revealui: {
+        type: 'remote',
+        url: opts.mcpUrl,
+        headers: { Authorization: `Bearer {env:${tokenEnvVar}}` },
+        oauth: false,
+        enabled: true,
+      },
+    },
+    tools: { 'revealui*': true },
+  };
+
+  // Reuses the same key-safety barrier as the Claude Code settings.json
+  // writer above -- permission keys become object keys in the emitted JSON,
+  // so the same prototype-pollution allowlist applies.
+  const permission: Record<string, 'allow' | 'ask' | 'deny'> = {};
+  for (const name of config.permissions.autoApprove) {
+    if (isSafeMcpServerName(name)) permission[name] = 'allow';
+  }
+  for (const name of config.permissions.deny) {
+    if (isSafeMcpServerName(name)) permission[name] = 'deny';
+  }
+  if (Object.keys(permission).length > 0) {
+    opencodeConfig.permission = permission;
+  }
+
+  return opencodeConfig;
+}
+
 // -- Helpers ---------------------------------------------------------------------
 
 /** Render rule content, substituting template variables. */

--- a/packages/harnesses/src/protocol/index.ts
+++ b/packages/harnesses/src/protocol/index.ts
@@ -30,13 +30,20 @@ export type {
 } from './capabilities.js';
 export { createDefaultCapabilities, TOOL_PROFILES } from './capabilities.js';
 // Config normalization
-export type { ClaudeCodeSettings, ConfigGenerationResult } from './config-normalizer.js';
+export type {
+  ClaudeCodeSettings,
+  ConfigGenerationResult,
+  OpenCodeConfig,
+  OpenCodeMcpOptions,
+  OpenCodeMcpServerConfig,
+} from './config-normalizer.js';
 export {
   claudeSettingsToProtocolConfig,
   generateAllConfigs,
   protocolConfigToAgentsMd,
   protocolConfigToClaudeSettings,
   protocolConfigToCursorrules,
+  protocolConfigToOpencodeConfig,
 } from './config-normalizer.js';
 // Degradation
 export type { DegradationStrategy } from './degradation-strategies.js';

--- a/packages/harnesses/src/protocol/roadmap-profiles.ts
+++ b/packages/harnesses/src/protocol/roadmap-profiles.ts
@@ -3,6 +3,8 @@
  *
  * Declared profiles for AI coding tools that the Harness Protocol spec
  * targets but which DO NOT have a working adapter in this package today.
+ * (`opencode` graduated to `./capabilities.ts` `TOOL_PROFILES` when
+ * `OpenCodeAdapter` shipped -- see `../adapters/opencode-adapter.ts`.)
  *
  * These entries describe what those tools support natively, useful for:
  *  - The degradation table in `./degradation-strategies.ts` (which knows
@@ -109,33 +111,6 @@ export const ROADMAP_PROFILES: Record<string, ProtocolCapabilities> = {
     supportsMcp: false,
     memory: { supported: false, backend: 'none' },
     maxContextTokens: 128_000,
-    lifecycleEvents: [],
-  },
-
-  // No working adapter yet (GAP-371 Phase 0: data only). Plugins exist in
-  // OpenCode but no adapter wiring ships, so hooks stay honestly unsupported.
-  opencode: {
-    dispatch: {
-      generateCode: true,
-      analyzeCode: true,
-      applyEdit: false,
-      executeCommand: true,
-    },
-    readWorkboard: false,
-    writeWorkboard: false,
-    claimTasks: false,
-    reportConflicts: false,
-    headless: true,
-    resumable: true,
-    forkable: true,
-    backgroundable: true,
-    hooks: { supported: false, granularity: 'none', canBlock: false },
-    sandbox: { supported: false, modes: [] },
-    supportsWorktrees: false,
-    supportsSkills: true,
-    supportsMcp: true,
-    memory: { supported: false, backend: 'none' },
-    maxContextTokens: 0,
     lifecycleEvents: [],
   },
 } as const;


### PR DESCRIPTION
## Summary

Phase 3 of the OpenCode integration: `OpenCodeAdapter`, the first external-CLI `HarnessAdapter` in `@revealui/harnesses`. Wraps the `opencode` CLI over `execFile` (mirroring the CLI-wrapping pattern in `translation-layer.ts`), promotes its capability profile from declared-roadmap to shipped, and adds a config writer for the governed RevealUI MCP endpoint.

- `OpenCodeAdapter` (`src/adapters/opencode-adapter.ts`): detects (`opencode --version`), drives one-shot `opencode run <prompt> --format json` for `headless-prompt`/`generate-code`/`analyze-code`, writes config for `apply-config`, uses existing `config-sync.ts` machinery for `sync-config`/`diff-config`, reports `apply-edit` as explicitly unsupported (opencode applies its own edits during `run`), and discovers running instances via the existing process-detector.
- Promotes the `opencode` capability profile from `ROADMAP_PROFILES` to `TOOL_PROFILES` (`protocol/capabilities.ts`), registers the adapter in `auto-detector.ts`, and updates the pinned contract tests (`protocol-types.test.ts`) accordingly.
- Registers the first entry in the previously-empty content-generator registry: `OpenCodeGenerator` (`content/generators/opencode.ts`) renders commands/agents into `.opencode/commands/*.md` and `.opencode/agents/*.md`. Rules/skills are intentionally not rendered by this generator — OpenCode has no documented native surface for either (rules already reach OpenCode via the separate, existing `protocolConfigToAgentsMd` → `AGENTS.md` path).
- Adds `protocolConfigToOpencodeConfig` (`protocol/config-normalizer.ts`) emitting the governed-MCP `opencode.json` block from the design doc — bearer token is always the `{env:VAR}` substitution syntax, never a literal value, regardless of what a caller places in `ProtocolConfig.environment.variables`.

## Test plan

- [x] `pnpm --filter @revealui/harnesses test` — 21 files / 319 tests, all green (3 new test files + 2 updated pinned files)
- [x] `pnpm --filter @revealui/harnesses typecheck` — clean
- [x] `pnpm --filter @revealui/harnesses lint` — clean (Biome)
- [x] Adapter contract tests: registry lifecycle (register / dup-throw / unregister-disposes), capabilities shape, `execute()` mapping for every command variant including the **graceful no-binary failure path** (exercised against the real absent `opencode` binary in this environment, not a mock — `which opencode` confirms it isn't installed)
- [x] `apply-config` path-traversal guard (refuses writes outside the project root) + nested-directory creation
- [x] Config-writer security test: asserts a literal token planted anywhere in `ProtocolConfig.environment.variables` never appears in the emitted JSON — only the `{env:VAR}` substitution string does
- [x] `opencode run --format json` output-shape parsing: **NOT verified against a real binary** — `opencode` is not installable in this build/sandbox environment. `parseOpenCodeRunOutput` is unit-tested against the documented-but-unverified shape (object with `output`/`text`/`message`/`content`, bare JSON string, non-JSON plain text) with graceful fallback in every case. This is flagged, not silently claimed as verified — real-binary pinning is a deferred follow-up for whichever environment first has `opencode` installed.
- [x] `.changeset/opencode-adapter.md` added (`@revealui/harnesses: minor`)
- [x] Internal security-sensitive-path checker run against this diff: reported no security-sensitive files, no coordinator gate required. `packages/harnesses` is confirmed NOT on the sensitive-path list. Flagged anyway per the build brief: the config writer does emit a token *env-var name* (never a value) into `opencode.json`; the no-literal-token invariant has its own dedicated test.

Left unmerged per instructions.
