### PR TITLE
feat: marketing block schemas + annotatable presentation renderer

### DIFF
--- a/.changeset/presentation-block-renderer.md
+++ b/.changeset/presentation-block-renderer.md
@@ -1,0 +1,18 @@
+---
+'@revealui/contracts': minor
+'@revealui/presentation': minor
+---
+
+Add marketing-shaped section blocks to the canonical block union and a shared, annotatable block renderer.
+
+**@revealui/contracts** — three new section-level block types on the canonical `BlockSchema` union (`pages.blocks`), each with a `create*Block` factory:
+
+- `hero` — `{ eyebrow?, title, subtitle?, support?, links? }`
+- `ctaSection` — `{ heading, body?, links?, snippet? }` (snippet is display-only CLI text)
+- `section` — `{ eyebrow?, heading, body?, items? }`, the generic repeater covering FAQ / demo-beats / cards
+
+Text fields are plain strings in P1 (no Lexical serialized state). A shared `MarketingLinkSchema` (`{ label, href, variant? }`) backs the hero and cta link arrays.
+
+**@revealui/presentation** — a new `RenderBlocks` renderer (server-safe, render-only) that validates each block against `BlockSchema` and dispatches to per-type components (`HeroBlock`, `CtaSectionBlock`, `SectionBlock`, plus thin renderers for `text`/`heading`/`quote`/`list`/`divider`/`spacer`). Unsupported or invalid blocks render nothing with a dev-only diagnostic.
+
+Edit-mode annotation contract: when `editable` and a `docId` are provided, every text-bearing element carries `data-rvui-doc` and `data-rvui-field` (a dot-path into the block array, e.g. `blocks.3.title`, `blocks.3.items.2.body`). No data attributes are emitted otherwise.

--- a/packages/contracts/src/content/__tests__/marketing-blocks.test.ts
+++ b/packages/contracts/src/content/__tests__/marketing-blocks.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BlockSchema,
+  CtaSectionBlockSchema,
+  createCtaSectionBlock,
+  createHeroBlock,
+  createSectionBlock,
+  HeroBlockSchema,
+  SectionBlockSchema,
+} from '../index.js';
+
+describe('Marketing section blocks', () => {
+  describe('HeroBlockSchema', () => {
+    it('round-trips a full hero block', () => {
+      const block = createHeroBlock('hero-1', 'Ship agents your business can audit', {
+        eyebrow: 'RevealUI',
+        subtitle: 'The self-hosted runtime for governed agents.',
+        support: 'Runs on any AI provider you choose.',
+        links: [
+          { label: 'Get started', href: '/start', variant: 'primary' },
+          { label: 'Read the docs', href: '/docs', variant: 'secondary' },
+        ],
+      });
+
+      const parsed = HeroBlockSchema.safeParse(block);
+      expect(parsed.success).toBe(true);
+      // Parses through the canonical union too.
+      expect(BlockSchema.safeParse(block).success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.type).toBe('hero');
+        expect(parsed.data.data.title).toBe('Ship agents your business can audit');
+        expect(parsed.data.data.links).toHaveLength(2);
+      }
+    });
+
+    it('requires a title', () => {
+      const parsed = HeroBlockSchema.safeParse({
+        id: 'hero-2',
+        type: 'hero',
+        data: { subtitle: 'no title here' },
+      });
+      expect(parsed.success).toBe(false);
+    });
+
+    it('rejects an unknown link variant', () => {
+      const parsed = HeroBlockSchema.safeParse({
+        id: 'hero-3',
+        type: 'hero',
+        data: { title: 'x', links: [{ label: 'a', href: '/a', variant: 'ghost' }] },
+      });
+      expect(parsed.success).toBe(false);
+    });
+  });
+
+  describe('CtaSectionBlockSchema', () => {
+    it('round-trips a cta block with a display-only snippet', () => {
+      const block = createCtaSectionBlock('cta-1', 'Deploy in one command', {
+        body: 'One roof for your business and the agents that run it.',
+        links: [{ label: 'Install', href: '/install', variant: 'primary' }],
+        snippet: {
+          lines: ['npx create-revealui', 'cd my-app'],
+          caption: 'That is the whole setup.',
+        },
+      });
+
+      const parsed = CtaSectionBlockSchema.safeParse(block);
+      expect(parsed.success).toBe(true);
+      expect(BlockSchema.safeParse(block).success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.data.snippet?.lines).toEqual(['npx create-revealui', 'cd my-app']);
+      }
+    });
+
+    it('requires a heading', () => {
+      const parsed = CtaSectionBlockSchema.safeParse({
+        id: 'cta-2',
+        type: 'ctaSection',
+        data: { body: 'no heading' },
+      });
+      expect(parsed.success).toBe(false);
+    });
+  });
+
+  describe('SectionBlockSchema', () => {
+    it('round-trips a repeater section', () => {
+      const block = createSectionBlock('sec-1', 'Questions', {
+        eyebrow: 'FAQ',
+        items: [
+          { title: 'Is it self-hosted?', body: 'Yes, it runs on your infrastructure.' },
+          { label: 'Beat 2', body: 'The receipt prints.' },
+        ],
+      });
+
+      const parsed = SectionBlockSchema.safeParse(block);
+      expect(parsed.success).toBe(true);
+      expect(BlockSchema.safeParse(block).success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.data.items).toHaveLength(2);
+      }
+    });
+
+    it('requires each item to carry a body', () => {
+      const parsed = SectionBlockSchema.safeParse({
+        id: 'sec-2',
+        type: 'section',
+        data: { heading: 'x', items: [{ title: 'no body' }] },
+      });
+      expect(parsed.success).toBe(false);
+    });
+  });
+});

--- a/packages/contracts/src/content/index.ts
+++ b/packages/contracts/src/content/index.ts
@@ -465,6 +465,97 @@ export const ComponentBlockSchema = BaseBlockSchema.extend({
 export type ComponentBlock = z.infer<typeof ComponentBlockSchema>;
 
 // =============================================================================
+// Marketing Link (shared by hero + cta section blocks)
+// =============================================================================
+
+/**
+ * A call-to-action link inside a marketing section block. `variant` maps to a
+ * visual emphasis in the renderer (primary = filled, secondary = outline);
+ * absent means the renderer picks a default.
+ */
+export const MarketingLinkSchema = z.object({
+  label: z.string(),
+  href: z.string(),
+  variant: z.enum(['primary', 'secondary']).optional(),
+});
+
+export type MarketingLink = z.infer<typeof MarketingLinkSchema>;
+
+// =============================================================================
+// Hero Block (section-level marketing)
+// =============================================================================
+
+/**
+ * Full-width lead section: eyebrow, headline, subtitle, a support line, and
+ * optional CTA links. Text fields are plain strings in P1 (no Lexical state).
+ */
+export const HeroBlockSchema = BaseBlockSchema.extend({
+  type: z.literal('hero'),
+  data: z.object({
+    eyebrow: z.string().optional(),
+    title: z.string(),
+    subtitle: z.string().optional(),
+    support: z.string().optional(),
+    links: z.array(MarketingLinkSchema).optional(),
+  }),
+});
+
+export type HeroBlock = z.infer<typeof HeroBlockSchema>;
+
+// =============================================================================
+// CTA Section Block (section-level marketing closer)
+// =============================================================================
+
+/**
+ * Closing call-to-action section: heading, optional body copy, CTA links, and
+ * an optional display-only CLI snippet (rendered as static text, never run).
+ */
+export const CtaSectionBlockSchema = BaseBlockSchema.extend({
+  type: z.literal('ctaSection'),
+  data: z.object({
+    heading: z.string(),
+    body: z.string().optional(),
+    links: z.array(MarketingLinkSchema).optional(),
+    snippet: z
+      .object({
+        lines: z.array(z.string()),
+        caption: z.string().optional(),
+      })
+      .optional(),
+  }),
+});
+
+export type CtaSectionBlock = z.infer<typeof CtaSectionBlockSchema>;
+
+// =============================================================================
+// Section Block (generic marketing repeater: FAQ / beats / cards)
+// =============================================================================
+
+/**
+ * Generic titled section with an optional list of repeater items. Covers the
+ * demo-beats, primitive-cards, and FAQ shapes, all of `{ label?, title?, body }`.
+ */
+export const SectionBlockSchema = BaseBlockSchema.extend({
+  type: z.literal('section'),
+  data: z.object({
+    eyebrow: z.string().optional(),
+    heading: z.string(),
+    body: z.string().optional(),
+    items: z
+      .array(
+        z.object({
+          label: z.string().optional(),
+          title: z.string().optional(),
+          body: z.string(),
+        }),
+      )
+      .optional(),
+  }),
+});
+
+export type SectionBlock = z.infer<typeof SectionBlockSchema>;
+
+// =============================================================================
 // Block Union (Discriminated by `type`)
 // =============================================================================
 
@@ -496,6 +587,9 @@ export const BlockSchema = z.union([
   FormBlockSchema,
   HtmlBlockSchema,
   ComponentBlockSchema,
+  HeroBlockSchema,
+  CtaSectionBlockSchema,
+  SectionBlockSchema,
 ]);
 
 export type Block = z.infer<typeof BlockSchema>;
@@ -524,6 +618,9 @@ export const BlockTypes = [
   'form',
   'html',
   'component',
+  'hero',
+  'ctaSection',
+  'section',
 ] as const;
 
 export type BlockType = (typeof BlockTypes)[number];
@@ -598,6 +695,67 @@ export function createCodeBlock(
     id,
     type: 'code',
     data: { code, language, showLineNumbers: false, ...options },
+    meta: { version: BLOCK_SCHEMA_VERSION },
+  };
+}
+
+/**
+ * Creates a hero section block
+ */
+export function createHeroBlock(
+  id: string,
+  title: string,
+  options?: {
+    eyebrow?: string;
+    subtitle?: string;
+    support?: string;
+    links?: MarketingLink[];
+  },
+): HeroBlock {
+  return {
+    id,
+    type: 'hero',
+    data: { title, ...options },
+    meta: { version: BLOCK_SCHEMA_VERSION },
+  };
+}
+
+/**
+ * Creates a CTA section block
+ */
+export function createCtaSectionBlock(
+  id: string,
+  heading: string,
+  options?: {
+    body?: string;
+    links?: MarketingLink[];
+    snippet?: { lines: string[]; caption?: string };
+  },
+): CtaSectionBlock {
+  return {
+    id,
+    type: 'ctaSection',
+    data: { heading, ...options },
+    meta: { version: BLOCK_SCHEMA_VERSION },
+  };
+}
+
+/**
+ * Creates a generic section block (repeater for FAQ / beats / cards)
+ */
+export function createSectionBlock(
+  id: string,
+  heading: string,
+  options?: {
+    eyebrow?: string;
+    body?: string;
+    items?: Array<{ label?: string; title?: string; body: string }>;
+  },
+): SectionBlock {
+  return {
+    id,
+    type: 'section',
+    data: { heading, ...options },
     meta: { version: BLOCK_SCHEMA_VERSION },
   };
 }

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -12,6 +12,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@revealui/contracts": "workspace:*",
     "@revealui/tokens": "workspace:*",
     "tailwind-merge": "^3.3.1"
   },

--- a/packages/presentation/src/__tests__/blocks/render-blocks.test.tsx
+++ b/packages/presentation/src/__tests__/blocks/render-blocks.test.tsx
@@ -1,0 +1,151 @@
+import type { Block } from '@revealui/contracts/content';
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RenderBlocks } from '../../blocks/RenderBlocks.js';
+
+const pageBlocks: Block[] = [
+  {
+    id: 'hero-1',
+    type: 'hero',
+    data: {
+      eyebrow: 'RevealUI',
+      title: 'Governed agents',
+      subtitle: 'One roof for your business.',
+      links: [{ label: 'Start', href: '/start', variant: 'primary' }],
+    },
+  },
+  {
+    id: 'sec-1',
+    type: 'section',
+    data: {
+      heading: 'Questions',
+      items: [
+        { title: 'First', body: 'Body one.' },
+        { label: 'Beat', body: 'Body two.' },
+      ],
+    },
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('RenderBlocks — annotation contract', () => {
+  it('emits data-rvui-doc/field on text-bearing elements when editable with a docId', () => {
+    const { container } = render(<RenderBlocks blocks={pageBlocks} docId="page-42" editable />);
+
+    const title = container.querySelector('[data-rvui-field="blocks.0.title"]');
+    expect(title).not.toBeNull();
+    expect(title?.getAttribute('data-rvui-doc')).toBe('page-42');
+    expect(title?.textContent).toBe('Governed agents');
+
+    // Nested repeater item field path uses items.<index>.<field>.
+    const nestedBody = container.querySelector('[data-rvui-field="blocks.1.items.1.body"]');
+    expect(nestedBody).not.toBeNull();
+    expect(nestedBody?.getAttribute('data-rvui-doc')).toBe('page-42');
+    expect(nestedBody?.textContent).toBe('Body two.');
+
+    const nestedLabel = container.querySelector('[data-rvui-field="blocks.1.items.0.title"]');
+    expect(nestedLabel?.textContent).toBe('First');
+  });
+
+  it('emits no data attributes when editable is false', () => {
+    const { container } = render(<RenderBlocks blocks={pageBlocks} docId="page-42" />);
+    expect(container.querySelector('[data-rvui-field]')).toBeNull();
+    expect(container.querySelector('[data-rvui-doc]')).toBeNull();
+  });
+
+  it('emits no data attributes when editable is true but docId is absent', () => {
+    const { container } = render(<RenderBlocks blocks={pageBlocks} editable />);
+    expect(container.querySelector('[data-rvui-field]')).toBeNull();
+  });
+});
+
+describe('RenderBlocks — unsupported + invalid blocks', () => {
+  it('renders nothing and warns for a valid block type with no renderer', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const blocks: Block[] = [
+      { id: 'code-1', type: 'code', data: { code: 'x', showLineNumbers: false } },
+    ];
+
+    const { container } = render(<RenderBlocks blocks={blocks} />);
+    expect(container.textContent).toBe('');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unsupported block type: code'));
+  });
+
+  it('skips and warns for a block that fails schema validation', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    // Missing required `title` — fails HeroBlockSchema.
+    const blocks = [{ id: 'bad', type: 'hero', data: {} }] as unknown as Block[];
+
+    const { container } = render(<RenderBlocks blocks={blocks} />);
+    expect(container.textContent).toBe('');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('failed schema validation'));
+  });
+});
+
+describe('RenderBlocks — cta section + primitive renderers', () => {
+  it('renders a cta section with a display-only snippet and annotated fields', () => {
+    const blocks: Block[] = [
+      {
+        id: 'cta-1',
+        type: 'ctaSection',
+        data: {
+          heading: 'Deploy in one command',
+          body: 'One roof.',
+          links: [{ label: 'Install', href: '/install', variant: 'primary' }],
+          snippet: { lines: ['npx create-revealui', 'cd app'], caption: 'That is it.' },
+        },
+      },
+    ];
+
+    const { container } = render(<RenderBlocks blocks={blocks} docId="d1" editable />);
+    expect(container.querySelector('[data-rvui-field="blocks.0.heading"]')?.textContent).toBe(
+      'Deploy in one command',
+    );
+    // Snippet renders as static text (both lines joined), never executed.
+    const snippet = container.querySelector('[data-rvui-field="blocks.0.snippet.lines"]');
+    expect(snippet?.textContent).toBe('npx create-revealui\ncd app');
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/install');
+  });
+
+  it('renders each supported content primitive with correct field paths', () => {
+    const blocks: Block[] = [
+      { id: 't', type: 'text', data: { content: 'Body copy', format: 'plain' } },
+      { id: 'h', type: 'heading', data: { text: 'A Heading', level: 'h2' } },
+      { id: 'q', type: 'quote', data: { content: 'Quoted', attribution: 'Someone' } },
+      {
+        id: 'l',
+        type: 'list',
+        data: {
+          variant: 'unordered',
+          items: [
+            { id: 'i0', content: 'One' },
+            { id: 'i1', content: 'Two' },
+          ],
+        },
+      },
+      { id: 'd', type: 'divider', data: { variant: 'dashed' } },
+      { id: 's', type: 'spacer', data: { height: '3rem' } },
+    ];
+
+    const { container } = render(<RenderBlocks blocks={blocks} docId="d2" editable />);
+
+    expect(container.querySelector('[data-rvui-field="blocks.0.content"]')?.textContent).toBe(
+      'Body copy',
+    );
+    const heading = container.querySelector('[data-rvui-field="blocks.1.text"]');
+    expect(heading?.tagName).toBe('H2');
+    expect(container.querySelector('[data-rvui-field="blocks.2.content"]')?.textContent).toBe(
+      'Quoted',
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.2.attribution"]')?.textContent).toBe(
+      'Someone',
+    );
+    expect(
+      container.querySelector('[data-rvui-field="blocks.3.items.1.content"]')?.textContent,
+    ).toBe('Two');
+    expect(container.querySelector('hr')).not.toBeNull();
+  });
+});

--- a/packages/presentation/src/blocks/CtaSectionBlock.tsx
+++ b/packages/presentation/src/blocks/CtaSectionBlock.tsx
@@ -1,0 +1,70 @@
+import type { CtaSectionBlock as CtaSectionBlockData } from '@revealui/contracts/content';
+import type React from 'react';
+import { cn } from '../utils/cn.js';
+import type { BlockAnnotation } from './annotation.js';
+import { fieldAttrs } from './annotation.js';
+import { MarketingLinks } from './marketing-links.js';
+
+export interface CtaSectionBlockProps {
+  block: CtaSectionBlockData;
+  /** Dot-path of this block within the page array, e.g. `blocks.3`. */
+  path: string;
+  annotation: BlockAnnotation;
+  className?: string;
+}
+
+/**
+ * Closing call-to-action section with optional CLI snippet. The snippet is
+ * display-only static text (never executed). Server-safe: no hooks/state.
+ */
+export function CtaSectionBlock({
+  block,
+  path,
+  annotation,
+  className,
+}: CtaSectionBlockProps): React.JSX.Element {
+  const { heading, body, links, snippet } = block.data;
+  return (
+    <section
+      className={cn(
+        'mx-auto flex max-w-3xl flex-col items-center gap-6 px-6 py-16 text-center',
+        className,
+      )}
+    >
+      <h2
+        className="text-balance text-3xl font-semibold tracking-tight text-foreground"
+        {...fieldAttrs(annotation, `${path}.heading`)}
+      >
+        {heading}
+      </h2>
+      {body ? (
+        <p
+          className="max-w-2xl text-lg text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.body`)}
+        >
+          {body}
+        </p>
+      ) : null}
+      {links && links.length > 0 ? (
+        <MarketingLinks links={links} className="justify-center" />
+      ) : null}
+      {snippet ? (
+        <figure className="w-full max-w-xl">
+          <pre className="overflow-x-auto rounded-[var(--rvui-radius-md)] border border-border bg-card px-4 py-3 text-left font-mono text-sm text-foreground">
+            <code {...fieldAttrs(annotation, `${path}.snippet.lines`)}>
+              {snippet.lines.join('\n')}
+            </code>
+          </pre>
+          {snippet.caption ? (
+            <figcaption
+              className="mt-2 text-xs text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.snippet.caption`)}
+            >
+              {snippet.caption}
+            </figcaption>
+          ) : null}
+        </figure>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/presentation/src/blocks/HeroBlock.tsx
+++ b/packages/presentation/src/blocks/HeroBlock.tsx
@@ -1,0 +1,66 @@
+import type { HeroBlock as HeroBlockData } from '@revealui/contracts/content';
+import type React from 'react';
+import { cn } from '../utils/cn.js';
+import type { BlockAnnotation } from './annotation.js';
+import { fieldAttrs } from './annotation.js';
+import { MarketingLinks } from './marketing-links.js';
+
+export interface HeroBlockProps {
+  block: HeroBlockData;
+  /** Dot-path of this block within the page array, e.g. `blocks.3`. */
+  path: string;
+  annotation: BlockAnnotation;
+  className?: string;
+}
+
+/**
+ * Full-width lead section. Server-safe (no hooks/state); text-bearing elements
+ * carry edit-mode annotations when active.
+ */
+export function HeroBlock({
+  block,
+  path,
+  annotation,
+  className,
+}: HeroBlockProps): React.JSX.Element {
+  const { eyebrow, title, subtitle, support, links } = block.data;
+  return (
+    <section
+      className={cn(
+        'mx-auto flex max-w-3xl flex-col items-center gap-6 px-6 py-20 text-center',
+        className,
+      )}
+    >
+      {eyebrow ? (
+        <p
+          className="text-sm font-medium uppercase tracking-widest text-primary"
+          {...fieldAttrs(annotation, `${path}.eyebrow`)}
+        >
+          {eyebrow}
+        </p>
+      ) : null}
+      <h1
+        className="text-balance text-4xl font-semibold tracking-tight text-foreground sm:text-5xl"
+        {...fieldAttrs(annotation, `${path}.title`)}
+      >
+        {title}
+      </h1>
+      {subtitle ? (
+        <p
+          className="max-w-2xl text-lg text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.subtitle`)}
+        >
+          {subtitle}
+        </p>
+      ) : null}
+      {support ? (
+        <p className="text-sm text-muted-foreground" {...fieldAttrs(annotation, `${path}.support`)}>
+          {support}
+        </p>
+      ) : null}
+      {links && links.length > 0 ? (
+        <MarketingLinks links={links} className="justify-center" />
+      ) : null}
+    </section>
+  );
+}

--- a/packages/presentation/src/blocks/RenderBlocks.tsx
+++ b/packages/presentation/src/blocks/RenderBlocks.tsx
@@ -1,0 +1,89 @@
+import type { Block } from '@revealui/contracts/content';
+import { BlockSchema } from '@revealui/contracts/content';
+import type React from 'react';
+import type { BlockAnnotation } from './annotation.js';
+import { devWarn, fieldAttrs } from './annotation.js';
+import { CtaSectionBlock } from './CtaSectionBlock.js';
+import { HeroBlock } from './HeroBlock.js';
+import {
+  DividerBlockView,
+  HeadingBlockView,
+  ListBlockView,
+  QuoteBlockView,
+  SpacerBlockView,
+  TextBlockView,
+} from './primitive-blocks.js';
+import { SectionBlock } from './SectionBlock.js';
+
+export interface RenderBlocksProps {
+  /** Page block array (canonical `pages.blocks` shape). */
+  blocks: Block[];
+  /** Document id for edit-mode annotations. Required for annotations to emit. */
+  docId?: string;
+  /** When true (with a docId), emit `data-rvui-doc`/`data-rvui-field` on text. */
+  editable?: boolean;
+}
+
+/**
+ * Shared, annotatable block renderer.
+ *
+ * Validates each block against the canonical `BlockSchema` from
+ * `@revealui/contracts` and dispatches to a per-type component. Blocks that fail
+ * validation or have no renderer are skipped (with a dev-only diagnostic).
+ *
+ * Render-only and server-safe: no hooks, no state, no `next/*` imports.
+ */
+export function RenderBlocks({ blocks, docId, editable }: RenderBlocksProps): React.JSX.Element {
+  const annotation: BlockAnnotation = { docId, editable };
+  return (
+    <>
+      {blocks.map((raw, index) => {
+        const parsed = BlockSchema.safeParse(raw);
+        if (!parsed.success) {
+          devWarn(`skipping block at index ${index}: failed schema validation`);
+          return null;
+        }
+        const block = parsed.data as Block;
+        const path = `blocks.${index}`;
+        return (
+          <BlockView key={block.id || path} block={block} path={path} annotation={annotation} />
+        );
+      })}
+    </>
+  );
+}
+
+interface BlockViewProps {
+  block: Block;
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+function BlockView({ block, path, annotation }: BlockViewProps): React.JSX.Element | null {
+  switch (block.type) {
+    case 'hero':
+      return <HeroBlock block={block} path={path} annotation={annotation} />;
+    case 'ctaSection':
+      return <CtaSectionBlock block={block} path={path} annotation={annotation} />;
+    case 'section':
+      return <SectionBlock block={block} path={path} annotation={annotation} />;
+    case 'text':
+      return <TextBlockView block={block} path={path} annotation={annotation} />;
+    case 'heading':
+      return <HeadingBlockView block={block} path={path} annotation={annotation} />;
+    case 'quote':
+      return <QuoteBlockView block={block} path={path} annotation={annotation} />;
+    case 'list':
+      return <ListBlockView block={block} path={path} annotation={annotation} />;
+    case 'divider':
+      return <DividerBlockView block={block} />;
+    case 'spacer':
+      return <SpacerBlockView block={block} />;
+    default:
+      devWarn(`unsupported block type: ${block.type}`);
+      return null;
+  }
+}
+
+/** Re-exported so consumers can build the same field dot-paths as the renderer. */
+export { fieldAttrs };

--- a/packages/presentation/src/blocks/SectionBlock.tsx
+++ b/packages/presentation/src/blocks/SectionBlock.tsx
@@ -1,0 +1,92 @@
+import type { SectionBlock as SectionBlockData } from '@revealui/contracts/content';
+import type React from 'react';
+import { cn } from '../utils/cn.js';
+import type { BlockAnnotation } from './annotation.js';
+import { fieldAttrs } from './annotation.js';
+
+export interface SectionBlockProps {
+  block: SectionBlockData;
+  /** Dot-path of this block within the page array, e.g. `blocks.3`. */
+  path: string;
+  annotation: BlockAnnotation;
+  className?: string;
+}
+
+/**
+ * Generic titled section with an optional repeater list. Covers the demo-beats,
+ * primitive-cards, and FAQ shapes. Server-safe: no hooks/state. Each repeater
+ * item's fields are addressed as `blocks.<i>.items.<j>.<field>`.
+ */
+export function SectionBlock({
+  block,
+  path,
+  annotation,
+  className,
+}: SectionBlockProps): React.JSX.Element {
+  const { eyebrow, heading, body, items } = block.data;
+  return (
+    <section className={cn('mx-auto max-w-5xl px-6 py-16', className)}>
+      <div className="mx-auto max-w-2xl text-center">
+        {eyebrow ? (
+          <p
+            className="text-sm font-medium uppercase tracking-widest text-primary"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {eyebrow}
+          </p>
+        ) : null}
+        <h2
+          className="mt-3 text-balance text-3xl font-semibold tracking-tight text-foreground"
+          {...fieldAttrs(annotation, `${path}.heading`)}
+        >
+          {heading}
+        </h2>
+        {body ? (
+          <p
+            className="mt-4 text-lg text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.body`)}
+          >
+            {body}
+          </p>
+        ) : null}
+      </div>
+      {items && items.length > 0 ? (
+        <ul className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((item, index) => {
+            const itemPath = `${path}.items.${index}`;
+            const headingText = item.title ?? item.label;
+            return (
+              <li
+                key={`${itemPath}:${headingText ?? item.body}`}
+                className="rounded-[var(--rvui-radius-md)] border border-border bg-card p-6 text-left"
+              >
+                {item.label ? (
+                  <p
+                    className="text-xs font-medium uppercase tracking-widest text-primary"
+                    {...fieldAttrs(annotation, `${itemPath}.label`)}
+                  >
+                    {item.label}
+                  </p>
+                ) : null}
+                {item.title ? (
+                  <h3
+                    className="mt-1 text-lg font-semibold text-foreground"
+                    {...fieldAttrs(annotation, `${itemPath}.title`)}
+                  >
+                    {item.title}
+                  </h3>
+                ) : null}
+                <p
+                  className="mt-2 text-sm text-muted-foreground"
+                  {...fieldAttrs(annotation, `${itemPath}.body`)}
+                >
+                  {item.body}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/presentation/src/blocks/annotation.ts
+++ b/packages/presentation/src/blocks/annotation.ts
@@ -1,0 +1,44 @@
+/**
+ * Edit-mode annotation contract for the shared block renderer.
+ *
+ * When a page is rendered `editable` with a `docId`, every text-bearing element
+ * carries two data attributes the edit-mode runtime (a later slice) reads:
+ *   - `data-rvui-doc`   — the document id the block array belongs to
+ *   - `data-rvui-field` — a dot-path addressing the field inside `blocks`,
+ *                          e.g. `blocks.3.title` or `blocks.3.items.2.body`.
+ *
+ * When not editable (or no docId), no data attributes are emitted at all.
+ */
+
+/** Render-time annotation state threaded down to every block component. */
+export interface BlockAnnotation {
+  /** Document id the block array belongs to. */
+  docId?: string;
+  /** Whether to emit edit-mode data attributes. */
+  editable?: boolean;
+}
+
+/** The attribute bag spread onto a text-bearing element. Empty when inactive. */
+export type AnnotationAttrs = Record<string, string>;
+
+/**
+ * Builds the `data-rvui-*` attribute bag for a single field. Returns an empty
+ * object (emitting nothing) unless annotation is active with a docId.
+ */
+export function fieldAttrs(annotation: BlockAnnotation, fieldPath: string): AnnotationAttrs {
+  if (annotation.editable && annotation.docId) {
+    return { 'data-rvui-doc': annotation.docId, 'data-rvui-field': fieldPath };
+  }
+  return {};
+}
+
+/**
+ * Emits a diagnostic in non-production builds only. Kept local so the framework
+ * pure package takes no logger dependency; guarded so production stays silent.
+ */
+export function devWarn(message: string): void {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+    // biome-ignore lint/suspicious/noConsole: dev-only diagnostic; framework-pure package takes no logger dep
+    console.warn(`[RenderBlocks] ${message}`); // console-allowed
+  }
+}

--- a/packages/presentation/src/blocks/index.ts
+++ b/packages/presentation/src/blocks/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared block renderer — marketing-shaped section blocks plus thin renderers
+ * for the reusable content primitives, with an edit-mode annotation contract.
+ *
+ * All exports are render-only and server-safe (no hooks, no state).
+ */
+
+export {
+  type AnnotationAttrs,
+  type BlockAnnotation,
+  fieldAttrs,
+} from './annotation.js';
+export { CtaSectionBlock, type CtaSectionBlockProps } from './CtaSectionBlock.js';
+export { HeroBlock, type HeroBlockProps } from './HeroBlock.js';
+export { MarketingLinks, type MarketingLinksProps } from './marketing-links.js';
+export {
+  DividerBlockView,
+  HeadingBlockView,
+  ListBlockView,
+  QuoteBlockView,
+  SpacerBlockView,
+  TextBlockView,
+} from './primitive-blocks.js';
+export { RenderBlocks, type RenderBlocksProps } from './RenderBlocks.js';
+export { SectionBlock, type SectionBlockProps } from './SectionBlock.js';

--- a/packages/presentation/src/blocks/marketing-links.tsx
+++ b/packages/presentation/src/blocks/marketing-links.tsx
@@ -1,0 +1,37 @@
+import type { MarketingLink } from '@revealui/contracts/content';
+import type React from 'react';
+import { buttonVariants } from '../components/Button.js';
+import { cn } from '../utils/cn.js';
+
+export interface MarketingLinksProps {
+  links: MarketingLink[];
+  className?: string;
+}
+
+/**
+ * Renders a row of marketing CTA links as branded anchors. `primary` maps to the
+ * filled brand button, everything else to a neutral outline. Server-safe: plain
+ * anchors styled with the shared `buttonVariants`, no hooks.
+ */
+export function MarketingLinks({ links, className }: MarketingLinksProps): React.JSX.Element {
+  return (
+    <div className={cn('flex flex-wrap items-center gap-3', className)}>
+      {links.map((link) => {
+        const isPrimary = link.variant === 'primary';
+        return (
+          <a
+            key={`${link.href}:${link.label}`}
+            href={link.href}
+            className={buttonVariants(
+              isPrimary
+                ? { appearance: 'solid', variant: 'brand', size: 'lg' }
+                : { appearance: 'outline', variant: 'neutral', size: 'lg' },
+            )}
+          >
+            {link.label}
+          </a>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/presentation/src/blocks/primitive-blocks.tsx
+++ b/packages/presentation/src/blocks/primitive-blocks.tsx
@@ -1,0 +1,123 @@
+import type {
+  DividerBlock,
+  HeadingBlock,
+  ListBlock,
+  QuoteBlock,
+  SpacerBlock,
+  TextBlock,
+} from '@revealui/contracts/content';
+import type React from 'react';
+import { cn } from '../utils/cn.js';
+import type { BlockAnnotation } from './annotation.js';
+import { fieldAttrs } from './annotation.js';
+
+interface PrimitiveProps<T> {
+  block: T;
+  /** Dot-path of this block within the page array, e.g. `blocks.3`. */
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+/**
+ * Thin, cheap renderers for the general-purpose primitives the marketing
+ * surface reuses. Rich formats (markdown/html/tiptap) render as plain text in
+ * P1; a richer pipeline is a later slice.
+ */
+
+export function TextBlockView({
+  block,
+  path,
+  annotation,
+}: PrimitiveProps<TextBlock>): React.JSX.Element {
+  return (
+    <p
+      className="text-base text-foreground leading-relaxed"
+      {...fieldAttrs(annotation, `${path}.content`)}
+    >
+      {block.data.content}
+    </p>
+  );
+}
+
+export function HeadingBlockView({
+  block,
+  path,
+  annotation,
+}: PrimitiveProps<HeadingBlock>): React.JSX.Element {
+  const Tag = block.data.level;
+  return (
+    <Tag
+      className="font-semibold text-foreground tracking-tight"
+      {...fieldAttrs(annotation, `${path}.text`)}
+    >
+      {block.data.text}
+    </Tag>
+  );
+}
+
+export function QuoteBlockView({
+  block,
+  path,
+  annotation,
+}: PrimitiveProps<QuoteBlock>): React.JSX.Element {
+  const { content, attribution } = block.data;
+  return (
+    <blockquote className="border-primary border-l-2 pl-4 text-muted-foreground italic">
+      <p {...fieldAttrs(annotation, `${path}.content`)}>{content}</p>
+      {attribution ? (
+        <footer
+          className="mt-2 text-foreground text-sm not-italic"
+          {...fieldAttrs(annotation, `${path}.attribution`)}
+        >
+          {attribution}
+        </footer>
+      ) : null}
+    </blockquote>
+  );
+}
+
+export function ListBlockView({
+  block,
+  path,
+  annotation,
+}: PrimitiveProps<ListBlock>): React.JSX.Element {
+  const { items, variant } = block.data;
+  const ListTag = variant === 'ordered' ? 'ol' : 'ul';
+  const listClass = cn(
+    'space-y-1 text-foreground',
+    variant === 'ordered'
+      ? 'list-decimal pl-5'
+      : variant === 'checklist'
+        ? 'pl-0'
+        : 'list-disc pl-5',
+  );
+  return (
+    <ListTag className={listClass}>
+      {items.map((item, index) => (
+        <li key={item.id} {...fieldAttrs(annotation, `${path}.items.${index}.content`)}>
+          {variant === 'checklist' ? (item.checked ? '✓ ' : '☐ ') : null}
+          {item.content}
+        </li>
+      ))}
+    </ListTag>
+  );
+}
+
+export function DividerBlockView({ block }: { block: DividerBlock }): React.JSX.Element {
+  return (
+    <hr
+      className={cn(
+        'border-border',
+        block.data.variant === 'dashed'
+          ? 'border-dashed'
+          : block.data.variant === 'dotted'
+            ? 'border-dotted'
+            : 'border-solid',
+      )}
+    />
+  );
+}
+
+export function SpacerBlockView({ block }: { block: SpacerBlock }): React.JSX.Element {
+  return <div aria-hidden="true" style={{ height: block.data.height }} />;
+}

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -8,6 +8,7 @@
 
 // Icon set + provider/social brand marks: previously only on the /server
 // entry, exported here so apps compose icons instead of handrolling SVGs.
+export * from './blocks/index.js';
 export * from './components/icon.js';
 export * from './components/index.js';
 export * from './hooks/index.js';

--- a/packages/presentation/src/server.ts
+++ b/packages/presentation/src/server.ts
@@ -5,6 +5,29 @@
  * These components don't use React hooks and can be rendered on the server.
  */
 
+// Shared block renderer — marketing section blocks + annotatable primitives.
+// Render-only and server-safe (no hooks/state), so they belong on /server.
+export {
+  type AnnotationAttrs,
+  type BlockAnnotation,
+  CtaSectionBlock,
+  type CtaSectionBlockProps,
+  DividerBlockView,
+  fieldAttrs,
+  HeadingBlockView,
+  HeroBlock,
+  type HeroBlockProps,
+  ListBlockView,
+  MarketingLinks,
+  type MarketingLinksProps,
+  QuoteBlockView,
+  RenderBlocks,
+  type RenderBlocksProps,
+  SectionBlock,
+  type SectionBlockProps,
+  SpacerBlockView,
+  TextBlockView,
+} from './blocks/index.js';
 export { TouchTarget } from './components/_button-shared.js';
 // Layout Components - Server Safe
 export { AuthLayout, type AuthLayoutProps } from './components/auth-layout.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1349,6 +1349,9 @@ importers:
 
   packages/presentation:
     dependencies:
+      '@revealui/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       '@revealui/tokens':
         specifier: workspace:*
         version: link:../tokens


### PR DESCRIPTION
## Summary

P1 slice 2 of the visual-edit-sessions program: marketing-shaped section blocks in the canonical block schema, plus a shared, annotatable block renderer in `@revealui/presentation`. One branch, one PR to `test`.

## New block schemas (`@revealui/contracts`, `content` union)

Three section-level marketing block types added to the canonical `BlockSchema` union (`pages.blocks`), each with a `create*Block` factory. Text fields are plain strings in P1 (no Lexical serialized state).

- `hero` — `{ eyebrow?, title, subtitle?, support?, links? }`
- `ctaSection` — `{ heading, body?, links?, snippet? }` (snippet = display-only CLI text, never executed)
- `section` — `{ eyebrow?, heading, body?, items? }`, the one generic repeater covering FAQ / demo-beats / primitive-cards, all of shape `{ label?, title?, body }`

A shared `MarketingLinkSchema` (`{ label, href, variant?: 'primary' | 'secondary' }`) backs the hero and cta link arrays.

**Naming / adapter reconciliation:** the admin app's Payload-style `blockType` vocabulary (`hero`/`cta`/`content`/`formBlock`/`archive`/`mediaBlock`) is a separate vocabulary that `schema-adapter.ts` transforms *into* the contracts union (`cta` -> `button`, `content` -> `text`, `mediaBlock` -> `image`/`video`, unknown types like admin `hero` -> a `component` block). Those transform *outputs* never include a `hero`/`ctaSection`/`section` `type`, so there is no collision. `hero` is kept as-is; `ctaSection` (not `cta`) is used to avoid confusion with the admin `cta` blockType input.

## Shared renderer (`@revealui/presentation`, new `src/blocks/`)

`RenderBlocks({ blocks, docId?, editable? })` validates each block against `BlockSchema` from `@revealui/contracts` (added as a `workspace:*` dep) and dispatches by `type` to per-block components: `HeroBlock`, `CtaSectionBlock`, `SectionBlock`, plus thin renderers for the reused primitives (`text`, `heading`, `quote`, `list`, `divider`, `spacer`). Unsupported or schema-invalid blocks render nothing with a dev-only diagnostic. Render-only and server-safe (no hooks, no state, no `next/*`); exported from the `.` and `./server` entrypoints.

### Annotation contract (consumed by the edit-mode runtime in a later slice)

When `editable` is true **and** a `docId` is provided, every text-bearing element carries:

- `data-rvui-doc` = the docId
- `data-rvui-field` = a dot-path into the block array, built by plain string concat (no regex):
  - `blocks.<i>.<field>` — e.g. `blocks.0.title`, `blocks.0.heading`, `blocks.0.snippet.lines`
  - `blocks.<i>.items.<j>.<field>` — e.g. `blocks.1.items.2.body`, `blocks.1.items.0.title`

When `editable` is false/absent, or `docId` is missing, **no** data attributes are emitted.

### Deviations from the design (with reasons)

- **`classNames?` prop map: not added.** The design said follow precedent only if one exists. No component in `@revealui/presentation` uses a `classNames` map, so I followed the actual precedent (a single `className?` prop per component) rather than invent a new pattern.
- **Dev warning uses a guarded `console.warn`, not a logger.** `@revealui/presentation` is framework-pure with no logger dependency (tokens + tailwind-merge + contracts). The warning is guarded to non-production and carries the repo's sanctioned `console-allowed` exemption plus a `biome-ignore`.

## Consumer note

The marketing wire-up and the edit canvas consume this in follow-up PRs (marketing pages render `RenderBlocks`; the edit-mode runtime reads the `data-rvui-*` attributes).

## Test plan

- Contracts: schema round-trip + factory tests for all three block types, required-field and bad-variant rejection, and union-parse coverage (`marketing-blocks.test.ts`). `pnpm --filter @revealui/contracts test` -> 39 files / 1016 tests pass.
- Presentation: annotation paths for nested items when editable, none when not editable, none when editable without docId, unsupported-type warns + renders nothing, invalid-block warns + skips, and smoke coverage of the cta snippet + every primitive renderer (`render-blocks.test.tsx`). `pnpm --filter @revealui/presentation test` -> 89 files / 995 tests pass.
- `pnpm --filter @revealui/contracts typecheck` and `pnpm --filter @revealui/presentation typecheck` clean.
- `pnpm gate:quick` -> PASS (all hard-fail validators green).

## Versioning

Changeset added: `@revealui/contracts` minor + `@revealui/presentation` minor (pre-1.0 minor for new capability).

Part of the visual-edit-sessions program per the internal spec (2026-07-02). Do not merge yet.
