### PR TITLE
docs(server): align revmarket route header with sandboxed executor

### DIFF
--- a/apps/server/src/routes/revmarket.ts
+++ b/apps/server/src/routes/revmarket.ts
@@ -1,12 +1,16 @@
 /**
- * RevMarket  -  Autonomous Agent Marketplace Routes (Phase 5.16)  -  PREVIEW
+ * RevMarket  -  Autonomous Agent Marketplace Routes (Phase 5.16)
  *
- * ⚠️  PREVIEW: Agent task execution runs in-process without sandbox isolation.
+ * Agent task execution is sandboxed: the executor runs one
+ * `child_process.fork()` per task with a memory cap and SIGTERM/SIGKILL
+ * timeout escalation (the `forkProvider` in `../services/revmarket-sandbox/`;
+ * see `../services/revmarket-executor.ts` for lifecycle + remaining caveats).
+ * Trusted self-hosted deployments may opt into `noSandboxProvider` via
+ * `configureExecutor`; hosted deployments must keep `forkProvider`.
  * x402 emission on POST /tasks is gated on `X402_ENABLED=true` (default off).
  * When enabled, paid agents (basePriceUsdc > 0) require a verified payment
  * proof before the task is queued; free agents are unaffected. Stripe
  * Connect 80/20 split to the agent publisher is deferred to Phase B.
- * Use only with trusted agents. Full sandboxing remains planned for Phase B.
  *
  * Extends the MCP Marketplace (Phase 5.5) with autonomous agent task execution.
  * Agents register with skills and pricing, users submit tasks, the system


### PR DESCRIPTION
## Summary

Doc-drift fix for #526: the header of `apps/server/src/routes/revmarket.ts` still described the retired in-process PREVIEW execution model ("runs in-process without sandbox isolation"). Task execution has run through the fork-based sandbox provider since the executor shipped: one `child_process.fork()` per task with a memory cap and SIGTERM/SIGKILL timeout escalation, with `noSandboxProvider` reserved for trusted self-hosted deployments via `configureExecutor`.

The header now describes that model and points at `revmarket-executor.ts` for the lifecycle and remaining caveats. Comment-only change; no code or behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
