### PR TITLE
fix(mcp): call content REST under /api/content/*

### DIFF
--- a/apps/server/src/routes/__tests__/mcp-endpoint.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/mcp-endpoint.pglite.test.ts
@@ -156,7 +156,7 @@ function startStubBackend(): Promise<void> {
       res.end(JSON.stringify({ error: 'unauthorized' }));
       return;
     }
-    if (url.pathname === '/api/sites') {
+    if (url.pathname === '/api/content/sites') {
       const owned = Object.entries(SITE_OWNERS)
         .filter(([, owner]) => owner === user)
         .map(([id]) => ({ id }));

--- a/packages/mcp/__tests__/revealui-content-factory.integration.test.ts
+++ b/packages/mcp/__tests__/revealui-content-factory.integration.test.ts
@@ -142,7 +142,7 @@ describe('revealui-content factory over Streamable HTTP', () => {
 
   it('proxies a tool call through the MCP HTTP transport to a mocked RevealUI API', async () => {
     const mockApi = await startMockApi({
-      '/api/sites': {
+      '/api/content/sites': {
         sites: [
           { id: 'site_1', name: 'Demo Site', createdAt: '2026-04-22T00:00:00Z' },
           { id: 'site_2', name: 'Another Site', createdAt: '2026-04-22T01:00:00Z' },
@@ -190,7 +190,7 @@ describe('revealui-content factory over Streamable HTTP', () => {
     expect(parsed._meta.tool).toBe('revealui_list_sites');
 
     // Mock API must have been called with the correct headers.
-    const apiReq = mockApi.requests.find((r) => r.path === '/api/sites');
+    const apiReq = mockApi.requests.find((r) => r.path === '/api/content/sites');
     expect(apiReq).toBeDefined();
     expect(apiReq?.headers.authorization).toBe('Bearer test-api-key');
     expect(apiReq?.headers['user-agent']).toBe('RevealUI-MCP/1.0');
@@ -214,15 +214,15 @@ describe('revealui-content factory over Streamable HTTP', () => {
 
   it('lists content collections as MCP resources', async () => {
     const mockApi = await startMockApi({
-      '/api/posts': {
+      '/api/content/posts': {
         docs: [
           { id: 'p1', title: 'First post' },
           { id: 'p2', title: 'Second post' },
         ],
       },
-      '/api/pages': { docs: [{ id: 'pg1', title: 'Home' }] },
-      '/api/products': { docs: [{ id: 'pr1', name: 'Widget' }] },
-      '/api/media': { docs: [{ id: 'm1', filename: 'hero.jpg' }] },
+      '/api/content/pages': { docs: [{ id: 'pg1', title: 'Home' }] },
+      '/api/content/products': { docs: [{ id: 'pr1', name: 'Widget' }] },
+      '/api/content/media': { docs: [{ id: 'm1', filename: 'hero.jpg' }] },
     });
     teardowns.push(mockApi.close);
     process.env.REVEALUI_API_URL = mockApi.url;
@@ -256,11 +256,11 @@ describe('revealui-content factory over Streamable HTTP', () => {
   });
 
   it('survives partial failure — an unavailable collection does not blank the list', async () => {
-    // /api/pages returns 404 (intentionally omitted); /api/posts returns docs.
+    // /api/content/pages returns 404 (intentionally omitted); /api/content/posts returns docs.
     const mockApi = await startMockApi({
-      '/api/posts': { docs: [{ id: 'p1', title: 'Only post' }] },
-      '/api/products': { docs: [] },
-      '/api/media': { docs: [] },
+      '/api/content/posts': { docs: [{ id: 'p1', title: 'Only post' }] },
+      '/api/content/products': { docs: [] },
+      '/api/content/media': { docs: [] },
     });
     teardowns.push(mockApi.close);
     process.env.REVEALUI_API_URL = mockApi.url;
@@ -284,7 +284,7 @@ describe('revealui-content factory over Streamable HTTP', () => {
 
   it('reads a resource by URI', async () => {
     const mockApi = await startMockApi({
-      '/api/posts/p1': { id: 'p1', title: 'First post', body: 'hello world' },
+      '/api/content/posts/p1': { id: 'p1', title: 'First post', body: 'hello world' },
     });
     teardowns.push(mockApi.close);
     process.env.REVEALUI_API_URL = mockApi.url;
@@ -348,10 +348,10 @@ describe('revealui-content factory over Streamable HTTP', () => {
           { slug: 'users', label: 'User', labelPlural: 'Users', mcpResource: false },
         ],
       },
-      '/api/posts': { docs: [{ id: 'p1', title: 'First post' }] },
-      // Even though /api/users would return docs, mcpResource: false should
+      '/api/content/posts': { docs: [{ id: 'p1', title: 'First post' }] },
+      // Even though /api/content/users would return docs, mcpResource: false should
       // prevent the factory from even asking for them.
-      '/api/users': { docs: [{ id: 'u1', email: 'user@example.com' }] },
+      '/api/content/users': { docs: [{ id: 'u1', email: 'user@example.com' }] },
     });
     teardowns.push(mockApi.close);
     process.env.REVEALUI_API_URL = mockApi.url;
@@ -375,8 +375,8 @@ describe('revealui-content factory over Streamable HTTP', () => {
     // Factory should have asked for collections once and posts once, but
     // never users (opted out at the summary layer).
     expect(mockApi.requests.some((r) => r.path === '/api/mcp/collections')).toBe(true);
-    expect(mockApi.requests.some((r) => r.path === '/api/posts')).toBe(true);
-    expect(mockApi.requests.some((r) => r.path === '/api/users')).toBe(false);
+    expect(mockApi.requests.some((r) => r.path === '/api/content/posts')).toBe(true);
+    expect(mockApi.requests.some((r) => r.path === '/api/content/users')).toBe(false);
   });
 
   it('injected collectionsProvider takes precedence over HTTP introspection', async () => {
@@ -388,7 +388,7 @@ describe('revealui-content factory over Streamable HTTP', () => {
       '/api/mcp/collections': {
         collections: [{ slug: 'posts', label: 'Post', labelPlural: 'Posts', mcpResource: true }],
       },
-      '/api/pages': { docs: [{ id: 'pg1', title: 'Home' }] },
+      '/api/content/pages': { docs: [{ id: 'pg1', title: 'Home' }] },
     });
     teardowns.push(mockApi.close);
     process.env.REVEALUI_API_URL = mockApi.url;
@@ -422,10 +422,10 @@ describe('revealui-content factory over Streamable HTTP', () => {
     // HTTP introspection fails. The curated set (posts/pages/products/
     // media) must still drive resource enumeration.
     const mockApi = await startMockApi({
-      '/api/posts': { docs: [{ id: 'p1', title: 'Only post' }] },
-      '/api/pages': { docs: [] },
-      '/api/products': { docs: [] },
-      '/api/media': { docs: [] },
+      '/api/content/posts': { docs: [{ id: 'p1', title: 'Only post' }] },
+      '/api/content/pages': { docs: [] },
+      '/api/content/products': { docs: [] },
+      '/api/content/media': { docs: [] },
     });
     teardowns.push(mockApi.close);
     process.env.REVEALUI_API_URL = mockApi.url;

--- a/packages/mcp/__tests__/revealui-content-governed.test.ts
+++ b/packages/mcp/__tests__/revealui-content-governed.test.ts
@@ -316,12 +316,12 @@ describe('I-5 a receipt per call', () => {
 // Per-tool authz (I-7) is only sound if one tool cannot reach another tool's
 // endpoint. `revealui_list_content` / `revealui_get_content` interpolate the
 // `collection` arg into `/api/<collection>`, so a free-string collection would
-// let a content tool reach e.g. `/api/users` — bypassing the admin gate on the
+// let a content tool reach e.g. `/api/content/users` — bypassing the admin gate on the
 // separate `revealui_list_users` tool. The factory now validates `collection`
 // against the RESOLVED exposed-collections allowlist, deny-by-default.
 
 describe('content tools reject collections outside the exposed allowlist', () => {
-  it('revealui_list_content denies collection=users — denied receipt, /api/users never reached', async () => {
+  it('revealui_list_content denies collection=users — denied receipt, /api/content/users never reached', async () => {
     const backend = await startFakeBackend(okBackend);
     // No collectionsProvider → curated fallback (posts/pages/products/media)
     // is the exposed set; `users` is not in it.
@@ -337,7 +337,7 @@ describe('content tools reject collections outside the exposed allowlist', () =>
     expect(result.isError).toBe(true);
     // The ambient/user backend is never reached for an unexposed collection.
     expect(backend.calls).toHaveLength(0);
-    expect(backend.calls.some((c) => c.url.startsWith('/api/users'))).toBe(false);
+    expect(backend.calls.some((c) => c.url.startsWith('/api/content/users'))).toBe(false);
     expect(governed.audits).toHaveLength(1);
     expect(governed.audits[0]?.outcome).toBe('denied');
     expect(governed.audits[0]?.reason).toBe('collection-not-exposed');
@@ -376,7 +376,7 @@ describe('content tools reject collections outside the exposed allowlist', () =>
     await client.close();
 
     expect(result.isError).toBeFalsy();
-    expect(backend.calls.some((c) => c.url.startsWith('/api/posts'))).toBe(true);
+    expect(backend.calls.some((c) => c.url.startsWith('/api/content/posts'))).toBe(true);
     expect(governed.audits[0]?.outcome).toBe('invoked');
   });
 
@@ -399,10 +399,10 @@ describe('content tools reject collections outside the exposed allowlist', () =>
     await client.close();
 
     expect(exposed.isError).toBeFalsy();
-    expect(backend.calls.some((c) => c.url.startsWith('/api/articles'))).toBe(true);
+    expect(backend.calls.some((c) => c.url.startsWith('/api/content/articles'))).toBe(true);
     // `posts` is in the curated fallback but NOT in the resolved provider set → denied.
     expect(curatedButNotExposed.isError).toBe(true);
-    expect(backend.calls.some((c) => c.url.startsWith('/api/posts'))).toBe(false);
+    expect(backend.calls.some((c) => c.url.startsWith('/api/content/posts'))).toBe(false);
   });
 });
 

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -793,8 +793,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
     }
 
     // Deny-by-default collection allowlist. The content tools interpolate the
-    // `collection` arg into `/api/<collection>`, so a free-string collection
-    // would let one tool reach another tool's endpoint (e.g. `/api/content/users`,
+    // `collection` arg into `/api/content/<collection>`, so a free-string
+    // collection would let one tool reach another endpoint (e.g. users,
     // bypassing the admin gate on `revealui_list_users`). A collection outside
     // the RESOLVED exposed set is denied before any REST call — the backend is
     // never reached for an unexposed collection.

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -699,7 +699,7 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
       const resources: Resource[] = [];
       for (const collection of collections) {
         try {
-          const body = await apiGet(apiUrl, apiKey, `/api/${collection.slug}`, {
+          const body = await apiGet(apiUrl, apiKey, `/api/content/${collection.slug}`, {
             limit: String(DEFAULT_RESOURCE_PAGE_SIZE),
             page: '1',
           });
@@ -731,7 +731,7 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
         throw new Error('REVEALUI_API_URL and REVEALUI_API_KEY must be set');
       }
 
-      const row = await apiGet(apiUrl, apiKey, `/api/${parsed.collection}/${parsed.id}`);
+      const row = await apiGet(apiUrl, apiKey, `/api/content/${parsed.collection}/${parsed.id}`);
       return {
         contents: [
           {
@@ -794,7 +794,7 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
 
     // Deny-by-default collection allowlist. The content tools interpolate the
     // `collection` arg into `/api/<collection>`, so a free-string collection
-    // would let one tool reach another tool's endpoint (e.g. `/api/users`,
+    // would let one tool reach another tool's endpoint (e.g. `/api/content/users`,
     // bypassing the admin gate on `revealui_list_users`). A collection outside
     // the RESOLVED exposed set is denied before any REST call — the backend is
     // never reached for an unexposed collection.
@@ -909,7 +909,8 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
           const parsed = validateToolArgs(ListSitesArgsSchema, rawArgs, toolName);
           if (!parsed.ok) return denied(parsed.error);
           const { limit = 20, page = 1 } = parsed.value;
-          data = await apiGet(apiUrl, apiKey, '/api/sites', {
+          // Content REST is mounted under /api/content/* (not bare /api/*).
+          data = await apiGet(apiUrl, apiKey, '/api/content/sites', {
             limit: String(limit),
             page: String(page),
           });
@@ -929,7 +930,7 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
           if (site_id) params.siteId = site_id;
           if (status) params.status = status;
 
-          data = await apiGet(apiUrl, apiKey, `/api/${collection}`, params);
+          data = await apiGet(apiUrl, apiKey, `/api/content/${collection}`, params);
           break;
         }
 
@@ -939,7 +940,7 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
           const { collection, id } = parsed.value;
           const notExposed = await denyIfCollectionNotExposed(collection);
           if (notExposed) return notExposed;
-          data = await apiGet(apiUrl, apiKey, `/api/${collection}/${id}`);
+          data = await apiGet(apiUrl, apiKey, `/api/content/${collection}/${id}`);
           break;
         }
 
@@ -953,18 +954,17 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
           };
           if (site_id) params.siteId = site_id;
 
-          data = await apiGet(apiUrl, apiKey, '/api/users', params);
+          data = await apiGet(apiUrl, apiKey, '/api/content/users', params);
           break;
         }
 
         case 'revealui_site_stats': {
           const parsed = validateToolArgs(SiteStatsArgsSchema, rawArgs, toolName);
           if (!parsed.ok) return denied(parsed.error);
-          const { site_id } = parsed.value;
-          const params: Record<string, string> = {};
-          if (site_id) params.siteId = site_id;
-
-          data = await apiGet(apiUrl, apiKey, '/api/health', params);
+          // Aggregate health is not under /api/* — public readiness probe.
+          // site_id is accepted for forward-compat; readiness is process-global.
+          void parsed.value.site_id;
+          data = await apiGet(apiUrl, apiKey, '/health/ready', {});
           break;
         }
 


### PR DESCRIPTION
## Summary
After `vercel:sync:apply` put **REVEALUI_API_URL** on revealui-api, Level 1 MCP still failed to dogfood because governed tools called **wrong REST paths**.

| Tool path (old) | Live API |
|-----------------|----------|
| `/api/sites` | **404** |
| `/api/content/sites` | **200** (fleet-marketing present) |
| `/api/users` | **404** |
| `/api/content/users` | **200** |
| `/api/<collection>` | **404** |
| `/api/content/<collection>` | **200** |

Content routes mount under `/api/content/*` (`apps/server/src/routes/content/index.ts`). The MCP factory still used bare `/api/*` (tests mocked those paths and hid the bug).

## Fix
- `revealui-content` factory: all tool + resource REST calls use `/api/content/…`
- `revealui_site_stats` → `/health/ready` (there is no `/api/health`)
- Tests updated; 25/25 mcp content integration/governed tests pass

## Owner after merge
Promote to main (or wait for next train) so **production** MCP tools pick this up. Env sync alone is not enough for path bugs.

## Related
- #2021 REVEALUI_API_URL on api (env) — **done** via `pnpm vercel:sync:apply`
- Electric vault shape errors on sync are separate (service-url looks like Vercel ciphertext in vault)

Posture: owner merges; no self-merge.