### PR TITLE
feat(marketing): wire edit-mode annotation and draft-store consumption

### DIFF
--- a/.changeset/editor-runtime-refetch-unknown-doc.md
+++ b/.changeset/editor-runtime-refetch-unknown-doc.md
@@ -1,0 +1,5 @@
+---
+'@revealui/editor': patch
+---
+
+Fix `initEditRuntime`'s inbound `rvui:apply-patch` handler silently dropping a patch whose docId was materialized on the session server after the runtime's initial preview fetch (the canonical case: a fresh session's first field patch, since a session doc only materializes on its own first PATCH). The handler now re-fetches the preview payload once on a doc-id miss, shared across any concurrent misses, before retrying the patch; a still-missing doc after the refetch (or a failed refetch) keeps the prior fail-quiet drop.

--- a/apps/marketing/app/lib/api.ts
+++ b/apps/marketing/app/lib/api.ts
@@ -129,14 +129,25 @@ export async function fetchPosts(page = 1, limit = 12): Promise<BlogPost[]> {
 }
 
 /**
- * Fetch the published `pages.blocks` array for a fleet-marketing page by slug.
- *
- * Returns null on any error, miss, or a page without a block array, so the
- * caller renders its static fallback with zero API dependency. The returned
- * array is unvalidated network data — callers validate it against the
- * contracts BlockSchema before rendering.
+ * A fleet-marketing page's CMS identity plus its published `blocks` array.
+ * `id` is present whenever the page row exists, independent of whether
+ * `blocks` validates — edit-mode annotation only needs the id, not a valid
+ * block array, to know a page can be targeted for editing.
  */
-export async function fetchPageBlocks(slug: string): Promise<Block[] | null> {
+export interface CmsPage {
+  readonly id: string;
+  readonly blocks: Block[] | null;
+}
+
+/**
+ * Fetch the published `pages` row for a fleet-marketing page by slug.
+ *
+ * Returns null on any error or a site/slug miss, so the caller renders its
+ * static fallback with zero API dependency. `blocks` is unvalidated network
+ * data when present — callers validate it against the contracts BlockSchema
+ * before rendering.
+ */
+export async function fetchPageBlocks(slug: string): Promise<CmsPage | null> {
   try {
     const res = await fetch(
       `${API_URL}/api/content/sites/${FLEET_MARKETING_SITE_ID}/pages?status=published`,
@@ -144,11 +155,11 @@ export async function fetchPageBlocks(slug: string): Promise<Block[] | null> {
     if (!res.ok) return null;
     const json = (await res.json()) as {
       success: boolean;
-      data?: Array<{ slug: string; blocks: unknown }>;
+      data?: Array<{ id: string; slug: string; blocks: unknown }>;
     };
     const page = json.data?.find((p) => p.slug === slug);
-    if (!(page && Array.isArray(page.blocks))) return null;
-    return page.blocks as Block[];
+    if (!page) return null;
+    return { id: page.id, blocks: Array.isArray(page.blocks) ? (page.blocks as Block[]) : null };
   } catch {
     return null;
   }

--- a/apps/marketing/app/lib/edit-mode.ts
+++ b/apps/marketing/app/lib/edit-mode.ts
@@ -5,8 +5,8 @@
  * chunk is dynamically imported ONLY in edit mode, so a normal visitor never
  * pays for it. In edit mode it initializes the runtime with a callback that
  * stashes the draft overlays into a module-level store. Page components
- * subscribe to that store to render drafts; wiring that consumption into the
- * block renderer is a follow-up slice.
+ * (`../use-page-blocks.ts`) subscribe to that store to render drafts and
+ * derive the click-to-edit annotation.
  *
  * The store follows the in-repo `useSyncExternalStore` shape (subscribe +
  * getSnapshot), matching @revealui/router.
@@ -43,13 +43,25 @@ const API_URL =
   import.meta.env.VITE_API_URL ??
   (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004');
 
+const EDIT_PARAM = 'rvui-edit';
+
+/**
+ * True when the URL carries an edit-mode token. Synchronous and independent of
+ * the runtime/draft-fetch lifecycle, so callers can activate edit-mode UI (e.g.
+ * click-to-edit annotations) on first render, before `initEditRuntime` resolves
+ * and before any draft overlay exists.
+ */
+export function isEditModeActive(): boolean {
+  return new URLSearchParams(window.location.search).has(EDIT_PARAM);
+}
+
 /**
  * Initialize edit mode if the URL carries an edit token. No-op (and no import)
  * otherwise, so a normal page load stays untouched.
  */
 export function initEditMode(): void {
   const params = new URLSearchParams(window.location.search);
-  if (!params.get('rvui-edit')) return;
+  if (!params.get(EDIT_PARAM)) return;
   void import('@revealui/editor/runtime').then(({ initEditRuntime }) => {
     void initEditRuntime({ apiBaseUrl: API_URL, onDraft: setDrafts });
   });

--- a/apps/marketing/app/lib/use-page-blocks.test.tsx
+++ b/apps/marketing/app/lib/use-page-blocks.test.tsx
@@ -1,5 +1,6 @@
 import type { Block } from '@revealui/contracts/content';
-import { renderHook, waitFor } from '@testing-library/react';
+import type { PreviewDoc } from '@revealui/editor/runtime';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchPageBlocks } from './api';
 import { HOME_FALLBACK_BLOCKS, homeBlocks, productsBlocks } from './page-blocks';
@@ -7,11 +8,36 @@ import { useMarketingPageBlocks } from './use-page-blocks';
 
 vi.mock('./api', () => ({ fetchPageBlocks: vi.fn() }));
 
+// A controllable stand-in for the module-level edit-mode draft store: the
+// runtime normally calls `setDrafts` (private) through `initEditRuntime`;
+// tests drive it directly via `editDraftsStore.set`.
+const editDraftsStore = vi.hoisted(() => {
+  let drafts: PreviewDoc[] = [];
+  const listeners = new Set<() => void>();
+  return {
+    getEditDrafts: (): PreviewDoc[] => drafts,
+    subscribeEditDrafts: (listener: () => void): (() => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    set: (next: PreviewDoc[]): void => {
+      drafts = next;
+      for (const listener of listeners) listener();
+    },
+  };
+});
+
+vi.mock('./edit-mode', () => ({
+  getEditDrafts: editDraftsStore.getEditDrafts,
+  subscribeEditDrafts: editDraftsStore.subscribeEditDrafts,
+}));
+
 const mockFetch = vi.mocked(fetchPageBlocks);
 
 describe('useMarketingPageBlocks', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    editDraftsStore.set([]);
   });
 
   afterEach(() => {
@@ -21,14 +47,14 @@ describe('useMarketingPageBlocks', () => {
   it('paints with the static fallback immediately', () => {
     mockFetch.mockResolvedValue(null);
     const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
-    expect(result.current).toBe(HOME_FALLBACK_BLOCKS);
+    expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
   });
 
   it('keeps the fallback when the API errors or misses', async () => {
     mockFetch.mockResolvedValue(null);
     const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
     await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('home'));
-    expect(result.current).toBe(HOME_FALLBACK_BLOCKS);
+    expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
   });
 
   it('overrides with a valid CMS payload of matching shape', async () => {
@@ -40,7 +66,7 @@ describe('useMarketingPageBlocks', () => {
     mockFetch.mockResolvedValue(overridden);
     const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
     await waitFor(() => {
-      const first = result.current[0];
+      const first = result.current.blocks[0];
       expect(first?.type === 'section' && first.data.heading).toBe('CMS-overridden demo heading');
     });
   });
@@ -51,7 +77,7 @@ describe('useMarketingPageBlocks', () => {
     mockFetch.mockResolvedValue([{ id: 'x', type: 'section' } as unknown as Block]);
     const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
     await waitFor(() => expect(warn).toHaveBeenCalled());
-    expect(result.current).toBe(HOME_FALLBACK_BLOCKS);
+    expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
   });
 
   it('keeps the fallback when the CMS payload shape does not match', async () => {
@@ -60,6 +86,71 @@ describe('useMarketingPageBlocks', () => {
     mockFetch.mockResolvedValue(productsBlocks().slice(0, 1));
     const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
     await waitFor(() => expect(warn).toHaveBeenCalled());
-    expect(result.current).toBe(HOME_FALLBACK_BLOCKS);
+    expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
+  });
+
+  describe('edit-mode draft overlay', () => {
+    it('stays inactive (editable: false) with no draft overlay for this page', () => {
+      mockFetch.mockResolvedValue(null);
+      const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+      expect(result.current.annotation).toEqual({ editable: false });
+      expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
+    });
+
+    it('renders the draft blocks and activates the annotation when a matching overlay exists', () => {
+      mockFetch.mockResolvedValue(null);
+      const draftBlocks = homeBlocks();
+      const section = draftBlocks[0];
+      if (section?.type === 'section') {
+        section.data.heading = 'Draft-overridden demo heading';
+      }
+      editDraftsStore.set([
+        { docType: 'page', docId: 'page-home-id', draft: { slug: 'home', blocks: draftBlocks } },
+      ]);
+
+      const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+
+      expect(result.current.annotation).toEqual({ editable: true, docId: 'page-home-id' });
+      const first = result.current.blocks[0];
+      expect(first?.type === 'section' && first.data.heading).toBe('Draft-overridden demo heading');
+    });
+
+    it('re-renders with the new draft value when the store updates after mount', () => {
+      mockFetch.mockResolvedValue(null);
+      const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+      expect(result.current.annotation).toEqual({ editable: false });
+
+      const draftBlocks = homeBlocks();
+      const section = draftBlocks[0];
+      if (section?.type === 'section') {
+        section.data.heading = 'Optimistically patched heading';
+      }
+      act(() => {
+        editDraftsStore.set([
+          { docType: 'page', docId: 'page-home-id', draft: { slug: 'home', blocks: draftBlocks } },
+        ]);
+      });
+
+      expect(result.current.annotation).toEqual({ editable: true, docId: 'page-home-id' });
+      const first = result.current.blocks[0];
+      expect(first?.type === 'section' && first.data.heading).toBe(
+        'Optimistically patched heading',
+      );
+    });
+
+    it('ignores an overlay whose slug does not match this page', () => {
+      mockFetch.mockResolvedValue(null);
+      const draftBlocks = homeBlocks();
+      editDraftsStore.set([
+        {
+          docType: 'page',
+          docId: 'page-products-id',
+          draft: { slug: 'products', blocks: draftBlocks },
+        },
+      ]);
+      const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+      expect(result.current.annotation).toEqual({ editable: false });
+      expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
+    });
   });
 });

--- a/apps/marketing/app/lib/use-page-blocks.test.tsx
+++ b/apps/marketing/app/lib/use-page-blocks.test.tsx
@@ -10,9 +10,12 @@ vi.mock('./api', () => ({ fetchPageBlocks: vi.fn() }));
 
 // A controllable stand-in for the module-level edit-mode draft store: the
 // runtime normally calls `setDrafts` (private) through `initEditRuntime`;
-// tests drive it directly via `editDraftsStore.set`.
+// tests drive it directly via `editDraftsStore.set`. `editActive` stands in
+// for the URL's `?rvui-edit=` token (`isEditModeActive()`), independent of
+// whether any draft overlay exists yet.
 const editDraftsStore = vi.hoisted(() => {
   let drafts: PreviewDoc[] = [];
+  let editActive = false;
   const listeners = new Set<() => void>();
   return {
     getEditDrafts: (): PreviewDoc[] => drafts,
@@ -20,9 +23,13 @@ const editDraftsStore = vi.hoisted(() => {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
+    isEditModeActive: (): boolean => editActive,
     set: (next: PreviewDoc[]): void => {
       drafts = next;
       for (const listener of listeners) listener();
+    },
+    setEditActive: (active: boolean): void => {
+      editActive = active;
     },
   };
 });
@@ -30,6 +37,7 @@ const editDraftsStore = vi.hoisted(() => {
 vi.mock('./edit-mode', () => ({
   getEditDrafts: editDraftsStore.getEditDrafts,
   subscribeEditDrafts: editDraftsStore.subscribeEditDrafts,
+  isEditModeActive: editDraftsStore.isEditModeActive,
 }));
 
 const mockFetch = vi.mocked(fetchPageBlocks);
@@ -38,6 +46,7 @@ describe('useMarketingPageBlocks', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     editDraftsStore.set([]);
+    editDraftsStore.setEditActive(false);
   });
 
   afterEach(() => {
@@ -63,7 +72,7 @@ describe('useMarketingPageBlocks', () => {
     if (section?.type === 'section') {
       section.data.heading = 'CMS-overridden demo heading';
     }
-    mockFetch.mockResolvedValue(overridden);
+    mockFetch.mockResolvedValue({ id: 'page-home-id', blocks: overridden });
     const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
     await waitFor(() => {
       const first = result.current.blocks[0];
@@ -74,7 +83,10 @@ describe('useMarketingPageBlocks', () => {
   it('keeps the fallback when the CMS payload fails schema validation', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     // A `section` block with no `data` is schema-invalid.
-    mockFetch.mockResolvedValue([{ id: 'x', type: 'section' } as unknown as Block]);
+    mockFetch.mockResolvedValue({
+      id: 'page-home-id',
+      blocks: [{ id: 'x', type: 'section' } as unknown as Block],
+    });
     const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
     await waitFor(() => expect(warn).toHaveBeenCalled());
     expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
@@ -83,7 +95,7 @@ describe('useMarketingPageBlocks', () => {
   it('keeps the fallback when the CMS payload shape does not match', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     // A valid hero block where the home fallback expects [section, ctaSection].
-    mockFetch.mockResolvedValue(productsBlocks().slice(0, 1));
+    mockFetch.mockResolvedValue({ id: 'page-home-id', blocks: productsBlocks().slice(0, 1) });
     const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
     await waitFor(() => expect(warn).toHaveBeenCalled());
     expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
@@ -151,6 +163,51 @@ describe('useMarketingPageBlocks', () => {
       const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
       expect(result.current.annotation).toEqual({ editable: false });
       expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
+    });
+  });
+
+  describe('edit-mode fresh-session bootstrap (no draft overlay yet)', () => {
+    it('activates the annotation with the CMS page id once edit mode is active and the CMS row resolves', async () => {
+      mockFetch.mockResolvedValue({ id: 'page-home-id', blocks: null });
+      editDraftsStore.setEditActive(true);
+
+      const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+      // First paint: the CMS fetch hasn't resolved yet, so no docId is known.
+      expect(result.current.annotation).toEqual({ editable: false });
+
+      await waitFor(() => {
+        expect(result.current.annotation).toEqual({ editable: true, docId: 'page-home-id' });
+      });
+      // Renders the fallback (no CMS/draft blocks in play), just annotated.
+      expect(result.current.blocks).toBe(HOME_FALLBACK_BLOCKS);
+    });
+
+    it('stays inactive when edit mode is active but the page has no CMS row (static-fallback-only page)', async () => {
+      mockFetch.mockResolvedValue(null);
+      editDraftsStore.setEditActive(true);
+
+      const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('home'));
+      expect(result.current.annotation).toEqual({ editable: false });
+    });
+
+    it('stays inactive with a known CMS row when edit mode is not active', async () => {
+      mockFetch.mockResolvedValue({ id: 'page-home-id', blocks: null });
+      const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('home'));
+      expect(result.current.annotation).toEqual({ editable: false });
+    });
+
+    it('prefers the draft overlay docId over the bootstrap CMS-page-id once a draft exists', () => {
+      mockFetch.mockResolvedValue({ id: 'page-home-id', blocks: null });
+      editDraftsStore.setEditActive(true);
+      const draftBlocks = homeBlocks();
+      editDraftsStore.set([
+        { docType: 'page', docId: 'page-home-id', draft: { slug: 'home', blocks: draftBlocks } },
+      ]);
+
+      const { result } = renderHook(() => useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS));
+      expect(result.current.annotation).toEqual({ editable: true, docId: 'page-home-id' });
     });
   });
 });

--- a/apps/marketing/app/lib/use-page-blocks.ts
+++ b/apps/marketing/app/lib/use-page-blocks.ts
@@ -11,8 +11,20 @@
  * overlay for this page (matched by `slug`), the draft's blocks take priority
  * over both the CMS fetch and the fallback, and the returned annotation activates
  * so the shared block renderer emits `data-rvui-*` attributes for click-to-edit.
- * Outside edit mode the drafts store is always empty, so this is zero-cost and
- * the return shape's `blocks`/`annotation` behave exactly as before.
+ *
+ * A draft overlay only exists once the FIRST field on a page has been patched
+ * (the session server materializes it lazily), so annotation cannot depend on
+ * a draft alone: a brand-new session would never have one, click-to-edit would
+ * never emit any `data-rvui-field`, and the very first click needed to create
+ * that first patch could never fire. To bootstrap, the annotation also
+ * activates (with the CMS page's own id as `docId`) whenever edit mode is
+ * active and the page's CMS row is known, even with zero drafts yet — the
+ * click fires, the canvas PATCHes the field, the session server materializes
+ * the doc, and the draft-overlay path above takes over for further edits.
+ *
+ * Outside edit mode the drafts store is always empty and `isEditModeActive()`
+ * is false, so this is zero-cost and `blocks`/`annotation` behave exactly as
+ * before.
  */
 
 import { type Block, BlockSchema } from '@revealui/contracts/content';
@@ -20,7 +32,7 @@ import type { PreviewDoc } from '@revealui/editor/runtime';
 import type { BlockAnnotation } from '@revealui/presentation';
 import { useEffect, useState, useSyncExternalStore } from 'react';
 import { fetchPageBlocks } from './api';
-import { getEditDrafts, subscribeEditDrafts } from './edit-mode';
+import { getEditDrafts, isEditModeActive, subscribeEditDrafts } from './edit-mode';
 import { blocksMatchFallback } from './page-blocks';
 
 function devWarn(message: string): void {
@@ -42,7 +54,11 @@ function parseBlocks(raw: Block[]): Block[] | null {
 
 export interface PageBlocksResult {
   readonly blocks: Block[];
-  /** Edit-mode annotation: active with a docId only when a matching draft overlay exists. */
+  /**
+   * Edit-mode annotation. Active with a matching draft overlay's `docId`, or
+   * (with no draft yet) the CMS page's own id whenever edit mode is active and
+   * the page's CMS row is known. Inactive otherwise.
+   */
   readonly annotation: BlockAnnotation;
 }
 
@@ -71,12 +87,15 @@ function findDraftForSlug(
  */
 export function useMarketingPageBlocks(slug: string, fallback: Block[]): PageBlocksResult {
   const [blocks, setBlocks] = useState<Block[]>(fallback);
+  const [cmsPageId, setCmsPageId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetchPageBlocks(slug).then((raw) => {
-      if (cancelled || !raw || raw.length === 0) return;
-      const parsed = parseBlocks(raw);
+    fetchPageBlocks(slug).then((page) => {
+      if (cancelled || !page) return;
+      setCmsPageId(page.id);
+      if (!page.blocks || page.blocks.length === 0) return;
+      const parsed = parseBlocks(page.blocks);
       if (!parsed) {
         devWarn(`rejected CMS blocks for "${slug}": failed schema validation`);
         return;
@@ -97,6 +116,9 @@ export function useMarketingPageBlocks(slug: string, fallback: Block[]): PageBlo
 
   if (draft) {
     return { blocks: draft.blocks, annotation: { editable: true, docId: draft.docId } };
+  }
+  if (isEditModeActive() && cmsPageId) {
+    return { blocks, annotation: { editable: true, docId: cmsPageId } };
   }
   return { blocks, annotation: { editable: false } };
 }

--- a/apps/marketing/app/lib/use-page-blocks.ts
+++ b/apps/marketing/app/lib/use-page-blocks.ts
@@ -6,11 +6,21 @@
  * the contracts BlockSchema and match the fallback's per-position shape. Any
  * error, empty payload, or shape mismatch keeps the fallback, so a page always
  * renders with zero API dependency and can never be reshaped by a bad payload.
+ *
+ * In edit mode, when the active edit session (see `./edit-mode`) carries a draft
+ * overlay for this page (matched by `slug`), the draft's blocks take priority
+ * over both the CMS fetch and the fallback, and the returned annotation activates
+ * so the shared block renderer emits `data-rvui-*` attributes for click-to-edit.
+ * Outside edit mode the drafts store is always empty, so this is zero-cost and
+ * the return shape's `blocks`/`annotation` behave exactly as before.
  */
 
 import { type Block, BlockSchema } from '@revealui/contracts/content';
-import { useEffect, useState } from 'react';
+import type { PreviewDoc } from '@revealui/editor/runtime';
+import type { BlockAnnotation } from '@revealui/presentation';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import { fetchPageBlocks } from './api';
+import { getEditDrafts, subscribeEditDrafts } from './edit-mode';
 import { blocksMatchFallback } from './page-blocks';
 
 function devWarn(message: string): void {
@@ -30,11 +40,36 @@ function parseBlocks(raw: Block[]): Block[] | null {
   return parsed;
 }
 
+export interface PageBlocksResult {
+  readonly blocks: Block[];
+  /** Edit-mode annotation: active with a docId only when a matching draft overlay exists. */
+  readonly annotation: BlockAnnotation;
+}
+
+/** The draft overlay (if any) among `drafts` whose page slug matches `slug`. */
+function findDraftForSlug(
+  drafts: readonly PreviewDoc[],
+  slug: string,
+  fallback: Block[],
+): { docId: string; blocks: Block[] } | null {
+  for (const doc of drafts) {
+    if (doc.docType !== 'page') continue;
+    const draft = doc.draft;
+    if (typeof draft !== 'object' || draft === null) continue;
+    const record = draft as Record<string, unknown>;
+    if (record.slug !== slug || !Array.isArray(record.blocks)) continue;
+    const parsed = parseBlocks(record.blocks as Block[]);
+    if (!(parsed && blocksMatchFallback(parsed, fallback))) continue;
+    return { docId: doc.docId, blocks: parsed };
+  }
+  return null;
+}
+
 /**
  * @param slug     the fleet-marketing page slug (`home`, `products`)
  * @param fallback the static block array derived from the content modules
  */
-export function useMarketingPageBlocks(slug: string, fallback: Block[]): Block[] {
+export function useMarketingPageBlocks(slug: string, fallback: Block[]): PageBlocksResult {
   const [blocks, setBlocks] = useState<Block[]>(fallback);
 
   useEffect(() => {
@@ -57,5 +92,11 @@ export function useMarketingPageBlocks(slug: string, fallback: Block[]): Block[]
     };
   }, [slug, fallback]);
 
-  return blocks;
+  const drafts = useSyncExternalStore(subscribeEditDrafts, getEditDrafts, getEditDrafts);
+  const draft = findDraftForSlug(drafts, slug, fallback);
+
+  if (draft) {
+    return { blocks: draft.blocks, annotation: { editable: true, docId: draft.docId } };
+  }
+  return { blocks, annotation: { editable: false } };
 }

--- a/apps/marketing/app/routes/HomePage.tsx
+++ b/apps/marketing/app/routes/HomePage.tsx
@@ -29,9 +29,6 @@ import {
 import { useAudienceHead } from '../lib/use-audience-head';
 import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
-// Annotation is inactive in this slice; the editor-canvas slice activates it.
-const INACTIVE_ANNOTATION: BlockAnnotation = { editable: false };
-
 /**
  * Developer-facing landing: `/?for=technical`, and the default `/` since the
  * 2026-07-09 funnel declutter. 17 sections trimmed to 11, then 11 to 7 in
@@ -97,7 +94,7 @@ export function HomePage() {
   const { search } = useLocation();
   const audience = selectAudience(search);
   useAudienceHead(audience);
-  const blocks = useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS);
+  const { blocks, annotation } = useMarketingPageBlocks('home', HOME_FALLBACK_BLOCKS);
   const demo = demoSlot(blocks);
   const primitives = primitivesSlot(blocks);
   const getStarted = getStartedSlot(blocks);
@@ -110,7 +107,7 @@ export function HomePage() {
           demo={demo}
           primitives={primitives}
           getStarted={getStarted}
-          annotation={INACTIVE_ANNOTATION}
+          annotation={annotation}
         />
       )}
     </div>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -1,4 +1,3 @@
-import type { BlockAnnotation } from '@revealui/presentation';
 import { useState } from 'react';
 import { Footer } from '../components/Footer';
 import { Faq } from '../components/landing/Faq';
@@ -20,9 +19,6 @@ import {
 } from '../lib/page-blocks';
 import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
-// Annotation is inactive in this slice; the editor-canvas slice activates it.
-const INACTIVE_ANNOTATION: BlockAnnotation = { editable: false };
-
 // Filter chips for the fleet-products table. "All" plus each status, ordered
 // stability-descending to match the grid.
 const STATUS_FILTERS: readonly (ProductStatus | 'All')[] = [
@@ -39,14 +35,14 @@ export function ProductsPage() {
     filter === 'All' ? PRODUCTS_SISTERS : PRODUCTS_SISTERS.filter((p) => p.status === filter);
   const countFor = (f: ProductStatus | 'All') =>
     f === 'All' ? PRODUCTS_SISTERS.length : PRODUCTS_SISTERS.filter((p) => p.status === f).length;
-  const blocks = useMarketingPageBlocks('products', PRODUCTS_FALLBACK_BLOCKS);
+  const { blocks, annotation } = useMarketingPageBlocks('products', PRODUCTS_FALLBACK_BLOCKS);
   const hero = productsHeroSlot(blocks);
   const faq = productsFaqSlot(blocks);
   const cta = productsCtaSlot(blocks);
   return (
     <div className="min-h-screen bg-background">
       {/* Hero */}
-      <ProductsHero data={hero.data} path={hero.path} annotation={INACTIVE_ANNOTATION} />
+      <ProductsHero data={hero.data} path={hero.path} annotation={annotation} />
 
       {/* Flagship — RevealUI featured card */}
       <section id={PRODUCTS_FLAGSHIP.slug} className="py-20 sm:py-24">
@@ -318,10 +314,10 @@ export function ProductsPage() {
       <Proof />
 
       {/* FAQ — handle licensing / self-host / production-ready objections */}
-      <Faq data={faq.data} path={faq.path} annotation={INACTIVE_ANNOTATION} />
+      <Faq data={faq.data} path={faq.path} annotation={annotation} />
 
       {/* CTA */}
-      <ProductsCta data={cta.data} path={cta.path} annotation={INACTIVE_ANNOTATION} />
+      <ProductsCta data={cta.data} path={cta.path} annotation={annotation} />
 
       <Footer />
     </div>

--- a/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
+++ b/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Integration coverage for the edit-mode wiring seam: HomePage/ProductsPage now
+ * derive their `annotation` from `useMarketingPageBlocks` instead of a hardcoded
+ * inactive value, and that hook consumes the edit-mode draft store (`../../lib/
+ * edit-mode`). This proves the pieces are actually connected end to end (each
+ * piece already had its own unit coverage: `page-blocks.test.tsx`'s slot paths,
+ * `components/__tests__/block-annotations.test.tsx`'s fieldAttrs emission, and
+ * `lib/use-page-blocks.test.tsx`'s draft-overlay resolution).
+ */
+import type { PreviewDoc } from '@revealui/editor/runtime';
+import { Router, RouterProvider } from '@revealui/router';
+import { act, cleanup, render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchPageBlocks } from '../../lib/api';
+import { homeBlocks, productsBlocks } from '../../lib/page-blocks';
+import { HomePage } from '../HomePage';
+import { ProductsPage } from '../ProductsPage';
+
+vi.mock('../../lib/api', () => ({ fetchPageBlocks: vi.fn() }));
+
+const editDraftsStore = vi.hoisted(() => {
+  let drafts: PreviewDoc[] = [];
+  const listeners = new Set<() => void>();
+  return {
+    getEditDrafts: (): PreviewDoc[] => drafts,
+    subscribeEditDrafts: (listener: () => void): (() => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    set: (next: PreviewDoc[]): void => {
+      drafts = next;
+      for (const listener of listeners) listener();
+    },
+  };
+});
+
+vi.mock('../../lib/edit-mode', () => ({
+  getEditDrafts: editDraftsStore.getEditDrafts,
+  subscribeEditDrafts: editDraftsStore.subscribeEditDrafts,
+}));
+
+const mockFetch = vi.mocked(fetchPageBlocks);
+
+function renderRouted(ui: ReactElement) {
+  return render(<RouterProvider router={new Router()}>{ui}</RouterProvider>);
+}
+
+afterEach(cleanup);
+
+describe('marketing pages: edit-mode wiring', () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue(null);
+    editDraftsStore.set([]);
+  });
+
+  it('HomePage and ProductsPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
+    const home = renderRouted(<HomePage />);
+    expect(home.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+    expect(home.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
+    home.unmount();
+
+    const products = renderRouted(<ProductsPage />);
+    expect(products.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+    expect(products.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
+  });
+
+  it('HomePage renders the draft heading annotated with the session docId when a matching overlay exists', () => {
+    const draftBlocks = homeBlocks();
+    const section = draftBlocks[0];
+    if (section?.type === 'section') {
+      section.data.heading = 'Canvas-edited demo heading';
+    }
+    editDraftsStore.set([
+      { docType: 'page', docId: 'page-home-id', draft: { slug: 'home', blocks: draftBlocks } },
+    ]);
+
+    const { container } = renderRouted(<HomePage />);
+    const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
+    expect(heading?.getAttribute('data-rvui-doc')).toBe('page-home-id');
+    expect(heading?.textContent).toBe('Canvas-edited demo heading');
+  });
+
+  it('ProductsPage renders the draft hero annotated with the session docId when a matching overlay exists', () => {
+    const draftBlocks = productsBlocks();
+    const hero = draftBlocks[0];
+    if (hero?.type === 'hero') {
+      hero.data.title = 'Canvas-edited hero title';
+    }
+    editDraftsStore.set([
+      {
+        docType: 'page',
+        docId: 'page-products-id',
+        draft: { slug: 'products', blocks: draftBlocks },
+      },
+    ]);
+
+    const { container } = renderRouted(<ProductsPage />);
+    const title = container.querySelector('[data-rvui-field="blocks.0.title"]');
+    expect(title?.getAttribute('data-rvui-doc')).toBe('page-products-id');
+    expect(title?.textContent).toBe('Canvas-edited hero title');
+  });
+
+  it('re-renders HomePage with the patched value after an optimistic draft-store update', () => {
+    const { container } = renderRouted(<HomePage />);
+    expect(container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+
+    const draftBlocks = homeBlocks();
+    const section = draftBlocks[0];
+    if (section?.type === 'section') {
+      section.data.heading = 'Optimistically re-rendered heading';
+    }
+    act(() => {
+      editDraftsStore.set([
+        { docType: 'page', docId: 'page-home-id', draft: { slug: 'home', blocks: draftBlocks } },
+      ]);
+    });
+
+    const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
+    expect(heading?.getAttribute('data-rvui-doc')).toBe('page-home-id');
+    expect(heading?.textContent).toBe('Optimistically re-rendered heading');
+  });
+});

--- a/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
+++ b/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
@@ -9,7 +9,7 @@
  */
 import type { PreviewDoc } from '@revealui/editor/runtime';
 import { Router, RouterProvider } from '@revealui/router';
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchPageBlocks } from '../../lib/api';
@@ -19,8 +19,11 @@ import { ProductsPage } from '../ProductsPage';
 
 vi.mock('../../lib/api', () => ({ fetchPageBlocks: vi.fn() }));
 
+// `editActive` stands in for the URL's `?rvui-edit=` token (`isEditModeActive()`),
+// independent of whether any draft overlay exists yet.
 const editDraftsStore = vi.hoisted(() => {
   let drafts: PreviewDoc[] = [];
+  let editActive = false;
   const listeners = new Set<() => void>();
   return {
     getEditDrafts: (): PreviewDoc[] => drafts,
@@ -28,9 +31,13 @@ const editDraftsStore = vi.hoisted(() => {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
+    isEditModeActive: (): boolean => editActive,
     set: (next: PreviewDoc[]): void => {
       drafts = next;
       for (const listener of listeners) listener();
+    },
+    setEditActive: (active: boolean): void => {
+      editActive = active;
     },
   };
 });
@@ -38,6 +45,7 @@ const editDraftsStore = vi.hoisted(() => {
 vi.mock('../../lib/edit-mode', () => ({
   getEditDrafts: editDraftsStore.getEditDrafts,
   subscribeEditDrafts: editDraftsStore.subscribeEditDrafts,
+  isEditModeActive: editDraftsStore.isEditModeActive,
 }));
 
 const mockFetch = vi.mocked(fetchPageBlocks);
@@ -52,6 +60,7 @@ describe('marketing pages: edit-mode wiring', () => {
   beforeEach(() => {
     mockFetch.mockResolvedValue(null);
     editDraftsStore.set([]);
+    editDraftsStore.setEditActive(false);
   });
 
   it('HomePage and ProductsPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
@@ -119,5 +128,23 @@ describe('marketing pages: edit-mode wiring', () => {
     const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
     expect(heading?.getAttribute('data-rvui-doc')).toBe('page-home-id');
     expect(heading?.textContent).toBe('Optimistically re-rendered heading');
+  });
+
+  it('HomePage bootstraps click-to-edit with the CMS page docId when edit mode is active and no draft exists yet', async () => {
+    // Fresh-session bootstrap: edit mode is active (the URL carries the edit
+    // token) and the CMS row for this page is known, but nothing has been
+    // patched yet, so `edit-mode`'s draft store is still empty. Without this
+    // path, `data-rvui-field` would never appear, so the FIRST click needed to
+    // create that first patch could never fire.
+    mockFetch.mockResolvedValue({ id: 'page-home-id', blocks: null });
+    editDraftsStore.setEditActive(true);
+
+    const { container } = renderRouted(<HomePage />);
+    expect(container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+
+    await waitFor(() => {
+      const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
+      expect(heading?.getAttribute('data-rvui-doc')).toBe('page-home-id');
+    });
   });
 });

--- a/packages/editor/src/runtime/__tests__/runtime.test.ts
+++ b/packages/editor/src/runtime/__tests__/runtime.test.ts
@@ -177,4 +177,173 @@ describe('initEditRuntime', () => {
     expect(onDraft).not.toHaveBeenCalled();
     expect(postSpy).not.toHaveBeenCalled();
   });
+
+  // A fresh session's initial preview payload carries `docs: []` (the session
+  // server only materializes a doc on its first field PATCH). The FIRST
+  // apply-patch for a page always targets a docId the runtime hasn't seen yet.
+  describe('apply-patch for a doc absent from the initial payload', () => {
+    function emptyPreviewResponse() {
+      return {
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { siteId: 'site-1', adminOrigin: ADMIN_ORIGIN, docs: [] },
+        }),
+      };
+    }
+
+    function previewResponseWith(docs: PreviewDoc[]) {
+      return {
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { siteId: 'site-1', adminOrigin: ADMIN_ORIGIN, docs },
+        }),
+      };
+    }
+
+    it('re-fetches the preview payload, applies the patch, and acks', async () => {
+      editUrl();
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(emptyPreviewResponse())
+        .mockResolvedValueOnce(
+          previewResponseWith([
+            { docType: 'page', docId: 'page-1', draft: { blocks: [{ title: 'Old' }] } },
+          ]),
+        );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const onDraft = vi.fn();
+      handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft });
+      onDraft.mockClear();
+      postSpy.mockClear();
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ADMIN_ORIGIN,
+          data: { type: RVUI_APPLY_PATCH, doc: 'page-1', field: 'blocks.0.title', value: 'New' },
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(onDraft).toHaveBeenCalledWith([
+          { docType: 'page', docId: 'page-1', draft: { blocks: [{ title: 'New' }] } },
+        ]);
+      });
+      expect(postSpy).toHaveBeenCalledWith(
+        { type: RVUI_PATCH_APPLIED, doc: 'page-1', field: 'blocks.0.title' },
+        ADMIN_ORIGIN,
+      );
+      // One refetch beyond the initial preview fetch  -  not zero (dropped) and
+      // not per-message.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('shares a single refetch across concurrent misses and applies both patches', async () => {
+      editUrl();
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(emptyPreviewResponse())
+        .mockResolvedValueOnce(
+          previewResponseWith([
+            {
+              docType: 'page',
+              docId: 'page-1',
+              draft: { blocks: [{ title: 'Old', body: 'Old body' }] },
+            },
+          ]),
+        );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const onDraft = vi.fn();
+      handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft });
+      onDraft.mockClear();
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ADMIN_ORIGIN,
+          data: {
+            type: RVUI_APPLY_PATCH,
+            doc: 'page-1',
+            field: 'blocks.0.title',
+            value: 'New title',
+          },
+        }),
+      );
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ADMIN_ORIGIN,
+          data: {
+            type: RVUI_APPLY_PATCH,
+            doc: 'page-1',
+            field: 'blocks.0.body',
+            value: 'New body',
+          },
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(onDraft).toHaveBeenCalledWith([
+          {
+            docType: 'page',
+            docId: 'page-1',
+            draft: { blocks: [{ title: 'New title', body: 'New body' }] },
+          },
+        ]);
+      });
+      // Initial preview fetch + exactly ONE shared refetch, not one per miss.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('drops the patch (fail-quiet) when the doc is still unknown after the refetch', async () => {
+      editUrl();
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(emptyPreviewResponse())
+        .mockResolvedValueOnce(emptyPreviewResponse());
+      vi.stubGlobal('fetch', fetchMock);
+
+      const onDraft = vi.fn();
+      handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft });
+      onDraft.mockClear();
+      postSpy.mockClear();
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ADMIN_ORIGIN,
+          data: { type: RVUI_APPLY_PATCH, doc: 'page-1', field: 'blocks.0.title', value: 'New' },
+        }),
+      );
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      expect(onDraft).not.toHaveBeenCalled();
+      expect(postSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops the patch (fail-quiet) when the refetch itself fails', async () => {
+      editUrl();
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(emptyPreviewResponse())
+        .mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const onDraft = vi.fn();
+      handle = await initEditRuntime({ apiBaseUrl: API_BASE, onDraft });
+      onDraft.mockClear();
+      postSpy.mockClear();
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: ADMIN_ORIGIN,
+          data: { type: RVUI_APPLY_PATCH, doc: 'page-1', field: 'blocks.0.title', value: 'New' },
+        }),
+      );
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      expect(onDraft).not.toHaveBeenCalled();
+      expect(postSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/editor/src/runtime/index.ts
+++ b/packages/editor/src/runtime/index.ts
@@ -13,6 +13,14 @@
  *
  * Click delegation reports edit intents (`rvui:click`); inbound `rvui:apply-patch`
  * updates the draft and re-invokes the host callback for optimistic re-render.
+ *
+ * A doc can be targeted by `rvui:apply-patch` before it exists in the local
+ * `docs` array: a fresh session's initial preview fetch returns `docs: []`
+ * (the session server only materializes a doc on its first field PATCH), so
+ * the FIRST patch to a page always targets a docId the runtime hasn't seen
+ * yet. On that miss, the runtime re-fetches the preview payload once (shared
+ * across any concurrent misses, see `ensureDocsRefetched`) to pick up the
+ * newly materialized doc, then retries the patch instead of dropping it.
  */
 
 import {
@@ -104,6 +112,35 @@ function isValidPayload(body: unknown): body is Required<PreviewResponse> {
 }
 
 /**
+ * Fetch + validate the session's read-only preview payload. Returns `null` on
+ * any transport error, non-OK response, or shape mismatch (never throws).
+ */
+async function fetchPreviewPayload(
+  apiBaseUrl: string,
+  sessionId: string,
+  token: string,
+): Promise<Required<PreviewResponse>['data'] | null> {
+  try {
+    const url = new URL(`/api/content/sessions/${sessionId}/preview`, apiBaseUrl);
+    url.searchParams.set('token', token);
+    const res = await fetch(url.toString(), { credentials: 'omit' });
+    if (!res.ok) {
+      devWarn(`preview fetch failed: ${res.status}`);
+      return null;
+    }
+    const body: unknown = await res.json();
+    if (!isValidPayload(body)) {
+      devWarn('preview payload malformed');
+      return null;
+    }
+    return body.data;
+  } catch (err) {
+    devWarn(`preview fetch threw: ${String(err)}`);
+    return null;
+  }
+}
+
+/**
  * Initialize the edit-mode runtime. Returns a handle, or `null` when the URL
  * carries no edit token (not edit mode) or the preview fetch fails.
  */
@@ -117,25 +154,8 @@ export async function initEditRuntime(
     return null;
   }
 
-  let payload: Required<PreviewResponse>['data'];
-  try {
-    const url = new URL(`/api/content/sessions/${sessionId}/preview`, config.apiBaseUrl);
-    url.searchParams.set('token', token);
-    const res = await fetch(url.toString(), { credentials: 'omit' });
-    if (!res.ok) {
-      devWarn(`preview fetch failed: ${res.status}`);
-      return null;
-    }
-    const body: unknown = await res.json();
-    if (!isValidPayload(body)) {
-      devWarn('preview payload malformed');
-      return null;
-    }
-    payload = body.data;
-  } catch (err) {
-    devWarn(`preview fetch threw: ${String(err)}`);
-    return null;
-  }
+  const payload = await fetchPreviewPayload(config.apiBaseUrl, sessionId, token);
+  if (!payload) return null;
 
   // The one trusted origin. Comes from the server config in the payload, NEVER
   // from the URL or from any received message.
@@ -150,6 +170,47 @@ export async function initEditRuntime(
     config.onDraft(docs.map((d) => ({ ...d, draft: d.draft })));
   };
 
+  // Shared in-flight refetch: concurrent apply-patch misses for the same (or
+  // different) unknown docIds await the SAME promise rather than each firing
+  // their own request, and each resumes independently once it resolves, so no
+  // patch is lost and no doc miss triggers more than one network round trip.
+  let refetchInFlight: Promise<void> | null = null;
+
+  const ensureDocsRefetched = (): Promise<void> => {
+    if (!refetchInFlight) {
+      refetchInFlight = fetchPreviewPayload(config.apiBaseUrl, sessionId, token)
+        .then((refetched) => {
+          if (!refetched) return;
+          for (const doc of refetched.docs) {
+            if (!docs.some((d) => d.docId === doc.docId)) {
+              docs.push(doc);
+            }
+          }
+        })
+        .finally(() => {
+          refetchInFlight = null;
+        });
+    }
+    return refetchInFlight;
+  };
+
+  const applyPatch = async (msg: ApplyPatchMessage): Promise<void> => {
+    let target = docs.find((d) => d.docId === msg.doc);
+    if (!target) {
+      // Not yet known locally: the session server may have just materialized
+      // this doc off its first patch. Refetch once, then retry the lookup.
+      await ensureDocsRefetched();
+      target = docs.find((d) => d.docId === msg.doc);
+    }
+    if (!target) {
+      devWarn(`apply-patch for unknown doc: ${msg.doc}`);
+      return;
+    }
+    setAtPath(target.draft, msg.field, msg.value);
+    emitDraft();
+    post({ type: RVUI_PATCH_APPLIED, doc: msg.doc, field: msg.field });
+  };
+
   const onMessage = (event: MessageEvent): void => {
     if (event.origin !== adminOrigin) {
       devWarn(`dropped message from foreign origin: ${event.origin}`);
@@ -159,15 +220,7 @@ export async function initEditRuntime(
       devWarn('dropped malformed message');
       return;
     }
-    const msg: ApplyPatchMessage = event.data;
-    const target = docs.find((d) => d.docId === msg.doc);
-    if (!target) {
-      devWarn(`apply-patch for unknown doc: ${msg.doc}`);
-      return;
-    }
-    setAtPath(target.draft, msg.field, msg.value);
-    emitDraft();
-    post({ type: RVUI_PATCH_APPLIED, doc: msg.doc, field: msg.field });
+    void applyPatch(event.data);
   };
 
   const onClick = (event: MouseEvent): void => {


### PR DESCRIPTION
## Summary

Wires marketing's edit mode so canvas edits actually render. This is the P1 seam that was deferred when the runtime/annotation/draft-store pieces each shipped in isolation without being connected.

Five gaps, all closed:

1. **Annotation was hardcoded inactive.** `HomePage.tsx`/`ProductsPage.tsx` passed a module-level `INACTIVE_ANNOTATION = { editable: false }` to every block component regardless of edit-mode state, so `fieldAttrs` never emitted `data-rvui-doc`/`data-rvui-field` and click-to-edit could never fire.
2. **Nothing consumed the draft store.** `apps/marketing/app/lib/edit-mode.ts`'s `getEditDrafts`/`subscribeEditDrafts` module store was populated by the runtime on every patch, but no component read it, so a patched field never appeared in the preview.
3. **Fresh-session bootstrap deadlock.** A session's draft overlay only materializes on the page's *first* field PATCH, but with (1) and (2) alone, `editable` only ever activated once a draft already existed. On a brand-new session with zero prior edits, nothing would ever be clickable: no draft → no annotation → no `data-rvui-field` → no click → no PATCH → no draft. Chicken-and-egg. Closed by activating the annotation off the CMS page's own id whenever edit mode is active and the page's CMS row is known, independent of whether a draft exists yet.
4. **Optimistic re-render silently dropped on the just-unblocked bootstrap path (Round 3).** Once (3) let the first click through, the canvas's autosave PATCH landed, but the runtime's `rvui:apply-patch` handler dropped the ack because its local `docs` array (fetched once, at iframe load, when it was still `[]`) never picked up the doc the server had just materialized. Closed in `packages/editor`'s runtime by re-fetching the preview payload on a doc-id miss.
5. **Annotation path contract was one segment short, silently corrupting every patch (Round 4).** Every `data-rvui-field` path built by `apps/marketing`'s block components (`Demo`, `Primitives`, `GetStarted`, `Faq`, `ProductsHero`, `ProductsCta`) — and, independently, `packages/presentation`'s `RenderBlocks` — stopped at the block's array index (`blocks.0.title`) instead of its data object (`blocks.0.data.title`), because every block component reads its fields from `block.data.*`. The session PATCH endpoint faithfully sets whatever raw path it's given, so a canvas edit wrote a stray sibling key next to `data` instead of the field inside it: invisible on screen, corrupting both the draft doc and (on publish) the live `pages.blocks` row. This is also why Round 3's optimistic re-render looked broken to the naked eye during the live walk even after the Round-3 fix landed — see "Adversarial review round" below for how this was actually diagnosed. Closed by appending `.data` to every path at its point of construction (`apps/marketing/app/lib/page-blocks.ts`'s `BlockSlot.path`, and `packages/presentation`'s `RenderBlocks`), not at each `fieldAttrs` call site.

`useMarketingPageBlocks` (`apps/marketing/app/lib/use-page-blocks.ts`) now owns all three: it subscribes to the draft store via `useSyncExternalStore` and returns `{ blocks, annotation }` instead of bare `Block[]`. `annotation` activates in priority order: (a) a draft overlay whose `draft.slug` matches the page being rendered (`{ editable: true, docId: <draft's docId> }`), else (b) edit mode active + the page's CMS row is known (`{ editable: true, docId: <CMS page id> }`), else (c) `{ editable: false }` — byte-identical to the old hardcoded value. `HomePage`/`ProductsPage` now thread that `annotation` through instead of the removed `INACTIVE_ANNOTATION` const.

## Seam citations (read before this PR)

- [`apps/marketing/app/lib/edit-mode.ts:19-40`](apps/marketing/app/lib/edit-mode.ts) — the module-level draft store (`getEditDrafts`/`subscribeEditDrafts`), already correct, now finally consumed.
- [`packages/editor/src/runtime/index.ts:27-31,149-151,163-170`](packages/editor/src/runtime/index.ts) — `PreviewDoc { docType, docId, draft }`; `emitDraft()` re-invokes the host callback on init and after every `rvui:apply-patch`, which is what makes the new hook's `useSyncExternalStore` subscription re-render optimistically.
- [`packages/presentation/src/blocks/annotation.ts:14-33`](packages/presentation/src/blocks/annotation.ts) — `fieldAttrs`/`BlockAnnotation` contract, unchanged; it was already correctly gated on `editable && docId`, it just never received an active value.
- [`apps/marketing/app/lib/page-blocks.ts:296-342`](apps/marketing/app/lib/page-blocks.ts) — `BlockSlot.path` is index-keyed (`blocks.0`, not a label — the #1995 review lesson holds), but through Round 3 it stopped one segment short of the field data (`blocks.0`, not `blocks.0.data`). Round 4 fixes this; see gap 5 and the Round 4 section below.
- [`apps/server/src/routes/content/sessions.ts:133-147`](apps/server/src/routes/content/sessions.ts) — `materializePageDraft()` is the server-side shape of `draft`: `{ ..., slug, blocks, ... }`. This is how the hook matches a draft overlay to a page (`draft.slug === slug`) and pulls `draft.blocks` in the same `Block[]` shape `fetchPageBlocks` already returns.
- [`apps/server/src/routes/content/sessions.ts:986-1004`](apps/server/src/routes/content/sessions.ts) — `GET /sessions/:id/preview` returns `docs: { docType, docId, draft }[]`, exactly `PreviewDoc[]`.
- [`apps/server/src/routes/content/sessions.ts:536-551`](apps/server/src/routes/content/sessions.ts) — a session's draft overlay (`editSessionDocs` row) only materializes lazily on the page's *first* field PATCH (`materializePageDraft`). This is why the bootstrap fix cannot rely on a draft existing.
- [`apps/server/src/routes/content/pages.ts:31-73`](apps/server/src/routes/content/pages.ts) — `GET /sites/:siteId/pages` (the endpoint `fetchPageBlocks` already calls) returns each page's `id` on the wire (`PageSchema.id`), just not previously captured in the marketing-side TS type. This is the source of the CMS page id used for the bootstrap path; no server change was needed.
- [`packages/editor/src/runtime/index.ts:173-188`](packages/editor/src/runtime/index.ts) — the runtime's `onClick` handler fires off `data-rvui-field` DOM presence alone; it does not check the preview payload's `docs` array. That's what makes the bootstrap path work: once the annotation emits the CMS page id, a click fires immediately, independent of whether any draft doc exists yet.
- [`packages/editor/src/runtime/index.ts:153-171`](packages/editor/src/runtime/index.ts) (pre-Round-3 shape) — `onMessage`'s `docs.find((d) => d.docId === msg.doc)` on the inbound `rvui:apply-patch` channel, with a silent `devWarn` drop on miss. This is the Round 3 defect: a fresh session's `docs` array is fetched once at iframe load (still `[]` before any patch), so the FIRST optimistic patch for a page always misses here.
- [`packages/editor/src/canvas/EditSessionCanvas.tsx:206-228`](packages/editor/src/canvas/EditSessionCanvas.tsx) — `commitPatch()` PATCHes the session doc (materializing it server-side) BEFORE posting `rvui:apply-patch` into the iframe. This ordering guarantee is why a single refetch-on-miss (rather than a retry/poll loop) is sufficient: by the time the message arrives, the doc is already materialized server-side.
- **Round 4** — [`apps/marketing/app/components/landing/Demo.tsx:14-21,42-44`](apps/marketing/app/components/landing/Demo.tsx) (and identically in `Primitives`/`GetStarted`/`Faq`/`ProductsHero`/`ProductsCta`) — `const { eyebrow, title, ... } = block.data` reads every field from `block.data.*`, but `fieldAttrs(annotation, `${path}.eyebrow`)` assumed `path` already pointed AT `block.data`. It didn't: `apps/marketing/app/lib/page-blocks.ts`'s `BlockSlot.path` was `blocks.${index}` (no `.data`).
- [`packages/presentation/src/blocks/HeroBlock.tsx:23,32-45`](packages/presentation/src/blocks/HeroBlock.tsx), [`SectionBlock.tsx:22-27,54-84`](packages/presentation/src/blocks/SectionBlock.tsx), [`CtaSectionBlock.tsx:22-27,29-58`](packages/presentation/src/blocks/CtaSectionBlock.tsx), [`primitive-blocks.tsx`](packages/presentation/src/blocks/primitive-blocks.tsx) (`TextBlockView`/`HeadingBlockView`/`QuoteBlockView`/`ListBlockView`) — audited every `fieldAttrs` call site in `packages/presentation/src/blocks/`. All of them destructure from `block.data` and build their path as `${path}.<field>`, identically to the `apps/marketing` components. None independently append `.data`, so the single fix point for this package is `RenderBlocks.tsx`'s path construction. `marketing-links.tsx` (`MarketingLinks`) has no `fieldAttrs` call — it renders the CTA link row as a whole, not a per-field target — so it needed no change.

## Correction to the round-4 diagnosis (verified against code, not the report)

The bug report named `packages/presentation/src/blocks/RenderBlocks.tsx` as the seam that produced the observed corruption. Grounding that against the actual code path (`HomePage`/`ProductsPage` render `apps/marketing`'s own bespoke section components — `Demo`, `Primitives`, `GetStarted`, `Faq`, `ProductsHero`, `ProductsCta`, from `apps/marketing/app/components/`), `RenderBlocks` is not in that path at all: `grep -rn "from '@revealui/presentation'" apps/ | grep RenderBlocks` returns nothing outside `packages/presentation`'s own tests. No app currently imports it. The corrupted path observed live (`blocks[0].items[0].title` landing as a sibling of `data`) traces exactly to `apps/marketing/app/lib/page-blocks.ts`'s `demoSlot()` (`HOME_DEMO_INDEX = 0`, a `section`-type block, `path = blocks.0`), consumed by `Demo.tsx`'s `fieldAttrs(annotation, `${path}.items.${index}.title`)`.

Both are real, independent instances of the identical bug pattern; `RenderBlocks` genuinely was broken (a published package, built-but-currently-unwired — no app consumes it yet), and the coordinator's requested fix there is still correct and included below. But the code that actually corrupted the live-walked data was `apps/marketing/app/lib/page-blocks.ts`, not `RenderBlocks.tsx`. Both are fixed in this round; the marketing-side one is the one that mattered for the live walk.

## What changed

- `apps/marketing/app/lib/api.ts` — `fetchPageBlocks` now returns `CmsPage { id, blocks } | null` instead of `Block[] | null`. `id` is present whenever the page row exists (from the same `GET /sites/:siteId/pages` response it already fetched), independent of whether `blocks` validates.
- `apps/marketing/app/lib/edit-mode.ts` — added `isEditModeActive()`: a synchronous check of the same `?rvui-edit=` URL param `initEditMode()` already reads, exposed so `useMarketingPageBlocks` can activate annotation on first render, before the async `initEditRuntime`/preview fetch resolves.
- `apps/marketing/app/lib/use-page-blocks.ts` — `useMarketingPageBlocks` returns `PageBlocksResult { blocks, annotation }` instead of `Block[]`. Subscribes to the edit-mode draft store via `useSyncExternalStore` (matching the pattern in `packages/router/src/components.tsx`'s `Routes`/`useLocation`). Annotation priority: a matching draft overlay's `docId` first (`docType === 'page'`, `draft.slug === slug`, `draft.blocks` valid + shape-matching the fallback via the existing `blocksMatchFallback` guard), then the CMS page's own `id` when edit mode is active and the row is known (the fresh-session bootstrap path, tracked in a new `cmsPageId` state set once the existing CMS fetch resolves), else `{ editable: false }` — identical behavior to before.
- `apps/marketing/app/routes/HomePage.tsx`, `apps/marketing/app/routes/ProductsPage.tsx` — removed the hardcoded `INACTIVE_ANNOTATION` const; both pages now destructure `{ blocks, annotation }` from the hook and pass the real `annotation` through to their block-driven sections.
- Test-only: `apps/marketing/app/lib/use-page-blocks.test.tsx` (extended) and `apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx` (extended).
- **Round 3:** `packages/editor/src/runtime/index.ts` — extracted the preview-fetch-and-validate logic into `fetchPreviewPayload()` (shared by `initEditRuntime`'s initial fetch and the new refetch path, no duplicated URL-building/parsing). `initEditRuntime`'s inbound-message handling split into a new `applyPatch(msg)` async helper: on a docId miss it awaits `ensureDocsRefetched()` (a shared in-flight `Promise<void>`, memoized so concurrent misses — same or different docIds — trigger exactly one refetch, not one each) which seeds any newly-materialized docs into the local `docs` array, then retries the lookup. Still-missing after refetch, or a failed refetch, falls through to the original fail-quiet `devWarn` drop. `onMessage` itself stays synchronous (origin + shape checks unchanged) and fires the async `applyPatch` without awaiting it, matching the file's existing `void import(...)` fire-and-forget style used elsewhere in the runtime package.
- New changeset: `.changeset/editor-runtime-refetch-unknown-doc.md` (`@revealui/editor`, patch).
- **Round 4:** `apps/marketing/app/lib/page-blocks.ts` — every `BlockSlot` resolver's `path` now ends in `.data` (`blocks.${index}.data`, not `blocks.${index}`). `apps/marketing/app/components/{GetStarted,landing/Demo,landing/Faq,landing/Primitives,products/ProductsCta,products/ProductsHero}.tsx` — updated each component's default `path` prop value to match (dead in production, since `HomePage`/`ProductsPage` always pass an explicit `path` from `BlockSlot`, but corrected for consistency/documentation so a future caller relying on the default isn't handed the buggy convention). `packages/presentation/src/blocks/RenderBlocks.tsx` — `path` construction now `blocks.${index}.data`, matching the fix above.
- New changeset: `.changeset/presentation-fix-block-annotation-path.md` (`@revealui/presentation`, patch).

No server change in any round (the CMS page id was already on the wire; the session-materialization ordering `packages/editor` now relies on was already the canvas's existing PATCH-then-postMessage sequence; the Round 4 path fix needed no server change either — the server-side `setAtPath` already correctly applies whatever path it's given).

## Tests

New/extended coverage, mimicking the existing `block-annotations.test.tsx` and `use-page-blocks.test.tsx` patterns:

- `apps/marketing/app/lib/use-page-blocks.test.tsx` — 5 base tests (updated to the new `{blocks, annotation}` return shape and the `CmsPage` mock payload shape), 4 tests under `edit-mode draft overlay` (inactive-by-default, draft-blocks + active annotation on a matching overlay, re-render on a store update after mount, ignoring an overlay for a different page's slug), and 4 new tests under `edit-mode fresh-session bootstrap (no draft overlay yet)`: activates with the CMS page id once edit mode is active and the CMS row resolves (inactive on first paint, active after the fetch resolves), stays inactive with edit mode active but no CMS row (static-fallback-only page), stays inactive with a known CMS row but edit mode inactive, and prefers the draft overlay's docId over the bootstrap CMS-page-id once a draft exists. 13 tests total in this file.
- `apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx` — integration-level, rendering the actual `HomePage`/`ProductsPage` components (wrapped in `RouterProvider`) with a mocked `edit-mode` store: zero `data-rvui-*` attributes with no active draft/edit mode (regression pin for byte-identical non-edit-mode rendering), correct `data-rvui-doc`/`data-rvui-field` + docId + patched text on both pages when a draft matches, a live re-render after an `act()`-wrapped store update, and the new bootstrap test — **"HomePage bootstraps click-to-edit with the CMS page docId when edit mode is active and no draft exists yet"** — asserting zero attributes on first paint, then `data-rvui-field`/`data-rvui-doc` present with the CMS page's docId once the fetch resolves. 5 tests total in this file.

Total: 18 marketing tests across the two files exercise this seam directly (118 marketing tests pass overall, up from 113).

**Round 3** (`packages/editor/src/runtime/__tests__/runtime.test.ts`, extended): a new `apply-patch for a doc absent from the initial payload` describe block with 4 tests — re-fetches the preview payload, applies the patch, and acks (asserting exactly 2 fetch calls: initial + one refetch, not zero and not per-message); shares a single refetch across two concurrent misses for the same doc and applies both patches correctly (still exactly 2 fetch calls, proving the shared-promise dedup); drops the patch (fail-quiet) when the doc is still unknown after the refetch resolves; drops the patch (fail-quiet) when the refetch itself fails (non-OK response). All 8 pre-existing runtime tests (init, click delegation, foreign-origin/malformed-message drops, the already-known-doc apply-patch happy path) pass unchanged. 12 tests total in this file, 18 in the `@revealui/editor` package overall.

**Round 4** — the cross-seam contract test the coordinator specifically asked for, plus corrected assertions:

- `packages/presentation/src/__tests__/blocks/render-blocks.test.tsx` — new `RenderBlocks — draft-path contract (cross-seam)` describe block: builds a representative page fixture covering every `RenderBlocks`-supported block type (`hero`, `section` with nested repeater items, `ctaSection` with a snippet, `text`, `heading`, `quote`, `list` with nested items, `divider`, `spacer`), renders it `editable` with a `docId`, collects every emitted `data-rvui-field` attribute value, and for each walks that dot-path through `{ blocks: contractBlocks }` — the exact shape `materializePageDraft` (`apps/server`) produces — using a small local `resolveDraftPath` helper (plain `.split('.')` segment walk, array-index vs. object-key branch, no regex). Asserts each resolved value is a `string` or `string[]` (the one legitimate array leaf is the CTA snippet's `.lines`, displayed joined); `undefined` or a whole object/block (the corruption signature — the path stopped short of the real field) fails. Also a sanity floor (`> 10` annotated elements) so a regression that stopped emitting attributes entirely wouldn't silently pass. All 4 pre-existing describe blocks' assertions updated to the corrected `blocks.<i>.data.<field>` paths (they were previously self-consistent but asserting the buggy convention, so they could not have caught this). 8 tests total in this file, 996 in the `@revealui/presentation` package overall.
- `apps/marketing/app/lib/page-blocks.test.ts` — the 6 `BlockSlot.path` assertions (one per slot resolver) updated from `blocks.<i>` to `blocks.<i>.data`.
- `apps/marketing/app/components/__tests__/block-annotations.test.tsx` — all `path="blocks.<i>"` props and their corresponding `data-rvui-field="blocks.<i>.<field>"` assertions updated to `blocks.<i>.data.<field>` across all 6 block-driven sections.
- `apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx` — the 4 `data-rvui-field` assertions (draft-match on HomePage, draft-match on ProductsPage, optimistic re-render, fresh-session bootstrap) updated from `blocks.0.heading`/`blocks.0.title` to `blocks.0.data.heading`/`blocks.0.data.title`. Notably: **this integration test already exercised the real, corrupted code path in Rounds 1-3 and passed anyway**, because its own assertions were written against the same wrong convention `page-blocks.ts` produced — a textbook "the test enshrines the bug" trap. The new cross-seam contract test above is structurally different for exactly this reason: it doesn't hand-write an expected path string, it derives pass/fail from whether the emitted path actually resolves inside the real draft shape.

### Prove-red transcripts

**Round 1** (annotation wiring + draft-store consumption), checked out the three pre-fix impl files from `origin/test`, keeping the new tests:

```
$ pnpm --filter marketing exec vitest run app/lib/use-page-blocks.test.tsx app/routes/__tests__/edit-mode-wiring.test.tsx
 Test Files  2 failed (2)
      Tests  12 failed | 1 passed (13)
```

**Round 2** (fresh-session bootstrap, this update), after an adversarial review flagged the bootstrap deadlock as a blocker: checked out the three impl files (`api.ts`, `edit-mode.ts`, `use-page-blocks.ts`) back to this PR's then-current HEAD (`54a1340e2`, already on `test`-bound, round-1-green), keeping the new/updated tests with the new `CmsPage`/`isEditModeActive` mock shapes, and ran them:

```
$ git checkout HEAD -- apps/marketing/app/lib/api.ts apps/marketing/app/lib/edit-mode.ts apps/marketing/app/lib/use-page-blocks.ts
$ pnpm --filter marketing exec vitest run app/lib/use-page-blocks.test.tsx app/routes/__tests__/edit-mode-wiring.test.tsx
 Test Files  2 failed (2)
      Tests  5 failed | 13 passed (18)
     Errors  7 errors (unhandled rejections: `raw is not iterable` — round-1's hook body iterating the new `CmsPage` object as if it were a `Block[]`, expected fallout of round-1's code meeting round-2's test mocks)
```

The 5 failures included both new bootstrap-path assertions (`use-page-blocks.test.tsx`'s "activates the annotation with the CMS page id..." and `edit-mode-wiring.test.tsx`'s "HomePage bootstraps click-to-edit..."). Restored the fix; reran: 118/118 pass, `tsc --noEmit` clean.

**Round 3** (optimistic re-render on the bootstrap path), after the live acceptance walk found `iframe-optimistic-rerender: false`: checked out `packages/editor/src/runtime/index.ts` back to this PR's Round-2 HEAD (`1a7b1e19d`, the commit CI had already gone green on), keeping the new runtime tests, and ran them:

```
$ git checkout HEAD -- packages/editor/src/runtime/index.ts
$ pnpm --filter @revealui/editor exec vitest run src/runtime/__tests__/runtime.test.ts
 Test Files  1 failed (1)
      Tests  4 failed | 8 passed (12)
```

All 4 new tests failed with the exact reported symptom (`[rvui-editor] apply-patch for unknown doc: page-1` on stderr, then the assertions on `onDraft`/`fetchMock` call counts failing); all 8 pre-existing tests stayed green. Restored the fix; reran: 12/12 pass. Rebuilt `@revealui/editor` (`pnpm --filter @revealui/editor build`) and reran `pnpm --filter marketing typecheck` to confirm the widened `PreviewDoc`-adjacent `.d.ts` output didn't regress the marketing-side type imports: clean.

**Round 4** (annotation path contract), after DB inspection found the corrupted `pages.blocks` row: checked out all 8 Round-4 implementation files (`page-blocks.ts`, the 6 marketing component default-path fixes, `RenderBlocks.tsx`) back to this PR's Round-3 HEAD (`7d46923db`, already CI-green), keeping the 4 updated/new test files, and ran the affected suites:

```
$ git checkout HEAD -- apps/marketing/app/lib/page-blocks.ts apps/marketing/app/components/GetStarted.tsx \
    apps/marketing/app/components/landing/Demo.tsx apps/marketing/app/components/landing/Faq.tsx \
    apps/marketing/app/components/landing/Primitives.tsx apps/marketing/app/components/products/ProductsCta.tsx \
    apps/marketing/app/components/products/ProductsHero.tsx packages/presentation/src/blocks/RenderBlocks.tsx

$ pnpm --filter @revealui/presentation exec vitest run src/__tests__/blocks/render-blocks.test.tsx
 Test Files  1 failed (1)
      Tests  4 failed | 4 passed (8)
# including: "every emitted data-rvui-field path resolves to a defined string in the
# materialized draft" — AssertionError: path "blocks.0.eyebrow" did not resolve to a
# string or string[]: got undefined

$ pnpm --filter marketing exec vitest run app/lib/page-blocks.test.ts \
    app/components/__tests__/block-annotations.test.tsx app/routes/__tests__/edit-mode-wiring.test.tsx
 Test Files  2 failed | 1 passed (3)
      Tests  8 failed | 15 passed (23)
```

12 of 31 assertions across the two packages failed against the pre-fix code, including the cross-seam contract test (the one that would have caught this from the start). Restored all 8 fixes; reran: presentation 996/996, marketing 118/118, editor 18/18, all clean.

## Verification run (post-fix, on this branch, all four rounds)

```
pnpm --filter @revealui/presentation test        # 89 files, 996 tests passed
pnpm --filter @revealui/presentation typecheck   # clean
pnpm --filter @revealui/presentation build       # rebuilt dist (marketing dev consumes it)
pnpm --filter @revealui/editor test              # 2 files, 18 tests passed
pnpm --filter @revealui/editor typecheck         # clean
pnpm --filter marketing test                     # 17 files, 118 tests passed
pnpm --filter marketing typecheck                # clean
pnpm biome check <changed files>                 # clean
pnpm gate --phase=1 --changed                    # PASS
```

No local goldens/visual-regression suite exists in `packages/presentation` to re-run directly; the CI "Showcase visual regression" job (green through Rounds 1-3) is the visual gate and will re-run on this push. Expected unaffected: `data-rvui-*` attributes only exist when `editable` + `docId` are both set (edit mode only), so default/published rendering — DOM structure, classes, text — is byte-identical before and after this round.

### Security-review gate note

`packages/editor/` is not currently a substring in `scripts/validate/security-review-gate.cjs`'s `SECURITY_PATHS` list, so the automated "Security review gate" CI check will not mechanically flag this diff. Flagging it here anyway on its merits: this PR's Round 3 change is inside the runtime's postMessage/origin-pinning surface (`onMessage`, the exact-origin-pinned inbound channel) and its cross-origin preview-token fetch path. Per the coordinator's directive, treat this PR as security-sensitive regardless of the mechanical gate result; the coordinator records the guardrail-2 verdict out of band. Not self-approving, not applying `sec-review:approved` or any gate-clearing label, and not modifying `SECURITY_PATHS` myself (that list is itself security-governance machinery, out of this PR's scope).

Round 4's `packages/presentation` change is a pure data-path fix (which draft field a patch lands in) with no auth/access-control/origin surface — `packages/presentation/` is also not in `SECURITY_PATHS`. Noting it for completeness, not raising a separate flag for it: the same guardrail-2 verdict already covers this PR.

## Design decisions for review

1. **Adversarial review round.** The first version of this PR flagged the fresh-session bootstrap deadlock as a follow-up rather than fixing it (annotation only activated off an existing draft overlay, but a draft overlay only ever materializes after a first click, and a first click can only fire if annotation is already active). Adversarial review correctly called this a blocker for the canonical acceptance flow ("open session → click headline" with zero prior patches), not a deferrable follow-up, since nothing would ever be clickable in a brand-new session. Fixed in this update per the review's proposed shape: activate off the CMS page's own id (already on the wire via the existing `fetchPageBlocks` call) whenever edit mode is active, independent of draft existence. Kept entirely inside `apps/marketing` — no server change needed.
2. **Draft blocks validated with the same `blocksMatchFallback` guard as the CMS fetch.** Not explicitly requested, but applying the existing shape-guard to draft blocks (not just CMS blocks) means a malformed/partial draft can never reshape which sections a page renders, consistent with the file's existing defense-in-depth posture. If a draft's blocks fail that guard, the hook silently falls through to the previous state (CMS/fallback) rather than throwing.
3. **Priority order: draft overlay docId > bootstrap CMS-page-id > inactive.** Once a draft exists, its `docId` (and blocks) win outright, since draft content is what the editor is actively looking at; the bootstrap path only fills the gap before that first patch lands. Outside edit mode (draft store always empty, `isEditModeActive()` false) both paths are no-ops.
4. **`isEditModeActive()` reads the URL synchronously rather than tracking "runtime initialized" state.** The coordinator's brief allowed either; reading the URL param directly (same one `initEditMode()` already reads) means the bootstrap annotation can activate as soon as the CMS fetch resolves, without waiting on the separate async `initEditRuntime`/preview-token round trip, and needs no new module-level state to keep in sync with the draft store.
5. **`fetchPageBlocks`'s return type changed shape (`Block[] | null` → `CmsPage | null`) rather than adding a second fetch function.** It already had the id on the wire from its one network call; splitting it into two functions would mean two requests to the same endpoint for the same data. Left the function name as-is since it still centers on fetching a page's blocks (the id is auxiliary metadata carried alongside).
6. **Round 3 concurrency choice: a single shared in-flight `Promise<void>`, re-apply after seed (not a queue).** The coordinator left this call open. Chose the shared-promise form because every `applyPatch` invocation is already independently `await`-able and idempotent-safe: two concurrent misses (same or different docId) both call `ensureDocsRefetched()`, get the identical in-flight promise (memoized in a closure variable, cleared in a `.finally()`), and once it resolves each continuation independently re-runs its OWN `docs.find(...)` and applies its OWN patch. No message is queued or buffered anywhere; nothing can be lost between "message arrived" and "patch applied" because each message's continuation holds its own `msg` in closure and simply pauses at the `await`. A queue would add ordering machinery this doesn't need since JS's single-threaded microtask ordering already guarantees continuations resume in registration order.
7. **Merge (append-only), not replace, when seeding refetched docs into the local `docs` array.** `ensureDocsRefetched` only pushes docs from the refetch that aren't already present locally (by `docId`); it never replaces the array or an existing entry's `draft` object. This matters because `applyPatch` holds direct references into `docs[i].draft` across the `await` — replacing the array wholesale could orphan an in-flight mutation on an already-known doc. Since the canvas already PATCHes-then-posts (see the `EditSessionCanvas.tsx` citation above), the refetched payload for an already-known doc would be stale-safe-equivalent anyway, but append-only sidesteps the question entirely.
8. **`onMessage` stays synchronous; `applyPatch` is a fire-and-forget async helper.** `window.addEventListener('message', ...)` doesn't await its listener's return value either way, and keeping the origin/shape checks synchronous in `onMessage` (unchanged from before) means those two existing tests (foreign origin, malformed message) needed no changes.
9. **Round 4: fixed both the actually-exercised bug (`apps/marketing/app/lib/page-blocks.ts`) and the latent identical bug the coordinator correctly flagged (`packages/presentation/src/blocks/RenderBlocks.tsx`), not just the one the report named.** See "Correction to the round-4 diagnosis" above — grounding the report against the actual `HomePage`/`ProductsPage` render path showed the real corruption came from `apps/marketing`'s own bespoke section components, not `RenderBlocks` (currently unused by any app). Fixing only the file the report named would have left the live product still broken.
10. **Fixed at path CONSTRUCTION (`BlockSlot.path` / `RenderBlocks`'s `path` variable), not at each `fieldAttrs` CALL SITE.** Every block component's `fieldAttrs(annotation, `${path}.field`)` calls were already doing the right thing — appending a field name onto whatever `path` they were handed. The bug was entirely in what `path` value they were handed. One fix point per package, not N call sites, and it's structurally impossible for a new field added to an existing block component to reintroduce this bug, since it never touches `path` construction at all.
11. **Round 4 default-path prop updates (`Demo.tsx` etc.) are cosmetic/dead in production but included anyway.** `HomePage`/`ProductsPage` always pass an explicit `path` from `BlockSlot`, so a component's own default `path = 'blocks.0'` prop value is only reachable via direct/test-only rendering without a `path` prop. Updated all 6 for consistency: leaving a stale, buggy example as the public default would be a footgun for any future direct caller and a misleading read for anyone auditing the contract.

## Flagged follow-up (not fixed here)

The session PATCH endpoint (`apps/server`, `PATCH /sessions/:id/docs/:docType/:docId`) accepts any `path` string and calls `setAtPath` without validating that it resolves within the existing draft structure, so any path typo or contract drift (this bug's class) silently writes a stray key instead of failing loudly — filing as a gap for a follow-up server-side change, out of this PR's `apps/marketing`/`packages/presentation`/`packages/editor` scope.
