### PR TITLE
docs: CR9-P1-05 residual sweep (RevealCoin/x402 heading, blog drafts, stamp)

### DIFF
--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -66,7 +66,7 @@ Pro packages are published to npm as compiled distributions. You can install the
 
 | | Free (OSS) | Pro | Max | Enterprise |
 |---|---|---|---|---|
-| **Price** | Free forever | Waitlist | Waitlist | Contact sales |
+| **Price** | Free forever | $49/month | $299/month | $1,499/month, sales-led |
 | **Sites** | 1 | 5 | 15 | Unlimited |
 | **Users/editors** | 3 | 25 | 100 | Unlimited |
 | **Agent tasks/mo** | 1,000 | 10,000 | 50,000 | Unlimited |

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -71,7 +71,7 @@ Pro packages are published to npm as compiled distributions. You can install the
 | **Users/editors** | 3 | 25 | 100 | Unlimited |
 | **Agent tasks/mo** | 1,000 | 10,000 | 50,000 | Unlimited |
 | **API rate limit** | 200 req/min | 300 req/min | 600 req/min | 1,000 req/min |
-| **Auth** | Session + OAuth (GitHub / Google / Vercel) | Same | Same | Session + OAuth + SSO/SAML (planned) |
+| **Auth** | Session + OAuth (GitHub / Google / Vercel) | Same | Same | Session + OAuth + SSO/SAML (planned, [#449](https://github.com/RevealUIStudio/revealui/issues/449)) |
 | **admin collections** | Unlimited | Unlimited | Unlimited | Unlimited |
 | **Real-time sync** | Basic | Full | Full | Full |
 | **Local AI inference (Snaps / Ollama)** | Yes | Yes | Yes | Yes |
@@ -82,8 +82,8 @@ Pro packages are published to npm as compiled distributions. You can install the
 | **Monitoring dashboard** | -- | Yes | Yes | Yes |
 | **Custom domains** | -- | Yes | Yes | Yes |
 | **Multi-tenant** | -- | -- | -- | Yes |
-| **White-label** | -- | -- | -- | Yes (planned) |
-| **Support** | Community | Email (48h) | Email (24h) | Slack (planned) |
+| **White-label** | -- | -- | -- | Yes (planned, [#515](https://github.com/RevealUIStudio/revealui/issues/515)) |
+| **Support** | Community | Email (48h) | Email (24h) | Slack (not yet available) |
 | **Source code** | Full | Full | Full | Full |
 
 A few things worth noting about this table.
@@ -92,7 +92,7 @@ A few things worth noting about this table.
 
 **All four business primitives work on free.** Users, Content, Products, Payments -- the MIT core -- are fully functional at every tier. Free doesn't cripple the business stack to pressure upgrades. The tier boundaries are about scale (more sites, more users, higher rate limits) and AI capabilities.
 
-**Pro will have a 7-day trial with no credit card required (coming soon).** The signup flow won't ask for payment information. You try it, you decide, you pay if it's worth it. If the product can't convince you in seven days, a payment wall on day one wasn't going to help.
+**Pro and Max include a 7-day trial.** You try it, you decide, you pay if it's worth it. If the product can't convince you in seven days, a payment wall on day one wasn't going to help.
 
 ### Three Pricing Tracks
 
@@ -178,7 +178,7 @@ What I do know is that the alternative -- restrictive licensing, crippled free t
 
 RevealUI is the business stack I wanted when I started building software companies. Users, content, products, payments, and intelligence -- pre-wired, open source, and ready to deploy. If it's useful to you at $0, that's a win. If it's useful enough to pay for, even better.
 
-The code is on [GitHub](https://github.com/RevealUIStudio/revealui). The license is MIT. The Pro features will have a free trial (coming soon). Everything I've described in this post is verifiable.
+The code is on [GitHub](https://github.com/RevealUIStudio/revealui). The license is MIT. The Pro features include a 7-day free trial. Everything I've described in this post is verifiable.
 
 Build something.
 

--- a/docs/blog/11-revfleet-product-family.md
+++ b/docs/blog/11-revfleet-product-family.md
@@ -48,7 +48,7 @@ Each of these came out of operating RevealUI ourselves. We needed them, so we bu
 
 **RevSkills** (Active, MIT) is a library of Claude Code skills: auth flows, schema patterns, test scaffolds, and more, ready to drop into any agent. Free, open, importable.
 
-**RevMarket** (Planned) is the agent tool marketplace. The runtime already ships a catalog of first-party integrations out of the box; RevMarket is the planned layer where third-party developers publish and discover MCP servers and agent capabilities. It is designed, not yet open to outside publishers, and we say so plainly on the roadmap.
+**RevMarket** (Planned, [#451](https://github.com/RevealUIStudio/revealui/issues/451)) is the agent tool marketplace. The runtime already ships a catalog of first-party integrations out of the box; RevMarket is the planned layer where third-party developers publish and discover MCP servers and agent capabilities. It is designed, not yet open to outside publishers, and we say so plainly on the roadmap.
 
 ## Why a fleet instead of one big product
 


### PR DESCRIPTION
## Audit reference

`~/revfleet/.jv/docs/MASTER_PLAN.md` §CR9-P1-05 (search "CR9-P1-05") records five prior closure rounds (`#450`/`#452`, `#517`, `#527`, `#529`, `#536`) plus a residual list: Visual Builder (owner-gated), the RevealCoin/x402 Agent Payments heading, blog drafts, the "Last updated: 2026-04-10" stamp, and misc surfaces.

## Ground-truth audit before editing (code-over-docs)

Re-verified each residual item against `origin/test` HEAD rather than trusting the MASTER_PLAN record:

1. **RevealCoin / x402 Agent Payments heading in `docs/ROADMAP.md`** — already resolved. No standalone heading exists; the content was folded into the `Agent Marketplace — #526` section during Round 3 (`#527`). Confirmed via `git log` + a direct read of the current file. **No change needed.**
2. **"Last updated: 2026-04-10" stamp** — already resolved. `docs/ROADMAP.md` carries `**Last updated:** 2026-07-11`, refreshed by a separate owner commit (`29c895592`, "docs(roadmap): close out future-tense marker sweep") that also resolved the Visual Builder heading to `Visual Editing — #1816` (owner-gated surface, left untouched here). **No change needed.**
3. **Blog drafts with unlinked future-tense markers** — found and fixed. `docs/blog/` has no draft/unpublished distinction (all 16 files are wired into `apps/marketing/app/lib/blog-posts.ts`'s `POST_METADATA` registry and published), so every file was in scope. Applying the `claim-drift.ts` `FUTURE_TENSE_PATTERN`/`TRACKER_PATTERN` logic by hand (those files aren't in the validator's `FUTURE_TENSE_SCAN_FILES` allowlist) surfaced 6 unlinked markers across 2 files. **Fixed in this PR** (see disposition below).

## Disposition per surface

| Surface | Change |
|---|---|
| `docs/ROADMAP.md` (RevealCoin/x402 heading) | None — already closed in Round 3 (`#527`), confirmed by re-reading current file content. |
| `docs/ROADMAP.md` ("Last updated" stamp) | None — already current (`2026-07-11`) via a separate owner commit. |
| `docs/blog/06-open-source-and-pro.md:74` SSO/SAML `(planned)` | Linked to existing tracker [#449](https://github.com/RevealUIStudio/revealui/issues/449). |
| `docs/blog/06-open-source-and-pro.md:85` White-label `(planned)` | Linked to existing tracker [#515](https://github.com/RevealUIStudio/revealui/issues/515). |
| `docs/blog/06-open-source-and-pro.md:86` Slack support `(planned)` | No substantive tracker exists for this specific claim. Rewrote to "Slack (not yet available)" — present-tense, no promise, no invented issue number. |
| `docs/blog/06-open-source-and-pro.md:95` "7-day trial, no credit card required (coming soon)" | The trial itself has shipped (`trial_period_days` wired in `apps/server/src/routes/billing.ts:919`), but `payment_method_collection` is not set to `if_required` anywhere in that route, so Stripe defaults to requiring a card at signup today — the "no credit card required" half of the claim is currently false. Rewrote to state the trial as live and dropped the false credit-card claim rather than re-promise it. |
| `docs/blog/06-open-source-and-pro.md:181` "Pro features will have a free trial (coming soon)" | Same fix — trial is live, rewrote to present tense. |
| `docs/blog/11-revfleet-product-family.md:51` RevMarket `(Planned)` | Linked to existing tracker [#451](https://github.com/RevealUIStudio/revealui/issues/451) (the same umbrella `docs/ROADMAP.md`'s RevFleet Product Maturity table already cites for RevMarket). |

Left untouched (out of scope for this PR, flagged for a future round): `docs/MARKETING_METRICS.md:99` has an `x402 Agent Payments | **Planned**` table row without an inline tracker link, but it wasn't one of the three named surfaces for this round.

## Addendum: pricing table correction (follow-up commit)

The same file's pricing comparison table also had a stale **Price** row (`Waitlist` for Pro/Max, `Contact sales` for Enterprise) left over from before checkout went live. Since this PR already touches `docs/blog/06-open-source-and-pro.md`, fixed it here rather than opening a second PR that would conflict.

Grounded in code, not docs: `packages/contracts/src/pricing.ts`'s `SUBSCRIPTION_TIERS` deliberately leaves `price` unset for free/pro/max/enterprise and defers to marketing. The actual canonical numbers live in `apps/marketing/app/lib/pricing-fallbacks.ts`'s `SUBSCRIPTION_PRICE_FALLBACKS` (pinned to `offerings-canonical.md`, 2026-06-07, and cross-checked against `docs/ROADMAP.md` §Pricing Tracks, which already states the same figures):

```
free:       { price: '$0' }
pro:        { price: '$49',    period: '/month' }
max:        { price: '$299',   period: '/month' }
enterprise: { price: '$1,499', period: '/month' }
```

Table row now reads `Free forever | $49/month | $299/month | $1,499/month, sales-led`. Enterprise keeps the "sales-led" qualifier rather than a bare price: `SUBSCRIPTION_TIERS`' enterprise entry uses `cta: 'Contact Sales'` with a `mailto:` href, not the self-serve `/signup?plan=` checkout link Pro and Max use, so a bare `$1,499/month` would misrepresent it as self-serve checkout.

Re-ran validators after this change:
- `pnpm validate:claims` — 0 mismatches, 0 unlinked future-tense markers (unchanged, clean).
- `pnpm validate:pricing-lockstep` — `OK: seed CATALOG cents match the marketing display fallbacks`.
- `pnpm validate:doc-currency` — 114 baselined, 0 NEW drift (unchanged).
- Pre-push gate (pricing lockstep, client-bundle safety, security audit, coverage, doc-currency, marketing voice, brand bridge, etc.) — PASS.

## Validation

- `pnpm validate:claims` — 0 mismatches, 0 unlinked future-tense markers, all other checks clean.
- `pnpm validate:doc-currency` — 114 baselined occurrences, 0 NEW drift.
- `pnpm validate:pricing-lockstep` — PASS (added for the pricing-table follow-up).
- `node ~/revfleet/.jv/scripts/security-pr-review-check.js --diff origin/test` — "no security-sensitive files — no coordinator gate" (docs-only diff).
- Pre-push gate (full `test`/`main`-branch gate) — PASS on both pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
