### PR TITLE
chore(deps): re-pin vite catalog to 8.0.16

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   tsup: ^8.5.1
   tsx: ^4.23.0
   typescript: ^6.0.3
-  vite: 8.1.3
+  vite: 8.0.16
   vitest: ^4.1.10
   yaml: ^2.6.1
   yjs: ^13.6.31


### PR DESCRIPTION
## Summary

Dependabot #1756 bumped the pnpm catalog entry for vite to 8.1.3 while the root `pnpm.overrides` pin holds vite at 8.0.16 (the 8.1.x transform regression that forced the pin is still unresolved). That left the repo's two version levers disagreeing: the catalog declared a version the override silently vetoed.

This re-pins the catalog to 8.0.16 so both levers agree again. The lockfile needs no change because the override already forced every resolution to 8.0.16; `git status` after `pnpm install` confirms only `pnpm-workspace.yaml` moves.

## Notes

- When a fixed vite release lands and is verified, the unpin should move the catalog and the override together.
- No runtime behavior change; resolved versions are identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
