### PR TITLE
docs(ai): update llm-provider reality to byok adapter surface

### DIFF
--- a/docs/features/ai.yml
+++ b/docs/features/ai.yml
@@ -21,7 +21,7 @@ api-surface:
     endpoint: "@revealui/ai — 18 import subpaths"
     openapi: false
     tested: true
-    notes: "CRDT memory, open-model LLM providers (inference snaps, Ollama), agent orchestration"
+    notes: "CRDT memory, LLM providers (local open models + BYOK adapters), agent orchestration"
 
 package-notes:
   subpaths: 18
@@ -35,7 +35,7 @@ limitations:
     summary: "@revealui/ai is dist-only in public repo — source in the private coordination hub"
   - id: llm-providers
     surface: api
-    summary: "Open models only — inference snaps (local, recommended), Ollama (local, fallback), cloud via self-hosted harness (Pro+). No proprietary providers."
+    summary: "No vendor SDKs and no RevealUI-hosted keys: local open models (inference snaps recommended, Ollama fallback) plus BYOK OpenAI-compatible adapters (anthropic, openai, groq, huggingface, xai/Grok) with user-brought keys (Pro+)."
   - id: license-required
     surface: api
     summary: "Requires Pro tier — currently gated by legacy feature checks that should converge on account-level entitlements"


### PR DESCRIPTION
## Summary

Two-line reality-doc fix in `docs/features/ai.yml`: the `llm-providers` limitation still claimed open-models-only with no proprietary providers, which predates the BYOK resolver work. The provider union in `packages/ai/src/llm/client.ts` now carries five user-brought OpenAI-compatible adapters (anthropic, openai, groq, huggingface, xai/Grok) alongside the local providers (#1934 added xai). No vendor SDK and no RevealUI-hosted key, which the new wording states explicitly.

Doc-only change, no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)