### PR TITLE
feat(marketing): /claims public claims-ledger page

### DIFF
--- a/apps/marketing/app/App.tsx
+++ b/apps/marketing/app/App.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { RootLayout } from './layouts/RootLayout';
 import { BlogIndexPage } from './routes/BlogIndexPage';
 import { BlogPostPage } from './routes/BlogPostPage';
+import { ClaimsPage } from './routes/ClaimsPage';
 import { ContactPage } from './routes/ContactPage';
 import { FairSourcePage } from './routes/FairSourcePage';
 import { ForOperatorsHowItWorksPage } from './routes/ForOperatorsHowItWorksPage';
@@ -71,6 +72,11 @@ export function App() {
         meta: { title: 'RevealUI Cloud (roadmap) | RevealUI Studio' },
       },
       { path: '/roadmap', component: RoadmapPage, meta: { title: 'Roadmap | RevealUI' } },
+      {
+        path: '/claims',
+        component: ClaimsPage,
+        meta: { title: 'The claims ledger | RevealUI' },
+      },
       { path: '/privacy', component: PrivacyPage, meta: { title: 'Privacy Policy | RevealUI' } },
       { path: '/terms', component: TermsPage, meta: { title: 'Terms of Service | RevealUI' } },
       { path: '/security', component: SecurityPage, meta: { title: 'Security | RevealUI' } },

--- a/apps/marketing/app/__tests__/routes.test.ts
+++ b/apps/marketing/app/__tests__/routes.test.ts
@@ -4,6 +4,7 @@ import { Router } from '@revealui/router';
 import { describe, expect, it } from 'vitest';
 import { BlogIndexPage } from '../routes/BlogIndexPage';
 import { BlogPostPage } from '../routes/BlogPostPage';
+import { ClaimsPage } from '../routes/ClaimsPage';
 import { ContactPage } from '../routes/ContactPage';
 import { FairSourcePage } from '../routes/FairSourcePage';
 import { HomePage } from '../routes/HomePage';
@@ -26,6 +27,7 @@ describe('marketing route registry', () => {
       { path: '/contact', component: ContactPage },
       { path: '/fair-source', component: FairSourcePage },
       { path: '/roadmap', component: RoadmapPage },
+      { path: '/claims', component: ClaimsPage },
       { path: '/privacy', component: PrivacyPage },
       { path: '/terms', component: TermsPage },
       { path: '/*notfound', component: NotFoundPage },
@@ -44,6 +46,7 @@ describe('marketing route registry', () => {
       '/contact',
       '/fair-source',
       '/roadmap',
+      '/claims',
       '/privacy',
       '/terms',
     ];

--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { BuiltWithRevealUI } from '@revealui/presentation';
 import {
+  FOOTER_CLAIMS_LEDGER_NOTE,
   FOOTER_COLUMNS,
   FOOTER_LEGAL,
   FOOTER_LEGAL_LINKS,
@@ -24,6 +25,15 @@ export function Footer() {
             <p className="text-muted-foreground text-sm leading-6 max-w-sm">{FOOTER_TAGLINE}</p>
             <p className="text-muted-foreground text-xs leading-6 max-w-sm mt-3">
               {FOOTER_SOLO_OPERATOR_NOTE}
+            </p>
+            <p className="text-muted-foreground text-xs leading-6 max-w-sm mt-3">
+              {FOOTER_CLAIMS_LEDGER_NOTE.prefix}{' '}
+              <a
+                href={FOOTER_CLAIMS_LEDGER_NOTE.href}
+                className="font-medium text-primary hover:underline"
+              >
+                {FOOTER_CLAIMS_LEDGER_NOTE.linkLabel}
+              </a>
             </p>
             <div className="mt-3 space-y-1">
               {FOOTER_SERVICE_LINKS.map((item) => (

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -66,6 +66,7 @@ export const COVERED_FILES: readonly CoveredFile[] = [
   { file: 'philosophy.ts' },
   { file: 'marketplace.ts' },
   { file: 'roadmap.ts' },
+  { file: 'claims.ts' },
 ] as const;
 
 const AUTH_SESSIONS: EvidenceRef = {
@@ -466,6 +467,30 @@ const MARKET_CITATIONS: EvidenceRef = {
   kind: 'url',
   ref: 'https://revealui.com/local-ai',
   note: 'external market citations, explicitly labeled as not RevealUI customers with an on-page disclaimer',
+};
+
+// ── /claims self-reference (frontend-excellence Phase 5, Fable ruling
+// 2026-07-16): the ledger page proves itself with the same artifacts it
+// renders for every other page. ──────────────────────────────────────────
+const CLAIMS_INDEX: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/marketing/app/content/claims-evidence.ts',
+  note: 'the claims index this page renders',
+};
+const CLAIMS_VALIDATOR: EvidenceRef = {
+  kind: 'code',
+  ref: 'scripts/validate/claims-evidence.ts',
+  note: 'the gate that enforces coverage, text staleness, and evidence-path existence on every PR',
+};
+const CLAIMS_ROUTE_MAP: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/marketing/app/content/claims-routes.ts',
+  note: 'file-to-route map; the validator fails when a covered file has no entry here',
+};
+const CLAIMS_PAGE_ROUTE: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/marketing/app/routes/ClaimsPage.tsx',
+  note: 'renders this index publicly at /claims',
 };
 
 export const CLAIMS: readonly ClaimEntry[] = [
@@ -3578,6 +3603,106 @@ export const CLAIMS: readonly ClaimEntry[] = [
     exportPath: 'ROADMAP_CTA.subtitle',
     text: 'We prioritize based on customer impact, product readiness, and community demand.',
     evidence: [ROADMAP],
+  },
+
+  // ── claims.ts — /claims self-reference ───────────────────────────────────
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_HERO.subtitle',
+    text: 'Every sentence on this site that makes a claim about the product carries an entry below. Each one links to the code, the command, or the page that proves it.',
+    evidence: [
+      { ...CLAIMS_INDEX, note: `${CLAIMS_INDEX.note}; sentence 1, "carries an entry below"` },
+      {
+        ...CLAIMS_PAGE_ROUTE,
+        note: `${CLAIMS_PAGE_ROUTE.note}; sentence 2, renders the code/command/page link per entry`,
+      },
+    ],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_LEDGER_INTRO',
+    text: 'The ledger below is grouped by page, starting with the homepage and moving outward through the site.',
+    evidence: [CLAIMS_ROUTE_MAP],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_KIND_LEGEND[0].description',
+    text: 'A file or directory in the public repository that implements the claim.',
+    evidence: [CLAIMS_PAGE_ROUTE],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_KIND_LEGEND[1].description',
+    text: 'A command you can run yourself to reproduce the claim.',
+    evidence: [CLAIMS_PAGE_ROUTE],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_KIND_LEGEND[2].description',
+    text: 'A live page or endpoint that demonstrates the claim in production.',
+    evidence: [CLAIMS_PAGE_ROUTE],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_KIND_LEGEND[3].description',
+    text: 'A number pinned to the codebase and checked by the claim-drift gate.',
+    evidence: [CLAIMS_PAGE_ROUTE, LICENSE_SPLIT],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_HONESTY_RAILS_SECTION.intro',
+    text: 'The validator that generates this page runs on every pull request and checks the following.',
+    evidence: [CLAIMS_VALIDATOR, CI_GATE],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_HONESTY_RAILS_SECTION.checks[0]',
+    text: 'Every covered sentence on the site carries a matching entry in this index.',
+    evidence: [CLAIMS_VALIDATOR, CLAIMS_INDEX],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_HONESTY_RAILS_SECTION.checks[1]',
+    text: "Each entry's text still matches the live copy, word for word.",
+    evidence: [CLAIMS_VALIDATOR],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_HONESTY_RAILS_SECTION.checks[2]',
+    text: 'Every code path an entry cites still exists in the tracked repository.',
+    evidence: [
+      { ...CLAIMS_VALIDATOR, note: `${CLAIMS_VALIDATOR.note}; the redaction-rail assertion` },
+    ],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_HONESTY_RAILS_SECTION.notCheckedHeading',
+    text: 'What this page does not check',
+    evidence: [CLAIMS_VALIDATOR],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_HONESTY_RAILS_SECTION.doesNotCheck[0]',
+    text: 'The gate does not check that the cited code actually does what the sentence claims.',
+    evidence: [
+      {
+        kind: 'url',
+        ref: 'https://github.com/RevealUIStudio/revealui',
+        note: 'negative claim: the gate cannot verify code behavior, only that cited paths exist and cited text matches; verify by reading the validator source',
+      },
+    ],
+  },
+  {
+    file: 'claims.ts',
+    exportPath: 'CLAIMS_HONESTY_RAILS_SECTION.doesNotCheck[1]',
+    text: 'That judgment is a human review layer, not an automated one.',
+    evidence: [
+      {
+        kind: 'url',
+        ref: 'https://revealui.com/claims',
+        note: 'positive claim about process, not code; the honesty-rails copy itself is the disclosure',
+      },
+    ],
   },
 ] as const;
 

--- a/apps/marketing/app/content/claims-routes.ts
+++ b/apps/marketing/app/content/claims-routes.ts
@@ -1,0 +1,74 @@
+// File → public route map for the claims-evidence index (locked design point
+// 5, frontend-excellence Phase 5, Fable ruling 2026-07-16). /claims groups
+// the ledger by this map: one anchor section per content file, ordered by
+// route depth, each section titled by the page it proves.
+//
+// Every file in claims-evidence.ts's COVERED_FILES must have an entry here.
+// scripts/validate/claims-evidence.ts fails the build when one is missing, so
+// a newly covered file can never render on the ledger with no page to link
+// to.
+//
+// Some covered files back copy that renders on more than one route, or that
+// currently renders nowhere at all (audited 2026-07-17, see the per-entry
+// notes below). This map is single-valued by design, one file maps to one
+// canonical section; where a file's content is unwired, it is mapped to the
+// route it was written for, and the drift is called out here rather than
+// silently hidden.
+
+export interface RouteEntry {
+  readonly route: string;
+  readonly pageTitle: string;
+}
+
+export const CONTENT_FILE_ROUTES: Readonly<Record<string, RouteEntry>> = {
+  'home.ts': { route: '/', pageTitle: 'Home' },
+  // HOME_PRIMITIVES_SECTION / HOME_PRIMITIVES render on "/" via
+  // components/landing/Primitives.tsx. This file also exports
+  // PRODUCTS_PRIMITIVES, which is not imported by any route or component
+  // (verified 2026-07-17) — built-but-unwired content, not live copy.
+  'primitives.ts': { route: '/', pageTitle: 'Home' },
+  // Sourced from the retired WhatsShipped.tsx home section (see the file's
+  // own header comment). No current route imports CAPABILITIES_SECTION or
+  // CAPABILITIES — mapped to "/", its last known home, pending re-wiring.
+  'capabilities.ts': { route: '/', pageTitle: 'Home' },
+  // Renders on both "/" (components/landing/Proof.tsx) and "/products"
+  // (ProductsPage.tsx reuses the same component); "/" is the primary,
+  // original placement.
+  'proof.ts': { route: '/', pageTitle: 'Home' },
+  'pricing-teaser.ts': { route: '/', pageTitle: 'Home' },
+  // SITE.brandTagline (the one claims-evidence entry sourced from this file)
+  // is not currently rendered by any route. SITE's other exports (urls,
+  // METRICS) are used throughout the site but carry no prose claims of
+  // their own.
+  'site.ts': { route: '/', pageTitle: 'Home' },
+  'products.ts': { route: '/products', pageTitle: 'Products' },
+  'pricing.ts': { route: '/pricing', pageTitle: 'Pricing' },
+  'pricing-faq.ts': { route: '/pricing', pageTitle: 'Pricing' },
+  // Canonical URL for the operator content is /services (ServicesPage.tsx);
+  // the same components also render inline on "/" behind
+  // ?for=non-technical.
+  'for-operators.ts': { route: '/services', pageTitle: 'Services' },
+  'for-operators-how-it-works.ts': {
+    route: '/for-operators/how-it-works',
+    pageTitle: 'How it works',
+  },
+  'for-operators-managed.ts': {
+    route: '/for-operators/managed',
+    pageTitle: 'RevealUI Cloud (roadmap)',
+  },
+  'local-ai.ts': { route: '/local-ai', pageTitle: 'Local-first AI' },
+  'fair-source.ts': { route: '/fair-source', pageTitle: 'Fair Source' },
+  'philosophy.ts': { route: '/philosophy', pageTitle: 'Why RevealUI exists' },
+  // The standalone /marketplace page is retired (308-redirects to /roadmap);
+  // this catalog is preserved seed data for a future revmarket repo (see the
+  // file's own header comment), not currently rendered anywhere.
+  'marketplace.ts': { route: '/roadmap', pageTitle: 'Roadmap' },
+  'roadmap.ts': { route: '/roadmap', pageTitle: 'Roadmap' },
+  'claims.ts': { route: '/claims', pageTitle: 'The claims ledger' },
+} as const;
+
+/** Number of non-empty path segments; "/" is depth 0. Zero authored regex. */
+export function routeDepth(route: string): number {
+  if (route === '/') return 0;
+  return route.split('/').filter((segment) => segment.length > 0).length;
+}

--- a/apps/marketing/app/content/claims.ts
+++ b/apps/marketing/app/content/claims.ts
@@ -1,0 +1,66 @@
+// Copy for /claims (ClaimsPage.tsx), the public claims ledger.
+//
+// Locked design: frontend-excellence Phase 5, Fable ruling 2026-07-16. The
+// page renders the claims-evidence index (claims-evidence.ts) directly, so
+// every prose sentence written here is itself indexed there too. The page
+// proves itself, the same way it proves every other page on the site.
+
+export const CLAIMS_HERO = {
+  eyebrow: 'Public proof',
+  h1: 'The claims ledger',
+  subtitle:
+    'Every sentence on this site that makes a claim about the product carries an entry below. Each one links to the code, the command, or the page that proves it.',
+} as const;
+
+export const CLAIMS_COUNTS_LABELS = {
+  entriesLabel: 'indexed claims',
+  filesLabel: 'covered files',
+} as const;
+
+export const CLAIMS_LEDGER_INTRO =
+  'The ledger below is grouped by page, starting with the homepage and moving outward through the site.' as const;
+
+export interface KindLegendEntry {
+  readonly kind: 'code' | 'command' | 'url' | 'metric';
+  readonly label: string;
+  readonly description: string;
+}
+
+export const CLAIMS_KIND_LEGEND: readonly KindLegendEntry[] = [
+  {
+    kind: 'code',
+    label: 'Code',
+    description: 'A file or directory in the public repository that implements the claim.',
+  },
+  {
+    kind: 'command',
+    label: 'Command',
+    description: 'A command you can run yourself to reproduce the claim.',
+  },
+  {
+    kind: 'url',
+    label: 'URL',
+    description: 'A live page or endpoint that demonstrates the claim in production.',
+  },
+  {
+    kind: 'metric',
+    label: 'Metric',
+    description: 'A number pinned to the codebase and checked by the claim-drift gate.',
+  },
+] as const;
+
+export const CLAIMS_HONESTY_RAILS_SECTION = {
+  heading: 'What this page checks',
+  intro:
+    'The validator that generates this page runs on every pull request and checks the following.',
+  checks: [
+    'Every covered sentence on the site carries a matching entry in this index.',
+    "Each entry's text still matches the live copy, word for word.",
+    'Every code path an entry cites still exists in the tracked repository.',
+  ],
+  notCheckedHeading: 'What this page does not check',
+  doesNotCheck: [
+    'The gate does not check that the cited code actually does what the sentence claims.',
+    'That judgment is a human review layer, not an automated one.',
+  ],
+} as const;

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -77,6 +77,16 @@ export const FOOTER_SERVICE_LINKS: readonly FooterServiceLink[] = [
   { prefix: 'Building for clients?', label: 'See agency licensing.', href: '/pricing#perpetual' },
 ] as const;
 
+// Every marketing page links to /claims, the public claims ledger (frontend-
+// excellence Phase 5, Fable ruling 2026-07-16). Uncovered by claims-evidence
+// on purpose: this line is global footer chrome on every page, not copy tied
+// to one page's claims. It still runs through the marketing-voice scan.
+export const FOOTER_CLAIMS_LEDGER_NOTE = {
+  prefix: 'Every sentence on this site is indexed against the code.',
+  linkLabel: 'See the claims ledger.',
+  href: '/claims',
+} as const;
+
 export const FOOTER_LEGAL = {
   operator: 'REVEALUI STUDIO L.L.C.',
   operatorHref: SITE.urls.agency,

--- a/apps/marketing/app/routes/ClaimsPage.tsx
+++ b/apps/marketing/app/routes/ClaimsPage.tsx
@@ -1,0 +1,264 @@
+import { Badge, Callout, CodeBlock, Divider } from '@revealui/presentation';
+import { Footer } from '../components/Footer';
+import {
+  CLAIMS_COUNTS_LABELS,
+  CLAIMS_HERO,
+  CLAIMS_HONESTY_RAILS_SECTION,
+  CLAIMS_KIND_LEGEND,
+  CLAIMS_LEDGER_INTRO,
+} from '../content/claims';
+import {
+  CLAIMS,
+  type ClaimEntry,
+  COVERED_FILES,
+  type EvidenceKind,
+} from '../content/claims-evidence';
+import { CONTENT_FILE_ROUTES, routeDepth } from '../content/claims-routes';
+import { SITE } from '../content/site';
+
+/** One accent color throughout (locked design point 10): every kind badge
+ *  reads "brand" (the Cobalt primary token). Kinds are told apart by label. */
+const KIND_BADGE_COLOR = 'brand' as const;
+
+// Partial + fallback so a future EvidenceKind (e.g. the capability-proof
+// 'test' kind) renders its raw kind as the badge instead of breaking the
+// build or showing an empty badge before the legend copy catches up.
+const KIND_LABEL: Partial<Record<EvidenceKind, string>> = Object.fromEntries(
+  CLAIMS_KIND_LEGEND.map((entry) => [entry.kind, entry.label]),
+);
+
+function codeHref(ref: string): string {
+  return `${SITE.urls.repo}/blob/main/${ref}`;
+}
+
+function anchorId(file: string): string {
+  return file.endsWith('.ts') ? file.slice(0, -3) : file;
+}
+
+interface FileSection {
+  readonly file: string;
+  readonly route: string;
+  readonly pageTitle: string;
+  readonly claims: readonly ClaimEntry[];
+}
+
+// One section per covered content file (locked design point 3), ordered by
+// the depth of the route it proves — the file mapping to "/" comes first.
+// COVERED_FILES already lists home.ts before deeper pages, so a stable sort
+// on depth alone preserves that order among ties.
+const FILE_SECTIONS: readonly FileSection[] = COVERED_FILES.map((covered) => {
+  // Guaranteed present by the validate:claims-evidence route-map assertion
+  // (scripts/validate/claims-evidence.ts check 4); the fallback only matters
+  // for a local dev build made before that gate has run.
+  const routeEntry = CONTENT_FILE_ROUTES[covered.file];
+  return {
+    file: covered.file,
+    route: routeEntry?.route ?? '/',
+    pageTitle: routeEntry?.pageTitle ?? covered.file,
+    claims: CLAIMS.filter((claim) => claim.file === covered.file),
+  };
+})
+  .slice()
+  .sort((a, b) => routeDepth(a.route) - routeDepth(b.route));
+
+function EvidenceRow({ evidence }: { evidence: ClaimEntry['evidence'][number] }) {
+  return (
+    <li className="flex flex-wrap items-start gap-x-2 gap-y-1 border-t border-dashed border-border py-2 font-mono text-xs">
+      <Badge color={KIND_BADGE_COLOR}>{KIND_LABEL[evidence.kind] ?? evidence.kind}</Badge>
+      {evidence.kind === 'command' ? (
+        <div className="w-full pt-1">
+          <CodeBlock code={evidence.ref} language="bash" />
+        </div>
+      ) : evidence.kind === 'code' || evidence.kind === 'metric' ? (
+        <a
+          href={codeHref(evidence.ref)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="break-all text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+        >
+          {evidence.ref}
+        </a>
+      ) : evidence.kind === 'url' ? (
+        <a
+          href={evidence.ref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="break-all text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+        >
+          {evidence.ref}
+        </a>
+      ) : (
+        // Future evidence kinds (e.g. the capability-proof 'test' kind, whose
+        // ref is "file#test title", not a URL) render as plain text until the
+        // page grows a dedicated treatment. Never emit an unknown ref as href.
+        <span className="break-all">{evidence.ref}</span>
+      )}
+      {evidence.note && (
+        <span className="w-full font-sans text-muted-foreground">{evidence.note}</span>
+      )}
+    </li>
+  );
+}
+
+function ClaimRow({
+  claim,
+  pageTitle,
+  route,
+}: {
+  claim: ClaimEntry;
+  pageTitle: string;
+  route: string;
+}) {
+  return (
+    <li className="py-6" data-testid="claim-row">
+      <p className="text-sm leading-6 text-foreground">{claim.text}</p>
+      <p className="mt-1 font-mono text-xs text-muted-foreground">
+        Proves{' '}
+        <a href={route} className="text-primary hover:text-primary/80">
+          {pageTitle}
+        </a>{' '}
+        &middot; {claim.exportPath}
+      </p>
+      <ul className="mt-2">
+        {claim.evidence.map((ev, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: evidence refs carry no stable id of their own
+          <EvidenceRow key={`${claim.exportPath}-${i}`} evidence={ev} />
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+export function ClaimsPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border px-6 pt-24 pb-12 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {CLAIMS_HERO.eyebrow}
+          </p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+            {CLAIMS_HERO.h1}
+          </h1>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
+            {CLAIMS_HERO.subtitle}
+          </p>
+          <div className="mt-6 flex flex-wrap gap-x-8 gap-y-2 font-mono text-sm tabular-nums text-foreground">
+            <span>
+              <strong className="font-semibold">{CLAIMS.length}</strong>{' '}
+              {CLAIMS_COUNTS_LABELS.entriesLabel}
+            </span>
+            <span>
+              <strong className="font-semibold">{COVERED_FILES.length}</strong>{' '}
+              {CLAIMS_COUNTS_LABELS.filesLabel}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <section className="border-b border-border bg-muted/40 px-6 py-8 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {CLAIMS_KIND_LEGEND.map((entry) => (
+              <div key={entry.kind} className="flex items-start gap-3">
+                <Badge color={KIND_BADGE_COLOR} className="mt-0.5 shrink-0">
+                  {entry.label}
+                </Badge>
+                <dd className="text-sm text-muted-foreground">{entry.description}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      <nav aria-label="Sections" className="border-b border-border px-6 py-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <p className="mb-3 text-sm leading-6 text-muted-foreground">{CLAIMS_LEDGER_INTRO}</p>
+          <ul className="flex flex-wrap gap-x-4 gap-y-2 font-mono text-xs">
+            {FILE_SECTIONS.map((section) => (
+              <li key={section.file}>
+                <a
+                  href={`#${anchorId(section.file)}`}
+                  className="text-primary hover:text-primary/80"
+                >
+                  {section.pageTitle}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </nav>
+
+      <main className="px-6 py-4 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          {FILE_SECTIONS.map((section, i) => (
+            <section
+              key={section.file}
+              id={anchorId(section.file)}
+              aria-labelledby={`${anchorId(section.file)}-heading`}
+              className="py-8"
+            >
+              <h2
+                id={`${anchorId(section.file)}-heading`}
+                className="text-xl font-semibold text-foreground"
+              >
+                {section.pageTitle}
+              </h2>
+              <p className="mt-1 font-mono text-xs text-muted-foreground">
+                <a href={section.route} className="text-primary hover:text-primary/80">
+                  {section.route}
+                </a>{' '}
+                &middot; sourced from{' '}
+                <code className="rounded bg-muted px-1 py-0.5">
+                  apps/marketing/app/content/{section.file}
+                </code>
+              </p>
+              {section.claims.length === 0 ? (
+                <p className="mt-4 text-sm text-muted-foreground">
+                  No indexed claims yet for this file.
+                </p>
+              ) : (
+                <ol className="mt-4 divide-y divide-border">
+                  {section.claims.map((claim) => (
+                    <ClaimRow
+                      key={claim.exportPath}
+                      claim={claim}
+                      pageTitle={section.pageTitle}
+                      route={section.route}
+                    />
+                  ))}
+                </ol>
+              )}
+              {i < FILE_SECTIONS.length - 1 && <Divider soft className="mt-8" />}
+            </section>
+          ))}
+        </div>
+      </main>
+
+      <section className="border-t border-border bg-muted/40 px-6 py-16 lg:px-8">
+        <div className="mx-auto max-w-3xl space-y-4">
+          <Callout variant="info" title={CLAIMS_HONESTY_RAILS_SECTION.heading}>
+            <p>{CLAIMS_HONESTY_RAILS_SECTION.intro}</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              {CLAIMS_HONESTY_RAILS_SECTION.checks.map((check) => (
+                <li key={check}>{check}</li>
+              ))}
+            </ul>
+          </Callout>
+          <div className="rounded-xl bg-muted p-4 ring-1 ring-border">
+            <p className="text-sm font-semibold text-foreground">
+              {CLAIMS_HONESTY_RAILS_SECTION.notCheckedHeading}
+            </p>
+            <div className="mt-1 space-y-1 text-sm text-muted-foreground">
+              {CLAIMS_HONESTY_RAILS_SECTION.doesNotCheck.map((sentence) => (
+                <p key={sentence}>{sentence}</p>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/marketing/app/routes/__tests__/ClaimsPage.test.tsx
+++ b/apps/marketing/app/routes/__tests__/ClaimsPage.test.tsx
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CLAIMS, COVERED_FILES } from '../../content/claims-evidence';
+import { ClaimsPage } from '../ClaimsPage';
+
+afterEach(cleanup);
+
+describe('ClaimsPage', () => {
+  it('renders the locked H1', async () => {
+    render(<ClaimsPage />);
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'The claims ledger' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders live counts computed from the imported index, not hardcoded', async () => {
+    render(<ClaimsPage />);
+    expect(await screen.findByText(String(CLAIMS.length))).toBeInTheDocument();
+    expect(await screen.findByText(String(COVERED_FILES.length))).toBeInTheDocument();
+  });
+
+  it('renders one row per claims-evidence entry', async () => {
+    render(<ClaimsPage />);
+    const rows = await screen.findAllByTestId('claim-row');
+    expect(rows).toHaveLength(CLAIMS.length);
+  });
+
+  it('renders a section for every covered file', async () => {
+    render(<ClaimsPage />);
+    for (const covered of COVERED_FILES) {
+      const anchor = covered.file.endsWith('.ts') ? covered.file.slice(0, -3) : covered.file;
+      const section = document.getElementById(anchor);
+      expect(section, `missing section for ${covered.file}`).not.toBeNull();
+    }
+  });
+
+  it('deep-links "code" evidence to the public GitHub repo', async () => {
+    render(<ClaimsPage />);
+    const allLinks = await screen.findAllByRole('link');
+    const codeEvidenceHrefPrefix = 'https://github.com/RevealUIStudio/revealui/blob/main/';
+    const codeLinks = allLinks.filter((link) =>
+      (link.getAttribute('href') ?? '').startsWith(codeEvidenceHrefPrefix),
+    );
+    expect(codeLinks.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -51,6 +51,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://revealui.com/claims</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://revealui.com/privacy</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>

--- a/scripts/validate/__tests__/claims-evidence.test.ts
+++ b/scripts/validate/__tests__/claims-evidence.test.ts
@@ -1,0 +1,133 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+  ClaimEntry,
+  CoveredFile,
+} from '../../../apps/marketing/app/content/claims-evidence.ts';
+import {
+  findMissingRouteEntries,
+  findUntrackedCodeEvidence,
+  isTrackedPath,
+  loadTrackedFiles,
+} from '../claims-evidence.ts';
+
+describe('findMissingRouteEntries', () => {
+  const covered: readonly CoveredFile[] = [{ file: 'home.ts' }, { file: 'pricing.ts' }];
+
+  it('flags a covered file with no entry in the route map', () => {
+    expect(
+      findMissingRouteEntries(covered, { 'home.ts': { route: '/', pageTitle: 'Home' } }),
+    ).toEqual(['pricing.ts']);
+  });
+
+  it('passes when every covered file has a route entry', () => {
+    expect(
+      findMissingRouteEntries(covered, {
+        'home.ts': { route: '/', pageTitle: 'Home' },
+        'pricing.ts': { route: '/pricing', pageTitle: 'Pricing' },
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns an empty array for an empty covered-file list', () => {
+    expect(findMissingRouteEntries([], {})).toEqual([]);
+  });
+});
+
+describe('isTrackedPath', () => {
+  const tracked = new Set(['apps/marketing/app/content/site.ts', 'packages/core/src/index.ts']);
+
+  it('matches an exact tracked file', () => {
+    expect(isTrackedPath(tracked, 'apps/marketing/app/content/site.ts')).toBe(true);
+  });
+
+  it('matches a directory-shaped ref that contains a tracked file', () => {
+    expect(isTrackedPath(tracked, 'packages/core/src')).toBe(true);
+  });
+
+  it('normalizes a trailing slash on a directory ref', () => {
+    expect(isTrackedPath(tracked, 'packages/core/src/')).toBe(true);
+  });
+
+  it('does not match a path outside the tracked set', () => {
+    expect(isTrackedPath(tracked, 'apps/marketing/app/content/nonexistent.ts')).toBe(false);
+  });
+
+  it('does not match a directory with no tracked files under it', () => {
+    expect(isTrackedPath(tracked, 'packages/nonexistent-pkg/src')).toBe(false);
+  });
+});
+
+describe('findUntrackedCodeEvidence', () => {
+  const tracked = new Set(['apps/marketing/app/content/site.ts']);
+
+  function claim(exportPath: string, evidence: ClaimEntry['evidence']): ClaimEntry {
+    return { file: 'home.ts', exportPath, text: 'placeholder text long enough to pass', evidence };
+  }
+
+  it('flags a code-kind ref to a path not tracked in the repo (proves red)', () => {
+    const claims = [
+      claim('HOME_HERO.h1', [{ kind: 'code', ref: 'apps/marketing/app/content/ghost.ts' }]),
+    ];
+    expect(findUntrackedCodeEvidence(claims, tracked)).toEqual([
+      { file: 'home.ts', exportPath: 'HOME_HERO.h1', ref: 'apps/marketing/app/content/ghost.ts' },
+    ]);
+  });
+
+  it('passes a code-kind ref to a tracked path (proves green)', () => {
+    const claims = [
+      claim('HOME_HERO.h1', [{ kind: 'code', ref: 'apps/marketing/app/content/site.ts' }]),
+    ];
+    expect(findUntrackedCodeEvidence(claims, tracked)).toEqual([]);
+  });
+
+  it('ignores non-code evidence kinds regardless of tracked state', () => {
+    const claims = [
+      claim('HOME_HERO.h1', [
+        { kind: 'url', ref: 'https://revealui.com/nonexistent' },
+        { kind: 'command', ref: 'pnpm nonexistent-script' },
+        { kind: 'metric', ref: 'apps/marketing/app/content/ghost-metric.ts' },
+      ]),
+    ];
+    expect(findUntrackedCodeEvidence(claims, tracked)).toEqual([]);
+  });
+
+  it('reports every claim citing a shared untracked ref, not just the first', () => {
+    const ghostRef: ClaimEntry['evidence'][number] = {
+      kind: 'code',
+      ref: 'apps/marketing/app/content/ghost.ts',
+    };
+    const claims = [claim('A.field', [ghostRef]), claim('B.field', [ghostRef])];
+    expect(findUntrackedCodeEvidence(claims, tracked)).toHaveLength(2);
+  });
+});
+
+describe('loadTrackedFiles', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claims-evidence-git-'));
+    execFileSync('git', ['init', '-q'], { cwd: tmp });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns files staged in the git index, not merely present on disk', () => {
+    fs.writeFileSync(path.join(tmp, 'staged.ts'), '');
+    fs.writeFileSync(path.join(tmp, 'unstaged.ts'), '');
+    execFileSync('git', ['add', 'staged.ts'], { cwd: tmp });
+
+    const tracked = loadTrackedFiles(tmp);
+    expect(tracked.has('staged.ts')).toBe(true);
+    expect(tracked.has('unstaged.ts')).toBe(false);
+  });
+
+  it('returns an empty set for a repo with nothing staged', () => {
+    expect(loadTrackedFiles(tmp)).toEqual(new Set());
+  });
+});

--- a/scripts/validate/claims-evidence.ts
+++ b/scripts/validate/claims-evidence.ts
@@ -19,18 +19,31 @@
  * route. Zero authored regex (fleet no-regex rule): substring predicates and
  * Set lookups only.
  *
+ * Two more checks back the public /claims page (frontend-excellence Phase 5):
+ *   4. route map — every covered file has an entry in claims-routes.ts, so
+ *      /claims always has a page to group its claims under;
+ *   5. redaction rail — every `code` evidence ref resolves to a path
+ *      TRACKED in the repo's git index, not merely present on the local
+ *      filesystem. `existsSync` (check 3, above) passes for gitignored or
+ *      unstaged local-only paths too; those would 404 on the public GitHub
+ *      deep link this page renders for `code` refs.
+ *
  * Usage:
  *   tsx scripts/validate/claims-evidence.ts          # exit 1 on violations
  *   tsx scripts/validate/claims-evidence.ts --warn   # warn-only (exit 0)
  */
 
+import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import {
   CLAIMS,
+  type ClaimEntry,
   COVERED_FILES,
+  type CoveredFile,
   NON_COPY_KEYS,
 } from '../../apps/marketing/app/content/claims-evidence.js';
+import { CONTENT_FILE_ROUTES } from '../../apps/marketing/app/content/claims-routes.js';
 
 const warnOnly = process.argv.includes('--warn');
 const repoRoot = join(import.meta.dirname, '..', '..');
@@ -77,85 +90,184 @@ function collectStrings(
   }
 }
 
-const violations: string[] = [];
-
-for (const covered of COVERED_FILES) {
-  const modulePath = join(contentDir, covered.file);
-  if (!existsSync(modulePath)) {
-    violations.push(`covered file missing: apps/marketing/app/content/${covered.file}`);
-    continue;
+/** Covered files with no entry in the file→route map. Pure; exported for tests. */
+export function findMissingRouteEntries(
+  covered: readonly CoveredFile[],
+  routes: Readonly<Record<string, unknown>>,
+): string[] {
+  const missing: string[] = [];
+  for (const c of covered) {
+    if (!(c.file in routes)) missing.push(c.file);
   }
-  const mod = (await import(modulePath)) as Record<string, unknown>;
+  return missing;
+}
 
-  const collected: CollectedString[] = [];
-  for (const [exportName, value] of Object.entries(mod)) {
-    if (covered.exportPrefix && !exportName.startsWith(covered.exportPrefix)) continue;
-    collectStrings(covered.file, value, exportName, exportName, collected);
+/** Every path (or `-z`-terminated NUL-separated line) `git ls-files` reports for `repoRoot`. */
+export function loadTrackedFiles(repoRootPath: string): Set<string> {
+  const raw = execFileSync('git', ['ls-files', '-z'], {
+    cwd: repoRootPath,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return new Set(raw.split('\0').filter((f) => f.length > 0));
+}
+
+/**
+ * True when `ref` is itself a tracked file, or (directory-shaped ref) at
+ * least one tracked file lives under it. Pure; exported for tests.
+ */
+export function isTrackedPath(tracked: ReadonlySet<string>, ref: string): boolean {
+  const clean = ref.endsWith('/') ? ref.slice(0, -1) : ref;
+  if (tracked.has(clean)) return true;
+  const prefix = `${clean}/`;
+  for (const file of tracked) {
+    if (file.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+export interface UntrackedCodeEvidence {
+  readonly file: string;
+  readonly exportPath: string;
+  readonly ref: string;
+}
+
+/** `code`-kind evidence refs across `claims` not tracked in `tracked`. Pure; exported for tests. */
+export function findUntrackedCodeEvidence(
+  claims: readonly ClaimEntry[],
+  tracked: ReadonlySet<string>,
+): UntrackedCodeEvidence[] {
+  const uniqueRefs = new Set<string>();
+  for (const claim of claims) {
+    for (const ev of claim.evidence) {
+      if (ev.kind === 'code') uniqueRefs.add(ev.ref);
+    }
+  }
+  const untrackedRefs = new Set<string>();
+  for (const ref of uniqueRefs) {
+    if (!isTrackedPath(tracked, ref)) untrackedRefs.add(ref);
+  }
+  if (untrackedRefs.size === 0) return [];
+
+  const results: UntrackedCodeEvidence[] = [];
+  for (const claim of claims) {
+    for (const ev of claim.evidence) {
+      if (ev.kind === 'code' && untrackedRefs.has(ev.ref)) {
+        results.push({ file: claim.file, exportPath: claim.exportPath, ref: ev.ref });
+      }
+    }
+  }
+  return results;
+}
+
+async function run(): Promise<void> {
+  const violations: string[] = [];
+
+  for (const covered of COVERED_FILES) {
+    const modulePath = join(contentDir, covered.file);
+    if (!existsSync(modulePath)) {
+      violations.push(`covered file missing: apps/marketing/app/content/${covered.file}`);
+      continue;
+    }
+    const mod = (await import(modulePath)) as Record<string, unknown>;
+
+    const collected: CollectedString[] = [];
+    for (const [exportName, value] of Object.entries(mod)) {
+      if (covered.exportPrefix && !exportName.startsWith(covered.exportPrefix)) continue;
+      collectStrings(covered.file, value, exportName, exportName, collected);
+    }
+
+    const fileClaims = CLAIMS.filter((c) => c.file === covered.file);
+    const textEntries = new Set(
+      fileClaims.filter((c) => (c.match ?? 'text') === 'text').map((c) => c.text),
+    );
+    const pathEntries = new Set(
+      fileClaims.filter((c) => c.match === 'path').map((c) => c.exportPath),
+    );
+
+    // 1. Coverage: every collected prose string is indexed.
+    for (const s of collected) {
+      if (textEntries.has(s.value)) continue;
+      if (pathEntries.has(s.path)) continue;
+      violations.push(
+        `${covered.file} :: ${s.path} — prose with no claims-evidence entry: "${s.value.slice(0, 80)}"`,
+      );
+    }
+
+    // 2. Staleness: every index entry still matches the module.
+    const collectedValues = new Set(collected.map((s) => s.value));
+    const collectedPaths = new Set(collected.map((s) => s.path));
+    for (const claim of fileClaims) {
+      if (claim.match === 'path') {
+        if (!collectedPaths.has(claim.exportPath)) {
+          violations.push(
+            `${covered.file} :: ${claim.exportPath} — path-matched entry resolves to no prose string (copy moved or field renamed)`,
+          );
+        }
+        continue;
+      }
+      if (!collectedValues.has(claim.text)) {
+        violations.push(
+          `${covered.file} :: ${claim.exportPath} — entry text no longer matches the copy: "${claim.text.slice(0, 80)}"`,
+        );
+      }
+    }
   }
 
-  const fileClaims = CLAIMS.filter((c) => c.file === covered.file);
-  const textEntries = new Set(
-    fileClaims.filter((c) => (c.match ?? 'text') === 'text').map((c) => c.text),
-  );
-  const pathEntries = new Set(
-    fileClaims.filter((c) => c.match === 'path').map((c) => c.exportPath),
-  );
+  // 3. Evidence: cited repo paths exist.
+  for (const claim of CLAIMS) {
+    for (const ev of claim.evidence) {
+      if (ev.kind === 'code' || ev.kind === 'metric') {
+        if (!existsSync(join(repoRoot, ev.ref))) {
+          violations.push(
+            `${claim.file} :: ${claim.exportPath} — evidence path missing: ${ev.ref}`,
+          );
+        }
+      } else if (ev.ref.trim() === '') {
+        violations.push(`${claim.file} :: ${claim.exportPath} — empty evidence ref`);
+      }
+    }
+  }
 
-  // 1. Coverage: every collected prose string is indexed.
-  for (const s of collected) {
-    if (textEntries.has(s.value)) continue;
-    if (pathEntries.has(s.path)) continue;
+  // 4. Route map: every covered file must resolve to a public route so
+  // /claims always has a page to group its section under.
+  for (const file of findMissingRouteEntries(COVERED_FILES, CONTENT_FILE_ROUTES)) {
     violations.push(
-      `${covered.file} :: ${s.path} — prose with no claims-evidence entry: "${s.value.slice(0, 80)}"`,
+      `${file} — no entry in claims-routes.ts CONTENT_FILE_ROUTES (add one so /claims can group its claims by page)`,
     );
   }
 
-  // 2. Staleness: every index entry still matches the module.
-  const collectedValues = new Set(collected.map((s) => s.value));
-  const collectedPaths = new Set(collected.map((s) => s.path));
-  for (const claim of fileClaims) {
-    if (claim.match === 'path') {
-      if (!collectedPaths.has(claim.exportPath)) {
-        violations.push(
-          `${covered.file} :: ${claim.exportPath} — path-matched entry resolves to no prose string (copy moved or field renamed)`,
-        );
-      }
-      continue;
-    }
-    if (!collectedValues.has(claim.text)) {
-      violations.push(
-        `${covered.file} :: ${claim.exportPath} — entry text no longer matches the copy: "${claim.text.slice(0, 80)}"`,
-      );
-    }
+  // 5. Redaction rail: every `code` evidence ref must resolve to a path
+  // tracked in the repo's git index, not merely present on the local
+  // filesystem (see the file-header comment for why `existsSync` is not
+  // enough on its own).
+  const trackedFiles = loadTrackedFiles(repoRoot);
+  for (const untracked of findUntrackedCodeEvidence(CLAIMS, trackedFiles)) {
+    violations.push(
+      `${untracked.file} :: ${untracked.exportPath} — code evidence path is not tracked in the repo (would 404 on GitHub): ${untracked.ref}`,
+    );
   }
-}
 
-// 3. Evidence: cited repo paths exist.
-for (const claim of CLAIMS) {
-  for (const ev of claim.evidence) {
-    if (ev.kind === 'code' || ev.kind === 'metric') {
-      if (!existsSync(join(repoRoot, ev.ref))) {
-        violations.push(`${claim.file} :: ${claim.exportPath} — evidence path missing: ${ev.ref}`);
-      }
-    } else if (ev.ref.trim() === '') {
-      violations.push(`${claim.file} :: ${claim.exportPath} — empty evidence ref`);
-    }
+  const coveredCount = CLAIMS.length;
+  if (violations.length === 0) {
+    console.log(
+      `claims-evidence: ${coveredCount} indexed claims across ${COVERED_FILES.length} covered files, all matched, all evidence paths present.`,
+    );
+    process.exit(0);
   }
-}
 
-const coveredCount = CLAIMS.length;
-if (violations.length === 0) {
-  console.log(
-    `claims-evidence: ${coveredCount} indexed claims across ${COVERED_FILES.length} covered files, all matched, all evidence paths present.`,
+  console.error(`claims-evidence: ${violations.length} violation(s):`);
+  for (const v of violations) {
+    console.error(`  ✗ ${v}`);
+  }
+  console.error(
+    '\nFix: index the sentence in apps/marketing/app/content/claims-evidence.ts with the code that proves it, update the stale entry, or restore the cited path. Copy with no proof does not ship.',
   );
-  process.exit(0);
+  process.exit(warnOnly ? 0 : 1);
 }
 
-console.error(`claims-evidence: ${violations.length} violation(s):`);
-for (const v of violations) {
-  console.error(`  ✗ ${v}`);
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+const selfPath = resolve(import.meta.dirname, 'claims-evidence.ts');
+if (invokedPath === selfPath) {
+  void run();
 }
-console.error(
-  '\nFix: index the sentence in apps/marketing/app/content/claims-evidence.ts with the code that proves it, update the stale entry, or restore the cited path. Copy with no proof does not ship.',
-);
-process.exit(warnOnly ? 0 : 1);


### PR DESCRIPTION
## What

Adds the public claims ledger at `/claims` on the marketing site: every covered marketing sentence rendered from the claims-evidence index, with the artifact that proves it.

- New route `ClaimsPage.tsx` composed entirely from existing `@revealui/presentation` primitives (Badge, Callout, CodeBlock, Divider). No new UI components.
- The page imports the SAME index module the validator checks (`app/content/claims-evidence.ts`), so it cannot drift from the gate. Header counts render live from the index length; nothing is hardcoded.
- One anchor section per covered content file, ordered by route depth. Code refs deep-link to this repo on `main`; command refs render as copyable code blocks.
- New exported file-to-route map (`claims-routes.ts`); the claims-evidence validator now fails CI when a covered file is missing from it.
- Redaction rail: the validator also asserts every `code` evidence ref resolves to a git-tracked path in this public repo (extends the existing validator, no new tool).
- The page's own copy (`claims.ts`) is added to COVERED_FILES and fully indexed: the page proves itself.
- Footer line on every marketing page: "Every sentence on this site is indexed against the code. See the claims ledger."
- Honesty rails section states exactly what the gate checks and what it does not.

## Verification

- claims-evidence validator: 498 indexed claims across 18 covered files, all matched, all paths present.
- claim-drift, marketing-voice: clean. Both new validator assertions proven red then green (missing route-map entry; untracked code ref).
- marketing typecheck clean, 80/80 tests pass (14 new validator unit tests + 5 page render tests), production build succeeds, biome clean.

## Coordination note

`feat/gap-354-capability-claim-validator` (sibling PR) adds a fifth evidence kind (`test`) to the same index. This page renders unknown kinds gracefully (badge falls back to the raw kind, ref renders as plain text, never as an href), so the two PRs merge cleanly in either order. Follow-up after both land: a legend entry and a dedicated link treatment for `test` refs.

## Follow-up surfaced during the build (not in this PR)

Several covered content files are built but not wired to any live route (`PRODUCTS_PRIMITIVES`, `CAPABILITIES`, `SITE.brandTagline`). Each is mapped to its best-fit historical route in `claims-routes.ts` with inline comments; tracked as a fleet gap for a wire-or-retire decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
