### PR TITLE
fix(marketing): re-pin product versions on the products page

### DIFF
--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -303,7 +303,7 @@ const REVFORGE_REF: EvidenceRef = {
 const REVDEV_REPO: EvidenceRef = {
   kind: 'url',
   ref: 'https://github.com/RevealUIStudio/revdev',
-  note: 'apps/studio + apps/console + packages/daemon at 0.1.1; the daemon registers and coordinates agents over JSON-RPC',
+  note: 'apps/studio + apps/console + packages/daemon at 0.2.0 (v0.2.0 tagged 2026-07-17); the daemon registers and coordinates agents over JSON-RPC',
 };
 const REVCON_REPO: EvidenceRef = {
   kind: 'url',

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -32,6 +32,13 @@
 // rendered were byte-identical dev-scaffold captures from 2026-04-27, not the
 // current product; no honest replacement imagery exists yet.
 //
+// 2026-07-17 (version re-pin): flagship v0.3.0 → v0.4.0 (root package.json is
+// the version anchor; the 0.3.0 pinned on 2026-07-12 was RevVault's number and
+// the flagship was never bumped) and RevDev v0.1.1 → v0.2.0 (v0.2.0 tagged in
+// the revdev repo 2026-07-17). Beta semantics reworded below: the fleet is
+// pre-revenue (docs/ROADMAP.md maturity table: "No paying users yet"), so the
+// old "limited paying users" gloss overstated reality.
+//
 // 2026-07-12 (claims-ratchet): product versions re-pinned (RevVault 0.3.0,
 // RevDev 0.1.1), RevForge switched to a Contact-us CTA with a private-preview
 // price label (the repo is private, the old GitHub link 404s for the public),
@@ -40,7 +47,7 @@
 // is indexed in content/claims-evidence.ts.
 //
 // Status semantics:
-//   Beta         — production-ready code, limited paying users / dogfooded
+//   Beta         — production-ready code, deployed and dogfooded in production, pre-revenue
 //   Alpha        — development-preview quality; works, ships, may break
 //   Active (MIT) — released, free-and-open library, no SLA
 //   Planned      — code-complete or scaffolded, not yet shipped to users
@@ -115,7 +122,7 @@ export const PRODUCTS_FLAGSHIP: FlagshipProduct = {
   name: 'RevealUI',
   eyebrow: 'FLAGSHIP',
   status: 'Beta',
-  version: 'v0.3.0',
+  version: 'v0.4.0',
   priceLabel: 'Free to self-host · Pro tier optional',
   tagline: 'The agentic business runtime',
   body: 'People, content, offers, payments, and agents: pre-wired into one runtime your team and your AI agents share through a single open protocol. The foundation every other RevFleet product builds on.',
@@ -199,7 +206,7 @@ export const PRODUCTS_SISTERS: readonly SisterProduct[] = [
       'Registers and coordinates agents over JSON-RPC',
     ],
     status: 'Alpha',
-    version: 'v0.1.1',
+    version: 'v0.2.0',
     priceLabel: 'Free · MIT core',
     iconPath: 'M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5',
     primaryCta: {


### PR DESCRIPTION
## Summary

Products-page accuracy re-pin from the 2026-07-17 fleet audit:

- Flagship RevealUI card: v0.3.0 to v0.4.0. The root package.json has been 0.4.0; the 0.3.0 pinned in the 2026-07-12 claims-ratchet was RevVault's number and the flagship version was never bumped.
- RevDev card: v0.1.1 to v0.2.0. v0.2.0 (plus studio-v0.2.0 and console-v0.2.0) was tagged in the revdev repo on 2026-07-17, so the page trailed a release.
- Beta status-semantics comment reworded: "limited paying users" to "deployed and dogfooded in production, pre-revenue". docs/ROADMAP.md's maturity table says "No paying users yet", so the old gloss overstated reality. Comment-only, nothing rendered changes.
- claims-evidence.ts REVDEV_REPO note updated to 0.2.0 to keep the evidence ledger accurate. Version strings themselves are exempt from claim coverage (below the isProse threshold), so no new claim entries are needed.

## Verification

- claims-evidence validator: 431 indexed claims, all matched
- claim-drift validator: 0 mismatches, METRICS drift 0
- Pre-push phase-1 gate: PASS (all hard-fail validators green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
