### PR TITLE
docs: refresh the M11 charge-readiness posture to current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Key postures — full definitions in `docs/methodology.md`.
 - **Revvault-first (M4):** all secrets live in `revvault`. No `.env` primary. No plaintext on disk. See `docs/SECRETS.md`.
 - **Per-session beacons + note.js (M9):** `session-note` SKILL + `note.js` CLI provide handoff continuity across Claude Code sessions. Context beacon written on stop.
 - **Workboard automation (M10):** `workboard-check.js` (read-only drift detector, fires on session-start) + `workboard-sweep.js` (idempotent cleanup, agent reviews diff + commits manually). Hooks never write to the workboard by design.
-- **Charge-readiness (M11):** subscription billing 3 days from live; Stripe LIVE_MODE owner-gated. Pro-package gates being removed via Path A (FSL-1.1-MIT normalization).
+- **Charge-readiness (M11):** Stripe live mode enabled 2026-06-26; first sale gated on the live acceptance walk (tracked in the internal hub). Pro-package license gates removed via Path A (FSL-1.1-MIT normalization, landed).
 
 ## Build & Security Status
 - All workspaces build and typecheck clean (run `pnpm build` and `pnpm typecheck:all`)

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -77,8 +77,8 @@ Hooks architecture detail: `~/.claude/rules/hooks-architecture.md` (private).
 
 ## Charge-readiness state (M11)
 
-- Production runs Stripe in TEST mode; the `STRIPE_LIVE_MODE` flip is owner-gated on the billing-readiness audit closing.
-- Pro-package gates are being removed via Path A: drop fake `checkXLicense` calls; normalize to FSL-1.1-MIT. Customers pay for hosted infra + support, not enforcement. Tracked in the internal hub master plan.
+- `STRIPE_LIVE_MODE` was flipped on 2026-06-26 (owner action); production runs Stripe in live mode. First sale remains gated on the live acceptance walk, tracked in the internal hub.
+- Pro-package gates were removed via Path A: fake `checkXLicense` calls dropped; packages normalized to FSL-1.1-MIT. Customers pay for hosted infra + support, not enforcement.
 
 ---
 


### PR DESCRIPTION
## Summary

Refreshes the stale M11 charge-readiness posture in CLAUDE.md and docs/methodology.md, found in the 2026-07-17 fleet audit:

- Both docs still described Stripe as test-mode with the live flip pending ("subscription billing 3 days from live"). The flip landed 2026-06-26; first sale is gated on the live acceptance walk, tracked in the internal hub.
- Path A is complete, not in-progress: no fake checkXLicense calls remain in the Pro packages and their LICENSE files carry FSL-1.1-MIT (verified against the tree; the Pro license validator confirms it on every gate run).

Doc-currency validator: 0 NEW stale-fact occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
