### PR TITLE
feat(marketing): wire cms block stream for home and products pages

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -1,23 +1,45 @@
-import { ButtonCVA } from '@revealui/presentation';
+import { type BlockAnnotation, ButtonCVA, fieldAttrs } from '@revealui/presentation';
 import { HOME_GET_STARTED } from '../content/home';
+import type { GetStartedData } from '../lib/page-blocks';
 import { NewsletterSignup } from './NewsletterSignup';
 
-export function GetStarted() {
+export interface GetStartedProps {
+  /** Rich CTA data; defaults to the static content module (byte-identical). */
+  data?: GetStartedData;
+  /** Dot-path base of this block within the page array, e.g. `blocks.1`. */
+  path?: string;
+  /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
+  annotation?: BlockAnnotation;
+}
+
+export function GetStarted({
+  data = HOME_GET_STARTED,
+  path = 'blocks.1',
+  annotation = {},
+}: GetStartedProps) {
   return (
     <section className="py-24 bg-card sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {HOME_GET_STARTED.heading}
+          <h2
+            className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{HOME_GET_STARTED.body}</p>
+          <p
+            className="mt-6 text-lg leading-8 text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.body`)}
+          >
+            {data.body}
+          </p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <ButtonCVA asChild size="lg" variant="brand">
-              <a href={HOME_GET_STARTED.cta.primary.href}>{HOME_GET_STARTED.cta.primary.label}</a>
+              <a href={data.cta.primary.href}>{data.cta.primary.label}</a>
             </ButtonCVA>
             <ButtonCVA asChild appearance="outline" variant="neutral" size="lg">
-              <a href={HOME_GET_STARTED.cta.secondary.href}>
-                {HOME_GET_STARTED.cta.secondary.label}
+              <a href={data.cta.secondary.href}>
+                {data.cta.secondary.label}
                 <svg
                   className="h-4 w-4 ml-1.5"
                   fill="none"
@@ -38,16 +60,19 @@ export function GetStarted() {
 
           {/* CLI quick-start, moved here from the hero (frontend-excellence
               Phase 1 hero declutter). */}
-          <div className="mt-8 inline-flex items-center gap-3 rounded-xl bg-foreground px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-background/10">
+          <div
+            className="mt-8 inline-flex items-center gap-3 rounded-xl bg-foreground px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-background/10"
+            {...fieldAttrs(annotation, `${path}.snippet.lines`)}
+          >
             <span className="select-none text-background/50">$</span>
-            {HOME_GET_STARTED.cli.command.map((token, index) => (
+            {data.cli.command.map((token, index) => (
               <span
                 // biome-ignore lint/suspicious/noArrayIndexKey: static, order-fixed command tokens
                 key={index}
                 className={
                   index === 0
                     ? 'text-emerald-400' // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
-                    : index === HOME_GET_STARTED.cli.command.length - 1
+                    : index === data.cli.command.length - 1
                       ? 'text-blue-300'
                       : 'text-background'
                 }
@@ -56,12 +81,17 @@ export function GetStarted() {
               </span>
             ))}
           </div>
-          <p className="mt-4 text-sm text-muted-foreground">{HOME_GET_STARTED.cli.caption}</p>
+          <p
+            className="mt-4 text-sm text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.snippet.caption`)}
+          >
+            {data.cli.caption}
+          </p>
 
           {/* Newsletter */}
           <div className="mt-16 pt-10 border-t border-border">
             <p className="text-sm font-medium text-muted-foreground mb-4">
-              {HOME_GET_STARTED.newsletter.label}
+              {data.newsletter.label}
             </p>
             <NewsletterSignup variant="stacked" />
           </div>

--- a/apps/marketing/app/components/__tests__/block-annotations.test.tsx
+++ b/apps/marketing/app/components/__tests__/block-annotations.test.tsx
@@ -1,0 +1,86 @@
+import type { BlockAnnotation } from '@revealui/presentation';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { HOME_DEMO, HOME_GET_STARTED } from '../../content/home';
+import { PRODUCTS_CTA_SECTION, PRODUCTS_PAGE_HERO } from '../../content/products';
+import { GetStarted } from '../GetStarted';
+import { Demo } from '../landing/Demo';
+import { ProductsCta } from '../products/ProductsCta';
+import { ProductsHero } from '../products/ProductsHero';
+
+const ACTIVE: BlockAnnotation = { docId: 'home', editable: true };
+
+describe('block-driven marketing sections: annotation suppression (inactive)', () => {
+  it('emits zero data-rvui-* attributes with default (inactive) annotation', () => {
+    for (const ui of [<Demo />, <GetStarted />, <ProductsHero />, <ProductsCta />]) {
+      const { container, unmount } = render(ui);
+      expect(container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+      expect(container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
+      unmount();
+    }
+  });
+
+  it('renders the copy identically whether or not annotation is active (visual parity)', () => {
+    const inactive = render(<Demo />);
+    expect(inactive.getByText(HOME_DEMO.heading)).toBeTruthy();
+    expect(inactive.getByText(HOME_DEMO.body)).toBeTruthy();
+    inactive.unmount();
+
+    const active = render(<Demo path="blocks.0" annotation={ACTIVE} />);
+    expect(active.getByText(HOME_DEMO.heading)).toBeTruthy();
+    expect(active.getByText(HOME_DEMO.body)).toBeTruthy();
+  });
+});
+
+describe('block-driven marketing sections: annotation emission (active)', () => {
+  it('Demo emits field paths on heading, body, and repeater items', () => {
+    const { container } = render(<Demo path="blocks.0" annotation={ACTIVE} />);
+    const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
+    expect(heading?.getAttribute('data-rvui-doc')).toBe('home');
+    expect(heading?.textContent).toBe(HOME_DEMO.heading);
+    expect(container.querySelector('[data-rvui-field="blocks.0.body"]')?.textContent).toBe(
+      HOME_DEMO.body,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.0.items.0.title"]')?.textContent).toBe(
+      HOME_DEMO.beats[0]?.title,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.0.items.0.label"]')?.textContent).toBe(
+      HOME_DEMO.beats[0]?.n,
+    );
+  });
+
+  it('GetStarted emits field paths on heading, body, and snippet', () => {
+    const { container } = render(<GetStarted path="blocks.1" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.1.heading"]')?.textContent).toBe(
+      HOME_GET_STARTED.heading,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.1.body"]')?.textContent).toBe(
+      HOME_GET_STARTED.body,
+    );
+    expect(
+      container.querySelector('[data-rvui-field="blocks.1.snippet.caption"]')?.textContent,
+    ).toBe(HOME_GET_STARTED.cli.caption);
+    expect(container.querySelector('[data-rvui-field="blocks.1.snippet.lines"]')).not.toBeNull();
+  });
+
+  it('ProductsHero emits field paths on title and subtitle', () => {
+    const { container } = render(<ProductsHero path="blocks.0" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.0.title"]')?.textContent).toBe(
+      PRODUCTS_PAGE_HERO.h1,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.0.subtitle"]')?.textContent).toBe(
+      PRODUCTS_PAGE_HERO.subtitle,
+    );
+  });
+
+  it('ProductsCta emits field paths on heading, body, and snippet', () => {
+    const { container } = render(<ProductsCta path="blocks.1" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.1.heading"]')?.textContent).toBe(
+      PRODUCTS_CTA_SECTION.heading,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.1.body"]')?.textContent).toBe(
+      PRODUCTS_CTA_SECTION.body,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.1.snippet.lines"]')).not.toBeNull();
+  });
+});

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -1,27 +1,62 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { HOME_DEMO } from '../../content/home';
+import type { DemoData } from '../../lib/page-blocks';
 
-export function Demo() {
+export interface DemoProps {
+  /** Rich section data; defaults to the static content module (byte-identical). */
+  data?: DemoData;
+  /** Dot-path base of this block within the page array, e.g. `blocks.0`. */
+  path?: string;
+  /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
+  annotation?: BlockAnnotation;
+}
+
+export function Demo({ data = HOME_DEMO, path = 'blocks.0', annotation = {} }: DemoProps) {
   return (
     <section id="demo" className="bg-secondary py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {HOME_DEMO.eyebrow}
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {data.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {HOME_DEMO.heading}
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{HOME_DEMO.body}</p>
+          <p
+            className="mt-6 text-lg leading-8 text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.body`)}
+          >
+            {data.body}
+          </p>
         </div>
 
         <div className="mx-auto mt-20 grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-3">
-          {HOME_DEMO.beats.map((b) => (
+          {data.beats.map((b, index) => (
             <div key={b.n} className="rounded-2xl bg-card p-8 ring-1 ring-border">
-              <div className="font-mono text-xs font-semibold uppercase tracking-widest text-primary">
+              <div
+                className="font-mono text-xs font-semibold uppercase tracking-widest text-primary"
+                {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+              >
                 {b.n}
               </div>
-              <h3 className="mt-3 text-lg font-semibold text-foreground">{b.title}</h3>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">{b.body}</p>
+              <h3
+                className="mt-3 text-lg font-semibold text-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.title`)}
+              >
+                {b.title}
+              </h3>
+              <p
+                className="mt-3 text-sm leading-6 text-muted-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+              >
+                {b.body}
+              </p>
             </div>
           ))}
         </div>

--- a/apps/marketing/app/components/products/ProductsCta.tsx
+++ b/apps/marketing/app/components/products/ProductsCta.tsx
@@ -1,0 +1,57 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import { PRODUCTS_CTA_SECTION } from '../../content/products';
+import type { ProductsCtaData } from '../../lib/page-blocks';
+
+export interface ProductsCtaProps {
+  /** Rich CTA data; defaults to the static content module (byte-identical). */
+  data?: ProductsCtaData;
+  /** Dot-path base of this block within the page array, e.g. `blocks.1`. */
+  path?: string;
+  /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
+  annotation?: BlockAnnotation;
+}
+
+export function ProductsCta({
+  data = PRODUCTS_CTA_SECTION,
+  path = 'blocks.1',
+  annotation = {},
+}: ProductsCtaProps) {
+  return (
+    <section className="py-24 sm:py-32">
+      <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
+        <h2
+          className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...fieldAttrs(annotation, `${path}.heading`)}
+        >
+          {data.heading}
+        </h2>
+        <p
+          className="mt-6 text-lg leading-8 text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.body`)}
+        >
+          {data.body}
+        </p>
+        <div
+          className="mt-8 rounded-lg bg-foreground px-6 py-4 text-left font-mono text-sm text-background"
+          {...fieldAttrs(annotation, `${path}.snippet.lines`)}
+        >
+          <span className="text-background/50">$</span> {data.cliSnippet}
+        </div>
+        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href={data.cta.docs.href}
+            className="rounded-md bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
+          >
+            {data.cta.docs.label}
+          </a>
+          <a
+            href={data.cta.pricing.href}
+            className="rounded-md bg-secondary px-8 py-4 text-base font-semibold text-foreground hover:bg-muted transition-colors"
+          >
+            {data.cta.pricing.label}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/components/products/ProductsHero.tsx
+++ b/apps/marketing/app/components/products/ProductsHero.tsx
@@ -1,0 +1,54 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import { PRODUCTS_FLAGSHIP, PRODUCTS_PAGE_HERO, PRODUCTS_SISTERS } from '../../content/products';
+import type { ProductsHeroData } from '../../lib/page-blocks';
+
+// Anchor chips are derived from the product roster, not block-driven prose.
+const ALL_PRODUCT_ANCHORS = [
+  { slug: PRODUCTS_FLAGSHIP.slug, name: PRODUCTS_FLAGSHIP.name },
+  ...PRODUCTS_SISTERS.map((p) => ({ slug: p.slug, name: p.name })),
+] as const;
+
+export interface ProductsHeroProps {
+  /** Rich hero data; defaults to the static content module (byte-identical). */
+  data?: ProductsHeroData;
+  /** Dot-path base of this block within the page array, e.g. `blocks.0`. */
+  path?: string;
+  /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
+  annotation?: BlockAnnotation;
+}
+
+export function ProductsHero({
+  data = PRODUCTS_PAGE_HERO,
+  path = 'blocks.0',
+  annotation = {},
+}: ProductsHeroProps) {
+  return (
+    <section className="relative overflow-hidden bg-gradient-to-br from-primary/5 via-background to-blue-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <div className="mx-auto max-w-4xl text-center">
+        <h1
+          className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+          {...fieldAttrs(annotation, `${path}.title`)}
+        >
+          {data.h1}
+        </h1>
+        <p
+          className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          {...fieldAttrs(annotation, `${path}.subtitle`)}
+        >
+          {data.subtitle}
+        </p>
+        <div className="mt-10 flex flex-wrap justify-center gap-2 text-sm font-medium">
+          {ALL_PRODUCT_ANCHORS.map((anchor) => (
+            <a
+              key={anchor.slug}
+              href={`#${anchor.slug}`}
+              className="rounded-full bg-card px-4 py-1.5 text-muted-foreground ring-1 ring-border transition-colors hover:bg-primary/10 hover:text-primary hover:ring-primary/30"
+            >
+              {anchor.name}
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/app/lib/api.ts
+++ b/apps/marketing/app/lib/api.ts
@@ -5,9 +5,14 @@
  * api.revealui.com in production builds and localhost:3004 in dev.
  */
 
+import type { Block } from '@revealui/contracts/content';
+
 const DEFAULT_API_URL = import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004';
 
 const API_URL = import.meta.env.VITE_API_URL ?? DEFAULT_API_URL;
+
+/** The fleet-marketing site row that owns revealui.com's published pages. */
+const FLEET_MARKETING_SITE_ID = 'fleet-marketing';
 
 export interface ContactPayload {
   name: string;
@@ -120,6 +125,32 @@ export async function fetchPosts(page = 1, limit = 12): Promise<BlogPost[]> {
     return json.data ?? [];
   } catch {
     return [];
+  }
+}
+
+/**
+ * Fetch the published `pages.blocks` array for a fleet-marketing page by slug.
+ *
+ * Returns null on any error, miss, or a page without a block array, so the
+ * caller renders its static fallback with zero API dependency. The returned
+ * array is unvalidated network data — callers validate it against the
+ * contracts BlockSchema before rendering.
+ */
+export async function fetchPageBlocks(slug: string): Promise<Block[] | null> {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/content/sites/${FLEET_MARKETING_SITE_ID}/pages?status=published`,
+    );
+    if (!res.ok) return null;
+    const json = (await res.json()) as {
+      success: boolean;
+      data?: Array<{ slug: string; blocks: unknown }>;
+    };
+    const page = json.data?.find((p) => p.slug === slug);
+    if (!(page && Array.isArray(page.blocks))) return null;
+    return page.blocks as Block[];
+  } catch {
+    return null;
   }
 }
 

--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -1,0 +1,141 @@
+import { BlockSchema } from '@revealui/contracts/content';
+import { describe, expect, it } from 'vitest';
+import { HOME_DEMO, HOME_GET_STARTED } from '../content/home';
+import { PRODUCTS_CTA_SECTION, PRODUCTS_FLAGSHIP, PRODUCTS_PAGE_HERO } from '../content/products';
+import { METRICS } from '../content/site';
+import {
+  blocksMatchFallback,
+  demoSlot,
+  getStartedSlot,
+  HOME_FALLBACK_BLOCKS,
+  homeBlocks,
+  PRODUCTS_FALLBACK_BLOCKS,
+  productsBlocks,
+  productsCtaSlot,
+  productsHeroSlot,
+} from './page-blocks';
+import { SUBSCRIPTION_PRICE_FALLBACKS } from './pricing-fallbacks';
+
+/** Collect every string value reachable in a JSON-ish value. */
+function collectStrings(value: unknown, out: string[] = []): string[] {
+  if (typeof value === 'string') {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, out);
+  } else if (value && typeof value === 'object') {
+    for (const v of Object.values(value)) collectStrings(v, out);
+  }
+  return out;
+}
+
+describe('page-blocks derivation', () => {
+  it('produces schema-valid blocks for both pages', () => {
+    for (const block of [...homeBlocks(), ...productsBlocks()]) {
+      expect(BlockSchema.safeParse(block).success).toBe(true);
+    }
+  });
+
+  it('derives the expected block types per page in order', () => {
+    expect(homeBlocks().map((b) => b.type)).toEqual(['section', 'ctaSection']);
+    expect(productsBlocks().map((b) => b.type)).toEqual(['hero', 'ctaSection']);
+  });
+});
+
+describe('claims safety: prose is single-sourced, pinned values never enter blocks', () => {
+  const strings = collectStrings([homeBlocks(), productsBlocks()]);
+  const haystack = strings.join(' ');
+
+  it('carries the copy sentences byte-identical to the content modules', () => {
+    expect(strings).toContain(HOME_DEMO.heading);
+    expect(strings).toContain(HOME_DEMO.body);
+    for (const beat of HOME_DEMO.beats) {
+      expect(strings).toContain(beat.title);
+      expect(strings).toContain(beat.body);
+    }
+    expect(strings).toContain(HOME_GET_STARTED.heading);
+    expect(strings).toContain(HOME_GET_STARTED.body);
+    expect(strings).toContain(HOME_GET_STARTED.cli.caption);
+    expect(strings).toContain(PRODUCTS_PAGE_HERO.h1);
+    expect(strings).toContain(PRODUCTS_PAGE_HERO.subtitle);
+    expect(strings).toContain(PRODUCTS_CTA_SECTION.heading);
+    expect(strings).toContain(PRODUCTS_CTA_SECTION.body);
+  });
+
+  it('never carries metric-derived numbers, prices, or product versions', () => {
+    // Product version strings stay in the flagship card TSX, never in blocks.
+    expect(haystack).not.toContain(PRODUCTS_FLAGSHIP.version);
+    // The pro price lives only on the pricing surfaces, never in a block.
+    expect(haystack).not.toContain(SUBSCRIPTION_PRICE_FALLBACKS.pro.price);
+    // Metric counters are rendered from METRICS in TSX, never as block prose.
+    for (const metric of [METRICS.packages, METRICS.dbTables, METRICS.mcpServers]) {
+      expect(strings).not.toContain(String(metric));
+    }
+  });
+});
+
+describe('reverse mappers round-trip the derivation losslessly', () => {
+  it('reconstructs the demo data byte-identical to HOME_DEMO', () => {
+    const slot = demoSlot(homeBlocks());
+    expect(slot.path).toBe('blocks.0');
+    expect(slot.data.eyebrow).toBe(HOME_DEMO.eyebrow);
+    expect(slot.data.heading).toBe(HOME_DEMO.heading);
+    expect(slot.data.body).toBe(HOME_DEMO.body);
+    expect(slot.data.beats).toEqual(
+      HOME_DEMO.beats.map((b) => ({ n: b.n, title: b.title, body: b.body })),
+    );
+  });
+
+  it('reconstructs the get-started data byte-identical to HOME_GET_STARTED', () => {
+    const slot = getStartedSlot(homeBlocks());
+    expect(slot.path).toBe('blocks.1');
+    expect(slot.data.heading).toBe(HOME_GET_STARTED.heading);
+    expect(slot.data.body).toBe(HOME_GET_STARTED.body);
+    expect(slot.data.cta.primary).toEqual({
+      label: HOME_GET_STARTED.cta.primary.label,
+      href: HOME_GET_STARTED.cta.primary.href,
+    });
+    expect(slot.data.cta.secondary).toEqual({
+      label: HOME_GET_STARTED.cta.secondary.label,
+      href: HOME_GET_STARTED.cta.secondary.href,
+    });
+    expect(slot.data.cli.command).toEqual([...HOME_GET_STARTED.cli.command]);
+    expect(slot.data.cli.caption).toBe(HOME_GET_STARTED.cli.caption);
+    expect(slot.data.newsletter).toEqual(HOME_GET_STARTED.newsletter);
+  });
+
+  it('reconstructs the products hero + cta byte-identical to their modules', () => {
+    const hero = productsHeroSlot(productsBlocks());
+    expect(hero.path).toBe('blocks.0');
+    expect(hero.data.h1).toBe(PRODUCTS_PAGE_HERO.h1);
+    expect(hero.data.subtitle).toBe(PRODUCTS_PAGE_HERO.subtitle);
+
+    const cta = productsCtaSlot(productsBlocks());
+    expect(cta.path).toBe('blocks.1');
+    expect(cta.data.heading).toBe(PRODUCTS_CTA_SECTION.heading);
+    expect(cta.data.body).toBe(PRODUCTS_CTA_SECTION.body);
+    expect(cta.data.cliSnippet).toBe(PRODUCTS_CTA_SECTION.cliSnippet);
+    expect(cta.data.cta.docs).toEqual({
+      label: PRODUCTS_CTA_SECTION.cta.docs.label,
+      href: PRODUCTS_CTA_SECTION.cta.docs.href,
+    });
+    expect(cta.data.cta.pricing).toEqual({
+      label: PRODUCTS_CTA_SECTION.cta.pricing.label,
+      href: PRODUCTS_CTA_SECTION.cta.pricing.href,
+    });
+  });
+});
+
+describe('blocksMatchFallback shape guard', () => {
+  it('accepts an array with matching length + per-position types', () => {
+    expect(blocksMatchFallback(homeBlocks(), HOME_FALLBACK_BLOCKS)).toBe(true);
+    expect(blocksMatchFallback(productsBlocks(), PRODUCTS_FALLBACK_BLOCKS)).toBe(true);
+  });
+
+  it('rejects empty, wrong-length, and wrong-type arrays', () => {
+    expect(blocksMatchFallback([], HOME_FALLBACK_BLOCKS)).toBe(false);
+    expect(blocksMatchFallback(homeBlocks().slice(0, 1), HOME_FALLBACK_BLOCKS)).toBe(false);
+    // Same length, wrong type at position 0 (hero where a section is expected).
+    const swapped = [...productsBlocks().slice(0, 1), ...homeBlocks().slice(1, 2)];
+    expect(blocksMatchFallback(swapped, HOME_FALLBACK_BLOCKS)).toBe(false);
+  });
+});

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -1,0 +1,263 @@
+/**
+ * Static-first block derivation for the marketing home + products pages.
+ *
+ * The marketing content modules (content/home.ts, content/products.ts) stay the
+ * single source of truth for every prose string. This module derives the
+ * canonical `pages.blocks` array from those modules with the `@revealui/contracts`
+ * factories — a PURE transform, so the CMS block stream and the static fallback
+ * can never carry a different sentence than the claim-covered modules do.
+ *
+ * The reverse mappers reconstruct each marketing component's own rich data shape
+ * from a block, so the styled marketing components keep their look while their
+ * prose can be overridden by the CMS. Only prose lives in blocks: metric-derived
+ * numbers, prices, product versions, and interactive logic never leave the TSX.
+ *
+ * No React or network imports live here so `scripts/seed-fleet-marketing-site.ts`
+ * can import the same derivation the runtime falls back to.
+ */
+
+import {
+  type Block,
+  type CtaSectionBlock,
+  createCtaSectionBlock,
+  createHeroBlock,
+  createSectionBlock,
+  type HeroBlock,
+  type MarketingLink,
+  type SectionBlock,
+} from '@revealui/contracts/content';
+import { HOME_DEMO, HOME_GET_STARTED } from '../content/home';
+import { PRODUCTS_CTA_SECTION, PRODUCTS_PAGE_HERO } from '../content/products';
+import type { Cta } from '../content/types';
+
+// ---------------------------------------------------------------------------
+// Component data shapes (the rich props each styled marketing section renders)
+// ---------------------------------------------------------------------------
+
+export interface DemoBeatData {
+  readonly n: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface DemoData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly beats: readonly DemoBeatData[];
+}
+
+export interface GetStartedData {
+  readonly heading: string;
+  readonly body: string;
+  readonly cta: { readonly primary: Cta; readonly secondary: Cta };
+  readonly cli: { readonly command: readonly string[]; readonly caption: string };
+  readonly newsletter: { readonly label: string };
+}
+
+export interface ProductsHeroData {
+  readonly h1: string;
+  readonly subtitle: string;
+}
+
+export interface ProductsCtaData {
+  readonly heading: string;
+  readonly body: string;
+  readonly cliSnippet: string;
+  readonly cta: { readonly docs: Cta; readonly pricing: Cta };
+}
+
+// ---------------------------------------------------------------------------
+// Stable block ids. Ids let the seed and fallback match, but the runtime never
+// routes by id (the CMS assigns its own) — it routes by array position + type.
+// ---------------------------------------------------------------------------
+
+export const HOME_DEMO_BLOCK_ID = 'home-demo';
+export const HOME_GET_STARTED_BLOCK_ID = 'home-get-started';
+export const PRODUCTS_HERO_BLOCK_ID = 'products-hero';
+export const PRODUCTS_CTA_BLOCK_ID = 'products-cta';
+
+function ctaToLink(cta: Cta, variant: 'primary' | 'secondary'): MarketingLink {
+  return { label: cta.label, href: cta.href, variant };
+}
+
+function linkToCta(link: MarketingLink): Cta {
+  return { label: link.label, href: link.href };
+}
+
+// ---------------------------------------------------------------------------
+// Forward transforms: content module const -> canonical block
+// ---------------------------------------------------------------------------
+
+function homeDemoBlock(): SectionBlock {
+  return createSectionBlock(HOME_DEMO_BLOCK_ID, HOME_DEMO.heading, {
+    eyebrow: HOME_DEMO.eyebrow,
+    body: HOME_DEMO.body,
+    items: HOME_DEMO.beats.map((beat) => ({
+      label: beat.n,
+      title: beat.title,
+      body: beat.body,
+    })),
+  });
+}
+
+function homeGetStartedBlock(): CtaSectionBlock {
+  return createCtaSectionBlock(HOME_GET_STARTED_BLOCK_ID, HOME_GET_STARTED.heading, {
+    body: HOME_GET_STARTED.body,
+    links: [
+      ctaToLink(HOME_GET_STARTED.cta.primary, 'primary'),
+      ctaToLink(HOME_GET_STARTED.cta.secondary, 'secondary'),
+    ],
+    snippet: {
+      lines: [HOME_GET_STARTED.cli.command.join(' ')],
+      caption: HOME_GET_STARTED.cli.caption,
+    },
+  });
+}
+
+function productsHeroBlock(): HeroBlock {
+  return createHeroBlock(PRODUCTS_HERO_BLOCK_ID, PRODUCTS_PAGE_HERO.h1, {
+    subtitle: PRODUCTS_PAGE_HERO.subtitle,
+  });
+}
+
+function productsCtaBlock(): CtaSectionBlock {
+  return createCtaSectionBlock(PRODUCTS_CTA_BLOCK_ID, PRODUCTS_CTA_SECTION.heading, {
+    body: PRODUCTS_CTA_SECTION.body,
+    links: [
+      ctaToLink(PRODUCTS_CTA_SECTION.cta.docs, 'primary'),
+      ctaToLink(PRODUCTS_CTA_SECTION.cta.pricing, 'secondary'),
+    ],
+    snippet: { lines: [PRODUCTS_CTA_SECTION.cliSnippet] },
+  });
+}
+
+/** Derives the home page's block-driven sections (Demo, GetStarted). */
+export function homeBlocks(): Block[] {
+  return [homeDemoBlock(), homeGetStartedBlock()];
+}
+
+/** Derives the products page's block-driven sections (Hero, CTA). */
+export function productsBlocks(): Block[] {
+  return [productsHeroBlock(), productsCtaBlock()];
+}
+
+export const HOME_FALLBACK_BLOCKS: Block[] = homeBlocks();
+export const PRODUCTS_FALLBACK_BLOCKS: Block[] = productsBlocks();
+
+// ---------------------------------------------------------------------------
+// Reverse mappers: canonical block -> rich component data shape
+// ---------------------------------------------------------------------------
+
+function sectionToDemo(block: SectionBlock): DemoData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    beats: (block.data.items ?? []).map((item) => ({
+      n: item.label ?? '',
+      title: item.title ?? '',
+      body: item.body,
+    })),
+  };
+}
+
+function ctaToGetStarted(block: CtaSectionBlock): GetStartedData {
+  const links = block.data.links ?? [];
+  const lines = block.data.snippet?.lines ?? [];
+  return {
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    cta: {
+      primary: links[0] ? linkToCta(links[0]) : HOME_GET_STARTED.cta.primary,
+      secondary: links[1] ? linkToCta(links[1]) : HOME_GET_STARTED.cta.secondary,
+    },
+    cli: {
+      command: lines[0] ? lines[0].split(' ') : [...HOME_GET_STARTED.cli.command],
+      caption: block.data.snippet?.caption ?? HOME_GET_STARTED.cli.caption,
+    },
+    // The newsletter is an interactive form label, not block-driven prose.
+    newsletter: HOME_GET_STARTED.newsletter,
+  };
+}
+
+function heroToProductsHero(block: HeroBlock): ProductsHeroData {
+  return {
+    h1: block.data.title,
+    subtitle: block.data.subtitle ?? '',
+  };
+}
+
+function ctaToProductsCta(block: CtaSectionBlock): ProductsCtaData {
+  const links = block.data.links ?? [];
+  const lines = block.data.snippet?.lines ?? [];
+  return {
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    cliSnippet: lines[0] ?? PRODUCTS_CTA_SECTION.cliSnippet,
+    cta: {
+      docs: links[0] ? linkToCta(links[0]) : PRODUCTS_CTA_SECTION.cta.docs,
+      pricing: links[1] ? linkToCta(links[1]) : PRODUCTS_CTA_SECTION.cta.pricing,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Slot resolvers: pick a block by type + position, return data + annotation path
+// ---------------------------------------------------------------------------
+
+export interface BlockSlot<T> {
+  readonly data: T;
+  /** Dot-path base of the block within the array, e.g. `blocks.0`. */
+  readonly path: string;
+}
+
+function firstOfType(blocks: Block[], type: Block['type']): { block: Block; index: number } | null {
+  const index = blocks.findIndex((block) => block.type === type);
+  if (index < 0) return null;
+  const block = blocks[index];
+  return block ? { block, index } : null;
+}
+
+export function demoSlot(blocks: Block[]): BlockSlot<DemoData> {
+  const found = firstOfType(blocks, 'section');
+  if (found && found.block.type === 'section') {
+    return { data: sectionToDemo(found.block), path: `blocks.${found.index}` };
+  }
+  return { data: sectionToDemo(homeDemoBlock()), path: 'blocks.0' };
+}
+
+export function getStartedSlot(blocks: Block[]): BlockSlot<GetStartedData> {
+  const found = firstOfType(blocks, 'ctaSection');
+  if (found && found.block.type === 'ctaSection') {
+    return { data: ctaToGetStarted(found.block), path: `blocks.${found.index}` };
+  }
+  return { data: ctaToGetStarted(homeGetStartedBlock()), path: 'blocks.1' };
+}
+
+export function productsHeroSlot(blocks: Block[]): BlockSlot<ProductsHeroData> {
+  const found = firstOfType(blocks, 'hero');
+  if (found && found.block.type === 'hero') {
+    return { data: heroToProductsHero(found.block), path: `blocks.${found.index}` };
+  }
+  return { data: heroToProductsHero(productsHeroBlock()), path: 'blocks.0' };
+}
+
+export function productsCtaSlot(blocks: Block[]): BlockSlot<ProductsCtaData> {
+  const found = firstOfType(blocks, 'ctaSection');
+  if (found && found.block.type === 'ctaSection') {
+    return { data: ctaToProductsCta(found.block), path: `blocks.${found.index}` };
+  }
+  return { data: ctaToProductsCta(productsCtaBlock()), path: 'blocks.1' };
+}
+
+// ---------------------------------------------------------------------------
+// Shape validation: a CMS payload is only accepted when it matches the
+// fallback's per-position block types, so a malformed override can never change
+// which sections a page renders.
+// ---------------------------------------------------------------------------
+
+export function blocksMatchFallback(candidate: Block[], fallback: Block[]): boolean {
+  if (candidate.length !== fallback.length || candidate.length === 0) return false;
+  return fallback.every((block, index) => candidate[index]?.type === block.type);
+}

--- a/apps/marketing/app/lib/use-page-blocks.test.tsx
+++ b/apps/marketing/app/lib/use-page-blocks.test.tsx
@@ -1,0 +1,65 @@
+import type { Block } from '@revealui/contracts/content';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchPageBlocks } from './api';
+import { HOME_FALLBACK_BLOCKS, homeBlocks, productsBlocks } from './page-blocks';
+import { useMarketingPageBlocks } from './use-page-blocks';
+
+vi.mock('./api', () => ({ fetchPageBlocks: vi.fn() }));
+
+const mockFetch = vi.mocked(fetchPageBlocks);
+
+describe('useMarketingPageBlocks', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('paints with the static fallback immediately', () => {
+    mockFetch.mockResolvedValue(null);
+    const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+    expect(result.current).toBe(HOME_FALLBACK_BLOCKS);
+  });
+
+  it('keeps the fallback when the API errors or misses', async () => {
+    mockFetch.mockResolvedValue(null);
+    const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('home'));
+    expect(result.current).toBe(HOME_FALLBACK_BLOCKS);
+  });
+
+  it('overrides with a valid CMS payload of matching shape', async () => {
+    const overridden = homeBlocks();
+    const section = overridden[0];
+    if (section?.type === 'section') {
+      section.data.heading = 'CMS-overridden demo heading';
+    }
+    mockFetch.mockResolvedValue(overridden);
+    const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+    await waitFor(() => {
+      const first = result.current[0];
+      expect(first?.type === 'section' && first.data.heading).toBe('CMS-overridden demo heading');
+    });
+  });
+
+  it('keeps the fallback when the CMS payload fails schema validation', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A `section` block with no `data` is schema-invalid.
+    mockFetch.mockResolvedValue([{ id: 'x', type: 'section' } as unknown as Block]);
+    const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(result.current).toBe(HOME_FALLBACK_BLOCKS);
+  });
+
+  it('keeps the fallback when the CMS payload shape does not match', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A valid hero block where the home fallback expects [section, ctaSection].
+    mockFetch.mockResolvedValue(productsBlocks().slice(0, 1));
+    const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(result.current).toBe(HOME_FALLBACK_BLOCKS);
+  });
+});

--- a/apps/marketing/app/lib/use-page-blocks.ts
+++ b/apps/marketing/app/lib/use-page-blocks.ts
@@ -1,0 +1,61 @@
+/**
+ * Static-first block hook for the marketing pages.
+ *
+ * Paints immediately with the static fallback derived from the content modules,
+ * then swaps in the published CMS blocks once they arrive AND validate against
+ * the contracts BlockSchema and match the fallback's per-position shape. Any
+ * error, empty payload, or shape mismatch keeps the fallback, so a page always
+ * renders with zero API dependency and can never be reshaped by a bad payload.
+ */
+
+import { type Block, BlockSchema } from '@revealui/contracts/content';
+import { useEffect, useState } from 'react';
+import { fetchPageBlocks } from './api';
+import { blocksMatchFallback } from './page-blocks';
+
+function devWarn(message: string): void {
+  if (import.meta.env.DEV) {
+    // biome-ignore lint/suspicious/noConsole: dev-only diagnostic for CMS payload rejection
+    console.warn(`[marketing:page-blocks] ${message}`); // console-allowed
+  }
+}
+
+function parseBlocks(raw: Block[]): Block[] | null {
+  const parsed: Block[] = [];
+  for (const candidate of raw) {
+    const result = BlockSchema.safeParse(candidate);
+    if (!result.success) return null;
+    parsed.push(result.data as Block);
+  }
+  return parsed;
+}
+
+/**
+ * @param slug     the fleet-marketing page slug (`home`, `products`)
+ * @param fallback the static block array derived from the content modules
+ */
+export function useMarketingPageBlocks(slug: string, fallback: Block[]): Block[] {
+  const [blocks, setBlocks] = useState<Block[]>(fallback);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchPageBlocks(slug).then((raw) => {
+      if (cancelled || !raw || raw.length === 0) return;
+      const parsed = parseBlocks(raw);
+      if (!parsed) {
+        devWarn(`rejected CMS blocks for "${slug}": failed schema validation`);
+        return;
+      }
+      if (!blocksMatchFallback(parsed, fallback)) {
+        devWarn(`rejected CMS blocks for "${slug}": shape does not match the static fallback`);
+        return;
+      }
+      setBlocks(parsed);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, fallback]);
+
+  return blocks;
+}

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -1,3 +1,4 @@
+import type { BlockAnnotation } from '@revealui/presentation';
 import { useLocation } from '@revealui/router';
 import { Footer } from '../components/Footer';
 import { ClosingCta } from '../components/for-operators/ClosingCta';
@@ -15,7 +16,19 @@ import { Primitives } from '../components/landing/Primitives';
 import { Problem } from '../components/landing/Problem';
 import { Proof } from '../components/landing/Proof';
 import { selectAudience } from '../lib/audience';
+import {
+  type BlockSlot,
+  type DemoData,
+  demoSlot,
+  type GetStartedData,
+  getStartedSlot,
+  HOME_FALLBACK_BLOCKS,
+} from '../lib/page-blocks';
 import { useAudienceHead } from '../lib/use-audience-head';
+import { useMarketingPageBlocks } from '../lib/use-page-blocks';
+
+// Annotation is inactive in this slice; the editor-canvas slice activates it.
+const INACTIVE_ANNOTATION: BlockAnnotation = { editable: false };
 
 /**
  * Developer-facing landing: `/?for=technical`, and the default `/` since the
@@ -32,16 +45,22 @@ import { useAudienceHead } from '../lib/use-audience-head';
  * pricing page's agents section). The hero's CLI block moved to GetStarted;
  * its two inline text CTAs (services, agency licensing) moved to the footer.
  */
-function TechnicalLanding() {
+interface TechnicalLandingProps {
+  demo: BlockSlot<DemoData>;
+  getStarted: BlockSlot<GetStartedData>;
+  annotation: BlockAnnotation;
+}
+
+function TechnicalLanding({ demo, getStarted, annotation }: TechnicalLandingProps) {
   return (
     <>
       <Hero />
       <Problem />
-      <Demo />
+      <Demo data={demo.data} path={demo.path} annotation={annotation} />
       <Primitives />
       <Proof />
       <PricingTeaser />
-      <GetStarted />
+      <GetStarted data={getStarted.data} path={getStarted.path} annotation={annotation} />
       <Footer />
     </>
   );
@@ -75,9 +94,16 @@ export function HomePage() {
   const { search } = useLocation();
   const audience = selectAudience(search);
   useAudienceHead(audience);
+  const blocks = useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS);
+  const demo = demoSlot(blocks);
+  const getStarted = getStartedSlot(blocks);
   return (
     <div className="min-h-screen bg-background">
-      {audience === 'non-technical' ? <NonTechnicalLanding /> : <TechnicalLanding />}
+      {audience === 'non-technical' ? (
+        <NonTechnicalLanding />
+      ) : (
+        <TechnicalLanding demo={demo} getStarted={getStarted} annotation={INACTIVE_ANNOTATION} />
+      )}
     </div>
   );
 }

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -1,21 +1,22 @@
+import type { BlockAnnotation } from '@revealui/presentation';
 import { useState } from 'react';
 import { Footer } from '../components/Footer';
 import { Faq } from '../components/landing/Faq';
 import { Proof } from '../components/landing/Proof';
+import { ProductsCta } from '../components/products/ProductsCta';
+import { ProductsHero } from '../components/products/ProductsHero';
 import {
   PRODUCT_STATUS_STYLES,
-  PRODUCTS_CTA_SECTION,
   PRODUCTS_FLAGSHIP,
-  PRODUCTS_PAGE_HERO,
   PRODUCTS_SISTERS,
   PRODUCTS_STATS_SECTION,
   type ProductStatus,
 } from '../content/products';
+import { PRODUCTS_FALLBACK_BLOCKS, productsCtaSlot, productsHeroSlot } from '../lib/page-blocks';
+import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
-const ALL_PRODUCT_ANCHORS = [
-  { slug: PRODUCTS_FLAGSHIP.slug, name: PRODUCTS_FLAGSHIP.name },
-  ...PRODUCTS_SISTERS.map((p) => ({ slug: p.slug, name: p.name })),
-] as const;
+// Annotation is inactive in this slice; the editor-canvas slice activates it.
+const INACTIVE_ANNOTATION: BlockAnnotation = { editable: false };
 
 // Filter chips for the fleet-products table. "All" plus each status, ordered
 // stability-descending to match the grid.
@@ -33,30 +34,13 @@ export function ProductsPage() {
     filter === 'All' ? PRODUCTS_SISTERS : PRODUCTS_SISTERS.filter((p) => p.status === filter);
   const countFor = (f: ProductStatus | 'All') =>
     f === 'All' ? PRODUCTS_SISTERS.length : PRODUCTS_SISTERS.filter((p) => p.status === f).length;
+  const blocks = useMarketingPageBlocks('products', PRODUCTS_FALLBACK_BLOCKS);
+  const hero = productsHeroSlot(blocks);
+  const cta = productsCtaSlot(blocks);
   return (
     <div className="min-h-screen bg-background">
       {/* Hero */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-primary/5 via-background to-blue-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-            {PRODUCTS_PAGE_HERO.h1}
-          </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-            {PRODUCTS_PAGE_HERO.subtitle}
-          </p>
-          <div className="mt-10 flex flex-wrap justify-center gap-2 text-sm font-medium">
-            {ALL_PRODUCT_ANCHORS.map((anchor) => (
-              <a
-                key={anchor.slug}
-                href={`#${anchor.slug}`}
-                className="rounded-full bg-card px-4 py-1.5 text-muted-foreground ring-1 ring-border transition-colors hover:bg-primary/10 hover:text-primary hover:ring-primary/30"
-              >
-                {anchor.name}
-              </a>
-            ))}
-          </div>
-        </div>
-      </section>
+      <ProductsHero data={hero.data} path={hero.path} annotation={INACTIVE_ANNOTATION} />
 
       {/* Flagship — RevealUI featured card */}
       <section id={PRODUCTS_FLAGSHIP.slug} className="py-20 sm:py-24">
@@ -331,33 +315,7 @@ export function ProductsPage() {
       <Faq />
 
       {/* CTA */}
-      <section className="py-24 sm:py-32">
-        <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {PRODUCTS_CTA_SECTION.heading}
-          </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">
-            {PRODUCTS_CTA_SECTION.body}
-          </p>
-          <div className="mt-8 rounded-lg bg-foreground px-6 py-4 text-left font-mono text-sm text-background">
-            <span className="text-background/50">$</span> {PRODUCTS_CTA_SECTION.cliSnippet}
-          </div>
-          <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href={PRODUCTS_CTA_SECTION.cta.docs.href}
-              className="rounded-md bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
-            >
-              {PRODUCTS_CTA_SECTION.cta.docs.label}
-            </a>
-            <a
-              href={PRODUCTS_CTA_SECTION.cta.pricing.href}
-              className="rounded-md bg-secondary px-8 py-4 text-base font-semibold text-foreground hover:bg-muted transition-colors"
-            >
-              {PRODUCTS_CTA_SECTION.cta.pricing.label}
-            </a>
-          </div>
-        </div>
-      </section>
+      <ProductsCta data={cta.data} path={cta.path} annotation={INACTIVE_ANNOTATION} />
 
       <Footer />
     </div>

--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -7,7 +7,6 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" },
@@ -17,7 +16,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.revealui.com https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.revealui.com https://vitals.vercel-insights.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'self' https://admin.revealui.com"
         }
       ]
     },

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -1,21 +1,31 @@
 #!/usr/bin/env tsx
 
 /**
- * Seed the `sites` table with the fleet-marketing row (Phase A.2).
+ * Seed the fleet-marketing `sites` row plus its `home` and `products` pages
+ * (Phase A.2 + the visual-edit-sessions block wire).
  *
- * Idempotent: if a row with id='fleet-marketing' already exists, logs and exits 0.
- * Resolves ownerId by looking up founder@revealui.com in the users table — fails fast
- * if that user does not exist yet (bootstrap must run first).
+ * The page `blocks` come from the SAME pure derivation the marketing app falls
+ * back to (`apps/marketing/app/lib/page-blocks.ts`), so the seeded CMS content
+ * and the site's static fallback can never drift: both are derived from the
+ * claim-covered content modules.
+ *
+ * Idempotent: the site row is inserted once; each page is inserted if missing,
+ * updated (with an optimistic version guard) only when its blocks changed, and
+ * skipped when its blocks already match. Soft-deleted pages are surfaced, never
+ * silently resurrected. Fails fast if the founder user or the site row is
+ * missing (bootstrap + site seed must run first).
  *
  * Usage:
  *   pnpm tsx scripts/seed-fleet-marketing-site.ts
  *   pnpm tsx scripts/seed-fleet-marketing-site.ts -- --dry-run
  *
- * Spec: .jv/docs/spec-2026-05-08-marketing-content-cms.md §2.1 + §9 row A2
+ * Spec: the internal visual-edit-sessions spec (2026-07-02); Phase A.2 row A2.
  */
 
+import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { config } from 'dotenv';
+import { homeBlocks, productsBlocks } from '../apps/marketing/app/lib/page-blocks';
 
 const rootDir = resolve(import.meta.dirname, '..');
 
@@ -39,6 +49,37 @@ const log = {
   error: (msg: string) => console.error(`  x ${msg}`),
 };
 
+interface PageSeed {
+  readonly slug: string;
+  readonly path: string;
+  readonly title: string;
+  readonly blocks: unknown[];
+  readonly seo: { title: string; description: string };
+}
+
+const PAGE_SEEDS: readonly PageSeed[] = [
+  {
+    slug: 'home',
+    path: '/',
+    title: 'Home',
+    blocks: homeBlocks(),
+    seo: {
+      title: 'RevealUI',
+      description: 'Agentic business runtime. People, content, offers, payments, and agents.',
+    },
+  },
+  {
+    slug: 'products',
+    path: '/products',
+    title: 'Products',
+    blocks: productsBlocks(),
+    seo: {
+      title: 'The RevFleet product family',
+      description: 'Seven products on one foundation, all built and operated by RevealUI Studio.',
+    },
+  },
+];
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
@@ -48,10 +89,14 @@ async function main(): Promise<void> {
   }
 
   const { getClient } = await import('@revealui/db/client');
-  const { users, sites } = await import('@revealui/db/schema');
-  const { eq } = await import('drizzle-orm');
+  const { users, sites, pages } = await import('@revealui/db/schema');
+  const { and, eq } = await import('drizzle-orm');
 
   const db = getClient('rest');
+
+  // ---------------------------------------------------------------------------
+  // Site row
+  // ---------------------------------------------------------------------------
 
   const founderRows = await db
     .select({ id: users.id })
@@ -68,70 +113,158 @@ async function main(): Promise<void> {
   const ownerId = founderRows[0].id;
   log.info(`Resolved ownerId for ${FOUNDER_EMAIL}: ${ownerId}`);
 
-  const existing = await db
+  const existingSite = await db
     .select({ id: sites.id, slug: sites.slug, status: sites.status })
     .from(sites)
     .where(eq(sites.id, SITE_ID))
     .limit(1);
-
-  if (existing.length > 0) {
-    const row = existing[0];
-    log.info('Already seeded, skipping.');
-    log.info(`  id:     ${row.id}`);
-    log.info(`  slug:   ${row.slug}`);
-    log.info(`  status: ${row.status}`);
-    return;
-  }
 
   const now = new Date();
 
-  const row = {
-    id: SITE_ID,
-    ownerId,
-    name: 'RevealUI fleet marketing',
-    slug: 'fleet-marketing',
-    description: 'revealui.com customer-facing copy',
-    status: 'published' as const,
-    theme: { brand: 'revealui-fleet' },
-    settings: {
-      cacheStrategy: 'edge-tag',
-      voiceProfile: 'fleet',
-      aiGeneration: {
-        provider: 'inference-snaps',
-        model: 'gemma3',
-        embedModel: 'gemma3',
+  if (existingSite.length > 0) {
+    const row = existingSite[0];
+    log.info('Site already seeded, skipping.');
+    log.info(`  id:     ${row.id}`);
+    log.info(`  slug:   ${row.slug}`);
+    log.info(`  status: ${row.status}`);
+  } else {
+    const siteRow = {
+      id: SITE_ID,
+      ownerId,
+      name: 'RevealUI fleet marketing',
+      slug: 'fleet-marketing',
+      description: 'revealui.com customer-facing copy',
+      status: 'published' as const,
+      theme: { brand: 'revealui-fleet' },
+      settings: {
+        cacheStrategy: 'edge-tag',
+        voiceProfile: 'fleet',
+        aiGeneration: {
+          provider: 'inference-snaps',
+          model: 'gemma3',
+          embedModel: 'gemma3',
+        },
       },
-    },
-    publishedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  };
+      publishedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    if (dryRun) {
+      log.info('Would insert site:');
+      log.info(JSON.stringify(siteRow, null, 2));
+    } else {
+      await db.insert(sites).values(siteRow).onConflictDoNothing({ target: sites.id });
+      const inserted = await db
+        .select({ id: sites.id })
+        .from(sites)
+        .where(eq(sites.id, SITE_ID))
+        .limit(1);
+      if (inserted.length === 0) {
+        log.error('Site insert reported no conflict but row is not present — unexpected state.');
+        process.exit(1);
+      }
+      log.success('Seeded fleet-marketing site row.');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pages (home + products) — version-safe, idempotent
+  // ---------------------------------------------------------------------------
+
+  for (const seed of PAGE_SEEDS) {
+    const existing = await db
+      .select({
+        id: pages.id,
+        version: pages.version,
+        blocks: pages.blocks,
+        status: pages.status,
+        deletedAt: pages.deletedAt,
+      })
+      .from(pages)
+      .where(and(eq(pages.siteId, SITE_ID), eq(pages.slug, seed.slug)))
+      .limit(1);
+
+    if (existing.length > 0) {
+      const row = existing[0];
+      if (row.deletedAt) {
+        log.warn(`Page "${seed.slug}" exists but is soft-deleted (id ${row.id}).`);
+        log.warn('Not resurrecting automatically — restore or hard-delete it deliberately.');
+        continue;
+      }
+
+      const currentJson = JSON.stringify(row.blocks ?? []);
+      const desiredJson = JSON.stringify(seed.blocks);
+      if (currentJson === desiredJson) {
+        log.info(`Page "${seed.slug}" already up to date (v${row.version}), skipping.`);
+        continue;
+      }
+
+      if (dryRun) {
+        log.info(
+          `Would update page "${seed.slug}" blocks (v${row.version} -> v${row.version + 1}).`,
+        );
+        continue;
+      }
+
+      // Optimistic version guard: only write if the row hasn't changed since read.
+      const updated = await db
+        .update(pages)
+        .set({
+          blocks: seed.blocks,
+          blockCount: seed.blocks.length,
+          version: row.version + 1,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(pages.id, row.id), eq(pages.version, row.version)))
+        .returning({ id: pages.id });
+
+      if (updated.length === 0) {
+        log.error(`Page "${seed.slug}" changed concurrently (version moved past ${row.version}).`);
+        log.error('Re-run the seed to reconcile.');
+        process.exit(1);
+      }
+      log.success(`Updated page "${seed.slug}" blocks -> v${row.version + 1}.`);
+      continue;
+    }
+
+    const pageRow = {
+      id: `rvl_${randomUUID()}`,
+      siteId: SITE_ID,
+      title: seed.title,
+      slug: seed.slug,
+      path: seed.path,
+      status: 'published',
+      blocks: seed.blocks,
+      blockCount: seed.blocks.length,
+      seo: seed.seo,
+      publishedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    if (dryRun) {
+      log.info(`Would insert page "${seed.slug}":`);
+      log.info(JSON.stringify(pageRow, null, 2));
+      continue;
+    }
+
+    await db.insert(pages).values(pageRow).onConflictDoNothing();
+    const inserted = await db
+      .select({ id: pages.id, status: pages.status })
+      .from(pages)
+      .where(and(eq(pages.siteId, SITE_ID), eq(pages.slug, seed.slug)))
+      .limit(1);
+    if (inserted.length === 0) {
+      log.error(`Page "${seed.slug}" insert reported no conflict but row is not present.`);
+      process.exit(1);
+    }
+    log.success(`Seeded page "${seed.slug}" (${inserted[0].status}).`);
+  }
 
   if (dryRun) {
-    log.info('Would insert:');
-    log.info(JSON.stringify(row, null, 2));
     log.success('Dry run complete — no writes made.');
-    return;
   }
-
-  await db.insert(sites).values(row).onConflictDoNothing({ target: sites.id });
-
-  const inserted = await db
-    .select({ id: sites.id, slug: sites.slug, status: sites.status })
-    .from(sites)
-    .where(eq(sites.id, SITE_ID))
-    .limit(1);
-
-  if (inserted.length === 0) {
-    log.error('Insert reported no conflict but row is not present — unexpected state.');
-    process.exit(1);
-  }
-
-  const seeded = inserted[0];
-  log.success('Seeded fleet-marketing site row.');
-  log.info(`  id:     ${seeded.id}`);
-  log.info(`  slug:   ${seeded.slug}`);
-  log.info(`  status: ${seeded.status}`);
 }
 
 try {


### PR DESCRIPTION
Part of the visual-edit-sessions program per the internal spec (2026-07-02). This is P1 slice 3: the marketing site's CMS block wire for `home` + `products`, the seed, and the frame-header amendment. The parallel editor-canvas slice activates the annotations this PR emits.

## What this does

The home (`Demo`, `GetStarted`) and products (`Hero`, `CTA`) sections now render from the canonical `pages.blocks` array, with a static-first fallback. Every other section (problem table, primitives, proof, pricing teaser, flagship card, sisters grid, stats, FAQ) renders exactly as before.

### Static-first override model

- `app/lib/page-blocks.ts` derives each page's block array from the existing content modules with the `@revealui/contracts` factories (a pure transform, no React/network imports).
- `useMarketingPageBlocks(slug, fallback)` paints from that fallback immediately, then fetches the published `pages.blocks` for the fleet-marketing site. A CMS payload replaces the fallback only when every block passes `BlockSchema` **and** the array matches the fallback's per-position block types. Any error, empty payload, schema failure, or shape mismatch keeps the fallback (with a dev-only warning). A page always renders with zero API dependency and can never be reshaped by a bad payload.
- Endpoint used: `GET /api/content/sites/fleet-marketing/pages?status=published` returns `{ success, data: Page[] }` (published-only for anonymous), filtered by slug, reading `.blocks`.
- The marketing site keeps its own styled section components. Reverse mappers reconstruct each component's rich data shape from a block, so the look never changes; the block only carries editable prose.

### Claims-safety design

- The static content modules stay canonical and unedited. The block derivation **imports** their strings rather than retyping them, so prose is single-sourced. `pnpm gate:quick` (claims-evidence + claim-drift + marketing-voice, all hard-fail) passes untouched, proving no pinned string moved.
- Metric-derived numbers, prices, product version strings, `PRODUCT_STATUS_STYLES`, icon paths, and interactive logic (the A/B hero variant, audience toggle, receipt motif, status filter, newsletter form) stay hardcoded TSX and never enter the block stream. A test asserts copy sentences ARE byte-identical in the stream while metrics/prices/versions ARE NOT.

### Annotation hookup

Each block-driven section spreads the presentation `fieldAttrs(annotation, path)` contract (`data-rvui-doc` / `data-rvui-field`, dot-paths like `blocks.0.items.2.title`) on its text elements. Annotation is inactive in this slice, so zero attributes emit and the DOM is unchanged; tests prove attributes emit when an active annotation is passed and suppress otherwise.

### Seed

`scripts/seed-fleet-marketing-site.ts` now upserts the `home` and `products` pages using the **same** pure derivation the runtime falls back to, so seed and fallback can never drift. Version-safe (optimistic `pages.version` guard), idempotent (skips when blocks already match), and `--dry-run` still works. Not run against any DB here; ships for the owner/CI to run.

### Frame headers (`apps/marketing/vercel.json`)

- CSP `frame-ancestors 'none'` becomes `frame-ancestors 'self' https://admin.revealui.com` so the admin origin can frame the marketing site for in-place visual editing.
- Dropped `X-Frame-Options: SAMEORIGIN`: it cannot express an allowlist, and CSP `frame-ancestors` supersedes it in every browser that honors CSP. Every other header byte is unchanged.

## Block mapping per route

- `home`: `[section (Demo), ctaSection (GetStarted)]`
- `products`: `[hero (Hero), ctaSection (CTA)]`

The home hero is intentionally excluded from the block wire (see Deviations).

## Deviations

- **Home hero not block-driven.** The home `Hero` uniquely combines the `?hero=foundation` A/B variant selection, the technical/non-technical audience fork, and the receipt print-motif. All three are interactive/presentational logic under the hard "interactive logic stays hardcoded" carve-out; wiring it to a static block would either drop the A/B variant (feature removal) or duplicate the selection logic. The `hero` block type is still exercised on `products`, so all three block types (`hero`, `section`, `ctaSection`) are covered across the two pages.
- **Existing `scripts/seed-fleet-marketing-home-page.ts` is now superseded** by this script's home-page upsert (it seeded an older Lexical-shaped hero block, incompatible with the contract marketing blocks). The version-safe upsert converges to the contract blocks regardless of run order. Left in place for the owner to retire deliberately rather than deleting it in this PR.

## Test plan

- `pnpm --filter marketing typecheck` — clean.
- `pnpm --filter marketing test` — 100 passed (15 files), including new coverage: transform round-trip byte-identity, claims-safety (pinned values absent / copy identical), fetch-fallback behavior (error to static, valid CMS overrides, invalid/mismatched to static + warn), and annotation emit/suppress per component.
- `pnpm gate:quick` — PASS (claims-evidence, claim-drift, marketing-voice all green untouched).
- Shared-transform import verified to resolve under `tsx` from the seed's cross-boundary path.

Do not merge; this is one slice of the program.
