### PR TITLE
fix(mcp): governed /api/mcp works through the real server (GAP-371 Phase 4 live catch)

### DIFF
--- a/apps/server/src/routes/__tests__/mcp-endpoint.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/mcp-endpoint.pglite.test.ts
@@ -434,3 +434,59 @@ describe('entitlement gate', () => {
     expect(res.status).not.toBe(200);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: the bridge must survive the production middleware stack
+// ---------------------------------------------------------------------------
+
+describe('bridge tolerates upstream middleware touching the request body (GAP-371 Phase 4)', () => {
+  // Found live (2026-07-17): through the REAL server every Initialize
+  // arrived body-less at the bridge and session bootstrap failed with
+  // "Session ID required", while this suite stayed green — its app mounts
+  // no global middleware. The exact stream-claimer in the production stack
+  // was not isolated (this gate-mounted repro alone did NOT reproduce it),
+  // so the fix removes the dependency class instead: the bridge parses the
+  // body web-side and passes it through, verified by a live A/B against
+  // the built server (base build fails, fixed build completes the loop).
+  // This case pins the pass-through path under a body-touching middleware.
+  let gatedServed: ReturnType<typeof serve> | undefined;
+  let gatedUrl = '';
+
+  beforeAll(async () => {
+    const { Hono } = await import('hono');
+    const { bodyLimitGate } = await import('../../middleware/body-limits.js');
+    const app = new Hono();
+    app.use('*', bodyLimitGate());
+    app.route('/', createMcpEndpointApp({ selfApiBaseUrl: stubUrl }));
+    await new Promise<void>((resolve) => {
+      gatedServed = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) => {
+        gatedUrl = `http://127.0.0.1:${info.port}/`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(() => {
+    gatedServed?.close();
+  });
+
+  it('initialize → tools/list → tools/call complete through the gate', async () => {
+    const c = new McpClient({
+      clientInfo: { name: 'e2e-gated', version: '0.0.1' },
+      transport: {
+        kind: 'streamable-http',
+        url: gatedUrl,
+        requestInit: { headers: { Authorization: `Bearer ${TOKEN_A}` } },
+      },
+    });
+    await c.connect();
+    const tools = await c.listTools();
+    expect(tools.map((t) => t.name)).toContain('revealui_list_sites');
+
+    const result = (await c.callTool('revealui_list_sites', {})) as {
+      isError?: boolean;
+    };
+    expect(result.isError).toBeFalsy();
+    await c.close();
+  });
+});

--- a/apps/server/src/routes/mcp-endpoint.ts
+++ b/apps/server/src/routes/mcp-endpoint.ts
@@ -394,8 +394,15 @@ export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointPar
     };
     (incoming as IncomingMessage & { auth?: McpAuthInfo }).auth = authInfo;
 
+    // Parse the body web-side and pass it through the bridge. Middleware on
+    // the real server ahead of this route can claim the raw Node stream, in
+    // which case the handler's raw read sees an empty body and rejects every
+    // Initialize with "Session ID required" (GAP-371 Phase 4 live catch).
+    const parsedBody =
+      c.req.method === 'POST' ? await c.req.json().catch(() => undefined) : undefined;
+
     try {
-      await handler(incoming, outgoing);
+      await handler(incoming, outgoing, parsedBody);
     } catch (err) {
       logger.error('[/api/mcp] handler error', {
         error: err instanceof Error ? err.message : String(err),

--- a/packages/mcp/src/streamable-http.ts
+++ b/packages/mcp/src/streamable-http.ts
@@ -82,7 +82,20 @@ export type StreamableHttpHandlerOptions = {
   onControl?: (control: StreamableHttpControl) => void;
 };
 
-export type StreamableHttpHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+/**
+ * The optional third argument carries a body the caller already parsed.
+ * A web-framework bridge (Hono on @hono/node-server) parses the body from
+ * the web Request and passes it through, because middleware ahead of the
+ * bridge can claim the raw Node stream and leave the raw read empty (found
+ * live in the GAP-371 Phase 4 e2e: every Initialize through the real server
+ * failed with "Session ID required"). Direct Node-server callers omit the
+ * argument and the raw read path is unchanged.
+ */
+export type StreamableHttpHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  parsedBody?: unknown,
+) => Promise<void>;
 
 /** Control surface over a handler's live session map. */
 export interface StreamableHttpControl {
@@ -143,8 +156,8 @@ export function createNodeStreamableHttpHandler(
     },
   });
 
-  return async function mcpStreamableHttpHandler(req, res) {
-    const body = req.method === 'POST' ? await readJsonBody(req) : undefined;
+  return async function mcpStreamableHttpHandler(req, res, parsedBody) {
+    const body = req.method === 'POST' ? (parsedBody ?? (await readJsonBody(req))) : undefined;
     const rawSession = req.headers['mcp-session-id'];
     const sessionId = typeof rawSession === 'string' ? rawSession : undefined;
 


### PR DESCRIPTION
## Summary

First deliverable of the GAP-371 Phase 4 e2e (internal tracker): the e2e's very first live run found that the governed `/api/mcp` endpoint has never worked through the REAL built server. Every Initialize died with `Session ID required` at 100% rate — auth, entitlements, and the feature gate all passed, but the MCP session bootstrap never saw a request body.

**Mechanism:** the Streamable-HTTP bridge hands the raw Node request to the MCP handler, which re-reads the body from the raw stream. Through the production middleware stack that stream arrives already claimed, so the handler sees an empty body and refuses the session. The exact claimer was not isolated (a minimal repro mounting the global body gate alone does NOT reproduce it), so the fix removes the dependency class: the bridge parses the body web-side (`c.req.json()`) and passes it through a new optional third argument on `StreamableHttpHandler`. Direct Node-server callers are unchanged.

**Why CI never caught it:** the Phase 1 acceptance suite serves the endpoint from a minimal Hono app with no global middleware. A new regression case mounts a body-touching middleware ahead of the endpoint and completes initialize, tools/list, and tools/call through it.

**Live A/B verification (same env, same DB, same credential):**
- Base build: SDK client initialize fails with `Session ID required`, every time.
- Fixed build: initialize succeeds, session created, 5 governed tools listed, tools/call executes, hash-chained `mcp:tool:*` receipts land in `audit_log`.
- Mid-session revocation (`user_devices.is_active=false`): next request 401 `Invalid or expired device token`; re-activation restores access (I-6 at system level).
- The real `opencode` 1.18.3 binary with the spec section 5.7 config (env-var reference only, no plaintext credential) completes MCP initialize plus the SSE stream against the endpoint.

## Additional live findings (carried to the gap, not fixed here)

1. The governed tools' REST forward paths (`/api/sites`, `/api/users`, `/api/health`) do not exist on apps/server (its content REST lives at `/api/content/*` with a different envelope) — the factory was specced against the admin engine REST, so `selfApiBaseUrl` must point at the admin app, or the paths need remapping. Only ever exercised against a test stub before.
2. `verifyMcpAuditChain` rejects multi-root chains, but the audit writer starts a fresh root per server process — verification over any corpus spanning a restart fails by construction. The Phase 2 option to define verification over per-process segments was never landed.
3. The stored OpenAI api-key entries in the vault are placeholder text, not real keys — the LLM-driven tool-call leg of the e2e needs a real key.

## Tests

- `mcp-endpoint.pglite.test.ts`: 8/8 (7 pre-existing plus the new middleware-tolerance case).
- `@revealui/mcp` package suite: 292/292.
- Fleet security checker: security-sensitive (packages/mcp plus the endpoint route) — this PR self-holds for a non-author guardrail-2 verdict and the owner label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
