### PR TITLE
fix(admin,marketing): stop leaking dev-only DB setup + raw errors, brand global-error

### DIFF
--- a/apps/admin/src/app/(backend)/error.tsx
+++ b/apps/admin/src/app/(backend)/error.tsx
@@ -47,21 +47,28 @@ export default function BackendError({
       </h2>
 
       {isDatabaseError ? (
-        <div className="flex max-w-lg flex-col gap-3 text-center text-sm text-muted-foreground">
-          <p>The admin dashboard cannot reach the database. To fix this:</p>
-          <ol className="list-inside list-decimal text-left text-xs text-muted-foreground">
-            <li>
-              Set <code className="text-foreground">POSTGRES_URL</code> or{' '}
-              <code className="text-foreground">DATABASE_URL</code> in your environment
-            </li>
-            <li>
-              Run <code className="text-foreground">pnpm db:migrate</code> to create tables
-            </li>
-            <li>
-              Run <code className="text-foreground">pnpm db:seed</code> for sample content
-            </li>
-          </ol>
-        </div>
+        process.env.NODE_ENV !== 'production' ? (
+          <div className="flex max-w-lg flex-col gap-3 text-center text-sm text-muted-foreground">
+            <p>The admin dashboard cannot reach the database. To fix this:</p>
+            <ol className="list-inside list-decimal text-left text-xs text-muted-foreground">
+              <li>
+                Set <code className="text-foreground">POSTGRES_URL</code> or{' '}
+                <code className="text-foreground">DATABASE_URL</code> in your environment
+              </li>
+              <li>
+                Run <code className="text-foreground">pnpm db:migrate</code> to create tables
+              </li>
+              <li>
+                Run <code className="text-foreground">pnpm db:seed</code> for sample content
+              </li>
+            </ol>
+          </div>
+        ) : (
+          <p className="max-w-md text-center text-sm text-muted-foreground">
+            We're having trouble reaching our systems. Our team has been notified. Please try again
+            shortly.
+          </p>
+        )
       ) : (
         <p className="max-w-md text-center text-sm text-muted-foreground">
           {isNetworkError

--- a/apps/admin/src/app/global-error.tsx
+++ b/apps/admin/src/app/global-error.tsx
@@ -3,6 +3,10 @@
 import * as Sentry from '@sentry/nextjs';
 import { useEffect } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
+// global-error.tsx replaces the root layout on error, so it renders outside every
+// route group and gets none of their CSS. Reuse (backend)'s Tailwind entry (tailwindcss
+// + tokens.css + the cobalt @theme bridge) so the branded classes below actually resolve.
+import './(backend)/custom.css';
 
 export default function GlobalError({
   error,
@@ -41,21 +45,35 @@ export default function GlobalError({
 
   return (
     <html lang="en">
-      <body>
-        <div style={{ padding: '20px', fontFamily: 'system-ui, sans-serif' }}>
-          <h2>Something went wrong!</h2>
-          <p>We apologize for the inconvenience. Please try again.</p>
+      <body className="bg-background text-foreground">
+        <div className="flex min-h-screen flex-col items-center justify-center gap-5 p-8 text-center">
+          <div className="flex size-14 items-center justify-center rounded-full bg-destructive/10">
+            <svg
+              className="size-7 text-destructive"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+              />
+            </svg>
+          </div>
+          <h2 className="text-lg font-semibold text-foreground">Something went wrong</h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            We apologize for the inconvenience. Our team has been notified. Please try again.
+          </p>
           {error?.digest && (
-            <p style={{ fontSize: '12px', color: '#666' }}>Error ID: {error.digest}</p>
+            <p className="font-mono text-xs text-muted-foreground">Error ID: {error.digest}</p>
           )}
           <button
-            onClick={() => reset()}
-            style={{
-              marginTop: '10px',
-              padding: '10px 20px',
-              cursor: 'pointer',
-            }}
             type="button"
+            onClick={() => reset()}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             Try again
           </button>

--- a/apps/marketing/app/components/ErrorBoundary.tsx
+++ b/apps/marketing/app/components/ErrorBoundary.tsx
@@ -9,14 +9,13 @@ interface Props {
 
 interface State {
   hasError: boolean;
-  error: Error | null;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false, error: null };
+  state: State = { hasError: false };
 
-  static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error };
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
@@ -27,13 +26,13 @@ export class ErrorBoundary extends Component<Props, State> {
 
   render(): ReactNode {
     if (this.state.hasError) {
-      return this.props.fallback ?? <DefaultErrorFallback error={this.state.error} />;
+      return this.props.fallback ?? <DefaultErrorFallback />;
     }
     return this.props.children;
   }
 }
 
-function DefaultErrorFallback({ error }: { error: Error | null }) {
+function DefaultErrorFallback() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-background p-8 text-center">
       <p className="text-sm font-semibold uppercase tracking-widest text-primary">Error</p>
@@ -41,7 +40,7 @@ function DefaultErrorFallback({ error }: { error: Error | null }) {
         Something went wrong
       </h1>
       <p className="mt-4 max-w-md text-sm text-muted-foreground">
-        {error?.message ?? 'An unexpected error occurred while rendering this page.'}
+        An unexpected error occurred while rendering this page. Our team has been notified.
       </p>
       <ButtonCVA asChild variant="primary" className="mt-6">
         <a href="/">Return home</a>


### PR DESCRIPTION
## Summary
MASTER_PLAN P1 error-page bundle (3 items, one PR per the plan's suggested grouping):

- **`apps/admin/src/app/(backend)/error.tsx:49-64`** leaked `POSTGRES_URL`/`DATABASE_URL`/`pnpm db:migrate`/`pnpm db:seed` setup instructions to any visitor hitting a DB error, in production too. Gated behind `process.env.NODE_ENV !== 'production'`; production visitors now see a generic "we're having trouble reaching our systems" message.
- **`apps/admin/src/app/global-error.tsx:45-46`** was unbranded (`<div style={{fontFamily:'system-ui, sans-serif'}}><h2>Something went wrong!</h2>`). Replaced with the cobalt design-system pattern already used by the sibling `(backend)/error.tsx` and `(frontend)/error.tsx`. `global-error.tsx` sits outside every route group's own layout (it replaces the root `<html>/<body>` on error), so it had zero Tailwind CSS pipeline; it now imports `(backend)`'s CSS entry (`tailwindcss` + `tokens.css` + the cobalt `@theme` bridge) so the branded utility classes actually resolve at runtime — verified by grepping the compiled client chunk for `bg-destructive/10`, `bg-primary`, `text-foreground`, `text-muted-foreground`.
- **`apps/marketing/app/components/ErrorBoundary.tsx:44`** rendered the raw thrown `error.message` to the user. It was already forwarded to Sentry via `captureRenderError` in `componentDidCatch`; the fallback now shows a static branded message only. Removed the now-dead error-carrying `State` field.

## Test plan
- [x] `pnpm --filter admin typecheck` clean
- [x] `pnpm --filter marketing typecheck` clean
- [x] `pnpm --filter marketing test` — 12 files / 78 tests passed
- [x] `pnpm build` — full monorepo build green; manually verified the compiled `global-error` client chunk contains the branded Tailwind classes (`bg-destructive/10`, `bg-primary`, `text-primary-foreground`, `text-foreground`, `text-muted-foreground`)
- [x] `npx biome check` on touched files — clean
- [x] `pnpm gate:quick` — PASS (0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)