### PR TITLE
fix(marketing): replace hardcoded palette colors with semantic tokens

### DIFF
--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -39,7 +39,7 @@ export function FairSourcePage() {
         />
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute -top-40 left-1/2 -z-10 h-[600px] w-[1000px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,oklch(0.55_0.18_245/0.18),oklch(0.55_0.18_245/0.04)_60%,transparent_80%)] blur-2xl"
+          className="pointer-events-none absolute -top-40 left-1/2 -z-10 h-[600px] w-[1000px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--rvui-brand-glow),transparent_70%)] blur-2xl"
         />
 
         <div className="relative mx-auto max-w-3xl text-center">
@@ -87,7 +87,7 @@ export function FairSourcePage() {
                 className={`rounded-2xl p-6 ring-1 transition ${
                   c.kind === 'yes'
                     ? 'bg-primary/10 ring-primary/20'
-                    : 'bg-amber-50/40 ring-amber-200'
+                    : 'bg-amber-500/15 ring-amber-500/30'
                 }`}
               >
                 <div className="flex items-start gap-3">
@@ -107,7 +107,7 @@ export function FairSourcePage() {
                     </svg>
                   ) : (
                     <svg
-                      className="mt-0.5 h-6 w-6 flex-shrink-0 text-amber-700"
+                      className="mt-0.5 h-6 w-6 flex-shrink-0 text-amber-800 dark:text-amber-200"
                       fill="currentColor"
                       viewBox="0 0 20 20"
                       aria-hidden="true"

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -67,9 +67,9 @@ export function ProductsPage() {
             <div className="relative">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                 <div className="flex items-center gap-4">
-                  <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 ring-1 ring-white/30 backdrop-blur">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary-foreground/15 ring-1 ring-primary-foreground/30 backdrop-blur">
                     <svg
-                      className="h-7 w-7 text-white"
+                      className="h-7 w-7 text-primary-foreground"
                       fill="none"
                       viewBox="0 0 24 24"
                       strokeWidth={1.75}
@@ -87,16 +87,16 @@ export function ProductsPage() {
                     <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary-foreground/90">
                       {PRODUCTS_FLAGSHIP.eyebrow}
                     </p>
-                    <h2 className="mt-1 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                    <h2 className="mt-1 text-3xl font-bold tracking-tight text-primary-foreground sm:text-4xl">
                       {PRODUCTS_FLAGSHIP.name}
                     </h2>
                   </div>
                 </div>
                 <div className="flex items-center gap-2 text-xs font-semibold">
-                  <span className="rounded-full bg-white/15 px-3 py-1 text-white ring-1 ring-white/30 backdrop-blur">
+                  <span className="rounded-full bg-primary-foreground/15 px-3 py-1 text-primary-foreground ring-1 ring-primary-foreground/30 backdrop-blur">
                     {PRODUCTS_FLAGSHIP.status}
                   </span>
-                  <span className="rounded-full bg-white/10 px-3 py-1 font-mono text-white/90 ring-1 ring-white/20">
+                  <span className="rounded-full bg-primary-foreground/10 px-3 py-1 font-mono text-primary-foreground/90 ring-1 ring-primary-foreground/20">
                     {PRODUCTS_FLAGSHIP.version}
                   </span>
                 </div>
@@ -113,19 +113,19 @@ export function ProductsPage() {
                 {PRODUCTS_FLAGSHIP.facts.map((fact) => (
                   <div
                     key={fact.label}
-                    className="rounded-xl bg-white/10 px-4 py-3 ring-1 ring-white/20 backdrop-blur"
+                    className="rounded-xl bg-primary-foreground/10 px-4 py-3 ring-1 ring-primary-foreground/20 backdrop-blur"
                   >
                     <dt className="text-xs uppercase tracking-wide text-primary-foreground/80">
                       {fact.label}
                     </dt>
-                    <dd className="mt-1 text-2xl font-bold tracking-tight text-white">
+                    <dd className="mt-1 text-2xl font-bold tracking-tight text-primary-foreground">
                       {fact.stat}
                     </dd>
                   </div>
                 ))}
               </dl>
 
-              <p className="mt-8 inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-1.5 text-sm font-semibold text-white ring-1 ring-white/30 backdrop-blur">
+              <p className="mt-8 inline-flex items-center gap-2 rounded-full bg-primary-foreground/15 px-4 py-1.5 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/30 backdrop-blur">
                 <svg
                   className="h-4 w-4"
                   fill="none"
@@ -158,7 +158,7 @@ export function ProductsPage() {
                 </a>
                 <a
                   href={PRODUCTS_FLAGSHIP.ctas.repo.href}
-                  className="rounded-md px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10"
+                  className="rounded-md px-6 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/10"
                   {...(PRODUCTS_FLAGSHIP.ctas.repo.external
                     ? { target: '_blank', rel: 'noreferrer' }
                     : {})}

--- a/apps/marketing/app/routes/StatusPage.tsx
+++ b/apps/marketing/app/routes/StatusPage.tsx
@@ -62,8 +62,8 @@ function badgeFor(
   }
   if (state.kind === 'link') {
     return (
-      <span className="inline-flex items-center gap-2 rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-700 ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-zinc-300 dark:ring-zinc-700">
-        <span aria-hidden="true" className="size-1.5 rounded-full bg-zinc-400" />
+      <span className="inline-flex items-center gap-2 rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground ring-1 ring-border">
+        <span aria-hidden="true" className="size-1.5 rounded-full bg-muted-foreground" />
         Visit to verify
       </span>
     );
@@ -71,8 +71,11 @@ function badgeFor(
   const r = state.result;
   if (r.status === 'pending') {
     return (
-      <span className="inline-flex items-center gap-2 rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-700 ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-zinc-300 dark:ring-zinc-700">
-        <span aria-hidden="true" className="size-1.5 animate-pulse rounded-full bg-zinc-400" />
+      <span className="inline-flex items-center gap-2 rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground ring-1 ring-border">
+        <span
+          aria-hidden="true"
+          className="size-1.5 animate-pulse rounded-full bg-muted-foreground"
+        />
         Checking…
       </span>
     );


### PR DESCRIPTION
## Summary

Owner-ruled task (option A, 2026-07-17): fix the marketing site's light/dark rendering by replacing hardcoded raw Tailwind palette classes with the OKLCH semantic tokens already used by ~60/68 marketing `.tsx` files, so the whole site auto-flips correctly with OS `prefers-color-scheme` (no manual toggle, no default-direction change).

Audited all 5 flagged files by actually rendering each route in a headless browser under both `prefers-color-scheme: light` and `dark` before and after editing (screenshots taken via Playwright against a local dev build). Only 3 of the 5 needed changes; the other 2 were already correct.

### Changed

- **`StatusPage.tsx`**: neutral "link"/"pending" status badges hardcoded `bg-zinc-100/900 text-zinc-700/300 ring-zinc-200/700` → `bg-muted text-muted-foreground ring-border` (matches the neutral-chip idiom used elsewhere, e.g. the FAQ accordion icon circle). Dot indicator `bg-zinc-400` → `bg-muted-foreground`.
- **`FairSourcePage.tsx`**:
  - Hero background glow: inline `bg-[radial-gradient(...,oklch(0.55 0.18 245/0.18),oklch(0.55 0.18 245/0.04) 60%,transparent 80%)]` → `bg-[radial-gradient(closest-side,var(--rvui-brand-glow),transparent 70%)]`, so the glow now tracks the token instead of a fixed inline value.
  - "Build a competing developer platform" restriction card: `bg-amber-50/40 ring-amber-200` (translucent-over-near-white blend) washed out to near-invisible gray in dark mode (confirmed via screenshot) → `bg-amber-500/15 ring-amber-500/30`, matching the amber-badge idiom already used on `PricingPage.tsx` (renders correctly in both modes).
  - The restriction icon `text-amber-700` had no dark-mode pairing → `text-amber-800 dark:text-amber-200` (same pairing as the sibling `PricingPage` amber badges).
- **`ProductsPage.tsx`**: the flagship RevealUI card mixed hardcoded `text-white`/`bg-white/*`/`ring-white/*` with `text-primary-foreground` used elsewhere in the *same card* for the identical role (text/overlay sitting on the `bg-primary` gradient). In dark mode this produced a visibly inconsistent card (e.g. the "28/93/14/1061" stat values rendered pure white right below dark-ink labels). Replaced every white/white-alpha class in that card with its `primary-foreground` equivalent, matching the pattern already established 6x in the same component.

### Audited, no change needed

- **`PricingPage.tsx`**: its raw-hue accent classes (green/amber/blue/violet) already carry correct `dark:` text pairing or render fine unpaired at the 500/600 step (confirmed via screenshot in both modes). No visual regression, no bridged-token gap.
- **`components/landing/Primitives.tsx`**: the blue/amber/cyan/violet icon accents are the documented, intentional "distinct non-brand hue" idiom explained in the file's own comment, and already render correctly in both modes (confirmed via screenshot on the homepage).

One item was deliberately left alone: `FairSourcePage.tsx:233`, a small decorative `bg-white` dot inside an always-opaque colored circle marker (not a text/legibility role, no clean semantic equivalent without over-engineering a single-use case).

No new CSS, no new tokens — every replacement uses classes/vars that already exist in `@revealui/tokens` / `apps/marketing/app/index.css` and are already consumed elsewhere in the app.

## Test plan

- [x] `pnpm biome check` on the 3 changed files — clean
- [x] `pnpm --filter marketing build` — clean production build
- [x] Grepped the built CSS/JS bundle to confirm the removed raw classes are gone from the marketing routes (remaining `text-white`/`text-zinc-700` hits trace to `@revealui/presentation`'s own components via the `@source` scan, unrelated to this change) and the new semantic classes (`bg-muted`, `text-primary-foreground`, `bg-amber-500/15`, `rvui-brand-glow`, etc.) are present
- [x] Screenshot-verified all 4 routed pages (`/status`, `/fair-source`, `/products`, `/pricing`) plus the homepage `Primitives` section in both `prefers-color-scheme: light` and `dark` via a headless Playwright script, before and after the edit
- [x] `pnpm gate:quick` — PASS (pre-existing warnings unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)