### PR TITLE
fix(admin): route free-tier signup to /welcome, not the cold dashboard

### DIFF
--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -105,7 +105,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
           if (plan) {
             navigateAfterAuthChange(`/account/billing?upgrade=${plan}`);
           } else {
-            navigateAfterAuthChange('/');
+            navigateAfterAuthChange('/welcome');
           }
         } else {
           setAwaitingVerification(true);
@@ -143,7 +143,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
       if (result.backupCodes?.length) {
         setBackupCodes(result.backupCodes);
       } else {
-        navigateAfterAuthChange(plan ? `/account/billing?upgrade=${plan}` : '/');
+        navigateAfterAuthChange(plan ? `/account/billing?upgrade=${plan}` : '/welcome');
       }
     }
   };
@@ -220,7 +220,9 @@ function SignupContent({ apiUrl }: SignupFormProps) {
           Each code can only be used once. Keep them somewhere safe.
         </p>
         <Button
-          onClick={() => navigateAfterAuthChange(plan ? `/account/billing?upgrade=${plan}` : '/')}
+          onClick={() =>
+            navigateAfterAuthChange(plan ? `/account/billing?upgrade=${plan}` : '/welcome')
+          }
           className="w-full"
         >
           I&apos;ve saved my codes

--- a/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
@@ -96,7 +96,7 @@ describe('SignupForm post-signup routing', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('sends an auto-verified (first) user straight in', async () => {
+  it('sends an auto-verified (first) free-tier user to /welcome, not the cold dashboard', async () => {
     vi.stubGlobal(
       'fetch',
       vi
@@ -109,7 +109,7 @@ describe('SignupForm post-signup routing', () => {
     fillAndSubmit();
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/welcome');
     });
     expect(mockPush).not.toHaveBeenCalled();
     expect(screen.queryByText('Check your inbox')).not.toBeInTheDocument();
@@ -137,7 +137,7 @@ describe('SignupForm post-signup routing', () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  it('ignores an unknown ?plan= value and routes home', async () => {
+  it('ignores an unknown ?plan= value and routes to /welcome as a free-tier signup', async () => {
     mockPlanParam = 'enterprise-deluxe';
     vi.stubGlobal(
       'fetch',
@@ -151,7 +151,7 @@ describe('SignupForm post-signup routing', () => {
     fillAndSubmit();
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/welcome');
     });
     expect(mockPush).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
MASTER_PLAN P1 item: free-tier (no `?plan=`) signups landed on `/` (the cold dashboard) after email verification, passkey registration, and the backup-codes continue button, even though an existing `/welcome` onboarding route (`apps/admin/src/app/(frontend)/welcome/page.tsx`) was never wired to it.

- `apps/admin/src/app/(frontend)/signup/SignupForm.tsx:108` — auto-verified free-tier user after standard signup now routes to `/welcome` instead of `/`.
- `SignupForm.tsx:146` — passkey signup free-tier path, same fix.
- `SignupForm.tsx:224` — the "I've saved my codes" continue button (backup-codes screen) free-tier path, same fix.
- Paid-tier (`?plan=pro|max`) signups are unchanged — they still route to `/account/billing?upgrade=<plan>`.

## Test plan
- [x] Proved red: reverted `SignupForm.tsx` to the `origin/test` version while keeping the updated test expectations — 2 of 5 tests failed as expected (`expected '/' to equal '/welcome'`).
- [x] Restored the fix — `pnpm --filter admin exec vitest run` on `SignupForm.test.tsx` — 5/5 passed.
- [x] `pnpm --filter admin typecheck` clean.
- [x] `npx biome check` on touched files — clean.
- [x] `pnpm gate:quick` — PASS (0 violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)