### PR TITLE
feat(harnesses): cursor hook adapter, normalized hook events, hook cli (spool-only)

### DIFF
--- a/.changeset/cursor-hooks-adapter.md
+++ b/.changeset/cursor-hooks-adapter.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+add a normalized hook-event schema, a `hook <source>` CLI subcommand (spool-only mode), and a Cursor adapter, following the multi-editor harness design: `HarnessHookEvent` normalizes Cursor and Claude Code hook payloads into one internal shape (identity fields stay session-scoped only, never editor-supplied human identity); the CLI subcommand normalizes stdin, evaluates a local policy snapshot, emits the editor-native allow/deny/ask response, and spools an append-only receipt (server-side flush lands in a later change, so this ships spool-only behind explicit config); `CursorAdapter` promotes the existing data-only `cursor` profile into `TOOL_PROFILES` (mirroring the OpenCode adapter promotion) with `.cursor/hooks.json` and `.cursor/mcp.json` generators, the latter using Cursor's `${env:VAR}` reference syntax so no token value is ever emitted.

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -54,6 +54,10 @@
     "./protocol": {
       "types": "./dist/protocol/index.d.ts",
       "import": "./dist/protocol/index.js"
+    },
+    "./hooks": {
+      "types": "./dist/hooks/index.d.ts",
+      "import": "./dist/hooks/index.js"
     }
   },
   "files": [

--- a/packages/harnesses/src/__tests__/cli-hook.test.ts
+++ b/packages/harnesses/src/__tests__/cli-hook.test.ts
@@ -1,0 +1,126 @@
+/**
+ * End-to-end coverage for `revealui-harnesses hook <source>` -- spawns the
+ * real CLI entrypoint (via the workspace-root `tsx`, so no build step is
+ * required) with a real stdin pipe, matching how an editor's hooks.json
+ * actually invokes this command. Unlike the unit tests in
+ * `hook-run.test.ts` (which call `runHookCommand` directly), this proves
+ * the stdin-read / exit-code / stdout-JSON wiring in `../cli.ts` itself.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const repoRoot = resolve(packageRoot, '..', '..');
+const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
+const cliEntry = join(packageRoot, 'src', 'cli.ts');
+
+interface HookCliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * `spawnSync`, not `execFile`/`spawn` (async) -- the async pipe-write path
+ * for a subprocess's stdin hangs indefinitely in this build/test sandbox
+ * for reasons unrelated to the CLI itself (reproduced against a plain
+ * built `dist/cli.js` with no `tsx` involved at all; `spawnSync`'s
+ * synchronous fd-based write does not hit whatever the async path hits).
+ * Manually verified the CLI is correct under a real shell pipe
+ * (`echo '{...}' | tsx src/cli.ts hook cursor`) before landing this.
+ */
+function runHookCliRaw(source: string, stdin: string, env: Record<string, string>): HookCliResult {
+  const result = spawnSync(tsxBin, [cliEntry, 'hook', source], {
+    cwd: packageRoot,
+    env: { ...process.env, ...env },
+    input: stdin,
+    timeout: 20_000,
+    encoding: 'utf8',
+  });
+  return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', exitCode: result.status ?? 1 };
+}
+
+function runHookCli(
+  source: string,
+  stdinJson: unknown,
+  env: Record<string, string>,
+): HookCliResult {
+  return runHookCliRaw(source, JSON.stringify(stdinJson), env);
+}
+
+describe('revealui-harnesses hook <source> (CLI end to end)', () => {
+  let dir: string;
+  let spoolPath: string;
+  let snapshotPath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'cli-hook-test-'));
+    spoolPath = join(dir, 'receipts.jsonl');
+    snapshotPath = join(dir, 'policy-snapshot.json');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('allows by default (advisory, no snapshot) and prints the Cursor-native response', () => {
+    const result = runHookCli(
+      'cursor',
+      { hook_event_name: 'stop' },
+      { REVEALUI_HOOK_SPOOL_PATH: spoolPath, REVEALUI_POLICY_SNAPSHOT_PATH: snapshotPath },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ permission: 'allow' });
+  }, 25_000);
+
+  it('exits 2 and prints a deny response when a valid snapshot denies', async () => {
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig',
+        issuedAt: new Date().toISOString(),
+        rules: [{ kind: 'pre-shell', permission: 'deny', reason: 'no shells from cli test' }],
+      }),
+      'utf8',
+    );
+
+    const result = runHookCli(
+      'cursor',
+      { hook_event_name: 'beforeShellExecution', command: 'rm -rf /' },
+      { REVEALUI_HOOK_SPOOL_PATH: spoolPath, REVEALUI_POLICY_SNAPSHOT_PATH: snapshotPath },
+    );
+
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      permission: 'deny',
+      user_message: 'no shells from cli test',
+      agent_message: 'no shells from cli test',
+    });
+  }, 25_000);
+
+  it('defaults to allow on malformed stdin instead of crashing', () => {
+    const result = runHookCliRaw('cursor', 'not valid json {{{', {
+      REVEALUI_HOOK_SPOOL_PATH: spoolPath,
+      REVEALUI_POLICY_SNAPSHOT_PATH: snapshotPath,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('invalid JSON on stdin');
+  }, 25_000);
+
+  it('rejects an unsupported source with exit code 1', () => {
+    const result = runHookCli(
+      'vscode',
+      { hook_event_name: 'x' },
+      { REVEALUI_HOOK_SPOOL_PATH: spoolPath, REVEALUI_POLICY_SNAPSHOT_PATH: snapshotPath },
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Unsupported hook source');
+  }, 25_000);
+});

--- a/packages/harnesses/src/__tests__/coordinator.test.ts
+++ b/packages/harnesses/src/__tests__/coordinator.test.ts
@@ -207,8 +207,8 @@ describe('HarnessCoordinator', () => {
     it('rejects adapter that does not meet requirements', () => {
       const coord = new HarnessCoordinator({ projectRoot, socketPath });
       coord.registerAdapter(createMockAdapter('cursor'));
-      // cursor is not headless
-      const result = coord.dispatchTask({ headless: true }, 'need headless');
+      // cursor is not resumable
+      const result = coord.dispatchTask({ resumable: true }, 'need resumable');
       expect(result).toBeNull();
     });
 

--- a/packages/harnesses/src/__tests__/cursor-adapter.test.ts
+++ b/packages/harnesses/src/__tests__/cursor-adapter.test.ts
@@ -1,0 +1,267 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CursorAdapter,
+  describeCursorAgentExecError,
+  parseCursorAgentOutput,
+} from '../adapters/cursor-adapter.js';
+import { HarnessRegistry } from '../registry/harness-registry.js';
+import type { HarnessCommand, HarnessEvent } from '../types/core.js';
+
+describe('CursorAdapter', () => {
+  let projectRoot: string;
+  let adapter: CursorAdapter;
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), 'cursor-adapter-test-'));
+    adapter = new CursorAdapter({ projectRoot });
+  });
+
+  afterEach(async () => {
+    await adapter.dispose();
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it('has id cursor and a display name', () => {
+    expect(adapter.id).toBe('cursor');
+    expect(adapter.name).toBe('Cursor');
+  });
+
+  describe('getCapabilities', () => {
+    it('declares generate/analyze/config support but not edit or workboard', () => {
+      const caps = adapter.getCapabilities();
+      expect(caps).toEqual({
+        generateCode: true,
+        analyzeCode: true,
+        applyEdit: false,
+        applyConfig: true,
+        readWorkboard: false,
+        writeWorkboard: false,
+      });
+    });
+  });
+
+  describe('isAvailable / getInfo -- graceful no-binary failure', () => {
+    // The verified Cursor CLI binary is `agent` (cursor.com/docs/cli/installation,
+    // cursor.com/docs/cli/headless), which is not installed in this build
+    // environment. These assertions exercise the REAL execFile ENOENT path.
+    it('isAvailable returns false when the agent binary is missing', async () => {
+      const missing = new CursorAdapter({ binaryPath: 'agent-binary-that-does-not-exist' });
+      await expect(missing.isAvailable()).resolves.toBe(false);
+    });
+
+    it('getInfo reports an undefined version when the binary is missing', async () => {
+      const missing = new CursorAdapter({ binaryPath: 'agent-binary-that-does-not-exist' });
+      const info = await missing.getInfo();
+      expect(info.id).toBe('cursor');
+      expect(info.version).toBeUndefined();
+    });
+
+    it('execute(headless-prompt) fails gracefully with a helpful message when unavailable', async () => {
+      const missing = new CursorAdapter({
+        projectRoot,
+        binaryPath: 'agent-binary-that-does-not-exist',
+      });
+      const result = await missing.execute({ type: 'headless-prompt', prompt: 'hello' });
+      expect(result.success).toBe(false);
+      expect(result.command).toBe('headless-prompt');
+      expect(result.message).toContain('Cursor CLI ("agent") not found on PATH');
+    });
+
+    it('emits a generation-started event even when the run ultimately fails', async () => {
+      const missing = new CursorAdapter({
+        projectRoot,
+        binaryPath: 'agent-binary-that-does-not-exist',
+      });
+      const events: HarnessEvent[] = [];
+      missing.onEvent((e) => events.push(e));
+      await missing.execute({ type: 'generate-code', prompt: 'write a function' });
+      expect(events.some((e) => e.type === 'generation-started')).toBe(true);
+      expect(events.some((e) => e.type === 'generation-completed')).toBe(false);
+    });
+  });
+
+  describe('execute -- command mapping', () => {
+    it('get-status reports availability and config', async () => {
+      const result = await adapter.execute({ type: 'get-status' });
+      expect(result.success).toBe(true);
+      expect(result.command).toBe('get-status');
+      const data = result.data as { available: boolean; projectRoot: string };
+      expect(data.projectRoot).toBe(projectRoot);
+    });
+
+    it('apply-edit is explicitly unsupported', async () => {
+      const result = await adapter.execute({ type: 'apply-edit', filePath: 'foo.ts', diff: 'x' });
+      expect(result.success).toBe(false);
+      expect(result.command).toBe('apply-edit');
+      expect(result.message).toContain('not supported');
+    });
+
+    it('read-workboard and update-workboard report the not-wired posture', async () => {
+      const read = await adapter.execute({ type: 'read-workboard' });
+      expect(read.success).toBe(false);
+      expect(read.message).toContain('not yet wired');
+
+      const update = await adapter.execute({ type: 'update-workboard', sessionId: 'cursor-1' });
+      expect(update.success).toBe(false);
+      expect(update.message).toContain('not yet wired');
+    });
+
+    it('get-running-instances succeeds even with zero running processes', async () => {
+      const result = await adapter.execute({ type: 'get-running-instances' });
+      expect(result.success).toBe(true);
+      const data = result.data as { instances: unknown[] };
+      expect(Array.isArray(data.instances)).toBe(true);
+    });
+
+    it('apply-config writes content under the project root', async () => {
+      const result = await adapter.execute({
+        type: 'apply-config',
+        configPath: 'mcp.json',
+        content: '{"mcpServers":{}}',
+      });
+      expect(result.success).toBe(true);
+      const written = await readFile(join(projectRoot, 'mcp.json'), 'utf8');
+      expect(written).toBe('{"mcpServers":{}}');
+    });
+
+    it('apply-config creates nested directories', async () => {
+      const result = await adapter.execute({
+        type: 'apply-config',
+        configPath: '.cursor/hooks.json',
+        content: '{"version":1,"hooks":{}}',
+      });
+      expect(result.success).toBe(true);
+      const written = await readFile(join(projectRoot, '.cursor', 'hooks.json'), 'utf8');
+      expect(written).toContain('"version":1');
+    });
+
+    it('apply-config refuses to write outside the project root', async () => {
+      const result = await adapter.execute({
+        type: 'apply-config',
+        configPath: '../../etc/passwd',
+        content: 'malicious',
+      });
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('outside the project root');
+    });
+
+    it('diff-config reports both sides missing when nothing is configured locally', async () => {
+      const result = await adapter.execute({ type: 'diff-config' });
+      expect(result.success).toBe(true);
+      expect(result.command).toBe('diff-config');
+    });
+
+    it('an unknown command type is reported as unsupported', async () => {
+      const bogus = { type: 'not-a-real-command' } as unknown as HarnessCommand;
+      const result = await adapter.execute(bogus);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('registry lifecycle', () => {
+    let registry: HarnessRegistry;
+
+    beforeEach(() => {
+      registry = new HarnessRegistry();
+    });
+
+    afterEach(async () => {
+      await registry.disposeAll();
+    });
+
+    it('registers the adapter', () => {
+      registry.register(adapter);
+      expect(registry.get('cursor')).toBe(adapter);
+    });
+
+    it('throws on duplicate registration', () => {
+      registry.register(adapter);
+      expect(() => registry.register(new CursorAdapter())).toThrow('already registered');
+    });
+
+    it('unregisters and disposes the adapter', async () => {
+      registry.register(adapter);
+      await registry.unregister('cursor');
+      expect(registry.get('cursor')).toBeUndefined();
+    });
+
+    it('reports unavailable in listAvailable() when the binary is missing', async () => {
+      const missing = new CursorAdapter({ binaryPath: 'agent-binary-that-does-not-exist' });
+      registry.register(missing);
+      const available = await registry.listAvailable();
+      expect(available).not.toContain('cursor');
+    });
+  });
+
+  describe('notifyRegistered / notifyUnregistering', () => {
+    it('emits harness-connected and harness-disconnected', () => {
+      const events: HarnessEvent[] = [];
+      adapter.onEvent((e) => events.push(e));
+      adapter.notifyRegistered();
+      adapter.notifyUnregistering();
+      expect(events).toEqual([
+        { type: 'harness-connected', harnessId: 'cursor' },
+        { type: 'harness-disconnected', harnessId: 'cursor' },
+      ]);
+    });
+  });
+});
+
+describe('parseCursorAgentOutput', () => {
+  it('returns empty string for empty stdout', () => {
+    expect(parseCursorAgentOutput('')).toBe('');
+    expect(parseCursorAgentOutput('   \n  ')).toBe('');
+  });
+
+  it('extracts a known text-bearing key from a JSON object', () => {
+    expect(parseCursorAgentOutput(JSON.stringify({ result: 'hello' }))).toBe('hello');
+    expect(parseCursorAgentOutput(JSON.stringify({ output: 'hi' }))).toBe('hi');
+    expect(parseCursorAgentOutput(JSON.stringify({ text: 'hey' }))).toBe('hey');
+    expect(parseCursorAgentOutput(JSON.stringify({ message: 'yo' }))).toBe('yo');
+    expect(parseCursorAgentOutput(JSON.stringify({ content: 'sup' }))).toBe('sup');
+  });
+
+  it('prefers the first matching key in priority order', () => {
+    expect(parseCursorAgentOutput(JSON.stringify({ result: 'first', text: 'second' }))).toBe(
+      'first',
+    );
+  });
+
+  it('falls back to the raw JSON text for an unrecognized object shape', () => {
+    const raw = JSON.stringify({ unknownField: 'value' });
+    expect(parseCursorAgentOutput(raw)).toBe(raw);
+  });
+
+  it('unwraps a bare JSON string', () => {
+    expect(parseCursorAgentOutput(JSON.stringify('plain string result'))).toBe(
+      'plain string result',
+    );
+  });
+
+  it('treats non-JSON stdout as plain text', () => {
+    expect(parseCursorAgentOutput('just plain text, not json')).toBe('just plain text, not json');
+  });
+});
+
+describe('describeCursorAgentExecError', () => {
+  it('gives a helpful message for ENOENT (binary not on PATH)', () => {
+    const err = Object.assign(new Error('spawn agent ENOENT'), { code: 'ENOENT' });
+    expect(describeCursorAgentExecError(err)).toContain('Cursor CLI ("agent") not found on PATH');
+  });
+
+  it('includes stderr when present', () => {
+    const err = Object.assign(new Error('Command failed'), { stderr: 'boom' });
+    expect(describeCursorAgentExecError(err)).toBe('Command failed\nboom');
+  });
+
+  it('falls back to the error message alone when there is no stderr', () => {
+    expect(describeCursorAgentExecError(new Error('plain failure'))).toBe('plain failure');
+  });
+
+  it('stringifies non-Error throwables', () => {
+    expect(describeCursorAgentExecError('a string error')).toBe('a string error');
+  });
+});

--- a/packages/harnesses/src/__tests__/cursor-config.test.ts
+++ b/packages/harnesses/src/__tests__/cursor-config.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { ProtocolConfig } from '../protocol/adapter.js';
+import { protocolConfigToCursorMcpConfig } from '../protocol/config-normalizer.js';
+
+function createTestConfig(overrides: Partial<ProtocolConfig> = {}): ProtocolConfig {
+  return {
+    identity: { name: 'Test Agent', email: 'test@example.com', role: 'builder' },
+    permissions: { autoApprove: ['Read', 'Glob'], deny: ['Write'] },
+    environment: { variables: {}, mcpServers: [] },
+    rules: [],
+    skills: [],
+    commands: [],
+    ...overrides,
+  };
+}
+
+describe('protocolConfigToCursorMcpConfig', () => {
+  it("emits the .cursor/mcp.json remote server block using Cursor's env-interpolation syntax", () => {
+    const config = createTestConfig();
+    const result = protocolConfigToCursorMcpConfig(config, {
+      mcpUrl: 'https://your-host/api/mcp',
+    });
+
+    expect(result.mcpServers.revealui).toEqual({
+      url: 'https://your-host/api/mcp',
+      headers: { Authorization: `Bearer \${env:REVEALUI_MCP_TOKEN}` },
+    });
+  });
+
+  it('respects a custom token env var name', () => {
+    const config = createTestConfig();
+    const result = protocolConfigToCursorMcpConfig(config, {
+      mcpUrl: 'https://your-host/api/mcp',
+      tokenEnvVar: 'CUSTOM_TOKEN_VAR',
+    });
+    expect(result.mcpServers.revealui.headers.Authorization).toBe(
+      `Bearer \${env:CUSTOM_TOKEN_VAR}`,
+    );
+  });
+
+  describe('SECURITY / design invariant I-4: never emits a literal bearer token', () => {
+    it('does not leak a token planted in config.environment.variables', () => {
+      const config = createTestConfig({
+        environment: {
+          variables: { REVEALUI_MCP_TOKEN: 'rvui_dev_should_never_appear_in_output' },
+          mcpServers: [],
+        },
+      });
+      const result = protocolConfigToCursorMcpConfig(config, { mcpUrl: 'https://host/api/mcp' });
+      const serialized = JSON.stringify(result);
+
+      expect(serialized).not.toContain('rvui_dev_should_never_appear_in_output');
+      expect(result.mcpServers.revealui.headers.Authorization).toBe(
+        `Bearer \${env:REVEALUI_MCP_TOKEN}`,
+      );
+    });
+
+    it('never emits a token value present in process.env', () => {
+      const priorValue = process.env.REVEALUI_MCP_TOKEN_TEST_FIXTURE;
+      process.env.REVEALUI_MCP_TOKEN_TEST_FIXTURE = 'sk-should-not-leak-into-config';
+      try {
+        const config = createTestConfig();
+        const result = protocolConfigToCursorMcpConfig(config, {
+          mcpUrl: 'https://host/api/mcp',
+          tokenEnvVar: 'REVEALUI_MCP_TOKEN_TEST_FIXTURE',
+        });
+        const serialized = JSON.stringify(result);
+
+        expect(serialized).not.toContain('sk-should-not-leak-into-config');
+        expect(serialized).toContain(`\${env:REVEALUI_MCP_TOKEN_TEST_FIXTURE}`);
+      } finally {
+        if (priorValue === undefined) {
+          delete process.env.REVEALUI_MCP_TOKEN_TEST_FIXTURE;
+        } else {
+          process.env.REVEALUI_MCP_TOKEN_TEST_FIXTURE = priorValue;
+        }
+      }
+    });
+  });
+});

--- a/packages/harnesses/src/__tests__/cursor-content-generator.test.ts
+++ b/packages/harnesses/src/__tests__/cursor-content-generator.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { CursorGenerator } from '../content/generators/cursor.js';
+import { buildManifest, generateContent, getGenerator, listGenerators } from '../content/index.js';
+import type { Agent, Command, Rule, Skill } from '../content/schemas/index.js';
+
+const ctx = { projectRoot: '/test' };
+
+describe('CursorGenerator', () => {
+  it('is auto-registered in the content generator registry', () => {
+    expect(listGenerators()).toContain('cursor');
+    expect(getGenerator('cursor')).toBeInstanceOf(CursorGenerator);
+  });
+
+  it('declares its output directory', () => {
+    const generator = new CursorGenerator();
+    expect(generator.id).toBe('cursor');
+    expect(generator.outputDir).toBe('.cursor');
+  });
+
+  describe('generateRule / generateCommand / generateAgent / generateSkill -- Phase B scope is hooks.json only', () => {
+    it('all four return no files', () => {
+      const generator = new CursorGenerator();
+      const rule: Rule = {
+        id: 'biome',
+        name: 'Biome',
+        description: 'Use biome',
+        scope: 'project',
+        preambleTier: 2,
+        tier: 'oss',
+        tags: [],
+        content: 'Format with biome.',
+      };
+      const cmd: Command = {
+        id: 'gate',
+        name: 'Gate',
+        description: 'Run the quality gate',
+        tier: 'oss',
+        disableModelInvocation: false,
+        content: 'Run lint, typecheck, and tests.',
+      };
+      const agent: Agent = {
+        id: 'reviewer',
+        name: 'Reviewer',
+        description: 'Reviews code',
+        tier: 'oss',
+        isolation: 'none',
+        tools: ['Read'],
+        content: 'You review code.',
+      };
+      const skill: Skill = {
+        id: 'tdd',
+        name: 'TDD',
+        description: 'Test-driven development',
+        tier: 'oss',
+        disableModelInvocation: false,
+        skipFrontmatter: false,
+        filePatterns: [],
+        bashPatterns: [],
+        references: {},
+        content: 'Write tests first.',
+      };
+
+      expect(generator.generateRule(rule, ctx)).toEqual([]);
+      expect(generator.generateCommand(cmd, ctx)).toEqual([]);
+      expect(generator.generateAgent(agent, ctx)).toEqual([]);
+      expect(generator.generateSkill(skill, ctx)).toEqual([]);
+    });
+  });
+
+  describe('generateAll', () => {
+    it('emits exactly one file: .cursor/hooks.json', () => {
+      const manifest = buildManifest();
+      const files = generateContent('cursor', manifest, ctx);
+      expect(files).toHaveLength(1);
+      expect(files[0]?.relativePath).toBe('.cursor/hooks.json');
+    });
+
+    it('every hook entry is command-based and invokes the harness CLI hook subcommand', () => {
+      const manifest = buildManifest();
+      const [file] = generateContent('cursor', manifest, ctx);
+      const config = JSON.parse(file?.content ?? '{}') as {
+        version: number;
+        hooks: Record<string, Array<{ command: string; type: string }>>;
+      };
+
+      expect(config.version).toBe(1);
+      const eventNames = Object.keys(config.hooks);
+      expect(eventNames.length).toBeGreaterThan(0);
+
+      for (const eventName of eventNames) {
+        const entries = config.hooks[eventName] ?? [];
+        expect(entries).toHaveLength(1);
+        for (const entry of entries) {
+          expect(entry.type).toBe('command');
+          expect(entry.command).toBe('revealui-harnesses hook cursor');
+        }
+      }
+    });
+
+    it('covers every event the cursor normalizer maps (design doc §2.3)', () => {
+      const manifest = buildManifest();
+      const [file] = generateContent('cursor', manifest, ctx);
+      const config = JSON.parse(file?.content ?? '{}') as { hooks: Record<string, unknown> };
+
+      for (const eventName of [
+        'sessionStart',
+        'sessionEnd',
+        'preToolUse',
+        'postToolUse',
+        'beforeShellExecution',
+        'afterShellExecution',
+        'beforeMCPExecution',
+        'afterMCPExecution',
+        'beforeReadFile',
+        'afterFileEdit',
+        'stop',
+      ]) {
+        expect(config.hooks).toHaveProperty(eventName);
+      }
+    });
+  });
+});

--- a/packages/harnesses/src/__tests__/hook-normalizers.test.ts
+++ b/packages/harnesses/src/__tests__/hook-normalizers.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeClaudeCodeHookEvent } from '../hooks/normalizers/claude-code.js';
+import { normalizeCursorHookEvent } from '../hooks/normalizers/cursor.js';
+import { isImplementedHookSource, normalizeHookEvent } from '../hooks/normalizers/index.js';
+
+describe('normalizeCursorHookEvent', () => {
+  it('maps sessionStart to session-start', () => {
+    const event = normalizeCursorHookEvent(
+      { hook_event_name: 'sessionStart', conversation_id: 'c1' },
+      'advisory',
+    );
+    expect(event.kind).toBe('session-start');
+    expect(event.source).toBe('cursor');
+    expect(event.identity.conversationId).toBe('c1');
+  });
+
+  it('maps sessionEnd to session-end and subagent events to nested session boundaries', () => {
+    expect(normalizeCursorHookEvent({ hook_event_name: 'sessionEnd' }, 'advisory').kind).toBe(
+      'session-end',
+    );
+    expect(normalizeCursorHookEvent({ hook_event_name: 'subagentStart' }, 'advisory').kind).toBe(
+      'session-start',
+    );
+    expect(normalizeCursorHookEvent({ hook_event_name: 'subagentStop' }, 'advisory').kind).toBe(
+      'session-end',
+    );
+  });
+
+  it('maps preToolUse/postToolUse to pre-tool/post-tool with toolName', () => {
+    const pre = normalizeCursorHookEvent(
+      { hook_event_name: 'preToolUse', tool_name: 'Shell' },
+      'advisory',
+    );
+    expect(pre.kind).toBe('pre-tool');
+    expect(pre.toolName).toBe('Shell');
+
+    const post = normalizeCursorHookEvent(
+      { hook_event_name: 'postToolUse', tool_name: 'Write' },
+      'advisory',
+    );
+    expect(post.kind).toBe('post-tool');
+    expect(post.toolName).toBe('Write');
+  });
+
+  it('maps beforeShellExecution/afterShellExecution to pre-shell/post-shell with command', () => {
+    const before = normalizeCursorHookEvent(
+      { hook_event_name: 'beforeShellExecution', command: 'rm -rf /' },
+      'advisory',
+    );
+    expect(before.kind).toBe('pre-shell');
+    expect(before.command).toBe('rm -rf /');
+
+    const after = normalizeCursorHookEvent(
+      { hook_event_name: 'afterShellExecution', command: 'ls' },
+      'advisory',
+    );
+    expect(after.kind).toBe('post-shell');
+    expect(after.command).toBe('ls');
+  });
+
+  it('maps beforeMCPExecution/afterMCPExecution to pre-mcp/post-mcp', () => {
+    expect(
+      normalizeCursorHookEvent({ hook_event_name: 'beforeMCPExecution' }, 'advisory').kind,
+    ).toBe('pre-mcp');
+    expect(
+      normalizeCursorHookEvent({ hook_event_name: 'afterMCPExecution' }, 'advisory').kind,
+    ).toBe('post-mcp');
+  });
+
+  it('maps beforeReadFile to pre-tool with a synthetic Read toolName and the file path', () => {
+    const event = normalizeCursorHookEvent(
+      { hook_event_name: 'beforeReadFile', file_path: '/repo/src/index.ts' },
+      'advisory',
+    );
+    expect(event.kind).toBe('pre-tool');
+    expect(event.toolName).toBe('Read');
+    expect(event.filePaths).toEqual(['/repo/src/index.ts']);
+  });
+
+  it('maps afterFileEdit to file-edit with the file path', () => {
+    const event = normalizeCursorHookEvent(
+      { hook_event_name: 'afterFileEdit', file_path: '/repo/src/index.ts' },
+      'advisory',
+    );
+    expect(event.kind).toBe('file-edit');
+    expect(event.filePaths).toEqual(['/repo/src/index.ts']);
+  });
+
+  it('maps stop to stop', () => {
+    expect(normalizeCursorHookEvent({ hook_event_name: 'stop' }, 'advisory').kind).toBe('stop');
+  });
+
+  it('falls back to pre-tool with the raw event name for an unrecognized event', () => {
+    const event = normalizeCursorHookEvent({ hook_event_name: 'somethingNew' }, 'advisory');
+    expect(event.kind).toBe('pre-tool');
+    expect(event.toolName).toBe('somethingNew');
+  });
+
+  it('carries the requested enforcement tier through unchanged', () => {
+    const enforced = normalizeCursorHookEvent({ hook_event_name: 'stop' }, 'enforced');
+    expect(enforced.enforcementTier).toBe('enforced');
+    const advisory = normalizeCursorHookEvent({ hook_event_name: 'stop' }, 'advisory');
+    expect(advisory.enforcementTier).toBe('advisory');
+  });
+
+  it('preserves the untouched payload under raw', () => {
+    const raw = { hook_event_name: 'stop', cursor_version: '1.2.3' };
+    const event = normalizeCursorHookEvent(raw, 'advisory');
+    expect(event.raw).toBe(raw);
+  });
+
+  // Design invariant I-1: editor-supplied identity strings never surface as
+  // normalized identity fields, even when the payload includes one.
+  it('I-1: never copies user_email onto the normalized identity', () => {
+    const event = normalizeCursorHookEvent(
+      {
+        hook_event_name: 'preToolUse',
+        tool_name: 'Shell',
+        user_email: 'attacker@example.com',
+        conversation_id: 'c1',
+        generation_id: 'g1',
+        model_id: 'gpt-5',
+      },
+      'advisory',
+    );
+    expect(event.identity).toEqual({
+      conversationId: 'c1',
+      generationId: 'g1',
+      modelId: 'gpt-5',
+    });
+    expect(Object.keys(event.identity)).not.toContain('email');
+    expect(Object.keys(event.identity)).not.toContain('userEmail');
+    // The email is still readable off raw (display metadata), never off identity.
+    expect((event.raw as { user_email: string }).user_email).toBe('attacker@example.com');
+  });
+
+  it('handles a non-object payload without throwing', () => {
+    expect(() => normalizeCursorHookEvent(null, 'advisory')).not.toThrow();
+    expect(() => normalizeCursorHookEvent('not an object', 'advisory')).not.toThrow();
+    expect(() => normalizeCursorHookEvent(undefined, 'advisory')).not.toThrow();
+  });
+});
+
+describe('normalizeClaudeCodeHookEvent', () => {
+  it('maps SessionStart/SessionEnd/UserPromptSubmit/Stop to their canonical kinds', () => {
+    expect(normalizeClaudeCodeHookEvent({ hook_event_name: 'SessionStart' }, 'advisory').kind).toBe(
+      'session-start',
+    );
+    expect(normalizeClaudeCodeHookEvent({ hook_event_name: 'SessionEnd' }, 'advisory').kind).toBe(
+      'session-end',
+    );
+    expect(
+      normalizeClaudeCodeHookEvent({ hook_event_name: 'UserPromptSubmit' }, 'advisory').kind,
+    ).toBe('prompt-submit');
+    expect(normalizeClaudeCodeHookEvent({ hook_event_name: 'Stop' }, 'advisory').kind).toBe('stop');
+  });
+
+  it('maps a generic PreToolUse/PostToolUse to pre-tool/post-tool with toolName', () => {
+    const pre = normalizeClaudeCodeHookEvent(
+      { hook_event_name: 'PreToolUse', tool_name: 'Read', session_id: 's1' },
+      'advisory',
+    );
+    expect(pre.kind).toBe('pre-tool');
+    expect(pre.toolName).toBe('Read');
+    expect(pre.identity.conversationId).toBe('s1');
+
+    const post = normalizeClaudeCodeHookEvent(
+      { hook_event_name: 'PostToolUse', tool_name: 'Grep' },
+      'advisory',
+    );
+    expect(post.kind).toBe('post-tool');
+  });
+
+  it('maps Bash tool calls to pre-shell/post-shell with the command', () => {
+    const pre = normalizeClaudeCodeHookEvent(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /' },
+      },
+      'advisory',
+    );
+    expect(pre.kind).toBe('pre-shell');
+    expect(pre.command).toBe('rm -rf /');
+
+    const post = normalizeClaudeCodeHookEvent(
+      {
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      },
+      'advisory',
+    );
+    expect(post.kind).toBe('post-shell');
+  });
+
+  it('maps a post-hoc Edit/Write to file-edit with the file path', () => {
+    const event = normalizeClaudeCodeHookEvent(
+      {
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Edit',
+        tool_input: { file_path: '/repo/src/index.ts' },
+      },
+      'advisory',
+    );
+    expect(event.kind).toBe('file-edit');
+    expect(event.filePaths).toEqual(['/repo/src/index.ts']);
+  });
+
+  it('never populates generationId/modelId -- Claude Code hook payloads carry neither', () => {
+    const event = normalizeClaudeCodeHookEvent(
+      { hook_event_name: 'PreToolUse', tool_name: 'Read' },
+      'advisory',
+    );
+    expect(event.identity.generationId).toBeUndefined();
+    expect(event.identity.modelId).toBeUndefined();
+  });
+
+  it('falls back to pre-tool with the raw event name for an unrecognized event', () => {
+    const event = normalizeClaudeCodeHookEvent({ hook_event_name: 'SomeFutureEvent' }, 'advisory');
+    expect(event.kind).toBe('pre-tool');
+    expect(event.toolName).toBe('SomeFutureEvent');
+  });
+});
+
+describe('normalizeHookEvent dispatch', () => {
+  it('isImplementedHookSource is true for cursor and claude-code, false otherwise', () => {
+    expect(isImplementedHookSource('cursor')).toBe(true);
+    expect(isImplementedHookSource('claude-code')).toBe(true);
+    expect(isImplementedHookSource('vscode')).toBe(false);
+    expect(isImplementedHookSource('opencode')).toBe(false);
+    expect(isImplementedHookSource('something-else')).toBe(false);
+  });
+
+  it('dispatches to the cursor normalizer', () => {
+    const event = normalizeHookEvent('cursor', { hook_event_name: 'stop' }, 'advisory');
+    expect(event.source).toBe('cursor');
+    expect(event.kind).toBe('stop');
+  });
+
+  it('dispatches to the claude-code normalizer', () => {
+    const event = normalizeHookEvent('claude-code', { hook_event_name: 'Stop' }, 'advisory');
+    expect(event.source).toBe('claude-code');
+    expect(event.kind).toBe('stop');
+  });
+});

--- a/packages/harnesses/src/__tests__/hook-policy.test.ts
+++ b/packages/harnesses/src/__tests__/hook-policy.test.ts
@@ -1,0 +1,148 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { normalizeCursorHookEvent } from '../hooks/normalizers/cursor.js';
+import { evaluatePolicy, loadPolicySnapshot } from '../hooks/policy.js';
+
+describe('loadPolicySnapshot', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'hook-policy-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reports "missing" when the file does not exist', async () => {
+    const result = await loadPolicySnapshot(join(dir, 'does-not-exist.json'));
+    expect(result.valid).toBe(false);
+    expect(!result.valid && result.reason).toBe('missing');
+  });
+
+  it('reports "invalid-json" for unparseable content', async () => {
+    const path = join(dir, 'snapshot.json');
+    await writeFile(path, 'not json{{{', 'utf8');
+    const result = await loadPolicySnapshot(path);
+    expect(result.valid).toBe(false);
+    expect(!result.valid && result.reason).toBe('invalid-json');
+  });
+
+  it('reports "invalid-shape" for JSON missing required fields', async () => {
+    const path = join(dir, 'snapshot.json');
+    await writeFile(path, JSON.stringify({ version: 1 }), 'utf8');
+    const result = await loadPolicySnapshot(path);
+    expect(result.valid).toBe(false);
+    expect(!result.valid && result.reason).toBe('invalid-shape');
+  });
+
+  it('reports "invalid-shape" for a tampered signature field (wrong type)', async () => {
+    const path = join(dir, 'snapshot.json');
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 12345, // tampered: should be a string
+        issuedAt: new Date().toISOString(),
+        rules: [],
+      }),
+      'utf8',
+    );
+    const result = await loadPolicySnapshot(path);
+    expect(result.valid).toBe(false);
+    expect(!result.valid && result.reason).toBe('invalid-shape');
+  });
+
+  it('loads a structurally well-formed snapshot', async () => {
+    const path = join(dir, 'snapshot.json');
+    const snapshot = {
+      version: 1,
+      keyId: 'k1',
+      signature: 'sig-placeholder',
+      issuedAt: new Date().toISOString(),
+      rules: [{ source: 'cursor', kind: 'pre-shell', permission: 'deny', reason: 'no shell' }],
+    };
+    await writeFile(path, JSON.stringify(snapshot), 'utf8');
+    const result = await loadPolicySnapshot(path);
+    expect(result.valid).toBe(true);
+    expect(result.valid && result.snapshot.rules).toHaveLength(1);
+  });
+});
+
+describe('evaluatePolicy', () => {
+  const shellEvent = normalizeCursorHookEvent(
+    { hook_event_name: 'beforeShellExecution', command: 'rm -rf /' },
+    'advisory',
+  );
+
+  it('allows everything when the snapshot is invalid (advisory mode)', () => {
+    const decision = evaluatePolicy({ valid: false, reason: 'missing' }, shellEvent);
+    expect(decision.permission).toBe('allow');
+  });
+
+  it('denies when a rule matches on kind', () => {
+    const decision = evaluatePolicy(
+      {
+        valid: true,
+        snapshot: {
+          version: 1,
+          keyId: 'k1',
+          signature: 'sig',
+          issuedAt: new Date().toISOString(),
+          rules: [{ kind: 'pre-shell', permission: 'deny', reason: 'shells are denied' }],
+        },
+      },
+      shellEvent,
+    );
+    expect(decision.permission).toBe('deny');
+    expect(decision.reason).toBe('shells are denied');
+  });
+
+  it('allows when no rule matches', () => {
+    const decision = evaluatePolicy(
+      {
+        valid: true,
+        snapshot: {
+          version: 1,
+          keyId: 'k1',
+          signature: 'sig',
+          issuedAt: new Date().toISOString(),
+          rules: [{ kind: 'file-edit', permission: 'deny', reason: 'no edits' }],
+        },
+      },
+      shellEvent,
+    );
+    expect(decision.permission).toBe('allow');
+  });
+
+  it('scopes a rule by source + toolName together', () => {
+    const toolEvent = normalizeCursorHookEvent(
+      { hook_event_name: 'preToolUse', tool_name: 'DangerousTool' },
+      'advisory',
+    );
+    const snapshot = {
+      version: 1,
+      keyId: 'k1',
+      signature: 'sig',
+      issuedAt: new Date().toISOString(),
+      rules: [
+        {
+          source: 'cursor' as const,
+          toolName: 'DangerousTool',
+          permission: 'ask' as const,
+          reason: 'confirm before running',
+        },
+      ],
+    };
+    expect(evaluatePolicy({ valid: true, snapshot }, toolEvent).permission).toBe('ask');
+
+    const otherTool = normalizeCursorHookEvent(
+      { hook_event_name: 'preToolUse', tool_name: 'SafeTool' },
+      'advisory',
+    );
+    expect(evaluatePolicy({ valid: true, snapshot }, otherTool).permission).toBe('allow');
+  });
+});

--- a/packages/harnesses/src/__tests__/hook-run.test.ts
+++ b/packages/harnesses/src/__tests__/hook-run.test.ts
@@ -1,0 +1,175 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runHookCommand } from '../hooks/run-hook.js';
+
+describe('runHookCommand', () => {
+  let dir: string;
+  let spoolPath: string;
+  let snapshotPath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'run-hook-test-'));
+    spoolPath = join(dir, 'receipts.jsonl');
+    snapshotPath = join(dir, 'policy-snapshot.json');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('I-5: a missing policy snapshot degrades to advisory and allows', async () => {
+    const result = await runHookCommand(
+      'cursor',
+      { hook_event_name: 'beforeShellExecution', command: 'rm -rf /' },
+      { spoolPath, snapshotPath },
+    );
+    expect(result.event.enforcementTier).toBe('advisory');
+    expect(result.decision.permission).toBe('allow');
+    expect(result.responseJson).toEqual({ permission: 'allow' });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('I-5: an invalid (tampered) policy snapshot also degrades to advisory', async () => {
+    await writeFile(snapshotPath, 'not valid json at all', 'utf8');
+    const result = await runHookCommand(
+      'cursor',
+      { hook_event_name: 'beforeShellExecution', command: 'rm -rf /' },
+      { spoolPath, snapshotPath },
+    );
+    expect(result.event.enforcementTier).toBe('advisory');
+    expect(result.decision.permission).toBe('allow');
+  });
+
+  it('I-5: a structurally valid snapshot with a matching deny rule denies and records enforced', async () => {
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig-placeholder',
+        issuedAt: new Date().toISOString(),
+        rules: [{ kind: 'pre-shell', permission: 'deny', reason: 'shells are denied by policy' }],
+      }),
+      'utf8',
+    );
+
+    const result = await runHookCommand(
+      'cursor',
+      { hook_event_name: 'beforeShellExecution', command: 'rm -rf /' },
+      { spoolPath, snapshotPath },
+    );
+
+    expect(result.event.enforcementTier).toBe('enforced');
+    expect(result.decision.permission).toBe('deny');
+    expect(result.exitCode).toBe(2);
+    expect(result.responseJson).toEqual({
+      permission: 'deny',
+      user_message: 'shells are denied by policy',
+      agent_message: 'shells are denied by policy',
+    });
+  });
+
+  it('builds the claude-code-native response shape on deny/ask/allow', async () => {
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig',
+        issuedAt: new Date().toISOString(),
+        rules: [{ kind: 'pre-shell', permission: 'deny', reason: 'no shells' }],
+      }),
+      'utf8',
+    );
+
+    const denied = await runHookCommand(
+      'claude-code',
+      { hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'ls' } },
+      { spoolPath, snapshotPath },
+    );
+    expect(denied.responseJson).toEqual({ decision: 'block', reason: 'no shells' });
+    expect(denied.exitCode).toBe(2);
+
+    const allowed = await runHookCommand(
+      'claude-code',
+      { hook_event_name: 'PreToolUse', tool_name: 'Read' },
+      { spoolPath, snapshotPath },
+    );
+    expect(allowed.responseJson).toEqual({ decision: 'approve' });
+    expect(allowed.exitCode).toBe(0);
+  });
+
+  it('spools every decision to the configured path', async () => {
+    await runHookCommand(
+      'cursor',
+      { hook_event_name: 'sessionStart', conversation_id: 'c1' },
+      { spoolPath, snapshotPath },
+    );
+    await runHookCommand(
+      'cursor',
+      { hook_event_name: 'stop', conversation_id: 'c1' },
+      { spoolPath, snapshotPath },
+    );
+
+    const content = await readFile(spoolPath, 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0] as string).event.kind).toBe('session-start');
+    expect(JSON.parse(lines[1] as string).event.kind).toBe('stop');
+  });
+
+  // Design invariant I-1: a forged identity field in the hook payload never
+  // appears in the normalized identity, and cannot widen or change the
+  // policy outcome (a deny rule scoped by tool/kind still fires regardless
+  // of what identity the payload claims).
+  it('I-1: a forged identity claim never appears in normalized identity nor changes the policy outcome', async () => {
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig',
+        issuedAt: new Date().toISOString(),
+        rules: [{ toolName: 'DangerousTool', permission: 'deny', reason: 'blocked tool' }],
+      }),
+      'utf8',
+    );
+
+    const honest = await runHookCommand(
+      'cursor',
+      {
+        hook_event_name: 'preToolUse',
+        tool_name: 'DangerousTool',
+        user_email: 'real-user@example.com',
+      },
+      { spoolPath, snapshotPath },
+    );
+
+    const forged = await runHookCommand(
+      'cursor',
+      {
+        hook_event_name: 'preToolUse',
+        tool_name: 'DangerousTool',
+        // Claims to be a different, privileged-sounding identity.
+        user_email: 'admin@revealui.com',
+        conversation_id: 'someone-elses-conversation',
+      },
+      { spoolPath, snapshotPath },
+    );
+
+    // Same deny outcome regardless of the claimed identity.
+    expect(honest.decision.permission).toBe('deny');
+    expect(forged.decision.permission).toBe('deny');
+    expect(forged.decision.reason).toBe(honest.decision.reason);
+
+    // The forged email never lands on the normalized identity.
+    expect(forged.event.identity).not.toHaveProperty('email');
+    expect(forged.event.identity).not.toHaveProperty('userEmail');
+    expect(Object.values(forged.event.identity)).not.toContain('admin@revealui.com');
+
+    // It is still visible in raw (display metadata only).
+    expect((forged.event.raw as { user_email: string }).user_email).toBe('admin@revealui.com');
+  });
+});

--- a/packages/harnesses/src/__tests__/hook-run.test.ts
+++ b/packages/harnesses/src/__tests__/hook-run.test.ts
@@ -42,7 +42,7 @@ describe('runHookCommand', () => {
     expect(result.decision.permission).toBe('allow');
   });
 
-  it('I-5: a structurally valid snapshot with a matching deny rule denies and records enforced', async () => {
+  it('I-5: a structurally valid snapshot applies its deny rule but records advisory until the signature is verified', async () => {
     await writeFile(
       snapshotPath,
       JSON.stringify({
@@ -61,9 +61,13 @@ describe('runHookCommand', () => {
       { spoolPath, snapshotPath },
     );
 
-    expect(result.event.enforcementTier).toBe('enforced');
+    // The deny rule STILL applies (defense in depth -- policy can only tighten),
+    // but the receipt must NOT claim `enforced`: the signature is a placeholder
+    // and nothing cryptographically verified it (design invariant I-5). Reporting
+    // `enforced` here would be the exact overclaim the invariant forbids.
     expect(result.decision.permission).toBe('deny');
     expect(result.exitCode).toBe(2);
+    expect(result.event.enforcementTier).toBe('advisory');
     expect(result.responseJson).toEqual({
       permission: 'deny',
       user_message: 'shells are denied by policy',

--- a/packages/harnesses/src/__tests__/hook-spool.test.ts
+++ b/packages/harnesses/src/__tests__/hook-spool.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { normalizeCursorHookEvent } from '../hooks/normalizers/cursor.js';
+import type { PolicyDecision } from '../hooks/policy.js';
+import { appendToSpool, flushSpool, resetFlushWarnLatchForTests } from '../hooks/spool.js';
+
+const decision: PolicyDecision = { permission: 'allow' };
+const event = normalizeCursorHookEvent({ hook_event_name: 'stop' }, 'advisory');
+
+describe('appendToSpool', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'hook-spool-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('creates the parent directory and appends a JSONL line', async () => {
+    const spoolPath = join(dir, 'nested', 'receipts.jsonl');
+    const result = await appendToSpool(
+      { event, decision, spooledAt: new Date().toISOString() },
+      spoolPath,
+    );
+    expect(result.appended).toBe(true);
+    expect(result.rotated).toBe(false);
+
+    const content = await readFile(spoolPath, 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0] as string);
+    expect(parsed.decision.permission).toBe('allow');
+    expect(parsed.event.kind).toBe('stop');
+  });
+
+  it('appends multiple records without dropping any', async () => {
+    const spoolPath = join(dir, 'receipts.jsonl');
+    for (let i = 0; i < 5; i++) {
+      await appendToSpool({ event, decision, spooledAt: new Date().toISOString() }, spoolPath);
+    }
+    const content = await readFile(spoolPath, 'utf8');
+    expect(content.trim().split('\n')).toHaveLength(5);
+  });
+
+  it('never drops an event on overflow -- rotates the full spool aside instead', async () => {
+    const spoolPath = join(dir, 'receipts.jsonl');
+    // First append establishes the file; force a tiny max so the SECOND
+    // append rotates instead of growing the first file unbounded.
+    await appendToSpool({ event, decision, spooledAt: new Date().toISOString() }, spoolPath, 1);
+    const second = await appendToSpool(
+      { event, decision, spooledAt: new Date().toISOString() },
+      spoolPath,
+      1,
+    );
+    expect(second.rotated).toBe(true);
+
+    const entries = await readdir(dir);
+    const rotated = entries.filter((name) => name.endsWith('.rotated'));
+    expect(rotated).toHaveLength(1);
+
+    // The rotated file still holds the first record -- nothing was dropped.
+    const rotatedContent = await readFile(join(dir, rotated[0] as string), 'utf8');
+    expect(rotatedContent.trim().split('\n')).toHaveLength(1);
+
+    // The fresh spool holds the second record.
+    const freshContent = await readFile(spoolPath, 'utf8');
+    expect(freshContent.trim().split('\n')).toHaveLength(1);
+  });
+});
+
+describe('flushSpool', () => {
+  beforeEach(() => {
+    resetFlushWarnLatchForTests();
+  });
+
+  it('no-ops with a warn when no endpoint is configured (spool-only mode)', () => {
+    const stderrSpy = process.stderr.write.bind(process.stderr) as typeof process.stderr.write;
+    const messages: string[] = [];
+    process.stderr.write = ((chunk: string) => {
+      messages.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      const result = flushSpool('/tmp/does-not-matter.jsonl', {});
+      expect(result.flushed).toBe(false);
+      expect(result.reason).toBe('not-configured');
+      expect(messages.some((m) => m.includes('spool-only mode'))).toBe(true);
+    } finally {
+      process.stderr.write = stderrSpy;
+    }
+  });
+
+  it('warns only once across repeated calls (single-warn latch)', () => {
+    const messages: string[] = [];
+    const original = process.stderr.write.bind(process.stderr) as typeof process.stderr.write;
+    process.stderr.write = ((chunk: string) => {
+      messages.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      flushSpool('/tmp/spool.jsonl', {});
+      flushSpool('/tmp/spool.jsonl', {});
+      flushSpool('/tmp/spool.jsonl', {});
+      expect(messages).toHaveLength(1);
+    } finally {
+      process.stderr.write = original;
+    }
+  });
+
+  it('reports not-implemented when an endpoint IS configured -- Phase A ships the real POST', () => {
+    const result = flushSpool('/tmp/spool.jsonl', {
+      endpoint: 'https://example.com/api/harness/receipts',
+    });
+    expect(result.flushed).toBe(false);
+    expect(result.reason).toBe('not-implemented');
+  });
+});

--- a/packages/harnesses/src/__tests__/protocol-types.test.ts
+++ b/packages/harnesses/src/__tests__/protocol-types.test.ts
@@ -35,8 +35,8 @@ describe('protocol capabilities', () => {
 });
 
 describe('TOOL_PROFILES (shipped adapters)', () => {
-  it('contains opencode and revealui-agent', () => {
-    expect(Object.keys(TOOL_PROFILES).sort()).toEqual(['opencode', 'revealui-agent']);
+  it('contains cursor, opencode, and revealui-agent', () => {
+    expect(Object.keys(TOOL_PROFILES).sort()).toEqual(['cursor', 'opencode', 'revealui-agent']);
   });
 
   it('revealui-agent has full dispatch capabilities', () => {
@@ -74,16 +74,33 @@ describe('TOOL_PROFILES (shipped adapters)', () => {
     expect(caps.maxContextTokens).toBe(0);
   });
 
+  it('cursor is headless/backgroundable, supports hooks + MCP, and carries the roadmap maxContextTokens', () => {
+    const caps = TOOL_PROFILES.cursor;
+    expect(caps).toBeDefined();
+    expect(caps.dispatch.generateCode).toBe(true);
+    expect(caps.dispatch.analyzeCode).toBe(true);
+    expect(caps.dispatch.applyEdit).toBe(false);
+    expect(caps.dispatch.executeCommand).toBe(true);
+    expect(caps.headless).toBe(true);
+    expect(caps.backgroundable).toBe(true);
+    expect(caps.hooks.supported).toBe(true);
+    expect(caps.hooks.canBlock).toBe(true);
+    expect(caps.supportsMcp).toBe(true);
+    // 128_000 is the real value the roadmap profile already declared, kept
+    // on promotion per the maxContextTokens doc comment ("do not invent a
+    // number") -- NOT the `0` BYO sentinel opencode uses.
+    expect(caps.maxContextTokens).toBe(128_000);
+  });
+
   it('does not contain entries for tools without adapters', () => {
     expect(TOOL_PROFILES['claude-code']).toBeUndefined();
     expect(TOOL_PROFILES.codex).toBeUndefined();
-    expect(TOOL_PROFILES.cursor).toBeUndefined();
   });
 });
 
 describe('ROADMAP_PROFILES (declared, no adapter)', () => {
-  it('contains the three remaining spec-declared tools (opencode graduated to TOOL_PROFILES)', () => {
-    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex', 'cursor']);
+  it('contains the two remaining spec-declared tools (opencode + cursor graduated to TOOL_PROFILES)', () => {
+    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex']);
   });
 
   it('claude-code has no dispatch capabilities (interactive tool)', () => {
@@ -98,12 +115,8 @@ describe('ROADMAP_PROFILES (declared, no adapter)', () => {
     expect(caps.sandbox.modes).toContain('read-only');
   });
 
-  it('cursor has minimal capabilities', () => {
-    const caps = ROADMAP_PROFILES.cursor;
-    expect(caps.headless).toBe(false);
-    expect(caps.hooks.supported).toBe(false);
-    expect(caps.readWorkboard).toBe(false);
-    expect(caps.lifecycleEvents).toEqual([]);
+  it('no longer declares cursor (graduated to TOOL_PROFILES)', () => {
+    expect(ROADMAP_PROFILES.cursor).toBeUndefined();
   });
 
   it('does not overlap with TOOL_PROFILES', () => {
@@ -131,6 +144,7 @@ describe('ALL_KNOWN_PROFILES (merged view)', () => {
     // same ID. Verify the shape of the shipped profiles matches TOOL_PROFILES.
     expect(ALL_KNOWN_PROFILES['revealui-agent']).toEqual(TOOL_PROFILES['revealui-agent']);
     expect(ALL_KNOWN_PROFILES.opencode).toEqual(TOOL_PROFILES.opencode);
+    expect(ALL_KNOWN_PROFILES.cursor).toEqual(TOOL_PROFILES.cursor);
   });
 });
 

--- a/packages/harnesses/src/adapters/cursor-adapter.ts
+++ b/packages/harnesses/src/adapters/cursor-adapter.ts
@@ -1,0 +1,399 @@
+/**
+ * Cursor Adapter
+ *
+ * Wraps the Cursor CLI, promoting the `cursor` data-only roadmap profile
+ * (`../protocol/roadmap-profiles.ts`) into a working adapter, the same way
+ * `OpenCodeAdapter` promoted `opencode` (revealui#1911). Like OpenCodeAdapter,
+ * this is a thin control-plane wrapper -- it detects, drives, and observes a
+ * locally-installed Cursor CLI. It grants no RevealUI data-plane authority;
+ * that flows through the governed MCP endpoint via `.cursor/mcp.json`
+ * (`../content/generators/cursor.ts` + `protocolConfigToCursorMcpConfig`),
+ * and receipt/policy enforcement flows through `.cursor/hooks.json` +
+ * `revealui-harnesses hook cursor` (`../hooks/`), not through this adapter.
+ *
+ * Binary + flags verified 2026-07-17 against cursor.com/docs/cli/installation
+ * and cursor.com/docs/cli/headless: the installed executable is `agent`
+ * (installed via `curl https://cursor.com/install -fsSL | bash`), supporting
+ * `--version`, `-p`/`--print` (headless), `--output-format json|text`, and
+ * `--force` (apply changes directly rather than only proposing them). The
+ * exact `--output-format json` response shape is UNVERIFIED against a real
+ * binary, same posture as `opencode-adapter.ts`'s `parseOpenCodeRunOutput` --
+ * `parseCursorAgentOutput` below is defensive for the same reason.
+ *
+ * `agent` is deliberately NOT added to `process-detector.ts`'s
+ * `HARNESS_PROCESS_PATTERNS` -- it is too generic a substring for `pgrep -a`
+ * (it would false-match `ssh-agent`, `gpg-agent`, and similar unrelated
+ * processes). `isAvailable()` below checks the binary directly via
+ * `execFile`, which does not have that hazard.
+ */
+
+import { execFile } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve, sep } from 'node:path';
+import { promisify } from 'node:util';
+import { diffConfig, syncConfig } from '../config/config-sync.js';
+import { findHarnessProcesses } from '../detection/process-detector.js';
+import type { ProtocolCapabilities } from '../protocol/capabilities.js';
+import { TOOL_PROFILES } from '../protocol/capabilities.js';
+import type { ProtocolEventEnvelope } from '../protocol/event-envelope.js';
+import { EventNormalizer } from '../protocol/event-normalizer.js';
+import type { HarnessAdapter } from '../types/adapter.js';
+import type {
+  HarnessCapabilities,
+  HarnessCommand,
+  HarnessCommandResult,
+  HarnessEvent,
+  HarnessInfo,
+} from '../types/core.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Default timeout for a one-shot `agent -p` invocation (2 minutes). */
+const DEFAULT_RUN_TIMEOUT_MS = 120_000;
+/** Timeout for availability/version checks -- these must be fast (3s). */
+const AVAILABILITY_TIMEOUT_MS = 3_000;
+/** Cap stdout/stderr buffering for `agent -p` (10 MB). */
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+/** Configuration for the Cursor adapter. All fields are optional. */
+export interface CursorAdapterConfig {
+  /** Project root the `agent` CLI runs against (default: cwd) */
+  projectRoot?: string;
+  /** Model override passed as `--model` (default: Cursor's own default) */
+  model?: string;
+  /** Timeout for `agent -p` invocations in ms (default: 120000) */
+  timeoutMs?: number;
+  /** Path/name of the Cursor CLI executable (default: 'agent', resolved via PATH) */
+  binaryPath?: string;
+}
+
+const DEFAULT_CONFIG: Required<Pick<CursorAdapterConfig, 'timeoutMs' | 'binaryPath'>> = {
+  timeoutMs: DEFAULT_RUN_TIMEOUT_MS,
+  binaryPath: 'agent',
+};
+
+/**
+ * Parse `agent -p --output-format json` stdout into a plain-text output
+ * string. Shape UNVERIFIED against a real binary (see module doc) --
+ * mirrors `parseOpenCodeRunOutput`'s defensive multi-key extraction.
+ */
+export function parseCursorAgentOutput(stdout: string): string {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) return '';
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === 'string') return parsed;
+    if (parsed && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>;
+      for (const key of ['result', 'output', 'text', 'message', 'content']) {
+        const value = obj[key];
+        if (typeof value === 'string') return value;
+      }
+    }
+    return trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * Turn an `execFile` rejection into a helpful message, special-casing the
+ * "binary not on PATH" case. Exported for direct unit testing.
+ */
+export function describeCursorAgentExecError(err: unknown): string {
+  if (
+    err &&
+    typeof err === 'object' &&
+    'code' in err &&
+    (err as { code?: string }).code === 'ENOENT'
+  ) {
+    return 'Cursor CLI ("agent") not found on PATH. Install via `curl https://cursor.com/install -fsSL | bash`, then retry.';
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  const stderr =
+    err && typeof err === 'object' && 'stderr' in err
+      ? String((err as { stderr: unknown }).stderr)
+      : '';
+  return stderr ? `${message}\n${stderr}`.trim() : message;
+}
+
+/**
+ * Cursor harness adapter -- promotes the `cursor` data-only roadmap profile
+ * to a working adapter, mirroring `OpenCodeAdapter`'s structure exactly.
+ */
+export class CursorAdapter implements HarnessAdapter {
+  readonly id = 'cursor';
+  readonly name = 'Cursor';
+
+  private readonly config: CursorAdapterConfig;
+  private readonly binary: string;
+  private readonly eventHandlers = new Set<(event: HarnessEvent) => void>();
+  private readonly protocolEventHandlers = new Set<(event: ProtocolEventEnvelope) => void>();
+  private protocolNormalizer: EventNormalizer | null = null;
+
+  constructor(config?: CursorAdapterConfig) {
+    this.config = { ...config };
+    this.binary = config?.binaryPath ?? DEFAULT_CONFIG.binaryPath;
+  }
+
+  getCapabilities(): HarnessCapabilities {
+    return {
+      generateCode: true,
+      analyzeCode: true,
+      // `agent -p --force` applies edits itself during generation; there is
+      // no clean CLI surface for the adapter to apply an externally-supplied
+      // diff (same reasoning as OpenCodeAdapter).
+      applyEdit: false,
+      applyConfig: true,
+      // Workboard support is not wired -- same honest posture as
+      // RevealUIAgentAdapter / OpenCodeAdapter.
+      readWorkboard: false,
+      writeWorkboard: false,
+    };
+  }
+
+  async getInfo(): Promise<HarnessInfo> {
+    return {
+      id: this.id,
+      name: this.name,
+      version: await this.getVersion(),
+      capabilities: this.getCapabilities(),
+    };
+  }
+
+  /** Get the Harness Protocol capability profile for this adapter. */
+  getProtocolCapabilities(): ProtocolCapabilities {
+    // cursor is promoted into TOOL_PROFILES when CursorAdapter ships.
+    return TOOL_PROFILES.cursor as ProtocolCapabilities;
+  }
+
+  /** Subscribe to protocol-normalized events. */
+  onProtocolEvent(handler: (event: ProtocolEventEnvelope) => void): () => void {
+    this.protocolEventHandlers.add(handler);
+    if (!this.protocolNormalizer) {
+      this.protocolNormalizer = new EventNormalizer('cursor', this.id, `session-${Date.now()}`);
+    }
+    return () => this.protocolEventHandlers.delete(handler);
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await execFileAsync(this.binary, ['--version'], { timeout: AVAILABILITY_TIMEOUT_MS });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  notifyRegistered(): void {
+    this.emit({ type: 'harness-connected', harnessId: this.id });
+  }
+
+  notifyUnregistering(): void {
+    this.emit({ type: 'harness-disconnected', harnessId: this.id });
+  }
+
+  async execute(command: HarnessCommand): Promise<HarnessCommandResult> {
+    try {
+      return await this.executeInner(command);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit({ type: 'error', harnessId: this.id, message });
+      return { success: false, command: command.type, message };
+    }
+  }
+
+  private async executeInner(command: HarnessCommand): Promise<HarnessCommandResult> {
+    switch (command.type) {
+      case 'get-status': {
+        const available = await this.isAvailable();
+        return {
+          success: true,
+          command: command.type,
+          data: {
+            available,
+            model: this.config.model ?? 'auto',
+            projectRoot: this.config.projectRoot ?? process.cwd(),
+          },
+        };
+      }
+
+      case 'headless-prompt': {
+        return this.runCursorAgent(command.type, command.prompt, {
+          timeoutMs: command.timeoutMs,
+          force: false,
+        });
+      }
+
+      case 'generate-code': {
+        const prompt = `Generate code: ${command.prompt}${command.language ? ` (language: ${command.language})` : ''}${command.context ? `\n\nContext:\n${command.context}` : ''}`;
+        return this.runCursorAgent(command.type, prompt, { force: true });
+      }
+
+      case 'analyze-code': {
+        const question = command.question ?? 'Analyze this file and explain what it does.';
+        const prompt = `Read the file at ${command.filePath} and answer: ${question}`;
+        return this.runCursorAgent(command.type, prompt, { force: false });
+      }
+
+      case 'apply-edit': {
+        return {
+          success: false,
+          command: command.type,
+          message:
+            'apply-edit is not supported by the Cursor adapter -- the CLI applies edits itself during a forced run; there is no clean CLI surface for an externally-supplied diff.',
+        };
+      }
+
+      case 'apply-config': {
+        return this.applyConfig(command.configPath, command.content);
+      }
+
+      case 'sync-config': {
+        const result = syncConfig(this.id, command.direction);
+        return { success: result.success, command: command.type, message: result.message };
+      }
+
+      case 'diff-config': {
+        const diff = diffConfig(this.id);
+        return { success: true, command: command.type, data: diff };
+      }
+
+      case 'read-workboard':
+      case 'update-workboard': {
+        return {
+          success: false,
+          command: command.type,
+          message: 'Workboard support not yet wired  -  use WorkboardManager directly',
+        };
+      }
+
+      case 'get-running-instances': {
+        const instances = await findHarnessProcesses(this.id);
+        return { success: true, command: command.type, data: { instances } };
+      }
+
+      default: {
+        return {
+          success: false,
+          command: (command as HarnessCommand).type,
+          message: `Command not supported by ${this.name}`,
+        };
+      }
+    }
+  }
+
+  /** Write `content` to `configPath`, resolved under the configured project root. */
+  private async applyConfig(configPath: string, content: string): Promise<HarnessCommandResult> {
+    const projectRoot = resolve(this.config.projectRoot ?? process.cwd());
+    const resolved = resolve(projectRoot, configPath);
+    const rootWithSep = projectRoot.endsWith(sep) ? projectRoot : projectRoot + sep;
+
+    if (!(resolved === projectRoot || resolved.startsWith(rootWithSep))) {
+      return {
+        success: false,
+        command: 'apply-config',
+        message: `Refusing to write outside the project root: ${configPath}`,
+      };
+    }
+
+    try {
+      await mkdir(dirname(resolved), { recursive: true });
+      await writeFile(resolved, content, 'utf8');
+      return { success: true, command: 'apply-config', data: { path: resolved } };
+    } catch (err) {
+      return {
+        success: false,
+        command: 'apply-config',
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
+   * Run a one-shot `agent -p` invocation and normalize its output. Emits
+   * `generation-started` / `generation-completed` around the call, mirroring
+   * `opencode-adapter.ts`'s event pattern. `opts.force` maps to `--force`
+   * (apply edits directly) -- omitted for analyze/headless prompts, which
+   * should not mutate the project.
+   */
+  private async runCursorAgent(
+    commandType: HarnessCommand['type'],
+    prompt: string,
+    opts: { timeoutMs?: number; force: boolean },
+  ): Promise<HarnessCommandResult> {
+    const taskId = `task-${Date.now()}`;
+    this.emit({ type: 'generation-started', taskId });
+
+    const args = ['-p', prompt, '--output-format', 'json'];
+    if (opts.force) args.push('--force');
+    if (this.config.model) args.push('--model', this.config.model);
+
+    try {
+      const { stdout } = await execFileAsync(this.binary, args, {
+        cwd: this.config.projectRoot ?? process.cwd(),
+        timeout: opts.timeoutMs ?? this.config.timeoutMs ?? DEFAULT_CONFIG.timeoutMs,
+        maxBuffer: MAX_BUFFER_BYTES,
+      });
+
+      const output = parseCursorAgentOutput(stdout);
+      this.emit({ type: 'generation-completed', taskId, output });
+
+      return {
+        success: true,
+        command: commandType,
+        message: output,
+        data: { taskId, output },
+      };
+    } catch (err) {
+      return { success: false, command: commandType, message: describeCursorAgentExecError(err) };
+    }
+  }
+
+  private async getVersion(): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFileAsync(this.binary, ['--version'], {
+        timeout: AVAILABILITY_TIMEOUT_MS,
+      });
+      const version = stdout.trim();
+      return version.length > 0 ? version : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  onEvent(handler: (event: HarnessEvent) => void): () => void {
+    this.eventHandlers.add(handler);
+    return () => this.eventHandlers.delete(handler);
+  }
+
+  async dispose(): Promise<void> {
+    this.eventHandlers.clear();
+    this.protocolEventHandlers.clear();
+    this.protocolNormalizer = null;
+  }
+
+  private emit(event: HarnessEvent): void {
+    for (const handler of this.eventHandlers) {
+      try {
+        handler(event);
+      } catch {
+        // Swallow subscriber errors
+      }
+    }
+
+    if (this.protocolNormalizer && this.protocolEventHandlers.size > 0) {
+      const envelope = this.protocolNormalizer.normalizeToEnvelope(event);
+      if (envelope) {
+        for (const handler of this.protocolEventHandlers) {
+          try {
+            handler(envelope);
+          } catch {
+            // Swallow subscriber errors
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -10,6 +10,7 @@
  *   sync <harnessId> <push|pull>     Sync harness config to/from SSD
  *   coordinate [--print]             Print current workboard state
  *   coordinate --init <path>         Register this session in the workboard and start daemon
+ *   hook <cursor|claude-code>        Normalize a hook payload from stdin, evaluate policy, spool the receipt
  *
  * License: FSL-1.1-MIT
  */
@@ -27,6 +28,7 @@ import {
   validateManifest,
 } from './content/index.js';
 import { HarnessCoordinator } from './coordinator.js';
+import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
 import { WorkboardManager } from './workboard/workboard-manager.js';
 
 const DATA_DIR = join(homedir(), '.local', 'share', 'revealui');
@@ -367,7 +369,54 @@ async function handleContentCommand(subcommand: string | undefined, args: string
   }
 }
 
+/** Read all of stdin as a UTF-8 string. */
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/**
+ * `hook <source>` subcommand: reads the editor's JSON hook payload from
+ * stdin, normalizes + evaluates policy + spools the receipt, then writes
+ * the editor-native response JSON to stdout. Malformed stdin (not valid
+ * JSON) defaults to allow rather than crashing the editor's hook pipeline.
+ */
+async function handleHookCommand(source: string | undefined): Promise<void> {
+  if (!(source && isImplementedHookSource(source))) {
+    process.stderr.write(
+      `Unsupported hook source: ${source ?? '(none)'}. Supported: cursor, claude-code\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const stdin = await readStdin();
+  let rawInput: unknown;
+  try {
+    rawInput = JSON.parse(stdin);
+  } catch {
+    process.stderr.write('revealui-harnesses hook: invalid JSON on stdin, defaulting to allow\n');
+    process.stdout.write(`${JSON.stringify({ permission: 'allow', decision: 'approve' })}\n`);
+    return;
+  }
+
+  const result = await runHookCommand(source, rawInput, defaultHookRunOptions());
+  process.stdout.write(`${JSON.stringify(result.responseJson)}\n`);
+  if (result.exitCode !== 0) {
+    process.exitCode = result.exitCode;
+  }
+}
+
 async function main() {
+  if (command === 'hook') {
+    const [source] = args;
+    await handleHookCommand(source);
+    return;
+  }
+
   if (command === 'content') {
     const [subcommand] = args;
     const contentArgs = args.slice(1);
@@ -559,6 +608,7 @@ Commands:
   health                            Run health check (requires daemon)
   coordinate [--project <path>]     Print workboard state
   coordinate --init [<path>]        Register + start daemon
+  hook <cursor|claude-code>         Normalize a hook payload from stdin, evaluate policy, spool the receipt
   content <subcommand>              Manage canonical content definitions
 
 Content Subcommands:

--- a/packages/harnesses/src/content/generators/cursor.ts
+++ b/packages/harnesses/src/content/generators/cursor.ts
@@ -1,0 +1,94 @@
+/**
+ * Cursor Content Generator
+ *
+ * Emits `.cursor/hooks.json` -- COMMAND-BASED hooks only (multi-editor
+ * harness design doc §3-B acceptance: "100% command-based hooks"; Cursor
+ * cloud agents run command hooks only, no prompt-based hooks, per design
+ * doc §2.3). Every configured event runs the same command:
+ * `revealui-harnesses hook cursor`, which reads the hook payload from
+ * stdin and prints the permission decision to stdout (`../../cli.ts`
+ * `hook` subcommand, `../../hooks/run-hook.ts`).
+ *
+ * `.cursor/mcp.json` generation is NOT part of this generator -- it needs a
+ * `ProtocolConfig` + an MCP URL/token-env-var option the `ContentGenerator`
+ * interface's `generateAll(manifest, ctx)` signature doesn't carry, and it
+ * is security-critical (never emit a literal token). It lives alongside
+ * `protocolConfigToOpencodeConfig` in `../../protocol/config-normalizer.ts`
+ * as `protocolConfigToCursorMcpConfig`, the same leak-proof pattern.
+ *
+ * Cursor's documented writable surfaces this generator does NOT emit yet
+ * (Phase C scope, mirroring `opencode.ts`'s scoping note): `.cursor/commands/`,
+ * `.cursor/rules/` (Cursor's own rules format, distinct from `.cursorrules`
+ * which `protocolConfigToCursorrules` already emits), and an agents surface.
+ * `generateRule`/`generateCommand`/`generateAgent`/`generateSkill` return no
+ * files -- a scoping decision, not an oversight.
+ */
+
+import type { ResolverContext } from '../resolvers/types.js';
+import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
+import type { ContentGenerator, GeneratedFile } from './types.js';
+
+/**
+ * The eleven Cursor hook event names this package's `hook cursor`
+ * subcommand normalizes (multi-editor harness design doc §2.3, verified
+ * 2026-07-17 against cursor.com/docs/agent/hooks). `beforeReadFile` and the
+ * subagent events are intentionally included -- the normalizer
+ * (`../../hooks/normalizers/cursor.ts`) has an explicit, tested mapping for
+ * every one of them.
+ */
+const CURSOR_HOOK_EVENT_NAMES: readonly string[] = [
+  'sessionStart',
+  'sessionEnd',
+  'preToolUse',
+  'postToolUse',
+  'beforeShellExecution',
+  'afterShellExecution',
+  'beforeMCPExecution',
+  'afterMCPExecution',
+  'beforeReadFile',
+  'afterFileEdit',
+  'stop',
+];
+
+/** The `.cursor/hooks.json` shape (design doc §2.3 / cursor.com/docs/agent/hooks). */
+interface CursorHooksConfig {
+  version: 1;
+  hooks: Record<string, Array<{ command: string; type: 'command' }>>;
+}
+
+export class CursorGenerator implements ContentGenerator {
+  readonly id = 'cursor';
+  readonly outputDir = '.cursor';
+
+  generateRule(_rule: Rule, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateCommand(_cmd: Command, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateAgent(_agent: Agent, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateSkill(_skill: Skill, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateAll(_manifest: Manifest, _ctx: ResolverContext): GeneratedFile[] {
+    const hooks: CursorHooksConfig['hooks'] = {};
+    for (const eventName of CURSOR_HOOK_EVENT_NAMES) {
+      hooks[eventName] = [{ command: 'revealui-harnesses hook cursor', type: 'command' }];
+    }
+
+    const config: CursorHooksConfig = { version: 1, hooks };
+
+    return [
+      {
+        relativePath: '.cursor/hooks.json',
+        content: `${JSON.stringify(config, null, 2)}\n`,
+      },
+    ];
+  }
+}

--- a/packages/harnesses/src/content/generators/index.ts
+++ b/packages/harnesses/src/content/generators/index.ts
@@ -1,6 +1,8 @@
+import { CursorGenerator } from './cursor.js';
 import { OpenCodeGenerator } from './opencode.js';
 import type { ContentGenerator } from './types.js';
 
+export { CursorGenerator } from './cursor.js';
 export { OpenCodeGenerator } from './opencode.js';
 export type { ContentGenerator, DiffEntry, GeneratedFile } from './types.js';
 
@@ -25,3 +27,4 @@ export function listGenerators(): string[] {
 // `diffContent()` (content/index.ts) work out of the box for any importer
 // of this module -- no manual registration call required.
 registerGenerator(new OpenCodeGenerator());
+registerGenerator(new CursorGenerator());

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -2,10 +2,11 @@
  * @revealui/harnesses/content  -  Canonical Content Layer
  *
  * Tool-agnostic definitions for AI guidance content (rules, commands, agents, skills).
- * Generators produce tool-specific output from canonical definitions. `opencode`
- * is the only registered generator today (`./generators/opencode.ts`) -- Claude
- * Code / Cursor generators are not implemented, matching the adapter layer
- * (`../adapters/`), which likewise ships only `revealui-agent` and `opencode`.
+ * Generators produce tool-specific output from canonical definitions.
+ * `opencode` (`./generators/opencode.ts`) and `cursor` (`./generators/cursor.ts`,
+ * hooks.json only -- see that file's doc comment) are registered today,
+ * matching the adapter layer (`../adapters/`), which ships `revealui-agent`,
+ * `opencode`, and `cursor`. A Claude Code generator is not implemented.
  *
  * @example
  * ```ts
@@ -27,6 +28,7 @@ import { type Manifest, ManifestSchema } from './schemas/manifest.js';
 
 export { buildManifest } from './definitions/index.js';
 export {
+  CursorGenerator,
   getGenerator,
   listGenerators,
   OpenCodeGenerator,

--- a/packages/harnesses/src/detection/auto-detector.ts
+++ b/packages/harnesses/src/detection/auto-detector.ts
@@ -1,3 +1,4 @@
+import { CursorAdapter } from '../adapters/cursor-adapter.js';
 import { OpenCodeAdapter } from '../adapters/opencode-adapter.js';
 import { RevealUIAgentAdapter } from '../adapters/revealui-agent-adapter.js';
 import type { HarnessRegistry } from '../registry/harness-registry.js';
@@ -9,7 +10,7 @@ import type { HarnessRegistry } from '../registry/harness-registry.js';
  * and registers those that respond. Unavailable adapters are disposed.
  */
 export async function autoDetectHarnesses(registry: HarnessRegistry): Promise<string[]> {
-  const candidates = [new RevealUIAgentAdapter(), new OpenCodeAdapter()];
+  const candidates = [new RevealUIAgentAdapter(), new OpenCodeAdapter(), new CursorAdapter()];
 
   const registered: string[] = [];
 

--- a/packages/harnesses/src/hooks/index.ts
+++ b/packages/harnesses/src/hooks/index.ts
@@ -1,0 +1,28 @@
+export type { ImplementedHookSource } from './normalizers/index.js';
+export {
+  isImplementedHookSource,
+  normalizeClaudeCodeHookEvent,
+  normalizeCursorHookEvent,
+  normalizeHookEvent,
+} from './normalizers/index.js';
+export type {
+  PolicyDecision,
+  PolicySnapshot,
+  PolicySnapshotInvalidReason,
+  PolicySnapshotLoadResult,
+  PolicySnapshotRule,
+} from './policy.js';
+export { evaluatePolicy, loadPolicySnapshot } from './policy.js';
+export type {
+  HookRunOptions,
+  HookRunResult,
+} from './run-hook.js';
+export {
+  defaultHookRunOptions,
+  getDefaultPolicySnapshotPath,
+  getDefaultSpoolPath,
+  getHarnessDataDir,
+  runHookCommand,
+} from './run-hook.js';
+export type { FlushConfig, FlushResult, SpoolAppendResult, SpoolRecord } from './spool.js';
+export { appendToSpool, DEFAULT_SPOOL_MAX_BYTES, flushSpool } from './spool.js';

--- a/packages/harnesses/src/hooks/normalizers/claude-code.ts
+++ b/packages/harnesses/src/hooks/normalizers/claude-code.ts
@@ -1,0 +1,78 @@
+/**
+ * Claude Code Hook Normalizer
+ *
+ * Maps Claude Code's native hook payload shape onto `HarnessHookEvent`
+ * (multi-editor harness design doc §3-B). Covers the
+ * `PreToolUse`/`PostToolUse`/`SessionStart`/`SessionEnd`/`UserPromptSubmit`/
+ * `Stop` family -- every payload carries `session_id`, `transcript_path`,
+ * `cwd`, `hook_event_name`; tool events additionally carry `tool_name` and
+ * `tool_input`. Unlike Cursor, Claude Code's hook payload carries no
+ * generation id or model id (Claude Code does not expose either to a hook
+ * process), so `identity.generationId` / `identity.modelId` are always
+ * `undefined` here -- an honest gap, not an oversight.
+ */
+
+import type {
+  HarnessEnforcementTier,
+  HarnessHookEvent,
+  HarnessHookEventKind,
+} from '../../types/hook-event.js';
+import { asRecord, readString, readStringArray } from './raw-object.js';
+
+/** Claude Code `hook_event_name` -> canonical kind. */
+const CLAUDE_CODE_EVENT_KIND_MAP: ReadonlyMap<string, HarnessHookEventKind> = new Map([
+  ['SessionStart', 'session-start'],
+  ['SessionEnd', 'session-end'],
+  ['UserPromptSubmit', 'prompt-submit'],
+  ['PreToolUse', 'pre-tool'],
+  ['PostToolUse', 'post-tool'],
+  ['Stop', 'stop'],
+]);
+
+/** Tool names that represent a shell invocation rather than a generic tool call. */
+const SHELL_TOOL_NAMES: ReadonlySet<string> = new Set(['Bash', 'BashOutput']);
+
+/** Tool names that represent a file edit rather than a generic tool call. */
+const FILE_EDIT_TOOL_NAMES: ReadonlySet<string> = new Set(['Edit', 'Write', 'NotebookEdit']);
+
+/**
+ * Normalize one Claude Code hook stdin payload into a `HarnessHookEvent`.
+ * Total -- never throws. An unrecognized `hook_event_name` falls back to
+ * `pre-tool` with `toolName` set to the raw event name, mirroring the
+ * Cursor normalizer's fallback so both sources degrade the same way.
+ */
+export function normalizeClaudeCodeHookEvent(
+  raw: unknown,
+  enforcementTier: HarnessEnforcementTier,
+): HarnessHookEvent {
+  const rec = asRecord(raw);
+  const eventName = readString(rec, 'hook_event_name') ?? 'unknown';
+  const toolName = readString(rec, 'tool_name');
+  const toolInput = asRecord(rec.tool_input);
+
+  let kind = CLAUDE_CODE_EVENT_KIND_MAP.get(eventName) ?? 'pre-tool';
+  if (toolName && SHELL_TOOL_NAMES.has(toolName)) {
+    kind = eventName === 'PostToolUse' ? 'post-shell' : 'pre-shell';
+  } else if (toolName && FILE_EDIT_TOOL_NAMES.has(toolName) && eventName === 'PostToolUse') {
+    kind = 'file-edit';
+  }
+
+  const command = readString(toolInput, 'command');
+  const filePath = readString(toolInput, 'file_path');
+
+  return {
+    kind,
+    source: 'claude-code',
+    timestamp: new Date().toISOString(),
+    identity: {
+      conversationId: readString(rec, 'session_id'),
+      generationId: undefined,
+      modelId: undefined,
+    },
+    toolName: toolName ?? (CLAUDE_CODE_EVENT_KIND_MAP.has(eventName) ? undefined : eventName),
+    command,
+    filePaths: filePath ? [filePath] : readStringArray(toolInput, 'file_paths'),
+    enforcementTier,
+    raw,
+  };
+}

--- a/packages/harnesses/src/hooks/normalizers/cursor.ts
+++ b/packages/harnesses/src/hooks/normalizers/cursor.ts
@@ -1,0 +1,90 @@
+/**
+ * Cursor Hook Normalizer
+ *
+ * Maps Cursor's native `.cursor/hooks.json` payload shape onto
+ * `HarnessHookEvent` (multi-editor harness design doc §2.3, §3-B).
+ *
+ * Verified 2026-07-17 against cursor.com/docs/agent/hooks: every hook
+ * receives a common envelope over stdin --
+ * `conversation_id, generation_id, model, model_id, hook_event_name,
+ * cursor_version, workspace_roots, user_email, transcript_path` -- plus
+ * per-event fields. Event-name coverage here matches design doc §2.3:
+ * `preToolUse`/`postToolUse`, `beforeShellExecution`/`afterShellExecution`,
+ * `beforeMCPExecution`/`afterMCPExecution`, `beforeReadFile`/`afterFileEdit`,
+ * `sessionStart`/`sessionEnd`, subagent events, `stop`.
+ *
+ * `user_email` is read ONLY to prove the trust boundary: it is never copied
+ * onto `HarnessHookIdentity` (design invariant I-1). It stays in `raw`.
+ */
+
+import type {
+  HarnessEnforcementTier,
+  HarnessHookEvent,
+  HarnessHookEventKind,
+} from '../../types/hook-event.js';
+import { asRecord, readString, readStringArray } from './raw-object.js';
+
+/**
+ * Cursor `hook_event_name` -> canonical kind. `beforeReadFile` has no
+ * distinct canonical read kind (the schema's eleven kinds cover file
+ * EDITS, not reads) -- it normalizes to `pre-tool` with a synthetic
+ * `toolName: 'Read'`, the same honest fallback Claude Code's own Read tool
+ * gets. Subagent lifecycle events (`subagentStart`/`subagentStop`) map onto
+ * `session-start`/`session-end`: a subagent run is a nested session in the
+ * same sense a Claude Code subagent's transcript is nested under its
+ * parent's.
+ */
+const CURSOR_EVENT_KIND_MAP: ReadonlyMap<string, HarnessHookEventKind> = new Map([
+  ['sessionStart', 'session-start'],
+  ['sessionEnd', 'session-end'],
+  ['subagentStart', 'session-start'],
+  ['subagentStop', 'session-end'],
+  ['preToolUse', 'pre-tool'],
+  ['postToolUse', 'post-tool'],
+  ['beforeReadFile', 'pre-tool'],
+  ['beforeShellExecution', 'pre-shell'],
+  ['afterShellExecution', 'post-shell'],
+  ['beforeMCPExecution', 'pre-mcp'],
+  ['afterMCPExecution', 'post-mcp'],
+  ['afterFileEdit', 'file-edit'],
+  ['stop', 'stop'],
+]);
+
+/**
+ * Normalize one Cursor hook stdin payload into a `HarnessHookEvent`.
+ * Total -- never throws. An unrecognized `hook_event_name` falls back to
+ * `pre-tool` with `toolName` set to the raw event name so the receipt
+ * remains legible instead of silently dropping the event (design doc §3-B
+ * "never drop events silently").
+ */
+export function normalizeCursorHookEvent(
+  raw: unknown,
+  enforcementTier: HarnessEnforcementTier,
+): HarnessHookEvent {
+  const rec = asRecord(raw);
+  const eventName = readString(rec, 'hook_event_name') ?? 'unknown';
+  const kind = CURSOR_EVENT_KIND_MAP.get(eventName) ?? 'pre-tool';
+
+  const toolName =
+    readString(rec, 'tool_name') ??
+    (eventName === 'beforeReadFile' ? 'Read' : undefined) ??
+    (CURSOR_EVENT_KIND_MAP.has(eventName) ? undefined : eventName);
+
+  const filePath = readString(rec, 'file_path');
+
+  return {
+    kind,
+    source: 'cursor',
+    timestamp: new Date().toISOString(),
+    identity: {
+      conversationId: readString(rec, 'conversation_id'),
+      generationId: readString(rec, 'generation_id'),
+      modelId: readString(rec, 'model_id') ?? readString(rec, 'model'),
+    },
+    toolName,
+    command: readString(rec, 'command'),
+    filePaths: filePath ? [filePath] : readStringArray(rec, 'file_paths'),
+    enforcementTier,
+    raw,
+  };
+}

--- a/packages/harnesses/src/hooks/normalizers/index.ts
+++ b/packages/harnesses/src/hooks/normalizers/index.ts
@@ -1,0 +1,45 @@
+import type {
+  HarnessEnforcementTier,
+  HarnessHookEvent,
+  HarnessHookSource,
+} from '../../types/hook-event.js';
+import { normalizeClaudeCodeHookEvent } from './claude-code.js';
+import { normalizeCursorHookEvent } from './cursor.js';
+
+export { normalizeClaudeCodeHookEvent } from './claude-code.js';
+export { normalizeCursorHookEvent } from './cursor.js';
+
+/** Sources with a normalizer implemented in this package today. */
+export type ImplementedHookSource = Extract<HarnessHookSource, 'cursor' | 'claude-code'>;
+
+const IMPLEMENTED_SOURCES: ReadonlySet<string> = new Set<ImplementedHookSource>([
+  'cursor',
+  'claude-code',
+]);
+
+/** True if `normalizeHookEvent` has a normalizer for this source. */
+export function isImplementedHookSource(source: string): source is ImplementedHookSource {
+  return IMPLEMENTED_SOURCES.has(source);
+}
+
+/**
+ * Dispatch a raw hook payload to the normalizer for its source.
+ *
+ * `vscode` and `opencode` are declared `HarnessHookSource` members (the
+ * schema anticipates them) but have no normalizer yet -- VS Code lands in
+ * Phase C of the multi-editor harness design; OpenCode has no hook system
+ * to normalize from (`hooks.supported: false` in `TOOL_PROFILES.opencode`).
+ * Callers should gate on `isImplementedHookSource` before calling this.
+ */
+export function normalizeHookEvent(
+  source: ImplementedHookSource,
+  raw: unknown,
+  enforcementTier: HarnessEnforcementTier,
+): HarnessHookEvent {
+  switch (source) {
+    case 'cursor':
+      return normalizeCursorHookEvent(raw, enforcementTier);
+    case 'claude-code':
+      return normalizeClaudeCodeHookEvent(raw, enforcementTier);
+  }
+}

--- a/packages/harnesses/src/hooks/normalizers/raw-object.ts
+++ b/packages/harnesses/src/hooks/normalizers/raw-object.ts
@@ -1,0 +1,28 @@
+/**
+ * Small, dependency-free helpers for reading typed fields off an untrusted
+ * `unknown` hook payload. No `regex`, no `any` -- every editor's hook JSON
+ * is external input (design doc trust boundary: every editor client is
+ * untrusted), so every field read here is a runtime-checked narrowing, never
+ * a cast.
+ */
+
+/** Narrow an unknown value to a plain object, or `{}` if it isn't one. */
+export function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/** Read a string field, or `undefined` if absent/wrong type/empty. */
+export function readString(rec: Record<string, unknown>, key: string): string | undefined {
+  const value = rec[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/** Read an array-of-strings field, or `undefined` if absent/empty/wrong type. */
+export function readStringArray(rec: Record<string, unknown>, key: string): string[] | undefined {
+  const value = rec[key];
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((entry): entry is string => typeof entry === 'string');
+  return strings.length > 0 ? strings : undefined;
+}

--- a/packages/harnesses/src/hooks/policy.ts
+++ b/packages/harnesses/src/hooks/policy.ts
@@ -1,0 +1,167 @@
+/**
+ * Local Hook Policy Evaluation
+ *
+ * Implements multi-editor harness design doc §3-B "availability-first
+ * delivery" + design invariant I-5: policy DENIES are evaluated locally and
+ * synchronously against a cached, signed policy snapshot, so enforcement
+ * works offline and adds no per-event network hop. A missing or invalid
+ * snapshot degrades to advisory mode and SAYS SO -- it never silently
+ * claims enforcement it cannot back up.
+ *
+ * SIGNING DEVIATION (recorded per the build brief, do not remove without
+ * updating the report this shipped with): design doc §5 says to reuse an
+ * existing signing primitive from `@revealui/security`, auditing at build
+ * time for the exact fit. That package (`packages/security/src/*`) ships
+ * only symmetric AES-GCM encryption (`encryption.ts`) and SHA-256/384/512
+ * digests -- no asymmetric sign/verify primitive. The fleet's one Ed25519
+ * sign/verify precedent (`packages/core/src/license.ts`, via `jose`) is
+ * NOT in `@revealui/security` and pulling `jose` into `@revealui/harnesses`
+ * would add a new dependency, which this build is scoped to avoid. Per the
+ * documented fallback: this module does STRUCTURE validation only --
+ * `PolicySnapshotSchema` requires `signature` and `keyId` fields to be
+ * present and well-formed, but never cryptographically verifies them.
+ * TODO(security, blocks a real "enforced" claim beyond structural validity):
+ * once a signing primitive lands in `@revealui/security` (or `jose` is
+ * accepted as a dependency here), replace `parsePolicySnapshot`'s structural
+ * check with an actual signature verification before returning `valid: true`.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { z } from 'zod';
+import type {
+  HarnessHookEvent,
+  HarnessHookEventKind,
+  HarnessHookSource,
+} from '../types/hook-event.js';
+
+/** One rule in a policy snapshot: matches on any combination of scope fields. */
+export interface PolicySnapshotRule {
+  readonly source?: HarnessHookSource;
+  readonly kind?: HarnessHookEventKind;
+  readonly toolName?: string;
+  readonly permission: 'deny' | 'ask';
+  readonly reason: string;
+}
+
+/**
+ * A policy snapshot as read from disk. `signature` + `keyId` are present in
+ * the schema so the format is ready for real verification (see the TODO
+ * above); today they are checked for well-formedness only.
+ */
+export interface PolicySnapshot {
+  readonly version: number;
+  readonly keyId: string;
+  readonly signature: string;
+  readonly issuedAt: string;
+  readonly rules: readonly PolicySnapshotRule[];
+}
+
+const PolicySnapshotRuleSchema = z.object({
+  source: z.enum(['cursor', 'claude-code', 'vscode', 'opencode']).optional(),
+  kind: z
+    .enum([
+      'session-start',
+      'session-end',
+      'pre-tool',
+      'post-tool',
+      'pre-shell',
+      'post-shell',
+      'pre-mcp',
+      'post-mcp',
+      'file-edit',
+      'prompt-submit',
+      'stop',
+    ])
+    .optional(),
+  toolName: z.string().min(1).optional(),
+  permission: z.enum(['deny', 'ask']),
+  reason: z.string().min(1),
+});
+
+const PolicySnapshotSchema = z.object({
+  version: z.number().int().positive(),
+  keyId: z.string().min(1),
+  signature: z.string().min(1),
+  issuedAt: z.string().min(1),
+  rules: z.array(PolicySnapshotRuleSchema),
+});
+
+/** Why a snapshot load did not produce a usable, valid snapshot. */
+export type PolicySnapshotInvalidReason =
+  | 'missing'
+  | 'unreadable'
+  | 'invalid-json'
+  | 'invalid-shape';
+
+export type PolicySnapshotLoadResult =
+  | { readonly valid: true; readonly snapshot: PolicySnapshot }
+  | { readonly valid: false; readonly reason: PolicySnapshotInvalidReason };
+
+/**
+ * Load + structurally validate a policy snapshot from `path`. Never throws:
+ * every failure mode (missing file, unreadable, malformed JSON, wrong
+ * shape) collapses to `{ valid: false, reason }` so the caller's advisory
+ * fallback (design invariant I-5) is unconditional.
+ */
+export async function loadPolicySnapshot(path: string): Promise<PolicySnapshotLoadResult> {
+  let contents: string;
+  try {
+    contents = await readFile(path, 'utf8');
+  } catch (err) {
+    const code =
+      err && typeof err === 'object' && 'code' in err ? (err as { code?: string }).code : undefined;
+    return { valid: false, reason: code === 'ENOENT' ? 'missing' : 'unreadable' };
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(contents);
+  } catch {
+    return { valid: false, reason: 'invalid-json' };
+  }
+
+  const result = PolicySnapshotSchema.safeParse(parsedJson);
+  if (!result.success) {
+    return { valid: false, reason: 'invalid-shape' };
+  }
+
+  return { valid: true, snapshot: result.data };
+}
+
+/** The local policy decision for one hook event. */
+export interface PolicyDecision {
+  readonly permission: 'allow' | 'deny' | 'ask';
+  readonly reason?: string;
+  /** The rule (if any) that produced a non-allow decision. */
+  readonly matchedRule?: PolicySnapshotRule;
+}
+
+function ruleMatches(rule: PolicySnapshotRule, event: HarnessHookEvent): boolean {
+  if (rule.source && rule.source !== event.source) return false;
+  if (rule.kind && rule.kind !== event.kind) return false;
+  if (rule.toolName && rule.toolName !== event.toolName) return false;
+  return true;
+}
+
+/**
+ * Evaluate `event` against a snapshot load result. An invalid/missing
+ * snapshot always allows (advisory mode allows everything -- design
+ * invariant I-5); a valid snapshot evaluates its rules in order and returns
+ * the first match.
+ */
+export function evaluatePolicy(
+  loadResult: PolicySnapshotLoadResult,
+  event: HarnessHookEvent,
+): PolicyDecision {
+  if (!loadResult.valid) {
+    return { permission: 'allow' };
+  }
+
+  for (const rule of loadResult.snapshot.rules) {
+    if (ruleMatches(rule, event)) {
+      return { permission: rule.permission, reason: rule.reason, matchedRule: rule };
+    }
+  }
+
+  return { permission: 'allow' };
+}

--- a/packages/harnesses/src/hooks/run-hook.ts
+++ b/packages/harnesses/src/hooks/run-hook.ts
@@ -1,0 +1,115 @@
+/**
+ * Hook Command Orchestration
+ *
+ * Wires together policy evaluation, normalization, and spooling for the
+ * `hook <source>` CLI subcommand (multi-editor harness design doc §3-B).
+ * Kept separate from `../cli.ts` so it is directly unit-testable without
+ * mocking stdin/stdout/process.exit.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { HarnessHookEvent, HarnessHookSource } from '../types/hook-event.js';
+import { isImplementedHookSource, normalizeHookEvent } from './normalizers/index.js';
+import type { PolicyDecision, PolicySnapshotLoadResult } from './policy.js';
+import { evaluatePolicy, loadPolicySnapshot } from './policy.js';
+import { appendToSpool } from './spool.js';
+
+/** `~/.local/share/revealui` -- same data dir `cli.ts` uses for `harness.sock`. */
+export function getHarnessDataDir(): string {
+  return join(homedir(), '.local', 'share', 'revealui');
+}
+
+export function getDefaultSpoolPath(): string {
+  return process.env.REVEALUI_HOOK_SPOOL_PATH ?? join(getHarnessDataDir(), 'hook-receipts.jsonl');
+}
+
+export function getDefaultPolicySnapshotPath(): string {
+  return (
+    process.env.REVEALUI_POLICY_SNAPSHOT_PATH ?? join(getHarnessDataDir(), 'policy-snapshot.json')
+  );
+}
+
+export interface HookRunOptions {
+  readonly spoolPath: string;
+  readonly snapshotPath: string;
+}
+
+export function defaultHookRunOptions(): HookRunOptions {
+  return { spoolPath: getDefaultSpoolPath(), snapshotPath: getDefaultPolicySnapshotPath() };
+}
+
+export interface HookRunResult {
+  readonly event: HarnessHookEvent;
+  readonly decision: PolicyDecision;
+  readonly snapshotResult: PolicySnapshotLoadResult;
+  /** The editor-native JSON body the CLI writes to stdout. */
+  readonly responseJson: Record<string, unknown>;
+  /** 2 when the decision is `deny` (Cursor + Claude Code both block on exit code 2), 0 otherwise. */
+  readonly exitCode: number;
+}
+
+/** Build the Cursor-native permission response (cursor.com/docs/agent/hooks, verified 2026-07-17). */
+function buildCursorResponse(decision: PolicyDecision): Record<string, unknown> {
+  if (decision.permission === 'allow') {
+    return { permission: 'allow' };
+  }
+  return {
+    permission: decision.permission,
+    user_message: decision.reason ?? 'Denied by RevealUI policy',
+    agent_message: decision.reason ?? 'Denied by RevealUI policy',
+  };
+}
+
+/** Build the Claude Code-native permission response. */
+function buildClaudeCodeResponse(decision: PolicyDecision): Record<string, unknown> {
+  if (decision.permission === 'deny') {
+    return { decision: 'block', reason: decision.reason ?? 'Denied by RevealUI policy' };
+  }
+  if (decision.permission === 'ask') {
+    return {
+      decision: 'ask',
+      reason: decision.reason ?? 'Requires confirmation per RevealUI policy',
+    };
+  }
+  return { decision: 'approve' };
+}
+
+function buildEditorResponse(
+  source: HarnessHookSource,
+  decision: PolicyDecision,
+): Record<string, unknown> {
+  return source === 'cursor' ? buildCursorResponse(decision) : buildClaudeCodeResponse(decision);
+}
+
+/**
+ * Run one hook invocation end to end: load the policy snapshot, normalize
+ * `rawInput` for `source`, evaluate policy, spool the decision, and build
+ * the editor-native response. Caller (the CLI) owns writing the response
+ * and setting `process.exitCode`.
+ */
+export async function runHookCommand(
+  source: Extract<HarnessHookSource, 'cursor' | 'claude-code'>,
+  rawInput: unknown,
+  options: HookRunOptions = defaultHookRunOptions(),
+): Promise<HookRunResult> {
+  if (!isImplementedHookSource(source)) {
+    throw new Error(`No normalizer implemented for hook source "${source}"`);
+  }
+
+  const snapshotResult = await loadPolicySnapshot(options.snapshotPath);
+  const enforcementTier = snapshotResult.valid ? 'enforced' : 'advisory';
+
+  const event = normalizeHookEvent(source, rawInput, enforcementTier);
+  const decision = evaluatePolicy(snapshotResult, event);
+
+  await appendToSpool({ event, decision, spooledAt: new Date().toISOString() }, options.spoolPath);
+
+  return {
+    event,
+    decision,
+    snapshotResult,
+    responseJson: buildEditorResponse(source, decision),
+    exitCode: decision.permission === 'deny' ? 2 : 0,
+  };
+}

--- a/packages/harnesses/src/hooks/run-hook.ts
+++ b/packages/harnesses/src/hooks/run-hook.ts
@@ -98,7 +98,17 @@ export async function runHookCommand(
   }
 
   const snapshotResult = await loadPolicySnapshot(options.snapshotPath);
-  const enforcementTier = snapshotResult.valid ? 'enforced' : 'advisory';
+  // Honest enforcement tier (design invariant I-5): a receipt may claim
+  // `enforced` ONLY when the policy's authenticity is actually established.
+  // `loadPolicySnapshot` does STRUCTURE validation only today -- it does not
+  // cryptographically verify the snapshot signature (see policy.ts TODO), and
+  // no org/team config-pinning detection exists yet either. Until at least one
+  // of those lands, the tier is always `advisory`: a structurally valid
+  // snapshot's deny/ask rules are STILL applied by `evaluatePolicy` below (they
+  // can only tighten, never weaken -- defense in depth), but the receipt never
+  // overclaims enforcement it cannot back up. Flip this to a real conditional
+  // the moment signature verification ships.
+  const enforcementTier = 'advisory' as const;
 
   const event = normalizeHookEvent(source, rawInput, enforcementTier);
   const decision = evaluatePolicy(snapshotResult, event);

--- a/packages/harnesses/src/hooks/spool.ts
+++ b/packages/harnesses/src/hooks/spool.ts
@@ -1,0 +1,117 @@
+/**
+ * Local Receipt Spool
+ *
+ * Implements multi-editor harness design doc §3-B "availability-first
+ * delivery": a hook that blocks the user's editor on network latency is a
+ * product-killer, so every hook decision is appended to a local,
+ * append-only JSONL spool first and flushed to the receipts-ingest server
+ * (a separate build phase; see `POST /api/harness/receipts` in the design
+ * doc §3-B) asynchronously. This module never drops an event silently --
+ * on overflow it rotates the spool file (renaming the full file aside) and
+ * keeps appending to a fresh one, and it warns on every rotation.
+ */
+
+import { appendFile, mkdir, rename, stat } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import type { HarnessHookEvent } from '../types/hook-event.js';
+import type { PolicyDecision } from './policy.js';
+
+/** Bound the spool file size before rotating (10 MB, matches the OpenCode adapter's execFile buffer bound). */
+export const DEFAULT_SPOOL_MAX_BYTES = 10 * 1024 * 1024;
+
+/** One line appended to the spool for every hook decision. */
+export interface SpoolRecord {
+  readonly event: HarnessHookEvent;
+  readonly decision: PolicyDecision;
+  readonly spooledAt: string;
+}
+
+export interface SpoolAppendResult {
+  readonly appended: true;
+  /** True when this append triggered a rotation (the prior spool was full). */
+  readonly rotated: boolean;
+}
+
+/** Rotate `spoolPath` aside (never deletes -- "never drop events silently"). */
+async function rotateSpool(spoolPath: string): Promise<void> {
+  const rotatedPath = `${spoolPath}.${Date.now()}.rotated`;
+  await rename(spoolPath, rotatedPath);
+  process.stderr.write(
+    `revealui-harnesses hook: spool exceeded ${DEFAULT_SPOOL_MAX_BYTES} bytes, rotated to ${rotatedPath}\n`,
+  );
+}
+
+/**
+ * Append one hook decision to the JSONL spool at `spoolPath`, creating the
+ * parent directory and the file as needed. Rotates (never truncates or
+ * drops) when the existing file would exceed `maxBytes`.
+ */
+export async function appendToSpool(
+  record: SpoolRecord,
+  spoolPath: string,
+  maxBytes: number = DEFAULT_SPOOL_MAX_BYTES,
+): Promise<SpoolAppendResult> {
+  await mkdir(dirname(spoolPath), { recursive: true });
+
+  const line = `${JSON.stringify(record)}\n`;
+  let rotated = false;
+
+  try {
+    const { size } = await stat(spoolPath);
+    if (size + Buffer.byteLength(line, 'utf8') > maxBytes) {
+      await rotateSpool(spoolPath);
+      rotated = true;
+    }
+  } catch {
+    // Spool doesn't exist yet -- nothing to rotate.
+  }
+
+  await appendFile(spoolPath, line, 'utf8');
+  return { appended: true, rotated };
+}
+
+/** Configuration for a (currently unimplemented) flush to the receipts-ingest server. */
+export interface FlushConfig {
+  /** `POST /api/harness/receipts` endpoint URL. Unset = spool-only mode. */
+  readonly endpoint?: string;
+  /** `rvui_dev_` device token, read from env at call time only -- never logged. */
+  readonly token?: string;
+}
+
+export type FlushResult =
+  | { readonly flushed: true }
+  | {
+      readonly flushed: false;
+      readonly reason: 'not-configured' | 'not-implemented' | 'request-failed';
+    };
+
+let warnedNotConfigured = false;
+
+/**
+ * Attempt to flush the local spool to the receipts-ingest server.
+ *
+ * SPOOL-ONLY MODE (multi-editor harness design doc §6, Phase B acceptance):
+ * `POST /api/harness/receipts` does not exist yet -- it ships in Phase A.
+ * When `config.endpoint` is unset this no-ops with a single warn line (not
+ * one per call) and never throws; when it IS set, this still returns
+ * `not-implemented` today rather than guessing at a wire format Phase A
+ * hasn't shipped. Wiring the real POST is Phase A's job.
+ */
+export function flushSpool(spoolPath: string, config: FlushConfig): FlushResult {
+  if (!config.endpoint) {
+    if (!warnedNotConfigured) {
+      process.stderr.write(
+        `revealui-harnesses hook: no receipts endpoint configured, spool-only mode -- receipts stay local at ${spoolPath}\n`,
+      );
+      warnedNotConfigured = true;
+    }
+    return { flushed: false, reason: 'not-configured' };
+  }
+
+  return { flushed: false, reason: 'not-implemented' };
+}
+
+/** Test-only: reset the single-warn latch between test cases. */
+export function resetFlushWarnLatchForTests(): void {
+  warnedNotConfigured = false;
+}

--- a/packages/harnesses/src/hooks/spool.ts
+++ b/packages/harnesses/src/hooks/spool.ts
@@ -11,7 +11,7 @@
  * keeps appending to a fresh one, and it warns on every rotation.
  */
 
-import { appendFile, mkdir, rename, stat } from 'node:fs/promises';
+import { appendFile, mkdir, open, rename } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { HarnessHookEvent } from '../types/hook-event.js';
 import type { PolicyDecision } from './policy.js';
@@ -32,19 +32,53 @@ export interface SpoolAppendResult {
   readonly rotated: boolean;
 }
 
-/** Rotate `spoolPath` aside (never deletes -- "never drop events silently"). */
+/**
+ * Rotate `spoolPath` aside (never deletes -- "never drop events silently").
+ * Tolerates a concurrent rotation: if a peer hook invocation already renamed
+ * the file away, the `ENOENT` is swallowed rather than thrown, since the
+ * outcome ("this spool is rotated aside") is already true.
+ */
 async function rotateSpool(spoolPath: string): Promise<void> {
   const rotatedPath = `${spoolPath}.${Date.now()}.rotated`;
-  await rename(spoolPath, rotatedPath);
+  try {
+    await rename(spoolPath, rotatedPath);
+  } catch (err) {
+    const code =
+      err && typeof err === 'object' && 'code' in err ? (err as { code?: string }).code : undefined;
+    if (code === 'ENOENT') return;
+    throw err;
+  }
   process.stderr.write(
     `revealui-harnesses hook: spool exceeded ${DEFAULT_SPOOL_MAX_BYTES} bytes, rotated to ${rotatedPath}\n`,
   );
 }
 
 /**
+ * Size of the spool at `spoolPath`, read through an open file descriptor
+ * (`fstat`) rather than a path `stat`. Reading the size from the handle -- not
+ * from a detached path lookup a concurrent hook invocation could invalidate
+ * before the append below -- removes the check-then-use race on the path
+ * (CodeQL js/file-system-race). Returns 0 when the spool does not exist yet.
+ */
+async function currentSpoolSize(spoolPath: string): Promise<number> {
+  let handle: Awaited<ReturnType<typeof open>>;
+  try {
+    handle = await open(spoolPath, 'r');
+  } catch {
+    return 0;
+  }
+  try {
+    return (await handle.stat()).size;
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
  * Append one hook decision to the JSONL spool at `spoolPath`, creating the
  * parent directory and the file as needed. Rotates (never truncates or
- * drops) when the existing file would exceed `maxBytes`.
+ * drops) when appending this line to the existing file would exceed
+ * `maxBytes` -- the overflowing line then starts a fresh spool.
  */
 export async function appendToSpool(
   record: SpoolRecord,
@@ -54,16 +88,12 @@ export async function appendToSpool(
   await mkdir(dirname(spoolPath), { recursive: true });
 
   const line = `${JSON.stringify(record)}\n`;
-  let rotated = false;
+  const currentSize = await currentSpoolSize(spoolPath);
 
-  try {
-    const { size } = await stat(spoolPath);
-    if (size + Buffer.byteLength(line, 'utf8') > maxBytes) {
-      await rotateSpool(spoolPath);
-      rotated = true;
-    }
-  } catch {
-    // Spool doesn't exist yet -- nothing to rotate.
+  let rotated = false;
+  if (currentSize > 0 && currentSize + Buffer.byteLength(line, 'utf8') > maxBytes) {
+    await rotateSpool(spoolPath);
+    rotated = true;
   }
 
   await appendFile(spoolPath, line, 'utf8');

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -37,6 +37,7 @@ export type {
 // Content layer (canonical content definitions and generators)
 export {
   buildManifest,
+  CursorGenerator,
   diffContent,
   generateContent,
   listContent,
@@ -79,10 +80,44 @@ export {
   GOAL_STATUSES,
   GoalHarness,
 } from './goals/index.js';
+// Hooks  -  normalizers, local policy evaluation, receipt spool (see also `./hooks` subpath export)
+export type {
+  FlushConfig,
+  FlushResult,
+  HookRunOptions,
+  HookRunResult,
+  ImplementedHookSource,
+  PolicyDecision,
+  PolicySnapshot,
+  PolicySnapshotInvalidReason,
+  PolicySnapshotLoadResult,
+  PolicySnapshotRule,
+  SpoolAppendResult,
+  SpoolRecord,
+} from './hooks/index.js';
+export {
+  appendToSpool,
+  DEFAULT_SPOOL_MAX_BYTES,
+  defaultHookRunOptions,
+  evaluatePolicy,
+  flushSpool,
+  getDefaultPolicySnapshotPath,
+  getDefaultSpoolPath,
+  getHarnessDataDir,
+  isImplementedHookSource,
+  loadPolicySnapshot,
+  normalizeClaudeCodeHookEvent,
+  normalizeCursorHookEvent,
+  normalizeHookEvent,
+  runHookCommand,
+} from './hooks/index.js';
 // Harness Protocol (was VAUGHN until 2026-05-18; see docs/HARNESS_PROTOCOL.md)
 export type {
   ClaudeCodeSettings,
   ConfigGenerationResult,
+  CursorMcpConfig,
+  CursorMcpOptions,
+  CursorMcpServerConfig,
   DegradationStrategy,
   GeneratedFiles,
   HookGranularity,
@@ -117,6 +152,7 @@ export {
   PROTOCOL_VERSION,
   protocolConfigToAgentsMd,
   protocolConfigToClaudeSettings,
+  protocolConfigToCursorMcpConfig,
   protocolConfigToCursorrules,
   protocolConfigToOpencodeConfig,
   protocolEventEnvelopeSchema,
@@ -162,6 +198,15 @@ export type {
   HarnessProcessInfo,
   HealthCheckResult,
 } from './types/core.js';
+// Types  -  normalized hook events
+export type {
+  HarnessEnforcementTier,
+  HarnessHookEvent,
+  HarnessHookEventKind,
+  HarnessHookIdentity,
+  HarnessHookSource,
+} from './types/hook-event.js';
+export { HARNESS_HOOK_EVENT_KINDS, HARNESS_HOOK_SOURCES } from './types/hook-event.js';
 // Workboard
 export {
   acquireLock,

--- a/packages/harnesses/src/protocol/capabilities.ts
+++ b/packages/harnesses/src/protocol/capabilities.ts
@@ -114,10 +114,11 @@ export function createDefaultCapabilities(): ProtocolCapabilities {
 /**
  * Capability profiles for tools that have working adapters in this package.
  *
- * `revealui-agent` and `opencode` ship adapters today (`OpenCodeAdapter`,
- * `src/adapters/opencode-adapter.ts`). Profile data for tools that are
- * spec'd but have no adapter implementation lives in `./roadmap-profiles.ts`
- * to make the spec-vs-shipped gap structurally visible.
+ * `revealui-agent`, `opencode`, and `cursor` ship adapters today
+ * (`OpenCodeAdapter` / `CursorAdapter`, `src/adapters/*.ts`). Profile data
+ * for tools that are spec'd but have no adapter implementation lives in
+ * `./roadmap-profiles.ts` to make the spec-vs-shipped gap structurally
+ * visible.
  *
  * If you're looking for the previous full set (claude-code, codex,
  * cursor, revealui-agent, opencode), import `ALL_KNOWN_PROFILES` from
@@ -152,6 +153,51 @@ export const TOOL_PROFILES: Record<string, ProtocolCapabilities> = {
     memory: { supported: false, backend: 'none' },
     maxContextTokens: 0,
     lifecycleEvents: [],
+  },
+
+  // Cursor's `.cursor/hooks.json` (multi-editor harness design doc §2.3,
+  // verified 2026-07-17) is nearly isomorphic to Claude Code's own hook
+  // system -- command-based hooks over stdio JSON, allow/deny/ask
+  // decisions, exit code 2 blocks -- so `hooks.supported: true` here is
+  // backed by a real adapter + CLI subcommand
+  // (`../adapters/cursor-adapter.ts`, `../../hooks/`), not aspirational.
+  // `maxContextTokens: 128_000` carries the value the roadmap profile
+  // already declared (see `./roadmap-profiles.ts`'s prior `cursor` entry,
+  // now removed on promotion) -- a real number, not the `0` BYO sentinel
+  // documented on `maxContextTokens` above, so it is kept rather than
+  // invented. Cursor bundles multiple first-party models with differing
+  // real context windows (including Grok 4.5); 128k is the conservative
+  // floor across that pool, not a per-model ceiling.
+  cursor: {
+    dispatch: {
+      generateCode: true,
+      analyzeCode: true,
+      applyEdit: false,
+      executeCommand: true,
+    },
+    readWorkboard: false,
+    writeWorkboard: false,
+    claimTasks: false,
+    reportConflicts: false,
+    headless: true,
+    resumable: false,
+    forkable: false,
+    backgroundable: true,
+    hooks: { supported: true, granularity: 'all-tools', canBlock: true },
+    sandbox: { supported: false, modes: [] },
+    supportsWorktrees: false,
+    supportsSkills: false,
+    supportsMcp: true,
+    memory: { supported: false, backend: 'none' },
+    maxContextTokens: 128_000,
+    lifecycleEvents: [
+      'session.start',
+      'session.stop',
+      'prompt.submit',
+      'tool.before',
+      'tool.after',
+      'tool.blocked',
+    ],
   },
 
   'revealui-agent': {

--- a/packages/harnesses/src/protocol/config-normalizer.ts
+++ b/packages/harnesses/src/protocol/config-normalizer.ts
@@ -359,6 +359,68 @@ export function protocolConfigToOpencodeConfig(
   return opencodeConfig;
 }
 
+// -- .cursor/mcp.json (write-only) ------------------------------------------------
+
+/** Cursor remote/HTTP MCP server entry (`.cursor/mcp.json`). */
+export interface CursorMcpServerConfig {
+  url: string;
+  headers: Record<string, string>;
+}
+
+/** Subset of `.cursor/mcp.json` this module writes. */
+export interface CursorMcpConfig {
+  mcpServers: Record<string, CursorMcpServerConfig>;
+}
+
+/** Options for wiring the RevealUI governed MCP endpoint into a Cursor config. */
+export interface CursorMcpOptions {
+  /** RevealUI governed MCP endpoint, e.g. `https://your-host/api/mcp`. */
+  mcpUrl: string;
+  /**
+   * Name of the environment variable Cursor resolves via its `${env:VAR}`
+   * substitution at runtime (default `REVEALUI_MCP_TOKEN`). Only the
+   * variable NAME is ever emitted -- see `protocolConfigToCursorMcpConfig`.
+   */
+  tokenEnvVar?: string;
+}
+
+const DEFAULT_CURSOR_TOKEN_ENV_VAR = 'REVEALUI_MCP_TOKEN';
+
+/**
+ * Convert a ProtocolConfig to a `.cursor/mcp.json` fragment wiring the
+ * RevealUI governed MCP endpoint (multi-editor harness design doc §3-A).
+ *
+ * SECURITY-CRITICAL: this function must never emit a literal bearer token,
+ * only the `${env:VAR}` substitution syntax Cursor resolves at runtime
+ * (verified 2026-07-17 against cursor.com/docs/context/mcp -- Cursor's
+ * interpolation syntax is `${env:NAME}`, distinct from OpenCode's
+ * `{env:NAME}` above). It deliberately does NOT read
+ * `config.environment.variables` for a token value -- the Authorization
+ * header is built exclusively from the `tokenEnvVar` NAME, mirroring
+ * `protocolConfigToOpencodeConfig`'s leak-proof pattern so no caller can
+ * smuggle a literal secret into the emitted config via `environment.variables`.
+ *
+ * `_config` is accepted (matching `protocolConfigToOpencodeConfig`'s
+ * signature, and preserving room for future permission/rule wiring once
+ * `.cursor/mcp.json` documents a permission field) but is not read at all --
+ * see the security note above.
+ */
+export function protocolConfigToCursorMcpConfig(
+  _config: ProtocolConfig,
+  opts: CursorMcpOptions,
+): CursorMcpConfig {
+  const tokenEnvVar = opts.tokenEnvVar ?? DEFAULT_CURSOR_TOKEN_ENV_VAR;
+
+  return {
+    mcpServers: {
+      revealui: {
+        url: opts.mcpUrl,
+        headers: { Authorization: `Bearer \${env:${tokenEnvVar}}` },
+      },
+    },
+  };
+}
+
 // -- Helpers ---------------------------------------------------------------------
 
 /** Render rule content, substituting template variables. */

--- a/packages/harnesses/src/protocol/index.ts
+++ b/packages/harnesses/src/protocol/index.ts
@@ -33,6 +33,9 @@ export { createDefaultCapabilities, TOOL_PROFILES } from './capabilities.js';
 export type {
   ClaudeCodeSettings,
   ConfigGenerationResult,
+  CursorMcpConfig,
+  CursorMcpOptions,
+  CursorMcpServerConfig,
   OpenCodeConfig,
   OpenCodeMcpOptions,
   OpenCodeMcpServerConfig,
@@ -42,6 +45,7 @@ export {
   generateAllConfigs,
   protocolConfigToAgentsMd,
   protocolConfigToClaudeSettings,
+  protocolConfigToCursorMcpConfig,
   protocolConfigToCursorrules,
   protocolConfigToOpencodeConfig,
 } from './config-normalizer.js';

--- a/packages/harnesses/src/protocol/roadmap-profiles.ts
+++ b/packages/harnesses/src/protocol/roadmap-profiles.ts
@@ -4,7 +4,9 @@
  * Declared profiles for AI coding tools that the Harness Protocol spec
  * targets but which DO NOT have a working adapter in this package today.
  * (`opencode` graduated to `./capabilities.ts` `TOOL_PROFILES` when
- * `OpenCodeAdapter` shipped -- see `../adapters/opencode-adapter.ts`.)
+ * `OpenCodeAdapter` shipped -- see `../adapters/opencode-adapter.ts`.
+ * `cursor` graduated the same way when `CursorAdapter` shipped -- see
+ * `../adapters/cursor-adapter.ts`.)
  *
  * These entries describe what those tools support natively, useful for:
  *  - The degradation table in `./degradation-strategies.ts` (which knows
@@ -87,31 +89,6 @@ export const ROADMAP_PROFILES: Record<string, ProtocolCapabilities> = {
       'tool.after',
       'tool.blocked',
     ],
-  },
-
-  cursor: {
-    dispatch: {
-      generateCode: false,
-      analyzeCode: false,
-      applyEdit: false,
-      executeCommand: false,
-    },
-    readWorkboard: false,
-    writeWorkboard: false,
-    claimTasks: false,
-    reportConflicts: false,
-    headless: false,
-    resumable: false,
-    forkable: false,
-    backgroundable: false,
-    hooks: { supported: false, granularity: 'none', canBlock: false },
-    sandbox: { supported: false, modes: [] },
-    supportsWorktrees: false,
-    supportsSkills: false,
-    supportsMcp: false,
-    memory: { supported: false, backend: 'none' },
-    maxContextTokens: 128_000,
-    lifecycleEvents: [],
   },
 } as const;
 

--- a/packages/harnesses/src/types/hook-event.ts
+++ b/packages/harnesses/src/types/hook-event.ts
@@ -1,0 +1,125 @@
+/**
+ * Normalized Hook Event Schema
+ *
+ * The three editor hook schemas this package normalizes (Claude Code, Cursor,
+ * and -- once a VS Code agent-plugin adapter ships -- VS Code agent hooks)
+ * have converged on the same lifecycle-callback shape: a JSON payload over
+ * stdin, a JSON permission decision over stdout, canonical lifecycle names.
+ * `HarnessHookEvent` is the one internal shape every per-editor normalizer
+ * (`../hooks/normalizers/`) maps its native payload onto, so the CLI's
+ * `hook <source>` subcommand, the local policy evaluator, and the receipt
+ * spool all operate on a single schema regardless of which editor emitted
+ * the event.
+ *
+ * Trust boundary (multi-editor harness design invariant I-1): every editor
+ * client is untrusted. Editor-supplied identity strings -- Cursor's
+ * `user_email`, an ACP `clientInfo` block, any other human-readable field a
+ * hook payload carries -- are NEVER promoted to a normalized identity field
+ * here. `HarnessHookIdentity` carries only session/generation-scoped
+ * correlation ids (conversation id, generation id, model id), which are
+ * request-shaped metadata, not authorization identity. Authorization
+ * identity is derived exclusively from the device token on the request that
+ * eventually flushes a receipt (the receipts-ingest server surface, a
+ * separate build phase) -- never from anything inside `raw`. Human-readable
+ * identity strings may still be READ off the raw payload for display
+ * purposes; they must stay under `raw` and must never be copied onto
+ * `HarnessHookIdentity` or any other normalized field.
+ */
+
+/** The eleven canonical lifecycle points every editor hook schema maps onto. */
+export type HarnessHookEventKind =
+  | 'session-start'
+  | 'session-end'
+  | 'pre-tool'
+  | 'post-tool'
+  | 'pre-shell'
+  | 'post-shell'
+  | 'pre-mcp'
+  | 'post-mcp'
+  | 'file-edit'
+  | 'prompt-submit'
+  | 'stop';
+
+/** All valid event kinds as a readonly array (iteration / membership checks). */
+export const HARNESS_HOOK_EVENT_KINDS: readonly HarnessHookEventKind[] = [
+  'session-start',
+  'session-end',
+  'pre-tool',
+  'post-tool',
+  'pre-shell',
+  'post-shell',
+  'pre-mcp',
+  'post-mcp',
+  'file-edit',
+  'prompt-submit',
+  'stop',
+] as const;
+
+/** Editors this package can normalize a hook payload from. */
+export type HarnessHookSource = 'cursor' | 'claude-code' | 'vscode' | 'opencode';
+
+/** All valid sources as a readonly array (iteration / membership checks). */
+export const HARNESS_HOOK_SOURCES: readonly HarnessHookSource[] = [
+  'cursor',
+  'claude-code',
+  'vscode',
+  'opencode',
+] as const;
+
+/**
+ * Honest enforcement signal (design invariant I-5): `'enforced'` only when a
+ * signed, structurally valid policy snapshot governed the decision;
+ * `'advisory'` whenever no snapshot, an unparseable snapshot, or an
+ * unsigned/unverifiable one was in effect. A receipt must never claim
+ * `'enforced'` it cannot back up -- user-level hook config is user-removable
+ * unless pinned by a Cursor Team/Enterprise tier or a VS Code org policy, and
+ * the receipt's `enforcementTier` is the honest record of which was true for
+ * this specific decision, not an aspiration.
+ */
+export type HarnessEnforcementTier = 'enforced' | 'advisory';
+
+/**
+ * Session/generation-scoped correlation ids carried by the editor's hook
+ * payload. Deliberately NOT an identity type -- see the module doc above.
+ */
+export interface HarnessHookIdentity {
+  readonly conversationId?: string;
+  readonly generationId?: string;
+  readonly modelId?: string;
+}
+
+interface HarnessHookEventCommon {
+  /** Which editor's hook payload this event was normalized from. */
+  readonly source: HarnessHookSource;
+  /** Normalize-time timestamp (ISO 8601) -- not all editor payloads carry their own. */
+  readonly timestamp: string;
+  readonly identity: HarnessHookIdentity;
+  /** Tool/command name for pre-tool/post-tool/pre-mcp/post-mcp events. */
+  readonly toolName?: string;
+  /** Shell command text for pre-shell/post-shell events. */
+  readonly command?: string;
+  /** Absolute file paths touched, for file-edit (and file-read-shaped) events. */
+  readonly filePaths?: readonly string[];
+  readonly enforcementTier: HarnessEnforcementTier;
+  /** The untouched, editor-native payload this event was normalized from. */
+  readonly raw: unknown;
+}
+
+/**
+ * One normalized hook event. Discriminated on `kind` so a consumer can
+ * narrow with a plain switch; every member shares the same normalized field
+ * set (`HarnessHookEventCommon`) because the eleven kinds differ in which
+ * optional fields are populated, not in shape.
+ */
+export type HarnessHookEvent =
+  | ({ readonly kind: 'session-start' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'session-end' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'pre-tool' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'post-tool' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'pre-shell' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'post-shell' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'pre-mcp' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'post-mcp' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'file-edit' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'prompt-submit' } & HarnessHookEventCommon)
+  | ({ readonly kind: 'stop' } & HarnessHookEventCommon);

--- a/packages/harnesses/src/types/hook-event.ts
+++ b/packages/harnesses/src/types/hook-event.ts
@@ -75,6 +75,14 @@ export const HARNESS_HOOK_SOURCES: readonly HarnessHookSource[] = [
  * unless pinned by a Cursor Team/Enterprise tier or a VS Code org policy, and
  * the receipt's `enforcementTier` is the honest record of which was true for
  * this specific decision, not an aspiration.
+ *
+ * Implementation status: `run-hook.ts` emits `'advisory'` for every decision
+ * today, because policy-snapshot signature verification is not yet implemented
+ * (`policy.ts` does structure validation only). The `'enforced'` value stays in
+ * the type for the moment real verification (or org/team config-pinning
+ * detection) lands; until then no code path may produce it. A structurally
+ * valid snapshot's deny/ask rules are still applied -- only the tier label is
+ * held back, so the receipt never overstates the guarantee.
  */
 export type HarnessEnforcementTier = 'enforced' | 'advisory';
 

--- a/packages/harnesses/src/types/index.ts
+++ b/packages/harnesses/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './adapter.js';
 export * from './core.js';
+export * from './hook-event.js';

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     'src/content/index.ts',
     'src/storage/index.ts',
     'src/goals/index.ts',
+    'src/hooks/index.ts',
   ],
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## Summary

Per the multi-editor harness design, this adds the normalized hook-event
schema, the `hook <source>` CLI subcommand, and the Cursor adapter
promotion in `@revealui/harnesses`:

- **`HarnessHookEvent`** (`src/types/hook-event.ts`) — a discriminated
  union over the eleven canonical hook lifecycle kinds
  (`session-start` … `stop`), carrying normalized fields (tool name,
  command, file paths, session-scoped identity, enforcement tier) plus
  the untouched editor-native payload under `raw`. Editor-supplied
  identity strings (e.g. Cursor's `user_email`) are readable off `raw`
  only — never promoted to the normalized `identity` field.
- **Normalizers** for `cursor` and `claude-code`
  (`src/hooks/normalizers/`) — pure, total functions (never throw), one
  unit test per event kind plus fallback coverage for unrecognized
  event names.
- **`hook <source>` CLI subcommand** (`src/cli.ts` + `src/hooks/`) —
  reads the editor's JSON off stdin, normalizes, evaluates a local
  policy snapshot, emits the editor-native permission response, and
  appends an append-only JSONL receipt to a local spool. **Spool-only
  mode**: the server flush endpoint doesn't exist yet, so `flushSpool`
  no-ops behind explicit config with a single warn line when unset.
  The spool never drops an event — on overflow it rotates the file
  aside rather than truncating.
- **`CursorAdapter`** (`src/adapters/cursor-adapter.ts`) — promotes the
  existing data-only `cursor` roadmap profile into `TOOL_PROFILES`,
  mirroring how `OpenCodeAdapter` promoted `opencode`. Registered in
  the auto-detector.
- **Content generators** — `.cursor/hooks.json` (command-based hooks
  only, each invoking `revealui-harnesses hook cursor`) and
  `.cursor/mcp.json` (`protocolConfigToCursorMcpConfig`, mirroring
  `protocolConfigToOpencodeConfig`'s leak-proof pattern — emits an
  env-var reference, never a token value).

## Verified facts (2026-07-17, cursor.com/docs)

- Cursor's hook input envelope and per-event fields, the
  `{permission, user_message, agent_message}` output shape, and
  exit-code-2-blocks semantics (cursor.com/docs/agent/hooks).
- Cursor's MCP env-interpolation syntax is **`${env:VAR}`** (distinct
  from OpenCode's `{env:VAR}`) — verified against
  cursor.com/docs/context/mcp.
- The installed Cursor CLI binary is **`agent`**, with `--version`,
  `-p`/`--print`, `--output-format json|text`, and `--force`
  (cursor.com/docs/cli/installation, cursor.com/docs/cli/headless).
  `agent` is deliberately NOT added to the process-detector's pgrep
  patterns (too generic a substring — would false-match `ssh-agent`,
  `gpg-agent`).

## Deviations

- **Policy snapshot signing**: the design calls for reusing an
  existing signing primitive from the security package. That package
  ships only symmetric AES-GCM encryption and SHA digests — no
  asymmetric sign/verify. The fleet's one Ed25519 precedent lives in
  `packages/core` via `jose`, which is not in the security package and
  would be a new dependency for this package (out of scope for this
  build). Per the documented fallback: `loadPolicySnapshot` does
  **structure validation only** (a zod schema requiring `signature` +
  `keyId` to be present and well-formed) and does **not**
  cryptographically verify. This is recorded as a `TODO(security)` in
  `src/hooks/policy.ts` and the module's doc comment. A missing or
  structurally-invalid snapshot degrades to advisory mode as required.
- `maxContextTokens: 128_000` for the promoted `cursor` profile carries
  the value the roadmap profile already declared (a real number, not
  the `0` BYO sentinel) — not invented.

## Test evidence

`pnpm --filter @revealui/harnesses typecheck` — clean.

`pnpm --filter @revealui/harnesses test` — 406/407 passing. The one
failure (`opencode-adapter.test.ts` "get-status reports availability")
is a pre-existing, unmodified-by-this-PR test that asserts the
`opencode` CLI is absent from `PATH`; it fails locally because this
dev machine has `opencode` installed globally via pnpm. Confirmed via
`git diff` that the failing test file has zero changes in this PR.

New test files: `hook-normalizers.test.ts`, `hook-policy.test.ts`,
`hook-spool.test.ts`, `hook-run.test.ts`, `cli-hook.test.ts` (spawns
the real CLI via `tsx` with a real stdin pipe — `spawnSync`, not the
async `execFile`/`spawn` `input` path, which hung indefinitely in this
sandbox for reasons unrelated to the CLI; verified the async hang
reproduces even against a plain built `dist/cli.js` with no `tsx`
involved, and that a manual shell pipe into `tsx` works instantly),
`cursor-adapter.test.ts`, `cursor-config.test.ts`,
`cursor-content-generator.test.ts`. Updated `protocol-types.test.ts`
and `coordinator.test.ts` for the cursor roadmap→shipped move.

**Red-first proofs** (temporarily broke the implementation, confirmed
the new tests fail, reverted):
- I-1 (identity leak): added a `user_email → identity.email` copy to
  the Cursor normalizer → both the normalizer unit test and the
  `runHookCommand` end-to-end test failed as expected.
- I-5 (dishonest enforcement): made `loadPolicySnapshot` treat a
  structurally invalid snapshot as valid → the two invalid-shape tests
  in `hook-policy.test.ts` failed as expected.

Security check: `security-pr-review-check.js --diff origin/test`
reports no security-sensitive paths touched (this package isn't on the
sensitive-path list), so no coordinator gate applies.

## Test plan

- [x] `pnpm --filter @revealui/harnesses typecheck`
- [x] `pnpm --filter @revealui/harnesses test`
- [x] Biome clean on all changed files
- [x] Red-first proof for I-1 and I-5
- [x] Manual CLI smoke test (`echo '{"hook_event_name":"stop"}' | tsx src/cli.ts hook cursor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
