### PR TITLE
feat(server): period-bind license exp and re-mint on renewal (GAP-287 PR-2)

### DIFF
--- a/.changeset/soft-lions-report.md
+++ b/.changeset/soft-lions-report.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": minor
+---
+
+Derive hosted subscription license JWT expiry from the Stripe billing period instead of a flat one year. New license issuer exports back the period-bound mint and renewal cadence: `RENEWAL_SLACK_DAYS` / `RENEWAL_SLACK_SECONDS`, `DEFAULT_SUBSCRIPTION_TTL_SECONDS`, `subscriptionLicenseExpiresInSeconds` (derives `period_end + 7d` slack, falling back to the one-year default when a subscription has no billing period), `subscriptionExpBound`, and `readLicenseExp` (unverified exp read for the re-mint decision). Perpetual and manual mints are unchanged.

--- a/apps/server/src/routes/__tests__/billing-lifecycle.test.ts
+++ b/apps/server/src/routes/__tests__/billing-lifecycle.test.ts
@@ -67,6 +67,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/entitlement-convergence.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/entitlement-convergence.pglite.test.ts
@@ -77,6 +77,9 @@ vi.mock('@revealui/db', async () => {
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn().mockResolvedValue('test-jwt-license-key'),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/server/src/routes/__tests__/perpetual-refund-scope.test.ts
+++ b/apps/server/src/routes/__tests__/perpetual-refund-scope.test.ts
@@ -65,6 +65,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn().mockResolvedValue('rv-key'),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({ logger: mockLogger }));

--- a/apps/server/src/routes/__tests__/refund-revoke-drill.test.ts
+++ b/apps/server/src/routes/__tests__/refund-revoke-drill.test.ts
@@ -68,6 +68,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn().mockResolvedValue('rv-key'),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 vi.mock('@revealui/core/observability/logger', () => ({ logger: mockLogger }));
 vi.mock('../../lib/webhook-emails.js', () => ({

--- a/apps/server/src/routes/__tests__/sweep-grace-periods.test.ts
+++ b/apps/server/src/routes/__tests__/sweep-grace-periods.test.ts
@@ -30,6 +30,9 @@ vi.mock('@revealui/db/client', () => ({
 
 vi.mock('@revealui/core/license', () => ({
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhook-downgrade-cap.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-downgrade-cap.test.ts
@@ -74,6 +74,9 @@ vi.mock('@revealui/db', async () => {
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn().mockResolvedValue('test-jwt-license-key'),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/server/src/routes/__tests__/webhook-handler.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-handler.test.ts
@@ -71,6 +71,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({
@@ -999,6 +1002,7 @@ describe('POST /stripe webhook  -  handler tests', () => {
       expect(vi.mocked(licenseModule.generateLicenseKey)).toHaveBeenCalledWith(
         expect.any(Object),
         'BEGIN\nMIDDLE\nEND',
+        expect.any(Number), // GAP-287 PR-2: period-bound expiresInSeconds
       );
     });
   });

--- a/apps/server/src/routes/__tests__/webhook-license-exp-derivation.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-license-exp-derivation.test.ts
@@ -1,0 +1,377 @@
+/**
+ * GAP-287 PR-2 — subscription license exp derivation + renewal re-mint cadence,
+ * driven through the REAL webhook handler and the REAL `@revealui/core/license`
+ * issuer (no mocked signer — the same pattern as webhook-license-roundtrip).
+ *
+ * Proves the wiring, not just the pure helpers:
+ *  - checkout.session.completed mints a token whose exp = current_period_end +
+ *    RENEWAL_SLACK (RED against the pre-GAP-287 flat 365d default).
+ *  - invoice.payment_succeeded on a healthy, already-active subscription
+ *    RE-MINTS when the stored key's exp is below the new period bound, and
+ *    SKIPS when the stored key already covers it (the WH-2 idempotency property
+ *    extended to the exp dimension — proven both directions).
+ */
+
+import { generateKeyPairSync } from 'node:crypto';
+import { Hono } from 'hono';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockConstructEvent,
+  mockSubscriptionsUpdate,
+  mockSubscriptionsRetrieve,
+  mockSubscriptionsList,
+  mockChargesRetrieve,
+} = vi.hoisted(() => ({
+  mockConstructEvent: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockSubscriptionsRetrieve: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockChargesRetrieve: vi.fn(),
+}));
+
+vi.mock('stripe', () => ({
+  default: vi.fn().mockImplementation(
+    class {
+      webhooks = { constructEventAsync: mockConstructEvent };
+      subscriptions = {
+        update: mockSubscriptionsUpdate,
+        retrieve: mockSubscriptionsRetrieve,
+        list: mockSubscriptionsList,
+      };
+      charges = { retrieve: mockChargesRetrieve };
+    } as unknown as (...args: unknown[]) => unknown,
+  ),
+}));
+
+vi.mock('@revealui/services', () => ({
+  protectedStripe: {
+    webhooks: { constructEventAsync: mockConstructEvent },
+    subscriptions: {
+      update: mockSubscriptionsUpdate,
+      retrieve: mockSubscriptionsRetrieve,
+      list: mockSubscriptionsList,
+    },
+    charges: { retrieve: mockChargesRetrieve },
+    customers: { update: vi.fn() },
+  },
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  isFeatureEnabled: vi.fn(),
+  getFeaturesForTier: vi.fn(() => ({})),
+}));
+
+// Resolve `@revealui/core/license` to REAL source so the handler signs with the
+// genuine issuer (see webhook-license-roundtrip.test.ts for the rationale).
+vi.mock('@revealui/core/license', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../../../packages/core/src/license.ts')
+  >('../../../../../packages/core/src/license.ts');
+  return actual;
+});
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../lib/webhook-emails.js', () => ({
+  sendLicenseActivatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentFailedEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentRecoveredEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentReceiptEmail: vi.fn().mockResolvedValue(undefined),
+  sendPerpetualLicenseActivatedEmail: vi.fn().mockResolvedValue(undefined),
+  sendTierFallbackAlert: vi.fn().mockResolvedValue(undefined),
+  sendTrialEndingEmail: vi.fn().mockResolvedValue(undefined),
+  sendWebhookFailureAlert: vi.fn().mockResolvedValue(undefined),
+  sendDisputeLostEmail: vi.fn().mockResolvedValue(undefined),
+  sendLivemodeMismatchAlert: vi.fn().mockResolvedValue(undefined),
+  provisionGitHubAccess: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockAuditAppend = vi.fn();
+const mockDbSelectChain = {
+  from: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  limit: vi.fn(),
+};
+const mockDbInsertChain = { values: vi.fn() };
+const mockDbUpdateChain = { set: vi.fn(), where: vi.fn() };
+const mockDbDeleteChain = { where: vi.fn().mockResolvedValue(undefined) };
+const mockDb = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn().mockReturnValue(mockDbDeleteChain),
+  transaction: vi.fn(),
+};
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(() => mockDb),
+  DrizzleAuditStore: vi.fn().mockImplementation(
+    class {
+      append = mockAuditAppend;
+    } as unknown as (...args: unknown[]) => unknown,
+  ),
+  executeSaga: vi.fn(
+    async (
+      db: unknown,
+      _sagaName: string,
+      _sagaKey: string,
+      steps: Array<{
+        name: string;
+        execute: (ctx: {
+          db: unknown;
+          sagaId: string;
+          checkpoint: (n: string, o: unknown) => Promise<void>;
+        }) => Promise<unknown>;
+      }>,
+    ) => {
+      const sagaId = `mock-saga-${Date.now()}`;
+      const ctx = { db, sagaId, checkpoint: async () => {} };
+      const completedSteps: string[] = [];
+      let lastOutput: unknown;
+      for (const step of steps) {
+        lastOutput = await step.execute(ctx);
+        completedSteps.push(step.name);
+      }
+      return { sagaId, status: 'completed', result: lastOutput, completedSteps };
+    },
+  ),
+}));
+
+import { generateLicenseKey, subscriptionLicenseExpiresInSeconds } from '@revealui/core/license';
+import webhooksApp from '../webhooks.js';
+
+const DAY = 86_400;
+const SLACK_SEC = 7 * DAY;
+
+function createApp() {
+  const app = new Hono();
+  app.route('/', webhooksApp);
+  return app;
+}
+
+function postStripe(eventJson: unknown, sig = 'valid-sig') {
+  return new Request('http://localhost/stripe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Stripe-Signature': sig },
+    body: JSON.stringify(eventJson),
+  });
+}
+
+function resetDbChains() {
+  mockDbSelectChain.from.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.where.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.orderBy.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.limit.mockResolvedValue([]);
+  mockDbInsertChain.values.mockResolvedValue(undefined);
+  mockDbUpdateChain.set.mockReturnValue(mockDbUpdateChain);
+  mockDbUpdateChain.where.mockResolvedValue({ rowCount: 1 });
+  mockDbDeleteChain.where.mockResolvedValue(undefined);
+  mockDb.select.mockReturnValue(mockDbSelectChain);
+  mockDb.insert.mockReturnValue(mockDbInsertChain);
+  mockDb.update.mockReturnValue(mockDbUpdateChain);
+  mockDb.delete.mockReturnValue(mockDbDeleteChain);
+  mockDb.transaction.mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) =>
+    cb(mockDb),
+  );
+}
+
+/** Decode a JWT segment (base64url) — split + Buffer + JSON.parse, no regex. */
+function decodeJwtClaims(jwt: string): Record<string, unknown> {
+  const segment = jwt.split('.')[1];
+  if (!segment) throw new Error('JWT missing claims segment');
+  return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
+}
+
+/** The `licenses` row the checkout saga inserted (the one carrying a licenseKey). */
+function capturedInsertedLicenseKey(): string | undefined {
+  for (const call of mockDbInsertChain.values.mock.calls) {
+    const arg = call[0] as Record<string, unknown> | undefined;
+    if (arg && typeof arg.licenseKey === 'string') return arg.licenseKey;
+  }
+  return undefined;
+}
+
+/** The licenseKey from a `db.update().set({ licenseKey })` call, if any (the re-mint). */
+function capturedUpdatedLicenseKey(): string | undefined {
+  for (const call of mockDbUpdateChain.set.mock.calls) {
+    const arg = call[0] as Record<string, unknown> | undefined;
+    if (arg && typeof arg.licenseKey === 'string') return arg.licenseKey;
+  }
+  return undefined;
+}
+
+let privateKeyPem: string;
+
+beforeAll(() => {
+  const { publicKey: _pub, privateKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  privateKeyPem = privateKey;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSubscriptionsUpdate.mockResolvedValue({});
+  mockSubscriptionsRetrieve.mockResolvedValue({ status: 'active', trial_end: null });
+  mockSubscriptionsList.mockResolvedValue({ data: [] });
+  mockChargesRetrieve.mockResolvedValue({ id: 'ch_test', customer: 'cus_test' });
+  mockAuditAppend.mockResolvedValue(undefined);
+  resetDbChains();
+
+  process.env.STRIPE_SECRET_KEY = 'sk_test_placeholder';
+  process.env.STRIPE_WEBHOOK_SECRET = 'whsec_placeholder';
+  process.env.REVEALUI_LICENSE_PRIVATE_KEY = privateKeyPem;
+});
+
+// ─── checkout.session.completed — period-bound exp ────────────────────────────
+
+describe('checkout.session.completed — exp = period_end + slack', () => {
+  function makeCheckoutEvent() {
+    return {
+      id: 'evt_checkout_exp',
+      type: 'checkout.session.completed',
+      created: Math.floor(Date.now() / 1000),
+      livemode: false,
+      data: {
+        object: {
+          mode: 'subscription',
+          subscription: 'sub_checkout_exp',
+          customer: 'cus_checkout_exp',
+          metadata: { tier: 'pro', revealui_user_id: 'user_exp' },
+        },
+      },
+    };
+  }
+
+  it('binds the minted exp to current_period_end + 7d (not a flat 365d)', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const periodEndSec = nowSec + 30 * DAY;
+
+    const event = makeCheckoutEvent();
+    mockConstructEvent.mockReturnValueOnce(event);
+    mockSubscriptionsRetrieve.mockResolvedValueOnce({
+      status: 'active',
+      trial_end: null,
+      metadata: { tier: 'pro' },
+      items: { data: [{ current_period_end: periodEndSec }] },
+    });
+    // verify-user-exists → found; insert-existing check → none.
+    mockDbSelectChain.limit.mockResolvedValueOnce([{ id: 'user_exp' }]).mockResolvedValueOnce([]);
+
+    const res = await createApp().request(postStripe(event));
+    expect(res.status).toBe(200);
+
+    const jwt = capturedInsertedLicenseKey();
+    expect(jwt).toBeDefined();
+    const claims = decodeJwtClaims(jwt as string);
+    const exp = claims.exp as number;
+
+    expect(Math.abs(exp - (periodEndSec + SLACK_SEC))).toBeLessThanOrEqual(5);
+    // Period-bound (~37d), decisively short of a year — the RED assertion.
+    expect(exp).toBeLessThan(nowSec + 60 * DAY);
+  });
+});
+
+// ─── invoice.payment_succeeded — renewal re-mint cadence ──────────────────────
+
+describe('invoice.payment_succeeded — renewal re-mint cadence', () => {
+  const customerId = 'cus_renew';
+  const subscriptionId = 'sub_renew';
+
+  function makeRenewalEvent(id: string, newPeriodEndSec: number) {
+    // Prime the active subscription Stripe returns from subscriptions.list.
+    mockSubscriptionsList.mockResolvedValue({
+      data: [
+        {
+          id: subscriptionId,
+          status: 'active',
+          cancel_at_period_end: false,
+          metadata: { tier: 'pro' },
+          items: { data: [{ current_period_end: newPeriodEndSec }] },
+        },
+      ],
+    });
+    return {
+      id,
+      type: 'invoice.payment_succeeded',
+      created: Math.floor(Date.now() / 1000),
+      livemode: false,
+      data: {
+        object: {
+          id: 'inv_renew',
+          customer: customerId,
+          customer_email: 'renew@test.com',
+          subscription: subscriptionId,
+          amount_paid: 4900,
+          currency: 'usd',
+          period_end: newPeriodEndSec,
+        },
+      },
+    };
+  }
+
+  /**
+   * Sequence the 5 `.limit(1)` reads the handler performs on the healthy active
+   * renewal path: receipt-tier lookup, existingLicense, hosted-status (two
+   * reads → 'active'), then the re-mint row carrying the stored key.
+   */
+  function sequenceRenewalReads(storedKey: string) {
+    mockDbSelectChain.limit
+      .mockResolvedValueOnce([{ tier: 'pro' }]) // receipt tier
+      .mockResolvedValueOnce([{ id: 'lic_1', status: 'active' }]) // existingLicense
+      .mockResolvedValueOnce([{ accountId: 'acct_1' }]) // hosted: subscription
+      .mockResolvedValueOnce([{ status: 'active' }]) // hosted: entitlement
+      .mockResolvedValueOnce([{ status: 'active', tier: 'pro', licenseKey: storedKey }]); // re-mint row
+  }
+
+  it('RE-MINTS when the stored key exp is below the new period bound', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const newPeriodEndSec = nowSec + 30 * DAY;
+
+    // Stored key expires ~now+7d — below the new bound (now+37d).
+    const staleKey = await generateLicenseKey(
+      { tier: 'pro', customerId },
+      privateKeyPem,
+      subscriptionLicenseExpiresInSeconds(new Date(nowSec * 1000)),
+    );
+
+    const event = makeRenewalEvent('evt_renew_remint', newPeriodEndSec);
+    mockConstructEvent.mockReturnValueOnce(event);
+    sequenceRenewalReads(staleKey);
+
+    const res = await createApp().request(postStripe(event));
+    expect(res.status).toBe(200);
+
+    const reminted = capturedUpdatedLicenseKey();
+    expect(reminted).toBeDefined();
+    const exp = decodeJwtClaims(reminted as string).exp as number;
+    expect(Math.abs(exp - (newPeriodEndSec + SLACK_SEC))).toBeLessThanOrEqual(5);
+  });
+
+  it('SKIPS re-mint when the stored key already covers the new bound (idempotent)', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const newPeriodEndSec = nowSec + 30 * DAY;
+
+    // Stored key expires ~now+97d — already beyond the new bound (now+37d).
+    const freshKey = await generateLicenseKey(
+      { tier: 'pro', customerId },
+      privateKeyPem,
+      subscriptionLicenseExpiresInSeconds(new Date((nowSec + 90 * DAY) * 1000)),
+    );
+
+    const event = makeRenewalEvent('evt_renew_skip', newPeriodEndSec);
+    mockConstructEvent.mockReturnValueOnce(event);
+    sequenceRenewalReads(freshKey);
+
+    const res = await createApp().request(postStripe(event));
+    expect(res.status).toBe(200);
+
+    // No license-key update occurred (markCompleted's update carries no licenseKey).
+    expect(capturedUpdatedLicenseKey()).toBeUndefined();
+  });
+});

--- a/apps/server/src/routes/__tests__/webhook-lifecycle-complete.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-lifecycle-complete.test.ts
@@ -78,6 +78,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({
@@ -424,6 +427,7 @@ describe('Webhook Lifecycle Complete', () => {
       expect(licenseModule.generateLicenseKey).toHaveBeenCalledWith(
         expect.objectContaining({ tier: 'max' }),
         expect.anything(),
+        expect.any(Number), // GAP-287 PR-2: period-bound expiresInSeconds
       );
     });
 

--- a/apps/server/src/routes/__tests__/webhook-livemode.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-livemode.test.ts
@@ -40,6 +40,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhook-payment-action-required.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-payment-action-required.test.ts
@@ -73,6 +73,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhook-payment-intent-requires-action.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-payment-intent-requires-action.test.ts
@@ -76,6 +76,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhook-pglite.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-pglite.test.ts
@@ -90,6 +90,9 @@ vi.mock('@revealui/db', async () => {
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn().mockResolvedValue('test-jwt-license-key'),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/features', () => ({

--- a/apps/server/src/routes/__tests__/webhook-safety.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-safety.test.ts
@@ -68,6 +68,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhook-signature-replay.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-signature-replay.test.ts
@@ -66,6 +66,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhook-signature-rotation.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-signature-rotation.test.ts
@@ -53,6 +53,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhooks-expansion.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks-expansion.test.ts
@@ -65,6 +65,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks-perpetual-refund.test.ts
@@ -61,6 +61,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn().mockResolvedValue('rv-test-key'),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/__tests__/webhooks.test.ts
+++ b/apps/server/src/routes/__tests__/webhooks.test.ts
@@ -57,6 +57,9 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/core/license', () => ({
   generateLicenseKey: vi.fn(),
   resetLicenseState: vi.fn(),
+  subscriptionLicenseExpiresInSeconds: vi.fn(() => 3600),
+  subscriptionExpBound: vi.fn(() => 9_999_999_999),
+  readLicenseExp: vi.fn(async () => null),
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -10,7 +10,13 @@
  */
 
 import { RELEVANT_STRIPE_WEBHOOK_EVENTS } from '@revealui/contracts';
-import { generateLicenseKey, resetLicenseState } from '@revealui/core/license';
+import {
+  generateLicenseKey,
+  readLicenseExp,
+  resetLicenseState,
+  subscriptionExpBound,
+  subscriptionLicenseExpiresInSeconds,
+} from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
 import { DrizzleAuditStore, executeSaga, getClient } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
@@ -361,6 +367,91 @@ function getSubscriptionPeriodDate(
   if (!item) return null;
   const value = item[field];
   return typeof value === 'number' ? new Date(value * 1000) : null;
+}
+
+/** Narrows a stored `licenses.tier` string to the mintable license tiers. */
+function asMintableTier(value: string): 'pro' | 'max' | 'enterprise' | null {
+  return value === 'pro' || value === 'max' || value === 'enterprise' ? value : null;
+}
+
+/**
+ * GAP-287 PR-2 renewal cadence. On `invoice.payment_succeeded` for a healthy,
+ * already-active hosted subscription license, advances the key's `exp` to the
+ * new billing period (`period_end + RENEWAL_SLACK`). A period-bound token would
+ * otherwise lapse mid-subscription: the renewal invoice is the billing-cycle
+ * signal that must extend it.
+ *
+ * Idempotent, extending the WH-2 anti-churn discipline into the exp dimension:
+ * re-mint IFF the stored key's exp is below the new bound, SKIP otherwise — so a
+ * duplicate/retried delivery re-derives the same decision and does nothing. Only
+ * touches an ACTIVE row scoped to this (customer, subscription); perpetual rows
+ * carry a null `subscriptionId` and never match, so they are untouched. The
+ * row's stored tier is authoritative here — a renewal never changes tier. No-op
+ * when the private key is unset (the checkout/recovery paths already surface
+ * that as a loud CRITICAL) or no matching active row exists.
+ */
+async function remintSubscriptionLicenseOnRenewal(
+  db: Database,
+  params: {
+    customerId: string;
+    subscriptionId: string;
+    periodEnd: Date;
+    eventCreatedSeconds: number;
+  },
+): Promise<void> {
+  const filter = and(
+    eq(licenses.customerId, params.customerId),
+    eq(licenses.subscriptionId, params.subscriptionId),
+    isNull(licenses.deletedAt),
+  );
+
+  const [row] = await db
+    .select({ status: licenses.status, tier: licenses.tier, licenseKey: licenses.licenseKey })
+    .from(licenses)
+    .where(filter)
+    .limit(1);
+  if (row?.status !== 'active') return;
+
+  const tier = asMintableTier(row.tier);
+  if (!tier) return;
+
+  // Idempotency pin (the WH-2 property, now covering renewals): skip when the
+  // stored key's exp already reaches the new bound.
+  const newBound = subscriptionExpBound(params.periodEnd);
+  const storedExp = await readLicenseExp(row.licenseKey);
+  if (storedExp !== null && storedExp >= newBound) return;
+
+  const privateKey = process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+  if (!privateKey) {
+    logger.error(
+      'CRITICAL: REVEALUI_LICENSE_PRIVATE_KEY not configured  -  renewal re-mint skipped',
+      undefined,
+      { customerId: params.customerId, subscriptionId: params.subscriptionId },
+    );
+    return;
+  }
+  const normalizedKey = privateKey.replaceAll('\\n', '\n');
+
+  const licenseKey = await generateLicenseKey(
+    { tier, customerId: params.customerId },
+    normalizedKey,
+    subscriptionLicenseExpiresInSeconds(params.periodEnd),
+  );
+
+  // WH-3-shaped monotonic guard: a stale (out-of-order) invoice must not clobber
+  // newer state. When the row's updatedAt is already at/after this event, the
+  // write affects 0 rows and the newer key stands.
+  await db
+    .update(licenses)
+    .set({ licenseKey, updatedAt: new Date() })
+    .where(and(filter, lt(licenses.updatedAt, new Date((params.eventCreatedSeconds + 1) * 1000))));
+
+  resetLicenseState();
+  resetDbStatusCache();
+  logger.info('License re-minted on renewal — exp advanced to new billing period', {
+    customerId: params.customerId,
+    subscriptionId: params.subscriptionId,
+  });
 }
 
 function resolveCustomerId(
@@ -1578,7 +1669,18 @@ app.openapi(stripeWebhookRoute, async (c) => {
                 )
                 .limit(1);
 
-              const licenseKey = await generateLicenseKey({ tier, customerId }, normalizedKey);
+              // GAP-287 PR-2: bind exp to the billing period (period_end + slack)
+              // instead of a flat 365d. A trialing checkout's current period ends
+              // at trial_end, so the token covers the trial and is re-minted on
+              // the first renewal invoice. Falls back to the 365d default only
+              // when the subscription has no billing period.
+              const licenseKey = await generateLicenseKey(
+                { tier, customerId },
+                normalizedKey,
+                subscriptionLicenseExpiresInSeconds(
+                  getSubscriptionPeriodDate(checkoutSubscription, 'current_period_end'),
+                ),
+              );
 
               if (existing) {
                 await ctx.db
@@ -2195,9 +2297,14 @@ app.openapi(stripeWebhookRoute, async (c) => {
                   };
                 }
 
+                // GAP-287 PR-2: same period-bound exp derivation as the checkout
+                // mint — a tier change re-issues the key for the current period.
                 const licenseKey = await generateLicenseKey(
                   { tier: newTier, customerId },
                   normalizedKey,
+                  subscriptionLicenseExpiresInSeconds(
+                    getSubscriptionPeriodDate(subscription, 'current_period_end'),
+                  ),
                 );
 
                 // WH-3: monotonic-timestamp guard against out-of-order delivery.
@@ -2741,17 +2848,41 @@ app.openapi(stripeWebhookRoute, async (c) => {
             }
 
             const normalizedKey = privateKey.replaceAll('\\n', '\n');
+            // GAP-287 PR-2: period-bound exp on the recovery re-mint too.
             const licenseKey = await generateLicenseKey(
               { tier: recoveredTier, customerId },
               normalizedKey,
+              subscriptionLicenseExpiresInSeconds(
+                getSubscriptionPeriodDate(recoveredSubscription, 'current_period_end'),
+              ),
             );
             await db
               .update(licenses)
               .set({ status: 'active', tier: recoveredTier, licenseKey, updatedAt: new Date() })
               .where(recoveryFilter);
           }
-        } else if (existingLicense && !shouldReactivateHosted && !shouldHealHostedState) {
-          break;
+        } else {
+          // GAP-287 PR-2 renewal cadence: the license is already active (not
+          // being reactivated), but a period-bound key must have its exp
+          // advanced to the new billing period on the renewal invoice. This is
+          // idempotent — it no-ops when the stored exp already covers the new
+          // bound (a duplicate/retried delivery re-derives the same decision).
+          const renewalPeriodEnd = getSubscriptionPeriodDate(
+            recoveredSubscription,
+            'current_period_end',
+          );
+          if (renewalPeriodEnd) {
+            await remintSubscriptionLicenseOnRenewal(db, {
+              customerId,
+              subscriptionId: recoveredSubscription.id,
+              periodEnd: renewalPeriodEnd,
+              eventCreatedSeconds: event.created,
+            });
+          }
+
+          if (existingLicense && !shouldReactivateHosted && !shouldHealHostedState) {
+            break;
+          }
         }
 
         if (

--- a/packages/core/src/__tests__/license-exp-derivation.test.ts
+++ b/packages/core/src/__tests__/license-exp-derivation.test.ts
@@ -1,0 +1,150 @@
+/**
+ * GAP-287 PR-2 — subscription license exp derivation (period_end + slack).
+ *
+ * Covers the pure derivation surface added to the license issuer:
+ *  - RENEWAL_SLACK_DAYS is the owner-countersigned 7 days (2026-07-18).
+ *  - subscriptionLicenseExpiresInSeconds derives a period-bound lifetime and
+ *    falls back to the 365d default when no billing period is available.
+ *  - subscriptionExpBound is the absolute epoch bound the renewal cadence
+ *    compares against.
+ *  - readLicenseExp reads (never verifies) a token's exp for that comparison.
+ *  - A subscription mint driven through these helpers sets exp = period_end +
+ *    slack (RED against the pre-GAP-287 flat 365d default).
+ *  - Exemptions: a perpetual mint still carries NO exp; the canary path is
+ *    untouched.
+ *  - Rotation interplay: a token minted under the OUTGOING key still verifies
+ *    during a dual-key window (GAP-259 composition).
+ */
+
+import { generateKeyPairSync } from 'node:crypto';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SUBSCRIPTION_TTL_SECONDS,
+  generateLicenseKey,
+  RENEWAL_SLACK_DAYS,
+  RENEWAL_SLACK_SECONDS,
+  readLicenseExp,
+  selfVerifyLicenseKeypair,
+  subscriptionExpBound,
+  subscriptionLicenseExpiresInSeconds,
+  validateLicenseKey,
+} from '../license.js';
+
+let publicKeyPem: string;
+let privateKeyPem: string;
+
+beforeAll(() => {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  publicKeyPem = publicKey;
+  privateKeyPem = privateKey;
+});
+
+const DAY = 86_400;
+
+describe('countersigned constants', () => {
+  it('RENEWAL_SLACK is the owner-ratified 7 days', () => {
+    expect(RENEWAL_SLACK_DAYS).toBe(7);
+    expect(RENEWAL_SLACK_SECONDS).toBe(7 * DAY);
+  });
+
+  it('DEFAULT_SUBSCRIPTION_TTL_SECONDS is one year', () => {
+    expect(DEFAULT_SUBSCRIPTION_TTL_SECONDS).toBe(365 * DAY);
+  });
+});
+
+describe('subscriptionLicenseExpiresInSeconds', () => {
+  it('derives (period_end + slack) − now', () => {
+    const now = 1_000_000_000_000; // fixed epoch ms
+    const periodEnd = new Date(now + 30 * DAY * 1000);
+    const got = subscriptionLicenseExpiresInSeconds(periodEnd, now);
+    expect(got).toBe(30 * DAY + RENEWAL_SLACK_SECONDS);
+  });
+
+  it('falls back to the 365d default when the period end is absent', () => {
+    expect(subscriptionLicenseExpiresInSeconds(null)).toBe(DEFAULT_SUBSCRIPTION_TTL_SECONDS);
+    expect(subscriptionLicenseExpiresInSeconds(undefined)).toBe(DEFAULT_SUBSCRIPTION_TTL_SECONDS);
+  });
+
+  it('floors at one second for a period already in the past (never a non-positive lifetime)', () => {
+    const now = 1_000_000_000_000;
+    const pastPeriodEnd = new Date(now - 60 * DAY * 1000);
+    expect(subscriptionLicenseExpiresInSeconds(pastPeriodEnd, now)).toBe(1);
+  });
+});
+
+describe('subscriptionExpBound', () => {
+  it('is the absolute epoch bound period_end + slack', () => {
+    const periodEnd = new Date(1_700_000_000_000);
+    expect(subscriptionExpBound(periodEnd)).toBe(1_700_000_000 + RENEWAL_SLACK_SECONDS);
+  });
+});
+
+describe('subscription mint exp derivation (end-to-end)', () => {
+  it('sets exp = period_end + slack (RED against the pre-GAP-287 flat 365d)', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const periodEnd = new Date((nowSec + 30 * DAY) * 1000);
+
+    const jwt = await generateLicenseKey(
+      { tier: 'pro', customerId: 'cus_exp' },
+      privateKeyPem,
+      subscriptionLicenseExpiresInSeconds(periodEnd),
+    );
+
+    const exp = await readLicenseExp(jwt);
+    expect(exp).not.toBeNull();
+    const expectedBound = subscriptionExpBound(periodEnd);
+    // Allow a couple seconds of skew between the call-site now and the sign-time now.
+    expect(Math.abs((exp as number) - expectedBound)).toBeLessThanOrEqual(5);
+
+    // The whole point of PR-2: the token is period-bound (~37d), NOT a flat year.
+    expect(exp as number).toBeLessThan(nowSec + 60 * DAY);
+  });
+});
+
+describe('exemptions (byte-identical behavior)', () => {
+  it('a perpetual mint still carries NO exp claim', async () => {
+    const jwt = await generateLicenseKey(
+      { tier: 'enterprise', customerId: 'cus_perp', perpetual: true },
+      privateKeyPem,
+      null,
+    );
+    expect(await readLicenseExp(jwt)).toBeNull();
+  });
+
+  it('the keypair canary path is untouched (self-verify still ok)', async () => {
+    const result = await selfVerifyLicenseKeypair(privateKeyPem, [publicKeyPem]);
+    expect(result.status).toBe('ok');
+  });
+});
+
+describe('rotation interplay (GAP-259 composition)', () => {
+  it('a period-bound token minted under the outgoing key verifies during a dual-key window', async () => {
+    const { publicKey: nextPublic } = generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const nowSec = Math.floor(Date.now() / 1000);
+    const periodEnd = new Date((nowSec + 30 * DAY) * 1000);
+    const jwt = await generateLicenseKey(
+      { tier: 'pro', customerId: 'cus_rot' },
+      privateKeyPem, // outgoing signer
+      subscriptionLicenseExpiresInSeconds(periodEnd),
+      publicKeyPem,
+    );
+
+    // Ordered multi-key set: incoming key first, outgoing key still present.
+    const payload = await validateLicenseKey(jwt, [nextPublic, publicKeyPem]);
+    expect(payload).not.toBeNull();
+    expect(payload?.tier).toBe('pro');
+  });
+});
+
+describe('readLicenseExp', () => {
+  it('returns null for an undecodable token', async () => {
+    expect(await readLicenseExp('not-a-jwt')).toBeNull();
+  });
+});

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -796,6 +796,77 @@ export function getMaxAgentTasks(): number {
 }
 
 /**
+ * Default subscription license JWT lifetime (seconds) — one year. Used as the
+ * fallback when a subscription's billing period is unavailable at mint time (an
+ * abnormal Stripe shape) so a period-bound token is never SHORTER than the
+ * pre-GAP-287 behavior, and as the default lifetime for {@link generateLicenseKey}
+ * when no explicit value is passed.
+ */
+export const DEFAULT_SUBSCRIPTION_TTL_SECONDS = 365 * 24 * 60 * 60;
+
+/**
+ * Slack added to a hosted subscription's `current_period_end` when deriving the
+ * license JWT `exp` (GAP-287 PR-2). Ratified by the owner 2026-07-18 at 7 days.
+ *
+ * The token's lifetime equals what billing has actually granted plus this slack.
+ * The slack must cover the Stripe dunning/retry window so a card that recovers
+ * on retry never presents a lapsed key. Renewals advance the exp each billing
+ * cycle by re-minting on `invoice.payment_succeeded`.
+ */
+export const RENEWAL_SLACK_DAYS = 7;
+export const RENEWAL_SLACK_SECONDS = RENEWAL_SLACK_DAYS * 24 * 60 * 60;
+
+/**
+ * Derives the relative `expiresInSeconds` argument for {@link generateLicenseKey}
+ * at the hosted subscription mint sites (GAP-287 PR-2): the token should expire
+ * at `periodEnd + RENEWAL_SLACK_SECONDS`. Because generateLicenseKey interprets a
+ * numeric lifetime relative to issue time, this returns that absolute bound minus
+ * now.
+ *
+ * Falls back to {@link DEFAULT_SUBSCRIPTION_TTL_SECONDS} when `periodEnd` is
+ * absent (a subscription with no billing period) so an unexpected Stripe shape
+ * never mints a shorter-than-before token. Never returns a non-positive lifetime:
+ * a period end already in the past floors at one second, leaving expiry to the
+ * validation grace + refresh window rather than minting an already-invalid token.
+ */
+export function subscriptionLicenseExpiresInSeconds(
+  periodEnd: Date | null | undefined,
+  nowMs: number = Date.now(),
+): number {
+  if (!periodEnd) return DEFAULT_SUBSCRIPTION_TTL_SECONDS;
+  const boundMs = periodEnd.getTime() + RENEWAL_SLACK_SECONDS * 1000;
+  return Math.max(1, Math.floor((boundMs - nowMs) / 1000));
+}
+
+/**
+ * Absolute epoch-second bound `periodEnd + RENEWAL_SLACK_SECONDS` a hosted
+ * subscription key should reach (GAP-287 PR-2). The renewal cadence re-mints IFF
+ * the stored key's `exp` is below this bound, so the comparison uses this
+ * absolute form while the mint uses the relative
+ * {@link subscriptionLicenseExpiresInSeconds}.
+ */
+export function subscriptionExpBound(periodEnd: Date): number {
+  return Math.floor(periodEnd.getTime() / 1000) + RENEWAL_SLACK_SECONDS;
+}
+
+/**
+ * Reads the `exp` (epoch seconds) claim from a license JWT WITHOUT verifying its
+ * signature. Internal use only, for the GAP-287 PR-2 renewal cadence: the token
+ * comes from our OWN store and the caller needs only its expiry to decide whether
+ * to re-mint — never as an authentication or entitlement decision. Returns null
+ * for a perpetual token (no exp claim) or one that cannot be decoded.
+ */
+export async function readLicenseExp(licenseKey: string): Promise<number | null> {
+  try {
+    const jose = await getJose();
+    const payload = jose.decodeJwt(licenseKey);
+    return typeof payload.exp === 'number' ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Generates a signed license key JWT.
  * Server-only in practice (requires the private key) but edge-compatible —
  * `jose.importPKCS8` and `SignJWT` both run on Web Crypto.
@@ -811,7 +882,7 @@ export function getMaxAgentTasks(): number {
 export async function generateLicenseKey(
   payload: Omit<LicensePayload, 'iat' | 'exp' | 'jti'> & { jti?: string },
   privateKey: string,
-  expiresInSeconds: number | null = 365 * 24 * 60 * 60,
+  expiresInSeconds: number | null = DEFAULT_SUBSCRIPTION_TTL_SECONDS,
   publicKey?: string,
 ): Promise<string> {
   const jose = await getJose();


### PR DESCRIPTION
## GAP-287 PR-2 — subscription license exp derivation + renewal re-mint cadence

Second PR of the GAP-287 license-JWT TTL program. Scope is exactly the §6 "PR-2" row of the design spec: derive the hosted subscription license JWT `exp` from the Stripe billing period at the three subscription mint sites, plus the re-mint cadence on renewal, plus the shared named constants. Manual-mint default and kit constant naming (§6 PR-3) are **not** in scope.

### Sequencing invariant holds

PR-1 (the `POST /api/license/refresh` endpoint, #1972) is **merged**, so the §6 precondition is satisfied: a customer holding a key that expires can fetch a fresh one. This PR ships the shortened, period-bound TTL only now that the refresh path exists (§2 brick-risk avoided). Extant 365d keys are untouched: no revocation, no backfill; they age out naturally.

### Countersigned numbers (§5, ratified by the owner 2026-07-18)

- Subscriptions: `exp = current_period_end + 7d` slack (`RENEWAL_SLACK_DAYS = 7`).
- Annual: same mechanism (no practical change).
- Perpetual (`webhooks.ts` perpetual mint): **exempt by design** — no exp, untouched.
- Canary (60s throwaway) and manual-mint: untouched (PR-3 owns the manual default).

### What changed

**`packages/core/src/license.ts`** — new pure derivation surface:
- `RENEWAL_SLACK_DAYS` / `RENEWAL_SLACK_SECONDS`, `DEFAULT_SUBSCRIPTION_TTL_SECONDS`.
- `subscriptionLicenseExpiresInSeconds(periodEnd)` — relative lifetime `(period_end + slack) − now`; falls back to the 365d default when a subscription has no billing period, so an abnormal Stripe shape never mints a shorter-than-before token.
- `subscriptionExpBound(periodEnd)` — the absolute epoch bound the renewal cadence compares against.
- `readLicenseExp(licenseKey)` — unverified exp read (internal, for the re-mint decision only; never an auth decision). `generateLicenseKey`'s default now references `DEFAULT_SUBSCRIPTION_TTL_SECONDS` (byte-identical).

**`apps/server/src/routes/webhooks.ts`** — the three subscription mint sites now derive exp from `current_period_end + slack`, and a new renewal cadence:
- Checkout issuance — `insert-subscription-license` saga step.
- Tier-change re-mint — `reactivate-license` saga step (`customer.subscription.updated`).
- Payment-recovery re-mint — `invoice.payment_succeeded` recovery branch.
- **Renewal cadence** — `remintSubscriptionLicenseOnRenewal` runs on `invoice.payment_succeeded` for an already-active license: re-mints IFF the stored key's exp is below `period_end + slack`, SKIPS otherwise.

### How the re-mint idempotency composes with the existing WH-2 pin

The existing WH-2 guards skip key regeneration when the row is already in the target **state** (recovery/reactivate: same tier + active) to prevent churn on saga retry. The renewal cadence adds a third idempotency dimension in the same shape: skip regeneration when the stored key's **exp** already reaches the new bound. A duplicate/retried `invoice.payment_succeeded` re-derives `storedExp >= period_end + slack` and does nothing — the exp comparison is the WH-2 anti-churn discipline extended to the exp axis, not a fight with it. The renewal re-mint also carries a WH-3-shaped monotonic `updatedAt` guard so a stale (out-of-order) invoice cannot clobber newer key state, and it only touches an active row scoped to `(customerId, subscriptionId)` — perpetual rows carry a null `subscriptionId` and never match.

### Red-first evidence (§7)

Proven by restoring `apps/server/src/routes/webhooks.ts` to `origin/test` (keeping the new core helpers so the suites load) and running the new webhook suite:

- **Checkout exp derivation — RED:** `expected 28339200 to be less than or equal to 5` — old code minted `exp ≈ now + 365d`, ~328 days off `period_end + 7d`. GREEN after the fix (exp within 5s of `period_end + 7d`).
- **Renewal re-mint — RED:** `expected undefined to be defined` — old code never re-mints on renewal, so no key update occurred. GREEN after the fix (update carries a key whose exp = new `period_end + 7d`).
- **Renewal skip — GREEN both ways:** old code never re-mints so the skip direction was trivially green; the new code proves it does not over-mint when the stored key already covers the bound.

Perpetual exemption and canary-untouched are asserted directly in the core suite (`a perpetual mint still carries NO exp claim`; `self-verify still ok`). Rotation interplay (GAP-259) is asserted: a period-bound token minted under the outgoing key verifies during a dual-key window.

### Test counts (all green)

- New: `packages/core/src/__tests__/license-exp-derivation.test.ts` (11) + `apps/server/src/routes/__tests__/webhook-license-exp-derivation.test.ts` (3).
- `@revealui/core` full suite: **112 files, 2800 passed**.
- `server` full suite: **169 files, 3001 passed, 2 skipped**.
- Typecheck (`@revealui/core` build, `server tsc --noEmit`) and Biome: clean.

18 existing server test files partially mock `@revealui/core/license`; they gained stubs for the three new exports (and two `toHaveBeenCalledWith` assertions gained the new period-bound `expiresInSeconds` arg matcher). No behavior changed in those tests. There are **no pre-existing unrelated failures** in the touched suites.

### Changeset

`.changeset/soft-lions-report.md` — minor bump for `@revealui/core` (new behavior + new exports). `server` is in the changeset ignore list, so no changeset for it.

### Guardrail-2 notice

This PR touches signing-adjacent surfaces (`webhooks.ts` license mint sites). The fleet security self-check reports **HOLD** (expected). It needs a **recorded non-author coordinator verdict** (`sec-review:approved` after a `<!-- guardrail2-verdict: APPROVE -->` review) before merge. I am the builder — **no self-merge, no self-applied label**. The owner merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
