### PR TITLE
feat(marketing): link /philosophy from the footer

### DIFF
--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -33,6 +33,7 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
       { label: 'Documentation', href: SITE.urls.docs },
       { label: 'Blog', href: '/blog' },
       { label: 'Roadmap', href: '/roadmap' },
+      { label: 'Philosophy', href: '/philosophy' },
     ],
   },
   {


### PR DESCRIPTION
The /philosophy page (the corpus §4.6 manifesto, corpus-locked, fully claims-indexed) has been live in the router and sitemap but had zero inbound links from nav, footer, or any content module: a shipped orphan page. Owner ruled 2026-07-17 that the manifesto's home is the standalone /philosophy page, so this makes it discoverable: one footer link in the Product column after Roadmap.

The link label lives in nav.ts, which is not a covered claims-evidence file, so no index entry is needed. Marketing tests 80/80, claims-evidence validator green, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)