### PR TITLE
chore(release): promote test to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -432,13 +432,16 @@ jobs:
     needs: [detect, deploy]
 
     steps:
-      # pnpm is required by the "Rollback on failure" step below. Without
-      # this setup, the rollback fails with `pnpm: command not found`
-      # before it can install vercel CLI, which leaves a broken deploy
-      # live (precedent: 2026-04-25 #540 incident, GAP-122).
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      # Checkout required for durable REST rollback script on failure
+      # (scripts/deploy/vercel-rollback-previous-prod.mjs). Shallow is enough.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v5.0.0
         with:
-          version: ${{ env.PNPM_VERSION }}
+          fetch-depth: 1
+
+      # Node for the rollback script (no pnpm/vercel CLI parse path).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v5.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Health check — API (readiness probe)
         run: |
@@ -499,93 +502,39 @@ jobs:
 
       - name: Rollback on failure
         if: failure()
-        # Per GAP-128: `vercel rollback` with no URL argument is a STATUS
-        # QUERY ("checking rollback status..."), not an action. To actually
-        # roll back, we must pass the previous-good deployment URL. This
-        # step pre-fetches it via `vercel ls --prod` and rolls the alias
-        # explicitly, then verifies the alias moved.
+        # Durable rollback (2026-07-21 #2027 postmortem): do NOT parse
+        # `vercel ls | grep | sed`. That path returned empty when
+        # VERCEL_TEAM_SLUG was set from TURBO_TEAM (wrong team vs the
+        # project-owning team id), left broken aliases live, and required
+        # manual REST alias reassignment.
         #
-        # Team scope: VERCEL_ORG_ID (team ID secret) is intentionally
-        # cleared here. `vercel rollback <url>` validates the deployment
-        # against the team from VERCEL_ORG_ID, but if the secret holds a
-        # value that doesn't match the team that owns the deployments it
-        # produces "Deployment belongs to a different team" (2026-05-15
-        # incident). The deploy step works because it uses VERCEL_PROJECT_ID
-        # directly and doesn't go through the same team-scope validation.
-        # Fix: route via --scope (team slug) instead of VERCEL_ORG_ID (team ID).
+        # Use scripts/deploy/vercel-rollback-previous-prod.mjs:
+        # Vercel REST + VERCEL_ORG_ID (team id secret) + project id from
+        # detect matrix. Reassigns every alias on the newest READY prod
+        # deploy to the previous READY prod deploy and verifies.
+        #
+        # Needs checkout for the script; smoke job previously had none.
         run: |
-          # GAP-252: use set +e so any individual grep/jq failure inside the
-          # loop does not abort the script early (GitHub Actions runs with
-          # set -eo pipefail by default; a grep that matches nothing exits 1
-          # and was aborting the loop on the first app, rolling back nothing).
-          # Failures are tracked via counters and surfaced at the end.
           set +e
-          echo "::warning::Smoke test failed — rolling back affected apps"
-          pnpm add -g vercel@56.3.1
+          echo "::warning::Smoke test failed — rolling back affected apps via Vercel REST"
           APP_LIST="${{ needs.detect.outputs.app-list }}"
           ROLLBACK_FAILED=0
-          ROLLBACK_NO_HISTORY=0
           for app in $APP_LIST; do
-            # Look the project id up from the detect job's matrix (built from the
-            # single-source .github/vercel-projects.json). This job has no checkout,
-            # so it reuses the matrix via env rather than reading the file. Unknown -> skip.
             PID=$(printf '%s' "$DETECT_MATRIX" | jq -r --arg a "$app" '.[] | select(.app == $a) | .["project-id"]' 2>/dev/null) || PID=""
-            if [ -z "$PID" ]; then continue; fi
-
+            if [ -z "$PID" ] || [ "$PID" = "null" ]; then continue; fi
             echo ""
             echo "=== Rolling back $app ($PID) ==="
-
-            # 1. List recent production deployments. Take the second-most-
-            #    recent READY one — the most recent IS the broken deploy.
-            DEPLOY_LIST=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod \
-              --token="$VERCEL_TOKEN" --scope="$VERCEL_TEAM_SLUG" 2>&1 || true)
-            PREV_URL=$(printf '%s\n' "$DEPLOY_LIST" \
-              | grep -oE 'https://[a-z0-9.-]+\.vercel\.app' \
-              | sed -n '2p') || PREV_URL=""
-
-            if [ -z "$PREV_URL" ]; then
-              echo "::warning::No previous deployment found for $app — broken deploy is live, manual intervention required"
-              ROLLBACK_NO_HISTORY=$((ROLLBACK_NO_HISTORY+1))
-              continue
-            fi
-
-            echo "Previous good deploy: $PREV_URL"
-
-            # 2. Roll the alias explicitly to that URL.
-            if ! VERCEL_PROJECT_ID="$PID" vercel rollback "$PREV_URL" \
-              --token="$VERCEL_TOKEN" --scope="$VERCEL_TEAM_SLUG" --yes 2>&1; then
-              echo "::warning::vercel rollback command failed for $app"
-              ROLLBACK_FAILED=$((ROLLBACK_FAILED+1))
-              continue
-            fi
-
-            # 3. Verify the alias actually moved by inspecting the
-            #    project's current production deploy. Wait briefly for
-            #    propagation.
-            sleep 5
-            CURRENT_URL=$(VERCEL_PROJECT_ID="$PID" vercel ls --prod \
-              --token="$VERCEL_TOKEN" --scope="$VERCEL_TEAM_SLUG" 2>&1 \
-              | grep -oE 'https://[a-z0-9.-]+\.vercel\.app' \
-              | head -n 1) || CURRENT_URL=""
-
-            if [ "$CURRENT_URL" = "$PREV_URL" ]; then
-              echo "✅ Rollback verified: $app production now serving $CURRENT_URL"
-            else
-              echo "::warning::Rollback issued but verification failed — current=$CURRENT_URL, expected=$PREV_URL"
+            if ! node scripts/deploy/vercel-rollback-previous-prod.mjs \
+              --project-id "$PID" \
+              --app-label "$app"; then
+              echo "::warning::REST rollback failed for $app"
               ROLLBACK_FAILED=$((ROLLBACK_FAILED+1))
             fi
           done
-
           echo ""
           echo "=== Rollback summary ==="
-          echo "Failed:     $ROLLBACK_FAILED"
-          echo "No history: $ROLLBACK_NO_HISTORY"
-
-          # Exit non-zero so the workflow status reflects the failed
-          # smoke test AND the rollback outcome. If any rollback failed
-          # or had no history, that's a clear "broken deploy still live"
-          # signal that needs human attention.
-          if [ "$ROLLBACK_FAILED" -gt 0 ] || [ "$ROLLBACK_NO_HISTORY" -gt 0 ]; then
+          echo "Failed: $ROLLBACK_FAILED"
+          if [ "$ROLLBACK_FAILED" -gt 0 ]; then
             echo "::error::One or more apps could not be auto-rolled-back — broken deploy may still be live; investigate immediately"
             exit 1
           fi
@@ -593,10 +542,8 @@ jobs:
           exit 1
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ""
-          VERCEL_TEAM_SLUG: ${{ vars.TURBO_TEAM || 'revealuistudio' }}
-          # Reuse the matrix the detect job built from .github/vercel-projects.json
-          # (this job has no checkout, so it can't read the file directly).
+          # Team id (team_…), NOT TURBO_TEAM slug — see script header.
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           DETECT_MATRIX: ${{ needs.detect.outputs.matrix }}
 
   # ---------------------------------------------------------------------------

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -55,10 +55,11 @@
     }
   },
   "scripts": {
-    "build": "tsup && pnpm run copy-sandbox-runner && pnpm run copy-resvg-wasm && pnpm run copy-og-fonts",
+    "build": "tsup && pnpm run copy-sandbox-runner && pnpm run copy-resvg-wasm && pnpm run copy-og-fonts && pnpm run assert-og-assets",
     "copy-sandbox-runner": "mkdir -p dist && cp src/services/revmarket-sandbox/revmarket-task-runner.mjs dist/",
     "copy-resvg-wasm": "node scripts/copy-resvg-wasm.mjs",
     "copy-og-fonts": "node scripts/copy-og-fonts.mjs",
+    "assert-og-assets": "node scripts/assert-og-assets.mjs",
     "dev": "tsx watch src/index.ts",
     "lint": "biome check .",
     "start": "node dist/index.js",

--- a/apps/server/scripts/assert-og-assets.mjs
+++ b/apps/server/scripts/assert-og-assets.mjs
@@ -1,0 +1,44 @@
+/**
+ * Build-time contract: OG fonts exist under dist/ and vercel.json includeFiles
+ * ships them. Catches the 2026-07-21 class where runtime readFileSync failed
+ * in the function because assets never landed in the NFT payload.
+ *
+ * Invoked from package.json build after copy-og-fonts.
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const fontsDir = join(root, 'dist', 'assets', 'fonts');
+const vercelJsonPath = join(root, 'vercel.json');
+
+const required = ['InterTight-Regular.ttf', 'InterTight-Bold.ttf'];
+
+if (!existsSync(fontsDir)) {
+  console.error(`assert-og-assets: missing fonts dir ${fontsDir} (ran copy-og-fonts?)`);
+  process.exit(1);
+}
+
+const present = new Set(readdirSync(fontsDir));
+for (const name of required) {
+  if (!present.has(name)) {
+    console.error(`assert-og-assets: missing ${name} in ${fontsDir}`);
+    process.exit(1);
+  }
+}
+
+const vercel = JSON.parse(readFileSync(vercelJsonPath, 'utf-8'));
+const include = vercel?.functions?.['api/**']?.includeFiles;
+const includeStr = typeof include === 'string' ? include : JSON.stringify(include ?? '');
+if (!includeStr.includes('dist/assets/fonts')) {
+  console.error(
+    `assert-og-assets: vercel.json functions.api/**.includeFiles must cover dist/assets/fonts (got: ${includeStr})`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `assert-og-assets: ok (${required.join(', ')} present; includeFiles covers dist/assets/fonts)`,
+);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -51,6 +51,7 @@ import {
   installAuditStorage,
 } from './lib/audit-storage.js';
 import { queryBillingStatusByCustomerId, querySupportExpiry } from './lib/billing-status.js';
+import { createLazyHonoRoute } from './lib/lazy-hono-route.js';
 import { runHostedLicenseCanary } from './lib/license-canary.js';
 import { resolveSelfApiBaseUrl } from './lib/self-api-url.js';
 import {
@@ -126,7 +127,6 @@ import marketplaceRoute from './routes/marketplace.js';
 import { mountMcpEndpoint } from './routes/mcp-endpoint.js';
 import mcpUsageRoute from './routes/mcp-usage.js';
 import nudgesRoute from './routes/nudges.js';
-import ogRoute from './routes/og.js';
 import pricingRoute from './routes/pricing.js';
 import ragIndexRoute from './routes/rag-index.js';
 import revmarketRoute from './routes/revmarket.js';
@@ -997,18 +997,39 @@ app.doc('/openapi.json', {
 // - the tsup banner injects `createRequire` + `const require`; a second
 //   `import { createRequire }` in this file becomes a SyntaxError in the
 //   bundled chunk (Identifier 'createRequire' has already been declared)
-const swaggerCss = readFileSync(
-  fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui.css')),
-  'utf-8',
-);
-const swaggerBundleJs = readFileSync(
-  fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui-bundle.js')),
-  'utf-8',
-);
-const swaggerPresetJs = readFileSync(
-  fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui-standalone-preset.js')),
-  'utf-8',
-);
+//
+// Lazy-load on first /docs* hit. Top-level readFileSync of swagger-ui-dist
+// (or missing NFT-traced node_modules files on Vercel) would crash module
+// evaluation and take down /health with FUNCTION_INVOCATION_FAILED — same
+// class as the 2026-07-21 post-#2027 API outage.
+interface SwaggerAssets {
+  css: string;
+  bundleJs: string;
+  presetJs: string;
+}
+
+let swaggerAssetsCache: SwaggerAssets | null = null;
+
+function loadSwaggerAssets(): SwaggerAssets {
+  if (!swaggerAssetsCache) {
+    swaggerAssetsCache = {
+      css: readFileSync(
+        fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui.css')),
+        'utf-8',
+      ),
+      bundleJs: readFileSync(
+        fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui-bundle.js')),
+        'utf-8',
+      ),
+      presetJs: readFileSync(
+        fileURLToPath(import.meta.resolve('swagger-ui-dist/swagger-ui-standalone-preset.js')),
+        'utf-8',
+      ),
+    };
+  }
+  return swaggerAssetsCache;
+}
+
 const swaggerInitJs = `window.addEventListener('load', function () {
   window.ui = SwaggerUIBundle({
     url: '/openapi.json',
@@ -1022,19 +1043,19 @@ const swaggerInitJs = `window.addEventListener('load', function () {
 const IMMUTABLE_ASSET = 'public, max-age=31536000, immutable';
 
 app.get('/docs/swagger-ui.css', (c) =>
-  c.body(swaggerCss, 200, {
+  c.body(loadSwaggerAssets().css, 200, {
     'content-type': 'text/css; charset=utf-8',
     'cache-control': IMMUTABLE_ASSET,
   }),
 );
 app.get('/docs/swagger-ui-bundle.js', (c) =>
-  c.body(swaggerBundleJs, 200, {
+  c.body(loadSwaggerAssets().bundleJs, 200, {
     'content-type': 'application/javascript; charset=utf-8',
     'cache-control': IMMUTABLE_ASSET,
   }),
 );
 app.get('/docs/swagger-ui-standalone-preset.js', (c) =>
-  c.body(swaggerPresetJs, 200, {
+  c.body(loadSwaggerAssets().presetJs, 200, {
     'content-type': 'application/javascript; charset=utf-8',
     'cache-control': IMMUTABLE_ASSET,
   }),
@@ -1251,7 +1272,11 @@ app.route('/api/jobs', jobsRoute);
 app.route('/api/ghcr', ghcrRoute);
 app.route('/api/maintenance', maintenanceRoute);
 app.route('/api/marketplace', marketplaceRoute);
-app.route('/api/og', ogRoute);
+// OG image generation: lazy-load satori/resvg/fonts — never on cold-start path.
+app.route(
+  '/api/og',
+  createLazyHonoRoute(() => import('./routes/og.js')),
+);
 app.route('/api/pricing', pricingRoute);
 app.route('/api/audit', auditRoute);
 app.route('/api/revmarket', revmarketRoute);
@@ -1319,7 +1344,10 @@ app.route('/api/v1/jobs', jobsRoute);
 app.route('/api/v1/ghcr', ghcrRoute);
 app.route('/api/v1/maintenance', maintenanceRoute);
 app.route('/api/v1/marketplace', marketplaceRoute);
-app.route('/api/v1/og', ogRoute);
+app.route(
+  '/api/v1/og',
+  createLazyHonoRoute(() => import('./routes/og.js')),
+);
 app.route('/api/v1/pricing', pricingRoute);
 app.route('/api/v1/audit', auditRoute);
 app.route('/api/v1/revmarket', revmarketRoute);

--- a/apps/server/src/lib/__tests__/lazy-hono-route.test.ts
+++ b/apps/server/src/lib/__tests__/lazy-hono-route.test.ts
@@ -1,0 +1,26 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+import { createLazyHonoRoute } from '../lazy-hono-route.js';
+
+describe('createLazyHonoRoute', () => {
+  it('does not call the loader until a request hits the proxy', async () => {
+    const loader = vi.fn(async () => {
+      const app = new Hono();
+      app.get('/', (c) => c.text('lazy-ok'));
+      return { default: app };
+    });
+
+    const proxy = createLazyHonoRoute(loader);
+    expect(loader).not.toHaveBeenCalled();
+
+    const res = await proxy.request('/');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('lazy-ok');
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    // Second request reuses the cached sub-app
+    const res2 = await proxy.request('/');
+    expect(await res2.text()).toBe('lazy-ok');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/server/src/lib/lazy-hono-route.ts
+++ b/apps/server/src/lib/lazy-hono-route.ts
@@ -1,0 +1,44 @@
+/**
+ * Lazy Hono sub-app mount — durable isolation of optional surfaces from boot.
+ *
+ * Static `import './routes/og.js'` pulls satori/resvg/font resolution into the
+ * serverless cold-start module graph. A throw during that evaluation aborts
+ * the whole function (including /health) — 2026-07-21 production class.
+ *
+ * This helper mounts a proxy that dynamic-imports the real sub-app on the
+ * first request to that path only. Health and other routes never load it.
+ */
+import { Hono } from 'hono';
+
+type HonoApp = Hono;
+
+export function createLazyHonoRoute(loader: () => Promise<{ default: HonoApp }>): HonoApp {
+  let cached: HonoApp | undefined;
+  let loadPromise: Promise<HonoApp> | undefined;
+
+  async function getApp(): Promise<HonoApp> {
+    if (cached) return cached;
+    if (!loadPromise) {
+      loadPromise = loader().then((mod) => {
+        cached = mod.default;
+        return cached;
+      });
+    }
+    return loadPromise;
+  }
+
+  const proxy = new Hono();
+  // When parent does app.route('/api/og', proxy), remaining path is '/' or '/*'.
+  proxy.all('*', async (c) => {
+    const app = await getApp();
+    // Node/Vercel request() paths often have no ExecutionContext; only pass it
+    // when present so unit tests and serverless both work.
+    try {
+      const exec = c.executionCtx;
+      return app.fetch(c.req.raw, c.env, exec);
+    } catch {
+      return app.fetch(c.req.raw, c.env);
+    }
+  });
+  return proxy;
+}

--- a/apps/server/src/routes/__tests__/og-boot-safety.test.ts
+++ b/apps/server/src/routes/__tests__/og-boot-safety.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression guard for the 2026-07-21 production outage:
+ * module-level font reads in og.ts threw during `import ogRoute`, which
+ * aborted the entire serverless handler (FUNCTION_INVOCATION_FAILED on
+ * /health, not just /api/og).
+ *
+ * Importing the route module must never throw. Font load is deferred to
+ * the first /api/og request (loadOgFonts).
+ */
+import { describe, expect, it } from 'vitest';
+import { loadOgFonts, readOgFont, resetOgFontsCacheForTests } from '../og.js';
+
+describe('OG route boot safety (no module-level asset throw)', () => {
+  it('imports the og route without requiring fonts at evaluation time', async () => {
+    // Dynamic re-import exercises the module graph; a top-level throw would fail here.
+    const mod = await import('../og.js');
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.loadOgFonts).toBe('function');
+  });
+
+  it('loadOgFonts resolves the committed static faces', () => {
+    resetOgFontsCacheForTests();
+    const fonts = loadOgFonts();
+    expect(fonts.regular.byteLength).toBeGreaterThan(1000);
+    expect(fonts.bold.byteLength).toBeGreaterThan(1000);
+    // Singleton
+    expect(loadOgFonts()).toBe(fonts);
+  });
+
+  it('readOgFont throws a clear error for a missing face name', () => {
+    expect(() => readOgFont('Does-Not-Exist.ttf')).toThrow(/OG font not found/);
+  });
+});

--- a/apps/server/src/routes/og.ts
+++ b/apps/server/src/routes/og.ts
@@ -8,6 +8,8 @@
  * parse variable-font fvar tables, so we ship single-weight static instances.
  * Regenerate via apps/server/scripts/regen-og-fonts.sh. Build copies fonts to
  * dist/assets/fonts (copy-og-fonts); vercel.json includeFiles ships them.
+ * Fonts load lazily on first /api/og hit so a missing file never takes down
+ * /health (2026-07-21 post-#2027 production outage class).
  *
  * Used by marketing + (future) blog post OG meta tags:
  *   <meta property="og:image"
@@ -68,17 +70,27 @@ function readResvgWasm() {
  * ERR_UNKNOWN_FILE_EXTENSION on bare `.ttf` imports (GAP-401). Runtime
  * readFileSync matches the WASM pattern.
  *
- * Resolution order:
- * 1. dist colocated copy from `copy-og-fonts` (prod / tsup bundle)
- * 2. source tree `src/assets/fonts` when running via tsx from `src/routes`
+ * CRITICAL: do not call this at module top level. A throw during import of
+ * og.ts (pulled in by `import ogRoute from './routes/og.js'` in index.ts)
+ * aborts the entire serverless handler, including `/health` — that is the
+ * 2026-07-21 production FUNCTION_INVOCATION_FAILED class after #2023.
+ * Load fonts lazily on the first `/api/og` request only.
+ *
+ * Resolution order (covers tsup chunk cwd, Vercel includeFiles layout, tsx):
+ * 1. next to this module (`dist/assets/fonts` when bundled into dist/*)
+ * 2. one level up (`src/assets/fonts` when this file is at `src/routes/og.ts`)
+ * 3. process.cwd()/dist/assets/fonts and process.cwd()/assets/fonts
+ * 4. process.cwd()/src/assets/fonts (tsx from monorepo apps/server)
  */
-function readOgFont(filename: string): Buffer {
+export function readOgFont(filename: string): Buffer {
   const here = dirname(fileURLToPath(import.meta.url));
-  // dist/index.js (or chunk next to dist/) → dist/assets/fonts
-  // src/routes/og.ts under tsx → src/assets/fonts
+  const cwd = process.cwd();
   const candidates = [
     join(here, 'assets', 'fonts', filename),
     join(here, '..', 'assets', 'fonts', filename),
+    join(cwd, 'dist', 'assets', 'fonts', filename),
+    join(cwd, 'assets', 'fonts', filename),
+    join(cwd, 'src', 'assets', 'fonts', filename),
   ];
   for (const path of candidates) {
     try {
@@ -92,8 +104,28 @@ function readOgFont(filename: string): Buffer {
   );
 }
 
-const InterTightRegular = readOgFont('InterTight-Regular.ttf');
-const InterTightBold = readOgFont('InterTight-Bold.ttf');
+interface OgFonts {
+  regular: Buffer;
+  bold: Buffer;
+}
+
+let ogFontsCache: OgFonts | null = null;
+
+/** Lazy singleton — safe for cold starts; never runs at import time. */
+export function loadOgFonts(): OgFonts {
+  if (!ogFontsCache) {
+    ogFontsCache = {
+      regular: readOgFont('InterTight-Regular.ttf'),
+      bold: readOgFont('InterTight-Bold.ttf'),
+    };
+  }
+  return ogFontsCache;
+}
+
+/** Test-only: drop the singleton so path-resolution tests can re-run. */
+export function resetOgFontsCacheForTests(): void {
+  ogFontsCache = null;
+}
 
 let wasmInitPromise: Promise<void> | null = null;
 function ensureWasm(): Promise<void> {
@@ -224,6 +256,7 @@ app.get('/', async (c) => {
   );
 
   const node = buildNode(title, description);
+  const fonts = loadOgFonts();
 
   // satori's signature is typed against React's ReactNode. We construct a
   // ReactNode-compatible object tree manually to avoid a runtime React dep
@@ -232,8 +265,8 @@ app.get('/', async (c) => {
     width: WIDTH,
     height: HEIGHT,
     fonts: [
-      { name: 'Inter Tight', data: InterTightRegular, weight: 400, style: 'normal' },
-      { name: 'Inter Tight', data: InterTightBold, weight: 700, style: 'normal' },
+      { name: 'Inter Tight', data: fonts.regular, weight: 400, style: 'normal' },
+      { name: 'Inter Tight', data: fonts.bold, weight: 700, style: 'normal' },
     ],
   });
 

--- a/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
+++ b/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
@@ -74,6 +74,24 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/**
+ * Preview iframe and origin-pinned click listener mount in the same state
+ * commit, but the listener is registered in a useEffect that runs after paint.
+ * Under CI load, a single dispatch right after findByTitle can race that effect
+ * and drop the message. Retry until the field editor opens.
+ */
+async function openFieldEditorFromPreview(): Promise<HTMLTextAreaElement> {
+  await screen.findByTitle('Content preview');
+  let textarea: HTMLTextAreaElement | undefined;
+  await waitFor(() => {
+    window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
+    textarea = screen.getByLabelText('Field value') as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+  });
+  if (!textarea) throw new Error('field editor did not open');
+  return textarea;
+}
+
 describe('EditSessionCanvas', () => {
   it('mints a preview token and renders the iframe with the previewUrl', async () => {
     const { fetcher, calls } = makeFetcher();
@@ -87,7 +105,10 @@ describe('EditSessionCanvas', () => {
     const { fetcher } = makeFetcher();
     render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
     await screen.findByTitle('Content preview');
-
+    // Flush the marketingOrigin effect so the origin-pinned listener is attached.
+    await act(async () => {
+      await Promise.resolve();
+    });
     act(() => {
       window.dispatchEvent(clickMessage(FOREIGN_ORIGIN));
     });
@@ -97,23 +118,14 @@ describe('EditSessionCanvas', () => {
   it('opens the field editor for a click from the preview origin', async () => {
     const { fetcher } = makeFetcher();
     render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
-    await screen.findByTitle('Content preview');
-
-    act(() => {
-      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
-    });
-    const textarea = (await screen.findByLabelText('Field value')) as HTMLTextAreaElement;
+    const textarea = await openFieldEditorFromPreview();
     expect(textarea.value).toBe('Old title');
   });
 
   it('PATCHes the session doc when a field edit is saved', async () => {
     const { fetcher, calls } = makeFetcher();
     render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
-    await screen.findByTitle('Content preview');
-    act(() => {
-      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
-    });
-    const textarea = await screen.findByLabelText('Field value');
+    const textarea = await openFieldEditorFromPreview();
     fireEvent.change(textarea, { target: { value: 'New title' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -131,11 +143,7 @@ describe('EditSessionCanvas', () => {
   it('debounces autosave into a single PATCH while typing', async () => {
     const { fetcher, calls } = makeFetcher();
     render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
-    await screen.findByTitle('Content preview');
-    act(() => {
-      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
-    });
-    const textarea = await screen.findByLabelText('Field value');
+    const textarea = await openFieldEditorFromPreview();
 
     // Two rapid changes, NO Save click: the debounce must coalesce them.
     fireEvent.change(textarea, { target: { value: 'A' } });

--- a/scripts/deploy/vercel-rollback-previous-prod.mjs
+++ b/scripts/deploy/vercel-rollback-previous-prod.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Durable production rollback for Vercel apps.
+ *
+ * Why this exists (2026-07-21 #2027 outage):
+ * - deploy.yml used `vercel ls --prod | grep | sed -n '2p'` which returned
+ *   empty under the wrong team slug (TURBO_TEAM ≠ project team), so auto-
+ *   rollback printed "No previous deployment found" and left the broken
+ *   deploy on the production alias.
+ * - This script uses the Vercel REST API with an explicit team id, finds the
+ *   second-most-recent READY production deployment, and re-points every
+ *   alias currently on the newest (broken) deploy to that previous one.
+ *
+ * Usage:
+ *   VERCEL_TOKEN=… VERCEL_TEAM_ID=team_… node scripts/deploy/vercel-rollback-previous-prod.mjs \
+ *     --project-id prj_… [--app-label api]
+ *
+ * Exit codes:
+ *   0 — previous deploy promoted (aliases reassigned) or nothing to do
+ *   1 — hard failure (no history, API error, verify failed)
+ *   2 — bad args / missing env
+ */
+import { parseArgs } from 'node:util';
+
+const API = 'https://api.vercel.com';
+
+function die(code, msg) {
+  console.error(msg);
+  process.exit(code);
+}
+
+const { values } = parseArgs({
+  options: {
+    'project-id': { type: 'string' },
+    'app-label': { type: 'string', default: 'app' },
+    'team-id': { type: 'string' },
+    token: { type: 'string' },
+    dry: { type: 'boolean', default: false },
+  },
+  allowPositionals: false,
+});
+
+const projectId = values['project-id'];
+const appLabel = values['app-label'] || 'app';
+const token = values.token || process.env.VERCEL_TOKEN;
+// Prefer explicit flag, then VERCEL_TEAM_ID, then VERCEL_ORG_ID (fleet secret
+// is the team id even when named ORG_ID — see deploy.yml / SECRETS.md).
+const teamId =
+  values['team-id'] || process.env.VERCEL_TEAM_ID || process.env.VERCEL_ORG_ID || '';
+
+if (!projectId) die(2, 'missing --project-id');
+if (!token) die(2, 'missing VERCEL_TOKEN / --token');
+if (!teamId) {
+  die(
+    2,
+    'missing team id: pass --team-id or set VERCEL_TEAM_ID / VERCEL_ORG_ID (team_… id, not TURBO_TEAM slug)',
+  );
+}
+
+async function api(path, init = {}) {
+  const url = new URL(path.startsWith('http') ? path : `${API}${path}`);
+  if (!url.searchParams.has('teamId')) url.searchParams.set('teamId', teamId);
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+  const text = await res.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { raw: text };
+  }
+  if (!res.ok) {
+    const err = new Error(
+      `Vercel API ${res.status} ${url.pathname}: ${JSON.stringify(body?.error || body).slice(0, 400)}`,
+    );
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return body;
+}
+
+async function listReadyProdDeployments() {
+  // v6 deployments: newest first
+  const data = await api(
+    `/v6/deployments?projectId=${encodeURIComponent(projectId)}&target=production&limit=20&state=READY`,
+  );
+  const list = (data.deployments || []).filter(
+    (d) => (d.readyState || d.state) === 'READY' || !d.readyState,
+  );
+  // Prefer readyState READY when present
+  return list.filter((d) => !d.readyState || d.readyState === 'READY');
+}
+
+async function listAliasesForDeployment(deploymentId) {
+  // Paginate aliases for the project; filter to those currently on deploymentId
+  const aliases = [];
+  let until;
+  for (let page = 0; page < 10; page++) {
+    let path = `/v2/aliases?projectId=${encodeURIComponent(projectId)}&limit=100`;
+    if (until) path += `&until=${until}`;
+    const data = await api(path);
+    const batch = data.aliases || [];
+    for (const a of batch) {
+      if (a.deploymentId === deploymentId) aliases.push(a);
+    }
+    if (batch.length < 100) break;
+    const last = batch[batch.length - 1];
+    until = last?.createdAt;
+    if (!until) break;
+  }
+  return aliases;
+}
+
+async function assignAlias(deploymentId, alias) {
+  return api(`/v2/deployments/${deploymentId}/aliases`, {
+    method: 'POST',
+    body: JSON.stringify({ alias }),
+  });
+}
+
+async function main() {
+  console.log(`=== Rollback previous prod: ${appLabel} (${projectId}) team=${teamId} ===`);
+
+  const deps = await listReadyProdDeployments();
+  if (deps.length < 2) {
+    die(
+      1,
+      `No previous READY production deployment for ${appLabel} (found ${deps.length}). Broken deploy may still be live.`,
+    );
+  }
+
+  const broken = deps[0];
+  const previous = deps[1];
+  console.log(`Newest (broken candidate): ${broken.uid} https://${broken.url}`);
+  console.log(`Previous (restore):        ${previous.uid} https://${previous.url}`);
+
+  const aliases = await listAliasesForDeployment(broken.uid);
+  if (aliases.length === 0) {
+    // Newest deploy may not own custom aliases yet, or smoke failed before
+    // alias assign. Still try to promote known production hostnames if any
+    // point at broken via a second list of all aliases that look production.
+    console.warn(
+      'No aliases currently bound to newest deploy — nothing to reassign via alias list.',
+    );
+    // Promote previous by assigning its own URL as a no-op check, then exit 1
+    // so humans notice: production alias may already be elsewhere.
+    die(
+      1,
+      `Could not discover aliases on newest deploy for ${appLabel}. Manual check required.`,
+    );
+  }
+
+  console.log(`Reassigning ${aliases.length} alias(es) to previous deploy…`);
+  const failures = [];
+  for (const a of aliases) {
+    const name = a.alias;
+    if (!name) continue;
+    console.log(`  → ${name}`);
+    if (values.dry) continue;
+    try {
+      await assignAlias(previous.uid, name);
+    } catch (e) {
+      console.error(`  FAIL ${name}: ${e.message}`);
+      failures.push(name);
+    }
+  }
+
+  if (values.dry) {
+    console.log('dry-run: no changes applied');
+    process.exit(0);
+  }
+
+  if (failures.length > 0) {
+    die(1, `Rollback incomplete for ${appLabel}: failed aliases: ${failures.join(', ')}`);
+  }
+
+  // Verify: production custom domains (non-vercel.app automatic) now point at previous
+  const verify = await listAliasesForDeployment(previous.uid);
+  const restored = new Set(verify.map((a) => a.alias));
+  const missing = aliases.map((a) => a.alias).filter((n) => n && !restored.has(n));
+  if (missing.length > 0) {
+    die(
+      1,
+      `Rollback issued but verification incomplete for ${appLabel}: still missing on previous: ${missing.join(', ')}`,
+    );
+  }
+
+  console.log(
+    `✅ Rollback verified: ${appLabel} production aliases now on ${previous.uid} (https://${previous.url})`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Promotion PR: `test` → `main`.

Carries **#2031** durable API boot isolation + REST prod rollback (plus backflow merges already on `test`).

Prior promote **#2030** is on `main` (includes #2029 MCP content paths) but Deploy smoke failed; prod was healthy via last-good **#2008** alias pin. This train is the durable app + rollback fix for the swagger cold-start / NFT class failure.

## Does not re-implement

- GAP-401 / GAP-403
- MCP env/paths (#2021/#2029)
- Lockfile / fleet-redundancy Phase 1

## Merge (ruleset)

`protect-main-promotion` allows **squash only**:

```bash
gh pr merge 2034 --repo RevealUIStudio/revealui --squash
```

(Agents do not self-merge. Owner disposes.)

## After merge

1. Watch Deploy on `main`: Smoke + invocation guard must pass.
2. Confirm `api.revealui.com` points at the **new** healthy deploy (not only the old #2008 pin).
3. `/health/live` and `/health/ready` both 200 on that deployment.
4. Close #2032 if still open (superseded) unless `/docs` still broken after promote.
5. MCP dogfood: `rfg revealui` → `revealui_list_sites`.

## Test plan

- [ ] CI green on this promote (incl. Unit Tests)
- [ ] Security review gate clear / `sec-review:approved` if required
- [ ] Owner squash-merge
- [ ] Deploy smoke green + new alias
- [ ] MCP list_sites dogfood
