### PR TITLE
fix(core,server): add 1s idempotency tolerance to renewal re-mint

### DIFF
--- a/.changeset/gap-287-remint-tolerance.md
+++ b/.changeset/gap-287-remint-tolerance.md
@@ -1,0 +1,5 @@
+---
+'@revealui/core': patch
+---
+
+Add a 1s idempotency tolerance (`coversRenewalBound`) to the GAP-287 PR-2 subscription renewal re-mint decision, so a stored license `exp` landing exactly 1s below the new period bound (a flooring artifact of the relative-TTL derivation and the JWT signer's own second granularity) is treated as already covering it. Fast-follow on a non-blocking finding from the #1978 guardrail-2 verdict: without this, a duplicate/retried `invoice.payment_succeeded` on that 1s boundary re-entered the re-mint path instead of no-opping (bounded churn, never an entitlement or money error).

--- a/apps/server/src/routes/__tests__/webhook-license-exp-derivation.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-license-exp-derivation.test.ts
@@ -186,6 +186,21 @@ function decodeJwtClaims(jwt: string): Record<string, unknown> {
   return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
 }
 
+/**
+ * Builds an unverified JWT-shaped string carrying an exact `exp` claim, for
+ * pinning the renewal idempotency-boundary test to a precise second without
+ * racing the real signer's own `iat` capture. `readLicenseExp` (the only
+ * consumer of the stored key on the re-mint path) decodes without verifying
+ * the signature, so a well-formed but unsigned token is a faithful stand-in.
+ */
+function fakeLicenseKeyWithExp(exp: number, customerId: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ tier: 'pro', customerId, exp })).toString(
+    'base64url',
+  );
+  return `${header}.${payload}.unverified-test-signature`;
+}
+
 /** The `licenses` row the checkout saga inserted (the one carrying a licenseKey). */
 function capturedInsertedLicenseKey(): string | undefined {
   for (const call of mockDbInsertChain.values.mock.calls) {
@@ -372,6 +387,27 @@ describe('invoice.payment_succeeded — renewal re-mint cadence', () => {
     expect(res.status).toBe(200);
 
     // No license-key update occurred (markCompleted's update carries no licenseKey).
+    expect(capturedUpdatedLicenseKey()).toBeUndefined();
+  });
+
+  it('SKIPS re-mint when the stored key exp is exactly 1s below the new bound (idempotency tolerance, #1978 verdict fast-follow)', async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const newPeriodEndSec = nowSec + 30 * DAY;
+    const newBound = newPeriodEndSec + SLACK_SEC;
+
+    // The flooring gap between subscriptionLicenseExpiresInSeconds's relative TTL
+    // and the signer's own second-granularity exp can leave a previously-minted
+    // key's exp exactly 1s short of the bound it targeted. A duplicate/retried
+    // invoice.payment_succeeded landing on that 1s gap must still no-op.
+    const staleByOneSecond = fakeLicenseKeyWithExp(newBound - 1, customerId);
+
+    const event = makeRenewalEvent('evt_renew_tolerance', newPeriodEndSec);
+    mockConstructEvent.mockReturnValueOnce(event);
+    sequenceRenewalReads(staleByOneSecond);
+
+    const res = await createApp().request(postStripe(event));
+    expect(res.status).toBe(200);
+
     expect(capturedUpdatedLicenseKey()).toBeUndefined();
   });
 });

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -11,6 +11,7 @@
 
 import { RELEVANT_STRIPE_WEBHOOK_EVENTS } from '@revealui/contracts';
 import {
+  coversRenewalBound,
   generateLicenseKey,
   readLicenseExp,
   resetLicenseState,
@@ -416,10 +417,11 @@ async function remintSubscriptionLicenseOnRenewal(
   if (!tier) return;
 
   // Idempotency pin (the WH-2 property, now covering renewals): skip when the
-  // stored key's exp already reaches the new bound.
+  // stored key's exp already reaches the new bound, within the 1s flooring
+  // tolerance documented on coversRenewalBound (fast-follow, #1978 verdict).
   const newBound = subscriptionExpBound(params.periodEnd);
   const storedExp = await readLicenseExp(row.licenseKey);
-  if (storedExp !== null && storedExp >= newBound) return;
+  if (coversRenewalBound(storedExp, newBound)) return;
 
   const privateKey = process.env.REVEALUI_LICENSE_PRIVATE_KEY;
   if (!privateKey) {

--- a/packages/core/src/__tests__/license-exp-derivation.test.ts
+++ b/packages/core/src/__tests__/license-exp-derivation.test.ts
@@ -19,8 +19,10 @@
 import { generateKeyPairSync } from 'node:crypto';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
+  coversRenewalBound,
   DEFAULT_SUBSCRIPTION_TTL_SECONDS,
   generateLicenseKey,
+  RENEWAL_IDEMPOTENCY_TOLERANCE_SECONDS,
   RENEWAL_SLACK_DAYS,
   RENEWAL_SLACK_SECONDS,
   readLicenseExp,
@@ -79,6 +81,31 @@ describe('subscriptionExpBound', () => {
   it('is the absolute epoch bound period_end + slack', () => {
     const periodEnd = new Date(1_700_000_000_000);
     expect(subscriptionExpBound(periodEnd)).toBe(1_700_000_000 + RENEWAL_SLACK_SECONDS);
+  });
+});
+
+// #1978 guardrail-2 verdict, non-blocking finding: the minted exp can floor 1s
+// below subscriptionExpBound's value, so a duplicate invoice.payment_succeeded
+// must still treat that 1s-short exp as covering the bound (SKIP re-mint).
+describe('coversRenewalBound (idempotency tolerance)', () => {
+  it('is 1 second', () => {
+    expect(RENEWAL_IDEMPOTENCY_TOLERANCE_SECONDS).toBe(1);
+  });
+
+  it('covers when the stored exp meets the bound exactly', () => {
+    expect(coversRenewalBound(1_700_000_000, 1_700_000_000)).toBe(true);
+  });
+
+  it('covers when the stored exp is exactly 1s below the bound (the flooring gap)', () => {
+    expect(coversRenewalBound(1_700_000_000 - 1, 1_700_000_000)).toBe(true);
+  });
+
+  it('does NOT cover when the stored exp is 2s or more below the bound', () => {
+    expect(coversRenewalBound(1_700_000_000 - 2, 1_700_000_000)).toBe(false);
+  });
+
+  it('does NOT cover a perpetual/undecodable token (null exp)', () => {
+    expect(coversRenewalBound(null, 1_700_000_000)).toBe(false);
   });
 });
 

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -860,6 +860,28 @@ export function subscriptionExpBound(periodEnd: Date): number {
 }
 
 /**
+ * Idempotency tolerance for the renewal re-mint decision (fast-follow from the
+ * non-blocking finding on the #1978 guardrail-2 verdict). `subscriptionLicenseExpiresInSeconds`
+ * floors its relative TTL to whole seconds and the JWT signer floors `exp` to
+ * `iat + expiresInSeconds` at its own second granularity, so the `exp` actually
+ * persisted for a subscription key can land exactly 1s below
+ * {@link subscriptionExpBound}'s value even though the mint targeted that bound.
+ * Without this tolerance a duplicate/retried `invoice.payment_succeeded` lands on
+ * that 1s gap and re-enters the re-mint path instead of no-opping.
+ */
+export const RENEWAL_IDEMPOTENCY_TOLERANCE_SECONDS = 1;
+
+/**
+ * True when a stored license `exp` already covers the renewal bound, within the
+ * {@link RENEWAL_IDEMPOTENCY_TOLERANCE_SECONDS} idempotency tolerance  -  i.e. the
+ * renewal re-mint should be SKIPPED. `null` (perpetual token, or an undecodable
+ * key) never covers, so the caller falls through to re-mint.
+ */
+export function coversRenewalBound(storedExp: number | null, newBound: number): boolean {
+  return storedExp !== null && storedExp >= newBound - RENEWAL_IDEMPOTENCY_TOLERANCE_SECONDS;
+}
+
+/**
  * Reads the `exp` (epoch seconds) claim from a license JWT WITHOUT verifying its
  * signature. Internal use only, for the GAP-287 PR-2 renewal cadence: the token
  * comes from our OWN store and the caller needs only its expiry to decide whether


### PR DESCRIPTION
## Fast-follow: 1s idempotency tolerance on the renewal re-mint decision

Non-blocking finding recorded on the guardrail-2 APPROVE verdict for merged PR #1978:

> idempotency off-by-one — the minted exp can floor 1s below subscriptionExpBound's value, so a duplicate invoice.payment_succeeded can re-enter the re-mint path instead of no-opping (bounded churn, not a money/entitlement error; the mocked tests don't cover the cross-function property). Suggested: compare with 1s tolerance (storedExp >= newBound - 1) or derive the skip bound with the same flooring as the mint.

### Change

- `packages/core/src/license.ts`: adds `RENEWAL_IDEMPOTENCY_TOLERANCE_SECONDS = 1` and `coversRenewalBound(storedExp, newBound)`, exactly the comparison the finding suggests (`storedExp >= newBound - 1`), documented against the flooring source (relative-TTL floor in `subscriptionLicenseExpiresInSeconds` plus the JWT signer's own second-granularity `exp`).
- `apps/server/src/routes/webhooks.ts`: `remintSubscriptionLicenseOnRenewal`'s idempotency check now calls `coversRenewalBound(storedExp, newBound)` instead of the bare `storedExp >= newBound`. This single function backs both call sites (the primary `invoice.payment_succeeded` renewal path and the payment-recovery re-mint), so both are covered.

No entitlement or tier logic changed. TTL-comparison only, matching the scope the original #1978 verdict approved.

### Red -> green evidence

Two levels, both proving the exact off-by-one:

**Pure boundary tests** (`packages/core/src/__tests__/license-exp-derivation.test.ts`, new `describe('coversRenewalBound (idempotency tolerance)')`): exercises `storedExp === newBound`, `storedExp === newBound - 1`, `storedExp === newBound - 2`, and `null`.
- RED (`git checkout origin/test -- packages/core/src/license.ts`): `coversRenewalBound is not a function` (the function doesn't exist yet on base) — 5/5 failing.
- GREEN (fix restored): 5/5 passing; `newBound - 1` correctly covers, `newBound - 2` correctly does not.

**Webhook integration test** (`apps/server/src/routes/__tests__/webhook-license-exp-derivation.test.ts`, new test `SKIPS re-mint when the stored key exp is exactly 1s below the new bound`): drives the real `invoice.payment_succeeded` handler with a stored license key whose `exp` is crafted (via an unverified-signature JWT-shaped string, since `readLicenseExp` never verifies the signature on this path) to land exactly `newBound - 1`.
- RED (`git checkout origin/test -- apps/server/src/routes/webhooks.ts packages/core/src/license.ts`, base comparison `storedExp >= newBound`): the handler re-minted — `expect(capturedUpdatedLicenseKey()).toBeUndefined()` failed, a JWT was captured.
- GREEN (fix restored): the handler correctly skips the re-mint — no update occurs.

### Test counts

- `license-exp-derivation.test.ts`: 16/16 passing (was 11, +5 new).
- `webhook-license-exp-derivation.test.ts`: 4/4 passing (was 3, +1 new).
- `@revealui/core` full suite: 2808/2808 passing.
- `server` app full suite: 3003/3003 passing (2 pre-existing skips, unrelated to this change).
- Typecheck (`tsc --noEmit`): clean on both `packages/core` and `apps/server` (required a `pnpm --filter @revealui/core build` first so the server's dist-resolved import of the new `coversRenewalBound` export type-checks).
- Biome: clean on all touched files.

### Guardrail-2 notice

This PR touches `apps/server/src/routes/webhooks.ts`, a guardrail-2 sensitive surface (billing/webhooks). Per the fleet security self-check output below, it requires a recorded coordinator verdict before merge — same gate #1975 and #1978 went through.

```
🔒 Current branch is SECURITY-SENSITIVE (vs origin/test). Touched: apps/server/src/routes/webhooks.ts
   When you open the PR, it needs a recorded coordinator verdict before merge (see dup-work-and-review-gates.md).
```

### Changeset

`@revealui/core` patch. `server` is changeset-ignored per repo convention; no separate server changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
