### PR TITLE
feat(db): audit_log ONE DOOR — single write path + CI enforcer (GAP-355 Stage 2)

### DIFF
--- a/.changeset/gap-355-audit-one-door.md
+++ b/.changeset/gap-355-audit-one-door.md
@@ -1,0 +1,5 @@
+---
+'@revealui/db': minor
+---
+
+audit_log ONE DOOR (GAP-355 Stage 2): `DrizzleAuditStore.append`/`appendBatch` now accept optional `signature`/`previousSignature` pass-through, so every `audit_log` writer routes through the single store (a new CI enforcer fails the build on any `insert(auditLog)` outside it). Absent values persist NULL, unchanged from Stage 1. Signing itself moves into the store in Stage 3.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
       - name: Empty-catch validation (hard fail)
         run: pnpm validate:empty-catch
 
+      - name: audit_log ONE DOOR validation (hard fail)
+        run: pnpm validate:audit-one-door
+
       - name: Seed script wiring validation (hard fail)
         run: pnpm validate:seed-wiring
 

--- a/apps/admin/src/app/api/setup/route.ts
+++ b/apps/admin/src/app/api/setup/route.ts
@@ -95,14 +95,15 @@ export async function POST(request: Request): Promise<NextResponse<BootstrapResu
       // Audit log — non-fatal.
       try {
         const { hostname } = await import('node:os');
-        const { auditLog } = await import('@revealui/db/schema');
+        const { DrizzleAuditStore } = await import('@revealui/db');
         const { classifyAuditWriteFailure, recordAuditWriteResult } = await import(
           '@revealui/core/security'
         );
         const eventId = crypto.randomUUID();
         try {
-          await db.insert(auditLog).values({
+          await new DrizzleAuditStore(db).append({
             id: eventId,
+            timestamp: new Date(),
             eventType: 'admin.bootstrap.completed',
             severity: 'info',
             agentId: 'web',

--- a/apps/server/src/lib/mcp-audit.ts
+++ b/apps/server/src/lib/mcp-audit.ts
@@ -41,8 +41,7 @@
 
 import { createHmac, randomUUID } from 'node:crypto';
 import { classifyAuditWriteFailure, recordAuditWriteResult } from '@revealui/core/security';
-import { getClient } from '@revealui/db';
-import { auditLog } from '@revealui/db/schema';
+import { DrizzleAuditStore, getClient } from '@revealui/db';
 
 export type McpAuditOutcome = 'invoked' | 'denied' | 'failed';
 
@@ -195,21 +194,21 @@ async function appendReceipt(input: McpAuditInput): Promise<void> {
   );
 
   try {
-    await getClient()
-      .insert(auditLog)
-      .values({
-        id,
-        timestamp,
-        eventType,
-        severity,
-        agentId,
-        taskId: null,
-        sessionId: input.sessionId ?? null,
-        payload,
-        policyViolations: [],
-        signature,
-        previousSignature,
-      });
+    // ONE DOOR (GAP-355 Stage 2): route through the single `insert(auditLog)`
+    // site in DrizzleAuditStore. The signature is still computed here (Stage 3
+    // moves signing into an injected signer) and passed as a value.
+    await new DrizzleAuditStore(getClient()).append({
+      id,
+      timestamp,
+      eventType,
+      severity,
+      agentId,
+      sessionId: input.sessionId ?? undefined,
+      payload,
+      policyViolations: [],
+      signature,
+      previousSignature,
+    });
     lastMcpSignature = signature;
     recordAuditWriteResult({ ok: true, eventId: id, eventType });
   } catch (err) {

--- a/apps/server/src/routes/api-keys.ts
+++ b/apps/server/src/routes/api-keys.ts
@@ -13,10 +13,10 @@ import crypto from 'node:crypto';
 import { LLM_PROVIDERS } from '@revealui/contracts';
 import { logger } from '@revealui/core/observability/logger';
 import { classifyAuditWriteFailure, recordAuditWriteResult } from '@revealui/core/security';
-import { getClient, withTransaction } from '@revealui/db';
+import { DrizzleAuditStore, getClient, withTransaction } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
 import { encryptApiKey, redactApiKey } from '@revealui/db/crypto';
-import { auditLog, tenantProviderConfigs, userApiKeys } from '@revealui/db/schema';
+import { tenantProviderConfigs, userApiKeys } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, eq } from 'drizzle-orm';
 import type { Context } from 'hono';
@@ -41,8 +41,9 @@ async function recordCredentialEvent(
 ): Promise<void> {
   const eventId = crypto.randomUUID();
   try {
-    await db.insert(auditLog).values({
+    await new DrizzleAuditStore(db).append({
       id: eventId,
+      timestamp: new Date(),
       eventType,
       severity: 'info',
       agentId: userId,

--- a/apps/server/src/services/revmarket-executor.ts
+++ b/apps/server/src/services/revmarket-executor.ts
@@ -30,8 +30,8 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
-import { getClient } from '@revealui/db';
-import { agentSkills, auditLog, marketplaceAgents, taskSubmissions } from '@revealui/db/schema';
+import { DrizzleAuditStore, getClient } from '@revealui/db';
+import { agentSkills, marketplaceAgents, taskSubmissions } from '@revealui/db/schema';
 import { and, eq, sql } from 'drizzle-orm';
 
 import { forkProvider, type SandboxProvider } from './revmarket-sandbox/index.js';
@@ -404,8 +404,9 @@ async function writeAuditEntry(
   const db = getClient();
 
   try {
-    await db.insert(auditLog).values({
+    await new DrizzleAuditStore(db).append({
       id: crypto.randomUUID(),
+      timestamp: new Date(),
       eventType: `revmarket:task:${status}`,
       severity: status === 'failed' ? 'warn' : 'info',
       agentId,
@@ -417,7 +418,7 @@ async function writeAuditEntry(
         artifactCount: result.artifacts.length,
         error: result.error ?? null,
       },
-      timestamp: new Date(),
+      policyViolations: [],
     });
   } catch (err) {
     // Audit trail failures must not break task completion

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "validate:changelogs": "tsx scripts/validate/changelog-format.ts",
     "validate:empty-catch": "tsx scripts/validate/empty-catch.ts",
     "validate:as-never-values": "tsx scripts/validate/as-never-values.ts",
+    "validate:audit-one-door": "tsx scripts/validate/audit-log-single-door.ts",
     "validate:kek-rotation": "vitest run scripts/security/__tests__/rotate-kek.test.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
     "validate:prod-env": "tsx scripts/validate/prod-env.ts",

--- a/packages/db/src/audit-store.ts
+++ b/packages/db/src/audit-store.ts
@@ -27,6 +27,17 @@ export interface AuditEntry {
   sessionId?: string;
   payload: Record<string, unknown>;
   policyViolations: string[];
+  /**
+   * Optional per-row signature and its predecessor (the governed-MCP receipt
+   * stream chains these). Pass-through only: this store does NOT compute a
+   * signature — GAP-355 Stage 2 makes `append` the single `insert(auditLog)`
+   * door, so a caller that signs (today only `mcp-audit.ts`) hands its value
+   * here instead of inserting directly. Absent → columns persist NULL, which
+   * is the honest Stage-1 state for unsigned rows. Stage 3 moves signing into
+   * an injected signer so callers stop computing it themselves.
+   */
+  signature?: string | null;
+  previousSignature?: string | null;
 }
 
 /** Filters for querying audit entries */
@@ -65,6 +76,8 @@ export class DrizzleAuditStore {
       sessionId: entry.sessionId ?? null,
       payload: entry.payload,
       policyViolations: entry.policyViolations,
+      signature: entry.signature ?? null,
+      previousSignature: entry.previousSignature ?? null,
     });
   }
 
@@ -83,6 +96,8 @@ export class DrizzleAuditStore {
         sessionId: entry.sessionId ?? null,
         payload: entry.payload,
         policyViolations: entry.policyViolations,
+        signature: entry.signature ?? null,
+        previousSignature: entry.previousSignature ?? null,
       })),
     );
   }

--- a/scripts/admin/bootstrap.ts
+++ b/scripts/admin/bootstrap.ts
@@ -157,14 +157,15 @@ async function main(): Promise<void> {
 
   // Audit log entry
   {
-    const { auditLog } = await import('@revealui/db/schema');
+    const { DrizzleAuditStore } = await import('@revealui/db');
     const { classifyAuditWriteFailure, recordAuditWriteResult } = await import(
       '@revealui/core/security'
     );
     const eventId = randomUUID();
     try {
-      await db.insert(auditLog).values({
+      await new DrizzleAuditStore(db).append({
         id: eventId,
+        timestamp: new Date(),
         eventType: 'admin.bootstrap.completed',
         severity: 'info',
         agentId: 'cli',

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -379,6 +379,11 @@ async function gate(): Promise<void> {
         args: ['validate:as-never-values'],
       },
       {
+        name: 'audit_log ONE DOOR (hard fail)',
+        command: 'pnpm',
+        args: ['validate:audit-one-door'],
+      },
+      {
         name: 'Stripe-client consolidation (hard fail)',
         command: 'pnpm',
         args: ['validate:stripe-client'],

--- a/scripts/validate/__tests__/audit-log-single-door.test.ts
+++ b/scripts/validate/__tests__/audit-log-single-door.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { findInsertAuditLogCalls } from '../audit-log-single-door.js';
+
+describe('findInsertAuditLogCalls', () => {
+  it('flags a direct insert(auditLog) writer', () => {
+    const src = `
+      await db.insert(auditLog).values({
+        id,
+        eventType: 'x',
+        agentId: 'y',
+        severity: 'info',
+        payload: {},
+        policyViolations: [],
+      });
+    `;
+    const hits = findInsertAuditLogCalls(src, 'fixture.ts');
+    expect(hits).toHaveLength(1);
+  });
+
+  it('flags a namespaced insert(schema.auditLog) writer', () => {
+    const src = `await db.insert(schema.auditLog).values({ id });`;
+    expect(findInsertAuditLogCalls(src, 'fixture.ts')).toHaveLength(1);
+  });
+
+  it('flags insert(auditLog) even without a chained .values() (partial builder)', () => {
+    const src = `const q = getClient().insert(auditLog);`;
+    expect(findInsertAuditLogCalls(src, 'fixture.ts')).toHaveLength(1);
+  });
+
+  it('does NOT flag a read of the audit_log table', () => {
+    const src = `const rows = await db.select().from(auditLog).where(eq(auditLog.id, id));`;
+    expect(findInsertAuditLogCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('does NOT flag an insert into a different table', () => {
+    const src = `await db.insert(users).values({ id, email });`;
+    expect(findInsertAuditLogCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('does NOT flag routing through the store (append is not an insert() call)', () => {
+    const src = `await new DrizzleAuditStore(db).append({ id, eventType, agentId, severity, payload, policyViolations: [] });`;
+    expect(findInsertAuditLogCalls(src, 'fixture.ts')).toHaveLength(0);
+  });
+
+  it('flags multiple external writers in one file', () => {
+    const src = `
+      await db.insert(auditLog).values({ id: a });
+      await other.insert(auditLog).values({ id: b });
+    `;
+    expect(findInsertAuditLogCalls(src, 'fixture.ts')).toHaveLength(2);
+  });
+});

--- a/scripts/validate/audit-log-single-door-allowlist.json
+++ b/scripts/validate/audit-log-single-door-allowlist.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": []
+}

--- a/scripts/validate/audit-log-single-door.ts
+++ b/scripts/validate/audit-log-single-door.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env tsx
+// console-allowed
+
+/**
+ * `audit_log` ONE DOOR — CI validator (GAP-355 Stage 2).
+ *
+ * The audit-receipt architecture (docs/decisions/2026-07-12-audit-receipt-architecture.md
+ * §5) requires exactly ONE code path that writes `audit_log`, so that every
+ * later integrity property (append-only enforcement, per-row signing, anchoring)
+ * has a single chokepoint to attach to. Without a mechanical enforcer, "door
+ * number seven reappears within a quarter" — which is exactly the state Stage 2
+ * collapsed: seven writers, one signer, an unclosable chain.
+ *
+ * This validator fails CI on any `.insert(auditLog)` / `.insert(schema.auditLog)`
+ * call outside the single door (`packages/db/src/audit-store.ts`,
+ * `DrizzleAuditStore`). Every other writer routes through `DrizzleAuditStore.append`
+ * / `.appendBatch`.
+ *
+ * Uses the TypeScript compiler API (`ts.createSourceFile` + `ts.forEachChild`),
+ * mirroring scripts/validate/as-never-values.ts, rather than authored regex, per
+ * the fleet's no-regex rule. This is a SYNTACTIC check with no type-checker: it
+ * matches `.insert(` whose FIRST argument is the identifier `auditLog` (or a
+ * property access ending in `.auditLog`). In this codebase the drizzle `auditLog`
+ * table symbol is the only thing ever passed as `insert(auditLog)`, so the
+ * syntactic match is exact in practice; a false match on an unrelated
+ * `.insert(auditLog)` would still be a genuine reason to route through the store.
+ *
+ * Pre-existing exceptions (there should be none after Stage 2) are enumerated in
+ * audit-log-single-door-allowlist.json with reasons (mirrors as-never-values.ts /
+ * raw-sql.ts); new violations fail CI unless explicitly allowlisted.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+
+const ALLOWLIST_PATH = join(REPO_ROOT, 'scripts/validate/audit-log-single-door-allowlist.json');
+
+const SCAN_ROOTS = ['apps', 'packages', 'scripts'];
+
+const SOURCE_EXTS = new Set(['.ts', '.tsx', '.mts', '.cts']);
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.turbo',
+  '.next',
+  'coverage',
+  'playwright-report',
+  'test-results',
+  'opensrc',
+]);
+
+/**
+ * The ONE DOOR. `insert(auditLog)` is permitted ONLY here. This is the built-in
+ * allowance; the JSON allowlist is for documented, temporary exceptions only.
+ */
+const ALLOWED_DOOR_FILES = new Set(['packages/db/src/audit-store.ts']);
+
+/**
+ * Test files exercise the door directly (PGlite integration tests seed rows via
+ * a raw insert to assert the store's own contract). They are not runtime writers
+ * and are excluded, matching as-never-values.ts's test exclusion.
+ */
+const EXCLUDED_PATH_SEGMENTS = [
+  '__tests__/',
+  '__mocks__/',
+  '.test.ts',
+  '.test.tsx',
+  '.spec.ts',
+  '.spec.tsx',
+  '.integration.test.ts',
+  '.integration.test.tsx',
+  '.e2e.ts',
+  '.e2e.tsx',
+  'scripts/validate/',
+  '/generated/',
+];
+
+// =============================================================================
+// Allowlist loading
+// =============================================================================
+
+interface AllowlistEntry {
+  path: string;
+  line?: number;
+  reason: string;
+}
+
+interface AllowlistFile {
+  version: number;
+  entries?: AllowlistEntry[];
+}
+
+interface AllowlistMatcher {
+  byPath: Map<string, AllowlistEntry[]>;
+}
+
+function loadAllowlist(): AllowlistMatcher {
+  if (!existsSync(ALLOWLIST_PATH)) {
+    return { byPath: new Map() };
+  }
+  const raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8')) as AllowlistFile;
+  const byPath = new Map<string, AllowlistEntry[]>();
+  for (const entry of raw.entries ?? []) {
+    if (!entry.reason?.trim()) {
+      throw new Error(
+        `audit-log-single-door-allowlist.json: entry "${entry.path}${entry.line ? `:${entry.line}` : ''}" is missing a non-empty reason.`,
+      );
+    }
+    const list = byPath.get(entry.path) ?? [];
+    list.push(entry);
+    byPath.set(entry.path, list);
+  }
+  return { byPath };
+}
+
+function isAllowlisted(allow: AllowlistMatcher, relPath: string, line: number): boolean {
+  const normalized = relPath.split('\\').join('/');
+  const entries = allow.byPath.get(normalized);
+  if (!entries) return false;
+  for (const entry of entries) {
+    if (entry.line === undefined) return true;
+    if (entry.line === line) return true;
+  }
+  return false;
+}
+
+// =============================================================================
+// File collection
+// =============================================================================
+
+interface FoundFile {
+  abs: string;
+  rel: string;
+}
+
+function collectFiles(dir: string, acc: FoundFile[] = []): FoundFile[] {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      collectFiles(abs, acc);
+      continue;
+    }
+    if (!SOURCE_EXTS.has(extname(entry.name))) continue;
+    acc.push({ abs, rel: relative(REPO_ROOT, abs).split('\\').join('/') });
+  }
+  return acc;
+}
+
+function includesAnyPathSegment(path: string, segments: readonly string[]): boolean {
+  return segments.some((seg) => path.includes(seg));
+}
+
+// =============================================================================
+// AST rule
+// =============================================================================
+
+export interface InsertAuditLogHit {
+  line: number;
+}
+
+/**
+ * Walk a source file's AST for `<expr>.insert(auditLog)` /
+ * `<expr>.insert(schema.auditLog)` calls — the drizzle insert whose target
+ * table is the `audit_log` table symbol.
+ *
+ * Matches a CallExpression whose callee is a `.insert` property access and whose
+ * FIRST argument is either the identifier `auditLog` or a property access ending
+ * in `.auditLog`. Syntactic only (no type-checker), the same trade-off
+ * as-never-values.ts accepts.
+ */
+export function findInsertAuditLogCalls(sourceText: string, fileName: string): InsertAuditLogHit[] {
+  const sourceFile = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+  const hits: InsertAuditLogHit[] = [];
+
+  function isAuditLogArg(arg: ts.Expression): boolean {
+    if (ts.isIdentifier(arg)) return arg.text === 'auditLog';
+    if (ts.isPropertyAccessExpression(arg)) return arg.name.text === 'auditLog';
+    return false;
+  }
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'insert' &&
+      node.arguments.length > 0 &&
+      isAuditLogArg(node.arguments[0])
+    ) {
+      const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      hits.push({ line: line + 1 });
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return hits;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+const Sep = '='.repeat(72);
+
+function main(): void {
+  out(Sep);
+  out('`audit_log` ONE DOOR — CI validator (GAP-355 Stage 2)');
+  out(Sep);
+
+  const allow = loadAllowlist();
+  out(`Allowlist entries: ${[...allow.byPath.values()].reduce((n, v) => n + v.length, 0)}`);
+  out(`Allowed door(s): ${[...ALLOWED_DOOR_FILES].join(', ')}`);
+
+  const files: FoundFile[] = [];
+  for (const root of SCAN_ROOTS) {
+    const abs = join(REPO_ROOT, root);
+    if (!existsSync(abs)) continue;
+    if (!statSync(abs).isDirectory()) continue;
+    collectFiles(abs, files);
+  }
+
+  out(`Scanning ${files.length} source files...`);
+  out('\n→ insert(auditLog)-outside-the-door');
+
+  const violations: string[] = [];
+  for (const file of files) {
+    if (ALLOWED_DOOR_FILES.has(file.rel)) continue;
+    if (includesAnyPathSegment(file.rel, EXCLUDED_PATH_SEGMENTS)) continue;
+    const content = readFileSync(file.abs, 'utf8');
+    for (const hit of findInsertAuditLogCalls(content, file.abs)) {
+      if (isAllowlisted(allow, file.rel, hit.line)) continue;
+      violations.push(
+        `  ${file.rel}:${hit.line}  insert(auditLog) outside the single door. Route this ` +
+          'through DrizzleAuditStore.append/.appendBatch (@revealui/db) so every audit_log ' +
+          'write shares one chokepoint (integrity, signing, anchoring). See GAP-355 Stage 2.',
+      );
+    }
+  }
+
+  if (violations.length === 0) {
+    out('  ✓ clean');
+  } else {
+    for (const v of violations) console.log(v);
+  }
+
+  out(`\n${Sep}`);
+  if (violations.length === 0) {
+    out('Result: PASS (0 violations)');
+    out(Sep);
+    process.exit(0);
+  }
+  out(
+    `Result: FAIL (${violations.length} writer${violations.length === 1 ? '' : 's'} outside the door)`,
+  );
+  out('');
+  out('  Fix options:');
+  out('    1. Route the write through DrizzleAuditStore.append/.appendBatch (preferred).');
+  out('    2. Add an entry to scripts/validate/audit-log-single-door-allowlist.json');
+  out('       with the file path (and optionally a line number) plus a reason.');
+  out(Sep);
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## GAP-355 Stage 2 — audit_log ONE DOOR

Builds the Stage 2 half of the audit-receipt architecture (ADR `2026-07-12-audit-receipt-architecture.md` §5): exactly one code path that writes `audit_log`, so every later integrity property (append-only, per-row signing in Stage 3, anchoring in Stage 4) has a single chokepoint.

### What changed
- **Collapsed six external writers onto `DrizzleAuditStore`** — the revmarket task executor, the api-keys credential-event writer, the admin setup route, the admin bootstrap CLI, and the governed-MCP receipt signer all now call `DrizzleAuditStore.append(...)` instead of `db.insert(auditLog)`.
- **Extended `append`/`appendBatch`** with optional `signature`/`previousSignature` pass-through, so the MCP signer routes through the door while still computing its own signature (signing moves into the store in Stage 3). Absent → NULL, unchanged from Stage 1.
- **New CI enforcer** `scripts/validate/audit-log-single-door.ts` (AST via the TS compiler API, zero authored regex; mirrors the Stage 0 `as-never-values.ts`) fails the build on any `insert(auditLog)` outside the store. Wired hard-fail into `ci-gate.ts` + `ci.yml`. Empty allowlist.

### The enforcer earned its keep immediately
My manual grep found 5 writers; the enforcer flagged a **6th** I'd missed (`scripts/admin/bootstrap.ts`) — a live demonstration that door number seven really does hide, which is why the mechanical check exists.

### Verification
- Enforcer: RED on the un-collapsed tree (caught `bootstrap.ts`), GREEN after (0 violations).
- Unit test `audit-log-single-door.test.ts` (7/7): fires on the `insert(auditLog)` pattern, passes on the `.append(...)` pattern and on reads — durable red/green proof.
- Runtime write path: `audit-storage.pglite.test.ts` + `mcp-audit-concurrency.pglite.test.ts` (12/12) — the MCP signed-chain concurrency test proves the signature pass-through works through the store end to end.
- `@revealui/db` typecheck clean; db `audit-store.integration.test.ts` 4/4.

### Scope
PR-1 of Stage 2. Deferred to PR-2 (separate review): the schema migration — monotonic sequence + tenant column + REVOKE UPDATE/DELETE.

### Security gate
Touches `routes/api-keys.ts` (security-sensitive). Per guardrail 2 this needs a recorded **non-author** verdict before merge — I authored it, so it stops here for the reviewer. I do not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
