### PR TITLE
fix(editor): stabilize EditSessionCanvas click-open tests

### DIFF
--- a/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
+++ b/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
@@ -74,6 +74,24 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/**
+ * Preview iframe and origin-pinned click listener mount in the same state
+ * commit, but the listener is registered in a useEffect that runs after paint.
+ * Under CI load, a single dispatch right after findByTitle can race that effect
+ * and drop the message. Retry until the field editor opens.
+ */
+async function openFieldEditorFromPreview(): Promise<HTMLTextAreaElement> {
+  await screen.findByTitle('Content preview');
+  let textarea: HTMLTextAreaElement | undefined;
+  await waitFor(() => {
+    window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
+    textarea = screen.getByLabelText('Field value') as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+  });
+  if (!textarea) throw new Error('field editor did not open');
+  return textarea;
+}
+
 describe('EditSessionCanvas', () => {
   it('mints a preview token and renders the iframe with the previewUrl', async () => {
     const { fetcher, calls } = makeFetcher();
@@ -87,7 +105,10 @@ describe('EditSessionCanvas', () => {
     const { fetcher } = makeFetcher();
     render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
     await screen.findByTitle('Content preview');
-
+    // Flush the marketingOrigin effect so the origin-pinned listener is attached.
+    await act(async () => {
+      await Promise.resolve();
+    });
     act(() => {
       window.dispatchEvent(clickMessage(FOREIGN_ORIGIN));
     });
@@ -97,23 +118,14 @@ describe('EditSessionCanvas', () => {
   it('opens the field editor for a click from the preview origin', async () => {
     const { fetcher } = makeFetcher();
     render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
-    await screen.findByTitle('Content preview');
-
-    act(() => {
-      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
-    });
-    const textarea = (await screen.findByLabelText('Field value')) as HTMLTextAreaElement;
+    const textarea = await openFieldEditorFromPreview();
     expect(textarea.value).toBe('Old title');
   });
 
   it('PATCHes the session doc when a field edit is saved', async () => {
     const { fetcher, calls } = makeFetcher();
     render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
-    await screen.findByTitle('Content preview');
-    act(() => {
-      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
-    });
-    const textarea = await screen.findByLabelText('Field value');
+    const textarea = await openFieldEditorFromPreview();
     fireEvent.change(textarea, { target: { value: 'New title' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -131,11 +143,7 @@ describe('EditSessionCanvas', () => {
   it('debounces autosave into a single PATCH while typing', async () => {
     const { fetcher, calls } = makeFetcher();
     render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
-    await screen.findByTitle('Content preview');
-    act(() => {
-      window.dispatchEvent(clickMessage(MARKETING_ORIGIN));
-    });
-    const textarea = await screen.findByLabelText('Field value');
+    const textarea = await openFieldEditorFromPreview();
 
     // Two rapid changes, NO Save click: the debounce must coalesce them.
     fireEvent.change(textarea, { target: { value: 'A' } });


### PR DESCRIPTION
## Summary

Stabilizes flaky `@revealui/editor` Unit Tests that block promote **#2034**.

### Root cause

`EditSessionCanvas` registers the origin-pinned `message` listener in a `useEffect` that runs **after paint**. Under CI load, tests that:

1. `await findByTitle('Content preview')`
2. dispatch a single `rvui:click` once

can race the effect and drop the message → `Unable to find a label with the text of: Field value`.

Observed on tip-push CI for #2031: first open-editor test failed, later siblings sometimes passed; re-run failed a different sibling (`PATCHes the session doc…`). PR-path Unit Tests on #2034 already passed once (same flake).

### Fix

`openFieldEditorFromPreview()` retries the preview-origin click inside `waitFor` until the field editor mounts. Foreign-origin test flushes the effect before asserting a drop.

### Test plan

- [x] `pnpm --filter @revealui/editor exec vitest run src/canvas/__tests__/EditSessionCanvas.test.tsx` → 6/6
- [ ] CI Unit Tests green on this PR
- [ ] After merge to `test`, #2034 (head=test) re-runs; owner squash-merge when green

Does **not** re-implement boot/swagger/NFT fixes.
