### PR TITLE
fix(revmarket): block admin transition of running task, alert on lost audit (GAP-352)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -48,6 +48,7 @@
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "@revealui/dev": "workspace:*",
+    "@revealui/test": "workspace:*",
     "dotenv": "catalog:",
     "postcss": "^8.5.16",
     "rimraf": "^6.1.3",

--- a/apps/admin/src/app/api/sync/task-submissions/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/task-submissions/[id]/route.ts
@@ -6,9 +6,13 @@
  *
  * Authenticated, owner-scoped. Mirrors the revmarket API's cancellation
  * policy (POST /api/revmarket/tasks/:id/cancel): non-admin users may only
- * cancel their own pending/queued tasks. Admins may set any valid status.
- * Deletion is owner-or-admin; non-admins may only delete unbilled tasks
- * that are not running or completed.
+ * cancel their own pending/queued tasks. Running transitions are
+ * executor-owned: a running task cannot be moved to any other status through
+ * this route by anyone, admins included, because that races the executor's
+ * status='running' completion CAS and destroys the run's audit row (GAP-352).
+ * Via this route only a pending/queued task may be cancelled, by its owner or
+ * an admin. Deletion is owner-or-admin; non-admins may only delete unbilled
+ * tasks that are not running or completed.
  */
 
 import { getSession } from '@revealui/auth/server';
@@ -93,13 +97,35 @@ export async function PATCH(
           403,
         );
       }
-      if (!CANCELLABLE_STATUSES.has(task.status)) {
-        return createApplicationErrorResponse(
-          `Cannot cancel task in '${task.status}' state`,
-          'VALIDATION_ERROR',
-          400,
-        );
-      }
+    }
+
+    // Running transitions are executor-owned, enforced for everyone including
+    // admins. The executor moves a task off 'running' via its status='running'
+    // completion CAS (revmarket-executor.ts completeTask); moving a running
+    // task to ANY other status through this route (cancelled, completed,
+    // failed) races that CAS, so the CAS then finds no row and skips the audit
+    // write, silently destroying the record of a run that actually happened
+    // (GAP-352). A cosmetic status flip here also lies about an outcome the
+    // sandbox is still producing. There is no legitimate human transition of a
+    // running task via this sync route.
+    if (task.status === 'running' && body.status !== 'running') {
+      return createApplicationErrorResponse(
+        `Cannot transition a running task to '${body.status}' here; running is executor-owned`,
+        'VALIDATION_ERROR',
+        400,
+      );
+    }
+
+    // Cancel-state-machine policy, enforced for everyone including admins: a
+    // task is only cancellable from a pending/queued state (this catches the
+    // remaining non-cancellable sources, e.g. cancelling a completed/failed
+    // task).
+    if (body.status === 'cancelled' && !CANCELLABLE_STATUSES.has(task.status)) {
+      return createApplicationErrorResponse(
+        `Cannot cancel task in '${task.status}' state`,
+        'VALIDATION_ERROR',
+        400,
+      );
     }
 
     const [updated] = await db

--- a/apps/admin/src/app/api/sync/task-submissions/__tests__/gap-352-cancel-audit.integration.test.ts
+++ b/apps/admin/src/app/api/sync/task-submissions/__tests__/gap-352-cancel-audit.integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * GAP-352 — an admin must not be able to cancel a running task via the sync
+ * PATCH route, because doing so races the executor's status='running'
+ * completion CAS and silently destroys the audit row for a run that actually
+ * happened. revmarket-executor is the ONE agent surface that writes an audit
+ * row, so this bug erases the only record of the run.
+ *
+ * This is a real-storage integration test: the actual admin PATCH handler and
+ * the actual executor `completeTask` both run against ONE migrated PGlite DB
+ * (via `getClient` mocked to the shared test client, mirroring
+ * apps/server/src/lib/__tests__/mcp-audit-concurrency.pglite.test.ts).
+ *
+ * Prove-red: on `origin/test` (pre-fix) the PATCH moves the running task to
+ * 'cancelled', the executor CAS then no-ops, and no audit row is written —
+ * both assertions below fail. After the fix the PATCH is rejected (400), the
+ * task stays running, the executor completes it, and its audit row exists.
+ */
+
+import * as authServer from '@revealui/auth/server';
+import { logger as coreLogger } from '@revealui/core/observability/logger';
+import { auditLog, taskSubmissions, users } from '@revealui/db/schema';
+import { createTestDb, type TestDb } from '@revealui/test';
+import { eq } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { completeTask } from '../../../../../../../../apps/server/src/services/revmarket-executor.js';
+import { PATCH } from '../[id]/route';
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@revealui/db')>();
+  return { ...actual, getClient: () => testDb.drizzle };
+});
+
+vi.mock('@revealui/auth/server', () => ({ getSession: vi.fn() }));
+
+vi.mock('@revealui/core/observability/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@revealui/core/observability/logger')>();
+  return {
+    ...actual,
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  };
+});
+
+const SUBMITTER_ID = 'gap352-user';
+const ADMIN_SESSION = { user: { id: 'gap352-admin', role: 'admin' } };
+
+function seedTask(id: string, status: string): Promise<unknown> {
+  return testDb.drizzle.insert(taskSubmissions).values({
+    id,
+    submitterId: SUBMITTER_ID,
+    skillName: 'summarize',
+    input: {},
+    status,
+  });
+}
+
+function patchRequest(id: string, status: string): NextRequest {
+  return new NextRequest(`http://localhost/api/sync/task-submissions/${id}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+}
+
+beforeAll(async () => {
+  testDb = await createTestDb();
+  await testDb.drizzle.insert(users).values({ id: SUBMITTER_ID, name: 'GAP-352 Submitter' });
+});
+
+beforeEach(() => {
+  vi.mocked(coreLogger.error).mockClear();
+  vi.mocked(authServer.getSession).mockResolvedValue(ADMIN_SESSION as never);
+});
+
+describe('GAP-352: admin cancel of a running task must not erase its audit row', () => {
+  it('rejects the admin cancel and the completed run keeps its audit row', async () => {
+    const taskId = '123e4567-e89b-12d3-a456-426614174000';
+    await seedTask(taskId, 'running');
+
+    const response = await PATCH(patchRequest(taskId, 'cancelled'), {
+      params: Promise.resolve({ id: taskId }),
+    });
+    // An admin is NOT exempt from the cancel state machine.
+    expect(response.status).toBe(400);
+
+    const [afterPatch] = await testDb.drizzle
+      .select({ status: taskSubmissions.status })
+      .from(taskSubmissions)
+      .where(eq(taskSubmissions.id, taskId));
+    expect(afterPatch?.status).toBe('running');
+
+    // The real run now completes through the executor.
+    const completed = await completeTask(taskId, {
+      success: true,
+      output: { summary: 'done' },
+      artifacts: [],
+      tokensUsed: 42,
+      durationMs: 100,
+    });
+    expect(completed).toBe(true);
+
+    // The audit row for the completed run must exist — this is the record the
+    // bug erased.
+    const audits = await testDb.drizzle.select().from(auditLog).where(eq(auditLog.taskId, taskId));
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.eventType).toBe('revmarket:task:completed');
+  });
+
+  it.each([
+    'completed',
+    'failed',
+  ])('rejects an admin moving a running task to %s and preserves its audit row', async (targetStatus) => {
+    const taskId = `gap352-running-to-${targetStatus}`;
+    await seedTask(taskId, 'running');
+
+    // Same audit-destroying race as cancel, different verb: an admin PATCH
+    // straight to completed/failed would move the row off 'running' and make
+    // the executor's completion CAS no-op, skipping the audit write.
+    const response = await PATCH(patchRequest(taskId, targetStatus), {
+      params: Promise.resolve({ id: taskId }),
+    });
+    expect(response.status).toBe(400);
+
+    const [afterPatch] = await testDb.drizzle
+      .select({ status: taskSubmissions.status })
+      .from(taskSubmissions)
+      .where(eq(taskSubmissions.id, taskId));
+    expect(afterPatch?.status).toBe('running');
+
+    const completed = await completeTask(taskId, {
+      success: true,
+      output: { summary: 'done' },
+      artifacts: [],
+      tokensUsed: 42,
+      durationMs: 100,
+    });
+    expect(completed).toBe(true);
+
+    const audits = await testDb.drizzle.select().from(auditLog).where(eq(auditLog.taskId, taskId));
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.eventType).toBe('revmarket:task:completed');
+  });
+
+  it('logs an ERROR (not a warn) when completeTask finds the row already off running', async () => {
+    const taskId = 'gap352-race-task';
+    // Simulate the race directly: the row was already moved off 'running'.
+    await seedTask(taskId, 'cancelled');
+
+    const completed = await completeTask(taskId, {
+      success: true,
+      output: null,
+      artifacts: [],
+      tokensUsed: 0,
+      durationMs: 0,
+    });
+
+    expect(completed).toBe(false);
+    expect(coreLogger.error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(coreLogger.error).mock.calls[0]?.[1]).toMatchObject({ taskId });
+
+    // A failed CAS writes no audit row.
+    const audits = await testDb.drizzle.select().from(auditLog).where(eq(auditLog.taskId, taskId));
+    expect(audits).toHaveLength(0);
+  });
+});

--- a/apps/server/src/services/revmarket-executor.ts
+++ b/apps/server/src/services/revmarket-executor.ts
@@ -351,7 +351,15 @@ export async function completeTask(taskId: string, result: TaskResult): Promise<
     .returning();
 
   if (!updated) {
-    logger.warn('RevMarket task completion failed  -  state race', { taskId });
+    // The row is no longer in 'running' (e.g. an admin PATCH moved it to
+    // 'cancelled' via the sync route). The CAS is a no-op AND the audit row
+    // below is never written, so a run that actually happened leaves no
+    // record. This is a data-integrity failure on the one agent surface that
+    // writes an audit row  -  it must alert, not be swallowed (GAP-352).
+    logger.error(
+      'RevMarket task completion CAS failed  -  task left running before completion; audit row NOT written',
+      { taskId, attemptedStatus: newStatus },
+    );
     return false;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
       '@revealui/dev':
         specifier: workspace:*
         version: link:../../packages/dev
+      '@revealui/test':
+        specifier: workspace:*
+        version: link:../../packages/test
       '@simplewebauthn/server':
         specifier: ^13.3.2
         version: 13.3.2


### PR DESCRIPTION
## What

Closes GAP-352, a data-integrity bug on the audit surface. On the task-submission sync PATCH route, the cancel-policy guard sat inside `if (session.user.role !== 'admin')`, so an admin could move a `running` task off `running`. Because `completeTask` compare-and-swaps on `status='running'` (`revmarket-executor.ts`), that CAS then no-ops and the audit-log write is skipped, so the one agent surface in the product that writes an audit row loses the record of a run that actually happened.

## Fix

- **Block all transitions out of `running` via this route, for everyone including admins.** Running/completed/failed are executor-owned transitions; there is no legitimate human status flip of a running task here. This closes the full hole, not just the `cancel` verb (an admin could equally have moved `running → completed` or `running → failed` and destroyed the same row).
- The existing cancel-state-machine check stays as a precise subset (cancelling a `completed`/`failed` task still gets its specific error).
- **Make the lost-audit CAS failure loud.** The `completeTask` CAS-failure branch now logs at ERROR with `{ taskId, attemptedStatus }` instead of a low-visibility WARN, so a skipped audit write alerts instead of being swallowed.
- Corrected the route docblock, which previously said "admins may set any other valid status" (the bug premise).

## Tests (prove-red)

New real-storage (PGlite) integration test asserts the audit row **survives**: PATCH a running task to `cancelled`/`completed`/`failed` as an admin is rejected (400), the task stays `running`, the executor completes it, and its `audit_log` row exists. All three verbs proven red against the pre-fix route, then green with the fix. 4/4 green; server + admin typecheck clean; biome clean; adjacent suites (`revmarket.test.ts` 25, sync/task-submission shapes 45) unbroken.

## Notes

Extra footprint: the test needs `createTestDb` across the admin/server boundary, so `@revealui/test` was added to `apps/admin` devDependencies (+3 lockfile lines). Sibling defects from the same 2026-07-12 governance audit: GAP-353 (unauthenticated agent.spawn) and GAP-355 (the audit substrate itself, Stage 1 in flight).

Security-sensitive surface: needs a recorded coordinator verdict before merge (guardrail 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
