### PR TITLE
docs(rules): branch-base hardline + monorepo pointer

### DIFF
--- a/.claude/.revcon-manifest.json
+++ b/.claude/.revcon-manifest.json
@@ -41,7 +41,7 @@
     },
     "rules/git.md": {
       "source": "profiles/revfleet/claude/rules/git.md",
-      "sha256": "c74adb8ef145d651353c9335245868ee75c5e23d4f439e7ff20b93748060a703"
+      "sha256": "59fdde78476f102a1b65f88ec4a874471f5178e6ee9c1cdbe68f53f532221694"
     },
     "rules/no-regex.md": {
       "source": "profiles/revealui/claude/rules/no-regex.md",
@@ -66,6 +66,10 @@
     "rules/skills-usage.md": {
       "source": "profiles/revealui/claude/rules/skills-usage.md",
       "sha256": "29f32b43a17f7842d34e05bb3c77e1abe5fa47247dc74ad9334aef60ed3211e3"
+    },
+    "rules/token-economy.md": {
+      "source": "profiles/revfleet/claude/rules/token-economy.md",
+      "sha256": "b30a830e9dd333b05085bc5ce3994c477ac66390aabe4cf41741a64ccd12ef57"
     },
     "rules/tool-routing.md": {
       "source": "profiles/revealui/claude/rules/tool-routing.md",

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -18,6 +18,20 @@
 - `main` only ever receives changes via a promotion PR whose head is `test` (enforced by `promotion-gate.yml`). Never push directly to `main` or `test`, and never open a feature PR directly against `main`.
 - Merge manually after review — no auto-merge.
 
+### HARDLINE: never branch off a feature branch (owner 2026-07-21)
+
+Always cut new branches from **`origin/test`**, never from an existing
+`feat/*` / `fix/*` / `chore/*` tip (even if that tip already equals test).
+
+```bash
+git fetch origin test
+git switch -c fix/<name> origin/test
+```
+
+Grok worktrees: always pass `--ref test` (or use `rfg`, which injects it).
+Without `--ref`, Grok bases the worktree on the source checkout's current
+HEAD, which is wrong when the main tree is mid-feature.
+
 ## Issue → PR → Close Workflow
 - PRs that fix a GitHub issue MUST include `Closes #N` in the PR description
 - Place `Closes #N` at the top of the PR body (the template prompts for it)

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -20,17 +20,17 @@
 
 ### HARDLINE: never branch off a feature branch (owner 2026-07-21)
 
-Always cut new branches from **`origin/test`**, never from an existing
-`feat/*` / `fix/*` / `chore/*` tip (even if that tip already equals test).
+Always cut new branches from **`origin/test`** (or `origin/main` when the
+repo has no `test`). Never from an existing `feat/*` / `fix/*` / `chore/*` tip.
 
 ```bash
 git fetch origin test
 git switch -c fix/<name> origin/test
 ```
 
-Grok worktrees: always pass `--ref test` (or use `rfg`, which injects it).
-Without `--ref`, Grok bases the worktree on the source checkout's current
-HEAD, which is wrong when the main tree is mid-feature.
+Grok worktrees: use `rfg … --worktree=…` (injects `--ref test`) or pass
+`--ref test` explicitly. Architecture: ADR
+`2026-07-21-harness-policy-runtime-launch-planes` (policy / runtime / launch).
 
 ## Issue → PR → Close Workflow
 - PRs that fix a GitHub issue MUST include `Closes #N` in the PR description

--- a/.claude/rules/token-economy.md
+++ b/.claude/rules/token-economy.md
@@ -1,0 +1,56 @@
+# Token Economy — Spend Tokens Only Where They Buy Value
+
+**Status:** convention, owner directive 2026-07-16. Governs the *amount of work*
+sent to any model, tool, loop, or automation (the companion to model routing,
+which picks the cheapest *capable* model).
+
+## The principle
+
+Every token spent must buy proportional value. Tokens are a real cost — to you
+now and to anyone running this fleet later — so the default is the smallest
+amount of work that reaches a correct, verified result. Thoroughness is not the
+enemy: a deep audit that prevents a wrong merge is worth thousands of tokens.
+Waste is spend that changes nothing — polling that a notification would have
+delivered for free, a re-read of a file you just wrote, a subagent whose answer
+you already had. Cut the second kind, never the first.
+
+## Loops, wakeups, and polling (the biggest avoidable drain)
+
+- **Never poll for background work the harness already tracks.** Background
+  agents and long-running commands re-invoke you automatically on completion.
+  Scheduling a wakeup or loop tick to "check on" them spends tokens to learn
+  what you'd have been told for free. Wait for the notification.
+- **Never schedule wakeups to keep a prompt cache warm.** The session cache
+  already covers the allowed delay range; extra wakeups are pure waste.
+- **Match any real loop's cadence to what it waits on.** An ~8-minute CI run
+  gets one ~480s check, not eight 60s ones. Idle heartbeats default to
+  1200–1800s.
+- **Stop a loop the moment it stops advancing work.** Three consecutive
+  "nothing actionable" ticks means scale back to one quick check and stop. If a
+  loop is only polling auto-notified work, stop it entirely. When in doubt,
+  pause rather than keep ticking — it can always be resumed.
+- **Surface and stop, don't silently burn.** If an automation is spending
+  tokens for no forward progress, end it and say so in one line.
+
+## Tools, skills, subagents, workflows
+
+- **Invoke for a result you don't already have, not for form's sake.** Don't run
+  a search whose answer is in context; don't re-read a file you just wrote;
+  don't re-derive a fact the transcript already established.
+- **One broad delegation beats many narrow calls.** Send one well-scoped
+  agent/search and keep the conclusion, rather than dozens of round-trips whose
+  intermediate output you don't need.
+- **Don't double-run delegated work.** Once a subagent owns a search or build,
+  don't also do it yourself — wait for its result.
+- **Reserve fan-out for proportional payoff.** Dozens of agents are right for a
+  genuine audit or migration; waste for a task one context can hold.
+- **Batch and cache external calls.** Make independent calls in one turn so they
+  run in parallel; don't refetch a URL/result already in context.
+
+## Verification is proportional, not skipped
+
+Right-sizing spend never means skipping verification on risky changes. Prove
+tests red before claiming a fix, drive the real flow on product changes, run the
+gate before a push. The economy is in not re-verifying what's already proven and
+not re-reading what can't have changed — never in cutting the check that catches
+a real bug. Correctness and authorization always outrank economy.

--- a/.grok/rules/monorepo.md
+++ b/.grok/rules/monorepo.md
@@ -36,3 +36,8 @@ pnpm validate:claims
 ## Branch
 
 Feature PRs → `test`. Never PR direct to `main`.
+
+Shared branch policy is **not** authored here (Plane A). Canon:
+`~/.claude/rules/git.md` + revcon `profiles/revfleet/claude/rules/git.md`.
+Launch: `rfg` (Plane C). Architecture ADR:
+`2026-07-21-harness-policy-runtime-launch-planes`.


### PR DESCRIPTION
## Summary
- Project `.claude/rules/git.md`: never branch off a feature branch; cut from `origin/test`.
- `.grok/rules/monorepo.md`: thin pointer to claude-config / revcon / rfg (no dual-authored policy body).

## Test plan
- [ ] Diff limited to the two rule files
- [ ] Aligns with fleet ADR + revcon profile + claude-config L1