### PR TITLE
feat(server): license refresh endpoint + read-only exemption (GAP-287 PR-1)

### DIFF
--- a/.changeset/gap-287-license-refresh-validator.md
+++ b/.changeset/gap-287-license-refresh-validator.md
@@ -1,0 +1,5 @@
+---
+'@revealui/core': minor
+---
+
+Add `validateLicenseKeyForRefresh` and the `REFRESH_ACCEPT_DAYS` constant to the license module. The refresh validator verifies a presented license JWT within a wider bounded-expiry window than the run-time validation grace, reusing the same rotation-aware multi-key verification path, so a running instance can obtain its current stored key without a new key being minted.

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -168,6 +168,7 @@ export default function LicensePage() {
     }
   };
 
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim();
   const tier = subscription?.tier ?? 'free';
   const limits = TIER_LIMITS[tier];
   const tierFeatures = features?.[tier];
@@ -303,6 +304,28 @@ export default function LicensePage() {
                 <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-2 text-xs font-mono dark:bg-zinc-900">
                   REVEALUI_LICENSE_KEY=your-key-here
                 </pre>
+              </div>
+            </div>
+            <div className="rounded-lg border p-3 dark:border-zinc-800">
+              <p className="text-xs font-medium text-zinc-600 uppercase tracking-wide mb-2">
+                Automatic key renewal
+              </p>
+              <div className="space-y-1.5 text-sm text-zinc-600 dark:text-zinc-400">
+                <p>
+                  Your subscription key is re-issued on your billing cycle. A running instance can
+                  pull its current key at any time from the refresh endpoint, so a renewed key
+                  reaches your deployment without a manual copy. Run this from the instance that
+                  holds the key:
+                </p>
+                <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-2 text-xs font-mono dark:bg-zinc-900">
+                  {`curl -X POST ${apiBase}/api/license/refresh \\
+  -H 'content-type: application/json' \\
+  -d "{\\"licenseKey\\":\\"$REVEALUI_LICENSE_KEY\\"}"`}
+                </pre>
+                <p className="text-xs text-zinc-400 mt-2">
+                  The endpoint returns your current key and never issues a new one. If your key is
+                  older than the renewal window, copy the key above from this page instead.
+                </p>
               </div>
             </div>
             {publicKey && (

--- a/apps/server/src/lib/__tests__/lifecycle-emails.test.ts
+++ b/apps/server/src/lib/__tests__/lifecycle-emails.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Lifecycle email copy — GAP-287 PR-1 discoverability.
+ *
+ * The day-7 outcome email for PAID tiers must surface the renewal path (the
+ * refresh endpoint + the license page that carries the one-line command) so a
+ * shortened-TTL key never strands a running instance. The free-tier email must
+ * NOT carry it (no license key to refresh).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildDay7Outcome } from '../lifecycle-emails.js';
+
+describe('buildDay7Outcome — renewal-path discoverability (GAP-287 PR-1)', () => {
+  for (const tier of ['pro', 'max', 'enterprise'] as const) {
+    it(`mentions the refresh endpoint and license page for a paid tier (${tier}), with agent actions`, () => {
+      const { html, text } = buildDay7Outcome(tier, 5);
+      expect(html).toContain('refresh endpoint');
+      expect(html).toContain('/account/license');
+      expect(text).toContain('refresh endpoint');
+      expect(text).toContain('/account/license');
+    });
+
+    it(`mentions the refresh endpoint and license page for a paid tier (${tier}), zero-state`, () => {
+      const { html, text } = buildDay7Outcome(tier, 0);
+      expect(html).toContain('refresh endpoint');
+      expect(text).toContain('/account/license');
+    });
+  }
+
+  it('does NOT mention the refresh endpoint for the free tier', () => {
+    const withActions = buildDay7Outcome('free', 3);
+    const zeroState = buildDay7Outcome('free', 0);
+    expect(withActions.html).not.toContain('refresh endpoint');
+    expect(withActions.text).not.toContain('refresh endpoint');
+    expect(zeroState.html).not.toContain('refresh endpoint');
+    expect(zeroState.text).not.toContain('refresh endpoint');
+  });
+
+  it('contains no em dashes in the renewal copy (fleet hardline)', () => {
+    const { html, text } = buildDay7Outcome('pro', 2);
+    expect(html).not.toContain('—');
+    expect(text).not.toContain('—');
+  });
+});

--- a/apps/server/src/lib/lifecycle-emails.ts
+++ b/apps/server/src/lib/lifecycle-emails.ts
@@ -99,9 +99,21 @@ ${supportFooter('If you have questions')}`,
 // =============================================================================
 
 export function buildDay7Outcome(
-  _tier: LifecycleTier,
+  tier: LifecycleTier,
   weeklyAgentActions: number,
 ): LifecycleEmailContent {
+  // Paid tiers get a note about the renewal path so a shortened-TTL key never
+  // strands a running instance: the key renews on the billing cycle and the
+  // instance can pull the current key from the refresh endpoint. The one-line
+  // command lives on the license page (GAP-287 PR-1, GAP-300 surface).
+  const renewalHtml = isPaidTier(tier)
+    ? `<p>One more thing worth knowing. Your license key renews on your billing cycle, and a running instance can pull the current key from the refresh endpoint, so a renewal reaches your deployment on its own. The one-line command is on your license page.</p>
+${ctaButton(licenseUrl(), 'See the renewal command')}`
+    : '';
+  const renewalText = isPaidTier(tier)
+    ? `\n\nOne more thing worth knowing. Your license key renews on your billing cycle, and a running instance can pull the current key from the refresh endpoint, so a renewal reaches your deployment on its own. The one-line command is on your license page: ${licenseUrl()}`
+    : '';
+
   if (weeklyAgentActions > 0) {
     const noun = weeklyAgentActions === 1 ? 'action' : 'actions';
     return {
@@ -112,9 +124,10 @@ export function buildDay7Outcome(
 <p>Here is your first week with RevealUI. Your agents took ${weeklyAgentActions} ${noun} this week, and every one of them left a receipt you can check.</p>
 <p>Open your dashboard to see exactly what your agents did and when.</p>
 ${ctaButton(dashboardUrl(), 'Open your dashboard')}
+${renewalHtml}
 ${supportFooter('If you have questions')}`,
       ),
-      text: `Here is your first week with RevealUI. Your agents took ${weeklyAgentActions} ${noun} this week, and every one of them left a receipt you can check.\n\nOpen your dashboard to see exactly what your agents did and when: ${dashboardUrl()}`,
+      text: `Here is your first week with RevealUI. Your agents took ${weeklyAgentActions} ${noun} this week, and every one of them left a receipt you can check.\n\nOpen your dashboard to see exactly what your agents did and when: ${dashboardUrl()}${renewalText}`,
     };
   }
 
@@ -126,9 +139,10 @@ ${supportFooter('If you have questions')}`,
 <p>You are a week into RevealUI and your agents have not acted yet. We would rather show you an honest zero than dress it up.</p>
 <p>The value shows up the moment an agent does something on your data, because it leaves a receipt you can check. One task is enough to see it.</p>
 ${ctaButton(dashboardUrl(), 'Run your first agent')}
+${renewalHtml}
 ${supportFooter('If you have questions')}`,
     ),
-    text: `You are a week into RevealUI and your agents have not acted yet. We would rather show you an honest zero than dress it up.\n\nThe value shows up the moment an agent does something on your data, because it leaves a receipt you can check. One task is enough to see it: ${dashboardUrl()}`,
+    text: `You are a week into RevealUI and your agents have not acted yet. We would rather show you an honest zero than dress it up.\n\nThe value shows up the moment an agent does something on your data, because it leaves a receipt you can check. One task is enough to see it: ${dashboardUrl()}${renewalText}`,
   };
 }
 

--- a/apps/server/src/middleware/__tests__/support-expiry.test.ts
+++ b/apps/server/src/middleware/__tests__/support-expiry.test.ts
@@ -329,6 +329,7 @@ describe('enforceReadOnlyWrites (GAP-310)', () => {
       '/api/billing/checkout-support-renewal',
       '/api/auth/signin',
       '/api/license/verify',
+      '/api/license/refresh',
       '/api/webhooks/stripe',
     ]) {
       const res = await app.request(path, { method: 'POST' });

--- a/apps/server/src/middleware/license.ts
+++ b/apps/server/src/middleware/license.ts
@@ -150,6 +150,10 @@ const READ_ONLY_EXEMPT: readonly string[] = [
   '/api/v1/license/verify',
   '/api/license/features',
   '/api/v1/license/features',
+  // License refresh — a read-only-mode customer fetching their current stored
+  // key is exactly the escape-hatch class this set exists for (GAP-287 PR-1).
+  '/api/license/refresh',
+  '/api/v1/license/refresh',
   // Machine webhooks (Stripe etc.). Renewal settles here — never block a machine write.
   '/api/webhooks/',
   '/api/v1/webhooks/',

--- a/apps/server/src/routes/__tests__/license-refresh.test.ts
+++ b/apps/server/src/routes/__tests__/license-refresh.test.ts
@@ -1,0 +1,270 @@
+/**
+ * POST /api/license/refresh — GAP-287 PR-1.
+ *
+ * The refresh endpoint returns the CURRENT stored license key for the customer
+ * identified by a presented (possibly recently-expired) key. It never mints.
+ * Auth is possession of a recently-valid signed key (validateLicenseKeyForRefresh)
+ * plus an ACTIVE license row for the token's customerId. Every failure returns
+ * the identical 403 body so nothing distinguishes revoked / missing / lapsed.
+ *
+ * The bounded-expiry WINDOW logic (accept within REFRESH_ACCEPT_DAYS, reject
+ * beyond) is unit-tested at the crypto layer in
+ * packages/core/src/__tests__/license.test.ts. Here the core validator is
+ * mocked, so the route sees "verified → payload" vs "not verified → null".
+ */
+
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/config/stripe-mode', () => ({
+  getConfiguredStripeMode: vi.fn(() => 'live'),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: vi.fn(() => ({ ai: true })),
+}));
+
+vi.mock('@revealui/core/license', () => ({
+  validateLicenseKey: vi.fn(),
+  validateLicenseKeyForRefresh: vi.fn(),
+  generateLicenseKey: vi.fn(),
+  getPublicKeys: vi.fn(() => ['pub-key']),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  licenses: {
+    status: 'status',
+    licenseKey: 'license_key',
+    customerId: 'customer_id',
+    deletedAt: 'deleted_at',
+    mode: 'mode',
+    createdAt: 'created_at',
+  },
+}));
+
+import {
+  generateLicenseKey,
+  getPublicKeys,
+  validateLicenseKeyForRefresh,
+} from '@revealui/core/license';
+import { getClient } from '@revealui/db';
+import licenseApp from '../license.js';
+
+const mockedRefreshValidate = vi.mocked(validateLicenseKeyForRefresh);
+const mockedGetPublicKeys = vi.mocked(getPublicKeys);
+const mockedGenerate = vi.mocked(generateLicenseKey);
+
+const VALID_PAYLOAD = {
+  tier: 'pro' as const,
+  customerId: 'cus_123',
+  jti: 'jti-current',
+  exp: Math.floor(Date.now() / 1000) + 86_400,
+};
+
+function createApp() {
+  const app = new Hono();
+  app.route('/', licenseApp);
+  return app;
+}
+
+function post(body: unknown) {
+  return {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  };
+}
+
+/** Mock the refresh DB chain: select().from().where().orderBy().limit() → rows. */
+function mockDbRows(rows: Array<{ licenseKey: string }>) {
+  vi.mocked(getClient).mockReturnValue({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: () => Promise.resolve(rows),
+          }),
+        }),
+      }),
+    }),
+  } as never);
+}
+
+function mockDbThrow() {
+  vi.mocked(getClient).mockReturnValue({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: () => Promise.reject(new Error('DB unavailable')),
+          }),
+        }),
+      }),
+    }),
+  } as never);
+}
+
+const DENIED = { error: 'refresh_denied' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetPublicKeys.mockReturnValue(['pub-key']);
+});
+
+describe('POST /refresh', () => {
+  it('returns the stored current key for a valid current key', async () => {
+    mockedRefreshValidate.mockResolvedValue(VALID_PAYLOAD as never);
+    mockDbRows([{ licenseKey: 'stored.current.key' }]);
+
+    const app = createApp();
+    const res = await app.request('/refresh', post({ licenseKey: 'presented.key' }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ licenseKey: 'stored.current.key' });
+  });
+
+  it('returns the stored key for a key expired within the refresh window', async () => {
+    // The core validator accepts a within-window expired token, so from the
+    // route's view this is identical to a live key: a payload comes back and
+    // the active row's stored key is returned.
+    mockedRefreshValidate.mockResolvedValue({ ...VALID_PAYLOAD, jti: 'jti-stale' } as never);
+    mockDbRows([{ licenseKey: 'stored.renewed.key' }]);
+
+    const app = createApp();
+    const res = await app.request('/refresh', post({ licenseKey: 'recently.expired.key' }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ licenseKey: 'stored.renewed.key' });
+  });
+
+  it('denies with 403 when the key is expired beyond the refresh window', async () => {
+    // Beyond REFRESH_ACCEPT_DAYS the core validator returns null.
+    mockedRefreshValidate.mockResolvedValue(null as never);
+    mockDbRows([{ licenseKey: 'stored.key' }]);
+
+    const app = createApp();
+    const res = await app.request('/refresh', post({ licenseKey: 'ancient.key' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(DENIED);
+  });
+
+  it('denies with 403 when there is no active license row', async () => {
+    mockedRefreshValidate.mockResolvedValue(VALID_PAYLOAD as never);
+    mockDbRows([]); // active-status filter excludes revoked/expired/lapsed rows
+
+    const app = createApp();
+    const res = await app.request('/refresh', post({ licenseKey: 'presented.key' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(DENIED);
+  });
+
+  it('denies with 403 for a revoked license (no active row survives the status filter)', async () => {
+    // A revoked license has status != 'active', so the active-row query returns
+    // nothing. This is row-level revocation, enforced by the active-row check.
+    mockedRefreshValidate.mockResolvedValue(VALID_PAYLOAD as never);
+    mockDbRows([]);
+
+    const app = createApp();
+    const res = await app.request('/refresh', post({ licenseKey: 'revoked.customer.key' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(DENIED);
+  });
+
+  it('denies with 403 when no public key is configured', async () => {
+    mockedGetPublicKeys.mockReturnValue([]);
+
+    const app = createApp();
+    const res = await app.request('/refresh', post({ licenseKey: 'presented.key' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(DENIED);
+    // Never even attempts verification without a key.
+    expect(mockedRefreshValidate).not.toHaveBeenCalled();
+  });
+
+  it('fails closed with 403 when the DB lookup throws', async () => {
+    mockedRefreshValidate.mockResolvedValue(VALID_PAYLOAD as never);
+    mockDbThrow();
+
+    const app = createApp();
+    const res = await app.request('/refresh', post({ licenseKey: 'presented.key' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(DENIED);
+  });
+
+  it('never mints — generateLicenseKey is not called on any path', async () => {
+    mockedRefreshValidate.mockResolvedValue(VALID_PAYLOAD as never);
+    mockDbRows([{ licenseKey: 'stored.current.key' }]);
+
+    const app = createApp();
+    await app.request('/refresh', post({ licenseKey: 'presented.key' }));
+
+    expect(mockedGenerate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a missing licenseKey', async () => {
+    const app = createApp();
+    const res = await app.request('/refresh', post({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('every denial is byte-identical (same status and body)', async () => {
+    const app = createApp();
+
+    // Expired-beyond-window
+    mockedRefreshValidate.mockResolvedValue(null as never);
+    mockDbRows([{ licenseKey: 'stored.key' }]);
+    const beyond = await app.request('/refresh', post({ licenseKey: 'a' }));
+
+    // No active row
+    mockedRefreshValidate.mockResolvedValue(VALID_PAYLOAD as never);
+    mockDbRows([]);
+    const noRow = await app.request('/refresh', post({ licenseKey: 'b' }));
+
+    // No public key
+    mockedGetPublicKeys.mockReturnValue([]);
+    const noKey = await app.request('/refresh', post({ licenseKey: 'c' }));
+    mockedGetPublicKeys.mockReturnValue(['pub-key']);
+
+    // DB throw
+    mockedRefreshValidate.mockResolvedValue(VALID_PAYLOAD as never);
+    mockDbThrow();
+    const dbErr = await app.request('/refresh', post({ licenseKey: 'd' }));
+
+    for (const res of [beyond, noRow, noKey, dbErr]) {
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual(DENIED);
+    }
+  });
+
+  // ─── RED until GAP-260 ─────────────────────────────────────────────────────
+  // Spec §4 binding 2: a token whose specific `jti` was revoked must be refused
+  // even when its customer's license row is still ACTIVE (the "a stolen old key
+  // extends the attacker's window" mitigation). That requires the GAP-260
+  // per-`jti` denylist, which is owner-gated and not yet built (no denylist
+  // store exists). Until it lands, an active-row customer's revoked-lineage key
+  // still refreshes (fail-open), so this asserts a behavior PR-1 does not yet
+  // deliver. Skipped so CI stays green; documented RED per spec §7.
+  it.skip('denies with 403 for a revoked jti even when the customer row is active (GAP-260)', async () => {
+    mockedRefreshValidate.mockResolvedValue({ ...VALID_PAYLOAD, jti: 'jti-revoked' } as never);
+    mockDbRows([{ licenseKey: 'stored.current.key' }]); // customer row is active
+
+    const app = createApp();
+    const res = await app.request('/refresh', post({ licenseKey: 'leaked.old.key' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(DENIED);
+  });
+});

--- a/apps/server/src/routes/license.ts
+++ b/apps/server/src/routes/license.ts
@@ -1,15 +1,18 @@
 import { timingSafeEqual } from 'node:crypto';
+import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import {
   generateLicenseKey,
+  getPublicKeys,
   type LicensePayload,
   validateLicenseKey,
+  validateLicenseKeyForRefresh,
 } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { licenses } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
-import { eq } from 'drizzle-orm';
+import { and, desc, eq, isNull } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 
 const app = new OpenAPIHono();
@@ -119,6 +122,26 @@ const LicenseGenerateResponseSchema = z.object({
 
 const ErrorSchema = z.object({
   error: z.string().openapi({ example: 'Invalid license key' }),
+});
+
+const LicenseRefreshRequestSchema = z.object({
+  licenseKey: z.string().min(1).openapi({
+    description: 'The current (possibly recently-expired) license key held by the instance',
+    example: 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9...',
+  }),
+});
+
+const LicenseRefreshResponseSchema = z.object({
+  licenseKey: z.string().openapi({
+    description: 'The current stored license key for this customer',
+  }),
+});
+
+const RefreshDeniedSchema = z.object({
+  error: z.literal('refresh_denied').openapi({
+    description: 'Uniform denial. Never distinguishes revoked, missing, or lapsed.',
+    example: 'refresh_denied',
+  }),
 });
 
 // ─── Routes ──────────────────────────────────────────────────────────────────
@@ -431,6 +454,115 @@ app.openapi(generateRoute, async (c) => {
     },
     201,
   );
+});
+
+// POST /api/license/refresh  -  Machine path to fetch the current stored key
+//
+// GAP-287 PR-1. A running self-hosted instance presents its current (possibly
+// recently-expired) key and receives the CURRENT stored key for its license.
+// It NEVER mints: it only returns what the webhook lifecycle already wrote, so
+// it cannot extend entitlement beyond what billing granted. Auth is possession
+// of a recently-valid signed key (within REFRESH_ACCEPT_DAYS of exp) plus an
+// ACTIVE license row for the token's customerId. Every failure returns the same
+// 403 with no reason, so nothing distinguishes revoked / missing / lapsed.
+const refreshRoute = createRoute({
+  method: 'post',
+  path: '/refresh',
+  tags: ['license'],
+  summary: 'Refresh a license key',
+  description:
+    'Returns the current stored license key for the customer identified by the presented key. Accepts a key expired within the refresh window. Never mints a new key. Any failure returns 403 with no distinguishing reason.',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: LicenseRefreshRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: LicenseRefreshResponseSchema,
+        },
+      },
+      description: 'The current stored license key',
+    },
+    403: {
+      content: {
+        'application/json': {
+          schema: RefreshDeniedSchema,
+        },
+      },
+      description: 'Refresh denied',
+    },
+  },
+});
+
+app.openapi(refreshRoute, async (c) => {
+  const { licenseKey } = c.req.valid('json');
+
+  // Every denial returns the identical body + status. The presented key's
+  // signature validity, expiry position, revocation, and row state must not be
+  // distinguishable to the caller (no refresh oracle).
+  const deny = () => c.json({ error: 'refresh_denied' as const }, 403);
+
+  // Verify against the ordered public-key set (current + rotation NEXT), so a
+  // key minted under the outgoing private key still refreshes during a rotation
+  // window (GAP-259). An unconfigured key is an operator fault, not a customer
+  // fault: fail closed but log loudly server-side.
+  const publicKeys = getPublicKeys();
+  if (publicKeys.length === 0) {
+    logger.error('REVEALUI_LICENSE_PUBLIC_KEY not configured; license refresh cannot verify');
+    return deny();
+  }
+
+  // Signature valid AND exp past by at most REFRESH_ACCEPT_DAYS. Beyond that
+  // window the verifier returns null and re-delivery goes through the admin page.
+  const payload = await validateLicenseKeyForRefresh(licenseKey, publicKeys);
+  if (!payload) {
+    return deny();
+  }
+
+  // NOTE (GAP-260): per-`jti` denylist revocation — refusing a specifically
+  // revoked token lineage even when its customer's row is still active — lands
+  // with the GAP-260 jti-denylist (owner-gated, not yet built). Until then,
+  // row-level revocation is enforced by the active-row check below: a revoked
+  // or lapsed license has status != 'active', so no key is returned.
+
+  // Return the current stored key for an ACTIVE, non-deleted license row of the
+  // token's customerId, scoped to this deployment's Stripe mode (mirrors
+  // getUserLicenseKey in billing.ts). Any DB failure fails closed to the same
+  // 403 rather than leaking a distinguishable error.
+  try {
+    const [row] = await getClient()
+      .select({ licenseKey: licenses.licenseKey })
+      .from(licenses)
+      .where(
+        and(
+          eq(licenses.customerId, payload.customerId),
+          eq(licenses.status, 'active'),
+          isNull(licenses.deletedAt),
+          eq(licenses.mode, getConfiguredStripeMode()),
+        ),
+      )
+      .orderBy(desc(licenses.createdAt))
+      .limit(1);
+
+    if (!row?.licenseKey) {
+      return deny();
+    }
+
+    logger.info('License key refreshed', { customerId: payload.customerId, tier: payload.tier });
+    return c.json({ licenseKey: row.licenseKey }, 200);
+  } catch (err) {
+    logger.warn('License refresh failed during DB lookup  -  failing closed', {
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+    return deny();
+  }
 });
 
 // GET /api/license/features  -  Public: list features per tier

--- a/packages/core/src/__tests__/license.test.ts
+++ b/packages/core/src/__tests__/license.test.ts
@@ -23,8 +23,10 @@ import {
   type LicenseTier,
   MAX_LICENSE_CACHE_TTL_MS,
   parseLicenseCacheTtlEnv,
+  REFRESH_ACCEPT_DAYS,
   resetLicenseState,
   validateLicenseKey,
+  validateLicenseKeyForRefresh,
 } from '../license.js';
 
 // ---------------------------------------------------------------------------
@@ -910,5 +912,117 @@ describe('validateLicenseKey — multi-key rotation (GAP-259 P0-3)', () => {
     // Collapse real newlines to the literal two-character escape sequence.
     process.env.REVEALUI_LICENSE_PUBLIC_KEY_NEXT = nextPublicKeyPem.split('\n').join('\\n');
     expect(await initializeLicense()).toBe('pro');
+  });
+});
+
+// =============================================================================
+// validateLicenseKeyForRefresh (GAP-287 PR-1)
+// =============================================================================
+
+describe('validateLicenseKeyForRefresh', () => {
+  const ISSUER = 'https://revealui.com';
+  const AUDIENCE = 'revealui-license';
+
+  /** Mint a token with an explicit absolute exp (epoch seconds). */
+  async function mintToken(opts: {
+    privateKey: string;
+    publicKey?: string;
+    expSec: number;
+    customerId?: string;
+  }): Promise<string> {
+    const key = await importPKCS8(opts.privateKey, 'EdDSA');
+    const header: { alg: string; kid?: string } = { alg: 'EdDSA' };
+    if (opts.publicKey) {
+      header.kid = await computeKeyId(opts.publicKey);
+    }
+    return new SignJWT({
+      tier: 'pro',
+      customerId: opts.customerId ?? 'cus_123',
+      jti: 'jti-refresh-test',
+    })
+      .setProtectedHeader(header)
+      .setIssuedAt()
+      .setNotBefore('0s')
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setExpirationTime(opts.expSec)
+      .sign(key);
+  }
+
+  const nowSec = () => Math.floor(Date.now() / 1000);
+
+  it('ratifies the refresh-accept window at 30 days', () => {
+    expect(REFRESH_ACCEPT_DAYS).toBe(30);
+  });
+
+  it('accepts a live (unexpired) key and returns its payload', async () => {
+    const token = await mintToken({ privateKey: privateKeyPem, expSec: nowSec() + 86_400 });
+    const payload = await validateLicenseKeyForRefresh(token, publicKeyPem);
+    expect(payload?.customerId).toBe('cus_123');
+    expect(payload?.tier).toBe('pro');
+  });
+
+  it('accepts a key expired WITHIN the refresh-accept window', async () => {
+    // Expired 20 days ago — inside the 30-day window.
+    const token = await mintToken({
+      privateKey: privateKeyPem,
+      expSec: nowSec() - 20 * 86_400,
+    });
+    const payload = await validateLicenseKeyForRefresh(token, publicKeyPem);
+    expect(payload?.customerId).toBe('cus_123');
+  });
+
+  it('rejects a key expired BEYOND the refresh-accept window', async () => {
+    // Expired 40 days ago — outside the 30-day window.
+    const token = await mintToken({
+      privateKey: privateKeyPem,
+      expSec: nowSec() - 40 * 86_400,
+    });
+    const payload = await validateLicenseKeyForRefresh(token, publicKeyPem);
+    expect(payload).toBeNull();
+  });
+
+  it('honors an explicit refreshAcceptDays override', async () => {
+    const token = await mintToken({
+      privateKey: privateKeyPem,
+      expSec: nowSec() - 10 * 86_400,
+    });
+    // A 5-day window rejects a token expired 10 days ago.
+    expect(await validateLicenseKeyForRefresh(token, publicKeyPem, 5)).toBeNull();
+    // A 15-day window accepts the same token.
+    expect((await validateLicenseKeyForRefresh(token, publicKeyPem, 15))?.customerId).toBe(
+      'cus_123',
+    );
+  });
+
+  it('refreshes a token signed by the OUTGOING key during a dual-key rotation window', async () => {
+    // GAP-259 composition: mint under an old keypair, verify against the ordered
+    // [current, next] set (the outgoing key is one of the candidates).
+    const { publicKey: oldPub, privateKey: oldPriv } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const token = await mintToken({
+      privateKey: oldPriv,
+      publicKey: oldPub,
+      expSec: nowSec() - 5 * 86_400, // recently expired, within window
+    });
+    // Ordered set: current (the module keypair) first, outgoing (old) second.
+    const payload = await validateLicenseKeyForRefresh(token, [publicKeyPem, oldPub]);
+    expect(payload?.customerId).toBe('cus_123');
+  });
+
+  it('rejects a token signed by an unrelated key', async () => {
+    const { privateKey: strayPriv } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const token = await mintToken({ privateKey: strayPriv, expSec: nowSec() + 86_400 });
+    expect(await validateLicenseKeyForRefresh(token, publicKeyPem)).toBeNull();
+  });
+
+  it('returns null when no candidate keys are supplied', async () => {
+    const token = await mintToken({ privateKey: privateKeyPem, expSec: nowSec() + 86_400 });
+    expect(await validateLicenseKeyForRefresh(token, [])).toBeNull();
   });
 });

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -283,6 +283,64 @@ export async function validateLicenseKey(
   publicKey: string | readonly string[],
   expectedCustomerId?: string,
 ): Promise<LicensePayload | null> {
+  // Accept tokens expired within the subscription grace window so the payload
+  // is available for grace-period calculations in isLicensed().
+  return verifyAndParseLicenseJwt(
+    licenseKey,
+    publicKey,
+    graceConfig.subscriptionDays * 86_400,
+    expectedCustomerId,
+  );
+}
+
+/**
+ * How far past `exp` a license JWT is still accepted by the refresh endpoint
+ * (GAP-287 PR-1). Ratified by the owner 2026-07-18 at 30 days.
+ *
+ * Deliberately wider than the subscription validation grace
+ * (`LICENSE_GRACE_SUBSCRIPTION_DAYS`, default 3): the validation grace answers
+ * "may you still run", the refresh-accept window answers "may you still fetch
+ * your renewal". A customer returning from a month away should still be able to
+ * pull their current key rather than being bricked. Beyond this window the
+ * refresh path refuses and re-delivery goes through the authenticated admin
+ * account page.
+ */
+export const REFRESH_ACCEPT_DAYS = 30;
+
+/**
+ * Refresh-path validator (GAP-287 PR-1). Verifies a presented license JWT for
+ * `POST /api/license/refresh`, accepting a token whose `exp` is past by at most
+ * `refreshAcceptDays` (default {@link REFRESH_ACCEPT_DAYS}).
+ *
+ * It reuses the SAME ordered multi-key verification (GAP-259 rotation
+ * composition) and payload schema as {@link validateLicenseKey}, so a token
+ * minted under the outgoing private key during a dual-key rotation window still
+ * verifies. It performs NO `customerId` binding: the refresh endpoint trusts
+ * the token's `customerId` claim and then independently requires an ACTIVE
+ * license row for it. This function only proves possession of a recently-valid
+ * signed key. It never mints and never grants entitlement on its own.
+ */
+export async function validateLicenseKeyForRefresh(
+  licenseKey: string,
+  publicKey: string | readonly string[],
+  refreshAcceptDays: number = REFRESH_ACCEPT_DAYS,
+): Promise<LicensePayload | null> {
+  return verifyAndParseLicenseJwt(licenseKey, publicKey, refreshAcceptDays * 86_400);
+}
+
+/**
+ * Shared verify + parse path for {@link validateLicenseKey} and
+ * {@link validateLicenseKeyForRefresh}. The ONLY behavioral difference between
+ * the two callers is `clockToleranceSeconds` — how far past `exp` a token is
+ * still accepted — so the rotation-aware multi-key loop and the payload schema
+ * live in exactly one place.
+ */
+async function verifyAndParseLicenseJwt(
+  licenseKey: string,
+  publicKey: string | readonly string[],
+  clockToleranceSeconds: number,
+  expectedCustomerId?: string,
+): Promise<LicensePayload | null> {
   const candidates = typeof publicKey === 'string' ? [publicKey] : [...publicKey];
   if (candidates.length === 0) return null;
   try {
@@ -297,11 +355,9 @@ export async function validateLicenseKey(
     for (const candidate of ordered) {
       try {
         const key = await jose.importSPKI(candidate, 'EdDSA');
-        // Accept tokens expired within the subscription grace window so the
-        // payload is available for grace-period calculations in isLicensed().
         const { payload } = await jose.jwtVerify(licenseKey, key, {
           algorithms: ['EdDSA'],
-          clockTolerance: graceConfig.subscriptionDays * 86_400,
+          clockTolerance: clockToleranceSeconds,
           issuer: LICENSE_ISSUER,
           audience: LICENSE_AUDIENCE,
         });
@@ -310,7 +366,7 @@ export async function validateLicenseKey(
         break;
       } catch {
         // This candidate did not verify (wrong key, malformed PEM, bad
-        // iss/aud, or expired beyond grace) — try the next before giving up.
+        // iss/aud, or expired beyond tolerance) — try the next before giving up.
       }
     }
 


### PR DESCRIPTION
## Scope — GAP-287 PR-1 (the refresh endpoint, first in the sequence)

The machine path a shortened license-JWT TTL requires, shipped FIRST so that no
TTL reduction can brick a valid self-hosted customer at expiry. This PR is
exactly the §6 "PR-1" row of the design spec: the §4 refresh endpoint, its
`READ_ONLY_EXEMPT` entry, and admin-page + day-7 email discoverability. It ships
while all extant keys are still long-lived, so customer risk is zero. It does
NOT touch the exp derivation (PR-2) or the manual-mint default (PR-3).

### What §4 defines that this implements

`POST /api/license/refresh` returns the customer's CURRENT stored license key.
It **never mints**, so it cannot extend entitlement beyond what billing granted;
it only delivers what the webhook lifecycle already wrote. Bindings, in order:

1. **Signature valid within a bounded expiry window.** New
   `validateLicenseKeyForRefresh` (in `@revealui/core/license`) verifies the
   presented key against the ordered public-key set (`getPublicKeys()`, current +
   `_NEXT`), reusing the same rotation-aware multi-key path as
   `validateLicenseKey` (GAP-259 composition), but with a **wider** clock
   tolerance: a key whose `exp` is past by at most `REFRESH_ACCEPT_DAYS`
   (ratified 30d) still refreshes. Beyond that window the verifier returns null.
2. **Active license row for the token's `customerId`.** Row-level revocation is
   enforced here: a revoked / expired / lapsed license has `status != 'active'`,
   so no key is returned. Scoped to the deployment's Stripe mode (mirrors
   `getUserLicenseKey`).
3. **Uniform denial.** Every failure (bad signature, expired-beyond-window, no
   active row, unconfigured key, DB error) returns the identical
   `403 { "error": "refresh_denied" }` with no oracle distinguishing revoked /
   missing / lapsed. Fails closed on DB error.

`READ_ONLY_EXEMPT` gains `/api/license/refresh` (+ `/api/v1/...`): a read-only
(lapsed-support) customer fetching their current key is exactly the escape-hatch
class that set exists for. Discoverability: the admin license page shows the
one-line command, and the day-7 lifecycle email (paid tiers) points to it.

### Deferred to GAP-260 (documented, not a gap in this PR)

Per-`jti` denylist revocation — refusing a specifically revoked token lineage
**even when its customer's row is still active** (the "a stolen old key extends
the attacker's window" mitigation) — requires the GAP-260 jti-denylist, which is
owner-gated and not yet built (no denylist store exists in the schema). Until it
lands, row-level revocation (binding 2 above) is the enforced revocation path.
The pure per-jti behavior is captured as a skipped, documented-RED test.

## Red-first evidence (per spec §7)

Each proof: revert the source to `origin/test`, run, capture RED, restore from
`HEAD`, confirm GREEN.

| Proof | Reverted source | Result (RED) |
|---|---|---|
| A. Core refresh validator | `packages/core/src/license.ts` | 8 tests fail — `REFRESH_ACCEPT_DAYS` undefined, `validateLicenseKeyForRefresh is not a function` |
| B. Refresh endpoint | `apps/server/src/routes/license.ts` | 9 tests fail — endpoint absent, `expected 404 to be 200/403` |
| C. Read-only exemption | `apps/server/src/middleware/license.ts` | 1 test fails — `/api/license/refresh must be exempt: expected 403 to be 200` |
| D. Email discoverability | `apps/server/src/lib/lifecycle-emails.ts` | 6 paid-tier tests fail — email missing "refresh endpoint" (free-tier + em-dash checks stay green) |
| E. GAP-260 documented-red | (un-skipped against THIS branch) | 1 test fails — `expected 200 to be 403`: an active-row customer's revoked-lineage key still refreshes today (no denylist). Kept `it.skip` so CI is green. |

All reverts restored; working tree clean after each proof.

## Test counts (all green)

- `packages/core` `license.test.ts`: **87 passed** (8 new refresh tests: window accept/reject, explicit-window override, rotation composition, unrelated-key reject, empty-candidate).
- `apps/server` refresh + license + support-expiry + lifecycle-emails: **66 passed, 1 skipped** (the GAP-260 documented-red).
- Typecheck: `@revealui/core`, `server`, `admin` all clean. Biome clean on all touched files.

## Guardrail-2 — crown-jewel-adjacent (signing surface)

This PR touches `routes/license.ts` and `middleware/license.ts`. The fleet
security self-check (`security-pr-review-check.js --diff origin/test`) correctly
returns **HOLD** for these paths. Per `dup-work-and-review-gates.md` this PR
requires a **recorded non-author verdict** (`sec-review:approved` label) before
merge. I am the builder and do **not** self-merge or self-clear.

## Sequencing warning (spec §6, load-bearing)

**PR-2 (exp derivation + re-mint cadence) must never land before this PR.**
Shortening the TTL before a refresh path exists would hard-fail license
validation for every current paying self-hosted subscriber at expiry, with no
machine path to a fresh key. This PR is the prerequisite that makes the TTL
reduction safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
