### PR TITLE
fix(ci): classify the review gate from the full paginated PR file list

### DIFF
--- a/scripts/validate/__tests__/security-review-gate.test.ts
+++ b/scripts/validate/__tests__/security-review-gate.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-const { SECURITY_PATHS, classifyFiles, decideReviewGate } = require('../security-review-gate.cjs');
+const {
+  SECURITY_PATHS,
+  MAX_CLASSIFIABLE_FILES,
+  classifyFiles,
+  decideReviewGate,
+  fetchPrFiles,
+  hitsForFiles,
+} = require('../security-review-gate.cjs');
 
 const CLEAR_LABEL = 'sec-review:approved';
 const noMarker = { status: 'no-marker' };
@@ -68,6 +75,54 @@ describe('decideReviewGate — B2: an APPROVE marker never clears without the ow
   });
   it('HOLDS a no-marker PR with neither label nor approving review', () => {
     expect(decideReviewGate({ verdict: noMarker, labels: ['bug'] }).action).toBe('hold');
+  });
+});
+
+describe('fetchPrFiles — the full paginated list, not the 100-file window', () => {
+  // The regression this pins: `gh pr view --json files` caps at 100 entries, so a
+  // 641-file promotion whose 19 security paths all sat beyond the window was
+  // classified "not security-sensitive" by a REQUIRED check. The fetch must page
+  // the REST endpoint and classification must see every file.
+  const sensitive = '.github/workflows/security-review-gate.yml';
+  const bigList = Array.from({ length: 150 }, (_, i) =>
+    i === 120 ? sensitive : `apps/docs/content/page-${String(i).padStart(3, '0')}.md`,
+  );
+
+  it('returns every file and classification sees a sensitive path beyond index 100', () => {
+    const calls: string[][] = [];
+    const ghImpl = (args: string[]) => {
+      calls.push(args);
+      return `${bigList.join('\n')}\n`;
+    };
+    const files = fetchPrFiles(1925, 'RevealUIStudio/revealui', ghImpl);
+    expect(files).toHaveLength(150);
+    expect(calls[0]).toContain('api');
+    expect(calls[0]).toContain('--paginate');
+    expect(calls[0]).toContain('repos/RevealUIStudio/revealui/pulls/1925/files');
+    expect(classifyFiles(files)).toContain(sensitive);
+  });
+
+  it('resolves the repo from the current directory when --repo is absent', () => {
+    const calls: string[][] = [];
+    const ghImpl = (args: string[]) => {
+      calls.push(args);
+      return 'README.md\n';
+    };
+    fetchPrFiles(7, undefined, ghImpl);
+    expect(calls[0]).toContain('repos/{owner}/{repo}/pulls/7/files');
+  });
+});
+
+describe('hitsForFiles — the API ceiling fails closed', () => {
+  const benign = (n: number) => Array.from({ length: n }, (_, i) => `docs/page-${i}.md`);
+
+  it('classifies normally below the ceiling', () => {
+    expect(hitsForFiles(benign(MAX_CLASSIFIABLE_FILES - 1))).toHaveLength(0);
+  });
+  it('treats a list at the ceiling as security-sensitive unconditionally', () => {
+    const hits = hitsForFiles(benign(MAX_CLASSIFIABLE_FILES));
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0]).toContain('failing closed');
   });
 });
 

--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -108,6 +108,39 @@ function gh(args) {
   return execFileSync('gh', args, { encoding: 'utf8', timeout: 15000 });
 }
 
+/**
+ * The REST list-files endpoint stops at 3000 files. A diff at (or past) that
+ * ceiling cannot be classified honestly, so `hitsForFiles` fails closed there.
+ */
+const MAX_CLASSIFIABLE_FILES = 3000;
+
+/**
+ * Full changed-file list for a PR, paginated. `gh pr view --json files` caps at
+ * 100 entries with no pagination, which let a 600+-file promotion be classified
+ * from a truncated window that happened to contain none of its security paths.
+ * The `{owner}/{repo}` placeholders resolve from the current directory's repo
+ * when no --repo was passed. Injectable `ghImpl` exists for the unit test.
+ */
+function fetchPrFiles(prNumber, repo, ghImpl) {
+  const run =
+    ghImpl ||
+    ((args) => execFileSync('gh', args, { encoding: 'utf8', timeout: 120000, maxBuffer: 32 * 1024 * 1024 }));
+  const path = `repos/${repo || '{owner}/{repo}'}/pulls/${prNumber}/files`;
+  const out = run(['api', path, '--paginate', '--jq', '.[].filename']);
+  return out.split('\n').filter((line) => line.length > 0);
+}
+
+/**
+ * Classification wrapper that fails closed at the API ceiling: a file list the
+ * endpoint may have truncated is treated as security-sensitive unconditionally.
+ */
+function hitsForFiles(files) {
+  if (files.length >= MAX_CLASSIFIABLE_FILES) {
+    return ['(file list at the API ceiling — unclassifiable, failing closed)'];
+  }
+  return classifyFiles(files);
+}
+
 function classifyFiles(files) {
   const hits = [];
   for (const f of files) {
@@ -163,7 +196,7 @@ function runPrMode(prNumber, repo) {
     'view',
     prNumber,
     '--json',
-    'files,labels,reviewDecision,title,author,reviews,comments',
+    'labels,reviewDecision,title,author,reviews,comments',
   ];
   if (repo) ghArgs.push('-R', repo);
   try {
@@ -176,8 +209,17 @@ function runPrMode(prNumber, repo) {
     process.exit(1);
   }
   const data = JSON.parse(raw);
-  const files = (data.files || []).map((f) => f.path);
-  const hits = classifyFiles(files);
+  let files;
+  try {
+    files = fetchPrFiles(prNumber, repo);
+  } catch (err) {
+    process.stderr.write(
+      `security-review-gate: file-list fetch failed for PR ${prNumber} (${err instanceof Error ? err.message : 'unknown'}). ` +
+        `Cannot classify — treating as HOLD.\n`,
+    );
+    process.exit(1);
+  }
+  const hits = hitsForFiles(files);
 
   if (hits.length === 0) {
     process.stdout.write(
@@ -272,7 +314,15 @@ function main() {
 // Export the surface list + classifier so the unit test can assert the
 // classification without spawning the CLI. Guarding main() behind
 // require.main === module keeps the CLI behavior identical when run directly.
-module.exports = { SECURITY_PATHS, SEC_REVIEW_LABELS, classifyFiles, decideReviewGate };
+module.exports = {
+  SECURITY_PATHS,
+  SEC_REVIEW_LABELS,
+  MAX_CLASSIFIABLE_FILES,
+  classifyFiles,
+  decideReviewGate,
+  fetchPrFiles,
+  hitsForFiles,
+};
 
 if (require.main === module) {
   main();


### PR DESCRIPTION
## What

The review gate fetched a PR's changed files via `gh pr view --json files`, which returns at most 100 entries with no pagination. A PR larger than that could be classified from a truncated window that omitted its security-sensitive paths, turning the check green without any recorded verdict or label. This PR:

- fetches the file list from the paginated REST endpoint (`pulls/N/files --paginate`), with the `{owner}/{repo}` placeholder preserving the no-`--repo` behavior;
- fails closed (exit 1, HOLD) if the file-list fetch errors;
- treats a list at the 3000-file API ceiling as security-sensitive unconditionally, since a diff that large cannot be classified honestly;
- leaves `--diff` mode untouched (git diff has no cap).

## Verification

- 4 new unit cases (22 total green): a 150-file list with the sensitive path at index 120 is fully returned and classified; the fetch call shape is pinned (`api` + `--paginate`); the ceiling fails closed; below-ceiling classification is unchanged.
- Live acceptance run against a current 641-file promotion PR: the fixed script classifies 29 security-sensitive paths and HOLDs; the shipped script classified the same PR from its first-100 window and saw none.
- The fleet checker copy carries the same fix in lockstep (its PR is referenced from the internal tracker).

## Merge posture

Edits the gate script itself, so this self-classifies as security-sensitive and needs an independent non-author guardrail-2 verdict, then the owner label. With the gate now a required check, this PR hard-blocks until labeled — which is the machinery working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
