### PR TITLE
fix(ci): scrub the [SENSITIVE] placeholder Vercel CLI 56.3 pulls for sensitive vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,8 +91,14 @@ jobs:
       # validateStartup at module init but were invisible to a name-only
       # `vercel env ls | grep` check. Closes GAP-125.
 
+      # Pinned, not @latest (all 3 install sites in this file): the unpinned
+      # CLI auto-bumped 56.2.1 -> 56.3.1 mid-train on 2026-07-17 and changed
+      # what `vercel pull` emits for sensitive-type vars (decrypted values ->
+      # the [SENSITIVE] placeholder), failing prod-env validation with 10
+      # findings while neither the repo nor the project env had changed.
+      # Bump deliberately, in lockstep with scripts/validate/prod-env.ts.
       - name: Install Vercel CLI
-        run: pnpm add -g vercel@latest
+        run: pnpm add -g vercel@56.3.1
 
       - name: Resolve api project id from .github/vercel-projects.json
         run: echo "API_PROJECT_ID=$(jq -r '.api' .github/vercel-projects.json)" >> "$GITHUB_ENV"
@@ -357,7 +363,7 @@ jobs:
           cache: pnpm
 
       - name: Install Vercel CLI
-        run: pnpm add -g vercel@latest
+        run: pnpm add -g vercel@56.3.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -499,7 +505,7 @@ jobs:
           # Failures are tracked via counters and surfaced at the end.
           set +e
           echo "::warning::Smoke test failed — rolling back affected apps"
-          pnpm add -g vercel@latest
+          pnpm add -g vercel@56.3.1
           APP_LIST="${{ needs.detect.outputs.app-list }}"
           ROLLBACK_FAILED=0
           ROLLBACK_NO_HISTORY=0

--- a/scripts/validate/__tests__/prod-env.test.ts
+++ b/scripts/validate/__tests__/prod-env.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   isVercelEncryptedBlob,
+  isVercelSensitivePlaceholder,
   parseDotenv,
+  scrubSensitivePlaceholders,
   scrubVercelEncryptedBlobs,
+  VERCEL_SENSITIVE_PLACEHOLDER,
   validatePulledEnv,
 } from '../prod-env';
 
@@ -25,6 +28,11 @@ function validHostedEnv(overrides: Record<string, string | undefined> = {}) {
     REVEALUI_CRON_SECRET: VALID_CRON,
     CORS_ORIGIN: 'https://revealui.com,https://admin.revealui.com',
     REVEALUI_ALERT_EMAIL: 'founder@revealui.com',
+    // Added to REQUIRED_IN_PRODUCTION after this fixture was written; the
+    // suite failed presence checks on every case until these landed.
+    REVEALUI_BILLING_PORTAL_CONFIG_ID: 'bpc_test123',
+    GOOGLE_SERVICE_ACCOUNT_EMAIL: 'sender@project.iam.gserviceaccount.com',
+    GOOGLE_PRIVATE_KEY: 'fixture-google-service-account-key',
     ...overrides,
   };
 }
@@ -294,6 +302,62 @@ describe('validatePulledEnv (Vercel v2 envelope integration)', () => {
 
   it('still fails on missing required vars even with blobs present (presence > format)', () => {
     const env = validHostedEnv({ CORS_ORIGIN: SAMPLE_V2_BLOB });
+    delete (env as Record<string, string | undefined>).REVEALUI_ALERT_EMAIL;
+    const result = validatePulledEnv(env);
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/REVEALUI_ALERT_EMAIL/);
+  });
+});
+
+describe('sensitive-placeholder scrub (Vercel CLI >= 56.3)', () => {
+  it('detects the exact [SENSITIVE] placeholder and nothing else', () => {
+    expect(isVercelSensitivePlaceholder(VERCEL_SENSITIVE_PLACEHOLDER)).toBe(true);
+    expect(isVercelSensitivePlaceholder('')).toBe(false);
+    expect(isVercelSensitivePlaceholder('[SENSITIVE] ')).toBe(false);
+    expect(isVercelSensitivePlaceholder('prefix [SENSITIVE]')).toBe(false);
+    expect(isVercelSensitivePlaceholder('sk_live_abc')).toBe(false);
+  });
+
+  it('scrubs placeholder values to empty strings and reports the keys', () => {
+    const { env, scrubbedKeys } = scrubSensitivePlaceholders({
+      REVEALUI_KEK: VERCEL_SENSITIVE_PLACEHOLDER,
+      CORS_ORIGIN: 'https://revealui.com',
+    });
+    expect(env.REVEALUI_KEK).toBe('');
+    expect(env.CORS_ORIGIN).toBe('https://revealui.com');
+    expect(scrubbedKeys).toEqual(['REVEALUI_KEK']);
+  });
+
+  it('passes the 2026-07-17 incident shape: every sensitive-type var pulled as [SENSITIVE]', () => {
+    // Mirrors deploy run 29559213155, where CLI 56.3.1 redacted all 10
+    // sensitive-type vars and each one failed a format check. With the
+    // scrub, these rejoin the lenient presence-only path (the pre-56.3
+    // empty-string behavior) and validation passes.
+    const result = validatePulledEnv(
+      validHostedEnv({
+        REVEALUI_KEK: VERCEL_SENSITIVE_PLACEHOLDER,
+        REVEALUI_SECRET: VERCEL_SENSITIVE_PLACEHOLDER,
+        NEXT_PUBLIC_SERVER_URL: VERCEL_SENSITIVE_PLACEHOLDER,
+        STRIPE_SECRET_KEY: VERCEL_SENSITIVE_PLACEHOLDER,
+        STRIPE_WEBHOOK_SECRET: VERCEL_SENSITIVE_PLACEHOLDER,
+        REVEALUI_CRON_SECRET: VERCEL_SENSITIVE_PLACEHOLDER,
+        REVEALUI_ALERT_EMAIL: VERCEL_SENSITIVE_PLACEHOLDER,
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.scrubbedSensitiveKeys).toEqual([
+      'REVEALUI_SECRET',
+      'REVEALUI_KEK',
+      'NEXT_PUBLIC_SERVER_URL',
+      'STRIPE_SECRET_KEY',
+      'STRIPE_WEBHOOK_SECRET',
+      'REVEALUI_CRON_SECRET',
+      'REVEALUI_ALERT_EMAIL',
+    ]);
+  });
+
+  it('still fails on missing required vars even with placeholders present (presence > format)', () => {
+    const env = validHostedEnv({ REVEALUI_KEK: VERCEL_SENSITIVE_PLACEHOLDER });
     delete (env as Record<string, string | undefined>).REVEALUI_ALERT_EMAIL;
     const result = validatePulledEnv(env);
     expect(result.ok).toBe(false);

--- a/scripts/validate/prod-env.ts
+++ b/scripts/validate/prod-env.ts
@@ -112,12 +112,61 @@ export function scrubVercelEncryptedBlobs(env: EnvMap): {
   return { env: result, scrubbedKeys };
 }
 
+/**
+ * Detect the redaction placeholder Vercel CLI >= 56.3 writes for
+ * `sensitive`-type env vars in `vercel pull` output.
+ *
+ * Sensitive vars are write-only by contract ("can never be read via any
+ * REST call" per Vercel's docs). CLI 56.2.1 and earlier pulled them as
+ * EMPTY strings, which the lenient validator already skips format checks
+ * on. CLI 56.3.1 (first seen in the 2026-07-17 main Deploy, run
+ * 29559213155) started writing the literal string `[SENSITIVE]` instead —
+ * non-empty, so every format check fired and the deploy failed with 10
+ * findings that were all sensitive-type vars. The stored project env had
+ * not changed since 2026-07-11.
+ *
+ * Exact match only: the placeholder is emitted verbatim by the CLI, and
+ * no real production value equals it.
+ */
+export const VERCEL_SENSITIVE_PLACEHOLDER = '[SENSITIVE]';
+
+export function isVercelSensitivePlaceholder(value: string): boolean {
+  return value === VERCEL_SENSITIVE_PLACEHOLDER;
+}
+
+/**
+ * Scrub `[SENSITIVE]` redaction placeholders from a pulled env map,
+ * replacing each with an empty string so the value rejoins the lenient
+ * path sensitive vars took before CLI 56.3 (presence-by-name passes,
+ * format checks skip). The apps/server runtime receives real decrypted
+ * values from Vercel and runs strict validateStartup() there, so the
+ * production gate is unaffected — same contract as the v2-envelope scrub
+ * above.
+ */
+export function scrubSensitivePlaceholders(env: EnvMap): {
+  env: EnvMap;
+  scrubbedKeys: string[];
+} {
+  const scrubbedKeys: string[] = [];
+  const result: EnvMap = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (isVercelSensitivePlaceholder(value)) {
+      result[key] = '';
+      scrubbedKeys.push(key);
+    } else {
+      result[key] = value;
+    }
+  }
+  return { env: result, scrubbedKeys };
+}
+
 export interface ValidateResult {
   ok: boolean;
   message: string;
   mode: 'forge' | 'hosted';
   stripeLiveMode: boolean;
   scrubbedBlobKeys: string[];
+  scrubbedSensitiveKeys: string[];
 }
 
 /**
@@ -134,7 +183,13 @@ export function validatePulledEnv(pulled: EnvMap): ValidateResult {
   // The apps/server runtime still receives decrypted values from Vercel
   // and runs strict validateStartup() there. See isVercelEncryptedBlob
   // for the detection contract.
-  const { env: scrubbed, scrubbedKeys } = scrubVercelEncryptedBlobs(pulled);
+  const { env: blobScrubbed, scrubbedKeys } = scrubVercelEncryptedBlobs(pulled);
+  // CLI >= 56.3 writes `[SENSITIVE]` for sensitive-type vars where older
+  // CLIs wrote empty strings; scrub the placeholder back to empty so those
+  // vars rejoin the lenient presence-only path. See
+  // isVercelSensitivePlaceholder for the incident record.
+  const { env: scrubbed, scrubbedKeys: scrubbedSensitiveKeys } =
+    scrubSensitivePlaceholders(blobScrubbed);
   const env: EnvMap = { ...scrubbed, NODE_ENV: 'production' };
 
   // Vercel-Sensitive vars pull as empty strings even though they're
@@ -154,6 +209,7 @@ export function validatePulledEnv(pulled: EnvMap): ValidateResult {
       mode,
       stripeLiveMode,
       scrubbedBlobKeys: scrubbedKeys,
+      scrubbedSensitiveKeys,
       message:
         'pulled env contains SKIP_ENV_VALIDATION=true. This bypasses every check at runtime; remove it from Vercel before deploying.',
     };
@@ -166,6 +222,7 @@ export function validatePulledEnv(pulled: EnvMap): ValidateResult {
       mode,
       stripeLiveMode,
       scrubbedBlobKeys: scrubbedKeys,
+      scrubbedSensitiveKeys,
       message: 'all production env presence + format checks satisfied.',
     };
   } catch (err) {
@@ -174,6 +231,7 @@ export function validatePulledEnv(pulled: EnvMap): ValidateResult {
       mode,
       stripeLiveMode,
       scrubbedBlobKeys: scrubbedKeys,
+      scrubbedSensitiveKeys,
       message: err instanceof Error ? err.message : String(err),
     };
   }
@@ -200,6 +258,12 @@ function main(): void {
   if (result.scrubbedBlobKeys.length > 0) {
     process.stdout.write(
       `validate:prod-env note: ${result.scrubbedBlobKeys.length} Vercel v2 encryption envelope(s) treated as opaque (presence checked, format skipped — runtime gets decrypted values). Keys: ${result.scrubbedBlobKeys.join(', ')}\n`,
+    );
+  }
+
+  if (result.scrubbedSensitiveKeys.length > 0) {
+    process.stdout.write(
+      `validate:prod-env note: ${result.scrubbedSensitiveKeys.length} sensitive-type var(s) pulled as the [SENSITIVE] redaction placeholder (CLI >= 56.3); presence checked, format skipped — runtime gets decrypted values. Keys: ${result.scrubbedSensitiveKeys.join(', ')}\n`,
     );
   }
 


### PR DESCRIPTION
## Summary

Root-cause fix for the 2026-07-17 prod deploy failure (run 29559213155, 10 validation findings, prod untouched).

**Diagnosis (verified, not the recorded hypothesis):** the api project's stored env never changed (no var updated since 2026-07-11, confirmed via the project env metadata), and the repo's project mapping was identical between the green 17:08 deploy and the failed one. What changed was the CLI: deploy.yml installs `vercel@latest`, which auto-bumped 56.2.1 -> 56.3.1 between the runs. 56.3 stopped emitting decrypted values for `sensitive`-type env vars in `vercel pull` and writes the literal `[SENSITIVE]` placeholder instead (matching Vercel's documented write-only contract for sensitive vars). All 10 findings were exactly the project's sensitive-type vars; every encrypted-type var passed.

**Fix, two parts:**
1. `scripts/validate/prod-env.ts`: scrub exact-match `[SENSITIVE]` values to empty strings before validation, so sensitive vars rejoin the lenient presence-only path they took when older CLIs pulled them as empty. Reported in the output like the existing v2-envelope scrub. The runtime `validateStartup()` in apps/server still format-checks the real decrypted values at boot, so nothing weakens that Vercel hasn't already made unreadable.
2. `.github/workflows/deploy.yml`: pin all three `vercel@latest` installs to `vercel@56.3.1` so the next silent CLI bump cannot fail a deploy mid-train; bump deliberately.

**Also fixed en route:** the prod-env test fixture was missing three vars added to REQUIRED_IN_PRODUCTION after it was written (`REVEALUI_BILLING_PORTAL_CONFIG_ID`, `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`), so the suite failed presence checks on every case before this change.

## Test plan

- 42/42 tests green, including a new incident-shape case (every sensitive var pulled as `[SENSITIVE]` -> validation passes with the keys reported) and exact-match negative cases.
- Prove-red: with the base validator checked out, exactly the 4 new placeholder tests fail; restored, all 42 pass.
- Fleet security checker on the committed diff: not security-sensitive, no coordinator gate.
- After merge + promotion, the next push to main re-runs the real validation against the live pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)