### PR TITLE
ci: bump Unit Tests timeout-minutes to 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
   test-unit:
     name: Unit Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: quality
 
     steps:


### PR DESCRIPTION
The Unit Tests job suite now takes approximately 9 minutes but was configured with a 10-minute timeout, causing failures on 2026-07-18 (twice observed). Bump the timeout to 15 minutes to provide adequate headroom for the current test suite runtime.