### PR TITLE
fix(server): docker deps stage misses setup (and 3 older) workspace closure members

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -22,10 +22,14 @@ COPY packages/contracts/package.json ./packages/contracts/
 COPY packages/core/package.json ./packages/core/
 COPY packages/db/package.json ./packages/db/
 COPY packages/dev/package.json ./packages/dev/
+COPY packages/knowledge-graph/package.json ./packages/knowledge-graph/
+COPY packages/mcp/package.json ./packages/mcp/
 COPY packages/openapi/package.json ./packages/openapi/
+COPY packages/paywall/package.json ./packages/paywall/
 COPY packages/resilience/package.json ./packages/resilience/
 COPY packages/security/package.json ./packages/security/
 COPY packages/services/package.json ./packages/services/
+COPY packages/setup/package.json ./packages/setup/
 COPY packages/utils/package.json ./packages/utils/
 COPY apps/server/package.json ./apps/server/
 

--- a/apps/server/Dockerfile.forge
+++ b/apps/server/Dockerfile.forge
@@ -27,6 +27,7 @@ COPY packages/paywall/package.json    ./packages/paywall/
 COPY packages/resilience/package.json ./packages/resilience/
 COPY packages/security/package.json   ./packages/security/
 COPY packages/services/package.json   ./packages/services/
+COPY packages/setup/package.json      ./packages/setup/
 COPY packages/utils/package.json      ./packages/utils/
 COPY apps/server/package.json            ./apps/server/
 


### PR DESCRIPTION
The Forge Docker image build has been red on every test push since 2026-07-16 21:15 (last green eb9a0efdf). `@revealui/setup` joined server's dependency closure via the revvault shared client, but the hardcoded COPY lists in the docker deps stage never gained it, so pnpm skipped its dev toolchain and the in-image `tsup` build died. Blocks the release-train promotion #1925 (shipping broken self-host images).

- `Dockerfile.forge`: + setup (the live breakage)
- `Dockerfile`: + knowledge-graph, mcp, paywall, setup (aligns with the real closure; this file lagged the earlier docker-paths follow-up too)
- `Dockerfile.worker`: untouched, copies the whole packages tree

Both lists verified against `pnpm --filter "server..." list --depth -1`. Follow-up worth filing: a CI lockstep check that diffs the Dockerfile COPY lists against the computed closure so this class stops recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)