### PR TITLE
fix(server): colocate swagger-ui assets for Vercel NFT (prod outage)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -55,10 +55,11 @@
     }
   },
   "scripts": {
-    "build": "tsup && pnpm run copy-sandbox-runner && pnpm run copy-resvg-wasm && pnpm run copy-og-fonts",
+    "build": "tsup && pnpm run copy-sandbox-runner && pnpm run copy-resvg-wasm && pnpm run copy-og-fonts && pnpm run copy-swagger-ui",
     "copy-sandbox-runner": "mkdir -p dist && cp src/services/revmarket-sandbox/revmarket-task-runner.mjs dist/",
     "copy-resvg-wasm": "node scripts/copy-resvg-wasm.mjs",
     "copy-og-fonts": "node scripts/copy-og-fonts.mjs",
+    "copy-swagger-ui": "node scripts/copy-swagger-ui.mjs",
     "dev": "tsx watch src/index.ts",
     "lint": "biome check .",
     "start": "node dist/index.js",

--- a/apps/server/scripts/copy-swagger-ui.mjs
+++ b/apps/server/scripts/copy-swagger-ui.mjs
@@ -1,0 +1,35 @@
+/**
+ * Copies swagger-ui-dist static assets next to the built bundle
+ * (dist/assets/swagger-ui/*).
+ *
+ * apps/server/src/index.ts serves /docs via readFileSync of those assets.
+ * After GAP-401, resolution uses import.meta.resolve / require.resolve, which
+ * @vercel/nft does not reliably keep in the serverless file set — especially
+ * with GAP-403 excludeFiles shrinking the monorepo NFT wall. Production cold
+ * start then dies with:
+ *   ERR_MODULE_NOT_FOUND: Cannot find package 'swagger-ui-dist'
+ * (deploy dpl_3hid… after #2027; FUNCTION_INVOCATION_FAILED on every route).
+ *
+ * Colocate + vercel.json includeFiles matches copy-resvg-wasm / copy-og-fonts.
+ */
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const distDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'assets', 'swagger-ui');
+mkdirSync(distDir, { recursive: true });
+
+const files = [
+  'swagger-ui.css',
+  'swagger-ui-bundle.js',
+  'swagger-ui-standalone-preset.js',
+];
+
+for (const name of files) {
+  const from = require.resolve(`swagger-ui-dist/${name}`);
+  const to = join(distDir, name);
+  copyFileSync(from, to);
+  process.stdout.write(`copy-swagger-ui: ${from} -> ${to}\n`);
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -20,6 +20,7 @@ if (process.env.SENTRY_DSN) {
 }
 
 import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getHeapStatistics } from 'node:v8';
 import { serve } from '@hono/node-server';
@@ -992,23 +993,28 @@ app.doc('/openapi.json', {
 });
 
 // Self-hosted Swagger UI (no CDN, CSP-strict compatible).
-// Resolve assets via import.meta.resolve so BOTH runtimes work (GAP-401):
-// - `tsx watch` has no tsup banner `require`
-// - the tsup banner injects `createRequire` + `const require`; a second
-//   `import { createRequire }` in this file becomes a SyntaxError in the
-//   bundled chunk (Identifier 'createRequire' has already been declared)
-const swaggerCss = readFileSync(
-  fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui.css')),
-  'utf-8',
-);
-const swaggerBundleJs = readFileSync(
-  fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui-bundle.js')),
-  'utf-8',
-);
-const swaggerPresetJs = readFileSync(
-  fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui-standalone-preset.js')),
-  'utf-8',
-);
+// Prefer dist/assets/swagger-ui copies from copy-swagger-ui (prod / NFT-safe).
+// Fall back to import.meta.resolve for tsx watch (GAP-401). Do NOT rely on
+// package resolution alone on Vercel: after GAP-403 excludeFiles, NFT drops
+// swagger-ui-dist and cold start throws ERR_MODULE_NOT_FOUND (FUNCTION_INVOCATION_FAILED).
+function readSwaggerAsset(filename: string): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, 'assets', 'swagger-ui', filename),
+    join(here, '..', 'assets', 'swagger-ui', filename),
+  ];
+  for (const path of candidates) {
+    try {
+      return readFileSync(path, 'utf-8');
+    } catch {
+      // try next / package resolve
+    }
+  }
+  return readFileSync(fileURLToPath(import.meta.resolve(`swagger-ui-dist/${filename}`)), 'utf-8');
+}
+const swaggerCss = readSwaggerAsset('swagger-ui.css');
+const swaggerBundleJs = readSwaggerAsset('swagger-ui-bundle.js');
+const swaggerPresetJs = readSwaggerAsset('swagger-ui-standalone-preset.js');
 const swaggerInitJs = `window.addEventListener('load', function () {
   window.ui = SwaggerUIBundle({
     url: '/openapi.json',

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -6,7 +6,7 @@
     "api/**": {
       "memory": 512,
       "maxDuration": 30,
-      "includeFiles": "{dist/index_bg.wasm,dist/assets/fonts/**}",
+      "includeFiles": "{dist/index_bg.wasm,dist/assets/fonts/**,dist/assets/swagger-ui/**}",
       "excludeFiles": "{**/*.ts,**/*.tsx,apps/admin/**,apps/marketing/**,apps/docs/**,packages/**/src/**,packages/**/templates/**,**/coverage/**,**/.next/**,**/.turbo/**,**/__tests__/**}"
     }
   },


### PR DESCRIPTION
## Summary

Production api after #2027 cold-started with **FUNCTION_INVOCATION_FAILED** on every route (including `/health/*`).

### Root cause (runtime logs on `dpl_3hidTMMbWiVTcYdr4uRXc4kCPnvx`)

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'swagger-ui-dist'
  imported from /var/task/apps/server/dist/chunk-….js
```

Module load still reaches CORS init, then dies when reading swagger assets for `/docs`. GAP-401 switched to `import.meta.resolve('swagger-ui-dist/…')`; combined with GAP-403 `excludeFiles`, **@vercel/nft no longer keeps `swagger-ui-dist` in the serverless file set**.

`validate:prod-env` and `REVEALUI_API_URL` were **not** the failure mode (env checks pass; crash is package missing).

### Mitigations already live

- `api.revealui.com` alias currently points at prior good deploy (`dpl_G64d…` / #2008 train) — **health endpoints 200**.
- Broken #2027 api deployment still 500s on its direct URL.

### Fix

Same pattern as resvg WASM / OG fonts:

1. `scripts/copy-swagger-ui.mjs` → `dist/assets/swagger-ui/*`
2. Wired into `server` `build` script
3. `vercel.json` `includeFiles` adds `dist/assets/swagger-ui/**`
4. `index.ts` prefers colocated paths; falls back to package resolve for tsx

## Test plan

- [x] `node scripts/copy-swagger-ui.mjs` copies three assets
- [x] local phase-1 gate PASS
- [ ] CI green on this PR
- [ ] Owner: merge → promote (or redeploy api from main after promote) → confirm `api.revealui.com/health/ready` 200 on the **new** deployment URL
- [ ] Confirm `/docs` still serves swagger CSS/JS

## Coord

P0 claim note: `.jv/.claude/workboard.d/notes/2026-07-21T02-prod-outage-coord.md`