### PR TITLE
feat(ai): add xai provider adapter (openai-compat byok)

### DIFF
--- a/.changeset/xai-provider-adapter.md
+++ b/.changeset/xai-provider-adapter.md
@@ -1,0 +1,5 @@
+---
+"@revealui/ai": minor
+---
+
+add xai (Grok) as a BYOK LLM provider: a thin OpenAI-compatible wrapper over `https://api.x.ai/v1` (default model `grok-4.5`), following the existing anthropic/groq adapter pattern (no vendor SDK). Wires `xai` into `LLMProviderType`, `hostedViable`, `createProvider`, `createLLMClientFromEnv` (`XAI_API_KEY`/`XAI_BASE_URL`), and the admin Settings, API Keys provider list.

--- a/apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx
@@ -48,6 +48,7 @@ describe('ApiKeysPageClient', () => {
       huggingface: true,
       ollama: false,
       'inference-snaps': false,
+      xai: true,
     });
     render(<ApiKeysPageClient providers={hostedProviders} isHosted={true} />);
 

--- a/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
+++ b/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
@@ -16,7 +16,7 @@ async function loadHostedViable(): Promise<Record<Provider, boolean>> {
 }
 
 describe('visibleProviders', () => {
-  it('offers all six providers on self-hosted, regardless of the hosted map', async () => {
+  it('offers all seven providers on self-hosted, regardless of the hosted map', async () => {
     const hostedViable = await loadHostedViable();
     expect(visibleProviders(false, hostedViable).map((p) => p.id)).toEqual(
       ALL_PROVIDERS.map((p) => p.id),
@@ -27,7 +27,7 @@ describe('visibleProviders', () => {
   it('hides localhost-only providers on hosted (GAP-360 defect 5)', async () => {
     const hostedViable = await loadHostedViable();
     const ids = visibleProviders(true, hostedViable).map((p) => p.id);
-    expect(ids).toEqual(['anthropic', 'openai', 'groq', 'huggingface']);
+    expect(ids).toEqual(['anthropic', 'openai', 'xai', 'groq', 'huggingface']);
     expect(ids).not.toContain('ollama');
     expect(ids).not.toContain('inference-snaps');
   });

--- a/apps/admin/src/lib/settings/api-key-providers.ts
+++ b/apps/admin/src/lib/settings/api-key-providers.ts
@@ -1,7 +1,7 @@
 /**
  * Provider catalog for the Settings, API Keys page (GAP-360 §5.7).
  *
- * Mirrors the six providers @revealui/ai's `LLMProviderType` supports
+ * Mirrors the seven providers @revealui/ai's `LLMProviderType` supports
  * (`packages/ai/src/llm/client.ts:49`). Kept as a local string union rather
  * than importing that type: `@revealui/ai` is an optional Pro peer
  * dependency for `apps/admin` (`package.json:67`) and every existing
@@ -16,7 +16,8 @@ export type Provider =
   | 'groq'
   | 'huggingface'
   | 'ollama'
-  | 'inference-snaps';
+  | 'inference-snaps'
+  | 'xai';
 
 export interface ProviderInfo {
   id: Provider;
@@ -25,7 +26,7 @@ export interface ProviderInfo {
   docsUrl: string;
 }
 
-/** All six providers, hosted-viable and localhost-only alike. */
+/** All seven providers, hosted-viable and localhost-only alike. */
 export const ALL_PROVIDERS: ProviderInfo[] = [
   {
     id: 'anthropic',
@@ -38,6 +39,12 @@ export const ALL_PROVIDERS: ProviderInfo[] = [
     label: 'OpenAI',
     placeholder: 'sk-...',
     docsUrl: 'https://platform.openai.com/api-keys',
+  },
+  {
+    id: 'xai',
+    label: 'xAI (Grok)',
+    placeholder: 'xai-...',
+    docsUrl: 'https://console.x.ai',
   },
   {
     id: 'groq',
@@ -68,9 +75,9 @@ export const ALL_PROVIDERS: ProviderInfo[] = [
 /**
  * Resolve which providers the Settings, API Keys page should offer.
  *
- * Self-hosted: all six. Hosted: only the ones `@revealui/ai`'s
+ * Self-hosted: all seven. Hosted: only the ones `@revealui/ai`'s
  * `hostedViable` map marks reachable from a serverless deployment
- * (anthropic/openai/groq/huggingface) — `ollama`/`inference-snaps` are
+ * (anthropic/openai/groq/huggingface/xai) — `ollama`/`inference-snaps` are
  * localhost-only and useless on hosted (GAP-360 defect 5). When the hosted
  * map can't be resolved (Pro package absent), fail open to the full list —
  * this only affects what the page DISPLAYS; execution-time provider choice

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -310,6 +310,7 @@ revealui/env/license   # Multi-key bundle for local dev: REVEALUI_LICENSE_PRIVAT
 credentials/openai/api-key              # AI features + test setup
 credentials/groq/api-key                # Groq inference
 credentials/huggingface/token           # HF model access
+credentials/xai/api-key                 # xAI (Grok) inference - BYOK adapter dev/test only, never a hosted key
 credentials/tavily/api-key              # Tavily search
 credentials/exa/api-key                 # Exa search
 ```

--- a/packages/ai/src/llm/__tests__/env-factory.test.ts
+++ b/packages/ai/src/llm/__tests__/env-factory.test.ts
@@ -37,6 +37,8 @@ const PROVIDER_ENV_KEYS = [
   'ANTHROPIC_BASE_URL',
   'OPENAI_API_KEY',
   'OPENAI_BASE_URL',
+  'XAI_API_KEY',
+  'XAI_BASE_URL',
   'HF_TOKEN',
   'HF_MODEL_URL',
   'LLM_MODEL',
@@ -91,6 +93,11 @@ describe('createProvider — new factory branches', () => {
         }),
     ).not.toThrow();
   });
+
+  it('constructs an xai provider without throwing', () => {
+    const client = new LLMClient({ provider: 'xai', apiKey: 'xai-test' });
+    expect(providerOf(client)).toBe('xai');
+  });
 });
 
 describe('createLLMClientFromEnv — explicit LLM_PROVIDER', () => {
@@ -109,6 +116,17 @@ describe('createLLMClientFromEnv — explicit LLM_PROVIDER', () => {
   it('throws a keyless error for anthropic without ANTHROPIC_API_KEY', () => {
     process.env.LLM_PROVIDER = 'anthropic';
     expect(() => createLLMClientFromEnv()).toThrow('ANTHROPIC_API_KEY');
+  });
+
+  it('resolves xai from LLM_PROVIDER + XAI_API_KEY', () => {
+    process.env.LLM_PROVIDER = 'xai';
+    process.env.XAI_API_KEY = 'xai-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('xai');
+  });
+
+  it('throws a keyless error for xai without XAI_API_KEY', () => {
+    process.env.LLM_PROVIDER = 'xai';
+    expect(() => createLLMClientFromEnv()).toThrow('XAI_API_KEY');
   });
 });
 
@@ -153,6 +171,17 @@ describe('createLLMClientFromEnv — auto-detect for new providers (appended aft
     expect(providerOf(createLLMClientFromEnv())).toBe('anthropic');
   });
 
+  it('XAI_API_KEY alone resolves to xai', () => {
+    process.env.XAI_API_KEY = 'xai-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('xai');
+  });
+
+  it('OPENAI still wins over a newly-added XAI_API_KEY (priority unchanged)', () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+    process.env.XAI_API_KEY = 'xai-test';
+    expect(providerOf(createLLMClientFromEnv())).toBe('openai');
+  });
+
   it('falls back to the inference-snaps localhost default with no provider env', () => {
     expect(providerOf(createLLMClientFromEnv())).toBe('inference-snaps');
   });
@@ -167,6 +196,7 @@ describe('hostedViable classification', () => {
       huggingface: true,
       ollama: false,
       'inference-snaps': false,
+      xai: true,
     });
   });
 
@@ -178,6 +208,7 @@ describe('hostedViable classification', () => {
       'huggingface',
       'ollama',
       'inference-snaps',
+      'xai',
     ];
     for (const p of providers) {
       expect(isHostedViable(p)).toBe(hostedViable[p]);

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -38,6 +38,7 @@ import {
 import { OllamaProvider, type OllamaProviderConfig } from './providers/ollama.js';
 import { OpenAIProvider, type OpenAIProviderConfig } from './providers/openai.js';
 import { type OpenAICompatConfig, OpenAICompatProvider } from './providers/openai-compat.js';
+import { XaiProvider, type XaiProviderConfig } from './providers/xai.js';
 import { type CacheStats, ResponseCache, type ResponseCacheOptions } from './response-cache.js';
 import {
   SemanticCache,
@@ -52,7 +53,8 @@ export type LLMProviderType =
   | 'groq'
   | 'huggingface'
   | 'ollama'
-  | 'inference-snaps';
+  | 'inference-snaps'
+  | 'xai';
 
 /**
  * Providers reachable from a hosted (serverless) deployment. Localhost-only
@@ -66,6 +68,7 @@ export const hostedViable: Record<LLMProviderType, boolean> = {
   huggingface: true,
   ollama: false,
   'inference-snaps': false,
+  xai: true,
 };
 
 /** True when the provider can serve a hosted (serverless) deployment. */
@@ -205,7 +208,8 @@ export class LLMClient {
       | OpenAIProviderConfig
       | GroqProviderConfig
       | OllamaProviderConfig
-      | InferenceSnapsProviderConfig,
+      | InferenceSnapsProviderConfig
+      | XaiProviderConfig,
   ): LLMProvider {
     switch (type) {
       case 'anthropic':
@@ -218,6 +222,8 @@ export class LLMClient {
         return new OllamaProvider(config as OllamaProviderConfig);
       case 'inference-snaps':
         return new InferenceSnapsProvider(config as InferenceSnapsProviderConfig);
+      case 'xai':
+        return new XaiProvider(config as XaiProviderConfig);
       case 'huggingface':
         // HuggingFace exposes an OpenAI-compatible inference endpoint; baseURL is
         // per-model (HF_MODEL_URL), so it has no dedicated wrapper — the compat
@@ -641,6 +647,7 @@ export class LLMClient {
  *   ollama          → gemma4:e2b        (base URL defaults to http://localhost:11434)
  *   anthropic       → claude-sonnet-4-6 (base URL defaults to https://api.anthropic.com/v1)
  *   openai          → gpt-4o            (base URL defaults to https://api.openai.com/v1)
+ *   xai             → grok-4.5          (base URL defaults to https://api.x.ai/v1)
  */
 export function createLLMClientFromEnv(): LLMClient {
   // Auto-detect provider when LLM_PROVIDER is not explicitly set. The existing
@@ -659,6 +666,8 @@ export function createLLMClientFromEnv(): LLMClient {
     provider = 'anthropic';
   } else if (process.env.OPENAI_API_KEY) {
     provider = 'openai';
+  } else if (process.env.XAI_API_KEY) {
+    provider = 'xai';
   } else {
     // Zero-config Ubuntu default: assume Inference Snaps on the standard local
     // port. This localhost default is unreachable inside a hosted serverless
@@ -686,6 +695,10 @@ export function createLLMClientFromEnv(): LLMClient {
     apiKey = process.env.OPENAI_API_KEY;
     baseURL = process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1';
     defaultModel = 'gpt-4o';
+  } else if (provider === 'xai') {
+    apiKey = process.env.XAI_API_KEY;
+    baseURL = process.env.XAI_BASE_URL ?? 'https://api.x.ai/v1';
+    defaultModel = 'grok-4.5';
   } else if (provider === 'huggingface') {
     apiKey = process.env.HF_TOKEN;
     baseURL = process.env.HF_MODEL_URL;
@@ -711,7 +724,7 @@ export function createLLMClientFromEnv(): LLMClient {
     throw new Error(
       `API key not found for provider "${provider}". Set the corresponding env var ` +
         `(INFERENCE_SNAPS_BASE_URL, GROQ_API_KEY, OLLAMA_BASE_URL, HF_TOKEN, ` +
-        `ANTHROPIC_API_KEY, or OPENAI_API_KEY).`,
+        `ANTHROPIC_API_KEY, OPENAI_API_KEY, or XAI_API_KEY).`,
     );
   }
 

--- a/packages/ai/src/llm/providers/xai.ts
+++ b/packages/ai/src/llm/providers/xai.ts
@@ -1,0 +1,73 @@
+/**
+ * xAI (Grok) Provider
+ *
+ * Thin wrapper over OpenAICompatProvider using xAI's OpenAI-compatible
+ * surface at https://api.x.ai/v1. No proprietary xAI SDK — the fleet posture
+ * is "No proprietary provider SDKs" (see client.ts). BYOK only: the user
+ * brings their own xAI API key, RevealUI never hosts one.
+ *
+ * Docs: https://docs.x.ai/developers/grok-4-5
+ */
+
+import type {
+  Embedding,
+  LLMChatOptions,
+  LLMChunk,
+  LLMEmbedOptions,
+  LLMProvider,
+  LLMProviderConfig,
+  LLMResponse,
+  LLMStreamOptions,
+  Message,
+  ReasonerCapabilities,
+} from './base.js';
+import { OpenAICompatProvider } from './openai-compat.js';
+
+export interface XaiProviderConfig extends Omit<LLMProviderConfig, 'apiKey'> {
+  apiKey: string;
+  /** Defaults to https://api.x.ai/v1 */
+  baseURL?: string;
+  /** Defaults to grok-4.5 */
+  model?: string;
+  timeout?: number;
+  maxRetries?: number;
+}
+
+export class XaiProvider implements LLMProvider {
+  private inner: OpenAICompatProvider;
+
+  constructor(config: XaiProviderConfig) {
+    this.inner = new OpenAICompatProvider({
+      ...config,
+      baseURL: config.baseURL ?? 'https://api.x.ai/v1',
+      model: config.model ?? 'grok-4.5',
+    });
+  }
+
+  capabilities(): ReasonerCapabilities {
+    return {
+      providerTag: 'xai',
+      tools: true,
+      parallelToolCalls: false,
+      vision: false,
+      streaming: true,
+      // xAI exposes no embeddings endpoint on its OpenAI-compat surface.
+      embeddings: false,
+      reasoningEffort: false,
+      promptCache: false,
+      structuredOutput: false,
+    };
+  }
+
+  chat(messages: Message[], options?: LLMChatOptions): Promise<LLMResponse> {
+    return this.inner.chat(messages, options);
+  }
+
+  stream(messages: Message[], options?: LLMStreamOptions): AsyncIterable<LLMChunk> {
+    return this.inner.stream(messages, options);
+  }
+
+  embed(_text: string | string[], _options?: LLMEmbedOptions): Promise<Embedding | Embedding[]> {
+    throw new Error('xAI does not expose an embeddings endpoint. Use OpenAI or Ollama.');
+  }
+}


### PR DESCRIPTION
## Summary

Adds xAI (Grok) as a BYOK LLM provider option in `@revealui/ai`. Grok 4.5 is OpenAI-SDK compatible via `baseURL https://api.x.ai/v1`, so this adapter follows the existing groq/anthropic pattern: a thin wrapper over `OpenAICompatProvider`, no vendor SDK, user-brought API key only (RevealUI never hosts one).

- `LLMProviderType` union + `hostedViable` map gain `xai` ([packages/ai/src/llm/client.ts](packages/ai/src/llm/client.ts))
- New [packages/ai/src/llm/providers/xai.ts](packages/ai/src/llm/providers/xai.ts) — mirrors `anthropic.ts` (default model `grok-4.5`, no embeddings endpoint)
- `createProvider` switch + `createLLMClientFromEnv` (`XAI_API_KEY` / `XAI_BASE_URL`, appended after the existing anthropic/openai auto-detect checks so priority order is unchanged) wired
- Admin Settings → API Keys provider catalog ([apps/admin/src/lib/settings/api-key-providers.ts](apps/admin/src/lib/settings/api-key-providers.ts)) gains the `xai` entry; its two consuming tests updated to the new seven-provider shape
- `docs/SECRETS.md` gets a `credentials/xai/api-key` entry alongside the existing groq/huggingface BYOK-style dev/test entries
- Changeset: `@revealui/ai` minor bump (`.changeset/xai-provider-adapter.md`)

Zero new dependencies. No RevealUI-hosted key path — BYOK only, per project positioning.

## Test plan

- [x] Red-first proof: committed the tests wired to `xai`, then `git checkout origin/test -- packages/ai/src/llm/client.ts` (reverting only the union/switch/env-factory change) and re-ran `env-factory.test.ts` — **5 new tests failed** (`Unknown provider type: xai`, missing `XAI_API_KEY` in the error message, auto-detect not resolving to `xai`, `hostedViable` missing the key), 16 pre-existing tests still passed. Restored with `git checkout feat/gap-382-xai-provider -- packages/ai/src/llm/client.ts`.
- [x] `pnpm --filter @revealui/ai test` — 69 files / 1018 tests passed (post-restore)
- [x] `npx turbo run typecheck --filter=@revealui/ai --filter=admin` — clean, exhaustive `createProvider` switch surfaced by typecheck required the new `case 'xai'`
- [x] `apps/admin` provider-list tests (`api-key-providers.test.ts`, `api-keys-client.test.tsx`) — 7 tests passed
- [x] Biome check on all changed/new files — clean
- [x] Security-sensitive path self-check against `origin/test` — no security-sensitive files touched, no coordinator gate applies
- [x] Pre-push gate (`pnpm gate`, phase 1) — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
