### PR TITLE
fix(server): scope api NFT trace away from monorepo TypeScript (GAP-403)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -385,7 +385,19 @@ jobs:
       - name: Override Vercel project settings for CI
         run: |
           if [ -f .vercel/project.json ]; then
-            jq '.settings.installCommand = "" | .settings.buildCommand = "pnpm turbo build --filter=${{ matrix.app }}"' .vercel/project.json > .vercel/project.json.tmp
+            # Deploy target "api" is package "server". Its vercel-build script also
+            # builds optional Pro packages (@revealui/ai, @revealui/services) when
+            # present — plain `turbo --filter=server` does not (optional peers are
+            # outside the graph). Other matrix apps match their package names.
+            APP="${{ matrix.app }}"
+            if [ "$APP" = "api" ]; then
+              BUILD_CMD='pnpm run vercel-build'
+            else
+              BUILD_CMD="pnpm turbo build --filter=${APP}"
+            fi
+            jq --arg cmd "$BUILD_CMD" \
+              '.settings.installCommand = "" | .settings.buildCommand = $cmd' \
+              .vercel/project.json > .vercel/project.json.tmp
             mv .vercel/project.json.tmp .vercel/project.json
           fi
 
@@ -395,12 +407,12 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ matrix.project-id }}
           SKIP_ENV_VALIDATION: "true"
-          # api: @vercel/node's TypeScript pass compiles far beyond the traced
-          # entry (sibling apps included) and its diagnostics are non-fatal
-          # noise on every run — but the pass sits at Node's default ~4GB heap
-          # ceiling and died OOM (exit 134, "Ineffective mark-compacts near
-          # heap limit") on run 29668080341 (2026-07-19) once the program grew
-          # past it. Raise the ceiling; ubuntu-latest runners have 16GB.
+          # Belt-and-suspenders after #2010: api once OOM'd at the default ~4GB
+          # heap (run 29668080341) when @vercel/node typechecked the monorepo.
+          # GAP-403 excludeFiles on apps/server/vercel.json is the durable fix
+          # (NFT no longer pulls sibling-app / package src into the TS pass).
+          # Keep the raised ceiling until one post-merge api deploy log shows
+          # zero ../marketing|../admin|../docs TS diagnostics; then drop it.
           NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Deploy

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -6,7 +6,20 @@
     "api/**": {
       "memory": 512,
       "maxDuration": 30,
-      "includeFiles": "dist/index_bg.wasm"
+      "includeFiles": "dist/index_bg.wasm",
+      "excludeFiles": [
+        "**/*.ts",
+        "**/*.tsx",
+        "apps/admin/**",
+        "apps/marketing/**",
+        "apps/docs/**",
+        "packages/**/src/**",
+        "packages/**/templates/**",
+        "**/coverage/**",
+        "**/.next/**",
+        "**/.turbo/**",
+        "**/__tests__/**"
+      ]
     }
   },
   "crons": [{ "path": "/api/cron/dispatch", "schedule": "0 6 * * *" }],


### PR DESCRIPTION
## Summary
Deploy api spent ~28 minutes and multi-GB heap on a non-fatal `@vercel/node` TypeScript pass over the whole monorepo (sibling apps + package sources). #2010 only raised `NODE_OPTIONS` to 6GB.

## Root cause (code + log + local NFT)
- Production Deploy api log (run 29668080341): ~3690 `error TS*` lines under `../marketing`, `../admin`, `../docs`, and `packages/**/src` before `Build Completed in .vercel/output [28m]`.
- Local `@vercel/nft` replay of `apps/server/api/index.js`:
  - **base = monorepo root:** ~9400 files, **~1700 `.ts`**
  - **base = apps/server:** ~43 files, **0 `.ts`**
- Production uses monorepo-root NFT base (monorepo layout). Entry is already plain JS → `dist/`; the TS pass is pure waste.

## Fix
1. **`apps/server/vercel.json`** — `functions["api/**"].excludeFiles` drops `**/*.{ts,tsx}`, sibling apps, package sources, tests, coverage, `.next`, `.turbo`.
2. **`deploy.yml`** — CI build override for `api` now runs `pnpm run vercel-build` (package name is `server`; Pro peers via `scripts/vercel-build.mjs`). Was `turbo --filter=api` (matches nothing).
3. **Keep** `NODE_OPTIONS=6144` until one post-merge api deploy log shows zero sibling-app TS diagnostics; then drop it.

## Local proof
With the new exclude list, NFT (monorepo base): **0 `.ts`**, dist + api + pg + `@revealui/ai` retained (~22s vs multi-minute typecheck wall).

## GAP
GAP-403 closed in private tracking (lockstep jv PR). Residual: remove heap bump after verified deploy.

## Test plan
- [x] Local NFT exclude proof (0 TS files)
- [x] Pre-push phase-1 gate PASS
- [ ] After merge → promote: Deploy api log has no `../marketing|../admin|../docs` TS wall; wall-clock drops; then PR to drop `NODE_OPTIONS` bump