### PR TITLE
docs(mcp): align the README 14-server roster with the CI counter

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -19,7 +19,7 @@ Centralized MCP server infrastructure, configuration, and documentation for Reve
 
 This package contains everything MCP-related:
 
-- **14 MCP Servers** — Code Validator, Contracts Introspection, RevealUI Docs, Neon, Next.js DevTools, Playwright, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Stripe, Supabase, Vercel, and an Email Provider helper. Ground-truth count is enforced by `pnpm validate:claims`.
+- **14 MCP Servers** - Code Validator, Contracts Introspection, RevealUI Docs, Neon, Next.js DevTools, Playwright, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Stripe, Supabase, Vercel, and the Adapter base (BaseAdapter with retry and idempotency, plus the Vercel/Stripe/Neon adapter subclasses). This roster matches the CI counter in `scripts/validate/claim-drift.ts` (adapter counted, the underscore-prefixed email-provider utility not); the count is enforced by `pnpm validate:claims`. Of the 14, eight are RevealUI-authored and six are first-party launchers that start vendor MCP server packages.
 - **Configuration Templates** - For Claude Code / Claude Desktop
 - **Utilities** - Config management, database adapters
 - **Documentation** - Complete guides and per-server docs


### PR DESCRIPTION
## What

Owner ruling 2026-07-17 (in-session, YouTube filming gate 4): the claim-drift CI counter's roster of the 14 MCP servers is canonical — `adapter.ts` is the 14th server and the underscore-prefixed `_email-provider.ts` utility is excluded (`scripts/validate/claim-drift.ts:260-266`).

`packages/mcp/README.md` line 22 diverged: its 14-item list swapped in "an Email Provider helper" instead of the adapter. This aligns the README with the counter and adds the owner-ruled honest framing (8 RevealUI-authored servers plus 6 first-party launchers for vendor MCP packages).

One line changed; the em dash in the original line was removed per the copy style rule.

## Note for merge

The fleet security checker flags this branch as security-sensitive purely on the `packages/mcp/` path (README-only diff, no code). Per guardrail 2 it needs the recorded verdict label before merge.

## Validation

- `pnpm validate:claims` counts servers from disk, not the README list, so the 14 pin is unaffected; the roster text now matches the counter's inclusion rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)