### PR TITLE
feat(editor): edit-session runtime, canvas, and preview-token flow

### DIFF
--- a/.changeset/editor-canvas-runtime.md
+++ b/.changeset/editor-canvas-runtime.md
@@ -1,0 +1,8 @@
+---
+'@revealui/editor': minor
+---
+
+Introduce @revealui/editor: the visual edit-session runtime and dashboard canvas.
+
+- `@revealui/editor/runtime`: a dependency-free, framework-agnostic edit-mode runtime the previewed site loads only in edit mode. It fetches read-only draft overlays with a signed preview token, hands drafts to the host page via a callback, and runs an exact-origin-pinned postMessage channel with the dashboard canvas.
+- `@revealui/editor/canvas`: React Client Components (`EditSessionCanvas`) that host the preview iframe, open a click-to-edit popover, drive debounced autosave through the authenticated session API, and surface publish/discard conflicts.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Six principles that give you a tested starting point for every architectural dec
 | Principle | What it means |
 | --- | --- |
 | **Justifiable** | Every default earns its place. No magic, no hidden complexity, no decisions you can't explain to your team. |
-| **Orthogonal** | Clean separation of concerns across 28 packages. Use what you need, replace what you don't. Zero circular dependencies. |
+| **Orthogonal** | Clean separation of concerns across 29 packages. Use what you need, replace what you don't. Zero circular dependencies. |
 | **Sovereign** | Your infrastructure, your data, your rules. Deploy anywhere. Fork anything. No vendor holds your business hostage. |
 | **Hermetic** | Auth doesn't leak into billing. Content doesn't tangle with payments. Sealed boundaries, clean contracts between every layer. |
 | **Unified** | One Zod schema defines the truth. Types, validation, and API flow from database to server to UI with zero drift. |
@@ -278,7 +278,7 @@ revealui/
 │   ├── admin/      # Admin dashboard + content management (port 4000)
 │   ├── docs/       # Documentation site (port 3002)
 │   └── marketing/  # revealui.com marketing site (port 3000)
-├── packages/       # 22 OSS + 5 Pro + 1 internal = 28 packages
+├── packages/       # 23 OSS + 5 Pro + 1 internal = 29 packages
 ├── docs/           # guides + reference
 └── scripts/        # CI gates, release tooling, dev tools
 ```

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -22,6 +22,7 @@ COPY packages/contracts/package.json ./packages/contracts/
 COPY packages/core/package.json ./packages/core/
 COPY packages/db/package.json ./packages/db/
 COPY packages/dev/package.json ./packages/dev/
+COPY packages/editor/package.json ./packages/editor/
 COPY packages/paywall/package.json ./packages/paywall/
 COPY packages/presentation/package.json ./packages/presentation/
 COPY packages/resilience/package.json ./packages/resilience/

--- a/apps/admin/Dockerfile.forge
+++ b/apps/admin/Dockerfile.forge
@@ -24,6 +24,7 @@ COPY packages/core/package.json          ./packages/core/
 COPY packages/create-revealui/package.json ./packages/create-revealui/
 COPY packages/db/package.json            ./packages/db/
 COPY packages/dev/package.json           ./packages/dev/
+COPY packages/editor/package.json        ./packages/editor/
 COPY packages/knowledge-graph/package.json ./packages/knowledge-graph/
 COPY packages/mcp/package.json           ./packages/mcp/
 COPY packages/paywall/package.json       ./packages/paywall/

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -107,6 +107,7 @@ const nextConfig = {
     '@revealui/contracts',
     '@revealui/auth',
     '@revealui/core',
+    '@revealui/editor',
     '@revealui/presentation',
     '@revealui/sync',
   ],

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -13,6 +13,7 @@
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
     "@revealui/db": "workspace:*",
+    "@revealui/editor": "workspace:*",
     "@revealui/knowledge-graph": "workspace:*",
     "@revealui/mcp": "workspace:*",
     "@revealui/paywall": "workspace:*",

--- a/apps/admin/src/app/(backend)/edit-sessions/[id]/page.tsx
+++ b/apps/admin/src/app/(backend)/edit-sessions/[id]/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+/**
+ * Edit-session canvas mount. Auth is enforced centrally by `proxy.ts` (the
+ * `(backend)` group requires a session cookie), so this route is mount-only:
+ * it unwraps the route id and renders the `@revealui/editor` canvas, injecting
+ * the admin's CSRF-aware `apiFetch` and the API base URL. No editing logic lives
+ * in the app; the canvas is the package component.
+ */
+
+import { EditSessionCanvas } from '@revealui/editor/canvas';
+import { type ReactElement, use } from 'react';
+import { apiFetch } from '@/lib/utils/csrf';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function EditSessionPage({ params }: PageProps): ReactElement {
+  const { id } = use(params);
+  return (
+    <div className="p-4" style={{ height: 'calc(100vh - 4rem)' }}>
+      <EditSessionCanvas sessionId={id} apiBaseUrl={API_BASE_URL} fetcher={apiFetch} />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(backend)/edit-sessions/page.tsx
+++ b/apps/admin/src/app/(backend)/edit-sessions/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+/**
+ * Edit-sessions list. Minimal: lists open sessions and links each to its canvas.
+ * Auth is enforced centrally by `proxy.ts`.
+ */
+
+import Link from 'next/link';
+import { type ReactElement, useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/utils/csrf';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com';
+
+interface SessionRow {
+  id: string;
+  title: string;
+  status: string;
+  siteId: string;
+}
+
+export default function EditSessionsListPage(): ReactElement {
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch(`${API_BASE_URL}/api/content/sessions?status=open`, {
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error(`load failed: ${res.status}`);
+        const body = (await res.json()) as { data: SessionRow[] };
+        if (!cancelled) setSessions(body.data);
+      } catch (err) {
+        if (!cancelled) setError(String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-lg font-semibold">Edit sessions</h1>
+      {error ? (
+        <p role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      ) : null}
+      {sessions.length === 0 ? (
+        <p className="text-sm text-neutral-500">No open sessions.</p>
+      ) : (
+        <ul className="space-y-1">
+          {sessions.map((s) => (
+            <li key={s.id}>
+              <Link
+                className="text-sm text-blue-400 hover:underline"
+                href={`/edit-sessions/${s.id}`}
+              >
+                {s.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -53,6 +53,13 @@ const contentItems: NavItem[] = [
       <NavIcon d="M4 4a2 2 0 0 0-2 2v1h16V6a2 2 0 0 0-2-2H4ZM18 9H2v5a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9ZM4 13a1 1 0 0 1 1-1h1a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1Zm5-1a1 1 0 1 0 0 2h1a1 1 0 1 0 0-2H9Z" />
     ),
   },
+  {
+    href: '/edit-sessions',
+    label: 'Edit sessions',
+    icon: (
+      <NavIcon d="M2.695 14.762l-1.262 3.155a.5.5 0 0 0 .65.65l3.155-1.262a4 4 0 0 0 1.343-.886L17.5 5.501a2.121 2.121 0 0 0-3-3L3.58 13.419a4 4 0 0 0-.885 1.343Z" />
+    ),
+  },
 ];
 
 const aiItems: NavItem[] = [

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -669,7 +669,7 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[3].answer',
-    text: 'Yes. 22 of 28 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
+    text: 'Yes. 23 of 29 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
     evidence: [LICENSE_SPLIT, LICENSE_MIT, SELF_HOST, POSTGRES],
   },
   {
@@ -893,7 +893,7 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_TIERS[0].description',
-    text: '22 of 28 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
+    text: '23 of 29 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
     evidence: [LICENSE_SPLIT, NO_TELEMETRY],
   },
   {

--- a/apps/marketing/app/content/fair-source.ts
+++ b/apps/marketing/app/content/fair-source.ts
@@ -1,6 +1,6 @@
 // Sourced from: app/routes/FairSourcePage.tsx (Phase 1 extraction).
 // Hero headline + body math reference the METRICS license split
-// (validator: 22 MIT + 5 FSL + 1 internal = 28 packages). The single internal
+// (validator: 23 MIT + 5 FSL + 1 internal = 29 packages). The single internal
 // package is @revealui/scripts (private build tooling, no license field).
 // Per the internal marketing-overhaul plan §4.4 + docs/MARKETING_METRICS.md §1.
 // claims-ratchet 2026-07-12: services description scoped to Stripe + email,

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -177,7 +177,7 @@ export const HOME_FAQ = {
     {
       question: 'Can I self-host?',
       answer:
-        'Yes. 22 of 28 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
+        'Yes. 23 of 29 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
     },
     {
       question: 'What does "agent-native" actually mean in code?',

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -29,7 +29,7 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
     id: 'free',
     name: 'Free',
     description:
-      '22 of 28 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
+      '23 of 29 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
     features: [
       'Full primitive stack',
       'Admin dashboard + API',

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -1,5 +1,5 @@
 // Sourced from: app/components/landing/Proof.tsx (Phase 1c extraction).
-// Phase 3 (2026-05-18) update: "22 of 28 packages MIT" trust card heading now
+// Phase 3 (2026-05-18) update: "23 of 29 packages MIT" trust card heading now
 // uses METRICS license split (21 MIT). Pre-Phase-3 audit had off-by-one count.
 // Per the internal marketing-overhaul plan §4.4 + docs/MARKETING_METRICS.md §1.
 //

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -21,11 +21,11 @@
  */
 export const METRICS = {
   /** Packages in `packages/` directories. Source: claim-drift countPackages. */
-  packages: 28,
+  packages: 29,
   /** Apps in `apps/`. Source: claim-drift countApps. */
   apps: 4,
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
-  workspaces: 32,
+  workspaces: 33,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
   testFiles: 1061,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
@@ -41,7 +41,7 @@ export const METRICS = {
   /** License split. Source: claim-drift licenseSplit. */
   licenseSplit: {
     /** MIT-licensed packages. */
-    mit: 22,
+    mit: 23,
     /** Fair Source (FSL-1.1-MIT) packages: @revealui/ai, engines, harnesses, mcp, services. */
     fsl: 5,
     /** Internal/none: `test` workspace package (private, no public license). */

--- a/apps/marketing/app/entry.client.tsx
+++ b/apps/marketing/app/entry.client.tsx
@@ -9,12 +9,15 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { initAnalytics } from './lib/analytics';
+import { initEditMode } from './lib/edit-mode';
 import { initSentry } from './lib/sentry';
 
 // Initialise Sentry before mounting. No-op if VITE_SENTRY_DSN is absent.
 initSentry();
 // Initialise analytics sink. No-op if VITE_ANALYTICS_DOMAIN is absent or DNT is enabled.
 initAnalytics();
+// Enter visual edit mode only when the URL carries an edit token. No-op otherwise.
+initEditMode();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/apps/marketing/app/lib/edit-mode.ts
+++ b/apps/marketing/app/lib/edit-mode.ts
@@ -1,0 +1,56 @@
+/**
+ * Edit-mode bootstrap for the marketing site.
+ *
+ * Zero cost when the `rvui-edit` param is absent: the @revealui/editor runtime
+ * chunk is dynamically imported ONLY in edit mode, so a normal visitor never
+ * pays for it. In edit mode it initializes the runtime with a callback that
+ * stashes the draft overlays into a module-level store. Page components
+ * subscribe to that store to render drafts; wiring that consumption into the
+ * block renderer is a follow-up slice.
+ *
+ * The store follows the in-repo `useSyncExternalStore` shape (subscribe +
+ * getSnapshot), matching @revealui/router.
+ */
+
+import type { PreviewDoc } from '@revealui/editor/runtime';
+
+type Listener = () => void;
+
+let currentDrafts: PreviewDoc[] = [];
+const listeners = new Set<Listener>();
+
+/** Subscribe to draft-overlay changes. Returns an unsubscribe function. */
+export function subscribeEditDrafts(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Current draft overlays. Stable reference until the drafts change. */
+export function getEditDrafts(): PreviewDoc[] {
+  return currentDrafts;
+}
+
+function setDrafts(docs: PreviewDoc[]): void {
+  currentDrafts = docs;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+const API_URL =
+  import.meta.env.VITE_API_URL ??
+  (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004');
+
+/**
+ * Initialize edit mode if the URL carries an edit token. No-op (and no import)
+ * otherwise, so a normal page load stays untouched.
+ */
+export function initEditMode(): void {
+  const params = new URLSearchParams(window.location.search);
+  if (!params.get('rvui-edit')) return;
+  void import('@revealui/editor/runtime').then(({ initEditRuntime }) => {
+    void initEditRuntime({ apiBaseUrl: API_URL, onDraft: setDrafts });
+  });
+}

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -10,6 +10,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.5",
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
+    "@revealui/editor": "workspace:*",
     "@revealui/presentation": "workspace:*",
     "@revealui/router": "workspace:*",
     "@sentry/react": "^10.63.0",

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -6,7 +6,7 @@
 
 - [Documentation home](https://docs.revealui.com): Architecture, primitives, deployment, agent integration
 - [What works today](https://docs.revealui.com/WHAT_WORKS_TODAY): Honest pre-launch status — what's tested, what's stub, what's not yet wired
-- [Architecture](https://docs.revealui.com/ARCHITECTURE): Five primitives, 4 apps (admin, server, docs, marketing), 28 packages (22 published to npm)
+- [Architecture](https://docs.revealui.com/ARCHITECTURE): Five primitives, 4 apps (admin, server, docs, marketing), 29 packages (23 published to npm)
 - [Meet the Fleet](https://docs.revealui.com/SUITE): Six products that compose **RevFleet**: RevealUI (runtime), RevDev (dev tools), RevVault (secrets), RevCon (configs), **RevealUI Fleet** (self-host runtime kit, deployed via the **RevForge** stamping tool — formerly RevealUI Forge), RevSkills (skills)
 
 ## Getting started

--- a/apps/server/src/routes/__tests__/edit-sessions-preview.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/edit-sessions-preview.pglite.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Preview-token endpoints  -  integration tests against a REAL migrated schema
+ * (PGlite) and the real Hono session routes.
+ *
+ * Covers the P1 slice-4 security posture:
+ *   - mint: returns a token + previewUrl carrying rvui-edit / rvui-session,
+ *     landing on the resolved page path (or site root)
+ *   - mint: auth (anon 401 / non-editor 403) + non-open session 409
+ *   - GET /preview: valid token returns docs + adminOrigin, no cookie needed
+ *   - GET /preview: bad / expired / wrong-session tokens rejected, docs NEVER leaked
+ *   - GET /preview: non-open session 409
+ *   - mutating routes reject a token-bearing UNAUTHENTICATED request (tokens
+ *     grant no writes)
+ */
+
+import type { DatabaseClient } from '@revealui/db/client';
+import * as schema from '@revealui/db/schema';
+import { OpenAPIHono } from '@revealui/openapi';
+import { HTTPException } from 'hono/http-exception';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+import { mintPreviewToken } from '../content/_helpers/preview-token.js';
+import type { ContentVariables } from '../content/index.js';
+import sessionsRoutes from '../content/sessions.js';
+
+const SECRET = 'preview-endpoint-test-secret';
+const MARKETING_URL = 'https://www.example-preview.test';
+const ADMIN_URL = 'https://admin.example-preview.test';
+
+process.env.REVEALUI_PREVIEW_TOKEN_SECRET = SECRET;
+process.env.REVEALUI_PUBLIC_SERVER_URL = MARKETING_URL;
+process.env.ADMIN_URL = ADMIN_URL;
+
+let testDb: TestDb;
+
+interface UserCtx {
+  id: string;
+  role: string;
+}
+
+const EDITOR: UserCtx = { id: 'user-editor', role: 'editor' };
+const VIEWER: UserCtx = { id: 'user-viewer', role: 'viewer' };
+
+const SITE_ID = 'site-1';
+const PAGE_ID = 'page-1';
+const OTHER_SITE = 'site-2';
+const OTHER_PAGE = 'page-2';
+
+function createApp(user: UserCtx | null) {
+  const app = new OpenAPIHono<{ Variables: ContentVariables }>();
+  app.use('*', async (c, next) => {
+    if (user) c.set('user', user);
+    c.set('db', testDb.drizzle as unknown as DatabaseClient);
+    await next();
+  });
+  app.route('/', sessionsRoutes);
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) return c.json({ error: err.message }, err.status);
+    return c.json({ error: 'Internal server error' }, 500);
+  });
+  return app;
+}
+
+async function seedBase(): Promise<void> {
+  const db = testDb.drizzle;
+  await db.insert(schema.users).values([
+    { id: EDITOR.id, name: 'Editor', email: 'editor@example.com', role: 'editor' },
+    { id: VIEWER.id, name: 'Viewer', email: 'viewer@example.com', role: 'viewer' },
+  ]);
+  await db.insert(schema.sites).values([
+    { id: SITE_ID, ownerId: EDITOR.id, name: 'Site One', slug: 'site-one', status: 'published' },
+    { id: OTHER_SITE, ownerId: EDITOR.id, name: 'Site Two', slug: 'site-two', status: 'published' },
+  ]);
+  await db.insert(schema.pages).values([
+    {
+      id: PAGE_ID,
+      siteId: SITE_ID,
+      title: 'Home',
+      slug: 'about',
+      path: '/about',
+      status: 'published',
+      version: 1,
+      blocks: [{ type: 'text', text: 'hello' }],
+      seo: null,
+    },
+    {
+      id: OTHER_PAGE,
+      siteId: OTHER_SITE,
+      title: 'Other',
+      slug: 'other',
+      path: '/other',
+      status: 'published',
+      version: 1,
+      blocks: [],
+      seo: null,
+    },
+  ]);
+}
+
+async function openSession(app: ReturnType<typeof createApp>): Promise<string> {
+  const res = await app.request('/sessions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ siteId: SITE_ID, title: 'My edits' }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { data: { id: string } };
+  return body.data.id;
+}
+
+async function materializeDoc(app: ReturnType<typeof createApp>, sessionId: string): Promise<void> {
+  const res = await app.request(`/sessions/${sessionId}/docs/page/${PAGE_ID}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ path: 'title', value: 'Draft Home' }),
+  });
+  expect(res.status).toBe(200);
+}
+
+beforeEach(async () => {
+  testDb = await createTestDb();
+  await seedBase();
+});
+
+afterAll(async () => {
+  await testDb?.close();
+});
+
+// ---------------------------------------------------------------------------
+// Mint
+// ---------------------------------------------------------------------------
+
+describe('POST /sessions/:id/preview-token', () => {
+  it('mints a token and a previewUrl carrying the edit params (page path)', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    const res = await app.request(`/sessions/${sessionId}/preview-token?pageId=${PAGE_ID}`, {
+      method: 'POST',
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      data: { token: string; expiresAt: string; previewUrl: string };
+    };
+    expect(body.data.token).toContain('.');
+    const url = new URL(body.data.previewUrl);
+    expect(url.origin).toBe(MARKETING_URL);
+    expect(url.pathname).toBe('/about');
+    expect(url.searchParams.get('rvui-edit')).toBe(body.data.token);
+    expect(url.searchParams.get('rvui-session')).toBe(sessionId);
+    expect(new Date(body.data.expiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('defaults to the site root when no pageId is given', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    const res = await app.request(`/sessions/${sessionId}/preview-token`, { method: 'POST' });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { data: { previewUrl: string } };
+    expect(new URL(body.data.previewUrl).pathname).toBe('/');
+  });
+
+  it('rejects a pageId that belongs to a different site', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    const res = await app.request(`/sessions/${sessionId}/preview-token?pageId=${OTHER_PAGE}`, {
+      method: 'POST',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects anonymous (401) and non-editor (403)', async () => {
+    const editorApp = createApp(EDITOR);
+    const sessionId = await openSession(editorApp);
+
+    const anon = await createApp(null).request(`/sessions/${sessionId}/preview-token`, {
+      method: 'POST',
+    });
+    expect(anon.status).toBe(401);
+
+    const viewer = await createApp(VIEWER).request(`/sessions/${sessionId}/preview-token`, {
+      method: 'POST',
+    });
+    expect(viewer.status).toBe(403);
+  });
+
+  it('rejects minting for a non-open session (409)', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await app.request(`/sessions/${sessionId}/discard`, { method: 'POST' });
+    const res = await app.request(`/sessions/${sessionId}/preview-token`, { method: 'POST' });
+    expect(res.status).toBe(409);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /preview
+// ---------------------------------------------------------------------------
+
+describe('GET /sessions/:id/preview', () => {
+  it('returns docs + adminOrigin for a valid token, no cookie required', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await materializeDoc(app, sessionId);
+    const { token } = mintPreviewToken(SECRET, sessionId);
+
+    // No user context on this request  -  token is the only credential.
+    const res = await createApp(null).request(`/sessions/${sessionId}/preview?token=${token}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toContain('no-store');
+    const body = (await res.json()) as {
+      data: {
+        siteId: string;
+        adminOrigin: string;
+        docs: Array<{ docType: string; docId: string; draft: { title: string } }>;
+      };
+    };
+    expect(body.data.siteId).toBe(SITE_ID);
+    expect(body.data.adminOrigin).toBe(ADMIN_URL);
+    expect(body.data.docs).toHaveLength(1);
+    expect(body.data.docs[0]).toMatchObject({ docType: 'page', docId: PAGE_ID });
+    expect(body.data.docs[0].draft.title).toBe('Draft Home');
+  });
+
+  it('rejects a missing token (400) and never leaks docs', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await materializeDoc(app, sessionId);
+    const res = await createApp(null).request(`/sessions/${sessionId}/preview`);
+    expect(res.status).toBe(400);
+    expect(await res.text()).not.toContain('Draft Home');
+  });
+
+  it('rejects a bad token (401) and never leaks docs', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await materializeDoc(app, sessionId);
+    const res = await createApp(null).request(
+      `/sessions/${sessionId}/preview?token=garbage.forged`,
+    );
+    expect(res.status).toBe(401);
+    expect(await res.text()).not.toContain('Draft Home');
+  });
+
+  it('rejects an expired token (401)', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    const expired = mintPreviewToken(SECRET, sessionId, -10).token;
+    const res = await createApp(null).request(`/sessions/${sessionId}/preview?token=${expired}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a token minted for a different session (403)', async () => {
+    const app = createApp(EDITOR);
+    const sessionA = await openSession(app);
+    const sessionB = await openSession(app);
+    const tokenForA = mintPreviewToken(SECRET, sessionA).token;
+    const res = await createApp(null).request(`/sessions/${sessionB}/preview?token=${tokenForA}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects preview of a non-open session (409)', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    const token = mintPreviewToken(SECRET, sessionId).token;
+    await app.request(`/sessions/${sessionId}/discard`, { method: 'POST' });
+    const res = await createApp(null).request(`/sessions/${sessionId}/preview?token=${token}`);
+    expect(res.status).toBe(409);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tokens grant NO writes
+// ---------------------------------------------------------------------------
+
+describe('preview tokens never authorize mutations', () => {
+  it('a token-bearing UNAUTHENTICATED PATCH is rejected (401)', async () => {
+    const editorApp = createApp(EDITOR);
+    const sessionId = await openSession(editorApp);
+    const token = mintPreviewToken(SECRET, sessionId).token;
+
+    // Attach the token as a query param on the mutating route and send NO user.
+    const res = await createApp(null).request(
+      `/sessions/${sessionId}/docs/page/${PAGE_ID}?token=${token}`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: 'title', value: 'hacked' }),
+      },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('a token-bearing UNAUTHENTICATED publish is rejected (401)', async () => {
+    const editorApp = createApp(EDITOR);
+    const sessionId = await openSession(editorApp);
+    const token = mintPreviewToken(SECRET, sessionId).token;
+    const res = await createApp(null).request(`/sessions/${sessionId}/publish?token=${token}`, {
+      method: 'POST',
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/server/src/routes/content/_helpers/__tests__/preview-token.test.ts
+++ b/apps/server/src/routes/content/_helpers/__tests__/preview-token.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Preview-token mint/verify unit tests: round-trip, expiry, tampering, timing-safe path.
+ */
+
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  mintPreviewToken,
+  PREVIEW_TOKEN_TTL_SECONDS,
+  verifyPreviewToken,
+} from '../preview-token.js';
+
+const SECRET = 'unit-test-secret-not-a-real-key';
+
+describe('mintPreviewToken / verifyPreviewToken', () => {
+  it('round-trips a valid token', () => {
+    const { token, exp } = mintPreviewToken(SECRET, 'session-abc');
+    const result = verifyPreviewToken(SECRET, token);
+    expect(result).toEqual({ ok: true, sid: 'session-abc', exp });
+  });
+
+  it('sets exp to now + TTL', () => {
+    const before = Math.floor(Date.now() / 1000);
+    const { exp } = mintPreviewToken(SECRET, 'session-abc', PREVIEW_TOKEN_TTL_SECONDS);
+    expect(exp).toBeGreaterThanOrEqual(before + PREVIEW_TOKEN_TTL_SECONDS - 1);
+    expect(exp).toBeLessThanOrEqual(before + PREVIEW_TOKEN_TTL_SECONDS + 1);
+  });
+
+  it('rejects an expired token', () => {
+    const { token } = mintPreviewToken(SECRET, 'session-abc', -10);
+    const result = verifyPreviewToken(SECRET, token);
+    expect(result).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('rejects a tampered payload', () => {
+    const { token } = mintPreviewToken(SECRET, 'session-abc');
+    const [, sig] = token.split('.');
+    const forgedPayload = Buffer.from(
+      JSON.stringify({ sid: 'session-evil', exp: Math.floor(Date.now() / 1000) + 600 }),
+      'utf8',
+    ).toString('base64url');
+    const result = verifyPreviewToken(SECRET, `${forgedPayload}.${sig}`);
+    expect(result).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('rejects a tampered signature', () => {
+    const { token } = mintPreviewToken(SECRET, 'session-abc');
+    const [payload] = token.split('.');
+    const otherSig = mintPreviewToken(SECRET, 'other-session').token.split('.')[1];
+    const result = verifyPreviewToken(SECRET, `${payload}.${otherSig}`);
+    expect(result).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const { token } = mintPreviewToken('a-different-secret', 'session-abc');
+    const result = verifyPreviewToken(SECRET, token);
+    expect(result).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(verifyPreviewToken(SECRET, '')).toEqual({ ok: false, reason: 'malformed' });
+    expect(verifyPreviewToken(SECRET, 'no-dot')).toEqual({ ok: false, reason: 'malformed' });
+    expect(verifyPreviewToken(SECRET, '.onlysig')).toEqual({ ok: false, reason: 'malformed' });
+    expect(verifyPreviewToken(SECRET, 'onlypayload.')).toEqual({ ok: false, reason: 'malformed' });
+    expect(verifyPreviewToken(SECRET, 'a.b.c')).toEqual({ ok: false, reason: 'malformed' });
+  });
+
+  it('rejects a well-signed but non-payload body', () => {
+    // Sign arbitrary base64url that is not JSON {sid,exp}: signature passes,
+    // payload decode/shape fails -> malformed (never ok).
+    const payloadB64 = Buffer.from('not json at all', 'utf8').toString('base64url');
+    const sig = createHmac('sha256', SECRET).update(payloadB64).digest().toString('base64url');
+    const result = verifyPreviewToken(SECRET, `${payloadB64}.${sig}`);
+    expect(result).toEqual({ ok: false, reason: 'malformed' });
+  });
+});

--- a/apps/server/src/routes/content/_helpers/preview-token.ts
+++ b/apps/server/src/routes/content/_helpers/preview-token.ts
@@ -1,0 +1,125 @@
+/**
+ * Preview-token minting and verification for visual edit sessions.
+ *
+ * A preview token authorizes a SINGLE read-only action: fetching a session's
+ * draft overlays through `GET /sessions/:id/preview`. It never authorizes a
+ * mutation. The marketing preview iframe is a different origin from the
+ * dashboard, so it cannot carry the editor's session cookie; the signed token
+ * is the only credential it holds, and it grants nothing but that one read.
+ *
+ * Format: `<payloadB64url>.<sigB64url>` where
+ *   - payload  = base64url(JSON.stringify({ sid, exp }))  (exp = unix seconds)
+ *   - sig      = base64url(HMAC-SHA256(secret, payloadB64url))
+ *
+ * Verification is timing-safe (node:crypto `timingSafeEqual`) and checks, in
+ * order: structural shape, signature, expiry. The caller separately checks that
+ * the token's `sid` matches the requested session and that the session is open.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { z } from '@revealui/openapi';
+
+/** Default token lifetime: 10 minutes. */
+export const PREVIEW_TOKEN_TTL_SECONDS = 600;
+
+/** Revvault path for the HMAC secret. Named in the fail-loud error below. */
+const SECRET_VAULT_PATH = 'revealui/prod/preview-token-secret';
+
+const PayloadSchema = z.object({
+  sid: z.string().min(1),
+  exp: z.number().int().positive(),
+});
+
+type Payload = z.infer<typeof PayloadSchema>;
+
+export interface MintedToken {
+  token: string;
+  /** Expiry as unix seconds. */
+  exp: number;
+}
+
+export type VerifyResult =
+  | { ok: true; sid: string; exp: number }
+  | { ok: false; reason: 'malformed' | 'bad_signature' | 'expired' };
+
+/**
+ * Read the HMAC secret from the environment. Fails loudly, naming the revvault
+ * path, when unset  -  no default, no fallback secret (secrets rule).
+ */
+export function getPreviewTokenSecret(): string {
+  const secret = process.env.REVEALUI_PREVIEW_TOKEN_SECRET;
+  if (!secret || secret.length === 0) {
+    throw new Error(
+      `REVEALUI_PREVIEW_TOKEN_SECRET is not set. Provision it from revvault: ${SECRET_VAULT_PATH}`,
+    );
+  }
+  return secret;
+}
+
+function sign(secret: string, payloadB64: string): Buffer {
+  return createHmac('sha256', secret).update(payloadB64).digest();
+}
+
+/** Mint a preview token for `sid`, expiring `ttlSeconds` from now. */
+export function mintPreviewToken(
+  secret: string,
+  sid: string,
+  ttlSeconds: number = PREVIEW_TOKEN_TTL_SECONDS,
+): MintedToken {
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const payload: Payload = { sid, exp };
+  const payloadB64 = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  const sigB64 = sign(secret, payloadB64).toString('base64url');
+  return { token: `${payloadB64}.${sigB64}`, exp };
+}
+
+/**
+ * Verify a preview token. Returns the decoded `{ sid, exp }` on success, or a
+ * discriminated failure reason. Never throws on malformed input.
+ */
+export function verifyPreviewToken(
+  secret: string,
+  token: string,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): VerifyResult {
+  const dot = token.indexOf('.');
+  if (dot <= 0 || dot === token.length - 1) {
+    return { ok: false, reason: 'malformed' };
+  }
+  const payloadB64 = token.slice(0, dot);
+  const sigB64 = token.slice(dot + 1);
+  if (token.indexOf('.', dot + 1) !== -1) {
+    // More than one separator: not our format.
+    return { ok: false, reason: 'malformed' };
+  }
+
+  const expected = sign(secret, payloadB64);
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(sigB64, 'base64url');
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+  // Length guard first: timingSafeEqual throws on a length mismatch.
+  if (provided.length !== expected.length) {
+    return { ok: false, reason: 'bad_signature' };
+  }
+  if (!timingSafeEqual(provided, expected)) {
+    return { ok: false, reason: 'bad_signature' };
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+  const parsed = PayloadSchema.safeParse(decoded);
+  if (!parsed.success) {
+    return { ok: false, reason: 'malformed' };
+  }
+  if (parsed.data.exp <= nowSeconds) {
+    return { ok: false, reason: 'expired' };
+  }
+  return { ok: true, sid: parsed.data.sid, exp: parsed.data.exp };
+}

--- a/apps/server/src/routes/content/sessions.ts
+++ b/apps/server/src/routes/content/sessions.ts
@@ -23,6 +23,12 @@ import { HTTPException } from 'hono/http-exception';
 import { authorizationSystem } from '../../middleware/authorization.js';
 import { IdParam } from '../_helpers/content-schemas.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
+import {
+  getPreviewTokenSecret,
+  mintPreviewToken,
+  PREVIEW_TOKEN_TTL_SECONDS,
+  verifyPreviewToken,
+} from './_helpers/preview-token.js';
 import type { ContentVariables } from './index.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
@@ -782,6 +788,218 @@ app.openapi(
     });
 
     return c.json({ success: true as const, data: serializeSession(discarded) }, 200);
+  },
+);
+
+// =============================================================================
+// Preview tokens  -  cross-origin, read-only draft access for the marketing
+// preview iframe. Tokens authorize the GET /preview read and NOTHING else; no
+// mutating route here reads or accepts them.
+// =============================================================================
+
+/**
+ * The public marketing origin the preview iframe loads from. Server config, not
+ * request input  -  the previewUrl we hand back is built against this trusted
+ * base, so the canvas can pin postMessage to its origin.
+ */
+function marketingBaseUrl(): string {
+  const raw = process.env.REVEALUI_PUBLIC_SERVER_URL ?? process.env.NEXT_PUBLIC_SERVER_URL;
+  if (!raw || raw.length === 0) {
+    throw new HTTPException(500, {
+      message: 'REVEALUI_PUBLIC_SERVER_URL is not configured; cannot build a preview URL',
+    });
+  }
+  return raw;
+}
+
+/**
+ * The dashboard origin the preview runtime pins its postMessage channel to.
+ * Server config, never the URL  -  this is the origin allowlist the runtime
+ * trusts, so it must come from a source the browser cannot influence.
+ */
+function adminOrigin(): string {
+  const raw = process.env.ADMIN_URL ?? process.env.NEXT_PUBLIC_ADMIN_URL;
+  if (!raw || raw.length === 0) {
+    throw new HTTPException(500, {
+      message: 'ADMIN_URL is not configured; cannot pin the preview origin',
+    });
+  }
+  return new URL(raw).origin;
+}
+
+const PreviewTokenSchema = z
+  .object({
+    token: z.string(),
+    expiresAt: DateTime,
+    previewUrl: z.string(),
+  })
+  .openapi('EditSessionPreviewToken');
+
+const PreviewDocSchema = z.object({
+  docType: z.string(),
+  docId: z.string(),
+  draft: z.unknown(),
+});
+
+const PreviewPayloadSchema = z
+  .object({
+    siteId: z.string(),
+    adminOrigin: z.string(),
+    docs: z.array(PreviewDocSchema),
+  })
+  .openapi('EditSessionPreviewPayload');
+
+// -----------------------------------------------------------------------------
+// POST /sessions/:id/preview-token  -  mint a short-lived preview token
+// -----------------------------------------------------------------------------
+
+app.openapi(
+  createRoute({
+    method: 'post',
+    path: '/sessions/{id}/preview-token',
+    tags: ['content'],
+    summary: 'Mint a preview token for an edit session',
+    request: {
+      params: IdParam,
+      query: z.object({ pageId: z.string().min(1).optional() }),
+    },
+    responses: {
+      201: {
+        content: {
+          'application/json': {
+            schema: z.object({ success: z.literal(true), data: PreviewTokenSchema }),
+          },
+        },
+        description: 'Preview token minted',
+      },
+      404: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Not found' },
+      409: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Session not open',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    requireContentEditor(c.get('user'));
+    const { id } = c.req.valid('param');
+    const { pageId } = c.req.valid('query');
+
+    const session = await sessionQueries.getEditSessionById(db, id);
+    if (!session) throw new HTTPException(404, { message: 'Session not found' });
+    if (session.status !== 'open') {
+      throw new HTTPException(409, { message: 'Session is not open' });
+    }
+
+    // Resolve the page path to land the iframe on. A pageId must belong to this
+    // session's site; otherwise fall back to the site root.
+    let path = '/';
+    if (pageId) {
+      const page = await sessionQueries.getLivePage(db, pageId);
+      if (!page || page.siteId !== session.siteId) {
+        throw new HTTPException(404, { message: 'Page not found in this session site' });
+      }
+      path = page.path;
+    }
+
+    const { token, exp } = mintPreviewToken(getPreviewTokenSecret(), id, PREVIEW_TOKEN_TTL_SECONDS);
+
+    const url = new URL(path, marketingBaseUrl());
+    url.searchParams.set('rvui-edit', token);
+    url.searchParams.set('rvui-session', id);
+
+    return c.json(
+      {
+        success: true as const,
+        data: {
+          token,
+          expiresAt: new Date(exp * 1000).toISOString(),
+          previewUrl: url.toString(),
+        },
+      },
+      201,
+    );
+  },
+);
+
+// -----------------------------------------------------------------------------
+// GET /sessions/:id/preview?token=...  -  read-only draft overlays, token-auth'd
+// -----------------------------------------------------------------------------
+// NO cookie auth: the marketing iframe is a different origin and holds only the
+// signed token. The token grants this read and nothing else.
+
+app.openapi(
+  createRoute({
+    method: 'get',
+    path: '/sessions/{id}/preview',
+    tags: ['content'],
+    summary: 'Read edit session draft overlays with a preview token',
+    request: {
+      params: IdParam,
+      query: z.object({ token: z.string().min(1) }),
+    },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({ success: z.literal(true), data: PreviewPayloadSchema }),
+          },
+        },
+        description: 'Draft overlays for the session',
+      },
+      401: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Invalid or expired token',
+      },
+      403: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Token does not authorize this session',
+      },
+      404: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Not found' },
+      409: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Session not open',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const { id } = c.req.valid('param');
+    const { token } = c.req.valid('query');
+
+    // Verify the token BEFORE touching any draft data, so an invalid token never
+    // leaks a doc.
+    const verified = verifyPreviewToken(getPreviewTokenSecret(), token);
+    if (!verified.ok) {
+      throw new HTTPException(401, { message: `Invalid preview token: ${verified.reason}` });
+    }
+    if (verified.sid !== id) {
+      throw new HTTPException(403, { message: 'Token does not authorize this session' });
+    }
+
+    const session = await sessionQueries.getEditSessionById(db, id);
+    if (!session) throw new HTTPException(404, { message: 'Session not found' });
+    if (session.status !== 'open') {
+      throw new HTTPException(409, { message: 'Session is not open' });
+    }
+
+    const docs = await sessionQueries.getSessionDocs(db, id);
+
+    // Read-only, never cached (belt-and-braces on top of the mount-level noStore).
+    c.header('Cache-Control', 'no-store, no-cache, must-revalidate');
+    c.header('Pragma', 'no-cache');
+
+    return c.json(
+      {
+        success: true as const,
+        data: {
+          siteId: session.siteId,
+          adminOrigin: adminOrigin(),
+          docs: docs.map((d) => ({ docType: d.docType, docId: d.docId, draft: d.draft })),
+        },
+      },
+      200,
+    );
   },
 );
 

--- a/docs/JOSHUA.md
+++ b/docs/JOSHUA.md
@@ -38,7 +38,7 @@ Every default earns its place. No magic, no hidden complexity, no decisions you 
 Clean separation of concerns. Each package has a single responsibility. No circular dependencies. Use what you need, replace what you don't.
 
 **Evidence:**
-- 28 packages, zero circular deps  -  enforced by Turborepo dependency graph
+- 29 packages, zero circular deps  -  enforced by Turborepo dependency graph
 - `@revealui/auth` knows nothing about billing; `@revealui/db` knows nothing about HTTP
 - `@revealui/contracts` is the only package that every other package may depend on (types + schemas)
 - `@revealui/presentation` has zero external UI dependencies (only clsx + CVA)

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -21,7 +21,7 @@ All gates must pass on the `main` branch before deploy.
 
 - [ ] `pnpm gate` passes all three phases (quality, typecheck, test + build) **(blocking)**
 - [ ] `pnpm lint` reports zero errors (Biome 2) **(blocking)**
-- [ ] `pnpm typecheck:all` clean across all 32 workspaces **(blocking)**
+- [ ] `pnpm typecheck:all` clean across all 33 workspaces **(blocking)**
 - [ ] `pnpm test` passes the full test suite **(blocking)**
 - [ ] `pnpm build` succeeds for all apps and packages **(blocking)**
 - [ ] `pnpm validate:structure` confirms workspace structure integrity **(blocking)**

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -25,15 +25,15 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-16 (
 
 | Metric | Canonical value | Source of truth (script ref) | Notes |
 |---|---|---|---|
-| Packages in `packages/` | **28** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
+| Packages in `packages/` | **29** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
 | Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (one app removed per PR #936 + #946 + #947). |
-| Workspaces (monorepo total) | **32** | `countWorkspaces()` (= 28 packages + 4 apps) | |
+| Workspaces (monorepo total) | **33** | `countWorkspaces()` (= 29 packages + 4 apps) | |
 | Test files | **1061** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
 | UI components in `packages/presentation/` | **65** | `countUIComponents()` | Marketing copy says "65 native React components" or similar. |
 | **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
 | DB tables (Drizzle pgTable) | **93** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86 (2026-06-22); corrected to 92 (2026-07-16); GAP-300 added `nudge_dismissals`, bringing the live count to 93 on 2026-07-17. `site.ts` METRICS is gate-enforced by claim-drift. |
 | Access-control enforcement tests | **60** | `countEnforcementTests()` — `it(`/`test(` in `packages/core/src/__tests__/auth/` + `collections/operations/__tests__/access-enforcement.test.ts` | Quoted by the blog, both security attestations (`INFORMATION_SECURITY_POLICY`, `ASSET_INVENTORY`), `LAUNCH-CHECKLIST`, and marketing primitives. Gate-enforced so all surfaces move together. |
-| License: MIT packages | **22** | `licenseSplit.mit` | |
+| License: MIT packages | **23** | `licenseSplit.mit` | |
 | License: FSL-1.1-MIT packages | **5** | `licenseSplit.fsl` | @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services |
 | License: internal/none | **1** | `licenseSplit.internal` | `test` workspace package (private) |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@ Honest labels for every product in the RevealUI ecosystem. Updated 2026-06-11.
 
 | Product | Maturity | Notes |
 |---------|----------|-------|
-| **RevealUI** (monorepo) | Beta | Deployed, 28 npm packages, extensive test suite. No paying users yet. |
+| **RevealUI** (monorepo) | Beta | Deployed, 29 npm packages, extensive test suite. No paying users yet. |
 | **RevealUI Fleet** (self-hosted) | Beta | Docker stack complete, license enforcement built. No external customers. |
 | **RevVault** (secrets) | Beta | Rust CLI + desktop app, age-encrypted vault. Not published to crates.io. |
 | **Studio** (desktop) | Alpha | Tauri 2 + React 19, agent coordination UI. No published binaries. |
@@ -57,7 +57,7 @@ Alpha = functional, not deployed/published. Planned = design or schema only.
 ### Launch (v0.3.3  -  current)
 
 - **Public repo** on GitHub with MIT license (OSS packages)
-- **28 packages** published to npm
+- **29 packages** published to npm
 - **5 CLI templates** (basic-blog, e-commerce, portfolio, starter, starter-native)  -  4 published as standalone template repos
 - **Production deploys**  -  admin, API, Marketing, Docs on Vercel
 - **Stripe test mode** verified end-to-end (checkout, webhooks, license generation)

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -122,6 +122,7 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/passkey/origin` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/passkey/rp-id` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/passkey/rp-name` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
+| `revealui/prod/preview-token-secret` | credential | yes | vercel:api | preview-token HMAC (visual edit sessions) |
 | `revealui/prod/public/api-url` | public-config | no | vercel:admin, vercel:marketing, vercel:docs |  |
 | `revealui/prod/public/is-live` | public-config | no | vercel:admin, vercel:marketing | NEXT_PUBLIC_IS_LIVE - Stripe live-mode feature flag |
 | `revealui/prod/public/server-url` | public-config | no | vercel:api, vercel:admin, vercel:marketing, fly:worker |  |

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -93,7 +93,7 @@ _Machine-generated from [`scripts/sync/secret-paths.ts`](../scripts/sync/secret-
 spec, the Vercel/Fly sync manifests, or their sensitivity markers. Change `secret-paths.ts`
 and re-run the renderer._
 
-Production runtime paths synced to Vercel + Fly (108 paths). `sensitive` = the
+Production runtime paths synced to Vercel + Fly (109 paths). `sensitive` = the
 value is never UI/API-revealable after write (credentials + private signing keys).
 
 | Path | Kind | Sensitive | Consumers | Notes |
@@ -122,7 +122,7 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/passkey/origin` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/passkey/rp-id` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/passkey/rp-name` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
-| `revealui/prod/preview-token-secret` | credential | yes | vercel:api | preview-token HMAC (visual edit sessions) |
+| `revealui/prod/preview-token-secret` | credential | yes | vercel:api | HMAC-SHA256 key for edit-session preview tokens - short-lived read-only credential |
 | `revealui/prod/public/api-url` | public-config | no | vercel:admin, vercel:marketing, vercel:docs |  |
 | `revealui/prod/public/is-live` | public-config | no | vercel:admin, vercel:marketing | NEXT_PUBLIC_IS_LIVE - Stripe live-mode feature flag |
 | `revealui/prod/public/server-url` | public-config | no | vercel:api, vercel:admin, vercel:marketing, fly:worker |  |

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -130,7 +130,7 @@ cd revealui
 pnpm install
 pnpm gate                # Run the full CI gate locally
 pnpm test                # Run the full test suite
-pnpm typecheck:all       # Typecheck all 32 workspaces
+pnpm typecheck:all       # Typecheck all 33 workspaces
 pnpm validate:claims     # Run the marketing/docs claim-drift gate
 ```
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -217,7 +217,7 @@ RevealUI's business primitives (auth, content, collections, the REST API, the ad
 
 The business model is straightforward: the Pro tier (AI agents, the memory system, the MCP framework, open-model orchestration) funds ongoing development. The things that make RevealUI useful for most use cases are free forever. The things that make it powerful for teams that need AI capabilities are commercially licensed but source-available.
 
-To be precise about the split: 22 of the 28 packages are MIT, forever. The five Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, and `@revealui/services`) are Fair Source under FSL-1.1-MIT: source-visible, commercially usable, and they convert to MIT two years after each release. One workspace package is internal build tooling with no public license. MCP integration is a Pro capability today, not a free add-on. I'd rather be honest about where the line sits than blur it. You can read every line of the Pro code on npm; the license key unlocks the features, it doesn't hide the source.
+To be precise about the split: 23 of the 29 packages are MIT, forever. The five Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, and `@revealui/services`) are Fair Source under FSL-1.1-MIT: source-visible, commercially usable, and they convert to MIT two years after each release. One workspace package is internal build tooling with no public license. MCP integration is a Pro capability today, not a free add-on. I'd rather be honest about where the line sits than blur it. You can read every line of the Pro code on npm; the license key unlocks the features, it doesn't hide the source.
 
 ## What makes RevealUI different
 
@@ -229,7 +229,7 @@ This is the part that's genuinely hard to replicate by stitching services togeth
 
 Some numbers on what's actually shipped:
 
-- **32 workspaces** across the monorepo (4 apps, 28 packages with 22 MIT, 5 Fair Source, 1 internal)
+- **33 workspaces** across the monorepo (4 apps, 29 packages with 23 MIT, 5 Fair Source, 1 internal)
 - **96 database tables** via Drizzle ORM on NeonDB (Postgres)
 - **65 UI components** in `@revealui/presentation`, with one third-party runtime dependency (`tailwind-merge`), built directly on Tailwind v4 and React, with `cva` and `cn` vendored in-package
 - **14 first-party MCP servers** in `@revealui/mcp`

--- a/docs/blog/14-claim-drift.md
+++ b/docs/blog/14-claim-drift.md
@@ -45,7 +45,7 @@ claim-drift: docs/blog/09-component-library.md
   -> fix the copy or fix the count, but they must agree
 ```
 
-That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 28 packages, 65 UI components, 14 first-party MCP servers, 96 database tables, 60 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
+That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 29 packages, 65 UI components, 14 first-party MCP servers, 96 database tables, 60 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
 
 ## The validator practices what we preach
 

--- a/docs/guides/technology-stack.md
+++ b/docs/guides/technology-stack.md
@@ -79,9 +79,9 @@ The runtime is provider-agnostic by contract and ships with no default AI vendor
 
 ## License posture
 
-- **22 of 28 packages MIT-licensed** (forever).
-- **5 of 28 packages Fair Source (FSL-1.1-MIT)** — source-visible, non-compete; convert to MIT 2 years after each release.
-- **1 of 28 packages internal** (`@revealui/scripts`) — unlicensed build tooling.
+- **23 of 29 packages MIT-licensed** (forever).
+- **5 of 29 packages Fair Source (FSL-1.1-MIT)** — source-visible, non-compete; convert to MIT 2 years after each release.
+- **1 of 29 packages internal** (`@revealui/scripts`) — unlicensed build tooling.
 
 See [FAIR_SOURCE.md](../FAIR_SOURCE.md) for the licensing rationale.
 

--- a/docs/security/INFORMATION_SECURITY_POLICY.md
+++ b/docs/security/INFORMATION_SECURITY_POLICY.md
@@ -132,7 +132,7 @@ RevealUI does not store credit card numbers or payment method details. All payme
 All changes pass through the CI gate before reaching `test` or `main`:
 
 1. **Quality** (parallel): Biome lint (hard fail), security audits (warn), structure checks (warn)
-2. **Type checking** (serial): TypeScript strict mode across all 32 workspaces
+2. **Type checking** (serial): TypeScript strict mode across all 33 workspaces
 3. **Test + Build** (parallel): Vitest (full suite, hard fail), Turborepo build verification
 
 ### Branch Pipeline

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,0 +1,94 @@
+{
+  "name": "@revealui/editor",
+  "version": "0.1.0",
+  "description": "Visual edit-session runtime and dashboard canvas for RevealUI content",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RevealUIStudio/revealui.git",
+    "directory": "packages/editor"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime/index.d.ts",
+      "import": "./dist/runtime/index.js"
+    },
+    "./canvas": {
+      "types": "./dist/canvas/index.d.ts",
+      "import": "./dist/canvas/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "dev": "tsup --watch",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage --coverage.reporter=json-summary --coverage.reporter=html --coverage.reporter=text",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@revealui/contracts": "workspace:*",
+    "@revealui/presentation": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@revealui/dev": "workspace:*",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "jsdom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24.13.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "author": "RevealUI Studio",
+  "homepage": "https://revealui.com",
+  "bugs": {
+    "url": "https://github.com/RevealUIStudio/revealui/issues"
+  },
+  "keywords": [
+    "revealui",
+    "editor",
+    "visual-editing",
+    "cms"
+  ]
+}

--- a/packages/editor/src/__tests__/setup.ts
+++ b/packages/editor/src/__tests__/setup.ts
@@ -1,0 +1,4 @@
+/**
+ * Vitest setup: jsdom + Testing Library matchers for the editor package.
+ */
+import '@testing-library/jest-dom';

--- a/packages/editor/src/canvas/EditSessionCanvas.tsx
+++ b/packages/editor/src/canvas/EditSessionCanvas.tsx
@@ -1,0 +1,338 @@
+/**
+ * EditSessionCanvas  -  the dashboard-side visual editor.
+ *
+ * Hosts the previewed marketing site in an iframe, listens for edit intents from
+ * the in-iframe runtime over an EXACT-origin-pinned postMessage channel, and
+ * drives field edits back through the authenticated session API.
+ *
+ * This is a Client Component. It must be mounted from a `'use client'` boundary
+ * (the admin route does this); it takes no `next/*` dependency.
+ *
+ * Data flow:
+ *   mount        -> POST /preview-token (cookie auth) -> iframe src = previewUrl
+ *   rvui:click   -> open the field editor popover
+ *   commit/type  -> PATCH the session doc (debounced autosave ~600ms) ->
+ *                   postMessage rvui:apply-patch into the iframe for optimistic
+ *                   re-render
+ *   publish/discard -> session API; per-doc 409 conflicts surfaced as plain text
+ */
+
+import { Button, cn } from '@revealui/presentation';
+import { type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import { type ClickMessage, isClickMessage, RVUI_APPLY_PATCH } from '../protocol.js';
+
+const BREAKPOINTS = {
+  desktop: { label: 'Desktop', width: 1280 },
+  tablet: { label: 'Tablet', width: 768 },
+  mobile: { label: 'Mobile', width: 375 },
+} as const;
+
+type Breakpoint = keyof typeof BREAKPOINTS;
+
+const AUTOSAVE_DEBOUNCE_MS = 600;
+
+export type Fetcher = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface EditSessionCanvasProps {
+  sessionId: string;
+  /** Base URL of the RevealUI API server, e.g. `https://api.revealui.com`. */
+  apiBaseUrl: string;
+  /**
+   * Authenticated fetch. The admin mount passes its CSRF-aware `apiFetch`; falls
+   * back to the global `fetch` (still credentialed) when omitted.
+   */
+  fetcher?: Fetcher;
+}
+
+interface SessionDoc {
+  id: string;
+  docId: string;
+  docType: string;
+}
+
+interface ActiveField {
+  doc: string;
+  field: string;
+  rect: ClickMessage['rect'];
+  value: string;
+}
+
+// -----------------------------------------------------------------------------
+// Field editor popover
+// -----------------------------------------------------------------------------
+
+interface FieldEditorPopoverProps {
+  field: ActiveField;
+  onCommit: (value: string) => void;
+  onClose: () => void;
+}
+
+function FieldEditorPopover({ field, onCommit, onClose }: FieldEditorPopoverProps): ReactElement {
+  const [value, setValue] = useState(field.value);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const scheduleAutosave = useCallback(
+    (next: string) => {
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => onCommit(next), AUTOSAVE_DEBOUNCE_MS);
+    },
+    [onCommit],
+  );
+
+  const flushAndClose = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    onCommit(value);
+    onClose();
+  }, [onCommit, onClose, value]);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Edit field"
+      className="fixed z-50 rounded-md border border-neutral-700 bg-neutral-900 p-2 shadow-lg"
+      style={{
+        top: Math.max(field.rect.top + field.rect.height + 4, 0),
+        left: Math.max(field.rect.left, 0),
+        minWidth: 240,
+      }}
+    >
+      <textarea
+        aria-label="Field value"
+        className="block w-full resize-y rounded border border-neutral-600 bg-neutral-800 p-1 text-sm text-neutral-100"
+        rows={3}
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          scheduleAutosave(e.target.value);
+        }}
+      />
+      <div className="mt-2 flex justify-end gap-2">
+        <Button size="sm" appearance="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={flushAndClose}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Canvas
+// -----------------------------------------------------------------------------
+
+export function EditSessionCanvas({
+  sessionId,
+  apiBaseUrl,
+  fetcher,
+}: EditSessionCanvasProps): ReactElement {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [marketingOrigin, setMarketingOrigin] = useState<string | null>(null);
+  const [docs, setDocs] = useState<SessionDoc[]>([]);
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>('desktop');
+  const [activeField, setActiveField] = useState<ActiveField | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const doFetch = useCallback<Fetcher>(
+    (path, init = {}) => {
+      const url = path.startsWith('http') ? path : `${apiBaseUrl}${path}`;
+      const f = fetcher ?? fetch;
+      return f(url, { credentials: 'include', ...init });
+    },
+    [apiBaseUrl, fetcher],
+  );
+
+  // Mount: read session detail (dirty-doc list) then mint a preview token.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const detailRes = await doFetch(`/api/content/sessions/${sessionId}`);
+        if (!detailRes.ok) throw new Error(`session load failed: ${detailRes.status}`);
+        const detail = (await detailRes.json()) as { data: { docs: SessionDoc[] } };
+        const firstPage = detail.data.docs.find((d) => d.docType === 'page');
+        const query = firstPage ? `?pageId=${encodeURIComponent(firstPage.docId)}` : '';
+        const mintRes = await doFetch(`/api/content/sessions/${sessionId}/preview-token${query}`, {
+          method: 'POST',
+        });
+        if (!mintRes.ok) throw new Error(`preview token failed: ${mintRes.status}`);
+        const mint = (await mintRes.json()) as { data: { previewUrl: string } };
+        if (cancelled) return;
+        setDocs(detail.data.docs);
+        setPreviewUrl(mint.data.previewUrl);
+        setMarketingOrigin(new URL(mint.data.previewUrl).origin);
+      } catch (err) {
+        if (!cancelled) setError(String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [doFetch, sessionId]);
+
+  // Origin-pinned inbound channel: only clicks from the preview origin open the editor.
+  useEffect(() => {
+    if (!marketingOrigin) return;
+    const onMessage = (event: MessageEvent): void => {
+      if (event.origin !== marketingOrigin) return;
+      if (!isClickMessage(event.data)) return;
+      setActiveField({
+        doc: event.data.doc,
+        field: event.data.field,
+        rect: event.data.rect,
+        value: event.data.currentValue,
+      });
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [marketingOrigin]);
+
+  const refreshDocs = useCallback(async () => {
+    const res = await doFetch(`/api/content/sessions/${sessionId}`);
+    if (!res.ok) return;
+    const detail = (await res.json()) as { data: { docs: SessionDoc[] } };
+    setDocs(detail.data.docs);
+  }, [doFetch, sessionId]);
+
+  const commitPatch = useCallback(
+    async (doc: string, field: string, value: string) => {
+      setNotice(null);
+      const res = await doFetch(`/api/content/sessions/${sessionId}/docs/page/${doc}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: field, value }),
+      });
+      if (!res.ok) {
+        setNotice(`Could not save this field (${res.status}).`);
+        return;
+      }
+      // Optimistic re-render inside the preview iframe.
+      if (marketingOrigin) {
+        iframeRef.current?.contentWindow?.postMessage(
+          { type: RVUI_APPLY_PATCH, doc, field, value },
+          marketingOrigin,
+        );
+      }
+      await refreshDocs();
+    },
+    [doFetch, marketingOrigin, refreshDocs, sessionId],
+  );
+
+  const publish = useCallback(async () => {
+    setNotice(null);
+    const res = await doFetch(`/api/content/sessions/${sessionId}/publish`, { method: 'POST' });
+    const body = (await res.json()) as {
+      partiallyPublished?: string[];
+      conflicts?: unknown[];
+    };
+    if (res.ok) {
+      setNotice('Published.');
+      await refreshDocs();
+      return;
+    }
+    if (res.status === 409) {
+      const stuck = body.partiallyPublished?.length
+        ? ` Some pages stayed live and need a retry: ${body.partiallyPublished.join(', ')}.`
+        : '';
+      setNotice(`Publish blocked by a version conflict.${stuck}`);
+      return;
+    }
+    setNotice(`Publish failed (${res.status}).`);
+  }, [doFetch, refreshDocs, sessionId]);
+
+  const discard = useCallback(async () => {
+    setNotice(null);
+    const res = await doFetch(`/api/content/sessions/${sessionId}/discard`, { method: 'POST' });
+    setNotice(res.ok ? 'Session discarded.' : `Discard failed (${res.status}).`);
+  }, [doFetch, sessionId]);
+
+  const width = BREAKPOINTS[breakpoint].width;
+
+  return (
+    <div className="flex h-full flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <fieldset className="m-0 flex gap-1 border-0 p-0">
+          <legend className="sr-only">Preview width</legend>
+          {(Object.keys(BREAKPOINTS) as Breakpoint[]).map((key) => (
+            <Button
+              key={key}
+              size="sm"
+              appearance={key === breakpoint ? 'solid' : 'outline'}
+              aria-pressed={key === breakpoint}
+              onClick={() => setBreakpoint(key)}
+            >
+              {BREAKPOINTS[key].label}
+            </Button>
+          ))}
+        </fieldset>
+        <div className="ml-auto flex gap-2">
+          <Button size="sm" appearance="outline" onClick={discard}>
+            Discard
+          </Button>
+          <Button size="sm" onClick={publish}>
+            Publish
+          </Button>
+        </div>
+      </div>
+
+      {notice ? (
+        <p role="status" className="text-sm text-amber-400">
+          {notice}
+        </p>
+      ) : null}
+      {error ? (
+        <p role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="flex min-h-0 flex-1 gap-3">
+        <aside className="w-56 shrink-0 overflow-auto rounded-md border border-neutral-800 p-2">
+          <h2 className="mb-2 text-xs font-semibold uppercase text-neutral-400">Changed docs</h2>
+          {docs.length === 0 ? (
+            <p className="text-sm text-neutral-500">No edits yet.</p>
+          ) : (
+            <ul className="space-y-1">
+              {docs.map((d) => (
+                <li key={d.id} className="truncate text-sm text-neutral-200">
+                  {d.docType}: {d.docId}
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
+
+        <div className="min-h-0 flex-1 overflow-auto rounded-md border border-neutral-800 bg-neutral-950">
+          {previewUrl ? (
+            <iframe
+              ref={iframeRef}
+              title="Content preview"
+              src={previewUrl}
+              className={cn('mx-auto block h-full border-0 bg-white')}
+              style={{ width }}
+            />
+          ) : (
+            <p className="p-4 text-sm text-neutral-500">Loading preview...</p>
+          )}
+        </div>
+      </div>
+
+      {activeField ? (
+        <FieldEditorPopover
+          field={activeField}
+          onCommit={(value) => commitPatch(activeField.doc, activeField.field, value)}
+          onClose={() => setActiveField(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
+++ b/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * EditSessionCanvas tests (jsdom + RTL): origin-pinned click handling, PATCH on
+ * commit, debounced autosave coalescing, and publish-conflict surfacing.
+ */
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RVUI_CLICK } from '../../protocol.js';
+import { EditSessionCanvas, type Fetcher } from '../EditSessionCanvas.js';
+
+const API_BASE = 'https://api.test';
+const PREVIEW_URL = 'https://www.market.test/about?rvui-edit=tok&rvui-session=sid';
+const MARKETING_ORIGIN = 'https://www.market.test';
+const FOREIGN_ORIGIN = 'https://evil.test';
+const SESSION = 'sid';
+
+interface Call {
+  url: string;
+  init?: RequestInit;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+interface FetcherOptions {
+  publishStatus?: number;
+  publishBody?: unknown;
+}
+
+function makeFetcher(opts: FetcherOptions = {}): { fetcher: Fetcher; calls: Call[] } {
+  const calls: Call[] = [];
+  const fetcher: Fetcher = async (url, init) => {
+    calls.push({ url, init });
+    const method = (init?.method ?? 'GET').toUpperCase();
+    if (url.includes('/preview-token')) {
+      return jsonResponse(201, { data: { previewUrl: PREVIEW_URL } });
+    }
+    if (url.includes('/publish')) {
+      return jsonResponse(opts.publishStatus ?? 200, opts.publishBody ?? { data: {} });
+    }
+    if (url.includes('/docs/page/') && method === 'PATCH') {
+      return jsonResponse(200, { data: {} });
+    }
+    // GET session detail
+    return jsonResponse(200, {
+      data: {
+        session: { id: SESSION, status: 'open' },
+        docs: [{ id: 'ov-1', docId: 'page-1', docType: 'page' }],
+      },
+    });
+  };
+  return { fetcher, calls };
+}
+
+function clickMessage(origin: string): MessageEvent {
+  return new MessageEvent('message', {
+    origin,
+    data: {
+      type: RVUI_CLICK,
+      doc: 'page-1',
+      field: 'blocks.0.title',
+      rect: { top: 10, left: 10, width: 100, height: 20 },
+      currentValue: 'Old title',
+    },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('EditSessionCanvas', () => {
+  it('mints a preview token and renders the iframe with the previewUrl', async () => {
+    const { fetcher, calls } = makeFetcher();
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    const iframe = (await screen.findByTitle('Content preview')) as HTMLIFrameElement;
+    expect(iframe.getAttribute('src')).toBe(PREVIEW_URL);
+    expect(calls.some((c) => c.url.includes('/preview-token'))).toBe(true);
+  });
+
+  it('ignores a click message from a foreign origin', async () => {
+    const { fetcher } = makeFetcher();
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    await screen.findByTitle('Content preview');
+
+    act(() => {
+      window.dispatchEvent(clickMessage(FOREIGN_ORIGIN));
+    });
+    expect(screen.queryByLabelText('Field value')).toBeNull();
+  });
+
+  it('opens the field editor for a click from the preview origin', async () => {
+    const { fetcher } = makeFetcher();
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    await screen.findByTitle('Content preview');
+
+    act(() => {
+      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
+    });
+    const textarea = (await screen.findByLabelText('Field value')) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('Old title');
+  });
+
+  it('PATCHes the session doc when a field edit is saved', async () => {
+    const { fetcher, calls } = makeFetcher();
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    await screen.findByTitle('Content preview');
+    act(() => {
+      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
+    });
+    const textarea = await screen.findByLabelText('Field value');
+    fireEvent.change(textarea, { target: { value: 'New title' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      const patch = calls.find((c) => (c.init?.method ?? 'GET').toUpperCase() === 'PATCH');
+      expect(patch).toBeTruthy();
+      expect(patch?.url).toBe(`${API_BASE}/api/content/sessions/${SESSION}/docs/page/page-1`);
+      expect(JSON.parse(String(patch?.init?.body))).toEqual({
+        path: 'blocks.0.title',
+        value: 'New title',
+      });
+    });
+  });
+
+  it('debounces autosave into a single PATCH while typing', async () => {
+    const { fetcher, calls } = makeFetcher();
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    await screen.findByTitle('Content preview');
+    act(() => {
+      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
+    });
+    const textarea = await screen.findByLabelText('Field value');
+
+    // Two rapid changes, NO Save click: the debounce must coalesce them.
+    fireEvent.change(textarea, { target: { value: 'A' } });
+    fireEvent.change(textarea, { target: { value: 'AB' } });
+
+    await waitFor(() => {
+      const patches = calls.filter((c) => (c.init?.method ?? 'GET').toUpperCase() === 'PATCH');
+      expect(patches).toHaveLength(1);
+      expect(JSON.parse(String(patches[0].init?.body)).value).toBe('AB');
+    });
+  });
+
+  it('surfaces a publish conflict, including partiallyPublished, as plain text', async () => {
+    const { fetcher } = makeFetcher({
+      publishStatus: 409,
+      publishBody: { partiallyPublished: ['page-1'], conflicts: [{ reason: 'version_conflict' }] },
+    });
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    await screen.findByTitle('Content preview');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+
+    const notice = await screen.findByRole('status');
+    expect(notice.textContent).toContain('version conflict');
+    expect(notice.textContent).toContain('page-1');
+  });
+});

--- a/packages/editor/src/canvas/index.ts
+++ b/packages/editor/src/canvas/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @revealui/editor/canvas  -  dashboard-side visual editor (Client Components).
+ *
+ * Mount `EditSessionCanvas` from a `'use client'` boundary. Built from
+ * @revealui/presentation primitives; takes no `next/*` dependency.
+ */
+export {
+  EditSessionCanvas,
+  type EditSessionCanvasProps,
+  type Fetcher,
+} from './EditSessionCanvas.js';

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @revealui/editor  -  visual edit-session runtime and dashboard canvas.
+ *
+ * Two entrypoints carry the actual implementations:
+ *   - `@revealui/editor/runtime`  -  dependency-free, loaded by the previewed site
+ *   - `@revealui/editor/canvas`   -  React Client Components, mounted in the dashboard
+ *
+ * The root entry re-exports the shared postMessage protocol (types + guards) so
+ * either side can import the contract without pulling in the other half.
+ */
+
+export {
+  type ApplyPatchMessage,
+  type CanvasToRuntimeMessage,
+  type ClickMessage,
+  type FieldRect,
+  isApplyPatchMessage,
+  isClickMessage,
+  isPatchAppliedMessage,
+  isReadyMessage,
+  type PatchAppliedMessage,
+  type ReadyMessage,
+  type RuntimeToCanvasMessage,
+  RVUI_APPLY_PATCH,
+  RVUI_CLICK,
+  RVUI_PATCH_APPLIED,
+  RVUI_READY,
+} from './protocol.js';

--- a/packages/editor/src/protocol.ts
+++ b/packages/editor/src/protocol.ts
@@ -1,0 +1,118 @@
+/**
+ * postMessage protocol shared by the edit-mode runtime (previewed site) and the
+ * dashboard canvas. Dependency-free by design: the runtime half ships to the
+ * marketing site and must stay tiny and framework-agnostic, so validation here
+ * is hand-written type guards, not a schema library.
+ *
+ * Origin pinning is enforced by the two peers, NOT here: every message is sent
+ * with an exact targetOrigin and every received message is dropped unless its
+ * `event.origin` equals the peer's configured origin. These guards only assert
+ * payload SHAPE once the origin check has already passed.
+ */
+
+/** Runtime -> canvas: the runtime has initialized and is listening. */
+export const RVUI_READY = 'rvui:ready';
+/** Runtime -> canvas: an editable field was clicked in the preview. */
+export const RVUI_CLICK = 'rvui:click';
+/** Runtime -> canvas: an inbound apply-patch was applied (ack). */
+export const RVUI_PATCH_APPLIED = 'rvui:patch-applied';
+/** Canvas -> runtime: apply a committed field value optimistically. */
+export const RVUI_APPLY_PATCH = 'rvui:apply-patch';
+
+export interface FieldRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export interface ReadyMessage {
+  type: typeof RVUI_READY;
+}
+
+export interface ClickMessage {
+  type: typeof RVUI_CLICK;
+  /** Document id (data-rvui-doc). */
+  doc: string;
+  /** Dot-path field address (data-rvui-field), e.g. `blocks.3.title`. */
+  field: string;
+  /** Viewport rect of the clicked element, for popover placement. */
+  rect: FieldRect;
+  /** Current text content of the clicked field. */
+  currentValue: string;
+}
+
+export interface PatchAppliedMessage {
+  type: typeof RVUI_PATCH_APPLIED;
+  doc: string;
+  field: string;
+}
+
+export interface ApplyPatchMessage {
+  type: typeof RVUI_APPLY_PATCH;
+  doc: string;
+  field: string;
+  value: string;
+}
+
+export type RuntimeToCanvasMessage = ReadyMessage | ClickMessage | PatchAppliedMessage;
+export type CanvasToRuntimeMessage = ApplyPatchMessage;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFieldRect(value: unknown): value is FieldRect {
+  return (
+    isRecord(value) &&
+    typeof value.top === 'number' &&
+    typeof value.left === 'number' &&
+    typeof value.width === 'number' &&
+    typeof value.height === 'number'
+  );
+}
+
+export function isReadyMessage(value: unknown): value is ReadyMessage {
+  return isRecord(value) && value.type === RVUI_READY;
+}
+
+export function isClickMessage(value: unknown): value is ClickMessage {
+  return (
+    isRecord(value) &&
+    value.type === RVUI_CLICK &&
+    typeof value.doc === 'string' &&
+    typeof value.field === 'string' &&
+    typeof value.currentValue === 'string' &&
+    isFieldRect(value.rect)
+  );
+}
+
+export function isPatchAppliedMessage(value: unknown): value is PatchAppliedMessage {
+  return (
+    isRecord(value) &&
+    value.type === RVUI_PATCH_APPLIED &&
+    typeof value.doc === 'string' &&
+    typeof value.field === 'string'
+  );
+}
+
+export function isApplyPatchMessage(value: unknown): value is ApplyPatchMessage {
+  return (
+    isRecord(value) &&
+    value.type === RVUI_APPLY_PATCH &&
+    typeof value.doc === 'string' &&
+    typeof value.field === 'string' &&
+    typeof value.value === 'string'
+  );
+}
+
+/**
+ * Dev-only diagnostic. Guarded so the shipped runtime stays silent in
+ * production and takes no logger dependency.
+ */
+export function devWarn(message: string): void {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+    // biome-ignore lint/suspicious/noConsole: dev-only diagnostic; dependency-free package takes no logger dep
+    console.warn(`[rvui-editor] ${message}`); // console-allowed
+  }
+}

--- a/packages/editor/src/runtime/__tests__/runtime.test.ts
+++ b/packages/editor/src/runtime/__tests__/runtime.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Edit-mode runtime tests (jsdom): init, draft callback, click delegation,
+ * origin-pinned inbound channel (foreign + malformed messages dropped),
+ * apply-patch optimistic update + ack.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RVUI_APPLY_PATCH, RVUI_CLICK, RVUI_PATCH_APPLIED, RVUI_READY } from '../../protocol.js';
+import { type EditRuntimeHandle, initEditRuntime, type PreviewDoc } from '../index.js';
+
+const API_BASE = 'https://api.test';
+const ADMIN_ORIGIN = 'https://admin.test';
+const FOREIGN_ORIGIN = 'https://evil.test';
+
+function mockPreview(docs: PreviewDoc[]): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { siteId: 'site-1', adminOrigin: ADMIN_ORIGIN, docs },
+      }),
+    })),
+  );
+}
+
+function editUrl(): void {
+  window.history.pushState({}, '', '/?rvui-edit=tok&rvui-session=sid');
+}
+
+let handle: EditRuntimeHandle | null = null;
+let postSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  postSpy = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  handle?.destroy();
+  handle = null;
+  document.body.innerHTML = '';
+  window.history.pushState({}, '', '/');
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function draftDocs(): PreviewDoc[] {
+  return [{ docType: 'page', docId: 'page-1', draft: { blocks: [{ title: 'Old' }] } }];
+}
+
+describe('initEditRuntime', () => {
+  it('returns null when the URL carries no edit token', async () => {
+    window.history.pushState({}, '', '/');
+    mockPreview(draftDocs());
+    handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft: () => {} });
+    expect(handle).toBeNull();
+  });
+
+  it('returns null when the preview fetch fails', async () => {
+    editUrl();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) })),
+    );
+    handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft: () => {} });
+    expect(handle).toBeNull();
+  });
+
+  it('hands drafts to the host and posts rvui:ready to the admin origin', async () => {
+    editUrl();
+    mockPreview(draftDocs());
+    const onDraft = vi.fn();
+    handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft });
+    expect(handle).not.toBeNull();
+    expect(onDraft).toHaveBeenCalledWith([
+      { docType: 'page', docId: 'page-1', draft: { blocks: [{ title: 'Old' }] } },
+    ]);
+    expect(postSpy).toHaveBeenCalledWith({ type: RVUI_READY }, ADMIN_ORIGIN);
+  });
+
+  it('posts rvui:click when an annotated element is clicked', async () => {
+    editUrl();
+    mockPreview(draftDocs());
+    handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft: () => {} });
+
+    const el = document.createElement('h1');
+    el.setAttribute('data-rvui-doc', 'page-1');
+    el.setAttribute('data-rvui-field', 'blocks.0.title');
+    el.textContent = 'Old';
+    document.body.appendChild(el);
+    el.click();
+
+    expect(postSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: RVUI_CLICK,
+        doc: 'page-1',
+        field: 'blocks.0.title',
+        currentValue: 'Old',
+      }),
+      ADMIN_ORIGIN,
+    );
+  });
+
+  it('does not post a click for an unannotated element', async () => {
+    editUrl();
+    mockPreview(draftDocs());
+    handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft: () => {} });
+    postSpy.mockClear();
+
+    const el = document.createElement('p');
+    el.textContent = 'plain';
+    document.body.appendChild(el);
+    el.click();
+
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('applies an inbound apply-patch from the admin origin and acks', async () => {
+    editUrl();
+    mockPreview(draftDocs());
+    const onDraft = vi.fn();
+    handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft });
+    onDraft.mockClear();
+    postSpy.mockClear();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: ADMIN_ORIGIN,
+        data: { type: RVUI_APPLY_PATCH, doc: 'page-1', field: 'blocks.0.title', value: 'New' },
+      }),
+    );
+
+    expect(onDraft).toHaveBeenCalledWith([
+      { docType: 'page', docId: 'page-1', draft: { blocks: [{ title: 'New' }] } },
+    ]);
+    expect(postSpy).toHaveBeenCalledWith(
+      { type: RVUI_PATCH_APPLIED, doc: 'page-1', field: 'blocks.0.title' },
+      ADMIN_ORIGIN,
+    );
+  });
+
+  it('drops a message from a foreign origin', async () => {
+    editUrl();
+    mockPreview(draftDocs());
+    const onDraft = vi.fn();
+    handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft });
+    onDraft.mockClear();
+    postSpy.mockClear();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: FOREIGN_ORIGIN,
+        data: { type: RVUI_APPLY_PATCH, doc: 'page-1', field: 'blocks.0.title', value: 'Hacked' },
+      }),
+    );
+
+    expect(onDraft).not.toHaveBeenCalled();
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('drops a malformed message from the admin origin', async () => {
+    editUrl();
+    mockPreview(draftDocs());
+    const onDraft = vi.fn();
+    handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft });
+    onDraft.mockClear();
+    postSpy.mockClear();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: ADMIN_ORIGIN,
+        data: { type: RVUI_APPLY_PATCH, doc: 'page-1' /* missing field + value */ },
+      }),
+    );
+
+    expect(onDraft).not.toHaveBeenCalled();
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/editor/src/runtime/index.ts
+++ b/packages/editor/src/runtime/index.ts
@@ -1,0 +1,206 @@
+/**
+ * Edit-mode runtime  -  loaded by the previewed site ONLY in edit mode.
+ *
+ * Dependency-free and framework-agnostic. It:
+ *   1. reads `?rvui-edit=<token>&rvui-session=<id>` from the URL,
+ *   2. fetches the read-only preview payload (draft overlays + the trusted
+ *      dashboard origin) from the API,
+ *   3. hands the drafts to the host page via a callback (the host decides how to
+ *      render them  -  the runtime never touches innerHTML), and
+ *   4. runs an EXACT-origin-pinned postMessage channel with the parent canvas:
+ *      it accepts messages ONLY from the admin origin returned by the server
+ *      (never from the URL) and posts ONLY to that origin.
+ *
+ * Click delegation reports edit intents (`rvui:click`); inbound `rvui:apply-patch`
+ * updates the draft and re-invokes the host callback for optimistic re-render.
+ */
+
+import {
+  type ApplyPatchMessage,
+  devWarn,
+  isApplyPatchMessage,
+  RVUI_CLICK,
+  RVUI_PATCH_APPLIED,
+  RVUI_READY,
+} from '../protocol.js';
+
+export interface PreviewDoc {
+  docType: string;
+  docId: string;
+  draft: Record<string, unknown>;
+}
+
+export interface EditRuntimeConfig {
+  /** Base URL of the RevealUI API server, e.g. `https://api.revealui.com`. */
+  apiBaseUrl: string;
+  /** Called with the current draft overlays whenever they change (init + patches). */
+  onDraft: (docs: PreviewDoc[]) => void;
+}
+
+export interface EditRuntimeHandle {
+  /** Remove all listeners. Idempotent. */
+  destroy: () => void;
+}
+
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isArrayIndex(segment: string): boolean {
+  if (segment.length === 0) return false;
+  for (let i = 0; i < segment.length; i++) {
+    const code = segment.charCodeAt(i);
+    if (code < 48 || code > 57) return false;
+  }
+  return true;
+}
+
+/** Set `value` at a dot/array path inside a draft. Prototype-pollution guarded. */
+function setAtPath(draft: Record<string, unknown>, path: string, value: unknown): void {
+  const segments = path.split('.');
+  for (const segment of segments) {
+    if (segment.length === 0 || DANGEROUS_KEYS.has(segment)) {
+      devWarn(`ignored patch with illegal path segment: ${path}`);
+      return;
+    }
+  }
+  let cursor: Record<string, unknown> | unknown[] = draft;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    if (segment === undefined) return;
+    const next: unknown = Array.isArray(cursor)
+      ? cursor[Number(segment)]
+      : (cursor as Record<string, unknown>)[segment];
+    if (next === null || typeof next !== 'object') {
+      devWarn(`patch target path does not exist: ${path}`);
+      return;
+    }
+    cursor = next as Record<string, unknown> | unknown[];
+  }
+  const last = segments[segments.length - 1];
+  if (last === undefined) return;
+  if (Array.isArray(cursor)) {
+    if (!isArrayIndex(last)) return;
+    cursor[Number(last)] = value;
+  } else {
+    (cursor as Record<string, unknown>)[last] = value;
+  }
+}
+
+function rectOf(el: Element): { top: number; left: number; width: number; height: number } {
+  const r = el.getBoundingClientRect();
+  return { top: r.top, left: r.left, width: r.width, height: r.height };
+}
+
+interface PreviewResponse {
+  success: boolean;
+  data?: { siteId: string; adminOrigin: string; docs: PreviewDoc[] };
+}
+
+function isValidPayload(body: unknown): body is Required<PreviewResponse> {
+  if (typeof body !== 'object' || body === null) return false;
+  const data = (body as { data?: unknown }).data;
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return typeof d.adminOrigin === 'string' && d.adminOrigin.length > 0 && Array.isArray(d.docs);
+}
+
+/**
+ * Initialize the edit-mode runtime. Returns a handle, or `null` when the URL
+ * carries no edit token (not edit mode) or the preview fetch fails.
+ */
+export async function initEditRuntime(
+  config: EditRuntimeConfig,
+): Promise<EditRuntimeHandle | null> {
+  const params = new URLSearchParams(window.location.search);
+  const token = params.get('rvui-edit');
+  const sessionId = params.get('rvui-session');
+  if (!(token && sessionId)) {
+    return null;
+  }
+
+  let payload: Required<PreviewResponse>['data'];
+  try {
+    const url = new URL(`/api/content/sessions/${sessionId}/preview`, config.apiBaseUrl);
+    url.searchParams.set('token', token);
+    const res = await fetch(url.toString(), { credentials: 'omit' });
+    if (!res.ok) {
+      devWarn(`preview fetch failed: ${res.status}`);
+      return null;
+    }
+    const body: unknown = await res.json();
+    if (!isValidPayload(body)) {
+      devWarn('preview payload malformed');
+      return null;
+    }
+    payload = body.data;
+  } catch (err) {
+    devWarn(`preview fetch threw: ${String(err)}`);
+    return null;
+  }
+
+  // The one trusted origin. Comes from the server config in the payload, NEVER
+  // from the URL or from any received message.
+  const adminOrigin = payload.adminOrigin;
+  const docs: PreviewDoc[] = payload.docs;
+
+  const post = (message: unknown): void => {
+    window.parent.postMessage(message, adminOrigin);
+  };
+
+  const emitDraft = (): void => {
+    config.onDraft(docs.map((d) => ({ ...d, draft: d.draft })));
+  };
+
+  const onMessage = (event: MessageEvent): void => {
+    if (event.origin !== adminOrigin) {
+      devWarn(`dropped message from foreign origin: ${event.origin}`);
+      return;
+    }
+    if (!isApplyPatchMessage(event.data)) {
+      devWarn('dropped malformed message');
+      return;
+    }
+    const msg: ApplyPatchMessage = event.data;
+    const target = docs.find((d) => d.docId === msg.doc);
+    if (!target) {
+      devWarn(`apply-patch for unknown doc: ${msg.doc}`);
+      return;
+    }
+    setAtPath(target.draft, msg.field, msg.value);
+    emitDraft();
+    post({ type: RVUI_PATCH_APPLIED, doc: msg.doc, field: msg.field });
+  };
+
+  const onClick = (event: MouseEvent): void => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const el = target.closest('[data-rvui-field]');
+    if (!el) return;
+    const doc = el.getAttribute('data-rvui-doc');
+    const field = el.getAttribute('data-rvui-field');
+    if (!(doc && field)) return;
+    post({
+      type: RVUI_CLICK,
+      doc,
+      field,
+      rect: rectOf(el),
+      currentValue: el.textContent ?? '',
+    });
+  };
+
+  window.addEventListener('message', onMessage);
+  document.addEventListener('click', onClick, true);
+
+  // Hand the host the initial drafts, then announce readiness.
+  emitDraft();
+  post({ type: RVUI_READY });
+
+  let destroyed = false;
+  return {
+    destroy(): void {
+      if (destroyed) return;
+      destroyed = true;
+      window.removeEventListener('message', onMessage);
+      document.removeEventListener('click', onClick, true);
+    },
+  };
+}

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../dev/src/ts/react-library.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
+}

--- a/packages/editor/tsup.config.ts
+++ b/packages/editor/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/runtime/index.ts', 'src/canvas/index.ts'],
+  format: ['esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: false,
+  clean: true,
+  external: ['react', 'react-dom', 'react/jsx-runtime', /^@revealui\//],
+  esbuildOptions(options) {
+    options.jsx = 'automatic';
+  },
+});

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -1,0 +1,21 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    pool: 'forks',
+    maxWorkers: 2,
+    setupFiles: ['./src/__tests__/setup.ts'],
+    testTimeout: 15_000,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      include: ['src/**/*.ts', 'src/**/*.tsx'],
+      exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/__tests__/**'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       '@revealui/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@revealui/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
       '@revealui/knowledge-graph':
         specifier: workspace:*
         version: link:../../packages/knowledge-graph
@@ -551,6 +554,9 @@ importers:
       '@revealui/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@revealui/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
       '@revealui/presentation':
         specifier: workspace:*
         version: link:../../packages/presentation
@@ -1145,6 +1151,61 @@ importers:
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+
+  packages/editor:
+    dependencies:
+      '@revealui/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@revealui/presentation':
+        specifier: workspace:*
+        version: link:../presentation
+    devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../dev
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.4
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.3(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      jsdom:
+        specifier: 29.0.1
+        version: 29.0.1(@noble/hashes@1.8.0)
+      react:
+        specifier: '>=19.2.4'
+        version: 19.2.7
+      react-dom:
+        specifier: '>=19.2.4'
+        version: 19.2.7(react@19.2.7)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(@microsoft/api-extractor@7.58.9(@types/node@25.9.4))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -100,6 +100,9 @@ REVEALUI_AUDIT_SIGNING_KEY   = { path = "revealui/prod/audit/signing-private-key
 REVEALUI_AUDIT_PUBLIC_KEY    = "revealui/prod/audit/signing-public-key"
 REVEALUI_SECRET              = { path = "revealui/prod/secret", sensitive = true }
 
+# Visual edit sessions — HMAC secret for read-only preview tokens
+REVEALUI_PREVIEW_TOKEN_SECRET = { path = "revealui/prod/preview-token-secret", sensitive = true }
+
 # Cron + alerting
 REVEALUI_CRON_SECRET = { path = "revealui/prod/cron-secret", sensitive = true }
 REVEALUI_ALERT_EMAIL = "revealui/prod/alert-email"

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -236,6 +236,18 @@ export const SECRET_PATHS: SecretPathDef[] = [
     envVars: ['REVEALUI_AUDIT_PUBLIC_KEY'],
     note: 'Ed25519 SPKI PEM - published for offline receipt verification; derivable from the private key',
   },
+  // Visual edit sessions (P1). HMAC-SHA256 key behind the read-only preview
+  // tokens; the API both mints and verifies (routes/content/sessions), no
+  // other consumer reads it and there is no fallback value.
+  {
+    path: 'revealui/prod/preview-token-secret',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'prod',
+    consumers: ['vercel:api'],
+    envVars: ['REVEALUI_PREVIEW_TOKEN_SECRET'],
+    note: 'HMAC-SHA256 key for edit-session preview tokens - short-lived read-only credential',
+  },
   // License signing keypair - CANONICAL stays at the live revdev/* path so the
   // gate is GREEN against today's manifest; the project-aligned target is
   // DECLARED via migratingTo (the value-move is P3-4, owner-gated - NOT here).


### PR DESCRIPTION
Part of the visual-edit-sessions program per the internal spec (2026-07-02). This is P1 slice 4: the `@revealui/editor` package (edit-mode runtime plus dashboard canvas), the signed preview-token flow, and the admin mount. Targets `test`. Do not merge.

## Summary

- New `packages/editor` (`@revealui/editor` 0.1.0) with two entrypoints:
  - `/runtime`: dependency-free, framework-agnostic edit-mode runtime the previewed site loads only in edit mode.
  - `/canvas`: React Client Components (`EditSessionCanvas`) hosting the preview iframe, click-to-edit popover, debounced autosave, publish and discard.
- Two new server endpoints in `apps/server/src/routes/content/sessions.ts` under `/api/content/sessions`.
- Admin mount at `apps/admin/src/app/(backend)/edit-sessions/[id]/page.tsx` plus a minimal list page and a sidebar link.
- Marketing edit-mode bootstrap (two files only).
- Secret manifest plus docs entry for the preview-token HMAC secret.

## Token design

- `POST /sessions/:id/preview-token` (authenticated content editor; session must be `open`) mints `{ token, expiresAt, previewUrl }`. `previewUrl` is built against the trusted public marketing origin and carries `?rvui-edit=<token>&rvui-session=<id>`, landing on the resolved page path or the site root.
- Token format: `<payloadB64url>.<sigB64url>` where payload is `base64url(JSON {sid, exp})` (exp in unix seconds) and sig is `base64url(HMAC-SHA256(secret, payloadB64url))`. TTL 10 minutes.
- `GET /sessions/:id/preview?token=...` takes NO cookie auth (the marketing iframe is a different origin). It verifies the HMAC with a timing-safe compare (`node:crypto` `timingSafeEqual`), then checks expiry, that `token.sid === :id`, and that the session is `open`, before reading any draft. Verification runs before any doc read, so an invalid token never leaks a doc. Responses are `no-store`.
- Read-only guarantee: the token authorizes that one read and nothing else. No mutating route reads or accepts it; the PATCH, publish, and discard routes ride the dashboard's authenticated session only. A regression test drives a token-bearing unauthenticated PATCH and publish and asserts 401.
- The HMAC secret comes from `REVEALUI_PREVIEW_TOKEN_SECRET`. First use fails loudly if unset, naming the revvault path `revealui/prod/preview-token-secret`. No default, no fallback secret.

## postMessage origin-pinning model

Three origins: the API server, the dashboard (canvas parent), and the marketing site (preview iframe).

- Runtime (in the iframe): accepts messages ONLY when `event.origin` equals the admin origin returned by the server in the preview payload, and posts ONLY to that origin. The allowlist origin is server config, never read from the URL. Foreign-origin and malformed messages are dropped and dev-warned.
- Canvas (in the dashboard): accepts click messages ONLY from the marketing preview origin (derived from the server-minted `previewUrl`), and posts `apply-patch` back into the iframe pinned to that origin.
- No `innerHTML` anywhere in the runtime; text values are applied through the host framework only. Message payload shapes are validated by hand-written type guards (no regex, no schema dependency) so the runtime stays dependency-free.

## Wired vs deferred in marketing

Wired this PR:
- One guarded init line in `apps/marketing/app/entry.client.tsx` and a new `apps/marketing/app/lib/edit-mode.ts`. Edit mode activates only when `rvui-edit` is present; the runtime chunk is dynamically imported only then, so a normal visit pays nothing.
- The bootstrap initializes the runtime with a callback that stashes draft overlays into a module-level store (subscribe plus getSnapshot, matching `@revealui/router`).

Deferred (owned by the parallel marketing block-wire slice):
- Wiring the block renderer to consume the draft store so page components re-render from drafts. The store is in place; no page consumes it yet.

## Owner provisioning steps

```
revvault set revealui/prod/preview-token-secret
```
```
pnpm vercel:sync:apply
```

## Test plan

- `packages/editor` (Vitest, jsdom): protocol guards; runtime init, draft callback, click delegation, apply-patch optimistic update plus ack, foreign-origin drop, malformed-message drop; canvas origin-pinned click handling, PATCH-on-commit, debounced autosave coalescing, publish-conflict surfacing. 14 tests.
- `apps/server` preview-token unit tests: mint/verify round-trip, expiry, tampered payload, tampered signature, wrong-secret, malformed, well-signed non-payload.
- `apps/server` preview-endpoint integration tests (PGlite): mint returns previewUrl with edit params; mint auth (anon 401 / non-editor 403) and non-open 409; GET preview returns docs plus adminOrigin with no cookie; bad, expired, and wrong-session tokens rejected with docs never leaked; non-open 409; token-bearing unauthenticated PATCH and publish rejected 401. 21 tests.
- Full server suite green (175 files, 3054 tests). `@revealui/editor`, `admin`, `marketing`, and `server` typecheck clean. `pnpm gate:quick` PASS.

## Notes

- New package starts at 0.1.0 with a changeset.
- Adding a package bumped the fleet package and workspace counts (28 to 29, 32 to 33, MIT 22 to 23); the count claims across docs and the canonical `site.ts` METRICS were updated so the claim-drift gate stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
