### PR TITLE
feat(server): 90d manual-mint default + named kit TTL constant (GAP-287 PR-3)

### DIFF
--- a/.changeset/gap-287-mint-defaults.md
+++ b/.changeset/gap-287-mint-defaults.md
@@ -1,0 +1,5 @@
+---
+'@revealui/core': minor
+---
+
+Drop the admin `POST /generate` manual-mint default license JWT lifetime from 365 to 90 days via a new named `DEFAULT_MANUAL_MINT_DAYS` constant (an explicit `expiresInDays` on the request is still honored unchanged). Name the RevForge kit mint's existing 365-day default as `DEFAULT_KIT_MINT_DAYS` in `revforge-license.ts` (no behavior change). Perpetual mint paths remain exempt and unchanged. Completes the GAP-287 shorter-lived license JWT program (PR-3 of 3).

--- a/apps/server/src/routes/__tests__/license-edge.test.ts
+++ b/apps/server/src/routes/__tests__/license-edge.test.ts
@@ -7,7 +7,7 @@
  * - Generate schema: domains array with 101 items fails max(100)
  * - Generate schema: customerId:'' fails min(1)
  * - Generate: REVEALUI_ADMIN_API_KEY not set → 401
- * - Generate: expiresInDays defaults to 365 when not provided
+ * - Generate: expiresInDays defaults to DEFAULT_MANUAL_MINT_DAYS (90) when not provided (GAP-287 PR-3)
  * - Generate: domains passed through to generateLicenseKey
  * - Verify: custom maxSites/maxUsers from JWT payload used over defaults
  * - Verify: DB throws during invalid-JWT status check → reason:invalid (fails open with logger.warn)
@@ -39,6 +39,7 @@ vi.mock('@revealui/core/observability/logger', () => ({
 }));
 
 vi.mock('@revealui/core/license', () => ({
+  DEFAULT_MANUAL_MINT_DAYS: 90,
   validateLicenseKey: vi.fn(),
   generateLicenseKey: vi.fn(),
 }));
@@ -145,15 +146,29 @@ describe('POST /generate  -  expiresInDays schema boundaries', () => {
     );
   });
 
-  it('defaults expiresInDays to 365 when not provided', async () => {
+  it('defaults expiresInDays to DEFAULT_MANUAL_MINT_DAYS (90) when not provided', async () => {
     const app = createApp();
     await app.request('/generate', post({ tier: 'pro', customerId: 'cus_abc' }, ADMIN_HEADER));
 
-    // Route: const expiresInSeconds = (expiresInDays ?? 365) * 24 * 60 * 60
+    // Route (GAP-287 PR-3): expiresInSeconds = (expiresInDays ?? DEFAULT_MANUAL_MINT_DAYS) * 86400
     expect(mockedGenerate).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      365 * 24 * 60 * 60,
+      90 * 24 * 60 * 60,
+    );
+  });
+
+  it('honors an explicit expiresInDays over the DEFAULT_MANUAL_MINT_DAYS default', async () => {
+    const app = createApp();
+    await app.request(
+      '/generate',
+      post({ tier: 'pro', customerId: 'cus_abc', expiresInDays: 30 }, ADMIN_HEADER),
+    );
+
+    expect(mockedGenerate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      30 * 24 * 60 * 60,
     );
   });
 });

--- a/apps/server/src/routes/__tests__/license.test.ts
+++ b/apps/server/src/routes/__tests__/license.test.ts
@@ -13,6 +13,7 @@ vi.mock('@revealui/core/features', () => ({
 }));
 
 vi.mock('@revealui/core/license', () => ({
+  DEFAULT_MANUAL_MINT_DAYS: 90,
   validateLicenseKey: vi.fn(),
   generateLicenseKey: vi.fn(),
 }));

--- a/apps/server/src/routes/license.ts
+++ b/apps/server/src/routes/license.ts
@@ -2,6 +2,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import {
+  DEFAULT_MANUAL_MINT_DAYS,
   generateLicenseKey,
   getPublicKeys,
   type LicensePayload,
@@ -103,8 +104,8 @@ const LicenseGenerateRequestSchema = z.object({
     example: 25,
   }),
   expiresInDays: z.number().int().positive().max(3650).optional().openapi({
-    description: 'License duration in days (default: 365, max: 10 years)',
-    example: 365,
+    description: 'License duration in days (default: 90, max: 10 years)',
+    example: 90,
   }),
 });
 
@@ -441,7 +442,10 @@ app.openapi(generateRoute, async (c) => {
     ...(maxUsers && { maxUsers }),
   };
 
-  const expiresInSeconds = (expiresInDays ?? 365) * 24 * 60 * 60;
+  // GAP-287 PR-3: default drops to DEFAULT_MANUAL_MINT_DAYS (90d, down from
+  // 365d) for manually-minted keys; an explicit expiresInDays is always
+  // honored unchanged.
+  const expiresInSeconds = (expiresInDays ?? DEFAULT_MANUAL_MINT_DAYS) * 24 * 60 * 60;
   const licenseKey = await generateLicenseKey(payload, normalizedKey, expiresInSeconds);
 
   logger.info('License key generated', { tier, customerId });

--- a/docs/api/rest-api/README.md
+++ b/docs/api/rest-api/README.md
@@ -738,7 +738,7 @@ Creates a signed JWT license key for a customer. Requires REVEALUI_LICENSE_PRIVA
 | `domains` | `array` |  -  | Licensed domains (optional) |
 | `maxSites` | `integer` |  -  | Maximum sites (defaults: Pro=5, Forge=unlimited) |
 | `maxUsers` | `integer` |  -  | Maximum users (defaults: Pro=25, Forge=unlimited) |
-| `expiresInDays` | `integer` |  -  | License duration in days (default: 365, max: 10 years) |
+| `expiresInDays` | `integer` |  -  | License duration in days (default: 90, max: 10 years) |
 
 **Responses**
 
@@ -794,7 +794,7 @@ Creates a signed JWT license key for a customer. Requires REVEALUI_LICENSE_PRIVA
 | `domains` | `array` |  -  | Licensed domains (optional) |
 | `maxSites` | `integer` |  -  | Maximum sites (defaults: Pro=5, Forge=unlimited) |
 | `maxUsers` | `integer` |  -  | Maximum users (defaults: Pro=25, Forge=unlimited) |
-| `expiresInDays` | `integer` |  -  | License duration in days (default: 365, max: 10 years) |
+| `expiresInDays` | `integer` |  -  | License duration in days (default: 90, max: 10 years) |
 
 **Responses**
 

--- a/examples/api/openapi.json
+++ b/examples/api/openapi.json
@@ -1858,8 +1858,8 @@
                     "minimum": 0,
                     "exclusiveMinimum": true,
                     "maximum": 3650,
-                    "description": "License duration in days (default: 365, max: 10 years)",
-                    "example": 365
+                    "description": "License duration in days (default: 90, max: 10 years)",
+                    "example": 90
                   }
                 },
                 "required": ["tier", "customerId"]
@@ -8587,8 +8587,8 @@
                     "minimum": 0,
                     "exclusiveMinimum": true,
                     "maximum": 3650,
-                    "description": "License duration in days (default: 365, max: 10 years)",
-                    "example": 365
+                    "description": "License duration in days (default: 90, max: 10 years)",
+                    "example": 90
                   }
                 },
                 "required": ["tier", "customerId"]

--- a/packages/core/src/__tests__/license.test.ts
+++ b/packages/core/src/__tests__/license.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   computeKeyId,
   configureGracePeriods,
+  DEFAULT_MANUAL_MINT_DAYS,
   generateLicenseKey,
   getCurrentTier,
   getLicensePayload,
@@ -133,6 +134,14 @@ describe('generateLicenseKey', () => {
     const now = Math.floor(Date.now() / 1000);
     expect(payload!.iat!).toBeGreaterThan(now - 10);
     expect(payload!.iat!).toBeLessThanOrEqual(now + 1);
+  });
+
+  // GAP-287 PR-3: the admin manual-mint default (routes/license.ts POST
+  // /generate) is a distinct value from generateLicenseKey's own internal
+  // default above — the route always computes and passes expiresInSeconds
+  // explicitly, so this constant is never read by generateLicenseKey itself.
+  it('DEFAULT_MANUAL_MINT_DAYS is the owner-ratified 90 days', () => {
+    expect(DEFAULT_MANUAL_MINT_DAYS).toBe(90);
   });
 });
 

--- a/packages/core/src/__tests__/revforge-license.test.ts
+++ b/packages/core/src/__tests__/revforge-license.test.ts
@@ -1,7 +1,7 @@
 import { generateKeyPairSync } from 'node:crypto';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { validateLicenseKey } from '../license.js';
-import { issueRevForgeLicense } from '../revforge-license.js';
+import { DEFAULT_KIT_MINT_DAYS, issueRevForgeLicense } from '../revforge-license.js';
 
 let privateKey: string;
 let publicKey: string;
@@ -84,6 +84,26 @@ describe('issueRevForgeLicense', () => {
     expect(verified).not.toBeNull();
     expect(verified?.exp).toBeUndefined();
     expect(verified?.perpetual).toBe(true);
+  });
+
+  // GAP-287 PR-3: the kit default is unchanged (365d) but is now the named
+  // DEFAULT_KIT_MINT_DAYS constant instead of an inline literal.
+  it('DEFAULT_KIT_MINT_DAYS is 365, unchanged', () => {
+    expect(DEFAULT_KIT_MINT_DAYS).toBe(365);
+  });
+
+  it('defaults to DEFAULT_KIT_MINT_DAYS when neither expiresInDays nor perpetual is given', async () => {
+    const before = Date.now();
+    const result = await issueRevForgeLicense(
+      { slug: 'default-ttl', tier: 'enterprise' },
+      { privateKey, publicKey },
+    );
+    const after = Date.now();
+
+    const expMs = new Date(result.expiresAt ?? '').getTime();
+    const defaultMs = DEFAULT_KIT_MINT_DAYS * 24 * 60 * 60 * 1000;
+    expect(expMs).toBeGreaterThanOrEqual(before + defaultMs - 1000);
+    expect(expMs).toBeLessThanOrEqual(after + defaultMs + 1000);
   });
 
   it('honors expiresInDays', async () => {

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -817,6 +817,16 @@ export const RENEWAL_SLACK_DAYS = 7;
 export const RENEWAL_SLACK_SECONDS = RENEWAL_SLACK_DAYS * 24 * 60 * 60;
 
 /**
+ * Default lifetime, in days, for a license JWT minted by the admin
+ * `POST /generate` manual-mint endpoint when the caller does not supply an
+ * explicit `expiresInDays` (GAP-287 PR-3). Ratified by the owner 2026-07-18 at
+ * 90, down from the prior flat 365-day default: this is an operator tool, and
+ * a short default nudges the right renewal habit for manually-issued keys. An
+ * explicit `expiresInDays` on the request is always honored unchanged.
+ */
+export const DEFAULT_MANUAL_MINT_DAYS = 90;
+
+/**
  * Derives the relative `expiresInSeconds` argument for {@link generateLicenseKey}
  * at the hosted subscription mint sites (GAP-287 PR-2): the token should expire
  * at `periodEnd + RENEWAL_SLACK_SECONDS`. Because generateLicenseKey interprets a

--- a/packages/core/src/revforge-license.ts
+++ b/packages/core/src/revforge-license.ts
@@ -18,6 +18,16 @@ export const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 export const VALID_REVFORGE_TIERS = ['pro', 'max', 'enterprise'] as const;
 export type RevForgeTier = (typeof VALID_REVFORGE_TIERS)[number];
 
+/**
+ * Default lifetime, in days, for a RevForge kit license JWT when neither
+ * `expiresInDays` nor `perpetual` is supplied (GAP-287 PR-3). Ratified by the
+ * owner 2026-07-18: stays at 365 (no behavior change), matching the annual
+ * kit contract — the renewal path already exists via the GAP-316
+ * `stamp.sh --license-only` re-mint. This constant only names the value that
+ * was previously an inline literal.
+ */
+export const DEFAULT_KIT_MINT_DAYS = 365;
+
 export interface IssueRevForgeLicenseOptions {
   /** Customer slug; becomes the JWT customerId. Must match SLUG_PATTERN. */
   slug: string;
@@ -105,12 +115,13 @@ export async function issueRevForgeLicense(
   };
 
   // Perpetual: pass null to omit exp claim. Otherwise translate days → seconds.
-  // Default (neither flag): 365-day subscription, matching generateLicenseKey's default.
+  // Default (neither flag): DEFAULT_KIT_MINT_DAYS (GAP-287 PR-3 named constant;
+  // value unchanged at 365).
   const expiresInSeconds = opts.perpetual
     ? null
     : opts.expiresInDays !== undefined
       ? opts.expiresInDays * 24 * 60 * 60
-      : 365 * 24 * 60 * 60;
+      : DEFAULT_KIT_MINT_DAYS * 24 * 60 * 60;
 
   const issuedAtMs = Date.now();
   const licenseKey = await generateLicenseKey(


### PR DESCRIPTION
## Summary

GAP-287 PR-3 (final rung of the shorter-lived license JWT program). Scope is exactly the §6 PR-3 row of the countersigned spec, built to the §5-ratified numbers (owner, 2026-07-18):

- **Admin `POST /generate` manual-mint default drops 365d → 90d** via a new named `DEFAULT_MANUAL_MINT_DAYS` constant in [`packages/core/src/license.ts`](packages/core/src/license.ts). An explicit `expiresInDays` on the request is still honored unchanged (route always passes it through explicitly).
- **RevForge kit mint default stays 365d, now a named constant** `DEFAULT_KIT_MINT_DAYS` in [`packages/core/src/revforge-license.ts`](packages/core/src/revforge-license.ts) — no behavior change, per spec ("no code change beyond naming the constant").
- **Perpetual paths untouched** (exempt by design, ruled in the spec).
- Updated the OpenAPI-generated docs (`examples/api/openapi.json` description/example + the two corresponding rows in `docs/api/rest-api/README.md`) to reflect the new 90d default. Hand-edited rather than full-regenerated — the checked-in doc carries unrelated pre-existing drift (Forge→Enterprise rename, em-dash formatting, frontmatter) that a full `pnpm docs:generate:api` run would have bundled into this diff.

Completes the GAP-287 build: PR-1 refresh endpoint (#1972, merged) → PR-2 period-bound exp derivation (#1978, merged) → this PR-3.

## Red/green evidence

Red-first proof (per `feedback-prove-tests-fail-without-the-fix`): reverted the three touched source files to `origin/test` via `git checkout origin/test -- <files>` (kept the new/updated tests at HEAD), ran the suites, confirmed failure, then restored via `git checkout HEAD -- <files>` and confirmed green.

**RED** (`apps/server/src/routes/__tests__/license-edge.test.ts`, against base):
```
× defaults expiresInDays to DEFAULT_MANUAL_MINT_DAYS (90) when not provided
  expected call [.., .., 7776000] but received [.., .., 31536000]
```
**RED** (`packages/core/src/__tests__/license.test.ts` + `revforge-license.test.ts`, against base — constants don't exist yet):
```
× DEFAULT_MANUAL_MINT_DAYS is the owner-ratified 90 days  (expected 90, got undefined)
× DEFAULT_KIT_MINT_DAYS is 365, unchanged  (expected 365, got undefined)
× defaults to DEFAULT_KIT_MINT_DAYS when neither expiresInDays nor perpetual is given  (NaN)
```
**GREEN** after restoring HEAD: all of the above pass; explicit-override case (`expiresInDays: 30`) and perpetual-unchanged case both green in both directions (no regression to existing perpetual/explicit-override tests).

## Test counts

- `packages/core` full suite: 112 test files, **2803 passed**.
- `apps/server` full suite: 169 test files, **3002 passed, 2 skipped** (pre-existing skips, unrelated).
- Touched-suite typecheck: `pnpm --filter @revealui/core typecheck` and `pnpm --filter server typecheck` both clean.
- Biome: clean on all touched files.

No pre-existing unrelated failures observed in either full suite run.

## Security self-check

```
the fleet security self-check (internal checker, --diff mode)
```
Result: **HOLD** (expected — `apps/server/src/routes/license.ts` is on the security-sensitive path list). Per guardrail-2 / `dup-work-and-review-gates.md`, this PR needs a recorded non-author coordinator verdict (`sec-review:approved` label or a marked verdict comment) before merge. I have not self-approved, applied the label, or merged.

## Changeset

`@revealui/core`: minor (new exported constants `DEFAULT_MANUAL_MINT_DAYS`, `DEFAULT_KIT_MINT_DAYS`; server/admin are changeset-ignored per repo convention).

## Deviations from the task brief

- Did not run `pnpm docs:generate:api` to fully regenerate `docs/api/rest-api/README.md` — the checked-in file has unrelated pre-existing drift (stale "Forge" tier naming, em-dash formatting differences, frontmatter) that a full regen would have pulled into this diff. Hand-edited only the two `expiresInDays` description/example rows instead, keeping the diff scoped to GAP-287 PR-3.

---

Closes the GAP-287 build plan (all 3 PRs shipped; owner/coordinator merges PR-1, PR-2 done, this PR-3 pending guardrail-2 verdict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

