### PR TITLE
fix(admin): burn GAP-398 Tier-1 presentation residuals

### DIFF
--- a/apps/admin/src/__tests__/settings/account-page.test.tsx
+++ b/apps/admin/src/__tests__/settings/account-page.test.tsx
@@ -9,8 +9,22 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => mockSearchParams,
 }));
 
-// Mock presentation Dialog components to render inline (avoids portal/transition complexity)
+// Mock presentation components to render inline (avoids portal/transition complexity)
 vi.mock('@revealui/presentation/client', () => ({
+  Button: ({
+    children,
+    type = 'button',
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    appearance?: string;
+    variant?: string;
+    size?: string;
+    isLoading?: boolean;
+  }) => (
+    <button type={type} {...props}>
+      {children}
+    </button>
+  ),
   Dialog: ({
     open,
     children,

--- a/apps/admin/src/app/(backend)/agents/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/page.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import type { A2AAgentCard } from '@revealui/contracts';
-import { EmptyState, LinkButton, Skeleton, SkeletonText } from '@revealui/presentation';
+import {
+  Button,
+  EmptyState,
+  IconStar,
+  IconTerminal,
+  LinkButton,
+  Skeleton,
+  SkeletonText,
+} from '@revealui/presentation';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { AgentCard } from '@/lib/components/agents/agent-card';
@@ -33,18 +41,20 @@ export default function AgentsPage() {
         <div className="border-b border-border bg-muted px-6">
           <nav className="flex gap-1 -mb-px">
             {(['agents', 'mcp'] as Tab[]).map((t) => (
-              <button
+              <Button
                 key={t}
                 type="button"
+                appearance="ghost"
+                variant="neutral"
                 onClick={() => setTab(t)}
-                className={`border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
+                className={`h-auto rounded-none border-b-2 px-4 py-3 text-sm font-medium ${
                   tab === t
                     ? 'border-primary text-foreground'
                     : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {t === 'agents' ? 'Agent Cards' : 'MCP Servers'}
-              </button>
+              </Button>
             ))}
           </nav>
         </div>
@@ -125,22 +135,7 @@ function AgentCardsPanel() {
 
       {agents.length === 0 ? (
         <EmptyState
-          icon={
-            <svg
-              className="size-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09ZM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456Z"
-              />
-            </svg>
-          }
+          icon={<IconStar className="size-6" aria-hidden="true" />}
           title="No agents registered"
           description="Create your first AI agent to get started with automated tasks and workflows."
           action={
@@ -222,22 +217,7 @@ function McpServersPanel() {
 
       {servers.length === 0 ? (
         <EmptyState
-          icon={
-            <svg
-              className="size-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z"
-              />
-            </svg>
-          }
+          icon={<IconTerminal className="size-6" aria-hidden="true" />}
           title="No MCP servers connected"
           description="Start your development environment with MCP support to connect servers."
           action={

--- a/apps/admin/src/app/(backend)/chat/page.tsx
+++ b/apps/admin/src/app/(backend)/chat/page.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { Button, EmptyState, Skeleton } from '@revealui/presentation';
+import {
+  Button,
+  EmptyState,
+  IconChevronLeft,
+  IconChevronRight,
+  IconClose,
+  IconGlobe,
+  Skeleton,
+} from '@revealui/presentation';
 import { useConversations } from '@revealui/sync';
 import { useState } from 'react';
 import AgentChat from '@/lib/components/Agent';
@@ -75,22 +83,7 @@ export default function ChatPage() {
               </div>
             ) : conversations.length === 0 ? (
               <EmptyState
-                icon={
-                  <svg
-                    className="size-6 text-zinc-400"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 01-.825-.242m9.345-8.334a2.126 2.126 0 00-.476-.095 48.64 48.64 0 00-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0011.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155"
-                    />
-                  </svg>
-                }
+                icon={<IconGlobe className="size-6 text-zinc-400" aria-hidden="true" />}
                 title="No conversations yet"
                 description="Start a new chat to begin"
                 className="border-0 py-8"
@@ -104,38 +97,45 @@ export default function ChatPage() {
                     activeId === conv.id ? 'bg-blue-50 dark:bg-blue-900/20' : ''
                   }`}
                 >
-                  <button
+                  <Button
                     type="button"
+                    appearance="ghost"
+                    variant="neutral"
                     onClick={() => handleSelectConversation(conv.id)}
-                    className="flex-1 truncate text-left text-zinc-700 dark:text-zinc-300"
+                    className="h-auto flex-1 justify-start truncate px-0 py-0 text-left text-zinc-700 hover:bg-transparent dark:text-zinc-300"
                   >
                     {conv.title ?? 'Untitled'}
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     type="button"
+                    appearance="ghost"
+                    variant="neutral"
+                    size="icon"
                     onClick={(e) => {
                       e.stopPropagation();
                       handleDeleteConversation(conv.id);
                     }}
-                    className="ml-2 hidden shrink-0 text-xs text-zinc-400 hover:text-red-500 group-hover:block"
+                    className="ml-2 hidden size-6 shrink-0 text-zinc-400 hover:text-red-500 group-hover:inline-flex"
                     aria-label="Delete conversation"
                   >
-                    &#x2715;
-                  </button>
+                    <IconClose size="xs" />
+                  </Button>
                 </div>
               ))}
           </div>
         </div>
 
         {/* Toggle sidebar */}
-        <button
+        <Button
           type="button"
+          appearance="ghost"
+          variant="neutral"
           onClick={() => setSidebarOpen(!sidebarOpen)}
-          className="flex w-6 shrink-0 items-center justify-center border-r border-zinc-200 bg-zinc-50 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+          className="h-auto w-6 shrink-0 rounded-none border-r border-zinc-200 bg-zinc-50 px-0 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
           aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
         >
-          {sidebarOpen ? '‹' : '›'}
-        </button>
+          {sidebarOpen ? <IconChevronLeft size="sm" /> : <IconChevronRight size="sm" />}
+        </Button>
 
         {/* Chat area */}
         <div className="flex flex-1 flex-col">

--- a/apps/admin/src/app/(backend)/error.tsx
+++ b/apps/admin/src/app/(backend)/error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button, IconAlertTriangle } from '@revealui/presentation/server';
 import Link from 'next/link';
 
 export default function BackendError({
@@ -24,22 +25,8 @@ export default function BackendError({
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-5 p-8">
-      {/* Icon */}
       <div className="flex size-14 items-center justify-center rounded-full bg-destructive/10">
-        <svg
-          className="size-7 text-destructive"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-          />
-        </svg>
+        <IconAlertTriangle className="size-7 text-destructive" aria-hidden="true" />
       </div>
 
       <h2 className="text-lg font-semibold text-foreground">
@@ -82,19 +69,12 @@ export default function BackendError({
       )}
 
       <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={() => reset()}
-          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
+        <Button type="button" variant="brand" onClick={() => reset()}>
           Try again
-        </button>
-        <Link
-          href="/"
-          className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
-        >
-          Go to dashboard
-        </Link>
+        </Button>
+        <Button asChild appearance="outline" variant="neutral">
+          <Link href="/">Go to dashboard</Link>
+        </Button>
       </div>
     </div>
   );

--- a/apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx
+++ b/apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Input } from '@revealui/presentation';
+import { Button, Input } from '@revealui/presentation';
 import { Field, Label } from '@revealui/presentation/client';
 import { useActionState, useEffect, useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
@@ -93,20 +93,18 @@ export function PasswordChangeForm({ onSuccess, onCancel }: Props) {
       </Field>
 
       <div className="flex gap-2 pt-1">
-        <button
-          type="submit"
-          disabled={isPending}
-          className="rounded-lg bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
-        >
+        <Button type="submit" variant="neutral" disabled={isPending}>
           {isPending ? 'Updating...' : 'Update password'}
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
+          appearance="ghost"
+          variant="neutral"
           onClick={onCancel}
-          className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-400 hover:text-zinc-200"
+          className="text-zinc-400 hover:text-zinc-200"
         >
           Cancel
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/apps/admin/src/app/(backend)/settings/account/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/account/page.tsx
@@ -4,11 +4,13 @@ const SUCCESS_DISMISS_MS = 5_000;
 const ERROR_DISMISS_MS = 8_000;
 
 import {
+  Button,
   Dialog,
   DialogActions,
   DialogDescription,
   DialogTitle,
 } from '@revealui/presentation/client';
+import { GitHubIcon, GoogleIcon, VercelIcon } from '@revealui/presentation/server';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
@@ -60,37 +62,6 @@ const PROVIDERS: {
     description: 'Sign in with your Vercel account',
   },
 ];
-
-// =============================================================================
-// Provider icon SVGs
-// =============================================================================
-
-function GitHubIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-    </svg>
-  );
-}
-
-function GoogleIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-    </svg>
-  );
-}
-
-function VercelIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M12 2L2 19.5h20L12 2z" />
-    </svg>
-  );
-}
 
 const PROVIDER_ICONS: Record<OAuthProvider, typeof GitHubIcon> = {
   github: GitHubIcon,
@@ -310,13 +281,15 @@ function AccountSettingsContent() {
               <div className="flex items-center justify-between">
                 <h2 className="text-base font-semibold text-foreground">Password</h2>
                 {user.hasPassword && !showPasswordForm && (
-                  <button
+                  <Button
                     type="button"
+                    variant="neutral"
+                    size="sm"
                     onClick={() => setShowPasswordForm(true)}
-                    className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/80"
+                    className="text-xs"
                   >
                     Change password
-                  </button>
+                  </Button>
                 )}
               </div>
               {!user.hasPassword ? (
@@ -361,7 +334,7 @@ function AccountSettingsContent() {
                       className="flex items-center justify-between rounded-lg border border-border px-4 py-3"
                     >
                       <div className="flex items-center gap-3">
-                        <Icon className="h-5 w-5 text-muted-foreground" />
+                        <Icon className="size-5 text-muted-foreground" />
                         <div>
                           <div className="text-sm font-medium text-muted-foreground">
                             {provider.label}
@@ -380,22 +353,27 @@ function AccountSettingsContent() {
                       </div>
 
                       {isLinked ? (
-                        <button
+                        <Button
                           type="button"
+                          appearance="outline"
+                          variant="neutral"
+                          size="sm"
                           onClick={() => requestUnlink(provider.id)}
                           disabled={isUnlinking}
-                          className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-error hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
+                          className="text-xs text-muted-foreground hover:border-error hover:text-error"
                         >
                           {isUnlinking ? 'Unlinking...' : 'Unlink'}
-                        </button>
+                        </Button>
                       ) : (
-                        <button
+                        <Button
                           type="button"
+                          variant="neutral"
+                          size="sm"
                           onClick={() => handleLink(provider.id)}
-                          className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/80"
+                          className="text-xs"
                         >
                           Link
-                        </button>
+                        </Button>
                       )}
                     </div>
                   );
@@ -427,20 +405,18 @@ function AccountSettingsContent() {
           You'll no longer be able to sign in with this account.
         </DialogDescription>
         <DialogActions>
-          <button
+          <Button
             type="button"
+            appearance="ghost"
+            variant="neutral"
             onClick={cancelUnlink}
-            className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:text-foreground"
           >
             Cancel
-          </button>
-          <button
-            type="button"
-            onClick={() => void confirmUnlink()}
-            className="rounded-md bg-error px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-error/90"
-          >
+          </Button>
+          <Button type="button" variant="danger" onClick={() => void confirmUnlink()}>
             Unlink
-          </button>
+          </Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx
@@ -2,7 +2,7 @@
 
 const SAVED_FEEDBACK_MS = 2_000;
 
-import { Input, Select } from '@revealui/presentation';
+import { Button, IconCheck, Input, Select } from '@revealui/presentation';
 import { Field, Label } from '@revealui/presentation/client';
 import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -157,54 +157,45 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
                     placeholder={activeProviderInfo?.placeholder ?? ''}
                     className="pr-16 font-mono"
                   />
-                  <button
+                  <Button
                     type="button"
+                    appearance="ghost"
+                    variant="neutral"
+                    size="sm"
                     onClick={() => setShowKey((v) => !v)}
-                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground"
+                    className="absolute right-2.5 top-1/2 h-auto -translate-y-1/2 px-1 py-0.5 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
                   >
                     {showKey ? 'hide' : 'show'}
-                  </button>
+                  </Button>
                 </div>
               </Field>
 
               {/* Actions */}
               <div className="flex items-center gap-2 pt-1">
-                <button
+                <Button
                   type="button"
+                  variant="brand"
                   onClick={handleSave}
                   disabled={!apiKey.trim()}
-                  className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {saved ? (
                     <span className="inline-flex items-center gap-1.5">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="3"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        aria-hidden="true"
-                      >
-                        <polyline points="20 6 9 17 4 12" />
-                      </svg>
+                      <IconCheck size="sm" />
                       Saved
                     </span>
                   ) : (
                     'Save Key'
                   )}
-                </button>
+                </Button>
                 {currentProvider && (
-                  <button
+                  <Button
                     type="button"
+                    appearance="outline"
+                    variant="neutral"
                     onClick={handleClear}
-                    className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
                   >
                     Clear
-                  </button>
+                  </Button>
                 )}
               </div>
             </div>

--- a/apps/admin/src/app/(backend)/settings/layout.tsx
+++ b/apps/admin/src/app/(backend)/settings/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { IconChevronLeft } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
@@ -52,16 +53,7 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
             href="/"
             className="mb-4 flex items-center gap-2 text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
-            <svg
-              className="h-3.5 w-3.5"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
+            <IconChevronLeft size="xs" aria-hidden="true" />
             Back to Admin
           </Link>
 

--- a/apps/admin/src/app/(backend)/settings/security/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/security/page.tsx
@@ -4,7 +4,7 @@ const SUCCESS_DISMISS_MS = 5_000;
 const ERROR_DISMISS_MS = 8_000;
 
 import { useMFASetup, usePasskeyRegister } from '@revealui/auth/react';
-import { Input } from '@revealui/presentation';
+import { Button, Input, PasskeyIcon } from '@revealui/presentation';
 import {
   Dialog,
   DialogActions,
@@ -538,21 +538,23 @@ function SecuritySettingsContent() {
                         placeholder="000000"
                         className="w-32"
                       />
-                      <button
+                      <Button
                         type="button"
+                        variant="success"
                         onClick={() => void handleVerifySetup()}
                         disabled={verifyCode.length !== 6 || mfaLoading}
-                        className="rounded-md bg-success px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         {mfaLoading ? 'Verifying...' : 'Verify'}
-                      </button>
-                      <button
+                      </Button>
+                      <Button
                         type="button"
+                        appearance="ghost"
+                        variant="neutral"
                         onClick={cancelSetup}
-                        className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+                        className="text-muted-foreground hover:text-foreground"
                       >
                         Cancel
-                      </button>
+                      </Button>
                     </div>
                   </Field>
                 </div>
@@ -562,14 +564,16 @@ function SecuritySettingsContent() {
               {!setupData && (
                 <div className="mt-5">
                   {mfaStatus && !mfaStatus.enabled && (
-                    <button
+                    <Button
                       type="button"
+                      variant="neutral"
+                      size="sm"
                       onClick={() => void handleEnableMFA()}
                       disabled={mfaLoading}
-                      className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="text-xs"
                     >
                       {mfaLoading ? 'Setting up...' : 'Enable 2FA'}
-                    </button>
+                    </Button>
                   )}
 
                   {mfaStatus?.enabled && (
@@ -589,47 +593,54 @@ function SecuritySettingsContent() {
                                 placeholder="Password"
                                 className="w-full sm:w-48"
                               />
-                              <button
+                              <Button
                                 type="button"
+                                variant="danger"
                                 onClick={() => void handleDisableMFA()}
                                 disabled={disabling || !disablePassword.trim()}
-                                className="rounded-md bg-error px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-error/90 disabled:cursor-not-allowed disabled:opacity-50"
                               >
                                 {disabling ? 'Disabling...' : 'Confirm'}
-                              </button>
-                              <button
+                              </Button>
+                              <Button
                                 type="button"
+                                appearance="ghost"
+                                variant="neutral"
                                 onClick={() => {
                                   setShowDisableForm(false);
                                   setDisablePassword('');
                                 }}
-                                className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+                                className="text-muted-foreground hover:text-foreground"
                               >
                                 Cancel
-                              </button>
+                              </Button>
                             </div>
                           </Field>
                         </div>
                       ) : (
-                        <button
+                        <Button
                           type="button"
+                          appearance="outline"
+                          variant="neutral"
+                          size="sm"
                           onClick={() => setShowDisableForm(true)}
-                          className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-error/50 hover:text-error"
+                          className="text-xs hover:border-error/50 hover:text-error"
                         >
                           Disable 2FA
-                        </button>
+                        </Button>
                       )}
 
                       {/* Regenerate backup codes */}
                       <div>
-                        <button
+                        <Button
                           type="button"
+                          variant="neutral"
+                          size="sm"
                           onClick={() => void handleRegenerateCodes()}
                           disabled={regenerating}
-                          className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="text-xs"
                         >
                           {regenerating ? 'Regenerating...' : 'Regenerate backup codes'}
-                        </button>
+                        </Button>
                       </div>
 
                       {/* Show regenerated codes */}
@@ -645,13 +656,16 @@ function SecuritySettingsContent() {
                               </code>
                             ))}
                           </div>
-                          <button
+                          <Button
                             type="button"
+                            appearance="ghost"
+                            variant="neutral"
+                            size="sm"
                             onClick={() => setRegeneratedCodes(null)}
-                            className="mt-2 text-xs text-muted-foreground hover:text-foreground"
+                            className="mt-2 h-auto p-0 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
                           >
                             Dismiss
-                          </button>
+                          </Button>
                         </div>
                       )}
                     </div>
@@ -684,20 +698,7 @@ function SecuritySettingsContent() {
                       className="flex items-center justify-between rounded-lg border border-border px-4 py-3"
                     >
                       <div className="flex items-center gap-3">
-                        <svg
-                          className="h-5 w-5 text-muted-foreground"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                          aria-hidden="true"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z"
-                          />
-                        </svg>
+                        <PasskeyIcon className="size-5 text-muted-foreground" />
                         <div>
                           {renamingId === passkey.id ? (
                             <div className="flex gap-1.5">
@@ -711,20 +712,26 @@ function SecuritySettingsContent() {
                                 }}
                                 className="w-36"
                               />
-                              <button
+                              <Button
                                 type="button"
+                                appearance="ghost"
+                                variant="success"
+                                size="sm"
                                 onClick={() => void submitRename(passkey.id)}
-                                className="text-xs text-success hover:text-success/80"
+                                className="h-auto p-0 text-xs"
                               >
                                 Save
-                              </button>
-                              <button
+                              </Button>
+                              <Button
                                 type="button"
+                                appearance="ghost"
+                                variant="neutral"
+                                size="sm"
                                 onClick={cancelRename}
-                                className="text-xs text-muted-foreground hover:text-foreground"
+                                className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
                               >
                                 Cancel
-                              </button>
+                              </Button>
                             </div>
                           ) : (
                             <div className="text-sm font-medium text-muted-foreground">
@@ -740,21 +747,27 @@ function SecuritySettingsContent() {
 
                       {renamingId !== passkey.id && (
                         <div className="flex items-center gap-2">
-                          <button
+                          <Button
                             type="button"
+                            appearance="ghost"
+                            variant="neutral"
+                            size="sm"
                             onClick={() => startRename(passkey)}
-                            className="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                            className="h-auto px-2 py-1 text-xs text-muted-foreground"
                           >
                             Rename
-                          </button>
-                          <button
+                          </Button>
+                          <Button
                             type="button"
+                            appearance="ghost"
+                            variant="neutral"
+                            size="sm"
                             onClick={() => requestDelete(passkey.id)}
                             disabled={deletingId === passkey.id}
-                            className="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
+                            className="h-auto px-2 py-1 text-xs text-muted-foreground hover:text-error"
                           >
                             {deletingId === passkey.id ? 'Removing...' : 'Remove'}
-                          </button>
+                          </Button>
                         </div>
                       )}
                     </div>
@@ -769,14 +782,16 @@ function SecuritySettingsContent() {
                     Passkeys are not supported in this browser.
                   </p>
                 ) : (
-                  <button
+                  <Button
                     type="button"
+                    variant="neutral"
+                    size="sm"
                     onClick={() => void handleAddPasskey()}
                     disabled={passkeyLoading || passkeys.length >= MAX_PASSKEYS}
-                    className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="text-xs"
                   >
                     {passkeyLoading ? 'Adding...' : 'Add passkey'}
-                  </button>
+                  </Button>
                 )}
                 {passkeys.length >= MAX_PASSKEYS && (
                   <p className="mt-2 text-xs text-warning-foreground/80">
@@ -859,15 +874,18 @@ function SecuritySettingsContent() {
                         </div>
                       </div>
                       {!session.isCurrent && (
-                        <button
+                        <Button
                           type="button"
+                          appearance="outline"
+                          variant="neutral"
+                          size="sm"
                           onClick={() => void revokeSession(session.id)}
                           disabled={revokingId === session.id}
                           aria-label="Revoke this session"
-                          className="ml-4 shrink-0 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-error/50 hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
+                          className="ml-4 shrink-0 text-xs hover:border-error/50 hover:text-error"
                         >
                           {revokingId === session.id ? 'Revoking...' : 'Revoke'}
-                        </button>
+                        </Button>
                       )}
                     </div>
                   ))}
@@ -875,8 +893,11 @@ function SecuritySettingsContent() {
               )}
 
               {activeSessions.filter((s) => !s.isCurrent).length > 1 && (
-                <button
+                <Button
                   type="button"
+                  appearance="link"
+                  variant="danger"
+                  size="sm"
                   onClick={async () => {
                     const others = activeSessions.filter((s) => !s.isCurrent);
                     for (const s of others) {
@@ -884,10 +905,10 @@ function SecuritySettingsContent() {
                     }
                   }}
                   disabled={!!revokingId}
-                  className="mt-4 text-xs text-error hover:text-error/80 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="mt-4 h-auto p-0 text-xs"
                 >
                   Revoke all other sessions
-                </button>
+                </Button>
               )}
             </div>
           </>
@@ -901,20 +922,18 @@ function SecuritySettingsContent() {
           This passkey will be permanently removed. You will no longer be able to sign in with it.
         </DialogDescription>
         <DialogActions>
-          <button
+          <Button
             type="button"
+            appearance="ghost"
+            variant="neutral"
             onClick={cancelDelete}
-            className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+            className="text-muted-foreground hover:text-foreground"
           >
             Cancel
-          </button>
-          <button
-            type="button"
-            onClick={() => void confirmDelete()}
-            className="rounded-md bg-error px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-error/90"
-          >
+          </Button>
+          <Button type="button" variant="danger" onClick={() => void confirmDelete()}>
             Remove
-          </button>
+          </Button>
         </DialogActions>
       </Dialog>
     </div>

--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -292,28 +292,34 @@ function BillingContent() {
               })}
             </strong>
             . You&apos;ll retain access to {TIER_LABELS[tier]} features until then.
-            <button
+            <Button
               type="button"
+              appearance="link"
+              variant="neutral"
+              size="sm"
               onClick={handleManageBilling}
               disabled={actionLoading}
-              className="ml-2 font-medium underline hover:text-amber-900 disabled:cursor-not-allowed dark:hover:text-amber-200"
+              className="ml-2 h-auto p-0 font-medium text-inherit underline"
             >
               Resubscribe
-            </button>
+            </Button>
           </div>
         )}
 
       {subscription?.status === 'expired' && (
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
           Your subscription has expired. Pro features are no longer available.
-          <button
+          <Button
             type="button"
+            appearance="link"
+            variant="neutral"
+            size="sm"
             onClick={() => void handleCheckout()}
             disabled={actionLoading}
-            className="ml-2 font-medium underline hover:text-red-900 dark:hover:text-red-200"
+            className="ml-2 h-auto p-0 font-medium text-inherit underline"
           >
             Resubscribe
-          </button>
+          </Button>
         </div>
       )}
 
@@ -327,14 +333,17 @@ function BillingContent() {
             support@revealui.com
           </a>{' '}
           or{' '}
-          <button
+          <Button
             type="button"
+            appearance="link"
+            variant="neutral"
+            size="sm"
             onClick={handleManageBilling}
             disabled={actionLoading}
-            className="font-medium underline hover:text-red-900 dark:hover:text-red-200"
+            className="inline h-auto p-0 font-medium text-inherit underline"
           >
             update your payment method
-          </button>
+          </Button>
           .
         </div>
       )}
@@ -351,14 +360,17 @@ function BillingContent() {
               })}
             </strong>
             . Please update your payment method to avoid losing access.
-            <button
+            <Button
               type="button"
+              appearance="link"
+              variant="neutral"
+              size="sm"
               onClick={handleManageBilling}
               disabled={actionLoading}
-              className="ml-2 font-medium underline hover:text-amber-900 dark:hover:text-amber-200"
+              className="ml-2 h-auto p-0 font-medium text-inherit underline"
             >
               Update payment
-            </button>
+            </Button>
           </div>
         )}
 
@@ -402,14 +414,17 @@ function BillingContent() {
       {subscriptionLoadFailed && upgrade && (
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
           We could not load your subscription, so checkout did not start automatically.
-          <button
+          <Button
             type="button"
+            appearance="link"
+            variant="neutral"
+            size="sm"
             onClick={() => void handleCheckout(upgrade)}
             disabled={actionLoading}
-            className="ml-2 font-medium underline hover:text-red-900 disabled:cursor-not-allowed dark:hover:text-red-200"
+            className="ml-2 h-auto p-0 font-medium text-inherit underline"
           >
             Continue to checkout
-          </button>
+          </Button>
         </div>
       )}
 

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -11,12 +11,16 @@ import {
 } from '@revealui/contracts/pricing';
 import type { FeatureFlags } from '@revealui/core/features';
 import {
+  Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from '@revealui/presentation/server';
+  IconCheck,
+  IconClose,
+  Input,
+} from '@revealui/presentation';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
@@ -268,17 +272,20 @@ export default function LicensePage() {
               <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-3 text-xs font-mono text-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
                 {subscription.licenseKey}
               </pre>
-              <button
+              <Button
                 type="button"
+                size="sm"
+                variant="neutral"
+                appearance="outline"
                 onClick={() => {
                   void navigator.clipboard.writeText(subscription.licenseKey ?? '');
                   setCopied(true);
                   setTimeout(() => setCopied(false), 2000);
                 }}
-                className="absolute right-2 top-2 rounded-md bg-white px-2 py-1 text-xs font-medium text-zinc-600 shadow-sm hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                className="absolute right-2 top-2 h-auto px-2 py-1 text-xs shadow-sm"
               >
                 {copied ? 'Copied!' : 'Copy'}
-              </button>
+              </Button>
             </div>
             <div className="rounded-lg border p-3 dark:border-zinc-800">
               <p className="text-xs font-medium text-zinc-600 uppercase tracking-wide mb-2">
@@ -355,17 +362,20 @@ export default function LicensePage() {
                     <pre className="overflow-x-auto rounded-lg bg-zinc-100 p-3 text-xs font-mono text-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
                       {publicKey}
                     </pre>
-                    <button
+                    <Button
                       type="button"
+                      size="sm"
+                      variant="neutral"
+                      appearance="outline"
                       onClick={() => {
                         void navigator.clipboard.writeText(publicKey);
                         setPubCopied(true);
                         setTimeout(() => setPubCopied(false), 2000);
                       }}
-                      className="absolute right-2 top-2 rounded-md bg-white px-2 py-1 text-xs font-medium text-zinc-600 shadow-sm hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                      className="absolute right-2 top-2 h-auto px-2 py-1 text-xs shadow-sm"
                     >
                       {pubCopied ? 'Copied!' : 'Copy'}
-                    </button>
+                    </Button>
                   </div>
                   <p className="text-xs text-zinc-400 mt-2">
                     Newer daemon builds bake this key in, so this step is only needed for older
@@ -418,14 +428,13 @@ export default function LicensePage() {
               <div className="space-y-2">
                 <label className="flex flex-col gap-1">
                   <span className="text-sm font-medium">GitHub username</span>
-                  <input
+                  <Input
                     type="text"
                     placeholder="your-github-handle"
                     value={githubUsername}
                     onChange={(
                       e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
                     ) => setGithubUsername(e.target.value)}
-                    className="rounded-md border px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-900"
                   />
                   <span className="text-xs text-zinc-600">
                     Added to the revealui-pro GitHub team for private package access.
@@ -442,16 +451,18 @@ export default function LicensePage() {
                   <p className="text-sm font-medium">{plan.label}</p>
                   <p className="text-xs text-zinc-600">{plan.description}</p>
                 </div>
-                <button
+                <Button
                   type="button"
+                  variant="neutral"
+                  size="sm"
                   disabled={perpetualLoading === plan.tier}
                   onClick={() => void handlePerpetualCheckout(plan)}
-                  className="shrink-0 ml-4 rounded-md bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                  className="ml-4 shrink-0 bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
                 >
                   {perpetualLoading === plan.tier
                     ? 'Redirecting…'
                     : `Buy ${pricing?.perpetual.find((t) => t.name === plan.label)?.price ?? '—'}`}
-                </button>
+                </Button>
               </div>
             ))}
           </CardContent>
@@ -483,14 +494,15 @@ export default function LicensePage() {
                 </span>
               </div>
             )}
-            <button
+            <Button
               type="button"
+              variant="neutral"
               disabled={renewalLoading}
               onClick={() => void handleSupportRenewal()}
-              className="w-full rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+              className="w-full bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
             >
               {renewalLoading ? 'Redirecting…' : 'Renew Support  -  1 Year'}
-            </button>
+            </Button>
           </CardContent>
         </Card>
       )}
@@ -509,9 +521,9 @@ export default function LicensePage() {
                 return (
                   <li key={key} className="flex items-center gap-3 text-sm">
                     {enabled ? (
-                      <CheckIcon className="text-green-500" />
+                      <IconCheck size="sm" className="text-green-500" />
                     ) : (
-                      <XIcon className="text-zinc-300 dark:text-zinc-600" />
+                      <IconClose size="sm" className="text-zinc-300 dark:text-zinc-600" />
                     )}
                     <span className={enabled ? '' : 'text-zinc-400'}>{label}</span>
                   </li>
@@ -522,46 +534,5 @@ export default function LicensePage() {
         </CardContent>
       </Card>
     </div>
-  );
-}
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={`shrink-0 ${className ?? ''}`}
-      aria-hidden="true"
-    >
-      <polyline points="20 6 9 17 4 12" />
-    </svg>
-  );
-}
-
-function XIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={`shrink-0 ${className ?? ''}`}
-      aria-hidden="true"
-    >
-      <line x1="18" y1="6" x2="6" y2="18" />
-      <line x1="6" y1="6" x2="18" y2="18" />
-    </svg>
   );
 }

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -426,9 +426,12 @@ export default function LicensePage() {
                 Optional - for package access
               </p>
               <div className="space-y-2">
-                <label className="flex flex-col gap-1">
-                  <span className="text-sm font-medium">GitHub username</span>
+                <div className="flex flex-col gap-1">
+                  <label htmlFor="github-username" className="text-sm font-medium">
+                    GitHub username
+                  </label>
                   <Input
+                    id="github-username"
                     type="text"
                     placeholder="your-github-handle"
                     value={githubUsername}
@@ -439,7 +442,7 @@ export default function LicensePage() {
                   <span className="text-xs text-zinc-600">
                     Added to the revealui-pro GitHub team for private package access.
                   </span>
-                </label>
+                </div>
               </div>
             </div>
             {PERPETUAL_PLANS.map((plan) => (

--- a/apps/admin/src/app/(frontend)/error.tsx
+++ b/apps/admin/src/app/(frontend)/error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button, IconAlertTriangle } from '@revealui/presentation/server';
 import Link from 'next/link';
 
 export default function FrontendError({
@@ -11,22 +12,8 @@ export default function FrontendError({
 }) {
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center gap-5 px-4 py-16">
-      {/* Icon */}
       <div className="flex size-14 items-center justify-center rounded-full bg-red-50 dark:bg-red-900/20">
-        <svg
-          className="size-7 text-red-500 dark:text-red-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-          />
-        </svg>
+        <IconAlertTriangle className="size-7 text-red-500 dark:text-red-400" aria-hidden="true" />
       </div>
 
       <h2 className="text-xl font-semibold text-neutral-900 dark:text-white">We hit a snag</h2>
@@ -42,19 +29,17 @@ export default function FrontendError({
       )}
 
       <div className="flex items-center gap-3">
-        <button
+        <Button
           type="button"
+          variant="neutral"
           onClick={() => reset()}
-          className="rounded-lg bg-neutral-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-neutral-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+          className="bg-neutral-900 text-white hover:bg-neutral-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
         >
           Try again
-        </button>
-        <Link
-          href="/"
-          className="rounded-lg border border-neutral-300 px-5 py-2.5 text-sm font-medium text-neutral-700 transition-colors hover:border-neutral-400 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500"
-        >
-          Go home
-        </Link>
+        </Button>
+        <Button asChild appearance="outline" variant="neutral">
+          <Link href="/">Go home</Link>
+        </Button>
       </div>
     </div>
   );

--- a/apps/admin/src/app/(frontend)/login/LoginForm.tsx
+++ b/apps/admin/src/app/(frontend)/login/LoginForm.tsx
@@ -201,14 +201,17 @@ function LoginContent({ oauthProviders }: LoginFormProps) {
           ) : (
             <div className="flex flex-col gap-2">
               <p>Your email address is not verified yet.</p>
-              <button
+              <Button
                 type="button"
+                size="sm"
+                variant="neutral"
+                appearance="outline"
                 onClick={() => void handleResendVerification()}
                 disabled={resendState === 'sending'}
-                className="self-start rounded-md bg-amber-100 px-3 py-1.5 text-xs font-medium text-amber-900 ring-1 ring-amber-300 transition-colors hover:bg-amber-200 disabled:opacity-60 dark:bg-amber-900/40 dark:text-amber-200 dark:ring-amber-800"
+                className="self-start border-amber-300 bg-amber-100 text-xs text-amber-900 hover:bg-amber-200 dark:border-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
               >
                 {resendState === 'sending' ? 'Sending…' : 'Resend verification email'}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/apps/admin/src/app/(frontend)/mfa/MFAForm.tsx
+++ b/apps/admin/src/app/(frontend)/mfa/MFAForm.tsx
@@ -129,17 +129,20 @@ function MFAContent() {
         </Button>
 
         <div className="flex flex-col items-center gap-2 text-xs text-muted-foreground">
-          <button
+          <Button
             type="button"
+            appearance="link"
+            variant="brand"
+            size="sm"
             onClick={() => {
               setUseBackupCode(!useBackupCode);
               setCode('');
               setFormError(null);
             }}
-            className="text-[var(--tenant-brand,#2563eb)] hover:underline"
+            className="h-auto p-0 text-xs text-[var(--tenant-brand,#2563eb)]"
           >
             {useBackupCode ? 'Use authenticator app instead' : 'Use a backup code instead'}
-          </button>
+          </Button>
 
           <Link href="/login" className="hover:underline">
             Back to sign in

--- a/apps/admin/src/app/(frontend)/not-found.tsx
+++ b/apps/admin/src/app/(frontend)/not-found.tsx
@@ -1,25 +1,11 @@
-import { Button } from '@revealui/presentation/server';
+import { Button, IconSearch } from '@revealui/presentation/server';
 import Link from 'next/link';
 
 export default function NotFound() {
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 py-16">
-      {/* Icon */}
       <div className="mb-5 flex size-14 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-        <svg
-          className="size-7 text-zinc-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-          />
-        </svg>
+        <IconSearch className="size-7 text-zinc-400" aria-hidden="true" />
       </div>
 
       <h1 className="text-4xl font-bold text-zinc-900 dark:text-white">404</h1>

--- a/apps/admin/src/app/(frontend)/welcome/page.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TIER_LABELS } from '@revealui/contracts/pricing';
-import { Badge } from '@revealui/presentation/client';
+import { Badge, Button } from '@revealui/presentation/client';
 import { useEffect, useState } from 'react';
 import { useLicense } from '@/lib/providers/LicenseProvider';
 
@@ -147,14 +147,17 @@ export default function WelcomePage() {
           </p>
           <div className="mt-4 flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-xs text-foreground">
             <code className="flex-1 truncate">{CLI_INSTALL_COMMAND}</code>
-            <button
+            <Button
               type="button"
+              appearance="outline"
+              variant="neutral"
+              size="sm"
               onClick={() => void handleCopyCli()}
-              className="rounded bg-card px-2 py-1 text-xs font-medium text-foreground ring-1 ring-border transition-colors hover:bg-muted"
+              className="h-auto px-2 py-1 text-xs"
               aria-label="Copy command to clipboard"
             >
               {cliCopied ? 'Copied' : 'Copy'}
-            </button>
+            </Button>
           </div>
         </div>
 

--- a/apps/admin/src/app/global-error.tsx
+++ b/apps/admin/src/app/global-error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as Sentry from '@sentry/nextjs';
+import { Button, IconAlertTriangle } from '@revealui/presentation/server';
 import { useEffect } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 // global-error.tsx replaces the root layout on error, so it renders outside every
@@ -48,20 +49,7 @@ export default function GlobalError({
       <body className="bg-background text-foreground">
         <div className="flex min-h-screen flex-col items-center justify-center gap-5 p-8 text-center">
           <div className="flex size-14 items-center justify-center rounded-full bg-destructive/10">
-            <svg
-              className="size-7 text-destructive"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-              />
-            </svg>
+            <IconAlertTriangle className="size-7 text-destructive" aria-hidden="true" />
           </div>
           <h2 className="text-lg font-semibold text-foreground">Something went wrong</h2>
           <p className="max-w-md text-sm text-muted-foreground">
@@ -70,13 +58,9 @@ export default function GlobalError({
           {error?.digest && (
             <p className="font-mono text-xs text-muted-foreground">Error ID: {error.digest}</p>
           )}
-          <button
-            type="button"
-            onClick={() => reset()}
-            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
+          <Button type="button" variant="brand" onClick={() => reset()}>
             Try again
-          </button>
+          </Button>
         </div>
       </body>
     </html>

--- a/apps/admin/src/app/global-error.tsx
+++ b/apps/admin/src/app/global-error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as Sentry from '@sentry/nextjs';
 import { Button, IconAlertTriangle } from '@revealui/presentation/server';
+import * as Sentry from '@sentry/nextjs';
 import { useEffect } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 // global-error.tsx replaces the root layout on error, so it renders outside every

--- a/apps/admin/src/components/ErrorBoundary.tsx
+++ b/apps/admin/src/components/ErrorBoundary.tsx
@@ -7,8 +7,8 @@
  * Integrates with Sentry for error reporting in production.
  */
 
-import * as Sentry from '@sentry/nextjs';
 import { Button } from '@revealui/presentation/server';
+import * as Sentry from '@sentry/nextjs';
 import React, { Component, type ErrorInfo, type ReactNode } from 'react';
 
 interface ErrorBoundaryProps {

--- a/apps/admin/src/components/ErrorBoundary.tsx
+++ b/apps/admin/src/components/ErrorBoundary.tsx
@@ -8,6 +8,7 @@
  */
 
 import * as Sentry from '@sentry/nextjs';
+import { Button } from '@revealui/presentation/server';
 import React, { Component, type ErrorInfo, type ReactNode } from 'react';
 
 interface ErrorBoundaryProps {
@@ -117,56 +118,32 @@ function DefaultErrorFallback({ error, errorInfo, reset }: DefaultErrorFallbackP
           The application encountered an unexpected error. This has been reported to our team.
         </p>
 
-        <div style={{ marginBottom: '1rem' }}>
-          <button
-            type="button"
-            onClick={reset}
-            style={{
-              padding: '0.5rem 1rem',
-              backgroundColor: '#0070f3',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-              marginRight: '0.5rem',
-            }}
-          >
+        <div style={{ marginBottom: '1rem', display: 'flex', gap: '0.5rem' }}>
+          <Button type="button" variant="brand" onClick={reset}>
             Try Again
-          </button>
+          </Button>
 
-          <button
+          <Button
             type="button"
+            variant="neutral"
+            appearance="outline"
             onClick={() => window.location.reload()}
-            style={{
-              padding: '0.5rem 1rem',
-              backgroundColor: '#666',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-            }}
           >
             Reload Page
-          </button>
+          </Button>
         </div>
 
         {process.env.NODE_ENV !== 'production' && (
           <>
-            <button
+            <Button
               type="button"
+              variant="neutral"
+              appearance="ghost"
+              size="sm"
               onClick={() => setShowDetails(!showDetails)}
-              style={{
-                padding: '0.5rem 1rem',
-                backgroundColor: 'transparent',
-                color: '#666',
-                border: '1px solid #ccc',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                fontSize: '0.875rem',
-              }}
             >
               {showDetails ? 'Hide' : 'Show'} Technical Details
-            </button>
+            </Button>
 
             {showDetails && (
               <div

--- a/apps/admin/src/components/FreeTierBanner.tsx
+++ b/apps/admin/src/components/FreeTierBanner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button, IconClose } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { useLicense } from '@/lib/providers/LicenseProvider';
@@ -35,16 +36,17 @@ export function FreeTierBanner() {
           Start your 7-day Pro trial &rarr;
         </Link>
       </p>
-      <button
+      <Button
         type="button"
+        appearance="ghost"
+        variant="neutral"
+        size="icon"
         onClick={handleDismiss}
-        className="-m-1.5 flex-none p-1.5 opacity-70 hover:opacity-100"
+        className="-m-1.5 size-8 shrink-0 text-primary-foreground opacity-70 hover:bg-primary-foreground/10 hover:opacity-100"
         aria-label="Dismiss"
       >
-        <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
-        </svg>
-      </button>
+        <IconClose size="sm" />
+      </Button>
     </div>
   );
 }

--- a/apps/admin/src/components/revealui/elements/install-command.tsx
+++ b/apps/admin/src/components/revealui/elements/install-command.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@revealui/presentation';
+import { Button, cn } from '@revealui/presentation';
 import { type ComponentProps, type ReactNode, useCallback, useRef, useState } from 'react';
 import { CheckmarkIcon } from '@/components/revealui/icons/checkmark-icon';
 import { Squares2StackedIcon } from '@/components/revealui/icons/squares-2-stacked-icon';
@@ -40,13 +40,16 @@ export function InstallCommand({
         <div className="text-current/60 select-none">$</div>
         <span ref={contentRef}>{snippet}</span>
       </div>
-      <button
+      <Button
         type="button"
+        appearance="ghost"
+        variant="neutral"
+        size="icon"
         onClick={handleCopy}
-        className="group relative flex size-9 items-center justify-center rounded-full after:absolute after:-inset-1 hover:bg-mist-950/10 dark:hover:bg-white/10 after:pointer-fine:hidden"
+        className="group relative size-9 rounded-full after:absolute after:-inset-1 hover:bg-mist-950/10 after:pointer-fine:hidden dark:hover:bg-white/10"
       >
         {copied ? <CheckmarkIcon /> : <Squares2StackedIcon />}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/admin/src/components/revealui/icons/arrow-narrow-right-icon.tsx
+++ b/apps/admin/src/components/revealui/icons/arrow-narrow-right-icon.tsx
@@ -1,30 +1,6 @@
-import { cn } from '@revealui/presentation/server';
+import { IconArrowRight } from '@revealui/presentation/server';
 import type { ComponentProps } from 'react';
 
 export function ArrowNarrowRightIcon({ className, ...props }: ComponentProps<'svg'>) {
-  return (
-    <svg
-      width={13}
-      height={7}
-      viewBox="0 0 13 7"
-      fill="none"
-      strokeWidth={1}
-      aria-hidden="true"
-      className={cn('inline-block', className)}
-      {...props}
-    >
-      <path
-        d="M12.5049 3.49512L0.504883 3.49512"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M9.5 6.5L12.5 3.5L9.5 0.5"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
+  return <IconArrowRight size="sm" className={className} aria-hidden="true" {...props} />;
 }

--- a/apps/admin/src/components/revealui/icons/checkmark-icon.tsx
+++ b/apps/admin/src/components/revealui/icons/checkmark-icon.tsx
@@ -1,22 +1,6 @@
-import { cn } from '@revealui/presentation/server';
+import { IconCheck } from '@revealui/presentation/server';
 import type { ComponentProps } from 'react';
 
 export function CheckmarkIcon({ className, ...props }: ComponentProps<'svg'>) {
-  return (
-    <svg
-      width={16}
-      height={16}
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      aria-hidden="true"
-      className={cn('inline-block', className)}
-      {...props}
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M12.416 3.376a.75.75 0 010 1.06l-7.5 7.5a.75.75 0 01-1.06 0l-3.5-3.5a.75.75 0 111.06-1.06l2.97 2.97 6.97-6.97a.75.75 0 011.06 0z"
-      />
-    </svg>
-  );
+  return <IconCheck size="sm" className={className} aria-hidden="true" {...props} />;
 }

--- a/apps/admin/src/components/revealui/icons/chevron-icon.tsx
+++ b/apps/admin/src/components/revealui/icons/chevron-icon.tsx
@@ -1,22 +1,6 @@
-import { cn } from '@revealui/presentation/server';
+import { IconChevronRight } from '@revealui/presentation/server';
 import type { ComponentProps } from 'react';
 
 export function ChevronIcon({ className, ...props }: ComponentProps<'svg'>) {
-  return (
-    <svg
-      width={5}
-      height={8}
-      viewBox="0 0 5 8"
-      fill="currentColor"
-      aria-hidden="true"
-      className={cn('inline-block', className)}
-      {...props}
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M.22.22a.75.75 0 011.06 0l3.25 3.25a.75.75 0 010 1.06L1.28 7.78A.75.75 0 01.22 6.72L2.94 4 .22 1.28a.75.75 0 010-1.06z"
-      />
-    </svg>
-  );
+  return <IconChevronRight size="xs" className={className} aria-hidden="true" {...props} />;
 }

--- a/apps/admin/src/components/revealui/icons/squares-2-stacked-icon.tsx
+++ b/apps/admin/src/components/revealui/icons/squares-2-stacked-icon.tsx
@@ -1,22 +1,6 @@
-import { cn } from '@revealui/presentation/server';
+import { IconCopy } from '@revealui/presentation/server';
 import type { ComponentProps } from 'react';
 
 export function Squares2StackedIcon({ className, ...props }: ComponentProps<'svg'>) {
-  return (
-    <svg
-      width={16}
-      height={16}
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      aria-hidden="true"
-      className={cn('inline-block', className)}
-      {...props}
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M1.5 2.5a1 1 0 011-1h11a1 1 0 011 1v11a1 1 0 01-1 1h-11a1 1 0 01-1-1v-11zm1 0v11h11v-11h-11zm2.5 2.5a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1h-6a1 1 0 01-1-1v-6zm1 0v6h6v-6h-6z"
-      />
-    </svg>
-  );
+  return <IconCopy size="sm" className={className} aria-hidden="true" {...props} />;
 }

--- a/apps/admin/src/lib/components/AdminBar/index.tsx
+++ b/apps/admin/src/lib/components/AdminBar/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@revealui/presentation';
+import { Button, cn } from '@revealui/presentation';
 
 import { usePathname, useRouter, useSelectedLayoutSegments } from 'next/navigation';
 import React, { useState } from 'react';
@@ -61,9 +61,16 @@ const RevealUIAdminBar = (props: RevealUIAdminBarProps) => {
         <div>{logo}</div>
         <div className="flex items-center gap-4">
           {preview ? (
-            <button type="button" onClick={onPreviewExit} className="text-sm underline">
+            <Button
+              type="button"
+              appearance="link"
+              variant="neutral"
+              size="sm"
+              onClick={onPreviewExit}
+              className="h-auto p-0 text-sm text-inherit underline"
+            >
               Exit Preview
-            </button>
+            </Button>
           ) : null}
         </div>
       </div>

--- a/apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx
+++ b/apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { SITE_NAME } from '@/lib/utils/siteBranding';
@@ -135,13 +136,16 @@ export default function OnboardingChecklist() {
             Welcome to {SITE_NAME}. Here are a few things to get you going.
           </p>
         </div>
-        <button
+        <Button
           type="button"
+          appearance="ghost"
+          variant="neutral"
+          size="sm"
           onClick={handleDismiss}
-          className="shrink-0 rounded-md px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:bg-zinc-700 hover:text-zinc-200"
+          className="shrink-0 text-xs text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
         >
           Dismiss
-        </button>
+        </Button>
       </div>
 
       <div className="grid gap-2 sm:grid-cols-2">

--- a/apps/admin/src/lib/components/BeforeDashboard/OnboardingNudge.tsx
+++ b/apps/admin/src/lib/components/BeforeDashboard/OnboardingNudge.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@revealui/presentation/server';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
@@ -76,13 +77,16 @@ export default function OnboardingNudge() {
             {nudge.ctaLabel}
           </Link>
         </div>
-        <button
+        <Button
           type="button"
+          appearance="ghost"
+          variant="neutral"
+          size="sm"
           onClick={handleDismiss}
-          className="shrink-0 rounded-md px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:bg-zinc-700 hover:text-zinc-200"
+          className="shrink-0 text-xs text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
         >
           Dismiss
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/apps/admin/src/lib/components/ErrorBoundary/index.tsx
+++ b/apps/admin/src/lib/components/ErrorBoundary/index.tsx
@@ -7,6 +7,7 @@
 
 'use client';
 
+import { Button } from '@revealui/presentation/server';
 import { logger } from '@revealui/utils/logger';
 import React, { Component, type ReactNode } from 'react';
 
@@ -101,13 +102,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               </details>
             )}
 
-            <button
-              onClick={this.handleReset}
-              className="self-start px-4 py-2 bg-error text-primary-foreground rounded hover:bg-error/90 transition-colors"
+            <Button
               type="button"
+              variant="danger"
+              className="self-start"
+              onClick={this.handleReset}
             >
               Try Again
-            </button>
+            </Button>
           </div>
         </div>
       );

--- a/apps/admin/src/lib/components/PasswordInput.tsx
+++ b/apps/admin/src/lib/components/PasswordInput.tsx
@@ -1,46 +1,7 @@
 'use client';
 
+import { Button, IconEye, IconEyeOff } from '@revealui/presentation/server';
 import type { ReactNode } from 'react';
-
-/** Eye icon (open)  -  password is visible */
-function EyeIcon() {
-  return (
-    <svg
-      className="h-4 w-4"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
-      <circle cx={12} cy={12} r={3} />
-    </svg>
-  );
-}
-
-/** Eye-off icon  -  password is hidden */
-function EyeOffIcon() {
-  return (
-    <svg
-      className="h-4 w-4"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" />
-      <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
-      <path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" />
-      <path d="m2 2 20 20" />
-    </svg>
-  );
-}
 
 interface PasswordInputProps {
   /** Whether the password is currently visible */
@@ -65,15 +26,18 @@ export function PasswordInput({ visible, onToggle, children }: PasswordInputProp
   return (
     <div className="relative">
       {children}
-      <button
+      <Button
         type="button"
+        appearance="ghost"
+        variant="neutral"
+        size="icon"
         onClick={onToggle}
-        className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded p-1 text-zinc-400 transition-colors hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-zinc-500 dark:hover:text-zinc-300"
+        className="absolute right-2.5 top-1/2 size-7 -translate-y-1/2 text-zinc-400 hover:bg-transparent hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
         aria-label={visible ? 'Hide password' : 'Show password'}
         tabIndex={-1}
       >
-        {visible ? <EyeIcon /> : <EyeOffIcon />}
-      </button>
+        {visible ? <IconEye size="sm" /> : <IconEyeOff size="sm" />}
+      </Button>
     </div>
   );
 }

--- a/apps/admin/src/lib/components/SystemHealthPanel/index.tsx
+++ b/apps/admin/src/lib/components/SystemHealthPanel/index.tsx
@@ -4,6 +4,7 @@
  * Displays system health status with individual health check details
  */
 
+import { Button, IconChevronDown } from '@revealui/presentation';
 import type React from 'react';
 import { useEffect, useState } from 'react';
 
@@ -140,14 +141,9 @@ export function SystemHealthPanel({
         <div className="text-error">
           <h2 className="text-lg font-semibold mb-2">Error Loading Health Data</h2>
           <p className="mb-4">{error}</p>
-          <button
-            onClick={onRetry}
-            className="bg-error text-primary-foreground hover:bg-error/90 px-4 py-2 rounded transition-colors disabled:opacity-50"
-            type="button"
-            disabled={!onRetry}
-          >
+          <Button type="button" variant="danger" onClick={onRetry} disabled={!onRetry}>
             Retry
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -188,24 +184,26 @@ export function SystemHealthPanel({
 
       <div className="space-y-3">
         {Object.entries(data.checks).map(([name, check]) => (
-          <button
+          <Button
             key={name}
             type="button"
-            className="border border-border rounded-lg p-4 hover:bg-muted transition-colors cursor-pointer w-full text-left"
+            appearance="ghost"
+            variant="neutral"
+            className="h-auto w-full cursor-pointer justify-start rounded-lg border border-border p-4 text-left hover:bg-muted"
             onClick={() => toggleCheck(name)}
             aria-expanded={expandedChecks[name]}
             aria-label={`${name} health check: ${check.status}`}
           >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3 flex-1">
+            <div className="flex w-full items-center justify-between">
+              <div className="flex flex-1 items-center gap-3">
                 <div
-                  className={`w-2 h-2 rounded-full ${getStatusColor(check.status)}`}
+                  className={`h-2 w-2 rounded-full ${getStatusColor(check.status)}`}
                   aria-hidden="true"
                   data-testid={`status-${check.status}`}
                 />
                 <div className="flex items-center gap-2">
                   <span
-                    className="font-medium text-foreground capitalize"
+                    className="font-medium capitalize text-foreground"
                     data-testid={`${name}-check-name`}
                   >
                     {name}
@@ -217,24 +215,15 @@ export function SystemHealthPanel({
                   )}
                 </div>
               </div>
-              <svg
-                className={`w-5 h-5 text-muted-foreground transition-transform ${expandedChecks[name] ? 'rotate-180' : ''}`}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+              <IconChevronDown
+                size="md"
+                className={`text-muted-foreground transition-transform ${expandedChecks[name] ? 'rotate-180' : ''}`}
                 aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
+              />
             </div>
 
             {expandedChecks[name] && (
-              <div className="mt-3 pt-3 border-t border-border">
+              <div className="mt-3 border-t border-border pt-3">
                 <p className="text-sm text-muted-foreground">{check.message}</p>
                 <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
                   <div>
@@ -248,7 +237,7 @@ export function SystemHealthPanel({
                 </div>
               </div>
             )}
-          </button>
+          </Button>
         ))}
       </div>
     </div>

--- a/apps/admin/src/lib/components/UpgradeDialog.tsx
+++ b/apps/admin/src/lib/components/UpgradeDialog.tsx
@@ -2,6 +2,7 @@
 
 import { getTiersFromCurrent } from '@revealui/contracts/pricing';
 import {
+  Button,
   Dialog,
   DialogActions,
   DialogBody,
@@ -97,13 +98,15 @@ export function UpgradeDialog() {
         >
           View full pricing
         </Link>
-        <button
+        <Button
           type="button"
+          appearance="ghost"
+          variant="neutral"
           onClick={handleClose}
-          className="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+          className="text-muted-foreground hover:text-foreground"
         >
           Maybe later
-        </button>
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
@@ -17,6 +17,20 @@ vi.mock('@revealui/contracts/pricing', () => ({
 
 // Mock presentation components
 vi.mock('@revealui/presentation/client', () => ({
+  Button: ({
+    children,
+    type = 'button',
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    appearance?: string;
+    variant?: string;
+    size?: string;
+    isLoading?: boolean;
+  }) => (
+    <button type={type} {...props}>
+      {children}
+    </button>
+  ),
   Dialog: ({
     open,
     onClose,

--- a/apps/admin/src/lib/components/agents/agent-memory.tsx
+++ b/apps/admin/src/lib/components/agents/agent-memory.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@revealui/presentation';
+import { Button, IconTrash } from '@revealui/presentation';
 import { useAgentMemory } from '@revealui/sync';
 import { useState } from 'react';
 
@@ -107,30 +107,28 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
     <div>
       {/* Filter chips — Tabs primitive not applicable: "All" requires null active value */}
       <div className="mb-4 flex items-center gap-2">
-        <button
+        <Button
           type="button"
+          size="sm"
+          appearance={filter === null ? 'solid' : 'ghost'}
+          variant={filter === null ? 'brand' : 'neutral'}
           onClick={() => setFilter(null)}
-          className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-            filter === null
-              ? 'bg-primary text-primary-foreground'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
+          className="h-auto px-2.5 py-1 text-xs"
         >
           All ({memories.length})
-        </button>
+        </Button>
         {Object.entries(MEMORY_TYPE_LABELS).map(([type, { label }]) => (
-          <button
+          <Button
             key={type}
             type="button"
+            size="sm"
+            appearance={filter === type ? 'solid' : 'ghost'}
+            variant={filter === type ? 'brand' : 'neutral'}
             onClick={() => setFilter(filter === type ? null : type)}
-            className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-              filter === type
-                ? 'bg-primary text-primary-foreground'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
+            className="h-auto px-2.5 py-1 text-xs"
           >
             {label} ({typeCounts[type] ?? 0})
-          </button>
+          </Button>
         ))}
         {isLoading && (
           <div
@@ -183,18 +181,7 @@ export function AgentMemory({ agentId }: AgentMemoryProps) {
                   title="Delete memory"
                   aria-label="Delete memory"
                 >
-                  <svg
-                    className="h-3.5 w-3.5"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
+                  <IconTrash size="xs" />
                 </Button>
               </div>
             </li>

--- a/apps/admin/src/lib/components/agents/mcp-server-card.tsx
+++ b/apps/admin/src/lib/components/agents/mcp-server-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge, Button, Card } from '@revealui/presentation';
+import { Badge, Button, Card, IconChevronDown } from '@revealui/presentation';
 import { useState } from 'react';
 
 export interface McpServerInfo {
@@ -76,16 +76,11 @@ export function McpServerCard({ server }: McpServerCardProps) {
             aria-expanded={expanded}
           >
             <span>{server.tools.length} tools</span>
-            <svg
-              aria-label={expanded ? 'Collapse tools' : 'Expand tools'}
-              className={`h-4 w-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
+            <IconChevronDown
+              size="sm"
+              label={expanded ? 'Collapse tools' : 'Expand tools'}
+              className={`transition-transform ${expanded ? 'rotate-180' : ''}`}
+            />
           </Button>
 
           {expanded && (

--- a/apps/admin/src/lib/components/mcp/resources-panel.tsx
+++ b/apps/admin/src/lib/components/mcp/resources-panel.tsx
@@ -9,6 +9,7 @@
 
 'use client';
 
+import { Button } from '@revealui/presentation';
 import { useCallback, useEffect, useState } from 'react';
 
 interface Resource {
@@ -119,18 +120,24 @@ export function ResourcesPanel({ tenant, server }: ResourcesPanelProps) {
               const selected = r.uri === selectedUri;
               return (
                 <li key={r.uri}>
-                  <button
+                  <Button
                     type="button"
+                    appearance="ghost"
+                    variant="neutral"
                     onClick={() => void handleSelect(r.uri)}
-                    className={`block w-full px-3 py-2 text-left transition-colors ${
+                    className={`h-auto w-full block justify-start rounded-none px-3 py-2 text-left ${
                       selected
-                        ? 'bg-success/10 text-success'
+                        ? 'bg-success/10 text-success hover:bg-success/10'
                         : 'text-muted-foreground hover:bg-muted'
                     }`}
                   >
-                    <div className="truncate font-mono text-xs">{r.name || r.uri}</div>
-                    <div className="mt-0.5 truncate text-[10px] text-muted-foreground">{r.uri}</div>
-                  </button>
+                    <span className="block w-full">
+                      <span className="block truncate font-mono text-xs">{r.name || r.uri}</span>
+                      <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
+                        {r.uri}
+                      </span>
+                    </span>
+                  </Button>
                 </li>
               );
             })}

--- a/apps/admin/src/lib/components/mcp/usage-dashboard.tsx
+++ b/apps/admin/src/lib/components/mcp/usage-dashboard.tsx
@@ -9,6 +9,7 @@
 'use client';
 
 import {
+  Button,
   Table,
   TableBody,
   TableCell,
@@ -144,19 +145,18 @@ export function UsageDashboard({ defaultRange = '24h' }: UsageDashboardProps) {
           aria-label="Time range"
         >
           {RANGES.map((r) => (
-            <button
+            <Button
               key={r}
               type="button"
+              size="sm"
+              appearance={range === r ? 'solid' : 'ghost'}
+              variant={range === r ? 'brand' : 'neutral'}
               onClick={() => setRange(r)}
               aria-pressed={range === r}
-              className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
-                range === r
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
+              className="h-auto rounded px-3 py-1 text-xs"
             >
               {r}
-            </button>
+            </Button>
           ))}
         </div>
       </header>

--- a/apps/admin/src/lib/providers/Theme/ThemeSelector/index.tsx
+++ b/apps/admin/src/lib/providers/Theme/ThemeSelector/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { IconChevronDown, IconChevronUp, Select } from '@revealui/presentation';
 import React, { useState } from 'react';
 import { useTheme } from '..';
 import type { Theme } from './types';
@@ -27,7 +28,7 @@ export const ThemeSelector = () => {
 
   return (
     <span className="group relative block">
-      <select
+      <Select
         value={value}
         onChange={onThemeChange}
         aria-label="Theme"
@@ -36,22 +37,10 @@ export const ThemeSelector = () => {
         <option value="auto">Auto</option>
         <option value="light">Light</option>
         <option value="dark">Dark</option>
-      </select>
-      <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-        <svg className="size-4 stroke-zinc-400" viewBox="0 0 16 16" aria-hidden="true" fill="none">
-          <path
-            d="M5.75 10.75L8 13L10.25 10.75"
-            strokeWidth={1.5}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <path
-            d="M10.25 5.25L8 3L5.75 5.25"
-            strokeWidth={1.5}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
+      </Select>
+      <span className="pointer-events-none absolute inset-y-0 right-0 flex flex-col items-center justify-center pr-2 text-zinc-400">
+        <IconChevronUp size="xs" className="size-3" aria-hidden="true" />
+        <IconChevronDown size="xs" className="size-3 -mt-0.5" aria-hidden="true" />
       </span>
     </span>
   );

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -4,537 +4,287 @@
     {
       "path": "apps/admin/src/app/(backend)/[[...segments]]/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; CMS catch-all shell decorative svg without Icon* match (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agent-tasks/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; task filter/action chips not yet on presentation Button (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agent-tasks/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; task status/row icons without Icon* match (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agents/new/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; multi-step agent wizard controls (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/agents/new/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/agents/page.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/agents/page.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/chat/page.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/chat/page.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; wizard step illustrations (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/coordination/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; coordination filters and row actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/coordination/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; coordination status icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/dashboard/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/error.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/error.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; dashboard metric/decorative icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; job table actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
       "tag": "select",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; job filter select needs Select migration pass (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/jobs/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; job status icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/knowledge-graph/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; graph toolbar actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/knowledge-graph/page.tsx",
       "tag": "input",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; graph search/query field (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; marketplace agent actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; marketplace detail icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; marketplace listing icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/publish/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; publish form actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/publish/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; publish flow icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/marketplace/tasks/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; marketplace task actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/mcp/inspect/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; MCP inspect toolbar (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/mcp/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; MCP hub tab/actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/media/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; media library bulk/actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/media/page.tsx",
       "tag": "input",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; media search and file inputs (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/media/page.tsx",
       "tag": "select",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; media type filter select (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/media/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; media type/file icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/refunds/page.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; refund table actions (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(backend)/refunds/page.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/settings/account/page.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/settings/account/page.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/settings/account/PasswordChangeForm.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/settings/layout.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/settings/security/page.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(backend)/settings/security/page.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/account/billing/page.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
-      "tag": "input",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/account/license/page.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/error.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/error.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/login/LoginForm.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/mfa/MFAForm.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/not-found.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; refund status icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/app/(frontend)/signup/SignupForm.tsx",
       "tag": "input",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/(frontend)/welcome/page.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/global-error.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/app/global-error.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/components/ErrorBoundary.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/components/FreeTierBanner.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/components/FreeTierBanner.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; ToS checkbox; presentation Checkbox a11y layout differs from label+links pattern (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/elements/button.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; local marketing Button primitive scaffold wrapping host button (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/elements/email-signup-form.tsx",
       "tag": "input",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/components/revealui/elements/install-command.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/components/revealui/icons/arrow-narrow-right-icon.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/components/revealui/icons/checkmark-icon.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/components/revealui/icons/chevron-icon.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/components/revealui/icons/squares-2-stacked-icon.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; marketing email field in legacy element kit (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/footer-with-newsletter-form-categories-and-social-icons.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; legacy marketing footer CTA (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/footer-with-newsletter-form-categories-and-social-icons.tsx",
       "tag": "input",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; legacy marketing footer newsletter input (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/navbar-with-links-actions-and-centered-logo.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; legacy marketing mobile nav toggles (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/navbar-with-links-actions-and-centered-logo.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; legacy marketing logo/menu paths (GAP-398)"
     },
     {
       "path": "apps/admin/src/components/revealui/sections/stats-with-graph.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/AdminBar/index.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; chart path geometry is content-driven (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/AdminSidebarLayout.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; NavIcon uses dynamic path data per nav item (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/Agent/index.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/agents/agent-memory.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/agents/agent-memory.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/agents/mcp-server-card.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/BeforeDashboard/OnboardingNudge.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; chat composer/tool controls dense surface (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/DataPanel/index.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/ErrorBoundary/index.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/mcp/resources-panel.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/mcp/usage-dashboard.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; data panel chrome icons (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/mcp/usage-dashboard.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/PasswordInput.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/PasswordInput.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; stacked outcome bar is data-driven SVG chart (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/components/SystemHealthMonitor/index.tsx",
       "tag": "select",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/SystemHealthPanel/index.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/SystemHealthPanel/index.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/components/UpgradeDialog.tsx",
-      "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; health monitor filter selects (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/features/embed/components/EmbedNodeComponent.tsx",
       "tag": "button",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; Lexical embed node edit chrome (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/features/embed/icons/EmbedIcon.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; Lexical toolbar feature icon (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/features/label/icons/LabelIcon.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; Lexical toolbar feature icon (GAP-398)"
     },
     {
       "path": "apps/admin/src/lib/features/largeBody/icons/LargeBodyIcon.tsx",
       "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/providers/Theme/ThemeSelector/index.tsx",
-      "tag": "select",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
-    },
-    {
-      "path": "apps/admin/src/lib/providers/Theme/ThemeSelector/index.tsx",
-      "tag": "svg",
-      "reason": "admin surface residual; migrate to presentation in follow-up (GAP-398)"
+      "reason": "admin residual; Lexical toolbar feature icon (GAP-398)"
     },
     {
       "path": "apps/docs/app/components/showcase/CodeView.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/components/showcase/Preview.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/components/showcase/PropPanel.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/components/showcase/PropPanel.tsx",
       "tag": "input",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/components/showcase/ShowcaseShell.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/components/showcase/ShowcaseShell.tsx",
       "tag": "svg",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/components/showcase/TokensPage.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/showcase/animations.showcase.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/showcase/drawer.showcase.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/showcase/icons.showcase.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/docs/app/showcase/theme.showcase.tsx",
       "tag": "button",
-      "reason": "docs design-system showcase exercises host elements on purpose (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/marketing/app/components/landing/Primitives.tsx",
       "tag": "svg",
-      "reason": "content-driven SVG path from content modules; no static Icon* mapping (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     },
     {
       "path": "apps/marketing/app/routes/ProductsPage.tsx",
       "tag": "svg",
-      "reason": "content-driven SVG path from content modules; no static Icon* mapping (GAP-398 residual)"
+      "reason": "GAP-398 residual burn-down (pre-existing Tier-1 handroll)"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Burn GAP-398 Tier-1 presentation allowlist residuals for **apps/admin** only.

Replaces hand-rolled `button` / `svg` / `input` / `select` hosts with `@revealui/presentation` (`Button`, `Select`, `Input`, `Icon*`, provider icons) across admin chrome and high-traffic account surfaces.

## Counts

| Scope | Before | After | Δ |
|-------|--------|-------|---|
| Admin allowlist entries | **94** | **44** | **−50 (−53%)** |
| Total allowlist entries | **107** | **57** | **−50** |
| Gate hits (all apps) | — | **110** all allowlisted | 0 violations |

Tag mix after (admin): svg 19, button 17, input 5, select 3.

## What was burned

- Error chrome: backend/frontend/`global-error`, both ErrorBoundaries
- Auth: Login resend, MFA backup toggle, PasswordInput eyes, PasswordChangeForm
- Settings: account OAuth row (GitHub/Google/Vercel icons), security (MFA/passkeys/sessions), API keys, layout chevron
- Account: billing banner CTAs, license copy/buy/renew + feature check icons
- Onboarding: checklist/nudge dismiss, free-tier banner, upgrade dialog, welcome copy
- Shell: AdminBar preview exit, SystemHealthPanel, ThemeSelector Select, MCP resources/usage range chips, agent-memory filters, mcp-server-card chevron, chat sidebar, agents tabs/empty states
- Local icon wrappers → presentation `Icon*` re-exports; install-command copy button

## What remains (and why)

| Residual class | Examples |
|----------------|----------|
| Dynamic path icons | `AdminSidebarLayout` NavIcon (path from data) |
| Lexical toolbar icons | Embed/Label/LargeBody feature SVGs |
| Dense chat surface | `lib/components/Agent` composer controls |
| Backend feature pages | media, jobs, marketplace, refunds, coordination, knowledge-graph, agent-tasks, agents/new |
| Data-driven charts | usage-dashboard stacked bar, stats-with-graph |
| Legacy marketing kit under admin | `components/revealui/elements/*`, navbar/footer sections |
| ToS checkbox | SignupForm input (a11y label+links pattern) |

## Verification

```bash
pnpm exec tsx scripts/validate/tier1-presentation.ts   # 0 violations
pnpm --filter admin typecheck                          # clean
# pre-push phase-1 gate: PASS
```

## Owner actions

Merge when green (manual squash to `test`); do not agent-merge.
