### PR TITLE
feat(marketing): receipt-motif hero, the receipt prints (Phase 5 PR-R2)

### DIFF
--- a/.changeset/receipt-hero-print-entrance.md
+++ b/.changeset/receipt-hero-print-entrance.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': minor
+---
+
+Add an optional `animate="print"` prop to `ReceiptCard`. When set, each `AuditLine` row and the integrity footer play a one-shot CSS entrance stagger (the receipt "prints" itself line by line), and the integrity footer's seal pulses once after its entrance. Pure CSS, no JS timeline. Disabled under `prefers-reduced-motion: reduce`. Default is unchanged (no `animate` prop = no visual change).

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -1,6 +1,12 @@
-import { ButtonCVA } from '@revealui/presentation';
-import { useLocation } from '@revealui/router';
+import { ButtonCVA, ReceiptCard } from '@revealui/presentation';
+import { Link, useLocation } from '@revealui/router';
 import { FOR_OPERATORS_HERO } from '../../content/for-operators';
+import {
+  RECEIPT_HERO_CAPTION,
+  RECEIPT_HERO_INTEGRITY,
+  RECEIPT_HERO_LINES,
+  RECEIPT_HERO_TITLE,
+} from '../../content/receipt';
 import { selectAudience } from '../../lib/audience';
 import { selectHomeHero } from '../../lib/hero-variant';
 import { AudienceToggle } from './AudienceToggle';
@@ -151,6 +157,26 @@ export function Hero() {
           </div>
 
           {audience === 'technical' ? <TechnicalHero hero={hero} /> : <NonTechnicalHero />}
+        </div>
+
+        {/* Receipt-motif moment (frontend-excellence Phase 5): one orchestrated
+            print entrance, shared verbatim by both audience variants. */}
+        <div className="mt-12 w-full max-w-md min-w-0 mx-auto text-left">
+          <ReceiptCard
+            title={RECEIPT_HERO_TITLE}
+            lines={[...RECEIPT_HERO_LINES]}
+            integrity={RECEIPT_HERO_INTEGRITY}
+            animate="print"
+          />
+          <p className="mt-4 text-center text-sm text-muted-foreground">
+            {RECEIPT_HERO_CAPTION.text}{' '}
+            <Link
+              to={RECEIPT_HERO_CAPTION.link.href}
+              className="text-foreground underline underline-offset-4 hover:text-primary"
+            >
+              {RECEIPT_HERO_CAPTION.link.label}
+            </Link>
+          </p>
         </div>
       </div>
     </section>

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -71,6 +71,7 @@ export const COVERED_FILES: readonly CoveredFile[] = [
   { file: 'marketplace.ts' },
   { file: 'roadmap.ts' },
   { file: 'claims.ts' },
+  { file: 'receipt.ts' },
 ] as const;
 
 const AUTH_SESSIONS: EvidenceRef = {
@@ -177,6 +178,16 @@ const AGENT_ROUTES: EvidenceRef = {
   kind: 'code',
   ref: 'apps/server/src/routes/agent-tasks.ts',
   note: 'agent surfaces mounted behind the same auth + entitlement middleware as user routes',
+};
+const REFUND_ROUTE: EvidenceRef = {
+  kind: 'code',
+  ref: 'apps/server/src/routes/billing.ts',
+  note: 'POST /api/billing/refund; admin-authenticated, full or partial refunds via Stripe',
+};
+const AUDIT_LOG_SCHEMA: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/db/src/schema/audit-log.ts',
+  note: 'audit_log table; single-door write path enforced by validate:audit-one-door',
 };
 const OPEN_STANDARDS: EvidenceRef = {
   kind: 'code',
@@ -3252,6 +3263,20 @@ export const CLAIMS: readonly ClaimEntry[] = [
         note: 'positive claim about process, not code; the honesty-rails copy itself is the disclosure',
       },
     ],
+  },
+
+  // ── receipt.ts — hero receipt-motif moment (Phase 5) ────────────────────
+  {
+    file: 'receipt.ts',
+    exportPath: 'RECEIPT_HERO_TITLE',
+    text: 'Refund, handled by an agent',
+    evidence: [REFUND_ROUTE, AGENT_ROUTES],
+  },
+  {
+    file: 'receipt.ts',
+    exportPath: 'RECEIPT_HERO_CAPTION.text',
+    text: "If an agent did it, there's a receipt.",
+    evidence: [AUDIT_LOG_SCHEMA, REFUND_ROUTE],
   },
 ] as const;
 

--- a/apps/marketing/app/content/claims-routes.ts
+++ b/apps/marketing/app/content/claims-routes.ts
@@ -30,6 +30,8 @@ export const CONTENT_FILE_ROUTES: Readonly<Record<string, RouteEntry>> = {
   // original placement.
   'proof.ts': { route: '/', pageTitle: 'Home' },
   'pricing-teaser.ts': { route: '/', pageTitle: 'Home' },
+  // The receipt-motif hero moment renders on "/" via components/landing/Hero.tsx.
+  'receipt.ts': { route: '/', pageTitle: 'Home' },
   // SITE.brandTagline renders on "/" in the Footer, under SITE.brand. SITE's
   // other exports (urls, METRICS) are used throughout the site but carry no
   // prose claims of their own.

--- a/apps/marketing/app/content/receipt.ts
+++ b/apps/marketing/app/content/receipt.ts
@@ -1,0 +1,50 @@
+// Receipt-motif hero content (frontend-excellence Phase 5, receipt-hero-concept
+// spec 2026-07-18). A demonstration, not live production data: timestamps are
+// static strings (never Date.now()) so the sequence is deterministic for SSR
+// and the visual gate. Content depicts something the product does today  -
+// see claims-evidence.ts for the evidence trail on every sentence here.
+
+import type { AuditEvent } from '@revealui/presentation';
+
+export const RECEIPT_HERO_TITLE = 'Refund, handled by an agent' as const;
+
+export const RECEIPT_HERO_LINES: readonly AuditEvent[] = [
+  {
+    ts: '09:41:07',
+    actor: 'support-agent',
+    action: 'signed in as',
+    object: 'agents@demo.revealui.com',
+  },
+  {
+    ts: '09:41:09',
+    actor: 'support-agent',
+    action: 'refunded',
+    object: 'order #4189',
+  },
+  {
+    ts: '09:41:09',
+    actor: 'policy',
+    action: 'allowed',
+    object: 'refunds under $100',
+  },
+  {
+    ts: '09:41:10',
+    actor: 'audit-log',
+    action: 'recorded',
+    // `object` stays a human-readable description (not the raw ref) so
+    // AuditLine's object text and its CopyRef affordance don't render the
+    // same string twice; `refId` carries the copyable id from the spec draft.
+    object: 'the receipt',
+    refId: 'rcpt_8f3ka91',
+  },
+] as const;
+
+export const RECEIPT_HERO_INTEGRITY = {
+  kind: 'sha256',
+  value: '4b6c…e91a',
+} as const;
+
+export const RECEIPT_HERO_CAPTION = {
+  text: "If an agent did it, there's a receipt.",
+  link: { label: 'See ours →', href: '/claims' },
+} as const;

--- a/packages/presentation/src/__tests__/components/receipt-card.test.tsx
+++ b/packages/presentation/src/__tests__/components/receipt-card.test.tsx
@@ -55,4 +55,51 @@ describe('ReceiptCard', () => {
     render(<ReceiptCard title="No seal" lines={lines} />);
     expect(screen.queryByText('sha256')).toBeNull();
   });
+
+  it('renders no animation classes, vars, or style tag when animate is unset', () => {
+    const { container } = render(
+      <ReceiptCard
+        title="Static"
+        lines={lines}
+        integrity={{ kind: 'sha256', value: 'a1b2c3d4' }}
+      />,
+    );
+    const items = screen.getAllByRole('listitem');
+    for (const item of items) {
+      expect(item.className).toBe('');
+      expect(item.getAttribute('style')).toBeNull();
+    }
+    const footer = container.querySelector('footer');
+    expect(footer?.className).not.toMatch(/rvui-receipt-print/);
+    expect(container.querySelector('style')).toBeNull();
+  });
+
+  it('stamps the per-row print delay custom property and renders all lines at first render when animate="print"', () => {
+    const { container } = render(
+      <ReceiptCard
+        title="Printing"
+        lines={lines}
+        integrity={{ kind: 'sha256', value: 'a1b2c3d4' }}
+        animate="print"
+      />,
+    );
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(lines.length);
+    items.forEach((item, i) => {
+      expect(item.className).toContain('rvui-receipt-print-line');
+      expect(item.style.getPropertyValue('--rvui-print-i')).toBe(String(i));
+    });
+
+    // All ledger content is present immediately  -  no waiting on the animation.
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('agent-system')).toBeInTheDocument();
+    expect(screen.getByText('sha256')).toBeInTheDocument();
+
+    const footer = container.querySelector('footer');
+    expect(footer?.className).toContain('rvui-receipt-print-seal');
+    expect(footer?.style.getPropertyValue('--rvui-print-i')).toBe(String(lines.length));
+
+    expect(container.querySelector('style')?.textContent).toContain('rvui-receipt-print');
+  });
 });

--- a/packages/presentation/src/animations/core/print-entrance.ts
+++ b/packages/presentation/src/animations/core/print-entrance.ts
@@ -1,0 +1,60 @@
+/**
+ * Receipt "print" entrance: the pure-CSS stagger that types each ledger line
+ * onto a `ReceiptCard` in sequence, then breathes the integrity seal once.
+ *
+ * CSS-only by design (no JS timeline, no IntersectionObserver): the browser
+ * runs the keyframes natively from first paint, so the effect works
+ * identically with or without hydration. `--rvui-duration-slow` and
+ * `--rvui-ease` come from `@revealui/tokens`; `--rvui-print-i` is the only
+ * value a consumer sets, via inline style, per row.
+ */
+
+/** Delay, in ms, before the first line begins printing. */
+export const RECEIPT_PRINT_START_DELAY_MS = 400;
+
+/** Gap, in ms, between successive line entrances. */
+export const RECEIPT_PRINT_STEP_MS = 420;
+
+/** Applied to each `AuditLine` row's wrapper. */
+export const RECEIPT_PRINT_LINE_CLASS = 'rvui-receipt-print-line';
+
+/** Applied to the integrity footer. */
+export const RECEIPT_PRINT_SEAL_CLASS = 'rvui-receipt-print-seal';
+
+export const RECEIPT_PRINT_KEYFRAMES = `
+@keyframes rvui-receipt-print {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes rvui-receipt-seal-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 transparent; }
+  50% { box-shadow: var(--rvui-shadow-glow, 0 0 32px oklch(0.58 0.150 240 / 0.42)); }
+}
+
+.${RECEIPT_PRINT_LINE_CLASS} {
+  opacity: 0;
+  animation: rvui-receipt-print var(--rvui-duration-slow, 350ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1)) both;
+  animation-delay: calc(${RECEIPT_PRINT_START_DELAY_MS}ms + var(--rvui-print-i, 0) * ${RECEIPT_PRINT_STEP_MS}ms);
+}
+
+.${RECEIPT_PRINT_SEAL_CLASS} {
+  opacity: 0;
+  animation:
+    rvui-receipt-print var(--rvui-duration-slow, 350ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1)) both,
+    rvui-receipt-seal-pulse 350ms var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1)) 1 both;
+  animation-delay:
+    calc(${RECEIPT_PRINT_START_DELAY_MS}ms + var(--rvui-print-i, 0) * ${RECEIPT_PRINT_STEP_MS}ms),
+    calc(${RECEIPT_PRINT_START_DELAY_MS}ms + var(--rvui-print-i, 0) * ${RECEIPT_PRINT_STEP_MS}ms + var(--rvui-duration-slow, 350ms));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .${RECEIPT_PRINT_LINE_CLASS},
+  .${RECEIPT_PRINT_SEAL_CLASS} {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    box-shadow: none;
+  }
+}
+`;

--- a/packages/presentation/src/animations/index.ts
+++ b/packages/presentation/src/animations/index.ts
@@ -3,6 +3,13 @@
 export type { EasingFunction } from './core/easing.js';
 export { cubicBezier, resolveEasing } from './core/easing.js';
 export { onFrame } from './core/frame-loop.js';
+export {
+  RECEIPT_PRINT_KEYFRAMES,
+  RECEIPT_PRINT_LINE_CLASS,
+  RECEIPT_PRINT_SEAL_CLASS,
+  RECEIPT_PRINT_START_DELAY_MS,
+  RECEIPT_PRINT_STEP_MS,
+} from './core/print-entrance.js';
 export type { SpringConfig, SpringPreset } from './core/spring.js';
 export {
   resolveSpringConfig,

--- a/packages/presentation/src/components/receipt-card.tsx
+++ b/packages/presentation/src/components/receipt-card.tsx
@@ -1,6 +1,11 @@
 'use client';
 
 import type React from 'react';
+import {
+  RECEIPT_PRINT_KEYFRAMES,
+  RECEIPT_PRINT_LINE_CLASS,
+  RECEIPT_PRINT_SEAL_CLASS,
+} from '../animations/core/print-entrance.js';
 import { cn } from '../utils/cn.js';
 import { CopyRef } from './_receipt-shared.js';
 import { type AuditEvent, AuditLine } from './audit-line.js';
@@ -19,6 +24,13 @@ export interface ReceiptCardProps {
   lines: AuditEvent[];
   /** Optional integrity footer sealing the receipt. */
   integrity?: ReceiptIntegrity;
+  /**
+   * When `'print'`, each line and the integrity footer play a one-shot CSS
+   * entrance stagger (the receipt "prints" itself), then the seal pulses
+   * once. Undefined (default) is the current, unanimated rendering with zero
+   * visual change. Disabled entirely under `prefers-reduced-motion: reduce`.
+   */
+  animate?: 'print';
   className?: string;
 }
 
@@ -55,9 +67,11 @@ export function ReceiptCard({
   title,
   lines,
   integrity,
+  animate,
   className,
 }: ReceiptCardProps): React.JSX.Element {
   const latest = lines.length > 0 ? lines[lines.length - 1]?.ts : undefined;
+  const printing = animate === 'print';
 
   return (
     <section
@@ -69,6 +83,8 @@ export function ReceiptCard({
         borderRadius: 'var(--rvui-radius-lg, 16px)',
       }}
     >
+      {printing && <style>{RECEIPT_PRINT_KEYFRAMES}</style>}
+
       <header className="flex items-baseline justify-between gap-3 px-4 py-3">
         <h3 className="text-sm font-semibold text-[var(--rvui-text-0)]">{title}</h3>
         {latest && (
@@ -88,7 +104,11 @@ export function ReceiptCard({
           style={{ borderColor: DASHED_BORDER }}
         >
           {lines.map((line, i) => (
-            <li key={line.refId ?? `${line.ts}-${line.actor}-${line.action}-${i}`}>
+            <li
+              key={line.refId ?? `${line.ts}-${line.actor}-${line.action}-${i}`}
+              className={printing ? RECEIPT_PRINT_LINE_CLASS : undefined}
+              style={printing ? ({ '--rvui-print-i': i } as React.CSSProperties) : undefined}
+            >
               <AuditLine event={line} dense />
             </li>
           ))}
@@ -97,8 +117,14 @@ export function ReceiptCard({
 
       {integrity && (
         <footer
-          className="flex items-center gap-2 border-t border-dashed px-4 py-2.5 text-xs"
-          style={{ borderColor: DASHED_BORDER }}
+          className={cn(
+            'flex items-center gap-2 border-t border-dashed px-4 py-2.5 text-xs',
+            printing && RECEIPT_PRINT_SEAL_CLASS,
+          )}
+          style={{
+            borderColor: DASHED_BORDER,
+            ...(printing ? ({ '--rvui-print-i': lines.length } as React.CSSProperties) : {}),
+          }}
         >
           <span aria-hidden="true" className="inline-flex shrink-0 text-[var(--rvui-text-2)]">
             <SealIcon />


### PR DESCRIPTION
## Stack dependency

**This PR is stacked on #1989** (`feat/receipt-hero-print`, PR-R1). It's branched from that branch, not from `test`, so its diff includes PR-R1's commit until #1989 merges. Merge #1989 first; this diff will shrink to the marketing-only delta once `test` has it.

## What

- New content module `apps/marketing/app/content/receipt.ts`: a typed `AuditEvent[]` (`RECEIPT_HERO_LINES`), `RECEIPT_HERO_TITLE`, `RECEIPT_HERO_INTEGRITY`, and `RECEIPT_HERO_CAPTION`, matching the spec's draft content verbatim. Timestamps are static strings, never `Date.now()`.
- `Hero.tsx`: renders the receipt centered below the trust strip, in **both** audience variants via one shared JSX block (not forked per audience), inside `mt-12 w-full max-w-md min-w-0 mx-auto text-left`, using `<ReceiptCard animate="print">` from #1989.
- A caption line under the card: the identity foil `"If an agent did it, there's a receipt."` plus a plain-text `/claims` link (`@revealui/router` `Link`, matching `NavBar.tsx`'s internal-path pattern), labeled `See ours →`. Not a button, outside the one-primary-CTA budget, same as the trust strip.
- `claims-evidence.ts`: added `receipt.ts` to `COVERED_FILES`, plus two entries covering the two strings the validator collects as prose (`RECEIPT_HERO_TITLE`, `RECEIPT_HERO_CAPTION.text`), each with `code` evidence (the real refund route and the audit-log schema). The short ledger fields (timestamps, actor names, `order #4189`, etc.) fall under the validator's own prose thresholds (< 26 chars or no space) the same way existing short list items across the site do.
- `claims-routes.ts`: added `receipt.ts -> "/"` so `/claims` has a page to group the new entries under.

## Why

Ships the hero's one orchestrated moment per the Phase 5 receipt-hero-concept spec: the product demonstrates its identity sentence instead of stating it.

## One content deviation from the spec draft (flagging for sign-off)

The spec's draft ASCII table shows the fourth ledger line as `audit-log  recorded  rcpt_8f3ka91  [copy]`. `AuditLine` renders `object` as plain text and then, separately, `refId` via a `CopyRef` affordance that *also* renders the value text. Setting both `object` and `refId` to the literal id would render the string twice back-to-back (`rcpt_8f3ka91 rcpt_8f3ka91 📋`) — a real duplicate-text bug, not a stylistic choice. I kept `refId: 'rcpt_8f3ka91'` for the copy affordance (matching the spec's `[copy]` marker and the exact id) and set `object: 'the receipt'` as the human-readable description, following the existing `ReceiptCard` test fixture's precedent (`object: 'claim #42'`, `refId: 'rcpt_1'` — two different strings). Net visible result: `audit-log recorded the receipt rcpt_8f3ka91 📋`, one occurrence of the id, copyable. Everything else in the draft content ships verbatim.

## Verification

- `pnpm --filter @revealui/presentation test` — 988/988 passing.
- `pnpm --filter @revealui/presentation typecheck` — clean.
- `pnpm --filter marketing test` — 80/80 passing (turbo, full dependency chain built first).
- `pnpm --filter marketing typecheck` — clean (turbo `typecheck --filter=marketing...`, 27/27 tasks).
- `pnpm validate:claims-evidence` — `436 indexed claims across 18 covered files, all matched, all evidence paths present.`
- `pnpm validate:claims` (claim-drift) — exit 0, "All claims match codebase reality...".
- `pnpm validate:marketing-voice` — `No new marketing-voice violations.`
- Biome — clean on all touched files.
- **Full pre-push gate** (phase 1 + phase 2, run from the worktree on `git push`) — PASS, all hard-fail checks green including Claims evidence, Marketing voice, Claim drift, Doc-currency, Design-context drift, Brand bridge, Security audit.
- **Overflow acceptance** (empirical, Playwright against `pnpm --filter marketing dev`, chromium, resolved via `createRequire`): zero horizontal overflow and a `<footer>` present at all four required widths:

  | width | scrollWidth | clientWidth | footer present |
  |---|---|---|---|
  | 375 | 375 | 375 | yes |
  | 414 | 414 | 414 | yes |
  | 660 | 660 | 660 | yes |
  | 700 | 700 | 700 | yes |

- **Reduced-motion acceptance** (same script, `page.emulateMedia({ reducedMotion: 'reduce' })`): all four `AuditLine` rows report `opacity: 1` immediately after load (`[1,1,1,1]`) — the CSS media query in #1989 disables the entrance animation and the resting state is the completed receipt.

## Fable verdicts required before merge

Per the spec: a copy verdict on the final receipt strings + caption, and a design verdict that the shipped motion matches the spec's restraint (one moment, once, under 2.5s). Not self-cleared by this PR.