### PR TITLE
chore(changeset): catch up db/contracts/mcp versioning since 0.8.0

### DIFF
--- a/.changeset/gap-300-nudge-schema.md
+++ b/.changeset/gap-300-nudge-schema.md
@@ -1,0 +1,6 @@
+---
+"@revealui/db": minor
+"@revealui/contracts": minor
+---
+
+add the `nudge_dismissals` table and its generated contract: server-tracked per-user, per-nudge dismissal state (snooze count + last-dismissed timestamp) backing the per-tier onboarding nudge surface. New schema surface in `@revealui/db` (`packages/db/src/schema/nudges.ts`, registered in `rest.ts` and the database types) and the matching additive entries in `@revealui/contracts` generated schemas.

--- a/.changeset/mcp-streamable-http-bridge-body.md
+++ b/.changeset/mcp-streamable-http-bridge-body.md
@@ -1,0 +1,5 @@
+---
+"@revealui/mcp": patch
+---
+
+fix the Streamable HTTP bridge so a governed mount works behind body-consuming middleware. `createNodeStreamableHttpHandler` now accepts an optional pre-parsed body (third argument); a web-framework bridge that has already read `Request.body` passes it through instead of re-reading the raw Node stream, which arrives empty when upstream middleware has claimed it. Direct Node-server callers are unchanged (the raw-read path still runs when no body is passed).


### PR DESCRIPTION
## Summary

Adds the missing changesets for publishable-package source changes that landed on `test` after today's 0.8.0 release, so the next `changeset version` bump is complete and SemVer-honest. Audited by diffing each publishable package's `src` between `main` (the 0.8.0 promotion) and `test`; four packages changed, only `@revealui/ai` (xai adapter) already had a changeset.

Adds two changesets:

- **`@revealui/db` minor + `@revealui/contracts` minor** — the `nudge_dismissals` table and its generated contract (GAP-300 onboarding nudges, #1929). New schema surface, additive.
- **`@revealui/mcp` patch** — the Streamable HTTP bridge body-parsing fix (GAP-371 Phase 4, #1937). Bugfix.

`@revealui/ai` (xai provider, #1934) keeps its existing `xai-provider-adapter` changeset. No source changes here — changeset markdown only.

## Verification

`pnpm changeset status` resolves: db/contracts/ai minor, mcp patch, plus the normal internal-dependency patch cascade. No major bumps. Fleet security checker: changeset-only diff, not security-sensitive.

This PR is the changeset half of the promotion prep; the `changeset version` bump, the test→main promotion, and the release dispatch are the owner's to sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)