### PR TITLE
fix(admin): unblock the P1 edit-session canvas (frame-src) + admin bootstrap import

### DIFF
--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -57,6 +57,22 @@ describe('admin proxy — CSP nonce (GAP-219)', () => {
     expect(directive(csp, 'img-src')).toContain('https://*.stripe.com');
   });
 
+  it('allows the marketing origin in frame-src so the edit-session canvas can frame the preview', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const frameSrc = directive(res.headers.get('content-security-policy') ?? '', 'frame-src');
+    // Hosted default when NEXT_PUBLIC_MARKETING_URL is unset.
+    expect(frameSrc).toContain('https://revealui.com');
+  });
+
+  it('frame-src honors NEXT_PUBLIC_MARKETING_URL when set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_MARKETING_URL', 'https://sites.example.com');
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const frameSrc = directive(res.headers.get('content-security-policy') ?? '', 'frame-src');
+    expect(frameSrc).toContain('https://sites.example.com');
+    expect(frameSrc).not.toContain('https://revealui.com');
+    vi.unstubAllEnvs();
+  });
+
   it('keeps unsafe-inline on style-src (intentional — Tailwind/Next/tenant inline styles)', async () => {
     const res = await proxy(new NextRequest('https://admin.example.com/login'));
     const styleSrc = directive(res.headers.get('content-security-policy'), 'style-src');

--- a/apps/admin/src/lib/security/csp.ts
+++ b/apps/admin/src/lib/security/csp.ts
@@ -47,6 +47,13 @@ export interface AdminCspOptions {
   /** `NEXT_PUBLIC_SERVER_URL` — optional deployment origin; `''` when unset. */
   serverUrl: string;
   /**
+   * `NEXT_PUBLIC_MARKETING_URL` — the marketing-site origin the edit-session
+   * canvas frames (trimmed, defaulted). `''` disables the frame-src entry.
+   * Named explicitly (not NEXT_PUBLIC_SERVER_URL) per the GAP-360 semantics
+   * precedent: SERVER_URL fleet-wide means the admin's own deployment origin.
+   */
+  marketingUrl: string;
+  /**
    * `REVEALUI_FLEET_MODE === 'true'` — running as a fleet kit.
    * When true, hosted third-party SDK domains (Stripe.js, Vercel Analytics,
    * Google Maps, Cloudinary) are omitted from every CSP directive. Fleet kits
@@ -75,7 +82,16 @@ export function generateNonce(): string {
  * the admin's same-origin live-preview iframe keeps working.
  */
 export function buildAdminCsp(options: AdminCspOptions): string {
-  const { nonce, isDev, isVercel, isVercelProd, apiUrl, serverUrl, isFleetMode = false } = options;
+  const {
+    nonce,
+    isDev,
+    isVercel,
+    isVercelProd,
+    apiUrl,
+    serverUrl,
+    marketingUrl,
+    isFleetMode = false,
+  } = options;
   const vercelPreview = isVercel && !isVercelProd;
 
   const scriptSrc = [
@@ -96,6 +112,10 @@ export function buildAdminCsp(options: AdminCspOptions): string {
 
   const frameSrc = [
     "'self'",
+    // The edit-session canvas frames the marketing site (preview iframe). The
+    // marketing side allows this via frame-ancestors; without the origin here
+    // the admin's own frame-src blocks the canvas.
+    ...(marketingUrl ? [marketingUrl] : []),
     ...(isFleetMode
       ? []
       : ['https://checkout.stripe.com', 'https://js.stripe.com', 'https://hooks.stripe.com']),

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -95,6 +95,10 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
     isVercelProd: process.env.VERCEL_ENV === 'production',
     apiUrl: (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim(),
     serverUrl: (process.env.NEXT_PUBLIC_SERVER_URL || '').trim(),
+    marketingUrl: (
+      process.env.NEXT_PUBLIC_MARKETING_URL ||
+      (process.env.REVEALUI_FLEET_MODE === 'true' ? '' : 'https://revealui.com')
+    ).trim(),
     isFleetMode: process.env.REVEALUI_FLEET_MODE === 'true',
   });
   const requestHeaders = new Headers(request.headers);

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -80,7 +80,6 @@ export default defineConfig({
       '@/access': path.resolve(__dirname, './src/lib/access'),
       '@/hooks': path.resolve(__dirname, './src/lib/hooks'),
       '@/fields': path.resolve(__dirname, './src/lib/fields'),
-      '@/utilities': path.resolve(__dirname, './src/lib/utilities'),
       '@/globals': path.resolve(__dirname, './src/lib/globals'),
       '@/heros': path.resolve(__dirname, './src/lib/heros'),
       '@/lib': path.resolve(__dirname, './src/lib'),

--- a/scripts/admin/bootstrap.ts
+++ b/scripts/admin/bootstrap.ts
@@ -101,7 +101,7 @@ async function main(): Promise<void> {
   // Get the RevealUI instance for bootstrap
   // We need to dynamically import to avoid pulling in the full admin app
   const { getRevealUIInstance } = await import(
-    '../../apps/admin/src/lib/utilities/revealui-singleton.js'
+    '../../apps/admin/src/lib/utils/revealui-singleton.js'
   );
   const revealui = await getRevealUIInstance();
 


### PR DESCRIPTION
## Summary

Fixes the three breaks found while running the visual-edit-sessions P1
acceptance walk locally (audit: the walk was driven end-to-end against a
fresh worktree of `test`, a throwaway pgvector Postgres, and the built
server bundle; every finding below was hit live and re-verified after the
fix).

1. **Admin CSP `frame-src` blocked the edit-session canvas.** The canvas
   frames the marketing site, and the marketing side already allows it via
   `frame-ancestors`, but the admin's own CSP (`frame-src 'self'` + Stripe)
   blocked the iframe — observed live as a CSP violation and an empty canvas,
   in any deployment topology including production origins. `buildAdminCsp`
   now takes a `marketingUrl` (from `NEXT_PUBLIC_MARKETING_URL`, trimmed;
   hosted default `https://revealui.com`, empty in fleet mode so white-label
   kits configure their own origin). Named explicitly rather than reusing
   `NEXT_PUBLIC_SERVER_URL`, which fleet-wide means the admin's own origin
   (same semantics-collision class the agent-stream 508 fix addressed).
   Two new tests pin the hosted default and the env override; both proven
   red against base (`2 failed | 18 passed`), green with the fix (20/20).

2. **`pnpm admin:bootstrap` crashed on a stale import.** The C7 refactor
   (`f03df0756`) moved `apps/admin/src/lib/utilities/` to `lib/utils` +
   `lib/cms`; `scripts/admin/bootstrap.ts` still imported
   `lib/utilities/revealui-singleton.js`, so bootstrap fails before doing
   anything. Path repaired. (Bootstrap still has further tsx-resolution
   issues on some invocation paths — tracked separately; this commit fixes
   the unambiguous stale path.)

3. **Dead `@/utilities` vitest alias removed** — it pointed at the removed
   directory and has zero consumers.

## Verification

- `pnpm --filter admin exec vitest run src/__tests__/proxy-csp.test.ts` — 20/20
  (prove-red transcript above: base fails exactly the 2 new tests).
- `pnpm --filter admin typecheck` clean.
- Live walk re-run after the fix: the canvas iframe loads the marketing
  preview URL with the minted token (previously blocked by the CSP), and the
  publish/discard chrome works end-to-end.

## Owner provisioning note

Hosted admin needs no new env (default covers `https://revealui.com`).
Fleet kits set `NEXT_PUBLIC_MARKETING_URL` to their marketing origin.
