### PR TITLE
chore(grok): project MCP attach config (env refs only)

### DIFF
--- a/.grok/config.toml
+++ b/.grok/config.toml
@@ -1,0 +1,12 @@
+# Project-scoped Grok MCP attach (RevealUI monorepo).
+# Durable: committed. Secrets never live here — only env references.
+# Launch with: rfg revealui  (loads REVEALUI_MCP_TOKEN from revvault)
+
+[mcp_servers.revealui]
+url = "${REVEALUI_MCP_URL:-https://api.revealui.com/api/mcp}"
+enabled = true
+startup_timeout_sec = 45
+tool_timeout_sec = 120
+
+[mcp_servers.revealui.headers]
+Authorization = "Bearer ${REVEALUI_MCP_TOKEN}"

--- a/.grok/rules/monorepo.md
+++ b/.grok/rules/monorepo.md
@@ -1,0 +1,38 @@
+# RevealUI monorepo (Grok project rules)
+
+Public agent entrypoint remains root `AGENTS.md` / `CLAUDE.md`. This file is Grok-native add-on only.
+
+## Layout
+
+- `apps/server` — Hono API `:3004`
+- `apps/admin` — Next.js 16 `:4000`
+- `apps/docs` — Vite docs
+- `apps/marketing` — Vite marketing
+- `packages/*` — OSS MIT + Pro FSL packages
+
+## Load-bearing packages
+
+| Concern | Package |
+|---------|---------|
+| CMS engine | `@revealui/core` |
+| Schemas | `@revealui/contracts` + `@revealui/db` |
+| UI | `@revealui/presentation` + tokens |
+| Hosted gates | server middleware entitlements + `@revealui/core/license` + `@revealui/paywall` |
+| Agents | `@revealui/ai`, `mcp`, `harnesses`, `engines` |
+
+## Commands
+
+```bash
+pnpm dev:app
+pnpm gate
+pnpm test
+pnpm validate:claims
+```
+
+## Skills already in-repo
+
+`.agents/skills/` and `.claude/skills/` (conventions, db, testing, safety, tdd). Prefer those over inventing new procedure.
+
+## Branch
+
+Feature PRs → `test`. Never PR direct to `main`.

--- a/package.json
+++ b/package.json
@@ -116,8 +116,7 @@
       "ws@8": ">=8.20.1",
       "@revealui/config": "workspace:*",
       "@revealui/contracts": "workspace:*",
-      "@revealui/db": "workspace:*",
-      "js-yaml@5": ">=5.2.1"
+      "@revealui/db": "workspace:*"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,7 +160,6 @@ overrides:
   '@revealui/config': workspace:*
   '@revealui/contracts': workspace:*
   '@revealui/db': workspace:*
-  js-yaml@5: '>=5.2.1'
 
 importers:
 


### PR DESCRIPTION
## Summary
- Commit `revealui/.grok/config.toml` with `[mcp_servers.revealui]` using `${REVEALUI_MCP_TOKEN}` only.
- Pairs with revkit `rfg` launcher (revkit#136). No secrets in the repo.

## Test plan
- [ ] `rfg revealui` after revkit helpers installed
- [ ] Confirm config has no token material