### PR TITLE
docs(harnesses): document fail-closed pairing flow + pairing-secret path (GAP-353 PR-3)

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -453,5 +453,24 @@ out of three isn't recoverable.
 
 ## Known deviations / escape hatches
 
-None currently. Any exception to this architecture must land here with
-a rationale, a review date, and a named owner.
+### Harness gateway bootstrap pairing secret
+
+**Path:** `~/.local/share/revealui/pairing-secret` (mode `0600`,
+machine-local; NOT in revvault)
+
+**Rationale:** the `@revealui/harnesses` HTTP gateway's bootstrap
+credential is intentionally filesystem-rooted rather than revvault-rooted.
+The party who can read a `0600` file in the daemon's own data dir is, by
+definition, the machine owner, and that is the trust anchor a never-paired
+daemon uses to admit its first pairing (the same bootstrap paradox SSH
+resolves the same way). Storing it in revvault would invert the design: it
+would require a working revvault unlock to reach a locally-running daemon,
+and it would move the credential off the single machine it authenticates.
+The daemon generates the secret on first start
+(`HttpGateway.initAuth()`, `packages/harnesses/src/server/http-gateway.ts`);
+only its SHA-256 hash is ever persisted (the `gateway_bootstrap` table),
+never the plaintext. See the harnesses README's "Remote Gateway (HTTP)"
+section for the pairing flow.
+
+**Review date:** 2027-07-18 (annual)
+**Owner:** RevealUI Studio (harness daemon maintainer)

--- a/packages/harnesses/README.md
+++ b/packages/harnesses/README.md
@@ -84,6 +84,29 @@ await manager.registerSession({
 })
 ```
 
+### Remote Gateway (HTTP)
+
+The daemon can optionally expose the same JSON-RPC surface as the Unix socket over HTTP, for remote access (for example the Studio app connecting from another machine on the network):
+
+```bash
+revealui-harnesses start --http-port 7890
+```
+
+The gateway is fail-closed. Every `/rpc` and `/api/*` call, including `agent.spawn` and `agent.stop`, is refused with `401` until it carries a valid bearer token. There is no pre-pairing bypass, on a fresh daemon or after a restart.
+
+**Pairing (challenge-response  -  the secret never crosses the wire):**
+
+1. On first start, the daemon generates a 32-byte secret at a `0600` file in its data dir and prints the path:
+   ```
+   ✓ Bootstrap pairing secret: ~/.local/share/revealui/pairing-secret
+   ```
+   Only someone who can read that file (the machine owner) can pair.
+2. The client requests a single-use, short-lived nonce: `GET /api/pair` → `{ nonce, expiresIn }` (expires in 2 minutes by default).
+3. The client reads the secret file and computes `HMAC-SHA256(secret, nonce)`, then posts it back: `POST /api/pair` with `{ nonce, hmac, label? }`.
+4. On a valid response the gateway mints a bearer token (`{ token, expiresAt }`) and stores only its SHA-256 hash. Send the token as `Authorization: Bearer <token>` on every subsequent call.
+
+Tokens are durable (default 90-day TTL) and persisted as hashes, so a daemon restart with a previously-issued token stays authenticated  -  it never reopens the pre-pairing window. Repeated failed pairing attempts trigger a per-source exponential-backoff lockout plus a global cooldown.
+
 ## Exports
 
 | Subpath | Contents |


### PR DESCRIPTION
## Summary

Final rung of the GAP-353 program (durable fail-closed bootstrap authn). PR-1 (#1968) shipped the schema + real process termination; PR-2 (#1975) shipped the fail-closed authn core with challenge-response pairing and already retired the 6-digit pairing code. This PR is documentation only — no auth logic changes.

## What was stale and what it now says

- [`packages/harnesses/README.md`](packages/harnesses/README.md): the README had **no mention at all** of the HTTP gateway, `--http-port`, or the pairing flow. Added a "Remote Gateway (HTTP)" section documenting: how to start the gateway, the fail-closed auth model (no pre-pairing bypass, ever), the challenge-response pairing flow (`GET /api/pair` nonce, HMAC over the nonce keyed on the secret, then a durable bearer token), where the `0600` bootstrap secret lives and how the CLI prints its path, the 90-day token TTL + restart-durability behavior, and the per-source lockout on failed pairing attempts.
- [`docs/SECRETS.md`](docs/SECRETS.md): added an entry under "Known deviations / escape hatches" for the gateway bootstrap pairing secret (`~/.local/share/revealui/pairing-secret`) — it's intentionally filesystem-rooted, not revvault-rooted, per the design's "machine owner is the root of trust" principle, with rationale, review date, and owner per that section's own format requirement.

I audited the rest of the repo (`docs/`, other `packages/harnesses/` docs, and a repo-wide grep for pairing/6-digit-code/gateway-auth references) and found no other stale description of the old flow — PR-2 landed with zero doc references to the retired code, so there was nothing else to correct, only the missing coverage above to add.

## Security self-check

`packages/harnesses/` is a blanket security-sensitive path marker (GAP-386, the harness hook/policy enforcement plane), so the fleet checker flags this PR even though the diff is docs-only:

```
the fleet security self-check (internal checker, --diff mode)
[security-sensitive] Current branch is SECURITY-SENSITIVE (vs origin/test). Touched: packages/harnesses/README.md
   When you open the PR, it needs a recorded coordinator verdict before merge (see dup-work-and-review-gates.md).
```

Needs a recorded coordinator verdict before merge per guardrail 2.

## Test plan

- [x] Ran the harnesses README and `docs/SECRETS.md` through `pnpm gate` (phase 1, changed-only) via the pre-push hook — PASS, including doc-currency, citations, brand-bridge, and structure validators.
- [x] Manually grepped the repo for stale pairing-flow references (6-digit code, `/api/pair`, gateway auth) — none found outside the two files touched.
- [x] Confirmed no Studio-facing pairing code exists in this repo (Studio itself lives in the separate revdev repo, out of scope for this PR).
- [ ] Coordinator security verdict (guardrail 2, see above).

This completes the GAP-353 program build (PR-1, PR-2, PR-3 all landed on `test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

