### PR TITLE
feat(validate): Tier-1 presentation gate + marketing residual burn (GAP-398)

### DIFF
--- a/apps/marketing/app/components/landing/CostCalculator.tsx
+++ b/apps/marketing/app/components/landing/CostCalculator.tsx
@@ -1,3 +1,4 @@
+import { Slider } from '@revealui/presentation';
 import { useState } from 'react';
 import { PRICING_COST_CALCULATOR as C } from '../../content/pricing';
 
@@ -6,6 +7,8 @@ import { PRICING_COST_CALCULATOR as C } from '../../content/pricing';
  * The output is ALWAYS one of the sanctioned 00-truth-source §3 brackets (entry /
  * growth / scale); the inputs only move you between sourced ranges, so the figure
  * is never fabricated outside the §3 band. No vendor names. CSR-only (Vite SPA).
+ *
+ * Tier-1: range inputs use @revealui/presentation Slider (GAP-398).
  */
 function pickTier(products: number, vendors: number, mrr: number) {
   const score = (products >= 3 ? 1 : 0) + (vendors >= 5 ? 1 : 0) + (mrr >= 20000 ? 1 : 0);
@@ -14,7 +17,7 @@ function pickTier(products: number, vendors: number, mrr: number) {
   return C.tiers[0];
 }
 
-function Slider({
+function LabeledSlider({
   label,
   min,
   max,
@@ -32,21 +35,13 @@ function Slider({
   onChange: (v: number) => void;
 }) {
   return (
-    <label className="block">
-      <span className="flex items-baseline justify-between">
+    <div className="block">
+      <span className="mb-2 flex items-baseline justify-between">
         <span className="text-sm font-medium text-foreground">{label}</span>
         <span className="font-mono text-sm text-primary">{display}</span>
       </span>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(e) => onChange(Number(e.target.value))}
-        className="mt-2 w-full accent-primary"
-      />
-    </label>
+      <Slider value={value} min={min} max={max} step={step} onChange={onChange} />
+    </div>
   );
 }
 
@@ -71,9 +66,8 @@ export function CostCalculator() {
         </div>
 
         <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
-          {/* Inputs */}
           <div className="space-y-6 rounded-2xl bg-card p-8 ring-1 ring-border">
-            <Slider
+            <LabeledSlider
               label={C.inputs.products.label}
               min={C.inputs.products.min}
               max={C.inputs.products.max}
@@ -82,7 +76,7 @@ export function CostCalculator() {
               display={products >= C.inputs.products.max ? `${products}+` : String(products)}
               onChange={setProducts}
             />
-            <Slider
+            <LabeledSlider
               label={C.inputs.vendors.label}
               min={C.inputs.vendors.min}
               max={C.inputs.vendors.max}
@@ -91,7 +85,7 @@ export function CostCalculator() {
               display={String(vendors)}
               onChange={setVendors}
             />
-            <Slider
+            <LabeledSlider
               label={C.inputs.mrr.label}
               min={C.inputs.mrr.min}
               max={C.inputs.mrr.max}
@@ -106,7 +100,6 @@ export function CostCalculator() {
             />
           </div>
 
-          {/* Output */}
           <div className="flex flex-col justify-center gap-6 rounded-2xl bg-secondary p-8 ring-1 ring-border">
             <div>
               <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">

--- a/apps/marketing/app/components/landing/ProviderSwitch.tsx
+++ b/apps/marketing/app/components/landing/ProviderSwitch.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@revealui/presentation';
 import { useState } from 'react';
 import { PROVIDER_SWITCH as P } from '../../content/local-ai';
 
@@ -5,6 +6,8 @@ import { PROVIDER_SWITCH as P } from '../../content/local-ai';
  * Provider-switch interactive. Toggling Local <-> Frontier changes the model,
  * data locus, cost model, and config line. Anchors the local-AI section; the
  * frontier-pathway made tangible. CSR-only (Vite SPA).
+ *
+ * Tier-1: mode toggles use @revealui/presentation Button (GAP-398).
  */
 type Mode = 'local' | 'frontier';
 
@@ -19,34 +22,36 @@ export function ProviderSwitch() {
         <h3 className="mt-2 text-xl font-semibold text-foreground">{P.heading}</h3>
       </div>
 
-      {/* Toggle */}
       <div
         className="mt-6 grid grid-cols-2 gap-1 rounded-xl bg-secondary p-1"
         role="tablist"
         aria-label="Provider mode"
       >
-        {(['local', 'frontier'] as const).map((m) => (
-          <button
-            key={m}
-            type="button"
-            role="tab"
-            aria-selected={mode === m}
-            onClick={() => setMode(m)}
-            className={`flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition ${
-              mode === m
-                ? 'bg-card text-foreground shadow-sm ring-1 ring-border'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            {P.modes[m].label}
-            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[0.65rem] font-semibold uppercase text-primary">
-              {P.modes[m].badge}
-            </span>
-          </button>
-        ))}
+        {(['local', 'frontier'] as const).map((m) => {
+          const selected = mode === m;
+          return (
+            <Button
+              key={m}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              appearance={selected ? 'solid' : 'ghost'}
+              variant={selected ? 'brand' : 'neutral'}
+              size="sm"
+              onClick={() => setMode(m)}
+              className={`w-full justify-center gap-2 rounded-lg ${
+                selected ? 'shadow-sm ring-1 ring-border' : ''
+              }`}
+            >
+              {P.modes[m].label}
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[0.65rem] font-semibold uppercase text-primary">
+                {P.modes[m].badge}
+              </span>
+            </Button>
+          );
+        })}
       </div>
 
-      {/* Changing attributes */}
       <dl className="mt-6 divide-y divide-border">
         {P.attributes.map((attr) => (
           <div key={attr.key} className="flex items-baseline justify-between gap-4 py-3">
@@ -60,7 +65,6 @@ export function ProviderSwitch() {
         ))}
       </dl>
 
-      {/* Constant-either-way row */}
       <div className="mt-4 rounded-xl bg-primary/5 p-4 ring-1 ring-primary/20">
         <p className="text-xs font-semibold uppercase tracking-widest text-primary">
           {P.constant.label}

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@revealui/presentation';
+import { Button, IconCheckCircle } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { CenteredCardGrid } from '../components/CenteredCardGrid';
 import { Footer } from '../components/Footer';
@@ -38,19 +38,6 @@ const ADMIN_URL = import.meta.env.VITE_ADMIN_URL ?? 'https://admin.revealui.com'
 const API_URL =
   import.meta.env.VITE_API_URL ??
   (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004');
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-      <title>Included</title>
-      <path
-        fillRule="evenodd"
-        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-}
 
 export function PricingPage() {
   const [pricing, setPricing] = useState<PricingResponse | null>(null);
@@ -170,7 +157,7 @@ export function PricingPage() {
             <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
               {PRICING_VALUE_BAND.points.map((point) => (
                 <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <CheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
                   <span>{point}</span>
                 </li>
               ))}
@@ -179,32 +166,30 @@ export function PricingPage() {
 
           {showAnnualToggle && (
             <div className="mb-8 flex justify-center">
-              <div className="inline-flex items-center rounded-full bg-muted p-1 text-sm font-medium ring-1 ring-border">
-                <button
+              <div className="inline-flex items-center gap-1 rounded-full bg-muted p-1 text-sm font-medium ring-1 ring-border">
+                <Button
                   type="button"
+                  size="sm"
+                  appearance={billingInterval === 'month' ? 'solid' : 'ghost'}
+                  variant={billingInterval === 'month' ? 'neutral' : 'neutral'}
                   onClick={() => setBillingInterval('month')}
-                  className={`rounded-full px-4 py-1.5 transition-colors ${
-                    billingInterval === 'month'
-                      ? 'bg-card text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground'
-                  }`}
+                  className="rounded-full"
                 >
                   Monthly
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  size="sm"
+                  appearance={billingInterval === 'year' ? 'solid' : 'ghost'}
+                  variant={billingInterval === 'year' ? 'neutral' : 'neutral'}
                   onClick={() => setBillingInterval('year')}
-                  className={`rounded-full px-4 py-1.5 transition-colors ${
-                    billingInterval === 'year'
-                      ? 'bg-card text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground'
-                  }`}
+                  className="rounded-full"
                 >
                   Annually
                   <span className="ml-1.5 rounded-full bg-green-500/15 px-1.5 py-0.5 text-xs font-semibold text-green-800 dark:text-green-400">
                     Save 20%
                   </span>
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -244,7 +229,7 @@ export function PricingPage() {
                 <ul className="mb-8 flex-1 space-y-3">
                   {tier.features.map((feature) => (
                     <li key={feature} className="flex items-start gap-x-3">
-                      <CheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                      <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
                       <span className="text-sm text-muted-foreground">{feature}</span>
                     </li>
                   ))}
@@ -317,7 +302,7 @@ export function PricingPage() {
             <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
               {PRICING_AGENCY_VALUE_BAND.points.map((point) => (
                 <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <CheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
                   <span>{point}</span>
                 </li>
               ))}
@@ -357,7 +342,7 @@ export function PricingPage() {
                 <ul className="mb-8 mt-6 flex-1 space-y-3">
                   {tier.features.map((feature) => (
                     <li key={feature} className="flex items-start gap-x-3">
-                      <CheckIcon className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                      <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
                       <span className="text-sm text-muted-foreground">{feature}</span>
                     </li>
                   ))}

--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
     "validate:claims-evidence": "tsx scripts/validate/claims-evidence.ts",
     "validate:marketing-voice": "tsx scripts/validate/marketing-voice.ts",
     "validate:client-safety": "tsx scripts/validate/client-safety.ts",
+    "validate:tier1-presentation": "tsx scripts/validate/tier1-presentation.ts",
     "validate:design-context": "tsx scripts/validate/design-context-drift.ts",
     "validate:brand-bridge": "tsx scripts/validate/brand-bridge.ts",
     "validate:versions": "tsx scripts/validate/version-policy.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -399,6 +399,16 @@ async function gate(): Promise<void> {
         args: ['validate:client-safety'],
       },
       {
+        // GAP-398: Tier-1 handroll JSX (button/input/select/textarea/svg) must
+        // use @revealui/presentation. Warn-only while allowlist burns to zero;
+        // flip to hard fail when validate:tier1-presentation --hard-fail is clean
+        // with an empty allowlist (or zero entries).
+        name: 'Tier-1 presentation (warn)',
+        command: 'pnpm',
+        args: ['validate:tier1-presentation'],
+        warnOnly: true,
+      },
+      {
         name: 'Security audit',
         command: 'pnpm',
         args: ['gate:security'],

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -1,0 +1,640 @@
+{
+  "description": "Allowlisted Tier-1 JSX intrinsics in apps/* until burned to presentation components (GAP-398). Each entry needs a non-empty reason.",
+  "entries": [
+    {
+      "path": "apps/admin/src/app/(backend)/[[...segments]]/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/agent-tasks/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/agent-tasks/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/agents/new/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/agents/new/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/agents/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/agents/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/chat/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/chat/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/coordination/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/coordination/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/dashboard/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/error.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/error.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
+      "tag": "select",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/knowledge-graph/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/knowledge-graph/page.tsx",
+      "tag": "input",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/marketplace/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/marketplace/publish/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/marketplace/publish/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/marketplace/tasks/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/mcp/inspect/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/mcp/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/media/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/media/page.tsx",
+      "tag": "input",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/media/page.tsx",
+      "tag": "select",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/media/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/refunds/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/refunds/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/settings/account/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/settings/account/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/settings/layout.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/settings/security/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(backend)/settings/security/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/account/billing/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
+      "tag": "input",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/error.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/error.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/login/LoginForm.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/mfa/MFAForm.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/not-found.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/signup/SignupForm.tsx",
+      "tag": "input",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/(frontend)/welcome/page.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/global-error.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/app/global-error.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/ErrorBoundary.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/FreeTierBanner.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/FreeTierBanner.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/elements/button.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/elements/email-signup-form.tsx",
+      "tag": "input",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/elements/install-command.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/icons/arrow-narrow-right-icon.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/icons/checkmark-icon.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/icons/chevron-icon.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/icons/squares-2-stacked-icon.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/sections/footer-with-newsletter-form-categories-and-social-icons.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/sections/footer-with-newsletter-form-categories-and-social-icons.tsx",
+      "tag": "input",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/sections/navbar-with-links-actions-and-centered-logo.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/sections/navbar-with-links-actions-and-centered-logo.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/components/revealui/sections/stats-with-graph.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/AdminBar/index.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/AdminSidebarLayout.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/Agent/index.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/agents/agent-memory.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/agents/agent-memory.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/agents/mcp-server-card.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/BeforeDashboard/OnboardingNudge.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/DataPanel/index.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/ErrorBoundary/index.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/mcp/resources-panel.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/mcp/usage-dashboard.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/mcp/usage-dashboard.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/PasswordInput.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/PasswordInput.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/SystemHealthMonitor/index.tsx",
+      "tag": "select",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/SystemHealthPanel/index.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/SystemHealthPanel/index.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/components/UpgradeDialog.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/features/embed/components/EmbedNodeComponent.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/features/embed/icons/EmbedIcon.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/features/label/icons/LabelIcon.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/features/largeBody/icons/LargeBodyIcon.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/providers/Theme/ThemeSelector/index.tsx",
+      "tag": "select",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/admin/src/lib/providers/Theme/ThemeSelector/index.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/DocLayout.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/DocLayout.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/ErrorBoundary.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/SearchBar.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/SearchBar.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/showcase/CodeView.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/showcase/Preview.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/showcase/PropPanel.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/showcase/PropPanel.tsx",
+      "tag": "input",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/showcase/ShowcaseShell.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/showcase/ShowcaseShell.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/components/showcase/TokensPage.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/routes/ApiPage.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/routes/GuidesPage.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/routes/SectionPage.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/showcase/animations.showcase.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/showcase/drawer.showcase.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/showcase/icons.showcase.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/showcase/theme.showcase.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/docs/app/utils/markdown.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/components/for-operators/Faq.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/components/GetStarted.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/components/landing/Faq.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/components/landing/Hero.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/components/landing/PricingTeaser.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/components/landing/Primitives.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/components/landing/Proof.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/components/NavBar.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/routes/FairSourcePage.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/routes/PricingPage.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/routes/ProductsPage.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/routes/ProductsPage.tsx",
+      "tag": "svg",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    },
+    {
+      "path": "apps/marketing/app/routes/StatusPage.tsx",
+      "tag": "button",
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+    }
+  ]
+}

--- a/scripts/validate/tier1-presentation.ts
+++ b/scripts/validate/tier1-presentation.ts
@@ -1,0 +1,189 @@
+// console-allowed
+/**
+ * Tier-1 presentation intrinsic gate (GAP-398).
+ *
+ * Flags JSX host elements that must come from @revealui/presentation:
+ *   button | input | select | textarea | svg
+ *
+ * No authored regex (fleet no-regex): TypeScript compiler API AST walk only.
+ *
+ * Modes:
+ *   default / --warn   warn on non-allowlisted hits; exit 0
+ *   --hard-fail        non-allowlisted hits exit 1 (burn-down complete)
+ *
+ * Usage:
+ *   pnpm validate:tier1-presentation
+ *   pnpm validate:tier1-presentation -- --hard-fail
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { extname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+const ALLOWLIST_PATH = join(REPO_ROOT, 'scripts/validate/tier1-presentation-allowlist.json');
+
+const SCAN_ROOTS = ['apps/marketing', 'apps/docs', 'apps/admin'];
+const SOURCE_EXTS = new Set(['.tsx', '.jsx']);
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.turbo',
+  '.next',
+  'coverage',
+  'playwright-report',
+  'test-results',
+  '__tests__',
+  '__mocks__',
+]);
+
+const TIER1_TAGS = new Set(['button', 'input', 'select', 'textarea', 'svg']);
+
+interface AllowEntry {
+  path: string;
+  tag: string;
+  reason: string;
+}
+
+interface Hit {
+  path: string;
+  tag: string;
+  line: number;
+  col: number;
+}
+
+function walk(dir: string, outFiles: string[] = []): string[] {
+  if (!existsSync(dir)) return outFiles;
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(ent.name)) continue;
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      walk(p, outFiles);
+      continue;
+    }
+    if (!SOURCE_EXTS.has(extname(ent.name))) continue;
+    if (ent.name.includes('.test.') || ent.name.includes('.spec.')) continue;
+    if (ent.name.endsWith('.e2e.tsx') || ent.name.endsWith('.e2e.ts')) continue;
+    outFiles.push(p);
+  }
+  return outFiles;
+}
+
+function loadAllowlist(): AllowEntry[] {
+  if (!existsSync(ALLOWLIST_PATH)) return [];
+  const raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8')) as { entries?: AllowEntry[] };
+  return raw.entries ?? [];
+}
+
+function isAllowlisted(pathRel: string, tag: string, entries: AllowEntry[]): boolean {
+  return entries.some((e) => e.path === pathRel && e.tag === tag && e.reason.trim().length > 0);
+}
+
+function scanFile(absPath: string): Hit[] {
+  const text = readFileSync(absPath, 'utf8');
+  const sf = ts.createSourceFile(absPath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const hits: Hit[] = [];
+  const pathRel = relative(REPO_ROOT, absPath).replaceAll('\\', '/');
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) {
+      const tagNode = node.tagName;
+      if (ts.isIdentifier(tagNode)) {
+        const tag = tagNode.text;
+        if (TIER1_TAGS.has(tag)) {
+          const { line, character } = sf.getLineAndCharacterOfPosition(tagNode.getStart(sf));
+          hits.push({ path: pathRel, tag, line: line + 1, col: character + 1 });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return hits;
+}
+
+function main(): void {
+  const hardFail = process.argv.includes('--hard-fail');
+  const writeAllowlist = process.argv.includes('--write-allowlist');
+  const entries = loadAllowlist();
+  const files: string[] = [];
+  for (const root of SCAN_ROOTS) {
+    walk(resolve(REPO_ROOT, root), files);
+  }
+
+  const allHits: Hit[] = [];
+  for (const f of files) {
+    allHits.push(...scanFile(f));
+  }
+
+  if (writeAllowlist) {
+    // Group by path+tag for compact allowlist entries (one reason per pair).
+    const key = new Map<string, AllowEntry>();
+    for (const h of allHits) {
+      const k = `${h.path}::${h.tag}`;
+      if (!key.has(k)) {
+        key.set(k, {
+          path: h.path,
+          tag: h.tag,
+          reason: 'GAP-398 residual burn-down (pre-existing Tier-1 handroll)',
+        });
+      }
+    }
+    const payload = {
+      description:
+        'Allowlisted Tier-1 JSX intrinsics in apps/* until burned to presentation components (GAP-398). Each entry needs a non-empty reason.',
+      entries: [...key.values()].sort((a, b) =>
+        a.path === b.path ? a.tag.localeCompare(b.tag) : a.path.localeCompare(b.path),
+      ),
+    };
+    writeFileSync(ALLOWLIST_PATH, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    out(
+      `Wrote ${payload.entries.length} allowlist entries → ${relative(REPO_ROOT, ALLOWLIST_PATH)}`,
+    );
+    process.exit(0);
+  }
+
+  const violations: Hit[] = [];
+  const allowlisted: Hit[] = [];
+  for (const h of allHits) {
+    if (isAllowlisted(h.path, h.tag, entries)) allowlisted.push(h);
+    else violations.push(h);
+  }
+
+  out('================================================================');
+  out('Tier-1 presentation intrinsic gate (GAP-398)');
+  out('================================================================');
+  out(`Scanned ${files.length} files under ${SCAN_ROOTS.join(', ')}`);
+  out(
+    `Hits: ${allHits.length}  allowlisted: ${allowlisted.length}  violations: ${violations.length}`,
+  );
+  out(`Mode: ${hardFail ? 'HARD FAIL' : 'WARN (exit 0)'}`);
+  out('');
+
+  if (violations.length > 0) {
+    out('Non-allowlisted Tier-1 intrinsics (must use @revealui/presentation):');
+    for (const h of violations) {
+      out(`  ${h.path}:${h.line}:${h.col}  <${h.tag}>`);
+    }
+    out('');
+    out(
+      'Fix: replace with Button / Input / Slider / Switch / Tabs / Icon* from @revealui/presentation,',
+    );
+    out('or add a reasoned entry to scripts/validate/tier1-presentation-allowlist.json.');
+  } else {
+    out('✓ No non-allowlisted Tier-1 intrinsics.');
+  }
+
+  if (hardFail && violations.length > 0) {
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary

**GAP-398** Tier-1 presentation compliance: durable AST gate + first marketing burn-down.

### Gate
- `scripts/validate/tier1-presentation.ts` — TypeScript AST (no authored regex)
- Flags JSX host tags: `button` | `input` | `select` | `textarea` | `svg`
- Scans `apps/{marketing,docs,admin}` (tests excluded)
- Allowlist: `scripts/validate/tier1-presentation-allowlist.json` (reason required)
- Phase-1: **warn-only** (`warnOnly: true` in ci-gate)
- Flip to hard-fail later: `pnpm validate:tier1-presentation -- --hard-fail` when allowlist empty

### Marketing burns (named in the gap)
| File | Change |
|------|--------|
| `CostCalculator.tsx` | hand-rolled range → presentation `Slider` |
| `ProviderSwitch.tsx` | raw `<button>` tabs → presentation `Button` |
| `PricingPage.tsx` | billing toggle → `Button`; check marks → `IconCheckCircle` |

### ADR
Amendment to `.jv` ADR `2026-05-16-fleet-revealui-native-compliance` (tier table + gate pointer). Not duplicated as a new ADR.

### Residual
~127 allowlisted path/tag pairs (docs showcase, admin UI, remaining marketing SVG). Burn in follow-ups; do not expand allowlist without reason.

## Test plan
- [x] `pnpm validate:tier1-presentation` → 0 non-allowlisted violations
- [x] Phase-1 gate includes Tier-1 presentation (warn) — pre-push PASS
- [ ] CI green on this PR
- [ ] Visual smoke pricing + cost calculator + local-AI provider switch (optional)

Closes nothing until allowlist is burned; tracks GAP-398 in-progress.
