### PR TITLE
feat(server): edit-session engine (schema, migration, API)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 |---------|---------|
 | @revealui/core | admin engine, REST API, auth, rich text, admin UI, plugins |
 | @revealui/contracts | Zod schemas + TypeScript types (single source of truth) |
-| @revealui/db | Drizzle ORM schema (93 tables) on NeonDB (Postgres) — legacy Supabase code remains in tree during phase-out |
+| @revealui/db | Drizzle ORM schema (96 tables) on NeonDB (Postgres) — legacy Supabase code remains in tree during phase-out |
 | @revealui/auth | Session auth, password reset, rate limiting |
 | @revealui/presentation | Native UI components in `packages/presentation/src/components/` (Tailwind v4, zero external UI deps  -  only clsx + CVA) |
 | @revealui/router | Lightweight file-based router with SSR |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ revealui/
 │   ├── config/         # Type-safe env config (Zod)
 │   ├── contracts/      # Zod schemas + TypeScript types
 │   ├── core/           # Runtime engine, REST API, plugins
-│   ├── db/             # Drizzle ORM schema (93 tables, NeonDB)
+│   ├── db/             # Drizzle ORM schema (96 tables, NeonDB)
 │   ├── dev/            # Shared configs (Biome, TS, Tailwind)
 │   ├── presentation/   # 65 UI components (Tailwind v4)
 │   ├── router/         # File-based router with SSR

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The RevealUI Studio agency site (revealuistudio.com) lives in [RevealUIStudio/ag
 | ------------------------------------------------------- | ------------------------------------------------- |
 | [`@revealui/core`](packages/core)                       | Runtime engine, REST API, auth, rich text, plugins |
 | [`@revealui/contracts`](packages/contracts)             | Zod schemas + TypeScript types (single source)    |
-| [`@revealui/db`](packages/db)                           | Drizzle ORM schema (93 tables), dual-DB client     |
+| [`@revealui/db`](packages/db)                           | Drizzle ORM schema (96 tables), dual-DB client     |
 | [`@revealui/auth`](packages/auth)                       | Session auth, password reset, rate limiting       |
 | [`@revealui/presentation`](packages/presentation)       | 65 UI components (Tailwind v4, zero ext deps)     |
 | [`@revealui/openapi`](packages/openapi)                 | OpenAPI route helpers and Swagger generation       |

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -37,7 +37,7 @@ export const METRICS = {
    */
   mcpServers: 14,
   /** Drizzle pgTable declarations across packages/db/src/schema/. Source: claim-drift countDbTables. */
-  dbTables: 93,
+  dbTables: 96,
   /** License split. Source: claim-drift licenseSplit. */
   licenseSplit: {
     /** MIT-licensed packages. */

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -60,7 +60,11 @@ import { auditMiddleware } from './middleware/audit.js';
 import { authMiddleware, requireRole } from './middleware/auth.js';
 import { requirePermission } from './middleware/authorization.js';
 import { bodyLimitGate } from './middleware/body-limits.js';
-import { noCacheCacheMiddleware, noStoreCacheMiddleware } from './middleware/cache-control.js';
+import {
+  noCacheCacheMiddleware,
+  noStoreCacheMiddleware,
+  publicCacheMiddleware,
+} from './middleware/cache-control.js';
 import { csrfMiddleware } from './middleware/csrf.js';
 import { dbMiddleware } from './middleware/db.js';
 import { entitlementMiddleware } from './middleware/entitlements.js';
@@ -413,6 +417,27 @@ app.use('*', dbMiddleware());
 // Audit logging  -  fire-and-forget, never crashes the request
 app.use('/api/*', auditMiddleware(audit));
 app.use('/api/v1/*', auditMiddleware(audit));
+
+// ---------------------------------------------------------------------------
+// Content cache strategy A (1s freshness)  -  published-content GET reads carry
+// a 1-second shared-CDN cache with a small stale-while-revalidate window. With
+// s-maxage=1 an edit-session publish is visible within ~1s without an active
+// cache purge. Edit-session routes are NOT cached here (they expose auth'd
+// drafts)  -  they get no-store below.
+// ---------------------------------------------------------------------------
+const publishedContentCache = publicCacheMiddleware({ sMaxAge: 1, staleWhileRevalidate: 5 });
+app.use('/api/content/pages/*', publishedContentCache);
+app.use('/api/v1/content/pages/*', publishedContentCache);
+app.use('/api/content/globals/*', publishedContentCache);
+app.use('/api/v1/content/globals/*', publishedContentCache);
+app.use('/api/content/posts/*', publishedContentCache);
+app.use('/api/v1/content/posts/*', publishedContentCache);
+
+// Edit-session routes expose draft content  -  never cache them.
+app.use('/api/content/sessions', noStoreCacheMiddleware());
+app.use('/api/v1/content/sessions', noStoreCacheMiddleware());
+app.use('/api/content/sessions/*', noStoreCacheMiddleware());
+app.use('/api/v1/content/sessions/*', noStoreCacheMiddleware());
 
 // ---------------------------------------------------------------------------
 // Rate limit configuration  -  all tunables in one place

--- a/apps/server/src/routes/__tests__/edit-sessions-cache-headers.test.ts
+++ b/apps/server/src/routes/__tests__/edit-sessions-cache-headers.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Content cache strategy A (1s freshness) header wiring.
+ *
+ * Proves the exact mounts index.ts applies: published-content GET reads carry
+ * `s-maxage=1` (+ a small stale-while-revalidate), while edit-session routes
+ * carry `no-store` because they expose auth'd drafts.
+ */
+
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { noStoreCacheMiddleware, publicCacheMiddleware } from '../../middleware/cache-control.js';
+
+function buildApp() {
+  const app = new Hono();
+  const publishedContentCache = publicCacheMiddleware({ sMaxAge: 1, staleWhileRevalidate: 5 });
+  app.use('/api/content/pages/*', publishedContentCache);
+  app.use('/api/content/globals/*', publishedContentCache);
+  app.use('/api/content/posts/*', publishedContentCache);
+  app.use('/api/content/sessions', noStoreCacheMiddleware());
+  app.use('/api/content/sessions/*', noStoreCacheMiddleware());
+
+  app.get('/api/content/pages/:id', (c) => c.json({ ok: true }));
+  app.get('/api/content/globals/:slug', (c) => c.json({ ok: true }));
+  app.get('/api/content/posts/:id', (c) => c.json({ ok: true }));
+  app.get('/api/content/sessions', (c) => c.json({ ok: true }));
+  app.get('/api/content/sessions/:id', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('content cache headers', () => {
+  it('published-content GET reads carry s-maxage=1', async () => {
+    const app = buildApp();
+    for (const url of [
+      '/api/content/pages/abc',
+      '/api/content/globals/header',
+      '/api/content/posts/xyz',
+    ]) {
+      const res = await app.request(url);
+      const cacheControl = res.headers.get('cache-control') ?? '';
+      expect(cacheControl).toContain('s-maxage=1');
+      expect(cacheControl).toContain('stale-while-revalidate=5');
+      expect(cacheControl).toContain('public');
+    }
+  });
+
+  it('edit-session routes carry no-store', async () => {
+    const app = buildApp();
+    for (const url of ['/api/content/sessions', '/api/content/sessions/abc']) {
+      const res = await app.request(url);
+      expect(res.headers.get('cache-control')).toBe('no-store');
+    }
+  });
+});

--- a/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
@@ -17,9 +17,53 @@
 import type { DatabaseClient } from '@revealui/db/client';
 import * as schema from '@revealui/db/schema';
 import { OpenAPIHono } from '@revealui/openapi';
-import { asc, eq } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
-import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Race-injection control for the mid-flight publish tests. Default (both unset)
+// passes every query straight through to the real implementation, so all other
+// tests exercise the genuine engine. Only the mid-flight tests set these.
+const raceControl = vi.hoisted(() => ({
+  bumpBeforePublish: null as { pageId: string; toVersion: number } | null,
+  failRestore: false,
+}));
+
+vi.mock('@revealui/db/queries/edit-sessions', async () => {
+  const actual = await vi.importActual<typeof import('@revealui/db/queries/edit-sessions')>(
+    '@revealui/db/queries/edit-sessions',
+  );
+  const schemaMod =
+    await vi.importActual<typeof import('@revealui/db/schema')>('@revealui/db/schema');
+  const { eq: eqOp } = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
+  return {
+    ...actual,
+    async publishDraftToPage(
+      db: Parameters<typeof actual.publishDraftToPage>[0],
+      data: Parameters<typeof actual.publishDraftToPage>[1],
+    ) {
+      const bump = raceControl.bumpBeforePublish;
+      if (bump && bump.pageId === data.pageId) {
+        // A concurrent writer wins the race between the pre-flight read and this
+        // doc's guarded write, so the guard below misses.
+        raceControl.bumpBeforePublish = null;
+        await db
+          .update(schemaMod.pages)
+          .set({ version: bump.toVersion })
+          .where(eqOp(schemaMod.pages.id, data.pageId));
+      }
+      return actual.publishDraftToPage(db, data);
+    },
+    async restorePageContent(
+      db: Parameters<typeof actual.restorePageContent>[0],
+      data: Parameters<typeof actual.restorePageContent>[1],
+    ) {
+      if (raceControl.failRestore) return null;
+      return actual.restorePageContent(db, data);
+    },
+  };
+});
+
 import {
   createTestDb,
   type TestDb,
@@ -39,6 +83,7 @@ const VIEWER: UserCtx = { id: 'user-viewer', role: 'viewer' };
 
 const SITE_ID = 'site-1';
 const PAGE_ID = 'page-1';
+const PAGE_B = 'page-2';
 
 function createApp(user: UserCtx | null) {
   const app = new OpenAPIHono<{ Variables: ContentVariables }>();
@@ -68,17 +113,30 @@ async function seedBase(): Promise<void> {
     slug: 'site-one',
     status: 'published',
   });
-  await db.insert(schema.pages).values({
-    id: PAGE_ID,
-    siteId: SITE_ID,
-    title: 'Original Title',
-    slug: 'home',
-    path: '/',
-    status: 'published',
-    version: 1,
-    blocks: [{ type: 'text', text: 'hello' }],
-    seo: { description: 'orig' },
-  });
+  await db.insert(schema.pages).values([
+    {
+      id: PAGE_ID,
+      siteId: SITE_ID,
+      title: 'Original Title',
+      slug: 'home',
+      path: '/',
+      status: 'published',
+      version: 1,
+      blocks: [{ type: 'text', text: 'hello' }],
+      seo: { description: 'orig' },
+    },
+    {
+      id: PAGE_B,
+      siteId: SITE_ID,
+      title: 'Second Page',
+      slug: 'about',
+      path: '/about',
+      status: 'published',
+      version: 1,
+      blocks: [{ type: 'text', text: 'about' }],
+      seo: { description: 'about-orig' },
+    },
+  ]);
 }
 
 async function openSession(app: ReturnType<typeof createApp>): Promise<string> {
@@ -98,7 +156,17 @@ async function patch(
   path: string,
   value: unknown,
 ): Promise<Response> {
-  return app.request(`/sessions/${sessionId}/docs/page/${PAGE_ID}`, {
+  return patchDoc(app, sessionId, PAGE_ID, path, value);
+}
+
+async function patchDoc(
+  app: ReturnType<typeof createApp>,
+  sessionId: string,
+  docId: string,
+  path: string,
+  value: unknown,
+): Promise<Response> {
+  return app.request(`/sessions/${sessionId}/docs/page/${docId}`, {
     method: 'PATCH',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ path, value }),
@@ -106,6 +174,8 @@ async function patch(
 }
 
 beforeEach(async () => {
+  raceControl.bumpBeforePublish = null;
+  raceControl.failRestore = false;
   testDb = await createTestDb();
   await seedBase();
 });
@@ -223,7 +293,7 @@ describe('open -> patch -> patch -> publish', () => {
     const app = createApp(EDITOR);
     const openId = await openSession(app);
     const discardId = await openSession(app);
-    await app.request(`/sessions/${discardId}`, { method: 'DELETE' });
+    await app.request(`/sessions/${discardId}/discard`, { method: 'POST' });
 
     const openList = await app.request('/sessions?status=open');
     const openBody = (await openList.json()) as { data: Array<{ id: string }> };
@@ -285,6 +355,132 @@ describe('publish after external edit', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Mid-flight publish conflict (a writer wins the race after the pre-flight)
+// ---------------------------------------------------------------------------
+
+describe('mid-flight publish conflict', () => {
+  async function openTwoDocSession(app: ReturnType<typeof createApp>): Promise<string> {
+    const sessionId = await openSession(app);
+    // page-1 sorts before page-2, so page-1 publishes first in the loop.
+    await patchDoc(app, sessionId, PAGE_ID, 'title', 'A-new');
+    await patchDoc(app, sessionId, PAGE_B, 'title', 'B-new');
+    return sessionId;
+  }
+
+  it('compensates already-written docs and returns a clean 409 (nothing published)', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openTwoDocSession(app);
+
+    // page-1 publishes; then a concurrent writer wins on page-2, so its guarded
+    // write misses mid-flight.
+    raceControl.bumpBeforePublish = { pageId: PAGE_B, toVersion: 4 };
+
+    const pub = await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' });
+    expect(pub.status).toBe(409);
+    const body = (await pub.json()) as {
+      error: string;
+      conflicts: Array<{ docId: string }>;
+      partiallyPublished?: string[];
+    };
+    expect(body.error).toBe('publish_conflict');
+    expect(body.conflicts.map((cft) => cft.docId)).toEqual([PAGE_B]);
+    expect(body.partiallyPublished ?? []).toEqual([]); // nothing left live
+
+    // page-1 was published then compensated back to its exact prior row.
+    const pageA = (
+      await testDb.drizzle.select().from(schema.pages).where(eq(schema.pages.id, PAGE_ID))
+    )[0];
+    expect(pageA.title).toBe('Original Title');
+    expect(pageA.version).toBe(1);
+    // The revision inserted during the failed attempt was deleted.
+    const revs = await testDb.drizzle
+      .select()
+      .from(schema.pageRevisions)
+      .where(eq(schema.pageRevisions.pageId, PAGE_ID));
+    expect(revs).toHaveLength(0);
+
+    // Session remains open (publish did not complete).
+    const session = (
+      await testDb.drizzle
+        .select()
+        .from(schema.editSessions)
+        .where(eq(schema.editSessions.id, sessionId))
+    )[0];
+    expect(session.status).toBe('open');
+  });
+
+  it('reports partiallyPublished when compensation fails, then a retry converges with no wedge', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openTwoDocSession(app);
+
+    // page-1 publishes; page-2 conflicts mid-flight; and compensation of page-1
+    // is forced to miss, so page-1 stays live.
+    raceControl.bumpBeforePublish = { pageId: PAGE_B, toVersion: 4 };
+    raceControl.failRestore = true;
+
+    const pub = await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' });
+    expect(pub.status).toBe(409);
+    const body = (await pub.json()) as {
+      conflicts: Array<{ docId: string }>;
+      partiallyPublished?: string[];
+    };
+    expect(body.conflicts.map((cft) => cft.docId)).toEqual([PAGE_B]);
+    expect(body.partiallyPublished).toEqual([PAGE_ID]);
+
+    // page-1 is live with the draft; its overlay base_version was advanced to the
+    // page's current version so a retry does not phantom-conflict on it.
+    const pageA = (
+      await testDb.drizzle.select().from(schema.pages).where(eq(schema.pages.id, PAGE_ID))
+    )[0];
+    expect(pageA.title).toBe('A-new');
+    const overlayA = (
+      await testDb.drizzle
+        .select()
+        .from(schema.editSessionDocs)
+        .where(
+          and(
+            eq(schema.editSessionDocs.sessionId, sessionId),
+            eq(schema.editSessionDocs.docId, PAGE_ID),
+          ),
+        )
+    )[0];
+    expect(overlayA.baseVersion).toBe(pageA.version);
+
+    // Resolve the page-2 conflict: reconcile its overlay base_version to the live
+    // version (what a client does after reviewing the concurrent change), clear the
+    // injected failures, and retry. Publish must now converge with no wedge.
+    const pageBLive = (
+      await testDb.drizzle.select().from(schema.pages).where(eq(schema.pages.id, PAGE_B))
+    )[0];
+    await testDb.drizzle
+      .update(schema.editSessionDocs)
+      .set({ baseVersion: pageBLive.version })
+      .where(
+        and(
+          eq(schema.editSessionDocs.sessionId, sessionId),
+          eq(schema.editSessionDocs.docId, PAGE_B),
+        ),
+      );
+    raceControl.bumpBeforePublish = null;
+    raceControl.failRestore = false;
+
+    const retry = await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' });
+    expect(retry.status).toBe(200);
+    const session = (
+      await testDb.drizzle
+        .select()
+        .from(schema.editSessions)
+        .where(eq(schema.editSessions.id, sessionId))
+    )[0];
+    expect(session.status).toBe('published');
+    const pageBFinal = (
+      await testDb.drizzle.select().from(schema.pages).where(eq(schema.pages.id, PAGE_B))
+    )[0];
+    expect(pageBFinal.title).toBe('B-new');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Discard
 // ---------------------------------------------------------------------------
 
@@ -294,7 +490,7 @@ describe('discard', () => {
     const sessionId = await openSession(app);
     await patch(app, sessionId, 'title', 'Draft Title');
 
-    const res = await app.request(`/sessions/${sessionId}`, { method: 'DELETE' });
+    const res = await app.request(`/sessions/${sessionId}/discard`, { method: 'POST' });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { data: { status: string } };
     expect(body.data.status).toBe('discarded');
@@ -386,7 +582,9 @@ describe('mutations on a non-open session', () => {
     expect((await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' })).status).toBe(
       409,
     );
-    expect((await app.request(`/sessions/${sessionId}`, { method: 'DELETE' })).status).toBe(409);
+    expect((await app.request(`/sessions/${sessionId}/discard`, { method: 'POST' })).status).toBe(
+      409,
+    );
   });
 });
 
@@ -413,7 +611,7 @@ describe('authorization on every session route', () => {
         body: { path: 'title', value: 'x' },
       },
       { method: 'POST', url: `/sessions/${sessionId}/publish` },
-      { method: 'DELETE', url: `/sessions/${sessionId}` },
+      { method: 'POST', url: `/sessions/${sessionId}/discard` },
     ];
   }
 

--- a/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Edit session engine  -  integration tests against a REAL migrated schema
+ * (PGlite) and the real Hono session routes.
+ *
+ * Covers the P1 slice-1 lifecycle and its invariants:
+ *   - open -> patch (materializes draft + base_version) -> patch -> publish
+ *     (page written, version bumped, revision snapshot, session published,
+ *     events complete + in order)
+ *   - publish after an out-of-band page edit -> 409 with per-doc detail, no write
+ *   - discard
+ *   - maxPerDoc=50 revision pruning
+ *   - prototype-pollution segment rejection
+ *   - authz: anonymous + non-editor rejected on EVERY route (GETs included)
+ *   - mutations on a non-open session -> 409
+ */
+
+import type { DatabaseClient } from '@revealui/db/client';
+import * as schema from '@revealui/db/schema';
+import { OpenAPIHono } from '@revealui/openapi';
+import { asc, eq } from 'drizzle-orm';
+import { HTTPException } from 'hono/http-exception';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+import type { ContentVariables } from '../content/index.js';
+import sessionsRoutes from '../content/sessions.js';
+
+let testDb: TestDb;
+
+interface UserCtx {
+  id: string;
+  role: string;
+}
+
+const EDITOR: UserCtx = { id: 'user-editor', role: 'editor' };
+const VIEWER: UserCtx = { id: 'user-viewer', role: 'viewer' };
+
+const SITE_ID = 'site-1';
+const PAGE_ID = 'page-1';
+
+function createApp(user: UserCtx | null) {
+  const app = new OpenAPIHono<{ Variables: ContentVariables }>();
+  app.use('*', async (c, next) => {
+    if (user) c.set('user', user);
+    c.set('db', testDb.drizzle as unknown as DatabaseClient);
+    await next();
+  });
+  app.route('/', sessionsRoutes);
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) return c.json({ error: err.message }, err.status);
+    return c.json({ error: 'Internal server error' }, 500);
+  });
+  return app;
+}
+
+async function seedBase(): Promise<void> {
+  const db = testDb.drizzle;
+  await db.insert(schema.users).values([
+    { id: EDITOR.id, name: 'Editor', email: 'editor@example.com', role: 'editor' },
+    { id: VIEWER.id, name: 'Viewer', email: 'viewer@example.com', role: 'viewer' },
+  ]);
+  await db.insert(schema.sites).values({
+    id: SITE_ID,
+    ownerId: EDITOR.id,
+    name: 'Site One',
+    slug: 'site-one',
+    status: 'published',
+  });
+  await db.insert(schema.pages).values({
+    id: PAGE_ID,
+    siteId: SITE_ID,
+    title: 'Original Title',
+    slug: 'home',
+    path: '/',
+    status: 'published',
+    version: 1,
+    blocks: [{ type: 'text', text: 'hello' }],
+    seo: { description: 'orig' },
+  });
+}
+
+async function openSession(app: ReturnType<typeof createApp>): Promise<string> {
+  const res = await app.request('/sessions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ siteId: SITE_ID, title: 'My edits' }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { data: { id: string } };
+  return body.data.id;
+}
+
+async function patch(
+  app: ReturnType<typeof createApp>,
+  sessionId: string,
+  path: string,
+  value: unknown,
+): Promise<Response> {
+  return app.request(`/sessions/${sessionId}/docs/page/${PAGE_ID}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ path, value }),
+  });
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  await seedBase();
+});
+
+afterAll(async () => {
+  await testDb?.close();
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe('open -> patch -> patch -> publish', () => {
+  it('materializes a draft with base_version, applies patches, and publishes atomically', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    // First patch materializes the overlay from the live page.
+    const p1 = await patch(app, sessionId, 'title', 'New Title');
+    expect(p1.status).toBe(200);
+    const doc1 = (await p1.json()) as { data: { baseVersion: number; draft: { title: string } } };
+    expect(doc1.data.baseVersion).toBe(1);
+    expect(doc1.data.draft.title).toBe('New Title');
+
+    // Second patch applies to the stored draft (nested array path).
+    const p2 = await patch(app, sessionId, 'blocks.0.text', 'updated body');
+    expect(p2.status).toBe(200);
+    const doc2 = (await p2.json()) as {
+      data: { draft: { title: string; blocks: Array<{ text: string }> } };
+    };
+    expect(doc2.data.draft.title).toBe('New Title');
+    expect(doc2.data.draft.blocks[0].text).toBe('updated body');
+
+    // Publish.
+    const pub = await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' });
+    expect(pub.status).toBe(200);
+    const pubBody = (await pub.json()) as { data: { status: string }; publishedDocs: number };
+    expect(pubBody.data.status).toBe('published');
+    expect(pubBody.publishedDocs).toBe(1);
+
+    // Page written + version bumped.
+    const page = (
+      await testDb.drizzle.select().from(schema.pages).where(eq(schema.pages.id, PAGE_ID))
+    )[0];
+    expect(page.title).toBe('New Title');
+    expect(page.version).toBe(2);
+    expect(page.status).toBe('published');
+    expect((page.blocks as Array<{ text: string }>)[0].text).toBe('updated body');
+
+    // Revision snapshot exists.
+    const revisions = await testDb.drizzle
+      .select()
+      .from(schema.pageRevisions)
+      .where(eq(schema.pageRevisions.pageId, PAGE_ID));
+    expect(revisions).toHaveLength(1);
+    expect(revisions[0].title).toBe('New Title');
+
+    // Session published.
+    const session = (
+      await testDb.drizzle
+        .select()
+        .from(schema.editSessions)
+        .where(eq(schema.editSessions.id, sessionId))
+    )[0];
+    expect(session.status).toBe('published');
+    expect(session.publishedAt).not.toBeNull();
+
+    // Events complete and in order.
+    const events = await testDb.drizzle
+      .select()
+      .from(schema.editSessionEvents)
+      .where(eq(schema.editSessionEvents.sessionId, sessionId))
+      .orderBy(asc(schema.editSessionEvents.id));
+    expect(events.map((e) => e.type)).toEqual(['opened', 'patched', 'patched', 'published']);
+    expect(events.every((e) => e.actorKind === 'human')).toBe(true);
+  });
+
+  it('GET /sessions/:id returns the session, its docs, and chronological events', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'Draft Title');
+
+    const res = await app.request(`/sessions/${sessionId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        session: { status: string };
+        docs: Array<{ docId: string; baseVersion: number }>;
+        events: Array<{ type: string }>;
+      };
+    };
+    expect(body.data.session.status).toBe('open');
+    expect(body.data.docs).toHaveLength(1);
+    expect(body.data.docs[0].docId).toBe(PAGE_ID);
+    expect(body.data.events.map((e) => e.type)).toEqual(['opened', 'patched']);
+  });
+
+  it('GET /sessions/:id/events polls after a cursor', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'A');
+
+    const all = await app.request(`/sessions/${sessionId}/events?after=0`);
+    const allBody = (await all.json()) as { data: Array<{ id: number }>; nextCursor: number };
+    expect(allBody.data.map((e) => e.id)).toHaveLength(2);
+    const cursor = allBody.data[0].id;
+
+    const after = await app.request(`/sessions/${sessionId}/events?after=${cursor}`);
+    const afterBody = (await after.json()) as { data: Array<{ type: string }>; nextCursor: number };
+    expect(afterBody.data.map((e) => e.type)).toEqual(['patched']);
+    expect(afterBody.nextCursor).toBe(allBody.nextCursor);
+  });
+
+  it('GET /sessions lists and filters by status', async () => {
+    const app = createApp(EDITOR);
+    const openId = await openSession(app);
+    const discardId = await openSession(app);
+    await app.request(`/sessions/${discardId}`, { method: 'DELETE' });
+
+    const openList = await app.request('/sessions?status=open');
+    const openBody = (await openList.json()) as { data: Array<{ id: string }> };
+    expect(openBody.data.map((s) => s.id)).toContain(openId);
+    expect(openBody.data.map((s) => s.id)).not.toContain(discardId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conflict  -  publish after an out-of-band page edit
+// ---------------------------------------------------------------------------
+
+describe('publish after external edit', () => {
+  it('returns 409 with per-doc detail and does not write', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'Draft Title');
+
+    // Out-of-band edit bumps the live page version.
+    await testDb.drizzle
+      .update(schema.pages)
+      .set({ version: 5, title: 'Externally Edited' })
+      .where(eq(schema.pages.id, PAGE_ID));
+
+    const pub = await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' });
+    expect(pub.status).toBe(409);
+    const body = (await pub.json()) as {
+      error: string;
+      conflicts: Array<{
+        docId: string;
+        reason: string;
+        baseVersion: number;
+        currentVersion: number;
+      }>;
+    };
+    expect(body.error).toBe('publish_conflict');
+    expect(body.conflicts).toHaveLength(1);
+    expect(body.conflicts[0]).toMatchObject({
+      docId: PAGE_ID,
+      reason: 'version_conflict',
+      baseVersion: 1,
+      currentVersion: 5,
+    });
+
+    // No partial publish: the page keeps the external edit, not the draft.
+    const page = (
+      await testDb.drizzle.select().from(schema.pages).where(eq(schema.pages.id, PAGE_ID))
+    )[0];
+    expect(page.title).toBe('Externally Edited');
+    expect(page.version).toBe(5);
+    const session = (
+      await testDb.drizzle
+        .select()
+        .from(schema.editSessions)
+        .where(eq(schema.editSessions.id, sessionId))
+    )[0];
+    expect(session.status).toBe('open');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Discard
+// ---------------------------------------------------------------------------
+
+describe('discard', () => {
+  it('marks the session discarded, writes an event, and retains overlay rows', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'Draft Title');
+
+    const res = await app.request(`/sessions/${sessionId}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { status: string } };
+    expect(body.data.status).toBe('discarded');
+
+    // Overlay row retained for audit.
+    const docs = await testDb.drizzle
+      .select()
+      .from(schema.editSessionDocs)
+      .where(eq(schema.editSessionDocs.sessionId, sessionId));
+    expect(docs).toHaveLength(1);
+
+    const events = await testDb.drizzle
+      .select()
+      .from(schema.editSessionEvents)
+      .where(eq(schema.editSessionEvents.sessionId, sessionId))
+      .orderBy(asc(schema.editSessionEvents.id));
+    expect(events.map((e) => e.type)).toEqual(['opened', 'patched', 'discarded']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Revision pruning
+// ---------------------------------------------------------------------------
+
+describe('maxPerDoc=50 revision pruning', () => {
+  it('keeps the newest 50 revisions for the published page', async () => {
+    // Pre-seed 50 existing revisions so the publish makes the 51st.
+    await testDb.drizzle.insert(schema.pageRevisions).values(
+      Array.from({ length: 50 }, (_, i) => ({
+        id: `rev-${i + 1}`,
+        pageId: PAGE_ID,
+        revisionNumber: i + 1,
+        title: `Rev ${i + 1}`,
+        blocks: [],
+        seo: null,
+      })),
+    );
+
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'Newest');
+    const pub = await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' });
+    expect(pub.status).toBe(200);
+
+    const revisions = await testDb.drizzle
+      .select()
+      .from(schema.pageRevisions)
+      .where(eq(schema.pageRevisions.pageId, PAGE_ID))
+      .orderBy(asc(schema.pageRevisions.revisionNumber));
+    expect(revisions).toHaveLength(50);
+    // The oldest (revisionNumber 1) was pruned; the newest is number 51.
+    expect(revisions[0].revisionNumber).toBe(2);
+    expect(revisions[revisions.length - 1].revisionNumber).toBe(51);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prototype pollution
+// ---------------------------------------------------------------------------
+
+describe('prototype-pollution guard', () => {
+  it('rejects dangerous path segments with 400', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    for (const badPath of ['__proto__.polluted', 'constructor.x', 'a.prototype.b']) {
+      const res = await patch(app, sessionId, badPath, 'x');
+      expect(res.status).toBe(400);
+    }
+
+    // The base object prototype was not polluted.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-open session mutations
+// ---------------------------------------------------------------------------
+
+describe('mutations on a non-open session', () => {
+  it('rejects patch, publish, and discard with 409 once published', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'x');
+    const pub = await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' });
+    expect(pub.status).toBe(200);
+
+    expect((await patch(app, sessionId, 'title', 'y')).status).toBe(409);
+    expect((await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' })).status).toBe(
+      409,
+    );
+    expect((await app.request(`/sessions/${sessionId}`, { method: 'DELETE' })).status).toBe(409);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authorization  -  every route rejects anonymous + non-editor (GETs included)
+// ---------------------------------------------------------------------------
+
+describe('authorization on every session route', () => {
+  interface Case {
+    method: string;
+    url: string;
+    body?: unknown;
+  }
+
+  function routeCases(sessionId: string): Case[] {
+    return [
+      { method: 'POST', url: '/sessions', body: { siteId: SITE_ID, title: 't' } },
+      { method: 'GET', url: '/sessions' },
+      { method: 'GET', url: `/sessions/${sessionId}` },
+      { method: 'GET', url: `/sessions/${sessionId}/events` },
+      {
+        method: 'PATCH',
+        url: `/sessions/${sessionId}/docs/page/${PAGE_ID}`,
+        body: { path: 'title', value: 'x' },
+      },
+      { method: 'POST', url: `/sessions/${sessionId}/publish` },
+      { method: 'DELETE', url: `/sessions/${sessionId}` },
+    ];
+  }
+
+  async function callAll(user: UserCtx | null): Promise<number[]> {
+    const setup = createApp(EDITOR);
+    const sessionId = await openSession(setup);
+    const app = createApp(user);
+    const statuses: number[] = [];
+    for (const rc of routeCases(sessionId)) {
+      const res = await app.request(rc.url, {
+        method: rc.method,
+        headers: rc.body ? { 'content-type': 'application/json' } : undefined,
+        body: rc.body ? JSON.stringify(rc.body) : undefined,
+      });
+      statuses.push(res.status);
+    }
+    return statuses;
+  }
+
+  it('rejects anonymous with 401 on every route including GETs', async () => {
+    const statuses = await callAll(null);
+    expect(statuses.every((s) => s === 401)).toBe(true);
+  });
+
+  it('rejects a non-editor (viewer) with 403 on every route including GETs', async () => {
+    const statuses = await callAll(VIEWER);
+    expect(statuses.every((s) => s === 403)).toBe(true);
+  });
+});

--- a/apps/server/src/routes/content/index.ts
+++ b/apps/server/src/routes/content/index.ts
@@ -45,6 +45,7 @@ import pagesRoutes from './pages.js';
 import postsRoutes from './posts.js';
 import productsRoutes from './products.js';
 import searchRoutes from './search.js';
+import sessionsRoutes from './sessions.js';
 import sitesRoutes from './sites.js';
 import usersRoutes from './users.js';
 
@@ -60,6 +61,7 @@ app.route('/', mediaRoutes);
 app.route('/', sitesRoutes);
 app.route('/', pagesRoutes);
 app.route('/', globalsRoutes);
+app.route('/', sessionsRoutes);
 app.route('/', searchRoutes);
 app.route('/', usersRoutes);
 app.route('/', productsRoutes);

--- a/apps/server/src/routes/content/sessions.ts
+++ b/apps/server/src/routes/content/sessions.ts
@@ -118,7 +118,12 @@ function setAtPath(draft: Record<string, unknown>, path: string, value: unknown)
   writeChild(cursor, segments[segments.length - 1], value);
 }
 
-/** Build the initial draft overlay from a live page (editable fields only). */
+/**
+ * Build the initial draft overlay from a live page. This is a FULL editable-doc
+ * snapshot (title + blocks + seo all captured), so at publish time the
+ * `draft.title/blocks/seo` fallbacks to the live page are belt-and-braces only  -
+ * a materialized draft always carries these fields.
+ */
 function materializePageDraft(page: Page): Record<string, unknown> {
   return {
     id: page.id,
@@ -133,6 +138,41 @@ function materializePageDraft(page: Page): Record<string, unknown> {
     seo: page.seo ?? null,
     version: page.version,
   };
+}
+
+/**
+ * Undo the page writes from a failed publish attempt (called on a mid-flight
+ * guard miss). For each already-written doc, restore its exact prior row, guarded
+ * on the version this attempt set. A successful restore leaves the page identical
+ * to before the attempt, so a retry's optimistic pre-flight passes and converges.
+ * If a restore itself misses (the page moved again), that doc stays live: it is
+ * returned so the caller can report it, and its overlay base_version is advanced
+ * to the current version so the retry does not phantom-conflict on this session's
+ * own write.
+ */
+async function compensatePublish(
+  db: Parameters<typeof sessionQueries.restorePageContent>[0],
+  written: Array<{ docId: string; overlayId: string; revisionId: string; original: Page }>,
+): Promise<string[]> {
+  const stillPublished: string[] = [];
+  for (let i = written.length - 1; i >= 0; i--) {
+    const w = written[i];
+    const restored = await sessionQueries.restorePageContent(db, {
+      pageId: w.docId,
+      expectedVersion: w.original.version + 1,
+      original: w.original,
+    });
+    if (restored) {
+      await sessionQueries.deletePageRevisionById(db, w.revisionId);
+    } else {
+      stillPublished.push(w.docId);
+      const current = await sessionQueries.getLivePage(db, w.docId);
+      if (current) {
+        await sessionQueries.setSessionDocBaseVersion(db, w.overlayId, current.version);
+      }
+    }
+  }
+  return stillPublished;
 }
 
 // =============================================================================
@@ -184,6 +224,9 @@ const ConflictSchema = z.object({
   success: z.literal(false),
   error: z.string(),
   conflicts: z.array(z.record(z.string(), z.unknown())),
+  // Present only when a mid-flight conflict left some docs live and compensation
+  // could not fully revert them. Empty/absent means nothing was published.
+  partiallyPublished: z.array(z.string()).optional(),
 });
 
 function serializeSession(row: EditSession): z.infer<typeof SessionSchema> {
@@ -607,6 +650,13 @@ app.openapi(
 
     // Phase 2  -  guarded writes. Each update is version-guarded (WHERE version =
     // baseVersion); a guard miss means a writer slipped in after the read phase.
+    // On a mid-flight miss we compensate the docs already written this attempt
+    // (restore their exact prior row + delete the revision we inserted) so the
+    // publish stays all-or-nothing. If a compensation write itself misses, that
+    // doc stays live and is reported via `partiallyPublished`, and its overlay
+    // base_version is advanced so a later retry does not phantom-conflict.
+    const written: Array<{ docId: string; overlayId: string; revisionId: string; original: Page }> =
+      [];
     for (const doc of docs) {
       const draft = doc.draft;
       const basePage = live.get(doc.docId) as Page;
@@ -623,19 +673,22 @@ app.openapi(
         publishedAt,
       });
       if (!updatedPage) {
+        const partiallyPublished = await compensatePublish(db, written);
         return c.json(
           {
             success: false as const,
             error: 'publish_conflict',
             conflicts: [{ docType: doc.docType, docId: doc.docId, reason: 'version_conflict' }],
+            ...(partiallyPublished.length > 0 ? { partiallyPublished } : {}),
           },
           409,
         );
       }
 
       const revisionNumber = await sessionQueries.nextPageRevisionNumber(db, doc.docId);
+      const revisionId = crypto.randomUUID();
       await sessionQueries.insertPageRevision(db, {
-        id: crypto.randomUUID(),
+        id: revisionId,
         pageId: doc.docId,
         createdBy: user.id,
         revisionNumber,
@@ -645,13 +698,14 @@ app.openapi(
         changeDescription: `Published via edit session ${id}`,
       });
       await sessionQueries.prunePageRevisions(db, doc.docId, MAX_REVISIONS_PER_DOC);
+      written.push({ docId: doc.docId, overlayId: doc.id, revisionId, original: basePage });
     }
 
-    const published = await sessionQueries.setEditSessionStatus(db, id, {
+    const publishedSession = await sessionQueries.setEditSessionStatus(db, id, {
       status: 'published',
       publishedAt,
     });
-    if (!published) throw new HTTPException(500, { message: 'Failed to publish session' });
+    if (!publishedSession) throw new HTTPException(500, { message: 'Failed to publish session' });
 
     await sessionQueries.insertSessionEvent(db, {
       sessionId: id,
@@ -662,20 +716,27 @@ app.openapi(
     });
 
     return c.json(
-      { success: true as const, data: serializeSession(published), publishedDocs: docs.length },
+      {
+        success: true as const,
+        data: serializeSession(publishedSession),
+        publishedDocs: docs.length,
+      },
       200,
     );
   },
 );
 
 // =============================================================================
-// DELETE /sessions/:id  -  discard (overlay rows retained for audit)
+// POST /sessions/:id/discard  -  discard (overlay rows retained for audit)
 // =============================================================================
+// A POST (not DELETE) so discard rides the content `update` permission like
+// open / patch / publish. The `/api/content/*` mount maps DELETE -> content
+// `delete` (admin only), which is wrong for abandoning your own draft.
 
 app.openapi(
   createRoute({
-    method: 'delete',
-    path: '/sessions/{id}',
+    method: 'post',
+    path: '/sessions/{id}/discard',
     tags: ['content'],
     summary: 'Discard an edit session',
     request: { params: IdParam },

--- a/apps/server/src/routes/content/sessions.ts
+++ b/apps/server/src/routes/content/sessions.ts
@@ -1,0 +1,727 @@
+/**
+ * Edit session API routes  -  the visual-edit-sessions engine (P1 slice 1).
+ *
+ * An edit session is a durable draft workspace over live content docs. Editors
+ * open a session, patch draft overlays (autosave), then publish atomically or
+ * discard. Every action appends to an auditable event log.
+ *
+ * Phase-1 slice: `doc_type` `page` is fully implemented. `global` / `post`
+ * overlays are accepted by the schema but PATCH / publish reject them with a
+ * clear 400 until a later slice.
+ *
+ * SECURITY: every route here exposes DRAFT content, so every route  -  GETs
+ * included  -  requires an authenticated user holding the content `update`
+ * permission. The `/api/content/*` mount only gates POST/PATCH/DELETE by verb;
+ * GET is public-read there, so these routes enforce authz explicitly.
+ */
+
+import * as sessionQueries from '@revealui/db/queries/edit-sessions';
+import * as siteQueries from '@revealui/db/queries/sites';
+import type { EditSession, EditSessionDoc, EditSessionEvent, Page } from '@revealui/db/schema';
+import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
+import { HTTPException } from 'hono/http-exception';
+import { authorizationSystem } from '../../middleware/authorization.js';
+import { IdParam } from '../_helpers/content-schemas.js';
+import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
+import type { ContentVariables } from './index.js';
+
+const app = new OpenAPIHono<{ Variables: ContentVariables }>();
+
+const MAX_REVISIONS_PER_DOC = 50;
+const RECENT_EVENTS_LIMIT = 50;
+const EVENTS_PAGE_LIMIT = 200;
+
+// =============================================================================
+// Authz  -  draft exposure requires an authenticated content editor everywhere
+// =============================================================================
+
+interface SessionUser {
+  id: string;
+  role: string;
+}
+
+/** Require an authenticated user holding content:update. Throws 401 / 403. */
+function requireContentEditor(user: SessionUser | undefined): SessionUser {
+  if (!user) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+  if (!authorizationSystem.hasPermission([user.role], 'content', 'update')) {
+    throw new HTTPException(403, { message: 'Permission denied: content:update' });
+  }
+  return user;
+}
+
+function actorKindFor(user: SessionUser): 'human' | 'agent' {
+  return user.role === 'agent' ? 'agent' : 'human';
+}
+
+// =============================================================================
+// Typed draft patch setter (no regex, prototype-pollution guarded)
+// =============================================================================
+
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isArrayIndex(segment: string): boolean {
+  if (segment.length === 0) return false;
+  for (let i = 0; i < segment.length; i++) {
+    const code = segment.charCodeAt(i);
+    if (code < 48 || code > 57) return false;
+  }
+  return true;
+}
+
+function readChild(container: Record<string, unknown> | unknown[], segment: string): unknown {
+  if (Array.isArray(container)) {
+    return isArrayIndex(segment) ? container[Number(segment)] : undefined;
+  }
+  return container[segment];
+}
+
+function writeChild(
+  container: Record<string, unknown> | unknown[],
+  segment: string,
+  value: unknown,
+): void {
+  if (Array.isArray(container)) {
+    if (!isArrayIndex(segment)) {
+      throw new HTTPException(400, { message: `Expected an array index, got '${segment}'` });
+    }
+    container[Number(segment)] = value;
+    return;
+  }
+  container[segment] = value;
+}
+
+/** Set `value` at a dot/array path inside a draft, creating intermediate containers. */
+function setAtPath(draft: Record<string, unknown>, path: string, value: unknown): void {
+  const segments = path.split('.');
+  for (const segment of segments) {
+    if (segment.length === 0) {
+      throw new HTTPException(400, { message: 'Patch path has an empty segment' });
+    }
+    if (DANGEROUS_KEYS.has(segment)) {
+      throw new HTTPException(400, { message: `Illegal path segment: ${segment}` });
+    }
+  }
+
+  let cursor: Record<string, unknown> | unknown[] = draft;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    const nextIsIndex = isArrayIndex(segments[i + 1]);
+    let child = readChild(cursor, segment);
+    if (child === null || typeof child !== 'object') {
+      child = nextIsIndex ? [] : {};
+      writeChild(cursor, segment, child);
+    }
+    cursor = child as Record<string, unknown> | unknown[];
+  }
+  writeChild(cursor, segments[segments.length - 1], value);
+}
+
+/** Build the initial draft overlay from a live page (editable fields only). */
+function materializePageDraft(page: Page): Record<string, unknown> {
+  return {
+    id: page.id,
+    siteId: page.siteId,
+    parentId: page.parentId,
+    templateId: page.templateId,
+    title: page.title,
+    slug: page.slug,
+    path: page.path,
+    status: page.status,
+    blocks: page.blocks ?? [],
+    seo: page.seo ?? null,
+    version: page.version,
+  };
+}
+
+// =============================================================================
+// Serializers + response schemas
+// =============================================================================
+
+const DateTime = z.string().openapi({ type: 'string', format: 'date-time' });
+
+const SessionSchema = z
+  .object({
+    id: z.string(),
+    siteId: z.string(),
+    title: z.string(),
+    status: z.string(),
+    createdBy: z.string().nullable(),
+    createdAt: DateTime,
+    updatedAt: DateTime,
+    publishedAt: z.string().nullable().openapi({ type: 'string', format: 'date-time' }),
+  })
+  .openapi('EditSession');
+
+const SessionDocSchema = z
+  .object({
+    id: z.string(),
+    sessionId: z.string(),
+    docType: z.string(),
+    docId: z.string(),
+    draft: z.unknown(),
+    baseVersion: z.number(),
+    updatedBy: z.string().nullable(),
+    updatedAt: DateTime,
+  })
+  .openapi('EditSessionDoc');
+
+const SessionEventSchema = z
+  .object({
+    id: z.number(),
+    sessionId: z.string(),
+    actorId: z.string().nullable(),
+    actorKind: z.string(),
+    type: z.string(),
+    payload: z.unknown().nullable(),
+    createdAt: DateTime,
+  })
+  .openapi('EditSessionEvent');
+
+const ErrorSchema = z.object({ success: z.literal(false), error: z.string() });
+const ConflictSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+  conflicts: z.array(z.record(z.string(), z.unknown())),
+});
+
+function serializeSession(row: EditSession): z.infer<typeof SessionSchema> {
+  return {
+    id: row.id,
+    siteId: row.siteId,
+    title: row.title,
+    status: row.status,
+    createdBy: row.createdBy,
+    createdAt: dateToString(row.createdAt),
+    updatedAt: dateToString(row.updatedAt),
+    publishedAt: nullableDateToString(row.publishedAt),
+  };
+}
+
+function serializeDoc(row: EditSessionDoc): z.infer<typeof SessionDocSchema> {
+  return {
+    id: row.id,
+    sessionId: row.sessionId,
+    docType: row.docType,
+    docId: row.docId,
+    draft: row.draft,
+    baseVersion: row.baseVersion,
+    updatedBy: row.updatedBy,
+    updatedAt: dateToString(row.updatedAt),
+  };
+}
+
+function serializeEvent(row: EditSessionEvent): z.infer<typeof SessionEventSchema> {
+  return {
+    id: row.id,
+    sessionId: row.sessionId,
+    actorId: row.actorId,
+    actorKind: row.actorKind,
+    type: row.type,
+    payload: row.payload ?? null,
+    createdAt: dateToString(row.createdAt),
+  };
+}
+
+// =============================================================================
+// POST /sessions  -  open a session
+// =============================================================================
+
+app.openapi(
+  createRoute({
+    method: 'post',
+    path: '/sessions',
+    tags: ['content'],
+    summary: 'Open an edit session',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({ siteId: z.string().min(1), title: z.string().min(1).max(500) }),
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        content: {
+          'application/json': {
+            schema: z.object({ success: z.literal(true), data: SessionSchema }),
+          },
+        },
+        description: 'Session opened',
+      },
+      404: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Site not found',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const user = requireContentEditor(c.get('user'));
+    const { siteId, title } = c.req.valid('json');
+
+    const site = await siteQueries.getSiteById(db, siteId);
+    if (!site) throw new HTTPException(404, { message: 'Site not found' });
+
+    const id = crypto.randomUUID();
+    const session = await sessionQueries.createEditSession(db, {
+      id,
+      siteId,
+      title,
+      createdBy: user.id,
+    });
+    if (!session) throw new HTTPException(500, { message: 'Failed to open session' });
+
+    await sessionQueries.insertSessionEvent(db, {
+      sessionId: id,
+      actorId: user.id,
+      actorKind: actorKindFor(user),
+      type: 'opened',
+      payload: { siteId, title },
+    });
+
+    return c.json({ success: true as const, data: serializeSession(session) }, 201);
+  },
+);
+
+// =============================================================================
+// GET /sessions  -  list (filter by status / site)
+// =============================================================================
+
+app.openapi(
+  createRoute({
+    method: 'get',
+    path: '/sessions',
+    tags: ['content'],
+    summary: 'List edit sessions',
+    request: {
+      query: z.object({
+        status: z.enum(['open', 'published', 'discarded']).optional(),
+        siteId: z.string().optional(),
+      }),
+    },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({ success: z.literal(true), data: z.array(SessionSchema) }),
+          },
+        },
+        description: 'Session list',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    requireContentEditor(c.get('user'));
+    const { status, siteId } = c.req.valid('query');
+    const rows = await sessionQueries.listEditSessions(db, { status, siteId });
+    return c.json({ success: true as const, data: rows.map(serializeSession) }, 200);
+  },
+);
+
+// =============================================================================
+// GET /sessions/:id  -  session + docs + recent events
+// =============================================================================
+
+app.openapi(
+  createRoute({
+    method: 'get',
+    path: '/sessions/{id}',
+    tags: ['content'],
+    summary: 'Get an edit session with its docs and recent events',
+    request: { params: IdParam },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.literal(true),
+              data: z.object({
+                session: SessionSchema,
+                docs: z.array(SessionDocSchema),
+                events: z.array(SessionEventSchema),
+              }),
+            }),
+          },
+        },
+        description: 'Session detail',
+      },
+      404: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Not found' },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    requireContentEditor(c.get('user'));
+    const { id } = c.req.valid('param');
+
+    const session = await sessionQueries.getEditSessionById(db, id);
+    if (!session) throw new HTTPException(404, { message: 'Session not found' });
+
+    const docs = await sessionQueries.getSessionDocs(db, id);
+    const recent = await sessionQueries.getRecentSessionEvents(db, id, RECENT_EVENTS_LIMIT);
+    recent.reverse(); // chronological for display
+
+    return c.json(
+      {
+        success: true as const,
+        data: {
+          session: serializeSession(session),
+          docs: docs.map(serializeDoc),
+          events: recent.map(serializeEvent),
+        },
+      },
+      200,
+    );
+  },
+);
+
+// =============================================================================
+// GET /sessions/:id/events  -  poll for events after a cursor (id-ordered)
+// =============================================================================
+
+app.openapi(
+  createRoute({
+    method: 'get',
+    path: '/sessions/{id}/events',
+    tags: ['content'],
+    summary: 'Poll session events after a cursor',
+    request: {
+      params: IdParam,
+      query: z.object({ after: z.coerce.number().int().nonnegative().optional() }),
+    },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.literal(true),
+              data: z.array(SessionEventSchema),
+              nextCursor: z.number(),
+            }),
+          },
+        },
+        description: 'Events after the cursor',
+      },
+      404: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Not found' },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    requireContentEditor(c.get('user'));
+    const { id } = c.req.valid('param');
+    const { after } = c.req.valid('query');
+
+    const session = await sessionQueries.getEditSessionById(db, id);
+    if (!session) throw new HTTPException(404, { message: 'Session not found' });
+
+    const cursor = after ?? 0;
+    const events = await sessionQueries.getSessionEventsAfter(db, id, cursor, EVENTS_PAGE_LIMIT);
+    const nextCursor = events.length > 0 ? events[events.length - 1].id : cursor;
+
+    return c.json({ success: true as const, data: events.map(serializeEvent), nextCursor }, 200);
+  },
+);
+
+// =============================================================================
+// PATCH /sessions/:id/docs/:docType/:docId  -  field patch (autosave)
+// =============================================================================
+
+app.openapi(
+  createRoute({
+    method: 'patch',
+    path: '/sessions/{id}/docs/{docType}/{docId}',
+    tags: ['content'],
+    summary: 'Patch a draft field in an edit session',
+    request: {
+      params: z.object({
+        id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+        docType: z.string().openapi({ param: { name: 'docType', in: 'path' } }),
+        docId: z.string().openapi({ param: { name: 'docId', in: 'path' } }),
+      }),
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({ path: z.string().min(1), value: z.unknown() }),
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({ success: z.literal(true), data: SessionDocSchema }),
+          },
+        },
+        description: 'Draft patched',
+      },
+      400: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Bad request' },
+      404: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Not found' },
+      409: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Session not open',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const user = requireContentEditor(c.get('user'));
+    const { id, docType, docId } = c.req.valid('param');
+    const { path, value } = c.req.valid('json');
+
+    const session = await sessionQueries.getEditSessionById(db, id);
+    if (!session) throw new HTTPException(404, { message: 'Session not found' });
+    if (session.status !== 'open') {
+      throw new HTTPException(409, { message: 'Session is not open' });
+    }
+    if (docType !== 'page') {
+      throw new HTTPException(400, {
+        message: `Editing '${docType}' docs is supported in a later slice`,
+      });
+    }
+
+    let doc = await sessionQueries.getSessionDoc(db, id, docType, docId);
+    if (!doc) {
+      // First patch on this doc: materialize the overlay from the live page.
+      const page = await sessionQueries.getLivePage(db, docId);
+      if (!page) throw new HTTPException(404, { message: 'Page not found' });
+      doc = await sessionQueries.insertSessionDoc(db, {
+        id: crypto.randomUUID(),
+        sessionId: id,
+        docType,
+        docId,
+        draft: materializePageDraft(page),
+        baseVersion: page.version,
+        updatedBy: user.id,
+      });
+      if (!doc) throw new HTTPException(500, { message: 'Failed to materialize draft' });
+    }
+
+    const nextDraft = structuredClone(doc.draft);
+    setAtPath(nextDraft, path, value);
+
+    const updated = await sessionQueries.updateSessionDocDraft(db, doc.id, {
+      draft: nextDraft,
+      updatedBy: user.id,
+    });
+    if (!updated) throw new HTTPException(500, { message: 'Failed to save draft' });
+
+    await sessionQueries.insertSessionEvent(db, {
+      sessionId: id,
+      actorId: user.id,
+      actorKind: actorKindFor(user),
+      type: 'patched',
+      payload: { docType, docId, path },
+    });
+
+    return c.json({ success: true as const, data: serializeDoc(updated) }, 200);
+  },
+);
+
+// =============================================================================
+// POST /sessions/:id/publish  -  optimistic, all-or-nothing publish
+// =============================================================================
+
+app.openapi(
+  createRoute({
+    method: 'post',
+    path: '/sessions/{id}/publish',
+    tags: ['content'],
+    summary: 'Publish an edit session',
+    request: { params: IdParam },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.literal(true),
+              data: SessionSchema,
+              publishedDocs: z.number(),
+            }),
+          },
+        },
+        description: 'Session published',
+      },
+      400: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Unsupported doc type',
+      },
+      404: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Not found' },
+      409: {
+        content: { 'application/json': { schema: ConflictSchema } },
+        description: 'Version conflict or session not open',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const user = requireContentEditor(c.get('user'));
+    const { id } = c.req.valid('param');
+
+    const session = await sessionQueries.getEditSessionById(db, id);
+    if (!session) throw new HTTPException(404, { message: 'Session not found' });
+    if (session.status !== 'open') {
+      throw new HTTPException(409, { message: 'Session is not open' });
+    }
+
+    const docs = await sessionQueries.getSessionDocs(db, id);
+
+    const unsupported = docs.find((d) => d.docType !== 'page');
+    if (unsupported) {
+      throw new HTTPException(400, {
+        message: `Publishing '${unsupported.docType}' docs is supported in a later slice`,
+      });
+    }
+
+    const publishedAt = new Date();
+
+    // Phase 1  -  read + verify every doc's base version before any write.
+    // Any conflict fails the whole publish with per-doc detail (no partial publish).
+    const live = new Map<string, Page>();
+    const conflicts: Array<Record<string, unknown>> = [];
+    for (const doc of docs) {
+      const page = await sessionQueries.getLivePage(db, doc.docId);
+      if (!page) {
+        conflicts.push({ docType: doc.docType, docId: doc.docId, reason: 'not_found' });
+        continue;
+      }
+      if (page.version !== doc.baseVersion) {
+        conflicts.push({
+          docType: doc.docType,
+          docId: doc.docId,
+          reason: 'version_conflict',
+          baseVersion: doc.baseVersion,
+          currentVersion: page.version,
+        });
+        continue;
+      }
+      live.set(doc.docId, page);
+    }
+    if (conflicts.length > 0) {
+      return c.json({ success: false as const, error: 'publish_conflict', conflicts }, 409);
+    }
+
+    // Phase 2  -  guarded writes. Each update is version-guarded (WHERE version =
+    // baseVersion); a guard miss means a writer slipped in after the read phase.
+    for (const doc of docs) {
+      const draft = doc.draft;
+      const basePage = live.get(doc.docId) as Page;
+      const title = typeof draft.title === 'string' ? draft.title : basePage.title;
+      const blocks = Array.isArray(draft.blocks) ? (draft.blocks as unknown[]) : null;
+      const seo = draft.seo ?? null;
+
+      const updatedPage = await sessionQueries.publishDraftToPage(db, {
+        pageId: doc.docId,
+        expectedVersion: doc.baseVersion,
+        title,
+        blocks,
+        seo,
+        publishedAt,
+      });
+      if (!updatedPage) {
+        return c.json(
+          {
+            success: false as const,
+            error: 'publish_conflict',
+            conflicts: [{ docType: doc.docType, docId: doc.docId, reason: 'version_conflict' }],
+          },
+          409,
+        );
+      }
+
+      const revisionNumber = await sessionQueries.nextPageRevisionNumber(db, doc.docId);
+      await sessionQueries.insertPageRevision(db, {
+        id: crypto.randomUUID(),
+        pageId: doc.docId,
+        createdBy: user.id,
+        revisionNumber,
+        title: updatedPage.title,
+        blocks: updatedPage.blocks ?? null,
+        seo: updatedPage.seo ?? null,
+        changeDescription: `Published via edit session ${id}`,
+      });
+      await sessionQueries.prunePageRevisions(db, doc.docId, MAX_REVISIONS_PER_DOC);
+    }
+
+    const published = await sessionQueries.setEditSessionStatus(db, id, {
+      status: 'published',
+      publishedAt,
+    });
+    if (!published) throw new HTTPException(500, { message: 'Failed to publish session' });
+
+    await sessionQueries.insertSessionEvent(db, {
+      sessionId: id,
+      actorId: user.id,
+      actorKind: actorKindFor(user),
+      type: 'published',
+      payload: { docCount: docs.length },
+    });
+
+    return c.json(
+      { success: true as const, data: serializeSession(published), publishedDocs: docs.length },
+      200,
+    );
+  },
+);
+
+// =============================================================================
+// DELETE /sessions/:id  -  discard (overlay rows retained for audit)
+// =============================================================================
+
+app.openapi(
+  createRoute({
+    method: 'delete',
+    path: '/sessions/{id}',
+    tags: ['content'],
+    summary: 'Discard an edit session',
+    request: { params: IdParam },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({ success: z.literal(true), data: SessionSchema }),
+          },
+        },
+        description: 'Session discarded',
+      },
+      404: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Not found' },
+      409: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Session not open',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const user = requireContentEditor(c.get('user'));
+    const { id } = c.req.valid('param');
+
+    const session = await sessionQueries.getEditSessionById(db, id);
+    if (!session) throw new HTTPException(404, { message: 'Session not found' });
+    if (session.status !== 'open') {
+      throw new HTTPException(409, { message: 'Session is not open' });
+    }
+
+    const discarded = await sessionQueries.setEditSessionStatus(db, id, {
+      status: 'discarded',
+      publishedAt: session.publishedAt,
+    });
+    if (!discarded) throw new HTTPException(500, { message: 'Failed to discard session' });
+
+    await sessionQueries.insertSessionEvent(db, {
+      sessionId: id,
+      actorId: user.id,
+      actorKind: actorKindFor(user),
+      type: 'discarded',
+      payload: null,
+    });
+
+    return c.json({ success: true as const, data: serializeSession(discarded) }, 200);
+  },
+);
+
+export default app;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,7 +69,7 @@ RevealUI is a Postgres-primary stack with comprehensive type safety, optional si
 
 ### Core Systems
 
-1. **NeonDB (POSTGRES_URL — primary)**: Transactional REST API source. Houses 93 tables including `agent_memories` and other vector-typed tables (NeonDB supports `pgvector`). Source of truth for the application.
+1. **NeonDB (POSTGRES_URL — primary)**: Transactional REST API source. Houses 96 tables including `agent_memories` and other vector-typed tables (NeonDB supports `pgvector`). Source of truth for the application.
 2. **Supabase (legacy RAG sidecar — retired for internal use)**: Historically hosted `rag_chunks` and related embedding tables; RAG embeddings now live on NeonDB `pgvector` and the sidecar was retired for internal use per the [Supabase-removal ADR](decisions/2026-05-01-supabase-removal.md). Legacy Supabase code remains in tree during phase-out.
 3. **ElectricSQL (optional sync layer)**: Real-time synchronization for agent contexts and conversations when enabled (env vars are off by default).
 4. **Vercel AI SDK**: Streaming AI completions with React hooks

--- a/docs/DEPLOYMENT-RUNBOOK.md
+++ b/docs/DEPLOYMENT-RUNBOOK.md
@@ -207,7 +207,7 @@ See [Section 5](#5-database-migration-steps) for details.
 
 - **Primary database**: NeonDB (PostgreSQL, Drizzle ORM)
 - **Secondary database**: ~~Supabase~~ **Legacy — retired per ADR `2026-05-01-supabase-removal.md`. Current stack: Neon (primary) + ElectricSQL (sync).**
-- **Schema definitions**: `packages/db/src/schema/` (93 tables)
+- **Schema definitions**: `packages/db/src/schema/` (96 tables)
 - **Migration files**: `packages/db/migrations/`
 - **ORM config**: `packages/db/drizzle.config.ts`
 

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -90,7 +90,7 @@ All gates must pass on the `main` branch before deploy.
 
 - [ ] `pnpm db:migrate` runs clean against production database **(blocking)**
 - [ ] Migration drift check passes (validated in `deploy.yml`) **(blocking)**
-- [ ] All 93 tables exist with correct schemas **(blocking)**
+- [ ] All 96 tables exist with correct schemas **(blocking)**
 - [ ] `pnpm db:seed` populates required initial data (admin user, default site) **(blocking)**
 - [ ] Indexes verified for high-traffic queries **(blocking)**
 - [ ] `circuit_breaker_state` table exists (Stripe resilience) **(blocking)**

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -107,7 +107,7 @@ Before starting the dev server, initialize the database schema:
 pnpm db:migrate
 ```
 
-This creates all 93 tables. If you see a connection error, double-check your `POSTGRES_URL`  -  it must include `?sslmode=require` for NeonDB.
+This creates all 96 tables. If you see a connection error, double-check your `POSTGRES_URL`  -  it must include `?sslmode=require` for NeonDB.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,7 +45,7 @@ Alpha = functional, not deployed/published. Planned = design or schema only.
 - **Billing stack**  -  Stripe checkout, subscriptions, webhooks, license keys, billing portal, tier enforcement (free/pro/max/enterprise)
 - **UI components**  -  59 native React 19 components in `@revealui/presentation` (80 with `@revealui/core` admin/richtext); Tailwind v4, zero external UI deps
 - **Real-time sync**  -  ElectricSQL integration for editor/client/agent sync _(experimental  -  basic shape subscriptions, no offline-first)_
-- **Database**  -  93 tables via Drizzle ORM. Neon (primary) + ElectricSQL (sync). Supabase retired per ADR `2026-05-01-supabase-removal.md`.
+- **Database**  -  96 tables via Drizzle ORM. Neon (primary) + ElectricSQL (sync). Supabase retired per ADR `2026-05-01-supabase-removal.md`.
 - **CLI**  -  `npx create-revealui my-app` scaffolds a full project from npm
 - **AI agents**  -  A2A protocol, CRDT memory, open-model inference, streaming, tool execution
 - **MCP servers**  -  12 first-party servers under `packages/mcp/src/servers/` (Stripe, Neon, Supabase, Vercel, Playwright, Code Validator, Next.js DevTools, RevealUI Content / Email / Memory / Stripe, plus the adapter base class)

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -25,7 +25,7 @@ and a REST API. The heart of RevealUI and the most mature part of the codebase.
 **65 native React components in `@revealui/presentation`** (plus admin and rich-text UI in `@revealui/core`), built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn). Just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
 
 ### Database schema
-**93 PostgreSQL tables** with Drizzle ORM, **72 CHECK constraints** enforced at the database level. NeonDB is the primary database (REST + agent memories via pgvector). Supabase is an optional sidecar today (RAG chunks + a legacy duplicate billing copy); Phase 7 in the roadmap consolidates RAG onto NeonDB pgvector and retires the Supabase dependency. ElectricSQL is an optional sync layer (off by default).
+**96 PostgreSQL tables** with Drizzle ORM, **72 CHECK constraints** enforced at the database level. NeonDB is the primary database (REST + agent memories via pgvector). Supabase is an optional sidecar today (RAG chunks + a legacy duplicate billing copy); Phase 7 in the roadmap consolidates RAG onto NeonDB pgvector and retires the Supabase dependency. ElectricSQL is an optional sync layer (off by default).
 
 ### Rich text editing
 Lexical-based rich text editor with custom nodes, serialization, and a plugin system.

--- a/docs/architecture/ADR-002-dual-database.md
+++ b/docs/architecture/ADR-002-dual-database.md
@@ -19,7 +19,7 @@ RevealUI needs both transactional SQL (users, content, billing, auth) and vector
 
 Two PostgreSQL databases, each with a distinct role:
 
-1. **NeonDB** (primary)  -  All transactional data: users, content, billing, sessions, auth, marketplace. Accessed via Drizzle ORM over HTTP (serverless-compatible). 93 tables. Schema managed by drizzle-kit migrations.
+1. **NeonDB** (primary)  -  All transactional data: users, content, billing, sessions, auth, marketplace. Accessed via Drizzle ORM over HTTP (serverless-compatible). 96 tables. Schema managed by drizzle-kit migrations.
 
 2. **Supabase** (vectors/auth)  -  Vector embeddings for AI memory, semantic search, and agent context. Accessed via the Supabase JS client. Also hosts Supabase Auth for social OAuth flows (GitHub, Google, Vercel) which redirect tokens back to RevealUI's session-based auth.
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -230,7 +230,7 @@ This is the part that's genuinely hard to replicate by stitching services togeth
 Some numbers on what's actually shipped:
 
 - **32 workspaces** across the monorepo (4 apps, 28 packages with 22 MIT, 5 Fair Source, 1 internal)
-- **93 database tables** via Drizzle ORM on NeonDB (Postgres)
+- **96 database tables** via Drizzle ORM on NeonDB (Postgres)
 - **65 UI components** in `@revealui/presentation`, with one third-party runtime dependency (`tailwind-merge`), built directly on Tailwind v4 and React, with `cva` and `cn` vendored in-package
 - **14 first-party MCP servers** in `@revealui/mcp`
 - **Extensive test coverage** across unit, integration, and E2E layers (run `pnpm test` for the current count)

--- a/docs/blog/10-own-your-data.md
+++ b/docs/blog/10-own-your-data.md
@@ -13,7 +13,7 @@ RevealUI takes the opposite position on every one of those. The database is stan
 
 ## Standard Postgres, not a proprietary database
 
-RevealUI runs on Postgres. Specifically NeonDB, which is Postgres, the real thing, with the standard wire protocol and `pg_dump` that does exactly what you expect. The schema is 93 tables defined with Drizzle ORM, typed end to end, and it is not hiding any vendor-only behavior in the hot path.
+RevealUI runs on Postgres. Specifically NeonDB, which is Postgres, the real thing, with the standard wire protocol and `pg_dump` that does exactly what you expect. The schema is 96 tables defined with Drizzle ORM, typed end to end, and it is not hiding any vendor-only behavior in the hot path.
 
 That choice has a few consequences worth naming:
 

--- a/docs/blog/14-claim-drift.md
+++ b/docs/blog/14-claim-drift.md
@@ -45,7 +45,7 @@ claim-drift: docs/blog/09-component-library.md
   -> fix the copy or fix the count, but they must agree
 ```
 
-That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 28 packages, 65 UI components, 14 first-party MCP servers, 93 database tables, 60 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
+That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 28 packages, 65 UI components, 14 first-party MCP servers, 96 database tables, 60 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
 
 ## The validator practices what we preach
 

--- a/docs/guides/technology-stack.md
+++ b/docs/guides/technology-stack.md
@@ -22,7 +22,7 @@ RevealUI is a framework, not a stack. The five primitives (people, content, offe
 
 | Choice | Role | Why |
 |---|---|---|
-| **NeonDB** (Postgres) | Primary database — 93 tables across the five primitives | Serverless Postgres; pgvector supported; any standard Postgres works as a substitute (the agnosticism principle is a contract, not a coupling). |
+| **NeonDB** (Postgres) | Primary database — 96 tables across the five primitives | Serverless Postgres; pgvector supported; any standard Postgres works as a substitute (the agnosticism principle is a contract, not a coupling). |
 | **Drizzle ORM** | Schema definition + type-safe queries | Schema-first, accurate types, no runtime overhead, no proprietary query DSL. |
 | **Cloudflare R2** | Canonical object-storage backend | S3-compatible, no egress fees; `@aws-sdk/client-s3` is the client. The legacy Vercel Blob backend is being retired per GAP-208. |
 | **ElectricSQL** (optional) | Real-time browser sync layer | Off by default. When enabled, syncs Postgres tables to a local PGlite store in the browser for offline-capable UIs. |

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -46,7 +46,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 |----|---------|---------|----------|---------------------|
 | PKG-001 | @revealui/core | Admin engine, REST API, auth, rich text, plugins | npm | Public |
 | PKG-002 | @revealui/contracts | Zod schemas + TypeScript types (single source of truth) | npm | Public |
-| PKG-003 | @revealui/db | Drizzle ORM schema (93 tables) on NeonDB (Postgres) | npm | Public |
+| PKG-003 | @revealui/db | Drizzle ORM schema (96 tables) on NeonDB (Postgres) | npm | Public |
 | PKG-004 | @revealui/auth | Session auth, password reset, rate limiting | npm | Public |
 | PKG-005 | @revealui/presentation | 65 native UI components (Tailwind v4) | npm | Public |
 | PKG-006 | @revealui/router | Lightweight file-based router with SSR | npm | Public |
@@ -82,7 +82,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 
 ### 3.1 Data Categories by Store
 
-**NeonDB (DS-001):** Primary relational data across 93 tables.
+**NeonDB (DS-001):** Primary relational data across 96 tables.
 - User accounts, profiles, and PII (email, name)
 - Session tokens and password hashes (bcrypt, 12 rounds)
 - Content (pages, products, collections)

--- a/docs/security/VENDOR_RISK_ASSESSMENTS.md
+++ b/docs/security/VENDOR_RISK_ASSESSMENTS.md
@@ -68,7 +68,7 @@ Each vendor is evaluated against the following criteria:
 | Backup/Recovery | Continuous PITR (Point-in-Time Recovery) | RPO: near-zero, RTO: minutes |
 
 **Data shared with Neon:**
-- All relational data across 93 tables (users, content, products, sessions, payments metadata)
+- All relational data across 96 tables (users, content, products, sessions, payments metadata)
 - Connection metadata and query execution logs
 
 **Compensating controls:**

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -821,6 +821,84 @@ export const CrdtOperationsInsertContract = createContract({
 })
 
 // =============================================================================
+// EditSessionDocs Contracts
+// =============================================================================
+
+/**
+ * Contract for editSessionDocs row (Select)
+ * Database table: edit_session_docs
+ */
+export const EditSessionDocsRowContract = createContract({
+  name: 'EditSessionDocsRow',
+  version: '1',
+  description: 'Database row contract for edit_session_docs table',
+  schema: Schemas.EditSessionDocsSelectSchema,
+})
+
+/**
+ * Contract for editSessionDocs insert
+ * Database table: edit_session_docs
+ */
+export const EditSessionDocsInsertContract = createContract({
+  name: 'EditSessionDocsInsert',
+  version: '1',
+  description: 'Database insert contract for edit_session_docs table',
+  schema: Schemas.EditSessionDocsInsertSchema,
+})
+
+// =============================================================================
+// EditSessionEvents Contracts
+// =============================================================================
+
+/**
+ * Contract for editSessionEvents row (Select)
+ * Database table: edit_session_events
+ */
+export const EditSessionEventsRowContract = createContract({
+  name: 'EditSessionEventsRow',
+  version: '1',
+  description: 'Database row contract for edit_session_events table',
+  schema: Schemas.EditSessionEventsSelectSchema,
+})
+
+/**
+ * Contract for editSessionEvents insert
+ * Database table: edit_session_events
+ */
+export const EditSessionEventsInsertContract = createContract({
+  name: 'EditSessionEventsInsert',
+  version: '1',
+  description: 'Database insert contract for edit_session_events table',
+  schema: Schemas.EditSessionEventsInsertSchema,
+})
+
+// =============================================================================
+// EditSessions Contracts
+// =============================================================================
+
+/**
+ * Contract for editSessions row (Select)
+ * Database table: edit_sessions
+ */
+export const EditSessionsRowContract = createContract({
+  name: 'EditSessionsRow',
+  version: '1',
+  description: 'Database row contract for edit_sessions table',
+  schema: Schemas.EditSessionsSelectSchema,
+})
+
+/**
+ * Contract for editSessions insert
+ * Database table: edit_sessions
+ */
+export const EditSessionsInsertContract = createContract({
+  name: 'EditSessionsInsert',
+  version: '1',
+  description: 'Database insert contract for edit_sessions table',
+  schema: Schemas.EditSessionsInsertSchema,
+})
+
+// =============================================================================
 // ErrorEvents Contracts
 // =============================================================================
 

--- a/packages/contracts/src/generated/zod-schemas.ts
+++ b/packages/contracts/src/generated/zod-schemas.ts
@@ -820,6 +820,84 @@ export type CrdtOperationsRow = z.infer<typeof CrdtOperationsSelectSchema>
 export type CrdtOperationsInsert = z.infer<typeof CrdtOperationsInsertSchema>
 
 // =============================================================================
+// EditSessionDocs Schemas
+// =============================================================================
+
+/**
+ * Zod schema for selecting editSessionDocs rows from database
+ * Generated from Drizzle table definition: tables.editSessionDocs
+ */
+export const EditSessionDocsSelectSchema = createSelectSchema(tables.editSessionDocs)
+
+/**
+ * Zod schema for inserting editSessionDocs rows to database
+ * Generated from Drizzle table definition: tables.editSessionDocs
+ */
+export const EditSessionDocsInsertSchema = createInsertSchema(tables.editSessionDocs)
+
+/**
+ * TypeScript type for editSessionDocs row (Select)
+ */
+export type EditSessionDocsRow = z.infer<typeof EditSessionDocsSelectSchema>
+
+/**
+ * TypeScript type for editSessionDocs insert
+ */
+export type EditSessionDocsInsert = z.infer<typeof EditSessionDocsInsertSchema>
+
+// =============================================================================
+// EditSessionEvents Schemas
+// =============================================================================
+
+/**
+ * Zod schema for selecting editSessionEvents rows from database
+ * Generated from Drizzle table definition: tables.editSessionEvents
+ */
+export const EditSessionEventsSelectSchema = createSelectSchema(tables.editSessionEvents)
+
+/**
+ * Zod schema for inserting editSessionEvents rows to database
+ * Generated from Drizzle table definition: tables.editSessionEvents
+ */
+export const EditSessionEventsInsertSchema = createInsertSchema(tables.editSessionEvents)
+
+/**
+ * TypeScript type for editSessionEvents row (Select)
+ */
+export type EditSessionEventsRow = z.infer<typeof EditSessionEventsSelectSchema>
+
+/**
+ * TypeScript type for editSessionEvents insert
+ */
+export type EditSessionEventsInsert = z.infer<typeof EditSessionEventsInsertSchema>
+
+// =============================================================================
+// EditSessions Schemas
+// =============================================================================
+
+/**
+ * Zod schema for selecting editSessions rows from database
+ * Generated from Drizzle table definition: tables.editSessions
+ */
+export const EditSessionsSelectSchema = createSelectSchema(tables.editSessions)
+
+/**
+ * Zod schema for inserting editSessions rows to database
+ * Generated from Drizzle table definition: tables.editSessions
+ */
+export const EditSessionsInsertSchema = createInsertSchema(tables.editSessions)
+
+/**
+ * TypeScript type for editSessions row (Select)
+ */
+export type EditSessionsRow = z.infer<typeof EditSessionsSelectSchema>
+
+/**
+ * TypeScript type for editSessions insert
+ */
+export type EditSessionsInsert = z.infer<typeof EditSessionsInsertSchema>
+
+// =============================================================================
 // ErrorEvents Schemas
 // =============================================================================
 

--- a/packages/db/migrations/0027_open_storm.sql
+++ b/packages/db/migrations/0027_open_storm.sql
@@ -1,0 +1,48 @@
+CREATE TABLE IF NOT EXISTS "edit_sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"site_id" text NOT NULL,
+	"title" text NOT NULL,
+	"status" text DEFAULT 'open' NOT NULL,
+	"created_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"published_at" timestamp with time zone,
+	CONSTRAINT "edit_sessions_status_check" CHECK (status IN ('open', 'published', 'discarded'))
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "edit_session_docs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"doc_type" text NOT NULL,
+	"doc_id" text NOT NULL,
+	"draft" jsonb NOT NULL,
+	"base_version" integer NOT NULL,
+	"updated_by" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "edit_session_docs_doc_type_check" CHECK (doc_type IN ('page', 'global', 'post'))
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "edit_session_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"actor_id" text,
+	"actor_kind" text NOT NULL,
+	"type" text NOT NULL,
+	"payload" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "edit_session_events_actor_kind_check" CHECK (actor_kind IN ('human', 'agent')),
+	CONSTRAINT "edit_session_events_type_check" CHECK (type IN ('opened', 'patched', 'commented', 'publish_requested', 'published', 'discarded'))
+);
+--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "edit_sessions" ADD CONSTRAINT "edit_sessions_site_id_sites_id_fk" FOREIGN KEY ("site_id") REFERENCES "public"."sites"("id") ON DELETE cascade ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "edit_sessions" ADD CONSTRAINT "edit_sessions_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "edit_session_docs" ADD CONSTRAINT "edit_session_docs_session_id_edit_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."edit_sessions"("id") ON DELETE cascade ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "edit_session_docs" ADD CONSTRAINT "edit_session_docs_updated_by_users_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TABLE "edit_session_events" ADD CONSTRAINT "edit_session_events_session_id_edit_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."edit_sessions"("id") ON DELETE cascade ON UPDATE no action; EXCEPTION WHEN duplicate_object THEN NULL; END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "edit_sessions_site_id_idx" ON "edit_sessions" USING btree ("site_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "edit_sessions_status_idx" ON "edit_sessions" USING btree ("status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "edit_sessions_site_status_idx" ON "edit_sessions" USING btree ("site_id","status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "edit_session_docs_session_id_idx" ON "edit_session_docs" USING btree ("session_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "edit_session_docs_session_doc_idx" ON "edit_session_docs" USING btree ("session_id","doc_type","doc_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "edit_session_events_session_id_idx" ON "edit_session_events" USING btree ("session_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "edit_session_events_session_id_id_idx" ON "edit_session_events" USING btree ("session_id","id");

--- a/packages/db/migrations/meta/0027_snapshot.json
+++ b/packages/db/migrations/meta/0027_snapshot.json
@@ -1,0 +1,12355 @@
+{
+  "id": "06d0116d-96b8-40aa-a248-31da033f418e",
+  "prevId": "cf97ab7d-16ba-4717-89ec-67319cff04ea",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.kg_edge_episodes": {
+      "name": "kg_edge_episodes",
+      "schema": "",
+      "columns": {
+        "edge_id": {
+          "name": "edge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kg_edge_episodes_edge_id_kg_edges_id_fk": {
+          "name": "kg_edge_episodes_edge_id_kg_edges_id_fk",
+          "tableFrom": "kg_edge_episodes",
+          "tableTo": "kg_edges",
+          "columnsFrom": [
+            "edge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kg_edge_episodes_episode_id_kg_episodes_id_fk": {
+          "name": "kg_edge_episodes_episode_id_kg_episodes_id_fk",
+          "tableFrom": "kg_edge_episodes",
+          "tableTo": "kg_episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kg_edge_episodes_edge_id_episode_id_pk": {
+          "name": "kg_edge_episodes_edge_id_episode_id_pk",
+          "columns": [
+            "edge_id",
+            "episode_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kg_edges": {
+      "name": "kg_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fact": {
+          "name": "fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_at": {
+          "name": "valid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_at": {
+          "name": "invalid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kg_edges_valid_at_idx": {
+          "name": "kg_edges_valid_at_idx",
+          "columns": [
+            {
+              "expression": "valid_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kg_edges_repo_idx": {
+          "name": "kg_edges_repo_idx",
+          "columns": [
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kg_edges_target_idx": {
+          "name": "kg_edges_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kg_edges_source_id_kg_nodes_id_fk": {
+          "name": "kg_edges_source_id_kg_nodes_id_fk",
+          "tableFrom": "kg_edges",
+          "tableTo": "kg_nodes",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kg_edges_target_id_kg_nodes_id_fk": {
+          "name": "kg_edges_target_id_kg_nodes_id_fk",
+          "tableFrom": "kg_edges",
+          "tableTo": "kg_nodes",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kg_episodes": {
+      "name": "kg_episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "episode_type": {
+          "name": "episode_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_ref": {
+          "name": "content_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "reference_time": {
+          "name": "reference_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kg_episodes_source_idx": {
+          "name": "kg_episodes_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kg_episodes_reference_time_idx": {
+          "name": "kg_episodes_reference_time_idx",
+          "columns": [
+            {
+              "expression": "reference_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kg_episodes_type_check": {
+          "name": "kg_episodes_type_check",
+          "value": "episode_type IN ('code-scan', 'git-commit', 'doc', 'agent-fact', 'memory', 'json', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kg_node_aliases": {
+      "name": "kg_node_aliases",
+      "schema": "",
+      "columns": {
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kg_node_aliases_node_id_kg_nodes_id_fk": {
+          "name": "kg_node_aliases_node_id_kg_nodes_id_fk",
+          "tableFrom": "kg_node_aliases",
+          "tableTo": "kg_nodes",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kg_node_aliases_alias_node_id_pk": {
+          "name": "kg_node_aliases_alias_node_id_pk",
+          "columns": [
+            "alias",
+            "node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kg_nodes": {
+      "name": "kg_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "natural_key": {
+          "name": "natural_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "attributes_clock": {
+          "name": "attributes_clock",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kg_nodes_natural_key_idx": {
+          "name": "kg_nodes_natural_key_idx",
+          "columns": [
+            {
+              "expression": "natural_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kg_nodes_kind_natural_key_idx": {
+          "name": "kg_nodes_kind_natural_key_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "natural_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kg_nodes_repo_idx": {
+          "name": "kg_nodes_repo_idx",
+          "columns": [
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kg_outbox": {
+      "name": "kg_outbox",
+      "schema": "",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op": {
+          "name": "op",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kg_outbox_pushed_at_idx": {
+          "name": "kg_outbox_pushed_at_idx",
+          "columns": [
+            {
+              "expression": "pushed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_actions": {
+      "name": "agent_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_actions_conversation_id_idx": {
+          "name": "agent_actions_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_actions_agent_id_idx": {
+          "name": "agent_actions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_actions_status_idx": {
+          "name": "agent_actions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_actions_conversation_id_conversations_id_fk": {
+          "name": "agent_actions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_actions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_actions_status_check": {
+          "name": "agent_actions_status_check",
+          "value": "status IN ('pending', 'running', 'completed', 'failed', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_contexts": {
+      "name": "agent_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_contexts_session_id_idx": {
+          "name": "agent_contexts_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_contexts_agent_id_idx": {
+          "name": "agent_contexts_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_contexts_session_id_ai_memory_sessions_id_fk": {
+          "name": "agent_contexts_session_id_ai_memory_sessions_id_fk",
+          "tableFrom": "agent_contexts",
+          "tableTo": "ai_memory_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_contexts_agent_id_registered_agents_id_fk": {
+          "name": "agent_contexts_agent_id_registered_agents_id_fk",
+          "tableFrom": "agent_contexts",
+          "tableTo": "registered_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_credit_balance": {
+      "name": "agent_credit_balance",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_purchased": {
+          "name": "total_purchased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_credit_balance_user_id_users_id_fk": {
+          "name": "agent_credit_balance_user_id_users_id_fk",
+          "tableFrom": "agent_credit_balance",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_credit_balance_non_negative": {
+          "name": "agent_credit_balance_non_negative",
+          "value": "balance >= 0"
+        },
+        "agent_credit_total_non_negative": {
+          "name": "agent_credit_total_non_negative",
+          "value": "total_purchased >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_credit_events": {
+      "name": "agent_credit_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tasks": {
+          "name": "tasks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_credit_events_user_id_users_id_fk": {
+          "name": "agent_credit_events_user_id_users_id_fk",
+          "tableFrom": "agent_credit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memories": {
+      "name": "agent_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_metadata": {
+          "name": "embedding_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "session_scope": {
+          "name": "session_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_facts": {
+          "name": "source_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_memories_site_id_idx": {
+          "name": "agent_memories_site_id_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memories_agent_id_idx": {
+          "name": "agent_memories_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memories_verified_idx": {
+          "name": "agent_memories_verified_idx",
+          "columns": [
+            {
+              "expression": "verified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memories_expires_at_idx": {
+          "name": "agent_memories_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memories_type_idx": {
+          "name": "agent_memories_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memories_scope_idx": {
+          "name": "agent_memories_scope_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memories_session_scope_idx": {
+          "name": "agent_memories_session_scope_idx",
+          "columns": [
+            {
+              "expression": "session_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_memories_verified_by_users_id_fk": {
+          "name": "agent_memories_verified_by_users_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "verified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_memories_site_id_sites_id_fk": {
+          "name": "agent_memories_site_id_sites_id_fk",
+          "tableFrom": "agent_memories",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_memories_type_check": {
+          "name": "agent_memories_type_check",
+          "value": "type IN ('fact', 'preference', 'decision', 'feedback', 'example', 'correction', 'skill', 'warning')"
+        },
+        "agent_memories_scope_check": {
+          "name": "agent_memories_scope_check",
+          "value": "scope IN ('private', 'shared', 'reconciled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_task_usage": {
+      "name": "agent_task_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cycle_start": {
+          "name": "cycle_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overage": {
+          "name": "overage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_task_usage_user_id_users_id_fk": {
+          "name": "agent_task_usage_user_id_users_id_fk",
+          "tableFrom": "agent_task_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_task_usage_user_id_cycle_start_pk": {
+          "name": "agent_task_usage_user_id_cycle_start_pk",
+          "columns": [
+            "user_id",
+            "cycle_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_memory_sessions": {
+      "name": "ai_memory_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_memory_sessions_user_id_users_id_fk": {
+          "name": "ai_memory_sessions_user_id_users_id_fk",
+          "tableFrom": "ai_memory_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_status_idx": {
+          "name": "conversations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_status_check": {
+          "name": "conversations_status_check",
+          "value": "status IN ('active', 'archived', 'ended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_role_idx": {
+          "name": "messages_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messages_role_check": {
+          "name": "messages_role_check",
+          "value": "role IN ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.registered_agents": {
+      "name": "registered_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "registered_agents_updated_at_idx": {
+          "name": "registered_agents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_metadata": {
+      "name": "sync_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_timestamp": {
+          "name": "last_sync_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sync_version": {
+          "name": "sync_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "device_count": {
+          "name": "device_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "conflicts_resolved": {
+          "name": "conflicts_resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_conflict_at": {
+          "name": "last_conflict_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_metadata_user_id_idx": {
+          "name": "sync_metadata_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_metadata_user_id_users_id_fk": {
+          "name": "sync_metadata_user_id_users_id_fk",
+          "tableFrom": "sync_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_devices": {
+      "name": "user_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_issued_at": {
+          "name": "token_issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_devices_user_id_users_id_fk": {
+          "name": "user_devices_user_id_users_id_fk",
+          "tableFrom": "user_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_devices_device_id_unique": {
+          "name": "user_devices_device_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_devices_device_type_check": {
+          "name": "user_devices_device_type_check",
+          "value": "device_type IS NULL OR device_type IN ('desktop', 'mobile', 'tablet', 'cli')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_entitlements": {
+      "name": "account_entitlements",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "limits": {
+          "name": "limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metering_status": {
+          "name": "metering_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        },
+        "grace_until": {
+          "name": "grace_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_entitlements_tier_idx": {
+          "name": "account_entitlements_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_entitlements_status_idx": {
+          "name": "account_entitlements_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_entitlements_account_status_idx": {
+          "name": "account_entitlements_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_entitlements_mode_idx": {
+          "name": "account_entitlements_mode_idx",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_entitlements_account_id_accounts_id_fk": {
+          "name": "account_entitlements_account_id_accounts_id_fk",
+          "tableFrom": "account_entitlements",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_entitlements_tier_check": {
+          "name": "account_entitlements_tier_check",
+          "value": "tier IN ('free', 'pro', 'max', 'enterprise')"
+        },
+        "account_entitlements_status_check": {
+          "name": "account_entitlements_status_check",
+          "value": "status IN ('active', 'trialing', 'past_due', 'canceled', 'expired', 'revoked')"
+        },
+        "account_entitlements_metering_status_check": {
+          "name": "account_entitlements_metering_status_check",
+          "value": "metering_status IN ('active', 'paused', 'exceeded')"
+        },
+        "account_entitlements_mode_check": {
+          "name": "account_entitlements_mode_check",
+          "value": "mode IN ('live', 'test')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_memberships": {
+      "name": "account_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_memberships_account_user_idx": {
+          "name": "account_memberships_account_user_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_memberships_user_id_idx": {
+          "name": "account_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_memberships_account_id_idx": {
+          "name": "account_memberships_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_memberships_status_idx": {
+          "name": "account_memberships_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_memberships_account_id_accounts_id_fk": {
+          "name": "account_memberships_account_id_accounts_id_fk",
+          "tableFrom": "account_memberships",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_memberships_user_id_users_id_fk": {
+          "name": "account_memberships_user_id_users_id_fk",
+          "tableFrom": "account_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_memberships_role_check": {
+          "name": "account_memberships_role_check",
+          "value": "role IN ('owner', 'admin', 'member')"
+        },
+        "account_memberships_status_check": {
+          "name": "account_memberships_status_check",
+          "value": "status IN ('active', 'invited', 'revoked')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_subscriptions": {
+      "name": "account_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_subscriptions_stripe_subscription_idx": {
+          "name": "account_subscriptions_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_subscriptions_account_id_idx": {
+          "name": "account_subscriptions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_subscriptions_stripe_customer_idx": {
+          "name": "account_subscriptions_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_subscriptions_status_idx": {
+          "name": "account_subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_subscriptions_account_status_idx": {
+          "name": "account_subscriptions_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_subscriptions_mode_idx": {
+          "name": "account_subscriptions_mode_idx",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_subscriptions_account_id_accounts_id_fk": {
+          "name": "account_subscriptions_account_id_accounts_id_fk",
+          "tableFrom": "account_subscriptions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_subscriptions_status_check": {
+          "name": "account_subscriptions_status_check",
+          "value": "status IN ('active', 'past_due', 'canceled', 'trialing', 'unpaid', 'expired', 'revoked', 'paused')"
+        },
+        "account_subscriptions_mode_check": {
+          "name": "account_subscriptions_mode_check",
+          "value": "mode IN ('live', 'test')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_slug_idx": {
+          "name": "accounts_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_status_idx": {
+          "name": "accounts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_status_created_at_idx": {
+          "name": "accounts_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "accounts_status_check": {
+          "name": "accounts_status_check",
+          "value": "status IN ('active', 'suspended', 'closed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_catalog": {
+      "name": "billing_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_model": {
+          "name": "billing_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_catalog_plan_id_mode_idx": {
+          "name": "billing_catalog_plan_id_mode_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_catalog_tier_idx": {
+          "name": "billing_catalog_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_catalog_billing_model_idx": {
+          "name": "billing_catalog_billing_model_idx",
+          "columns": [
+            {
+              "expression": "billing_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_catalog_active_idx": {
+          "name": "billing_catalog_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_catalog_mode_idx": {
+          "name": "billing_catalog_mode_idx",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_catalog_tier_check": {
+          "name": "billing_catalog_tier_check",
+          "value": "tier IN ('free', 'pro', 'max', 'enterprise')"
+        },
+        "billing_catalog_billing_model_check": {
+          "name": "billing_catalog_billing_model_check",
+          "value": "billing_model IN ('subscription', 'perpetual', 'renewal', 'credits')"
+        },
+        "billing_catalog_mode_check": {
+          "name": "billing_catalog_mode_check",
+          "value": "mode IN ('live', 'test')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_meters": {
+      "name": "usage_meters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter_name": {
+          "name": "meter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errored": {
+          "name": "errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_meters_idempotency_key_idx": {
+          "name": "usage_meters_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meters_account_id_idx": {
+          "name": "usage_meters_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meters_meter_name_idx": {
+          "name": "usage_meters_meter_name_idx",
+          "columns": [
+            {
+              "expression": "meter_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meters_period_start_idx": {
+          "name": "usage_meters_period_start_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meters_account_period_idx": {
+          "name": "usage_meters_account_period_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_meters_account_id_accounts_id_fk": {
+          "name": "usage_meters_account_id_accounts_id_fk",
+          "tableFrom": "usage_meters",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "usage_meters_source_check": {
+          "name": "usage_meters_source_check",
+          "value": "source IN ('system', 'user', 'agent', 'api')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.global_footer": {
+      "name": "global_footer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "copyright": {
+          "name": "copyright",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_header": {
+      "name": "global_header",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "nav_items": {
+          "name": "nav_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "logo_id": {
+          "name": "logo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_settings": {
+      "name": "global_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_description": {
+          "name": "site_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_meta": {
+          "name": "default_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_profiles": {
+          "name": "social_profiles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analytics_id": {
+          "name": "analytics_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_point": {
+          "name": "focal_point",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes": {
+          "name": "sizes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_uploaded_by_users_id_fk": {
+          "name": "media_uploaded_by_users_id_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_image_id": {
+          "name": "featured_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "posts_author_id_idx": {
+          "name": "posts_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_featured_image_id_idx": {
+          "name": "posts_featured_image_id_idx",
+          "columns": [
+            {
+              "expression": "featured_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_deleted_at_idx": {
+          "name": "posts_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_featured_image_id_media_id_fk": {
+          "name": "posts_featured_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": [
+            "featured_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "posts_status_check": {
+          "name": "posts_status_check",
+          "value": "status IN ('draft', 'published', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_provider_configs": {
+      "name": "tenant_provider_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_provider_configs_user_id_idx": {
+          "name": "tenant_provider_configs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_provider_configs_user_id_users_id_fk": {
+          "name": "tenant_provider_configs_user_id_users_id_fk",
+          "tableFrom": "tenant_provider_configs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_api_keys": {
+      "name": "user_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hint": {
+          "name": "key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_api_keys_user_id_idx": {
+          "name": "user_api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_api_keys_user_provider_idx": {
+          "name": "user_api_keys_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_api_keys_deleted_at_idx": {
+          "name": "user_api_keys_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_api_keys_user_id_users_id_fk": {
+          "name": "user_api_keys_user_id_users_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_api_keys_provider_check": {
+          "name": "user_api_keys_provider_check",
+          "value": "provider IN ('anthropic', 'openai', 'groq', 'huggingface', 'inference-snaps', 'ollama')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_logs": {
+      "name": "app_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_logs_timestamp_idx": {
+          "name": "app_logs_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_app_level_idx": {
+          "name": "app_logs_app_level_idx",
+          "columns": [
+            {
+              "expression": "app",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_logs_level_check": {
+          "name": "app_logs_level_check",
+          "value": "level IN ('warn', 'error', 'fatal')"
+        },
+        "app_logs_app_check": {
+          "name": "app_logs_app_check",
+          "value": "app IN ('admin', 'api', 'marketing', 'mainframe')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "policy_violations": {
+          "name": "policy_violations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_signature": {
+          "name": "previous_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_event_type_idx": {
+          "name": "audit_log_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_agent_id_idx": {
+          "name": "audit_log_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_timestamp_idx": {
+          "name": "audit_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_severity_idx": {
+          "name": "audit_log_severity_idx",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_seq_idx": {
+          "name": "audit_log_seq_idx",
+          "columns": [
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_tenant_idx": {
+          "name": "audit_log_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_severity_check": {
+          "name": "audit_log_severity_check",
+          "value": "severity IN ('info', 'warn', 'critical')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.circuit_breaker_state": {
+      "name": "circuit_breaker_state",
+      "schema": "",
+      "columns": {
+        "service_name": {
+          "name": "service_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'closed'"
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_changed_at": {
+          "name": "state_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "circuit_breaker_state_at_idx": {
+          "name": "circuit_breaker_state_at_idx",
+          "columns": [
+            {
+              "expression": "state_changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "circuit_breaker_state_check": {
+          "name": "circuit_breaker_state_check",
+          "value": "state IN ('closed', 'open', 'half-open')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.code_provenance": {
+      "name": "code_provenance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "function_name": {
+          "name": "function_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_start": {
+          "name": "line_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_end": {
+          "name": "line_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_type": {
+          "name": "author_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_session_id": {
+          "name": "ai_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_commit_hash": {
+          "name": "git_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_author": {
+          "name": "git_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreviewed'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines_of_code": {
+          "name": "lines_of_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_provenance_reviewed_by_users_id_fk": {
+          "name": "code_provenance_reviewed_by_users_id_fk",
+          "tableFrom": "code_provenance",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "code_provenance_author_type_check": {
+          "name": "code_provenance_author_type_check",
+          "value": "author_type IN ('ai_generated', 'human_written', 'ai_assisted', 'mixed')"
+        },
+        "code_provenance_review_status_check": {
+          "name": "code_provenance_review_status_check",
+          "value": "review_status IN ('unreviewed', 'reviewed', 'approved', 'rejected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.code_reviews": {
+      "name": "code_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provenance_id": {
+          "name": "provenance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_type": {
+          "name": "review_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_reviews_provenance_id_code_provenance_id_fk": {
+          "name": "code_reviews_provenance_id_code_provenance_id_fk",
+          "tableFrom": "code_reviews",
+          "tableTo": "code_provenance",
+          "columnsFrom": [
+            "provenance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "code_reviews_reviewer_id_users_id_fk": {
+          "name": "code_reviews_reviewer_id_users_id_fk",
+          "tableFrom": "code_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "code_reviews_review_type_check": {
+          "name": "code_reviews_review_type_check",
+          "value": "review_type IN ('human_review', 'ai_review', 'human_approval', 'ai_suggestion')"
+        },
+        "code_reviews_status_check": {
+          "name": "code_reviews_status_check",
+          "value": "status IN ('approved', 'rejected', 'needs_changes', 'informational')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collab_edits": {
+      "name": "collab_edits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_type": {
+          "name": "client_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_model": {
+          "name": "agent_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_data": {
+          "name": "update_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "update_size": {
+          "name": "update_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collab_edits_document_id_idx": {
+          "name": "collab_edits_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collab_edits_document_id_yjs_documents_id_fk": {
+          "name": "collab_edits_document_id_yjs_documents_id_fk",
+          "tableFrom": "collab_edits",
+          "tableTo": "yjs_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coordination_agents": {
+      "name": "coordination_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "total_sessions": {
+          "name": "total_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "coordination_agents_last_seen_idx": {
+          "name": "coordination_agents_last_seen_idx",
+          "columns": [
+            {
+              "expression": "last_seen",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coordination_events": {
+      "name": "coordination_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "coordination_events_agent_type_idx": {
+          "name": "coordination_events_agent_type_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coordination_events_session_id_coordination_sessions_id_fk": {
+          "name": "coordination_events_session_id_coordination_sessions_id_fk",
+          "tableFrom": "coordination_events",
+          "tableTo": "coordination_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coordination_file_claims": {
+      "name": "coordination_file_claims",
+      "schema": "",
+      "columns": {
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "coordination_file_claims_session_id_idx": {
+          "name": "coordination_file_claims_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coordination_file_claims_session_id_coordination_sessions_id_fk": {
+          "name": "coordination_file_claims_session_id_coordination_sessions_id_fk",
+          "tableFrom": "coordination_file_claims",
+          "tableTo": "coordination_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coordination_file_claims_file_path_session_id_pk": {
+          "name": "coordination_file_claims_file_path_session_id_pk",
+          "columns": [
+            "file_path",
+            "session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coordination_mail": {
+      "name": "coordination_mail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_agent": {
+          "name": "from_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_agent": {
+          "name": "to_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "coordination_mail_to_read_idx": {
+          "name": "coordination_mail_to_read_idx",
+          "columns": [
+            {
+              "expression": "to_agent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coordination_queue_items": {
+      "name": "coordination_queue_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "from_agent": {
+          "name": "from_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed": {
+          "name": "consumed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "coordination_queue_target_consumed_idx": {
+          "name": "coordination_queue_target_consumed_idx",
+          "columns": [
+            {
+              "expression": "target_agent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "coordination_queue_items_priority_check": {
+          "name": "coordination_queue_items_priority_check",
+          "value": "priority IN ('low', 'normal', 'high', 'urgent')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.coordination_sessions": {
+      "name": "coordination_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'(starting)'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "coordination_sessions_agent_status_idx": {
+          "name": "coordination_sessions_agent_status_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "coordination_sessions_started_at_idx": {
+          "name": "coordination_sessions_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coordination_sessions_agent_id_coordination_agents_id_fk": {
+          "name": "coordination_sessions_agent_id_coordination_agents_id_fk",
+          "tableFrom": "coordination_sessions",
+          "tableTo": "coordination_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "coordination_sessions_status_check": {
+          "name": "coordination_sessions_status_check",
+          "value": "status IN ('active', 'ended', 'crashed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.coordination_work_items": {
+      "name": "coordination_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_agent": {
+          "name": "owner_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_session": {
+          "name": "owner_session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "coordination_work_items_status_owner_idx": {
+          "name": "coordination_work_items_status_owner_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_agent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coordination_work_items_owner_session_coordination_sessions_id_fk": {
+          "name": "coordination_work_items_owner_session_coordination_sessions_id_fk",
+          "tableFrom": "coordination_work_items",
+          "tableTo": "coordination_sessions",
+          "columnsFrom": [
+            "owner_session"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "coordination_work_items_status_check": {
+          "name": "coordination_work_items_status_check",
+          "value": "status IN ('open', 'claimed', 'done', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.crdt_operations": {
+      "name": "crdt_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "crdt_id": {
+          "name": "crdt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crdt_type": {
+          "name": "crdt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crdt_operations_crdt_id_idx": {
+          "name": "crdt_operations_crdt_id_idx",
+          "columns": [
+            {
+              "expression": "crdt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crdt_operations_node_id_idx": {
+          "name": "crdt_operations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "crdt_operations_crdt_type_check": {
+          "name": "crdt_operations_crdt_type_check",
+          "value": "crdt_type IN ('lww_register', 'or_set', 'pn_counter')"
+        },
+        "crdt_operations_operation_type_check": {
+          "name": "crdt_operations_operation_type_check",
+          "value": "operation_type IN ('set', 'add', 'remove', 'increment', 'decrement')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edit_session_docs": {
+      "name": "edit_session_docs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_type": {
+          "name": "doc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_version": {
+          "name": "base_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "edit_session_docs_session_id_idx": {
+          "name": "edit_session_docs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_session_docs_session_doc_idx": {
+          "name": "edit_session_docs_session_doc_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doc_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edit_session_docs_session_id_edit_sessions_id_fk": {
+          "name": "edit_session_docs_session_id_edit_sessions_id_fk",
+          "tableFrom": "edit_session_docs",
+          "tableTo": "edit_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edit_session_docs_updated_by_users_id_fk": {
+          "name": "edit_session_docs_updated_by_users_id_fk",
+          "tableFrom": "edit_session_docs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edit_session_docs_doc_type_check": {
+          "name": "edit_session_docs_doc_type_check",
+          "value": "doc_type IN ('page', 'global', 'post')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edit_session_events": {
+      "name": "edit_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "edit_session_events_session_id_idx": {
+          "name": "edit_session_events_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_session_events_session_id_id_idx": {
+          "name": "edit_session_events_session_id_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edit_session_events_session_id_edit_sessions_id_fk": {
+          "name": "edit_session_events_session_id_edit_sessions_id_fk",
+          "tableFrom": "edit_session_events",
+          "tableTo": "edit_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edit_session_events_actor_kind_check": {
+          "name": "edit_session_events_actor_kind_check",
+          "value": "actor_kind IN ('human', 'agent')"
+        },
+        "edit_session_events_type_check": {
+          "name": "edit_session_events_type_check",
+          "value": "type IN ('opened', 'patched', 'commented', 'publish_requested', 'published', 'discarded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.edit_sessions": {
+      "name": "edit_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_sessions_site_id_idx": {
+          "name": "edit_sessions_site_id_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_sessions_status_idx": {
+          "name": "edit_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "edit_sessions_site_status_idx": {
+          "name": "edit_sessions_site_status_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "edit_sessions_site_id_sites_id_fk": {
+          "name": "edit_sessions_site_id_sites_id_fk",
+          "tableFrom": "edit_sessions",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edit_sessions_created_by_users_id_fk": {
+          "name": "edit_sessions_created_by_users_id_fk",
+          "tableFrom": "edit_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "edit_sessions_status_check": {
+          "name": "edit_sessions_status_check",
+          "value": "status IN ('open', 'published', 'discarded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.error_events": {
+      "name": "error_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'error'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'production'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "error_events_timestamp_idx": {
+          "name": "error_events_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_events_app_env_idx": {
+          "name": "error_events_app_env_idx",
+          "columns": [
+            {
+              "expression": "app",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_events_level_idx": {
+          "name": "error_events_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "error_events_level_check": {
+          "name": "error_events_level_check",
+          "value": "level IN ('error', 'fatal', 'warn')"
+        },
+        "error_events_app_check": {
+          "name": "error_events_app_check",
+          "value": "app IN ('admin', 'api', 'marketing')"
+        },
+        "error_events_context_check": {
+          "name": "error_events_context_check",
+          "value": "context IS NULL OR context IN ('server', 'client', 'edge')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gdpr_breaches": {
+      "name": "gdpr_breaches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affected_users": {
+          "name": "affected_users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "data_categories": {
+          "name": "data_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mitigation": {
+          "name": "mitigation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        }
+      },
+      "indexes": {
+        "gdpr_breaches_detected_at_idx": {
+          "name": "gdpr_breaches_detected_at_idx",
+          "columns": [
+            {
+              "expression": "detected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gdpr_breaches_status_idx": {
+          "name": "gdpr_breaches_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gdpr_breaches_severity_idx": {
+          "name": "gdpr_breaches_severity_idx",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gdpr_breaches_severity_check": {
+          "name": "gdpr_breaches_severity_check",
+          "value": "severity IN ('low', 'medium', 'high', 'critical')"
+        },
+        "gdpr_breaches_status_check": {
+          "name": "gdpr_breaches_status_check",
+          "value": "status IN ('detected', 'investigating', 'notified', 'resolved')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gdpr_consents": {
+      "name": "gdpr_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'explicit'"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gdpr_consents_user_id_idx": {
+          "name": "gdpr_consents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gdpr_consents_type_idx": {
+          "name": "gdpr_consents_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gdpr_consents_granted_idx": {
+          "name": "gdpr_consents_granted_idx",
+          "columns": [
+            {
+              "expression": "granted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gdpr_consents_user_type_uq": {
+          "name": "gdpr_consents_user_type_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "gdpr_consents_type_check": {
+          "name": "gdpr_consents_type_check",
+          "value": "type IN ('necessary', 'functional', 'analytics', 'marketing', 'personalization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gdpr_deletion_requests": {
+      "name": "gdpr_deletion_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "data_categories": {
+          "name": "data_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"personal\"]'::jsonb"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retained_data": {
+          "name": "retained_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_data": {
+          "name": "deleted_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gdpr_deletion_requests_user_id_idx": {
+          "name": "gdpr_deletion_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gdpr_deletion_requests_status_idx": {
+          "name": "gdpr_deletion_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gdpr_deletion_requests_requested_at_idx": {
+          "name": "gdpr_deletion_requests_requested_at_idx",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gdpr_deletion_requests_status_check": {
+          "name": "gdpr_deletion_requests_status_check",
+          "value": "status IN ('pending', 'processing', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idempotency_keys_operation_type_idx": {
+          "name": "idempotency_keys_operation_type_idx",
+          "columns": [
+            {
+              "expression": "operation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idempotency_keys_expires_at_idx": {
+          "name": "idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_inference_configs": {
+      "name": "workspace_inference_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hint": {
+          "name": "key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_inference_configs_workspace_id_uidx": {
+          "name": "workspace_inference_configs_workspace_id_uidx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_inference_configs_workspace_id_sites_id_fk": {
+          "name": "workspace_inference_configs_workspace_id_sites_id_fk",
+          "tableFrom": "workspace_inference_configs",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_inference_configs_provider_check": {
+          "name": "workspace_inference_configs_provider_check",
+          "value": "provider IN ('anthropic', 'openai', 'groq', 'huggingface', 'inference-snaps', 'ollama')"
+        },
+        "workspace_inference_configs_key_pairing_check": {
+          "name": "workspace_inference_configs_key_pairing_check",
+          "value": "(\n        (provider IN ('inference-snaps', 'ollama') AND encrypted_api_key IS NULL)\n        OR\n        (provider IN ('anthropic', 'openai', 'groq', 'huggingface') AND encrypted_api_key IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_limit": {
+          "name": "retry_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "start_after": {
+          "name": "start_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expire_at": {
+          "name": "expire_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "jobs_state_start_after_idx": {
+          "name": "jobs_state_start_after_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_name_idx": {
+          "name": "jobs_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_state_idx": {
+          "name": "jobs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_locked_until_idx": {
+          "name": "jobs_locked_until_idx",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "state = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "jobs_state_check": {
+          "name": "jobs_state_check",
+          "value": "state IN ('created', 'active', 'completed', 'failed', 'retry')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.licenses": {
+      "name": "licenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_key": {
+          "name": "license_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perpetual": {
+          "name": "perpetual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "support_expires_at": {
+          "name": "support_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "npm_username": {
+          "name": "npm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        }
+      },
+      "indexes": {
+        "licenses_customer_id_idx": {
+          "name": "licenses_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_user_id_idx": {
+          "name": "licenses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_status_idx": {
+          "name": "licenses_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_subscription_id_idx": {
+          "name": "licenses_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_deleted_at_idx": {
+          "name": "licenses_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_mode_idx": {
+          "name": "licenses_mode_idx",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_customer_subscription_unique": {
+          "name": "licenses_customer_subscription_unique",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_perpetual_user_tier_unique": {
+          "name": "licenses_perpetual_user_tier_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "perpetual = true AND deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_user_tier_status_idx": {
+          "name": "licenses_user_tier_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "licenses_perpetual_status_support_idx": {
+          "name": "licenses_perpetual_status_support_idx",
+          "columns": [
+            {
+              "expression": "perpetual",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "support_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "licenses_user_id_users_id_fk": {
+          "name": "licenses_user_id_users_id_fk",
+          "tableFrom": "licenses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "licenses_tier_check": {
+          "name": "licenses_tier_check",
+          "value": "tier IN ('pro', 'max', 'enterprise')"
+        },
+        "licenses_status_check": {
+          "name": "licenses_status_check",
+          "value": "status IN ('active', 'expired', 'revoked', 'support_expired')"
+        },
+        "licenses_mode_check": {
+          "name": "licenses_mode_check",
+          "value": "mode IN ('live', 'test')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lifecycle_emails_sent": {
+      "name": "lifecycle_emails_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lifecycle_emails_sent_idempotency_key_idx": {
+          "name": "lifecycle_emails_sent_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lifecycle_emails_sent_user_id_idx": {
+          "name": "lifecycle_emails_sent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lifecycle_emails_sent_user_id_users_id_fk": {
+          "name": "lifecycle_emails_sent_user_id_users_id_fk",
+          "tableFrom": "lifecycle_emails_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lifecycle_emails_sent_email_type_check": {
+          "name": "lifecycle_emails_sent_email_type_check",
+          "value": "email_type IN ('day0_welcome', 'day1_checkin', 'day7_outcome')"
+        },
+        "lifecycle_emails_sent_status_check": {
+          "name": "lifecycle_emails_sent_status_check",
+          "value": "status IN ('sent', 'dry_run')"
+        },
+        "lifecycle_emails_sent_tier_check": {
+          "name": "lifecycle_emails_sent_tier_check",
+          "value": "tier IN ('free', 'pro', 'max', 'enterprise')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_salt": {
+          "name": "token_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_id_idx": {
+          "name": "magic_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_token_hash_idx": {
+          "name": "magic_links_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_at_idx": {
+          "name": "magic_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketplace_servers": {
+      "name": "marketplace_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "price_per_call_usdc": {
+          "name": "price_per_call_usdc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.001'"
+        },
+        "developer_id": {
+          "name": "developer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "call_count": {
+          "name": "call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "marketplace_servers_developer_id_users_id_fk": {
+          "name": "marketplace_servers_developer_id_users_id_fk",
+          "tableFrom": "marketplace_servers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "developer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "marketplace_servers_status_check": {
+          "name": "marketplace_servers_status_check",
+          "value": "status IN ('pending', 'active', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.marketplace_transactions": {
+      "name": "marketplace_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caller_id": {
+          "name": "caller_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_usdc": {
+          "name": "amount_usdc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_usdc": {
+          "name": "platform_fee_usdc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "developer_amount_usdc": {
+          "name": "developer_amount_usdc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'x402'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "marketplace_transactions_server_id_idx": {
+          "name": "marketplace_transactions_server_id_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_transactions_status_idx": {
+          "name": "marketplace_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_transactions_created_at_idx": {
+          "name": "marketplace_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "marketplace_transactions_server_id_marketplace_servers_id_fk": {
+          "name": "marketplace_transactions_server_id_marketplace_servers_id_fk",
+          "tableFrom": "marketplace_transactions",
+          "tableTo": "marketplace_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "marketplace_transactions_status_check": {
+          "name": "marketplace_transactions_status_check",
+          "value": "status IN ('pending', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_document_operations": {
+      "name": "mcp_document_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector_clock": {
+          "name": "vector_clock",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_document_operations_document_id_idx": {
+          "name": "mcp_document_operations_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_document_operations_node_id_idx": {
+          "name": "mcp_document_operations_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_document_operations_created_at_idx": {
+          "name": "mcp_document_operations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_id_mappings": {
+      "name": "node_id_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_id_mappings_node_id_unique": {
+          "name": "node_id_mappings_node_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "node_id_mappings_entity_type_check": {
+          "name": "node_id_mappings_entity_type_check",
+          "value": "entity_type IN ('session', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.nudge_dismissals": {
+      "name": "nudge_dismissals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nudge_id": {
+          "name": "nudge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismiss_count": {
+          "name": "dismiss_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_dismissed_at": {
+          "name": "last_dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nudge_dismissals_user_nudge_idx": {
+          "name": "nudge_dismissals_user_nudge_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nudge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nudge_dismissals_user_id_idx": {
+          "name": "nudge_dismissals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nudge_dismissals_user_id_users_id_fk": {
+          "name": "nudge_dismissals_user_id_users_id_fk",
+          "tableFrom": "nudge_dismissals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "nudge_dismissals_dismiss_count_check": {
+          "name": "nudge_dismissals_dismiss_count_check",
+          "value": "dismiss_count BETWEEN 1 AND 2"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_email": {
+          "name": "provider_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_avatar_url": {
+          "name": "provider_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymized_at": {
+          "name": "anonymized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_accounts_provider_user_idx": {
+          "name": "oauth_accounts_provider_user_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_accounts_user_id_idx": {
+          "name": "oauth_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_accounts_deleted_at_idx": {
+          "name": "oauth_accounts_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_revisions": {
+      "name": "page_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision_number": {
+          "name": "revision_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "seo": {
+          "name": "seo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_description": {
+          "name": "change_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "page_revisions_page_id_idx": {
+          "name": "page_revisions_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_revisions_page_id_pages_id_fk": {
+          "name": "page_revisions_page_id_pages_id_fk",
+          "tableFrom": "page_revisions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_revisions_created_by_users_id_fk": {
+          "name": "page_revisions_created_by_users_id_fk",
+          "tableFrom": "page_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "seo": {
+          "name": "seo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_count": {
+          "name": "block_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock": {
+          "name": "lock",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_site_id_idx": {
+          "name": "pages_site_id_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_site_status_idx": {
+          "name": "pages_site_status_idx",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_slug_site_id_idx": {
+          "name": "pages_slug_site_id_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_deleted_at_idx": {
+          "name": "pages_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_site_id_sites_id_fk": {
+          "name": "pages_site_id_sites_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_parent_id_pages_id_fk": {
+          "name": "pages_parent_id_pages_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pages_status_check": {
+          "name": "pages_status_check",
+          "value": "status IN ('draft', 'published', 'archived', 'scheduled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_last_used_at_idx": {
+          "name": "passkeys_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_salt": {
+          "name": "token_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_expires_at_idx": {
+          "name": "password_reset_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_in_cents": {
+          "name": "total_in_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "orders_customer_id_idx": {
+          "name": "orders_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orders_status_idx": {
+          "name": "orders_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orders_created_at_idx": {
+          "name": "orders_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orders_deleted_at_idx": {
+          "name": "orders_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orders_customer_id_users_id_fk": {
+          "name": "orders_customer_id_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "orders_status_check": {
+          "name": "orders_status_check",
+          "value": "status IN ('pending', 'confirmed', 'processing', 'shipped', 'delivered', 'cancelled', 'refunded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_in_cents": {
+          "name": "price_in_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_owner_id_idx": {
+          "name": "products_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_status_idx": {
+          "name": "products_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_deleted_at_idx": {
+          "name": "products_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_slug_idx": {
+          "name": "products_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_owner_id_users_id_fk": {
+          "name": "products_owner_id_users_id_fk",
+          "tableFrom": "products",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "products_status_check": {
+          "name": "products_status_check",
+          "value": "status IN ('draft', 'published', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.failed_attempts": {
+      "name": "failed_attempts",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limits_reset_at_idx": {
+          "name": "rate_limits_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_reviews": {
+      "name": "agent_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_reviews_agent_id_idx": {
+          "name": "agent_reviews_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_reviews_reviewer_id_idx": {
+          "name": "agent_reviews_reviewer_id_idx",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_reviews_agent_id_marketplace_agents_id_fk": {
+          "name": "agent_reviews_agent_id_marketplace_agents_id_fk",
+          "tableFrom": "agent_reviews",
+          "tableTo": "marketplace_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_reviews_reviewer_id_users_id_fk": {
+          "name": "agent_reviews_reviewer_id_users_id_fk",
+          "tableFrom": "agent_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skills": {
+      "name": "agent_skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "examples": {
+          "name": "examples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skills_agent_id_idx": {
+          "name": "agent_skills_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_skills_name_idx": {
+          "name": "agent_skills_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_skills_agent_id_marketplace_agents_id_fk": {
+          "name": "agent_skills_agent_id_marketplace_agents_id_fk",
+          "tableFrom": "agent_skills",
+          "tableTo": "marketplace_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketplace_agents": {
+      "name": "marketplace_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.1.0'"
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_model": {
+          "name": "pricing_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'per-task'"
+        },
+        "base_price_usdc": {
+          "name": "base_price_usdc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.10'"
+        },
+        "max_execution_secs": {
+          "name": "max_execution_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "resource_limits": {
+          "name": "resource_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"maxMemoryMb\":512,\"maxCpuPercent\":50}'::jsonb"
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "task_count": {
+          "name": "task_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "marketplace_agents_publisher_id_idx": {
+          "name": "marketplace_agents_publisher_id_idx",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_agents_status_idx": {
+          "name": "marketplace_agents_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_agents_category_idx": {
+          "name": "marketplace_agents_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "marketplace_agents_rating_idx": {
+          "name": "marketplace_agents_rating_idx",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "marketplace_agents_publisher_id_users_id_fk": {
+          "name": "marketplace_agents_publisher_id_users_id_fk",
+          "tableFrom": "marketplace_agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "marketplace_agents_pricing_model_check": {
+          "name": "marketplace_agents_pricing_model_check",
+          "value": "pricing_model IN ('per-task', 'per-minute', 'flat')"
+        },
+        "marketplace_agents_status_check": {
+          "name": "marketplace_agents_status_check",
+          "value": "status IN ('draft', 'published', 'suspended', 'deprecated')"
+        },
+        "marketplace_agents_category_check": {
+          "name": "marketplace_agents_category_check",
+          "value": "category IN ('coding', 'writing', 'data', 'design', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_submissions": {
+      "name": "task_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submitter_id": {
+          "name": "submitter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "cost_usdc": {
+          "name": "cost_usdc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_meta": {
+          "name": "execution_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_submissions_submitter_id_idx": {
+          "name": "task_submissions_submitter_id_idx",
+          "columns": [
+            {
+              "expression": "submitter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_submissions_agent_id_idx": {
+          "name": "task_submissions_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_submissions_status_idx": {
+          "name": "task_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_submissions_skill_name_idx": {
+          "name": "task_submissions_skill_name_idx",
+          "columns": [
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_submissions_created_at_idx": {
+          "name": "task_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_submissions_submitter_id_users_id_fk": {
+          "name": "task_submissions_submitter_id_users_id_fk",
+          "tableFrom": "task_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_submissions_agent_id_marketplace_agents_id_fk": {
+          "name": "task_submissions_agent_id_marketplace_agents_id_fk",
+          "tableFrom": "task_submissions",
+          "tableTo": "marketplace_agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "task_submissions_status_check": {
+          "name": "task_submissions_status_check",
+          "value": "status IN ('pending', 'queued', 'running', 'completed', 'failed', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shared_facts": {
+      "name": "shared_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fact_type": {
+          "name": "fact_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shared_facts_session_id_idx": {
+          "name": "shared_facts_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_facts_agent_id_idx": {
+          "name": "shared_facts_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_facts_fact_type_idx": {
+          "name": "shared_facts_fact_type_idx",
+          "columns": [
+            {
+              "expression": "fact_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_facts_created_at_idx": {
+          "name": "shared_facts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shared_facts_fact_type_check": {
+          "name": "shared_facts_fact_type_check",
+          "value": "fact_type IN ('discovery', 'bug', 'decision', 'warning', 'question', 'answer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.site_collaborators": {
+      "name": "site_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "site_collaborators_site_user_unique": {
+          "name": "site_collaborators_site_user_unique",
+          "columns": [
+            {
+              "expression": "site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "site_collaborators_site_id_sites_id_fk": {
+          "name": "site_collaborators_site_id_sites_id_fk",
+          "tableFrom": "site_collaborators",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_collaborators_user_id_users_id_fk": {
+          "name": "site_collaborators_user_id_users_id_fk",
+          "tableFrom": "site_collaborators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "site_collaborators_added_by_users_id_fk": {
+          "name": "site_collaborators_added_by_users_id_fk",
+          "tableFrom": "site_collaborators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "site_collaborators_role_check": {
+          "name": "site_collaborators_role_check",
+          "value": "role IN ('owner', 'admin', 'editor', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sites_deleted_at_idx": {
+          "name": "sites_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sites_status_deleted_at_idx": {
+          "name": "sites_status_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sites_active_slug_idx": {
+          "name": "sites_active_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sites_active_owner_id_idx": {
+          "name": "sites_active_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sites_active_status_idx": {
+          "name": "sites_active_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sites_owner_id_idx": {
+          "name": "sites_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sites_owner_id_users_id_fk": {
+          "name": "sites_owner_id_users_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_slug_unique": {
+          "name": "sites_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sites_status_check": {
+          "name": "sites_status_check",
+          "value": "status IN ('draft', 'published', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roles": {
+          "name": "roles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "domains": {
+          "name": "domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "_json": {
+          "name": "_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_email_idx": {
+          "name": "tenants_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_columns": {
+      "name": "board_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wip_limit": {
+          "name": "wip_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_columns_board_id_boards_id_fk": {
+          "name": "board_columns_board_id_boards_id_fk",
+          "tableFrom": "board_columns",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "boards_tenant_id_idx": {
+          "name": "boards_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boards_owner_id_idx": {
+          "name": "boards_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boards_owner_id_users_id_fk": {
+          "name": "boards_owner_id_users_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ticket_comments": {
+      "name": "ticket_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ticket_comments_ticket_id_idx": {
+          "name": "ticket_comments_ticket_id_idx",
+          "columns": [
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ticket_comments_author_id_idx": {
+          "name": "ticket_comments_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ticket_comments_ticket_id_tickets_id_fk": {
+          "name": "ticket_comments_ticket_id_tickets_id_fk",
+          "tableFrom": "ticket_comments",
+          "tableTo": "tickets",
+          "columnsFrom": [
+            "ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ticket_comments_author_id_users_id_fk": {
+          "name": "ticket_comments_author_id_users_id_fk",
+          "tableFrom": "ticket_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ticket_label_assignments": {
+      "name": "ticket_label_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ticket_label_unique_idx": {
+          "name": "ticket_label_unique_idx",
+          "columns": [
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ticket_label_assignments_ticket_id_tickets_id_fk": {
+          "name": "ticket_label_assignments_ticket_id_tickets_id_fk",
+          "tableFrom": "ticket_label_assignments",
+          "tableTo": "tickets",
+          "columnsFrom": [
+            "ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ticket_label_assignments_label_id_ticket_labels_id_fk": {
+          "name": "ticket_label_assignments_label_id_ticket_labels_id_fk",
+          "tableFrom": "ticket_label_assignments",
+          "tableTo": "ticket_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ticket_labels": {
+      "name": "ticket_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6366f1'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ticket_labels_tenant_id_idx": {
+          "name": "ticket_labels_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_ticket_id": {
+          "name": "parent_ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_number": {
+          "name": "ticket_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'task'"
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_effort": {
+          "name": "estimated_effort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tickets_board_id_idx": {
+          "name": "tickets_board_id_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tickets_column_id_idx": {
+          "name": "tickets_column_id_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tickets_assignee_id_idx": {
+          "name": "tickets_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tickets_parent_ticket_id_idx": {
+          "name": "tickets_parent_ticket_id_idx",
+          "columns": [
+            {
+              "expression": "parent_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tickets_reporter_id_idx": {
+          "name": "tickets_reporter_id_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tickets_board_ticket_number_idx": {
+          "name": "tickets_board_ticket_number_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticket_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tickets_board_id_boards_id_fk": {
+          "name": "tickets_board_id_boards_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tickets_column_id_board_columns_id_fk": {
+          "name": "tickets_column_id_board_columns_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "board_columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tickets_parent_ticket_id_tickets_id_fk": {
+          "name": "tickets_parent_ticket_id_tickets_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "tickets",
+          "columnsFrom": [
+            "parent_ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tickets_assignee_id_users_id_fk": {
+          "name": "tickets_assignee_id_users_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tickets_reporter_id_users_id_fk": {
+          "name": "tickets_reporter_id_users_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tickets_status_check": {
+          "name": "tickets_status_check",
+          "value": "status IN ('backlog', 'todo', 'in_progress', 'review', 'done', 'closed')"
+        },
+        "tickets_priority_check": {
+          "name": "tickets_priority_check",
+          "value": "priority IN ('critical', 'high', 'medium', 'low')"
+        },
+        "tickets_type_check": {
+          "name": "tickets_type_check",
+          "value": "type IN ('bug', 'feature', 'task', 'improvement', 'epic')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persistent": {
+          "name": "persistent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_token_hash_idx": {
+          "name": "sessions_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_expires_idx": {
+          "name": "sessions_user_expires_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_deleted_at_idx": {
+          "name": "sessions_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'human'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_rotate_password": {
+          "name": "must_rotate_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "agent_model": {
+          "name": "agent_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_capabilities": {
+          "name": "agent_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_config": {
+          "name": "agent_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_verification_token": {
+          "name": "email_verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_token_expires_at": {
+          "name": "email_verification_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_version": {
+          "name": "tos_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_enabled": {
+          "name": "mfa_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mfa_secret": {
+          "name": "mfa_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_backup_codes": {
+          "name": "mfa_backup_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_verified_at": {
+          "name": "mfa_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_last_used_counter": {
+          "name": "mfa_last_used_counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_key_fingerprint": {
+          "name": "ssh_key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "devkit_profile": {
+          "name": "devkit_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymized_at": {
+          "name": "anonymized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_deletion_status": {
+          "name": "stripe_deletion_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_deletion_at": {
+          "name": "stripe_deletion_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_json": {
+          "name": "_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_type_idx": {
+          "name": "users_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_status_idx": {
+          "name": "users_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_deleted_at_idx": {
+          "name": "users_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_status_deleted_at_idx": {
+          "name": "users_status_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_active_email_idx": {
+          "name": "users_active_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_active_status_idx": {
+          "name": "users_active_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_stripe_customer_id_idx": {
+          "name": "users_stripe_customer_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ssh_key_fingerprint_idx": {
+          "name": "users_ssh_key_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "ssh_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_verified_idx": {
+          "name": "users_email_verified_idx",
+          "columns": [
+            {
+              "expression": "email_verified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "role IN ('owner', 'admin', 'editor', 'viewer', 'agent', 'contributor')"
+        },
+        "users_status_check": {
+          "name": "users_status_check",
+          "value": "status IN ('active', 'suspended', 'deleted', 'pending')"
+        },
+        "users_type_check": {
+          "name": "users_type_check",
+          "value": "type IN ('human', 'agent', 'system')"
+        },
+        "users_devkit_profile_check": {
+          "name": "users_devkit_profile_check",
+          "value": "devkit_profile IS NULL OR devkit_profile IN ('agents', 'claude', 'cursor', 'revealui', 'zed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.processed_webhook_events": {
+      "name": "processed_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_processed_at_idx": {
+          "name": "webhook_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_status_claimed_idx": {
+          "name": "webhook_events_status_claimed_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.unreconciled_webhooks": {
+      "name": "unreconciled_webhooks",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_object_id": {
+          "name": "stripe_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_trace": {
+          "name": "error_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unreconciled_webhooks_customer_id_idx": {
+          "name": "unreconciled_webhooks_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unreconciled_webhooks_unresolved_idx": {
+          "name": "unreconciled_webhooks_unresolved_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"unreconciled_webhooks\".\"resolved_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.yjs_document_patches": {
+      "name": "yjs_document_patches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patch_type": {
+          "name": "patch_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "yjs_document_patches_doc_applied_idx": {
+          "name": "yjs_document_patches_doc_applied_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "applied",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "yjs_document_patches_created_at_idx": {
+          "name": "yjs_document_patches_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "yjs_document_patches_document_id_yjs_documents_id_fk": {
+          "name": "yjs_document_patches_document_id_yjs_documents_id_fk",
+          "tableFrom": "yjs_document_patches",
+          "tableTo": "yjs_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "yjs_document_patches_type_check": {
+          "name": "yjs_document_patches_type_check",
+          "value": "patch_type IN ('append_section', 'append_item', 'replace_section', 'set_key')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.yjs_documents": {
+      "name": "yjs_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_vector": {
+          "name": "state_vector",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_clients": {
+          "name": "connected_clients",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_chunks": {
+      "name": "rag_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rag_chunks_document_id_idx": {
+          "name": "rag_chunks_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_chunks_workspace_id_idx": {
+          "name": "rag_chunks_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rag_chunks_document_id_rag_documents_id_fk": {
+          "name": "rag_chunks_document_id_rag_documents_id_fk",
+          "tableFrom": "rag_chunks",
+          "tableTo": "rag_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rag_chunks_workspace_id_sites_id_fk": {
+          "name": "rag_chunks_workspace_id_sites_id_fk",
+          "tableFrom": "rag_chunks",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_documents": {
+      "name": "rag_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_collection": {
+          "name": "source_collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'text/plain'"
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "token_estimate": {
+          "name": "token_estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rag_documents_workspace_id_sites_id_fk": {
+          "name": "rag_documents_workspace_id_sites_id_fk",
+          "tableFrom": "rag_documents",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rag_documents_source_type_check": {
+          "name": "rag_documents_source_type_check",
+          "value": "source_type IN ('admin_collection', 'url', 'file', 'text')"
+        },
+        "rag_documents_status_check": {
+          "name": "rag_documents_status_check",
+          "value": "status IN ('pending', 'processing', 'indexed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.rag_workspaces": {
+      "name": "rag_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'nomic-embed-text'"
+        },
+        "chunk_size": {
+          "name": "chunk_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 512
+        },
+        "chunk_overlap": {
+          "name": "chunk_overlap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 64
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1784400000000,
       "tag": "0026_audit_log_append_only",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1784500000000,
+      "tag": "0027_open_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -178,6 +178,10 @@
       "types": "./dist/queries/pages.d.ts",
       "import": "./dist/queries/pages.js"
     },
+    "./queries/edit-sessions": {
+      "types": "./dist/queries/edit-sessions.d.ts",
+      "import": "./dist/queries/edit-sessions.js"
+    },
     "./queries/users": {
       "types": "./dist/queries/users.d.ts",
       "import": "./dist/queries/users.js"

--- a/packages/db/src/queries/edit-sessions.ts
+++ b/packages/db/src/queries/edit-sessions.ts
@@ -1,0 +1,275 @@
+/**
+ * Edit session database queries
+ *
+ * Typed data-access for the visual-edit-sessions engine: sessions, draft
+ * overlays, the append-only event log, and the publish-path page writes.
+ *
+ * The publish path deliberately owns its own snapshot write (direct insert into
+ * `page_revisions`) rather than routing through core's snapshot operation, per
+ * the note in `core/collections/operations/snapshot.ts`.
+ */
+
+import { and, asc, desc, eq, gt, inArray, isNull } from 'drizzle-orm';
+import type { Database } from '../client/index.js';
+import {
+  type EditSession,
+  type EditSessionDoc,
+  type EditSessionEvent,
+  editSessionDocs,
+  editSessionEvents,
+  editSessions,
+} from '../schema/edit-sessions.js';
+import { type Page, pageRevisions, pages } from '../schema/pages.js';
+
+// =============================================================================
+// Sessions
+// =============================================================================
+
+export async function createEditSession(
+  db: Database,
+  data: { id: string; siteId: string; title: string; createdBy: string | null },
+): Promise<EditSession | null> {
+  const result = await db.insert(editSessions).values(data).returning();
+  return result[0] ?? null;
+}
+
+export async function getEditSessionById(db: Database, id: string): Promise<EditSession | null> {
+  const result = await db.select().from(editSessions).where(eq(editSessions.id, id)).limit(1);
+  return result[0] ?? null;
+}
+
+export async function listEditSessions(
+  db: Database,
+  filter: { status?: string; siteId?: string } = {},
+): Promise<EditSession[]> {
+  const conditions = [
+    ...(filter.status ? [eq(editSessions.status, filter.status)] : []),
+    ...(filter.siteId ? [eq(editSessions.siteId, filter.siteId)] : []),
+  ];
+  const query = db.select().from(editSessions);
+  const scoped = conditions.length > 0 ? query.where(and(...conditions)) : query;
+  return scoped.orderBy(desc(editSessions.createdAt));
+}
+
+export async function setEditSessionStatus(
+  db: Database,
+  id: string,
+  data: { status: string; publishedAt?: Date | null },
+): Promise<EditSession | null> {
+  const result = await db
+    .update(editSessions)
+    .set({ status: data.status, publishedAt: data.publishedAt ?? null, updatedAt: new Date() })
+    .where(eq(editSessions.id, id))
+    .returning();
+  return result[0] ?? null;
+}
+
+// =============================================================================
+// Draft overlays
+// =============================================================================
+
+export async function getSessionDoc(
+  db: Database,
+  sessionId: string,
+  docType: string,
+  docId: string,
+): Promise<EditSessionDoc | null> {
+  const result = await db
+    .select()
+    .from(editSessionDocs)
+    .where(
+      and(
+        eq(editSessionDocs.sessionId, sessionId),
+        eq(editSessionDocs.docType, docType),
+        eq(editSessionDocs.docId, docId),
+      ),
+    )
+    .limit(1);
+  return result[0] ?? null;
+}
+
+export async function getSessionDocs(db: Database, sessionId: string): Promise<EditSessionDoc[]> {
+  return db
+    .select()
+    .from(editSessionDocs)
+    .where(eq(editSessionDocs.sessionId, sessionId))
+    .orderBy(asc(editSessionDocs.docType), asc(editSessionDocs.docId));
+}
+
+export async function insertSessionDoc(
+  db: Database,
+  data: {
+    id: string;
+    sessionId: string;
+    docType: string;
+    docId: string;
+    draft: Record<string, unknown>;
+    baseVersion: number;
+    updatedBy: string | null;
+  },
+): Promise<EditSessionDoc | null> {
+  const result = await db.insert(editSessionDocs).values(data).returning();
+  return result[0] ?? null;
+}
+
+export async function updateSessionDocDraft(
+  db: Database,
+  id: string,
+  data: { draft: Record<string, unknown>; updatedBy: string | null },
+): Promise<EditSessionDoc | null> {
+  const result = await db
+    .update(editSessionDocs)
+    .set({ draft: data.draft, updatedBy: data.updatedBy, updatedAt: new Date() })
+    .where(eq(editSessionDocs.id, id))
+    .returning();
+  return result[0] ?? null;
+}
+
+// =============================================================================
+// Events (append-only)
+// =============================================================================
+
+export async function insertSessionEvent(
+  db: Database,
+  data: {
+    sessionId: string;
+    actorId: string | null;
+    actorKind: string;
+    type: string;
+    payload?: Record<string, unknown> | null;
+  },
+): Promise<EditSessionEvent | null> {
+  const result = await db
+    .insert(editSessionEvents)
+    .values({
+      sessionId: data.sessionId,
+      actorId: data.actorId,
+      actorKind: data.actorKind,
+      type: data.type,
+      payload: data.payload ?? null,
+    })
+    .returning();
+  return result[0] ?? null;
+}
+
+/** Most-recent events first (route reverses to chronological for display). */
+export async function getRecentSessionEvents(
+  db: Database,
+  sessionId: string,
+  limit: number,
+): Promise<EditSessionEvent[]> {
+  return db
+    .select()
+    .from(editSessionEvents)
+    .where(eq(editSessionEvents.sessionId, sessionId))
+    .orderBy(desc(editSessionEvents.id))
+    .limit(limit);
+}
+
+/** Events strictly after `afterId`, id-ordered ascending. */
+export async function getSessionEventsAfter(
+  db: Database,
+  sessionId: string,
+  afterId: number,
+  limit: number,
+): Promise<EditSessionEvent[]> {
+  return db
+    .select()
+    .from(editSessionEvents)
+    .where(and(eq(editSessionEvents.sessionId, sessionId), gt(editSessionEvents.id, afterId)))
+    .orderBy(asc(editSessionEvents.id))
+    .limit(limit);
+}
+
+// =============================================================================
+// Publish-path page writes (edit-session-owned snapshot path)
+// =============================================================================
+
+export async function getLivePage(db: Database, pageId: string): Promise<Page | null> {
+  const result = await db
+    .select()
+    .from(pages)
+    .where(and(eq(pages.id, pageId), isNull(pages.deletedAt)))
+    .limit(1);
+  return result[0] ?? null;
+}
+
+/**
+ * Optimistically write a draft over a live page: only succeeds when the page's
+ * current version still equals `expectedVersion`, bumping it by one. Returns the
+ * updated row, or null when the guard missed (a concurrent writer moved on).
+ */
+export async function publishDraftToPage(
+  db: Database,
+  data: {
+    pageId: string;
+    expectedVersion: number;
+    title: string;
+    blocks: unknown[] | null;
+    seo: unknown;
+    publishedAt: Date;
+  },
+): Promise<Page | null> {
+  const result = await db
+    .update(pages)
+    .set({
+      title: data.title,
+      blocks: data.blocks,
+      seo: data.seo,
+      version: data.expectedVersion + 1,
+      status: 'published',
+      publishedAt: data.publishedAt,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(pages.id, data.pageId), eq(pages.version, data.expectedVersion)))
+    .returning();
+  return result[0] ?? null;
+}
+
+export async function nextPageRevisionNumber(db: Database, pageId: string): Promise<number> {
+  const rows = await db
+    .select({ n: pageRevisions.revisionNumber })
+    .from(pageRevisions)
+    .where(eq(pageRevisions.pageId, pageId))
+    .orderBy(desc(pageRevisions.revisionNumber))
+    .limit(1);
+  return (rows[0]?.n ?? 0) + 1;
+}
+
+export async function insertPageRevision(
+  db: Database,
+  data: {
+    id: string;
+    pageId: string;
+    createdBy: string | null;
+    revisionNumber: number;
+    title: string;
+    blocks: unknown[] | null;
+    seo: unknown;
+    changeDescription: string | null;
+  },
+): Promise<void> {
+  await db.insert(pageRevisions).values(data);
+}
+
+/** Retain the newest `keep` revisions for a page; delete any older ones. */
+export async function prunePageRevisions(
+  db: Database,
+  pageId: string,
+  keep: number,
+): Promise<number> {
+  const stale = await db
+    .select({ id: pageRevisions.id })
+    .from(pageRevisions)
+    .where(eq(pageRevisions.pageId, pageId))
+    .orderBy(desc(pageRevisions.revisionNumber))
+    .offset(keep);
+  if (stale.length === 0) return 0;
+  await db.delete(pageRevisions).where(
+    inArray(
+      pageRevisions.id,
+      stale.map((r) => r.id),
+    ),
+  );
+  return stale.length;
+}

--- a/packages/db/src/queries/edit-sessions.ts
+++ b/packages/db/src/queries/edit-sessions.ts
@@ -273,3 +273,55 @@ export async function prunePageRevisions(
   );
   return stale.length;
 }
+
+/**
+ * Compensating write for a mid-flight publish conflict: restore a page to its
+ * exact pre-publish row (content + status + publishedAt + the ORIGINAL version),
+ * guarded on the version this session set. Resetting the version to the original
+ * means a clean compensation leaves the page byte-identical to before the attempt
+ * (nothing published), so a later retry's optimistic pre-flight passes without a
+ * phantom conflict. Returns the row, or null if the guard missed (page moved
+ * again  -  that doc stays published and the caller reports it).
+ */
+export async function restorePageContent(
+  db: Database,
+  data: { pageId: string; expectedVersion: number; original: Page },
+): Promise<Page | null> {
+  const result = await db
+    .update(pages)
+    .set({
+      title: data.original.title,
+      blocks: data.original.blocks,
+      seo: data.original.seo,
+      status: data.original.status,
+      publishedAt: data.original.publishedAt,
+      version: data.original.version,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(pages.id, data.pageId), eq(pages.version, data.expectedVersion)))
+    .returning();
+  return result[0] ?? null;
+}
+
+export async function deletePageRevisionById(db: Database, revisionId: string): Promise<void> {
+  await db.delete(pageRevisions).where(eq(pageRevisions.id, revisionId));
+}
+
+/**
+ * Advance an overlay's `base_version` to a page's current version. Used when a
+ * mid-flight conflict leaves a doc published (compensation missed): the overlay
+ * must track the version this session already produced so a retry's pre-flight
+ * does not report a phantom conflict on the session's own write.
+ */
+export async function setSessionDocBaseVersion(
+  db: Database,
+  docId: string,
+  baseVersion: number,
+): Promise<EditSessionDoc | null> {
+  const result = await db
+    .update(editSessionDocs)
+    .set({ baseVersion, updatedAt: new Date() })
+    .where(eq(editSessionDocs.id, docId))
+    .returning();
+  return result[0] ?? null;
+}

--- a/packages/db/src/schema/edit-sessions.ts
+++ b/packages/db/src/schema/edit-sessions.ts
@@ -1,0 +1,132 @@
+/**
+ * Edit session tables - the visual-edit-sessions engine
+ *
+ * An edit session is a durable, auditable draft workspace over one or more
+ * published content docs. `edit_sessions` is the workspace, `edit_session_docs`
+ * holds one draft overlay per touched doc (materialized on first patch), and
+ * `edit_session_events` is an append-only activity log.
+ *
+ * Follows the `pages.ts` conventions: text PKs, timestamptz, FK cascade/set-null,
+ * CHECK constraints for enum-like columns. The events table uses a serial `id`
+ * (not a text UUID) so it yields a monotonic, id-ordered cursor for polling.
+ */
+
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { sites } from './sites.js';
+import { users } from './users.js';
+
+// =============================================================================
+// Edit Sessions
+// =============================================================================
+
+export const editSessions = pgTable(
+  'edit_sessions',
+  {
+    id: text('id').primaryKey(),
+    siteId: text('site_id')
+      .notNull()
+      .references(() => sites.id, { onDelete: 'cascade' }),
+    title: text('title').notNull(),
+    // Lifecycle: open (mutable) -> published | discarded (both terminal)
+    status: text('status').notNull().default('open'),
+    createdBy: text('created_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .$onUpdateFn(() => new Date())
+      .defaultNow()
+      .notNull(),
+    publishedAt: timestamp('published_at', { withTimezone: true }),
+  },
+  (table) => [
+    index('edit_sessions_site_id_idx').on(table.siteId),
+    index('edit_sessions_status_idx').on(table.status),
+    index('edit_sessions_site_status_idx').on(table.siteId, table.status),
+    check('edit_sessions_status_check', sql`status IN ('open', 'published', 'discarded')`),
+  ],
+);
+
+// =============================================================================
+// Edit Session Docs (draft overlays)
+// =============================================================================
+
+export const editSessionDocs = pgTable(
+  'edit_session_docs',
+  {
+    id: text('id').primaryKey(),
+    sessionId: text('session_id')
+      .notNull()
+      .references(() => editSessions.id, { onDelete: 'cascade' }),
+    docType: text('doc_type').notNull(),
+    docId: text('doc_id').notNull(),
+    // Full draft doc, materialized from the live doc on first patch.
+    draft: jsonb('draft').$type<Record<string, unknown>>().notNull(),
+    // Optimistic-locking baseline: the live doc's version at materialization time.
+    baseVersion: integer('base_version').notNull(),
+    updatedBy: text('updated_by').references(() => users.id, { onDelete: 'set null' }),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .$onUpdateFn(() => new Date())
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index('edit_session_docs_session_id_idx').on(table.sessionId),
+    // One overlay row per touched doc within a session.
+    uniqueIndex('edit_session_docs_session_doc_idx').on(
+      table.sessionId,
+      table.docType,
+      table.docId,
+    ),
+    check('edit_session_docs_doc_type_check', sql`doc_type IN ('page', 'global', 'post')`),
+  ],
+);
+
+// =============================================================================
+// Edit Session Events (append-only)
+// =============================================================================
+
+export const editSessionEvents = pgTable(
+  'edit_session_events',
+  {
+    // serial: monotonic + id-ordered so `?after=<id>` polling is stable.
+    id: serial('id').primaryKey(),
+    sessionId: text('session_id')
+      .notNull()
+      .references(() => editSessions.id, { onDelete: 'cascade' }),
+    actorId: text('actor_id'),
+    actorKind: text('actor_kind').notNull(),
+    type: text('type').notNull(),
+    payload: jsonb('payload').$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('edit_session_events_session_id_idx').on(table.sessionId),
+    index('edit_session_events_session_id_id_idx').on(table.sessionId, table.id),
+    check('edit_session_events_actor_kind_check', sql`actor_kind IN ('human', 'agent')`),
+    check(
+      'edit_session_events_type_check',
+      sql`type IN ('opened', 'patched', 'commented', 'publish_requested', 'published', 'discarded')`,
+    ),
+  ],
+);
+
+// =============================================================================
+// Type exports
+// =============================================================================
+
+export type EditSession = typeof editSessions.$inferSelect;
+export type NewEditSession = typeof editSessions.$inferInsert;
+export type EditSessionDoc = typeof editSessionDocs.$inferSelect;
+export type NewEditSessionDoc = typeof editSessionDocs.$inferInsert;
+export type EditSessionEvent = typeof editSessionEvents.$inferSelect;
+export type NewEditSessionEvent = typeof editSessionEvents.$inferInsert;

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -71,6 +71,7 @@ import { appLogs } from './app-logs.js';
 import { auditLog } from './audit-log.js';
 import { codeProvenance, codeReviews } from './code-provenance.js';
 import { collabEdits } from './collab-edits.js';
+import { editSessionDocs, editSessionEvents, editSessions } from './edit-sessions.js';
 import { errorEvents } from './error-events.js';
 import { workspaceInferenceConfigs } from './inference-configs.js';
 import { licenses } from './licenses.js';
@@ -272,6 +273,38 @@ export const pageRevisionsRelations = relations(pageRevisions, ({ one }) => ({
   createdByUser: one(users, {
     fields: [pageRevisions.createdBy],
     references: [users.id],
+  }),
+}));
+
+// Edit session relations
+export const editSessionsRelations = relations(editSessions, ({ one, many }) => ({
+  site: one(sites, {
+    fields: [editSessions.siteId],
+    references: [sites.id],
+  }),
+  createdByUser: one(users, {
+    fields: [editSessions.createdBy],
+    references: [users.id],
+  }),
+  docs: many(editSessionDocs),
+  events: many(editSessionEvents),
+}));
+
+export const editSessionDocsRelations = relations(editSessionDocs, ({ one }) => ({
+  session: one(editSessions, {
+    fields: [editSessionDocs.sessionId],
+    references: [editSessions.id],
+  }),
+  updatedByUser: one(users, {
+    fields: [editSessionDocs.updatedBy],
+    references: [users.id],
+  }),
+}));
+
+export const editSessionEventsRelations = relations(editSessionEvents, ({ one }) => ({
+  session: one(editSessions, {
+    fields: [editSessionEvents.sessionId],
+    references: [editSessions.id],
   }),
 }));
 

--- a/packages/db/src/schema/rest.ts
+++ b/packages/db/src/schema/rest.ts
@@ -52,6 +52,7 @@ export * from './code-provenance.js';
 export * from './collab-edits.js';
 export * from './coordination.js';
 export * from './crdt-operations.js';
+export * from './edit-sessions.js';
 export * from './error-events.js';
 export * from './gdpr.js';
 export * from './idempotency.js';

--- a/packages/db/src/types/database.ts
+++ b/packages/db/src/types/database.ts
@@ -40,6 +40,9 @@ import type {
   coordinationSessions,
   coordinationWorkItems,
   crdtOperations,
+  editSessionDocs,
+  editSessionEvents,
+  editSessions,
   errorEvents,
   failedAttempts,
   gdprBreaches,
@@ -262,6 +265,21 @@ export type CoordinationWorkItemsUpdate = Partial<CoordinationWorkItemsInsert>
 export type CrdtOperationsRow = typeof crdtOperations.$inferSelect
 export type CrdtOperationsInsert = typeof crdtOperations.$inferInsert
 export type CrdtOperationsUpdate = Partial<CrdtOperationsInsert>
+
+// Edit Session Docs
+export type EditSessionDocsRow = typeof editSessionDocs.$inferSelect
+export type EditSessionDocsInsert = typeof editSessionDocs.$inferInsert
+export type EditSessionDocsUpdate = Partial<EditSessionDocsInsert>
+
+// Edit Session Events
+export type EditSessionEventsRow = typeof editSessionEvents.$inferSelect
+export type EditSessionEventsInsert = typeof editSessionEvents.$inferInsert
+export type EditSessionEventsUpdate = Partial<EditSessionEventsInsert>
+
+// Edit Sessions
+export type EditSessionsRow = typeof editSessions.$inferSelect
+export type EditSessionsInsert = typeof editSessions.$inferInsert
+export type EditSessionsUpdate = Partial<EditSessionsInsert>
 
 // Error Events
 export type ErrorEventsRow = typeof errorEvents.$inferSelect
@@ -628,6 +646,9 @@ export type DatabaseRelationships = {
   coordinationSessions: Relationship[]
   coordinationWorkItems: Relationship[]
   crdtOperations: Relationship[]
+  editSessionDocs: Relationship[]
+  editSessionEvents: Relationship[]
+  editSessions: Relationship[]
   errorEvents: Relationship[]
   failedAttempts: Relationship[]
   gdprBreaches: Relationship[]
@@ -814,6 +835,23 @@ export const coordinationWorkItemsRelationships: readonly Relationship[] = []
 
 // CrdtOperations relationships
 export const crdtOperationsRelationships: readonly Relationship[] = []
+
+// EditSessionDocs relationships
+export const editSessionDocsRelationships = [
+  { foreignKeyName: 'edit_session_docs_session_id_edit_sessions_id_fk', columns: ['session_id'], isOneToOne: true, referencedRelation: 'edit_sessions', referencedColumns: ['id'] },
+  { foreignKeyName: 'edit_session_docs_updated_by_users_id_fk', columns: ['updated_by'], isOneToOne: true, referencedRelation: 'users', referencedColumns: ['id'] },
+] as const satisfies readonly Relationship[]
+
+// EditSessionEvents relationships
+export const editSessionEventsRelationships = [
+  { foreignKeyName: 'edit_session_events_session_id_edit_sessions_id_fk', columns: ['session_id'], isOneToOne: true, referencedRelation: 'edit_sessions', referencedColumns: ['id'] },
+] as const satisfies readonly Relationship[]
+
+// EditSessions relationships
+export const editSessionsRelationships = [
+  { foreignKeyName: 'edit_sessions_site_id_sites_id_fk', columns: ['site_id'], isOneToOne: true, referencedRelation: 'sites', referencedColumns: ['id'] },
+  { foreignKeyName: 'edit_sessions_created_by_users_id_fk', columns: ['created_by'], isOneToOne: true, referencedRelation: 'users', referencedColumns: ['id'] },
+] as const satisfies readonly Relationship[]
 
 // ErrorEvents relationships
 export const errorEventsRelationships: readonly Relationship[] = []
@@ -1285,6 +1323,24 @@ export type Database = {
         Insert: CrdtOperationsInsert
         Update: CrdtOperationsUpdate
         Relationships: typeof crdtOperationsRelationships
+      }
+      edit_session_docs: {
+        Row: EditSessionDocsRow
+        Insert: EditSessionDocsInsert
+        Update: EditSessionDocsUpdate
+        Relationships: typeof editSessionDocsRelationships
+      }
+      edit_session_events: {
+        Row: EditSessionEventsRow
+        Insert: EditSessionEventsInsert
+        Update: EditSessionEventsUpdate
+        Relationships: typeof editSessionEventsRelationships
+      }
+      edit_sessions: {
+        Row: EditSessionsRow
+        Insert: EditSessionsInsert
+        Update: EditSessionsUpdate
+        Relationships: typeof editSessionsRelationships
       }
       error_events: {
         Row: ErrorEventsRow


### PR DESCRIPTION
## Summary

Adds the P1 slice-1 **edit-session engine**: a durable, auditable draft workspace over live content docs. Editors open a session, patch draft overlays (autosave), then publish atomically or discard. Every action appends to an append-only event log.

This is the engine layer only (Drizzle schema + migration + Hono session API). No UI.

### Data model (migration `0027_open_storm`)

- `edit_sessions` — the workspace (site, title, status `open|published|discarded`, timestamps).
- `edit_session_docs` — one draft overlay per touched doc, materialized from the live doc on first patch, with `base_version` for optimistic locking. Unique on `(session_id, doc_type, doc_id)`.
- `edit_session_events` — append-only log with a `serial` id so `?after=<id>` polling is monotonic and stable.

The regenerated snapshot also heals a pre-existing drift: migrations 0021-0026 were hand-written and never updated the drizzle snapshot chain (snapshots jumped 0020 → 0027). The new `0027` snapshot captures true full state, so future `db:generate` runs diff cleanly. The `0027` SQL itself contains only the edit-session delta (idempotent DDL per the repo's migration discipline).

## Endpoints (mounted under `/api/content`)

| Method | Path | Purpose |
|---|---|---|
| POST | `/sessions` | Open a session; writes `opened` event |
| GET | `/sessions` | List (filter by `status` / `siteId`) |
| GET | `/sessions/:id` | Session + its docs + recent events |
| PATCH | `/sessions/:id/docs/:docType/:docId` | Field patch (autosave); materializes the draft from the live doc on first patch, records `base_version`; writes `patched` event |
| GET | `/sessions/:id/events?after=<cursor>` | Poll events after an id-ordered cursor |
| POST | `/sessions/:id/publish` | Optimistic, all-or-nothing publish; snapshots into `page_revisions`, prunes to 50/doc; writes `published` event |
| POST | `/sessions/:id/discard` | Discard; overlay rows retained for audit; writes `discarded` event |

Discard is a **POST** (`/sessions/:id/discard`), not a DELETE. The `/api/content/*` mount maps the DELETE verb to the content `delete` permission (admin only), which is wrong for abandoning your own draft. As a POST it rides the content `update` permission like open/patch/publish.

Mutations on a non-`open` session return 409. The draft patch setter walks dot/array path segments with a prototype-pollution guard (`__proto__` / `constructor` / `prototype` rejected) and no authored regex.

### Deliberate Phase-1 slice: `page` only

`doc_type` `page` is fully implemented. `global` and `post` are accepted by the schema but PATCH and publish reject them with a clear **400 "supported in a later slice"**. This is intentional for slice 1.

### Publish is optimistic + compensated, not a DB transaction (by necessity)

The production driver is Neon HTTP, which has no interactive transactions (`drizzle-orm/neon-http` throws `No transactions support`). Publish is therefore:

1. **Pre-flight** — read and version-check every doc. Any mismatch → 409 with per-doc detail and **zero writes**. This catches the common case (an external edit landed after the draft was based) before anything is written.
2. **Guarded writes** — each page update is version-guarded (`UPDATE ... WHERE version = base_version`), snapshots a revision, and prunes to 50/doc.
3. **Compensation on a mid-flight miss** — if a guarded write misses (a writer won the race in the narrow window after pre-flight), the docs already written this attempt are **rolled back**: each is restored to its exact prior row (guarded on the version this attempt set) and its just-inserted revision is deleted. If every restore succeeds the 409 is clean — nothing is live. If a restore itself misses, that doc stays live and is named in a `partiallyPublished: [docId]` field on the 409, and its overlay `base_version` is advanced so a **retry converges with no wedge** (no phantom conflict on the session's own write).

Net semantics: all-or-nothing in the common and mid-flight-race cases; a double-race (write + compensation both lose) degrades to a reported partial that a retry heals, rather than a silent partial or a permanently wedged session. This holds identically on Neon HTTP (prod) and the PGlite test driver — no driver-specific transaction call.

### Security: draft routes are authed everywhere

Every session route exposes draft content, so every route — **GETs included** — requires an authenticated user holding the content `update` permission, enforced explicitly inside the routes (the `/api/content/*` mount only gates POST/PATCH/DELETE by verb; GET is public-read there). Tests prove anonymous → 401 and a non-editor → 403 on every endpoint.

### Cache strategy A (1s freshness)

Published-content GET reads (`/api/content/pages/*`, `/globals/*`, `/posts/*`) now carry `s-maxage=1` with a small stale-while-revalidate via the existing-but-unused `publicCacheMiddleware`. With `s-maxage=1` an edit-session publish is visible within ~1s without an active cache purge, meeting the publish SLA. Session routes are `no-store` (they serve authed drafts).

## Test plan

PGlite integration + cache-header tests (all green; full server suite 3016 passed / 2 skipped):

- open → patch (materializes draft + `base_version`) → patch again → publish (page written, version bumped, revision snapshot exists, session published, events complete and in order)
- publish after an out-of-band page edit → 409 with per-doc detail, no write
- mid-flight publish conflict (a concurrent writer wins the race after pre-flight, injected in the test): compensation restores the already-written doc to its exact prior row and deletes its revision → clean 409, nothing live, session still open
- mid-flight conflict with compensation forced to fail → 409 names the doc in `partiallyPublished`; a retry after resolving the conflict converges to a full publish with no wedge
- discard path (overlay rows retained)
- `maxPerDoc=50` revision pruning
- prototype-pollution segment rejection
- authz: anonymous + non-editor rejected on every route including GETs
- non-`open` session mutations → 409
- cache headers: content GETs carry `s-maxage=1`, session routes carry `no-store`

Verification: `server` typecheck + full `server` test + `@revealui/db` typecheck + `gate:quick` all pass.

Part of the visual-edit-sessions program per the internal spec (2026-07-02). Merge after the F7 hygiene PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
