### PR TITLE
fix(security): hold merge on live guardrail-2 REQUEST-CHANGES verdict

### DIFF
--- a/.github/workflows/sec-audit-label-guard.yml
+++ b/.github/workflows/sec-audit-label-guard.yml
@@ -2,10 +2,13 @@
 # sec-review audit gate.
 #
 # The clearance label `sec-review:approved` may only stand while the PR's
-# security audit is green. The harness hook withholds the label at APPLY time
-# for commands run through a session; this catches the out-of-band case — the
-# label applied from a terminal, or an audit that goes RED after the label was
-# added — by REVOKING a premature label and commenting why.
+# security audit is green AND no guardrail-2 REQUEST-CHANGES verdict is
+# outstanding. The harness hook withholds the label at APPLY time for commands
+# run through a session; this catches the out-of-band case — the label applied
+# from a terminal, an audit that goes RED after the label was added, or a
+# REQUEST-CHANGES verdict posted after the label (the revealui#1910 miss) — by
+# REVOKING a premature label and commenting why. Fires on label / review /
+# comment / check_suite events so a fresh REQUEST-CHANGES un-sticks the label.
 #
 # CONSERVATIVE: revokes only on a definitive audit FAILURE (never pending /
 # missing / cancelled), so it cannot false-revoke during the audit's in-flight
@@ -21,11 +24,15 @@ on:
   pull_request:
     branches: [test, main]
     types: [labeled]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  issue_comment:
+    types: [created, edited]
   check_suite:
     types: [completed]
 
 concurrency:
-  group: sec-audit-label-guard-${{ github.event.pull_request.number || github.event.check_suite.id }}
+  group: sec-audit-label-guard-${{ github.event.pull_request.number || github.event.issue.number || github.event.check_suite.id }}
   cancel-in-progress: false
 
 permissions:
@@ -43,6 +50,7 @@ jobs:
         with:
           sparse-checkout: |
             scripts/validate/sec-audit-label-decision.cjs
+            scripts/validate/guardrail2-verdict.cjs
           sparse-checkout-cone-mode: false
 
       - name: Guard the clearance label
@@ -55,10 +63,11 @@ jobs:
           KILL=false
           if [ "${KILL_SWITCH:-}" = "true" ]; then KILL=true; fi
 
-          # PR numbers from whichever event fired, read from the event payload
-          # (a labeled event carries .pull_request; a check_suite carries
-          # .check_suite.pull_requests[]). De-duplicated, blanks dropped.
-          prs=$(jq -r '(.pull_request.number // empty), (.check_suite.pull_requests[]?.number // empty)' \
+          # PR numbers from whichever event fired, read from the event payload:
+          # a labeled/review event carries .pull_request; a check_suite carries
+          # .check_suite.pull_requests[]; an issue_comment carries .issue.number
+          # (only for PRs — guarded on .issue.pull_request). De-duplicated, blanks dropped.
+          prs=$(jq -r '(.pull_request.number // empty), (.check_suite.pull_requests[]?.number // empty), (if .issue.pull_request then .issue.number else empty end)' \
             "$GITHUB_EVENT_PATH" | grep -E '^[0-9]+$' | sort -u || true)
           if [ -z "$prs" ]; then
             echo "No associated PR — nothing to guard."
@@ -78,6 +87,17 @@ jobs:
               echo "::warning::PR #$pr — could not read PR metadata (transient API error?); skipping."
               echo "::endgroup::"; continue
             fi
+
+            # Guardrail-2 verdict inputs: PR author + review + comment bodies. The
+            # decision script parses the `<!-- guardrail2-verdict: ... -->` markers.
+            # Default to empty on a transient error — an empty set yields no hold,
+            # and the label-guard revoke is defense-in-depth behind the required
+            # security-review-gate status check, which independently holds the merge.
+            prAuthor=$(gh pr view "$pr" --repo "$REPO" --json author --jq '.author.login' 2>/dev/null || echo "")
+            reviews=$(gh pr view "$pr" --repo "$REPO" --json reviews --jq '.reviews' 2>/dev/null || echo "[]")
+            comments=$(gh pr view "$pr" --repo "$REPO" --json comments --jq '.comments' 2>/dev/null || echo "[]")
+            [ -n "$reviews" ] || reviews="[]"
+            [ -n "$comments" ] || comments="[]"
 
             # Fetch check-runs resiliently. A transient gh-API 5xx can return an
             # HTML body, which crashes jq ("invalid character '<'"). Fetch RAW
@@ -103,7 +123,10 @@ jobs:
               --argjson checkRuns "$checks" \
               --argjson labels "$labels" \
               --argjson killSwitch "$KILL" \
-              '{checkRuns: $checkRuns, labels: $labels, killSwitch: $killSwitch}')
+              --argjson reviews "$reviews" \
+              --argjson comments "$comments" \
+              --arg prAuthor "$prAuthor" \
+              '{checkRuns: $checkRuns, labels: $labels, killSwitch: $killSwitch, reviews: $reviews, comments: $comments, prAuthor: $prAuthor}')
 
             decision=$(printf '%s' "$payload" | node scripts/validate/sec-audit-label-decision.cjs)
             action=$(printf '%s' "$decision" | awk '{print $1}')
@@ -117,7 +140,7 @@ jobs:
                 "" \
                 "Reason: $reason" \
                 "" \
-                "The clearance label may only stand while the security audit is green on the current head. Re-apply it once the failing check(s) pass. It is deterministic (check conclusions only) and additive — never merges around a required check, only withholds a premature approval." \
+                "The clearance label may only stand while the security audit is green on the current head AND no guardrail-2 REQUEST-CHANGES verdict is outstanding. Resolve the reason above (a passing audit, or a later non-author guardrail-2 APPROVE marker) and re-apply the label. The guard is deterministic and additive — it never merges around a required check, only withholds a premature approval." \
                 "" \
                 "Overrides: apply the \`sec-audit-override\` label to exempt this PR, or set the repo variable \`SEC_AUDIT_GATE_DISABLED=true\` as a kill switch.")
               gh pr comment "$pr" --repo "$REPO" --body "$body"

--- a/scripts/validate/__tests__/guardrail2-verdict.test.ts
+++ b/scripts/validate/__tests__/guardrail2-verdict.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+
+const {
+  verdictForBody,
+  collectVerdicts,
+  evaluateGuardrail2,
+} = require('../guardrail2-verdict.cjs');
+
+const RC_MARKER = '<!-- guardrail2-verdict: REQUEST-CHANGES -->';
+const AP_MARKER = '<!-- guardrail2-verdict: APPROVE -->';
+
+// A realistic verdict comment: human-readable heading + the machine marker on its
+// own trailing line, exactly as the marker contract prescribes.
+const rcBody = `## Guardrail-2 security verdict: REQUEST-CHANGES\n\nTwo blockers found.\n\n${RC_MARKER}`;
+const apBody = `## Guardrail-2 security verdict: APPROVE\n\nLooks good.\n\n${AP_MARKER}`;
+
+const review = (login: string, ts: string, body: string) => ({
+  author: { login },
+  submittedAt: ts,
+  body,
+});
+const comment = (login: string, ts: string, body: string) => ({
+  author: { login },
+  createdAt: ts,
+  body,
+});
+
+describe('verdictForBody', () => {
+  it('reads a well-formed REQUEST-CHANGES marker on its own line', () => {
+    expect(verdictForBody(rcBody)).toBe('REQUEST-CHANGES');
+  });
+  it('reads a well-formed APPROVE marker', () => {
+    expect(verdictForBody(apBody)).toBe('APPROVE');
+  });
+  it('returns null when there is no marker', () => {
+    expect(verdictForBody('## verdict: APPROVE (heading only, no marker)')).toBeNull();
+  });
+  it('ignores a marker with an unknown token (malformed)', () => {
+    expect(verdictForBody('<!-- guardrail2-verdict: MAYBE -->')).toBeNull();
+  });
+  it('ignores prose that merely mentions the marker mid-sentence', () => {
+    // Not a bare marker line: there is text after the closing --> so endsWith fails.
+    expect(
+      verdictForBody('The contract is `<!-- guardrail2-verdict: APPROVE -->` on its own line.'),
+    ).toBeNull();
+  });
+  it('takes the LAST well-formed marker when a body carries duplicates', () => {
+    // A reviewer who corrects themselves within one comment: last line wins.
+    expect(verdictForBody(`${AP_MARKER}\nOn reflection:\n${RC_MARKER}`)).toBe('REQUEST-CHANGES');
+  });
+  it('handles a non-string / empty body without throwing', () => {
+    expect(verdictForBody(undefined)).toBeNull();
+    expect(verdictForBody('')).toBeNull();
+  });
+});
+
+describe('collectVerdicts', () => {
+  it('tags author vs non-author and normalizes both timestamp fields', () => {
+    const recs = collectVerdicts({
+      reviews: [review('reviewer', '2026-07-16T02:00:00Z', apBody)],
+      comments: [comment('builder', '2026-07-16T01:00:00Z', rcBody)],
+      authorLogin: 'builder',
+    });
+    expect(recs).toEqual([
+      {
+        verdict: 'APPROVE',
+        timestamp: '2026-07-16T02:00:00Z',
+        author: 'reviewer',
+        isAuthor: false,
+      },
+      {
+        verdict: 'REQUEST-CHANGES',
+        timestamp: '2026-07-16T01:00:00Z',
+        author: 'builder',
+        isAuthor: true,
+      },
+    ]);
+  });
+  it('drops bodies without a marker', () => {
+    const recs = collectVerdicts({
+      comments: [comment('x', '2026-07-16T01:00:00Z', 'no marker here')],
+    });
+    expect(recs).toEqual([]);
+  });
+});
+
+describe('evaluateGuardrail2 — no markers', () => {
+  it('returns no-marker so the caller falls back to legacy label logic', () => {
+    expect(
+      evaluateGuardrail2({ comments: [comment('x', '2026-07-16T01:00:00Z', 'hi')] }).status,
+    ).toBe('no-marker');
+    expect(evaluateGuardrail2({}).status).toBe('no-marker');
+  });
+});
+
+describe('evaluateGuardrail2 — distinct-reviewer topology (spec primary logic)', () => {
+  it('HOLDS on a lone non-author REQUEST-CHANGES', () => {
+    const r = evaluateGuardrail2({
+      comments: [comment('reviewer', '2026-07-16T01:00:00Z', rcBody)],
+      authorLogin: 'builder',
+    });
+    expect(r.status).toBe('hold');
+    expect(r.reviewer).toBe('reviewer');
+  });
+  it('CLEARS when a later non-author APPROVE resolves the REQUEST-CHANGES', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('reviewer', '2026-07-16T01:00:00Z', rcBody),
+        comment('reviewer', '2026-07-16T03:00:00Z', apBody),
+      ],
+      authorLogin: 'builder',
+    });
+    expect(r.status).toBe('clear');
+  });
+  it("IGNORES the author's own REQUEST-CHANGES when a non-author APPROVE exists", () => {
+    // The builder cannot re-block a reviewer-approved PR: with a non-author verdict
+    // present, author markers are excluded entirely — even a LATER author RC.
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('reviewer', '2026-07-16T01:00:00Z', apBody),
+        comment('builder', '2026-07-16T05:00:00Z', rcBody),
+      ],
+      authorLogin: 'builder',
+    });
+    expect(r.status).toBe('clear');
+  });
+  it('the builder cannot self-clear a reviewer REQUEST-CHANGES with a later author APPROVE', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('reviewer', '2026-07-16T01:00:00Z', rcBody),
+        comment('builder', '2026-07-16T05:00:00Z', apBody),
+      ],
+      authorLogin: 'builder',
+    });
+    expect(r.status).toBe('hold');
+    expect(r.reviewer).toBe('reviewer');
+  });
+});
+
+describe('evaluateGuardrail2 — single-login fail-safe (current fleet topology)', () => {
+  // Verified 2026-07-16: every fleet comment/review is authored by RevealUIStudio,
+  // the PR author too. Login cannot separate reviewer from builder, so author
+  // markers must NOT be dropped — dropping them would ignore the reviewer's own
+  // REQUEST-CHANGES, which IS the #1910 miss. Latest verdict governs; RC holds.
+  it('HOLDS on a latest author-login REQUEST-CHANGES (the #1910 reviewer verdict)', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('RevealUIStudio', '2026-07-17T00:04:57Z', apBody),
+        comment('RevealUIStudio', '2026-07-17T00:13:55Z', rcBody),
+      ],
+      authorLogin: 'RevealUIStudio',
+    });
+    expect(r.status).toBe('hold');
+  });
+  it('CLEARS when the latest same-login verdict is APPROVE', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('RevealUIStudio', '2026-07-17T00:13:55Z', rcBody),
+        comment('RevealUIStudio', '2026-07-17T00:20:00Z', apBody),
+      ],
+      authorLogin: 'RevealUIStudio',
+    });
+    expect(r.status).toBe('clear');
+  });
+  it('breaks a same-timestamp tie toward REQUEST-CHANGES (fail-safe)', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('RevealUIStudio', '2026-07-17T00:13:55Z', apBody),
+        comment('RevealUIStudio', '2026-07-17T00:13:55Z', rcBody),
+      ],
+      authorLogin: 'RevealUIStudio',
+    });
+    expect(r.status).toBe('hold');
+  });
+});
+
+// The regression the whole change exists to prevent. Reproduces revealui#1910:
+// a security-sensitive PR carrying sec-review:approved with a live REQUEST-CHANGES
+// verdict. BEFORE this change the gate cleared it on the label; AFTER, it holds.
+describe('evaluateGuardrail2 — revealui#1910 prove-red (before/after)', () => {
+  const pr1910 = {
+    author: { login: 'RevealUIStudio' },
+    labels: [{ name: 'sec-review:approved' }],
+    reviewDecision: '',
+    reviews: [],
+    comments: [
+      comment('RevealUIStudio', '2026-07-17T00:04:57Z', apBody),
+      comment('RevealUIStudio', '2026-07-17T00:13:55Z', rcBody),
+    ],
+  };
+
+  // The OLD gate logic, verbatim: label present OR approving review → clear.
+  function legacyDecision(pr: typeof pr1910): 'clear' | 'hold' {
+    const labels = new Set(pr.labels.map((l) => l.name));
+    const hasReviewLabel = [...labels].some((l) =>
+      ['sec-review:approved', 'security-reviewed', 'coordinator-approved'].includes(l),
+    );
+    const approved = pr.reviewDecision === 'APPROVED';
+    return approved || hasReviewLabel ? 'clear' : 'hold';
+  }
+
+  it('BEFORE: the legacy label-only logic cleared #1910 (the bug)', () => {
+    expect(legacyDecision(pr1910)).toBe('clear');
+  });
+
+  it('AFTER: the marker-aware evaluation HOLDS #1910 despite the label', () => {
+    const r = evaluateGuardrail2({
+      reviews: pr1910.reviews,
+      comments: pr1910.comments,
+      authorLogin: pr1910.author.login,
+    });
+    expect(r.status).toBe('hold');
+    expect(r.timestamp).toBe('2026-07-17T00:13:55Z');
+  });
+});

--- a/scripts/validate/__tests__/sec-audit-label-decision.test.ts
+++ b/scripts/validate/__tests__/sec-audit-label-decision.test.ts
@@ -75,3 +75,73 @@ describe('decide', () => {
     expect(r.action).toBe('revoke');
   });
 });
+
+const RC_MARKER = '<!-- guardrail2-verdict: REQUEST-CHANGES -->';
+const AP_MARKER = '<!-- guardrail2-verdict: APPROVE -->';
+const rcComment = (login: string, ts: string) => ({
+  author: { login },
+  createdAt: ts,
+  body: `## Guardrail-2 verdict: REQUEST-CHANGES\n\n${RC_MARKER}`,
+});
+const apComment = (login: string, ts: string) => ({
+  author: { login },
+  createdAt: ts,
+  body: `## Guardrail-2 verdict: APPROVE\n\n${AP_MARKER}`,
+});
+
+describe('decide — guardrail-2 REQUEST-CHANGES revoke (revealui#1910)', () => {
+  it('REVOKES a clearance label with a live REQUEST-CHANGES, even with a green audit', () => {
+    const r = decide({
+      checkRuns: allGreen(),
+      labels: [CLEAR_LABEL],
+      prAuthor: 'RevealUIStudio',
+      comments: [
+        apComment('RevealUIStudio', '2026-07-17T00:04:57Z'),
+        rcComment('RevealUIStudio', '2026-07-17T00:13:55Z'),
+      ],
+    });
+    expect(r.action).toBe('revoke');
+    expect(r.reason).toContain('REQUEST-CHANGES');
+  });
+  it('SKIPS once a later APPROVE resolves the REQUEST-CHANGES', () => {
+    const r = decide({
+      checkRuns: allGreen(),
+      labels: [CLEAR_LABEL],
+      prAuthor: 'RevealUIStudio',
+      comments: [
+        rcComment('RevealUIStudio', '2026-07-17T00:13:55Z'),
+        apComment('RevealUIStudio', '2026-07-17T00:20:00Z'),
+      ],
+    });
+    expect(r.action).toBe('skip');
+  });
+  it('the per-PR override label wins over a live REQUEST-CHANGES', () => {
+    const r = decide({
+      checkRuns: allGreen(),
+      labels: [CLEAR_LABEL, OVERRIDE_LABEL],
+      prAuthor: 'RevealUIStudio',
+      comments: [rcComment('RevealUIStudio', '2026-07-17T00:13:55Z')],
+    });
+    expect(r.action).toBe('skip');
+    expect(r.reason).toContain('override');
+  });
+  it('the kill switch wins over a live REQUEST-CHANGES', () => {
+    const r = decide({
+      killSwitch: true,
+      checkRuns: allGreen(),
+      labels: [CLEAR_LABEL],
+      prAuthor: 'RevealUIStudio',
+      comments: [rcComment('RevealUIStudio', '2026-07-17T00:13:55Z')],
+    });
+    expect(r.action).toBe('skip');
+  });
+  it('SKIPS when there is no clearance label, regardless of a REQUEST-CHANGES', () => {
+    const r = decide({
+      checkRuns: allGreen(),
+      labels: ['bug'],
+      prAuthor: 'RevealUIStudio',
+      comments: [rcComment('RevealUIStudio', '2026-07-17T00:13:55Z')],
+    });
+    expect(r.action).toBe('skip');
+  });
+});

--- a/scripts/validate/guardrail2-verdict.cjs
+++ b/scripts/validate/guardrail2-verdict.cjs
@@ -1,0 +1,131 @@
+'use strict';
+// guardrail2-verdict.cjs — parse guardrail-2 verdict markers off PR comments and
+// reviews, and decide whether an outstanding REQUEST-CHANGES holds the merge.
+//
+// Why this exists: the review-before-merge gate (security-review-gate.cjs) and the
+// server-side label guard (sec-audit-label-decision.cjs) both used to clear a PR on
+// the `sec-review:approved` label alone. Neither looked for a live REQUEST-CHANGES.
+// revealui#1910 merged with the label applied AGAINST a REQUEST-CHANGES verdict that
+// was sitting right there as a comment. This module is the shared parse+decide logic
+// both gates now consult so a REQUEST-CHANGES cannot be papered over by the label.
+//
+// THE MARKER CONTRACT: every guardrail-2 verdict a session posts (comment OR review
+// body) carries a machine-parseable trailer on its own line:
+//     <!-- guardrail2-verdict: REQUEST-CHANGES -->
+//     <!-- guardrail2-verdict: APPROVE -->
+// An HTML comment: invisible in rendered markdown, unambiguous, greppable. The
+// human-readable `## Guardrail-2 ... verdict: <VERDICT>` heading stays too, for people.
+//
+// TOPOLOGY NOTE (verified 2026-07-16, load-bearing). Every fleet PR — and every
+// comment and review on it — is authored by the single GitHub account
+// `RevealUIStudio` (the only account `gh` can post as). So login CANNOT tell the
+// builder's comment apart from the reviewer's comment today. Two consequences:
+//   - The `evaluateGuardrail2` DISTINCT-REVIEWER branch (login-filtered non-author
+//     verdicts, the spec's primary logic) is correct and unit-tested, but only
+//     ENGAGES once reviewer verdicts carry a distinct identity (post org-migration,
+//     or a reviewing session that authenticates `gh` as a different account).
+//   - Until then the SINGLE-LOGIN fail-safe branch runs: author markers are NOT
+//     dropped (dropping them would ignore the reviewer's own REQUEST-CHANGES — the
+//     exact #1910 miss), the latest verdict governs, and a REQUEST-CHANGES holds.
+// This module only supplies the hold/clear signal. The `sec-review:approved` label
+// stays owner-applied; clearing a PR still needs both a non-holding verdict AND the
+// label the way it always did.
+//
+// Zero authored regex (fleet no-regex HARDLINE): startsWith/endsWith/slice/trim + a
+// lexicographic timestamp compare (ISO-8601 Z strings sort chronologically).
+//
+// Mirrored — keep in lockstep with the fleet checker's copy at
+// .jv/scripts/guardrail2-verdict.js. The two live in different repos and cannot
+// require each other; this is the same deliberate two-lists-drift discipline the
+// SECURITY_PATHS lists carry.
+
+const MARKER_OPEN = '<!-- guardrail2-verdict:';
+const MARKER_CLOSE = '-->';
+const REQUEST_CHANGES = 'REQUEST-CHANGES';
+const APPROVE = 'APPROVE';
+
+// The verdict for ONE body: its LAST well-formed marker line, or null. A line counts
+// only when, trimmed, it starts with MARKER_OPEN, ends with MARKER_CLOSE, and the text
+// between them trims to exactly one of the two tokens. Prose that merely mentions the
+// marker mid-sentence, or an unknown token, is not a verdict. Last-wins lets a reviewer
+// correct themselves within a single comment.
+function verdictForBody(body) {
+  if (typeof body !== 'string' || body.length === 0) return null;
+  let found = null;
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    if (!line.startsWith(MARKER_OPEN) || !line.endsWith(MARKER_CLOSE)) continue;
+    const inner = line.slice(MARKER_OPEN.length, line.length - MARKER_CLOSE.length).trim();
+    if (inner === REQUEST_CHANGES || inner === APPROVE) found = inner;
+    // malformed / unknown token → ignored (fail-safe: an ambiguous marker is not a verdict)
+  }
+  return found;
+}
+
+// Normalize reviews + comments into verdict records — one per body that carries a
+// verdict. Author-inclusive; each record is tagged `isAuthor`. Reviews stamp their
+// time in `submittedAt`, comments in `createdAt`.
+function collectVerdicts({ reviews = [], comments = [], authorLogin = '' } = {}) {
+  const out = [];
+  const consume = (item) => {
+    const login = (item && item.author && item.author.login) || '';
+    const body = (item && item.body) || '';
+    const timestamp = (item && (item.submittedAt || item.createdAt)) || '';
+    const verdict = verdictForBody(body);
+    if (verdict) {
+      out.push({ verdict, timestamp, author: login, isAuthor: login !== '' && login === authorLogin });
+    }
+  };
+  for (const r of reviews) consume(r);
+  for (const c of comments) consume(c);
+  return out;
+}
+
+// Max-timestamp record; on a timestamp tie, REQUEST-CHANGES wins (fail-safe — a
+// same-instant APPROVE never masks a REQUEST-CHANGES). ISO-8601 Z strings compare
+// lexicographically === chronologically.
+function latest(records) {
+  let best = null;
+  for (const rec of records) {
+    if (best === null || rec.timestamp > best.timestamp) {
+      best = rec;
+    } else if (rec.timestamp === best.timestamp && rec.verdict === REQUEST_CHANGES) {
+      best = rec;
+    }
+  }
+  return best;
+}
+
+// The gate decision.
+//   { status: 'no-marker' }                                  → caller falls back to legacy label/review logic
+//   { status: 'hold',  reviewer, timestamp, verdict }        → an outstanding REQUEST-CHANGES; do NOT clear
+//   { status: 'clear', reviewer, timestamp, verdict }        → latest verdict is APPROVE
+function evaluateGuardrail2({ reviews = [], comments = [], authorLogin = '' } = {}) {
+  const all = collectVerdicts({ reviews, comments, authorLogin });
+  if (all.length === 0) return { status: 'no-marker' };
+
+  // DISTINCT-REVIEWER branch (spec's primary logic; engages when reviewer verdicts
+  // carry a login other than the PR author). The builder can never self-clear: only
+  // NON-AUTHOR verdicts are considered, so a later author APPROVE cannot lift a
+  // reviewer's REQUEST-CHANGES.
+  const nonAuthor = all.filter((r) => !r.isAuthor);
+  const pool = nonAuthor.length > 0 ? nonAuthor : all;
+  // SINGLE-LOGIN fail-safe: when no verdict is attributable to a non-author (today's
+  // topology), fall back to the whole set rather than dropping the reviewer's verdict.
+
+  const gov = latest(pool);
+  if (gov.verdict === REQUEST_CHANGES) {
+    return { status: 'hold', reviewer: gov.author, timestamp: gov.timestamp, verdict: gov.verdict };
+  }
+  return { status: 'clear', reviewer: gov.author, timestamp: gov.timestamp, verdict: gov.verdict };
+}
+
+module.exports = {
+  MARKER_OPEN,
+  MARKER_CLOSE,
+  REQUEST_CHANGES,
+  APPROVE,
+  verdictForBody,
+  collectVerdicts,
+  evaluateGuardrail2,
+};

--- a/scripts/validate/sec-audit-label-decision.cjs
+++ b/scripts/validate/sec-audit-label-decision.cjs
@@ -14,9 +14,17 @@
 // required checks in those states anyway). Deterministic: check conclusions
 // only, no model (keeps ADR 2026-07-10 condition 4 — additive-to-CI — intact).
 //
+// It ALSO revokes when a live guardrail-2 REQUEST-CHANGES verdict stands against
+// the label with no later resolving APPROVE (the revealui#1910 miss: the label was
+// applied over an outstanding REQUEST-CHANGES). This makes the label un-stickable
+// while a REQUEST-CHANGES is live, mirroring the audit-fail revoke.
+//
 // Pure `decide()` / `checkState()` are unit-tested; the thin CLI reads a JSON
-// { checkRuns, labels, killSwitch } from stdin and prints "revoke <reason>" or
-// "skip <reason>" for the workflow to act on. Zero deps, zero authored regex.
+// { checkRuns, labels, killSwitch, reviews, comments, prAuthor } from stdin and
+// prints "revoke <reason>" or "skip <reason>" for the workflow to act on. Zero
+// deps, zero authored regex.
+
+const { evaluateGuardrail2 } = require("./guardrail2-verdict.cjs");
 
 const REQUIRED_AUDIT_CHECKS = [
   "Security Gate",
@@ -66,6 +74,21 @@ function decide(input) {
   if (labelSet.has(OVERRIDE_LABEL)) {
     return { action: "skip", reason: `per-PR override label '${OVERRIDE_LABEL}' present` };
   }
+
+  // A live guardrail-2 REQUEST-CHANGES verdict makes the clearance label invalid,
+  // just like a failing audit does. Revoke it (revealui#1910).
+  const verdict = evaluateGuardrail2({
+    reviews: (input && input.reviews) || [],
+    comments: (input && input.comments) || [],
+    authorLogin: (input && input.prAuthor) || "",
+  });
+  if (verdict.status === "hold") {
+    return {
+      action: "revoke",
+      reason: `live guardrail-2 REQUEST-CHANGES verdict (reviewer ${verdict.reviewer || "unknown"}, ${verdict.timestamp || "unknown time"})`,
+    };
+  }
+
   const failing = REQUIRED_AUDIT_CHECKS.filter(
     (n) => checkState(checkRuns, n) === "failing"
   );
@@ -83,7 +106,7 @@ module.exports = {
   OVERRIDE_LABEL,
 };
 
-// CLI: node sec-audit-label-decision.cjs  <  {"checkRuns":[...],"labels":[...],"killSwitch":false}
+// CLI: node sec-audit-label-decision.cjs  <  {"checkRuns":[...],"labels":[...],"killSwitch":false,"reviews":[...],"comments":[...],"prAuthor":"..."}
 if (require.main === module) {
   let raw = "";
   process.stdin.setEncoding("utf8");

--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -6,6 +6,13 @@
 // SEC_REVIEW_LABELS — before it merges. PRs that do not touch such a surface
 // pass immediately, so this check is safe to require on every PR.
 //
+// A live guardrail-2 REQUEST-CHANGES verdict OVERRIDES the label. Verdicts are
+// posted as comments/reviews carrying a machine-parseable marker
+// (`<!-- guardrail2-verdict: REQUEST-CHANGES -->` / `... APPROVE -->`); the shared
+// guardrail2-verdict.cjs parser decides hold/clear. This closes the revealui#1910
+// miss, where sec-review:approved was applied against an outstanding REQUEST-CHANGES
+// and the gate — which only checked the label — cleared it anyway.
+//
 //   --pr <N>        Inspect PR #N via `gh` (files + labels + reviewDecision).
 //   --repo <o/r>    Target repo for --pr; defaults to the repo inferred from
 //                   the current directory.
@@ -22,6 +29,7 @@
 'use strict';
 
 const { execFileSync } = require('child_process');
+const { evaluateGuardrail2 } = require('./guardrail2-verdict.cjs');
 
 // A changed file is security-sensitive if its path contains ANY of these
 // substrings. Deliberately broad — money, identity, credential, code-exec,
@@ -83,6 +91,7 @@ const SECURITY_PATHS = [
   // Keep in lockstep with the fleet checker (separate .jv PR).
   'scripts/validate/security-review-gate',
   'scripts/validate/sec-audit-label-decision',
+  'scripts/validate/guardrail2-verdict',
   '.github/workflows/security-review-gate',
   '.github/workflows/sec-audit-label-guard',
   '.github/workflows/security.yml',
@@ -114,7 +123,13 @@ function classifyFiles(files) {
 
 function runPrMode(prNumber, repo) {
   let raw;
-  const ghArgs = ['pr', 'view', prNumber, '--json', 'files,labels,reviewDecision,title'];
+  const ghArgs = [
+    'pr',
+    'view',
+    prNumber,
+    '--json',
+    'files,labels,reviewDecision,title,author,reviews,comments',
+  ];
   if (repo) ghArgs.push('-R', repo);
   try {
     raw = gh(ghArgs);
@@ -136,6 +151,36 @@ function runPrMode(prNumber, repo) {
     process.exit(0);
   }
 
+  // A live guardrail-2 REQUEST-CHANGES marker holds the merge even when the
+  // sec-review:approved label is present (the revealui#1910 miss: the label was
+  // applied against an outstanding REQUEST-CHANGES). This is checked FIRST so the
+  // hold cannot be papered over by the label/review-decision fallback below.
+  const verdict = evaluateGuardrail2({
+    reviews: data.reviews || [],
+    comments: data.comments || [],
+    authorLogin: (data.author && data.author.login) || '',
+  });
+
+  if (verdict.status === 'hold') {
+    process.stderr.write(
+      `HOLD — PR #${prNumber} has a live guardrail-2 REQUEST-CHANGES verdict ` +
+        `(reviewer ${verdict.reviewer || 'unknown'}, ${verdict.timestamp || 'unknown time'}).\n` +
+        `   The sec-review:approved label and any approving review are OVERRIDDEN while this stands.\n` +
+        `   Required to clear: a LATER non-author guardrail-2 APPROVE marker resolving it.\n`,
+    );
+    process.exit(1);
+  }
+
+  if (verdict.status === 'clear') {
+    process.stdout.write(
+      `PR #${prNumber} is security-sensitive AND carries a guardrail-2 APPROVE verdict ` +
+        `(reviewer ${verdict.reviewer || 'unknown'}, ${verdict.timestamp || 'unknown time'}) — clear to merge.\n`,
+    );
+    process.exit(0);
+  }
+
+  // No verdict marker on the PR — fall back to the legacy label / approving-review
+  // signal (backward compatible for PRs that predate the marker convention).
   const labels = new Set((data.labels || []).map((l) => l.name));
   const hasReviewLabel = [...labels].some((l) => SEC_REVIEW_LABELS.has(l));
   const approved = data.reviewDecision === 'APPROVED';


### PR DESCRIPTION
## What

Make the security-review gates enforce an outstanding **guardrail-2 REQUEST-CHANGES** verdict across sessions. Today both gates clear a security PR on the `sec-review:approved` label alone and never look for a live REQUEST-CHANGES.

## Why (the #1910 incident + GAP-374)

`revealui#1910` merged with `sec-review:approved` applied **against a live REQUEST-CHANGES verdict**. The reviewer's two blockers were sitting in a PR comment; the label ignored them, and `GAP-374` (governed `/api/mcp` resources bypass) is the blocker that slipped onto `test` as a result. Root cause: `security-review-gate.cjs` and `sec-audit-label-decision.cjs` only checked the label / `reviewDecision`, and in the solo-account topology agents post verdicts as **comments** (GitHub refuses a self-approving formal review), so `reviewDecision` never sees them.

## The marker contract

Every guardrail-2 verdict now carries a machine-parseable trailer on its own line, alongside the existing human heading:

```
<!-- guardrail2-verdict: REQUEST-CHANGES -->
<!-- guardrail2-verdict: APPROVE -->
```

An HTML comment: invisible when rendered, unambiguous, greppable (no regex — `indexOf`/`startsWith`/`endsWith`). Documented in `dup-work-and-review-gates.md` guardrail 2 (the paired `.jv` PR).

## Files changed (revealui)

- `scripts/validate/guardrail2-verdict.cjs` (new) — shared parser + `evaluateGuardrail2` hold/clear/no-marker decision. One source, required by both consumers below.
- `scripts/validate/security-review-gate.cjs` — fetches `author,reviews,comments`; a live REQUEST-CHANGES now **HOLDS**, overriding the label; latest APPROVE clears; no marker falls back to the legacy label/review signal (backward compatible). Added the `scripts/validate/guardrail2-verdict` self-protection marker.
- `scripts/validate/sec-audit-label-decision.cjs` — server-side revoke now also fires on a live REQUEST-CHANGES, honoring the same `sec-audit-override` label + `SEC_AUDIT_GATE_DISABLED` kill switch.
- `.github/workflows/sec-audit-label-guard.yml` — fires on `pull_request_review` + `issue_comment` (not just `labeled`/`check_suite`), passes reviews/comments/author to the decision, so a fresh REQUEST-CHANGES un-sticks the label.
- Tests: `__tests__/guardrail2-verdict.test.ts` (new) + `__tests__/sec-audit-label-decision.test.ts` (extended). **50 tests pass.**

## Prove-red (before/after)

The `#1910` prove-red fixture (a security PR carrying `sec-review:approved` with a live REQUEST-CHANGES comment):

- **BEFORE** — the legacy label-only logic returned `clear` (the bug).
- **AFTER** — `evaluateGuardrail2` returns `hold` at the REQUEST-CHANGES timestamp, despite the label.

Both assertions are in `guardrail2-verdict.test.ts` (`revealui#1910 prove-red (before/after)`).

## Load-bearing finding — single-login topology (please read before merge)

Verified live on `#1910`: the PR author **and** every comment/review are authored by the single `RevealUIStudio` account (the only account `gh` posts as). So login cannot yet separate the builder from the reviewer. The gate's **distinct-reviewer** logic (a builder cannot self-clear a reviewer's REQUEST-CHANGES with a later author APPROVE) is implemented + unit-tested, but only fully engages once reviewer verdicts carry a distinct identity (org-migration, or a reviewing session that authenticates `gh` as a different account). Until then a **fail-safe** branch runs: author markers are not dropped (dropping them would ignore the reviewer's own REQUEST-CHANGES — the exact #1910 miss), the latest verdict governs, and a REQUEST-CHANGES holds. This means the deviation from the original spec's "ignore the author's own REQUEST-CHANGES" is intentional and safe (over-hold, never under-hold). Recommended follow-up (owner): post guardrail-2 verdicts from a distinct GitHub identity so the stronger self-clear guarantee bites.

## Merge posture

This PR edits the security-enforcement machinery, so it self-classifies as security-sensitive and **needs an independent non-author guardrail-2 verdict before merge**. Do not self-merge, do not apply `sec-review:approved`. Paired with the `.jv` PR (fleet checker + marker-convention docs).
