### PR TITLE
feat(audit): assert audit env parity at install (GAP-355 Stage 1 closure)

### DIFF
--- a/apps/server/src/__tests__/index.startup.test.ts
+++ b/apps/server/src/__tests__/index.startup.test.ts
@@ -167,6 +167,25 @@ describe('apps/server/src/index.ts — post-Phase-2 invariants', () => {
       'the audit round-trip self-test must NOT run on the Vercel cold-start path',
     ).not.toContain('auditStorageSelfTest');
   });
+
+  it('asserts audit env parity in the production guard so a diverged-env deploy fails (GAP-355 Stage 1 closure)', () => {
+    // The serverless serving process installs storage but cannot run the async
+    // round-trip self-test. assertAuditStorageEnv() is the synchronous
+    // substitute: it fails the deploy when audit-critical env has diverged
+    // (a required connection var missing/empty), rather than serving with a
+    // sink that can never write. Owner-ruled 2026-07-17 as the Stage-1 closure.
+    const body = extractBranchBody(indexSource, PROD_GUARD, 'validateStartup()');
+    expect(
+      body,
+      'index.ts production guard must call assertAuditStorageEnv() before installAuditStorage()',
+    ).toContain('assertAuditStorageEnv()');
+    const assertIdx = body.indexOf('assertAuditStorageEnv()');
+    const installIdx = body.indexOf('installAuditStorage()');
+    expect(
+      assertIdx >= 0 && installIdx >= 0 && assertIdx < installIdx,
+      'the env-parity assertion must run BEFORE installAuditStorage()',
+    ).toBe(true);
+  });
 });
 
 describe('apps/server/src/worker.ts — Fly entry invariants', () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -44,7 +44,11 @@ import { logger as honoLogger } from 'hono/logger';
 // (POST /api/jobs/run) invocations see the same registry. See
 // CR8-P2-01 phase C.
 import { assertDispatchFlagConfigured } from './jobs/register-handlers.js';
-import { auditStorageSelfTest, installAuditStorage } from './lib/audit-storage.js';
+import {
+  assertAuditStorageEnv,
+  auditStorageSelfTest,
+  installAuditStorage,
+} from './lib/audit-storage.js';
 import { queryBillingStatusByCustomerId, querySupportExpiry } from './lib/billing-status.js';
 import { runHostedLicenseCanary } from './lib/license-canary.js';
 import {
@@ -1327,6 +1331,7 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   // runner regardless of any NODE_ENV stub, so it's the reliable signal.
   if (!process.env.VITEST) {
     // Swap in persistent audit storage (replaces default InMemoryAuditStorage).
+    assertAuditStorageEnv();
     installAuditStorage();
     validateStartup();
     // validateLicenseAtStartup is a no-op in hosted mode (REVEALUI_LICENSE_PRIVATE_KEY
@@ -1429,6 +1434,10 @@ configureClientIp({ trustedProxyCount: 1 });
 if (process.env.NODE_ENV === 'production') {
   if (!process.env.VITEST) {
     validateStartup();
+    // Fail the deploy if audit-critical env has diverged, rather than installing
+    // a store that can never write (GAP-355 Stage 1 closure). Synchronous, no
+    // round trip — the serverless-safe substitute for the worker's self-test.
+    assertAuditStorageEnv();
     installAuditStorage();
   }
 }

--- a/apps/server/src/lib/__tests__/audit-storage.pglite.test.ts
+++ b/apps/server/src/lib/__tests__/audit-storage.pglite.test.ts
@@ -27,6 +27,7 @@ import {
   type TestDb,
 } from '../../../../../packages/test/src/utils/drizzle-test-db.js';
 import {
+  assertAuditStorageEnv,
   auditStorageSelfTest,
   DrizzleBackedAuditStorage,
   mapSeverityToDb,
@@ -152,5 +153,23 @@ describe('auditStorageSelfTest — boot-time round-trip gate', () => {
     };
     const system = new AuditSystem(writeOnly);
     await expect(auditStorageSelfTest(system)).rejects.toThrow('AUDIT STORAGE SELF-TEST FAILED');
+  });
+});
+
+describe('assertAuditStorageEnv — synchronous env-parity guard (GAP-355 Stage 1 closure)', () => {
+  it('throws when no database connection env is set (refuse-to-deploy)', () => {
+    expect(() => assertAuditStorageEnv({})).toThrow('AUDIT STORAGE ENV PARITY FAILED');
+  });
+
+  it('treats an empty connection var as absent', () => {
+    expect(() => assertAuditStorageEnv({ DATABASE_URL: '' })).toThrow(
+      'AUDIT STORAGE ENV PARITY FAILED',
+    );
+  });
+
+  it('passes when any of DATABASE_URL / POSTGRES_URL / DATABASE_HOST is present', () => {
+    expect(() => assertAuditStorageEnv({ DATABASE_URL: 'postgres://x' })).not.toThrow();
+    expect(() => assertAuditStorageEnv({ POSTGRES_URL: 'postgres://x' })).not.toThrow();
+    expect(() => assertAuditStorageEnv({ DATABASE_HOST: 'db.internal' })).not.toThrow();
   });
 });

--- a/apps/server/src/lib/audit-storage.ts
+++ b/apps/server/src/lib/audit-storage.ts
@@ -165,12 +165,53 @@ function reconstructEvent(entry: {
 }
 
 /**
+ * Synchronous env-parity assertion for the audit write path — GAP-355 Stage 1
+ * closure, owner-ruled 2026-07-17.
+ *
+ * The Vercel serving process installs audit storage but, unlike the worker,
+ * does not run the async round-trip self-test (serverless has no clean "refuse
+ * to serve" for a boot-time DB round trip). This asserts the audit path's ENV
+ * preconditions SYNCHRONOUSLY at the install point, so a deploy whose
+ * audit-critical env has diverged (a required var missing or empty) FAILS THE
+ * DEPLOY rather than serving with an audit sink that silently drops every row.
+ * It is the audit-owned home for that contract: a future audit env dependency
+ * (e.g. the Stage 3 Ed25519 signing key) is asserted here on every serving
+ * process, not only wherever the general required-env list happens to cover it.
+ *
+ * Scope, honestly: this catches env-var ABSENCE/emptiness synchronously — which
+ * `installAuditStorage()` itself does not, because `getClient()` is a lazy pool
+ * factory, so a missing connection URL would otherwise surface only on the
+ * first write, at request time. It does NOT, and on serverless cannot, catch
+ * migration-state divergence (the `audit_log` table missing or misshapen on the
+ * target DB); that needs the write-read round trip the worker runs. See
+ * `auditStorageSelfTest`. The DB connection group is also validated by
+ * `validateStartup()` (REQUIRED_ALWAYS_GROUPS); this is the audit-owned,
+ * install-co-located restatement so the contract cannot silently drift.
+ */
+export function assertAuditStorageEnv(env: NodeJS.ProcessEnv = process.env): void {
+  const hasDbConnection = Boolean(env.DATABASE_URL || env.POSTGRES_URL || env.DATABASE_HOST);
+  if (!hasDbConnection) {
+    throw new Error(
+      'AUDIT STORAGE ENV PARITY FAILED: no database connection env is set (one of ' +
+        'DATABASE_URL, POSTGRES_URL, DATABASE_HOST is required), so the audit write path ' +
+        'cannot persist rows. Refusing to serve — an agent action that cannot be recorded ' +
+        'must not execute (fail-closed integrity, ' +
+        'docs/decisions/2026-07-12-audit-receipt-architecture.md §2a).',
+    );
+  }
+}
+
+/**
  * Swap the process-wide `audit` system onto persistent Postgres storage.
  * Synchronous and side-effect-free at call time: `getClient()` is a lazy pool
  * factory (no connection opened here), so this is safe to run on the Vercel
  * cold-start path alongside `validateStartup()`. WITHOUT this call in
  * production, request-level audit events fell into the default
  * `InMemoryAuditStorage` and evaporated on every serverless invocation.
+ *
+ * Call `assertAuditStorageEnv()` before this at each install site so a
+ * diverged-env deploy fails loudly instead of installing a store that can
+ * never write.
  */
 export function installAuditStorage(): void {
   audit.setStorage(new DrizzleBackedAuditStorage(getClient()));

--- a/apps/server/src/worker.ts
+++ b/apps/server/src/worker.ts
@@ -43,7 +43,11 @@ import { serve } from '@hono/node-server';
 import { initializeLicense } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
 import app, { initAlerting, terminalWs } from './index.js';
-import { auditStorageSelfTest, installAuditStorage } from './lib/audit-storage.js';
+import {
+  assertAuditStorageEnv,
+  auditStorageSelfTest,
+  installAuditStorage,
+} from './lib/audit-storage.js';
 import { hydrateInferenceConfigs } from './lib/hydrate-inference-configs.js';
 import { runHostedLicenseCanary } from './lib/license-canary.js';
 import {
@@ -53,7 +57,10 @@ import {
 } from './lib/validate-startup.js';
 import { startExecutor } from './services/revmarket-executor.js';
 
-// Persistent audit storage (replaces default InMemoryAuditStorage).
+// Persistent audit storage (replaces default InMemoryAuditStorage). The env
+// parity assertion fails the deploy on diverged audit-critical env; the async
+// round-trip self-test below is the worker's superset check (GAP-355 Stage 1).
+assertAuditStorageEnv();
 installAuditStorage();
 
 // Environment + license + billing catalog validation.


### PR DESCRIPTION
## What

GAP-355 **Stage 1 closure** (owner-ruled 2026-07-17): the prod install-time env-parity assertion. Stage 1 (revealui#1942) landed audit rows in production, but the boot round-trip self-test runs only on the worker + dev, not on the Vercel serving process (serverless has no clean "refuse to serve" for an async boot round trip). You ruled the synchronous install-time assertion, not a request-path self-test, as the closure. This is that.

## Change

- New `assertAuditStorageEnv(env = process.env)` in `apps/server/src/lib/audit-storage.ts`: synchronously asserts the audit write path's connection env is present (one of `DATABASE_URL` / `POSTGRES_URL` / `DATABASE_HOST`), throwing a clear "AUDIT STORAGE ENV PARITY FAILED — refusing to serve" error otherwise.
- Wired at all three install sites, immediately before `installAuditStorage()`: the Vercel prod guard (`index.ts`), the dev boot block, and the worker (`worker.ts`).

## Why it adds protection

`installAuditStorage()` is synchronous but `getClient()` is a **lazy** pool, so a missing/empty connection var would not fail at install — it would surface only on the first audit write, at request time (dropping the row or erroring the request). The assertion converts exactly that class of env divergence into a **failed deploy**, which is the only clean refuse-to-serve semantics serverless offers, with zero request-path latency and no false-positive availability risk.

Honest scope (also in the code docblock): the DB connection group is *also* validated by `validateStartup()` (`REQUIRED_ALWAYS_GROUPS`), so for today's single audit-critical var this is defense-in-depth. Its durable value is being the **audit-owned, install-co-located home** for that contract, so a future audit env dependency (e.g. the Stage 3 Ed25519 signing key) is asserted here on every serving process rather than only wherever the general required list happens to cover it. It does not, and on serverless cannot, catch migration-state divergence (`audit_log` missing/misshapen) — that needs the write-read round trip the worker runs.

## Tests

- 3 unit tests: throws on empty env, treats an empty connection var as absent, passes when any of the three vars is present.
- 1 startup-guard test: the prod guard calls `assertAuditStorageEnv()` **before** `installAuditStorage()`. Proven red against base `index.ts` (fails "must call assertAuditStorageEnv()"), green with the wiring.
- Full runs: audit-storage 11/11, index.startup 14/14; server typecheck clean (via turbo); biome clean.

Stages 2-6 remain queued (one door, signing, anchoring, audit-the-agents), Stage 3+ on Fable per the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
