### PR TITLE
feat(harnesses): gateway authn schema + SIGTERM-grace-SIGKILL termination (GAP-353 PR-1)

### DIFF
--- a/.changeset/gateway-authn-schema-termination.md
+++ b/.changeset/gateway-authn-schema-termination.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+add the gateway authn persistence substrate and real process termination to the harness daemon: two additive PGlite tables (`gateway_bootstrap`, a singleton hash of the HTTP-gateway bootstrap secret; `gateway_tokens`, hashed durable bearer tokens with expiry/revocation) plus `DaemonStore` methods (`putBootstrapSecretHash`, `getBootstrapSecretHash`, `insertToken`, `findValidToken`, `revokeToken`, `pruneExpiredTokens`) as substrate for a later fail-closed gateway; and `SpawnerService.stop`/`stopAll` now escalate SIGTERM to SIGKILL after a bounded, configurable grace period (`terminationGraceMs`, default 5000ms) with event-driven status, so a child that ignores SIGTERM is actually killed and `agent.list` never reports a live process as stopped. Substrate only, no callers wired yet.

--- a/packages/harnesses/src/__tests__/daemon-store.test.ts
+++ b/packages/harnesses/src/__tests__/daemon-store.test.ts
@@ -305,4 +305,72 @@ describe('DaemonStore', () => {
     const pruned = await store.pruneEvents(0);
     expect(pruned).toBeGreaterThanOrEqual(0);
   });
+
+  // ---------------------------------------------------------------------------
+  // Gateway authn substrate (GAP-353 D3)
+  // ---------------------------------------------------------------------------
+
+  it('round-trips the bootstrap secret hash', async () => {
+    expect(await store.getBootstrapSecretHash()).toBeNull();
+    const row = await store.putBootstrapSecretHash('hash-abc');
+    expect(row.id).toBe(1);
+    expect(row.secret_hash).toBe('hash-abc');
+    expect(await store.getBootstrapSecretHash()).toBe('hash-abc');
+  });
+
+  it('keeps the bootstrap secret a singleton (re-persist overwrites)', async () => {
+    await store.putBootstrapSecretHash('hash-old');
+    await store.putBootstrapSecretHash('hash-new');
+    expect(await store.getBootstrapSecretHash()).toBe('hash-new');
+  });
+
+  it('inserts and finds a valid token', async () => {
+    const inserted = await store.insertToken({ tokenHash: 'tok-1', label: 'studio-macbook' });
+    expect(inserted.token_hash).toBe('tok-1');
+    expect(inserted.label).toBe('studio-macbook');
+    expect(inserted.revoked_at).toBeNull();
+
+    const found = await store.findValidToken('tok-1');
+    expect(found?.token_hash).toBe('tok-1');
+  });
+
+  it('findValidToken returns null for an unknown hash', async () => {
+    expect(await store.findValidToken('nope')).toBeNull();
+  });
+
+  it('findValidToken excludes revoked tokens', async () => {
+    await store.insertToken({ tokenHash: 'tok-2' });
+    const revoked = await store.revokeToken('tok-2');
+    expect(revoked).toBe(true);
+    expect(await store.findValidToken('tok-2')).toBeNull();
+  });
+
+  it('revokeToken returns false when nothing was revoked', async () => {
+    expect(await store.revokeToken('absent')).toBe(false);
+  });
+
+  it('findValidToken excludes expired tokens', async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    await store.insertToken({ tokenHash: 'tok-3', expiresAt: past });
+    expect(await store.findValidToken('tok-3')).toBeNull();
+  });
+
+  it('honors a future expiry as still valid', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    await store.insertToken({ tokenHash: 'tok-4', expiresAt: future });
+    expect(await store.findValidToken('tok-4')).not.toBeNull();
+  });
+
+  it('prunes only expired tokens', async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    await store.insertToken({ tokenHash: 'tok-expired', expiresAt: past });
+    await store.insertToken({ tokenHash: 'tok-future', expiresAt: future });
+    await store.insertToken({ tokenHash: 'tok-forever' });
+
+    const pruned = await store.pruneExpiredTokens();
+    expect(pruned).toBe(1);
+    expect(await store.findValidToken('tok-future')).not.toBeNull();
+    expect(await store.findValidToken('tok-forever')).not.toBeNull();
+  });
 });

--- a/packages/harnesses/src/server/__tests__/fixtures/ignore-sigterm.mjs
+++ b/packages/harnesses/src/server/__tests__/fixtures/ignore-sigterm.mjs
@@ -1,0 +1,11 @@
+// Test fixture: a child process that ignores SIGTERM.
+//
+// Used to prove SpawnerService escalates SIGTERM -> grace -> SIGKILL (GAP-353 D6).
+// It stays alive under SIGTERM and only dies to SIGKILL (which is uncatchable),
+// with a self-exit backstop so a run that never escalates cannot orphan it.
+process.on('SIGTERM', () => {
+  // deliberately ignore
+});
+setInterval(() => {}, 1000);
+setTimeout(() => process.exit(0), 30_000).unref();
+process.stdout.write('ready\n');

--- a/packages/harnesses/src/server/__tests__/spawner-service.test.ts
+++ b/packages/harnesses/src/server/__tests__/spawner-service.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for SpawnerService process termination (GAP-353 D6 / §7 R2).
+ *
+ * `node:child_process` spawn is mocked to launch a real child running the
+ * SIGTERM-ignoring fixture regardless of backend, so the SIGTERM -> grace ->
+ * SIGKILL escalation and the event-driven status transition can be exercised
+ * against a genuinely wedged process.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const { fileURLToPath } = await import('node:url');
+  const fixturePath = fileURLToPath(new URL('./fixtures/ignore-sigterm.mjs', import.meta.url));
+  return {
+    ...actual,
+    spawn: vi.fn(() =>
+      actual.spawn(process.execPath, [fixturePath], { stdio: ['ignore', 'pipe', 'pipe'] }),
+    ),
+  };
+});
+
+import type { AgentExitEvent, AgentOutputEvent } from '../spawner-service.js';
+import { SpawnerService } from '../spawner-service.js';
+
+function waitReady(service: SpawnerService): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const onOutput = (event: AgentOutputEvent): void => {
+      if (event.data.includes('ready')) {
+        service.off('output', onOutput);
+        resolve();
+      }
+    };
+    service.on('output', onOutput);
+  });
+}
+
+function onceExit(service: SpawnerService): Promise<AgentExitEvent> {
+  return new Promise<AgentExitEvent>((resolve) => service.once('exit', resolve));
+}
+
+describe('SpawnerService termination (D6)', () => {
+  let service: SpawnerService;
+
+  afterEach(async () => {
+    // Reap any still-running child so a failed assertion cannot orphan it.
+    const running = service.list().some((s) => s.status === 'running');
+    if (running) {
+      const exited = onceExit(service);
+      service.stopAll();
+      await exited;
+    }
+  });
+
+  it('escalates SIGTERM to SIGKILL for a child that ignores SIGTERM', async () => {
+    service = new SpawnerService({ terminationGraceMs: 150 });
+    const id = service.spawn('wedged', 'Ollama', 'model', 'prompt');
+    await waitReady(service);
+
+    const exited = onceExit(service);
+    const start = Date.now();
+    service.stop(id);
+
+    // Event-driven status: still running immediately after stop(), never a
+    // synchronous 'stopped' lie.
+    expect(service.list()[0]?.status).toBe('running');
+
+    const event = await exited;
+    // The child ignored SIGTERM, so it only exited once SIGKILL landed after the
+    // grace period.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(150);
+    expect(event.code).toBeNull();
+    const finalStatus = service.list()[0]?.status;
+    expect(finalStatus).not.toBe('running');
+    expect(['stopped', 'errored']).toContain(finalStatus);
+  });
+
+  it('keeps status running immediately after stop() on a live child', async () => {
+    service = new SpawnerService({ terminationGraceMs: 100 });
+    const id = service.spawn('wedged', 'Ollama', 'model', 'prompt');
+    await waitReady(service);
+
+    const exited = onceExit(service);
+    service.stop(id);
+    expect(service.list()[0]?.status).toBe('running');
+
+    // Reap via the SIGKILL escalation.
+    await exited;
+    expect(service.list()[0]?.status).not.toBe('running');
+  });
+
+  it('stopAll escalates and does not lie about status', async () => {
+    service = new SpawnerService({ terminationGraceMs: 120 });
+    service.spawn('wedged', 'Ollama', 'model', 'prompt');
+    await waitReady(service);
+
+    const exited = onceExit(service);
+    service.stopAll();
+    expect(service.list()[0]?.status).toBe('running');
+
+    await exited;
+    expect(service.list()[0]?.status).not.toBe('running');
+  });
+});

--- a/packages/harnesses/src/server/spawner-service.ts
+++ b/packages/harnesses/src/server/spawner-service.ts
@@ -34,11 +34,17 @@ export interface SpawnerConfig {
   snapEndpoint: string;
   /** Max concurrent agent sessions (default: 8) */
   maxSessions: number;
+  /**
+   * Grace period, in milliseconds, between SIGTERM and the SIGKILL escalation
+   * for a child that does not exit on its own (default: 5000).
+   */
+  terminationGraceMs: number;
 }
 
 const DEFAULT_CONFIG: SpawnerConfig = {
   snapEndpoint: 'http://localhost:9090',
   maxSessions: 8,
+  terminationGraceMs: 5000,
 };
 
 // ── Service ─────────────────────────────────────────────────────────
@@ -50,6 +56,8 @@ interface AgentProcess {
   prompt: string;
   child: ChildProcess;
   status: 'running' | 'stopped' | 'errored';
+  /** Pending SIGKILL escalation timer, set while a SIGTERM grace window is open. */
+  graceTimer?: ReturnType<typeof setTimeout>;
 }
 
 /**
@@ -134,8 +142,14 @@ export class SpawnerService extends EventEmitter {
       }
     });
 
-    // Handle exit
+    // Handle exit. The close handler is the single source of truth for terminal
+    // status; if a SIGTERM grace window is still open, close-before-timeout wins
+    // and the pending SIGKILL escalation is cancelled.
     child.on('close', (code) => {
+      if (proc.graceTimer) {
+        clearTimeout(proc.graceTimer);
+        proc.graceTimer = undefined;
+      }
       proc.status = code === 0 ? 'stopped' : 'errored';
       this.emit('exit', { sessionId, code } satisfies AgentExitEvent);
     });
@@ -148,13 +162,18 @@ export class SpawnerService extends EventEmitter {
     return sessionId;
   }
 
-  /** Stop a running agent by killing its process. */
+  /**
+   * Request termination of a running agent: SIGTERM now, SIGKILL after the
+   * configured grace period if it has not exited. Returns once SIGTERM is sent;
+   * the status transition is event-driven (the child's `close` handler sets the
+   * terminal status), so `list()` keeps reporting `running` until the process
+   * actually exits.
+   */
   stop(sessionId: string): void {
     const proc = this.sessions.get(sessionId);
     if (!proc) throw new Error(`No agent session: ${sessionId}`);
     if (proc.status !== 'running') throw new Error(`Agent is not running (${proc.status})`);
-    proc.child.kill('SIGTERM');
-    proc.status = 'stopped';
+    this.terminate(proc);
   }
 
   /** List all agent sessions. */
@@ -183,13 +202,36 @@ export class SpawnerService extends EventEmitter {
     this.sessions.delete(sessionId);
   }
 
-  /** Kill all running agents (called on daemon shutdown). */
+  /**
+   * Request termination of all running agents (called on daemon shutdown).
+   * Same SIGTERM → grace → SIGKILL escalation as `stop`, with event-driven
+   * status, so shutdown neither wedges a child that ignores SIGTERM nor lies
+   * about its status.
+   */
   stopAll(): void {
     for (const [, proc] of this.sessions) {
       if (proc.status === 'running') {
-        proc.child.kill('SIGTERM');
-        proc.status = 'stopped';
+        this.terminate(proc);
       }
     }
+  }
+
+  /**
+   * Send SIGTERM and arm a bounded SIGKILL escalation. Status is left `running`;
+   * the child's `close` handler owns the terminal transition. Idempotent while a
+   * grace window is already open. The escalation timer is unref'd so it can never
+   * keep the process alive or fire after exit.
+   */
+  private terminate(proc: AgentProcess): void {
+    if (proc.graceTimer) return;
+    proc.child.kill('SIGTERM');
+    const timer = setTimeout(() => {
+      proc.graceTimer = undefined;
+      if (proc.status === 'running') {
+        proc.child.kill('SIGKILL');
+      }
+    }, this.config.terminationGraceMs);
+    timer.unref?.();
+    proc.graceTimer = timer;
   }
 }

--- a/packages/harnesses/src/storage/daemon-store.ts
+++ b/packages/harnesses/src/storage/daemon-store.ts
@@ -16,6 +16,8 @@ import type {
   AgentWorktree,
   DaemonEvent,
   FileReservation,
+  GatewayBootstrapRow,
+  GatewayTokenRow,
   GoalCriterionRow,
   GoalRow,
   MergeRequest,
@@ -874,5 +876,86 @@ export class DaemonStore {
       [criterionId, taskId],
     );
     return result.rows[0] ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Gateway authn substrate (HTTP gateway bootstrap secret + bearer tokens)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Persist the SHA-256 hash of the bootstrap pairing secret (singleton row).
+   * Upserts so a fresh data dir can re-adopt an existing on-disk secret file.
+   */
+  async putBootstrapSecretHash(secretHash: string): Promise<GatewayBootstrapRow> {
+    const db = this.getDb();
+    const result = await db.query<GatewayBootstrapRow>(
+      `INSERT INTO gateway_bootstrap (id, secret_hash)
+       VALUES (1, $1)
+       ON CONFLICT (id) DO UPDATE SET secret_hash = EXCLUDED.secret_hash
+       RETURNING *`,
+      [secretHash],
+    );
+    // RETURNING * always produces a row for INSERT ... ON CONFLICT DO UPDATE
+    return result.rows[0] as GatewayBootstrapRow;
+  }
+
+  /** Get the persisted bootstrap secret hash, or null if never set. */
+  async getBootstrapSecretHash(): Promise<string | null> {
+    const db = this.getDb();
+    const result = await db.query<GatewayBootstrapRow>(
+      'SELECT * FROM gateway_bootstrap WHERE id = 1',
+    );
+    return result.rows[0]?.secret_hash ?? null;
+  }
+
+  /** Insert a hashed bearer token with optional expiry and label. */
+  async insertToken(token: {
+    tokenHash: string;
+    expiresAt?: string | null;
+    label?: string | null;
+  }): Promise<GatewayTokenRow> {
+    const db = this.getDb();
+    const result = await db.query<GatewayTokenRow>(
+      `INSERT INTO gateway_tokens (token_hash, expires_at, label)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [token.tokenHash, token.expiresAt ?? null, token.label ?? null],
+    );
+    // RETURNING * always produces a row for a plain INSERT
+    return result.rows[0] as GatewayTokenRow;
+  }
+
+  /** Find a token by hash that is neither revoked nor expired. */
+  async findValidToken(tokenHash: string): Promise<GatewayTokenRow | null> {
+    const db = this.getDb();
+    const result = await db.query<GatewayTokenRow>(
+      `SELECT * FROM gateway_tokens
+       WHERE token_hash = $1
+         AND revoked_at IS NULL
+         AND (expires_at IS NULL OR expires_at > NOW())`,
+      [tokenHash],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /** Revoke a token by hash. Returns true if a non-revoked token was revoked. */
+  async revokeToken(tokenHash: string): Promise<boolean> {
+    const db = this.getDb();
+    const result = await db.query(
+      `UPDATE gateway_tokens SET revoked_at = NOW()
+       WHERE token_hash = $1 AND revoked_at IS NULL
+       RETURNING token_hash`,
+      [tokenHash],
+    );
+    return (result.rows?.length ?? 0) > 0;
+  }
+
+  /** Delete tokens whose expiry has passed. Returns the number removed. */
+  async pruneExpiredTokens(): Promise<number> {
+    const db = this.getDb();
+    const result = await db.query(
+      'DELETE FROM gateway_tokens WHERE expires_at IS NOT NULL AND expires_at < NOW()',
+    );
+    return result.affectedRows ?? 0;
   }
 }

--- a/packages/harnesses/src/storage/schema.ts
+++ b/packages/harnesses/src/storage/schema.ts
@@ -12,6 +12,8 @@
  *   - merge_requests: agent-branch merge lifecycle tracking
  *   - goals: durable verifiable objectives (goal harness)
  *   - goal_criteria: acceptance criteria gating goal completion
+ *   - gateway_bootstrap: singleton hash of the HTTP-gateway bootstrap secret
+ *   - gateway_tokens: hashed, durable HTTP-gateway bearer tokens
  *
  * Uses raw SQL (no Drizzle ORM) to keep the daemon dependency-free.
  * PGlite runs in-process  -  no external database needed.
@@ -164,6 +166,20 @@ export const SCHEMA_SQL = `
 
   CREATE INDEX IF NOT EXISTS idx_goal_criteria_goal
     ON goal_criteria (goal_id);
+
+  CREATE TABLE IF NOT EXISTS gateway_bootstrap (
+    id            INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    secret_hash   TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+
+  CREATE TABLE IF NOT EXISTS gateway_tokens (
+    token_hash    TEXT PRIMARY KEY,
+    issued_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at    TIMESTAMPTZ,
+    revoked_at    TIMESTAMPTZ,
+    label         TEXT
+  );
 `;
 
 /** Session row shape. */
@@ -292,4 +308,20 @@ export interface GoalCriterionRow {
   verified_at: string | null;
   task_id: string | null;
   created_at: string;
+}
+
+/** Gateway bootstrap secret row shape (singleton, id = 1). */
+export interface GatewayBootstrapRow {
+  id: number;
+  secret_hash: string;
+  created_at: string;
+}
+
+/** Gateway bearer-token row shape (token stored as a hash). */
+export interface GatewayTokenRow {
+  token_hash: string;
+  issued_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  label: string | null;
 }


### PR DESCRIPTION
## GAP-353 PR-1 — gateway authn schema + real process termination

Builds PR-1 of the GAP-353 program to the recorded spec (`GAP-353-bootstrap-authn-design.md`): the durable authn **substrate** (§D3) plus real SIGTERM→grace→SIGKILL **termination** (§D6, incl. §7 R2). This is the lowest-risk slice; termination is independent of authn. PR-2 (fail-closed `checkAuth`, token persistence wiring, rate limit) and PR-3 (code retirement + docs) are separate and out of scope here — no caller wires the new store methods yet.

### What changed, per spec section

**§D3 — schema + `DaemonStore` methods (substrate only)** — `packages/harnesses/src/storage/`
- Two additive PGlite tables matching the spec SQL exactly:
  - `gateway_bootstrap` — singleton row (`id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1)`, `secret_hash`, `created_at`), holds the SHA-256 hash of the `0600` bootstrap secret.
  - `gateway_tokens` — `token_hash` PK, `issued_at`, nullable `expires_at`, `revoked_at`, `label`.
- Six `DaemonStore` methods following the existing store style (parameterized queries, `getDb()`, `Promise<...>` return types): `putBootstrapSecretHash` (upsert — supports the §7 R5 fresh-DB-re-adopts-existing-file case), `getBootstrapSecretHash`, `insertToken`, `findValidToken(hash)` (excludes revoked + expired), `revokeToken`, `pruneExpiredTokens` (expired only; revoked rows retained for audit).
- No caller wired — PR-2 consumes these.

**§D6 — real process termination (also §7 R2: BOTH SIGTERM sites)** — `packages/harnesses/src/server/spawner-service.ts`
- `stop()` and `stopAll()` both now go through a shared `terminate(proc)`: `child.kill('SIGTERM')`, do **not** set status synchronously (stays `running`), arm a bounded grace timer, and on expiry `child.kill('SIGKILL')`.
- The `close` handler remains the **single source of truth** for terminal status; if close fires first it clears the timer, so status is fully event-driven and `agent.list` never reports a live child as `stopped`.
- Grace period is configurable via `SpawnerConfig.terminationGraceMs`, default **5000ms** (spec §6 C-C recommendation).
- The escalation timer is `unref()`'d and cleared on close, so it can neither keep the process alive nor fire after exit. `terminate` is idempotent while a grace window is open.
- §7 R2 addressed: `stopAll` (daemon shutdown) gets the identical treatment, so shutdown neither wedges a SIGTERM-ignoring child nor lies about status.

### Red/green proof (required)

Tests were proven red against base before the fix. After committing, base `spawner-service.ts` was restored with `git checkout origin/test -- packages/harnesses/src/server/spawner-service.ts` (never `git stash pop`), the termination tests were run, then the fix was restored with `git checkout HEAD -- ...`.

**Red run (base source, all 3 termination tests FAIL):**
```
FAIL  SpawnerService termination (D6) > escalates SIGTERM to SIGKILL for a child that ignores SIGTERM
FAIL  SpawnerService termination (D6) > keeps status running immediately after stop() on a live child
      AssertionError: expected 'stopped' to be 'running'
FAIL  SpawnerService termination (D6) > stopAll escalates and does not lie about status
      AssertionError: expected 'stopped' to be 'running'
 Tests  3 failed (3)
```
Base fails two ways at once: it sets `status = 'stopped'` **synchronously** (the status lie), and it never escalates, so the SIGTERM-ignoring fixture never exits (the escalation test hangs to timeout). Both are exactly what D6/R2 fix.

**Green run (fix restored):** `Tests  3 passed (3)`.

The three termination tests use a real committed fixture (`ignore-sigterm.mjs`) that traps/ignores SIGTERM and stays alive on a `setInterval` (with a 30s self-exit backstop so a non-escalating run cannot orphan it); `node:child_process` `spawn` is mocked to launch it regardless of backend. A short configured grace (~100-150ms) is used in tests, not 5s.

### Test counts

- New tests: **3** termination (`spawner-service.test.ts`) + **9** gateway-substrate round-trip (appended to `daemon-store.test.ts`: bootstrap put/get, singleton overwrite, insert/find, unknown-hash, revoked-excluded, revoke-returns-false, expired-excluded, future-expiry-valid, prune-expired-only) = **12 new**.
- Full package suite: **450 passed, 1 failed (451)**. The one failure is **pre-existing and environmental**, unrelated to this diff: `opencode-adapter.test.ts` asserts `opencode` is not installed, but this build machine has `opencode 1.18.3` on PATH. Verified the opencode adapter test + source are byte-identical to `origin/test` (empty `git diff`), and this PR touches no opencode code. Not fixed here per the "don't fix unrelated pre-existing failures" instruction.
- `pnpm --filter @revealui/harnesses typecheck`: clean.

### Security-sensitive surface

This PR touches `packages/harnesses/` — on the guardrail-2 security-sensitive list. The fleet self-check (`security-pr-review-check.js --diff origin/test`) returns **HOLD**, which is expected and correct: it needs a **recorded non-author guardrail-2 verdict + `sec-review:approved` label** before merge. I did not self-approve, did not apply the label, and will not self-merge.

Changeset: `@revealui/harnesses` minor (behavior change inside 0.x = minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
