### PR TITLE
docs(blog): founder essay — own the upside of AI

### DIFF
--- a/apps/docs/app/lib/nav.ts
+++ b/apps/docs/app/lib/nav.ts
@@ -99,6 +99,11 @@ export function buildDocNavSections(showcaseItems: NavItem[]): NavSection[] {
     {
       title: 'Blog',
       items: [
+        {
+          label: 'Own the Upside of AI',
+          path: '/blog/17-shareable-upside',
+        },
+        { label: 'UI of the Future', path: '/blog/16-ui-of-the-future' },
         { label: 'Why We Built RevealUI', path: '/blog/01-why-we-built-revealui' },
         { label: 'HTTP 402 Payments', path: '/blog/02-http-402-payments' },
         { label: 'Multi-Agent Coordination', path: '/blog/03-multi-agent-coordination' },

--- a/apps/docs/app/lib/slug-manifest.ts
+++ b/apps/docs/app/lib/slug-manifest.ts
@@ -6,7 +6,7 @@
  * Used by the markdown resolver to translate flat URLs
  * (docs.revealui.com/admin-guide) into file fetches
  * (/admin-guide.md served from public/).
- * Generated: 65 entries.
+ * Generated: 72 entries.
  */
 
 export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
@@ -35,6 +35,13 @@ export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
   'blog/08-getting-started': 'blog/08-getting-started.md',
   'blog/09-component-library': 'blog/09-component-library.md',
   'blog/10-own-your-data': 'blog/10-own-your-data.md',
+  'blog/11-revfleet-product-family': 'blog/11-revfleet-product-family.md',
+  'blog/12-own-your-secrets': 'blog/12-own-your-secrets.md',
+  'blog/13-zero-regex': 'blog/13-zero-regex.md',
+  'blog/14-claim-drift': 'blog/14-claim-drift.md',
+  'blog/15-dashboard-agent-chat': 'blog/15-dashboard-agent-chat.md',
+  'blog/16-ui-of-the-future': 'blog/16-ui-of-the-future.md',
+  'blog/17-shareable-upside': 'blog/17-shareable-upside.md',
   'build-your-business': 'BUILD_YOUR_BUSINESS.md',
   'component-catalog': 'COMPONENT_CATALOG.md',
   'core-stability': 'CORE_STABILITY.md',
@@ -42,6 +49,9 @@ export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
   'decisions/2026-05-01-supabase-removal': 'decisions/2026-05-01-supabase-removal.md',
   'decisions/2026-05-08-deployment-target-vercel-not-k8s':
     'decisions/2026-05-08-deployment-target-vercel-not-k8s.md',
+  'decisions/2026-06-13-collab-snapshot-durability':
+    'decisions/2026-06-13-collab-snapshot-durability.md',
+  'decisions/2026-06-14-stripe-mode-coherence': 'decisions/2026-06-14-stripe-mode-coherence.md',
   'decisions/licensing-platform-evaluation': 'decisions/licensing-platform-evaluation.md',
   'environment-variables-guide': 'ENVIRONMENT-VARIABLES-GUIDE.md',
   examples: 'EXAMPLES.md',
@@ -49,7 +59,6 @@ export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
   fleet: 'FLEET.md',
   'fleet/revcon': 'fleet/revcon.md',
   'fleet/revdev': 'fleet/revdev.md',
-  'fleet/revkit': 'fleet/revkit.md',
   'fleet/revskills': 'fleet/revskills.md',
   'fleet/revvault': 'fleet/revvault.md',
   forge: 'FORGE.md',

--- a/apps/marketing/app/__tests__/routes.test.ts
+++ b/apps/marketing/app/__tests__/routes.test.ts
@@ -43,6 +43,7 @@ describe('marketing route registry', () => {
       '/blog',
       '/blog/getting-started',
       '/blog/ui-of-the-future',
+      '/blog/shareable-upside',
       '/contact',
       '/fair-source',
       '/roadmap',

--- a/apps/marketing/app/lib/blog-posts.ts
+++ b/apps/marketing/app/lib/blog-posts.ts
@@ -31,6 +31,15 @@ interface PostMeta {
 
 const POST_METADATA: PostMeta[] = [
   {
+    slug: 'shareable-upside',
+    title: 'I Built This So More People Could Own the Upside of AI',
+    excerpt:
+      'AI is splitting outcomes. I spent the longer path building a self-hosted runtime so more people could own the tools, not only rent them.',
+    publishedAt: '2026-07-21T12:00:00.000Z',
+    author: 'Joshua Vaughn',
+    file: '17-shareable-upside.md',
+  },
+  {
     slug: 'ui-of-the-future',
     title: 'The UI of the Future Has Yet to Reveal Itself',
     excerpt:

--- a/docs/blog/17-shareable-upside.md
+++ b/docs/blog/17-shareable-upside.md
@@ -1,0 +1,72 @@
+---
+title: "I Built This So More People Could Own the Upside of AI"
+description: "AI is splitting outcomes. I spent the longer path building a self-hosted runtime so more people could own the tools, not only rent them."
+visibility: public
+status: narrative
+audience: user
+author: Joshua Vaughn
+---
+
+I spent about ten years managing and training people in AT&T and T-Mobile authorized retail. High volume. Real customers. Teams that had to show up and perform whether the systems cooperated or not. That job taught me something software culture often forgets: if you cannot hand a system off to someone else and have it still work, you did not finish.
+
+In 2019 I started teaching myself to code while running my own businesses. I was not chasing a credential. I was trying to stop renting every critical piece of a company from someone else. I built a fleet of software that began as a full-stack framework for multi-product businesses: the boring, load-bearing parts that every product needs before the product is allowed to exist.
+
+Then generative AI stopped being a demo and started being a force that rewrites work. I could have bolted a chat box onto what I already had and called it a day. I did not. I rebuilt the fleet for that future. The result is RevealUI: a self-hosted runtime where your business and the AI agents that run it live under one roof. Every agent is a governed and audited user that lives on your infrastructure.
+
+If an agent did it, there's a receipt.
+
+## The split I refuse to ignore
+
+AI is advancing fast enough that outcomes are splitting. Some people will own the tools, the infrastructure, and the upside. Many will not. Economists call shapes like that K-shaped. You do not need a chart to feel it. You only need to watch who gets leverage from new models and who gets automated past without a path up.
+
+I did not want my life's work to be a private machine that makes me rich while that split widens. I wanted what I learned to be shareable and usable. Not a TED talk. Not a thread of advice with no floor under it. A system people can run.
+
+That is why the extra years went into the fleet instead of the shortest path to a closed product and a quiet exit. Open and fair-source packages. Self-host on infrastructure you control. Provider choice so the model is not the lock-in. A studio practice built to deploy and hand off, not to keep you dependent forever.
+
+I am still allowed to make a living. Paid work and public work can fund each other. The point is not purity theater. The point is that the default shape of the thing is shareable.
+
+## What I am asking of you
+
+I will be direct. I do not have a wall of famous logos to hide behind. The honest stage of this work is: the code is real, the thesis is lived, and the commercial proof is still being earned. So yes, there is a leap of faith.
+
+The leap is not "trust me forever." The leap is "give the work a fair look." Read the repo. Run what you can. Ask hard questions. If the craft holds, take the next step. If it does not, walk away. I would rather lose you on the merits than keep you with marketing.
+
+What I will not do is pretend a slogan is the same as a handoff. Mission without a runnable path is a speech. Mission with a runnable path is an invitation.
+
+## What "shareable" means in practice
+
+Shareable is not a feeling. It is a set of choices.
+
+**You can read it.** Source is public for the open packages. Pro packages are fair source with a path that does not pretend secrecy is the product.
+
+**You can run it.** The runtime is meant to live on infrastructure you own or control, not only as a rented dashboard you cannot move.
+
+**You can choose the model.** Closed APIs are adapters. The business runtime should not die when a vendor changes a price or a policy.
+
+**You can be left with it.** RevealUI Studio's job, when you hire us, is forward-deployed in spirit: stamp, wire, train, hand over. You keep the runtime. I spent a decade training people in retail. I know what unfinished training looks like. I do not want to sell unfinished training with a prettier UI.
+
+**Agents are not a side script.** They are users of the same business system, with policy and a trail you can check. That is the only way "AI runs part of the business" stays something a human can supervise.
+
+## Who this is for
+
+If you are a technical founder or a small team that wants to run your business and your agents on something you own, this is for you.
+
+If you deploy systems for other people (the industry now calls that forward deployed work, under several job titles), this is a substrate you can leave behind when the engagement ends.
+
+If you only want a magic button that prints money with no learning, this is not for you. The upward side of a K-shaped curve still requires a leap and then work. I can remove the false choice between "learn alone with nothing" and "rent everything forever." I cannot remove effort.
+
+## Who I am in one breath
+
+Retail manager and trainer for about a decade. Self-taught engineer from 2019 while running businesses. Builder of a software fleet that started as a full-stack framework and was rebuilt for the agent era. Founder of RevealUI Studio. Someone who wants more people on the upward side of what AI is doing to the economy, and who is willing to put years into a shareable system instead of only extracting the upside for himself.
+
+## The invitation
+
+Look at the work.
+
+- Product: [revealui.com](https://revealui.com)
+- Code: [github.com/RevealUIStudio/revealui](https://github.com/RevealUIStudio/revealui)
+- Studio: [revealuistudio.com](https://revealuistudio.com)
+
+If it earns your trust, take the leap. Host it. Break it. Tell me where it fails. Hire the studio if you want a hand with the last mile. Or build on your own with the same discipline of putting real systems in real hands. The goal is not that every path runs through me. The goal is that more people own the upside.
+
+I built this so you could keep the runtime.


### PR DESCRIPTION
## Summary

Publishes the founder essay **I Built This So More People Could Own the Upside of AI** to the public marketing blog and docs site.

- **Canonical markdown:** `docs/blog/17-shareable-upside.md` (`visibility: public`)
- **Marketing:** registered in `apps/marketing/app/lib/blog-posts.ts` as slug `shareable-upside` (newest first)
- **Docs:** slug-manifest regen + nav entry
- **Route smoke:** `/blog/shareable-upside` added to marketing routes advertised-path test

## URL after merge + marketing deploy

https://revealui.com/blog/shareable-upside

(Also on docs once docs deploy serves the public blog file: `/blog/17-shareable-upside`.)

## Honesty notes

- Pre-revenue / no logo wall stated honestly
- Soft receipt foil (canonical locked wording)
- No embarged hash-chain / SOC2 claims
- Job-search paragraph cut for product audience
- Companion 60s video script remains in private jv drafts until recorded

## Test plan

- [x] File present + registered in `blog-posts.ts`
- [x] Slug manifest includes `blog/17-shareable-upside`
- [ ] CI green on PR
- [ ] After merge to `test` + marketing deploy: open `/blog/shareable-upside` and confirm title + body
- [ ] Optional: CMS import via `tsx scripts/blog/import-markdown.ts` if admin CMS should mirror static post

## Owner

```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash   # when green
```