### PR TITLE
fix(docs): remap gen-previews button variants to two-axis api

### DIFF
--- a/apps/docs/scripts/gen-previews/registry.tsx
+++ b/apps/docs/scripts/gen-previews/registry.tsx
@@ -245,8 +245,12 @@ function authoredSnapshots(): Record<string, CuratedEntry> {
                 DialogActions,
                 {},
                 <>
-                  {React.createElement(ButtonCVA, { variant: 'outline' }, 'Cancel')}
-                  {React.createElement(ButtonCVA, { variant: 'destructive' }, 'Delete')}
+                  {React.createElement(
+                    ButtonCVA,
+                    { appearance: 'outline', variant: 'neutral' },
+                    'Cancel',
+                  )}
+                  {React.createElement(ButtonCVA, { variant: 'danger' }, 'Delete')}
                 </>,
               )}
             </div>
@@ -273,8 +277,12 @@ function authoredSnapshots(): Record<string, CuratedEntry> {
                 DrawerFooter,
                 {},
                 <>
-                  {React.createElement(ButtonCVA, { variant: 'outline' }, 'Reset')}
-                  {React.createElement(ButtonCVA, { variant: 'primary' }, 'Apply')}
+                  {React.createElement(
+                    ButtonCVA,
+                    { appearance: 'outline', variant: 'neutral' },
+                    'Reset',
+                  )}
+                  {React.createElement(ButtonCVA, { variant: 'brand' }, 'Apply')}
                 </>,
               )}
             </div>
@@ -289,7 +297,11 @@ function authoredSnapshots(): Record<string, CuratedEntry> {
           label: 'Visible state',
           node: (
             <div className="dsc-tooltip-demo">
-              {React.createElement(ButtonCVA, { variant: 'outline' }, 'Hover me')}
+              {React.createElement(
+                ButtonCVA,
+                { appearance: 'outline', variant: 'neutral' },
+                'Hover me',
+              )}
               <span className="dsc-tooltip-bubble" role="tooltip">
                 Saves your changes
               </span>


### PR DESCRIPTION
Follow-up to #1974 (button family sovereignty). The independent review of #1974 flagged that `apps/docs/scripts/gen-previews/registry.tsx` still passed the retired flat variant values (`outline`/`destructive`/`primary`) via `React.createElement`. It escaped the PR-2 sweep because the docs tsconfig `include` is `["app"]`, so `scripts/` is never typechecked and CI stayed green.

Remap to the owned two-axis API:
- `variant: 'outline'` -> `appearance: 'outline', variant: 'neutral'` (x3: Dialog Cancel, Drawer Reset, Tooltip Hover me)
- `variant: 'destructive'` -> `variant: 'danger'` (Dialog Delete)
- `variant: 'primary'` -> `variant: 'brand'` (Drawer Apply)

registry.tsx imports the built `packages/presentation/dist`, so it now matches the merged Button API. One-file change; no other surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)