### PR TITLE
feat(presentation): print entrance for the receipt motif (Phase 5 PR-R1)

### DIFF
--- a/.changeset/receipt-hero-print-entrance.md
+++ b/.changeset/receipt-hero-print-entrance.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': minor
+---
+
+Add an optional `animate="print"` prop to `ReceiptCard`. When set, each `AuditLine` row and the integrity footer play a one-shot CSS entrance stagger (the receipt "prints" itself line by line), and the integrity footer's seal pulses once after its entrance. Pure CSS, no JS timeline. Disabled under `prefers-reduced-motion: reduce`. Default is unchanged (no `animate` prop = no visual change).

--- a/packages/presentation/src/__tests__/components/receipt-card.test.tsx
+++ b/packages/presentation/src/__tests__/components/receipt-card.test.tsx
@@ -55,4 +55,51 @@ describe('ReceiptCard', () => {
     render(<ReceiptCard title="No seal" lines={lines} />);
     expect(screen.queryByText('sha256')).toBeNull();
   });
+
+  it('renders no animation classes, vars, or style tag when animate is unset', () => {
+    const { container } = render(
+      <ReceiptCard
+        title="Static"
+        lines={lines}
+        integrity={{ kind: 'sha256', value: 'a1b2c3d4' }}
+      />,
+    );
+    const items = screen.getAllByRole('listitem');
+    for (const item of items) {
+      expect(item.className).toBe('');
+      expect(item.getAttribute('style')).toBeNull();
+    }
+    const footer = container.querySelector('footer');
+    expect(footer?.className).not.toMatch(/rvui-receipt-print/);
+    expect(container.querySelector('style')).toBeNull();
+  });
+
+  it('stamps the per-row print delay custom property and renders all lines at first render when animate="print"', () => {
+    const { container } = render(
+      <ReceiptCard
+        title="Printing"
+        lines={lines}
+        integrity={{ kind: 'sha256', value: 'a1b2c3d4' }}
+        animate="print"
+      />,
+    );
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(lines.length);
+    items.forEach((item, i) => {
+      expect(item.className).toContain('rvui-receipt-print-line');
+      expect(item.style.getPropertyValue('--rvui-print-i')).toBe(String(i));
+    });
+
+    // All ledger content is present immediately  -  no waiting on the animation.
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('agent-system')).toBeInTheDocument();
+    expect(screen.getByText('sha256')).toBeInTheDocument();
+
+    const footer = container.querySelector('footer');
+    expect(footer?.className).toContain('rvui-receipt-print-seal');
+    expect(footer?.style.getPropertyValue('--rvui-print-i')).toBe(String(lines.length));
+
+    expect(container.querySelector('style')?.textContent).toContain('rvui-receipt-print');
+  });
 });

--- a/packages/presentation/src/animations/core/print-entrance.ts
+++ b/packages/presentation/src/animations/core/print-entrance.ts
@@ -1,0 +1,60 @@
+/**
+ * Receipt "print" entrance: the pure-CSS stagger that types each ledger line
+ * onto a `ReceiptCard` in sequence, then breathes the integrity seal once.
+ *
+ * CSS-only by design (no JS timeline, no IntersectionObserver): the browser
+ * runs the keyframes natively from first paint, so the effect works
+ * identically with or without hydration. `--rvui-duration-slow` and
+ * `--rvui-ease` come from `@revealui/tokens`; `--rvui-print-i` is the only
+ * value a consumer sets, via inline style, per row.
+ */
+
+/** Delay, in ms, before the first line begins printing. */
+export const RECEIPT_PRINT_START_DELAY_MS = 400;
+
+/** Gap, in ms, between successive line entrances. */
+export const RECEIPT_PRINT_STEP_MS = 420;
+
+/** Applied to each `AuditLine` row's wrapper. */
+export const RECEIPT_PRINT_LINE_CLASS = 'rvui-receipt-print-line';
+
+/** Applied to the integrity footer. */
+export const RECEIPT_PRINT_SEAL_CLASS = 'rvui-receipt-print-seal';
+
+export const RECEIPT_PRINT_KEYFRAMES = `
+@keyframes rvui-receipt-print {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes rvui-receipt-seal-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 transparent; }
+  50% { box-shadow: var(--rvui-shadow-glow, 0 0 32px oklch(0.58 0.150 240 / 0.42)); }
+}
+
+.${RECEIPT_PRINT_LINE_CLASS} {
+  opacity: 0;
+  animation: rvui-receipt-print var(--rvui-duration-slow, 350ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1)) both;
+  animation-delay: calc(${RECEIPT_PRINT_START_DELAY_MS}ms + var(--rvui-print-i, 0) * ${RECEIPT_PRINT_STEP_MS}ms);
+}
+
+.${RECEIPT_PRINT_SEAL_CLASS} {
+  opacity: 0;
+  animation:
+    rvui-receipt-print var(--rvui-duration-slow, 350ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1)) both,
+    rvui-receipt-seal-pulse 350ms var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1)) 1 both;
+  animation-delay:
+    calc(${RECEIPT_PRINT_START_DELAY_MS}ms + var(--rvui-print-i, 0) * ${RECEIPT_PRINT_STEP_MS}ms),
+    calc(${RECEIPT_PRINT_START_DELAY_MS}ms + var(--rvui-print-i, 0) * ${RECEIPT_PRINT_STEP_MS}ms + var(--rvui-duration-slow, 350ms));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .${RECEIPT_PRINT_LINE_CLASS},
+  .${RECEIPT_PRINT_SEAL_CLASS} {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    box-shadow: none;
+  }
+}
+`;

--- a/packages/presentation/src/animations/index.ts
+++ b/packages/presentation/src/animations/index.ts
@@ -3,6 +3,13 @@
 export type { EasingFunction } from './core/easing.js';
 export { cubicBezier, resolveEasing } from './core/easing.js';
 export { onFrame } from './core/frame-loop.js';
+export {
+  RECEIPT_PRINT_KEYFRAMES,
+  RECEIPT_PRINT_LINE_CLASS,
+  RECEIPT_PRINT_SEAL_CLASS,
+  RECEIPT_PRINT_START_DELAY_MS,
+  RECEIPT_PRINT_STEP_MS,
+} from './core/print-entrance.js';
 export type { SpringConfig, SpringPreset } from './core/spring.js';
 export {
   resolveSpringConfig,

--- a/packages/presentation/src/components/receipt-card.tsx
+++ b/packages/presentation/src/components/receipt-card.tsx
@@ -1,6 +1,11 @@
 'use client';
 
 import type React from 'react';
+import {
+  RECEIPT_PRINT_KEYFRAMES,
+  RECEIPT_PRINT_LINE_CLASS,
+  RECEIPT_PRINT_SEAL_CLASS,
+} from '../animations/core/print-entrance.js';
 import { cn } from '../utils/cn.js';
 import { CopyRef } from './_receipt-shared.js';
 import { type AuditEvent, AuditLine } from './audit-line.js';
@@ -19,6 +24,13 @@ export interface ReceiptCardProps {
   lines: AuditEvent[];
   /** Optional integrity footer sealing the receipt. */
   integrity?: ReceiptIntegrity;
+  /**
+   * When `'print'`, each line and the integrity footer play a one-shot CSS
+   * entrance stagger (the receipt "prints" itself), then the seal pulses
+   * once. Undefined (default) is the current, unanimated rendering with zero
+   * visual change. Disabled entirely under `prefers-reduced-motion: reduce`.
+   */
+  animate?: 'print';
   className?: string;
 }
 
@@ -55,9 +67,11 @@ export function ReceiptCard({
   title,
   lines,
   integrity,
+  animate,
   className,
 }: ReceiptCardProps): React.JSX.Element {
   const latest = lines.length > 0 ? lines[lines.length - 1]?.ts : undefined;
+  const printing = animate === 'print';
 
   return (
     <section
@@ -69,6 +83,8 @@ export function ReceiptCard({
         borderRadius: 'var(--rvui-radius-lg, 16px)',
       }}
     >
+      {printing && <style>{RECEIPT_PRINT_KEYFRAMES}</style>}
+
       <header className="flex items-baseline justify-between gap-3 px-4 py-3">
         <h3 className="text-sm font-semibold text-[var(--rvui-text-0)]">{title}</h3>
         {latest && (
@@ -88,7 +104,11 @@ export function ReceiptCard({
           style={{ borderColor: DASHED_BORDER }}
         >
           {lines.map((line, i) => (
-            <li key={line.refId ?? `${line.ts}-${line.actor}-${line.action}-${i}`}>
+            <li
+              key={line.refId ?? `${line.ts}-${line.actor}-${line.action}-${i}`}
+              className={printing ? RECEIPT_PRINT_LINE_CLASS : undefined}
+              style={printing ? ({ '--rvui-print-i': i } as React.CSSProperties) : undefined}
+            >
               <AuditLine event={line} dense />
             </li>
           ))}
@@ -97,8 +117,14 @@ export function ReceiptCard({
 
       {integrity && (
         <footer
-          className="flex items-center gap-2 border-t border-dashed px-4 py-2.5 text-xs"
-          style={{ borderColor: DASHED_BORDER }}
+          className={cn(
+            'flex items-center gap-2 border-t border-dashed px-4 py-2.5 text-xs',
+            printing && RECEIPT_PRINT_SEAL_CLASS,
+          )}
+          style={{
+            borderColor: DASHED_BORDER,
+            ...(printing ? ({ '--rvui-print-i': lines.length } as React.CSSProperties) : {}),
+          }}
         >
           <span aria-hidden="true" className="inline-flex shrink-0 text-[var(--rvui-text-2)]">
             <SealIcon />


### PR DESCRIPTION
## What

Adds an optional `animate?: 'print'` prop to `ReceiptCard` (default `undefined`, current behavior, zero visual change when off). When set:

- Each rendered `AuditLine` row and the integrity footer get a CSS entrance: opacity 0→1, translateY 6px→0, `var(--rvui-duration-slow)`, `var(--rvui-ease)`, fill-mode forwards, `animation-delay = 400ms + index * 420ms` (integrity footer is the last index).
- The integrity footer additionally gets a one-shot brand-glow box-shadow pulse (350ms) after its entrance.
- Pure CSS: keyframes + per-row delay via a CSS custom property (`--rvui-print-i`, set inline per row/footer). No JS timeline, no `IntersectionObserver`.
- Disabled entirely under `prefers-reduced-motion: reduce` (media query kills the keyframes; resting state is the completed receipt).

New file: `packages/presentation/src/animations/core/print-entrance.ts` (keyframes + class names + timing constants), exported from `animations/index.ts` alongside the existing `core/` exports.

## Why

Ships the receipt-motif hero's entrance animation as an additive, reusable `@revealui/presentation` capability, per the Phase 5 receipt-hero concept spec (build order: PR-R1 presentation, additive; PR-R2 marketing integration follows, stacked on this branch).

## Verification

- `pnpm --filter @revealui/presentation test` — 988/988 passing, including 2 new tests on `ReceiptCard`: prop off renders no animation classes/vars/style tag; prop on stamps the per-row `--rvui-print-i` delay custom property on each row and the footer, and all ledger content (including the integrity footer) is present in the DOM at first render with no waiting on the animation.
- `pnpm --filter @revealui/presentation typecheck` — clean.
- `pnpm --filter @revealui/presentation build` — clean (Vite lib build + `.d.ts` generation).
- Biome — clean on all touched files.
- **Goldens unchanged by design.** No visual-harness golden currently exists for `ReceiptCard` in this checkout, and the change is additive-only: the prop is `undefined` unless a consumer opts in, so the resting/default render path is byte-for-byte the same JSX as before this PR (verified by reading the diff — no unconditional change to any existing element's className/style).

## Changeset

Minor bump on `@revealui/presentation` (new additive prop + export).