### PR TITLE
fix(marketing): footer horizontal scroll on mobile + presentation icon adoption

### DIFF
--- a/.changeset/export-icons-main-entry.md
+++ b/.changeset/export-icons-main-entry.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': minor
+---
+
+Export the icon set and provider/social brand marks from the main entry (previously `/server`-only), and add `XIcon` (the X, formerly Twitter, mark). Apps can now compose `GitHubIcon`, `XIcon`, `LinkedInIcon`, `IconMenu`, `IconClose`, and the rest of the icon set instead of handrolling inline SVGs.

--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { BuiltWithRevealUI } from '@revealui/presentation';
+import { BuiltWithRevealUI, GitHubIcon, LinkedInIcon, XIcon } from '@revealui/presentation';
 import {
   FOOTER_CLAIMS_LEDGER_NOTE,
   FOOTER_COLUMNS,
@@ -65,34 +65,21 @@ export function Footer() {
                 className="text-muted-foreground hover:text-foreground transition-colors"
                 aria-label="GitHub"
               >
-                <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-                  <title>GitHub</title>
-                  <path
-                    fillRule="evenodd"
-                    d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z"
-                    clipRule="evenodd"
-                  />
-                </svg>
+                <GitHubIcon className="size-5" />
               </a>
               <a
                 href={SITE.urls.x}
                 className="text-muted-foreground hover:text-foreground transition-colors"
                 aria-label="RevealUI on X"
               >
-                <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-                  <title>X (Twitter)</title>
-                  <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z" />
-                </svg>
+                <XIcon className="size-5" />
               </a>
               <a
                 href={SITE.urls.linkedin}
                 className="text-muted-foreground hover:text-foreground transition-colors"
                 aria-label="RevealUI on LinkedIn"
               >
-                <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-                  <title>LinkedIn</title>
-                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-                </svg>
+                <LinkedInIcon className="size-5" />
               </a>
             </div>
           </div>
@@ -118,7 +105,7 @@ export function Footer() {
           ))}
         </div>
         <div className="mt-12 pt-8 border-t border-border flex flex-col sm:flex-row items-center justify-between gap-4 text-muted-foreground text-sm">
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center justify-center gap-4 sm:justify-start">
             <p>
               &copy; {currentYear} RevealUI is operated by{' '}
               <a
@@ -133,7 +120,7 @@ export function Footer() {
             </p>
             <BuiltWithRevealUI size="sm" />
           </div>
-          <div className="flex gap-6">
+          <div className="flex flex-wrap justify-center gap-x-6 gap-y-2">
             {FOOTER_LEGAL_LINKS.map(({ label, href }) => (
               <a key={label} href={href} className="hover:text-foreground transition-colors">
                 {label}

--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -1,4 +1,7 @@
 import {
+  GitHubIcon,
+  IconClose,
+  IconMenu,
   LinkButton,
   useClickOutside,
   useEscapeKey,
@@ -95,13 +98,7 @@ export function NavBar() {
             aria-label="GitHub"
           >
             <span className="sr-only">GitHub</span>
-            <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                fillRule="evenodd"
-                d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <GitHubIcon className="size-5" />
           </a>
         </div>
 
@@ -125,31 +122,9 @@ export function NavBar() {
             onClick={() => setOpen((o) => !o)}
           >
             {open ? (
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-                aria-hidden="true"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              <IconClose size="md" strokeWidth={2} />
             ) : (
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-                />
-              </svg>
+              <IconMenu size="md" strokeWidth={2} />
             )}
           </button>
         </div>

--- a/packages/presentation/src/icons/providers.tsx
+++ b/packages/presentation/src/icons/providers.tsx
@@ -1,5 +1,5 @@
 /**
- * OAuth provider + passkey icons.
+ * OAuth provider, social, + passkey icons.
  *
  * Mono icons in `currentColor` — they inherit the parent button's text color so
  * the OAuth row reads as a uniform visual family rather than a multi-color grid.
@@ -74,6 +74,15 @@ export function VercelIcon(props: IconProps) {
   return (
     <BaseIcon {...props}>
       <path d="M24 22.525H0l12-21.05 12 21.05z" />
+    </BaseIcon>
+  );
+}
+
+/** X (formerly Twitter) mark. */
+export function XIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.657l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25h6.826l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
     </BaseIcon>
   );
 }

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -6,7 +6,11 @@
  * multiple apps in the RevealUI monorepo.
  */
 
+// Icon set + provider/social brand marks: previously only on the /server
+// entry, exported here so apps compose icons instead of handrolling SVGs.
+export * from './components/icon.js';
 export * from './components/index.js';
 export * from './hooks/index.js';
+export * from './icons/providers.js';
 export * from './primitives/index.js';
 export * from './utils/index.js';

--- a/packages/presentation/src/server.ts
+++ b/packages/presentation/src/server.ts
@@ -114,13 +114,14 @@ export {
   IconUsers,
   IconXCircle,
 } from './components/icon.js';
-// OAuth provider + passkey icons - Server Safe
+// OAuth provider, social, + passkey icons - Server Safe
 export {
   GitHubIcon,
   GoogleIcon,
   LinkedInIcon,
   PasskeyIcon,
   VercelIcon,
+  XIcon,
 } from './icons/providers.js';
 
 // Primitives - Server Safe


### PR DESCRIPTION
## Summary

Fixes site-wide horizontal scroll on mobile (reported on an iPhone 11, 375px viewport) and converts the marketing Footer/NavBar handrolled SVGs to `@revealui/presentation` icons.

### Root cause

The footer's legal-links row (`Footer.tsx`) rendered six links in a `flex gap-6` container with no `flex-wrap`. Flex items cannot shrink below their longest word, so the row had a ~435px hard minimum width. At 375px that overflowed the page by 30px and widened the whole document.

### Changes

- `fix(marketing)`: both footer bottom-bar groups now wrap (`flex-wrap` + gap utilities); handrolled GitHub/X/LinkedIn and menu/close SVGs in Footer and NavBar replaced with presentation icons.
- `feat(presentation)`: the icon set (`components/icon.tsx`) and provider/social brand marks (`icons/providers.tsx`) are now exported from the main entry (previously `/server`-only), and the missing `XIcon` (X, formerly Twitter, mark) was added next to the existing `GitHubIcon`/`LinkedInIcon`. Changeset included (minor).

The X social link now renders the actual X logo instead of the legacy Twitter bird.

### Verification (empirical, Playwright at 375/414/660/700px)

- Before: `scrollWidth` 405 at a 375px viewport (30px overflow); the widest in-flow element was the legal-links row at 435px.
- After: `scrollWidth` equals the viewport at all four widths (zero overflow, footer present), verified against the dev server; footer and nav icons visually confirmed via screenshots at 375px and 1280px.
- `pnpm --filter @revealui/presentation test` 986 passed; `pnpm --filter marketing test` 80 passed; typecheck clean on both; Biome clean; full phase-1 pre-push gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
