### PR TITLE
fix(ci): migrate the smoke database before starting E2E servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,7 +498,10 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        # pgvector/pgvector bundles pgvector into postgres:16. The migrations
+        # applied below (0000_init CREATE EXTENSION, vector(768) columns) cannot
+        # run on vanilla postgres:16, same as the Drizzle Migrations job.
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,6 +536,17 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "true"
 
+      # The API server refuses to boot if it cannot write the audit_log table
+      # (GAP-355 audit-integrity: no serving without a working audit path).
+      # The smoke database starts empty, so migrate it before starting servers,
+      # exactly as the Drizzle Migrations job does for its own fresh Postgres.
+      # Without this the server exits at startup on a missing audit_log relation
+      # and "Wait for servers" times out.
+      - name: Apply migrations to the smoke database
+        run: pnpm --filter @revealui/db db:migrate
+        env:
+          POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+
       - name: Start API server
         run: pnpm --filter server start &
         env:


### PR DESCRIPTION
## Summary

Fixes the E2E Smoke failure that blocks the #1944 promotion. The E2E Smoke job starts its `smoke` Postgres empty and never runs migrations, then boots the servers. That was survivable until #1942 made the boot-time audit self-test **fatal** (GAP-355 audit-integrity: the server refuses to serve if it cannot write `audit_log`). Against the empty smoke DB the audit write hits a missing `audit_log` relation, the API server exits at startup, never binds :3004, and `Wait for servers` times out at 240s.

Root cause confirmed from the failed run: postgres logs `relation "audit_log" does not exist` and the server logs `Startup validation failed; exiting` from the `audit-storage-self-test`.

**Fix:** add a `pnpm --filter @revealui/db db:migrate` step against the smoke DB after the build and before the servers start — mirroring exactly what the `Drizzle Migrations` job already does for its own fresh Postgres. This is the correct fix (the code is behaving as designed — refuse to boot without a working audit path; the smoke env was under-provisioned), not a softening of the audit guard.

## Validation note

E2E Smoke only runs on promotions (`base_ref == main`), so it does not run on this feature→test PR. The fix is validated (a) locally — server boots against a migrated smoke DB and crashes against an un-migrated one (posted below) — and (b) definitively when #1944's E2E Smoke re-runs after this merges to `test`. CI-only change, not security-sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)