### PR TITLE
chore(admin): unregister tableless collections, mark orphans (F7)

### DIFF
--- a/apps/admin/src/lib/blocks/ArchiveBlock/config.ts
+++ b/apps/admin/src/lib/blocks/ArchiveBlock/config.ts
@@ -61,17 +61,22 @@ export const ArchiveBlock: Block = {
         },
       ],
     },
-    {
-      name: 'categories',
-      type: 'relationship',
-      admin: {
-        condition: (_: unknown, siblingData: ArchiveBlockData) =>
-          siblingData?.populateBy === 'collection',
-      },
-      hasMany: true,
-      label: 'Categories To Show',
-      relationTo: 'categories',
-    },
+    // WIRE-UP-PENDING — the `categories` relationship is disabled: its target
+    // `categories` collection has no backing table and is unregistered (see
+    // collections/registry.ts). ArchiveBlock is a live block (offered by Pages
+    // and rendered as `archive`), so it must not reference an unregistered
+    // slug. Re-enable once a `categories` migration + registration land.
+    // {
+    //   name: 'categories',
+    //   type: 'relationship',
+    //   admin: {
+    //     condition: (_: unknown, siblingData: ArchiveBlockData) =>
+    //       siblingData?.populateBy === 'collection',
+    //   },
+    //   hasMany: true,
+    //   label: 'Categories To Show',
+    //   relationTo: 'categories',
+    // },
     {
       name: 'limit',
       type: 'number',

--- a/apps/admin/src/lib/blocks/PageContent/index.ts
+++ b/apps/admin/src/lib/blocks/PageContent/index.ts
@@ -1,3 +1,8 @@
+// WIRE-UP-PENDING — this `pageContent` block config is not offered by any
+// collection's `blocks` field (the Pages editor block list) and has no
+// renderer in `apps/admin/src/lib/blocks/RenderBlocks.tsx`. It is config-only
+// with no consumer. Kept on disk pending a per-item register-vs-delete
+// decision in PR review.
 import type { Block } from '@revealui/core';
 
 export const PageContent: Block = {

--- a/apps/admin/src/lib/blocks/PageList/index.ts
+++ b/apps/admin/src/lib/blocks/PageList/index.ts
@@ -1,3 +1,8 @@
+// WIRE-UP-PENDING — this `pageList` block config is not offered by any
+// collection's `blocks` field (the Pages editor block list) and has no
+// renderer in `apps/admin/src/lib/blocks/RenderBlocks.tsx`. It is config-only
+// with no consumer. Kept on disk pending a per-item register-vs-delete
+// decision in PR review.
 import type { Block } from '@revealui/core';
 
 const PageListField = {

--- a/apps/admin/src/lib/blocks/RelatedPosts/Component.tsx
+++ b/apps/admin/src/lib/blocks/RelatedPosts/Component.tsx
@@ -1,3 +1,8 @@
+// WIRE-UP-PENDING — this `RelatedPosts` block component has no config file, is
+// not offered by any collection's `blocks` field (the Pages editor block list),
+// is not referenced by `apps/admin/src/lib/blocks/RenderBlocks.tsx`, and is not
+// imported anywhere. Kept on disk pending a per-item register-vs-delete
+// decision in PR review.
 import type { Post } from '@revealui/core/types/admin';
 import { cn } from '@revealui/presentation/server';
 import { Card } from '@/lib/components/Card/index';

--- a/apps/admin/src/lib/blocks/ReusableContent/index.ts
+++ b/apps/admin/src/lib/blocks/ReusableContent/index.ts
@@ -1,3 +1,8 @@
+// WIRE-UP-PENDING — this `reusableContent` block config is not offered by any
+// collection's `blocks` field (the Pages editor block list) and has no
+// renderer in `apps/admin/src/lib/blocks/RenderBlocks.tsx`. It is config-only
+// with no consumer (its Contents import is commented out). Kept on disk
+// pending a per-item register-vs-delete decision in PR review.
 import type { Block } from '@revealui/core';
 // import Contents from "../../collections/Contents/index.js";
 

--- a/apps/admin/src/lib/blocks/SiteTitle/index.ts
+++ b/apps/admin/src/lib/blocks/SiteTitle/index.ts
@@ -1,3 +1,8 @@
+// WIRE-UP-PENDING — this `siteTitle` block config is not offered by any
+// collection's `blocks` field (the Pages editor block list) and has no
+// renderer in `apps/admin/src/lib/blocks/RenderBlocks.tsx`. It is config-only
+// with no consumer. Kept on disk pending a per-item register-vs-delete
+// decision in PR review.
 import type { Block } from '@revealui/core';
 
 export const SiteTitle: Block = {

--- a/apps/admin/src/lib/collections/Info/index.ts
+++ b/apps/admin/src/lib/collections/Info/index.ts
@@ -1,3 +1,7 @@
+// WIRE-UP-PENDING — this `info` collection config is NOT registered in
+// `apps/admin/src/lib/collections/registry.ts` (`allCollections`) and is not
+// consumed anywhere. It has no backing Postgres table. Kept on disk pending a
+// per-item register-vs-delete decision in PR review.
 import type { CollectionConfig } from '@revealui/core';
 import { anyone, authenticated, isAdmin } from '@/lib/access';
 

--- a/apps/admin/src/lib/collections/Posts/index.ts
+++ b/apps/admin/src/lib/collections/Posts/index.ts
@@ -92,15 +92,20 @@ export const Posts: RevealCollectionConfig<Post> = {
               hasMany: true,
               relationTo: 'posts',
             },
-            {
-              name: 'categories',
-              type: 'relationship',
-              admin: {
-                position: 'sidebar',
-              },
-              hasMany: true,
-              relationTo: 'categories',
-            },
+            // WIRE-UP-PENDING — the `categories` relationship is disabled: its
+            // target `categories` collection has no backing table and is
+            // unregistered (see collections/registry.ts). A registered
+            // collection must not reference an unregistered slug. Re-enable
+            // this field once a `categories` migration + registration land.
+            // {
+            //   name: 'categories',
+            //   type: 'relationship',
+            //   admin: {
+            //     position: 'sidebar',
+            //   },
+            //   hasMany: true,
+            //   relationTo: 'categories',
+            // },
           ],
         },
         {

--- a/apps/admin/src/lib/collections/Products/index.ts
+++ b/apps/admin/src/lib/collections/Products/index.ts
@@ -116,15 +116,20 @@ const Products: RevealCollectionConfig<Product> = {
         },
       ],
     },
-    {
-      name: 'categories',
-      type: 'relationship',
-      relationTo: 'categories',
-      hasMany: true,
-      admin: {
-        position: 'sidebar',
-      },
-    },
+    // WIRE-UP-PENDING — the `categories` relationship is disabled: its target
+    // `categories` collection has no backing table and is unregistered (see
+    // collections/registry.ts). A registered collection must not reference an
+    // unregistered slug. Re-enable this field once a `categories` migration +
+    // registration land.
+    // {
+    //   name: 'categories',
+    //   type: 'relationship',
+    //   relationTo: 'categories',
+    //   hasMany: true,
+    //   admin: {
+    //     position: 'sidebar',
+    //   },
+    // },
     {
       name: 'relatedProducts',
       type: 'relationship',

--- a/apps/admin/src/lib/collections/Videos/index.ts
+++ b/apps/admin/src/lib/collections/Videos/index.ts
@@ -1,3 +1,7 @@
+// WIRE-UP-PENDING — this `videos` collection config is NOT registered in
+// `apps/admin/src/lib/collections/registry.ts` (`allCollections`) and is not
+// consumed anywhere. It has no backing Postgres table. Kept on disk pending a
+// per-item register-vs-delete decision in PR review.
 import type { CollectionConfig } from '@revealui/core';
 
 const Videos: CollectionConfig = {

--- a/apps/admin/src/lib/collections/__tests__/registry-backing-storage.test.ts
+++ b/apps/admin/src/lib/collections/__tests__/registry-backing-storage.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Registry backing-storage guard (F7 — table/orphan hygiene).
+ *
+ * Every collection registered in `allCollections` must have a backing Postgres
+ * table whose name equals its slug. The admin storage layer resolves a
+ * collection to storage by slug in both tiers:
+ *   - the typed-storage bridge (`apps/admin/src/lib/db/typedCollectionStorage.ts`)
+ *     keys its handlers by `collection.slug`;
+ *   - the dynamic SQL adapter
+ *     (`packages/core/src/collections/operations/sqlAdapter.ts`) issues
+ *     `... FROM "<slug>"` where the table name IS the slug.
+ * Either way, a registered collection whose slug has no matching table renders
+ * in the dashboard but throws on every read and write.
+ *
+ * This test derives the real table set from the Drizzle schema (the same schema
+ * the storage bridge reads/writes through) and fails if any registered slug has
+ * no matching table — so a future registration without a migration fails CI.
+ */
+
+import * as schema from '@revealui/db/schema';
+import { getTableName, is, Table } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { allCollections } from '../registry';
+
+function drizzleTableNames(): Set<string> {
+  const names = new Set<string>();
+  for (const value of Object.values(schema)) {
+    if (is(value, Table)) {
+      names.add(getTableName(value));
+    }
+  }
+  return names;
+}
+
+describe('registry backing-storage invariant', () => {
+  const tableNames = drizzleTableNames();
+
+  it('resolves a non-trivial set of Drizzle tables (schema import sanity)', () => {
+    expect(tableNames.size).toBeGreaterThan(0);
+    expect(tableNames.has('users')).toBe(true);
+  });
+
+  it.each(
+    allCollections.map((collection) => collection.slug),
+  )('registered collection "%s" has a backing table named the same as its slug', (slug) => {
+    expect(tableNames.has(slug)).toBe(true);
+  });
+});

--- a/apps/admin/src/lib/collections/registry.ts
+++ b/apps/admin/src/lib/collections/registry.ts
@@ -13,35 +13,44 @@
  */
 
 import type { CollectionConfig } from '@revealui/contracts/admin';
-import Categories from './Categories';
-import Contents from './Contents';
 import { Conversations } from './Conversations';
-import Events from './Events';
 import { Media } from './Media';
 import { Orders } from './Orders';
 import { Pages } from './Pages/index';
 import { Posts } from './Posts';
-import Prices from './Prices';
 import Products from './Products';
-import Subscriptions from './Subscriptions';
-import Tags from './Tags';
 import { Tenants } from './Tenants';
 import Users from './Users';
 
+/**
+ * WIRE-UP-PENDING — collections registered in the admin UI without a backing
+ * Postgres table are intentionally NOT included below. A registered collection
+ * whose slug has no table renders in the dashboard but every read/write throws
+ * (the dynamic SQL adapter issues `SELECT * FROM "<slug>"` against a missing
+ * relation, and the typed-storage bridge has no handler for it), so the UI is
+ * silently broken. These are unregistered here until a migration lands, then
+ * re-registered:
+ *
+ *   - Contents       (slug `contents`      — no `contents` table)
+ *   - Categories     (slug `categories`    — no `categories` table)
+ *   - Tags           (slug `tags`          — no `tags` table)
+ *   - Events         (slug `events`        — no `events` table)
+ *   - Prices         (slug `prices`        — no `prices` table)
+ *   - Subscriptions  (slug `subscriptions` — no `subscriptions` table)
+ *
+ * Their config files stay on disk (imported by submodule consumers and kept as
+ * the wire-up starting point). The backing-storage guard test in
+ * `__tests__/registry-backing-storage.test.ts` fails CI if any collection is
+ * added back here without a matching Drizzle table.
+ */
 export const allCollections = [
   Users,
   Tenants,
   Pages,
   Media,
-  Contents,
-  Categories,
-  Tags,
-  Events,
   Products,
-  Prices,
   Orders,
   Posts,
-  Subscriptions,
   Conversations,
   // biome-ignore lint/suspicious/noExplicitAny: heterogeneous collection array requires invariant generic
 ] as CollectionConfig<any>[];

--- a/apps/admin/src/lib/globals/MainMenu.ts
+++ b/apps/admin/src/lib/globals/MainMenu.ts
@@ -1,3 +1,8 @@
+// WIRE-UP-PENDING — the `main-menu` global is re-exported from
+// `apps/admin/src/lib/globals/index.ts` but is NOT registered in
+// `apps/admin/revealui.config.ts` (`globals: [Settings, Header, Footer]`), so
+// it never reaches the admin runtime. Kept on disk pending a per-item
+// register-vs-delete decision in PR review.
 import type { GlobalConfig } from '@revealui/core';
 
 import { link } from '@/lib/fields/link';

--- a/apps/marketing/app/content/marketplace.ts
+++ b/apps/marketing/app/content/marketplace.ts
@@ -1,3 +1,10 @@
+// WIRE-UP-PENDING — no runtime component imports this file's exports; the
+// standalone marketing /marketplace page was removed and /marketplace now
+// 308-redirects to /roadmap. The only references are string `exportPath`
+// values in `content/claims-evidence.ts` (the claims-drift validator registry,
+// not a code import). Kept on disk pending a per-item keep-vs-delete decision
+// in PR review (default recommendation: keep as revmarket seed data).
+//
 // PRESERVED SEED DATA — revmarket extraction
 // This MCP-server catalog is preserved as the seed for the future `revmarket`
 // repo's public discovery UI (per the marketplace-extraction ADR). The


### PR DESCRIPTION
## Summary

Foundation repair F7 (table/orphan hygiene). Two problems from the internal 2026-07-02 CMS content-surfaces audit:

- **B4 (tableless collections):** collections registered in the admin dashboard whose slug has no backing Postgres table. The storage layer resolves a collection to storage by slug in both tiers: the typed-storage bridge (`apps/admin/src/lib/db/typedCollectionStorage.ts`) keys handlers by `collection.slug`, and the dynamic SQL adapter (`packages/core/src/collections/operations/sqlAdapter.ts`) issues `... FROM "<slug>"` where the table name **is** the slug. A registered collection with no matching table renders in the dashboard but throws on every read and write.
- **B9 (orphans):** collection configs, a global, and blocks that exist on disk but are never registered or consumed.

This PR **unregisters** the tableless collections (config files kept on disk), adds a **CI guard** so this cannot silently regress, and marks every orphan with a `WIRE-UP-PENDING` header so the register-vs-delete call is made per item in review.

Code is the source of truth: the audit's stale B4 list was re-derived against the current schema/migrations. Cards/Heros/Layouts/Banners from the stale list are already gone (retired from the registry by the F1 pages-model refit), so they are not in scope here.

## Derived tableless list (B4) — evidence

Registered collections are enumerated in `apps/admin/src/lib/collections/registry.ts`. The real table set was derived from the Drizzle schema (`packages/db/src/schema/`) and migrations (`packages/db/migrations/0000`–`0026`). No collection declares a `dbName`/`tableName` override, so slug == table name.

| Collection | Slug | Backing table? | Evidence |
|---|---|---|---|
| Contents | `contents` | **No** | No `contents` pgTable in schema; no `CREATE TABLE contents` in any migration |
| Categories | `categories` | **No** | No `categories` pgTable; not in migrations |
| Tags | `tags` | **No** | No `tags` pgTable; not in migrations |
| Events | `events` | **No** | No `events` pgTable; not in migrations |
| Prices | `prices` | **No** | No `prices` pgTable; schema has `billing_catalog` but no `prices` table |
| Subscriptions | `subscriptions` | **No** | No `subscriptions` pgTable; schema has `account_subscriptions` but no bare `subscriptions` table |

**Kept registered (backing table confirmed present):** Users (`users`), Tenants (`tenants`), Pages (`pages`), Media (`media`, `schema/admin.ts`), Products (`products`), Orders (`orders`, `schema/products.ts`), Posts (`posts`, `schema/admin.ts`), Conversations (`conversations`, `schema/agents.ts`). All eight resolve to a Drizzle pgTable whose name equals the slug.

None of the six unregistered collections gained a table post-F1/F4/F6, so none were left registered.

## Orphan decision table (B9)

Default is `WIRE-UP-PENDING`, not deletion. Each file now carries a header stating it is not registered/consumed; the reviewer decides per item.

| Orphan | File | Status in code | Recommendation |
|---|---|---|---|
| Info collection | `apps/admin/src/lib/collections/Info/index.ts` | Not in `allCollections`; no consumer; no `info` table | **Delete** — no table, no product surface consuming it |
| Videos collection | `apps/admin/src/lib/collections/Videos/index.ts` | Not in `allCollections`; no consumer; no `videos` table | **Delete** — same as Info |
| MainMenu global | `apps/admin/src/lib/globals/MainMenu.ts` | Re-exported from `globals/index.ts` but not in `revealui.config.ts` `globals: [Settings, Header, Footer]` | **Register** if nav-from-CMS is wanted (a `main_menu` global table would follow), else delete |
| PageContent block | `apps/admin/src/lib/blocks/PageContent/index.ts` | Not offered by any collection `blocks` field; no renderer in `RenderBlocks.tsx` | **Wire up or delete** — config-only |
| PageList block | `apps/admin/src/lib/blocks/PageList/index.ts` | Same as PageContent | **Wire up or delete** |
| ReusableContent block | `apps/admin/src/lib/blocks/ReusableContent/index.ts` | Same; its Contents import is commented out | **Wire up or delete** |
| SiteTitle block | `apps/admin/src/lib/blocks/SiteTitle/index.ts` | Same | **Wire up or delete** |
| RelatedPosts block | `apps/admin/src/lib/blocks/RelatedPosts/Component.tsx` | Component only, no config; not offered, not rendered, not imported | **Wire up or delete** |
| marketplace content | `apps/marketing/app/content/marketplace.ts` | No component imports its exports; `/marketplace` 308-redirects to `/roadmap`; only string `exportPath` references in `claims-evidence.ts` (claims-drift validator, not a code import) | **Keep** — preserved revmarket seed data |

## Dangling relations from live surfaces (review follow-up)

After unregistering the six collections, three **registered** surfaces still pointed a `relationTo` at the now-unregistered `categories` slug. Behavior was verified before changing anything: the admin form renders relationship fields as a plain ID text input (`packages/core/src/client/admin/components/DocumentForm.tsx`, no options fetch to the target collection), afterRead population skips an unresolved target (`packages/core/src/relationships/population.ts` — `if (!relatedCollection) return;`), and there is no write-path existence check. So the layer degrades gracefully rather than hard-erroring — but a registered surface should not reference an unregistered slug. Per the F7 default these are commented out with WIRE-UP-PENDING markers (re-enable once a `categories` migration + registration land):

| Surface | File | Fix |
|---|---|---|
| Posts collection (registered) | `apps/admin/src/lib/collections/Posts/index.ts` | `categories` relationship field disabled |
| Products collection (registered) | `apps/admin/src/lib/collections/Products/index.ts` | `categories` relationship field disabled |
| ArchiveBlock (live block: offered by Pages, rendered as `archive`) | `apps/admin/src/lib/blocks/ArchiveBlock/config.ts` | `categories` relationship field disabled |

The other `relationTo` references to the six slugs live only on already-orphaned surfaces (`PageList`, `ReusableContent` blocks; the `Prices` collection), which already carry WIRE-UP-PENDING headers and are left as-is.

**Guard-extension considered, not added:** a "every `relationTo` reachable from a registered surface must be a registered slug" test is not cheap with the current config shapes. `FormBlock` (a live block) references `relationTo: 'forms'`, and `forms`/`form-submissions` are collections injected at build time by `formBuilderPlugin` — they are not members of `allCollections`, so a static guard over the registry plus Drizzle tables would false-flag them. Modeling plugin-injected collections would drag the whole plugin pipeline into a unit test, so it is out of scope here.

**Additional B9 note (not a file-header item):** Pages offers the `Code` and `Banner` blocks in its editor block list (`apps/admin/src/lib/collections/Pages/index.ts`), but `RenderBlocks.tsx` renders only `hero`, `archive`, `content`, `cta`, `formBlock`, `mediaBlock`. So `Code`/`Banner` are editable in admin but unrenderable. Not touched here (they are live, editor-offered blocks, not orphan files) — flagged for a follow-up: add renderers or remove from the Pages block list.

## Guard

`apps/admin/src/lib/collections/__tests__/registry-backing-storage.test.ts` derives the table set from the Drizzle schema via `getTableName`/`is(x, Table)` (no regex, no hardcoded list) and asserts every registered collection slug has a matching table. Adding a collection back to the registry without a migration fails CI. Proven red: temporarily re-registering `categories` fails the guard on the `categories` case; removing it passes.

## Test plan

- `pnpm --filter admin typecheck` — clean
- `pnpm --filter admin test` — 2023 passed, 13 skipped, 0 failed (includes the new guard: 9 assertions)
- New guard proven to fail when a tableless collection is registered (prove-red)
- `pnpm gate:quick` — PASS (all phase-1 checks green, including claims-evidence and marketing-voice, which still resolve `marketplace.ts` correctly after the header comment)
- `pnpm exec biome check` on all changed files — clean

Part of the visual-edit-sessions foundation repairs (F7) per the internal 2026-07-02 CMS content-surfaces audit (B4/B9).
