### PR TITLE
fix(security): classify the harnesses enforcement plane as security-sensitive

### DIFF
--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -95,6 +95,14 @@ const SECURITY_PATHS = [
   '.github/workflows/security-review-gate',
   '.github/workflows/sec-audit-label-guard',
   '.github/workflows/security.yml',
+  // Harness hook/policy enforcement plane. packages/harnesses/src/hooks/
+  // decides ALLOW/DENY for editor agent actions and emits the config that
+  // binds editors to it; the package's server surface forks caller-supplied
+  // agent commands. Added after an enforcement-plane PR merged over an
+  // outstanding request-changes because this list did not classify it as
+  // security-sensitive. Whole-package entry, matching packages/mcp//security//
+  // paywall/; adapters ride along fine. Keep in lockstep with the fleet checker.
+  'packages/harnesses/',
 ];
 
 // A recorded reviewer verdict = an approving GH review OR one of these labels.


### PR DESCRIPTION
## Summary

The harness hook/policy enforcement plane (`packages/harnesses/src/hooks/`: deny/ask policy evaluation, editor permission responses, receipt spool, and the generators that emit the config binding editors to it) decides allow/deny for editor agent actions, and the package's server surface forks caller-supplied agent commands. Neither security-review gate covered any `packages/harnesses/` path, so an enforcement-plane PR merged over an outstanding request-changes without the gate holding it.

Adds `packages/harnesses/` as a whole-package entry to `SECURITY_PATHS`, matching how `packages/mcp/`, `packages/security/`, and `packages/paywall/` are already handled. Whole-package (rather than a subpath list) closes the drift class permanently. Kept in lockstep with the fleet checker (paired private-repo change).

## Verification

- Syntax valid; `--diff` post-commit correctly self-classifies this gate change as security-sensitive (self-protection entry).
- The identical entry in the fleet checker was verified against a real PR touching `packages/harnesses/`: it flipped from "no security-sensitive files" to a HOLD requiring a recorded verdict.

This PR is itself security-sensitive (edits the gate), so it needs a recorded reviewer verdict before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)