### PR TITLE
ci(security): pin enforcement script checkout to the PR base sha

### DIFF
--- a/.github/workflows/sec-audit-label-guard.yml
+++ b/.github/workflows/sec-audit-label-guard.yml
@@ -48,6 +48,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          # Evaluate with the BASE branch's copy of the decision scripts (same
+          # provenance rule as security-review-gate.yml). On issue_comment and
+          # check_suite events there is no pull_request payload, so this
+          # expression is empty and checkout falls back to the default-branch
+          # ref those events already run from.
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: |
             scripts/validate/sec-audit-label-decision.cjs
             scripts/validate/guardrail2-verdict.cjs

--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -33,6 +33,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          # Evaluate with the BASE branch's copy of the gate scripts: the
+          # trusted (base) logic judges the untrusted (head) change, so a PR's
+          # own edits to these files cannot influence its evaluation. Changed
+          # files, labels, comments, and reviews all come from the API, so the
+          # checkout exists only to supply this script code.
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: |
             scripts/validate/security-review-gate.cjs
             scripts/validate/guardrail2-verdict.cjs


### PR DESCRIPTION
## What

Both enforcement workflows (`security-review-gate.yml`, `sec-audit-label-guard.yml`) checked out the default ref, which on pull_request events is the PR merge commit — so the enforcement scripts they execute were the PR's own copies. This pins each checkout to `github.event.pull_request.base.sha`, so the base branch's logic evaluates the change under review, and a PR's own edits to those scripts cannot influence its evaluation.

## Why this is safe

- Changed files, labels, comments, and reviews all come from the API (`gh`), not the checkout — verified empirically during the #1916 review by running the gate script from an empty directory. The checkout exists only to supply the script code, so behavior is otherwise identical.
- On `issue_comment` and `check_suite` events (label guard only) there is no `pull_request` payload; the expression evaluates empty and checkout keeps the default-branch behavior those events already run from.
- A PR that legitimately changes the gate (like #1916 was) is then judged by the pre-change logic, which is the correct direction for a gate: its improvements take effect for subsequent PRs after merge.

## Scope note

This is the script-provenance increment. Trigger-level provenance is a separate follow-up tracked internally as planned scope.

## Merge posture

Touches the enforcement workflows, so this self-classifies as security-sensitive and needs an independent non-author guardrail-2 verdict before merge (I authored it and will not self-clear). The fleet checker was run post-commit and confirms the hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
