### PR TITLE
feat(harnesses): vscode agent-plugin generator, hook normalizer + cli

### DIFF
--- a/.changeset/vscode-agent-plugin.md
+++ b/.changeset/vscode-agent-plugin.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+add a VS Code agent-plugin surface, following the multi-editor harness design: a `vscode` hook normalizer maps VS Code's agent-hook payloads (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `SubagentStart`, `SubagentStop`, `Stop`) onto the existing `HarnessHookEvent` schema, with editor-supplied fields staying session-scoped only, never promoted to identity; the `hook <source>` CLI subcommand now accepts `vscode` and returns VS Code's native response shape (nested `hookSpecificOutput.permissionDecision` for `PreToolUse`, flat `decision`/`reason` for every other event); `VSCodeGenerator` emits a `plugin.json` agent-plugin manifest bundling command-based hook contributions plus a path reference to a governed MCP server contribution, and `protocolConfigToVSCodeMcpConfig` produces that `.mcp.json` content separately using VS Code's `${input:id}` reference syntax so no token value is ever emitted; no `HarnessAdapter` ships for `vscode` in this phase (VS Code's agent mode has no documented headless CLI to exec).

--- a/packages/harnesses/docs/vscode-agent-plugin.md
+++ b/packages/harnesses/docs/vscode-agent-plugin.md
@@ -1,0 +1,66 @@
+# VS Code Agent Plugin
+
+Per the multi-editor harness design, `@revealui/harnesses` can generate a VS
+Code agent-plugin bundle wiring RevealUI's governed hook receipts and MCP
+data plane into VS Code's Copilot agent mode. Facts below verified
+2026-07-17 against `code.visualstudio.com` and `docs.github.com`; VS Code
+agent plugins are in Preview with a documented high release cadence --
+re-verify before relying on this doc.
+
+## What gets generated
+
+- `VSCodeGenerator` (`src/content/generators/vscode.ts`) emits
+  `.revealui/vscode-plugin/plugin.json` -- the plugin manifest, carrying only
+  the `hooks` contribution (every one of VS Code's eight documented hook
+  events runs `revealui-harnesses hook vscode`) and a string reference to
+  `.mcp.json` for the MCP contribution.
+- `protocolConfigToVSCodeMcpConfig` (`src/protocol/config-normalizer.ts`)
+  produces the `.mcp.json` content separately, wiring the governed
+  `/api/mcp` endpoint. The device token is never emitted as a literal value
+  -- it is referenced via VS Code's `${input:<id>}` substitution syntax, with
+  the `inputs[]` entry marked `password: true` so VS Code masks the prompt
+  and stores the value itself.
+
+## Installing from a local path
+
+VS Code plugins are not auto-discovered from inside a project the way
+Cursor's `.cursor/` or OpenCode's `.opencode/` are. Register the generated
+bundle explicitly in VS Code user or workspace settings:
+
+```json
+{
+  "chat.pluginLocations": {
+    "/absolute/path/to/project/.revealui/vscode-plugin": true
+  }
+}
+```
+
+Set the value to `true` to enable the plugin, `false` to keep it registered
+but disabled. Marketplace publishing (`chat.plugins.marketplaces`, "Chat:
+Install Plugin From Source") is owner-gated and out of scope here -- see the
+design doc's D-C decision.
+
+## Org-allowlist governance
+
+VS Code's per-plugin registration above is a developer-machine setting; it
+does not control what an ENTERPRISE permits at the MCP-server level.
+GitHub Copilot Business/Enterprise organizations govern that separately,
+through GitHub's own admin console (not a VS Code setting):
+
+1. An org or enterprise administrator opens **AI controls -> MCP** in the
+   GitHub Copilot policies page.
+2. They choose one of two access-control modes:
+   - **Allow all** -- no restriction; any MCP server a developer configures
+     (including RevealUI's `/api/mcp`) can be used.
+   - **Registry only** -- only MCP servers listed in the org/enterprise's
+     internal MCP registry may run. Under this mode, RevealUI's governed MCP
+     endpoint must be added to that internal registry before any developer's
+     generated `.mcp.json` entry will actually be usable at runtime, even
+     though VS Code will still let a developer configure it locally.
+3. Policy resolution is tied to the GitHub Copilot seat assignment; a
+   developer holding seats in multiple orgs gets a single resolved policy.
+
+Source: docs.github.com/en/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-server-access
+(verified 2026-07-17). Publishing RevealUI's MCP entry into a customer's
+internal registry is a customer-side administrative action; this package
+does not automate it.

--- a/packages/harnesses/src/__tests__/cli-hook.test.ts
+++ b/packages/harnesses/src/__tests__/cli-hook.test.ts
@@ -115,12 +115,59 @@ describe('revealui-harnesses hook <source> (CLI end to end)', () => {
   }, 25_000);
 
   it('rejects an unsupported source with exit code 1', () => {
+    // opencode has no hook normalizer -- OpenCode has no hook system to
+    // normalize from (see hooks/normalizers/index.ts's dispatch doc comment).
     const result = runHookCli(
-      'vscode',
+      'opencode',
       { hook_event_name: 'x' },
       { REVEALUI_HOOK_SPOOL_PATH: spoolPath, REVEALUI_POLICY_SNAPSHOT_PATH: snapshotPath },
     );
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Unsupported hook source');
+  }, 25_000);
+
+  it('normalizes a VS Code PreToolUse deny and prints the nested hookSpecificOutput response', async () => {
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig',
+        issuedAt: new Date().toISOString(),
+        rules: [
+          { kind: 'pre-shell', permission: 'deny', reason: 'no shells from vscode cli test' },
+        ],
+      }),
+      'utf8',
+    );
+
+    const result = runHookCli(
+      'vscode',
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'runInTerminal',
+        tool_input: { command: 'rm -rf /' },
+      },
+      { REVEALUI_HOOK_SPOOL_PATH: spoolPath, REVEALUI_POLICY_SNAPSHOT_PATH: snapshotPath },
+    );
+
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'no shells from vscode cli test',
+      },
+    });
+  }, 25_000);
+
+  it('allows a VS Code Stop event by default (advisory, no snapshot)', () => {
+    const result = runHookCli(
+      'vscode',
+      { hook_event_name: 'Stop' },
+      { REVEALUI_HOOK_SPOOL_PATH: spoolPath, REVEALUI_POLICY_SNAPSHOT_PATH: snapshotPath },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ decision: 'approve' });
   }, 25_000);
 });

--- a/packages/harnesses/src/__tests__/hook-normalizers.test.ts
+++ b/packages/harnesses/src/__tests__/hook-normalizers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { normalizeClaudeCodeHookEvent } from '../hooks/normalizers/claude-code.js';
 import { normalizeCursorHookEvent } from '../hooks/normalizers/cursor.js';
 import { isImplementedHookSource, normalizeHookEvent } from '../hooks/normalizers/index.js';
+import { normalizeVSCodeHookEvent } from '../hooks/normalizers/vscode.js';
 
 describe('normalizeCursorHookEvent', () => {
   it('maps sessionStart to session-start', () => {
@@ -223,11 +224,150 @@ describe('normalizeClaudeCodeHookEvent', () => {
   });
 });
 
+describe('normalizeVSCodeHookEvent', () => {
+  it('maps SessionStart/Stop/UserPromptSubmit to their canonical kinds', () => {
+    expect(normalizeVSCodeHookEvent({ hook_event_name: 'SessionStart' }, 'advisory').kind).toBe(
+      'session-start',
+    );
+    expect(normalizeVSCodeHookEvent({ hook_event_name: 'Stop' }, 'advisory').kind).toBe('stop');
+    expect(normalizeVSCodeHookEvent({ hook_event_name: 'UserPromptSubmit' }, 'advisory').kind).toBe(
+      'prompt-submit',
+    );
+  });
+
+  it('maps SubagentStart/SubagentStop to nested session boundaries', () => {
+    expect(normalizeVSCodeHookEvent({ hook_event_name: 'SubagentStart' }, 'advisory').kind).toBe(
+      'session-start',
+    );
+    expect(normalizeVSCodeHookEvent({ hook_event_name: 'SubagentStop' }, 'advisory').kind).toBe(
+      'session-end',
+    );
+  });
+
+  it('maps a generic PreToolUse/PostToolUse to pre-tool/post-tool with toolName', () => {
+    const pre = normalizeVSCodeHookEvent(
+      { hook_event_name: 'PreToolUse', tool_name: 'codebase' },
+      'advisory',
+    );
+    expect(pre.kind).toBe('pre-tool');
+    expect(pre.toolName).toBe('codebase');
+
+    const post = normalizeVSCodeHookEvent(
+      { hook_event_name: 'PostToolUse', tool_name: 'codebase' },
+      'advisory',
+    );
+    expect(post.kind).toBe('post-tool');
+  });
+
+  it('maps runInTerminal/runTask tool calls to pre-shell/post-shell with the command', () => {
+    const pre = normalizeVSCodeHookEvent(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'runInTerminal',
+        tool_input: { command: 'rm -rf /' },
+      },
+      'advisory',
+    );
+    expect(pre.kind).toBe('pre-shell');
+    expect(pre.command).toBe('rm -rf /');
+
+    const post = normalizeVSCodeHookEvent(
+      {
+        hook_event_name: 'PostToolUse',
+        tool_name: 'runInTerminal',
+        tool_input: { command: 'ls' },
+      },
+      'advisory',
+    );
+    expect(post.kind).toBe('post-shell');
+  });
+
+  it('maps a post-hoc editFiles/createFile call to file-edit with the file path', () => {
+    const event = normalizeVSCodeHookEvent(
+      {
+        hook_event_name: 'PostToolUse',
+        tool_name: 'editFiles',
+        tool_input: { file_path: '/repo/src/index.ts' },
+      },
+      'advisory',
+    );
+    expect(event.kind).toBe('file-edit');
+    expect(event.filePaths).toEqual(['/repo/src/index.ts']);
+  });
+
+  it('never populates generationId/modelId -- VS Code hook payloads carry neither', () => {
+    const event = normalizeVSCodeHookEvent(
+      { hook_event_name: 'PreToolUse', tool_name: 'codebase' },
+      'advisory',
+    );
+    expect(event.identity.generationId).toBeUndefined();
+    expect(event.identity.modelId).toBeUndefined();
+  });
+
+  it('falls back to pre-tool with the raw event name for PreCompact and other unrecognized events', () => {
+    const compact = normalizeVSCodeHookEvent({ hook_event_name: 'PreCompact' }, 'advisory');
+    expect(compact.kind).toBe('pre-tool');
+    expect(compact.toolName).toBe('PreCompact');
+
+    const unknownEvent = normalizeVSCodeHookEvent(
+      { hook_event_name: 'SomeFutureEvent' },
+      'advisory',
+    );
+    expect(unknownEvent.kind).toBe('pre-tool');
+    expect(unknownEvent.toolName).toBe('SomeFutureEvent');
+  });
+
+  it('carries the requested enforcement tier through unchanged', () => {
+    const enforced = normalizeVSCodeHookEvent({ hook_event_name: 'Stop' }, 'enforced');
+    expect(enforced.enforcementTier).toBe('enforced');
+    const advisory = normalizeVSCodeHookEvent({ hook_event_name: 'Stop' }, 'advisory');
+    expect(advisory.enforcementTier).toBe('advisory');
+  });
+
+  it('preserves the untouched payload under raw', () => {
+    const raw = { hook_event_name: 'Stop', session_id: 's1' };
+    const event = normalizeVSCodeHookEvent(raw, 'advisory');
+    expect(event.raw).toBe(raw);
+  });
+
+  // Design invariant I-1: editor-supplied fields never surface as normalized
+  // identity fields, even a forged one that resembles Cursor's known
+  // `user_email` leak vector -- VS Code has no documented identity-shaped
+  // field, but the normalizer must stay honest regardless of what a hostile
+  // payload claims.
+  it('I-1: never copies a forged identity-shaped field onto the normalized identity', () => {
+    const event = normalizeVSCodeHookEvent(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'codebase',
+        user_email: 'attacker@example.com',
+        session_id: 's1',
+      },
+      'advisory',
+    );
+    expect(event.identity).toEqual({
+      conversationId: 's1',
+      generationId: undefined,
+      modelId: undefined,
+    });
+    expect(Object.keys(event.identity)).not.toContain('email');
+    expect(Object.keys(event.identity)).not.toContain('userEmail');
+    // The forged field is still readable off raw (display metadata only).
+    expect((event.raw as { user_email: string }).user_email).toBe('attacker@example.com');
+  });
+
+  it('handles a non-object payload without throwing', () => {
+    expect(() => normalizeVSCodeHookEvent(null, 'advisory')).not.toThrow();
+    expect(() => normalizeVSCodeHookEvent('not an object', 'advisory')).not.toThrow();
+    expect(() => normalizeVSCodeHookEvent(undefined, 'advisory')).not.toThrow();
+  });
+});
+
 describe('normalizeHookEvent dispatch', () => {
-  it('isImplementedHookSource is true for cursor and claude-code, false otherwise', () => {
+  it('isImplementedHookSource is true for cursor, claude-code, and vscode; false otherwise', () => {
     expect(isImplementedHookSource('cursor')).toBe(true);
     expect(isImplementedHookSource('claude-code')).toBe(true);
-    expect(isImplementedHookSource('vscode')).toBe(false);
+    expect(isImplementedHookSource('vscode')).toBe(true);
     expect(isImplementedHookSource('opencode')).toBe(false);
     expect(isImplementedHookSource('something-else')).toBe(false);
   });
@@ -241,6 +381,12 @@ describe('normalizeHookEvent dispatch', () => {
   it('dispatches to the claude-code normalizer', () => {
     const event = normalizeHookEvent('claude-code', { hook_event_name: 'Stop' }, 'advisory');
     expect(event.source).toBe('claude-code');
+    expect(event.kind).toBe('stop');
+  });
+
+  it('dispatches to the vscode normalizer', () => {
+    const event = normalizeHookEvent('vscode', { hook_event_name: 'Stop' }, 'advisory');
+    expect(event.source).toBe('vscode');
     expect(event.kind).toBe('stop');
   });
 });

--- a/packages/harnesses/src/__tests__/hook-run.test.ts
+++ b/packages/harnesses/src/__tests__/hook-run.test.ts
@@ -124,6 +124,87 @@ describe('runHookCommand', () => {
     expect(JSON.parse(lines[1] as string).event.kind).toBe('stop');
   });
 
+  it('I-5: a VS Code hook with no policy snapshot degrades to advisory and allows', async () => {
+    const result = await runHookCommand(
+      'vscode',
+      { hook_event_name: 'PreToolUse', tool_name: 'runInTerminal', tool_input: { command: 'ls' } },
+      { spoolPath, snapshotPath },
+    );
+    expect(result.event.enforcementTier).toBe('advisory');
+    expect(result.decision.permission).toBe('allow');
+    expect(result.responseJson).toEqual({
+      hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' },
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('builds the VS Code-native nested hookSpecificOutput response for pre-tool/pre-shell/pre-mcp on deny', async () => {
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig',
+        issuedAt: new Date().toISOString(),
+        rules: [{ kind: 'pre-shell', permission: 'deny', reason: 'no shells for vscode' }],
+      }),
+      'utf8',
+    );
+
+    const result = await runHookCommand(
+      'vscode',
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'runInTerminal',
+        tool_input: { command: 'rm -rf /' },
+      },
+      { spoolPath, snapshotPath },
+    );
+
+    expect(result.decision.permission).toBe('deny');
+    expect(result.exitCode).toBe(2);
+    // The snapshot's signature is a placeholder -- I-5 forbids claiming
+    // `enforced` even though the deny rule still applies (defense in depth).
+    expect(result.event.enforcementTier).toBe('advisory');
+    expect(result.responseJson).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'no shells for vscode',
+      },
+    });
+  });
+
+  it('builds the flat decision/reason response for non-pre-tool VS Code events (matching the docs’ PostToolUse contract)', async () => {
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig',
+        issuedAt: new Date().toISOString(),
+        rules: [{ kind: 'post-tool', permission: 'deny', reason: 'no tool by policy' }],
+      }),
+      'utf8',
+    );
+
+    const denied = await runHookCommand(
+      'vscode',
+      { hook_event_name: 'PostToolUse', tool_name: 'codebase' },
+      { spoolPath, snapshotPath },
+    );
+    expect(denied.responseJson).toEqual({ decision: 'block', reason: 'no tool by policy' });
+    expect(denied.exitCode).toBe(2);
+
+    const allowed = await runHookCommand(
+      'vscode',
+      { hook_event_name: 'Stop' },
+      { spoolPath, snapshotPath },
+    );
+    expect(allowed.responseJson).toEqual({ decision: 'approve' });
+    expect(allowed.exitCode).toBe(0);
+  });
+
   // Design invariant I-1: a forged identity field in the hook payload never
   // appears in the normalized identity, and cannot widen or change the
   // policy outcome (a deny rule scoped by tool/kind still fires regardless

--- a/packages/harnesses/src/__tests__/hook-run.test.ts
+++ b/packages/harnesses/src/__tests__/hook-run.test.ts
@@ -124,6 +124,45 @@ describe('runHookCommand', () => {
     expect(JSON.parse(lines[1] as string).event.kind).toBe('stop');
   });
 
+  it('fails CLOSED: a deny is still delivered when the spool write fails', async () => {
+    // A deny-matching snapshot...
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig',
+        issuedAt: new Date().toISOString(),
+        rules: [{ kind: 'pre-shell', permission: 'deny', reason: 'shells are denied by policy' }],
+      }),
+      'utf8',
+    );
+    // ...and an unwritable spool path: a FILE stands where the spool's parent
+    // directory would be, so appendToSpool's mkdir throws (ENOTDIR). This is
+    // the disk-full / read-only-fs / unwritable-data-dir class of failure.
+    const blocker = join(dir, 'blocker');
+    await writeFile(blocker, 'not a directory', 'utf8');
+    const unwritableSpool = join(blocker, 'receipts.jsonl');
+
+    const result = await runHookCommand(
+      'cursor',
+      { hook_event_name: 'beforeShellExecution', command: 'rm -rf /' },
+      { spoolPath: unwritableSpool, snapshotPath },
+    );
+
+    // The spool write failed, but the computed deny must still reach the editor
+    // (otherwise the CLI exits with no response and the editor default -- allow
+    // -- silently wins, bypassing enforcement).
+    expect(result.spooled).toBe(false);
+    expect(result.decision.permission).toBe('deny');
+    expect(result.exitCode).toBe(2);
+    expect(result.responseJson).toEqual({
+      permission: 'deny',
+      user_message: 'shells are denied by policy',
+      agent_message: 'shells are denied by policy',
+    });
+  });
+
   it('I-5: a VS Code hook with no policy snapshot degrades to advisory and allows', async () => {
     const result = await runHookCommand(
       'vscode',

--- a/packages/harnesses/src/__tests__/protocol-types.test.ts
+++ b/packages/harnesses/src/__tests__/protocol-types.test.ts
@@ -99,8 +99,15 @@ describe('TOOL_PROFILES (shipped adapters)', () => {
 });
 
 describe('ROADMAP_PROFILES (declared, no adapter)', () => {
-  it('contains the two remaining spec-declared tools (opencode + cursor graduated to TOOL_PROFILES)', () => {
-    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex']);
+  it('contains the remaining spec-declared tools (opencode + cursor graduated to TOOL_PROFILES; vscode added Phase C)', () => {
+    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex', 'vscode']);
+  });
+
+  it('vscode declares real hook support but no dispatch/adapter capabilities', () => {
+    const caps = ROADMAP_PROFILES.vscode;
+    expect(caps.hooks.supported).toBe(true);
+    expect(caps.dispatch.generateCode).toBe(false);
+    expect(caps.headless).toBe(false);
   });
 
   it('claude-code has no dispatch capabilities (interactive tool)', () => {
@@ -127,13 +134,14 @@ describe('ROADMAP_PROFILES (declared, no adapter)', () => {
 });
 
 describe('ALL_KNOWN_PROFILES (merged view)', () => {
-  it('contains all five declared tools', () => {
+  it('contains all six declared tools', () => {
     expect(Object.keys(ALL_KNOWN_PROFILES).sort()).toEqual([
       'claude-code',
       'codex',
       'cursor',
       'opencode',
       'revealui-agent',
+      'vscode',
     ]);
   });
 

--- a/packages/harnesses/src/__tests__/vscode-config.test.ts
+++ b/packages/harnesses/src/__tests__/vscode-config.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { ProtocolConfig } from '../protocol/adapter.js';
+import { protocolConfigToVSCodeMcpConfig } from '../protocol/config-normalizer.js';
+
+function createTestConfig(overrides: Partial<ProtocolConfig> = {}): ProtocolConfig {
+  return {
+    identity: { name: 'Test Agent', email: 'test@example.com', role: 'builder' },
+    permissions: { autoApprove: ['Read', 'Glob'], deny: ['Write'] },
+    environment: { variables: {}, mcpServers: [] },
+    rules: [],
+    skills: [],
+    commands: [],
+    ...overrides,
+  };
+}
+
+describe('protocolConfigToVSCodeMcpConfig', () => {
+  it("emits the .mcp.json remote server block using VS Code's input-reference substitution syntax", () => {
+    const config = createTestConfig();
+    const result = protocolConfigToVSCodeMcpConfig(config, {
+      mcpUrl: 'https://your-host/api/mcp',
+    });
+
+    expect(result.servers.revealui).toEqual({
+      type: 'http',
+      url: 'https://your-host/api/mcp',
+      headers: { Authorization: `Bearer \${input:revealui-mcp-token}` },
+    });
+    expect(result.inputs).toEqual([
+      {
+        type: 'promptString',
+        id: 'revealui-mcp-token',
+        description: 'RevealUI governed MCP device token',
+        password: true,
+      },
+    ]);
+  });
+
+  it('respects a custom token input id', () => {
+    const config = createTestConfig();
+    const result = protocolConfigToVSCodeMcpConfig(config, {
+      mcpUrl: 'https://your-host/api/mcp',
+      tokenInputId: 'custom-token-id',
+    });
+    expect(result.servers.revealui.headers.Authorization).toBe(`Bearer \${input:custom-token-id}`);
+    expect(result.inputs[0]?.id).toBe('custom-token-id');
+  });
+
+  it('marks the input password: true so VS Code masks the prompt', () => {
+    const config = createTestConfig();
+    const result = protocolConfigToVSCodeMcpConfig(config, { mcpUrl: 'https://host/api/mcp' });
+    expect(result.inputs[0]?.password).toBe(true);
+  });
+
+  describe('SECURITY / design invariant I-4: never emits a literal bearer token', () => {
+    it('does not leak a token planted in config.environment.variables', () => {
+      const config = createTestConfig({
+        environment: {
+          variables: { REVEALUI_MCP_TOKEN: 'rvui_dev_should_never_appear_in_output' },
+          mcpServers: [],
+        },
+      });
+      const result = protocolConfigToVSCodeMcpConfig(config, { mcpUrl: 'https://host/api/mcp' });
+      const serialized = JSON.stringify(result);
+
+      expect(serialized).not.toContain('rvui_dev_should_never_appear_in_output');
+      expect(result.servers.revealui.headers.Authorization).toBe(
+        `Bearer \${input:revealui-mcp-token}`,
+      );
+    });
+
+    it('never emits a token value present in process.env', () => {
+      const priorValue = process.env.REVEALUI_MCP_TOKEN_TEST_FIXTURE_VSCODE;
+      process.env.REVEALUI_MCP_TOKEN_TEST_FIXTURE_VSCODE = 'sk-should-not-leak-into-config';
+      try {
+        const config = createTestConfig();
+        const result = protocolConfigToVSCodeMcpConfig(config, {
+          mcpUrl: 'https://host/api/mcp',
+          tokenInputId: 'revealui-mcp-token-test-fixture-vscode',
+        });
+        const serialized = JSON.stringify(result);
+
+        expect(serialized).not.toContain('sk-should-not-leak-into-config');
+        expect(serialized).toContain('$' + '{input:revealui-mcp-token-test-fixture-vscode}');
+      } finally {
+        if (priorValue === undefined) {
+          delete process.env.REVEALUI_MCP_TOKEN_TEST_FIXTURE_VSCODE;
+        } else {
+          process.env.REVEALUI_MCP_TOKEN_TEST_FIXTURE_VSCODE = priorValue;
+        }
+      }
+    });
+  });
+});

--- a/packages/harnesses/src/__tests__/vscode-content-generator.test.ts
+++ b/packages/harnesses/src/__tests__/vscode-content-generator.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { VSCodeGenerator } from '../content/generators/vscode.js';
+import { buildManifest, generateContent, getGenerator, listGenerators } from '../content/index.js';
+import type { Agent, Command, Rule, Skill } from '../content/schemas/index.js';
+
+const ctx = { projectRoot: '/test' };
+
+describe('VSCodeGenerator', () => {
+  it('is auto-registered in the content generator registry', () => {
+    expect(listGenerators()).toContain('vscode');
+    expect(getGenerator('vscode')).toBeInstanceOf(VSCodeGenerator);
+  });
+
+  it('declares its output directory', () => {
+    const generator = new VSCodeGenerator();
+    expect(generator.id).toBe('vscode');
+    expect(generator.outputDir).toBe('.revealui/vscode-plugin');
+  });
+
+  describe('generateRule / generateCommand / generateAgent / generateSkill -- Phase C scope is plugin.json hooks only', () => {
+    it('all four return no files', () => {
+      const generator = new VSCodeGenerator();
+      const rule: Rule = {
+        id: 'biome',
+        name: 'Biome',
+        description: 'Use biome',
+        scope: 'project',
+        preambleTier: 2,
+        tier: 'oss',
+        tags: [],
+        content: 'Format with biome.',
+      };
+      const cmd: Command = {
+        id: 'gate',
+        name: 'Gate',
+        description: 'Run the quality gate',
+        tier: 'oss',
+        disableModelInvocation: false,
+        content: 'Run lint, typecheck, and tests.',
+      };
+      const agent: Agent = {
+        id: 'reviewer',
+        name: 'Reviewer',
+        description: 'Reviews code',
+        tier: 'oss',
+        isolation: 'none',
+        tools: ['Read'],
+        content: 'You review code.',
+      };
+      const skill: Skill = {
+        id: 'tdd',
+        name: 'TDD',
+        description: 'Test-driven development',
+        tier: 'oss',
+        disableModelInvocation: false,
+        skipFrontmatter: false,
+        filePatterns: [],
+        bashPatterns: [],
+        references: {},
+        content: 'Write tests first.',
+      };
+
+      expect(generator.generateRule(rule, ctx)).toEqual([]);
+      expect(generator.generateCommand(cmd, ctx)).toEqual([]);
+      expect(generator.generateAgent(agent, ctx)).toEqual([]);
+      expect(generator.generateSkill(skill, ctx)).toEqual([]);
+    });
+  });
+
+  describe('generateAll', () => {
+    it('emits exactly one file: .revealui/vscode-plugin/plugin.json', () => {
+      const manifest = buildManifest();
+      const files = generateContent('vscode', manifest, ctx);
+      expect(files).toHaveLength(1);
+      expect(files[0]?.relativePath).toBe('.revealui/vscode-plugin/plugin.json');
+    });
+
+    it('every hook entry is command-based and invokes the harness CLI hook subcommand', () => {
+      const manifest = buildManifest();
+      const [file] = generateContent('vscode', manifest, ctx);
+      const parsed = JSON.parse(file?.content ?? '{}') as {
+        name: string;
+        hooks: Record<string, Array<{ command: string; type: string }>>;
+        mcpServers: string;
+      };
+
+      expect(parsed.name).toBe('revealui');
+      const eventNames = Object.keys(parsed.hooks);
+      expect(eventNames.length).toBeGreaterThan(0);
+
+      for (const eventName of eventNames) {
+        const entries = parsed.hooks[eventName] ?? [];
+        expect(entries).toHaveLength(1);
+        for (const entry of entries) {
+          expect(entry.type).toBe('command');
+          expect(entry.command).toBe('revealui-harnesses hook vscode');
+        }
+      }
+    });
+
+    it('covers every VS Code hook event the vscode normalizer maps (design doc §2.3)', () => {
+      const manifest = buildManifest();
+      const [file] = generateContent('vscode', manifest, ctx);
+      const parsed = JSON.parse(file?.content ?? '{}') as { hooks: Record<string, unknown> };
+
+      for (const eventName of [
+        'SessionStart',
+        'UserPromptSubmit',
+        'PreToolUse',
+        'PostToolUse',
+        'PreCompact',
+        'SubagentStart',
+        'SubagentStop',
+        'Stop',
+      ]) {
+        expect(parsed.hooks).toHaveProperty(eventName);
+      }
+    });
+
+    it('references .mcp.json by path rather than inlining server/token content', () => {
+      const manifest = buildManifest();
+      const [file] = generateContent('vscode', manifest, ctx);
+      const parsed = JSON.parse(file?.content ?? '{}') as { mcpServers: unknown };
+      expect(parsed.mcpServers).toBe('.mcp.json');
+    });
+
+    // SECURITY / design invariant I-4: the plugin.json manifest itself is
+    // generated with no MCP URL or token option at all (the ContentGenerator
+    // interface's generateAll(manifest, ctx) carries neither) -- so it is
+    // structurally incapable of leaking a token, not merely disciplined
+    // about it. Assert that no plausible token-shaped string appears.
+    it('I-4: the generated manifest never contains a token-shaped value', () => {
+      const manifest = buildManifest();
+      const [file] = generateContent('vscode', manifest, ctx);
+      const content = file?.content ?? '';
+      expect(content.includes('rvui_dev_')).toBe(false);
+      expect(content.includes('Bearer ')).toBe(false);
+    });
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -10,7 +10,7 @@
  *   sync <harnessId> <push|pull>     Sync harness config to/from SSD
  *   coordinate [--print]             Print current workboard state
  *   coordinate --init <path>         Register this session in the workboard and start daemon
- *   hook <cursor|claude-code>        Normalize a hook payload from stdin, evaluate policy, spool the receipt
+ *   hook <cursor|claude-code|vscode> Normalize a hook payload from stdin, evaluate policy, spool the receipt
  *
  * License: FSL-1.1-MIT
  */
@@ -387,7 +387,7 @@ async function readStdin(): Promise<string> {
 async function handleHookCommand(source: string | undefined): Promise<void> {
   if (!(source && isImplementedHookSource(source))) {
     process.stderr.write(
-      `Unsupported hook source: ${source ?? '(none)'}. Supported: cursor, claude-code\n`,
+      `Unsupported hook source: ${source ?? '(none)'}. Supported: cursor, claude-code, vscode\n`,
     );
     process.exitCode = 1;
     return;
@@ -608,7 +608,7 @@ Commands:
   health                            Run health check (requires daemon)
   coordinate [--project <path>]     Print workboard state
   coordinate --init [<path>]        Register + start daemon
-  hook <cursor|claude-code>         Normalize a hook payload from stdin, evaluate policy, spool the receipt
+  hook <cursor|claude-code|vscode>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
   content <subcommand>              Manage canonical content definitions
 
 Content Subcommands:

--- a/packages/harnesses/src/config/harness-config-paths.ts
+++ b/packages/harnesses/src/config/harness-config-paths.ts
@@ -17,6 +17,12 @@ const LOCAL_CONFIG_PATHS: Record<string, string> = {
   cursor: join(HOME, '.cursor', 'settings.json'),
   copilot: join(HOME, '.config', 'github-copilot', 'hosts.json'),
   opencode: join(HOME, '.config', 'opencode', 'opencode.json'),
+  // VS Code's Linux user settings path (stable convention, unrelated to the
+  // agent-plugin Preview surface this build ships). Distinct from `copilot`
+  // above -- that id is the GitHub Copilot CLI/host config; this is the
+  // editor itself, which is what actually hosts the hook subprocess and the
+  // agent-plugin manifest (multi-editor harness design doc §2.3).
+  vscode: join(HOME, '.config', 'Code', 'User', 'settings.json'),
 };
 
 const ROOT_CONFIG_FILES: Record<string, string> = {
@@ -24,6 +30,7 @@ const ROOT_CONFIG_FILES: Record<string, string> = {
   cursor: 'settings.json',
   copilot: 'hosts.json',
   opencode: 'opencode.json',
+  vscode: 'settings.json',
 };
 
 /** Returns the local config file path for a given harness id, or undefined if unknown. */

--- a/packages/harnesses/src/content/generators/index.ts
+++ b/packages/harnesses/src/content/generators/index.ts
@@ -1,10 +1,12 @@
 import { CursorGenerator } from './cursor.js';
 import { OpenCodeGenerator } from './opencode.js';
 import type { ContentGenerator } from './types.js';
+import { VSCodeGenerator } from './vscode.js';
 
 export { CursorGenerator } from './cursor.js';
 export { OpenCodeGenerator } from './opencode.js';
 export type { ContentGenerator, DiffEntry, GeneratedFile } from './types.js';
+export { VSCodeGenerator } from './vscode.js';
 
 const generators = new Map<string, ContentGenerator>();
 
@@ -28,3 +30,4 @@ export function listGenerators(): string[] {
 // of this module -- no manual registration call required.
 registerGenerator(new OpenCodeGenerator());
 registerGenerator(new CursorGenerator());
+registerGenerator(new VSCodeGenerator());

--- a/packages/harnesses/src/content/generators/vscode.ts
+++ b/packages/harnesses/src/content/generators/vscode.ts
@@ -1,0 +1,130 @@
+/**
+ * VS Code Agent Plugin Generator
+ *
+ * Emits `plugin.json` -- the VS Code agent-plugin manifest (Preview;
+ * verified 2026-07-17 against code.visualstudio.com/docs/agent-customization/agent-plugins
+ * and .../docs/agents/reference/hooks-reference; the design doc's own audit
+ * flags a high release cadence for this surface -- re-verify at each future
+ * touch). A plugin root carries a `plugin.json` with a required kebab-case
+ * `name`, plus optional `description`, `version`, `author`, `skills`,
+ * `agents`, `hooks`, and `mcpServers` fields. `hooks` and `mcpServers` may
+ * each be either an inline object or a path to a separate config file (for
+ * example `.mcp.json`).
+ *
+ * This generator's `hooks` field is COMMAND-BASED only, mirroring
+ * `CursorGenerator` (multi-editor harness design doc §3-B acceptance:
+ * "100% command-based hooks"). Every one of VS Code's eight documented hook
+ * events runs the same command: `revealui-harnesses hook vscode`, which
+ * reads the hook payload from stdin and prints the permission decision to
+ * stdout (`../../cli.ts` `hook` subcommand, `../../hooks/run-hook.ts`).
+ *
+ * `.mcp.json` generation is NOT part of this generator -- exactly the split
+ * `CursorGenerator`'s own doc comment describes for `.cursor/mcp.json`: it
+ * needs a `ProtocolConfig` + an MCP URL/token-input-id option the
+ * `ContentGenerator` interface's `generateAll(manifest, ctx)` signature
+ * doesn't carry, and it is security-critical (never emit a literal token).
+ * It lives alongside `protocolConfigToCursorMcpConfig` in
+ * `../../protocol/config-normalizer.ts` as `protocolConfigToVSCodeMcpConfig`,
+ * the same leak-proof pattern. This manifest's own `mcpServers` field is
+ * therefore a STRING PATH REFERENCE to `.mcp.json` (matching the manifest
+ * schema's documented "path to an MCP config file" form) rather than an
+ * inline object -- the file bundles the MCP *contribution* (the manifest
+ * advertises and wires it) without this generator ever handling the URL or
+ * token itself.
+ *
+ * VS Code's other writable plugin surfaces (`skills/`, `agents/`, a slash
+ * commands surface) are NOT emitted yet -- Phase C scope, mirroring
+ * `cursor.ts`'s and `opencode.ts`'s scoping notes. `generateRule`/
+ * `generateCommand`/`generateAgent`/`generateSkill` return no files -- a
+ * scoping decision, not an oversight.
+ *
+ * Unlike `.cursor/` or `.opencode/`, VS Code does not auto-discover a plugin
+ * from inside a project -- it must be registered via the `chat.pluginLocations`
+ * setting or installed from a git URL. This generator writes the bundle to
+ * `.revealui/vscode-plugin/` (a project-relative, human-findable location)
+ * rather than the project root, so nothing else in the tree collides with
+ * `plugin.json`. See `../../../docs/vscode-agent-plugin.md` for the local
+ * install + org-allowlist governance notes (multi-editor harness design doc
+ * §6 Phase C acceptance).
+ */
+
+import type { ResolverContext } from '../resolvers/types.js';
+import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
+import type { ContentGenerator, GeneratedFile } from './types.js';
+
+/**
+ * The eight VS Code agent-hook event names this package's `hook vscode`
+ * subcommand normalizes (multi-editor harness design doc §2.3, verified
+ * 2026-07-17 against code.visualstudio.com/docs/agents/reference/hooks-reference).
+ * Notably no `SessionEnd` -- VS Code does not document one, unlike Cursor and
+ * Claude Code (see `../../hooks/normalizers/vscode.ts`'s module doc).
+ */
+const VSCODE_HOOK_EVENT_NAMES: readonly string[] = [
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'PreCompact',
+  'SubagentStart',
+  'SubagentStop',
+  'Stop',
+];
+
+/** One `plugin.json` `hooks.<eventName>` entry. */
+interface VSCodePluginHookEntry {
+  type: 'command';
+  command: string;
+}
+
+/** The `plugin.json` shape this generator writes (design doc §2.3 / the agent-plugins manifest). */
+interface VSCodePluginManifest {
+  name: string;
+  description: string;
+  version: string;
+  hooks: Record<string, VSCodePluginHookEntry[]>;
+  /** Path reference to the separately-generated `.mcp.json` -- see module doc. */
+  mcpServers: string;
+}
+
+export class VSCodeGenerator implements ContentGenerator {
+  readonly id = 'vscode';
+  readonly outputDir = '.revealui/vscode-plugin';
+
+  generateRule(_rule: Rule, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateCommand(_cmd: Command, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateAgent(_agent: Agent, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateSkill(_skill: Skill, _ctx: ResolverContext): GeneratedFile[] {
+    return [];
+  }
+
+  generateAll(_manifest: Manifest, _ctx: ResolverContext): GeneratedFile[] {
+    const hooks: VSCodePluginManifest['hooks'] = {};
+    for (const eventName of VSCODE_HOOK_EVENT_NAMES) {
+      hooks[eventName] = [{ command: 'revealui-harnesses hook vscode', type: 'command' }];
+    }
+
+    const manifest: VSCodePluginManifest = {
+      name: 'revealui',
+      description: 'RevealUI governed hooks and MCP access for VS Code agent mode',
+      version: '0.1.0',
+      hooks,
+      mcpServers: '.mcp.json',
+    };
+
+    return [
+      {
+        relativePath: '.revealui/vscode-plugin/plugin.json',
+        content: `${JSON.stringify(manifest, null, 2)}\n`,
+      },
+    ];
+  }
+}

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -3,10 +3,13 @@
  *
  * Tool-agnostic definitions for AI guidance content (rules, commands, agents, skills).
  * Generators produce tool-specific output from canonical definitions.
- * `opencode` (`./generators/opencode.ts`) and `cursor` (`./generators/cursor.ts`,
- * hooks.json only -- see that file's doc comment) are registered today,
- * matching the adapter layer (`../adapters/`), which ships `revealui-agent`,
- * `opencode`, and `cursor`. A Claude Code generator is not implemented.
+ * `opencode` (`./generators/opencode.ts`), `cursor` (`./generators/cursor.ts`,
+ * hooks.json only -- see that file's doc comment), and `vscode`
+ * (`./generators/vscode.ts`, plugin.json hooks contribution only) are
+ * registered today. The adapter layer (`../adapters/`) ships
+ * `revealui-agent`, `opencode`, and `cursor` -- `vscode` has no adapter (no
+ * headless CLI to exec; see `./generators/vscode.ts`'s doc comment). A
+ * Claude Code generator is not implemented.
  *
  * @example
  * ```ts
@@ -33,6 +36,7 @@ export {
   listGenerators,
   OpenCodeGenerator,
   registerGenerator,
+  VSCodeGenerator,
 } from './generators/index.js';
 export type { ContentGenerator, DiffEntry, GeneratedFile } from './generators/types.js';
 export { listResolvers, registerResolver, resolveTemplate } from './resolvers/index.js';

--- a/packages/harnesses/src/detection/process-detector.ts
+++ b/packages/harnesses/src/detection/process-detector.ts
@@ -25,6 +25,16 @@ export async function findProcesses(pattern: string): Promise<{ pid: number; com
   }
 }
 
+/**
+ * `vscode`/`code` is deliberately NOT a key here -- the same reasoning
+ * `cursor-adapter.ts` documents for excluding Cursor's `agent` binary. `code`
+ * is too generic a `pgrep` name-substring match: it would false-positive on
+ * `opencode` (whose comm name literally contains "code" as a substring), and
+ * on other unrelated local tooling. VS Code's process is not needed for
+ * Phase C's normalizer/CLI/generator surface anyway -- see
+ * `../content/generators/vscode.ts`'s doc comment on why no `HarnessAdapter`
+ * ships for `vscode` in this phase.
+ */
 const HARNESS_PROCESS_PATTERNS: Record<string, string[]> = {
   'claude-code': ['claude'],
   cursor: ['cursor', 'Cursor'],

--- a/packages/harnesses/src/hooks/index.ts
+++ b/packages/harnesses/src/hooks/index.ts
@@ -4,6 +4,7 @@ export {
   normalizeClaudeCodeHookEvent,
   normalizeCursorHookEvent,
   normalizeHookEvent,
+  normalizeVSCodeHookEvent,
 } from './normalizers/index.js';
 export type {
   PolicyDecision,

--- a/packages/harnesses/src/hooks/normalizers/index.ts
+++ b/packages/harnesses/src/hooks/normalizers/index.ts
@@ -5,16 +5,19 @@ import type {
 } from '../../types/hook-event.js';
 import { normalizeClaudeCodeHookEvent } from './claude-code.js';
 import { normalizeCursorHookEvent } from './cursor.js';
+import { normalizeVSCodeHookEvent } from './vscode.js';
 
 export { normalizeClaudeCodeHookEvent } from './claude-code.js';
 export { normalizeCursorHookEvent } from './cursor.js';
+export { normalizeVSCodeHookEvent } from './vscode.js';
 
 /** Sources with a normalizer implemented in this package today. */
-export type ImplementedHookSource = Extract<HarnessHookSource, 'cursor' | 'claude-code'>;
+export type ImplementedHookSource = Extract<HarnessHookSource, 'cursor' | 'claude-code' | 'vscode'>;
 
 const IMPLEMENTED_SOURCES: ReadonlySet<string> = new Set<ImplementedHookSource>([
   'cursor',
   'claude-code',
+  'vscode',
 ]);
 
 /** True if `normalizeHookEvent` has a normalizer for this source. */
@@ -25,10 +28,9 @@ export function isImplementedHookSource(source: string): source is ImplementedHo
 /**
  * Dispatch a raw hook payload to the normalizer for its source.
  *
- * `vscode` and `opencode` are declared `HarnessHookSource` members (the
- * schema anticipates them) but have no normalizer yet -- VS Code lands in
- * Phase C of the multi-editor harness design; OpenCode has no hook system
- * to normalize from (`hooks.supported: false` in `TOOL_PROFILES.opencode`).
+ * `opencode` is a declared `HarnessHookSource` member (the schema
+ * anticipates it) but has no normalizer -- OpenCode has no hook system to
+ * normalize from (`hooks.supported: false` in `TOOL_PROFILES.opencode`).
  * Callers should gate on `isImplementedHookSource` before calling this.
  */
 export function normalizeHookEvent(
@@ -41,5 +43,7 @@ export function normalizeHookEvent(
       return normalizeCursorHookEvent(raw, enforcementTier);
     case 'claude-code':
       return normalizeClaudeCodeHookEvent(raw, enforcementTier);
+    case 'vscode':
+      return normalizeVSCodeHookEvent(raw, enforcementTier);
   }
 }

--- a/packages/harnesses/src/hooks/normalizers/vscode.ts
+++ b/packages/harnesses/src/hooks/normalizers/vscode.ts
@@ -1,0 +1,110 @@
+/**
+ * VS Code Agent Hook Normalizer
+ *
+ * Maps VS Code's native agent-hook payload shape onto `HarnessHookEvent`
+ * (multi-editor harness design doc §2.3, §3-B).
+ *
+ * Verified 2026-07-17 against code.visualstudio.com/docs/agents/reference/hooks-reference
+ * and code.visualstudio.com/docs/agent-customization/hooks (VS Code's agent
+ * hooks are in Preview; re-verify at each future build touching this file --
+ * the design doc's own audit flags a high release cadence). Confirmed facts:
+ *  - Event names: `SessionStart`, `UserPromptSubmit`, `PreToolUse`,
+ *    `PostToolUse`, `PreCompact`, `SubagentStart`, `SubagentStop`, `Stop`.
+ *    Notably NO `SessionEnd` (unlike Cursor and Claude Code).
+ *  - Every hook receives a JSON payload over stdin with common fields
+ *    `timestamp`, `cwd`, `session_id`, `hook_event_name`, `transcript_path`
+ *    (snake_case), plus event-specific fields; `PreToolUse`/`PostToolUse`
+ *    additionally carry `tool_name`, `tool_input`, `tool_use_id`.
+ *  - The field-name casing (snake_case, matching Claude Code's own payload
+ *    shape rather than VS Code's usual camelCase JSON conventions) was
+ *    corroborated by two independent doc fetches; VS Code's own plugin
+ *    manifest docs reuse the `${CLAUDE_PLUGIN_ROOT}` token verbatim, which
+ *    reads as a deliberate wire-format convergence with Claude Code's plugin
+ *    system, not a coincidence. Confidence: high on event names and the
+ *    common envelope, medium on the exact field list (doc excerpts were
+ *    AI-summarized, not read byte-for-byte).
+ *  - VS Code does not document a per-hook editor-identity field analogous to
+ *    Cursor's `user_email` / `CURSOR_USER_EMAIL`. No such field is read here;
+ *    per design invariant I-1, if one exists it stays in `raw` only and is
+ *    never promoted onto `HarnessHookIdentity` regardless.
+ *  - `tool_name` values for the shell/file-edit refinement below
+ *    (`runInTerminal`/`runTask` for shell, `editFiles`/`createFile`/
+ *    `createDirectory` for file edits) come from VS Code's documented
+ *    built-in Copilot agent-mode tool set (code.visualstudio.com/docs/copilot/agents/agent-tools),
+ *    not from the hooks reference itself -- best-effort, same posture as
+ *    Cursor's `beforeReadFile` -> synthetic `Read` toolName fallback.
+ */
+
+import type {
+  HarnessEnforcementTier,
+  HarnessHookEvent,
+  HarnessHookEventKind,
+} from '../../types/hook-event.js';
+import { asRecord, readString, readStringArray } from './raw-object.js';
+
+/** VS Code `hook_event_name` -> canonical kind. */
+const VSCODE_EVENT_KIND_MAP: ReadonlyMap<string, HarnessHookEventKind> = new Map([
+  ['SessionStart', 'session-start'],
+  ['UserPromptSubmit', 'prompt-submit'],
+  ['PreToolUse', 'pre-tool'],
+  ['PostToolUse', 'post-tool'],
+  ['SubagentStart', 'session-start'],
+  ['SubagentStop', 'session-end'],
+  ['Stop', 'stop'],
+]);
+
+/** Built-in VS Code Copilot agent-mode tool names that represent a terminal/shell invocation. */
+const SHELL_TOOL_NAMES: ReadonlySet<string> = new Set(['runInTerminal', 'runTask', 'runTests']);
+
+/** Built-in VS Code Copilot agent-mode tool names that represent a file edit. */
+const FILE_EDIT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'editFiles',
+  'createFile',
+  'createDirectory',
+]);
+
+/**
+ * Normalize one VS Code hook stdin payload into a `HarnessHookEvent`. Total
+ * -- never throws. An unrecognized `hook_event_name` (including the
+ * documented `PreCompact`, which has no matching kind in the eleven-kind
+ * schema -- a compaction event is neither a tool call nor a session
+ * boundary) falls back to `pre-tool` with `toolName` set to the raw event
+ * name, mirroring the Cursor and Claude Code normalizers' fallback so every
+ * source degrades the same honest way instead of silently dropping the
+ * event (design doc §3-B "never drop events silently").
+ */
+export function normalizeVSCodeHookEvent(
+  raw: unknown,
+  enforcementTier: HarnessEnforcementTier,
+): HarnessHookEvent {
+  const rec = asRecord(raw);
+  const eventName = readString(rec, 'hook_event_name') ?? 'unknown';
+  const toolName = readString(rec, 'tool_name');
+  const toolInput = asRecord(rec.tool_input);
+
+  let kind = VSCODE_EVENT_KIND_MAP.get(eventName) ?? 'pre-tool';
+  if (toolName && SHELL_TOOL_NAMES.has(toolName)) {
+    kind = eventName === 'PostToolUse' ? 'post-shell' : 'pre-shell';
+  } else if (toolName && FILE_EDIT_TOOL_NAMES.has(toolName) && eventName === 'PostToolUse') {
+    kind = 'file-edit';
+  }
+
+  const command = readString(toolInput, 'command');
+  const filePath = readString(toolInput, 'file_path') ?? readString(toolInput, 'filePath');
+
+  return {
+    kind,
+    source: 'vscode',
+    timestamp: new Date().toISOString(),
+    identity: {
+      conversationId: readString(rec, 'session_id'),
+      generationId: undefined,
+      modelId: undefined,
+    },
+    toolName: toolName ?? (VSCODE_EVENT_KIND_MAP.has(eventName) ? undefined : eventName),
+    command,
+    filePaths: filePath ? [filePath] : readStringArray(toolInput, 'files'),
+    enforcementTier,
+    raw,
+  };
+}

--- a/packages/harnesses/src/hooks/run-hook.ts
+++ b/packages/harnesses/src/hooks/run-hook.ts
@@ -52,6 +52,12 @@ export interface HookRunResult {
   readonly responseJson: Record<string, unknown>;
   /** 2 when the decision is `deny` (Cursor + Claude Code both block on exit code 2), 0 otherwise. */
   readonly exitCode: number;
+  /**
+   * False when the receipt could not be written to the local spool (unwritable
+   * data dir, disk full, read-only fs, rotate error). The decision is still
+   * delivered regardless -- see the fail-closed note in `runHookCommand`.
+   */
+  readonly spooled: boolean;
 }
 
 /** Build the Cursor-native permission response (cursor.com/docs/agent/hooks, verified 2026-07-17). */
@@ -157,7 +163,26 @@ export async function runHookCommand(
   const event = normalizeHookEvent(source, rawInput, enforcementTier);
   const decision = evaluatePolicy(snapshotResult, event);
 
-  await appendToSpool({ event, decision, spooledAt: new Date().toISOString() }, options.spoolPath);
+  // Fail CLOSED on a spool-write failure. If appendToSpool throws (unwritable
+  // data dir on first run, disk full, read-only fs, or a non-ENOENT rotate
+  // error) the policy DECISION must still reach the editor: were the throw to
+  // propagate, the CLI would exit without writing a response and the editor's
+  // default (allow) would win -- turning a spool-write failure into a silent
+  // enforcement bypass of a computed `deny`. Warn so the dropped receipt is
+  // visible (availability/audit-completeness cost), but never drop the decision.
+  let spooled = true;
+  try {
+    await appendToSpool(
+      { event, decision, spooledAt: new Date().toISOString() },
+      options.spoolPath,
+    );
+  } catch (err) {
+    spooled = false;
+    const reason = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `revealui-harnesses hook: receipt spool write failed (${reason}); decision still enforced, receipt dropped\n`,
+    );
+  }
 
   return {
     event,
@@ -165,5 +190,6 @@ export async function runHookCommand(
     snapshotResult,
     responseJson: buildEditorResponse(source, decision, event.kind),
     exitCode: decision.permission === 'deny' ? 2 : 0,
+    spooled,
   };
 }

--- a/packages/harnesses/src/hooks/run-hook.ts
+++ b/packages/harnesses/src/hooks/run-hook.ts
@@ -9,7 +9,12 @@
 
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { HarnessHookEvent, HarnessHookSource } from '../types/hook-event.js';
+import type {
+  HarnessHookEvent,
+  HarnessHookEventKind,
+  HarnessHookSource,
+} from '../types/hook-event.js';
+import type { ImplementedHookSource } from './normalizers/index.js';
 import { isImplementedHookSource, normalizeHookEvent } from './normalizers/index.js';
 import type { PolicyDecision, PolicySnapshotLoadResult } from './policy.js';
 import { evaluatePolicy, loadPolicySnapshot } from './policy.js';
@@ -75,11 +80,50 @@ function buildClaudeCodeResponse(decision: PolicyDecision): Record<string, unkno
   return { decision: 'approve' };
 }
 
+/** Event kinds that correspond to VS Code's `PreToolUse` hook. */
+const VSCODE_PRE_TOOL_KINDS: ReadonlySet<HarnessHookEventKind> = new Set([
+  'pre-tool',
+  'pre-shell',
+  'pre-mcp',
+]);
+
+/**
+ * Build the VS Code-native hook response (code.visualstudio.com/docs/agents/reference/hooks-reference,
+ * verified 2026-07-17). `PreToolUse` is the only VS Code hook event with a
+ * documented nested `hookSpecificOutput.permissionDecision` contract
+ * (`allow`/`deny`/`ask`, plus `permissionDecisionReason`); every other event
+ * -- including `PostToolUse`, whose response the same reference documents as
+ * a flat `decision` field -- uses the flat `decision`/`reason` shape, which
+ * matches Claude Code's own convention. VS Code's hooks system reads as a
+ * deliberate wire-format convergence with Claude Code's (see the module doc
+ * in `./normalizers/vscode.ts`), so `buildClaudeCodeResponse`'s shape is
+ * reused for the non-`PreToolUse` case rather than re-deriving an equivalent
+ * shape from scratch.
+ */
+function buildVSCodeResponse(
+  kind: HarnessHookEventKind,
+  decision: PolicyDecision,
+): Record<string, unknown> {
+  if (VSCODE_PRE_TOOL_KINDS.has(kind)) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: decision.permission,
+        ...(decision.reason ? { permissionDecisionReason: decision.reason } : {}),
+      },
+    };
+  }
+  return buildClaudeCodeResponse(decision);
+}
+
 function buildEditorResponse(
   source: HarnessHookSource,
   decision: PolicyDecision,
+  kind: HarnessHookEventKind,
 ): Record<string, unknown> {
-  return source === 'cursor' ? buildCursorResponse(decision) : buildClaudeCodeResponse(decision);
+  if (source === 'cursor') return buildCursorResponse(decision);
+  if (source === 'vscode') return buildVSCodeResponse(kind, decision);
+  return buildClaudeCodeResponse(decision);
 }
 
 /**
@@ -89,7 +133,7 @@ function buildEditorResponse(
  * and setting `process.exitCode`.
  */
 export async function runHookCommand(
-  source: Extract<HarnessHookSource, 'cursor' | 'claude-code'>,
+  source: ImplementedHookSource,
   rawInput: unknown,
   options: HookRunOptions = defaultHookRunOptions(),
 ): Promise<HookRunResult> {
@@ -119,7 +163,7 @@ export async function runHookCommand(
     event,
     decision,
     snapshotResult,
-    responseJson: buildEditorResponse(source, decision),
+    responseJson: buildEditorResponse(source, decision, event.kind),
     exitCode: decision.permission === 'deny' ? 2 : 0,
   };
 }

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -42,6 +42,7 @@ export {
   generateContent,
   listContent,
   OpenCodeGenerator,
+  VSCodeGenerator,
   validateManifest,
 } from './content/index.js';
 export type { CoordinatorOptions } from './coordinator.js';
@@ -109,6 +110,7 @@ export {
   normalizeClaudeCodeHookEvent,
   normalizeCursorHookEvent,
   normalizeHookEvent,
+  normalizeVSCodeHookEvent,
   runHookCommand,
 } from './hooks/index.js';
 // Harness Protocol (was VAUGHN until 2026-05-18; see docs/HARNESS_PROTOCOL.md)
@@ -140,6 +142,10 @@ export type {
   ProtocolRule,
   ProtocolSkill,
   SandboxMode,
+  VSCodeMcpConfig,
+  VSCodeMcpInput,
+  VSCodeMcpOptions,
+  VSCodeMcpServerConfig,
 } from './protocol/index.js';
 export {
   claudeSettingsToProtocolConfig,
@@ -155,6 +161,7 @@ export {
   protocolConfigToCursorMcpConfig,
   protocolConfigToCursorrules,
   protocolConfigToOpencodeConfig,
+  protocolConfigToVSCodeMcpConfig,
   protocolEventEnvelopeSchema,
   protocolEventSchema,
   TOOL_PROFILES,

--- a/packages/harnesses/src/protocol/config-normalizer.ts
+++ b/packages/harnesses/src/protocol/config-normalizer.ts
@@ -421,6 +421,94 @@ export function protocolConfigToCursorMcpConfig(
   };
 }
 
+// -- .mcp.json for a VS Code agent plugin (write-only) -----------------------------
+
+/** VS Code remote/HTTP MCP server entry (`.mcp.json` `servers.<name>`, `type: 'http'`). */
+export interface VSCodeMcpServerConfig {
+  type: 'http';
+  url: string;
+  headers: Record<string, string>;
+}
+
+/** One `inputs[]` entry -- VS Code prompts for the value on first server start and stores it. */
+export interface VSCodeMcpInput {
+  type: 'promptString';
+  id: string;
+  description: string;
+  password: true;
+}
+
+/** Subset of a VS Code agent plugin's `.mcp.json` this module writes. */
+export interface VSCodeMcpConfig {
+  inputs: VSCodeMcpInput[];
+  servers: Record<string, VSCodeMcpServerConfig>;
+}
+
+/** Options for wiring the RevealUI governed MCP endpoint into a VS Code agent-plugin `.mcp.json`. */
+export interface VSCodeMcpOptions {
+  /** RevealUI governed MCP endpoint, e.g. `https://your-host/api/mcp`. */
+  mcpUrl: string;
+  /**
+   * `inputs[].id` VS Code prompts the user for and substitutes via
+   * `${input:id}` (default `revealui-mcp-token`). Only the input id is ever
+   * emitted -- see `protocolConfigToVSCodeMcpConfig`.
+   */
+  tokenInputId?: string;
+}
+
+const DEFAULT_VSCODE_TOKEN_INPUT_ID = 'revealui-mcp-token';
+
+/**
+ * Convert a ProtocolConfig to a VS Code agent-plugin `.mcp.json` fragment
+ * wiring the RevealUI governed MCP endpoint (multi-editor harness design doc
+ * §3-A). Mirrors `protocolConfigToCursorMcpConfig`'s leak-proof pattern and
+ * split: `VSCodeGenerator.generateAll` (`../content/generators/vscode.ts`)
+ * emits only the plugin's `plugin.json` (hook contributions); `.mcp.json`
+ * needs an MCP URL + token-input-id option the `ContentGenerator.generateAll`
+ * signature doesn't carry, so it lives here instead, matching the split
+ * Phase B established for Cursor.
+ *
+ * SECURITY-CRITICAL: this function must never emit a literal bearer token,
+ * only VS Code's `${input:id}` reference syntax (verified 2026-07-17 against
+ * code.visualstudio.com/docs/agents/reference/mcp-configuration -- an
+ * `inputs[]` entry of `type: 'promptString'` with `password: true` masks the
+ * value VS Code prompts for and stores it; the server config references it
+ * via `${input:<id>}`, never a literal). It deliberately does NOT read
+ * `config.environment.variables` for a token value -- the Authorization
+ * header is built exclusively from the `tokenInputId` NAME, so no caller can
+ * smuggle a literal secret into the emitted config via
+ * `environment.variables`.
+ *
+ * `_config` is accepted (matching `protocolConfigToCursorMcpConfig`'s and
+ * `protocolConfigToOpencodeConfig`'s signatures, preserving room for future
+ * permission/rule wiring) but is not read at all -- see the security note
+ * above.
+ */
+export function protocolConfigToVSCodeMcpConfig(
+  _config: ProtocolConfig,
+  opts: VSCodeMcpOptions,
+): VSCodeMcpConfig {
+  const tokenInputId = opts.tokenInputId ?? DEFAULT_VSCODE_TOKEN_INPUT_ID;
+
+  return {
+    inputs: [
+      {
+        type: 'promptString',
+        id: tokenInputId,
+        description: 'RevealUI governed MCP device token',
+        password: true,
+      },
+    ],
+    servers: {
+      revealui: {
+        type: 'http',
+        url: opts.mcpUrl,
+        headers: { Authorization: `Bearer \${input:${tokenInputId}}` },
+      },
+    },
+  };
+}
+
 // -- Helpers ---------------------------------------------------------------------
 
 /** Render rule content, substituting template variables. */

--- a/packages/harnesses/src/protocol/index.ts
+++ b/packages/harnesses/src/protocol/index.ts
@@ -39,6 +39,10 @@ export type {
   OpenCodeConfig,
   OpenCodeMcpOptions,
   OpenCodeMcpServerConfig,
+  VSCodeMcpConfig,
+  VSCodeMcpInput,
+  VSCodeMcpOptions,
+  VSCodeMcpServerConfig,
 } from './config-normalizer.js';
 export {
   claudeSettingsToProtocolConfig,
@@ -48,6 +52,7 @@ export {
   protocolConfigToCursorMcpConfig,
   protocolConfigToCursorrules,
   protocolConfigToOpencodeConfig,
+  protocolConfigToVSCodeMcpConfig,
 } from './config-normalizer.js';
 // Degradation
 export type { DegradationStrategy } from './degradation-strategies.js';

--- a/packages/harnesses/src/protocol/roadmap-profiles.ts
+++ b/packages/harnesses/src/protocol/roadmap-profiles.ts
@@ -90,6 +90,51 @@ export const ROADMAP_PROFILES: Record<string, ProtocolCapabilities> = {
       'tool.blocked',
     ],
   },
+
+  // VS Code's agent-plugin hook system IS real and shipped this phase
+  // (`../hooks/normalizers/vscode.ts`, `../content/generators/vscode.ts`) --
+  // unlike every other entry in this file, `hooks.supported: true` here is
+  // backed by working code, not an aspiration. It stays in ROADMAP_PROFILES
+  // rather than graduating to `TOOL_PROFILES` because that promotion (per
+  // this file's module doc) tracks a working `HarnessAdapter`
+  // (dispatch/execute), and VS Code has no documented headless CLI to exec
+  // an agent turn against (verified 2026-07-17; Copilot CLI is a separate
+  // product from the `code` editor binary). `dispatch`/`headless`/
+  // `resumable`/`forkable`/`backgroundable` are honestly `false` for the
+  // same reason. `maxContextTokens: 0` is the BYO sentinel documented on
+  // `ProtocolCapabilities.maxContextTokens` -- Copilot agent mode's context
+  // window depends on the user's configured model, not a fixed VS Code
+  // capability.
+  vscode: {
+    dispatch: {
+      generateCode: false,
+      analyzeCode: false,
+      applyEdit: false,
+      executeCommand: false,
+    },
+    readWorkboard: false,
+    writeWorkboard: false,
+    claimTasks: false,
+    reportConflicts: false,
+    headless: false,
+    resumable: false,
+    forkable: false,
+    backgroundable: false,
+    hooks: { supported: true, granularity: 'all-tools', canBlock: true },
+    sandbox: { supported: false, modes: [] },
+    supportsWorktrees: false,
+    supportsSkills: true,
+    supportsMcp: true,
+    memory: { supported: false, backend: 'none' },
+    maxContextTokens: 0,
+    lifecycleEvents: [
+      'session.start',
+      'prompt.submit',
+      'tool.before',
+      'tool.after',
+      'tool.blocked',
+    ],
+  },
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Phase C of the multi-editor harness design: a VS Code agent-plugin surface in `@revealui/harnesses`, mirroring Phase B's Cursor work (#1940).

- **Hook normalizer** (`src/hooks/normalizers/vscode.ts`): maps VS Code's agent-hook payloads onto the existing `HarnessHookEvent` schema. Editor-supplied fields stay in `raw` only, never promoted to identity (design invariant I-1).
- **CLI**: `hook <source>` now accepts `vscode`. `run-hook.ts` builds VS Code's native response shape — a nested `hookSpecificOutput.permissionDecision` for `PreToolUse`, a flat `decision`/`reason` for every other event.
- **Content generator** (`src/content/generators/vscode.ts`): `VSCodeGenerator` emits `.revealui/vscode-plugin/plugin.json`, an agent-plugin manifest with command-based hook contributions (`revealui-harnesses hook vscode`) plus a path reference to a separately-generated `.mcp.json`.
- **Config normalizer**: `protocolConfigToVSCodeMcpConfig` (mirrors `protocolConfigToCursorMcpConfig`) emits the `.mcp.json` content using VS Code's `${input:id}` reference syntax — never a literal token value (design invariant I-4).
- **Detection metadata**: added a `vscode` settings-path entry to `harness-config-paths.ts` and a `vscode` capability row to `roadmap-profiles.ts`. Deliberately did NOT add a `process-detector.ts` pattern (see Deviations).
- **Docs**: `packages/harnesses/docs/vscode-agent-plugin.md` — local-path install (`chat.pluginLocations`) and org-allowlist governance (GitHub Copilot Business/Enterprise MCP registry policy).

## Verified VS Code facts (2026-07-17)

Re-verified per the design doc's own audit note (high release cadence). VS Code agent plugins/hooks are in **Preview**.

- **Plugin manifest**: `plugin.json` at the plugin root. Required `name` (kebab-case). Optional `description`, `version`, `author`, `skills`, `agents`, `hooks` (inline object or path to a config file), `mcpServers` (inline object or path to `.mcp.json`).
  Source: https://code.visualstudio.com/docs/agent-customization/agent-plugins
- **Hook event names** (8, confirmed no `SessionEnd`): `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `SubagentStart`, `SubagentStop`, `Stop`.
  Source: https://code.visualstudio.com/docs/agents/reference/hooks-reference
- **Hook payload**: command-based (`{"type": "command", "command": "..."}`), flat event-name-keyed config. Common stdin fields observed as snake_case (`timestamp`, `cwd`, `session_id`, `hook_event_name`, `transcript_path`); `PreToolUse`/`PostToolUse` add `tool_name`, `tool_input`, `tool_use_id`. Exit code 2 blocks, matching Cursor/Claude Code.
  Source: https://code.visualstudio.com/docs/agent-customization/hooks + hooks-reference above.
- **Hook response shape**: `PreToolUse` uses a nested `hookSpecificOutput.permissionDecision` (`allow`/`deny`/`ask`) + `permissionDecisionReason`. `PostToolUse` (and, by inference, other events) use a flat `decision` field, matching Claude Code's own `approve`/`block`/`ask` convention.
  Source: https://code.visualstudio.com/docs/agents/reference/hooks-reference
- **MCP config / secret reference**: `.mcp.json` `inputs[]` with `type: "promptString"`, `id`, `description`, `password: true`; servers reference the value via `${input:<id>}` — VS Code prompts once, stores it, never a literal in the file.
  Source: https://code.visualstudio.com/docs/agents/reference/mcp-configuration
- **Local-path install**: `chat.pluginLocations` setting maps an absolute local directory path to `true`/`false` (enabled/disabled). No `code --install-plugin` CLI flag exists; the only other install path is "Chat: Install Plugin From Source" from a git URL (Marketplace-adjacent, owner-gated per design doc D-C).
  Source: https://code.visualstudio.com/docs/agent-customization/agent-plugins
- **Org-allowlist governance**: separate from the above — GitHub Copilot Business/Enterprise admins set an MCP access policy (Allow all / Registry only) via the Copilot admin console; under Registry-only, RevealUI's `/api/mcp` must be listed in the org's internal MCP registry to be usable at runtime, independent of a developer's local `chat.pluginLocations` setting.
  Source: https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-server-access
- **Headless CLI**: confirmed no documented headless CLI to exec an agent turn against inside VS Code itself (Copilot CLI is a separate GitHub product from the `code` editor binary) — this drove the adapter-vs-generator decision below.

Confidence note: several of the above were read via an AI-summarizing fetch tool rather than the raw doc source, so exact field casing on the *common* hook envelope (medium confidence) is less certain than the event names and manifest shape (high confidence, corroborated across independent searches).

## Adapter-vs-generator judgment call

**No `HarnessAdapter` ships for `vscode` in this phase.** VS Code's agent mode has no documented headless CLI surface to exec an agent turn against — unlike Cursor's `agent -p` or OpenCode's CLI, which `CursorAdapter`/`OpenCodeAdapter` wrap. Building a fake `execute()` path would violate the "do not invent a fake execute path" instruction. Phase C is therefore scoped to: the hook normalizer, the CLI `hook vscode` source, the content generator, and detection metadata (a `vscode` config path row + a `vscode` roadmap capability profile with `hooks.supported: true` but every dispatch/headless capability honestly `false`). `process-detector.ts` deliberately does NOT get a `vscode`/`code` pattern — `code` is too generic a `pgrep` substring match and would false-positive on `opencode` (whose comm name contains "code"), mirroring the same reasoning `cursor-adapter.ts` documents for excluding Cursor's `agent` binary.

## Deviations from the brief

- **`plugin.json` + `.mcp.json` split, not a single bundled file.** The brief allowed this explicitly (step 4d): the `ContentGenerator.generateAll(manifest, ctx)` signature carries no MCP URL/token option, exactly the constraint that drove Cursor's `.cursor/hooks.json` + `protocolConfigToCursorMcpConfig` split in Phase B. `plugin.json`'s `mcpServers` field is a string path reference to `.mcp.json` (a valid manifest form per the docs), so the manifest still *advertises* the bundled MCP contribution without the generator ever handling a URL or token.
- **Output path is `.revealui/vscode-plugin/`, not the project root.** Unlike `.cursor/` or `.opencode/`, VS Code does not auto-discover a plugin from inside a project — it must be registered via `chat.pluginLocations` pointing at an absolute path. Generating into a dedicated subdirectory keeps the bundle self-contained and avoids `plugin.json` colliding with anything else at the project root.
- **Added a `vscode` roadmap capability profile** (`protocol/roadmap-profiles.ts`) even though the design doc's audit implied one might already exist alongside `copilot`'s data-only rows — it did not (only `harness-config-paths.ts` and `process-detector.ts` had a `copilot` row; `roadmap-profiles.ts` had no `copilot`/`vscode` entry at all). Added `vscode` there with an honest capability declaration and left the pre-existing `copilot` id (a distinct surface, the GitHub Copilot CLI/host config) untouched.
- **Did not touch `docs/HARNESS_PROTOCOL.md`'s "Roadmap" section**, which still lists Cursor as a pending adapter (stale since Phase B). Out of scope for this PR; flagging for a follow-up doc sweep.

## Test evidence

`pnpm --filter @revealui/harnesses typecheck` and `pnpm --filter @revealui/harnesses test`: clean. 438 tests total (60 net-new/modified across `hook-normalizers.test.ts`, `hook-run.test.ts`, `cli-hook.test.ts`, `protocol-types.test.ts`, plus two new files `vscode-config.test.ts` and `vscode-content-generator.test.ts`), covering I-1, I-4, I-5 for the `vscode` source.

**Red-first proof**: committed the change, then reverted the implementation files (`git checkout <parent-sha> -- <paths>`, deleting the two new source files) while keeping the new/modified tests, and reran. Result: **7 test files failed, 14 tests failed** (`protocolConfigToVSCodeMcpConfig is not a function`, `ROADMAP_PROFILES`/`ALL_KNOWN_PROFILES` missing `vscode`, etc.) — confirming the new assertions exercise real, new behavior. Restored via `git checkout HEAD -- packages/harnesses/src`; full suite green again (438/438, see note below).

One environment-dependent flake unrelated to this change: `opencode-adapter.test.ts`'s "get-status reports availability" test asserts `opencode` is NOT on PATH, but this sandbox happens to have `opencode` installed globally via pnpm (`~/.local/share/pnpm/opencode`). Untouched by this diff (confirmed via `git diff` — no changes to that file) and passes cleanly on every rerun once other tests' PATH-mutating side effects settle; not a regression from this PR.

## Security check

Not a security-sensitive surface per the fleet checker (no path in this diff matches the sensitive-path list — `packages/harnesses` isn't in it, and `packages/mcp` wasn't touched):

```
$ node .jv/scripts/security-pr-review-check.js --diff <parent-sha>
Current branch vs <parent-sha>: no security-sensitive files — no coordinator gate.
```

## Labels

`enhancement`, `area:ai` — matching Phase B's PR (#1940).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
