### PR TITLE
ci(docker): required context moves to an always-run summary job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,10 +13,15 @@ name: Build & Push Forge Docker Images
 #
 # PR runs (GAP-328 work item 2): pull_request builds are verification-only —
 # no GHCR login, no push, no provenance/SBOM. The pull_request trigger carries
-# no path filter on purpose: the Build server/admin/migrate contexts are
-# REQUIRED checks, and a workflow-level path filter would leave unrelated PRs
-# stuck on "Expected". Path scoping happens in the `changes` job instead; a
-# skipped build job satisfies the required check.
+# no path filter on purpose: the `Docker images` summary context is a REQUIRED
+# check, and a workflow-level path filter would leave unrelated PRs stuck on
+# "Expected". Path scoping happens in the `changes` job instead.
+#
+# The required context is the non-matrix `docker-images` summary job, NOT the
+# per-app Build jobs: a matrix job skipped at the job level never expands its
+# matrix, so GitHub reports one check literally named "Build ${{ matrix.app }}"
+# and the expanded contexts sit on "Expected" forever. The summary job always
+# runs, passes on build success or skip, and fails on any build failure.
 
 on:
   push:
@@ -182,3 +187,28 @@ jobs:
           # skip both (nothing is published).
           provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
           sbom: ${{ github.event_name != 'pull_request' }}
+
+  # The REQUIRED status context. Always runs (if: always()), so it reports on
+  # every PR regardless of path scoping: success when the build matrix
+  # succeeded or was skipped as image-irrelevant, failure on any build
+  # failure or cancellation. Required-checks live on this single context
+  # because skipped matrix jobs never expand into their per-app contexts.
+  docker-images:
+    name: Docker images
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes, build-and-push]
+    if: always()
+    steps:
+      - name: Evaluate build matrix result
+        env:
+          RESULT: ${{ needs.build-and-push.result }}
+        run: |
+          case "$RESULT" in
+            success) echo "image builds green" ;;
+            skipped) echo "image-irrelevant diff, builds skipped" ;;
+            *)
+              echo "build-and-push result: $RESULT"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Summary

Fixes the matrix-skip hole in the #1967 required-checks design, hit first by #1968: a matrix job skipped at the job level never expands its matrix, so GitHub reports one check literally named `Build ${{ matrix.app }}` and the required Build server/admin/migrate contexts sit on Expected forever, blocking every PR outside the image build graph.

- Adds a non-matrix `Docker images` summary job with `if: always()`: success when the build matrix succeeded or skipped as image-irrelevant, failure on any build failure or cancellation.
- After this lands on test, the protect-main-test ruleset swaps the three matrix contexts for the single `Docker images` context (I will apply it, same authorization as the first flip).
- This PR touches docker.yml, so the matrix RUNS here and the current required contexts report normally; it can merge under the existing ruleset.

## Verification

- YAML parses clean.
- This PR exercises both the matrix (runs, docker.yml is in the changes list) and the new summary job live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)