### PR TITLE
fix(security): raise pnpm overrides to clear critical/high audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "revealui",
   "version": "0.4.0",
   "private": true,
-  "description": "Agentic business runtime. Users, content, products, payments, and AI — pre-wired, open source, and ready to deploy.",
+  "description": "Agentic business runtime. Users, content, products, payments, and AI \u2014 pre-wired, open source, and ready to deploy.",
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@biomejs/biome": "catalog:",
@@ -61,11 +61,11 @@
   "packageManager": "pnpm@10.28.2",
   "pnpm": {
     "overrides": {
-      "shell-quote": ">=1.8.4",
+      "shell-quote": ">=1.9.0",
       "form-data": ">=4.0.6",
       "path-to-regexp": ">=6.3.0",
       "tar-fs": ">=2.1.4",
-      "tar": ">=7.5.16",
+      "tar": ">=7.5.19",
       "drizzle-orm": "^0.45.2",
       "lodash": ">=4.18.0",
       "lodash-es": ">=4.18.0",
@@ -82,7 +82,7 @@
       "js-yaml@4": ">=4.2.0",
       "js-yaml@3": "^3.15.0",
       "minimatch": ">=10.2.4",
-      "brace-expansion@5": ">=5.0.6",
+      "brace-expansion@5": ">=5.0.7",
       "rollup": ">=4.59.0",
       "serialize-javascript": ">=7.0.3",
       "immutable": ">=5.1.5",
@@ -113,7 +113,8 @@
       "ws@8": ">=8.20.1",
       "@revealui/config": "workspace:*",
       "@revealui/contracts": "workspace:*",
-      "@revealui/db": "workspace:*"
+      "@revealui/db": "workspace:*",
+      "js-yaml@5": ">=5.2.1"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,11 +104,11 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  shell-quote: '>=1.8.4'
+  shell-quote: '>=1.9.0'
   form-data: '>=4.0.6'
   path-to-regexp: '>=6.3.0'
   tar-fs: '>=2.1.4'
-  tar: '>=7.5.16'
+  tar: '>=7.5.19'
   drizzle-orm: ^0.45.2
   lodash: '>=4.18.0'
   lodash-es: '>=4.18.0'
@@ -125,7 +125,7 @@ overrides:
   js-yaml@4: '>=4.2.0'
   js-yaml@3: ^3.15.0
   minimatch: '>=10.2.4'
-  brace-expansion@5: '>=5.0.6'
+  brace-expansion@5: '>=5.0.7'
   rollup: '>=4.59.0'
   serialize-javascript: '>=7.0.3'
   immutable: '>=5.1.5'
@@ -157,6 +157,7 @@ overrides:
   '@revealui/config': workspace:*
   '@revealui/contracts': workspace:*
   '@revealui/db': workspace:*
+  js-yaml@5: '>=5.2.1'
 
 importers:
 
@@ -5326,8 +5327,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -7957,8 +7958,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -8274,10 +8275,6 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
-    engines: {node: '>=18'}
 
   tar@7.5.19:
     resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
@@ -11899,7 +11896,7 @@ snapshots:
       semver: 7.5.4
       stat-mode: 0.3.0
       stream-to-promise: 2.2.0
-      tar: 7.5.16
+      tar: 7.5.19
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
@@ -12617,7 +12614,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12807,7 +12804,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -14513,7 +14510,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 
@@ -15453,7 +15450,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -15758,14 +15755,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-
-  tar@7.5.16:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
 
   tar@7.5.19:
     dependencies:


### PR DESCRIPTION
## Summary
**Fleet-wide** Security Gate failure on every open PR (`critical=1 high=3`):

| Severity | Package | Floor |
|----------|---------|-------|
| critical | `tar` (via `vercel` → `@vercel/fun`) | `>=7.5.19` |
| high | `tar` (same path) | covered by above |
| high | `brace-expansion@5` (via minimatch) | `>=5.0.7` |
| high | `shell-quote` (via concurrently) | `>=1.9.0` |
| moderate (warn) | `js-yaml@5` | `>=5.2.1` |

## Why not per-PR
This is not a code regression in any feature branch. All of #2014–#2019 fail the same Dependency audit check. One override PR unblocks the board.

## Proof
```
pnpm audit  → critical=0 high=0 moderate=3
pnpm gate:security → Result: PASS
```

## Peer coordination
After this merges to `test`, rebase/merge open PRs:
- #2015 excludeFiles string (this session)
- #2016 fleet-redundancy mechanical (peer)
- #2017 PEM/HMAC docs (peer) — also has Unit Tests fail, separate from audit
- #2018 ButtonCVA migrate (peer)
- #2019 grok MCP config (peer)
- #2014 promotion (after #2015 + this)

Do **not** pile more audit-only commits onto feature branches.

## Owner
```bash
gh pr merge <N> --repo RevealUIStudio/revealui --merge
```