### PR TITLE
fix(ci): repair security-review-gate wiring (B1/B2/B3) after #1914

### DIFF
--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -16,9 +16,16 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   pull_request_review:
     types: [submitted, dismissed]
+  # Verdicts are posted as COMMENTS carrying a guardrail-2 marker, and a comment
+  # fires neither `pull_request` nor `pull_request_review`. Without this trigger a
+  # fresh REQUEST-CHANGES comment never re-runs the gate, leaving a stale green
+  # over a live hold (the #1910 class, narrowed). Guarded to PR comments below.
+  issue_comment:
+    types: [created, edited]
 
 concurrency:
-  group: security-review-gate-${{ github.event.pull_request.number }}
+  # issue_comment events carry the PR number under `issue`, not `pull_request`.
+  group: security-review-gate-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 permissions:
@@ -28,13 +35,18 @@ permissions:
 jobs:
   security-review-gate:
     name: Security review gate
+    # issue_comment fires on every issue; only run for comments on a PR.
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
         with:
+          # security-review-gate.cjs requires ./guardrail2-verdict.cjs — BOTH must
+          # be materialized or the gate crashes with MODULE_NOT_FOUND on checkout.
           sparse-checkout: |
             scripts/validate/security-review-gate.cjs
+            scripts/validate/guardrail2-verdict.cjs
           sparse-checkout-cone-mode: false
 
       - name: Evaluate review gate
@@ -42,5 +54,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/validate/security-review-gate.cjs \
-            --pr "${{ github.event.pull_request.number }}" \
+            --pr "${{ github.event.pull_request.number || github.event.issue.number }}" \
             --repo "${{ github.repository }}"

--- a/scripts/validate/__tests__/security-review-gate.test.ts
+++ b/scripts/validate/__tests__/security-review-gate.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-const { SECURITY_PATHS, classifyFiles } = require('../security-review-gate.cjs');
+const {
+  SECURITY_PATHS,
+  classifyFiles,
+  resolveGateDecision,
+} = require('../security-review-gate.cjs');
 
 // The enforcement-machinery markers this gate must self-protect. A PR editing
 // any of these files has to carry a recorded guardrail-2 verdict before merge.
@@ -27,6 +31,70 @@ describe('classifyFiles — enforcement-machinery self-protection', () => {
     // were removed, ENFORCEMENT_MACHINERY_FILES above would stop being flagged;
     // this line guarantees the markers are not so broad they catch everything.
     expect(classifyFiles(['apps/marketing/app/components/Hero.tsx'])).toEqual([]);
+  });
+});
+
+describe('resolveGateDecision — clearance policy (B2: marker alone never merges)', () => {
+  it('non-security-sensitive PR always clears', () => {
+    expect(
+      resolveGateDecision({
+        securitySensitive: false,
+        verdictStatus: 'no-marker',
+        hasOwnerClearance: false,
+      }).clear,
+    ).toBe(true);
+  });
+
+  it('a live REQUEST-CHANGES holds even WITH owner clearance', () => {
+    const d = resolveGateDecision({
+      securitySensitive: true,
+      verdictStatus: 'hold',
+      hasOwnerClearance: true,
+    });
+    expect(d.clear).toBe(false);
+    expect(d.kind).toBe('hold');
+  });
+
+  // The B2 regression: before the fix, a `clear` marker exited 0 without ever
+  // consulting the label, so a self-posted APPROVE comment cleared the gate.
+  it('B2: a clear APPROVE marker WITHOUT owner clearance HOLDS', () => {
+    const d = resolveGateDecision({
+      securitySensitive: true,
+      verdictStatus: 'clear',
+      hasOwnerClearance: false,
+    });
+    expect(d.clear).toBe(false);
+    expect(d.kind).toBe('verdict-without-owner');
+  });
+
+  it('a clear APPROVE marker WITH owner clearance clears', () => {
+    const d = resolveGateDecision({
+      securitySensitive: true,
+      verdictStatus: 'clear',
+      hasOwnerClearance: true,
+    });
+    expect(d.clear).toBe(true);
+    expect(d.kind).toBe('verdict-and-owner');
+  });
+
+  it('no marker + no owner clearance holds (legacy path, security-sensitive)', () => {
+    const d = resolveGateDecision({
+      securitySensitive: true,
+      verdictStatus: 'no-marker',
+      hasOwnerClearance: false,
+    });
+    expect(d.clear).toBe(false);
+    expect(d.kind).toBe('no-verdict');
+  });
+
+  it('no marker + owner clearance clears (legacy backward-compat)', () => {
+    const d = resolveGateDecision({
+      securitySensitive: true,
+      verdictStatus: 'no-marker',
+      hasOwnerClearance: true,
+    });
+    expect(d.clear).toBe(true);
+    expect(d.kind).toBe('legacy-owner');
   });
 });
 

--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -121,6 +121,24 @@ function classifyFiles(files) {
   return hits;
 }
 
+// Pure clearance decision, factored out of runPrMode so the exit-code policy is
+// unit-testable without spawning the CLI. Returns { clear, kind } where `kind`
+// selects the human message below. The B2 invariant lives here: a `clear`
+// verdict marker WITHOUT owner clearance holds — a marker alone never merges.
+function resolveGateDecision({ securitySensitive, verdictStatus, hasOwnerClearance }) {
+  if (!securitySensitive) return { clear: true, kind: 'not-sensitive' };
+  if (verdictStatus === 'hold') return { clear: false, kind: 'hold' };
+  if (verdictStatus === 'clear') {
+    return hasOwnerClearance
+      ? { clear: true, kind: 'verdict-and-owner' }
+      : { clear: false, kind: 'verdict-without-owner' };
+  }
+  // no-marker — legacy fallback, same owner-clearance requirement.
+  return hasOwnerClearance
+    ? { clear: true, kind: 'legacy-owner' }
+    : { clear: false, kind: 'no-verdict' };
+}
+
 function runPrMode(prNumber, repo) {
   let raw;
   const ghArgs = [
@@ -144,61 +162,53 @@ function runPrMode(prNumber, repo) {
   const files = (data.files || []).map((f) => f.path);
   const hits = classifyFiles(files);
 
-  if (hits.length === 0) {
-    process.stdout.write(
-      `PR #${prNumber}: no security-sensitive files touched — no review gate.\n`,
-    );
-    process.exit(0);
-  }
-
   // A live guardrail-2 REQUEST-CHANGES marker holds the merge even when the
   // sec-review:approved label is present (the revealui#1910 miss: the label was
-  // applied against an outstanding REQUEST-CHANGES). This is checked FIRST so the
-  // hold cannot be papered over by the label/review-decision fallback below.
+  // applied against an outstanding REQUEST-CHANGES). Clearance ALWAYS requires
+  // the owner-applied label / approving review — the marker records the
+  // reviewer's judgment, the label records the OWNER's disposition, and both are
+  // required so a self-posted APPROVE comment can never clear the gate on its own.
   const verdict = evaluateGuardrail2({
     reviews: data.reviews || [],
     comments: data.comments || [],
     authorLogin: (data.author && data.author.login) || '',
   });
-
-  if (verdict.status === 'hold') {
-    process.stderr.write(
-      `HOLD — PR #${prNumber} has a live guardrail-2 REQUEST-CHANGES verdict ` +
-        `(reviewer ${verdict.reviewer || 'unknown'}, ${verdict.timestamp || 'unknown time'}).\n` +
-        `   The sec-review:approved label and any approving review are OVERRIDDEN while this stands.\n` +
-        `   Required to clear: a LATER non-author guardrail-2 APPROVE marker resolving it.\n`,
-    );
-    process.exit(1);
-  }
-
-  if (verdict.status === 'clear') {
-    process.stdout.write(
-      `PR #${prNumber} is security-sensitive AND carries a guardrail-2 APPROVE verdict ` +
-        `(reviewer ${verdict.reviewer || 'unknown'}, ${verdict.timestamp || 'unknown time'}) — clear to merge.\n`,
-    );
-    process.exit(0);
-  }
-
-  // No verdict marker on the PR — fall back to the legacy label / approving-review
-  // signal (backward compatible for PRs that predate the marker convention).
   const labels = new Set((data.labels || []).map((l) => l.name));
   const hasReviewLabel = [...labels].some((l) => SEC_REVIEW_LABELS.has(l));
   const approved = data.reviewDecision === 'APPROVED';
+  const hasOwnerClearance = approved || hasReviewLabel;
 
-  if (approved || hasReviewLabel) {
-    process.stdout.write(
-      `PR #${prNumber} is security-sensitive AND carries a recorded verdict ` +
-        `(${approved ? 'approving review' : 'review label'}) — clear to merge.\n`,
-    );
-    process.exit(0);
-  }
+  const decision = resolveGateDecision({
+    securitySensitive: hits.length > 0,
+    verdictStatus: verdict.status,
+    hasOwnerClearance,
+  });
+  const who = `reviewer ${verdict.reviewer || 'unknown'}, ${verdict.timestamp || 'unknown time'}`;
+  const clearanceKind = approved ? 'approving review' : 'review label';
+  const labelName = [...SEC_REVIEW_LABELS][0];
 
-  process.stderr.write(
-    `HOLD — PR #${prNumber} touches a security-sensitive surface with NO recorded reviewer verdict.\n` +
+  const MESSAGES = {
+    'not-sensitive': `PR #${prNumber}: no security-sensitive files touched — no review gate.\n`,
+    hold:
+      `HOLD — PR #${prNumber} has a live guardrail-2 REQUEST-CHANGES verdict (${who}).\n` +
+      `   The sec-review:approved label and any approving review are OVERRIDDEN while this stands.\n` +
+      `   Required to clear: a LATER non-author guardrail-2 APPROVE marker resolving it.\n`,
+    'verdict-and-owner':
+      `PR #${prNumber} is security-sensitive AND carries a guardrail-2 APPROVE verdict (${who}) ` +
+      `plus owner clearance (${clearanceKind}) — clear to merge.\n`,
+    'verdict-without-owner':
+      `HOLD — PR #${prNumber} carries a guardrail-2 APPROVE marker (${who}) but NO owner clearance.\n` +
+      `   The marker records the reviewer's judgment; clearing still requires the OWNER's ` +
+      `"${labelName}" label (or an approving review).\n`,
+    'legacy-owner': `PR #${prNumber} is security-sensitive AND carries a recorded verdict (${clearanceKind}) — clear to merge.\n`,
+    'no-verdict':
+      `HOLD — PR #${prNumber} touches a security-sensitive surface with NO recorded reviewer verdict.\n` +
       `   Touched: ${[...new Set(hits)].join(', ')}\n` +
-      `   Required before merge: an approving review OR a "${[...SEC_REVIEW_LABELS][0]}" label.\n`,
-  );
-  process.exit(1);
+      `   Required before merge: an approving review OR a "${labelName}" label.\n`,
+  };
+
+  (decision.clear ? process.stdout : process.stderr).write(MESSAGES[decision.kind]);
+  process.exit(decision.clear ? 0 : 1);
 }
 
 function runDiffMode(base) {
@@ -246,7 +256,7 @@ function main() {
 // Export the surface list + classifier so the unit test can assert the
 // classification without spawning the CLI. Guarding main() behind
 // require.main === module keeps the CLI behavior identical when run directly.
-module.exports = { SECURITY_PATHS, SEC_REVIEW_LABELS, classifyFiles };
+module.exports = { SECURITY_PATHS, SEC_REVIEW_LABELS, classifyFiles, resolveGateDecision };
 
 if (require.main === module) {
   main();


### PR DESCRIPTION
## What

Follow-up to **#1914**, which merged to `test` against its live guardrail-2 REQUEST-CHANGES with three blockers unaddressed. This lands those three fixes. The gate the enforcement machinery relies on is currently self-crashing on `test`; this repairs it.

## The three fixes (from the #1914 + jv#505 verdicts)

- **B1 — the gate crashes on checkout.** `security-review-gate.cjs` now `require('./guardrail2-verdict.cjs')`, but `security-review-gate.yml`'s sparse-checkout only materialized `security-review-gate.cjs`, so the "Security review gate" job throws `Cannot find module './guardrail2-verdict.cjs'` on every run. Added `guardrail2-verdict.cjs` to the sparse-checkout.
- **B2 — clear-without-label authorization regression.** `runPrMode` exited `0` on a `clear` verdict marker before ever checking labels, so in the single-login topology any APPROVE-marker comment (a proposal-shaped action any session can post) cleared the gate with no owner disposition. Now a `clear` marker is treated as "no hold" and falls through to the owner-clearance requirement (`sec-review:approved` label or approving review). **Clearing requires the verdict AND the owner label.** The decision is extracted into a pure `resolveGateDecision()` and unit-tested; the B2 case is proven red against the pre-fix behavior.
- **B3 — a comment-borne REQUEST-CHANGES never re-ran the gate.** Verdicts are comments, which fire neither `pull_request` nor `pull_request_review`. Added `issue_comment: [created, edited]` (guarded to PR comments via a job-level `if`), plus the `issue.number` fallback for the PR-number and concurrency-group expressions.

## Note on B3 + required-check status (for O1)

`issue_comment`-triggered runs attach their status to the default-branch SHA, not the PR head, so for a **required** check the reliable re-evaluation path remains the label-revoke bounce in `sec-audit-label-guard.yml` (a REQUEST-CHANGES comment revokes the `sec-review:approved` label → `unlabeled` fires `pull_request` → the gate re-runs against the PR head). Because B2 now makes the label mandatory for any green, that bounce is always engaged. The `issue_comment` trigger added here is the additive immediate re-run for the visible/advisory check. This does not block making "Security review gate" a required check (O1) — do that **after** this B1 fix lands, or every open PR blocks on the crash.

## Tests

- `resolveGateDecision` unit tests (new): the B2 hold, the verdict+owner clear, the hold override, and both legacy paths. **18/18 pass**; the B2 assertion was proven red against the pre-fix `clear`-exits-0 behavior.
- No regex; CommonJS; dependency-free (Node built-ins + `gh`), matching the existing gate.

## Merge gate

This edits the security-enforcement machinery (`scripts/validate/security-review-gate`, `.github/workflows/security-review-gate`), so it self-classifies security-sensitive and needs an **independent non-author** guardrail-2 verdict before merge. I authored it — do not self-merge; owner applies `sec-review:approved`. Paired with the `.jv` fleet-checker fixes (jv#505 B1/B2).
