### PR TITLE
fix(a11y): skip-to-content link, aria-live feedback, fix TOS label nesting

### DIFF
--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -326,7 +326,15 @@ function SignupContent({ apiUrl }: SignupFormProps) {
             required
             className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-[var(--tenant-brand,#2563eb)] accent-[var(--tenant-brand,#2563eb)]"
           />
-          <label htmlFor="tos" className="text-sm text-zinc-600 dark:text-zinc-400">
+          {/* The checkbox's accessible name comes from this sr-only label rather than
+           * wrapping the visible text in a <label>, because the visible text contains
+           * <Link> anchors: a <label> nesting interactive links is an a11y anti-pattern
+           * (ambiguous click target between the label's implicit toggle and the link's
+           * own navigation, and inconsistent accessible-name computation). */}
+          <label htmlFor="tos" className="sr-only">
+            Accept the Terms of Service and Privacy Policy
+          </label>
+          <span className="text-sm text-zinc-600 dark:text-zinc-400">
             I agree to the{' '}
             <Link
               href="/legal/terms"
@@ -343,7 +351,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
             >
               Privacy Policy
             </Link>
-          </label>
+          </span>
         </div>
 
         <Button type="submit" disabled={anyLoading || !tosAccepted} className="w-full">

--- a/apps/marketing/app/components/ContactForm.tsx
+++ b/apps/marketing/app/components/ContactForm.tsx
@@ -80,7 +80,7 @@ export function ContactForm() {
 
   if (status === 'success') {
     return (
-      <Callout variant="success" title="Message sent">
+      <Callout variant="success" title="Message sent" role="status">
         <p className="text-sm">
           We&apos;ll get back to you within 1-2 business days.{' '}
           <a
@@ -152,7 +152,11 @@ export function ContactForm() {
           placeholder="Tell us about your project or question..."
         />
       </FormField>
-      {status === 'error' && <Callout variant="error">{errorMessage}</Callout>}
+      {status === 'error' && (
+        <Callout variant="error" role="alert">
+          {errorMessage}
+        </Callout>
+      )}
       <Button
         type="submit"
         variant="primary"

--- a/apps/marketing/app/components/NewsletterSignup.tsx
+++ b/apps/marketing/app/components/NewsletterSignup.tsx
@@ -27,6 +27,7 @@ export function NewsletterSignup({ variant = 'inline' }: { variant?: 'inline' | 
   if (status === 'success') {
     return (
       <p
+        role="status"
         className={`animate-[fade-in_300ms_ease-out] text-sm font-medium text-primary ${
           variant === 'stacked' ? 'text-center' : ''
         }`}
@@ -58,7 +59,11 @@ export function NewsletterSignup({ variant = 'inline' }: { variant?: 'inline' | 
         >
           {status === 'loading' ? 'Subscribing…' : 'Subscribe'}
         </Button>
-        {status === 'error' && <p className="text-xs text-destructive">{message}</p>}
+        {status === 'error' && (
+          <p role="alert" className="text-xs text-destructive">
+            {message}
+          </p>
+        )}
         <p className="text-xs text-muted-foreground">
           Product updates and engineering insights. No spam.
         </p>
@@ -92,7 +97,11 @@ export function NewsletterSignup({ variant = 'inline' }: { variant?: 'inline' | 
           Subscribe
         </Button>
       </div>
-      {status === 'error' && <p className="text-xs text-destructive">{message}</p>}
+      {status === 'error' && (
+        <p role="alert" className="text-xs text-destructive">
+          {message}
+        </p>
+      )}
     </form>
   );
 }

--- a/apps/marketing/app/layouts/RootLayout.tsx
+++ b/apps/marketing/app/layouts/RootLayout.tsx
@@ -4,8 +4,14 @@ import { NavBar } from '../components/NavBar';
 export function RootLayout({ children }: { children: ReactNode }) {
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground"
+      >
+        Skip to content
+      </a>
       <NavBar />
-      {children}
+      <main id="main-content">{children}</main>
     </>
   );
 }

--- a/apps/marketing/app/routes/ClaimsPage.tsx
+++ b/apps/marketing/app/routes/ClaimsPage.tsx
@@ -214,7 +214,9 @@ export function ClaimsPage() {
         </div>
       </nav>
 
-      <main className="px-6 py-4 lg:px-8">
+      {/* RootLayout already supplies the page's <main> landmark; use a div here
+       * to avoid nesting <main> elements (invalid HTML, duplicate a11y landmark). */}
+      <div className="px-6 py-4 lg:px-8">
         <div className="mx-auto max-w-3xl">
           {FILE_SECTIONS.map((section, i) => (
             <section
@@ -258,7 +260,7 @@ export function ClaimsPage() {
             </section>
           ))}
         </div>
-      </main>
+      </div>
 
       <section className="border-t border-border bg-muted/40 px-6 py-16 lg:px-8">
         <div className="mx-auto max-w-3xl space-y-4">


### PR DESCRIPTION
## Summary
MASTER_PLAN P1 a11y sweep (3 of 4 sub-items were actually broken; the mobile-menu focus trap was already fixed):

- Add a skip-to-content link + `<main id="main-content">` landmark to `apps/marketing/app/layouts/RootLayout.tsx` (WCAG 2.4.1 Bypass Blocks). Adjusted `ClaimsPage.tsx`'s own `<main>` to a `<div>` to avoid nested `<main>` landmarks.
- Mark form success/error feedback as ARIA live regions: `role="status"` on success in `ContactForm.tsx` / `NewsletterSignup.tsx`, `role="alert"` on error paths (both variants of `NewsletterSignup.tsx`).
- Stop nesting the Terms of Service / Privacy Policy links inside the signup TOS checkbox's `<label>` in `apps/admin/src/app/(frontend)/signup/SignupForm.tsx` — ambiguous click target between the label's implicit toggle and the links' own navigation. The checkbox now gets its accessible name from a `sr-only` label; the visible text with links renders as a sibling `<span>`.
- Verified already fixed, no change needed: the mobile nav's focus trap (`apps/marketing/app/components/NavBar.tsx:54` already calls `useFocusTrap(menuRef, open)`).

## Test plan
- [x] `pnpm --filter admin typecheck` clean
- [x] `pnpm --filter marketing typecheck` clean
- [x] `pnpm --filter marketing test` — 12 files / 78 tests passed
- [x] `pnpm --filter admin exec vitest run` on `SignupForm.test.tsx` — 5 tests passed
- [x] `pnpm gate:quick` — PASS (0 violations)
- [x] `npx biome check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)