### PR TITLE
fix(harnesses): bound the initAuth secret-file retry loop

### DIFF
--- a/.changeset/gap-353-initauth-retry-cap.md
+++ b/.changeset/gap-353-initauth-retry-cap.md
@@ -1,0 +1,5 @@
+---
+'@revealui/harnesses': patch
+---
+
+Bound the `HttpGateway.initAuth` bootstrap-secret retry loop to 5 attempts before failing closed, so a persistent create/delete race on the secret file cannot livelock daemon startup. Fast-follow on a non-blocking finding from the #1975 guardrail-2 security verdict (DoS-only defense-in-depth; O_EXCL + O_NOFOLLOW already prevent secret substitution).

--- a/packages/harnesses/src/server/__tests__/http-gateway.test.ts
+++ b/packages/harnesses/src/server/__tests__/http-gateway.test.ts
@@ -25,7 +25,17 @@ import type { RpcServer } from '../rpc-server.js';
 // call (which runs immediately before the exclusive 'wx' write) to deterministically
 // exercise the create-path EEXIST fallback. Every other test leaves it null, so
 // mkdirSync passes straight through to the real implementation.
-const fsHooks = vi.hoisted(() => ({ beforeMkdir: null as (() => void) | null }));
+//
+// `forceCreateEexist` + `onCreateAttempt` simulate a PERSISTENT create-path race
+// (GAP-353 initAuth retry-cap test): every exclusive ('wx') write attempt fails
+// with EEXIST and the winner's file is never actually written, so the read-back
+// that follows also ENOENTs. That is the shape a bounded-retry regression test
+// needs to prove the loop gives up on its own rather than spinning forever.
+const fsHooks = vi.hoisted(() => ({
+  beforeMkdir: null as (() => void) | null,
+  forceCreateEexist: false,
+  onCreateAttempt: null as (() => void) | null,
+}));
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return {
@@ -34,6 +44,22 @@ vi.mock('node:fs', async (importOriginal) => {
       fsHooks.beforeMkdir?.();
       return actual.mkdirSync(path, options);
     }) as typeof actual.mkdirSync,
+    writeFileSync: ((
+      path: Parameters<typeof actual.writeFileSync>[0],
+      data: Parameters<typeof actual.writeFileSync>[1],
+      options?: Parameters<typeof actual.writeFileSync>[2],
+    ) => {
+      const flag = (options as { flag?: string } | undefined)?.flag;
+      if (flag === 'wx') {
+        fsHooks.onCreateAttempt?.();
+        if (fsHooks.forceCreateEexist) {
+          const err = new Error('EEXIST: file already exists') as NodeJS.ErrnoException;
+          err.code = 'EEXIST';
+          throw err;
+        }
+      }
+      return actual.writeFileSync(path, data, options);
+    }) as typeof actual.writeFileSync,
   };
 });
 
@@ -478,6 +504,60 @@ describe('HttpGateway fail-closed auth (GAP-353 PR-2)', () => {
         expect(res.status).toBe(200);
       } finally {
         fsHooks.beforeMkdir = null;
+      }
+    });
+
+    it('bounds the create-path retry loop so a persistent EEXIST race cannot livelock startup (#1975 verdict fast-follow)', async () => {
+      // A persistent adversary (or a crash-looping peer) makes every exclusive
+      // create attempt fail with EEXIST while never actually writing a winner
+      // file, so the read-back that follows also ENOENTs every time. Without a
+      // bound the for(;;) loop spins forever. SAFETY_VALVE releases the forced
+      // EEXIST after an unreasonably high attempt count purely so this test
+      // itself terminates against pre-fix code -- it plays no role in the fix.
+      const SAFETY_VALVE = 200;
+      const dir = mkdtempSync(join(tmpdir(), 'gw-authn-'));
+      dirs.push(dir);
+      const secretPath = join(dir, 'pairing-secret');
+      let attempts = 0;
+      fsHooks.forceCreateEexist = true;
+      fsHooks.onCreateAttempt = () => {
+        attempts++;
+        if (attempts >= SAFETY_VALVE) fsHooks.forceCreateEexist = false;
+      };
+
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        const store = new DaemonStore({ dataDir: '' });
+        await store.init();
+        stores.push(store);
+        const gateway = new HttpGateway({
+          port: 0,
+          host: '127.0.0.1',
+          rpcDispatch: makeDispatchStub(),
+          store,
+          secretPath,
+        });
+        gateways.push(gateway);
+        await gateway.initAuth();
+
+        // The loop must give up on its own, well under the safety valve.
+        expect(attempts).toBeGreaterThan(0);
+        expect(attempts).toBeLessThan(SAFETY_VALVE);
+
+        await gateway.start();
+        const base = `http://127.0.0.1:${gateway.getPort()}`;
+        // Fail-closed: initAuth gave up without adopting a secret, so pairing 503s.
+        const { nonce } = (await (await fetch(`${base}/api/pair`)).json()) as { nonce: string };
+        const res = await fetch(`${base}/api/pair`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ nonce, hmac: '00'.repeat(32) }),
+        });
+        expect(res.status).toBe(503);
+      } finally {
+        stderrSpy.mockRestore();
+        fsHooks.forceCreateEexist = false;
+        fsHooks.onCreateAttempt = null;
       }
     });
   });

--- a/packages/harnesses/src/server/http-gateway.ts
+++ b/packages/harnesses/src/server/http-gateway.ts
@@ -105,6 +105,12 @@ const DEFAULT_BASE_LOCKOUT_MS = 60 * 1000;
 const DEFAULT_MAX_LOCKOUT_MS = 60 * 60 * 1000;
 const DEFAULT_GLOBAL_FAILURE_CEILING = 100;
 const MAX_PENDING_NONCES = 256;
+// #1975 guardrail-2 verdict, non-blocking follow-up: the initAuth create-path
+// retry loop only ever advances on EEXIST (another process winning the create
+// race), so it is bounded here to stop a persistent create/delete race from
+// livelocking startup. DoS-only concern (O_EXCL + O_NOFOLLOW still hold, so no
+// secret can be substituted); defense-in-depth, not a new attack surface.
+const MAX_INIT_AUTH_ATTEMPTS = 5;
 const SECRET_BYTES = 32;
 const NONCE_BYTES = 32;
 const TOKEN_BYTES = 32;
@@ -235,8 +241,10 @@ export class HttpGateway {
     const secretPath = this.config.secretPath;
 
     // Looped so a create-path race that loses to another process (EEXIST) falls
-    // back to reading the winner's file rather than failing the daemon.
-    for (;;) {
+    // back to reading the winner's file rather than failing the daemon. Bounded
+    // at MAX_INIT_AUTH_ATTEMPTS so a persistent create/delete race cannot
+    // livelock startup.
+    for (let attempt = 1; attempt <= MAX_INIT_AUTH_ATTEMPTS; attempt++) {
       const dbHash = await this.config.store.getBootstrapSecretHash();
 
       // Read path: open ONE fd with O_NOFOLLOW, then fstat + read that same fd.
@@ -334,6 +342,11 @@ export class HttpGateway {
         closeSync(fd);
       }
     }
+
+    this.bootstrapSecret = null;
+    this.logAuth(
+      `bootstrap secret initialization at ${secretPath} did not converge after ${MAX_INIT_AUTH_ATTEMPTS} attempts (persistent create/delete race); refusing new pairings`,
+    );
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
## Fast-follow: bound the initAuth secret-file retry loop

Non-blocking finding recorded on the guardrail-2 APPROVE verdict for merged PR #1975:

> the `for(;;)` retry has no iteration cap; a local adversary with data-dir write access could livelock startup (DoS only, no secret compromise since O_EXCL + O_NOFOLLOW hold). Recommend a 3-5 attempt bound then fail-closed, as defense-in-depth in a later PR.

### Change

`HttpGateway.initAuth()` (`packages/harnesses/src/server/http-gateway.ts`) now bounds the create-path retry loop at `MAX_INIT_AUTH_ATTEMPTS = 5`. The loop only ever re-iterates on an `EEXIST` from the exclusive (`wx`) secret-file create (another process winning the create race). After 5 attempts it fails closed: `bootstrapSecret = null`, a loud `logAuth` message naming the secret path and attempt count, and pairing then 503s exactly as it already does for every other fail-closed path in this function. No change to the read-path or create-path TOCTOU protections (`O_NOFOLLOW` + `O_EXCL`) landed in #1975/#1978 — those still hold; this is defense-in-depth against a livelock, not a new secret-substitution vector.

### Red -> green evidence

New test `bounds the create-path retry loop so a persistent EEXIST race cannot livelock startup (#1975 verdict fast-follow)` in `packages/harnesses/src/server/__tests__/http-gateway.test.ts`, driven by a `writeFileSync` mock that forces every exclusive create attempt to throw `EEXIST` while never actually writing a winner file (so the read-back also always `ENOENT`s) — a persistent create/delete race.

- **RED** (`git checkout origin/test -- packages/harnesses/src/server/http-gateway.ts`, base code, unbounded loop): the loop never gave up on its own — it only stopped when the test's own 200-attempt safety valve released the forced `EEXIST`. `expect(attempts).toBeLessThan(200)` failed with `attempts === 200`.
- **GREEN** (fix restored): the loop gives up after exactly 5 attempts, well under the safety valve, `initAuth()` returns with the secret unset, and a subsequent pairing attempt 503s (fail-closed).

### Test counts

- `http-gateway.test.ts`: 23/23 passing (was 22, +1 new).
- `@revealui/harnesses` full suite: 473/474 passing. The one failure (`opencode-adapter.test.ts > get-status reports availability`) is pre-existing and environment-dependent — it asserts `available: false` assuming the `opencode` CLI is not installed, but it is present in this dev environment (`which opencode` resolves). Unrelated to this change; the file is untouched by this diff.
- Typecheck (`tsc --noEmit`): clean.
- Biome: clean on touched files.

### Guardrail-2 notice

This PR touches `packages/harnesses/src/server/http-gateway.ts`, a guardrail-2 sensitive surface (auth/secret-file handling). Per the fleet security self-check output below, it requires a recorded coordinator verdict before merge — same gate #1975 and #1978 went through.

```
🔒 Current branch is SECURITY-SENSITIVE (vs origin/test). Touched: packages/harnesses/src/server/__tests__/http-gateway.test.ts, packages/harnesses/src/server/http-gateway.ts
   When you open the PR, it needs a recorded coordinator verdict before merge (see dup-work-and-review-gates.md).
```

### Changeset

`@revealui/harnesses` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
