### PR TITLE
feat(security): RFC 8785 JCS + Ed25519 audit signing library (GAP-355 Stage 3 PR-1)

### DIFF
--- a/.changeset/gap-355-stage3-signing-lib.md
+++ b/.changeset/gap-355-stage3-signing-lib.md
@@ -1,0 +1,5 @@
+---
+'@revealui/security': minor
+---
+
+audit signing library (GAP-355 Stage 3 PR-1): add `canonicalizeJcs` (RFC 8785 JSON canonicalization, promoted + hardened from the mcp-audit canonicalizer) to the client-safe barrel, and the per-row Ed25519 signer + verifier to `@revealui/security/server` — `Ed25519AuditRowSigner` (implements the `AuditRowSigner` injection interface, emits `v1.ed25519.<kid>.<base64url>`), `verifyEd25519AuditSignature` / `verifyAuditRow`, `auditSignableBytes` (the shared sign-and-verify byte builder over the integrity-bearing columns incl. `sequence`/`tenant`), and `classifyAuditSignature`. Library only — no caller wired yet (Stage 3 PR-2 injects it at the DrizzleAuditStore door and retires the legacy HMAC).

--- a/packages/security/src/__tests__/audit-signing.test.ts
+++ b/packages/security/src/__tests__/audit-signing.test.ts
@@ -1,0 +1,137 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  type AuditSignable,
+  auditSignableBytes,
+  classifyAuditSignature,
+  Ed25519AuditRowSigner,
+  verifyAuditRow,
+  verifyEd25519AuditSignature,
+} from '../audit-signing.js';
+
+function makeKeypair(): { privateKeyPem: string; publicKeyPem: string } {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  return {
+    privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    publicKeyPem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+  };
+}
+
+function makeRow(overrides: Partial<AuditSignable> = {}): AuditSignable {
+  return {
+    id: 'row-1',
+    sequence: 42,
+    tenant: 'acct_123',
+    timestamp: new Date('2026-07-18T00:00:00.000Z'),
+    eventType: 'agent:tool:called',
+    severity: 'info',
+    agentId: 'agent-1',
+    taskId: null,
+    sessionId: 'sess-1',
+    payload: { tool: 'read', args: { b: 2, a: 1 } },
+    policyViolations: [],
+    ...overrides,
+  };
+}
+
+describe('Ed25519 audit signing (GAP-355 Stage 3)', () => {
+  let priv: string;
+  let pub: string;
+  let signer: Ed25519AuditRowSigner;
+  const resolve = (kid: string) => (kid === 'kid-1' ? pub : null);
+
+  beforeAll(() => {
+    const kp = makeKeypair();
+    priv = kp.privateKeyPem;
+    pub = kp.publicKeyPem;
+    signer = new Ed25519AuditRowSigner(priv, 'kid-1');
+  });
+
+  it('signs and verifies a row round-trip', () => {
+    const row = makeRow();
+    const { value } = signer.sign(auditSignableBytes(row));
+    expect(value.startsWith('v1.ed25519.kid-1.')).toBe(true);
+    expect(verifyAuditRow(row, value, resolve).valid).toBe(true);
+  });
+
+  it('verification fails when ANY signed field is tampered', () => {
+    const row = makeRow();
+    const { value } = signer.sign(auditSignableBytes(row));
+    for (const tampered of [
+      makeRow({ severity: 'critical' }),
+      makeRow({ agentId: 'attacker' }),
+      makeRow({ payload: { tool: 'delete' } }),
+      makeRow({ tenant: 'acct_other' }),
+    ]) {
+      expect(verifyAuditRow(tampered, value, resolve).valid).toBe(false);
+    }
+  });
+
+  it('verification fails when the sequence is renumbered (binds row to slot)', () => {
+    const row = makeRow({ sequence: 42 });
+    const { value } = signer.sign(auditSignableBytes(row));
+    expect(verifyAuditRow(makeRow({ sequence: 43 }), value, resolve).valid).toBe(false);
+  });
+
+  it('a Date and its equivalent ISO string produce identical signed bytes', () => {
+    const a = auditSignableBytes(makeRow({ timestamp: new Date('2026-07-18T00:00:00.000Z') }));
+    const b = auditSignableBytes(makeRow({ timestamp: '2026-07-18T00:00:00.000Z' }));
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+
+  it('signing is stable regardless of payload key order (canonicalization)', () => {
+    const v1 = signer.sign(auditSignableBytes(makeRow({ payload: { a: 1, b: 2 } }))).value;
+    const v2 = signer.sign(auditSignableBytes(makeRow({ payload: { b: 2, a: 1 } }))).value;
+    expect(v1).toBe(v2);
+  });
+
+  it('verification fails for an unresolvable kid', () => {
+    const row = makeRow();
+    const { value } = signer.sign(auditSignableBytes(row));
+    const result = verifyAuditRow(row, value, () => null);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/no public key/);
+  });
+
+  it('verification fails (never throws) on a malformed signature value', () => {
+    const bytes = auditSignableBytes(makeRow());
+    expect(verifyEd25519AuditSignature(bytes, 'not-a-signature', resolve).valid).toBe(false);
+    expect(verifyEd25519AuditSignature(bytes, 'v2.ed25519.kid-1.abc', resolve).valid).toBe(false);
+    expect(verifyEd25519AuditSignature(bytes, 'v1.rsa.kid-1.abc', resolve).valid).toBe(false);
+  });
+
+  it('verification fails when a DIFFERENT key signed it', () => {
+    const other = new Ed25519AuditRowSigner(makeKeypair().privateKeyPem, 'kid-1');
+    const row = makeRow();
+    const forged = other.sign(auditSignableBytes(row)).value;
+    // kid resolves to OUR public key, but the bytes were signed by another key.
+    expect(verifyAuditRow(row, forged, resolve).valid).toBe(false);
+  });
+
+  it('rejects a kid containing the "." delimiter', () => {
+    expect(() => new Ed25519AuditRowSigner(priv, 'bad.kid')).toThrow(/kid/);
+    expect(() => new Ed25519AuditRowSigner(priv, '')).toThrow(/kid/);
+  });
+
+  it('rejects a non-ed25519 private key', () => {
+    const rsa = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const rsaPem = rsa.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    expect(() => new Ed25519AuditRowSigner(rsaPem, 'kid-1')).toThrow(/ed25519/);
+  });
+
+  describe('classifyAuditSignature', () => {
+    it('classifies NULL as unsigned', () => {
+      expect(classifyAuditSignature(null)).toBe('unsigned');
+      expect(classifyAuditSignature(undefined)).toBe('unsigned');
+    });
+    it('classifies a bare hex value as a legacy HMAC', () => {
+      expect(classifyAuditSignature('a1b2c3d4e5f6')).toBe('legacy-hmac');
+    });
+    it('classifies a v1.ed25519 value', () => {
+      expect(classifyAuditSignature('v1.ed25519.kid-1.abc')).toBe('ed25519');
+    });
+    it('classifies an unknown dotted value as unknown', () => {
+      expect(classifyAuditSignature('v9.dsa.k.s')).toBe('unknown');
+    });
+  });
+});

--- a/packages/security/src/__tests__/jcs.test.ts
+++ b/packages/security/src/__tests__/jcs.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalizeJcs } from '../jcs.js';
+
+describe('canonicalizeJcs (RFC 8785)', () => {
+  it('sorts object keys by UTF-16 code unit', () => {
+    expect(canonicalizeJcs({ b: 1, a: 2, c: 3 })).toBe('{"a":2,"b":1,"c":3}');
+  });
+
+  it('sorts nested object keys recursively', () => {
+    expect(canonicalizeJcs({ z: { y: 1, x: 2 }, a: 1 })).toBe('{"a":1,"z":{"x":2,"y":1}}');
+  });
+
+  it('orders ASCII before higher code points (a before é)', () => {
+    // JCS sorts by UTF-16 code unit: 'a' (U+0061) < 'é' (U+00E9).
+    expect(canonicalizeJcs({ é: 1, a: 2 })).toBe('{"a":2,"é":1}');
+  });
+
+  it('orders uppercase before lowercase (code-unit order)', () => {
+    // 'A' (U+0041) < 'a' (U+0061)
+    expect(canonicalizeJcs({ a: 1, A: 2 })).toBe('{"A":2,"a":1}');
+  });
+
+  it('preserves array element order (arrays are not sorted)', () => {
+    expect(canonicalizeJcs([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('serializes scalars', () => {
+    expect(canonicalizeJcs(null)).toBe('null');
+    expect(canonicalizeJcs(true)).toBe('true');
+    expect(canonicalizeJcs(false)).toBe('false');
+    expect(canonicalizeJcs('hello')).toBe('"hello"');
+    expect(canonicalizeJcs(42)).toBe('42');
+    expect(canonicalizeJcs(1.5)).toBe('1.5');
+  });
+
+  it('normalizes -0 to 0', () => {
+    expect(canonicalizeJcs(-0)).toBe('0');
+    expect(canonicalizeJcs({ n: -0 })).toBe('{"n":0}');
+  });
+
+  it('escapes strings per JSON (quotes, backslash, control chars)', () => {
+    expect(canonicalizeJcs('a"b\\c')).toBe('"a\\"b\\\\c"');
+    expect(canonicalizeJcs('tab\tnewline\n')).toBe('"tab\\tnewline\\n"');
+  });
+
+  it('is stable regardless of input key insertion order (the load-bearing property)', () => {
+    const a = canonicalizeJcs({ one: 1, two: 2, three: 3 });
+    const b = canonicalizeJcs({ three: 3, one: 1, two: 2 });
+    expect(a).toBe(b);
+  });
+
+  it('canonicalizes a representative audit payload deterministically', () => {
+    const payload = { userId: 'u1', tool: 'read', nested: { b: [2, 3], a: 1 } };
+    expect(canonicalizeJcs(payload)).toBe(
+      '{"nested":{"a":1,"b":[2,3]},"tool":"read","userId":"u1"}',
+    );
+  });
+
+  // Fail-loud on non-JSON-representable input — the property that stops a signer
+  // from signing something other than what it was handed.
+  it('throws on undefined', () => {
+    expect(() => canonicalizeJcs(undefined)).toThrow(/undefined/);
+  });
+
+  it('throws on a non-finite number (NaN / Infinity)', () => {
+    expect(() => canonicalizeJcs(Number.NaN)).toThrow(/non-finite/);
+    expect(() => canonicalizeJcs(Number.POSITIVE_INFINITY)).toThrow(/non-finite/);
+  });
+
+  it('throws on bigint, function, and symbol — including nested', () => {
+    expect(() => canonicalizeJcs(1n)).toThrow(/bigint/);
+    expect(() => canonicalizeJcs({ f: () => 0 })).toThrow(/function/);
+    expect(() => canonicalizeJcs({ s: Symbol('x') })).toThrow(/symbol/);
+  });
+
+  it('throws on an undefined object value rather than dropping the key', () => {
+    expect(() => canonicalizeJcs({ a: 1, b: undefined })).toThrow(/undefined/);
+  });
+});

--- a/packages/security/src/audit-signing.ts
+++ b/packages/security/src/audit-signing.ts
@@ -1,0 +1,199 @@
+/**
+ * Per-row Ed25519 signing + verification for the `audit_log` (GAP-355 Stage 3).
+ *
+ * ADR `2026-07-12-audit-receipt-architecture`: rows are signed independently with
+ * an Ed25519 private key; the public key is published so a customer can verify a
+ * receipt OFFLINE without our secret. Symmetric HMAC cannot support that (a
+ * verifier who can check can also forge), which is why Stage 3 replaces it.
+ *
+ * This module is the LIBRARY only — the pure canonicalizer + signer + verifier +
+ * the shared "what bytes get signed" builder. It wires into no caller here:
+ * Stage 3 PR-2 injects the signer at the single `DrizzleAuditStore` door (the
+ * ONE DOOR from Stage 2) and retires the legacy HMAC. Keeping this crypto in
+ * `@revealui/security/server` (node:crypto) preserves the store's crypto-free
+ * dependency direction.
+ *
+ * Signature wire format (in the existing `signature` text column):
+ *
+ *   v1.ed25519.<kid>.<base64url(signature)>
+ *
+ * Legacy discrimination is trivial and total: a NULL column is unsigned; a
+ * bare-hex value (no `.`) is a legacy MCP HMAC chain row; `v1.ed25519.*` is a
+ * Stage-3 signature. An unknown version/alg verifies as invalid, never as an
+ * assumed HMAC.
+ */
+
+import { createPrivateKey, createPublicKey, type KeyObject, sign, verify } from 'node:crypto';
+import { canonicalizeJcs } from './jcs.js';
+
+// ── What gets signed (ADR §3 / spec D2) ──────────────────────────────
+
+/**
+ * The integrity-bearing columns of an `audit_log` row, excluding the signature
+ * fields themselves. Every field is signed; any unsigned column would be a
+ * freely-editable column, which contradicts the claim the signature backs.
+ */
+export interface AuditSignable {
+  id: string;
+  sequence: number;
+  tenant: string | null;
+  timestamp: Date | string;
+  eventType: string;
+  severity: string;
+  agentId: string;
+  taskId: string | null;
+  sessionId: string | null;
+  payload: unknown;
+  policyViolations: string[];
+}
+
+/**
+ * Render a timestamp to the exact ISO-8601 UTC string (millisecond precision)
+ * that is signed. The verifier derives the SAME string from the `timestamptz`
+ * readback, so a row round-tripped through the DB re-canonicalizes identically.
+ * Timestamp re-serialization is the second most likely verify bug after key
+ * order, so it lives in one shared helper used by sign AND verify.
+ */
+export function auditTimestampString(ts: Date | string): string {
+  const d = typeof ts === 'string' ? new Date(ts) : ts;
+  if (Number.isNaN(d.getTime())) {
+    throw new Error('auditTimestampString: invalid timestamp');
+  }
+  return d.toISOString();
+}
+
+/** Build the canonical byte string signed for a row (shared by sign + verify). */
+export function auditSignableBytes(row: AuditSignable): Uint8Array {
+  const canonical = canonicalizeJcs({
+    id: row.id,
+    sequence: row.sequence,
+    tenant: row.tenant ?? null,
+    timestamp: auditTimestampString(row.timestamp),
+    eventType: row.eventType,
+    severity: row.severity,
+    agentId: row.agentId,
+    taskId: row.taskId ?? null,
+    sessionId: row.sessionId ?? null,
+    payload: row.payload ?? null,
+    policyViolations: row.policyViolations ?? [],
+  });
+  return new TextEncoder().encode(canonical);
+}
+
+// ── Signer (spec D5) ─────────────────────────────────────────────────
+
+/**
+ * The store's injection point. `sign` is synchronous — `crypto.sign` for
+ * Ed25519 is microseconds, so there is no async hop on the write path.
+ */
+export interface AuditRowSigner {
+  /** Sign canonical bytes, returning the `v1.ed25519.<kid>.<sig>` column value. */
+  sign(canonicalBytes: Uint8Array): { value: string };
+  /** The key id embedded in every signature this signer produces. */
+  readonly kid: string;
+}
+
+const SIG_VERSION = 'v1';
+const SIG_ALG = 'ed25519';
+
+function assertKidSafe(kid: string): void {
+  // `.` is the wire-format delimiter; a kid containing one would make the
+  // 4-part split ambiguous. Reject rather than silently corrupt.
+  if (kid.length === 0 || kid.includes('.')) {
+    throw new Error('Ed25519AuditRowSigner: kid must be non-empty and contain no "."');
+  }
+}
+
+export class Ed25519AuditRowSigner implements AuditRowSigner {
+  private readonly key: KeyObject;
+  readonly kid: string;
+
+  /**
+   * @param privateKeyPem Ed25519 private key, PKCS#8 PEM (GAP-261 convention).
+   * @param kid           Self-asserted key id, embedded in each signature.
+   */
+  constructor(privateKeyPem: string, kid: string) {
+    assertKidSafe(kid);
+    this.key = createPrivateKey(privateKeyPem);
+    if (this.key.asymmetricKeyType !== 'ed25519') {
+      throw new Error(
+        `Ed25519AuditRowSigner: expected an ed25519 key, got ${this.key.asymmetricKeyType ?? 'unknown'}`,
+      );
+    }
+    this.kid = kid;
+  }
+
+  sign(canonicalBytes: Uint8Array): { value: string } {
+    const signature = sign(null, Buffer.from(canonicalBytes), this.key);
+    return { value: `${SIG_VERSION}.${SIG_ALG}.${this.kid}.${signature.toString('base64url')}` };
+  }
+}
+
+// ── Verifier (spec D8) ───────────────────────────────────────────────
+
+/** Coarse classification of a stored `signature` column value. */
+export type AuditSignatureKind = 'unsigned' | 'legacy-hmac' | 'ed25519' | 'unknown';
+
+/** Classify a `signature` column value without verifying it. */
+export function classifyAuditSignature(signature: string | null | undefined): AuditSignatureKind {
+  if (signature === null || signature === undefined) return 'unsigned';
+  if (signature.startsWith(`${SIG_VERSION}.${SIG_ALG}.`)) return 'ed25519';
+  // A bare hex HMAC (legacy MCP chain rows) contains no `.`.
+  if (!signature.includes('.')) return 'legacy-hmac';
+  return 'unknown';
+}
+
+export interface Ed25519VerifyResult {
+  valid: boolean;
+  kid?: string;
+  reason?: string;
+}
+
+/** Resolve a `kid` to its Ed25519 public key (SPKI PEM or a KeyObject). */
+export type PublicKeyResolver = (kid: string) => string | KeyObject | null | undefined;
+
+/**
+ * Verify a `v1.ed25519.*` signature against the canonical bytes. Returns
+ * `{ valid: false, reason }` (never throws) on a malformed value or an
+ * unresolvable kid, so a caller iterating rows gets a verdict per row.
+ */
+export function verifyEd25519AuditSignature(
+  canonicalBytes: Uint8Array,
+  signatureValue: string,
+  resolvePublicKey: PublicKeyResolver,
+): Ed25519VerifyResult {
+  const parts = signatureValue.split('.');
+  if (parts.length !== 4 || parts[0] !== SIG_VERSION || parts[1] !== SIG_ALG) {
+    return { valid: false, reason: 'unrecognized signature format' };
+  }
+  const [, , kid, encoded] = parts;
+  if (!(kid && encoded)) {
+    return { valid: false, kid, reason: 'malformed signature: empty kid or body' };
+  }
+  const resolved = resolvePublicKey(kid);
+  if (!resolved) {
+    return { valid: false, kid, reason: `no public key registered for kid "${kid}"` };
+  }
+  let key: KeyObject;
+  try {
+    key = typeof resolved === 'string' ? createPublicKey(resolved) : resolved;
+  } catch {
+    return { valid: false, kid, reason: 'public key could not be parsed' };
+  }
+  let valid: boolean;
+  try {
+    valid = verify(null, Buffer.from(canonicalBytes), key, Buffer.from(encoded, 'base64url'));
+  } catch {
+    return { valid: false, kid, reason: 'signature bytes could not be decoded' };
+  }
+  return { valid, kid };
+}
+
+/** Convenience: verify a row's signature end to end from its `AuditSignable`. */
+export function verifyAuditRow(
+  row: AuditSignable,
+  signatureValue: string,
+  resolvePublicKey: PublicKeyResolver,
+): Ed25519VerifyResult {
+  return verifyEd25519AuditSignature(auditSignableBytes(row), signatureValue, resolvePublicKey);
+}

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -87,6 +87,8 @@ export {
   SecurityPresets,
   setRateLimitHeaders,
 } from './headers.js';
+// RFC 8785 JSON canonicalization (pure — no node: built-ins)
+export { canonicalizeJcs } from './jcs.js';
 // Logger configuration
 export type { SecurityLogger } from './logger.js';
 export { configureSecurityLogger } from './logger.js';

--- a/packages/security/src/jcs.ts
+++ b/packages/security/src/jcs.ts
@@ -1,0 +1,73 @@
+/**
+ * RFC 8785 (JSON Canonicalization Scheme) — deterministic JSON serialization.
+ *
+ * GAP-355 Stage 3: the single fleet canonicalizer. Signing an `audit_log` row
+ * over `JSON.stringify(payload)` is not verifiable, because the payload is a
+ * `jsonb` column and Postgres does not preserve object key order — the bytes
+ * signed at write time cannot be reconstructed at read time (ADR
+ * `2026-07-12-audit-receipt-architecture` finding 2). Canonicalizing to a
+ * deterministic byte string at BOTH sign and verify time is what makes a
+ * per-row signature reproducible from storage.
+ *
+ * Promoted from `apps/server/src/lib/mcp-audit.ts`'s `canonicalJson` (which was
+ * already most of RFC 8785: recursive lexicographic key sort via JS string `<`,
+ * which is UTF-16 code-unit ordering as JCS specifies, and `JSON.stringify` per
+ * scalar, which adopts ES number/string serialization). Hardened here to full
+ * conformance: it FAILS LOUDLY on any value JSON cannot represent rather than
+ * silently coercing it (a signer must never sign something other than what it
+ * was handed), and normalizes `-0` to `0`.
+ *
+ * Zero authored regex (fleet no-regex rule) — a manual recursive serializer.
+ *
+ * Number caveat: scalar numbers use `JSON.stringify` (ES `Number.prototype.
+ * toString`), which is RFC 8785 §3.2.2.3-conformant across the range audit rows
+ * carry (integers within `Number.MAX_SAFE_INTEGER`, ordinary decimals). The full
+ * ECMAScript number-formatting edge cases (extreme exponents) are not
+ * independently reimplemented; audit payloads do not carry such values.
+ */
+
+/**
+ * Canonicalize a JSON-compatible value to its RFC 8785 string form.
+ *
+ * Throws on any value JSON cannot represent — `undefined`, functions, symbols,
+ * `bigint`, and non-finite numbers (`NaN`/`±Infinity`) — wherever it appears in
+ * the tree. This is deliberate: silently coercing `undefined`/`NaN` to `null`
+ * (as `JSON.stringify` does) would let a signer sign bytes that differ from the
+ * caller's intent, which is exactly the class of bug this module exists to kill.
+ */
+export function canonicalizeJcs(value: unknown): string {
+  switch (typeof value) {
+    case 'undefined':
+      throw new Error('canonicalizeJcs: undefined is not JSON-representable');
+    case 'function':
+    case 'symbol':
+      throw new Error(`canonicalizeJcs: ${typeof value} is not JSON-representable`);
+    case 'bigint':
+      throw new Error('canonicalizeJcs: bigint is not JSON-representable');
+    case 'number':
+      if (!Number.isFinite(value)) {
+        throw new Error('canonicalizeJcs: non-finite number is not JSON-representable');
+      }
+      // Normalize -0 to 0 (JCS/ES serialization); JSON.stringify(-0) is "0"
+      // already, but be explicit so the intent survives refactors.
+      return Object.is(value, -0) ? '0' : JSON.stringify(value);
+    case 'boolean':
+    case 'string':
+      return JSON.stringify(value);
+    case 'object': {
+      if (value === null) return 'null';
+      if (Array.isArray(value)) {
+        return `[${value.map(canonicalizeJcs).join(',')}]`;
+      }
+      // Object: sort keys by UTF-16 code unit (JS string comparison), then
+      // recurse. An `undefined` value on any key throws via the recursion above
+      // rather than being dropped, so the canonical form is total over the input.
+      const entries = Object.entries(value as Record<string, unknown>).sort((a, b) =>
+        a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0,
+      );
+      return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalizeJcs(v)}`).join(',')}}`;
+    }
+    default:
+      throw new Error(`canonicalizeJcs: unsupported type ${typeof value}`);
+  }
+}

--- a/packages/security/src/server.ts
+++ b/packages/security/src/server.ts
@@ -35,6 +35,22 @@ export {
   signAuditEntry,
   verifyAuditEntry,
 } from './audit.js';
+// Per-row Ed25519 audit signing (GAP-355 Stage 3 — node:crypto)
+export type {
+  AuditRowSigner,
+  AuditSignable,
+  AuditSignatureKind,
+  Ed25519VerifyResult,
+  PublicKeyResolver,
+} from './audit-signing.js';
+export {
+  auditSignableBytes,
+  auditTimestampString,
+  classifyAuditSignature,
+  Ed25519AuditRowSigner,
+  verifyAuditRow,
+  verifyEd25519AuditSignature,
+} from './audit-signing.js';
 export type { AuditWriteFailureReason } from './audit-write-failures.js';
 export {
   classifyAuditWriteFailure,


### PR DESCRIPTION
## GAP-355 Stage 3 PR-1 — Ed25519 audit signing library

The signing primitive for the audit-substrate arc (ADR `2026-07-12-audit-receipt-architecture`), per the recorded spec `GAP-355-stage-3-signing-design.md` / jv#518. **Library only — no caller wired.** Stage 2 (ONE DOOR + `seq`/`tenant`) is merged; PR-2 injects this signer at the `DrizzleAuditStore` door and retires the legacy HMAC.

### What changed — `@revealui/security`
- **`canonicalizeJcs`** (RFC 8785 JSON canonicalization) added to the **client-safe barrel** (pure, no `node:` built-ins). Promoted from `mcp-audit.ts`'s `canonicalJson` (already UTF-16 code-unit key sort + ES scalar serialization) and **hardened**: it now throws on any non-JSON-representable value (`undefined`, functions, symbols, `bigint`, non-finite numbers) instead of silently coercing to `null`/`0`, and normalizes `-0`. This is what stops a signer from signing bytes other than what it was handed — the class of bug (jsonb key-order) this whole arc exists to fix.
- **Ed25519 signer + verifier** added to **`@revealui/security/server`** (`node:crypto`):
  - `Ed25519AuditRowSigner` implements the `AuditRowSigner` injection interface (`sign(bytes) → { value }`, synchronous), emitting `v1.ed25519.<kid>.<base64url>`. Rejects a `.`-bearing kid (delimiter safety) and a non-ed25519 key.
  - `auditSignableBytes(row)` — the **shared** builder over every integrity-bearing column (`id, sequence, tenant, timestamp, eventType, severity, agentId, taskId, sessionId, payload, policyViolations`), with one timestamp helper used by both sign and verify (the row round-trips through `timestamptz` identically). Signing `sequence` binds each row to its slot.
  - `verifyEd25519AuditSignature` / `verifyAuditRow` — never throw; return a per-row verdict. `classifyAuditSignature` distinguishes unsigned / legacy-HMAC / ed25519 / unknown so legacy MCP rows and NULL rows are handled explicitly.

### Verification
- **28 new unit tests**, all green: RFC 8785 vectors (key sorting incl. `a` before `é`, uppercase-before-lowercase, nested, `-0`, escaping, insertion-order stability) + Ed25519 sign/verify round-trip + tamper detection on every field + sequence-renumber detection + wrong-key + malformed-value + Date-vs-ISO-string byte equality + classification.
- Full `@revealui/security` suite **736/736**; `typecheck` clean; build clean. `mcp-audit.ts` left untouched (its canonicalizer collapse is PR-2, per spec D7).

### Security gate
Touches `packages/security/` → guardrail-2. Needs a recorded **non-author** verdict + `sec-review:approved` before merge. I authored it; I do not self-clear or merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
