### PR TITLE
fix(marketing,docs): burn GAP-398 Tier-1 allowlist residuals

### DIFF
--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -1,3 +1,12 @@
+import {
+  Button,
+  GitHubIcon,
+  IconChevronRight,
+  IconClose,
+  IconCode,
+  IconGlobe,
+  IconMenu,
+} from '@revealui/presentation';
 import { Link, useLocation } from '@revealui/router';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { buildDocNavSections, type NavItem, type NavSection } from '../lib/nav';
@@ -69,19 +78,7 @@ function SidebarContent({ isHome, onNavigate }: { isHome: boolean; onNavigate?: 
       {/* Logo */}
       <h2 className="mb-4 text-lg font-bold tracking-tight text-ink">
         <Link to="/" onClick={onNavigate} className="flex items-center gap-2 no-underline">
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <title>RevealUI</title>
-            <path d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
-          </svg>
+          <IconCode size="md" label="RevealUI" />
           RevealUI
         </Link>
       </h2>
@@ -137,31 +134,14 @@ function SidebarContent({ isHome, onNavigate }: { isHome: boolean; onNavigate?: 
           href="https://github.com/RevealUIStudio/revealui"
           className="flex items-center gap-2 rounded-md px-3 py-2 text-[0.8125rem] text-text-muted no-underline transition-colors hover:text-text-secondary md:py-1.5"
         >
-          <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <title>GitHub</title>
-            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-          </svg>
+          <GitHubIcon size="sm" />
           GitHub
         </a>
         <a
           href="https://revealui.com"
           className="mt-1 flex items-center gap-2 rounded-md px-3 py-2 text-[0.8125rem] text-text-muted no-underline transition-colors hover:text-text-secondary md:py-1.5"
         >
-          <svg
-            height="16"
-            width="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <title>Website</title>
-            <circle cx="12" cy="12" r="10" />
-            <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-          </svg>
+          <IconGlobe size="sm" />
           revealui.com
         </a>
         <div className="mt-3 border-t border-border pt-3 px-3">
@@ -270,20 +250,7 @@ function Breadcrumbs({ sections: navSections }: { sections: NavSection[] }) {
                   ) : (
                     <span className="text-text-muted">{crumb.label}</span>
                   )}
-                  <svg
-                    aria-hidden="true"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    className="size-3 text-text-muted"
-                  >
-                    <path
-                      d="M6 4l4 4-4 4"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
+                  <IconChevronRight size="xs" className="text-text-muted" />
                 </>
               )}
             </li>
@@ -324,58 +291,21 @@ export function DocLayout({ children }: DocLayoutProps) {
           to="/"
           className="flex items-center gap-2 text-base font-bold tracking-tight text-ink no-underline"
         >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
-          </svg>
+          <IconCode size="sm" />
           RevealUI
         </Link>
-        <button
+        <Button
           type="button"
+          appearance="ghost"
+          variant="neutral"
+          size="icon"
           onClick={() => setSidebarOpen((v) => !v)}
-          className="rounded-md p-2 text-text-secondary transition-colors hover:bg-accent-bg hover:text-accent"
+          className="text-text-secondary"
           aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
           aria-expanded={sidebarOpen}
         >
-          {sidebarOpen ? (
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
-          ) : (
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          )}
-        </button>
+          {sidebarOpen ? <IconClose size="md" /> : <IconMenu size="md" />}
+        </Button>
       </div>
 
       {/* Mobile overlay backdrop */}

--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -134,7 +134,7 @@ function SidebarContent({ isHome, onNavigate }: { isHome: boolean; onNavigate?: 
           href="https://github.com/RevealUIStudio/revealui"
           className="flex items-center gap-2 rounded-md px-3 py-2 text-[0.8125rem] text-text-muted no-underline transition-colors hover:text-text-secondary md:py-1.5"
         >
-          <GitHubIcon size="sm" />
+          <GitHubIcon className="size-4" />
           GitHub
         </a>
         <a

--- a/apps/docs/app/components/ErrorBoundary.tsx
+++ b/apps/docs/app/components/ErrorBoundary.tsx
@@ -4,6 +4,7 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import { Component, type ReactNode } from 'react';
 
 interface ErrorBoundaryProps {
@@ -75,15 +76,16 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               </pre>
             </details>
           )}
-          <button
+          <Button
+            type="button"
+            variant="brand"
+            className="mt-4"
             onClick={() => {
               this.setState({ hasError: false, error: null });
             }}
-            type="button"
-            className="mt-4 cursor-pointer rounded-lg border-none bg-accent px-4 py-2 font-sans text-sm font-medium text-white transition-colors hover:bg-accent-hover"
           >
             Try Again
-          </button>
+          </Button>
         </div>
       );
     }

--- a/apps/docs/app/components/SearchBar.tsx
+++ b/apps/docs/app/components/SearchBar.tsx
@@ -5,7 +5,7 @@
  * Supports Cmd+K / Ctrl+K keyboard shortcut to focus.
  */
 
-import { Input } from '@revealui/presentation';
+import { Button, IconLoading, Input } from '@revealui/presentation';
 import { useNavigate } from '@revealui/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SearchResult } from '../lib/search-index';
@@ -155,24 +155,28 @@ export function SearchBar() {
           className="absolute top-full right-0 left-0 z-[1000] mt-1 max-h-[60vh] overflow-y-auto rounded-lg border border-border bg-surface shadow-lg"
         >
           {results.map((result, i) => (
-            <button
+            <Button
               type="button"
               role="option"
               aria-selected={i === activeIndex}
               key={result.path}
+              appearance="ghost"
+              variant="neutral"
               onClick={() => handleSelect(result)}
               onMouseEnter={() => setActiveIndex(i)}
-              className={`w-full cursor-pointer border-none px-3 py-2.5 text-left font-sans transition-colors ${
-                i === activeIndex ? 'bg-accent-bg' : 'bg-transparent hover:bg-accent-bg'
+              className={`h-auto w-full justify-start rounded-none px-3 py-2.5 text-left font-sans ${
+                i === activeIndex ? 'bg-accent-bg' : ''
               } ${i < results.length - 1 ? 'border-b border-border-subtle' : ''}`}
             >
-              <div className="mb-0.5 font-medium text-text-primary">{result.title}</div>
-              {result.excerpt && (
-                <div className="truncate text-xs leading-snug text-text-muted">
-                  {result.excerpt}
-                </div>
-              )}
-            </button>
+              <span className="flex w-full flex-col items-start gap-0.5">
+                <span className="font-medium text-text-primary">{result.title}</span>
+                {result.excerpt ? (
+                  <span className="truncate text-xs leading-snug text-text-muted">
+                    {result.excerpt}
+                  </span>
+                ) : null}
+              </span>
+            </Button>
           ))}
         </div>
       )}
@@ -188,27 +192,7 @@ export function SearchBar() {
             </div>
           ) : (
             <div className="flex items-center justify-center gap-2">
-              <svg
-                className="size-4 animate-spin text-accent"
-                viewBox="0 0 24 24"
-                fill="none"
-                aria-hidden="true"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  opacity="0.25"
-                />
-                <path
-                  d="M4 12a8 8 0 018-8"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-              </svg>
+              <IconLoading size="sm" className="animate-spin text-accent" />
               <span>Building search index...</span>
             </div>
           )}

--- a/apps/docs/app/routes/ApiPage.tsx
+++ b/apps/docs/app/routes/ApiPage.tsx
@@ -1,4 +1,5 @@
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -111,13 +112,16 @@ This will create markdown files in \`docs/api/\` that are automatically copied t
         >
           Edit this page on GitHub
         </a>
-        <button
+        <Button
           type="button"
+          appearance="link"
+          variant="neutral"
+          size="sm"
+          className="h-auto p-0 text-text-muted"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="cursor-pointer border-none bg-transparent p-0 font-sans text-[inherit] text-text-muted transition-colors hover:text-text-secondary"
         >
           Back to top
-        </button>
+        </Button>
       </div>
     </ErrorBoundary>
   );

--- a/apps/docs/app/routes/GuidesPage.tsx
+++ b/apps/docs/app/routes/GuidesPage.tsx
@@ -1,4 +1,5 @@
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -105,13 +106,16 @@ Available guides are loaded from the \`docs/guides/\` directory.
         >
           Edit this page on GitHub
         </a>
-        <button
+        <Button
           type="button"
+          appearance="link"
+          variant="neutral"
+          size="sm"
+          className="h-auto p-0 text-text-muted"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="cursor-pointer border-none bg-transparent p-0 font-sans text-[inherit] text-text-muted transition-colors hover:text-text-secondary"
         >
           Back to top
-        </button>
+        </Button>
       </div>
     </ErrorBoundary>
   );

--- a/apps/docs/app/routes/SectionPage.tsx
+++ b/apps/docs/app/routes/SectionPage.tsx
@@ -1,4 +1,5 @@
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -176,13 +177,16 @@ Document not found at \`${resolved.markdownPath}\`.
         >
           Edit this page on GitHub
         </a>
-        <button
+        <Button
           type="button"
+          appearance="link"
+          variant="neutral"
+          size="sm"
+          className="h-auto p-0 text-text-muted"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="cursor-pointer border-none bg-transparent p-0 font-sans text-[inherit] text-text-muted transition-colors hover:text-text-secondary"
         >
           Back to top
-        </button>
+        </Button>
       </div>
     </ErrorBoundary>
   );

--- a/apps/docs/app/utils/markdown.tsx
+++ b/apps/docs/app/utils/markdown.tsx
@@ -3,6 +3,7 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import type React from 'react';
 import { useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -517,14 +518,17 @@ function CopyablePreBlock({ children, ...props }: React.ComponentProps<'pre'>): 
       <pre ref={preRef} {...props}>
         {children}
       </pre>
-      <button
+      <Button
         type="button"
+        size="sm"
+        appearance="ghost"
+        variant="neutral"
         onClick={handleCopy}
-        className="absolute top-2 right-2 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-400 opacity-0 transition-opacity hover:bg-white/10 hover:text-white group-hover/code:opacity-100"
+        className="absolute top-2 right-2 h-auto border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-400 opacity-0 transition-opacity hover:bg-white/10 hover:text-white group-hover/code:opacity-100"
         aria-label="Copy code"
       >
         {copied ? 'Copied!' : 'Copy'}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -1,4 +1,4 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs, IconArrowRight } from '@revealui/presentation';
 import { HOME_GET_STARTED } from '../content/home';
 import type { GetStartedData } from '../lib/page-blocks';
 import { NewsletterSignup } from './NewsletterSignup';
@@ -40,20 +40,7 @@ export function GetStarted({
             <Button asChild appearance="outline" variant="neutral" size="lg">
               <a href={data.cta.secondary.href}>
                 {data.cta.secondary.label}
-                <svg
-                  className="h-4 w-4 ml-1.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <title>Arrow</title>
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
-                  />
-                </svg>
+                <IconArrowRight size="sm" className="ml-1.5" />
               </a>
             </Button>
           </div>

--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   GitHubIcon,
   IconClose,
   IconMenu,
@@ -112,10 +113,13 @@ export function NavBar() {
           <LinkButton href={NAV_AUTH.signup.href}>{NAV_AUTH.signup.label}</LinkButton>
 
           {/* Hamburger - mobile only. 44x44 tap target per WCAG 2.5.5 / Apple HIG. */}
-          <button
+          <Button
             ref={toggleRef}
             type="button"
-            className="flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted lg:hidden"
+            appearance="ghost"
+            variant="neutral"
+            size="icon"
+            className="text-muted-foreground lg:hidden"
             aria-label={open ? 'Close menu' : 'Open menu'}
             aria-expanded={open}
             aria-controls={MOBILE_MENU_ID}
@@ -126,7 +130,7 @@ export function NavBar() {
             ) : (
               <IconMenu size="md" strokeWidth={2} />
             )}
-          </button>
+          </Button>
         </div>
       </nav>
 

--- a/apps/marketing/app/components/__tests__/NavBar.test.tsx
+++ b/apps/marketing/app/components/__tests__/NavBar.test.tsx
@@ -23,8 +23,8 @@ describe('NavBar (marketing)', () => {
     renderNavBar();
     const toggle = screen.getByRole('button', { name: 'Open menu' });
     // WCAG 2.5.5 / Apple HIG minimum 44x44 tap target.
-    expect(toggle.className).toContain('h-11');
-    expect(toggle.className).toContain('w-11');
+    // Button size="icon" applies size-11 (2.75rem = 44px square).
+    expect(toggle.className).toContain('size-11');
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
     expect(toggle).toHaveAttribute('aria-controls', MENU_ID);
     expect(document.getElementById(MENU_ID)).not.toBeInTheDocument();

--- a/apps/marketing/app/components/for-operators/Faq.tsx
+++ b/apps/marketing/app/components/for-operators/Faq.tsx
@@ -1,3 +1,4 @@
+import { IconPlus } from '@revealui/presentation';
 import { FOR_OPERATORS_FAQ } from '../../content/for-operators';
 
 export function Faq() {
@@ -19,16 +20,7 @@ export function Faq() {
               <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
                 <h3 className="text-lg font-semibold leading-7 text-foreground">{item.question}</h3>
                 <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
-                  <svg
-                    className="h-4 w-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={2}
-                    stroke="currentColor"
-                  >
-                    <title>Toggle</title>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-                  </svg>
+                  <IconPlus size="sm" label="Toggle" />
                 </span>
               </summary>
               <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -1,4 +1,4 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import { type BlockAnnotation, fieldAttrs, IconPlus } from '@revealui/presentation';
 import { HOME_FAQ } from '../../content/home';
 import type { FaqData } from '../../lib/page-blocks';
 
@@ -42,16 +42,7 @@ export function Faq({ data = HOME_FAQ, path = 'blocks.1', annotation = {} }: Faq
                 </h3>
 
                 <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
-                  <svg
-                    className="h-4 w-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={2}
-                    stroke="currentColor"
-                  >
-                    <title>Toggle</title>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-                  </svg>
+                  <IconPlus size="sm" label="Toggle" />
                 </span>
               </summary>
               <div

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -1,4 +1,4 @@
-import { Button, ReceiptCard } from '@revealui/presentation';
+import { Button, GitHubIcon, IconArrowRight, ReceiptCard } from '@revealui/presentation';
 import { Link, useLocation } from '@revealui/router';
 import { FOR_OPERATORS_HERO } from '../../content/for-operators';
 import {
@@ -16,20 +16,6 @@ import { AudienceToggle } from './AudienceToggle';
 // "Local-first AI" chip lands without forking the ?hero=foundation A/B or
 // adding a third hero variant (positioning decision d).
 const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as const;
-
-const ArrowIcon = () => (
-  <svg
-    className="h-4 w-4"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-    strokeWidth={2}
-    aria-hidden="true"
-  >
-    <title>Arrow</title>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
-  </svg>
-);
 
 /**
  * Hero background: one quiet signature background (frontend-excellence Phase 1;
@@ -64,7 +50,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         <Button asChild size="lg" className="w-full sm:w-auto gap-2">
           <a href={hero.cta.primary.href}>
             {hero.cta.primary.label}
-            <ArrowIcon />
+            <IconArrowRight size="sm" />
           </a>
         </Button>
         <Button
@@ -75,10 +61,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
           className="w-full sm:w-auto gap-2"
         >
           <a href={hero.cta.secondary.href} target="_blank" rel="noopener noreferrer">
-            <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <title>GitHub</title>
-              <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.38s1.95.13 2.86.38c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.18c0 .31.21.67.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-            </svg>
+            <GitHubIcon size="sm" />
             {hero.cta.secondary.label}
           </a>
         </Button>
@@ -122,7 +105,7 @@ function NonTechnicalHero() {
         <Button asChild size="lg" className="w-full sm:w-auto gap-2">
           <a href={hero.primaryCta.href} target="_blank" rel="noopener noreferrer">
             {hero.primaryCta.label}
-            <ArrowIcon />
+            <IconArrowRight size="sm" />
           </a>
         </Button>
       </div>

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -61,7 +61,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
           className="w-full sm:w-auto gap-2"
         >
           <a href={hero.cta.secondary.href} target="_blank" rel="noopener noreferrer">
-            <GitHubIcon size="sm" />
+            <GitHubIcon className="size-4" />
             {hero.cta.secondary.label}
           </a>
         </Button>

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -1,5 +1,5 @@
 import type { PricingResponse } from '@revealui/contracts/pricing';
-import { Button } from '@revealui/presentation';
+import { Button, IconCheckCircle } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import {
   PRICING_TEASER_FOOTER,
@@ -100,20 +100,12 @@ export function PricingTeaser() {
                         t.highlight ? 'text-background/80' : 'text-foreground'
                       }`}
                     >
-                      <svg
-                        className={`mt-0.5 h-4 w-4 flex-shrink-0 ${
+                      <IconCheckCircle
+                        size="sm"
+                        className={`mt-0.5 flex-shrink-0 ${
                           t.highlight ? 'text-primary' : 'text-primary'
                         }`}
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                      >
-                        <title>Included</title>
-                        <path
-                          fillRule="evenodd"
-                          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
+                      />
                       {f}
                     </li>
                   ))}

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -23,7 +23,7 @@ export function Proof() {
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-md bg-card px-3 py-1.5 text-sm font-medium text-foreground ring-1 ring-border hover:ring-border/80 transition"
             >
-              <GitHubIcon size="sm" />
+              <GitHubIcon className="size-4" />
               {PROOF_SECTION.repoLinkLabel}
             </a>
           </div>

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@revealui/presentation';
+import { Button, GitHubIcon } from '@revealui/presentation';
 import { PROOF_SECTION, PROOF_TRUST } from '../../content/proof';
 import { SITE } from '../../content/site';
 import { LiveMetricsBadge } from './LiveMetricsBadge';
@@ -23,10 +23,7 @@ export function Proof() {
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-md bg-card px-3 py-1.5 text-sm font-medium text-foreground ring-1 ring-border hover:ring-border/80 transition"
             >
-              <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
-                <title>GitHub</title>
-                <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.25 1.89-.38 2.86-.38s1.95.13 2.86.38c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.18c0 .31.21.67.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-              </svg>
+              <GitHubIcon size="sm" />
               {PROOF_SECTION.repoLinkLabel}
             </a>
           </div>

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@revealui/presentation';
+import { Button, IconCheckCircle, IconPlus, IconXCircle } from '@revealui/presentation';
 import { useEffect } from 'react';
 import { Footer } from '../components/Footer';
 import {
@@ -92,33 +92,12 @@ export function FairSourcePage() {
               >
                 <div className="flex items-start gap-3">
                   {c.kind === 'yes' ? (
-                    <svg
-                      className="mt-0.5 h-6 w-6 flex-shrink-0 text-primary"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      aria-hidden="true"
-                    >
-                      <title>Yes</title>
-                      <path
-                        fillRule="evenodd"
-                        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
+                    <IconCheckCircle size="md" className="mt-0.5 flex-shrink-0 text-primary" />
                   ) : (
-                    <svg
-                      className="mt-0.5 h-6 w-6 flex-shrink-0 text-amber-800 dark:text-amber-200"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      aria-hidden="true"
-                    >
-                      <title>One restriction</title>
-                      <path
-                        fillRule="evenodd"
-                        d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
+                    <IconXCircle
+                      size="md"
+                      className="mt-0.5 flex-shrink-0 text-amber-800 dark:text-amber-200"
+                    />
                   )}
                   <div>
                     <h3 className="text-lg font-semibold text-foreground">{c.title}</h3>
@@ -289,21 +268,7 @@ export function FairSourcePage() {
                 <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
                   <h3 className="text-lg font-semibold leading-7 text-foreground">{f.question}</h3>
                   <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
-                    <svg
-                      className="h-4 w-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth={2}
-                      stroke="currentColor"
-                      aria-hidden="true"
-                    >
-                      <title>Toggle</title>
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 4.5v15m7.5-7.5h-15"
-                      />
-                    </svg>
+                    <IconPlus size="sm" label="Toggle" />
                   </span>
                 </summary>
                 <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -1,4 +1,10 @@
-import { Button, IconCheckCircle } from '@revealui/presentation';
+import {
+  Button,
+  IconCheckCircle,
+  IconCode,
+  IconSearch,
+  IconTerminal,
+} from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { CenteredCardGrid } from '../components/CenteredCardGrid';
 import { Footer } from '../components/Footer';
@@ -382,21 +388,7 @@ export function PricingPage() {
             <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
               <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
                 <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
-                  <svg
-                    className="h-5 w-5 text-primary"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <title>Discovery</title>
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-                    />
-                  </svg>
+                  <IconSearch size="md" className="text-primary" />
                 </div>
                 <h3 className="text-base font-semibold text-foreground">
                   {PRICING_AGENT_A2A.heading}
@@ -417,21 +409,7 @@ export function PricingPage() {
 
               <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
                 <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 ring-1 ring-blue-500/20">
-                  <svg
-                    className="h-5 w-5 text-blue-600"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <title>Payment</title>
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z"
-                    />
-                  </svg>
+                  <IconCode size="md" className="text-blue-600" />
                 </div>
                 <h3 className="text-base font-semibold text-foreground">
                   {PRICING_AGENT_X402.heading}
@@ -441,21 +419,7 @@ export function PricingPage() {
 
               <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
                 <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-violet-500/10 ring-1 ring-violet-500/20">
-                  <svg
-                    className="h-5 w-5 text-violet-600"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <title>MCP</title>
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M14.25 6.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003 0-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25 1.875c0 .369.128.713.349 1.003.215.283.401.604.401.959v0a.64.64 0 0 1-.657.643 48.39 48.39 0 0 1-4.163-.3c.186 1.613.293 3.25.315 4.907a.656.656 0 0 1-.658.663v0c-.355 0-.676-.186-.959-.401a1.647 1.647 0 0 0-1.003-.349c-1.036 0-1.875 1.007-1.875 2.25s.84 2.25 1.875 2.25c.369 0 .713-.128 1.003-.349.283-.215.604-.401.959-.401v0c.31 0 .555.26.532.57a48.039 48.039 0 0 1-.642 5.056c1.518.19 3.058.309 4.616.354a.64.64 0 0 0 .657-.643v0c0-.355-.186-.676-.401-.959a1.647 1.647 0 0 1-.349-1.003c0-1.035 1.008-1.875 2.25-1.875 1.243 0 2.25.84 2.25 1.875 0 .369-.128.713-.349 1.003-.215.283-.401.604-.401.959v0c0 .333.277.599.61.58a48.1 48.1 0 0 0 5.427-.63 48.05 48.05 0 0 0 .582-4.717.532.532 0 0 0-.533-.57v0c-.355 0-.676.186-.959.401-.29.221-.634.349-1.003.349-1.036 0-1.875-1.008-1.875-2.25s.84-2.25 1.875-2.25c.369 0 .713.128 1.003.349.283.215.604.401.959.401v0c.317 0 .573-.262.553-.578a48.14 48.14 0 0 0-.529-5.004.546.546 0 0 0-.574-.473 40.098 40.098 0 0 0-4.93.357.62.62 0 0 1-.658-.647v0Z"
-                    />
-                  </svg>
+                  <IconTerminal size="md" className="text-violet-600" />
                 </div>
                 <h3 className="text-base font-semibold text-foreground">
                   {PRICING_AGENT_MCP.heading}
@@ -477,21 +441,7 @@ export function PricingPage() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-lg bg-card px-4 py-2 text-sm font-medium text-muted-foreground ring-1 ring-border transition-colors hover:bg-muted"
               >
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <title>API</title>
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
-                  />
-                </svg>
+                <IconCode size="sm" />
                 {PRICING_AGENT_CTA_LINKS.openapi.label}
               </a>
               <a

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -1,3 +1,4 @@
+import { Button, IconCheckCircle } from '@revealui/presentation';
 import { useState } from 'react';
 import { Footer } from '../components/Footer';
 import { Faq } from '../components/landing/Faq';
@@ -179,21 +180,20 @@ export function ProductsPage() {
             {STATUS_FILTERS.map((f) => {
               const selected = filter === f;
               return (
-                <button
+                <Button
                   key={f}
                   type="button"
                   role="tab"
                   aria-selected={selected}
+                  size="sm"
+                  appearance={selected ? 'solid' : 'outline'}
+                  variant={selected ? 'brand' : 'neutral'}
                   onClick={() => setFilter(f)}
-                  className={`inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-sm font-medium ring-1 transition ${
-                    selected
-                      ? 'bg-primary/10 text-primary ring-primary/30'
-                      : 'bg-card text-muted-foreground ring-border hover:text-foreground hover:ring-border/80'
-                  }`}
+                  className="rounded-full"
                 >
                   {f}
                   <span className="text-xs text-muted-foreground">{countFor(f)}</span>
-                </button>
+                </Button>
               );
             })}
           </div>
@@ -250,18 +250,7 @@ export function ProductsPage() {
                         key={highlight}
                         className="flex items-start gap-2.5 text-sm leading-6 text-muted-foreground"
                       >
-                        <svg
-                          className="mt-1 h-4 w-4 flex-shrink-0 text-primary"
-                          fill="currentColor"
-                          viewBox="0 0 20 20"
-                          aria-hidden="true"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                            clipRule="evenodd"
-                          />
-                        </svg>
+                        <IconCheckCircle size="sm" className="mt-1 flex-shrink-0 text-primary" />
                         {highlight}
                       </li>
                     ))}

--- a/apps/marketing/app/routes/StatusPage.tsx
+++ b/apps/marketing/app/routes/StatusPage.tsx
@@ -1,4 +1,4 @@
-import { Callout } from '@revealui/presentation';
+import { Button, Callout } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { Footer } from '../components/Footer';
 import { SITE } from '../content/site';
@@ -184,9 +184,12 @@ export function StatusPage() {
           This page probes the API health endpoint in your browser when you load it. It reflects
           what your network sees right now, not a separate uptime service. Solo-operator company: we
           do not run 24×7 manned monitoring you can subscribe to.{' '}
-          <button
+          <Button
             type="button"
-            className="underline"
+            appearance="link"
+            variant="brand"
+            size="sm"
+            className="inline h-auto p-0"
             onClick={() => {
               setProbes((prev) => {
                 const next: Record<string, ProbeResult> = { ...prev };
@@ -197,7 +200,7 @@ export function StatusPage() {
             }}
           >
             Re-check now
-          </button>
+          </Button>
           .
         </Callout>
       </div>

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -472,26 +472,6 @@
       "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
-      "path": "apps/docs/app/components/DocLayout.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/components/DocLayout.tsx",
-      "tag": "svg",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/components/SearchBar.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/components/SearchBar.tsx",
-      "tag": "svg",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
       "path": "apps/docs/app/components/showcase/CodeView.tsx",
       "tag": "button",
       "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
@@ -527,21 +507,6 @@
       "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
-      "path": "apps/docs/app/routes/ApiPage.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/routes/GuidesPage.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/routes/SectionPage.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
       "path": "apps/docs/app/showcase/animations.showcase.tsx",
       "tag": "button",
       "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
@@ -560,11 +525,6 @@
       "path": "apps/docs/app/showcase/theme.showcase.tsx",
       "tag": "button",
       "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
-    },
-    {
-      "path": "apps/docs/app/utils/markdown.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/marketing/app/components/landing/Primitives.tsx",

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -4,637 +4,577 @@
     {
       "path": "apps/admin/src/app/(backend)/[[...segments]]/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agent-tasks/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agent-tasks/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agents/new/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agents/new/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agents/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agents/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/chat/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/chat/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/coordination/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/coordination/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/dashboard/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/error.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/error.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
       "tag": "select",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/knowledge-graph/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/knowledge-graph/page.tsx",
       "tag": "input",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/publish/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/publish/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/tasks/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/mcp/inspect/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/mcp/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/media/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/media/page.tsx",
       "tag": "input",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/media/page.tsx",
       "tag": "select",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/media/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/refunds/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/refunds/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/settings/account/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/settings/account/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/settings/layout.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/settings/security/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/settings/security/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/account/billing/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
       "tag": "input",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/error.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/error.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/login/LoginForm.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/mfa/MFAForm.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/not-found.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/signup/SignupForm.tsx",
       "tag": "input",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/welcome/page.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/global-error.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/global-error.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/ErrorBoundary.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/FreeTierBanner.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/FreeTierBanner.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/elements/button.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/elements/email-signup-form.tsx",
       "tag": "input",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/elements/install-command.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/icons/arrow-narrow-right-icon.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/icons/checkmark-icon.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/icons/chevron-icon.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/icons/squares-2-stacked-icon.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/footer-with-newsletter-form-categories-and-social-icons.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/footer-with-newsletter-form-categories-and-social-icons.tsx",
       "tag": "input",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/navbar-with-links-actions-and-centered-logo.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/navbar-with-links-actions-and-centered-logo.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/stats-with-graph.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/AdminBar/index.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/AdminSidebarLayout.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/Agent/index.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/agents/agent-memory.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/agents/agent-memory.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/agents/mcp-server-card.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/BeforeDashboard/OnboardingNudge.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/DataPanel/index.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/ErrorBoundary/index.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/mcp/resources-panel.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/mcp/usage-dashboard.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/mcp/usage-dashboard.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/PasswordInput.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/PasswordInput.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/SystemHealthMonitor/index.tsx",
       "tag": "select",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/SystemHealthPanel/index.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/SystemHealthPanel/index.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/UpgradeDialog.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/features/embed/components/EmbedNodeComponent.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/features/embed/icons/EmbedIcon.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/features/label/icons/LabelIcon.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/features/largeBody/icons/LargeBodyIcon.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/providers/Theme/ThemeSelector/index.tsx",
       "tag": "select",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/providers/Theme/ThemeSelector/index.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/docs/app/components/DocLayout.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/docs/app/components/DocLayout.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/docs/app/components/ErrorBoundary.tsx",
-      "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/docs/app/components/SearchBar.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/docs/app/components/SearchBar.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/docs/app/components/showcase/CodeView.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/components/showcase/Preview.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/components/showcase/PropPanel.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/components/showcase/PropPanel.tsx",
       "tag": "input",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/components/showcase/ShowcaseShell.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/components/showcase/ShowcaseShell.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/components/showcase/TokensPage.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/routes/ApiPage.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/docs/app/routes/GuidesPage.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/docs/app/routes/SectionPage.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/docs/app/showcase/animations.showcase.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/showcase/drawer.showcase.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/showcase/icons.showcase.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/showcase/theme.showcase.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
       "path": "apps/docs/app/utils/markdown.tsx",
       "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/components/for-operators/Faq.tsx",
-      "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/components/GetStarted.tsx",
-      "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/components/landing/Faq.tsx",
-      "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/components/landing/Hero.tsx",
-      "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/components/landing/PricingTeaser.tsx",
-      "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/marketing/app/components/landing/Primitives.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/components/landing/Proof.tsx",
-      "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/components/NavBar.tsx",
-      "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/routes/FairSourcePage.tsx",
-      "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/routes/PricingPage.tsx",
-      "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/routes/ProductsPage.tsx",
-      "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "content-driven SVG path from content modules; no static Icon* mapping (GAP-398 residual)"
     },
     {
       "path": "apps/marketing/app/routes/ProductsPage.tsx",
       "tag": "svg",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
-    },
-    {
-      "path": "apps/marketing/app/routes/StatusPage.tsx",
-      "tag": "button",
-      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
+      "reason": "content-driven SVG path from content modules; no static Icon* mapping (GAP-398 residual)"
     }
   ]
 }


### PR DESCRIPTION
## Summary

GAP-398 allowlist burn-down (follow-up to #2037).

### Marketing (nearly clear)
Replaced hand-rolled `<button>` / `<svg>` with `@revealui/presentation`:
- **NavBar** mobile menu → `Button`
- **Hero** arrows/GitHub → `IconArrowRight` / `GitHubIcon`
- **GetStarted** arrow → `IconArrowRight`
- **Faq** (home + for-operators + FairSource) plus toggles → `IconPlus`
- **PricingTeaser** / **Products** checkmarks → `IconCheckCircle`
- **Proof** GitHub → `GitHubIcon`
- **Products** status filters → `Button`
- **FairSource** yes/no → `IconCheckCircle` / `IconXCircle`
- **Status** re-check → `Button` link
- **Pricing** agent icons → `IconSearch` / `IconCode` / `IconTerminal`

**Marketing residual (2 files, content-driven SVG paths):**
- `Primitives.tsx`, `ProductsPage.tsx` — icon paths from content modules (no static Icon* map yet)

### Docs
- **ErrorBoundary** Try Again → `Button`

### Allowlist
- **127 → 115** path/tag entries
- Hits **234 → 215**
- Reasons refined (admin/docs residual vs content-driven vs showcase)

Still **warn-only** in phase-1. Hard-fail flip waits on admin/docs/showcase burn or explicit carve-outs.

## Test plan
- [x] `pnpm validate:tier1-presentation` → 0 violations
- [x] Pre-push phase-1 gate PASS
- [ ] CI green
- [ ] Optional visual smoke: pricing, products filters, mobile nav
