### PR TITLE
fix(ves): land .data path contract, create-session UI, default preview page

### DIFF
--- a/.changeset/editor-canvas-default-preview-page.md
+++ b/.changeset/editor-canvas-default-preview-page.md
@@ -1,0 +1,5 @@
+---
+'@revealui/editor': patch
+---
+
+Land canvas defaults for a fresh edit session: resolve a published page (`home` then `products` then first) when no dirty docs exist, so the preview iframe is not stuck on bare `/`. Export `pickDefaultPreviewPageId` for the preference order.

--- a/.changeset/presentation-fix-block-annotation-path.md
+++ b/.changeset/presentation-fix-block-annotation-path.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': patch
+---
+
+Fix `RenderBlocks` emitting `data-rvui-field` paths one segment short of the real draft structure (e.g. `blocks.0.title` instead of `blocks.0.data.title`). Every block component reads its fields from `block.data.*`, so a path stopping at the block index landed an edit-session patch as a sibling of `data` instead of inside it — silently corrupting the block's data on write, both in the session draft and (on publish) the live page. Attributes only appear in edit mode (`editable` + `docId`), so this does not affect any non-edit-mode rendering or visual output.

--- a/.changeset/ves-p2-voice-block-ops.md
+++ b/.changeset/ves-p2-voice-block-ops.md
@@ -1,0 +1,6 @@
+---
+'@revealui/contracts': patch
+'@revealui/editor': patch
+---
+
+VES P2 slice: gate fleet-marketing session patches with marketing-voice Tier-1 validation, extend prose slots for contracts block shapes, and add blocks.insert/remove/move ops on the session API plus canvas block chrome.

--- a/apps/admin/src/app/(backend)/edit-sessions/page.tsx
+++ b/apps/admin/src/app/(backend)/edit-sessions/page.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 /**
- * Edit-sessions list. Minimal: lists open sessions and links each to its canvas.
- * Auth is enforced centrally by `proxy.ts`.
+ * Edit-sessions list + open form.
+ *
+ * Lists open sessions and opens a new session (site + title) via the Hono
+ * content API, then navigates to the canvas. Auth is enforced centrally by
+ * `proxy.ts` for the `(backend)` group.
  */
 
 import Link from 'next/link';
-import { type ReactElement, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, type ReactElement, useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com';
@@ -18,20 +22,54 @@ interface SessionRow {
   siteId: string;
 }
 
+interface SiteRow {
+  id: string;
+  name: string;
+  slug: string;
+}
+
 export default function EditSessionsListPage(): ReactElement {
+  const router = useRouter();
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [sites, setSites] = useState<SiteRow[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [title, setTitle] = useState('');
+  const [siteId, setSiteId] = useState('');
+
+  const loadSessions = useCallback(async (): Promise<void> => {
+    const res = await apiFetch(`${API_BASE_URL}/api/content/sessions?status=open`, {
+      credentials: 'include',
+    });
+    if (!res.ok) throw new Error(`load failed: ${res.status}`);
+    const body = (await res.json()) as { data: SessionRow[] };
+    setSessions(body.data);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await apiFetch(`${API_BASE_URL}/api/content/sessions?status=open`, {
-          credentials: 'include',
-        });
-        if (!res.ok) throw new Error(`load failed: ${res.status}`);
-        const body = (await res.json()) as { data: SessionRow[] };
-        if (!cancelled) setSessions(body.data);
+        const [sessionsRes, sitesRes] = await Promise.all([
+          apiFetch(`${API_BASE_URL}/api/content/sessions?status=open`, {
+            credentials: 'include',
+          }),
+          apiFetch(`${API_BASE_URL}/api/content/sites?limit=50`, {
+            credentials: 'include',
+          }),
+        ]);
+        if (!sessionsRes.ok) throw new Error(`session list failed: ${sessionsRes.status}`);
+        if (!sitesRes.ok) throw new Error(`site list failed: ${sitesRes.status}`);
+        const sessionsBody = (await sessionsRes.json()) as { data: SessionRow[] };
+        const sitesBody = (await sitesRes.json()) as { data: SiteRow[] };
+        if (cancelled) return;
+        setSessions(sessionsBody.data);
+        setSites(sitesBody.data);
+        // Prefer fleet-marketing when present; else first site.
+        const preferred =
+          sitesBody.data.find((s) => s.slug === 'fleet-marketing') ?? sitesBody.data[0];
+        if (preferred) setSiteId(preferred.id);
       } catch (err) {
         if (!cancelled) setError(String(err));
       }
@@ -41,9 +79,94 @@ export default function EditSessionsListPage(): ReactElement {
     };
   }, []);
 
+  const onCreate = async (event: FormEvent): Promise<void> => {
+    event.preventDefault();
+    setCreateError(null);
+    if (!siteId || title.trim().length === 0) {
+      setCreateError('Pick a site and enter a session title.');
+      return;
+    }
+    setCreating(true);
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/api/content/sessions`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ siteId, title: title.trim() }),
+      });
+      if (!res.ok) {
+        setCreateError(`Could not open session (${res.status}).`);
+        return;
+      }
+      const body = (await res.json()) as { data: { id: string } };
+      router.push(`/edit-sessions/${body.data.id}`);
+    } catch (err) {
+      setCreateError(String(err));
+    } finally {
+      setCreating(false);
+      void loadSessions().catch(() => {
+        /* list refresh is best-effort after create */
+      });
+    }
+  };
+
   return (
     <div className="p-4">
       <h1 className="mb-4 text-lg font-semibold">Edit sessions</h1>
+
+      <form
+        onSubmit={onCreate}
+        className="mb-8 max-w-lg space-y-3 rounded-md border border-neutral-800 p-4"
+        aria-label="Open a new edit session"
+      >
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-400">
+          Open session
+        </h2>
+        <label className="block text-sm text-neutral-300">
+          Site
+          <select
+            className="mt-1 block w-full rounded border border-neutral-700 bg-neutral-900 p-2 text-neutral-100"
+            value={siteId}
+            onChange={(e) => setSiteId(e.target.value)}
+            required
+          >
+            {sites.length === 0 ? <option value="">No sites available</option> : null}
+            {sites.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name} ({s.slug})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-sm text-neutral-300">
+          Title
+          <input
+            type="text"
+            className="mt-1 block w-full rounded border border-neutral-700 bg-neutral-900 p-2 text-neutral-100"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Homepage copy pass"
+            maxLength={500}
+            required
+          />
+        </label>
+        {createError ? (
+          <p role="alert" className="text-sm text-red-400">
+            {createError}
+          </p>
+        ) : null}
+        <button
+          type="submit"
+          disabled={creating || sites.length === 0}
+          className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+        >
+          {creating ? 'Opening…' : 'Open session'}
+        </button>
+      </form>
+
+      <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-neutral-400">
+        Open sessions
+      </h2>
       {error ? (
         <p role="alert" className="text-sm text-red-400">
           {error}

--- a/apps/admin/src/app/(backend)/edit-sessions/page.tsx
+++ b/apps/admin/src/app/(backend)/edit-sessions/page.tsx
@@ -8,6 +8,8 @@
  * `proxy.ts` for the `(backend)` group.
  */
 
+import { Button, Input, Select } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type FormEvent, type ReactElement, useCallback, useEffect, useState } from 'react';
@@ -122,13 +124,13 @@ export default function EditSessionsListPage(): ReactElement {
         <h2 className="text-sm font-semibold uppercase tracking-wide text-neutral-400">
           Open session
         </h2>
-        <label className="block text-sm text-neutral-300">
-          Site
-          <select
-            className="mt-1 block w-full rounded border border-neutral-700 bg-neutral-900 p-2 text-neutral-100"
+        <Field>
+          <Label className="block text-sm text-neutral-300">Site</Label>
+          <Select
             value={siteId}
             onChange={(e) => setSiteId(e.target.value)}
             required
+            className="mt-1"
           >
             {sites.length === 0 ? <option value="">No sites available</option> : null}
             {sites.map((s) => (
@@ -136,32 +138,28 @@ export default function EditSessionsListPage(): ReactElement {
                 {s.name} ({s.slug})
               </option>
             ))}
-          </select>
-        </label>
-        <label className="block text-sm text-neutral-300">
-          Title
-          <input
+          </Select>
+        </Field>
+        <Field>
+          <Label className="block text-sm text-neutral-300">Title</Label>
+          <Input
             type="text"
-            className="mt-1 block w-full rounded border border-neutral-700 bg-neutral-900 p-2 text-neutral-100"
+            className="mt-1"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="Homepage copy pass"
             maxLength={500}
             required
           />
-        </label>
+        </Field>
         {createError ? (
           <p role="alert" className="text-sm text-red-400">
             {createError}
           </p>
         ) : null}
-        <button
-          type="submit"
-          disabled={creating || sites.length === 0}
-          className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
-        >
+        <Button type="submit" disabled={creating || sites.length === 0} size="sm">
           {creating ? 'Opening…' : 'Open session'}
-        </button>
+        </Button>
       </form>
 
       <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-neutral-400">

--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -6,7 +6,7 @@ import { NewsletterSignup } from './NewsletterSignup';
 export interface GetStartedProps {
   /** Rich CTA data; defaults to the static content module (byte-identical). */
   data?: GetStartedData;
-  /** Dot-path base of this block within the page array, e.g. `blocks.1`. */
+  /** Dot-path of this block's data object within the page array, e.g. `blocks.1.data`. */
   path?: string;
   /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
   annotation?: BlockAnnotation;
@@ -14,7 +14,7 @@ export interface GetStartedProps {
 
 export function GetStarted({
   data = HOME_GET_STARTED,
-  path = 'blocks.1',
+  path = 'blocks.1.data',
   annotation = {},
 }: GetStartedProps) {
   return (

--- a/apps/marketing/app/components/__tests__/block-annotations.test.tsx
+++ b/apps/marketing/app/components/__tests__/block-annotations.test.tsx
@@ -36,90 +36,97 @@ describe('block-driven marketing sections: annotation suppression (inactive)', (
     expect(inactive.getByText(HOME_DEMO.body)).toBeTruthy();
     inactive.unmount();
 
-    const active = render(<Demo path="blocks.0" annotation={ACTIVE} />);
+    const active = render(<Demo path="blocks.0.data" annotation={ACTIVE} />);
     expect(active.getByText(HOME_DEMO.heading)).toBeTruthy();
     expect(active.getByText(HOME_DEMO.body)).toBeTruthy();
   });
 });
 
+// Every field path lives under `blocks.<index>.data.*`  -  the same structure
+// a session server's materialized draft carries (see the RenderBlocks +
+// page-blocks contract test for the cross-seam version of this assertion).
 describe('block-driven marketing sections: annotation emission (active)', () => {
   it('Demo emits field paths on heading, body, and repeater items', () => {
-    const { container } = render(<Demo path="blocks.0" annotation={ACTIVE} />);
-    const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
+    const { container } = render(<Demo path="blocks.0.data" annotation={ACTIVE} />);
+    const heading = container.querySelector('[data-rvui-field="blocks.0.data.heading"]');
     expect(heading?.getAttribute('data-rvui-doc')).toBe('home');
     expect(heading?.textContent).toBe(HOME_DEMO.heading);
-    expect(container.querySelector('[data-rvui-field="blocks.0.body"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.0.data.body"]')?.textContent).toBe(
       HOME_DEMO.body,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.0.items.0.title"]')?.textContent).toBe(
-      HOME_DEMO.beats[0]?.title,
-    );
-    expect(container.querySelector('[data-rvui-field="blocks.0.items.0.label"]')?.textContent).toBe(
-      HOME_DEMO.beats[0]?.n,
-    );
+    expect(
+      container.querySelector('[data-rvui-field="blocks.0.data.items.0.title"]')?.textContent,
+    ).toBe(HOME_DEMO.beats[0]?.title);
+    expect(
+      container.querySelector('[data-rvui-field="blocks.0.data.items.0.label"]')?.textContent,
+    ).toBe(HOME_DEMO.beats[0]?.n);
   });
 
   it('Primitives emits field paths on heading, body, and repeater items', () => {
-    const { container } = render(<Primitives path="blocks.1" annotation={ACTIVE} />);
-    expect(container.querySelector('[data-rvui-field="blocks.1.heading"]')?.textContent).toBe(
+    const { container } = render(<Primitives path="blocks.1.data" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.1.data.heading"]')?.textContent).toBe(
       HOME_PRIMITIVES_SECTION.heading,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.1.body"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.1.data.body"]')?.textContent).toBe(
       HOME_PRIMITIVES_SECTION.body,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.1.items.0.label"]')?.textContent).toBe(
-      HOME_PRIMITIVES[0]?.label,
-    );
-    expect(container.querySelector('[data-rvui-field="blocks.1.items.0.body"]')?.textContent).toBe(
-      HOME_PRIMITIVES[0]?.body,
-    );
+    expect(
+      container.querySelector('[data-rvui-field="blocks.1.data.items.0.label"]')?.textContent,
+    ).toBe(HOME_PRIMITIVES[0]?.label);
+    expect(
+      container.querySelector('[data-rvui-field="blocks.1.data.items.0.body"]')?.textContent,
+    ).toBe(HOME_PRIMITIVES[0]?.body);
   });
 
   it('GetStarted emits field paths on heading, body, and snippet', () => {
-    const { container } = render(<GetStarted path="blocks.2" annotation={ACTIVE} />);
-    expect(container.querySelector('[data-rvui-field="blocks.2.heading"]')?.textContent).toBe(
+    const { container } = render(<GetStarted path="blocks.2.data" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.2.data.heading"]')?.textContent).toBe(
       HOME_GET_STARTED.heading,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.2.body"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.2.data.body"]')?.textContent).toBe(
       HOME_GET_STARTED.body,
     );
     expect(
-      container.querySelector('[data-rvui-field="blocks.2.snippet.caption"]')?.textContent,
+      container.querySelector('[data-rvui-field="blocks.2.data.snippet.caption"]')?.textContent,
     ).toBe(HOME_GET_STARTED.cli.caption);
-    expect(container.querySelector('[data-rvui-field="blocks.2.snippet.lines"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-rvui-field="blocks.2.data.snippet.lines"]'),
+    ).not.toBeNull();
   });
 
   it('Faq emits field paths on heading and per-item question + answer', () => {
-    const { container } = render(<Faq path="blocks.1" annotation={ACTIVE} />);
-    expect(container.querySelector('[data-rvui-field="blocks.1.heading"]')?.textContent).toBe(
+    const { container } = render(<Faq path="blocks.1.data" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.1.data.heading"]')?.textContent).toBe(
       HOME_FAQ.heading,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.1.items.0.label"]')?.textContent).toBe(
-      HOME_FAQ.items[0]?.question,
-    );
-    expect(container.querySelector('[data-rvui-field="blocks.1.items.0.body"]')?.textContent).toBe(
-      HOME_FAQ.items[0]?.answer,
-    );
+    expect(
+      container.querySelector('[data-rvui-field="blocks.1.data.items.0.label"]')?.textContent,
+    ).toBe(HOME_FAQ.items[0]?.question);
+    expect(
+      container.querySelector('[data-rvui-field="blocks.1.data.items.0.body"]')?.textContent,
+    ).toBe(HOME_FAQ.items[0]?.answer);
   });
 
   it('ProductsHero emits field paths on title and subtitle', () => {
-    const { container } = render(<ProductsHero path="blocks.0" annotation={ACTIVE} />);
-    expect(container.querySelector('[data-rvui-field="blocks.0.title"]')?.textContent).toBe(
+    const { container } = render(<ProductsHero path="blocks.0.data" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.0.data.title"]')?.textContent).toBe(
       PRODUCTS_PAGE_HERO.h1,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.0.subtitle"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.0.data.subtitle"]')?.textContent).toBe(
       PRODUCTS_PAGE_HERO.subtitle,
     );
   });
 
   it('ProductsCta emits field paths on heading, body, and snippet', () => {
-    const { container } = render(<ProductsCta path="blocks.2" annotation={ACTIVE} />);
-    expect(container.querySelector('[data-rvui-field="blocks.2.heading"]')?.textContent).toBe(
+    const { container } = render(<ProductsCta path="blocks.2.data" annotation={ACTIVE} />);
+    expect(container.querySelector('[data-rvui-field="blocks.2.data.heading"]')?.textContent).toBe(
       PRODUCTS_CTA_SECTION.heading,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.2.body"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.2.data.body"]')?.textContent).toBe(
       PRODUCTS_CTA_SECTION.body,
     );
-    expect(container.querySelector('[data-rvui-field="blocks.2.snippet.lines"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-rvui-field="blocks.2.data.snippet.lines"]'),
+    ).not.toBeNull();
   });
 });

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -5,13 +5,13 @@ import type { DemoData } from '../../lib/page-blocks';
 export interface DemoProps {
   /** Rich section data; defaults to the static content module (byte-identical). */
   data?: DemoData;
-  /** Dot-path base of this block within the page array, e.g. `blocks.0`. */
+  /** Dot-path of this block's data object within the page array, e.g. `blocks.0.data`. */
   path?: string;
   /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
   annotation?: BlockAnnotation;
 }
 
-export function Demo({ data = HOME_DEMO, path = 'blocks.0', annotation = {} }: DemoProps) {
+export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {} }: DemoProps) {
   return (
     <section id="demo" className="bg-secondary py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -5,13 +5,13 @@ import type { FaqData } from '../../lib/page-blocks';
 export interface FaqProps {
   /** Rich FAQ data; defaults to the static content module (byte-identical). */
   data?: FaqData;
-  /** Dot-path base of this block within the page array, e.g. `blocks.1`. */
+  /** Dot-path of this block's data object within the page array, e.g. `blocks.1.data`. */
   path?: string;
   /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
   annotation?: BlockAnnotation;
 }
 
-export function Faq({ data = HOME_FAQ, path = 'blocks.1', annotation = {} }: FaqProps) {
+export function Faq({ data = HOME_FAQ, path = 'blocks.1.data', annotation = {} }: FaqProps) {
   return (
     <section id="faq" className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -28,7 +28,7 @@ const primitiveStyles = HOME_PRIMITIVES.map((p) => ({ color: p.color, iconPath: 
 export interface PrimitivesProps {
   /** Rich section data; defaults to the static content modules (byte-identical). */
   data?: PrimitivesData;
-  /** Dot-path base of this block within the page array, e.g. `blocks.1`. */
+  /** Dot-path of this block's data object within the page array, e.g. `blocks.1.data`. */
   path?: string;
   /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
   annotation?: BlockAnnotation;
@@ -36,7 +36,7 @@ export interface PrimitivesProps {
 
 export function Primitives({
   data = PRIMITIVES_FALLBACK_DATA,
-  path = 'blocks.1',
+  path = 'blocks.1.data',
   annotation = {},
 }: PrimitivesProps) {
   return (

--- a/apps/marketing/app/components/products/ProductsCta.tsx
+++ b/apps/marketing/app/components/products/ProductsCta.tsx
@@ -5,7 +5,7 @@ import type { ProductsCtaData } from '../../lib/page-blocks';
 export interface ProductsCtaProps {
   /** Rich CTA data; defaults to the static content module (byte-identical). */
   data?: ProductsCtaData;
-  /** Dot-path base of this block within the page array, e.g. `blocks.1`. */
+  /** Dot-path of this block's data object within the page array, e.g. `blocks.1.data`. */
   path?: string;
   /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
   annotation?: BlockAnnotation;
@@ -13,7 +13,7 @@ export interface ProductsCtaProps {
 
 export function ProductsCta({
   data = PRODUCTS_CTA_SECTION,
-  path = 'blocks.1',
+  path = 'blocks.1.data',
   annotation = {},
 }: ProductsCtaProps) {
   return (

--- a/apps/marketing/app/components/products/ProductsHero.tsx
+++ b/apps/marketing/app/components/products/ProductsHero.tsx
@@ -11,7 +11,7 @@ const ALL_PRODUCT_ANCHORS = [
 export interface ProductsHeroProps {
   /** Rich hero data; defaults to the static content module (byte-identical). */
   data?: ProductsHeroData;
-  /** Dot-path base of this block within the page array, e.g. `blocks.0`. */
+  /** Dot-path of this block's data object within the page array, e.g. `blocks.0.data`. */
   path?: string;
   /** Edit-mode annotation. Inactive by default: emits zero data attributes. */
   annotation?: BlockAnnotation;
@@ -19,7 +19,7 @@ export interface ProductsHeroProps {
 
 export function ProductsHero({
   data = PRODUCTS_PAGE_HERO,
-  path = 'blocks.0',
+  path = 'blocks.0.data',
   annotation = {},
 }: ProductsHeroProps) {
   return (

--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -93,7 +93,7 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
 describe('reverse mappers round-trip the derivation losslessly', () => {
   it('reconstructs the demo data byte-identical to HOME_DEMO', () => {
     const slot = demoSlot(homeBlocks());
-    expect(slot.path).toBe('blocks.0');
+    expect(slot.path).toBe('blocks.0.data');
     expect(slot.data.eyebrow).toBe(HOME_DEMO.eyebrow);
     expect(slot.data.heading).toBe(HOME_DEMO.heading);
     expect(slot.data.body).toBe(HOME_DEMO.body);
@@ -104,7 +104,7 @@ describe('reverse mappers round-trip the derivation losslessly', () => {
 
   it('reconstructs the primitives data byte-identical to its content modules', () => {
     const slot = primitivesSlot(homeBlocks());
-    expect(slot.path).toBe('blocks.1');
+    expect(slot.path).toBe('blocks.1.data');
     expect(slot.data.eyebrow).toBe(HOME_PRIMITIVES_SECTION.eyebrow);
     expect(slot.data.heading).toBe(HOME_PRIMITIVES_SECTION.heading);
     expect(slot.data.body).toBe(HOME_PRIMITIVES_SECTION.body);
@@ -113,7 +113,7 @@ describe('reverse mappers round-trip the derivation losslessly', () => {
 
   it('reconstructs the get-started data byte-identical to HOME_GET_STARTED', () => {
     const slot = getStartedSlot(homeBlocks());
-    expect(slot.path).toBe('blocks.2');
+    expect(slot.path).toBe('blocks.2.data');
     expect(slot.data.heading).toBe(HOME_GET_STARTED.heading);
     expect(slot.data.body).toBe(HOME_GET_STARTED.body);
     expect(slot.data.cta.primary).toEqual({
@@ -131,12 +131,12 @@ describe('reverse mappers round-trip the derivation losslessly', () => {
 
   it('reconstructs the products hero, faq, and cta byte-identical to their modules', () => {
     const hero = productsHeroSlot(productsBlocks());
-    expect(hero.path).toBe('blocks.0');
+    expect(hero.path).toBe('blocks.0.data');
     expect(hero.data.h1).toBe(PRODUCTS_PAGE_HERO.h1);
     expect(hero.data.subtitle).toBe(PRODUCTS_PAGE_HERO.subtitle);
 
     const faq = productsFaqSlot(productsBlocks());
-    expect(faq.path).toBe('blocks.1');
+    expect(faq.path).toBe('blocks.1.data');
     expect(faq.data.eyebrow).toBe(HOME_FAQ.eyebrow);
     expect(faq.data.heading).toBe(HOME_FAQ.heading);
     expect(faq.data.items).toEqual(
@@ -144,7 +144,7 @@ describe('reverse mappers round-trip the derivation losslessly', () => {
     );
 
     const cta = productsCtaSlot(productsBlocks());
-    expect(cta.path).toBe('blocks.2');
+    expect(cta.path).toBe('blocks.2.data');
     expect(cta.data.heading).toBe(PRODUCTS_CTA_SECTION.heading);
     expect(cta.data.body).toBe(PRODUCTS_CTA_SECTION.body);
     expect(cta.data.cliSnippet).toBe(PRODUCTS_CTA_SECTION.cliSnippet);

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -295,48 +295,54 @@ export const PRIMITIVES_FALLBACK_DATA: PrimitivesData = sectionToPrimitives(home
 
 export interface BlockSlot<T> {
   readonly data: T;
-  /** Dot-path base of this block within the array, e.g. `blocks.0`. */
+  /**
+   * Dot-path of this block's DATA object within the array, e.g. `blocks.0.data`
+   * (not `blocks.0`  -  every field a block component addresses via
+   * `fieldAttrs` lives under `block.data.*`, per the canonical `Block` shape;
+   * a path stopping at the block index would land a patch as a sibling of
+   * `data` instead of inside it).
+   */
   readonly path: string;
 }
 
 export function demoSlot(blocks: Block[]): BlockSlot<DemoData> {
   const block = blocks[HOME_DEMO_INDEX];
-  const path = `blocks.${HOME_DEMO_INDEX}`;
+  const path = `blocks.${HOME_DEMO_INDEX}.data`;
   if (block && block.type === 'section') return { data: sectionToDemo(block), path };
   return { data: sectionToDemo(homeDemoBlock()), path };
 }
 
 export function primitivesSlot(blocks: Block[]): BlockSlot<PrimitivesData> {
   const block = blocks[HOME_PRIMITIVES_INDEX];
-  const path = `blocks.${HOME_PRIMITIVES_INDEX}`;
+  const path = `blocks.${HOME_PRIMITIVES_INDEX}.data`;
   if (block && block.type === 'section') return { data: sectionToPrimitives(block), path };
   return { data: sectionToPrimitives(homePrimitivesBlock()), path };
 }
 
 export function getStartedSlot(blocks: Block[]): BlockSlot<GetStartedData> {
   const block = blocks[HOME_GET_STARTED_INDEX];
-  const path = `blocks.${HOME_GET_STARTED_INDEX}`;
+  const path = `blocks.${HOME_GET_STARTED_INDEX}.data`;
   if (block && block.type === 'ctaSection') return { data: ctaToGetStarted(block), path };
   return { data: ctaToGetStarted(homeGetStartedBlock()), path };
 }
 
 export function productsHeroSlot(blocks: Block[]): BlockSlot<ProductsHeroData> {
   const block = blocks[PRODUCTS_HERO_INDEX];
-  const path = `blocks.${PRODUCTS_HERO_INDEX}`;
+  const path = `blocks.${PRODUCTS_HERO_INDEX}.data`;
   if (block && block.type === 'hero') return { data: heroToProductsHero(block), path };
   return { data: heroToProductsHero(productsHeroBlock()), path };
 }
 
 export function productsFaqSlot(blocks: Block[]): BlockSlot<FaqData> {
   const block = blocks[PRODUCTS_FAQ_INDEX];
-  const path = `blocks.${PRODUCTS_FAQ_INDEX}`;
+  const path = `blocks.${PRODUCTS_FAQ_INDEX}.data`;
   if (block && block.type === 'section') return { data: sectionToFaq(block), path };
   return { data: sectionToFaq(productsFaqBlock()), path };
 }
 
 export function productsCtaSlot(blocks: Block[]): BlockSlot<ProductsCtaData> {
   const block = blocks[PRODUCTS_CTA_INDEX];
-  const path = `blocks.${PRODUCTS_CTA_INDEX}`;
+  const path = `blocks.${PRODUCTS_CTA_INDEX}.data`;
   if (block && block.type === 'ctaSection') return { data: ctaToProductsCta(block), path };
   return { data: ctaToProductsCta(productsCtaBlock()), path };
 }

--- a/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
+++ b/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
@@ -85,7 +85,7 @@ describe('marketing pages: edit-mode wiring', () => {
     ]);
 
     const { container } = renderRouted(<HomePage />);
-    const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
+    const heading = container.querySelector('[data-rvui-field="blocks.0.data.heading"]');
     expect(heading?.getAttribute('data-rvui-doc')).toBe('page-home-id');
     expect(heading?.textContent).toBe('Canvas-edited demo heading');
   });
@@ -105,7 +105,7 @@ describe('marketing pages: edit-mode wiring', () => {
     ]);
 
     const { container } = renderRouted(<ProductsPage />);
-    const title = container.querySelector('[data-rvui-field="blocks.0.title"]');
+    const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
     expect(title?.getAttribute('data-rvui-doc')).toBe('page-products-id');
     expect(title?.textContent).toBe('Canvas-edited hero title');
   });
@@ -125,7 +125,7 @@ describe('marketing pages: edit-mode wiring', () => {
       ]);
     });
 
-    const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
+    const heading = container.querySelector('[data-rvui-field="blocks.0.data.heading"]');
     expect(heading?.getAttribute('data-rvui-doc')).toBe('page-home-id');
     expect(heading?.textContent).toBe('Optimistically re-rendered heading');
   });
@@ -143,7 +143,7 @@ describe('marketing pages: edit-mode wiring', () => {
     expect(container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
 
     await waitFor(() => {
-      const heading = container.querySelector('[data-rvui-field="blocks.0.heading"]');
+      const heading = container.querySelector('[data-rvui-field="blocks.0.data.heading"]');
       expect(heading?.getAttribute('data-rvui-doc')).toBe('page-home-id');
     });
   });

--- a/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
@@ -688,6 +688,116 @@ describe('structural path validation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// P2 — block array ops + fleet-marketing voice gate
+// ---------------------------------------------------------------------------
+
+describe('P2 block array ops', () => {
+  async function blockOp(
+    app: ReturnType<typeof createApp>,
+    sessionId: string,
+    payload: Record<string, unknown>,
+  ): Promise<Response> {
+    return app.request(`/sessions/${sessionId}/docs/page/${PAGE_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  it('inserts a text block at the end', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    expect((await patch(app, sessionId, 'title', 'T')).status).toBe(200);
+
+    const res = await blockOp(app, sessionId, {
+      op: 'blocks.insert',
+      index: 1,
+      block: { id: 'blk-new', type: 'text', data: { content: 'fresh' } },
+    });
+    expect(res.status).toBe(200);
+
+    const get = await app.request(`/sessions/${sessionId}`);
+    const body = (await get.json()) as {
+      data: { docs: Array<{ draft: { blocks: Array<{ id: string; type: string }> } }> };
+    };
+    expect(body.data.docs[0].draft.blocks).toHaveLength(2);
+    expect(body.data.docs[0].draft.blocks[1].id).toBe('blk-new');
+    expect(body.data.docs[0].draft.blocks[1].type).toBe('text');
+  });
+
+  it('moves and removes blocks', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'T');
+    await blockOp(app, sessionId, {
+      op: 'blocks.insert',
+      index: 1,
+      block: { id: 'blk-2', type: 'text', data: { content: 'second' } },
+    });
+
+    expect((await blockOp(app, sessionId, { op: 'blocks.move', from: 1, to: 0 })).status).toBe(200);
+
+    let get = await app.request(`/sessions/${sessionId}`);
+    let body = (await get.json()) as {
+      data: { docs: Array<{ draft: { blocks: Array<{ id: string }> } }> };
+    };
+    expect(body.data.docs[0].draft.blocks[0].id).toBe('blk-2');
+
+    expect((await blockOp(app, sessionId, { op: 'blocks.remove', index: 0 })).status).toBe(200);
+    get = await app.request(`/sessions/${sessionId}`);
+    body = (await get.json()) as {
+      data: { docs: Array<{ draft: { blocks: Array<{ id: string }> } }> };
+    };
+    expect(body.data.docs[0].draft.blocks).toHaveLength(1);
+    expect(body.data.docs[0].draft.blocks[0].id).toBe('blk-1');
+  });
+
+  it('refuses to remove the last block', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'T');
+    const res = await blockOp(app, sessionId, { op: 'blocks.remove', index: 0 });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('P2 voice gate on fleet-marketing', () => {
+  beforeEach(async () => {
+    await testDb.drizzle
+      .update(schema.sites)
+      .set({ slug: 'fleet-marketing' })
+      .where(eq(schema.sites.id, SITE_ID));
+  });
+
+  it('rejects an em-dash field patch with 422 and does not write', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    const res = await patch(app, sessionId, 'blocks.0.data.text', 'Hello\u2014world');
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as {
+      rejected?: boolean;
+      violations?: unknown[];
+    };
+    expect(body.rejected).toBe(true);
+    expect(Array.isArray(body.violations)).toBe(true);
+    expect((body.violations ?? []).length).toBeGreaterThan(0);
+
+    const get = await app.request(`/sessions/${sessionId}`);
+    const detail = (await get.json()) as { data: { docs: unknown[] } };
+    // First patch rejected: no overlay row.
+    expect(detail.data.docs).toHaveLength(0);
+  });
+
+  it('accepts a clean field patch on fleet-marketing', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    const res = await patch(app, sessionId, 'blocks.0.data.text', 'Clean copy');
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Non-open session mutations
 // ---------------------------------------------------------------------------
 

--- a/apps/server/src/routes/content/sessions.ts
+++ b/apps/server/src/routes/content/sessions.ts
@@ -15,6 +15,13 @@
  * GET is public-read there, so these routes enforce authz explicitly.
  */
 
+import {
+  FLEET_MARKETING_VOICE_RULES,
+  type MarketingBlock,
+  UnmappedBlockTypeError,
+  type Violation,
+  validateMarketingBlock,
+} from '@revealui/contracts/marketing-voice';
 import * as sessionQueries from '@revealui/db/queries/edit-sessions';
 import * as siteQueries from '@revealui/db/queries/sites';
 import type { EditSession, EditSessionDoc, EditSessionEvent, Page } from '@revealui/db/schema';
@@ -30,6 +37,9 @@ import {
   verifyPreviewToken,
 } from './_helpers/preview-token.js';
 import type { ContentVariables } from './index.js';
+
+/** Site slug whose session patches are gated by the fleet marketing-voice engine. */
+const FLEET_MARKETING_SITE_SLUG = 'fleet-marketing';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -187,6 +197,132 @@ function applyDraftPatch(draft: Record<string, unknown>, path: string, value: un
   }
 
   throw pathError(root, UNPATCHABLE_ROOT_HINT);
+}
+
+// =============================================================================
+// Block array ops (P2) — insert / remove / move on the blocks array only
+// =============================================================================
+
+type BlockOp =
+  | { op: 'blocks.insert'; index: number; block: Record<string, unknown> }
+  | { op: 'blocks.remove'; index: number }
+  | { op: 'blocks.move'; from: number; to: number };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getBlocksArray(draft: Record<string, unknown>): unknown[] {
+  if (!Array.isArray(draft.blocks)) {
+    throw new HTTPException(400, { message: 'Draft has no blocks array' });
+  }
+  return draft.blocks;
+}
+
+/** Apply a structural block-array operation. Mutates `draft.blocks` in place. */
+function applyBlockOp(draft: Record<string, unknown>, op: BlockOp): void {
+  const blocks = getBlocksArray(draft);
+  if (op.op === 'blocks.insert') {
+    if (op.index < 0 || op.index > blocks.length) {
+      throw pathError(String(op.index), 'insert index out of range');
+    }
+    if (!isRecord(op.block)) {
+      throw new HTTPException(400, { message: 'blocks.insert requires a block object' });
+    }
+    // Identity + type are required; reject prototype-dangerous keys on the block.
+    for (const key of Object.keys(op.block)) {
+      if (DANGEROUS_KEYS.has(key)) {
+        throw new HTTPException(400, { message: `Illegal block key: ${key}` });
+      }
+    }
+    if (typeof op.block.type !== 'string' || op.block.type.length === 0) {
+      throw new HTTPException(400, { message: 'blocks.insert requires block.type' });
+    }
+    if (typeof op.block.id !== 'string' || op.block.id.length === 0) {
+      throw new HTTPException(400, { message: 'blocks.insert requires block.id' });
+    }
+    if (!isRecord(op.block.data)) {
+      throw new HTTPException(400, { message: 'blocks.insert requires block.data object' });
+    }
+    blocks.splice(op.index, 0, structuredClone(op.block));
+    return;
+  }
+  if (op.op === 'blocks.remove') {
+    if (op.index < 0 || op.index >= blocks.length) {
+      throw pathError(String(op.index), 'remove index out of range');
+    }
+    if (blocks.length <= 1) {
+      throw new HTTPException(400, {
+        message: 'Cannot remove the last block (page must keep at least one)',
+      });
+    }
+    blocks.splice(op.index, 1);
+    return;
+  }
+  // blocks.move
+  if (op.from < 0 || op.from >= blocks.length) {
+    throw pathError(String(op.from), 'move from-index out of range');
+  }
+  if (op.to < 0 || op.to >= blocks.length) {
+    throw pathError(String(op.to), 'move to-index out of range');
+  }
+  if (op.from === op.to) return;
+  const [item] = blocks.splice(op.from, 1);
+  blocks.splice(op.to, 0, item);
+}
+
+// =============================================================================
+// Fleet-marketing voice gate (P2) — Tier-1 hard reject on session.patch
+// =============================================================================
+
+/**
+ * Adapt a page block (VES contracts shape OR admin Lexical shape) into the
+ * marketing-voice engine's MarketingBlock view.
+ */
+function toMarketingBlock(raw: unknown): MarketingBlock | null {
+  if (!isRecord(raw)) return null;
+  if (typeof raw.blockType === 'string') {
+    return raw as MarketingBlock;
+  }
+  if (typeof raw.type === 'string') {
+    return { blockType: raw.type, ...raw };
+  }
+  return null;
+}
+
+interface VoiceViolation extends Violation {
+  blockIndex: number;
+}
+
+/**
+ * Run Tier-1 marketing-voice validation over every block in the draft when the
+ * session targets the fleet-marketing site. Returns violations (empty = pass).
+ * Throws HTTPException 422 only via the caller's response construction for
+ * unmapped block types (fail-closed).
+ */
+function collectVoiceViolations(draft: Record<string, unknown>): VoiceViolation[] {
+  const blocks = Array.isArray(draft.blocks) ? draft.blocks : [];
+  const violations: VoiceViolation[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    const mb = toMarketingBlock(blocks[i]);
+    if (!mb) continue;
+    try {
+      const report = validateMarketingBlock(mb, FLEET_MARKETING_VOICE_RULES);
+      if (!report.tier1.passed) {
+        for (const v of report.tier1.violations) {
+          violations.push({ ...v, blockIndex: i });
+        }
+      }
+    } catch (err) {
+      if (err instanceof UnmappedBlockTypeError) {
+        throw new HTTPException(422, {
+          message: `Voice gate: unmapped blockType at blocks[${i}]: ${err.blockType}`,
+        });
+      }
+      throw err;
+    }
+  }
+  return violations;
 }
 
 /**
@@ -541,15 +677,56 @@ app.openapi(
 );
 
 // =============================================================================
-// PATCH /sessions/:id/docs/:docType/:docId  -  field patch (autosave)
+// PATCH /sessions/:id/docs/:docType/:docId  -  field patch or block op (autosave)
 // =============================================================================
+
+const FieldPatchBody = z
+  .object({ path: z.string().min(1), value: z.unknown() })
+  .openapi('EditSessionFieldPatch');
+
+const BlockInsertBody = z
+  .object({
+    op: z.literal('blocks.insert'),
+    index: z.number().int().nonnegative(),
+    block: z.record(z.string(), z.unknown()),
+  })
+  .openapi('EditSessionBlockInsert');
+
+const BlockRemoveBody = z
+  .object({
+    op: z.literal('blocks.remove'),
+    index: z.number().int().nonnegative(),
+  })
+  .openapi('EditSessionBlockRemove');
+
+const BlockMoveBody = z
+  .object({
+    op: z.literal('blocks.move'),
+    from: z.number().int().nonnegative(),
+    to: z.number().int().nonnegative(),
+  })
+  .openapi('EditSessionBlockMove');
+
+const PatchBody = z.union([FieldPatchBody, BlockInsertBody, BlockRemoveBody, BlockMoveBody]);
+
+const VoiceRejectSchema = z.object({
+  success: z.literal(false),
+  rejected: z.literal(true),
+  violations: z.array(z.record(z.string(), z.unknown())),
+});
+
+function isBlockOpBody(
+  body: z.infer<typeof PatchBody>,
+): body is z.infer<typeof BlockInsertBody | typeof BlockRemoveBody | typeof BlockMoveBody> {
+  return 'op' in body;
+}
 
 app.openapi(
   createRoute({
     method: 'patch',
     path: '/sessions/{id}/docs/{docType}/{docId}',
     tags: ['content'],
-    summary: 'Patch a draft field in an edit session',
+    summary: 'Patch a draft field or apply a block-array op in an edit session',
     request: {
       params: z.object({
         id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
@@ -559,7 +736,7 @@ app.openapi(
       body: {
         content: {
           'application/json': {
-            schema: z.object({ path: z.string().min(1), value: z.unknown() }),
+            schema: PatchBody,
           },
         },
       },
@@ -579,13 +756,17 @@ app.openapi(
         content: { 'application/json': { schema: ErrorSchema } },
         description: 'Session not open',
       },
+      422: {
+        content: { 'application/json': { schema: VoiceRejectSchema } },
+        description: 'Voice validation rejected the patch (fleet-marketing only)',
+      },
     },
   }),
   async (c) => {
     const db = c.get('db');
     const user = requireContentEditor(c.get('user'));
     const { id, docType, docId } = c.req.valid('param');
-    const { path, value } = c.req.valid('json');
+    const body = c.req.valid('json');
 
     const session = await sessionQueries.getEditSessionById(db, id);
     if (!session) throw new HTTPException(404, { message: 'Session not found' });
@@ -601,39 +782,71 @@ app.openapi(
     // Validate + apply against the in-memory draft BEFORE any write: a 400 on
     // the first patch must not materialize an overlay row.
     const doc = await sessionQueries.getSessionDoc(db, id, docType, docId);
-    let updated: typeof doc;
+    let nextDraft: Record<string, unknown>;
+    let materializeBaseVersion: number | null = null;
     if (doc) {
-      const nextDraft = structuredClone(doc.draft);
-      applyDraftPatch(nextDraft, path, value);
+      nextDraft = structuredClone(doc.draft);
+    } else {
+      const page = await sessionQueries.getLivePage(db, docId);
+      if (!page) throw new HTTPException(404, { message: 'Page not found' });
+      nextDraft = materializePageDraft(page);
+      materializeBaseVersion = page.version;
+    }
+
+    if (isBlockOpBody(body)) {
+      applyBlockOp(nextDraft, body);
+    } else {
+      applyDraftPatch(nextDraft, body.path, body.value);
+    }
+
+    // Fleet-marketing only: Tier-1 marketing-voice hard-reject before any write.
+    const site = await siteQueries.getSiteById(db, session.siteId);
+    if (site?.slug === FLEET_MARKETING_SITE_SLUG) {
+      const violations = collectVoiceViolations(nextDraft);
+      if (violations.length > 0) {
+        return c.json(
+          {
+            success: false as const,
+            rejected: true as const,
+            violations: violations as unknown as Array<Record<string, unknown>>,
+          },
+          422,
+        );
+      }
+    }
+
+    let updated: EditSessionDoc | null;
+    if (doc) {
       updated = await sessionQueries.updateSessionDocDraft(db, doc.id, {
         draft: nextDraft,
         updatedBy: user.id,
       });
     } else {
-      // First patch on this doc: materialize the overlay from the live page
-      // with the patch already applied (single write).
-      const page = await sessionQueries.getLivePage(db, docId);
-      if (!page) throw new HTTPException(404, { message: 'Page not found' });
-      const nextDraft = materializePageDraft(page);
-      applyDraftPatch(nextDraft, path, value);
       updated = await sessionQueries.insertSessionDoc(db, {
         id: crypto.randomUUID(),
         sessionId: id,
         docType,
         docId,
         draft: nextDraft,
-        baseVersion: page.version,
+        baseVersion: materializeBaseVersion ?? 1,
         updatedBy: user.id,
       });
     }
     if (!updated) throw new HTTPException(500, { message: 'Failed to save draft' });
+
+    const eventPayload: Record<string, unknown> = { docType, docId };
+    if (isBlockOpBody(body)) {
+      eventPayload.op = body.op;
+    } else {
+      eventPayload.path = body.path;
+    }
 
     await sessionQueries.insertSessionEvent(db, {
       sessionId: id,
       actorId: user.id,
       actorKind: actorKindFor(user),
       type: 'patched',
-      payload: { docType, docId, path },
+      payload: eventPayload,
     });
 
     return c.json({ success: true as const, data: serializeDoc(updated) }, 200);

--- a/packages/contracts/src/marketing-voice/blocks.ts
+++ b/packages/contracts/src/marketing-voice/blocks.ts
@@ -65,10 +65,41 @@ export class UnmappedBlockTypeError extends Error {
  * Phase B block types register here. Field paths may use a single array-glob
  * segment (e.g. `items[].q`) resolved by `resolveFieldPath`.
  */
+/**
+ * Source of truth mapping a block type to voice-validated prose field paths.
+ *
+ * Covers both shapes still in the fleet:
+ * - **Admin/legacy Lexical:** `blockType` + top-level `richText` (hero/content/cta).
+ * - **VES contracts blocks:** `type` adapted to `blockType` + plain-string fields
+ *   under `data.*` (hero/section/ctaSection/primitives). Missing paths are skipped
+ *   by `getProseSlots`; both shapes can share an entry.
+ *
+ * Empty arrays mean "no prose" (structural blocks like divider/spacer): validation
+ * runs, finds nothing, and passes. Unregistered types still throw
+ * `UnmappedBlockTypeError` (fail-closed).
+ */
 export const MARKETING_PROSE_SLOTS: Record<string, string[]> = {
-  hero: ['richText'],
+  // Admin Lexical + VES contracts hero
+  hero: ['richText', 'data.title', 'data.subtitle', 'data.eyebrow', 'data.support'],
   content: ['richText'],
   cta: ['richText'],
+  // VES marketing contracts blocks
+  section: [
+    'data.heading',
+    'data.body',
+    'data.eyebrow',
+    'data.items[].title',
+    'data.items[].body',
+    'data.items[].label',
+  ],
+  ctaSection: ['data.heading', 'data.body', 'data.snippet.caption'],
+  // `data.text` is accepted as a legacy/plain alias next to contracts `content`.
+  text: ['data.content', 'data.text'],
+  heading: ['data.text'],
+  quote: ['data.content', 'data.attribution'],
+  list: ['data.items[].content'],
+  divider: [],
+  spacer: [],
 };
 
 const PROSE_CONTAINER_TYPES = new Set(['paragraph', 'heading', 'listitem', 'quote']);

--- a/packages/editor/src/canvas/EditSessionCanvas.tsx
+++ b/packages/editor/src/canvas/EditSessionCanvas.tsx
@@ -50,6 +50,24 @@ interface SessionDoc {
   docType: string;
 }
 
+interface PreviewPageCandidate {
+  id: string;
+  slug: string;
+}
+
+/**
+ * Choose which published page a fresh (empty) session should land the iframe on.
+ * Prefers the VES Phase-1 marketing slice (`home`, then `products`), else the
+ * first published page. Pure helper so canvas tests can lock the order.
+ */
+export function pickDefaultPreviewPageId(
+  pages: readonly PreviewPageCandidate[],
+): string | undefined {
+  if (pages.length === 0) return undefined;
+  const bySlug = (slug: string): string | undefined => pages.find((p) => p.slug === slug)?.id;
+  return bySlug('home') ?? bySlug('products') ?? pages[0]?.id;
+}
+
 interface ActiveField {
   doc: string;
   field: string;
@@ -152,15 +170,37 @@ export function EditSessionCanvas({
   );
 
   // Mount: read session detail (dirty-doc list) then mint a preview token.
+  // When the session has no overlays yet (brand-new open), resolve a default
+  // published page on the session's site (home → products → first) so the
+  // iframe does not land on bare `/` with nothing annotated.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         const detailRes = await doFetch(`/api/content/sessions/${sessionId}`);
         if (!detailRes.ok) throw new Error(`session load failed: ${detailRes.status}`);
-        const detail = (await detailRes.json()) as { data: { docs: SessionDoc[] } };
-        const firstPage = detail.data.docs.find((d) => d.docType === 'page');
-        const query = firstPage ? `?pageId=${encodeURIComponent(firstPage.docId)}` : '';
+        const detail = (await detailRes.json()) as {
+          data: {
+            session: { siteId: string };
+            docs: SessionDoc[];
+          };
+        };
+        const dirtyPage = detail.data.docs.find((d) => d.docType === 'page');
+        let pageId = dirtyPage?.docId;
+
+        if (!pageId && detail.data.session.siteId) {
+          const pagesRes = await doFetch(
+            `/api/content/sites/${detail.data.session.siteId}/pages?status=published`,
+          );
+          if (pagesRes.ok) {
+            const pagesBody = (await pagesRes.json()) as {
+              data: PreviewPageCandidate[];
+            };
+            pageId = pickDefaultPreviewPageId(pagesBody.data ?? []);
+          }
+        }
+
+        const query = pageId ? `?pageId=${encodeURIComponent(pageId)}` : '';
         const mintRes = await doFetch(`/api/content/sessions/${sessionId}/preview-token${query}`, {
           method: 'POST',
         });

--- a/packages/editor/src/canvas/EditSessionCanvas.tsx
+++ b/packages/editor/src/canvas/EditSessionCanvas.tsx
@@ -48,6 +48,30 @@ interface SessionDoc {
   id: string;
   docId: string;
   docType: string;
+  draft?: { blocks?: unknown[] };
+}
+
+interface BlockMeta {
+  index: number;
+  type: string;
+  id: string;
+}
+
+function blockMetaFromDocs(docs: SessionDoc[], pageId: string | null): BlockMeta[] {
+  if (!pageId) return [];
+  const doc = docs.find((d) => d.docType === 'page' && d.docId === pageId);
+  const blocks = doc?.draft?.blocks;
+  if (!Array.isArray(blocks)) return [];
+  const out: BlockMeta[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    const raw = blocks[i];
+    if (typeof raw !== 'object' || raw === null) continue;
+    const rec = raw as Record<string, unknown>;
+    const type = typeof rec.type === 'string' ? rec.type : 'unknown';
+    const id = typeof rec.id === 'string' ? rec.id : `idx-${i}`;
+    out.push({ index: i, type, id });
+  }
+  return out;
 }
 
 interface PreviewPageCandidate {
@@ -155,6 +179,7 @@ export function EditSessionCanvas({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [marketingOrigin, setMarketingOrigin] = useState<string | null>(null);
   const [docs, setDocs] = useState<SessionDoc[]>([]);
+  const [previewPageId, setPreviewPageId] = useState<string | null>(null);
   const [breakpoint, setBreakpoint] = useState<Breakpoint>('desktop');
   const [activeField, setActiveField] = useState<ActiveField | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -208,6 +233,7 @@ export function EditSessionCanvas({
         const mint = (await mintRes.json()) as { data: { previewUrl: string } };
         if (cancelled) return;
         setDocs(detail.data.docs);
+        if (pageId) setPreviewPageId(pageId);
         setPreviewUrl(mint.data.previewUrl);
         setMarketingOrigin(new URL(mint.data.previewUrl).origin);
       } catch (err) {
@@ -225,6 +251,7 @@ export function EditSessionCanvas({
     const onMessage = (event: MessageEvent): void => {
       if (event.origin !== marketingOrigin) return;
       if (!isClickMessage(event.data)) return;
+      setPreviewPageId(event.data.doc);
       setActiveField({
         doc: event.data.doc,
         field: event.data.field,
@@ -243,6 +270,9 @@ export function EditSessionCanvas({
     setDocs(detail.data.docs);
   }, [doFetch, sessionId]);
 
+  const targetDocId = previewPageId ?? docs.find((d) => d.docType === 'page')?.docId ?? null;
+  const blockList = blockMetaFromDocs(docs, targetDocId);
+
   const commitPatch = useCallback(
     async (doc: string, field: string, value: string) => {
       setNotice(null);
@@ -251,6 +281,10 @@ export function EditSessionCanvas({
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ path: field, value }),
       });
+      if (res.status === 422) {
+        setNotice('Voice rules rejected this edit. Adjust the copy and try again.');
+        return;
+      }
       if (!res.ok) {
         setNotice(`Could not save this field (${res.status}).`);
         return;
@@ -265,6 +299,32 @@ export function EditSessionCanvas({
       await refreshDocs();
     },
     [doFetch, marketingOrigin, refreshDocs, sessionId],
+  );
+
+  const commitBlockOp = useCallback(
+    async (payload: Record<string, unknown>) => {
+      if (!targetDocId) {
+        setNotice('No page selected for block operations.');
+        return;
+      }
+      setNotice(null);
+      const res = await doFetch(`/api/content/sessions/${sessionId}/docs/page/${targetDocId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 422) {
+        setNotice('Voice rules rejected this block change.');
+        return;
+      }
+      if (!res.ok) {
+        setNotice(`Block operation failed (${res.status}).`);
+        return;
+      }
+      setNotice('Blocks updated. Reload the preview to see structure changes.');
+      await refreshDocs();
+    },
+    [doFetch, refreshDocs, sessionId, targetDocId],
   );
 
   const publish = useCallback(async () => {
@@ -336,12 +396,12 @@ export function EditSessionCanvas({
       ) : null}
 
       <div className="flex min-h-0 flex-1 gap-3">
-        <aside className="w-56 shrink-0 overflow-auto rounded-md border border-neutral-800 p-2">
+        <aside className="w-64 shrink-0 overflow-auto rounded-md border border-neutral-800 p-2">
           <h2 className="mb-2 text-xs font-semibold uppercase text-neutral-400">Changed docs</h2>
           {docs.length === 0 ? (
-            <p className="text-sm text-neutral-500">No edits yet.</p>
+            <p className="mb-3 text-sm text-neutral-500">No edits yet.</p>
           ) : (
-            <ul className="space-y-1">
+            <ul className="mb-3 space-y-1">
               {docs.map((d) => (
                 <li key={d.id} className="truncate text-sm text-neutral-200">
                   {d.docType}: {d.docId}
@@ -349,6 +409,75 @@ export function EditSessionCanvas({
               ))}
             </ul>
           )}
+
+          <h2 className="mb-2 text-xs font-semibold uppercase text-neutral-400">Blocks</h2>
+          {blockList.length === 0 ? (
+            <p className="mb-2 text-sm text-neutral-500">
+              Edit a field first, or add a text block, to materialize the draft.
+            </p>
+          ) : (
+            <ul className="mb-2 space-y-2">
+              {blockList.map((b) => (
+                <li
+                  key={`${b.id}-${b.index}`}
+                  className="rounded border border-neutral-800 p-1.5 text-xs text-neutral-200"
+                >
+                  <div className="mb-1 truncate font-medium">
+                    {b.index}. {b.type}
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    <Button
+                      size="sm"
+                      appearance="outline"
+                      disabled={b.index === 0}
+                      onClick={() =>
+                        void commitBlockOp({ op: 'blocks.move', from: b.index, to: b.index - 1 })
+                      }
+                    >
+                      Up
+                    </Button>
+                    <Button
+                      size="sm"
+                      appearance="outline"
+                      disabled={b.index >= blockList.length - 1}
+                      onClick={() =>
+                        void commitBlockOp({ op: 'blocks.move', from: b.index, to: b.index + 1 })
+                      }
+                    >
+                      Down
+                    </Button>
+                    <Button
+                      size="sm"
+                      appearance="outline"
+                      variant="danger"
+                      disabled={blockList.length <= 1}
+                      onClick={() => void commitBlockOp({ op: 'blocks.remove', index: b.index })}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Button
+            size="sm"
+            appearance="outline"
+            disabled={!targetDocId}
+            onClick={() =>
+              void commitBlockOp({
+                op: 'blocks.insert',
+                index: blockList.length,
+                block: {
+                  id: `text-${crypto.randomUUID()}`,
+                  type: 'text',
+                  data: { content: 'New text block' },
+                },
+              })
+            }
+          >
+            Add text block
+          </Button>
         </aside>
 
         <div className="min-h-0 flex-1 overflow-auto rounded-md border border-neutral-800 bg-neutral-950">

--- a/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
+++ b/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
@@ -6,7 +6,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RVUI_CLICK } from '../../protocol.js';
-import { EditSessionCanvas, type Fetcher } from '../EditSessionCanvas.js';
+import { EditSessionCanvas, pickDefaultPreviewPageId, type Fetcher } from '../EditSessionCanvas.js';
 
 const API_BASE = 'https://api.test';
 const PREVIEW_URL = 'https://www.market.test/about?rvui-edit=tok&rvui-session=sid';
@@ -32,7 +32,13 @@ interface FetcherOptions {
   publishBody?: unknown;
 }
 
-function makeFetcher(opts: FetcherOptions = {}): { fetcher: Fetcher; calls: Call[] } {
+interface MakeFetcherOptions extends FetcherOptions {
+  /** When true, session has zero dirty docs (fresh open). */
+  emptyDocs?: boolean;
+  pages?: Array<{ id: string; slug: string }>;
+}
+
+function makeFetcher(opts: MakeFetcherOptions = {}): { fetcher: Fetcher; calls: Call[] } {
   const calls: Call[] = [];
   const fetcher: Fetcher = async (url, init) => {
     calls.push({ url, init });
@@ -46,11 +52,19 @@ function makeFetcher(opts: FetcherOptions = {}): { fetcher: Fetcher; calls: Call
     if (url.includes('/docs/page/') && method === 'PATCH') {
       return jsonResponse(200, { data: {} });
     }
+    if (url.includes('/sites/') && url.includes('/pages')) {
+      return jsonResponse(200, {
+        data: opts.pages ?? [
+          { id: 'page-products', slug: 'products' },
+          { id: 'page-home', slug: 'home' },
+        ],
+      });
+    }
     // GET session detail
     return jsonResponse(200, {
       data: {
-        session: { id: SESSION, status: 'open' },
-        docs: [{ id: 'ov-1', docId: 'page-1', docType: 'page' }],
+        session: { id: SESSION, status: 'open', siteId: 'site-1' },
+        docs: opts.emptyDocs ? [] : [{ id: 'ov-1', docId: 'page-1', docType: 'page' }],
       },
     });
   };
@@ -63,7 +77,8 @@ function clickMessage(origin: string): MessageEvent {
     data: {
       type: RVUI_CLICK,
       doc: 'page-1',
-      field: 'blocks.0.title',
+      // Canonical annotation path includes `.data` (block fields live under block.data.*).
+      field: 'blocks.0.data.title',
       rect: { top: 10, left: 10, width: 100, height: 20 },
       currentValue: 'Old title',
     },
@@ -134,10 +149,32 @@ describe('EditSessionCanvas', () => {
       expect(patch).toBeTruthy();
       expect(patch?.url).toBe(`${API_BASE}/api/content/sessions/${SESSION}/docs/page/page-1`);
       expect(JSON.parse(String(patch?.init?.body))).toEqual({
-        path: 'blocks.0.title',
+        path: 'blocks.0.data.title',
         value: 'New title',
       });
     });
+  });
+
+  it('mints preview-token with the home pageId when the session has no dirty docs', async () => {
+    const { fetcher, calls } = makeFetcher({ emptyDocs: true });
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    await screen.findByTitle('Content preview');
+    await waitFor(() => {
+      const mint = calls.find((c) => c.url.includes('/preview-token'));
+      expect(mint?.url).toContain('pageId=page-home');
+    });
+  });
+
+  it('pickDefaultPreviewPageId prefers home then products then first', () => {
+    expect(
+      pickDefaultPreviewPageId([
+        { id: 'p', slug: 'products' },
+        { id: 'h', slug: 'home' },
+      ]),
+    ).toBe('h');
+    expect(pickDefaultPreviewPageId([{ id: 'p', slug: 'products' }])).toBe('p');
+    expect(pickDefaultPreviewPageId([{ id: 'x', slug: 'about' }])).toBe('x');
+    expect(pickDefaultPreviewPageId([])).toBeUndefined();
   });
 
   it('debounces autosave into a single PATCH while typing', async () => {

--- a/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
+++ b/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
@@ -64,7 +64,18 @@ function makeFetcher(opts: MakeFetcherOptions = {}): { fetcher: Fetcher; calls: 
     return jsonResponse(200, {
       data: {
         session: { id: SESSION, status: 'open', siteId: 'site-1' },
-        docs: opts.emptyDocs ? [] : [{ id: 'ov-1', docId: 'page-1', docType: 'page' }],
+        docs: opts.emptyDocs
+          ? []
+          : [
+              {
+                id: 'ov-1',
+                docId: 'page-1',
+                docType: 'page',
+                draft: {
+                  blocks: [{ id: 'blk-1', type: 'text', data: { content: 'hello' } }],
+                },
+              },
+            ],
       },
     });
   };
@@ -175,6 +186,23 @@ describe('EditSessionCanvas', () => {
     expect(pickDefaultPreviewPageId([{ id: 'p', slug: 'products' }])).toBe('p');
     expect(pickDefaultPreviewPageId([{ id: 'x', slug: 'about' }])).toBe('x');
     expect(pickDefaultPreviewPageId([])).toBeUndefined();
+  });
+
+  it('renders block chrome and PATCHes a blocks.insert op', async () => {
+    const { fetcher, calls } = makeFetcher();
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    await screen.findByTitle('Content preview');
+    const add = await screen.findByRole('button', { name: 'Add text block' });
+    fireEvent.click(add);
+    await waitFor(() => {
+      const patch = calls.find(
+        (c) =>
+          (c.init?.method ?? 'GET').toUpperCase() === 'PATCH' &&
+          String(c.init?.body ?? '').includes('blocks.insert'),
+      );
+      expect(patch).toBeTruthy();
+      expect(JSON.parse(String(patch?.init?.body)).op).toBe('blocks.insert');
+    });
   });
 
   it('debounces autosave into a single PATCH while typing', async () => {

--- a/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
+++ b/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
@@ -6,7 +6,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RVUI_CLICK } from '../../protocol.js';
-import { EditSessionCanvas, pickDefaultPreviewPageId, type Fetcher } from '../EditSessionCanvas.js';
+import { EditSessionCanvas, type Fetcher, pickDefaultPreviewPageId } from '../EditSessionCanvas.js';
 
 const API_BASE = 'https://api.test';
 const PREVIEW_URL = 'https://www.market.test/about?rvui-edit=tok&rvui-session=sid';

--- a/packages/editor/src/canvas/index.ts
+++ b/packages/editor/src/canvas/index.ts
@@ -6,7 +6,7 @@
  */
 export {
   EditSessionCanvas,
-  pickDefaultPreviewPageId,
   type EditSessionCanvasProps,
   type Fetcher,
+  pickDefaultPreviewPageId,
 } from './EditSessionCanvas.js';

--- a/packages/editor/src/canvas/index.ts
+++ b/packages/editor/src/canvas/index.ts
@@ -6,6 +6,7 @@
  */
 export {
   EditSessionCanvas,
+  pickDefaultPreviewPageId,
   type EditSessionCanvasProps,
   type Fetcher,
 } from './EditSessionCanvas.js';

--- a/packages/presentation/src/__tests__/blocks/render-blocks.test.tsx
+++ b/packages/presentation/src/__tests__/blocks/render-blocks.test.tsx
@@ -35,18 +35,20 @@ describe('RenderBlocks — annotation contract', () => {
   it('emits data-rvui-doc/field on text-bearing elements when editable with a docId', () => {
     const { container } = render(<RenderBlocks blocks={pageBlocks} docId="page-42" editable />);
 
-    const title = container.querySelector('[data-rvui-field="blocks.0.title"]');
+    // Every field path lives under `blocks.<index>.data.*`  -  the same
+    // structure a session server's materialized draft carries.
+    const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
     expect(title).not.toBeNull();
     expect(title?.getAttribute('data-rvui-doc')).toBe('page-42');
     expect(title?.textContent).toBe('Governed agents');
 
     // Nested repeater item field path uses items.<index>.<field>.
-    const nestedBody = container.querySelector('[data-rvui-field="blocks.1.items.1.body"]');
+    const nestedBody = container.querySelector('[data-rvui-field="blocks.1.data.items.1.body"]');
     expect(nestedBody).not.toBeNull();
     expect(nestedBody?.getAttribute('data-rvui-doc')).toBe('page-42');
     expect(nestedBody?.textContent).toBe('Body two.');
 
-    const nestedLabel = container.querySelector('[data-rvui-field="blocks.1.items.0.title"]');
+    const nestedLabel = container.querySelector('[data-rvui-field="blocks.1.data.items.0.title"]');
     expect(nestedLabel?.textContent).toBe('First');
   });
 
@@ -101,11 +103,11 @@ describe('RenderBlocks — cta section + primitive renderers', () => {
     ];
 
     const { container } = render(<RenderBlocks blocks={blocks} docId="d1" editable />);
-    expect(container.querySelector('[data-rvui-field="blocks.0.heading"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.0.data.heading"]')?.textContent).toBe(
       'Deploy in one command',
     );
     // Snippet renders as static text (both lines joined), never executed.
-    const snippet = container.querySelector('[data-rvui-field="blocks.0.snippet.lines"]');
+    const snippet = container.querySelector('[data-rvui-field="blocks.0.data.snippet.lines"]');
     expect(snippet?.textContent).toBe('npx create-revealui\ncd app');
     expect(container.querySelector('a')?.getAttribute('href')).toBe('/install');
   });
@@ -132,20 +134,140 @@ describe('RenderBlocks — cta section + primitive renderers', () => {
 
     const { container } = render(<RenderBlocks blocks={blocks} docId="d2" editable />);
 
-    expect(container.querySelector('[data-rvui-field="blocks.0.content"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.0.data.content"]')?.textContent).toBe(
       'Body copy',
     );
-    const heading = container.querySelector('[data-rvui-field="blocks.1.text"]');
+    const heading = container.querySelector('[data-rvui-field="blocks.1.data.text"]');
     expect(heading?.tagName).toBe('H2');
-    expect(container.querySelector('[data-rvui-field="blocks.2.content"]')?.textContent).toBe(
+    expect(container.querySelector('[data-rvui-field="blocks.2.data.content"]')?.textContent).toBe(
       'Quoted',
     );
-    expect(container.querySelector('[data-rvui-field="blocks.2.attribution"]')?.textContent).toBe(
-      'Someone',
-    );
     expect(
-      container.querySelector('[data-rvui-field="blocks.3.items.1.content"]')?.textContent,
+      container.querySelector('[data-rvui-field="blocks.2.data.attribution"]')?.textContent,
+    ).toBe('Someone');
+    expect(
+      container.querySelector('[data-rvui-field="blocks.3.data.items.1.content"]')?.textContent,
     ).toBe('Two');
     expect(container.querySelector('hr')).not.toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Cross-seam contract: every emitted `data-rvui-field` path must be a VALID
+// path into the page draft the session server actually materializes
+// (`{ id, slug, blocks, ... }`  -  see apps/server's `materializePageDraft`).
+// This is the test that would have caught the annotation-path bug: prior
+// component-level tests only checked that RenderBlocks' output was
+// self-consistent (the path it emits matches the path it emits), never that
+// the path RESOLVES against the real draft shape. It didn't, because every
+// block component reads its fields from `block.data.*`, but the path handed
+// down stopped at the block index, landing patches as siblings of `data`
+// instead of inside it.
+// -----------------------------------------------------------------------------
+
+/**
+ * Plain segment-walk (no regex): resolves a dot-path against a value the same
+ * way the session server's `setAtPath` (and the runtime's) would descend it.
+ * Returns `undefined` on any missing/invalid step.
+ */
+function resolveDraftPath(root: unknown, path: string): unknown {
+  let cursor: unknown = root;
+  for (const segment of path.split('.')) {
+    if (cursor === null || cursor === undefined) return undefined;
+    if (Array.isArray(cursor)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index)) return undefined;
+      cursor = cursor[index];
+    } else if (typeof cursor === 'object') {
+      cursor = (cursor as Record<string, unknown>)[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return cursor;
+}
+
+describe('RenderBlocks — draft-path contract (cross-seam)', () => {
+  // One of every block type RenderBlocks supports, including nested repeater
+  // items, mirroring a real page's `blocks` array.
+  const contractBlocks: Block[] = [
+    {
+      id: 'hero-1',
+      type: 'hero',
+      data: {
+        eyebrow: 'RevealUI',
+        title: 'Governed agents',
+        subtitle: 'One roof for your business.',
+        support: 'Self-hosted, open source.',
+        links: [{ label: 'Start', href: '/start', variant: 'primary' }],
+      },
+    },
+    {
+      id: 'sec-1',
+      type: 'section',
+      data: {
+        eyebrow: 'FAQ',
+        heading: 'Questions',
+        body: 'Answers to the common ones.',
+        items: [{ label: 'Beat', title: 'First', body: 'Body one.' }, { body: 'Body two.' }],
+      },
+    },
+    {
+      id: 'cta-1',
+      type: 'ctaSection',
+      data: {
+        heading: 'Deploy in one command',
+        body: 'One roof.',
+        links: [{ label: 'Install', href: '/install', variant: 'primary' }],
+        snippet: { lines: ['npx create-revealui', 'cd app'], caption: 'That is it.' },
+      },
+    },
+    { id: 'text-1', type: 'text', data: { content: 'Body copy', format: 'plain' } },
+    { id: 'heading-1', type: 'heading', data: { text: 'A Heading', level: 'h2' } },
+    { id: 'quote-1', type: 'quote', data: { content: 'Quoted', attribution: 'Someone' } },
+    {
+      id: 'list-1',
+      type: 'list',
+      data: {
+        variant: 'unordered',
+        items: [
+          { id: 'i0', content: 'One' },
+          { id: 'i1', content: 'Two' },
+        ],
+      },
+    },
+    { id: 'divider-1', type: 'divider', data: { variant: 'dashed' } },
+    { id: 'spacer-1', type: 'spacer', data: { height: '3rem' } },
+  ];
+
+  it('every emitted data-rvui-field path resolves to a defined string in the materialized draft', () => {
+    // The exact shape `materializePageDraft` (apps/server) produces: a page
+    // draft object with `blocks` as a top-level key.
+    const draft = { blocks: contractBlocks };
+
+    const { container } = render(<RenderBlocks blocks={contractBlocks} docId="page-1" editable />);
+    const annotated = Array.from(container.querySelectorAll('[data-rvui-field]'));
+
+    // Sanity: the fixture actually exercises annotation (would falsely pass a
+    // regression that stopped emitting any attributes at all).
+    expect(annotated.length).toBeGreaterThan(10);
+
+    for (const el of annotated) {
+      const path = el.getAttribute('data-rvui-field');
+      expect(path).not.toBeNull();
+      const resolved = resolveDraftPath(draft, path as string);
+      // Almost every field is a scalar string; the CTA snippet's `.lines` is
+      // the one legitimate array-of-strings leaf (displayed joined). Either
+      // is a genuinely resolved leaf; `undefined` or a whole block/object
+      // (the corruption signature: the path stopped short of the real field)
+      // is not.
+      const isValidLeaf =
+        typeof resolved === 'string' ||
+        (Array.isArray(resolved) && resolved.every((v) => typeof v === 'string'));
+      expect(
+        isValidLeaf,
+        `path "${path}" did not resolve to a string or string[]: got ${JSON.stringify(resolved)}`,
+      ).toBe(true);
+    }
   });
 });

--- a/packages/presentation/src/blocks/RenderBlocks.tsx
+++ b/packages/presentation/src/blocks/RenderBlocks.tsx
@@ -44,7 +44,12 @@ export function RenderBlocks({ blocks, docId, editable }: RenderBlocksProps): Re
           return null;
         }
         const block = parsed.data as Block;
-        const path = `blocks.${index}`;
+        // `.data`: every block component addresses its fields as
+        // `block.data.<field>` (fieldAttrs paths mirror that), so the path
+        // handed down must already point at the data object, not the block
+        // itself  -  otherwise a patch lands as a sibling of `data` instead of
+        // inside it.
+        const path = `blocks.${index}.data`;
         return (
           <BlockView key={block.id || path} block={block} path={path} annotation={annotation} />
         );

--- a/packages/presentation/src/blocks/annotation.ts
+++ b/packages/presentation/src/blocks/annotation.ts
@@ -4,8 +4,9 @@
  * When a page is rendered `editable` with a `docId`, every text-bearing element
  * carries two data attributes the edit-mode runtime (a later slice) reads:
  *   - `data-rvui-doc`   — the document id the block array belongs to
- *   - `data-rvui-field` — a dot-path addressing the field inside `blocks`,
- *                          e.g. `blocks.3.title` or `blocks.3.items.2.body`.
+ *   - `data-rvui-field` — a dot-path addressing the field inside the block's
+ *                          `data` object, e.g. `blocks.3.data.title` or
+ *                          `blocks.3.data.items.2.body`.
  *
  * When not editable (or no docId), no data attributes are emitted at all.
  */


### PR DESCRIPTION
## Summary

Closes the VES P1 product loop gaps found in the 2026-07-21 CMS/live-preview audit:

1. **Annotation path contract** — lands the `.data` segment fix that never reached `test` after #2004 (it only lived on `feat/marketing-edit-mode-wire` as `a8ec88882`). Without this, GAP-402's server allowlist rejects every block-field PATCH with 400 (`blocks.0.title` vs required `blocks.0.data.title`).
2. **Admin create-session UI** — `/edit-sessions` can open a session (site + title) and navigate to the canvas, not only list existing sessions. Uses `@revealui/presentation` Select/Input/Button (GAP-398 clean).
3. **Fresh-session preview target** — when a session has no dirty docs, the canvas resolves a published page on the site (`home` → `products` → first) before minting the preview token, so the iframe is not stuck on bare `/`.

## Test plan

- [x] `pnpm --filter @revealui/presentation test` (996 pass)
- [x] `pnpm --filter @revealui/editor test` (20 pass, including default pageId + path `.data`)
- [x] Marketing `page-blocks` + `block-annotations` path contract tests (18 pass)
- [x] pre-push phase-1 gate PASS
- [ ] Owner: open session in admin → click field on home → save → publish (after seed if needed)

## Notes

- No security-sensitive surfaces (no auth/crypto/payment). Content session paths already gated; this is client path alignment + admin mount UX.
- P2 (block ops, media picker, MCP session tools, voice gate) and P3 (templates) remain out of scope for this PR.
- Prod fleet-marketing seed remains owner-attended.

Refs: visual-edit-sessions lane; amends marketing-content-cms; related #2004 #2005 GAP-402.
