### PR TITLE
feat(mcp): tool authorization, quota, and session caps for /api/mcp

### DIFF
--- a/apps/server/src/lib/__tests__/mcp-audit-concurrency.pglite.test.ts
+++ b/apps/server/src/lib/__tests__/mcp-audit-concurrency.pglite.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Finding-1 (GAP-371 Phase-1 review MUST-FIX) — the governed-MCP audit chain
+ * head is a read-modify-write across the insert `await`. Concurrent
+ * `recordMcpToolAudit` calls that both read the same head before either advances
+ * it FORK the hash chain (two rows chained to one parent). Phase 2 turns on the
+ * fail-closed mutating-audit path, so every append is on the hot path.
+ *
+ * This test interleaves many `recordMcpToolAudit` calls against a real migrated
+ * `audit_log` (PGlite) and asserts the resulting rows form ONE unbroken,
+ * unforked, tamper-evident chain via `verifyMcpAuditChain`. Without the
+ * serialization fix it fails: multiple rows carry `previousSignature === null`
+ * (multiple roots) and the verifier reports a fork.
+ */
+
+import * as schema from '@revealui/db/schema';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+import {
+  __resetMcpAuditChainForTest,
+  type McpAuditChainRow,
+  recordMcpToolAudit,
+  verifyMcpAuditChain,
+} from '../mcp-audit.js';
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/db')>('@revealui/db');
+  return { ...actual, getClient: () => testDb.drizzle };
+});
+
+const SECRET = 'test-secret-value-at-least-32-chars-long!!';
+
+beforeAll(async () => {
+  process.env.REVEALUI_AUDIT_HMAC_SECRET = SECRET;
+  testDb = await createTestDb();
+});
+
+afterEach(() => {
+  __resetMcpAuditChainForTest();
+});
+
+function receiptInput(i: number) {
+  return {
+    outcome: 'invoked' as const,
+    clientName: 'opencode',
+    sessionId: `session-${i}`,
+    userId: 'user-A',
+    accountId: 'acct-A',
+    tool: 'revealui_list_sites',
+    argsDigest: 'd'.repeat(64),
+    scalars: {},
+    durationMs: i,
+  };
+}
+
+describe('Finding-1: concurrent MCP audit writes keep one unforked chain', () => {
+  it('interleaved recordMcpToolAudit calls form a single verifiable chain', async () => {
+    __resetMcpAuditChainForTest();
+    const N = 30;
+
+    // Fire all N concurrently. Each reads the chain head BEFORE its insert await;
+    // without serialization they all read the same head and fork.
+    await Promise.all(Array.from({ length: N }, (_, i) => recordMcpToolAudit(receiptInput(i))));
+
+    const rows = await testDb.drizzle.select().from(schema.auditLog);
+    // No dropped writes.
+    expect(rows).toHaveLength(N);
+
+    const chainRows: McpAuditChainRow[] = rows.map((r) => ({
+      timestamp: r.timestamp,
+      eventType: r.eventType,
+      severity: r.severity,
+      agentId: r.agentId,
+      payload: r.payload,
+      signature: r.signature,
+      previousSignature: r.previousSignature,
+    }));
+
+    // Exactly one root and no two rows chained to the same parent (fork check),
+    // independent of the verifier — this is the property a race destroys.
+    const roots = chainRows.filter((r) => r.previousSignature === null);
+    expect(roots).toHaveLength(1);
+    const parents = chainRows
+      .map((r) => r.previousSignature)
+      .filter((p): p is string => p !== null);
+    expect(new Set(parents).size).toBe(parents.length);
+
+    // Full tamper-evident verification: one unbroken, unforked, signed chain.
+    const result = verifyMcpAuditChain(chainRows, SECRET);
+    expect(result.reason).toBeUndefined();
+    expect(result.valid).toBe(true);
+  });
+});

--- a/apps/server/src/lib/mcp-audit.ts
+++ b/apps/server/src/lib/mcp-audit.ts
@@ -20,6 +20,23 @@
  * verifiable by walking its own eventType stream. Consolidating both onto a
  * single shared chain head is a deliberate future refactor, not a Phase-1
  * concern (audit-first §Mindfulness: classified INTENTIONAL).
+ *
+ * Concurrency (GAP-371 Phase 2, Finding-1 fix). The chain head is a read-modify-
+ * write: read `lastMcpSignature`, sign against it, INSERT, then advance the head
+ * on success. Two `recordMcpToolAudit` calls racing across the insert `await`
+ * would both read the same head and both write it as `previousSignature`, FORKING
+ * the chain (two rows chained to one parent, later tampering on a stranded branch
+ * undetectable). Phase 2 turns on the fail-closed mutating-audit path, so every
+ * append is on the hot path. The fix serializes appends through a promise-chain
+ * mutex (`appendQueue`): each call's critical section runs only after the prior
+ * one has settled, so the head is read and advanced atomically per process. A
+ * failed write does NOT advance the head and does NOT poison the queue — the next
+ * append chains from the last DURABLE signature, leaving no gap.
+ *
+ * Verification tolerates the per-process segmentation this design already has: a
+ * serverless deployment runs many processes, each an independent segment rooted
+ * at `previousSignature = null`. `verifyMcpAuditChain` verifies one segment (one
+ * process's rows) as a single unbroken, unforked, tamper-evident chain.
  */
 
 import { createHmac, randomUUID } from 'node:crypto';
@@ -52,14 +69,26 @@ export interface McpAuditInput {
   scalars: Record<string, string>;
   durationMs: number;
   httpStatus?: number;
+  /** Why a call was denied (`authz` / `rate-limit`), when `outcome === 'denied'`. */
+  reason?: string;
 }
 
 /** Per-process hash-chain head for the MCP receipt stream. */
 let lastMcpSignature: string | null = null;
 
-/** Test-only reset of the chain head. */
+/**
+ * Serialization gate for the chain-head read-modify-write (Finding-1). Appends
+ * run one at a time: each `recordMcpToolAudit` chains its critical section after
+ * the previous one settles, so concurrent calls cannot both read the same head
+ * and fork the chain. A rejected append is caught HERE (so the queue is never
+ * poisoned) while the original promise still rejects to the caller.
+ */
+let appendQueue: Promise<void> = Promise.resolve();
+
+/** Test-only reset of the chain head and serialization queue. */
 export function __resetMcpAuditChainForTest(): void {
   lastMcpSignature = null;
+  appendQueue = Promise.resolve();
 }
 
 function getAuditSecret(): string {
@@ -75,9 +104,26 @@ function getAuditSecret(): string {
 }
 
 /**
+ * Deterministic JSON with object keys sorted recursively. The receipt payload
+ * is stored as `jsonb`, which does NOT preserve key insertion order on
+ * readback, so signing over `JSON.stringify(payload)` directly would make a
+ * row un-verifiable from storage. Signing over the CANONICAL form makes the
+ * signature reproducible from the DB regardless of jsonb's reordering. No
+ * regex; a manual recursive serializer.
+ */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>).sort((a, b) =>
+    a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0,
+  );
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(',')}}`;
+}
+
+/**
  * HMAC-SHA256 over the receipt's immutable fields chained to the previous
- * signature. Mirrors the canonical form used by the security-event chain so
- * both streams verify the same way.
+ * signature. The payload is canonicalized (sorted keys) so the signature is
+ * reproducible from the jsonb-stored row (`verifyMcpAuditChain`).
  */
 function signChained(
   entry: {
@@ -95,7 +141,7 @@ function signChained(
     eventType: entry.eventType,
     severity: entry.severity,
     agentId: entry.agentId,
-    payload: entry.payload,
+    payload: canonicalJson(entry.payload),
     previousSignature: previousSig ?? '',
   });
   return createHmac('sha256', secret).update(canonical).digest('hex');
@@ -105,8 +151,23 @@ function signChained(
  * Append one governed-MCP receipt. Throws on a failed write (already classified
  * + counted) so the caller can fail closed. The chain head only advances on a
  * durable write, so a failed write leaves no gap.
+ *
+ * Appends are serialized (Finding-1): concurrent calls queue so the chain-head
+ * read-modify-write is atomic per process and can never fork.
  */
 export async function recordMcpToolAudit(input: McpAuditInput): Promise<void> {
+  const run = appendQueue.then(() => appendReceipt(input));
+  // Keep the queue alive regardless of this write's outcome (a rejection here
+  // must not poison later appends), while still surfacing it to the caller.
+  appendQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/** The serialized critical section: read head → sign → insert → advance head. */
+async function appendReceipt(input: McpAuditInput): Promise<void> {
   const id = randomUUID();
   const timestamp = new Date();
   const eventType = OUTCOME_TO_EVENT_TYPE[input.outcome];
@@ -123,6 +184,7 @@ export async function recordMcpToolAudit(input: McpAuditInput): Promise<void> {
     ...input.scalars,
   };
   if (input.httpStatus !== undefined) payload.httpStatus = input.httpStatus;
+  if (input.reason !== undefined) payload.reason = input.reason;
 
   const secret = getAuditSecret();
   const previousSignature = lastMcpSignature;
@@ -159,4 +221,109 @@ export async function recordMcpToolAudit(input: McpAuditInput): Promise<void> {
     });
     throw err;
   }
+}
+
+/** A stored MCP receipt row, as read back from `audit_log`. */
+export interface McpAuditChainRow {
+  timestamp: Date | string;
+  eventType: string;
+  severity: string;
+  agentId: string;
+  payload: unknown;
+  signature: string | null;
+  previousSignature: string | null;
+}
+
+/** Result of verifying one process-segment of the MCP receipt chain. */
+export interface McpAuditChainVerification {
+  valid: boolean;
+  reason?: string;
+}
+
+function normalizeTimestamp(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+/**
+ * Verify one per-process segment of the MCP receipt chain (Finding-1). Given the
+ * rows of a single process's stream (any order), assert they form ONE unbroken,
+ * unforked, tamper-evident chain:
+ *
+ *  - every row's stored signature recomputes from its own fields + its
+ *    `previousSignature` (tamper detection);
+ *  - no two rows share a `previousSignature` and no two share a `signature`
+ *    (fork detection — the exact failure a racing read-modify-write produces);
+ *  - exactly one root (`previousSignature === null`) and every row is reachable
+ *    by following signature links from it (single unbroken path).
+ *
+ * Order-independent: it reconstructs the linkage rather than trusting storage
+ * order (there is no monotonic sequence column on `audit_log`).
+ */
+export function verifyMcpAuditChain(
+  rows: readonly McpAuditChainRow[],
+  secret: string,
+): McpAuditChainVerification {
+  if (rows.length === 0) return { valid: true };
+
+  const bySignature = new Map<string, McpAuditChainRow>();
+  const seenPrevious = new Set<string>();
+  let root: McpAuditChainRow | null = null;
+
+  for (const row of rows) {
+    if (typeof row.signature !== 'string') {
+      return { valid: false, reason: 'row is missing a signature' };
+    }
+    const expected = signChained(
+      {
+        timestamp: normalizeTimestamp(row.timestamp),
+        eventType: row.eventType,
+        severity: row.severity,
+        agentId: row.agentId,
+        payload: row.payload,
+      },
+      row.previousSignature,
+      secret,
+    );
+    if (expected !== row.signature) {
+      return { valid: false, reason: `signature mismatch for row ${row.signature}` };
+    }
+    if (bySignature.has(row.signature)) {
+      return { valid: false, reason: `duplicate signature ${row.signature}` };
+    }
+    bySignature.set(row.signature, row);
+
+    const prev = row.previousSignature;
+    if (prev === null) {
+      if (root) return { valid: false, reason: 'chain has more than one root (fork)' };
+      root = row;
+    } else {
+      if (seenPrevious.has(prev)) {
+        return { valid: false, reason: `two rows chain to the same parent ${prev} (fork)` };
+      }
+      seenPrevious.add(prev);
+    }
+  }
+
+  if (!root) return { valid: false, reason: 'chain has no root' };
+
+  // Walk from the root following signature → next(previousSignature) links; the
+  // whole segment must be reachable in one unbroken path.
+  let reachable = 0;
+  let cursor: McpAuditChainRow | undefined = root;
+  const nextByPrevious = new Map<string, McpAuditChainRow>();
+  for (const row of rows) {
+    if (row.previousSignature !== null) nextByPrevious.set(row.previousSignature, row);
+  }
+  while (cursor) {
+    reachable += 1;
+    cursor = cursor.signature ? nextByPrevious.get(cursor.signature) : undefined;
+  }
+  if (reachable !== rows.length) {
+    return {
+      valid: false,
+      reason: `chain is broken: ${reachable} of ${rows.length} rows reachable`,
+    };
+  }
+
+  return { valid: true };
 }

--- a/apps/server/src/lib/mcp-tool-access.ts
+++ b/apps/server/src/lib/mcp-tool-access.ts
@@ -1,0 +1,110 @@
+/**
+ * Governed-MCP tool authorization policy (GAP-371 Phase 2, §5.4).
+ *
+ * Two independent gates decide whether a bound user may execute a tool:
+ *
+ *  1. ROLE gate (RBAC) — deny-by-default per-tool permission keyed
+ *     `mcp:tool:<name>` through the existing `AuthorizationSystem`. Keys are
+ *     EXACT strings, so the engine's `pattern === resource` fast path matches
+ *     and its glob→RegExp branch is never taken (fleet no-regex posture; the
+ *     GAP-371 ground-truth anchor's caution about that matcher). PII/admin tools
+ *     (`revealui_list_users`) are granted to owner/admin only.
+ *  2. TIER gate — the pro-gated surface. Content reads are available on every
+ *     tier that can reach `/api/mcp`; `revealui_list_users` requires pro+. The
+ *     tier is SERVER-DERIVED from the account entitlement (I-9), never client
+ *     input.
+ *
+ * A tool is authorized iff BOTH gates pass. Unknown tool or unknown role →
+ * denied (deny-by-default). This module owns the product policy; the
+ * `@revealui/mcp` factory owns the mechanism (filtering + gating + receipts).
+ */
+
+import { AuthorizationSystem } from '@revealui/core/security';
+
+/** Server-derived account tier (mirrors `EntitlementContext['tier']`). */
+export type McpTier = 'free' | 'pro' | 'max' | 'enterprise';
+
+/** The governed tool surface (Phase 1 scope: the five read tools). */
+export const MCP_TOOL_NAMES = [
+  'revealui_list_sites',
+  'revealui_list_content',
+  'revealui_get_content',
+  'revealui_site_stats',
+  'revealui_list_users',
+] as const;
+export type McpToolName = (typeof MCP_TOOL_NAMES)[number];
+
+const CONTENT_READ_TOOLS: readonly McpToolName[] = [
+  'revealui_list_sites',
+  'revealui_list_content',
+  'revealui_get_content',
+  'revealui_site_stats',
+];
+const ADMIN_TOOLS: readonly McpToolName[] = ['revealui_list_users'];
+
+const EXECUTE_ACTION = 'execute';
+
+function toolPermissionKey(toolName: string): string {
+  return `mcp:tool:${toolName}`;
+}
+
+/** Which tools each role may execute (RBAC grants). */
+const ROLE_TOOL_GRANTS: Record<string, readonly McpToolName[]> = {
+  owner: [...CONTENT_READ_TOOLS, ...ADMIN_TOOLS],
+  admin: [...CONTENT_READ_TOOLS, ...ADMIN_TOOLS],
+  editor: CONTENT_READ_TOOLS,
+  viewer: CONTENT_READ_TOOLS,
+  agent: CONTENT_READ_TOOLS,
+  contributor: CONTENT_READ_TOOLS,
+};
+
+/** Which tiers may see/execute each tool (tier gate). `list_users` is pro-gated. */
+const ALL_TIERS: ReadonlySet<McpTier> = new Set<McpTier>(['free', 'pro', 'max', 'enterprise']);
+const PAID_TIERS: ReadonlySet<McpTier> = new Set<McpTier>(['pro', 'max', 'enterprise']);
+const TOOL_TIER_GATE: Record<McpToolName, ReadonlySet<McpTier>> = {
+  revealui_list_sites: ALL_TIERS,
+  revealui_list_content: ALL_TIERS,
+  revealui_get_content: ALL_TIERS,
+  revealui_site_stats: ALL_TIERS,
+  revealui_list_users: PAID_TIERS,
+};
+
+// A dedicated engine instance registered with the exact tool-permission keys.
+// Not the global `authorization` singleton: registration state there is not
+// guaranteed, and a security control must be deterministic and self-contained.
+const mcpAuthz = new AuthorizationSystem();
+for (const [roleId, tools] of Object.entries(ROLE_TOOL_GRANTS)) {
+  mcpAuthz.registerRole({
+    id: roleId,
+    name: roleId,
+    permissions: tools.map((tool) => ({
+      resource: toolPermissionKey(tool),
+      action: EXECUTE_ACTION,
+    })),
+  });
+}
+
+/** The verified, server-derived identity the authz decision is made against. */
+export interface McpAuthzIdentity {
+  /** The user's role from the DB (`users.role`), resolved via the bearer token. */
+  role: string;
+  /** The account's effective tier from the entitlement record (I-9). */
+  tier: McpTier;
+}
+
+/**
+ * Deny-by-default authorization for one governed tool. True iff the identity's
+ * role holds the `mcp:tool:<name>` permission AND the tool is available at the
+ * identity's server-derived tier. Governs both `tools/list` filtering and
+ * `tools/call` execution.
+ */
+export function authorizeMcpTool(identity: McpAuthzIdentity, toolName: string): boolean {
+  const roleAllowed = mcpAuthz.hasPermission(
+    [identity.role],
+    toolPermissionKey(toolName),
+    EXECUTE_ACTION,
+  );
+  if (!roleAllowed) return false;
+  const tierGate = TOOL_TIER_GATE[toolName as McpToolName];
+  return tierGate !== undefined && tierGate.has(identity.tier);
+}

--- a/apps/server/src/routes/__tests__/mcp-endpoint-authz.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/mcp-endpoint-authz.pglite.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Governed MCP endpoint — Phase 2 authorization / quota / session invariants
+ * (GAP-371 §6, I-7..I-10) against a REAL migrated schema (PGlite), the real
+ * `@hono/node-server`, and the real `@modelcontextprotocol/sdk` client.
+ *
+ * The Phase-1 pglite test proves identity/audit (I-1..I-6). This proves the
+ * Phase-2 depth with the REAL policy (RBAC + tier gate + `McpRateLimiter` +
+ * entitlement-derived tier + session caps/TTL):
+ *
+ *   I-7   role gate: a viewer does not see/execute `revealui_list_users`;
+ *         tier gate (free vs pro discovery): a free-tier caller does not
+ *         see/execute the pro-gated tool; both denials are audited (authz).
+ *   I-8   per-user + tier rate limit: exceeding denies with reason rate-limit;
+ *         a second user is unaffected.
+ *   I-9   the effective tier is server-derived: a client-supplied tier header is
+ *         ignored; the outcome follows the account entitlement.
+ *   I-10  sessions are bounded: opening past the per-user cap evicts the oldest;
+ *         a session idle past the TTL no longer accepts requests.
+ */
+
+import { createHash } from 'node:crypto';
+import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { serve } from '@hono/node-server';
+import * as schema from '@revealui/db/schema';
+import { McpClient } from '@revealui/mcp/client';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+import { createMcpEndpointApp, type McpEndpointConfig } from '../mcp-endpoint.js';
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/db')>('@revealui/db');
+  return { ...actual, getClient: () => testDb.drizzle };
+});
+vi.mock('@revealui/auth/server', () => ({ getSession: async () => null }));
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+// role admin / tier pro
+const TOKEN_ADMIN_PRO = `rvui_dev_${'1'.repeat(64)}`;
+// role viewer / tier pro
+const TOKEN_VIEWER_PRO = `rvui_dev_${'2'.repeat(64)}`;
+// role admin / tier free (with the mcp feature)
+const TOKEN_ADMIN_FREE = `rvui_dev_${'3'.repeat(64)}`;
+// role admin / tier pro — second user for rate-limit isolation
+const TOKEN_ADMIN_PRO_B = `rvui_dev_${'4'.repeat(64)}`;
+
+const TOKEN_TO_USER: Record<string, string> = {
+  [`Bearer ${TOKEN_ADMIN_PRO}`]: 'user-admin-pro',
+  [`Bearer ${TOKEN_VIEWER_PRO}`]: 'user-viewer-pro',
+  [`Bearer ${TOKEN_ADMIN_FREE}`]: 'user-admin-free',
+  [`Bearer ${TOKEN_ADMIN_PRO_B}`]: 'user-admin-pro-b',
+};
+
+let stubBackend: NodeHttpServer;
+let stubUrl: string;
+const servedApps: Array<ReturnType<typeof serve>> = [];
+
+// Injectable clock for the session TTL/cap invariants (I-10).
+let clockNow = 1_000_000;
+const clock = (): number => clockNow;
+
+async function seed(): Promise<void> {
+  const db = testDb.drizzle;
+  const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+  await db.insert(schema.users).values([
+    { id: 'user-admin-pro', name: 'AdminPro', email: 'adminpro@example.com', role: 'admin' },
+    { id: 'user-viewer-pro', name: 'ViewerPro', email: 'viewerpro@example.com', role: 'viewer' },
+    { id: 'user-admin-free', name: 'AdminFree', email: 'adminfree@example.com', role: 'admin' },
+    { id: 'user-admin-pro-b', name: 'AdminProB', email: 'adminprob@example.com', role: 'admin' },
+  ]);
+
+  await db.insert(schema.userDevices).values(
+    [
+      ['dev-admin-pro', 'user-admin-pro', TOKEN_ADMIN_PRO],
+      ['dev-viewer-pro', 'user-viewer-pro', TOKEN_VIEWER_PRO],
+      ['dev-admin-free', 'user-admin-free', TOKEN_ADMIN_FREE],
+      ['dev-admin-pro-b', 'user-admin-pro-b', TOKEN_ADMIN_PRO_B],
+    ].map(([id, userId, token]) => ({
+      id,
+      userId,
+      deviceId: `device-${id}`,
+      deviceType: 'cli' as const,
+      tokenHash: tokenHash(token),
+      tokenExpiresAt: future,
+      isActive: true,
+    })),
+  );
+
+  await db.insert(schema.accounts).values([
+    { id: 'acct-admin-pro', name: 'AdminPro', slug: 'acct-admin-pro' },
+    { id: 'acct-viewer-pro', name: 'ViewerPro', slug: 'acct-viewer-pro' },
+    { id: 'acct-admin-free', name: 'AdminFree', slug: 'acct-admin-free' },
+    { id: 'acct-admin-pro-b', name: 'AdminProB', slug: 'acct-admin-pro-b' },
+  ]);
+
+  await db.insert(schema.accountMemberships).values([
+    {
+      id: 'mem-1',
+      accountId: 'acct-admin-pro',
+      userId: 'user-admin-pro',
+      role: 'owner',
+      status: 'active',
+    },
+    {
+      id: 'mem-2',
+      accountId: 'acct-viewer-pro',
+      userId: 'user-viewer-pro',
+      role: 'owner',
+      status: 'active',
+    },
+    {
+      id: 'mem-3',
+      accountId: 'acct-admin-free',
+      userId: 'user-admin-free',
+      role: 'owner',
+      status: 'active',
+    },
+    {
+      id: 'mem-4',
+      accountId: 'acct-admin-pro-b',
+      userId: 'user-admin-pro-b',
+      role: 'owner',
+      status: 'active',
+    },
+  ]);
+
+  // Every account has the `mcp` feature (so it can reach `/api/mcp`); the
+  // difference driving I-7 tier-gating is the TIER (free vs pro).
+  await db.insert(schema.accountEntitlements).values([
+    {
+      id: 'ent-1',
+      accountId: 'acct-admin-pro',
+      planId: 'p',
+      tier: 'pro',
+      status: 'active',
+      features: { mcp: true },
+      mode: 'test',
+    },
+    {
+      id: 'ent-2',
+      accountId: 'acct-viewer-pro',
+      planId: 'p',
+      tier: 'pro',
+      status: 'active',
+      features: { mcp: true },
+      mode: 'test',
+    },
+    {
+      id: 'ent-3',
+      accountId: 'acct-admin-free',
+      planId: 'p',
+      tier: 'free',
+      status: 'active',
+      features: { mcp: true },
+      mode: 'test',
+    },
+    {
+      id: 'ent-4',
+      accountId: 'acct-admin-pro-b',
+      planId: 'p',
+      tier: 'pro',
+      status: 'active',
+      features: { mcp: true },
+      mode: 'test',
+    },
+  ]);
+}
+
+/** Stub REST backend: any known token → 200 for every `/api/*` path. */
+function startStubBackend(): Promise<void> {
+  stubBackend = createHttpServer((req, res) => {
+    const user = TOKEN_TO_USER[req.headers.authorization ?? ''];
+    res.setHeader('content-type', 'application/json');
+    if (!user) {
+      res.statusCode = 401;
+      res.end(JSON.stringify({ error: 'unauthorized' }));
+      return;
+    }
+    res.statusCode = 200;
+    res.end(JSON.stringify({ docs: [] }));
+  });
+  return new Promise<void>((resolve) => {
+    stubBackend.listen(0, '127.0.0.1', () => {
+      const { port } = stubBackend.address() as AddressInfo;
+      stubUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+}
+
+/** Serve a governed endpoint on an ephemeral port with the given config. */
+function startEndpoint(config: Omit<McpEndpointConfig, 'selfApiBaseUrl'> = {}): Promise<string> {
+  const app = createMcpEndpointApp({ selfApiBaseUrl: stubUrl, ...config });
+  return new Promise<string>((resolve) => {
+    const served = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) => {
+      resolve(`http://127.0.0.1:${info.port}/`);
+    });
+    servedApps.push(served);
+  });
+}
+
+function client(token: string, url: string, extraHeaders: Record<string, string> = {}): McpClient {
+  return new McpClient({
+    clientInfo: { name: 'authz-e2e', version: '0.0.1' },
+    transport: {
+      kind: 'streamable-http',
+      url,
+      requestInit: { headers: { Authorization: `Bearer ${token}`, ...extraHeaders } },
+    },
+  });
+}
+
+interface DeniedRow {
+  reason?: string;
+  tool?: string;
+  userId?: string;
+}
+
+async function deniedRows(): Promise<DeniedRow[]> {
+  const rows = await testDb.drizzle
+    .select()
+    .from(schema.auditLog)
+    .where(eq(schema.auditLog.eventType, 'mcp:tool:denied'));
+  return rows.map((r) => r.payload as DeniedRow);
+}
+
+async function rawInitialize(url: string, token: string): Promise<string> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'raw', version: '0' },
+      },
+    }),
+  });
+  const sid = res.headers.get('mcp-session-id');
+  if (!sid) throw new Error('no session id issued');
+  return sid;
+}
+
+function rawRequest(url: string, sessionId: string, token: string): Promise<Response> {
+  return fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      'Mcp-Session-Id': sessionId,
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+  });
+}
+
+beforeAll(async () => {
+  process.env.REVEALUI_SECRET = 'test-secret-value-at-least-32-chars-long!!';
+  testDb = await createTestDb();
+  await seed();
+  await startStubBackend();
+});
+
+afterAll(async () => {
+  for (const served of servedApps) served.close();
+  stubBackend?.close();
+});
+
+// ---------------------------------------------------------------------------
+// I-7 — discovery and execution are independently authorized (role gate)
+// ---------------------------------------------------------------------------
+
+describe('I-7 role gate: viewer cannot see or execute list_users', () => {
+  it('filters tools/list by role and denies a direct call (audited authz)', async () => {
+    const url = await startEndpoint();
+
+    const admin = client(TOKEN_ADMIN_PRO, url);
+    await admin.connect();
+    const adminTools = (await admin.listTools()).map((t) => t.name);
+    await admin.close();
+    expect(adminTools).toContain('revealui_list_users');
+
+    const viewer = client(TOKEN_VIEWER_PRO, url);
+    await viewer.connect();
+    const viewerTools = (await viewer.listTools()).map((t) => t.name);
+    expect(viewerTools).toContain('revealui_list_sites');
+    expect(viewerTools).not.toContain('revealui_list_users');
+
+    // A tool absent from the list is STILL independently denied on a direct call.
+    const denied = await viewer.callTool('revealui_list_users', {});
+    await viewer.close();
+    expect(denied.isError).toBe(true);
+
+    const rows = await deniedRows();
+    expect(
+      rows.some(
+        (r) =>
+          r.userId === 'user-viewer-pro' &&
+          r.tool === 'revealui_list_users' &&
+          r.reason === 'authz',
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-7 — free-vs-pro discovery (tier gate)
+// ---------------------------------------------------------------------------
+
+describe('I-7 tier gate: free tier never sees/executes the pro-gated tool', () => {
+  it('a free-tier admin lacks list_users; a pro admin has it', async () => {
+    const url = await startEndpoint();
+
+    const free = client(TOKEN_ADMIN_FREE, url);
+    await free.connect();
+    const freeTools = (await free.listTools()).map((t) => t.name);
+    expect(freeTools).toContain('revealui_list_sites'); // content reads on every tier
+    expect(freeTools).not.toContain('revealui_list_users'); // pro-gated
+
+    const denied = await free.callTool('revealui_list_users', {});
+    await free.close();
+    expect(denied.isError).toBe(true);
+
+    const rows = await deniedRows();
+    expect(
+      rows.some(
+        (r) =>
+          r.userId === 'user-admin-free' &&
+          r.tool === 'revealui_list_users' &&
+          r.reason === 'authz',
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-8 — rate limits bind per user + tier
+// ---------------------------------------------------------------------------
+
+describe('I-8 per-user + tier rate limit', () => {
+  it('denies once the tier limit is exceeded; a second user is unaffected', async () => {
+    const url = await startEndpoint({ rateLimits: { pro: { maxRequests: 2, windowMs: 60_000 } } });
+
+    const a = client(TOKEN_ADMIN_PRO, url);
+    await a.connect();
+    const first = await a.callTool('revealui_list_sites', {});
+    const second = await a.callTool('revealui_list_sites', {});
+    const third = await a.callTool('revealui_list_sites', {});
+    await a.close();
+
+    expect(first.isError).toBeFalsy();
+    expect(second.isError).toBeFalsy();
+    expect(third.isError).toBe(true); // over the limit
+
+    // A different user has an independent budget.
+    const b = client(TOKEN_ADMIN_PRO_B, url);
+    await b.connect();
+    const bCall = await b.callTool('revealui_list_sites', {});
+    await b.close();
+    expect(bCall.isError).toBeFalsy();
+
+    const rows = await deniedRows();
+    expect(
+      rows.some(
+        (r) =>
+          r.userId === 'user-admin-pro' &&
+          r.tool === 'revealui_list_sites' &&
+          r.reason === 'rate-limit',
+      ),
+    ).toBe(true);
+    // The second user was never rate-limited.
+    expect(rows.some((r) => r.userId === 'user-admin-pro-b' && r.reason === 'rate-limit')).toBe(
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-9 — the effective tier is server-derived (client input ignored)
+// ---------------------------------------------------------------------------
+
+describe('I-9 tier is server-derived', () => {
+  it('a client-supplied tier header is ignored; the outcome follows the entitlement', async () => {
+    const url = await startEndpoint();
+    const spoofHeader = { 'X-RevealUI-Tier': 'enterprise' };
+
+    // Free-tier caller SHOUTS enterprise via a header — still denied the pro tool.
+    const free = client(TOKEN_ADMIN_FREE, url, spoofHeader);
+    await free.connect();
+    const freeTools = (await free.listTools()).map((t) => t.name);
+    const freeDenied = await free.callTool('revealui_list_users', {});
+    await free.close();
+    expect(freeTools).not.toContain('revealui_list_users');
+    expect(freeDenied.isError).toBe(true);
+
+    // Pro-tier caller sending the SAME header is allowed — the difference is the
+    // entitlement record, not the client-supplied tier.
+    const pro = client(TOKEN_ADMIN_PRO, url, spoofHeader);
+    await pro.connect();
+    const proAllowed = await pro.callTool('revealui_list_users', {});
+    await pro.close();
+    expect(proAllowed.isError).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metering — one usage_meters row per executed call, source `agent` (§5.5 tail)
+// ---------------------------------------------------------------------------
+
+describe('metering writes an agent-sourced usage row per executed call', () => {
+  it('records a source=agent usage_meters row for an executed tool call', async () => {
+    const url = await startEndpoint();
+    const c = client(TOKEN_ADMIN_PRO_B, url);
+    await c.connect();
+    const result = await c.callTool('revealui_list_sites', {});
+    await c.close();
+    expect(result.isError).toBeFalsy();
+
+    const rows = await testDb.drizzle
+      .select()
+      .from(schema.usageMeters)
+      .where(eq(schema.usageMeters.accountId, 'acct-admin-pro-b'));
+    expect(rows.length).toBeGreaterThan(0);
+    // Billing sink stays separate from the audit sink; every MCP row is agent-sourced.
+    expect(rows.every((r) => r.source === 'agent')).toBe(true);
+    expect(rows.some((r) => r.meterName === 'mcp.tool.call')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-10 — sessions are bounded (per-user cap + idle TTL)
+// ---------------------------------------------------------------------------
+
+describe('I-10 sessions are bounded', () => {
+  it('opening past the per-user cap evicts the oldest session', async () => {
+    clockNow = 5_000_000;
+    const url = await startEndpoint({ maxSessionsPerUser: 2, now: clock });
+
+    const first = await rawInitialize(url, TOKEN_ADMIN_PRO);
+    clockNow += 1;
+    await rawInitialize(url, TOKEN_ADMIN_PRO);
+    clockNow += 1;
+    const third = await rawInitialize(url, TOKEN_ADMIN_PRO);
+
+    // The oldest session was evicted when the 3rd opened (cap = 2).
+    const evicted = await rawRequest(url, first, TOKEN_ADMIN_PRO);
+    expect(evicted.status).not.toBe(200);
+    // The newest session still works.
+    const alive = await rawRequest(url, third, TOKEN_ADMIN_PRO);
+    expect(alive.status).toBe(200);
+  });
+
+  it('a session idle past the TTL no longer accepts requests', async () => {
+    clockNow = 9_000_000;
+    const url = await startEndpoint({ idleSessionTtlMs: 100, now: clock });
+
+    const sid = await rawInitialize(url, TOKEN_ADMIN_PRO);
+    // Within the TTL: still accepted.
+    clockNow += 50;
+    const withinTtl = await rawRequest(url, sid, TOKEN_ADMIN_PRO);
+    expect(withinTtl.status).toBe(200);
+
+    // Past the TTL: refused.
+    clockNow += 500;
+    const expired = await rawRequest(url, sid, TOKEN_ADMIN_PRO);
+    expect(expired.status).toBe(401);
+  });
+});

--- a/apps/server/src/routes/mcp-endpoint.ts
+++ b/apps/server/src/routes/mcp-endpoint.ts
@@ -27,14 +27,23 @@
  * wired so Phase 2 writes inherit it.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { RESPONSE_ALREADY_SENT } from '@hono/node-server/utils/response';
 import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { usageMeters } from '@revealui/db/schema';
+import {
+  DEFAULT_TIER_LIMITS,
+  McpRateLimiter,
+  type RateLimitConfig,
+} from '@revealui/mcp/rate-limiter';
 import {
   createRevealuiContentServer,
   type McpToolAuditRecord,
   type McpToolAuditSink,
   type McpToolCallContext,
+  type McpToolMeterSink,
   type ResolvedApiCredentials,
 } from '@revealui/mcp/revealui-content-factory';
 import {
@@ -44,6 +53,7 @@ import {
 import type { Handler, MiddlewareHandler } from 'hono';
 import { Hono } from 'hono';
 import { recordMcpToolAudit } from '../lib/mcp-audit.js';
+import { authorizeMcpTool, type McpTier } from '../lib/mcp-tool-access.js';
 import { authMiddleware } from '../middleware/auth.js';
 import { entitlementMiddleware, getEntitlementsFromContext } from '../middleware/entitlements.js';
 import { requireFeature } from '../middleware/license.js';
@@ -65,6 +75,10 @@ interface McpAuthInfo {
 interface McpAuthExtra extends Record<string, unknown> {
   userId: string;
   accountId: string | null;
+  /** The user's role (`users.role`), for deny-by-default per-tool authz (I-7). */
+  role: string;
+  /** The account's server-derived tier, re-resolved per request (I-9). */
+  tier: McpTier;
 }
 
 export interface McpEndpointConfig {
@@ -78,6 +92,28 @@ export interface McpEndpointConfig {
   allowedHosts?: string[];
   /** DNS-rebinding guard: allowed `Origin` headers. Defaults from env. */
   allowedOrigins?: string[];
+  /**
+   * Per-user + tier rate-limit config (I-8). Defaults to `DEFAULT_TIER_LIMITS`.
+   * Injectable so tests can use tiny windows without hammering the real limits.
+   */
+  rateLimits?: Record<string, RateLimitConfig>;
+  /** Max concurrent MCP sessions per user (I-10). Default: 8. Excess evicts LRU. */
+  maxSessionsPerUser?: number;
+  /** Idle session TTL in ms (I-10). Default: 24h. A session idle past this 401s. */
+  idleSessionTtlMs?: number;
+  /** Clock for session activity/TTL. Defaults to `Date.now`; injectable for tests. */
+  now?: () => number;
+}
+
+const DEFAULT_MAX_SESSIONS_PER_USER = 8;
+const DEFAULT_IDLE_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Per-session state kept by the mount: the bound identity (I-3) + activity (I-10). */
+interface SessionState {
+  userId: string;
+  accountId: string | null;
+  createdAt: number;
+  lastActivityAt: number;
 }
 
 function splitEnvList(value: string | undefined): string[] | undefined {
@@ -100,7 +136,12 @@ function extraFromContext(ctx: McpToolCallContext): McpAuthExtra | undefined {
   const info = ctx.authInfo as McpAuthInfo | undefined;
   const extra = info?.extra as Partial<McpAuthExtra> | undefined;
   if (!extra || typeof extra.userId !== 'string') return undefined;
-  return { userId: extra.userId, accountId: extra.accountId ?? null };
+  return {
+    userId: extra.userId,
+    accountId: extra.accountId ?? null,
+    role: typeof extra.role === 'string' ? extra.role : 'viewer',
+    tier: (extra.tier as McpTier | undefined) ?? 'free',
+  };
 }
 
 export interface McpEndpointParts {
@@ -120,9 +161,38 @@ export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointPar
   const allowedHosts = config.allowedHosts ?? splitEnvList(process.env.REVEALUI_MCP_ALLOWED_HOSTS);
   const allowedOrigins =
     config.allowedOrigins ?? splitEnvList(process.env.REVEALUI_MCP_ALLOWED_ORIGINS);
+  const maxSessionsPerUser = config.maxSessionsPerUser ?? DEFAULT_MAX_SESSIONS_PER_USER;
+  const idleSessionTtlMs = config.idleSessionTtlMs ?? DEFAULT_IDLE_SESSION_TTL_MS;
+  const clock = config.now ?? Date.now;
 
-  // sessionId → the identity that created the session (I-3).
-  const sessionBindings = new Map<string, McpAuthExtra>();
+  // sessionId → the identity + activity of the session (I-3 binding, I-10 caps).
+  const sessionBindings = new Map<string, SessionState>();
+
+  // Shared per-user + tier rate limiter (I-8). One fixed-window store for the
+  // life of the mount; keyed `${userId}:${tool}` with limits from the tier.
+  const rateLimiter = new McpRateLimiter({ limits: config.rateLimits ?? DEFAULT_TIER_LIMITS });
+
+  // Control surface over the handler's live session map (set in onControl,
+  // below, during handler construction — before any request runs).
+  let control: StreamableHttpControl | null = null;
+
+  // Evict the least-recently-active sessions of a user once over the cap (I-10),
+  // never the session just created. Deletes the binding first (idempotent) then
+  // tears down the transport.
+  function enforceSessionCap(userId: string, keepSessionId: string): void {
+    const owned = [...sessionBindings.entries()].filter(([, s]) => s.userId === userId);
+    if (owned.length <= maxSessionsPerUser) return;
+    const evictable = owned
+      .filter(([sid]) => sid !== keepSessionId)
+      .sort((a, b) => a[1].lastActivityAt - b[1].lastActivityAt);
+    let over = owned.length - maxSessionsPerUser;
+    for (const [sid] of evictable) {
+      if (over <= 0) break;
+      sessionBindings.delete(sid);
+      if (control?.hasSession(sid)) void control.terminateSession(sid).catch(() => undefined);
+      over -= 1;
+    }
+  }
 
   // The credentialsProvider is the SOLE credential source on this path (I-4).
   const credentialsProvider = (ctx: McpToolCallContext): ResolvedApiCredentials => {
@@ -155,15 +225,55 @@ export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointPar
       scalars: record.scalars,
       durationMs: record.durationMs,
       httpStatus: record.httpStatus,
+      reason: record.reason,
     });
   };
 
-  let control: StreamableHttpControl | null = null;
+  // Deny-by-default per-tool authz (I-7): resolve the caller's role + tier from
+  // the threaded identity, then apply the role+tier policy. No identity → deny.
+  const toolAuthorizer = (ctx: McpToolCallContext, toolName: string): boolean => {
+    const identity = extraFromContext(ctx);
+    if (!identity) return false;
+    return authorizeMcpTool({ role: identity.role, tier: identity.tier }, toolName);
+  };
+
+  // Per-user + tier rate limit (I-8): key by user + tool, limits from the tier.
+  const rateLimit = async (ctx: McpToolCallContext, toolName: string): Promise<boolean> => {
+    const identity = extraFromContext(ctx);
+    if (!identity) return false;
+    const result = await rateLimiter.check(`${identity.userId}:${toolName}`, identity.tier);
+    return result.allowed;
+  };
+
+  // One `usage_meters` row per executed tool call, `source: 'agent'` (§5.5 tail).
+  // Account-scoped (FK); a caller with no account has no billable usage row.
+  const meterSink: McpToolMeterSink = async (ctx, event): Promise<void> => {
+    const identity = extraFromContext(ctx);
+    if (!identity?.accountId) return;
+    const now = new Date();
+    await getClient()
+      .insert(usageMeters)
+      .values({
+        id: randomUUID(),
+        accountId: identity.accountId,
+        meterName: 'mcp.tool.call',
+        quantity: 1,
+        periodStart: now,
+        source: 'agent',
+        idempotencyKey: `mcp:${randomUUID()}`,
+        durationMs: event.durationMs,
+        errored: event.errored,
+      });
+  };
+
   const handler = createNodeStreamableHttpHandler({
     createServer: () =>
       createRevealuiContentServer({
         credentialsProvider,
         auditSink,
+        toolAuthorizer,
+        rateLimiter: rateLimit,
+        meterSink,
         // Phase 1 exposes read tools only. The set is empty in production; the
         // fail-closed branch it feeds is exercised by the invariant tests.
         mutatingTools: new Set<string>(),
@@ -181,7 +291,15 @@ export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointPar
       const auth = (req as { auth?: McpAuthInfo }).auth;
       const extra = auth?.extra as Partial<McpAuthExtra> | undefined;
       if (extra && typeof extra.userId === 'string') {
-        sessionBindings.set(id, { userId: extra.userId, accountId: extra.accountId ?? null });
+        const now = clock();
+        sessionBindings.set(id, {
+          userId: extra.userId,
+          accountId: extra.accountId ?? null,
+          createdAt: now,
+          lastActivityAt: now,
+        });
+        // Bound the per-user concurrent-session count (I-10).
+        enforceSessionCap(extra.userId, id);
       }
     },
     onSessionClosed: (id) => {
@@ -212,7 +330,7 @@ export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointPar
       );
     }
 
-    const user = c.get('user') as { id: string } | undefined;
+    const user = c.get('user') as { id: string; role?: string } | undefined;
     const token = bearerFromHeader(c.req.header('Authorization'));
     if (!(user && token)) {
       // authMiddleware(required) should have 401'd already; belt-and-braces.
@@ -221,27 +339,49 @@ export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointPar
         401,
       );
     }
-    const accountId = getEntitlementsFromContext(c).accountId;
-    const identity: McpAuthExtra = { userId: user.id, accountId };
+    // Tier + account are re-derived server-side every request (I-9): a
+    // client-supplied tier/tenant field can never influence the decision.
+    const entitlements = getEntitlementsFromContext(c);
+    const identity: McpAuthExtra = {
+      userId: user.id,
+      accountId: entitlements.accountId,
+      role: user.role ?? 'viewer',
+      tier: entitlements.tier,
+    };
 
     const sessionId = c.req.header('Mcp-Session-Id');
     if (sessionId) {
       const bound = sessionBindings.get(sessionId);
-      if (bound && bound.userId !== user.id) {
-        // I-3: a valid token for a DIFFERENT user on an existing session. The
-        // session id is not authority — reject and terminate it.
-        sessionBindings.delete(sessionId);
-        if (control?.hasSession(sessionId)) {
-          await control.terminateSession(sessionId).catch(() => undefined);
+      if (bound) {
+        if (bound.userId !== user.id) {
+          // I-3: a valid token for a DIFFERENT user on an existing session. The
+          // session id is not authority — reject and terminate it.
+          sessionBindings.delete(sessionId);
+          if (control?.hasSession(sessionId)) {
+            await control.terminateSession(sessionId).catch(() => undefined);
+          }
+          return c.json(
+            {
+              jsonrpc: '2.0',
+              error: { code: -32001, message: 'Session identity mismatch' },
+              id: null,
+            },
+            401,
+          );
         }
-        return c.json(
-          {
-            jsonrpc: '2.0',
-            error: { code: -32001, message: 'Session identity mismatch' },
-            id: null,
-          },
-          401,
-        );
+        // I-10: a session idle past the TTL no longer accepts requests.
+        const now = clock();
+        if (now - bound.lastActivityAt > idleSessionTtlMs) {
+          sessionBindings.delete(sessionId);
+          if (control?.hasSession(sessionId)) {
+            await control.terminateSession(sessionId).catch(() => undefined);
+          }
+          return c.json(
+            { jsonrpc: '2.0', error: { code: -32001, message: 'Session expired' }, id: null },
+            401,
+          );
+        }
+        bound.lastActivityAt = now;
       }
     }
 

--- a/packages/mcp/__tests__/revealui-content-authz.test.ts
+++ b/packages/mcp/__tests__/revealui-content-authz.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Governed-path authorization / quota / metering SEAM tests for the
+ * `revealui-content` factory (GAP-371 Phase 2). Drives a real MCP client over
+ * Streamable HTTP against the factory with injected `toolAuthorizer`,
+ * `rateLimiter`, and `meterSink`, and a fake REST backend. DB-free — the
+ * end-to-end policy wiring (real RBAC + tier + `McpRateLimiter` + entitlements)
+ * lives in the server-side pglite test.
+ *
+ * Covers, at the factory/transport seam:
+ *   I-7  deny-by-default per-tool authz gates BOTH `tools/list` (filtered) and
+ *        `tools/call` (denied + audited with reason `authz`, no REST call)
+ *   I-8  the rate limiter denies with reason `rate-limit` (no REST call)
+ *   §5.5 tail  one meter event per EXECUTED call, with the errored flag; a
+ *        denied call is never metered
+ */
+
+import { createServer as createHttpServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { McpClient } from '../src/client.js';
+import {
+  createRevealuiContentServer,
+  type McpToolAuditRecord,
+  type McpToolMeterEvent,
+} from '../src/servers/factories/revealui-content.js';
+import { createNodeStreamableHttpHandler } from '../src/streamable-http.js';
+
+const teardowns: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (teardowns.length > 0) {
+    const t = teardowns.pop();
+    if (t) await t().catch(() => undefined);
+  }
+});
+
+interface BackendCall {
+  url: string;
+}
+
+async function startFakeBackend(
+  respond: () => { status: number; body: unknown } = () => ({ status: 200, body: { docs: [] } }),
+): Promise<{ url: string; calls: BackendCall[] }> {
+  const calls: BackendCall[] = [];
+  const server = createHttpServer((req, res) => {
+    calls.push({ url: req.url ?? '' });
+    const { status, body } = respond();
+    res.statusCode = status;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const { port } = server.address() as AddressInfo;
+  teardowns.push(() => new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res()))));
+  return { url: `http://127.0.0.1:${port}`, calls };
+}
+
+interface GovernedServer {
+  url: string;
+  audits: McpToolAuditRecord[];
+  meters: McpToolMeterEvent[];
+}
+
+async function startGoverned(opts: {
+  backendUrl: string;
+  allowTools?: ReadonlySet<string>;
+  rateOk?: () => boolean;
+  backendStatus?: () => { status: number; body: unknown };
+}): Promise<GovernedServer> {
+  const audits: McpToolAuditRecord[] = [];
+  const meters: McpToolMeterEvent[] = [];
+  const handler = createNodeStreamableHttpHandler({
+    enableJsonResponse: true,
+    createServer: () =>
+      createRevealuiContentServer({
+        credentialsProvider: () => ({ apiUrl: opts.backendUrl, apiKey: 'tokenA' }),
+        auditSink: async (record) => {
+          audits.push(record);
+        },
+        toolAuthorizer: opts.allowTools ? (_ctx, tool) => opts.allowTools!.has(tool) : undefined,
+        rateLimiter: opts.rateOk ? () => opts.rateOk!() : undefined,
+        meterSink: (_ctx, event) => {
+          meters.push(event);
+        },
+      }),
+  });
+
+  const server: NodeHttpServer = createHttpServer((req, res) => {
+    (req as { auth?: unknown }).auth = {
+      token: 'tokenA',
+      extra: { userId: 'A', accountId: 'acct-A' },
+    };
+    void handler(req, res).catch((err) => {
+      if (!res.headersSent) res.statusCode = 500;
+      res.end(JSON.stringify({ error: String(err) }));
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const { port } = server.address() as AddressInfo;
+  teardowns.push(() => new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res()))));
+  return { url: `http://127.0.0.1:${port}/`, audits, meters };
+}
+
+function connectClient(url: string): Promise<McpClient> {
+  const client = new McpClient({
+    clientInfo: { name: 'authz-test', version: '0.0.1' },
+    transport: { kind: 'streamable-http', url },
+  });
+  return client.connect().then(() => client);
+}
+
+// ---------------------------------------------------------------------------
+// I-7 — deny-by-default authz gates discovery AND execution
+// ---------------------------------------------------------------------------
+
+describe('I-7 authz gates discovery and execution independently', () => {
+  it('tools/list shows only authorized tools', async () => {
+    const backend = await startFakeBackend();
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      allowTools: new Set(['revealui_list_sites', 'revealui_list_content']),
+    });
+    const client = await connectClient(governed.url);
+    const names = (await client.listTools()).map((t) => t.name);
+    await client.close();
+
+    expect(names).toContain('revealui_list_sites');
+    expect(names).not.toContain('revealui_list_users');
+  });
+
+  it('a direct call to an unauthorized tool is denied + audited (reason authz), never reaching the backend', async () => {
+    const backend = await startFakeBackend();
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      // list_users is hidden from discovery AND must be independently denied.
+      allowTools: new Set(['revealui_list_sites']),
+    });
+    const client = await connectClient(governed.url);
+    const result = await client.callTool('revealui_list_users', {});
+    await client.close();
+
+    expect(result.isError).toBe(true);
+    expect(backend.calls).toHaveLength(0);
+    expect(governed.audits).toHaveLength(1);
+    expect(governed.audits[0]?.outcome).toBe('denied');
+    expect(governed.audits[0]?.reason).toBe('authz');
+    // A denied call is not billable usage.
+    expect(governed.meters).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I-8 — rate limiter denies with reason rate-limit
+// ---------------------------------------------------------------------------
+
+describe('I-8 rate-limit denial', () => {
+  it('denies with reason rate-limit and does not reach the backend or meter', async () => {
+    const backend = await startFakeBackend();
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      allowTools: new Set(['revealui_list_sites']),
+      rateOk: () => false,
+    });
+    const client = await connectClient(governed.url);
+    const result = await client.callTool('revealui_list_sites', {});
+    await client.close();
+
+    expect(result.isError).toBe(true);
+    expect(backend.calls).toHaveLength(0);
+    expect(governed.audits[0]?.outcome).toBe('denied');
+    expect(governed.audits[0]?.reason).toBe('rate-limit');
+    expect(governed.meters).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metering — one event per executed call, carrying the errored flag
+// ---------------------------------------------------------------------------
+
+describe('metering fires once per executed call', () => {
+  it('meters a successful call with errored=false', async () => {
+    const backend = await startFakeBackend();
+    const governed = await startGoverned({ backendUrl: backend.url, rateOk: () => true });
+    const client = await connectClient(governed.url);
+    await client.callTool('revealui_list_sites', {});
+    await client.close();
+
+    expect(governed.meters).toHaveLength(1);
+    expect(governed.meters[0]?.tool).toBe('revealui_list_sites');
+    expect(governed.meters[0]?.errored).toBe(false);
+  });
+
+  it('meters a failed call with errored=true', async () => {
+    const backend = await startFakeBackend(() => ({ status: 503, body: { error: 'down' } }));
+    const governed = await startGoverned({ backendUrl: backend.url });
+    const client = await connectClient(governed.url);
+    const result = await client.callTool('revealui_list_sites', {});
+    await client.close();
+
+    expect(result.isError).toBe(true);
+    expect(governed.meters).toHaveLength(1);
+    expect(governed.meters[0]?.errored).toBe(true);
+  });
+});

--- a/packages/mcp/__tests__/revealui-content-governed.test.ts
+++ b/packages/mcp/__tests__/revealui-content-governed.test.ts
@@ -20,6 +20,7 @@ import type { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it } from 'vitest';
 import { McpClient } from '../src/client.js';
 import {
+  type CollectionMcpSummary,
   createRevealuiContentServer,
   type McpToolAuditRecord,
 } from '../src/servers/factories/revealui-content.js';
@@ -77,6 +78,7 @@ async function startGoverned(opts: {
   authInfo: () => unknown;
   mutatingTools?: Set<string>;
   auditFails?: boolean;
+  collectionsProvider?: () => Promise<CollectionMcpSummary[] | null>;
 }): Promise<GovernedServer> {
   const audits: McpToolAuditRecord[] = [];
   const handler = createNodeStreamableHttpHandler({
@@ -84,6 +86,7 @@ async function startGoverned(opts: {
     createServer: () =>
       createRevealuiContentServer({
         mutatingTools: opts.mutatingTools ?? new Set<string>(),
+        collectionsProvider: opts.collectionsProvider,
         credentialsProvider: (ctx) => {
           const info = ctx.authInfo as { token?: string } | undefined;
           if (!info?.token) throw new Error('no per-request credential');
@@ -301,5 +304,102 @@ describe('I-5 a receipt per call', () => {
     expect(result.isError).toBeFalsy();
     // The read executed despite the audit failure (degrade, not fail-closed).
     expect(backend.calls.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collection allowlist — a content tool may only reach an EXPOSED collection
+// ---------------------------------------------------------------------------
+//
+// Per-tool authz (I-7) is only sound if one tool cannot reach another tool's
+// endpoint. `revealui_list_content` / `revealui_get_content` interpolate the
+// `collection` arg into `/api/<collection>`, so a free-string collection would
+// let a content tool reach e.g. `/api/users` — bypassing the admin gate on the
+// separate `revealui_list_users` tool. The factory now validates `collection`
+// against the RESOLVED exposed-collections allowlist, deny-by-default.
+
+describe('content tools reject collections outside the exposed allowlist', () => {
+  it('revealui_list_content denies collection=users — denied receipt, /api/users never reached', async () => {
+    const backend = await startFakeBackend(okBackend);
+    // No collectionsProvider → curated fallback (posts/pages/products/media)
+    // is the exposed set; `users` is not in it.
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+
+    const result = await client.callTool('revealui_list_content', { collection: 'users' });
+    await client.close();
+
+    expect(result.isError).toBe(true);
+    // The ambient/user backend is never reached for an unexposed collection.
+    expect(backend.calls).toHaveLength(0);
+    expect(backend.calls.some((c) => c.url.startsWith('/api/users'))).toBe(false);
+    expect(governed.audits).toHaveLength(1);
+    expect(governed.audits[0]?.outcome).toBe('denied');
+    expect(governed.audits[0]?.reason).toBe('collection-not-exposed');
+  });
+
+  it('revealui_get_content denies an unexposed collection — denied receipt, backend never reached', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+
+    const result = await client.callTool('revealui_get_content', {
+      collection: 'users',
+      id: 'u-1',
+    });
+    await client.close();
+
+    expect(result.isError).toBe(true);
+    expect(backend.calls).toHaveLength(0);
+    expect(governed.audits).toHaveLength(1);
+    expect(governed.audits[0]?.outcome).toBe('denied');
+    expect(governed.audits[0]?.reason).toBe('collection-not-exposed');
+  });
+
+  it('an exposed collection (posts) still lists normally, reaching the backend', async () => {
+    const backend = await startFakeBackend(okBackend);
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+    });
+    const client = await connectClient(governed.url);
+
+    const result = await client.callTool('revealui_list_content', { collection: 'posts' });
+    await client.close();
+
+    expect(result.isError).toBeFalsy();
+    expect(backend.calls.some((c) => c.url.startsWith('/api/posts'))).toBe(true);
+    expect(governed.audits[0]?.outcome).toBe('invoked');
+  });
+
+  it('the allowlist is the RESOLVED exposed set, not a hardcoded curated list', async () => {
+    const backend = await startFakeBackend(okBackend);
+    // Provider exposes ONLY `articles`; curated `posts` is NOT exposed here.
+    const governed = await startGoverned({
+      backendUrl: backend.url,
+      authInfo: () => ({ token: 'tokenA', extra: { userId: 'A', accountId: 'acct-A' } }),
+      collectionsProvider: async () => [
+        { slug: 'articles', label: 'Article', labelPlural: 'Articles', mcpResource: true },
+      ],
+    });
+    const client = await connectClient(governed.url);
+
+    const exposed = await client.callTool('revealui_list_content', { collection: 'articles' });
+    const curatedButNotExposed = await client.callTool('revealui_list_content', {
+      collection: 'posts',
+    });
+    await client.close();
+
+    expect(exposed.isError).toBeFalsy();
+    expect(backend.calls.some((c) => c.url.startsWith('/api/articles'))).toBe(true);
+    // `posts` is in the curated fallback but NOT in the resolved provider set → denied.
+    expect(curatedButNotExposed.isError).toBe(true);
+    expect(backend.calls.some((c) => c.url.startsWith('/api/posts'))).toBe(false);
   });
 });

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -103,6 +103,13 @@ export interface McpToolAuditRecord {
   scalars: Record<string, string>;
   durationMs: number;
   httpStatus?: number;
+  /**
+   * Why a call was denied, when `outcome === 'denied'`. `'authz'` for a
+   * deny-by-default tool-permission miss (I-7); `'rate-limit'` when the
+   * per-user quota is exhausted (I-8). Absent for a validation/unknown-tool
+   * denial and for non-denied outcomes.
+   */
+  reason?: string;
   /** The MCP client that connected (from the `initialize` handshake). */
   clientInfo?: { name: string; version: string };
   context: McpToolCallContext;
@@ -114,6 +121,46 @@ export interface McpToolAuditRecord {
  * call (fail-closed); for a read tool it degrades to log-and-continue.
  */
 export type McpToolAuditSink = (record: McpToolAuditRecord) => Promise<void>;
+
+/**
+ * Deny-by-default per-tool authorization gate (GAP-371 Phase 2, I-7). Returns
+ * true iff the identity threaded through `ctx.authInfo` may execute `toolName`
+ * at its server-derived tier and role. Governs BOTH `tools/list` filtering and
+ * `tools/call` execution — a tool absent from the list is still independently
+ * denied on a direct call. Absent on the stdio path (every tool allowed).
+ */
+export type McpToolAuthorizer = (ctx: McpToolCallContext, toolName: string) => boolean;
+
+/**
+ * Per-call rate-limit gate (GAP-371 Phase 2, I-8). Consumed once per authorized
+ * `tools/call`, keyed by the caller's user + tool with limits from the
+ * server-derived tier. Returns false when the quota is exhausted. Absent on the
+ * stdio path (unlimited). Never consumed for `tools/list` or for a denied call.
+ */
+export type McpToolRateLimiter = (
+  ctx: McpToolCallContext,
+  toolName: string,
+) => Promise<boolean> | boolean;
+
+/** One usage-meter event, emitted once per EXECUTED tool call (I-8 tail). */
+export interface McpToolMeterEvent {
+  tool: string;
+  durationMs: number;
+  /** True when the tool surfaced an error (bad args reaching the backend, throw, non-2xx). */
+  errored: boolean;
+}
+
+/**
+ * Usage-meter sink (GAP-371 Phase 2). Fired once per tool call that actually
+ * executed (success or failure) — never for an authz/rate-limit denial, which
+ * are audit events, not billable usage. Sink errors are swallowed: metering
+ * must never break the underlying tool call. Billing and audit are separate
+ * sinks by design.
+ */
+export type McpToolMeterSink = (
+  ctx: McpToolCallContext,
+  event: McpToolMeterEvent,
+) => void | Promise<void>;
 
 /** sha256 (hex) of the canonical JSON of an arbitrary argument object. */
 function digestArgs(args: unknown): string {
@@ -395,6 +442,27 @@ export interface CreateRevealuiContentServerOptions {
    * (and so the branch is testable now with a simulated mutating tool).
    */
   mutatingTools?: ReadonlySet<string>;
+
+  /**
+   * Governed-path deny-by-default per-tool authorization (I-7). When set, it
+   * gates BOTH `tools/list` (advertised set) and `tools/call` (execution). A
+   * tool the caller may not execute is neither listed nor callable. Leave unset
+   * for the stdio launcher (no per-tool authz — the OS account is the boundary).
+   */
+  toolAuthorizer?: McpToolAuthorizer;
+
+  /**
+   * Governed-path per-call rate limiter (I-8). When set, an authorized
+   * `tools/call` consumes one token; exhaustion yields a JSON-RPC error and a
+   * `mcp:tool:denied` receipt with `reason: 'rate-limit'`. Unset → unlimited.
+   */
+  rateLimiter?: McpToolRateLimiter;
+
+  /**
+   * Governed-path usage-meter sink. When set, one meter event fires per
+   * executed tool call (source `agent` downstream). Unset → no metering.
+   */
+  meterSink?: McpToolMeterSink;
 }
 
 /** Error carrying the upstream HTTP status, for audit `httpStatus`. */
@@ -585,7 +653,18 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
     return cachedCollections;
   }
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+  server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
+    const authorizer = options?.toolAuthorizer;
+    if (!authorizer) return { tools: TOOLS };
+    // Filtered discovery (I-7): advertise only tools this caller may execute.
+    // This is UX; execution authz below is the security control — a tool hidden
+    // here is still independently denied on a direct `tools/call`.
+    const ctx: McpToolCallContext = {
+      authInfo: (extra as { authInfo?: unknown } | undefined)?.authInfo,
+      sessionId: (extra as { sessionId?: string } | undefined)?.sessionId,
+    };
+    return { tools: TOOLS.filter((tool) => authorizer(ctx, tool.name)) };
+  });
 
   // -------------------------------------------------------------------------
   // Resources (Stage 4.1 + 4.2)
@@ -665,7 +744,7 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
     // (the stdio path).
     async function writeReceipt(
       outcome: McpToolAuditOutcome,
-      httpStatus?: number,
+      opts?: { httpStatus?: number; reason?: string },
     ): Promise<boolean> {
       if (!auditSink) return true;
       const client = server.getClientVersion();
@@ -675,7 +754,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         argsDigest: digestArgs(rawArgs ?? null),
         scalars: pickAuditScalars(rawArgs),
         durationMs: Date.now() - startTime,
-        httpStatus,
+        httpStatus: opts?.httpStatus,
+        reason: opts?.reason,
         clientInfo: client ? { name: client.name, version: client.version } : undefined,
         context: ctx,
       };
@@ -687,12 +767,56 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
       }
     }
 
-    // A call rejected before it executes (unknown tool, invalid args). Records
-    // a `denied` receipt (best-effort — a denial that mutates nothing degrades
-    // like a read) and returns the client-facing error.
-    async function denied(response: McpToolError): Promise<McpToolError> {
-      await writeReceipt('denied');
+    // A call rejected before it executes (unknown tool, invalid args, authz or
+    // rate-limit denial). Records a `denied` receipt (best-effort — a denial
+    // that mutates nothing degrades like a read) and returns the client error.
+    async function denied(response: McpToolError, reason?: string): Promise<McpToolError> {
+      await writeReceipt('denied', reason ? { reason } : undefined);
       return response;
+    }
+
+    // Emit one usage-meter event for a call that actually executed. Swallows
+    // sink errors so metering can never break the tool call.
+    async function fireMeter(errored: boolean): Promise<void> {
+      if (!options?.meterSink) return;
+      try {
+        await options.meterSink(ctx, {
+          tool: toolName,
+          durationMs: Date.now() - startTime,
+          errored,
+        });
+      } catch {
+        // empty-catch-ok: metering is best-effort and must not affect the call
+      }
+    }
+
+    // Deny-by-default per-tool authorization (I-7). Runs before credentials are
+    // resolved, so an unauthorized caller never triggers a credential lookup or
+    // a REST call. A tool hidden from `tools/list` is still denied here.
+    if (options?.toolAuthorizer && !options.toolAuthorizer(ctx, toolName)) {
+      return denied(
+        {
+          content: [{ type: 'text', text: `Error: not authorized to call tool: ${toolName}` }],
+          isError: true,
+        },
+        'authz',
+      );
+    }
+
+    // Per-user + tier rate limit (I-8). Consumed only for an authorized call,
+    // before any credential resolution or execution. A denial is audited with
+    // `reason: 'rate-limit'` and never meters (a rejected call is not usage).
+    if (options?.rateLimiter) {
+      const allowed = await options.rateLimiter(ctx, toolName);
+      if (!allowed) {
+        return denied(
+          {
+            content: [{ type: 'text', text: `Error: rate limit exceeded for tool: ${toolName}` }],
+            isError: true,
+          },
+          'rate-limit',
+        );
+      }
     }
 
     // Resolve credentials. Governed path: the injected provider is the sole
@@ -815,6 +939,7 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
       // write failure (the data is already fetched; the sink logs + marks the
       // degraded write). Mutations already recorded their receipt above.
       if (!mutating) await writeReceipt('invoked');
+      await fireMeter(false);
 
       return {
         content: [
@@ -838,7 +963,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
       };
     } catch (err) {
       const httpStatus = err instanceof ApiRequestError ? err.status : undefined;
-      await writeReceipt('failed', httpStatus);
+      await writeReceipt('failed', { httpStatus });
+      await fireMeter(true);
       return {
         content: [
           { type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` },

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -775,6 +775,25 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
       return response;
     }
 
+    // Deny-by-default collection allowlist. The content tools interpolate the
+    // `collection` arg into `/api/<collection>`, so a free-string collection
+    // would let one tool reach another tool's endpoint (e.g. `/api/users`,
+    // bypassing the admin gate on `revealui_list_users`). A collection outside
+    // the RESOLVED exposed set is denied before any REST call — the backend is
+    // never reached for an unexposed collection.
+    async function denyIfCollectionNotExposed(collection: string): Promise<McpToolError | null> {
+      const exposed = await resolveCollections();
+      const slugs = new Set(exposed.map((c) => c.slug));
+      if (slugs.has(collection)) return null;
+      return denied(
+        {
+          content: [{ type: 'text', text: `Error: collection is not exposed: ${collection}` }],
+          isError: true,
+        },
+        'collection-not-exposed',
+      );
+    }
+
     // Emit one usage-meter event for a call that actually executed. Swallows
     // sink errors so metering can never break the tool call.
     async function fireMeter(errored: boolean): Promise<void> {
@@ -884,6 +903,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
           const parsed = validateToolArgs(ListContentArgsSchema, rawArgs, toolName);
           if (!parsed.ok) return denied(parsed.error);
           const { site_id, collection, limit = 20, page = 1, status } = parsed.value;
+          const notExposed = await denyIfCollectionNotExposed(collection);
+          if (notExposed) return notExposed;
           const params: Record<string, string> = {
             limit: String(limit),
             page: String(page),
@@ -899,6 +920,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
           const parsed = validateToolArgs(GetContentArgsSchema, rawArgs, toolName);
           if (!parsed.ok) return denied(parsed.error);
           const { collection, id } = parsed.value;
+          const notExposed = await denyIfCollectionNotExposed(collection);
+          if (notExposed) return notExposed;
           data = await apiGet(apiUrl, apiKey, `/api/${collection}/${id}`);
           break;
         }


### PR DESCRIPTION
## Summary

Extends the governed MCP endpoint (`/api/mcp`) with authorization depth, quota,
and session bounding, and fixes a concurrency defect in the governed audit
writer surfaced by the endpoint review. Identity threading, session binding, and
per-tool audit receipts already shipped; this builds on top of them (no rebuild).

## What this adds

- **Deny-by-default per-tool authorization.** Every `tools/call` passes a
  permission gate keyed `mcp:tool:<name>` through the existing
  `AuthorizationSystem` (exact-string keys, so the glob-to-RegExp match path is
  never taken) using the bound user's role, before any credential resolution or
  REST call. A denied call yields a JSON-RPC error and a `mcp:tool:denied`
  receipt with `reason: authz`.
- **Tier-filtered discovery.** `tools/list` returns only the tools the caller may
  execute at their server-derived tier. Discovery filtering is UX; a tool hidden
  from the list is still independently denied on a direct call.
- **Per-user + tier rate limiting.** Wires the existing `McpRateLimiter` at the
  `tools/call` boundary, keyed by user and tool with limits from the tier. Over
  the limit yields a JSON-RPC error and a `mcp:tool:denied` receipt with
  `reason: rate-limit`. A second user has an independent budget.
- **Metering.** One `usage_meters` row per executed tool call with
  `source: 'agent'`. Billing and audit stay separate sinks.
- **Server-derived authorization context.** The effective tier comes from the
  account entitlement record, re-resolved every request. Any client-supplied
  tier or tenant field (headers, params, args) is ignored.
- **Session caps and idle TTL.** A per-user concurrent-session cap (default 8,
  evicts the least-recently-active) and an idle TTL (default 24h) bound resource
  use.

The stdio launcher is unchanged: it constructs the factory without these seams,
so its local single-operator model keeps unlimited, unfiltered access under the
OS-account trust boundary.

## Audit hash-chain concurrency fix

The governed audit writer kept the chain head in a per-process variable with a
read-modify-write across the insert `await`. Concurrent receipts could both read
the same head and write it as `previousSignature`, forking the chain. This phase
turns on the fail-closed mutating-audit path, so every append is on the hot path.

The fix serializes appends through a promise-chain mutex so the head is read and
advanced atomically per process, and signs over a canonical (key-sorted) payload
so a receipt is reproducible from the `jsonb`-stored row. Adds
`verifyMcpAuditChain`, which verifies one process segment as a single unbroken,
unforked, tamper-evident chain. A failed write neither advances the head nor
poisons the queue.

## Invariants and tests (red-first)

Each new assertion was watched failing against the un-gated code before the
implementation made it pass:

- **I-7** role and tier gate discovery and execution independently; denials are
  audited with `reason: authz`; a free-tier caller never sees or executes the
  pro-gated tool. Disabling the seams reddened all four assertions.
- **I-8** the rate limit binds per user and tier; a second user is unaffected.
- **I-9** the effective tier follows the entitlement record, not a client-sent
  tier header.
- **I-10** opening past the per-user cap evicts the oldest session; a session
  idle past the TTL no longer accepts requests. Disabling the cap and TTL
  reddened both.
- **Audit fix** 30 interleaved audit writes form one verifiable chain. Without
  serialization all 30 rows chained to a null parent (a maximal fork).

Test files: the factory-seam suite (`packages/mcp/__tests__/`), the endpoint
invariant suite and the concurrency test (`apps/server/.../__tests__/`), mirroring
the existing Phase-1 test files.

## Verification

- `@revealui/mcp`: 440 passed / 5 skipped. `server`: 2924 passed / 1 skipped.
- `pnpm --filter @revealui/mcp typecheck` and `pnpm --filter server typecheck` clean.
- Biome clean on all changed files.
- Fleet security checker (`security-pr-review-check.js --diff origin/test`):
  flagged SECURITY-SENSITIVE (touches `packages/mcp/`), needs a recorded
  coordinator verdict before merge.

## Merge gate

This touches security-sensitive surfaces (`packages/mcp`, governed auth and
audit). It needs an independent NON-AUTHOR security verdict recorded on the PR
(`sec-review:approved`) before merge. The building session does not self-clear.
Per the model-allocation rule, a Fable adversarial pass applies to this phase.
