### PR TITLE
feat(marketing): wire primitives and faq into the block stream

### DIFF
--- a/apps/marketing/app/components/__tests__/Primitives.test.tsx
+++ b/apps/marketing/app/components/__tests__/Primitives.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { HOME_PRIMITIVES } from '../../content/primitives';
+import { PRIMITIVES_FALLBACK_DATA, type PrimitivesData } from '../../lib/page-blocks';
+import { Primitives } from '../landing/Primitives';
+
+describe('Primitives: structural style keyed by index, not label', () => {
+  it('keeps each card icon + accent color when an operator renames the label', () => {
+    // Simulate the core P1 inline-edit flow: the first card's label is edited to
+    // something that no longer matches the static const. Index-keyed lookup must
+    // still resolve the first primitive's icon path and accent color.
+    const renamed: PrimitivesData = {
+      ...PRIMITIVES_FALLBACK_DATA,
+      items: PRIMITIVES_FALLBACK_DATA.items.map((item, index) =>
+        index === 0 ? { ...item, label: 'Renamed By An Operator' } : item,
+      ),
+    };
+
+    const { container, getByRole } = render(<Primitives data={renamed} />);
+
+    // The edited label renders as the card heading...
+    expect(getByRole('heading', { level: 3, name: 'Renamed By An Operator' })).toBeTruthy();
+
+    // ...and the first card still shows the FIRST primitive's icon path (index 0),
+    // not a label-lookup miss that would drop the icon.
+    const firstIcon = HOME_PRIMITIVES[0]?.iconPath ?? '';
+    const path = container.querySelector(`path[d="${firstIcon}"]`);
+    expect(path).not.toBeNull();
+
+    // ...and the first card keeps the emerald accent (index 0 → bg-primary/10).
+    const accentDiv = path?.closest('div');
+    expect(accentDiv?.className).toContain('bg-primary/10');
+  });
+
+  it('resolves every card icon path by position', () => {
+    const { container } = render(<Primitives />);
+    for (const primitive of HOME_PRIMITIVES) {
+      expect(container.querySelector(`path[d="${primitive.iconPath}"]`)).not.toBeNull();
+    }
+  });
+});

--- a/apps/marketing/app/components/__tests__/block-annotations.test.tsx
+++ b/apps/marketing/app/components/__tests__/block-annotations.test.tsx
@@ -1,10 +1,13 @@
 import type { BlockAnnotation } from '@revealui/presentation';
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { HOME_DEMO, HOME_GET_STARTED } from '../../content/home';
+import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../../content/home';
+import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../../content/primitives';
 import { PRODUCTS_CTA_SECTION, PRODUCTS_PAGE_HERO } from '../../content/products';
 import { GetStarted } from '../GetStarted';
 import { Demo } from '../landing/Demo';
+import { Faq } from '../landing/Faq';
+import { Primitives } from '../landing/Primitives';
 import { ProductsCta } from '../products/ProductsCta';
 import { ProductsHero } from '../products/ProductsHero';
 
@@ -12,7 +15,14 @@ const ACTIVE: BlockAnnotation = { docId: 'home', editable: true };
 
 describe('block-driven marketing sections: annotation suppression (inactive)', () => {
   it('emits zero data-rvui-* attributes with default (inactive) annotation', () => {
-    for (const ui of [<Demo />, <GetStarted />, <ProductsHero />, <ProductsCta />]) {
+    for (const ui of [
+      <Demo />,
+      <Primitives />,
+      <GetStarted />,
+      <Faq />,
+      <ProductsHero />,
+      <ProductsCta />,
+    ]) {
       const { container, unmount } = render(ui);
       expect(container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
       expect(container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
@@ -49,18 +59,47 @@ describe('block-driven marketing sections: annotation emission (active)', () => 
     );
   });
 
-  it('GetStarted emits field paths on heading, body, and snippet', () => {
-    const { container } = render(<GetStarted path="blocks.1" annotation={ACTIVE} />);
+  it('Primitives emits field paths on heading, body, and repeater items', () => {
+    const { container } = render(<Primitives path="blocks.1" annotation={ACTIVE} />);
     expect(container.querySelector('[data-rvui-field="blocks.1.heading"]')?.textContent).toBe(
-      HOME_GET_STARTED.heading,
+      HOME_PRIMITIVES_SECTION.heading,
     );
     expect(container.querySelector('[data-rvui-field="blocks.1.body"]')?.textContent).toBe(
+      HOME_PRIMITIVES_SECTION.body,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.1.items.0.label"]')?.textContent).toBe(
+      HOME_PRIMITIVES[0]?.label,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.1.items.0.body"]')?.textContent).toBe(
+      HOME_PRIMITIVES[0]?.body,
+    );
+  });
+
+  it('GetStarted emits field paths on heading, body, and snippet', () => {
+    const { container } = render(<GetStarted path="blocks.2" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.2.heading"]')?.textContent).toBe(
+      HOME_GET_STARTED.heading,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.2.body"]')?.textContent).toBe(
       HOME_GET_STARTED.body,
     );
     expect(
-      container.querySelector('[data-rvui-field="blocks.1.snippet.caption"]')?.textContent,
+      container.querySelector('[data-rvui-field="blocks.2.snippet.caption"]')?.textContent,
     ).toBe(HOME_GET_STARTED.cli.caption);
-    expect(container.querySelector('[data-rvui-field="blocks.1.snippet.lines"]')).not.toBeNull();
+    expect(container.querySelector('[data-rvui-field="blocks.2.snippet.lines"]')).not.toBeNull();
+  });
+
+  it('Faq emits field paths on heading and per-item question + answer', () => {
+    const { container } = render(<Faq path="blocks.1" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.1.heading"]')?.textContent).toBe(
+      HOME_FAQ.heading,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.1.items.0.label"]')?.textContent).toBe(
+      HOME_FAQ.items[0]?.question,
+    );
+    expect(container.querySelector('[data-rvui-field="blocks.1.items.0.body"]')?.textContent).toBe(
+      HOME_FAQ.items[0]?.answer,
+    );
   });
 
   it('ProductsHero emits field paths on title and subtitle', () => {
@@ -74,13 +113,13 @@ describe('block-driven marketing sections: annotation emission (active)', () => 
   });
 
   it('ProductsCta emits field paths on heading, body, and snippet', () => {
-    const { container } = render(<ProductsCta path="blocks.1" annotation={ACTIVE} />);
-    expect(container.querySelector('[data-rvui-field="blocks.1.heading"]')?.textContent).toBe(
+    const { container } = render(<ProductsCta path="blocks.2" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.2.heading"]')?.textContent).toBe(
       PRODUCTS_CTA_SECTION.heading,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.1.body"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.2.body"]')?.textContent).toBe(
       PRODUCTS_CTA_SECTION.body,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.1.snippet.lines"]')).not.toBeNull();
+    expect(container.querySelector('[data-rvui-field="blocks.2.snippet.lines"]')).not.toBeNull();
   });
 });

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -1,23 +1,45 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { HOME_FAQ } from '../../content/home';
+import type { FaqData } from '../../lib/page-blocks';
 
-export function Faq() {
+export interface FaqProps {
+  /** Rich FAQ data; defaults to the static content module (byte-identical). */
+  data?: FaqData;
+  /** Dot-path base of this block within the page array, e.g. `blocks.1`. */
+  path?: string;
+  /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
+  annotation?: BlockAnnotation;
+}
+
+export function Faq({ data = HOME_FAQ, path = 'blocks.1', annotation = {} }: FaqProps) {
   return (
     <section id="faq" className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {HOME_FAQ.eyebrow}
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {data.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {HOME_FAQ.heading}
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
           </h2>
         </div>
 
         <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
-          {HOME_FAQ.items.map((item) => (
+          {data.items.map((item, index) => (
             <details key={item.question} className="group py-6">
               <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                <h3 className="text-lg font-semibold leading-7 text-foreground">{item.question}</h3>
+                <h3
+                  className="text-lg font-semibold leading-7 text-foreground"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+                >
+                  {item.question}
+                </h3>
 
                 <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
                   <svg
@@ -32,7 +54,10 @@ export function Faq() {
                   </svg>
                 </span>
               </summary>
-              <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">
+              <div
+                className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+              >
                 {item.answer}
               </div>
             </details>

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -18,11 +18,12 @@ const accentBg: Record<string, string> = {
   violet: 'bg-violet-500/10 text-violet-500 ring-violet-500/20',
 };
 
-// Color + icon are structural, not editable prose: keyed by primitive label so
-// they stay in the TSX while the label + body flow through the block stream.
-const primitiveStyle = new Map(
-  HOME_PRIMITIVES.map((p) => [p.label, { color: p.color, iconPath: p.iconPath }]),
-);
+// Color + icon are structural, not editable prose: they stay in the TSX while
+// the label + body flow through the block stream. Keyed by ORDER, not label —
+// the label is a CMS-editable field, so an operator renaming a card must not
+// drop its icon/accent. Block item order mirrors HOME_PRIMITIVES by construction
+// of the shared transform.
+const primitiveStyles = HOME_PRIMITIVES.map((p) => ({ color: p.color, iconPath: p.iconPath }));
 
 export interface PrimitivesProps {
   /** Rich section data; defaults to the static content modules (byte-identical). */
@@ -68,7 +69,7 @@ export function Primitives({
         <div className="mx-auto mt-16 max-w-4xl space-y-10 sm:space-y-14">
           {data.items.map((item, index) => {
             const flipped = index % 2 === 1;
-            const style = primitiveStyle.get(item.label);
+            const style = primitiveStyles[index];
             return (
               <div
                 key={item.label}

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -1,5 +1,6 @@
-import { ButtonCVA } from '@revealui/presentation';
+import { type BlockAnnotation, ButtonCVA, fieldAttrs } from '@revealui/presentation';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../../content/primitives';
+import { PRIMITIVES_FALLBACK_DATA, type PrimitivesData } from '../../lib/page-blocks';
 
 // Accent chips must be surface-relative so they adapt under the token-based
 // theme (dark-first; light via system pref OR a manual [data-theme] override).
@@ -17,19 +18,47 @@ const accentBg: Record<string, string> = {
   violet: 'bg-violet-500/10 text-violet-500 ring-violet-500/20',
 };
 
-export function Primitives() {
+// Color + icon are structural, not editable prose: keyed by primitive label so
+// they stay in the TSX while the label + body flow through the block stream.
+const primitiveStyle = new Map(
+  HOME_PRIMITIVES.map((p) => [p.label, { color: p.color, iconPath: p.iconPath }]),
+);
+
+export interface PrimitivesProps {
+  /** Rich section data; defaults to the static content modules (byte-identical). */
+  data?: PrimitivesData;
+  /** Dot-path base of this block within the page array, e.g. `blocks.1`. */
+  path?: string;
+  /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
+  annotation?: BlockAnnotation;
+}
+
+export function Primitives({
+  data = PRIMITIVES_FALLBACK_DATA,
+  path = 'blocks.1',
+  annotation = {},
+}: PrimitivesProps) {
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {HOME_PRIMITIVES_SECTION.eyebrow}
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {data.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {HOME_PRIMITIVES_SECTION.heading}
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">
-            {HOME_PRIMITIVES_SECTION.body}
+          <p
+            className="mt-6 text-lg leading-8 text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.body`)}
+          >
+            {data.body}
           </p>
         </div>
 
@@ -37,17 +66,18 @@ export function Primitives() {
             rhythm. Each primitive is a generous row with a large accent icon that
             alternates sides; the copy hugs toward it. */}
         <div className="mx-auto mt-16 max-w-4xl space-y-10 sm:space-y-14">
-          {HOME_PRIMITIVES.map((p, index) => {
+          {data.items.map((item, index) => {
             const flipped = index % 2 === 1;
+            const style = primitiveStyle.get(item.label);
             return (
               <div
-                key={p.label}
+                key={item.label}
                 className={`flex flex-col gap-5 sm:items-center sm:gap-10 ${
                   flipped ? 'sm:flex-row-reverse' : 'sm:flex-row'
                 }`}
               >
                 <div
-                  className={`flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl ring-1 ${accentBg[p.color]}`}
+                  className={`flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl ring-1 ${style ? accentBg[style.color] : ''}`}
                 >
                   <svg
                     className="h-10 w-10"
@@ -56,13 +86,25 @@ export function Primitives() {
                     strokeWidth={1.5}
                     stroke="currentColor"
                   >
-                    <title>{p.label}</title>
-                    <path strokeLinecap="round" strokeLinejoin="round" d={p.iconPath} />
+                    <title>{item.label}</title>
+                    {style ? (
+                      <path strokeLinecap="round" strokeLinejoin="round" d={style.iconPath} />
+                    ) : null}
                   </svg>
                 </div>
                 <div className={`flex-1 ${flipped ? 'sm:text-right' : ''}`}>
-                  <h3 className="text-xl font-semibold text-foreground">{p.label}</h3>
-                  <p className="mt-2 text-base leading-7 text-muted-foreground">{p.body}</p>
+                  <h3
+                    className="text-xl font-semibold text-foreground"
+                    {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+                  >
+                    {item.label}
+                  </h3>
+                  <p
+                    className="mt-2 text-base leading-7 text-muted-foreground"
+                    {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+                  >
+                    {item.body}
+                  </p>
                 </div>
               </div>
             );

--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -1,6 +1,7 @@
 import { BlockSchema } from '@revealui/contracts/content';
 import { describe, expect, it } from 'vitest';
-import { HOME_DEMO, HOME_GET_STARTED } from '../content/home';
+import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
+import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../content/primitives';
 import { PRODUCTS_CTA_SECTION, PRODUCTS_FLAGSHIP, PRODUCTS_PAGE_HERO } from '../content/products';
 import { METRICS } from '../content/site';
 import {
@@ -10,8 +11,10 @@ import {
   HOME_FALLBACK_BLOCKS,
   homeBlocks,
   PRODUCTS_FALLBACK_BLOCKS,
+  primitivesSlot,
   productsBlocks,
   productsCtaSlot,
+  productsFaqSlot,
   productsHeroSlot,
 } from './page-blocks';
 import { SUBSCRIPTION_PRICE_FALLBACKS } from './pricing-fallbacks';
@@ -36,8 +39,8 @@ describe('page-blocks derivation', () => {
   });
 
   it('derives the expected block types per page in order', () => {
-    expect(homeBlocks().map((b) => b.type)).toEqual(['section', 'ctaSection']);
-    expect(productsBlocks().map((b) => b.type)).toEqual(['hero', 'ctaSection']);
+    expect(homeBlocks().map((b) => b.type)).toEqual(['section', 'section', 'ctaSection']);
+    expect(productsBlocks().map((b) => b.type)).toEqual(['hero', 'section', 'ctaSection']);
   });
 });
 
@@ -52,11 +55,21 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
       expect(strings).toContain(beat.title);
       expect(strings).toContain(beat.body);
     }
+    expect(strings).toContain(HOME_PRIMITIVES_SECTION.heading);
+    expect(strings).toContain(HOME_PRIMITIVES_SECTION.body);
+    for (const primitive of HOME_PRIMITIVES) {
+      expect(strings).toContain(primitive.label);
+      expect(strings).toContain(primitive.body);
+    }
     expect(strings).toContain(HOME_GET_STARTED.heading);
     expect(strings).toContain(HOME_GET_STARTED.body);
     expect(strings).toContain(HOME_GET_STARTED.cli.caption);
     expect(strings).toContain(PRODUCTS_PAGE_HERO.h1);
     expect(strings).toContain(PRODUCTS_PAGE_HERO.subtitle);
+    for (const item of HOME_FAQ.items) {
+      expect(strings).toContain(item.question);
+      expect(strings).toContain(item.answer);
+    }
     expect(strings).toContain(PRODUCTS_CTA_SECTION.heading);
     expect(strings).toContain(PRODUCTS_CTA_SECTION.body);
   });
@@ -69,6 +82,10 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     // Metric counters are rendered from METRICS in TSX, never as block prose.
     for (const metric of [METRICS.packages, METRICS.dbTables, METRICS.mcpServers]) {
       expect(strings).not.toContain(String(metric));
+    }
+    // Primitive colors + icon paths are structural, never block prose.
+    for (const primitive of HOME_PRIMITIVES) {
+      expect(strings).not.toContain(primitive.iconPath);
     }
   });
 });
@@ -85,9 +102,18 @@ describe('reverse mappers round-trip the derivation losslessly', () => {
     );
   });
 
+  it('reconstructs the primitives data byte-identical to its content modules', () => {
+    const slot = primitivesSlot(homeBlocks());
+    expect(slot.path).toBe('blocks.1');
+    expect(slot.data.eyebrow).toBe(HOME_PRIMITIVES_SECTION.eyebrow);
+    expect(slot.data.heading).toBe(HOME_PRIMITIVES_SECTION.heading);
+    expect(slot.data.body).toBe(HOME_PRIMITIVES_SECTION.body);
+    expect(slot.data.items).toEqual(HOME_PRIMITIVES.map((p) => ({ label: p.label, body: p.body })));
+  });
+
   it('reconstructs the get-started data byte-identical to HOME_GET_STARTED', () => {
     const slot = getStartedSlot(homeBlocks());
-    expect(slot.path).toBe('blocks.1');
+    expect(slot.path).toBe('blocks.2');
     expect(slot.data.heading).toBe(HOME_GET_STARTED.heading);
     expect(slot.data.body).toBe(HOME_GET_STARTED.body);
     expect(slot.data.cta.primary).toEqual({
@@ -103,14 +129,22 @@ describe('reverse mappers round-trip the derivation losslessly', () => {
     expect(slot.data.newsletter).toEqual(HOME_GET_STARTED.newsletter);
   });
 
-  it('reconstructs the products hero + cta byte-identical to their modules', () => {
+  it('reconstructs the products hero, faq, and cta byte-identical to their modules', () => {
     const hero = productsHeroSlot(productsBlocks());
     expect(hero.path).toBe('blocks.0');
     expect(hero.data.h1).toBe(PRODUCTS_PAGE_HERO.h1);
     expect(hero.data.subtitle).toBe(PRODUCTS_PAGE_HERO.subtitle);
 
+    const faq = productsFaqSlot(productsBlocks());
+    expect(faq.path).toBe('blocks.1');
+    expect(faq.data.eyebrow).toBe(HOME_FAQ.eyebrow);
+    expect(faq.data.heading).toBe(HOME_FAQ.heading);
+    expect(faq.data.items).toEqual(
+      HOME_FAQ.items.map((i) => ({ question: i.question, answer: i.answer })),
+    );
+
     const cta = productsCtaSlot(productsBlocks());
-    expect(cta.path).toBe('blocks.1');
+    expect(cta.path).toBe('blocks.2');
     expect(cta.data.heading).toBe(PRODUCTS_CTA_SECTION.heading);
     expect(cta.data.body).toBe(PRODUCTS_CTA_SECTION.body);
     expect(cta.data.cliSnippet).toBe(PRODUCTS_CTA_SECTION.cliSnippet);
@@ -134,8 +168,8 @@ describe('blocksMatchFallback shape guard', () => {
   it('rejects empty, wrong-length, and wrong-type arrays', () => {
     expect(blocksMatchFallback([], HOME_FALLBACK_BLOCKS)).toBe(false);
     expect(blocksMatchFallback(homeBlocks().slice(0, 1), HOME_FALLBACK_BLOCKS)).toBe(false);
-    // Same length, wrong type at position 0 (hero where a section is expected).
-    const swapped = [...productsBlocks().slice(0, 1), ...homeBlocks().slice(1, 2)];
+    // Same length (3), wrong type at position 0 (hero where a section is expected).
+    const swapped = [...productsBlocks().slice(0, 1), ...homeBlocks().slice(1, 3)];
     expect(blocksMatchFallback(swapped, HOME_FALLBACK_BLOCKS)).toBe(false);
   });
 });

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -1,16 +1,17 @@
 /**
  * Static-first block derivation for the marketing home + products pages.
  *
- * The marketing content modules (content/home.ts, content/products.ts) stay the
- * single source of truth for every prose string. This module derives the
- * canonical `pages.blocks` array from those modules with the `@revealui/contracts`
- * factories — a PURE transform, so the CMS block stream and the static fallback
- * can never carry a different sentence than the claim-covered modules do.
+ * The marketing content modules (content/home.ts, content/primitives.ts,
+ * content/products.ts) stay the single source of truth for every prose string.
+ * This module derives the canonical `pages.blocks` array from those modules with
+ * the `@revealui/contracts` factories — a PURE transform, so the CMS block stream
+ * and the static fallback can never carry a different sentence than the
+ * claim-covered modules do.
  *
  * The reverse mappers reconstruct each marketing component's own rich data shape
  * from a block, so the styled marketing components keep their look while their
  * prose can be overridden by the CMS. Only prose lives in blocks: metric-derived
- * numbers, prices, product versions, and interactive logic never leave the TSX.
+ * numbers, prices, product versions, colors, and icon paths never leave the TSX.
  *
  * No React or network imports live here so `scripts/seed-fleet-marketing-site.ts`
  * can import the same derivation the runtime falls back to.
@@ -26,7 +27,8 @@ import {
   type MarketingLink,
   type SectionBlock,
 } from '@revealui/contracts/content';
-import { HOME_DEMO, HOME_GET_STARTED } from '../content/home';
+import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
+import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../content/primitives';
 import { PRODUCTS_CTA_SECTION, PRODUCTS_PAGE_HERO } from '../content/products';
 import type { Cta } from '../content/types';
 
@@ -47,12 +49,35 @@ export interface DemoData {
   readonly beats: readonly DemoBeatData[];
 }
 
+export interface PrimitiveItemData {
+  readonly label: string;
+  readonly body: string;
+}
+
+export interface PrimitivesData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly items: readonly PrimitiveItemData[];
+}
+
 export interface GetStartedData {
   readonly heading: string;
   readonly body: string;
   readonly cta: { readonly primary: Cta; readonly secondary: Cta };
   readonly cli: { readonly command: readonly string[]; readonly caption: string };
   readonly newsletter: { readonly label: string };
+}
+
+export interface FaqItemData {
+  readonly question: string;
+  readonly answer: string;
+}
+
+export interface FaqData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly items: readonly FaqItemData[];
 }
 
 export interface ProductsHeroData {
@@ -68,14 +93,24 @@ export interface ProductsCtaData {
 }
 
 // ---------------------------------------------------------------------------
-// Stable block ids. Ids let the seed and fallback match, but the runtime never
-// routes by id (the CMS assigns its own) — it routes by array position + type.
+// Stable block ids + positions. Ids let the seed and fallback match, but the
+// runtime routes each slot by array POSITION + type (the CMS assigns its own
+// ids, and a page carries more than one `section` block).
 // ---------------------------------------------------------------------------
 
 export const HOME_DEMO_BLOCK_ID = 'home-demo';
+export const HOME_PRIMITIVES_BLOCK_ID = 'home-primitives';
 export const HOME_GET_STARTED_BLOCK_ID = 'home-get-started';
 export const PRODUCTS_HERO_BLOCK_ID = 'products-hero';
+export const PRODUCTS_FAQ_BLOCK_ID = 'products-faq';
 export const PRODUCTS_CTA_BLOCK_ID = 'products-cta';
+
+const HOME_DEMO_INDEX = 0;
+const HOME_PRIMITIVES_INDEX = 1;
+const HOME_GET_STARTED_INDEX = 2;
+const PRODUCTS_HERO_INDEX = 0;
+const PRODUCTS_FAQ_INDEX = 1;
+const PRODUCTS_CTA_INDEX = 2;
 
 function ctaToLink(cta: Cta, variant: 'primary' | 'secondary'): MarketingLink {
   return { label: cta.label, href: cta.href, variant };
@@ -101,6 +136,17 @@ function homeDemoBlock(): SectionBlock {
   });
 }
 
+function homePrimitivesBlock(): SectionBlock {
+  return createSectionBlock(HOME_PRIMITIVES_BLOCK_ID, HOME_PRIMITIVES_SECTION.heading, {
+    eyebrow: HOME_PRIMITIVES_SECTION.eyebrow,
+    body: HOME_PRIMITIVES_SECTION.body,
+    items: HOME_PRIMITIVES.map((primitive) => ({
+      label: primitive.label,
+      body: primitive.body,
+    })),
+  });
+}
+
 function homeGetStartedBlock(): CtaSectionBlock {
   return createCtaSectionBlock(HOME_GET_STARTED_BLOCK_ID, HOME_GET_STARTED.heading, {
     body: HOME_GET_STARTED.body,
@@ -121,6 +167,16 @@ function productsHeroBlock(): HeroBlock {
   });
 }
 
+function productsFaqBlock(): SectionBlock {
+  return createSectionBlock(PRODUCTS_FAQ_BLOCK_ID, HOME_FAQ.heading, {
+    eyebrow: HOME_FAQ.eyebrow,
+    items: HOME_FAQ.items.map((item) => ({
+      label: item.question,
+      body: item.answer,
+    })),
+  });
+}
+
 function productsCtaBlock(): CtaSectionBlock {
   return createCtaSectionBlock(PRODUCTS_CTA_BLOCK_ID, PRODUCTS_CTA_SECTION.heading, {
     body: PRODUCTS_CTA_SECTION.body,
@@ -132,14 +188,14 @@ function productsCtaBlock(): CtaSectionBlock {
   });
 }
 
-/** Derives the home page's block-driven sections (Demo, GetStarted). */
+/** Derives the home page's block-driven sections (Demo, Primitives, GetStarted). */
 export function homeBlocks(): Block[] {
-  return [homeDemoBlock(), homeGetStartedBlock()];
+  return [homeDemoBlock(), homePrimitivesBlock(), homeGetStartedBlock()];
 }
 
-/** Derives the products page's block-driven sections (Hero, CTA). */
+/** Derives the products page's block-driven sections (Hero, FAQ, CTA). */
 export function productsBlocks(): Block[] {
-  return [productsHeroBlock(), productsCtaBlock()];
+  return [productsHeroBlock(), productsFaqBlock(), productsCtaBlock()];
 }
 
 export const HOME_FALLBACK_BLOCKS: Block[] = homeBlocks();
@@ -157,6 +213,18 @@ function sectionToDemo(block: SectionBlock): DemoData {
     beats: (block.data.items ?? []).map((item) => ({
       n: item.label ?? '',
       title: item.title ?? '',
+      body: item.body,
+    })),
+  };
+}
+
+function sectionToPrimitives(block: SectionBlock): PrimitivesData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    items: (block.data.items ?? []).map((item) => ({
+      label: item.label ?? '',
       body: item.body,
     })),
   };
@@ -181,6 +249,17 @@ function ctaToGetStarted(block: CtaSectionBlock): GetStartedData {
   };
 }
 
+function sectionToFaq(block: SectionBlock): FaqData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    items: (block.data.items ?? []).map((item) => ({
+      question: item.label ?? '',
+      answer: item.body,
+    })),
+  };
+}
+
 function heroToProductsHero(block: HeroBlock): ProductsHeroData {
   return {
     h1: block.data.title,
@@ -202,53 +281,64 @@ function ctaToProductsCta(block: CtaSectionBlock): ProductsCtaData {
   };
 }
 
+/**
+ * Default (fallback) data for the Primitives section. No single content const
+ * carries both the header and the item list, so it is composed here once.
+ */
+export const PRIMITIVES_FALLBACK_DATA: PrimitivesData = sectionToPrimitives(homePrimitivesBlock());
+
 // ---------------------------------------------------------------------------
-// Slot resolvers: pick a block by type + position, return data + annotation path
+// Slot resolvers: pick a block by POSITION + type, return data + annotation path.
+// blocksMatchFallback() guarantees the type at each index matches the fallback,
+// so a page can carry several `section` blocks without ambiguity.
 // ---------------------------------------------------------------------------
 
 export interface BlockSlot<T> {
   readonly data: T;
-  /** Dot-path base of the block within the array, e.g. `blocks.0`. */
+  /** Dot-path base of this block within the array, e.g. `blocks.0`. */
   readonly path: string;
 }
 
-function firstOfType(blocks: Block[], type: Block['type']): { block: Block; index: number } | null {
-  const index = blocks.findIndex((block) => block.type === type);
-  if (index < 0) return null;
-  const block = blocks[index];
-  return block ? { block, index } : null;
+export function demoSlot(blocks: Block[]): BlockSlot<DemoData> {
+  const block = blocks[HOME_DEMO_INDEX];
+  const path = `blocks.${HOME_DEMO_INDEX}`;
+  if (block && block.type === 'section') return { data: sectionToDemo(block), path };
+  return { data: sectionToDemo(homeDemoBlock()), path };
 }
 
-export function demoSlot(blocks: Block[]): BlockSlot<DemoData> {
-  const found = firstOfType(blocks, 'section');
-  if (found && found.block.type === 'section') {
-    return { data: sectionToDemo(found.block), path: `blocks.${found.index}` };
-  }
-  return { data: sectionToDemo(homeDemoBlock()), path: 'blocks.0' };
+export function primitivesSlot(blocks: Block[]): BlockSlot<PrimitivesData> {
+  const block = blocks[HOME_PRIMITIVES_INDEX];
+  const path = `blocks.${HOME_PRIMITIVES_INDEX}`;
+  if (block && block.type === 'section') return { data: sectionToPrimitives(block), path };
+  return { data: sectionToPrimitives(homePrimitivesBlock()), path };
 }
 
 export function getStartedSlot(blocks: Block[]): BlockSlot<GetStartedData> {
-  const found = firstOfType(blocks, 'ctaSection');
-  if (found && found.block.type === 'ctaSection') {
-    return { data: ctaToGetStarted(found.block), path: `blocks.${found.index}` };
-  }
-  return { data: ctaToGetStarted(homeGetStartedBlock()), path: 'blocks.1' };
+  const block = blocks[HOME_GET_STARTED_INDEX];
+  const path = `blocks.${HOME_GET_STARTED_INDEX}`;
+  if (block && block.type === 'ctaSection') return { data: ctaToGetStarted(block), path };
+  return { data: ctaToGetStarted(homeGetStartedBlock()), path };
 }
 
 export function productsHeroSlot(blocks: Block[]): BlockSlot<ProductsHeroData> {
-  const found = firstOfType(blocks, 'hero');
-  if (found && found.block.type === 'hero') {
-    return { data: heroToProductsHero(found.block), path: `blocks.${found.index}` };
-  }
-  return { data: heroToProductsHero(productsHeroBlock()), path: 'blocks.0' };
+  const block = blocks[PRODUCTS_HERO_INDEX];
+  const path = `blocks.${PRODUCTS_HERO_INDEX}`;
+  if (block && block.type === 'hero') return { data: heroToProductsHero(block), path };
+  return { data: heroToProductsHero(productsHeroBlock()), path };
+}
+
+export function productsFaqSlot(blocks: Block[]): BlockSlot<FaqData> {
+  const block = blocks[PRODUCTS_FAQ_INDEX];
+  const path = `blocks.${PRODUCTS_FAQ_INDEX}`;
+  if (block && block.type === 'section') return { data: sectionToFaq(block), path };
+  return { data: sectionToFaq(productsFaqBlock()), path };
 }
 
 export function productsCtaSlot(blocks: Block[]): BlockSlot<ProductsCtaData> {
-  const found = firstOfType(blocks, 'ctaSection');
-  if (found && found.block.type === 'ctaSection') {
-    return { data: ctaToProductsCta(found.block), path: `blocks.${found.index}` };
-  }
-  return { data: ctaToProductsCta(productsCtaBlock()), path: 'blocks.1' };
+  const block = blocks[PRODUCTS_CTA_INDEX];
+  const path = `blocks.${PRODUCTS_CTA_INDEX}`;
+  if (block && block.type === 'ctaSection') return { data: ctaToProductsCta(block), path };
+  return { data: ctaToProductsCta(productsCtaBlock()), path };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -23,6 +23,8 @@ import {
   type GetStartedData,
   getStartedSlot,
   HOME_FALLBACK_BLOCKS,
+  type PrimitivesData,
+  primitivesSlot,
 } from '../lib/page-blocks';
 import { useAudienceHead } from '../lib/use-audience-head';
 import { useMarketingPageBlocks } from '../lib/use-page-blocks';
@@ -47,17 +49,18 @@ const INACTIVE_ANNOTATION: BlockAnnotation = { editable: false };
  */
 interface TechnicalLandingProps {
   demo: BlockSlot<DemoData>;
+  primitives: BlockSlot<PrimitivesData>;
   getStarted: BlockSlot<GetStartedData>;
   annotation: BlockAnnotation;
 }
 
-function TechnicalLanding({ demo, getStarted, annotation }: TechnicalLandingProps) {
+function TechnicalLanding({ demo, primitives, getStarted, annotation }: TechnicalLandingProps) {
   return (
     <>
       <Hero />
       <Problem />
       <Demo data={demo.data} path={demo.path} annotation={annotation} />
-      <Primitives />
+      <Primitives data={primitives.data} path={primitives.path} annotation={annotation} />
       <Proof />
       <PricingTeaser />
       <GetStarted data={getStarted.data} path={getStarted.path} annotation={annotation} />
@@ -96,13 +99,19 @@ export function HomePage() {
   useAudienceHead(audience);
   const blocks = useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS);
   const demo = demoSlot(blocks);
+  const primitives = primitivesSlot(blocks);
   const getStarted = getStartedSlot(blocks);
   return (
     <div className="min-h-screen bg-background">
       {audience === 'non-technical' ? (
         <NonTechnicalLanding />
       ) : (
-        <TechnicalLanding demo={demo} getStarted={getStarted} annotation={INACTIVE_ANNOTATION} />
+        <TechnicalLanding
+          demo={demo}
+          primitives={primitives}
+          getStarted={getStarted}
+          annotation={INACTIVE_ANNOTATION}
+        />
       )}
     </div>
   );

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -12,7 +12,12 @@ import {
   PRODUCTS_STATS_SECTION,
   type ProductStatus,
 } from '../content/products';
-import { PRODUCTS_FALLBACK_BLOCKS, productsCtaSlot, productsHeroSlot } from '../lib/page-blocks';
+import {
+  PRODUCTS_FALLBACK_BLOCKS,
+  productsCtaSlot,
+  productsFaqSlot,
+  productsHeroSlot,
+} from '../lib/page-blocks';
 import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
 // Annotation is inactive in this slice; the editor-canvas slice activates it.
@@ -36,6 +41,7 @@ export function ProductsPage() {
     f === 'All' ? PRODUCTS_SISTERS.length : PRODUCTS_SISTERS.filter((p) => p.status === f).length;
   const blocks = useMarketingPageBlocks('products', PRODUCTS_FALLBACK_BLOCKS);
   const hero = productsHeroSlot(blocks);
+  const faq = productsFaqSlot(blocks);
   const cta = productsCtaSlot(blocks);
   return (
     <div className="min-h-screen bg-background">
@@ -312,7 +318,7 @@ export function ProductsPage() {
       <Proof />
 
       {/* FAQ — handle licensing / self-host / production-ready objections */}
-      <Faq />
+      <Faq data={faq.data} path={faq.path} annotation={INACTIVE_ANNOTATION} />
 
       {/* CTA */}
       <ProductsCta data={cta.data} path={cta.path} annotation={INACTIVE_ANNOTATION} />


### PR DESCRIPTION
Follow-up to #1994 (P1 slice 3 of the visual-edit-sessions program per the internal spec, 2026-07-02), addressing the coordinator's coverage note: wire the remaining pure-copy repeaters into the block stream. #1994 was squash-merged to `test` before this landed, so this ships as its own PR on top.

## What this does

Extends the CMS block wire from `[Demo, GetStarted]` / `[Hero, CTA]` to cover every zero-interactivity copy repeater on the two pages.

### Block mapping per route (updated)

| Route | Block stream (position → styled component) | Static (non-block) sections |
|-------|--------------------------------------------|-----------------------------|
| `home` | `0 section` → Demo, `1 section` → Primitives, `2 ctaSection` → GetStarted | Hero, Problem, Proof, PricingTeaser |
| `products` | `0 hero` → Hero, `1 section` → FAQ, `2 ctaSection` → CTA | Flagship, Sisters grid, Stats, Proof |

- **Primitives → home `section` block.** `HOME_PRIMITIVES_SECTION` header + `HOME_PRIMITIVES` items (`{label, body}`). Each primitive's accent `color` and `iconPath` are structural, so they stay in the component, keyed by primitive label (a `Map`), never in the block. A test asserts the icon paths never enter the stream.
- **FAQ → products `section` block.** `HOME_FAQ` items map to `{label: question, body: answer}`.

### Correction to the coordinator's note

The note asked to wire FAQ into the **home** block stream, but `HOME_FAQ` does not render on home. `Faq` was cut from the home page in frontend-excellence Phase 1 (HomePage renders Hero/Problem/Demo/Primitives/Proof/PricingTeaser/GetStarted). `HOME_FAQ` renders on **/products** (ProductsPage imports `landing/Faq`). So FAQ is wired into the **products** stream, where its answers actually appear and are the inline copy an operator is most likely to edit. The `Faq` component is shared but imported only by ProductsPage, so no home surface changes.

### Slot resolution: position-based

Both pages now carry two `section` blocks, so slot resolution moved from first-of-type to array **position + type**. `blocksMatchFallback` already guarantees each index's type matches the fallback, so a page can carry several `section` blocks without ambiguity, and a malformed CMS payload still can't reshape the page.

### Claims safety

Unchanged model: the derivation imports the content modules' strings (single-sourced), so `gate:quick` (claims-evidence + claim-drift + marketing-voice, all hard-fail) stays green. Tests assert Primitives + FAQ copy is byte-identical in the stream, and that colors, icon paths, metrics, prices, and versions are absent.

### Seed

`scripts/seed-fleet-marketing-site.ts` uses the same pure derivation, so the seeded `home` (3 blocks) and `products` (3 blocks) pages pick up Primitives + FAQ automatically. Version-safe + idempotent as before.

## Deviations (carried from #1994)

- **Home hero stays out of the block wire** (accepted): it combines the `?hero=foundation` A/B variant, the audience toggle fork, and the receipt print-motif — interactive logic under the hard carve-out. Recorded as a **P2 follow-up**: revisit once the editor slice can express variant-aware or interactive blocks.
- **Products FAQ is wired; home has no FAQ section to wire** (see correction above). The asymmetry is deliberate and matches where the content renders.

## Test plan

- `pnpm --filter marketing typecheck` — clean.
- `pnpm --filter marketing test` — 103 passed (15 files); adds Primitives + FAQ round-trip byte-identity and annotation emit/suppress coverage.
- `pnpm gate:quick` — PASS (claims-evidence, claim-drift, marketing-voice green).
- Shared-transform import re-verified under `tsx`: home `[section, section, ctaSection]`, products `[hero, section, ctaSection]`.

Do not merge; awaiting the coordinator's review pass.
