### PR TITLE
fix(ci): restore the security review gate and require a label to clear

### DIFF
--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           sparse-checkout: |
             scripts/validate/security-review-gate.cjs
+            scripts/validate/guardrail2-verdict.cjs
           sparse-checkout-cone-mode: false
 
       - name: Evaluate review gate

--- a/scripts/validate/__tests__/security-review-gate.test.ts
+++ b/scripts/validate/__tests__/security-review-gate.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-const { SECURITY_PATHS, classifyFiles } = require('../security-review-gate.cjs');
+const { SECURITY_PATHS, classifyFiles, decideReviewGate } = require('../security-review-gate.cjs');
+
+const CLEAR_LABEL = 'sec-review:approved';
+const noMarker = { status: 'no-marker' };
+const holdVerdict = { status: 'hold', reviewer: 'reviewer', timestamp: '2026-07-17T00:13:55Z' };
+const clearVerdict = { status: 'clear', reviewer: 'reviewer', timestamp: '2026-07-17T00:20:00Z' };
 
 // The enforcement-machinery markers this gate must self-protect. A PR editing
 // any of these files has to carry a recorded guardrail-2 verdict before merge.
@@ -27,6 +32,42 @@ describe('classifyFiles — enforcement-machinery self-protection', () => {
     // were removed, ENFORCEMENT_MACHINERY_FILES above would stop being flagged;
     // this line guarantees the markers are not so broad they catch everything.
     expect(classifyFiles(['apps/marketing/app/components/Hero.tsx'])).toEqual([]);
+  });
+});
+
+describe('decideReviewGate — a live REQUEST-CHANGES holds, overriding the label', () => {
+  it('HOLDS on a live REQUEST-CHANGES even with the clearance label present', () => {
+    const d = decideReviewGate({ verdict: holdVerdict, labels: [CLEAR_LABEL] });
+    expect(d.action).toBe('hold');
+    expect(d.kind).toBe('request-changes');
+  });
+});
+
+describe('decideReviewGate — B2: an APPROVE marker never clears without the owner label', () => {
+  // The #1914 B2 regression: a `clear` guardrail-2 verdict used to exit 0 on its
+  // own, so any APPROVE-marker comment (which the PR author can post) cleared the
+  // gate with no owner label. A marker is a reviewer proposal; the label is the
+  // owner disposition. Clearing requires the label (or an approving review) too.
+  it('HOLDS on a clear marker when no owner label / approving review exists', () => {
+    const d = decideReviewGate({ verdict: clearVerdict, labels: [] });
+    expect(d.action).toBe('hold');
+    expect(d.kind).toBe('no-verdict');
+  });
+  it('CLEARS when the clear marker is accompanied by the owner label', () => {
+    const d = decideReviewGate({ verdict: clearVerdict, labels: [CLEAR_LABEL] });
+    expect(d.action).toBe('clear');
+    expect(d.kind).toBe('label');
+  });
+  it('CLEARS a no-marker PR on the owner label (legacy path, unchanged)', () => {
+    expect(decideReviewGate({ verdict: noMarker, labels: [CLEAR_LABEL] }).action).toBe('clear');
+  });
+  it('CLEARS a no-marker PR on an approving review (legacy path, unchanged)', () => {
+    const d = decideReviewGate({ verdict: noMarker, labels: [], reviewDecision: 'APPROVED' });
+    expect(d.action).toBe('clear');
+    expect(d.kind).toBe('review');
+  });
+  it('HOLDS a no-marker PR with neither label nor approving review', () => {
+    expect(decideReviewGate({ verdict: noMarker, labels: ['bug'] }).action).toBe('hold');
   });
 });
 

--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -121,6 +121,41 @@ function classifyFiles(files) {
   return hits;
 }
 
+/**
+ * The gate decision for a security-sensitive PR (pure; unit-tested). Inputs are
+ * the guardrail-2 marker verdict plus the legacy label/review signal.
+ *
+ *  - A live guardrail-2 REQUEST-CHANGES marker HOLDS, overriding the label (the
+ *    revealui#1910 miss). Checked first.
+ *  - Otherwise the gate clears ONLY on the owner-applied sec-review:approved
+ *    label (or an approving review). A guardrail-2 APPROVE marker RESOLVES a
+ *    prior REQUEST-CHANGES hold but never substitutes for the owner's clearance
+ *    label: markers are reviewer proposals, the label is the owner disposition.
+ *    So both a `clear` verdict and a `no-marker` verdict fall through to the
+ *    same label/review requirement. (Fixes the #1914 B2 regression, where a
+ *    `clear` marker exited 0 on its own — so any APPROVE-marker comment, which
+ *    the PR author can post, cleared the gate with no owner label.)
+ *
+ * Returns `{ action: 'hold' | 'clear', kind, reviewer?, timestamp? }`.
+ */
+function decideReviewGate({ verdict, labels = [], reviewDecision = '' }) {
+  if (verdict && verdict.status === 'hold') {
+    return {
+      action: 'hold',
+      kind: 'request-changes',
+      reviewer: verdict.reviewer,
+      timestamp: verdict.timestamp,
+    };
+  }
+  const labelSet = new Set(labels);
+  const hasReviewLabel = [...labelSet].some((l) => SEC_REVIEW_LABELS.has(l));
+  const approved = reviewDecision === 'APPROVED';
+  if (approved || hasReviewLabel) {
+    return { action: 'clear', kind: approved ? 'review' : 'label' };
+  }
+  return { action: 'hold', kind: 'no-verdict' };
+}
+
 function runPrMode(prNumber, repo) {
   let raw;
   const ghArgs = [
@@ -151,46 +186,37 @@ function runPrMode(prNumber, repo) {
     process.exit(0);
   }
 
-  // A live guardrail-2 REQUEST-CHANGES marker holds the merge even when the
-  // sec-review:approved label is present (the revealui#1910 miss: the label was
-  // applied against an outstanding REQUEST-CHANGES). This is checked FIRST so the
-  // hold cannot be papered over by the label/review-decision fallback below.
+  // Compute the guardrail-2 marker verdict (comments/reviews) and hand it, with
+  // the legacy label/review signal, to the pure `decideReviewGate`. A live
+  // REQUEST-CHANGES holds even with the label; a clear/no-marker verdict still
+  // requires the owner label (or an approving review) — see the function header.
   const verdict = evaluateGuardrail2({
     reviews: data.reviews || [],
     comments: data.comments || [],
     authorLogin: (data.author && data.author.login) || '',
   });
+  const decision = decideReviewGate({
+    verdict,
+    labels: (data.labels || []).map((l) => l.name),
+    reviewDecision: data.reviewDecision,
+  });
 
-  if (verdict.status === 'hold') {
-    process.stderr.write(
-      `HOLD — PR #${prNumber} has a live guardrail-2 REQUEST-CHANGES verdict ` +
-        `(reviewer ${verdict.reviewer || 'unknown'}, ${verdict.timestamp || 'unknown time'}).\n` +
-        `   The sec-review:approved label and any approving review are OVERRIDDEN while this stands.\n` +
-        `   Required to clear: a LATER non-author guardrail-2 APPROVE marker resolving it.\n`,
-    );
-    process.exit(1);
-  }
-
-  if (verdict.status === 'clear') {
-    process.stdout.write(
-      `PR #${prNumber} is security-sensitive AND carries a guardrail-2 APPROVE verdict ` +
-        `(reviewer ${verdict.reviewer || 'unknown'}, ${verdict.timestamp || 'unknown time'}) — clear to merge.\n`,
-    );
-    process.exit(0);
-  }
-
-  // No verdict marker on the PR — fall back to the legacy label / approving-review
-  // signal (backward compatible for PRs that predate the marker convention).
-  const labels = new Set((data.labels || []).map((l) => l.name));
-  const hasReviewLabel = [...labels].some((l) => SEC_REVIEW_LABELS.has(l));
-  const approved = data.reviewDecision === 'APPROVED';
-
-  if (approved || hasReviewLabel) {
+  if (decision.action === 'clear') {
     process.stdout.write(
       `PR #${prNumber} is security-sensitive AND carries a recorded verdict ` +
-        `(${approved ? 'approving review' : 'review label'}) — clear to merge.\n`,
+        `(${decision.kind === 'review' ? 'approving review' : 'sec-review:approved label'}) — clear to merge.\n`,
     );
     process.exit(0);
+  }
+
+  if (decision.kind === 'request-changes') {
+    process.stderr.write(
+      `HOLD — PR #${prNumber} has a live guardrail-2 REQUEST-CHANGES verdict ` +
+        `(reviewer ${decision.reviewer || 'unknown'}, ${decision.timestamp || 'unknown time'}).\n` +
+        `   The sec-review:approved label and any approving review are OVERRIDDEN while this stands.\n` +
+        `   Required to clear: a LATER non-author guardrail-2 APPROVE marker AND the sec-review:approved label.\n`,
+    );
+    process.exit(1);
   }
 
   process.stderr.write(
@@ -246,7 +272,7 @@ function main() {
 // Export the surface list + classifier so the unit test can assert the
 // classification without spawning the CLI. Guarding main() behind
 // require.main === module keeps the CLI behavior identical when run directly.
-module.exports = { SECURITY_PATHS, SEC_REVIEW_LABELS, classifyFiles };
+module.exports = { SECURITY_PATHS, SEC_REVIEW_LABELS, classifyFiles, decideReviewGate };
 
 if (require.main === module) {
   main();


### PR DESCRIPTION
## What

Fast-follow to the guardrail-2 verdict-enforcement change, fixing two defects and correcting one over-broad clear condition in the "Security review gate" check.

1. **Workflow load failure.** The gate's Actions workflow sparse-checkouts only `scripts/validate/security-review-gate.cjs`, but that script now `require()`s `scripts/validate/guardrail2-verdict.cjs`, which was not being checked out — so the check errored on load for every PR. Fix: add the parser to the sparse-checkout list (the label-guard workflow already lists it).

2. **Clear condition.** A guardrail-2 `APPROVE` marker now *resolves* a prior REQUEST-CHANGES hold but no longer clears the gate on its own. Clearing still requires the owner-applied `sec-review:approved` label (or an approving review): a marker is a reviewer proposal, the label is the owner disposition (per `disposition-actions.md`). Both a `clear` verdict and a no-marker verdict fall through to the same label/review requirement. The decision is extracted into a pure `decideReviewGate()` so it is unit-testable.

## Tests

- New `decideReviewGate` cases in `security-review-gate.test.ts` (18 tests total, green): a live REQUEST-CHANGES holds even with the label; a `clear` marker without the owner label **holds**; a `clear` marker **with** the label clears; the legacy label / approving-review paths are unchanged.
- Prove-red verified: reverting the decision to the prior clear-path turns the clear-without-label case red; restored → green. Ran alongside `guardrail2-verdict.test.ts` + `sec-audit-label-decision.test.ts` (56 tests, green).

## Note on the comment re-trigger

A comment-borne REQUEST-CHANGES is re-evaluated on the PR head via the existing label-guard bounce (comment → the label guard revokes the clearance label → the resulting `unlabeled` event re-runs this gate on the head SHA). An `issue_comment` trigger is deliberately **not** added to this workflow, because such runs would attach their check to the default-branch SHA rather than the PR head and so would not update the required check. With the clear-condition fix above, a green gate implies the label is present, so the bounce reliably re-holds.

## Merge posture

Edits the security-review-gate machinery, so this self-classifies as security-sensitive and needs an independent, non-author guardrail-2 verdict before merge. Do not self-merge; do not apply `sec-review:approved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
