### PR TITLE
feat(ves): P2 voice gate + block insert/remove/move

### DIFF
--- a/.changeset/ves-p2-voice-block-ops.md
+++ b/.changeset/ves-p2-voice-block-ops.md
@@ -1,0 +1,6 @@
+---
+'@revealui/contracts': patch
+'@revealui/editor': patch
+---
+
+VES P2 slice: gate fleet-marketing session patches with marketing-voice Tier-1 validation, extend prose slots for contracts block shapes, and add blocks.insert/remove/move ops on the session API plus canvas block chrome.

--- a/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
+++ b/apps/server/src/routes/__tests__/edit-sessions.pglite.test.ts
@@ -688,6 +688,116 @@ describe('structural path validation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// P2 — block array ops + fleet-marketing voice gate
+// ---------------------------------------------------------------------------
+
+describe('P2 block array ops', () => {
+  async function blockOp(
+    app: ReturnType<typeof createApp>,
+    sessionId: string,
+    payload: Record<string, unknown>,
+  ): Promise<Response> {
+    return app.request(`/sessions/${sessionId}/docs/page/${PAGE_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  it('inserts a text block at the end', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    expect((await patch(app, sessionId, 'title', 'T')).status).toBe(200);
+
+    const res = await blockOp(app, sessionId, {
+      op: 'blocks.insert',
+      index: 1,
+      block: { id: 'blk-new', type: 'text', data: { content: 'fresh' } },
+    });
+    expect(res.status).toBe(200);
+
+    const get = await app.request(`/sessions/${sessionId}`);
+    const body = (await get.json()) as {
+      data: { docs: Array<{ draft: { blocks: Array<{ id: string; type: string }> } }> };
+    };
+    expect(body.data.docs[0].draft.blocks).toHaveLength(2);
+    expect(body.data.docs[0].draft.blocks[1].id).toBe('blk-new');
+    expect(body.data.docs[0].draft.blocks[1].type).toBe('text');
+  });
+
+  it('moves and removes blocks', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'T');
+    await blockOp(app, sessionId, {
+      op: 'blocks.insert',
+      index: 1,
+      block: { id: 'blk-2', type: 'text', data: { content: 'second' } },
+    });
+
+    expect((await blockOp(app, sessionId, { op: 'blocks.move', from: 1, to: 0 })).status).toBe(200);
+
+    let get = await app.request(`/sessions/${sessionId}`);
+    let body = (await get.json()) as {
+      data: { docs: Array<{ draft: { blocks: Array<{ id: string }> } }> };
+    };
+    expect(body.data.docs[0].draft.blocks[0].id).toBe('blk-2');
+
+    expect((await blockOp(app, sessionId, { op: 'blocks.remove', index: 0 })).status).toBe(200);
+    get = await app.request(`/sessions/${sessionId}`);
+    body = (await get.json()) as {
+      data: { docs: Array<{ draft: { blocks: Array<{ id: string }> } }> };
+    };
+    expect(body.data.docs[0].draft.blocks).toHaveLength(1);
+    expect(body.data.docs[0].draft.blocks[0].id).toBe('blk-1');
+  });
+
+  it('refuses to remove the last block', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    await patch(app, sessionId, 'title', 'T');
+    const res = await blockOp(app, sessionId, { op: 'blocks.remove', index: 0 });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('P2 voice gate on fleet-marketing', () => {
+  beforeEach(async () => {
+    await testDb.drizzle
+      .update(schema.sites)
+      .set({ slug: 'fleet-marketing' })
+      .where(eq(schema.sites.id, SITE_ID));
+  });
+
+  it('rejects an em-dash field patch with 422 and does not write', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+
+    const res = await patch(app, sessionId, 'blocks.0.data.text', 'Hello\u2014world');
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as {
+      rejected?: boolean;
+      violations?: unknown[];
+    };
+    expect(body.rejected).toBe(true);
+    expect(Array.isArray(body.violations)).toBe(true);
+    expect((body.violations ?? []).length).toBeGreaterThan(0);
+
+    const get = await app.request(`/sessions/${sessionId}`);
+    const detail = (await get.json()) as { data: { docs: unknown[] } };
+    // First patch rejected: no overlay row.
+    expect(detail.data.docs).toHaveLength(0);
+  });
+
+  it('accepts a clean field patch on fleet-marketing', async () => {
+    const app = createApp(EDITOR);
+    const sessionId = await openSession(app);
+    const res = await patch(app, sessionId, 'blocks.0.data.text', 'Clean copy');
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Non-open session mutations
 // ---------------------------------------------------------------------------
 

--- a/apps/server/src/routes/content/sessions.ts
+++ b/apps/server/src/routes/content/sessions.ts
@@ -15,6 +15,13 @@
  * GET is public-read there, so these routes enforce authz explicitly.
  */
 
+import {
+  FLEET_MARKETING_VOICE_RULES,
+  type MarketingBlock,
+  UnmappedBlockTypeError,
+  type Violation,
+  validateMarketingBlock,
+} from '@revealui/contracts/marketing-voice';
 import * as sessionQueries from '@revealui/db/queries/edit-sessions';
 import * as siteQueries from '@revealui/db/queries/sites';
 import type { EditSession, EditSessionDoc, EditSessionEvent, Page } from '@revealui/db/schema';
@@ -30,6 +37,9 @@ import {
   verifyPreviewToken,
 } from './_helpers/preview-token.js';
 import type { ContentVariables } from './index.js';
+
+/** Site slug whose session patches are gated by the fleet marketing-voice engine. */
+const FLEET_MARKETING_SITE_SLUG = 'fleet-marketing';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -187,6 +197,132 @@ function applyDraftPatch(draft: Record<string, unknown>, path: string, value: un
   }
 
   throw pathError(root, UNPATCHABLE_ROOT_HINT);
+}
+
+// =============================================================================
+// Block array ops (P2) — insert / remove / move on the blocks array only
+// =============================================================================
+
+type BlockOp =
+  | { op: 'blocks.insert'; index: number; block: Record<string, unknown> }
+  | { op: 'blocks.remove'; index: number }
+  | { op: 'blocks.move'; from: number; to: number };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getBlocksArray(draft: Record<string, unknown>): unknown[] {
+  if (!Array.isArray(draft.blocks)) {
+    throw new HTTPException(400, { message: 'Draft has no blocks array' });
+  }
+  return draft.blocks;
+}
+
+/** Apply a structural block-array operation. Mutates `draft.blocks` in place. */
+function applyBlockOp(draft: Record<string, unknown>, op: BlockOp): void {
+  const blocks = getBlocksArray(draft);
+  if (op.op === 'blocks.insert') {
+    if (op.index < 0 || op.index > blocks.length) {
+      throw pathError(String(op.index), 'insert index out of range');
+    }
+    if (!isRecord(op.block)) {
+      throw new HTTPException(400, { message: 'blocks.insert requires a block object' });
+    }
+    // Identity + type are required; reject prototype-dangerous keys on the block.
+    for (const key of Object.keys(op.block)) {
+      if (DANGEROUS_KEYS.has(key)) {
+        throw new HTTPException(400, { message: `Illegal block key: ${key}` });
+      }
+    }
+    if (typeof op.block.type !== 'string' || op.block.type.length === 0) {
+      throw new HTTPException(400, { message: 'blocks.insert requires block.type' });
+    }
+    if (typeof op.block.id !== 'string' || op.block.id.length === 0) {
+      throw new HTTPException(400, { message: 'blocks.insert requires block.id' });
+    }
+    if (!isRecord(op.block.data)) {
+      throw new HTTPException(400, { message: 'blocks.insert requires block.data object' });
+    }
+    blocks.splice(op.index, 0, structuredClone(op.block));
+    return;
+  }
+  if (op.op === 'blocks.remove') {
+    if (op.index < 0 || op.index >= blocks.length) {
+      throw pathError(String(op.index), 'remove index out of range');
+    }
+    if (blocks.length <= 1) {
+      throw new HTTPException(400, {
+        message: 'Cannot remove the last block (page must keep at least one)',
+      });
+    }
+    blocks.splice(op.index, 1);
+    return;
+  }
+  // blocks.move
+  if (op.from < 0 || op.from >= blocks.length) {
+    throw pathError(String(op.from), 'move from-index out of range');
+  }
+  if (op.to < 0 || op.to >= blocks.length) {
+    throw pathError(String(op.to), 'move to-index out of range');
+  }
+  if (op.from === op.to) return;
+  const [item] = blocks.splice(op.from, 1);
+  blocks.splice(op.to, 0, item);
+}
+
+// =============================================================================
+// Fleet-marketing voice gate (P2) — Tier-1 hard reject on session.patch
+// =============================================================================
+
+/**
+ * Adapt a page block (VES contracts shape OR admin Lexical shape) into the
+ * marketing-voice engine's MarketingBlock view.
+ */
+function toMarketingBlock(raw: unknown): MarketingBlock | null {
+  if (!isRecord(raw)) return null;
+  if (typeof raw.blockType === 'string') {
+    return raw as MarketingBlock;
+  }
+  if (typeof raw.type === 'string') {
+    return { blockType: raw.type, ...raw };
+  }
+  return null;
+}
+
+interface VoiceViolation extends Violation {
+  blockIndex: number;
+}
+
+/**
+ * Run Tier-1 marketing-voice validation over every block in the draft when the
+ * session targets the fleet-marketing site. Returns violations (empty = pass).
+ * Throws HTTPException 422 only via the caller's response construction for
+ * unmapped block types (fail-closed).
+ */
+function collectVoiceViolations(draft: Record<string, unknown>): VoiceViolation[] {
+  const blocks = Array.isArray(draft.blocks) ? draft.blocks : [];
+  const violations: VoiceViolation[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    const mb = toMarketingBlock(blocks[i]);
+    if (!mb) continue;
+    try {
+      const report = validateMarketingBlock(mb, FLEET_MARKETING_VOICE_RULES);
+      if (!report.tier1.passed) {
+        for (const v of report.tier1.violations) {
+          violations.push({ ...v, blockIndex: i });
+        }
+      }
+    } catch (err) {
+      if (err instanceof UnmappedBlockTypeError) {
+        throw new HTTPException(422, {
+          message: `Voice gate: unmapped blockType at blocks[${i}]: ${err.blockType}`,
+        });
+      }
+      throw err;
+    }
+  }
+  return violations;
 }
 
 /**
@@ -541,15 +677,56 @@ app.openapi(
 );
 
 // =============================================================================
-// PATCH /sessions/:id/docs/:docType/:docId  -  field patch (autosave)
+// PATCH /sessions/:id/docs/:docType/:docId  -  field patch or block op (autosave)
 // =============================================================================
+
+const FieldPatchBody = z
+  .object({ path: z.string().min(1), value: z.unknown() })
+  .openapi('EditSessionFieldPatch');
+
+const BlockInsertBody = z
+  .object({
+    op: z.literal('blocks.insert'),
+    index: z.number().int().nonnegative(),
+    block: z.record(z.string(), z.unknown()),
+  })
+  .openapi('EditSessionBlockInsert');
+
+const BlockRemoveBody = z
+  .object({
+    op: z.literal('blocks.remove'),
+    index: z.number().int().nonnegative(),
+  })
+  .openapi('EditSessionBlockRemove');
+
+const BlockMoveBody = z
+  .object({
+    op: z.literal('blocks.move'),
+    from: z.number().int().nonnegative(),
+    to: z.number().int().nonnegative(),
+  })
+  .openapi('EditSessionBlockMove');
+
+const PatchBody = z.union([FieldPatchBody, BlockInsertBody, BlockRemoveBody, BlockMoveBody]);
+
+const VoiceRejectSchema = z.object({
+  success: z.literal(false),
+  rejected: z.literal(true),
+  violations: z.array(z.record(z.string(), z.unknown())),
+});
+
+function isBlockOpBody(
+  body: z.infer<typeof PatchBody>,
+): body is z.infer<typeof BlockInsertBody | typeof BlockRemoveBody | typeof BlockMoveBody> {
+  return 'op' in body;
+}
 
 app.openapi(
   createRoute({
     method: 'patch',
     path: '/sessions/{id}/docs/{docType}/{docId}',
     tags: ['content'],
-    summary: 'Patch a draft field in an edit session',
+    summary: 'Patch a draft field or apply a block-array op in an edit session',
     request: {
       params: z.object({
         id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
@@ -559,7 +736,7 @@ app.openapi(
       body: {
         content: {
           'application/json': {
-            schema: z.object({ path: z.string().min(1), value: z.unknown() }),
+            schema: PatchBody,
           },
         },
       },
@@ -579,13 +756,17 @@ app.openapi(
         content: { 'application/json': { schema: ErrorSchema } },
         description: 'Session not open',
       },
+      422: {
+        content: { 'application/json': { schema: VoiceRejectSchema } },
+        description: 'Voice validation rejected the patch (fleet-marketing only)',
+      },
     },
   }),
   async (c) => {
     const db = c.get('db');
     const user = requireContentEditor(c.get('user'));
     const { id, docType, docId } = c.req.valid('param');
-    const { path, value } = c.req.valid('json');
+    const body = c.req.valid('json');
 
     const session = await sessionQueries.getEditSessionById(db, id);
     if (!session) throw new HTTPException(404, { message: 'Session not found' });
@@ -601,39 +782,71 @@ app.openapi(
     // Validate + apply against the in-memory draft BEFORE any write: a 400 on
     // the first patch must not materialize an overlay row.
     const doc = await sessionQueries.getSessionDoc(db, id, docType, docId);
-    let updated: typeof doc;
+    let nextDraft: Record<string, unknown>;
+    let materializeBaseVersion: number | null = null;
     if (doc) {
-      const nextDraft = structuredClone(doc.draft);
-      applyDraftPatch(nextDraft, path, value);
+      nextDraft = structuredClone(doc.draft);
+    } else {
+      const page = await sessionQueries.getLivePage(db, docId);
+      if (!page) throw new HTTPException(404, { message: 'Page not found' });
+      nextDraft = materializePageDraft(page);
+      materializeBaseVersion = page.version;
+    }
+
+    if (isBlockOpBody(body)) {
+      applyBlockOp(nextDraft, body);
+    } else {
+      applyDraftPatch(nextDraft, body.path, body.value);
+    }
+
+    // Fleet-marketing only: Tier-1 marketing-voice hard-reject before any write.
+    const site = await siteQueries.getSiteById(db, session.siteId);
+    if (site?.slug === FLEET_MARKETING_SITE_SLUG) {
+      const violations = collectVoiceViolations(nextDraft);
+      if (violations.length > 0) {
+        return c.json(
+          {
+            success: false as const,
+            rejected: true as const,
+            violations: violations as unknown as Array<Record<string, unknown>>,
+          },
+          422,
+        );
+      }
+    }
+
+    let updated: EditSessionDoc | null;
+    if (doc) {
       updated = await sessionQueries.updateSessionDocDraft(db, doc.id, {
         draft: nextDraft,
         updatedBy: user.id,
       });
     } else {
-      // First patch on this doc: materialize the overlay from the live page
-      // with the patch already applied (single write).
-      const page = await sessionQueries.getLivePage(db, docId);
-      if (!page) throw new HTTPException(404, { message: 'Page not found' });
-      const nextDraft = materializePageDraft(page);
-      applyDraftPatch(nextDraft, path, value);
       updated = await sessionQueries.insertSessionDoc(db, {
         id: crypto.randomUUID(),
         sessionId: id,
         docType,
         docId,
         draft: nextDraft,
-        baseVersion: page.version,
+        baseVersion: materializeBaseVersion ?? 1,
         updatedBy: user.id,
       });
     }
     if (!updated) throw new HTTPException(500, { message: 'Failed to save draft' });
+
+    const eventPayload: Record<string, unknown> = { docType, docId };
+    if (isBlockOpBody(body)) {
+      eventPayload.op = body.op;
+    } else {
+      eventPayload.path = body.path;
+    }
 
     await sessionQueries.insertSessionEvent(db, {
       sessionId: id,
       actorId: user.id,
       actorKind: actorKindFor(user),
       type: 'patched',
-      payload: { docType, docId, path },
+      payload: eventPayload,
     });
 
     return c.json({ success: true as const, data: serializeDoc(updated) }, 200);

--- a/packages/contracts/src/marketing-voice/blocks.ts
+++ b/packages/contracts/src/marketing-voice/blocks.ts
@@ -65,10 +65,41 @@ export class UnmappedBlockTypeError extends Error {
  * Phase B block types register here. Field paths may use a single array-glob
  * segment (e.g. `items[].q`) resolved by `resolveFieldPath`.
  */
+/**
+ * Source of truth mapping a block type to voice-validated prose field paths.
+ *
+ * Covers both shapes still in the fleet:
+ * - **Admin/legacy Lexical:** `blockType` + top-level `richText` (hero/content/cta).
+ * - **VES contracts blocks:** `type` adapted to `blockType` + plain-string fields
+ *   under `data.*` (hero/section/ctaSection/primitives). Missing paths are skipped
+ *   by `getProseSlots`; both shapes can share an entry.
+ *
+ * Empty arrays mean "no prose" (structural blocks like divider/spacer): validation
+ * runs, finds nothing, and passes. Unregistered types still throw
+ * `UnmappedBlockTypeError` (fail-closed).
+ */
 export const MARKETING_PROSE_SLOTS: Record<string, string[]> = {
-  hero: ['richText'],
+  // Admin Lexical + VES contracts hero
+  hero: ['richText', 'data.title', 'data.subtitle', 'data.eyebrow', 'data.support'],
   content: ['richText'],
   cta: ['richText'],
+  // VES marketing contracts blocks
+  section: [
+    'data.heading',
+    'data.body',
+    'data.eyebrow',
+    'data.items[].title',
+    'data.items[].body',
+    'data.items[].label',
+  ],
+  ctaSection: ['data.heading', 'data.body', 'data.snippet.caption'],
+  // `data.text` is accepted as a legacy/plain alias next to contracts `content`.
+  text: ['data.content', 'data.text'],
+  heading: ['data.text'],
+  quote: ['data.content', 'data.attribution'],
+  list: ['data.items[].content'],
+  divider: [],
+  spacer: [],
 };
 
 const PROSE_CONTAINER_TYPES = new Set(['paragraph', 'heading', 'listitem', 'quote']);

--- a/packages/editor/src/canvas/EditSessionCanvas.tsx
+++ b/packages/editor/src/canvas/EditSessionCanvas.tsx
@@ -48,6 +48,30 @@ interface SessionDoc {
   id: string;
   docId: string;
   docType: string;
+  draft?: { blocks?: unknown[] };
+}
+
+interface BlockMeta {
+  index: number;
+  type: string;
+  id: string;
+}
+
+function blockMetaFromDocs(docs: SessionDoc[], pageId: string | null): BlockMeta[] {
+  if (!pageId) return [];
+  const doc = docs.find((d) => d.docType === 'page' && d.docId === pageId);
+  const blocks = doc?.draft?.blocks;
+  if (!Array.isArray(blocks)) return [];
+  const out: BlockMeta[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    const raw = blocks[i];
+    if (typeof raw !== 'object' || raw === null) continue;
+    const rec = raw as Record<string, unknown>;
+    const type = typeof rec.type === 'string' ? rec.type : 'unknown';
+    const id = typeof rec.id === 'string' ? rec.id : `idx-${i}`;
+    out.push({ index: i, type, id });
+  }
+  return out;
 }
 
 interface PreviewPageCandidate {
@@ -155,6 +179,7 @@ export function EditSessionCanvas({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [marketingOrigin, setMarketingOrigin] = useState<string | null>(null);
   const [docs, setDocs] = useState<SessionDoc[]>([]);
+  const [previewPageId, setPreviewPageId] = useState<string | null>(null);
   const [breakpoint, setBreakpoint] = useState<Breakpoint>('desktop');
   const [activeField, setActiveField] = useState<ActiveField | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -208,6 +233,7 @@ export function EditSessionCanvas({
         const mint = (await mintRes.json()) as { data: { previewUrl: string } };
         if (cancelled) return;
         setDocs(detail.data.docs);
+        if (pageId) setPreviewPageId(pageId);
         setPreviewUrl(mint.data.previewUrl);
         setMarketingOrigin(new URL(mint.data.previewUrl).origin);
       } catch (err) {
@@ -225,6 +251,7 @@ export function EditSessionCanvas({
     const onMessage = (event: MessageEvent): void => {
       if (event.origin !== marketingOrigin) return;
       if (!isClickMessage(event.data)) return;
+      setPreviewPageId(event.data.doc);
       setActiveField({
         doc: event.data.doc,
         field: event.data.field,
@@ -243,6 +270,9 @@ export function EditSessionCanvas({
     setDocs(detail.data.docs);
   }, [doFetch, sessionId]);
 
+  const targetDocId = previewPageId ?? docs.find((d) => d.docType === 'page')?.docId ?? null;
+  const blockList = blockMetaFromDocs(docs, targetDocId);
+
   const commitPatch = useCallback(
     async (doc: string, field: string, value: string) => {
       setNotice(null);
@@ -251,6 +281,10 @@ export function EditSessionCanvas({
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ path: field, value }),
       });
+      if (res.status === 422) {
+        setNotice('Voice rules rejected this edit. Adjust the copy and try again.');
+        return;
+      }
       if (!res.ok) {
         setNotice(`Could not save this field (${res.status}).`);
         return;
@@ -265,6 +299,32 @@ export function EditSessionCanvas({
       await refreshDocs();
     },
     [doFetch, marketingOrigin, refreshDocs, sessionId],
+  );
+
+  const commitBlockOp = useCallback(
+    async (payload: Record<string, unknown>) => {
+      if (!targetDocId) {
+        setNotice('No page selected for block operations.');
+        return;
+      }
+      setNotice(null);
+      const res = await doFetch(`/api/content/sessions/${sessionId}/docs/page/${targetDocId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 422) {
+        setNotice('Voice rules rejected this block change.');
+        return;
+      }
+      if (!res.ok) {
+        setNotice(`Block operation failed (${res.status}).`);
+        return;
+      }
+      setNotice('Blocks updated. Reload the preview to see structure changes.');
+      await refreshDocs();
+    },
+    [doFetch, refreshDocs, sessionId, targetDocId],
   );
 
   const publish = useCallback(async () => {
@@ -336,12 +396,12 @@ export function EditSessionCanvas({
       ) : null}
 
       <div className="flex min-h-0 flex-1 gap-3">
-        <aside className="w-56 shrink-0 overflow-auto rounded-md border border-neutral-800 p-2">
+        <aside className="w-64 shrink-0 overflow-auto rounded-md border border-neutral-800 p-2">
           <h2 className="mb-2 text-xs font-semibold uppercase text-neutral-400">Changed docs</h2>
           {docs.length === 0 ? (
-            <p className="text-sm text-neutral-500">No edits yet.</p>
+            <p className="mb-3 text-sm text-neutral-500">No edits yet.</p>
           ) : (
-            <ul className="space-y-1">
+            <ul className="mb-3 space-y-1">
               {docs.map((d) => (
                 <li key={d.id} className="truncate text-sm text-neutral-200">
                   {d.docType}: {d.docId}
@@ -349,6 +409,75 @@ export function EditSessionCanvas({
               ))}
             </ul>
           )}
+
+          <h2 className="mb-2 text-xs font-semibold uppercase text-neutral-400">Blocks</h2>
+          {blockList.length === 0 ? (
+            <p className="mb-2 text-sm text-neutral-500">
+              Edit a field first, or add a text block, to materialize the draft.
+            </p>
+          ) : (
+            <ul className="mb-2 space-y-2">
+              {blockList.map((b) => (
+                <li
+                  key={`${b.id}-${b.index}`}
+                  className="rounded border border-neutral-800 p-1.5 text-xs text-neutral-200"
+                >
+                  <div className="mb-1 truncate font-medium">
+                    {b.index}. {b.type}
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    <Button
+                      size="sm"
+                      appearance="outline"
+                      disabled={b.index === 0}
+                      onClick={() =>
+                        void commitBlockOp({ op: 'blocks.move', from: b.index, to: b.index - 1 })
+                      }
+                    >
+                      Up
+                    </Button>
+                    <Button
+                      size="sm"
+                      appearance="outline"
+                      disabled={b.index >= blockList.length - 1}
+                      onClick={() =>
+                        void commitBlockOp({ op: 'blocks.move', from: b.index, to: b.index + 1 })
+                      }
+                    >
+                      Down
+                    </Button>
+                    <Button
+                      size="sm"
+                      appearance="outline"
+                      variant="danger"
+                      disabled={blockList.length <= 1}
+                      onClick={() => void commitBlockOp({ op: 'blocks.remove', index: b.index })}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Button
+            size="sm"
+            appearance="outline"
+            disabled={!targetDocId}
+            onClick={() =>
+              void commitBlockOp({
+                op: 'blocks.insert',
+                index: blockList.length,
+                block: {
+                  id: `text-${crypto.randomUUID()}`,
+                  type: 'text',
+                  data: { content: 'New text block' },
+                },
+              })
+            }
+          >
+            Add text block
+          </Button>
         </aside>
 
         <div className="min-h-0 flex-1 overflow-auto rounded-md border border-neutral-800 bg-neutral-950">

--- a/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
+++ b/packages/editor/src/canvas/__tests__/EditSessionCanvas.test.tsx
@@ -64,7 +64,18 @@ function makeFetcher(opts: MakeFetcherOptions = {}): { fetcher: Fetcher; calls: 
     return jsonResponse(200, {
       data: {
         session: { id: SESSION, status: 'open', siteId: 'site-1' },
-        docs: opts.emptyDocs ? [] : [{ id: 'ov-1', docId: 'page-1', docType: 'page' }],
+        docs: opts.emptyDocs
+          ? []
+          : [
+              {
+                id: 'ov-1',
+                docId: 'page-1',
+                docType: 'page',
+                draft: {
+                  blocks: [{ id: 'blk-1', type: 'text', data: { content: 'hello' } }],
+                },
+              },
+            ],
       },
     });
   };
@@ -175,6 +186,23 @@ describe('EditSessionCanvas', () => {
     expect(pickDefaultPreviewPageId([{ id: 'p', slug: 'products' }])).toBe('p');
     expect(pickDefaultPreviewPageId([{ id: 'x', slug: 'about' }])).toBe('x');
     expect(pickDefaultPreviewPageId([])).toBeUndefined();
+  });
+
+  it('renders block chrome and PATCHes a blocks.insert op', async () => {
+    const { fetcher, calls } = makeFetcher();
+    render(<EditSessionCanvas sessionId={SESSION} apiBaseUrl={API_BASE} fetcher={fetcher} />);
+    await screen.findByTitle('Content preview');
+    const add = await screen.findByRole('button', { name: 'Add text block' });
+    fireEvent.click(add);
+    await waitFor(() => {
+      const patch = calls.find(
+        (c) =>
+          (c.init?.method ?? 'GET').toUpperCase() === 'PATCH' &&
+          String(c.init?.body ?? '').includes('blocks.insert'),
+      );
+      expect(patch).toBeTruthy();
+      expect(JSON.parse(String(patch?.init?.body)).op).toBe('blocks.insert');
+    });
   });
 
   it('debounces autosave into a single PATCH while typing', async () => {


### PR DESCRIPTION
## Summary

VES **P2 slice 1**, stacked on #2048 (`fix/ves-p1-path-and-create`).

1. **Voice gate on `session.patch`** for site slug `fleet-marketing`: runs `validateMarketingBlock` Tier-1 after the draft is mutated and **before any write**. Off-canon copy → **422** `{ rejected: true, violations }` and no overlay materialization.
2. **`MARKETING_PROSE_SLOTS` extended** for contracts VES shapes (`section`, `ctaSection`, `text`, … + `data.*` paths) while keeping Lexical `richText` for admin-legacy blocks.
3. **Block array ops** on the same PATCH endpoint: `blocks.insert` / `blocks.remove` / `blocks.move` (last-block remove refused; insert requires `id`+`type`+`data`).
4. **Canvas chrome**: block list with Up / Down / Delete + Add text block; surfaces voice 422 as a plain status notice.

## Stack

```
test
  └── #2048 fix/ves-p1-path-and-create   (.data path + create-session UI)
        └── this PR feat/ves-p2-voice-and-block-ops
```

Merge **#2048 first**, then this (or merge-commit when both green). Base of this PR is `fix/ves-p1-path-and-create`.

## Test plan

- [x] `edit-sessions.pglite.test.ts` 25/25 (insert/move/remove + em-dash 422 + clean pass)
- [x] `@revealui/editor` 21/21
- [x] marketing-voice unit 149/149
- [x] pre-push phase-1 gate PASS
- [ ] Owner: after #2048 + this, dogfood open session → add text block → off-canon reject → clean publish

## Security

Touches `apps/server/src/routes/content/sessions.ts` and `packages/editor` canvas (SECURITY_PATHS). Author cannot self-approve. Needs non-author guardrail-2 / `sec-review:approved` before merge.

## Out of this slice

Media picker, token theming, remaining marketing routes, MCP `content.session.*` (next PRs).
