### PR TITLE
ci(release): fail fast on non-main dispatch + retire the CLI's stale claim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,19 @@ jobs:
     environment: npm-publish
 
     steps:
+      # Publishing is main-only: changeset status resolves against the main
+      # base ref and the npm trusted publisher is registered for this workflow
+      # running on main. Dispatching on any other ref used to die mid-run with
+      # changesets' "Failed to find where HEAD diverged from main" (GAP-380,
+      # runs 29518547299 + 29559527527, both dispatched on test). Fail fast
+      # with an actionable message instead.
+      - name: Guard dispatch ref (main only)
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::release.yml publishes from main only; it was dispatched on ${{ github.ref }}."
+          echo "::error::Re-run with: gh workflow run release.yml --ref main"
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/scripts/cli/release.ts
+++ b/scripts/cli/release.ts
@@ -5,7 +5,15 @@
  *
  * Unified CLI for version management and package publishing.
  * Handles versioning and npm publishing for the monorepo.
- * Replaces GitHub Actions release.yml and release-pro.yml workflows.
+ *
+ * CANONICAL PATH NOTE (GAP-380, 2026-07-17): the canonical publish path is
+ * the GitHub Actions release.yml workflow (OIDC trusted publishing with
+ * provenance, dispatched on main). This CLI is the documented owner-run
+ * FALLBACK for cases the workflow cannot handle (e.g. a first publish of a
+ * new package before its npm trusted publisher exists). It publishes with a
+ * local npm login instead of OIDC provenance. An earlier version of this
+ * header claimed the CLI "replaces" release.yml; that claim was wrong and
+ * is retired.
  *
  * Commands:
  *   status            Show changeset status (pending versions)


### PR DESCRIPTION
## Summary

GAP-380 hardening (internal tracker), both residual items:

1. **release.yml ref guard.** The workflow publishes from main only: changeset status resolves against the main base ref and the npm trusted publisher is registered for this workflow on main. Two of the three red runs on 2026-07-16/17 were dispatches on test that died mid-run with changesets' "Failed to find where HEAD diverged from main". The new first step fails immediately on any non-main ref with the exact re-run command in the error.

2. **Release CLI header truth.** scripts/cli/release.ts claimed it "Replaces GitHub Actions release.yml and release-pro.yml workflows". The canonical path is release.yml (OIDC trusted publishing with provenance, proven end-to-end today); the CLI is the documented owner-run fallback for cases the workflow cannot handle, such as a first publish before a trusted publisher exists. The header now says exactly that.

No behavior change for correctly-dispatched runs; the guard step is skipped on main.

## Test plan

- Comment-only change in the CLI; the workflow guard is a single conditional step using only github.ref. Fleet security checker on the committed diff: not security-sensitive, no coordinator gate.
- Verification after merge reaches main: dispatch once with `--ref test` and observe the immediate, clearly-worded failure; dispatch with `--ref main` no-ops through the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)