### PR TITLE
docs: refresh MARKETING_METRICS pins and stale Stripe-status rows

### DIFF
--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -27,7 +27,7 @@ export const METRICS = {
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
   workspaces: 32,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
-  testFiles: 984,
+  testFiles: 1061,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
   uiComponents: 65,
   /**

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -93,12 +93,12 @@ Server fallback (when Stripe unreachable): `apps/server/src/routes/pricing.ts:50
 
 | Feature | Status | Notes |
 |---|---|---|
-| Stripe live payments | **In flight** | 3 of 5 pre-flip gates remain (Cat C heal + stripe:seed re-run + owner flip directive). Marketing copy may NOT claim "live payments today" / "accept payments immediately" — only "Stripe billing wired; live keys in flight." |
+| Stripe live payments | **Live** | `STRIPE_LIVE_MODE` flipped ON 2026-06-26 (owner directive). Post-flip marketing PHRASING is still pending an owner ruling; until ruled, describe billing capability only. Do not use "accept payments today", and the retired "live keys in flight" line is now false. |
 | Dashboard Agent Chat | **Shipped** | Live at admin.revealui.com. |
 | Documentation Site | **Shipped** | docs.revealui.com. |
-| x402 Agent Payments | **Planned** | `X402_ENABLED=false` default; code-complete but dormant. "Designed; gated on Stripe live." |
+| x402 Agent Payments | **Planned** | `X402_ENABLED=false` default; code-complete but dormant, enabled only by owner directive. Tracked in [revealui#526](https://github.com/RevealUIStudio/revealui/issues/526) section D. |
 | MCP Marketplace (third-party publishing) | **Planned** | First-party catalog (14 servers) shipped; third-party publishing + revenue share not built. NO "80/20 revenue share" claims. |
-| Perpetual Licenses (Track C) | **In flight** | `comingSoon: false` in contracts (asserted by `apps/server/src/routes/__tests__/pricing-accuracy.test.ts`); Stripe products seeded. Renders as available; live charging gated on the Stripe live-mode flip (same gate as subscriptions). |
+| Perpetual Licenses (Track C) | **In flight** | `comingSoon: false` in contracts (asserted by `apps/server/src/routes/__tests__/pricing-accuracy.test.ts`); Stripe products seeded. Renders as available; the Stripe live-mode flip landed 2026-06-26, so charging rides the live catalog. |
 | Self-Hosted Docker Images (RevealUI Fleet) | **Planned** | Designed, not built. |
 | Visual Builder | **Planned** | Backlog. |
 | Enterprise SSO / SAML | **Planned** | Designed, not built. |

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -21,19 +21,19 @@ If a number appears in marketing copy, it MUST match the value below. If a value
 
 ## 1. Codebase metrics (validated by claim-drift CI gate)
 
-Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-06-22 (commit `a5cf84240`).
+Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-16 (commit `6223dfa21`).
 
 | Metric | Canonical value | Source of truth (script ref) | Notes |
 |---|---|---|---|
-| Packages in `packages/` | **27** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
+| Packages in `packages/` | **28** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
 | Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (one app removed per PR #936 + #946 + #947). |
 | Workspaces (monorepo total) | **32** | `countWorkspaces()` (= 28 packages + 4 apps) | |
-| Test files | **984** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
+| Test files | **1061** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
 | UI components in `packages/presentation/` | **65** | `countUIComponents()` | Marketing copy says "65 native React components" or similar. |
 | **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
-| DB tables (Drizzle pgTable) | **86** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86; corrected to the live count. `site.ts` METRICS is now gate-enforced by claim-drift. |
-| Access-control enforcement tests | **59** | `countEnforcementTests()` — `it(`/`test(` in `packages/core/src/__tests__/auth/` + `collections/operations/__tests__/access-enforcement.test.ts` | Quoted by the blog, both security attestations (`INFORMATION_SECURITY_POLICY`, `ASSET_INVENTORY`), `LAUNCH-CHECKLIST`, and marketing primitives. Gate-enforced so all surfaces move together. |
-| License: MIT packages | **21** | `licenseSplit.mit` | |
+| DB tables (Drizzle pgTable) | **92** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86 (2026-06-22); corrected to the live count 92 on 2026-07-16. `site.ts` METRICS is gate-enforced by claim-drift. |
+| Access-control enforcement tests | **60** | `countEnforcementTests()` — `it(`/`test(` in `packages/core/src/__tests__/auth/` + `collections/operations/__tests__/access-enforcement.test.ts` | Quoted by the blog, both security attestations (`INFORMATION_SECURITY_POLICY`, `ASSET_INVENTORY`), `LAUNCH-CHECKLIST`, and marketing primitives. Gate-enforced so all surfaces move together. |
+| License: MIT packages | **22** | `licenseSplit.mit` | |
 | License: FSL-1.1-MIT packages | **5** | `licenseSplit.fsl` | @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services |
 | License: internal/none | **1** | `licenseSplit.internal` | `test` workspace package (private) |
 

--- a/docs/blog/14-claim-drift.md
+++ b/docs/blog/14-claim-drift.md
@@ -45,7 +45,7 @@ claim-drift: docs/blog/09-component-library.md
   -> fix the copy or fix the count, but they must agree
 ```
 
-That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 28 packages, 65 UI components, 14 first-party MCP servers, 92 database tables, 59 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
+That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 28 packages, 65 UI components, 14 first-party MCP servers, 92 database tables, 60 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
 
 ## The validator practices what we preach
 


### PR DESCRIPTION
## What

Refreshes the pinned-truth marketing metrics doc to the claim-drift counter's live output, and corrects three stale-fact status rows.

**Audit reference:** `pnpm tsx scripts/validate/claim-drift.ts` run on this branch (commit 6223dfa21 base), 2026-07-16, during the content-truth copy sweep. Surfaced while reconciling the YouTube video canon (CHANNEL-PLAN §4 drift #2): the canon was being re-pinned to MARKETING_METRICS.md values that were themselves behind the gate-enforced site.ts METRICS.

## Changes

- **docs/MARKETING_METRICS.md §1:** packages 27 → 28, test files 984 → 1061, DB tables 86 → 92, enforcement tests 59 → 60, MIT packages 21 → 22; source line re-dated to the 2026-07-16 validator run.
- **apps/marketing/app/content/site.ts:** `testFiles` pin 984 → 1061 (was passing only via the gate's +/-100 tolerance).
- **docs/blog/14-claim-drift.md:** the one stale integer (59 enforcement tests → 60); every other count in that post was already current.
- **docs/MARKETING_METRICS.md §status table:** Stripe live payments row updated from the pre-flip framing to the 2026-06-26 flip fact (doc-currency rule `stripe-not-live-claim`), keeping a conservative phrasing note pending the owner's post-flip copy ruling; x402 Planned row now links revealui#526 section D per the CR9-P2-02 convention; perpetual-licenses row no longer describes the flip as pending.

## Validation

- `claim-drift.ts`: 0 mismatches, 0 unlinked future-tense markers, 0 site.ts METRICS drift.
- `validate:doc-currency`: 114 baselined, 0 NEW drift.
- Fleet checker `security-pr-review-check.js --diff` on the committed diff: no security-sensitive files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)