### PR TITLE
fix(ci): hard-fail GAP-398 Tier-1 presentation gate

### DIFF
--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -400,13 +400,11 @@ async function gate(): Promise<void> {
       },
       {
         // GAP-398: Tier-1 handroll JSX (button/input/select/textarea/svg) must
-        // use @revealui/presentation. Warn-only while allowlist burns to zero;
-        // flip to hard fail when validate:tier1-presentation --hard-fail is clean
-        // with an empty allowlist (or zero entries).
-        name: 'Tier-1 presentation (warn)',
+        // use @revealui/presentation. Hard-fail on non-allowlisted hits (burn
+        // remaining allowlist entries separately; do not re-widen).
+        name: 'Tier-1 presentation (hard fail)',
         command: 'pnpm',
-        args: ['validate:tier1-presentation'],
-        warnOnly: true,
+        args: ['validate:tier1-presentation', '--', '--hard-fail'],
       },
       {
         name: 'Security audit',


### PR DESCRIPTION
## Summary
- Flip phase-1 `ci-gate` Tier-1 presentation check from warn-only to **hard fail**.
- Runs `pnpm validate:tier1-presentation -- --hard-fail` (non-allowlisted host elements fail CI).
- Empirically clean on current `test` (110 hits, 110 allowlisted, 0 violations).
- Remaining work: burn the 57 allowlist entries (follow-up PR).

## Test plan
- [ ] Quality / gate phase 1 includes "Tier-1 presentation (hard fail)"
- [ ] Local: `pnpm validate:tier1-presentation -- --hard-fail` exits 0
- [ ] Introducing a raw `<button>` outside the allowlist fails the gate

Closes nothing alone; advances GAP-398.