### PR TITLE
fix(server): wire REVEALUI_API_URL onto api for MCP loopback

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -51,6 +51,7 @@ import {
 } from './lib/audit-storage.js';
 import { queryBillingStatusByCustomerId, querySupportExpiry } from './lib/billing-status.js';
 import { runHostedLicenseCanary } from './lib/license-canary.js';
+import { resolveSelfApiBaseUrl } from './lib/self-api-url.js';
 import {
   validateBillingCatalogAtStartup,
   validateLicenseAtStartup,
@@ -983,7 +984,7 @@ app.doc('/openapi.json', {
   },
   servers: [
     {
-      url: process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL ?? 'http://localhost:3004',
+      url: resolveSelfApiBaseUrl() || 'http://localhost:3004',
       description: process.env.NODE_ENV === 'production' ? 'Production' : 'Development server',
     },
   ],

--- a/apps/server/src/lib/__tests__/self-api-url.test.ts
+++ b/apps/server/src/lib/__tests__/self-api-url.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { MISSING_SELF_API_URL_MESSAGE, resolveSelfApiBaseUrl } from '../self-api-url.js';
+
+describe('resolveSelfApiBaseUrl', () => {
+  it('prefers explicit override over env', () => {
+    const env = {
+      REVEALUI_API_URL: 'https://env.example',
+    } as NodeJS.ProcessEnv;
+    expect(resolveSelfApiBaseUrl('https://override.example/', env)).toBe(
+      'https://override.example',
+    );
+  });
+
+  it('uses REVEALUI_API_URL before NEXT_PUBLIC_API_URL and API_URL', () => {
+    const env = {
+      REVEALUI_API_URL: 'https://api.example/',
+      NEXT_PUBLIC_API_URL: 'https://public.example',
+      API_URL: 'https://legacy.example',
+    } as NodeJS.ProcessEnv;
+    expect(resolveSelfApiBaseUrl(undefined, env)).toBe('https://api.example');
+  });
+
+  it('falls back to NEXT_PUBLIC_API_URL then API_URL', () => {
+    expect(
+      resolveSelfApiBaseUrl(undefined, {
+        NEXT_PUBLIC_API_URL: 'https://public.example/',
+      } as NodeJS.ProcessEnv),
+    ).toBe('https://public.example');
+    expect(
+      resolveSelfApiBaseUrl(undefined, {
+        API_URL: 'http://localhost:3004/',
+      } as NodeJS.ProcessEnv),
+    ).toBe('http://localhost:3004');
+  });
+
+  it('returns empty string when nothing is set', () => {
+    expect(resolveSelfApiBaseUrl(undefined, {} as NodeJS.ProcessEnv)).toBe('');
+  });
+
+  it('missing-config message names vault path and sync surface', () => {
+    expect(MISSING_SELF_API_URL_MESSAGE).toContain('revealui/prod/public/api-url');
+    expect(MISSING_SELF_API_URL_MESSAGE).toContain('revealui-api');
+  });
+});

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -28,6 +28,8 @@ function validLiveProdEnv(overrides: EnvMap = {}): EnvMap {
     REVEALUI_KEK: HEX_64,
     REVEALUI_PUBLIC_SERVER_URL: HTTPS_URL,
     NEXT_PUBLIC_SERVER_URL: HTTPS_URL,
+    // Governed MCP tool loopback origin (required hosted boot as of GAP-MCP-self-url)
+    REVEALUI_API_URL: 'https://api.revealui.com',
     STRIPE_SECRET_KEY: 'sk_live_deadbeef',
     STRIPE_WEBHOOK_SECRET: 'whsec_deadbeef',
     REVEALUI_LICENSE_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----',
@@ -301,6 +303,12 @@ describe('validateStartup — production format checks (live mode)', () => {
 
   it('accepts a fully valid live-mode production environment', () => {
     expect(() => validateStartup(validLiveProdEnv())).not.toThrow();
+  });
+
+  it('rejects hosted production without REVEALUI_API_URL (MCP loopback)', () => {
+    const env = validLiveProdEnv();
+    delete env.REVEALUI_API_URL;
+    expect(() => validateStartup(env)).toThrow(/REVEALUI_API_URL/);
   });
 
   it('does NOT emit the test-mode warning when STRIPE_LIVE_MODE=true', () => {
@@ -848,6 +856,7 @@ describe('validateStartup — lenient mode (Vercel-Sensitive var handling)', () 
       POSTGRES_URL: 'postgresql://user:pw@host/db',
       REVEALUI_PUBLIC_SERVER_URL: 'https://api.revealui.com',
       NEXT_PUBLIC_SERVER_URL: 'https://api.revealui.com',
+      REVEALUI_API_URL: 'https://api.revealui.com',
       CORS_ORIGIN: 'https://revealui.com',
       // Hosted-mode signals — non-empty (would be sensitive in real Vercel,
       // but their PRESENCE is what mode detection cares about; the value is

--- a/apps/server/src/lib/required-env.ts
+++ b/apps/server/src/lib/required-env.ts
@@ -67,4 +67,8 @@ export const REQUIRED_IN_PRODUCTION_HOSTED = [
   // serve. validate-startup additionally parses it as a valid Ed25519 PKCS#8 key.
   // No REVEALUI_SECRET fallback — the legacy HMAC fallback was retired.
   'REVEALUI_AUDIT_SIGNING_KEY',
+  // Governed MCP tool loopback base URL (mcp-endpoint credentialsProvider).
+  // Without it, /api/mcp auth can still succeed while every tool fails with
+  // "REVEALUI_API_URL is not configured". Vault: revealui/prod/public/api-url.
+  'REVEALUI_API_URL',
 ] as const;

--- a/apps/server/src/lib/self-api-url.ts
+++ b/apps/server/src/lib/self-api-url.ts
@@ -1,0 +1,34 @@
+/**
+ * Public base URL for this API process (self origin).
+ *
+ * Used by:
+ * - Governed MCP tool loopback (`mcp-endpoint` credentialsProvider → REST)
+ * - OpenAPI server list (index.ts)
+ *
+ * Priority:
+ * 1. explicit override (tests + DI)
+ * 2. `REVEALUI_API_URL` (canonical hosted/server name)
+ * 3. `NEXT_PUBLIC_API_URL` (parity twin used by admin/marketing)
+ * 4. `API_URL` (legacy local/scripts)
+ *
+ * Trailing slashes are stripped. Empty string means "not configured".
+ * Vault leaf: `revealui/prod/public/api-url` (synced onto revealui-api).
+ */
+export function resolveSelfApiBaseUrl(
+  override?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const raw =
+    (override && override.trim()) ||
+    env.REVEALUI_API_URL?.trim() ||
+    env.NEXT_PUBLIC_API_URL?.trim() ||
+    env.API_URL?.trim() ||
+    '';
+  return raw.replace(/\/+$/, '');
+}
+
+/** Loud missing-config message for the governed MCP credentialsProvider. */
+export const MISSING_SELF_API_URL_MESSAGE =
+  'governed MCP endpoint: REVEALUI_API_URL is not configured ' +
+  '(set REVEALUI_API_URL to this API public origin; vault path ' +
+  'revealui/prod/public/api-url; sync via scripts/sync/revvault-vercel.toml → revealui-api)';

--- a/apps/server/src/routes/mcp-endpoint.ts
+++ b/apps/server/src/routes/mcp-endpoint.ts
@@ -54,9 +54,13 @@ import type { Handler, MiddlewareHandler } from 'hono';
 import { Hono } from 'hono';
 import { recordMcpToolAudit } from '../lib/mcp-audit.js';
 import { authorizeMcpTool, type McpTier } from '../lib/mcp-tool-access.js';
+import { MISSING_SELF_API_URL_MESSAGE, resolveSelfApiBaseUrl } from '../lib/self-api-url.js';
 import { authMiddleware } from '../middleware/auth.js';
 import { entitlementMiddleware, getEntitlementsFromContext } from '../middleware/entitlements.js';
 import { requireFeature } from '../middleware/license.js';
+
+// Re-export for callers/tests that already imported from this module path.
+export { resolveSelfApiBaseUrl } from '../lib/self-api-url.js';
 
 /**
  * Minimal structural mirror of the MCP SDK's `AuthInfo`. Defined locally so
@@ -85,7 +89,7 @@ export interface McpEndpointConfig {
   /**
    * Base URL the governed tools call back into (this same API). The forwarded
    * REST request carries the caller's token, so identity reaches enforcement.
-   * Defaults to `REVEALUI_API_URL`.
+   * Defaults via {@link resolveSelfApiBaseUrl} (`REVEALUI_API_URL` first).
    */
   selfApiBaseUrl?: string;
   /** DNS-rebinding guard: allowed `Host` headers. Defaults from env. */
@@ -157,7 +161,7 @@ export interface McpEndpointParts {
  * without shadowing the sibling `/api/mcp/usage` route.
  */
 export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointParts {
-  const selfApiBaseUrl = config.selfApiBaseUrl ?? process.env.REVEALUI_API_URL ?? '';
+  const selfApiBaseUrl = resolveSelfApiBaseUrl(config.selfApiBaseUrl);
   const allowedHosts = config.allowedHosts ?? splitEnvList(process.env.REVEALUI_MCP_ALLOWED_HOSTS);
   const allowedOrigins =
     config.allowedOrigins ?? splitEnvList(process.env.REVEALUI_MCP_ALLOWED_ORIGINS);
@@ -202,7 +206,7 @@ export function buildMcpEndpoint(config: McpEndpointConfig = {}): McpEndpointPar
       throw new Error('governed MCP endpoint: no per-request credential — refusing tool call');
     }
     if (!selfApiBaseUrl) {
-      throw new Error('governed MCP endpoint: REVEALUI_API_URL is not configured');
+      throw new Error(MISSING_SELF_API_URL_MESSAGE);
     }
     return { apiUrl: selfApiBaseUrl, apiKey: token };
   };

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -123,7 +123,7 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/passkey/rp-id` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/passkey/rp-name` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/preview-token-secret` | credential | yes | vercel:api | HMAC-SHA256 key for edit-session preview tokens - short-lived read-only credential |
-| `revealui/prod/public/api-url` | public-config | no | vercel:admin, vercel:marketing, vercel:docs |  |
+| `revealui/prod/public/api-url` | public-config | no | vercel:api, vercel:admin, vercel:marketing, vercel:docs | required@boot; api self-origin: REVEALUI_API_URL (+ NEXT_PUBLIC_API_URL twin). Governed MCP tools fail without it. |
 | `revealui/prod/public/is-live` | public-config | no | vercel:admin, vercel:marketing | NEXT_PUBLIC_IS_LIVE - Stripe live-mode feature flag |
 | `revealui/prod/public/server-url` | public-config | no | vercel:api, vercel:admin, vercel:marketing, fly:worker |  |
 | `revealui/prod/r2/access-key-id` | credential | yes | vercel:api, vercel:admin, fly:worker |  |
@@ -173,7 +173,7 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/staging/passkey/origin` | public-config | no | vercel:api-staging, vercel:admin-staging | the admin app origin, https://admin.staging.revealui.com |
 | `revealui/staging/passkey/rp-id` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
 | `revealui/staging/passkey/rp-name` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
-| `revealui/staging/public/api-url` | public-config | no | vercel:admin-staging, vercel:marketing-staging | the api own origin; also VITE_API_URL on marketing (the anti-cross-wire fix, GAP-343) |
+| `revealui/staging/public/api-url` | public-config | no | vercel:api-staging, vercel:admin-staging, vercel:marketing-staging | the api own origin (MCP loopback + OpenAPI); also VITE_API_URL on marketing (anti-cross-wire, GAP-343) |
 | `revealui/staging/public/server-url` | public-config | no | vercel:api-staging, vercel:admin-staging, vercel:marketing-staging | the admin app own origin (parity with the prod server-url leaf) |
 | `revealui/staging/r2/access-key-id` | credential | yes | vercel:api-staging, vercel:admin-staging |  |
 | `revealui/staging/r2/account-id` | public-config | no | vercel:api-staging, vercel:admin-staging |  |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "revealui",
   "version": "0.4.0",
   "private": true,
-  "description": "Agentic business runtime. Users, content, products, payments, and AI — pre-wired, open source, and ready to deploy.",
+  "description": "Agentic business runtime. Users, content, products, payments, and AI \u2014 pre-wired, open source, and ready to deploy.",
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@biomejs/biome": "catalog:",
@@ -61,11 +61,11 @@
   "packageManager": "pnpm@10.28.2",
   "pnpm": {
     "overrides": {
-      "shell-quote": ">=1.8.4",
+      "shell-quote": ">=1.9.0",
       "form-data": ">=4.0.6",
       "path-to-regexp": ">=6.3.0",
       "tar-fs": ">=2.1.4",
-      "tar": ">=7.5.16",
+      "tar": ">=7.5.19",
       "drizzle-orm": "^0.45.2",
       "lodash": ">=4.18.0",
       "lodash-es": ">=4.18.0",
@@ -82,7 +82,7 @@
       "js-yaml@4": ">=4.2.0",
       "js-yaml@3": "^3.15.0",
       "minimatch": ">=10.2.4",
-      "brace-expansion@5": ">=5.0.6",
+      "brace-expansion@5": ">=5.0.7",
       "rollup": ">=4.59.0",
       "serialize-javascript": ">=7.0.3",
       "immutable": ">=5.1.5",
@@ -113,7 +113,8 @@
       "ws@8": ">=8.20.1",
       "@revealui/config": "workspace:*",
       "@revealui/contracts": "workspace:*",
-      "@revealui/db": "workspace:*"
+      "@revealui/db": "workspace:*",
+      "js-yaml@5": ">=5.2.1"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,11 +104,11 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  shell-quote: '>=1.8.4'
+  shell-quote: '>=1.9.0'
   form-data: '>=4.0.6'
   path-to-regexp: '>=6.3.0'
   tar-fs: '>=2.1.4'
-  tar: '>=7.5.16'
+  tar: '>=7.5.19'
   drizzle-orm: ^0.45.2
   lodash: '>=4.18.0'
   lodash-es: '>=4.18.0'
@@ -125,7 +125,7 @@ overrides:
   js-yaml@4: '>=4.2.0'
   js-yaml@3: ^3.15.0
   minimatch: '>=10.2.4'
-  brace-expansion@5: '>=5.0.6'
+  brace-expansion@5: '>=5.0.7'
   rollup: '>=4.59.0'
   serialize-javascript: '>=7.0.3'
   immutable: '>=5.1.5'
@@ -157,6 +157,7 @@ overrides:
   '@revealui/config': workspace:*
   '@revealui/contracts': workspace:*
   '@revealui/db': workspace:*
+  js-yaml@5: '>=5.2.1'
 
 importers:
 
@@ -5326,8 +5327,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -7957,8 +7958,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -8274,10 +8275,6 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
-    engines: {node: '>=18'}
 
   tar@7.5.19:
     resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
@@ -11899,7 +11896,7 @@ snapshots:
       semver: 7.5.4
       stat-mode: 0.3.0
       stream-to-promise: 2.2.0
-      tar: 7.5.16
+      tar: 7.5.19
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
@@ -12617,7 +12614,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12807,7 +12804,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -14513,7 +14510,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 
@@ -15453,7 +15450,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -15758,14 +15755,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-
-  tar@7.5.16:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
 
   tar@7.5.19:
     dependencies:

--- a/scripts/sync/revvault-vercel-staging.toml
+++ b/scripts/sync/revvault-vercel-staging.toml
@@ -150,6 +150,9 @@ REVEALUI_BILLING_PORTAL_CONFIG_ID = "revealui/staging/stripe/billing-portal-conf
 # binding, both of which treat NEXT_PUBLIC_SERVER_URL as the admin origin.
 NEXT_PUBLIC_SERVER_URL     = "revealui/staging/public/server-url"
 REVEALUI_PUBLIC_SERVER_URL = "revealui/staging/public/server-url"
+# Self origin for governed MCP tool loopback (parity with prod api).
+REVEALUI_API_URL           = "revealui/staging/public/api-url"
+NEXT_PUBLIC_API_URL        = "revealui/staging/public/api-url"
 
 
 # ── revealui-admin-staging ──────────────────────────────────────────────────

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -144,6 +144,12 @@ ELECTRIC_SECRET      = { path = "revealui/prod/electric/secret", sensitive = tru
 # Public (bundled into client; not secret, kept canonical for reproducibility)
 NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
 REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
+# Self origin for governed MCP tool loopback (credentialsProvider → REST).
+# Missing on api caused live tool calls to fail while /api/mcp auth still
+# returned 400 Session ID required (auth green, tools dead). Same vault leaf
+# as admin/marketing NEXT_PUBLIC_API_URL / REVEALUI_API_URL.
+REVEALUI_API_URL           = "revealui/prod/public/api-url"
+NEXT_PUBLIC_API_URL        = "revealui/prod/public/api-url"
 
 
 # ── revealui-admin ──────────────────────────────────────────────────────────

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -517,7 +517,11 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'public-config',
     sensitive: false,
     tier: 'prod',
-    consumers: ['vercel:admin', 'vercel:marketing', 'vercel:docs'],
+    // vercel:api is required for governed MCP tool loopback (self REST calls).
+    consumers: ['vercel:api', 'vercel:admin', 'vercel:marketing', 'vercel:docs'],
+    requiredInProdHosted: true,
+    envVars: ['REVEALUI_API_URL'],
+    note: 'api self-origin: REVEALUI_API_URL (+ NEXT_PUBLIC_API_URL twin). Governed MCP tools fail without it.',
   },
   {
     path: 'revealui/prod/public/is-live',
@@ -811,8 +815,8 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'public-config',
     sensitive: false,
     tier: 'staging',
-    consumers: ['vercel:admin-staging', 'vercel:marketing-staging'],
-    note: 'the api own origin; also VITE_API_URL on marketing (the anti-cross-wire fix, GAP-343)',
+    consumers: ['vercel:api-staging', 'vercel:admin-staging', 'vercel:marketing-staging'],
+    note: 'the api own origin (MCP loopback + OpenAPI); also VITE_API_URL on marketing (anti-cross-wire, GAP-343)',
   },
 
   // ── Env bundle (derived, verify-only - NOT synced to any platform) ────────


### PR DESCRIPTION
## Summary
Level 1 MCP auth was green while tool calls failed with `REVEALUI_API_URL is not configured`. Root cause: vault leaf `revealui/prod/public/api-url` and admin/marketing sync existed, but **revealui-api never received the env**.

## Durable fix
1. **Sync:** `REVEALUI_API_URL` + `NEXT_PUBLIC_API_URL` on `revealui-api` (prod) and `revealui-api-staging`.
2. **Spec:** `secret-paths` consumers + `requiredInProdHosted` + SECRETS.md regen.
3. **Boot:** `REQUIRED_IN_PRODUCTION_HOSTED` includes `REVEALUI_API_URL` so hosted deploys fail loud instead of shipping dead MCP tools.
4. **Code:** leaf `resolveSelfApiBaseUrl` cascade (`REVEALUI_API_URL` → `NEXT_PUBLIC_API_URL` → `API_URL`) used by MCP credentialsProvider + OpenAPI servers list.

## Owner after merge
```bash
cd ~/revfleet/revealui
pnpm vercel:sync:apply
# redeploy api (or wait for next deploy) so production picks up the env
```

## Test plan
- [x] `self-api-url` unit tests
- [x] secret-paths lockstep + prod-required coverage
- [x] local `pnpm gate` feature-branch path PASS
- [ ] After owner sync: dogfood `revealui_list_sites` from Grok MCP

Posture: owner merges; no self-merge.