### PR TITLE
fix(admin): agent-stream rewrite targets the API host, not the admin origin

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -156,24 +156,40 @@ const nextConfig = {
     ]
   },
   async rewrites() {
-    // GAP-360 §5.5: the admin Run / Watch-live UI POSTs same-origin to
-    // /api/agent-stream and /api/agent-stream/elicit, but those handlers live
-    // on the API host, not the admin app, so the calls 404 without a proxy.
-    // Rewrite them to the API host so the request stays same-origin (the
-    // CSRF/cookie/CORS posture is untouched) and the SSE stream is proxied
-    // through. When NEXT_PUBLIC_SERVER_URL is unset (single-origin dev), no
-    // rewrite is added so nothing loops back on itself.
-    let serverUrl = process.env.NEXT_PUBLIC_SERVER_URL
-    if (!serverUrl) return []
-    while (serverUrl.endsWith('/')) serverUrl = serverUrl.slice(0, -1)
+    // The admin Run / Watch-live UI POSTs same-origin to /api/agent-stream and
+    // /api/agent-stream/elicit, but those handlers live on the API host, not
+    // the admin app, so the calls 404 without a proxy. Rewrite them to the API
+    // host so the request stays same-origin (the CSRF/cookie/CORS posture is
+    // untouched) and the SSE stream is proxied through.
+    //
+    // The destination is NEXT_PUBLIC_API_URL (the API host, e.g.
+    // https://api.revealui.com), NOT NEXT_PUBLIC_SERVER_URL: fleet-wide,
+    // SERVER_URL means the admin app's OWN origin (proxy.ts, the license
+    // domain binding, and the revvault sync manifests all bind it that way),
+    // so pointing the rewrite at it made the proxy rewrite to itself and
+    // every hosted call died with a 508 rewrite loop. When NEXT_PUBLIC_API_URL
+    // is unset (single-origin dev), no rewrite is added.
+    let apiUrl = process.env.NEXT_PUBLIC_API_URL
+    if (!apiUrl) return []
+    while (apiUrl.endsWith('/')) apiUrl = apiUrl.slice(0, -1)
+    // Self-origin guard: if the configured API host IS this admin origin, a
+    // rewrite would loop (the 508 failure mode above). Fail loud and skip.
+    let selfUrl = process.env.NEXT_PUBLIC_SERVER_URL?.trim() ?? ''
+    while (selfUrl.endsWith('/')) selfUrl = selfUrl.slice(0, -1)
+    if (selfUrl && apiUrl === selfUrl) {
+      console.error(
+        `agent-stream rewrite disabled: NEXT_PUBLIC_API_URL (${apiUrl}) equals the admin origin; a rewrite would loop (508). Point NEXT_PUBLIC_API_URL at the API host.`,
+      )
+      return []
+    }
     return [
       {
         source: '/api/agent-stream',
-        destination: `${serverUrl}/api/agent-stream`,
+        destination: `${apiUrl}/api/agent-stream`,
       },
       {
         source: '/api/agent-stream/:path*',
-        destination: `${serverUrl}/api/agent-stream/:path*`,
+        destination: `${apiUrl}/api/agent-stream/:path*`,
       },
     ]
   },


### PR DESCRIPTION
## Summary

The hosted Run/Watch-live path is broken on prod by a variable-semantics collision, found while verifying the deployment prereq for the pending live acceptance walk:

- Live probe: `POST https://admin.revealui.com/api/agent-stream` returns **508 Loop Detected**; the same route on `https://api.revealui.com` returns 403 (alive, auth enforced).
- Root cause: the rewrite consumed `NEXT_PUBLIC_SERVER_URL` as the API host, but fleet-wide that variable means the admin app's OWN origin: proxy.ts and the license domain binding treat it that way, and the revvault store carries `revealui/prod/public/server-url = https://admin.revealui.com`. The rewrite therefore pointed at itself and looped.
- Fix: destination moves to `NEXT_PUBLIC_API_URL` (already synced to prod admin as `https://api.revealui.com` via the sync manifest), plus a loud self-origin guard that disables the rewrite with a console.error instead of looping when misconfigured. Unset still means no rewrite (single-origin dev unchanged).

## Verification

- `node --check` clean (biome ignores next.config.mjs by config).
- Live-prod re-probe after this deploys should return 403 (auth) instead of 508 on the admin origin; that plus the acceptance walk is the real proof.

Touches the agent-stream routing surface, so this needs a recorded verdict + `sec-review:approved` before merge; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)