### PR TITLE
fix(docs): burn GAP-398 Tier-1 chrome residuals

### DIFF
--- a/apps/docs/app/components/DocLayout.tsx
+++ b/apps/docs/app/components/DocLayout.tsx
@@ -1,3 +1,12 @@
+import {
+  Button,
+  GitHubIcon,
+  IconChevronRight,
+  IconClose,
+  IconCode,
+  IconGlobe,
+  IconMenu,
+} from '@revealui/presentation';
 import { Link, useLocation } from '@revealui/router';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { buildDocNavSections, type NavItem, type NavSection } from '../lib/nav';
@@ -69,19 +78,7 @@ function SidebarContent({ isHome, onNavigate }: { isHome: boolean; onNavigate?: 
       {/* Logo */}
       <h2 className="mb-4 text-lg font-bold tracking-tight text-ink">
         <Link to="/" onClick={onNavigate} className="flex items-center gap-2 no-underline">
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <title>RevealUI</title>
-            <path d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
-          </svg>
+          <IconCode size="md" label="RevealUI" />
           RevealUI
         </Link>
       </h2>
@@ -137,31 +134,14 @@ function SidebarContent({ isHome, onNavigate }: { isHome: boolean; onNavigate?: 
           href="https://github.com/RevealUIStudio/revealui"
           className="flex items-center gap-2 rounded-md px-3 py-2 text-[0.8125rem] text-text-muted no-underline transition-colors hover:text-text-secondary md:py-1.5"
         >
-          <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <title>GitHub</title>
-            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-          </svg>
+          <GitHubIcon size="sm" />
           GitHub
         </a>
         <a
           href="https://revealui.com"
           className="mt-1 flex items-center gap-2 rounded-md px-3 py-2 text-[0.8125rem] text-text-muted no-underline transition-colors hover:text-text-secondary md:py-1.5"
         >
-          <svg
-            height="16"
-            width="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <title>Website</title>
-            <circle cx="12" cy="12" r="10" />
-            <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-          </svg>
+          <IconGlobe size="sm" />
           revealui.com
         </a>
         <div className="mt-3 border-t border-border pt-3 px-3">
@@ -270,20 +250,7 @@ function Breadcrumbs({ sections: navSections }: { sections: NavSection[] }) {
                   ) : (
                     <span className="text-text-muted">{crumb.label}</span>
                   )}
-                  <svg
-                    aria-hidden="true"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    className="size-3 text-text-muted"
-                  >
-                    <path
-                      d="M6 4l4 4-4 4"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
+                  <IconChevronRight size="xs" className="text-text-muted" />
                 </>
               )}
             </li>
@@ -324,58 +291,21 @@ export function DocLayout({ children }: DocLayoutProps) {
           to="/"
           className="flex items-center gap-2 text-base font-bold tracking-tight text-ink no-underline"
         >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
-          </svg>
+          <IconCode size="sm" />
           RevealUI
         </Link>
-        <button
+        <Button
           type="button"
+          appearance="ghost"
+          variant="neutral"
+          size="icon"
           onClick={() => setSidebarOpen((v) => !v)}
-          className="rounded-md p-2 text-text-secondary transition-colors hover:bg-accent-bg hover:text-accent"
+          className="text-text-secondary"
           aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
           aria-expanded={sidebarOpen}
         >
-          {sidebarOpen ? (
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
-          ) : (
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          )}
-        </button>
+          {sidebarOpen ? <IconClose size="md" /> : <IconMenu size="md" />}
+        </Button>
       </div>
 
       {/* Mobile overlay backdrop */}

--- a/apps/docs/app/components/SearchBar.tsx
+++ b/apps/docs/app/components/SearchBar.tsx
@@ -5,7 +5,7 @@
  * Supports Cmd+K / Ctrl+K keyboard shortcut to focus.
  */
 
-import { Input } from '@revealui/presentation';
+import { Button, IconLoading, Input } from '@revealui/presentation';
 import { useNavigate } from '@revealui/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SearchResult } from '../lib/search-index';
@@ -155,24 +155,28 @@ export function SearchBar() {
           className="absolute top-full right-0 left-0 z-[1000] mt-1 max-h-[60vh] overflow-y-auto rounded-lg border border-border bg-surface shadow-lg"
         >
           {results.map((result, i) => (
-            <button
+            <Button
               type="button"
               role="option"
               aria-selected={i === activeIndex}
               key={result.path}
+              appearance="ghost"
+              variant="neutral"
               onClick={() => handleSelect(result)}
               onMouseEnter={() => setActiveIndex(i)}
-              className={`w-full cursor-pointer border-none px-3 py-2.5 text-left font-sans transition-colors ${
-                i === activeIndex ? 'bg-accent-bg' : 'bg-transparent hover:bg-accent-bg'
+              className={`h-auto w-full justify-start rounded-none px-3 py-2.5 text-left font-sans ${
+                i === activeIndex ? 'bg-accent-bg' : ''
               } ${i < results.length - 1 ? 'border-b border-border-subtle' : ''}`}
             >
-              <div className="mb-0.5 font-medium text-text-primary">{result.title}</div>
-              {result.excerpt && (
-                <div className="truncate text-xs leading-snug text-text-muted">
-                  {result.excerpt}
-                </div>
-              )}
-            </button>
+              <span className="flex w-full flex-col items-start gap-0.5">
+                <span className="font-medium text-text-primary">{result.title}</span>
+                {result.excerpt ? (
+                  <span className="truncate text-xs leading-snug text-text-muted">
+                    {result.excerpt}
+                  </span>
+                ) : null}
+              </span>
+            </Button>
           ))}
         </div>
       )}
@@ -188,27 +192,7 @@ export function SearchBar() {
             </div>
           ) : (
             <div className="flex items-center justify-center gap-2">
-              <svg
-                className="size-4 animate-spin text-accent"
-                viewBox="0 0 24 24"
-                fill="none"
-                aria-hidden="true"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  opacity="0.25"
-                />
-                <path
-                  d="M4 12a8 8 0 018-8"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                />
-              </svg>
+              <IconLoading size="sm" className="animate-spin text-accent" />
               <span>Building search index...</span>
             </div>
           )}

--- a/apps/docs/app/routes/ApiPage.tsx
+++ b/apps/docs/app/routes/ApiPage.tsx
@@ -1,4 +1,5 @@
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -111,13 +112,16 @@ This will create markdown files in \`docs/api/\` that are automatically copied t
         >
           Edit this page on GitHub
         </a>
-        <button
+        <Button
           type="button"
+          appearance="link"
+          variant="neutral"
+          size="sm"
+          className="h-auto p-0 text-text-muted"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="cursor-pointer border-none bg-transparent p-0 font-sans text-[inherit] text-text-muted transition-colors hover:text-text-secondary"
         >
           Back to top
-        </button>
+        </Button>
       </div>
     </ErrorBoundary>
   );

--- a/apps/docs/app/routes/GuidesPage.tsx
+++ b/apps/docs/app/routes/GuidesPage.tsx
@@ -1,4 +1,5 @@
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -105,13 +106,16 @@ Available guides are loaded from the \`docs/guides/\` directory.
         >
           Edit this page on GitHub
         </a>
-        <button
+        <Button
           type="button"
+          appearance="link"
+          variant="neutral"
+          size="sm"
+          className="h-auto p-0 text-text-muted"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="cursor-pointer border-none bg-transparent p-0 font-sans text-[inherit] text-text-muted transition-colors hover:text-text-secondary"
         >
           Back to top
-        </button>
+        </Button>
       </div>
     </ErrorBoundary>
   );

--- a/apps/docs/app/routes/SectionPage.tsx
+++ b/apps/docs/app/routes/SectionPage.tsx
@@ -1,4 +1,5 @@
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
@@ -176,13 +177,16 @@ Document not found at \`${resolved.markdownPath}\`.
         >
           Edit this page on GitHub
         </a>
-        <button
+        <Button
           type="button"
+          appearance="link"
+          variant="neutral"
+          size="sm"
+          className="h-auto p-0 text-text-muted"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="cursor-pointer border-none bg-transparent p-0 font-sans text-[inherit] text-text-muted transition-colors hover:text-text-secondary"
         >
           Back to top
-        </button>
+        </Button>
       </div>
     </ErrorBoundary>
   );

--- a/apps/docs/app/utils/markdown.tsx
+++ b/apps/docs/app/utils/markdown.tsx
@@ -3,6 +3,7 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
+import { Button } from '@revealui/presentation';
 import type React from 'react';
 import { useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -517,14 +518,17 @@ function CopyablePreBlock({ children, ...props }: React.ComponentProps<'pre'>): 
       <pre ref={preRef} {...props}>
         {children}
       </pre>
-      <button
+      <Button
         type="button"
+        size="sm"
+        appearance="ghost"
+        variant="neutral"
         onClick={handleCopy}
-        className="absolute top-2 right-2 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-400 opacity-0 transition-opacity hover:bg-white/10 hover:text-white group-hover/code:opacity-100"
+        className="absolute top-2 right-2 h-auto border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-400 opacity-0 transition-opacity hover:bg-white/10 hover:text-white group-hover/code:opacity-100"
         aria-label="Copy code"
       >
         {copied ? 'Copied!' : 'Copy'}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -472,26 +472,6 @@
       "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
-      "path": "apps/docs/app/components/DocLayout.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/components/DocLayout.tsx",
-      "tag": "svg",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/components/SearchBar.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/components/SearchBar.tsx",
-      "tag": "svg",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
       "path": "apps/docs/app/components/showcase/CodeView.tsx",
       "tag": "button",
       "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
@@ -527,21 +507,6 @@
       "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
     },
     {
-      "path": "apps/docs/app/routes/ApiPage.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/routes/GuidesPage.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/docs/app/routes/SectionPage.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
       "path": "apps/docs/app/showcase/animations.showcase.tsx",
       "tag": "button",
       "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
@@ -560,11 +525,6 @@
       "path": "apps/docs/app/showcase/theme.showcase.tsx",
       "tag": "button",
       "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
-    },
-    {
-      "path": "apps/docs/app/utils/markdown.tsx",
-      "tag": "button",
-      "reason": "docs chrome residual; migrate to presentation in follow-up (GAP-398)"
     },
     {
       "path": "apps/marketing/app/components/landing/Primitives.tsx",


### PR DESCRIPTION
## Summary

GAP-398 docs chrome burn (stacked on **#2038**).

### Burned
- **DocLayout** — logo/menu/GitHub/globe/breadcrumbs → presentation `Icon*` + `Button` + `GitHubIcon`
- **SearchBar** — result rows → `Button`; spinner → `IconLoading`
- **ApiPage / GuidesPage / SectionPage** — back-to-top → `Button` link
- **markdown copy** — `Button`

### Allowlist
- **115 → 107** (vs #2038 tip); hits **215 → 201**
- Docs non-showcase chrome **clear**
- Remaining docs: **showcase only** (intentional host demos)
- Marketing still 2 content-path SVG files; admin 94

### Stack
Base: `fix/gap-398-allowlist-burn` (#2038). After #2038 merges to `test`, rebase this branch onto `test` if GitHub needs it.

## Test plan
- [x] `pnpm validate:tier1-presentation` clean
- [x] Pre-push phase-1 PASS
- [ ] CI green after #2038 lands
