### PR TITLE
feat(contracts): GAP-332 marketing-voice runtime + content generation pipeline

### DIFF
--- a/apps/server/src/lib/marketing-content/__tests__/generate.test.ts
+++ b/apps/server/src/lib/marketing-content/__tests__/generate.test.ts
@@ -1,0 +1,169 @@
+import {
+  FLEET_MARKETING_VOICE_RULES,
+  type MarketingBlock,
+  type MarketingVoiceRules,
+  type Tier3Report,
+} from '@revealui/contracts/marketing-voice';
+import { describe, expect, it } from 'vitest';
+import { type ZodType, z } from 'zod/v4';
+import {
+  generateBlock,
+  type LLMClient,
+  type LLMMessage,
+  parseAndValidate,
+  validateMarketingBlock,
+} from '../generate.js';
+
+const blockSchema = z
+  .object({ blockType: z.string() })
+  .catchall(z.unknown()) as unknown as ZodType<MarketingBlock>;
+
+function block(text: string, blockType = 'hero'): MarketingBlock {
+  return {
+    blockType,
+    richText: {
+      root: { type: 'root', children: [{ type: 'paragraph', children: [{ type: 'text', text }] }] },
+    },
+  };
+}
+
+const CLEAN = block('The self-hosted agentic business runtime.');
+const RVC_PRICING = block('Buy RVC at $0.10 per token');
+const HYPE = block('A revolutionary runtime');
+
+/** A client that returns queued response strings in order. */
+function fakeClient(responses: string[]): LLMClient {
+  let i = 0;
+  return {
+    async chat(_messages: LLMMessage[]): Promise<{ content: string }> {
+      const content = responses[Math.min(i, responses.length - 1)] ?? '';
+      i++;
+      return { content };
+    },
+  };
+}
+
+const deps = {
+  blockSchema,
+  voiceRules: FLEET_MARKETING_VOICE_RULES,
+  renderSystemPrompt: () => 'system',
+  renderUserPrompt: () => 'user',
+};
+
+describe('parseAndValidate', () => {
+  it('returns null on malformed JSON', () => {
+    expect(parseAndValidate('{ not json', blockSchema)).toBeNull();
+  });
+
+  it('returns null on well-formed but schema-invalid JSON', () => {
+    expect(parseAndValidate(JSON.stringify({ notBlockType: 1 }), blockSchema)).toBeNull();
+  });
+
+  it('returns typed data on valid JSON', () => {
+    const parsed = parseAndValidate(JSON.stringify(CLEAN), blockSchema);
+    expect(parsed?.blockType).toBe('hero');
+  });
+});
+
+describe('validateMarketingBlock', () => {
+  it('reports tier1 + tier2 with tier3 null when no judge is injected', () => {
+    const report = validateMarketingBlock(CLEAN, FLEET_MARKETING_VOICE_RULES);
+    expect(report.tier1.passed).toBe(true);
+    expect(report.tier2.passed).toBe(true);
+    expect(report.tier3).toBeNull();
+    expect(report.passed).toBe(true);
+  });
+
+  it('fails tier1 on an RVC pricing claim', () => {
+    const report = validateMarketingBlock(RVC_PRICING, FLEET_MARKETING_VOICE_RULES);
+    expect(report.tier1.passed).toBe(false);
+    expect(report.passed).toBe(false);
+  });
+
+  it('runs the injected tier3 judge but keeps it out of `passed`', () => {
+    const judge = (): Tier3Report => ({ scores: {}, findings: [], verdict: 'fail' });
+    const report = validateMarketingBlock(CLEAN, FLEET_MARKETING_VOICE_RULES, { tier3: judge });
+    expect(report.tier3?.verdict).toBe('fail');
+    expect(report.passed).toBe(true); // tier3 advisory only
+  });
+});
+
+describe('generateBlock', () => {
+  it('returns ok on the first valid clean block', async () => {
+    const result = await generateBlock(fakeClient([JSON.stringify(CLEAN)]), deps, 'go', {
+      maxRetries: 3,
+    });
+    expect(result.outcome).toBe('ok');
+    expect(result.attempts).toBe(1);
+    expect(result.validation?.passed).toBe(true);
+  });
+
+  it('retries past a malformed-JSON response, then succeeds', async () => {
+    const result = await generateBlock(
+      fakeClient(['{ broken', JSON.stringify(CLEAN)]),
+      deps,
+      'go',
+      {
+        maxRetries: 3,
+      },
+    );
+    expect(result.outcome).toBe('ok');
+    expect(result.attempts).toBe(2);
+  });
+
+  it('returns tier1-blocked without retrying (structural, not regenerable)', async () => {
+    const result = await generateBlock(fakeClient([JSON.stringify(RVC_PRICING)]), deps, 'go', {
+      maxRetries: 3,
+    });
+    expect(result.outcome).toBe('tier1-blocked');
+    expect(result.attempts).toBe(1);
+    expect(result.validation?.tier1.passed).toBe(false);
+  });
+
+  it('re-prompts on a tier2 violation, then succeeds', async () => {
+    const rules: MarketingVoiceRules = {
+      tier1: FLEET_MARKETING_VOICE_RULES.tier1,
+      tier2: [
+        {
+          kind: 'banned-tokens',
+          ruleId: 't2.hype',
+          tokens: ['revolutionary'],
+          caseInsensitive: true,
+        },
+      ],
+    };
+    const result = await generateBlock(
+      fakeClient([JSON.stringify(HYPE), JSON.stringify(CLEAN)]),
+      { ...deps, voiceRules: rules },
+      'go',
+      { maxRetries: 3 },
+    );
+    expect(result.outcome).toBe('ok');
+    expect(result.attempts).toBe(2);
+  });
+
+  it('returns exhausted (best attempt + violations) when every attempt fails tier2', async () => {
+    const rules: MarketingVoiceRules = {
+      tier1: FLEET_MARKETING_VOICE_RULES.tier1,
+      tier2: [
+        {
+          kind: 'banned-tokens',
+          ruleId: 't2.hype',
+          tokens: ['revolutionary'],
+          caseInsensitive: true,
+        },
+      ],
+    };
+    const result = await generateBlock(
+      fakeClient([JSON.stringify(HYPE)]),
+      { ...deps, voiceRules: rules },
+      'go',
+      {
+        maxRetries: 2,
+      },
+    );
+    expect(result.outcome).toBe('exhausted');
+    expect(result.attempts).toBe(2);
+    expect(result.validation?.tier2.passed).toBe(false);
+  });
+});

--- a/apps/server/src/lib/marketing-content/generate.ts
+++ b/apps/server/src/lib/marketing-content/generate.ts
@@ -1,0 +1,118 @@
+import {
+  type MarketingBlock,
+  type MarketingValidationReport,
+  type MarketingVoiceRules,
+  type Tier3Judge,
+  type Violation,
+  validateMarketingBlock,
+} from '@revealui/contracts/marketing-voice';
+import type { ZodType } from 'zod/v4';
+
+// The marketing-content generation pipeline (spec §7.2). GAP-332 ships the pure
+// helper, the shared validation seam, and the retry-loop STRUCTURE with its
+// dependencies injected so it is unit-testable with a fake client. The LIVE
+// wiring (the real @revealui/ai provider, `getSite`, the block Zod schemas, the
+// `POST /api/marketing/generate` route) is Phase B.
+
+export type {
+  MarketingValidationReport,
+  MarketingVoiceRules,
+} from '@revealui/contracts/marketing-voice';
+/** Re-export the shared validation seam so callers can `import` it from `lib/`. */
+export { validateMarketingBlock } from '@revealui/contracts/marketing-voice';
+
+/**
+ * Parse an LLM JSON response and validate it against the requested block's Zod
+ * schema in one step. Returns `null` on EITHER failure so the retry loop treats
+ * "malformed JSON" and "well-formed but schema-invalid" identically. Never
+ * throws. Verbatim from spec §7.2.
+ */
+export function parseAndValidate<T>(text: string, schema: ZodType<T>): T | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null; // malformed JSON — retry
+  }
+  const result = schema.safeParse(parsed);
+  return result.success ? result.data : null; // schema-invalid — retry
+}
+
+export interface LLMMessage {
+  role: 'system' | 'user';
+  content: string;
+}
+
+export interface LLMClient {
+  chat(
+    messages: LLMMessage[],
+    opts: { maxTokens: number; temperature: number },
+  ): Promise<{ content: string }>;
+}
+
+/** Injected dependencies — the real providers are supplied by the Phase-B route. */
+export interface GenerateBlockDeps {
+  blockSchema: ZodType<MarketingBlock>;
+  voiceRules: MarketingVoiceRules;
+  renderSystemPrompt: (ctx: { voiceRules: MarketingVoiceRules }) => string;
+  renderUserPrompt: (ctx: {
+    prompt: string;
+    lastBlock: MarketingBlock | null;
+    tier2Violations: Violation[];
+  }) => string;
+}
+
+export type GenerateOutcome = 'ok' | 'tier1-blocked' | 'exhausted';
+
+export interface GenerateBlockResult {
+  block: MarketingBlock | null;
+  validation: MarketingValidationReport | null;
+  outcome: GenerateOutcome;
+  attempts: number;
+}
+
+/**
+ * Retry-loop orchestrator (spec §7.2). Tier-1 failures are structural and NOT
+ * regenerable — return the block for the author to fix. Tier-2 failures are
+ * re-prompted with the violations as feedback until `maxRetries`, then the best
+ * attempt is returned with violations attached.
+ */
+export async function generateBlock(
+  client: LLMClient,
+  deps: GenerateBlockDeps,
+  prompt: string,
+  opts: { maxRetries: number; tier3?: Tier3Judge },
+): Promise<GenerateBlockResult> {
+  let attempts = 0;
+  let lastBlock: MarketingBlock | null = null;
+  let tier2Violations: Violation[] = [];
+
+  while (attempts < opts.maxRetries) {
+    attempts++;
+    const messages: LLMMessage[] = [
+      { role: 'system', content: deps.renderSystemPrompt({ voiceRules: deps.voiceRules }) },
+      { role: 'user', content: deps.renderUserPrompt({ prompt, lastBlock, tier2Violations }) },
+    ];
+    const response = await client.chat(messages, { maxTokens: 1500, temperature: 0.4 });
+
+    const block = parseAndValidate(response.content, deps.blockSchema);
+    if (!block) continue; // malformed JSON or schema-invalid — retry
+
+    const report = validateMarketingBlock(block, deps.voiceRules);
+    if (!report.tier1.passed) {
+      return { block, validation: report, outcome: 'tier1-blocked', attempts };
+    }
+    if (!report.tier2.passed) {
+      tier2Violations = report.tier2.violations;
+      lastBlock = block;
+      continue;
+    }
+    const validation = opts.tier3
+      ? validateMarketingBlock(block, deps.voiceRules, { tier3: opts.tier3 })
+      : report;
+    return { block, validation, outcome: 'ok', attempts };
+  }
+
+  const validation = lastBlock ? validateMarketingBlock(lastBlock, deps.voiceRules) : null;
+  return { block: lastBlock, validation, outcome: 'exhausted', attempts };
+}

--- a/packages/contracts/src/marketing-voice/__tests__/ast-walk.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/ast-walk.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findAdrCiteInBlock,
+  getProseContainers,
+  getProseSlots,
+  type MarketingBlock,
+  UnmappedBlockTypeError,
+  walkLexicalAst,
+} from '../blocks.js';
+import {
+  code,
+  contentBlock,
+  heading,
+  heroBlock,
+  link,
+  list,
+  listItem,
+  paragraph,
+  text,
+} from './helpers.js';
+
+describe('walkLexicalAst', () => {
+  it('yields heading + paragraph + text nodes from a seed-shaped hero block', () => {
+    const block = heroBlock(heading('h1', 'RevealUI'), paragraph(text('People and agents.')));
+    const types = [...walkLexicalAst(block)].map((n) => n.type);
+    expect(types).toContain('heading');
+    expect(types).toContain('paragraph');
+    expect(types.filter((t) => t === 'text')).toHaveLength(2);
+  });
+
+  it('prunes code subtrees — a text node inside a code node is never yielded', () => {
+    const block = contentBlock(paragraph(text('intro')), code('RVC at $0.001'));
+    const nodes = [...walkLexicalAst(block)];
+    expect(nodes.some((n) => n.type === 'code')).toBe(false);
+    // The code node's inner text ("RVC at $0.001") must not surface either.
+    expect(nodes.some((n) => n.type === 'text' && n.text === 'RVC at $0.001')).toBe(false);
+    expect(nodes.some((n) => n.type === 'text' && n.text === 'intro')).toBe(true);
+  });
+
+  it('yields link nodes (so findAdrCiteInBlock can consume them)', () => {
+    const block = contentBlock(
+      paragraph(text('see '), link('../docs/decisions/2026-05-12-x.md', 'ADR')),
+    );
+    const links = [...walkLexicalAst(block)].filter((n) => n.type === 'link');
+    expect(links).toHaveLength(1);
+    expect(links[0]?.url).toBe('../docs/decisions/2026-05-12-x.md');
+  });
+
+  it('does not throw on deeply nested trees (depth-bound)', () => {
+    let node = text('deep');
+    for (let i = 0; i < 40; i++) node = { type: 'paragraph', children: [node] };
+    const block = contentBlock(node);
+    expect(() => [...walkLexicalAst(block)]).not.toThrow();
+  });
+});
+
+describe('getProseSlots', () => {
+  it('normalizes a plain-string slot to one synthetic paragraph', () => {
+    const block: MarketingBlock = { blockType: 'hero', richText: 'Just a string headline' };
+    const containers = getProseContainers(block);
+    expect(containers).toHaveLength(1);
+    expect(containers[0]?.nodeType).toBe('paragraph');
+    expect(containers[0]?.text).toBe('Just a string headline');
+  });
+
+  it('throws UnmappedBlockTypeError for an unregistered blockType (fail-closed)', () => {
+    const block: MarketingBlock = { blockType: 'mystery', richText: 'x' };
+    expect(() => getProseSlots(block)).toThrow(UnmappedBlockTypeError);
+  });
+});
+
+describe('getProseContainers', () => {
+  it('does not double-count a paragraph nested inside a quote', () => {
+    const block = contentBlock({ type: 'quote', children: [paragraph(text('quoted line'))] });
+    const containers = getProseContainers(block);
+    expect(containers).toHaveLength(1);
+    expect(containers[0]?.nodeType).toBe('quote');
+    expect(containers[0]?.text).toBe('quoted line');
+  });
+
+  it('expands a list into one container per listitem', () => {
+    const block = contentBlock(list(listItem('first'), listItem('second')));
+    const containers = getProseContainers(block);
+    expect(containers.map((c) => c.text)).toEqual(['first', 'second']);
+    expect(containers.every((c) => c.nodeType === 'listitem')).toBe(true);
+  });
+
+  it('carries the heading tag through', () => {
+    const block = heroBlock(heading('h2', 'Section'));
+    const containers = getProseContainers(block);
+    expect(containers[0]?.tag).toBe('h2');
+  });
+});
+
+describe('findAdrCiteInBlock', () => {
+  it('finds an ADR-cite link via node.url', () => {
+    const block = contentBlock(
+      paragraph(text('x '), link('../docs/decisions/2026-05-12-rvc.md', 'per ADR')),
+    );
+    expect(findAdrCiteInBlock(block)).not.toBeNull();
+  });
+
+  it('finds an ADR-cite link via fields.url', () => {
+    const block = contentBlock(
+      paragraph(text('x '), {
+        type: 'link',
+        fields: { url: '../docs/decisions/2026-05-12-rvc.md' },
+        children: [text('per ADR')],
+      }),
+    );
+    expect(findAdrCiteInBlock(block)).not.toBeNull();
+  });
+
+  it('returns null for a non-ADR link', () => {
+    const block = contentBlock(paragraph(text('x '), link('../some-other-doc.md', 'foo')));
+    expect(findAdrCiteInBlock(block)).toBeNull();
+  });
+
+  it('returns null for an invalid-date ADR filename (Date.parse rejects month 13)', () => {
+    const block = contentBlock(paragraph(link('../docs/decisions/2026-13-99-bogus.md', 'foo')));
+    expect(findAdrCiteInBlock(block)).toBeNull();
+  });
+});

--- a/packages/contracts/src/marketing-voice/__tests__/check-rule.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/check-rule.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { checkRule, runTier1, walkLexicalAst } from '../check-rule.js';
+import type { CheckContext } from '../check-rule.js';
+import { checkRule } from '../check-rule.js';
 import type { Rule } from '../rules.js';
 import { tokenize } from '../tokenize.js';
 
@@ -258,29 +259,142 @@ describe('checkRule — banned-token-near', () => {
   });
 });
 
-describe('checkRule — deferred variants throw', () => {
-  const deferredKinds: Rule['kind'][] = [
-    'h2-shape',
-    'fake-trust',
-    'pricing-proximity',
-    'rvc-pricing-proximity',
-    'unicode-range-tokens',
-  ];
+describe('checkRule — rvc-pricing-proximity + the $-split fix', () => {
+  const rule: Extract<Rule, { kind: 'rvc-pricing-proximity' }> = {
+    kind: 'rvc-pricing-proximity',
+    ruleId: 'tier1.rvc-pricing-without-adr',
+    anchorTokenLowercase: 'rvc',
+    proximityPredicates: ['isDollarShape', 'isPercentShape', 'isUsdShape'],
+    withinTokens: 30,
+    unless: 'adr-cite-in-block',
+  };
 
-  it.each(deferredKinds)('"%s" throws with Phase B message', (kind) => {
-    const rule = { kind, ruleId: 'test' } as unknown as Rule;
-    expect(() => checkRule(rule, [], {})).toThrow('deferred to CMS-spec Phase B');
+  it('the tokenizer splits "$0.10" into a separate "$" symbol token (the boundary this fix handles)', () => {
+    const tokens = tokenize('RVC at $0.10');
+    const dollar = tokens.find((t) => t.text === '$');
+    expect(dollar?.kind).toBe('symbol');
+    // The number arrives as its own word token, so a naive word-only window
+    // would drop the "$" and miss the price.
+    expect(tokens.some((t) => t.kind === 'word' && t.text === '0.10')).toBe(true);
+  });
+
+  it('STILL fires on the $-split form (RVC near "$" + "0.10")', () => {
+    expect(checkRule(rule, tokenize('RVC at $0.10'), {})).toHaveLength(1);
+  });
+
+  it('fires on the two-token percent form (RVC near "5" + "%")', () => {
+    expect(checkRule(rule, tokenize('RVC vesting unlocks 5% per quarter'), {})).toHaveLength(1);
+  });
+
+  it('is bidirectional — a price preceding the anchor fires', () => {
+    expect(checkRule(rule, tokenize('$0.10 for RVC'), {})).toHaveLength(1);
+  });
+
+  it('is exonerated when ctx.adrCitePresent is true', () => {
+    expect(checkRule(rule, tokenize('RVC at $0.10'), { adrCitePresent: true })).toHaveLength(0);
+  });
+
+  it('respects the window boundary — fires at the edge, not past it', () => {
+    const tight = { ...rule, withinTokens: 3 };
+    expect(checkRule(tight, tokenize('RVC a b $5'), {})).toHaveLength(1); // distance 3
+    expect(checkRule(tight, tokenize('RVC a b c $5'), {})).toHaveLength(0); // distance 4
   });
 });
 
-describe('runTier1 — deferred stub', () => {
-  it('throws with Phase B message', () => {
-    expect(() => runTier1({}, [])).toThrow('deferred to CMS-spec Phase B');
+describe('checkRule — pricing-proximity', () => {
+  const rule: Extract<Rule, { kind: 'pricing-proximity' }> = {
+    kind: 'pricing-proximity',
+    ruleId: 'tier1.pricing-proximity',
+    anchorPredicate: 'isDollarShape',
+    proximityPredicate: 'isEngagementUnit',
+    withinTokens: 6,
+    unless: ['adr-cite-in-block', 'pricing-tier-source'],
+  };
+
+  it('flags a $ figure next to an engagement unit', () => {
+    expect(checkRule(rule, tokenize('$5,000 per engagement'), {})).toHaveLength(1);
+  });
+
+  it('is exonerated on a pricing-tier source block', () => {
+    const ctx: CheckContext = { pricingTierSource: true };
+    expect(checkRule(rule, tokenize('$5,000 per engagement'), ctx)).toHaveLength(0);
+  });
+
+  it('does not flag a $ figure with no engagement unit nearby', () => {
+    expect(checkRule(rule, tokenize('a donation of $5,000 helps'), {})).toHaveLength(0);
   });
 });
 
-describe('walkLexicalAst — deferred stub', () => {
-  it('throws with Phase B message', () => {
-    expect(() => walkLexicalAst({})).toThrow('deferred to CMS-spec Phase B');
+describe('checkRule — fake-trust', () => {
+  const rule: Extract<Rule, { kind: 'fake-trust' }> = {
+    kind: 'fake-trust',
+    ruleId: 'tier1.fake-trust',
+    anchor: { tokenSequence: ['trusted', 'by'], caseInsensitive: true },
+    requiresProximity: 'positive-integer-token',
+    withinTokens: 4,
+    unless: 'adr-cite-in-block',
+  };
+
+  it('flags "Trusted by 400 teams"', () => {
+    expect(checkRule(rule, tokenize('Trusted by 400 teams'), {})).toHaveLength(1);
+  });
+
+  it('does not flag "Trusted by developers" (no integer)', () => {
+    expect(checkRule(rule, tokenize('Trusted by developers everywhere'), {})).toHaveLength(0);
+  });
+
+  it('is exonerated when ctx.adrCitePresent is true', () => {
+    expect(
+      checkRule(rule, tokenize('Trusted by 400 teams'), { adrCitePresent: true }),
+    ).toHaveLength(0);
+  });
+});
+
+describe('checkRule — h2-shape', () => {
+  const rule: Extract<Rule, { kind: 'h2-shape' }> = {
+    kind: 'h2-shape',
+    ruleId: 'tier1.rhetorical-question-heading',
+    predicates: [{ kind: 'startsWithToken', token: 'why' }],
+    requiresSuffixToken: '?',
+  };
+
+  it('flags an interrogative heading ending in ? (node-scoped to headings)', () => {
+    expect(checkRule(rule, tokenize('Why RevealUI?'), { nodeType: 'heading' })).toHaveLength(1);
+  });
+
+  it('does not flag the same text in a paragraph', () => {
+    expect(checkRule(rule, tokenize('Why RevealUI?'), { nodeType: 'paragraph' })).toHaveLength(0);
+  });
+
+  it('does not flag an interrogative opener without the ? suffix', () => {
+    expect(checkRule(rule, tokenize('Why RevealUI works'), { nodeType: 'heading' })).toHaveLength(
+      0,
+    );
+  });
+});
+
+describe('checkRule — unicode-range-tokens', () => {
+  const emDash: Extract<Rule, { kind: 'unicode-range-tokens' }> = {
+    kind: 'unicode-range-tokens',
+    ruleId: 'tier1.em-dash',
+    codepointRanges: [{ startInclusive: 0x2014, endInclusive: 0x2014 }],
+  };
+
+  it('flags an em dash', () => {
+    const text = `agents ${String.fromCodePoint(0x2014)} pre-wired`;
+    expect(checkRule(emDash, tokenize(text), {})).toHaveLength(1);
+  });
+
+  it('does not flag prose without the target codepoint', () => {
+    expect(checkRule(emDash, tokenize('agents, pre-wired'), {})).toHaveLength(0);
+  });
+
+  it('flags an emoji via its codepoint range', () => {
+    const emoji: Extract<Rule, { kind: 'unicode-range-tokens' }> = {
+      kind: 'unicode-range-tokens',
+      ruleId: 'tier2.emoji',
+      codepointRanges: [{ startInclusive: 0x1f300, endInclusive: 0x1faff }],
+    };
+    expect(checkRule(emoji, tokenize('ship it 🚀 today'), {}).length).toBeGreaterThan(0);
   });
 });

--- a/packages/contracts/src/marketing-voice/__tests__/helpers.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/helpers.ts
@@ -1,0 +1,52 @@
+import type { LexicalNodeLike, MarketingBlock } from '../blocks.js';
+
+// Dependency-free Lexical builders. The engine targets the REAL shipped block
+// shape (blockType + richText editor state), so tests construct that shape
+// directly rather than parsing markdown.
+
+export function text(value: string): LexicalNodeLike {
+  return { type: 'text', text: value };
+}
+
+export function paragraph(...children: LexicalNodeLike[]): LexicalNodeLike {
+  return { type: 'paragraph', children };
+}
+
+/** A paragraph holding a single text run — the common case. */
+export function prose(value: string): LexicalNodeLike {
+  return paragraph(text(value));
+}
+
+export function heading(tag: string, value: string): LexicalNodeLike {
+  return { type: 'heading', tag, children: [text(value)] };
+}
+
+export function code(value: string): LexicalNodeLike {
+  return { type: 'code', children: [text(value)] };
+}
+
+export function link(url: string, value: string): LexicalNodeLike {
+  return { type: 'link', url, children: [text(value)] };
+}
+
+export function listItem(value: string): LexicalNodeLike {
+  return { type: 'listitem', children: [text(value)] };
+}
+
+export function list(...items: LexicalNodeLike[]): LexicalNodeLike {
+  return { type: 'list', listType: 'bullet', children: items };
+}
+
+export function root(...children: LexicalNodeLike[]): {
+  root: { type: 'root'; children: LexicalNodeLike[] };
+} {
+  return { root: { type: 'root', children } };
+}
+
+export function heroBlock(...children: LexicalNodeLike[]): MarketingBlock {
+  return { blockType: 'hero', richText: root(...children) };
+}
+
+export function contentBlock(...children: LexicalNodeLike[]): MarketingBlock {
+  return { blockType: 'content', richText: root(...children) };
+}

--- a/packages/contracts/src/marketing-voice/__tests__/proximity-calibration.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/proximity-calibration.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import type { MarketingBlock } from '../blocks.js';
+import { runTier1 } from '../check-rule.js';
+import { type Rule, RVC_PRICING_WITHIN_TOKENS } from '../rules.js';
+import { code, contentBlock, link, paragraph, prose, text } from './helpers.js';
+
+// Calibration corpus for RVC_PRICING_WITHIN_TOKENS (spec §9 B3b / design §4.3).
+// The window unit is WORD-KIND token distance. Two boundary samples make the
+// sweep decisive: a "stress" BAD with RVC ~24 word tokens from a price (so a
+// 20 window misses it), and a "far" GOOD with RVC ~45 word tokens from an
+// unrelated price (so a 50+ window false-positives on it). Everything between
+// is caught by the smallest window that clears both.
+
+const filler = (n: number): string => Array(n).fill('word').join(' ');
+
+/** RVC ~24 word tokens before a price — a genuine claim a tight window misses. */
+const stressBad = contentBlock(prose(`RVC ${filler(23)} $5`));
+/** RVC ~45 word tokens from an unrelated price — not a claim; a wide window over-flags. */
+const goodFar = contentBlock(prose(`RVC ${filler(44)} $5`));
+
+const BAD_BLOCKS: MarketingBlock[] = [
+  contentBlock(prose('Buy RVC at $0.10 per token')),
+  contentBlock(prose('RVC vesting unlocks 5% per quarter')),
+  contentBlock(prose('Stake rvc and earn 5% APY')),
+  contentBlock(prose('RVC is priced at 100 usd today')),
+  contentBlock(prose('Get RVC for $1,000 in the presale')),
+  contentBlock(prose('The RVC token now trades at $0.42')),
+  contentBlock(prose('Earn 12% staking rewards on your RVC')),
+  contentBlock(prose('RVC airdrop worth $500 for early holders')),
+  contentBlock(prose('Each RVC costs $2.50 at launch')),
+  contentBlock(prose('RVC yields 8% annually')),
+  contentBlock(prose('rvc is available for 250 usd')),
+  contentBlock(prose('Hold RVC and unlock 3% monthly bonuses')),
+  contentBlock(prose('RVC presale price is $0.05')),
+  contentBlock(prose('Trade RVC at $3.14 per coin')),
+  contentBlock(prose('RVC rewards you 15% back')),
+  contentBlock(prose('Buy 1000 RVC for $99')),
+  contentBlock(prose('RVC staking returns 6% APY')),
+  contentBlock(prose('The price of RVC hit $12,000 this year')),
+  contentBlock(prose('Claim RVC worth 400 usd')),
+  contentBlock(prose('RVC now at $0.001 per token')),
+  contentBlock(prose('RVC bonus of $50 for referrals')),
+  contentBlock(prose('rvc trades near $7 today')),
+  contentBlock(prose('RVC APY is 9% this month')),
+  contentBlock(prose('Purchase RVC at $250 each')),
+  contentBlock(prose('RVC pays 5% quarterly')),
+  contentBlock(prose('Lock RVC for $1,500 rewards')),
+  contentBlock(prose('RVC valued at 30 usd')),
+  contentBlock(prose('Stake RVC for 11% returns')),
+  contentBlock(prose('RVC costs only $0.99')),
+  contentBlock(prose('RVC drop worth $2,000 announced')),
+  stressBad,
+];
+
+const GOOD_BLOCKS: MarketingBlock[] = [
+  contentBlock(prose('RVC is our community governance token')),
+  contentBlock(prose('The RVC roadmap ships next quarter')),
+  contentBlock(prose('Join the RVC community on Discord')),
+  contentBlock(prose('RVC holders vote on proposals')),
+  contentBlock(prose('Learn how RVC governance works')),
+  contentBlock(prose('The RVC whitepaper explains the design')),
+  contentBlock(prose('RVC powers on-chain coordination')),
+  contentBlock(prose('Our pricing starts at $99 monthly')),
+  contentBlock(prose('Enterprise plans are $5,000 per year')),
+  contentBlock(prose('Save 20% with annual billing')),
+  contentBlock(prose('The Pro tier costs $49 a month')),
+  contentBlock(prose('Get 30% off during launch week')),
+  contentBlock(prose('Plans range from $0 to $499')),
+  contentBlock(prose('Teams pay 100 usd per seat')),
+  contentBlock(prose('The runtime is free and open source')),
+  contentBlock(prose('RVC is a cancelled project token')),
+  contentBlock(prose('RVC was retired in 2026')),
+  contentBlock(prose('Read about the RVC governance model')),
+  contentBlock(prose('RVC community calls happen weekly')),
+  contentBlock(prose('The RVC token has no listed figure today')),
+  contentBlock(prose('Our agents run on your infrastructure')),
+  contentBlock(prose('Every agent leaves a receipt you can check')),
+  contentBlock(prose('Deploy RevealUI in minutes')),
+  contentBlock(prose('The marketplace charges a 20% commission')),
+  contentBlock(prose('RVC documentation lives in the wiki')),
+  contentBlock(prose('RVC contributors meet monthly')),
+  contentBlock(prose('The RVC brand guidelines are internal')),
+  contentBlock(prose('RVC is discussed in the forum')),
+  contentBlock(prose('Annual plans cost $1,200 upfront')),
+  contentBlock(prose('RVC governance is fully on-chain')),
+  // Exoneration cases — window-independent:
+  contentBlock(
+    paragraph(
+      text('RVC at $0.10 '),
+      link('../docs/decisions/2026-05-12-rvc-pricing.md', 'per ADR'),
+    ),
+  ),
+  contentBlock(code('RVC priced at $0.001')),
+  goodFar,
+];
+
+const SWEEP = [20, 30, 40, 50, 60, 80];
+
+function rvcRule(withinTokens: number): Rule {
+  return {
+    kind: 'rvc-pricing-proximity',
+    ruleId: 'tier1.rvc-pricing-without-adr',
+    anchorTokenLowercase: 'rvc',
+    proximityPredicates: ['isDollarShape', 'isPercentShape', 'isUsdShape'],
+    withinTokens,
+    unless: 'adr-cite-in-block',
+  };
+}
+
+function fires(block: MarketingBlock, withinTokens: number): boolean {
+  return runTier1(block, [rvcRule(withinTokens)]).violations.length > 0;
+}
+
+function falseNegatives(withinTokens: number): number {
+  return BAD_BLOCKS.filter((b) => !fires(b, withinTokens)).length;
+}
+
+function falsePositives(withinTokens: number): number {
+  return GOOD_BLOCKS.filter((b) => fires(b, withinTokens)).length;
+}
+
+describe('RVC_PRICING_WITHIN_TOKENS calibration', () => {
+  it('has a corpus of at least 30 known-bad and 30 known-good samples', () => {
+    expect(BAD_BLOCKS.length).toBeGreaterThanOrEqual(30);
+    expect(GOOD_BLOCKS.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('the pinned window catches every known-bad and flags no known-good', () => {
+    expect(falseNegatives(RVC_PRICING_WITHIN_TOKENS)).toBe(0);
+    expect(falsePositives(RVC_PRICING_WITHIN_TOKENS)).toBe(0);
+  });
+
+  it('the pinned window is the SMALLEST value in the sweep with zero FN and zero FP', () => {
+    const valid = SWEEP.filter((w) => falseNegatives(w) === 0 && falsePositives(w) === 0);
+    expect(valid.length).toBeGreaterThan(0);
+    expect(Math.min(...valid)).toBe(RVC_PRICING_WITHIN_TOKENS);
+  });
+});

--- a/packages/contracts/src/marketing-voice/__tests__/tier1.test.ts
+++ b/packages/contracts/src/marketing-voice/__tests__/tier1.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { runTier1 } from '../check-rule.js';
+import type { ValidationResult } from '../rules.js';
+import { FLEET_VOICE_RULES } from '../voice-rules.js';
+import { code, contentBlock, heading, heroBlock, link, paragraph, prose, text } from './helpers.js';
+
+function hasRule(result: ValidationResult, ruleId: string): boolean {
+  return result.violations.some((v) => v.rule === ruleId);
+}
+
+const RVC = 'tier1.rvc-pricing-without-adr';
+
+// Spec §5.5 fixture cases (a)–(g), rewritten to the REAL block shape
+// (blockType + richText root), semantics preserved.
+describe('runTier1 — RVC pricing claims must cite an ADR', () => {
+  it('(a) blocks RVC near a $-amount in plain prose, attributing to the slot', () => {
+    const block = heroBlock(heading('h1', 'Buy RVC at $0.10 per token'));
+    const result = runTier1(block, FLEET_VOICE_RULES);
+    const violation = result.violations.find((v) => v.rule === RVC);
+    expect(violation).toBeDefined();
+    expect(violation?.field).toBe('richText'); // real slot, not the spec's aspirational 'h1'
+    expect(result.passed).toBe(false);
+  });
+
+  it('(b) blocks RVC near a percentage in plain prose', () => {
+    const block = contentBlock(
+      heading('h2', 'Vesting'),
+      prose('RVC vesting unlocks 5% per quarter.'),
+    );
+    expect(hasRule(runTier1(block, FLEET_VOICE_RULES), RVC)).toBe(true);
+  });
+
+  it('(c) allows RVC near a $-amount inside a code node (structural exclusion)', () => {
+    const block = contentBlock(heading('h2', 'API'), code('const price = "RVC at $0.001/token"'));
+    expect(hasRule(runTier1(block, FLEET_VOICE_RULES), RVC)).toBe(false);
+  });
+
+  it('(d) blocks lowercase rvc near a percentage (token-lowercase comparison)', () => {
+    const block = heroBlock(heading('h1', 'Stake'), prose('Earn 5% APY by staking rvc tokens'));
+    expect(hasRule(runTier1(block, FLEET_VOICE_RULES), RVC)).toBe(true);
+  });
+
+  it('(e) allows RVC near a $-amount with a valid ADR-cite link in the same block', () => {
+    const block = contentBlock(
+      heading('h2', 'RVC pricing'),
+      paragraph(
+        text('RVC at $0.10 '),
+        link('../docs/decisions/2026-05-12-rvc-pricing.md', 'per ADR'),
+      ),
+    );
+    expect(hasRule(runTier1(block, FLEET_VOICE_RULES), RVC)).toBe(false);
+  });
+
+  it('(f) blocks RVC near a $-amount with a non-ADR link in the same block', () => {
+    const block = contentBlock(
+      heading('h2', 'RVC pricing'),
+      paragraph(text('RVC at $0.10 '), link('../some-other-doc.md', 'foo')),
+    );
+    expect(hasRule(runTier1(block, FLEET_VOICE_RULES), RVC)).toBe(true);
+  });
+
+  it('(g) blocks when the ADR cite has invalid date semantics (month 13)', () => {
+    const block = contentBlock(
+      heading('h2', 'RVC pricing'),
+      paragraph(text('RVC at $0.10 '), link('../docs/decisions/2026-13-99-bogus.md', 'foo')),
+    );
+    expect(hasRule(runTier1(block, FLEET_VOICE_RULES), RVC)).toBe(true);
+  });
+});
+
+describe('runTier1 — h2-shape (rhetorical-question heading)', () => {
+  const RULE = 'tier1.rhetorical-question-heading';
+
+  it('blocks an interrogative heading ending in ?', () => {
+    expect(
+      hasRule(runTier1(heroBlock(heading('h2', 'Why RevealUI?')), FLEET_VOICE_RULES), RULE),
+    ).toBe(true);
+  });
+
+  it('allows a declarative heading', () => {
+    expect(
+      hasRule(runTier1(heroBlock(heading('h2', 'How it works')), FLEET_VOICE_RULES), RULE),
+    ).toBe(false);
+  });
+
+  it('does not fire on a body paragraph that starts with an interrogative', () => {
+    expect(
+      hasRule(runTier1(contentBlock(prose('Why does this matter?')), FLEET_VOICE_RULES), RULE),
+    ).toBe(false);
+  });
+});
+
+describe('runTier1 — fake-trust', () => {
+  const RULE = 'tier1.fake-trust';
+
+  it('blocks "Trusted by 400 teams" without an ADR', () => {
+    expect(
+      hasRule(runTier1(contentBlock(prose('Trusted by 400 teams')), FLEET_VOICE_RULES), RULE),
+    ).toBe(true);
+  });
+
+  it('allows it with an ADR cite in the same block', () => {
+    const block = contentBlock(
+      paragraph(
+        text('Trusted by 400 teams '),
+        link('../docs/decisions/2026-05-12-trust.md', 'source'),
+      ),
+    );
+    expect(hasRule(runTier1(block, FLEET_VOICE_RULES), RULE)).toBe(false);
+  });
+});
+
+describe('runTier1 — pricing-proximity', () => {
+  it('blocks "$5,000 per engagement" outside a pricing-tier source', () => {
+    const result = runTier1(contentBlock(prose('$5,000 per engagement')), FLEET_VOICE_RULES);
+    expect(hasRule(result, 'tier1.pricing-proximity')).toBe(true);
+  });
+});
+
+describe('runTier1 — composition', () => {
+  it('returns both violations across two prose containers', () => {
+    const block = heroBlock(heading('h1', 'Buy RVC at $0.10'), prose('Trusted by 400 teams'));
+    const result = runTier1(block, FLEET_VOICE_RULES);
+    expect(hasRule(result, RVC)).toBe(true);
+    expect(hasRule(result, 'tier1.fake-trust')).toBe(true);
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes a clean block with no violations', () => {
+    const block = heroBlock(
+      heading('h1', 'RevealUI'),
+      prose('The self-hosted agentic business runtime.'),
+    );
+    const result = runTier1(block, FLEET_VOICE_RULES);
+    expect(result.passed).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+});

--- a/packages/contracts/src/marketing-voice/blocks.ts
+++ b/packages/contracts/src/marketing-voice/blocks.ts
@@ -1,0 +1,244 @@
+import { isAdrCitePath } from './predicates.js';
+
+/**
+ * Minimal structural view of a marketing block for the voice engine. This is
+ * NOT the Phase-B admin Zod schema — the engine deliberately depends only on
+ * the shape it actually reads (`blockType` + prose fields holding Lexical
+ * editor state) so it does not block on the block-schema work.
+ *
+ * The real, shipped block shape stores prose as a Lexical `richText` editor
+ * state inside a `blockType`-discriminated block (see the fleet-marketing seed:
+ * a `blockType: 'hero'` block whose `richText.root.children` is a heading + a
+ * paragraph). The spec's named-slot model (`Hero.h1`, `Hero.subhead`) was never
+ * built; per code-over-docs the engine targets the real shape.
+ */
+export interface MarketingBlock {
+  blockType: string;
+  [field: string]: unknown;
+}
+
+/** A Lexical node as the walker reads it — only the fields the engine touches. */
+export interface LexicalNodeLike {
+  type: string;
+  tag?: string;
+  text?: string;
+  url?: string;
+  fields?: { url?: string; newTab?: boolean; linkType?: string };
+  listType?: string;
+  children?: LexicalNodeLike[];
+}
+
+/** The `SerializedEditorState` container shape: `{ root: { children: [...] } }`. */
+export interface LexicalRootLike {
+  root: { type?: string; children?: LexicalNodeLike[] };
+}
+
+/** One voice-validated prose field of a block, with its owning field path. */
+export interface ProseSlot {
+  field: string;
+  value: LexicalRootLike | string;
+}
+
+/**
+ * Thrown when a block's `blockType` has no `MARKETING_PROSE_SLOTS` entry. A
+ * block the engine cannot introspect is a block it cannot clear, so this fails
+ * closed (loud error) rather than silently skipping validation.
+ */
+export class UnmappedBlockTypeError extends Error {
+  readonly blockType: string;
+  constructor(blockType: string) {
+    super(
+      `Unmapped marketing blockType '${blockType}': no MARKETING_PROSE_SLOTS entry. ` +
+        'A block the voice engine cannot introspect cannot be cleared — register its ' +
+        'prose slots in MARKETING_PROSE_SLOTS.',
+    );
+    this.name = 'UnmappedBlockTypeError';
+    this.blockType = blockType;
+  }
+}
+
+/**
+ * Source of truth mapping a REAL `blockType` to the field paths that hold voice-
+ * validated prose. Keyed on the shipped block-type values, pointing at the real
+ * `richText` Lexical fields — NOT the spec's aspirational `Hero.h1` named slots.
+ *
+ * Phase B block types register here. Field paths may use a single array-glob
+ * segment (e.g. `items[].q`) resolved by `resolveFieldPath`.
+ */
+export const MARKETING_PROSE_SLOTS: Record<string, string[]> = {
+  hero: ['richText'],
+  content: ['richText'],
+  cta: ['richText'],
+};
+
+const PROSE_CONTAINER_TYPES = new Set(['paragraph', 'heading', 'listitem', 'quote']);
+const CODE_NODE_TYPES = new Set(['code', 'codehighlight']);
+/** Depth cap, mirroring the existing content validator posture (maxDepth 20). */
+const MAX_DEPTH = 20;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function asLexicalRoot(value: LexicalRootLike | string): LexicalNodeLike {
+  if (typeof value === 'string') {
+    // A plain-text slot normalizes to one synthetic paragraph so it flows
+    // through the same walker as Lexical slots.
+    return {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'text', text: value }] }],
+    };
+  }
+  const root = value.root;
+  return { type: 'root', children: root?.children ?? [] };
+}
+
+/**
+ * Resolve a field path against a block. Supports plain fields (`richText`) and a
+ * single array-glob segment (`items[].q` → the `q` of every element of `items`).
+ * Returns every matching value (empty array when the path does not resolve).
+ */
+function resolveFieldPath(block: MarketingBlock, path: string): unknown[] {
+  const segments = path.split('.');
+  let current: unknown[] = [block];
+  for (const segment of segments) {
+    const next: unknown[] = [];
+    const isGlob = segment.endsWith('[]');
+    const key = isGlob ? segment.slice(0, -2) : segment;
+    for (const node of current) {
+      if (!isRecord(node)) continue;
+      const value = node[key];
+      if (isGlob) {
+        if (Array.isArray(value)) next.push(...value);
+      } else if (value !== undefined) {
+        next.push(value);
+      }
+    }
+    current = next;
+  }
+  return current;
+}
+
+function isProseSlotValue(value: unknown): value is LexicalRootLike | string {
+  return typeof value === 'string' || (isRecord(value) && isRecord(value.root));
+}
+
+/**
+ * Enumerate a block's voice-validated prose slots, with field attribution
+ * preserved. Throws `UnmappedBlockTypeError` for an unregistered `blockType`
+ * (fail-closed). A registered field that is present but not a prose value
+ * (string or `{root}`) is skipped — it carries no prose to validate.
+ */
+export function getProseSlots(block: MarketingBlock): ProseSlot[] {
+  const fieldPaths = MARKETING_PROSE_SLOTS[block.blockType];
+  if (fieldPaths === undefined) throw new UnmappedBlockTypeError(block.blockType);
+  const slots: ProseSlot[] = [];
+  for (const path of fieldPaths) {
+    for (const value of resolveFieldPath(block, path)) {
+      if (isProseSlotValue(value)) slots.push({ field: path, value });
+    }
+  }
+  return slots;
+}
+
+function* walkNodes(nodes: LexicalNodeLike[], depth: number): Generator<LexicalNodeLike> {
+  if (depth > MAX_DEPTH) return;
+  for (const node of nodes) {
+    if (!isRecord(node) || typeof node.type !== 'string') continue;
+    if (CODE_NODE_TYPES.has(node.type)) continue; // prune code subtrees structurally
+    yield node;
+    if (Array.isArray(node.children)) yield* walkNodes(node.children, depth + 1);
+  }
+}
+
+/**
+ * Yield every descendant node across a block's prose slots, EXCEPT nodes inside
+ * a code subtree (pruned structurally — no fenced-code preprocessing). Callers
+ * filter by `node.type`: prose-text extraction filters to containers, ADR-cite
+ * detection filters to `link`.
+ */
+export function* walkLexicalAst(block: MarketingBlock): Generator<LexicalNodeLike> {
+  for (const slot of getProseSlots(block)) {
+    const root = asLexicalRoot(slot.value);
+    yield* walkNodes(root.children ?? [], 0);
+  }
+}
+
+/**
+ * Yield the top-most prose containers of a slot root (headings, paragraphs,
+ * quotes, and each list's `listitem`s), descending through non-container
+ * wrappers (`root`, `list`) but never into a container once found — so a
+ * paragraph nested in a quote is covered by the quote, not counted twice. Code
+ * subtrees are pruned.
+ */
+function* proseContainers(root: LexicalNodeLike, depth: number): Generator<LexicalNodeLike> {
+  if (depth > MAX_DEPTH) return;
+  for (const node of root.children ?? []) {
+    if (!isRecord(node) || typeof node.type !== 'string') continue;
+    if (CODE_NODE_TYPES.has(node.type)) continue;
+    if (PROSE_CONTAINER_TYPES.has(node.type)) {
+      yield node;
+    } else if (Array.isArray(node.children)) {
+      yield* proseContainers(node, depth + 1);
+    }
+  }
+}
+
+/**
+ * Concatenate the text of a container's descendant `text` nodes (including text
+ * inside `link` nodes), left-to-right, stopping at code descendants. This is the
+ * text stream the token rules run over — a whole prose container, so a
+ * bold-split `**RVC**` and a later `$0.10` in the same paragraph are one stream.
+ */
+function nodeText(node: LexicalNodeLike, depth: number): string {
+  if (depth > MAX_DEPTH) return '';
+  if (CODE_NODE_TYPES.has(node.type)) return '';
+  let out = typeof node.text === 'string' ? node.text : '';
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      if (isRecord(child) && typeof child.type === 'string') out += nodeText(child, depth + 1);
+    }
+  }
+  return out;
+}
+
+/** A prose container paired with its text and node type, for rule evaluation. */
+export interface ProseContainer {
+  field: string;
+  nodeType: string;
+  tag?: string;
+  text: string;
+}
+
+/**
+ * Enumerate every prose container of a block, with field attribution and the
+ * container's flattened text. This is what `runTier1`/`runTier2` iterate.
+ */
+export function getProseContainers(block: MarketingBlock): ProseContainer[] {
+  const out: ProseContainer[] = [];
+  for (const slot of getProseSlots(block)) {
+    const root = asLexicalRoot(slot.value);
+    for (const container of proseContainers(root, 0)) {
+      out.push({
+        field: slot.field,
+        nodeType: container.type,
+        ...(typeof container.tag === 'string' ? { tag: container.tag } : {}),
+        text: nodeText(container, 0),
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Find any ADR-cite link anywhere in the block (block-level exoneration). Any
+ * ADR link in the block exonerates the whole block for the pricing rules.
+ */
+export function findAdrCiteInBlock(block: MarketingBlock): LexicalNodeLike | null {
+  for (const node of walkLexicalAst(block)) {
+    if (node.type !== 'link') continue;
+    const url = typeof node.url === 'string' ? node.url : node.fields?.url;
+    if (typeof url === 'string' && isAdrCitePath(url)) return node;
+  }
+  return null;
+}

--- a/packages/contracts/src/marketing-voice/check-rule.ts
+++ b/packages/contracts/src/marketing-voice/check-rule.ts
@@ -1,9 +1,33 @@
-import type { Rule, ValidationResult, Violation } from './rules.js';
-import type { Token } from './tokenize.js';
+import { findAdrCiteInBlock, getProseContainers, type MarketingBlock } from './blocks.js';
+import {
+  isDollarShape,
+  isDollarShapeAdjacent,
+  isEngagementUnit,
+  isPercentShape,
+  isPositiveIntegerToken,
+  isPricingTierSourceBlock,
+  isUsdShape,
+} from './predicates.js';
+import type {
+  H2ShapePredicate,
+  PredicateName,
+  Rule,
+  ValidationResult,
+  Violation,
+} from './rules.js';
+import { type Token, tokenize } from './tokenize.js';
 
 export interface CheckContext {
   blockType?: string;
   field?: string;
+  /** Current prose container's node type (e.g. `heading`, `paragraph`). */
+  nodeType?: string;
+  /** Heading tag (`h1`..`h6`) when `nodeType === 'heading'`. */
+  headingTag?: string;
+  /** Whether the block carries an ADR-cite link — computed once per block. */
+  adrCitePresent?: boolean;
+  /** Whether the block is a pricing-tier source — computed once per block. */
+  pricingTierSource?: boolean;
 }
 
 export function checkRule(rule: Rule, tokens: Token[], ctx: CheckContext): Violation[] {
@@ -17,13 +41,15 @@ export function checkRule(rule: Rule, tokens: Token[], ctx: CheckContext): Viola
     case 'banned-token-near':
       return checkBannedTokenNear(rule, tokens, ctx);
     case 'h2-shape':
+      return checkH2Shape(rule, tokens, ctx);
     case 'fake-trust':
+      return checkFakeTrust(rule, tokens, ctx);
     case 'pricing-proximity':
+      return checkPricingProximity(rule, tokens, ctx);
     case 'rvc-pricing-proximity':
+      return checkRvcPricingProximity(rule, tokens, ctx);
     case 'unicode-range-tokens':
-      throw new Error(
-        `Rule kind '${rule.kind}' is not yet implemented — deferred to CMS-spec Phase B (see docs/spec-2026-05-08-marketing-content-cms.md §5.2.1)`,
-      );
+      return checkUnicodeRangeTokens(rule, tokens, ctx);
   }
 }
 
@@ -194,14 +220,274 @@ function checkBannedTokenNear(
   return violations;
 }
 
-export function runTier1(_block: unknown, _rules: Rule[]): ValidationResult {
-  throw new Error(
-    'runTier1 is not yet implemented — deferred to CMS-spec Phase B (see docs/spec-2026-05-08-marketing-content-cms.md §5.2.1)',
-  );
+// ---------------------------------------------------------------------------
+// Proximity scanner (shared by pricing-proximity + rvc-pricing-proximity).
+//
+// Distance is measured in WORD-KIND token distance; the pricing PREDICATES are
+// evaluated against the FULL token stream so a `$`-split price (`$` + `0.10`)
+// or a two-token percent (`5` + `%`) is recognized rather than dropped.
+// ---------------------------------------------------------------------------
+
+/** `wordIndex[i]` = number of word-kind tokens in `tokens[0..i)`. */
+function wordIndexPrefix(tokens: Token[]): number[] {
+  const prefix: number[] = new Array(tokens.length);
+  let count = 0;
+  for (let i = 0; i < tokens.length; i++) {
+    prefix[i] = count;
+    if (tokens[i]?.kind === 'word') count++;
+  }
+  return prefix;
 }
 
-export function walkLexicalAst(_block: unknown): IterableIterator<unknown> {
-  throw new Error(
-    'walkLexicalAst is not yet implemented — deferred to CMS-spec Phase B (see docs/spec-2026-05-08-marketing-content-cms.md §5.2.1)',
-  );
+type StreamPredicate = (tokens: Token[], i: number) => boolean;
+
+function matchesDollar(tokens: Token[], i: number): boolean {
+  const cur = tokens[i];
+  if (cur === undefined) return false;
+  if (cur.text.length > 1 && isDollarShape(cur)) return true; // whole `$100` token
+  return isDollarShapeAdjacent(tokens[i - 1], cur); // `$` + `0.10`
+}
+
+function resolveStreamPredicate(name: PredicateName): StreamPredicate {
+  switch (name) {
+    case 'isDollarShape':
+      return matchesDollar;
+    case 'isPercentShape':
+      return (t, i) => {
+        const c = t[i];
+        return c !== undefined && isPercentShape(c, t[i + 1]);
+      };
+    case 'isUsdShape':
+      return (t, i) => {
+        const c = t[i];
+        return c !== undefined && isUsdShape(c, t[i + 1]);
+      };
+    case 'isEngagementUnit':
+      return (t, i) => {
+        const c = t[i];
+        return c !== undefined && isEngagementUnit(c);
+      };
+    case 'isPositiveIntegerToken':
+      return (t, i) => {
+        const c = t[i];
+        return c !== undefined && isPositiveIntegerToken(c);
+      };
+  }
+}
+
+function checkRvcPricingProximity(
+  rule: Extract<Rule, { kind: 'rvc-pricing-proximity' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  if (rule.unless === 'adr-cite-in-block' && ctx.adrCitePresent) return [];
+  const matchers = rule.proximityPredicates.map(resolveStreamPredicate);
+  const prefix = wordIndexPrefix(tokens);
+  const violations: Violation[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const anchor = tokens[i];
+    if (anchor === undefined || anchor.kind !== 'word') continue;
+    if (anchor.text.toLowerCase() !== rule.anchorTokenLowercase) continue;
+    const anchorWord = prefix[i] ?? 0;
+    let hit = false;
+    for (let j = 0; j < tokens.length && !hit; j++) {
+      if (j === i) continue;
+      if (Math.abs((prefix[j] ?? 0) - anchorWord) > rule.withinTokens) continue;
+      for (const match of matchers) {
+        if (match(tokens, j)) {
+          hit = true;
+          break;
+        }
+      }
+    }
+    if (hit) {
+      violations.push(makeViolation(rule, ctx, 'RVC pricing claim without an ADR cite', anchor));
+    }
+  }
+  return violations;
+}
+
+function checkPricingProximity(
+  rule: Extract<Rule, { kind: 'pricing-proximity' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  const exonerated =
+    (rule.unless.includes('adr-cite-in-block') && ctx.adrCitePresent === true) ||
+    (rule.unless.includes('pricing-tier-source') && ctx.pricingTierSource === true);
+  if (exonerated) return [];
+  const anchorMatch = resolveStreamPredicate(rule.anchorPredicate);
+  const proximityMatch = resolveStreamPredicate(rule.proximityPredicate);
+  const prefix = wordIndexPrefix(tokens);
+  for (let i = 0; i < tokens.length; i++) {
+    if (!anchorMatch(tokens, i)) continue;
+    const anchorWord = prefix[i] ?? 0;
+    for (let j = 0; j < tokens.length; j++) {
+      if (j === i) continue;
+      if (Math.abs((prefix[j] ?? 0) - anchorWord) > rule.withinTokens) continue;
+      if (proximityMatch(tokens, j)) {
+        const anchor = tokens[i];
+        return anchor !== undefined
+          ? [makeViolation(rule, ctx, `Pricing figure near "${anchor.text}"`, anchor)]
+          : [];
+      }
+    }
+  }
+  return [];
+}
+
+function checkFakeTrust(
+  rule: Extract<Rule, { kind: 'fake-trust' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  if (rule.unless === 'adr-cite-in-block' && ctx.adrCitePresent) return [];
+  const words = wordTokens(tokens);
+  const seq = rule.anchor.tokenSequence;
+  if (seq.length === 0) return [];
+  const violations: Violation[] = [];
+  for (let i = 0; i + seq.length <= words.length; i++) {
+    let match = true;
+    for (let k = 0; k < seq.length; k++) {
+      const w = words[i + k];
+      const s = seq[k];
+      if (w === undefined || s === undefined) {
+        match = false;
+        break;
+      }
+      const a = rule.anchor.caseInsensitive ? w.text.toLowerCase() : w.text;
+      const b = rule.anchor.caseInsensitive ? s.toLowerCase() : s;
+      if (a !== b) {
+        match = false;
+        break;
+      }
+    }
+    if (!match) continue;
+    const start = i + seq.length;
+    let found = false;
+    for (let j = start; j < Math.min(words.length, start + rule.withinTokens); j++) {
+      const w = words[j];
+      if (w !== undefined && isPositiveIntegerToken(w)) {
+        found = true;
+        break;
+      }
+    }
+    const anchor = words[i];
+    if (found && anchor !== undefined) {
+      violations.push(
+        makeViolation(
+          rule,
+          ctx,
+          `Unsupported "${seq.join(' ')}" claim without an ADR cite`,
+          anchor,
+        ),
+      );
+    }
+  }
+  return violations;
+}
+
+function matchesH2Predicate(predicate: H2ShapePredicate, words: Token[]): boolean {
+  if (predicate.kind === 'startsWithToken') {
+    const first = words[0];
+    return first !== undefined && first.text.toLowerCase() === predicate.token.toLowerCase();
+  }
+  for (let k = 0; k < predicate.tokens.length; k++) {
+    const w = words[k];
+    const s = predicate.tokens[k];
+    if (w === undefined || s === undefined) return false;
+    if (w.text.toLowerCase() !== s.toLowerCase()) return false;
+  }
+  return true;
+}
+
+function lastNonWhitespaceToken(tokens: Token[]): Token | undefined {
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const t = tokens[i];
+    if (t !== undefined && t.kind !== 'whitespace') return t;
+  }
+  return undefined;
+}
+
+function checkH2Shape(
+  rule: Extract<Rule, { kind: 'h2-shape' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  // Node-scoped: the anti-pattern is a rhetorical-question heading, so a body
+  // paragraph that happens to start with an interrogative does not fire.
+  if (ctx.nodeType !== 'heading') return [];
+  const words = wordTokens(tokens);
+  if (words.length === 0) return [];
+  if (!rule.predicates.some((p) => matchesH2Predicate(p, words))) return [];
+  if (rule.requiresSuffixToken !== undefined) {
+    const last = lastNonWhitespaceToken(tokens);
+    if (last?.text !== rule.requiresSuffixToken) return [];
+  }
+  const anchor = words[0];
+  return anchor !== undefined
+    ? [makeViolation(rule, ctx, 'Rhetorical-question heading', anchor)]
+    : [];
+}
+
+function checkUnicodeRangeTokens(
+  rule: Extract<Rule, { kind: 'unicode-range-tokens' }>,
+  tokens: Token[],
+  ctx: CheckContext,
+): Violation[] {
+  const violations: Violation[] = [];
+  for (const token of tokens) {
+    if (token.kind === 'whitespace') continue;
+    let hit = false;
+    for (const ch of token.text) {
+      const cp = ch.codePointAt(0);
+      if (cp === undefined) continue;
+      for (const range of rule.codepointRanges) {
+        if (cp >= range.startInclusive && cp <= range.endInclusive) {
+          hit = true;
+          break;
+        }
+      }
+      if (hit) break;
+    }
+    if (hit) {
+      violations.push(makeViolation(rule, ctx, `Disallowed character in "${token.text}"`, token));
+    }
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Engine — compose tokenize + checkRule over a block's enumerated prose slots.
+// ---------------------------------------------------------------------------
+
+function runRules(block: MarketingBlock, rules: Rule[]): ValidationResult {
+  const adrCitePresent = findAdrCiteInBlock(block) !== null;
+  const pricingTierSource = isPricingTierSourceBlock({ type: block.blockType });
+  const violations: Violation[] = [];
+  for (const container of getProseContainers(block)) {
+    const tokens = tokenize(container.text);
+    const ctx: CheckContext = {
+      blockType: block.blockType,
+      field: container.field,
+      nodeType: container.nodeType,
+      ...(container.tag !== undefined ? { headingTag: container.tag } : {}),
+      adrCitePresent,
+      pricingTierSource,
+    };
+    for (const rule of rules) {
+      violations.push(...checkRule(rule, tokens, ctx));
+    }
+  }
+  return { passed: violations.length === 0, violations };
+}
+
+/** Tier-1 (structural, un-overridable) voice validation over a block. */
+export function runTier1(block: MarketingBlock, rules: Rule[]): ValidationResult {
+  return runRules(block, rules);
+}
+
+/** Tier-2 (banned words / AI flow) voice validation — same engine, tier-2 rules. */
+export function runTier2(block: MarketingBlock, rules: Rule[]): ValidationResult {
+  return runRules(block, rules);
 }

--- a/packages/contracts/src/marketing-voice/index.ts
+++ b/packages/contracts/src/marketing-voice/index.ts
@@ -1,4 +1,7 @@
+export * from './blocks.js';
 export * from './check-rule.js';
 export * from './predicates.js';
 export * from './rules.js';
+export * from './tier3.js';
 export * from './tokenize.js';
+export * from './voice-rules.js';

--- a/packages/contracts/src/marketing-voice/predicates.ts
+++ b/packages/contracts/src/marketing-voice/predicates.ts
@@ -9,8 +9,23 @@ export function stripCommas(s: string): string {
 
 export function isDollarShape(t: Token): boolean {
   if (!t.text.startsWith('$')) return false;
-  const num = Number(stripCommas(t.text.slice(1)));
-  return Number.isFinite(num);
+  const rest = t.text.slice(1);
+  if (rest.length === 0) return false;
+  return Number.isFinite(Number(stripCommas(rest)));
+}
+
+/**
+ * Two-token dollar shape: a bare `$` symbol token immediately followed by a
+ * numeric token, e.g. `$` + `0.10` or `$` + `5,000`. `Intl.Segmenter` splits
+ * `$0.10` into a `$` symbol token and a `0.10` word token
+ * (tokenize.test.ts:42-46), so the single-token `isDollarShape` misses the
+ * split form. The proximity scanners evaluate this against the `(prev, cur)`
+ * pair so a `$`-split price is still recognized.
+ */
+export function isDollarShapeAdjacent(prev: Token | undefined, cur: Token): boolean {
+  if (prev?.text !== '$') return false;
+  if (cur.text.length === 0) return false;
+  return Number.isFinite(Number(stripCommas(cur.text)));
 }
 
 export function isPercentShape(t: Token, next: Token | undefined): boolean {

--- a/packages/contracts/src/marketing-voice/rules.ts
+++ b/packages/contracts/src/marketing-voice/rules.ts
@@ -80,3 +80,22 @@ export interface ValidationResult {
   passed: boolean;
   violations: Violation[];
 }
+
+/**
+ * Proximity window, in WORD-KIND token distance, for the `rvc-pricing-proximity`
+ * rule (spec §5.2 Rule T1.N). An `rvc` anchor with a pricing figure this many
+ * word tokens away (in either direction, within one prose container) is a
+ * pricing claim about the cancelled RevealCoin token and must cite an ADR.
+ *
+ * The unit is word-token distance, NOT characters: the proximity scanner
+ * windows over word tokens, and symbol tokens (`$`, `%`) are matched adjacently
+ * rather than counted in the window.
+ *
+ * Calibrated by __tests__/proximity-calibration.test.ts against a 60+ sample
+ * corpus (≥30 known-bad that must block, ≥30 known-good that must not). This is
+ * the smallest value in the sweep [20,30,40,50,60,80] that catches every
+ * known-bad without flagging any known-good — a tighter window is the lower
+ * false-positive risk when several pass. See that test for the reproducible
+ * sweep. Not a magic number.
+ */
+export const RVC_PRICING_WITHIN_TOKENS = 30;

--- a/packages/contracts/src/marketing-voice/tier3.ts
+++ b/packages/contracts/src/marketing-voice/tier3.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod/v4';
+import type { MarketingBlock } from './blocks.js';
+
+// Tier 3 — LLM judge (spec §5.4). GAP-332 declares the typed injection seam and
+// the output schema only; the judge implementation + @revealui/ai wiring are
+// Phase C. Kept in its own module (the only zod dependency in marketing-voice)
+// so the rule engine + rule data stay dependency-light for the CI gate.
+
+export const Tier3FindingSchema = z.object({
+  rule: z.string(),
+  field: z.string(),
+  message: z.string(),
+  severity: z.enum(['high', 'low']),
+});
+
+export const Tier3OutputSchema = z.object({
+  scores: z.record(z.string(), z.union([z.literal(0), z.literal(1)])),
+  findings: z.array(Tier3FindingSchema),
+  verdict: z.enum(['pass', 'warn', 'fail']),
+});
+
+export type AdvisoryFinding = z.infer<typeof Tier3FindingSchema>;
+export type Tier3Report = z.infer<typeof Tier3OutputSchema>;
+
+/** Injection seam for the Phase-C LLM judge. Absent = Tier 3 skipped. */
+export type Tier3Judge = (block: MarketingBlock) => Tier3Report;

--- a/packages/contracts/src/marketing-voice/voice-rules.ts
+++ b/packages/contracts/src/marketing-voice/voice-rules.ts
@@ -1,0 +1,165 @@
+import type { MarketingBlock } from './blocks.js';
+import { runTier1, runTier2 } from './check-rule.js';
+import { type Rule, RVC_PRICING_WITHIN_TOKENS, type ValidationResult } from './rules.js';
+import type { Tier3Judge, Tier3Report } from './tier3.js';
+
+/** A voice rule with its tier + human description (spec §5.5 ports model). */
+export interface VoiceRuleEntry {
+  id: string;
+  tier: 1 | 2 | 3;
+  description: string;
+  severity: 'high' | 'low';
+  rule: Rule;
+}
+
+/**
+ * Tier-1 rule set — structural, un-overridable anti-patterns. These are the
+ * rules `runTier1(block, FLEET_VOICE_RULES)` enforces at admin save, the VES
+ * `session.patch` gate, and CI over repo-committed block content.
+ *
+ * Tier-2 banned-word DATA (`FLEET_VOICE_RULES_TIER_2`) is Phase B admin scope;
+ * GAP-332 ships the ENGINE that evaluates tier-2 rule kinds, with an empty
+ * tier-2 set until Phase B populates it.
+ */
+export const FLEET_VOICE_RULES_TIER_1: VoiceRuleEntry[] = [
+  {
+    id: 'tier1.codename-leak.rvui',
+    tier: 1,
+    description: 'RVUI codename in customer copy',
+    severity: 'high',
+    rule: {
+      kind: 'banned-tokens',
+      ruleId: 'tier1.codename-leak.rvui',
+      tokens: ['RVUI'],
+      caseInsensitive: false,
+    },
+  },
+  {
+    id: 'tier1.rvc-pricing-without-adr',
+    tier: 1,
+    description: 'RVC (cancelled token) near a pricing figure without an ADR cite',
+    severity: 'high',
+    rule: {
+      kind: 'rvc-pricing-proximity',
+      ruleId: 'tier1.rvc-pricing-without-adr',
+      anchorTokenLowercase: 'rvc',
+      proximityPredicates: ['isDollarShape', 'isPercentShape', 'isUsdShape'],
+      withinTokens: RVC_PRICING_WITHIN_TOKENS,
+      unless: 'adr-cite-in-block',
+    },
+  },
+  {
+    id: 'tier1.rhetorical-question-heading',
+    tier: 1,
+    description: 'Rhetorical-question heading (interrogative opener + trailing ?)',
+    severity: 'low',
+    rule: {
+      kind: 'h2-shape',
+      ruleId: 'tier1.rhetorical-question-heading',
+      predicates: [
+        { kind: 'startsWithToken', token: 'why' },
+        { kind: 'startsWithToken', token: 'what' },
+        { kind: 'startsWithToken', token: 'how' },
+        { kind: 'startsWithToken', token: 'is' },
+        { kind: 'startsWithToken', token: 'are' },
+        { kind: 'startsWithToken', token: 'can' },
+        { kind: 'startsWithToken', token: 'should' },
+        { kind: 'startsWithToken', token: 'do' },
+        { kind: 'startsWithToken', token: 'does' },
+        { kind: 'startsWithToken', token: 'will' },
+        { kind: 'startsWithToken', token: 'ready' },
+      ],
+      requiresSuffixToken: '?',
+    },
+  },
+  {
+    id: 'tier1.fake-trust',
+    tier: 1,
+    description: 'Unsupported "Trusted by N" claim without an ADR cite',
+    severity: 'high',
+    rule: {
+      kind: 'fake-trust',
+      ruleId: 'tier1.fake-trust',
+      anchor: { tokenSequence: ['trusted', 'by'], caseInsensitive: true },
+      requiresProximity: 'positive-integer-token',
+      withinTokens: 4,
+      unless: 'adr-cite-in-block',
+    },
+  },
+  {
+    id: 'tier1.pricing-proximity',
+    tier: 1,
+    description: 'A dollar figure next to an engagement unit outside a pricing-tier source',
+    severity: 'high',
+    rule: {
+      kind: 'pricing-proximity',
+      ruleId: 'tier1.pricing-proximity',
+      anchorPredicate: 'isDollarShape',
+      proximityPredicate: 'isEngagementUnit',
+      withinTokens: 6,
+      unless: ['adr-cite-in-block', 'pricing-tier-source'],
+    },
+  },
+  {
+    id: 'tier1.em-dash',
+    tier: 1,
+    description: 'Em dash (U+2014) in customer copy',
+    severity: 'low',
+    rule: {
+      kind: 'unicode-range-tokens',
+      ruleId: 'tier1.em-dash',
+      codepointRanges: [{ startInclusive: 0x2014, endInclusive: 0x2014 }],
+    },
+  },
+];
+
+/** Tier-2 banned-word rules — Phase B admin scope; empty until then. */
+export const FLEET_VOICE_RULES_TIER_2: VoiceRuleEntry[] = [];
+
+/** Flat rule list (tier-1 + tier-2), per spec §5.5. Used by `runTier1` + CI. */
+export const FLEET_VOICE_RULES: Rule[] = [
+  ...FLEET_VOICE_RULES_TIER_1.map((e) => e.rule),
+  ...FLEET_VOICE_RULES_TIER_2.map((e) => e.rule),
+];
+
+/**
+ * Tier-1 and tier-2 rules kept separate so a consumer (VES, the AI generate
+ * flow) can gate tier-1 hard and tier-2 soft. A flat `Rule[]` cannot be
+ * partitioned by tier (the engine dispatches by `kind`, not tier), so the
+ * pipeline seam takes this structured set.
+ */
+export interface MarketingVoiceRules {
+  tier1: Rule[];
+  tier2: Rule[];
+}
+
+export const FLEET_MARKETING_VOICE_RULES: MarketingVoiceRules = {
+  tier1: FLEET_VOICE_RULES_TIER_1.map((e) => e.rule),
+  tier2: FLEET_VOICE_RULES_TIER_2.map((e) => e.rule),
+};
+
+export interface MarketingValidationReport {
+  tier1: ValidationResult;
+  tier2: ValidationResult;
+  /** Null unless a Tier-3 judge is injected. Advisory only — never gates here. */
+  tier3: Tier3Report | null;
+  /** Tier 1 AND Tier 2 pass. Tier 3 is advisory and excluded from `passed`. */
+  passed: boolean;
+}
+
+/**
+ * The single validation seam CI, admin save, and the VES `session.patch` gate
+ * all consume. Pure and synchronous when no Tier-3 judge is injected. Runs
+ * `runTier1` then `runTier2` over the same engine; calls the judge only if
+ * supplied.
+ */
+export function validateMarketingBlock(
+  block: MarketingBlock,
+  rules: MarketingVoiceRules,
+  opts?: { tier3?: Tier3Judge },
+): MarketingValidationReport {
+  const tier1 = runTier1(block, rules.tier1);
+  const tier2 = runTier2(block, rules.tier2);
+  const tier3 = opts?.tier3 ? opts.tier3(block) : null;
+  return { tier1, tier2, tier3, passed: tier1.passed && tier2.passed };
+}

--- a/scripts/seed-fleet-marketing-home-page.ts
+++ b/scripts/seed-fleet-marketing-home-page.ts
@@ -125,7 +125,7 @@ async function main(): Promise<void> {
                 {
                   type: 'text',
                   version: 1,
-                  text: 'People, content, offers, payments, and agents — pre-wired.',
+                  text: 'People, content, offers, payments, and agents. Pre-wired.',
                 },
               ],
             },
@@ -146,7 +146,7 @@ async function main(): Promise<void> {
     blockCount: blocks.length,
     seo: {
       title: 'RevealUI',
-      description: 'Agentic business runtime — people, content, offers, payments, and agents.',
+      description: 'Agentic business runtime. People, content, offers, payments, and agents.',
     },
     publishedAt: now,
     createdAt: now,

--- a/scripts/validate/__tests__/marketing-voice.test.ts
+++ b/scripts/validate/__tests__/marketing-voice.test.ts
@@ -12,6 +12,7 @@ import {
   scanAll,
   scanLine,
   tokenize,
+  validateBlockExports,
 } from '../marketing-voice.js';
 
 const CONTENT: LineScanOptions = { scanHype: true, scanPunctuation: true, scanVoice: true };
@@ -179,5 +180,46 @@ describe('helpers', () => {
     expect(baselineKey({ file: 'a.ts', ruleId: 'hype-word', token: 'powerful' })).toBe(
       'a.ts::hype-word::powerful',
     );
+  });
+});
+
+describe('validateBlockExports — block-content Tier-1 pass', () => {
+  const heroBlock = (text: string) => ({
+    blockType: 'hero',
+    richText: {
+      root: { children: [{ type: 'heading', tag: 'h1', children: [{ type: 'text', text }] }] },
+    },
+  });
+
+  it('returns no findings for a clean block module', () => {
+    const findings = validateBlockExports('x.blocks.ts', {
+      blocks: [heroBlock('The self-hosted agentic runtime')],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('flags an RVUI codename leak', () => {
+    const findings = validateBlockExports('x.blocks.ts', {
+      blocks: [heroBlock('Powered by RVUI internals')],
+    });
+    expect(findings.some((f) => f.rule === 'tier1.codename-leak.rvui')).toBe(true);
+  });
+
+  it('flags an RVC pricing claim without an ADR', () => {
+    const findings = validateBlockExports('x.blocks.ts', {
+      blocks: [heroBlock('Buy RVC at $0.10 per token')],
+    });
+    expect(findings.some((f) => f.rule === 'tier1.rvc-pricing-without-adr')).toBe(true);
+  });
+
+  it('fails closed on an unmapped block type', () => {
+    const findings = validateBlockExports('x.blocks.ts', {
+      blocks: [{ blockType: 'mystery', richText: 'x' }],
+    });
+    expect(findings.some((f) => f.rule === 'block-validation-error')).toBe(true);
+  });
+
+  it('ignores non-array and non-block exports', () => {
+    expect(validateBlockExports('x.blocks.ts', { meta: 'string', n: 42 })).toHaveLength(0);
   });
 });

--- a/scripts/validate/marketing-voice.ts
+++ b/scripts/validate/marketing-voice.ts
@@ -50,37 +50,29 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+// Consolidated onto the shared @revealui/contracts/marketing-voice engine
+// (GAP-332). Imported from SOURCE, not the built package, so this phase-1 gate
+// stays dependency-light: tsx transpiles the .ts on the fly, no package build
+// required, and the engine's import chain here is zod-free.
+import type { MarketingBlock } from '../../packages/contracts/src/marketing-voice/blocks.js';
+import { runTier1 } from '../../packages/contracts/src/marketing-voice/check-rule.js';
+import type { Token } from '../../packages/contracts/src/marketing-voice/tokenize.js';
+import { tokenize } from '../../packages/contracts/src/marketing-voice/tokenize.js';
+import { FLEET_MARKETING_VOICE_RULES } from '../../packages/contracts/src/marketing-voice/voice-rules.js';
 
 const ROOT = path.resolve(import.meta.dirname, '../..');
 const BASELINE_PATH = path.join(ROOT, 'scripts/validate/marketing-voice-baseline.json');
 const UPDATE_BASELINE = process.argv.includes('--update-baseline');
 
 // ---------------------------------------------------------------------------
-// Tokenizer — Intl.Segmenter word granularity (mirrors the shared
-// @revealui/contracts/marketing-voice tokenizer, inlined to stay self-
-// contained). No authored regex.
+// Tokenizer — CONSOLIDATED onto the shared engine (imported above). The prior
+// inlined copy was an ACCIDENTAL duplicate the gate header flagged for
+// consolidation; it is gone (GAP-332). Re-exported so the gate's tests keep
+// importing `tokenize` / `Token` from here.
 // ---------------------------------------------------------------------------
 
-export interface Token {
-  text: string;
-  kind: 'word' | 'symbol' | 'whitespace';
-  offset: number;
-}
-
-const SEGMENTER = new Intl.Segmenter('en', { granularity: 'word' });
-
-export function tokenize(text: string): Token[] {
-  const out: Token[] = [];
-  for (const part of SEGMENTER.segment(text)) {
-    const isWord = (part as Intl.SegmentData & { isWordLike?: boolean }).isWordLike === true;
-    out.push({
-      text: part.segment,
-      kind: isWord ? 'word' : part.segment.trim() === '' ? 'whitespace' : 'symbol',
-      offset: part.index,
-    });
-  }
-  return out;
-}
+export type { Token };
+export { tokenize };
 
 // ---------------------------------------------------------------------------
 // Rule data — derived verbatim from the corpus §4.1 / §4.2.
@@ -434,6 +426,108 @@ export function scanAll(): Finding[] {
 }
 
 // ---------------------------------------------------------------------------
+// Block-content pass (GAP-332)
+//
+// Repo-committed CANONICAL block modules (`content/**/*.blocks.ts` exporting
+// `MarketingBlock[]`) are validated with the shared Tier-1 engine. HARD FAIL,
+// no baseline: Tier-1 rules are un-overridable structural anti-patterns.
+//
+// The runtime write path (admin save + the VES session.patch gate) is the real
+// enforcement — DB blocks are opaque jsonb and invisible to CI. This pass
+// covers the repo-committed complement. Phase B lands the block modules; today
+// there are none, so this pass is a wired no-op ready to catch the first one.
+// ---------------------------------------------------------------------------
+
+const BLOCK_MODULE_SUFFIX = '.blocks.ts';
+
+export interface BlockFinding {
+  file: string;
+  rule: string;
+  field: string;
+  message: string;
+}
+
+function isMarketingBlock(value: unknown): value is MarketingBlock {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { blockType?: unknown }).blockType === 'string'
+  );
+}
+
+/** Pure: validate one module's exported block arrays. Exported for tests. */
+export function validateBlockExports(
+  rel: string,
+  moduleExports: Record<string, unknown>,
+): BlockFinding[] {
+  const findings: BlockFinding[] = [];
+  const rules = FLEET_MARKETING_VOICE_RULES.tier1;
+  for (const value of Object.values(moduleExports)) {
+    if (!Array.isArray(value)) continue;
+    for (const block of value) {
+      if (!isMarketingBlock(block)) continue;
+      try {
+        for (const v of runTier1(block, rules).violations) {
+          findings.push({ file: rel, rule: v.rule, field: v.field, message: v.message });
+        }
+      } catch (err) {
+        // Fail closed: an unmapped block type (or any engine error) is a hard
+        // finding, never a silent skip.
+        findings.push({
+          file: rel,
+          rule: 'block-validation-error',
+          field: '',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+function findBlockModules(): string[] {
+  const out: string[] = [];
+  const start = path.join(ROOT, MARKETING_APP, 'content');
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name === '__tests__' || e.name === 'node_modules') continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (e.name.endsWith(BLOCK_MODULE_SUFFIX)) out.push(full);
+    }
+  };
+  walk(start);
+  return out;
+}
+
+export async function scanBlockModules(): Promise<BlockFinding[]> {
+  const findings: BlockFinding[] = [];
+  for (const abs of findBlockModules().sort()) {
+    const rel = path.relative(ROOT, abs).split(path.sep).join('/');
+    let mod: Record<string, unknown>;
+    try {
+      mod = (await import(pathToFileURL(abs).href)) as Record<string, unknown>;
+    } catch (err) {
+      findings.push({
+        file: rel,
+        rule: 'block-module-import',
+        field: '',
+        message: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+    findings.push(...validateBlockExports(rel, mod));
+  }
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
 // Baseline
 // ---------------------------------------------------------------------------
 
@@ -467,7 +561,7 @@ function writeBaseline(findings: Finding[]): number {
 // Main
 // ---------------------------------------------------------------------------
 
-function run(): void {
+async function run(): Promise<void> {
   console.log('Marketing Voice Validator');
   console.log('=========================\n');
 
@@ -492,27 +586,43 @@ function run(): void {
 
   const distinct = new Set(findings.map(baselineKey)).size;
   console.log(
-    `Scanned ${MARKETING_APP}: ${findings.length} occurrences, ${distinct} distinct, ${baseline.size} grandfathered, ${fresh.length} new.\n`,
+    `Scanned ${MARKETING_APP}: ${findings.length} occurrences, ${distinct} distinct, ${baseline.size} grandfathered, ${fresh.length} new.`,
   );
 
-  if (fresh.length === 0) {
+  // Block-content pass — HARD FAIL, no baseline (Tier-1 is un-overridable).
+  const blockFindings = await scanBlockModules();
+  console.log(
+    `Block modules (content/**/*${BLOCK_MODULE_SUFFIX}): ${blockFindings.length} Tier-1 violation(s).\n`,
+  );
+
+  if (fresh.length === 0 && blockFindings.length === 0) {
     console.log('No new marketing-voice violations. ✓');
     return;
   }
 
-  console.error(
-    'New marketing-voice violations (fix the copy, or justify + run --update-baseline):\n',
-  );
-  for (const f of fresh) {
-    console.error(`  ${f.file}:${f.line}  [${f.ruleId}] ${f.token}`);
-    console.error(`    ${f.text}`);
+  if (fresh.length > 0) {
+    console.error(
+      'New marketing-voice violations (fix the copy, or justify + run --update-baseline):\n',
+    );
+    for (const f of fresh) {
+      console.error(`  ${f.file}:${f.line}  [${f.ruleId}] ${f.token}`);
+      console.error(`    ${f.text}`);
+    }
+    console.error(
+      `\n${fresh.length} new line-scan violation(s). See the voice-and-headline-rules corpus (§4.1 banned words, §4.2 codenames, §2/§4.3 fleet voice) and the no-em-dash style rule (use a comma, colon, or period).`,
+    );
   }
-  console.error(
-    `\n${fresh.length} new violation(s). See the voice-and-headline-rules corpus (§4.1 banned words, §4.2 codenames, §2/§4.3 fleet voice) and the no-em-dash style rule (use a comma, colon, or period).`,
-  );
+
+  if (blockFindings.length > 0) {
+    console.error('\nBlock-content Tier-1 violations (fix the block; Tier-1 has no override):\n');
+    for (const f of blockFindings) {
+      console.error(`  ${f.file}  [${f.rule}] ${f.field}: ${f.message}`);
+    }
+  }
+
   process.exitCode = 1;
 }
 
 const invokedDirectly =
   process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
-if (invokedDirectly) run();
+if (invokedDirectly) void run();


### PR DESCRIPTION
## What & why

Implements the marketing-CMS Phase B/C voice-check runtime and the
`apps/server/src/lib/marketing-content/` generation pipeline. Lands the three
`@revealui/contracts/marketing-voice` functions that were stubbed to throw
(`runTier1`, `walkLexicalAst`, the `rvc-pricing-proximity` rule kind) plus the
remaining rule kinds and consumers `runTier1`/`runTier2` need.

**Audit / design reference:** built against the merged Fable design
`docs/gap-specs/GAP-332-marketing-voice-runtime-design.md` (jv#434), which
implements `docs/spec-2026-05-08-marketing-content-cms.md` as amended by the
visual-edit-sessions spec. This is a BUILD, not a redesign; where the design and
code reality conflicted, code reality won and the divergence is flagged below.

## Slices (one commit each, per design §8.3)

| # | Slice | Commit | Disposition |
|---|-------|--------|-------------|
| 1 | Engine (`packages/contracts`) | `feat(contracts): implement marketing-voice tier-1 runtime engine` | Done. `walkLexicalAst`/`getProseSlots`/`getProseContainers`, `runTier1`/`runTier2`, all five remaining `checkRule` kinds, `isDollarShapeAdjacent` ($-split fix), `RVC_PRICING_WITHIN_TOKENS` (calibrated), `validateMarketingBlock` seam, typed Tier-3 injection seam. |
| 2 | Pipeline (`apps/server`) | `feat(server): add marketing-content generation pipeline` | Done. `parseAndValidate` verbatim (§7.2), `validateMarketingBlock` re-export, `generateBlock` retry-loop with client + deps injected. Live `@revealui/ai` + HTTP route stay Phase B (design §5.1). |
| 3 | CI wiring | `feat(ci): validate marketing blocks via shared voice engine` | Done. Tokenizer consolidation onto the shared engine + hard-fail block-content pass. See "gate machinery" note below. |

## Test counts

- **New/changed tests:** `ast-walk.test.ts` (16), `tier1.test.ts` (17), `check-rule.test.ts` (rewrote the 3 deferred-throw suites into behavior tests), `proximity-calibration.test.ts` (3, a 62-sample corpus), server `generate.test.ts` (11), gate `validateBlockExports` (5).
- **Suites:** `@revealui/contracts` full suite **1007 passed**; `server` marketing-content **11 passed**; gate `marketing-voice.test.ts` **33 passed**.
- Typecheck clean (`@revealui/contracts`, `server`), biome clean, `pnpm validate:claims` clean, `pnpm validate:marketing-voice` exits 0.

### Red-test proof (prove-tests-fail-without-the-fix)

The central audit finding is that `Intl.Segmenter` splits `$0.10` into a separate
`$` symbol token, so a naive word-only window drops the `$` and misses the price.
Neutering `isDollarShapeAdjacent` to `return false` turned exactly the dollar-split
tests red (the `$`-split `checkRule` test, the calibration FN/FP asserts, and
`tier1` cases (a)/(f)/(g) + pricing-proximity + composition: 11 failures) while
the percent-based cases (b)/(d) stayed green. That isolates the failures to the
real `$`-split false negative the fix closes. Implementation then restored; all green.

## Design-vs-code divergences (flagged, not improvised)

1. **Block model (central finding, design §1.3/§9.4).** The spec's named-slot model (`Hero.h1`, `Hero.subhead`) was never built. The engine targets the REAL shipped shape (`blockType` + `richText` Lexical editor state, per the fleet-marketing seed). `MARKETING_PROSE_SLOTS` maps real `blockType` (`hero`/`content`/`cta`) to `richText`. Fixture tests assert `field: 'richText'`, not the spec's `'h1'`. **Spec amendment recorded here** per design §9.4.
2. **`validateMarketingBlock` signature.** The design wrote `validateMarketingBlock(block, FLEET_VOICE_RULES)`, but a flat `Rule[]` cannot be partitioned by tier (the engine dispatches by `kind`, not tier). The seam takes a structured `{ tier1, tier2 }` set (`FLEET_MARKETING_VOICE_RULES`); the flat `FLEET_VOICE_RULES` (spec §5.5) is still exported for `runTier1`/CI.
3. **`pricingTierSource`.** `PRICING_TIER_BLOCK_KINDS` uses the spec's Model-C `'PricingTracks'` name; real block types are lowercase and the pricing block is Phase B, so `runTier1`'s `pricingTierSource` is currently always false for shipped types. The exoneration path is unit-tested at the `checkRule` level.
4. **`isDollarShape` tightened** to reject a bare `$` (previously `Number('') === 0` made it true). Correctness improvement; all existing predicate tests still pass.
5. **Tier-3 schemas split** into `tier3.ts` so `voice-rules.ts` stays zod-free at runtime, letting the dependency-light phase-1 gate import the engine from source.

## Deferred (design §9, stated plainly)

Tier-3 LLM judge (only the typed seam ships), Tier-2 banned-word DATA (`FLEET_VOICE_RULES_TIER_2` is empty until Phase B), the block Zod schemas + admin collection + AI-generate route/UI, and the VES session tables/route. DB-block CI validation is architecturally impossible (opaque jsonb) — the runtime write path is the real enforcement; CI covers the repo-committed complement (zero `*.blocks.ts` modules exist today, so slice 3's block pass is a wired no-op ready for the first one).

## Gate machinery + security verdict

- **Fleet security checker:** `security-pr-review-check.js --diff origin/test` returns **clear** (no file matches its security-path list; the changes are marketing-voice + a validator script).
- **Transparency:** slice 3 modifies the `validate:marketing-voice` gate (hard-fail, phase 1). Per the design §8.2 reading of dup-work-and-review-gates guardrail 2 (widened to gate/validator machinery), a non-author recorded verdict before merge is appropriate even though the fleet checker does not flag `scripts/validate/` as security-sensitive. Flagging so the owner/reviewer can decide.

Do not merge without a reviewer verdict; leaving the worktree in place.

## Addendum

- **Seed em-dash fix** (`fix(seed): remove the em dash from the home subhead`, design §6.3 conformance): fixed the em dash in `scripts/seed-fleet-marketing-home-page.ts` per the no-em-dashes hardline (split into two sentences). Applied to BOTH customer-facing copy fields found in the seed — the home subhead block text (`seed:128`) and the SEO meta description (`seed:149`); the six remaining em dashes are internal comments/log lines, exempt from the rule. `pnpm validate:claims` + `pnpm validate:marketing-voice` still clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
