### PR TITLE
fix(cli): declare react-compiler and @types deps in scaffold templates

### DIFF
--- a/.changeset/create-revealui-scaffold-build-fix.md
+++ b/.changeset/create-revealui-scaffold-build-fix.md
@@ -1,0 +1,10 @@
+---
+"@revealui/cli": patch
+---
+
+fix the four Next.js scaffold templates (starter, basic-blog, e-commerce, portfolio) so `pnpm build` succeeds out of the box with no manual dependency additions and no network self-healing:
+
+- declare `babel-plugin-react-compiler` as a devDependency. `next.config.mjs` sets `reactCompiler: true`, but Next lists the plugin only as an optional peer dependency, so pnpm never installed it and `pnpm build` failed with "Failed to resolve package babel-plugin-react-compiler".
+- declare `@types/react` and `@types/node` as devDependencies so an offline or `--frozen-lockfile` build doesn't depend on Next auto-installing them at build time.
+
+`starter-native` (Vite, not Next) is unaffected.

--- a/packages/cli/src/__tests__/template-structure.test.ts
+++ b/packages/cli/src/__tests__/template-structure.test.ts
@@ -189,6 +189,24 @@ describe('package.json integrity after scaffolding', () => {
       expect(pkg.dependencies?.['@revealui/core']).toBeDefined();
       expect(pkg.dependencies?.['@revealui/core']).toMatch(/^(latest|\^?\d+\.\d+)/);
     });
+
+    // Regression test: next.config.mjs sets reactCompiler: true, but next lists
+    // babel-plugin-react-compiler only as an OPTIONAL peer dependency, so pnpm
+    // never installs it unless the template declares it directly. Without it,
+    // `pnpm build` fails with "Failed to resolve package babel-plugin-react-compiler".
+    // @types/react and @types/node must also be declared directly so an offline
+    // or --frozen-lockfile build doesn't depend on Next auto-installing them.
+    it(`${template}: package.json declares babel-plugin-react-compiler and @types/{react,node}`, async () => {
+      const projectPath = path.join(tmpDir, `${template}-compiler-deps`);
+      await createProject(baseConfig(template, projectPath));
+
+      const pkg = JSON.parse(
+        await fs.readFile(path.join(projectPath, 'package.json'), 'utf-8'),
+      ) as { devDependencies?: Record<string, string> };
+      expect(pkg.devDependencies?.['babel-plugin-react-compiler']).toBeDefined();
+      expect(pkg.devDependencies?.['@types/react']).toBeDefined();
+      expect(pkg.devDependencies?.['@types/node']).toBeDefined();
+    });
   }
 });
 

--- a/packages/cli/templates/basic-blog/package.json
+++ b/packages/cli/templates/basic-blog/package.json
@@ -29,6 +29,9 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@tailwindcss/postcss": "^4.1.0",
+    "@types/node": "^25.9.4",
+    "@types/react": "^19.2.17",
+    "babel-plugin-react-compiler": "^1.0.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^6.0.0",
     "vitest": "^4.0.0"

--- a/packages/cli/templates/e-commerce/package.json
+++ b/packages/cli/templates/e-commerce/package.json
@@ -29,6 +29,9 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@tailwindcss/postcss": "^4.1.0",
+    "@types/node": "^25.9.4",
+    "@types/react": "^19.2.17",
+    "babel-plugin-react-compiler": "^1.0.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^6.0.0",
     "vitest": "^4.0.0"

--- a/packages/cli/templates/portfolio/package.json
+++ b/packages/cli/templates/portfolio/package.json
@@ -29,6 +29,9 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@tailwindcss/postcss": "^4.1.0",
+    "@types/node": "^25.9.4",
+    "@types/react": "^19.2.17",
+    "babel-plugin-react-compiler": "^1.0.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^6.0.0",
     "vitest": "^4.0.0"

--- a/packages/cli/templates/starter/package.json
+++ b/packages/cli/templates/starter/package.json
@@ -29,6 +29,9 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@tailwindcss/postcss": "^4.1.0",
+    "@types/node": "^25.9.4",
+    "@types/react": "^19.2.17",
+    "babel-plugin-react-compiler": "^1.0.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^6.0.0",
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary

Fixes a verified out-of-the-box build failure in `create-revealui`: scaffolding the default `starter` template (or `basic-blog`/`e-commerce`/`portfolio`, which share the same package.json/next.config.mjs shape) and running `pnpm build` fails with:

```
Failed to resolve package babel-plugin-react-compiler while attempting to resolve React Compiler
```

**Root cause** (`packages/cli/templates/{starter,basic-blog,e-commerce,portfolio}/next.config.mjs:3`): `reactCompiler: true` is set top-level (deliberately, added in c539abda7 for the Next 16 / TS 6 template update), but `next@16.2.10`'s own `peerDependenciesMeta` marks `babel-plugin-react-compiler` **optional**, so pnpm never installs it from the template's `package.json:29-35` devDependencies block — it was never declared there.

**Secondary defect**: `@types/react` / `@types/node` aren't declared in the templates' devDependencies despite `tsconfig.json` shipping. Next auto-installs them at build time, which only works online and breaks under `--frozen-lockfile` / offline builds.

## reactCompiler keep-vs-remove decision

Kept `reactCompiler: true` and fixed the dependency, rather than removing the flag. Evidence:

- The fleet's own Next.js app (`apps/admin`) does **not** set `reactCompiler` and does not depend on `babel-plugin-react-compiler` — so the "does the fleet use it" convention check comes back negative for admin.
- However, `git log` on the template's `next.config.mjs` shows the flag was **intentionally** added/promoted in commit c539abda7 ("fix(cli): update templates for Next.js 16 and TypeScript 6" — "Move reactCompiler from experimental to top-level (all 4 templates)"). It's deliberate template-modernization for scaffolded customer apps, not accidental drift.
- The verified failure's own manual workaround (`pnpm add -D babel-plugin-react-compiler`) is the direct, minimal, lower-risk fix that matches the documented root cause. Removing the flag would revert intentional prior work and change scaffolded-app behavior beyond what the bug report calls for.

Documenting this here per the task's request to state the decision + evidence; happy to revisit if the fleet convention should instead be "off by default in scaffolds."

## Changes

- `packages/cli/templates/{starter,basic-blog,e-commerce,portfolio}/package.json`: add `babel-plugin-react-compiler@^1.0.0`, `@types/react@^19.2.17`, `@types/node@^25.9.4` to devDependencies (versions match the monorepo's own catalog pins for the same TS 6 / React 19 pairing).
- `packages/cli/src/__tests__/template-structure.test.ts`: new regression test per template asserting `babel-plugin-react-compiler`, `@types/react`, `@types/node` are declared.
- `.changeset/create-revealui-scaffold-build-fix.md`: patch bump for `@revealui/cli` (cascades to `create-revealui` via `workspace:*` + `updateInternalDependencies: patch`).

`starter-native` (Vite, not Next.js) doesn't set `reactCompiler` and is unaffected.

## Verification

Built `@revealui/cli` from this branch (`pnpm turbo build --filter=@revealui/cli`) and invoked its bin directly (`node packages/cli/bin/create-revealui.js starter-app -t starter -y --skip-git --skip-install`) to scaffold a `starter` app from the modified local template into a scratch directory outside the monorepo. Ran `pnpm install` (real npm registry, no workspace linking) then `pnpm build`:

```
+ babel-plugin-react-compiler 1.0.0
+ @types/node 25.9.5 (26.1.1 is available)
+ @types/react 19.2.17
...
▲ Next.js 16.2.10 (Turbopack)
✓ Compiled successfully in 5.8s
  Running TypeScript ...
  Finished TypeScript in 5.2s ...
✓ Generating static pages using 4 workers (3/3) in 782ms
```

Build passed with zero manual dependency additions.

Also ran `pnpm --filter @revealui/cli test` (211/211 passing, including the new regression tests) and `pnpm gate:quick` (full pass).

## Test plan

- [x] `pnpm --filter @revealui/cli test` — 211/211 passing
- [x] `pnpm gate:quick` — full pass
- [x] Scaffolded `starter` from the modified local template into a scratch dir, `pnpm install` + `pnpm build` passed with zero manual dependency additions
- [ ] Owner: confirm the reactCompiler keep decision above, or ask for removal instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
