### PR TITLE
fix(server): validate edit-session patch paths against draft structure

### DIFF
--- a/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
@@ -122,7 +122,7 @@ async function seedBase(): Promise<void> {
       path: '/',
       status: 'published',
       version: 1,
-      blocks: [{ type: 'text', text: 'hello' }],
+      blocks: [{ id: 'blk-1', type: 'text', data: { text: 'hello' } }],
       seo: { description: 'orig' },
     },
     {
@@ -133,7 +133,7 @@ async function seedBase(): Promise<void> {
       path: '/about',
       status: 'published',
       version: 1,
-      blocks: [{ type: 'text', text: 'about' }],
+      blocks: [{ id: 'blk-b1', type: 'text', data: { text: 'about' } }],
       seo: { description: 'about-orig' },
     },
   ]);
@@ -201,13 +201,13 @@ describe('open -> patch -> patch -> publish', () => {
     expect(doc1.data.draft.title).toBe('New Title');
 
     // Second patch applies to the stored draft (nested array path).
-    const p2 = await patch(app, sessionId, 'blocks.0.text', 'updated body');
+    const p2 = await patch(app, sessionId, 'blocks.0.data.text', 'updated body');
     expect(p2.status).toBe(200);
     const doc2 = (await p2.json()) as {
-      data: { draft: { title: string; blocks: Array<{ text: string }> } };
+      data: { draft: { title: string; blocks: Array<{ data: { text: string } }> } };
     };
     expect(doc2.data.draft.title).toBe('New Title');
-    expect(doc2.data.draft.blocks[0].text).toBe('updated body');
+    expect(doc2.data.draft.blocks[0].data.text).toBe('updated body');
 
     // Publish.
     const pub = await app.request(`/sessions/${sessionId}/publish`, { method: 'POST' });
@@ -223,7 +223,7 @@ describe('open -> patch -> patch -> publish', () => {
     expect(page.title).toBe('New Title');
     expect(page.version).toBe(2);
     expect(page.status).toBe('published');
-    expect((page.blocks as Array<{ text: string }>)[0].text).toBe('updated body');
+    expect((page.blocks as Array<{ data: { text: string } }>)[0].data.text).toBe('updated body');
 
     // Revision snapshot exists.
     const revisions = await testDb.drizzle
@@ -563,6 +563,127 @@ describe('prototype-pollution guard', () => {
 
     // The base object prototype was not polluted.
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural path validation — the patch path must resolve through EXISTING
+// draft structure inside an allowlisted writable root (title / seo.* /
+// blocks.<i>.data.*). A stray path is a 400 naming the offending segment and
+// writes NOTHING (publish-shape invariants are unpatchable by construction).
+// ---------------------------------------------------------------------------
+
+describe('structural path validation', () => {
+  async function expect400Naming(
+    app: ReturnType<typeof createApp>,
+    sessionId: string,
+    path: string,
+    offendingSegment: string,
+  ): Promise<void> {
+    const res = await patch(app, sessionId, path, 'x');
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: { message?: string }; message?: string };
+    const message = body.error?.message ?? body.message ?? JSON.stringify(body);
+    expect(message).toContain(offendingSegment);
+  }
+
+  it('rejects a stray sibling-of-data path and writes nothing', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    // Materialize with a valid patch first.
+    expect((await patch(app, sessionId, 'title', 'T')).status).toBe(200);
+
+    // The exact corruption shape from the P1 walk: a path missing the `.data`
+    // segment lands as a sibling of `data` inside the block.
+    await expect400Naming(app, sessionId, 'blocks.0.items', 'items');
+    await expect400Naming(app, sessionId, 'blocks.0.items.0.title', 'items');
+
+    // The draft carries no stray key.
+    const get = await app.request(`/sessions/${sessionId}`);
+    const body = (await get.json()) as {
+      data: { docs: Array<{ draft: { blocks: Array<Record<string, unknown>> } }> };
+    };
+    expect(body.data.docs[0].draft.blocks[0].items).toBeUndefined();
+  });
+
+  it('rejects unpatchable publish-shape roots', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    for (const root of ['id', 'slug', 'path', 'version', 'status', 'siteId', 'templateId']) {
+      await expect400Naming(app, sessionId, root, root);
+    }
+  });
+
+  it('rejects structural block segments (whole array, whole block, type, id)', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    await expect400Naming(app, sessionId, 'blocks', 'blocks');
+    await expect400Naming(app, sessionId, 'blocks.0', 'blocks.0');
+    await expect400Naming(app, sessionId, 'blocks.0.type', 'type');
+    await expect400Naming(app, sessionId, 'blocks.0.id', 'id');
+  });
+
+  it('rejects an out-of-range block index and a non-numeric index', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    await expect400Naming(app, sessionId, 'blocks.5.data.text', '5');
+    await expect400Naming(app, sessionId, 'blocks.x.data.text', 'x');
+  });
+
+  it('rejects a missing intermediate inside data', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    // data exists but has no `items` container to descend through.
+    await expect400Naming(app, sessionId, 'blocks.0.data.items.0.title', 'items');
+  });
+
+  it('a 400 on the FIRST patch does not materialize an overlay row', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    await expect400Naming(app, sessionId, 'blocks.0.items', 'items');
+
+    const get = await app.request(`/sessions/${sessionId}`);
+    const body = (await get.json()) as { data: { docs: unknown[] } };
+    expect(body.data.docs).toHaveLength(0);
+  });
+
+  it('allows the valid surface: title, seo leafs, data leafs, and NEW keys under data', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    expect((await patch(app, sessionId, 'title', 'T2')).status).toBe(200);
+    expect((await patch(app, sessionId, 'blocks.0.data.text', 'body')).status).toBe(200);
+    // New leaf whose parent object exists INSIDE data is allowed.
+    expect((await patch(app, sessionId, 'blocks.0.data.subtitle', 'sub')).status).toBe(200);
+    // Existing seo leaf is patchable; whole-seo replacement is patchable.
+    expect((await patch(app, sessionId, 'seo.description', 'd2')).status).toBe(200);
+    expect((await patch(app, sessionId, 'seo', { description: 'd3' })).status).toBe(200);
+    // A NEW key under seo is not (finals outside blocks data must already exist).
+    await expect400Naming(app, sessionId, 'seo.brandNew', 'brandNew');
+
+    const get = await app.request(`/sessions/${sessionId}`);
+    const body = (await get.json()) as {
+      data: {
+        docs: Array<{
+          draft: {
+            title: string;
+            seo: { description: string };
+            blocks: Array<{ data: { text: string; subtitle: string } }>;
+          };
+        }>;
+      };
+    };
+    const draft = body.data.docs[0].draft;
+    expect(draft.title).toBe('T2');
+    expect(draft.blocks[0].data.text).toBe('body');
+    expect(draft.blocks[0].data.subtitle).toBe('sub');
+    expect(draft.seo.description).toBe('d3');
   });
 });
 

--- a/apps/server/src/routes/content/sessions.ts
+++ b/apps/server/src/routes/content/sessions.ts
@@ -62,10 +62,24 @@ function actorKindFor(user: SessionUser): 'human' | 'agent' {
 }
 
 // =============================================================================
-// Typed draft patch setter (no regex, prototype-pollution guarded)
+// Typed draft patch setter (no regex, prototype-pollution guarded, structural)
+//
+// The patch path must resolve through EXISTING draft structure inside an
+// allowlisted writable root: `title` (leaf), `seo` (whole object or an
+// existing leaf), or `blocks.<i>.data` and deeper. Everything else — page
+// identity and publish-shape invariants (id/slug/path/version/status),
+// whole-blocks or whole-block writes, block `type`/`id` — is rejected with a
+// 400 naming the offending segment, and nothing is written. Intermediate
+// containers are never created: silent structure creation is exactly how a
+// path typo (or a misbehaving agent caller) corrupts published page JSON.
+// A NEW final key is allowed only where its parent object already exists
+// inside a block's `data` subtree; array writes never extend the array.
 // =============================================================================
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+const UNPATCHABLE_ROOT_HINT =
+  "not a writable root (writable: 'title', 'seo', 'blocks.<i>.data...')";
 
 function isArrayIndex(segment: string): boolean {
   if (segment.length === 0) return false;
@@ -76,30 +90,61 @@ function isArrayIndex(segment: string): boolean {
   return true;
 }
 
-function readChild(container: Record<string, unknown> | unknown[], segment: string): unknown {
-  if (Array.isArray(container)) {
-    return isArrayIndex(segment) ? container[Number(segment)] : undefined;
-  }
-  return container[segment];
+function pathError(offender: string, reason: string): HTTPException {
+  return new HTTPException(400, {
+    message: `Invalid patch path at '${offender}': ${reason}`,
+  });
 }
 
-function writeChild(
-  container: Record<string, unknown> | unknown[],
-  segment: string,
+/**
+ * Descend `segments` (from index `start`) through existing containers only,
+ * then set `value` on the final segment. `allowNewFinal` permits a new key
+ * when the final segment's parent is an existing plain object (the
+ * blocks.<i>.data carve-out); array indices must be in range everywhere —
+ * appends are a P2 block-operations concern, not a patch.
+ */
+function setThroughExisting(
+  root: Record<string, unknown> | unknown[],
+  segments: string[],
+  start: number,
   value: unknown,
+  allowNewFinal: boolean,
 ): void {
-  if (Array.isArray(container)) {
-    if (!isArrayIndex(segment)) {
-      throw new HTTPException(400, { message: `Expected an array index, got '${segment}'` });
+  let cursor: Record<string, unknown> | unknown[] = root;
+  for (let i = start; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    let child: unknown;
+    if (Array.isArray(cursor)) {
+      if (!isArrayIndex(segment)) throw pathError(segment, 'expected an array index');
+      if (Number(segment) >= cursor.length) throw pathError(segment, 'array index out of range');
+      child = cursor[Number(segment)];
+    } else {
+      if (!Object.hasOwn(cursor, segment)) {
+        throw pathError(segment, 'does not resolve through existing draft structure');
+      }
+      child = cursor[segment];
     }
-    container[Number(segment)] = value;
+    if (child === null || typeof child !== 'object') {
+      throw pathError(segment, 'is not a container in the draft');
+    }
+    cursor = child as Record<string, unknown> | unknown[];
+  }
+
+  const final = segments[segments.length - 1];
+  if (Array.isArray(cursor)) {
+    if (!isArrayIndex(final)) throw pathError(final, 'expected an array index');
+    if (Number(final) >= cursor.length) throw pathError(final, 'array index out of range');
+    cursor[Number(final)] = value;
     return;
   }
-  container[segment] = value;
+  if (!(Object.hasOwn(cursor, final) || allowNewFinal)) {
+    throw pathError(final, 'does not exist (new keys are only allowed inside block data)');
+  }
+  cursor[final] = value;
 }
 
-/** Set `value` at a dot/array path inside a draft, creating intermediate containers. */
-function setAtPath(draft: Record<string, unknown>, path: string, value: unknown): void {
+/** Apply a validated patch to a draft, or throw a 400 naming the offending segment. */
+function applyDraftPatch(draft: Record<string, unknown>, path: string, value: unknown): void {
   const segments = path.split('.');
   for (const segment of segments) {
     if (segment.length === 0) {
@@ -110,18 +155,38 @@ function setAtPath(draft: Record<string, unknown>, path: string, value: unknown)
     }
   }
 
-  let cursor: Record<string, unknown> | unknown[] = draft;
-  for (let i = 0; i < segments.length - 1; i++) {
-    const segment = segments[i];
-    const nextIsIndex = isArrayIndex(segments[i + 1]);
-    let child = readChild(cursor, segment);
-    if (child === null || typeof child !== 'object') {
-      child = nextIsIndex ? [] : {};
-      writeChild(cursor, segment, child);
-    }
-    cursor = child as Record<string, unknown> | unknown[];
+  const root = segments[0];
+
+  if (root === 'title') {
+    if (segments.length !== 1) throw pathError(segments[1], "'title' is a leaf value");
+    draft.title = value;
+    return;
   }
-  writeChild(cursor, segments[segments.length - 1], value);
+
+  if (root === 'seo') {
+    if (segments.length === 1) {
+      draft.seo = value;
+      return;
+    }
+    setThroughExisting(draft, segments, 0, value, false);
+    return;
+  }
+
+  if (root === 'blocks') {
+    if (segments.length === 1) {
+      throw pathError('blocks', 'the blocks array is not writable as a whole');
+    }
+    if (segments.length === 2) {
+      throw pathError(`blocks.${segments[1]}`, 'a whole block is not writable');
+    }
+    if (segments[2] !== 'data') {
+      throw pathError(segments[2], "only a block's 'data' subtree is writable");
+    }
+    setThroughExisting(draft, segments, 0, value, true);
+    return;
+  }
+
+  throw pathError(root, UNPATCHABLE_ROOT_HINT);
 }
 
 /**
@@ -533,30 +598,34 @@ app.openapi(
       });
     }
 
-    let doc = await sessionQueries.getSessionDoc(db, id, docType, docId);
-    if (!doc) {
-      // First patch on this doc: materialize the overlay from the live page.
+    // Validate + apply against the in-memory draft BEFORE any write: a 400 on
+    // the first patch must not materialize an overlay row.
+    const doc = await sessionQueries.getSessionDoc(db, id, docType, docId);
+    let updated: typeof doc;
+    if (doc) {
+      const nextDraft = structuredClone(doc.draft);
+      applyDraftPatch(nextDraft, path, value);
+      updated = await sessionQueries.updateSessionDocDraft(db, doc.id, {
+        draft: nextDraft,
+        updatedBy: user.id,
+      });
+    } else {
+      // First patch on this doc: materialize the overlay from the live page
+      // with the patch already applied (single write).
       const page = await sessionQueries.getLivePage(db, docId);
       if (!page) throw new HTTPException(404, { message: 'Page not found' });
-      doc = await sessionQueries.insertSessionDoc(db, {
+      const nextDraft = materializePageDraft(page);
+      applyDraftPatch(nextDraft, path, value);
+      updated = await sessionQueries.insertSessionDoc(db, {
         id: crypto.randomUUID(),
         sessionId: id,
         docType,
         docId,
-        draft: materializePageDraft(page),
+        draft: nextDraft,
         baseVersion: page.version,
         updatedBy: user.id,
       });
-      if (!doc) throw new HTTPException(500, { message: 'Failed to materialize draft' });
     }
-
-    const nextDraft = structuredClone(doc.draft);
-    setAtPath(nextDraft, path, value);
-
-    const updated = await sessionQueries.updateSessionDocDraft(db, doc.id, {
-      draft: nextDraft,
-      updatedBy: user.id,
-    });
     if (!updated) throw new HTTPException(500, { message: 'Failed to save draft' });
 
     await sessionQueries.insertSessionEvent(db, {


### PR DESCRIPTION
## What
Session PATCH paths must now resolve through existing draft structure inside an allowlisted writable root: `title` (leaf), `seo` (whole object or an existing leaf), or `blocks.<i>.data` and deeper. Anything else is a 400 naming the offending segment, and nothing is written.

## Why
The endpoint accepted any dot-path and auto-created intermediate containers. A path typo wrote stray keys into the draft, and publish persisted them into live page JSON with zero errors anywhere — proven live during the P1 acceptance walk (the pre-fix renderer emitted paths missing the `.data` segment and every canvas edit landed as a stray sibling of `data`). The renderer was fixed in #2004; this closes the durable server-side hazard before the P2 MCP agent tools drive this endpoint programmatically.

## Design ruling (writable roots)
- Allowlist over denylist: `title`, `seo`/`seo.*`, `blocks.<i>.data...`. Page identity + publish-shape fields (`id`, `slug`, `path`, `version`, `status`), whole-`blocks`/whole-block writes, and block `type`/`id`/`style`/`meta` are unpatchable by construction (P2 block operations get their own deliberate surface).
- Structural resolution: every intermediate must exist as a container; array indices in range everywhere (no appends). Intermediate creation removed entirely.
- New final keys only where the parent object already exists inside a block's `data` subtree; `seo.*` finals must already exist.
- Validation runs before overlay materialization: a rejected first patch creates no row. Zero regex (segment walk + `Object.hasOwn`).

## Testing
- Prove-red: the 7 new PGlite tests (stray sibling-of-data, unpatchable roots, structural block segments, out-of-range/non-numeric index, missing intermediate, no-materialize-on-400, valid-surface regression) all FAILED against the old setter, then 20/20 green with the fix.
- Suite fixtures updated to the canonical `{ id, type, data: {...} }` block shape from the contracts block schema (the old seed predated the block contract).
- `pnpm --filter server typecheck` clean; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
