### PR TITLE
fix(security): widen SECURITY_PATHS for editor + audit-substrate surface

### DIFF
--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -103,6 +103,23 @@ const SECURITY_PATHS = [
   // security-sensitive. Whole-package entry, matching packages/mcp//security//
   // paywall/; adapters ride along fine. Keep in lockstep with the fleet checker.
   'packages/harnesses/',
+  // GAP-400: the edit-session engine + preview-token flow (HMAC credential
+  // minting/verification, cross-origin postMessage, draft-read authorization)
+  // and the canvas/runtime package that consumes it. A prior PR shipped this
+  // surface and both gates classified it NOT security-sensitive; a manual
+  // review pass covered that PR, but the automated backstop had a hole for
+  // every future PR touching this surface. Keep in lockstep with the fleet
+  // checker (internal tooling, separate .jv PR).
+  'routes/content/sessions',
+  'preview-token',
+  'packages/editor/',
+  // GAP-400: audit-substrate widening. The append-only audit log is the
+  // tamper-evidence record for every other security-sensitive write in the
+  // fleet; its schema, store, and migrations are themselves a
+  // security-sensitive surface. Keep in lockstep with the fleet checker.
+  'packages/db/src/schema/audit-log',
+  'packages/db/src/audit-store',
+  'packages/db/migrations/',
 ];
 
 // A recorded reviewer verdict = an approving GH review OR one of these labels.


### PR DESCRIPTION
## Summary

Widens `scripts/validate/security-review-gate.cjs`'s `SECURITY_PATHS` to cover
the edit-session/preview-token/editor and audit-substrate surfaces.

The edit-session engine, its preview-token flow (HMAC credential minting and
verification, cross-origin `postMessage`, draft-read authorization), and the
`packages/editor/` canvas/runtime package that consumes it are genuinely
security-sensitive, but neither this gate nor the fleet checker (internal
tooling) flagged any PR touching that surface. The append-only audit-log
schema, store, and migrations are added for the same reason: they are the
tamper-evidence record for every other security-sensitive write in the fleet.

Added entries:
- `routes/content/sessions`
- `preview-token`
- `packages/editor/`
- `packages/db/src/schema/audit-log`
- `packages/db/src/audit-store`
- `packages/db/migrations/`

The fleet-side mirror was updated in lockstep the same day, so the two
checkers stay in sync.

## Proof (red -> green)

Before this change, a whitespace-only touch to
`apps/server/src/routes/content/sessions.ts` did NOT trip the gate:

```
$ node scripts/validate/security-review-gate.cjs --diff origin/test
Current branch vs origin/test: no security-sensitive files — no review gate.
(exit 0)
```

After this change, the same touch (plus this PR's own diff) trips the gate:

```
$ node scripts/validate/security-review-gate.cjs --diff origin/test
Current branch is SECURITY-SENSITIVE (vs origin/test). Touched: apps/server/src/routes/content/sessions.ts, scripts/validate/security-review-gate.cjs
   The PR will need a recorded reviewer verdict before merge.
(exit 1)
```

## Expected: this PR will itself trip the gate

This PR touches `scripts/validate/security-review-gate.cjs`, which is on the
gate's own self-protection list. That is expected: it means the gate is
correctly classifying edits to the enforcement machinery as security-sensitive.
It needs a recorded reviewer verdict before merge.

## Test plan

- [x] `node --check scripts/validate/security-review-gate.cjs`
- [x] `npx vitest run scripts/validate/__tests__/security-review-gate.test.ts` (22/22 passed)
- [x] `pnpm gate --phase=1 --changed` (PASS)
- [x] Red -> green proof above, captured verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)
