### PR TITLE
fix(mcp): omit resources surface on governed mcp mount (GAP-373)

### DIFF
--- a/packages/mcp/__tests__/revealui-content-governed.test.ts
+++ b/packages/mcp/__tests__/revealui-content-governed.test.ts
@@ -18,7 +18,7 @@
 import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it } from 'vitest';
-import { McpClient } from '../src/client.js';
+import { McpCapabilityError, McpClient } from '../src/client.js';
 import {
   createRevealuiContentServer,
   type McpToolAuditRecord,
@@ -301,5 +301,67 @@ describe('I-5 a receipt per call', () => {
     expect(result.isError).toBeFalsy();
     // The read executed despite the audit failure (degrade, not fail-closed).
     expect(backend.calls.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GAP-373 — the governed path exposes no resources surface (#1910 Blocker 2)
+// ---------------------------------------------------------------------------
+//
+// The resource handlers read through the process-global resolveCredentials()
+// (ambient REVEALUI_API_KEY), never the per-request credentialsProvider, and
+// write no receipt. On the governed mount that is a cross-tenant read channel:
+// any authenticated client could resources/read with the ambient admin key,
+// unaudited. Per the countersigned design §4-D, Phase 1's governed endpoint
+// exposes ONLY the five read tools — the resources capability must be
+// structurally absent when a credentialsProvider is present, not merely
+// credential-gated. (Stdio/local mode keeps resources; see the stdio launcher.)
+
+describe('GAP-373 governed path exposes no resources surface', () => {
+  it('does not advertise the resources capability on the governed mount', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+    const caps = client.getServerCapabilities();
+    await client.close();
+
+    // Tools stay; resources is structurally absent on the governed path.
+    expect(caps?.tools).toBeDefined();
+    expect(caps?.resources).toBeUndefined();
+  });
+
+  it('refuses resources/list and resources/read, never reaching the ambient-key backend', async () => {
+    const prev = process.env.REVEALUI_API_KEY;
+    const prevUrl = process.env.REVEALUI_API_URL;
+    try {
+      const backend = await startFakeBackend(okBackend);
+      // Ambient admin-equivalent credentials point at the real backend, so a
+      // resource handler that consulted resolveCredentials() (the bug) would be
+      // observable here as a backend call carrying the ambient key.
+      process.env.REVEALUI_API_KEY = 'ambient-admin-key';
+      process.env.REVEALUI_API_URL = backend.url;
+      const governed = await startGoverned({
+        backendUrl: backend.url,
+        authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+      });
+      const client = await connectClient(governed.url);
+
+      await expect(client.listResources()).rejects.toThrow(McpCapabilityError);
+      await expect(client.readResource('revealui-content://posts/row-1')).rejects.toThrow(
+        McpCapabilityError,
+      );
+      await client.close();
+
+      // The ambient key never reached the backend: no cross-tenant read channel.
+      expect(backend.calls).toHaveLength(0);
+    } finally {
+      if (prev === undefined) delete process.env.REVEALUI_API_KEY;
+      else process.env.REVEALUI_API_KEY = prev;
+      if (prevUrl === undefined) delete process.env.REVEALUI_API_URL;
+      else process.env.REVEALUI_API_URL = prevUrl;
+    }
   });
 });

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -548,9 +548,17 @@ async function fetchCollectionsFromAdmin(
  * consume this factory; the factory itself is transport-agnostic.
  */
 export function createRevealuiContentServer(options?: CreateRevealuiContentServerOptions): Server {
+  // A `credentialsProvider` marks the governed/hosted mount (`/api/mcp`). On
+  // that path Phase 1 exposes ONLY the five read tools (design §4-D): the
+  // resource handlers below resolve the ambient service credential rather than
+  // the caller's token and write no receipt, so on a multi-tenant mount they
+  // would be a cross-tenant, unaudited read channel. The capability is therefore
+  // structurally absent when governed — not merely credential-gated. The stdio /
+  // local mount (no options) keeps resources unchanged (single-operator trust).
+  const governed = options?.credentialsProvider !== undefined;
   const server = new Server(
     { name: 'revealui-content', version: '1.0.0' },
-    { capabilities: { tools: {}, resources: {} } },
+    { capabilities: governed ? { tools: {} } : { tools: {}, resources: {} } },
   );
 
   // Per-server memoization: resolve the effective collection set once and
@@ -589,64 +597,73 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
 
   // -------------------------------------------------------------------------
   // Resources (Stage 4.1 + 4.2)
+  //
+  // Registered ONLY on the ungoverned (stdio / local) path. These handlers use
+  // the process-global `resolveCredentials()` and emit no receipt, so on the
+  // governed mount they are omitted entirely (see capability gate above,
+  // design §4-D). The guard and the capability advertisement must stay in
+  // lockstep: a registered handler with no advertised capability, or vice
+  // versa, reintroduces the bypass.
   // -------------------------------------------------------------------------
 
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    const { apiUrl, apiKey } = resolveCredentials();
-    if (!(apiUrl && apiKey)) {
-      // Without credentials the server can't enumerate rows; advertise an
-      // empty list rather than erroring — clients still see the resources
-      // capability and can retry once creds are set.
-      return { resources: [] };
-    }
-
-    const collections = await resolveCollections();
-    const resources: Resource[] = [];
-    for (const collection of collections) {
-      try {
-        const body = await apiGet(apiUrl, apiKey, `/api/${collection.slug}`, {
-          limit: String(DEFAULT_RESOURCE_PAGE_SIZE),
-          page: '1',
-        });
-        for (const row of extractDocs(body)) {
-          resources.push(resourceForRow(collection, row));
-        }
-      } catch {
-        // empty-catch-ok: an unavailable collection shouldn't blank-out the entire resource list
+  if (!governed) {
+    server.setRequestHandler(ListResourcesRequestSchema, async () => {
+      const { apiUrl, apiKey } = resolveCredentials();
+      if (!(apiUrl && apiKey)) {
+        // Without credentials the server can't enumerate rows; advertise an
+        // empty list rather than erroring — clients still see the resources
+        // capability and can retry once creds are set.
+        return { resources: [] };
       }
-    }
-    return { resources };
-  });
 
-  server.setRequestHandler(ReadResourceRequestSchema, async (request: ReadResourceRequest) => {
-    const parsed = parseResourceUri(request.params.uri);
-    if (!parsed) {
-      throw new Error(
-        `Unknown resource URI (expected ${RESOURCE_URI_PREFIX}<collection>/<id>): ${request.params.uri}`,
-      );
-    }
-    const collections = await resolveCollections();
-    const collection = collections.find((c) => c.slug === parsed.collection);
-    if (!collection) {
-      throw new Error(`Collection is not exposed as a resource: ${parsed.collection}`);
-    }
+      const collections = await resolveCollections();
+      const resources: Resource[] = [];
+      for (const collection of collections) {
+        try {
+          const body = await apiGet(apiUrl, apiKey, `/api/${collection.slug}`, {
+            limit: String(DEFAULT_RESOURCE_PAGE_SIZE),
+            page: '1',
+          });
+          for (const row of extractDocs(body)) {
+            resources.push(resourceForRow(collection, row));
+          }
+        } catch {
+          // empty-catch-ok: an unavailable collection shouldn't blank-out the entire resource list
+        }
+      }
+      return { resources };
+    });
 
-    const { apiUrl, apiKey } = resolveCredentials();
-    if (!(apiUrl && apiKey)) {
-      throw new Error('REVEALUI_API_URL and REVEALUI_API_KEY must be set');
-    }
+    server.setRequestHandler(ReadResourceRequestSchema, async (request: ReadResourceRequest) => {
+      const parsed = parseResourceUri(request.params.uri);
+      if (!parsed) {
+        throw new Error(
+          `Unknown resource URI (expected ${RESOURCE_URI_PREFIX}<collection>/<id>): ${request.params.uri}`,
+        );
+      }
+      const collections = await resolveCollections();
+      const collection = collections.find((c) => c.slug === parsed.collection);
+      if (!collection) {
+        throw new Error(`Collection is not exposed as a resource: ${parsed.collection}`);
+      }
 
-    const row = await apiGet(apiUrl, apiKey, `/api/${parsed.collection}/${parsed.id}`);
-    return {
-      contents: [
-        {
-          uri: request.params.uri,
-          mimeType: 'application/json',
-          text: JSON.stringify(row, null, 2),
-        },
-      ],
-    };
-  });
+      const { apiUrl, apiKey } = resolveCredentials();
+      if (!(apiUrl && apiKey)) {
+        throw new Error('REVEALUI_API_URL and REVEALUI_API_KEY must be set');
+      }
+
+      const row = await apiGet(apiUrl, apiKey, `/api/${parsed.collection}/${parsed.id}`);
+      return {
+        contents: [
+          {
+            uri: request.params.uri,
+            mimeType: 'application/json',
+            text: JSON.stringify(row, null, 2),
+          },
+        ],
+      };
+    });
+  }
 
   server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest, extra) => {
     const startTime = Date.now();


### PR DESCRIPTION
## GAP-373 (blocker): governed MCP resources surface bypasses per-request auth + audit

Post-merge finding from the #1910 guardrail-2 review, **Blocker 2**.

### The bug

`createRevealuiContentServer(options)` advertised `capabilities: { tools: {}, resources: {} }` and registered `ListResourcesRequestSchema` + `ReadResourceRequestSchema` handlers that resolve credentials via the process-global `resolveCredentials()` (ambient `REVEALUI_API_KEY`), **not** the per-request `options.credentialsProvider`, and write **no** `auditSink` receipt. The tools path (`CallToolRequestSchema`) is correctly governed via `credentialsProvider` + `auditSink`.

The governed `/api/mcp` mount ([mcp-endpoint.ts:164](apps/server/src/routes/mcp-endpoint.ts)) constructs the factory **with** a `credentialsProvider`. So on that endpoint any authenticated MCP client could `resources/read` `revealui-content://<collection>/<id>` and have the server fetch with the ambient admin-equivalent key instead of the caller's token, **unaudited** — a cross-tenant read channel the moment `REVEALUI_API_KEY` is set in the API process env.

### The fix (design section 4-D scope)

The countersigned design decision (section 4-D) scopes Phase 1's governed endpoint to **only the five read tools, no resources surface**. Rather than re-route the resource handlers through the governed seams, the resources surface is made **structurally absent** when governed:

- The `resources` capability is advertised only when **not** governed (`options?.credentialsProvider === undefined`). Governed construction advertises `{ tools: {} }` only.
- Both `server.setRequestHandler(...Resource...)` registrations are guarded behind `if (!governed)`.
- Stdio/local mode (constructed with no options, single-operator trust) keeps resources unchanged.

The governed mount never advertises or depends on resources (grep of [mcp-endpoint.ts](apps/server/src/routes/mcp-endpoint.ts) for `resource`/`capabilit` is empty; the construction comment already states "Phase 1 exposes read tools only"), so disabling is the minimal correct shape and the smaller blast radius the design prefers over re-routing.

### Files changed

- [packages/mcp/src/servers/factories/revealui-content.ts](packages/mcp/src/servers/factories/revealui-content.ts): `governed` flag, conditional `resources` capability, both resource handlers wrapped in `if (!governed)`. Tools path untouched.
- [packages/mcp/__tests__/revealui-content-governed.test.ts](packages/mcp/__tests__/revealui-content-governed.test.ts): new negative test (the original PR had **no** resources test).

### Prove-red evidence

The new test was run against the **pre-fix** factory first (TDD order) and failed exactly as expected:

```
FAIL  GAP-373 governed path exposes no resources surface > refuses resources/list and resources/read, never reaching the ambient-key backend
  expected client.listResources() to reject with McpCapabilityError
  + Received: [ posts/row-1, pages/row-1, products/row-1, media/row-1 ]   <- fetched via the ambient-key backend
Test Files  1 failed (1)
     Tests  2 failed | 8 skipped (10)
```

Both new tests fail pre-fix (capability advertised; `resources/list`/`resources/read` reach the ambient backend). After the fix both pass:

```
Test Files  1 passed (1)
     Tests  2 passed | 8 skipped (10)
```

### Test results

- `pnpm --filter @revealui/mcp exec vitest run` — **25 files passed, 437 passed, 5 skipped** (green).
- `pnpm --filter @revealui/mcp typecheck` — clean.

### pglite mount status (separate #1910 finding, report-only)

The #1910 review found `apps/server/src/routes/__tests__/mcp-endpoint.pglite.test.ts` **5/7 RED** (broken Hono mount). On this base (`test` @ #1910 merge) it is now **GREEN: 7/7 passed** — the builder's post-verdict commits fixed the mount. Not a second blocker.

Refs GAP-373, #1910 review Blocker 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
