### PR TITLE
ci(deploy): raise node heap for vercel build to clear api builder OOM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -395,6 +395,13 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ matrix.project-id }}
           SKIP_ENV_VALIDATION: "true"
+          # api: @vercel/node's TypeScript pass compiles far beyond the traced
+          # entry (sibling apps included) and its diagnostics are non-fatal
+          # noise on every run — but the pass sits at Node's default ~4GB heap
+          # ceiling and died OOM (exit 134, "Ineffective mark-compacts near
+          # heap limit") on run 29668080341 (2026-07-19) once the program grew
+          # past it. Raise the ceiling; ubuntu-latest runners have 16GB.
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Deploy
         id: deploy


### PR DESCRIPTION
The Deploy api job on the #2008 promotion (run 29668080341) failed with a V8 heap OOM (exit 134) at the end of the @vercel/node TypeScript pass:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
Aborted (core dumped) vercel build --prod
```

Diagnosis:
- The huge wall of TS errors in the log is longstanding NON-fatal builder noise: the last successful deploy (run 29654720425) printed the identical errors and passed. The builder compiles far beyond the traced entry (sibling apps, dual drizzle-orm instances) and its diagnostics never fail the build.
- The real failure is memory: the pass sits at Node's default ~4GB old-space ceiling, and the promotion nudged the compiled program size past it. The rerun reproduced it, so it is deterministic, not cold-cache.

Fix: set `NODE_OPTIONS: --max-old-space-size=6144` on the shared Build step (ubuntu-latest runners have 16GB). Harmless for admin/marketing/docs; unblocks api.

Follow-up (separate): the builder typechecking sibling apps + the dual drizzle-orm instance blowup deserve their own cleanup so the pass shrinks instead of the ceiling growing forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
