### PR TITLE
feat(marketing): secondary FDE deployers band under Proof

### DIFF
--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -1,5 +1,5 @@
 import { Button, GitHubIcon } from '@revealui/presentation';
-import { PROOF_SECTION, PROOF_TRUST } from '../../content/proof';
+import { PROOF_DEPLOYERS, PROOF_SECTION, PROOF_TRUST } from '../../content/proof';
 import { SITE } from '../../content/site';
 import { LiveMetricsBadge } from './LiveMetricsBadge';
 
@@ -56,6 +56,25 @@ export function Proof() {
           >
             <a href={PROOF_TRUST.changelogCta.href}>{PROOF_TRUST.changelogCta.label}</a>
           </Button>
+        </div>
+
+        {/* Secondary FDE layer — same homepage section (≤7 rule), not a new section */}
+        <div className="mx-auto mt-20 max-w-2xl rounded-2xl border border-border bg-card px-6 py-10 text-center sm:px-10">
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+            {PROOF_DEPLOYERS.eyebrow}
+          </p>
+          <h3 className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+            {PROOF_DEPLOYERS.heading}
+          </h3>
+          <p className="mt-4 text-base leading-7 text-muted-foreground">{PROOF_DEPLOYERS.body}</p>
+          <p className="mt-4 text-sm leading-6 text-muted-foreground">{PROOF_DEPLOYERS.foil}</p>
+          <div className="mt-8">
+            <Button asChild size="default" className="items-center justify-center">
+              <a href={PROOF_DEPLOYERS.cta.href} target="_blank" rel="noopener noreferrer">
+                {PROOF_DEPLOYERS.cta.label}
+              </a>
+            </Button>
+          </div>
         </div>
       </div>
     </section>

--- a/apps/marketing/app/content/__tests__/proof-deployers.test.ts
+++ b/apps/marketing/app/content/__tests__/proof-deployers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { PROOF_DEPLOYERS, PROOF_SECTION } from '../proof';
+import { SITE } from '../site';
+
+describe('PROOF_DEPLOYERS (FDE secondary band)', () => {
+  it('keeps the open-source H2 identity separate from the deployers H3', () => {
+    expect(PROOF_SECTION.heading).toBe('Inspect the code before you commit to it.');
+    expect(PROOF_DEPLOYERS.heading).toBe('Built for people who deploy, not only demo.');
+    expect(PROOF_DEPLOYERS.heading).not.toEqual(PROOF_SECTION.heading);
+  });
+
+  it('is scenario-first and points at Studio, not a product rename', () => {
+    expect(PROOF_DEPLOYERS.body).toMatch(/forward-deployed engineer/);
+    expect(PROOF_DEPLOYERS.body).toMatch(/self-hosted runtime/);
+    expect(PROOF_DEPLOYERS.body.toLowerCase()).not.toContain('fde platform');
+    expect(PROOF_DEPLOYERS.cta.href).toBe(SITE.urls.agency);
+  });
+
+  it('contains no em dash', () => {
+    const blob = [
+      PROOF_DEPLOYERS.eyebrow,
+      PROOF_DEPLOYERS.heading,
+      PROOF_DEPLOYERS.body,
+      PROOF_DEPLOYERS.foil,
+      PROOF_DEPLOYERS.cta.label,
+    ].join(' ');
+    expect(blob).not.toContain('\u2014');
+  });
+});

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -876,6 +876,49 @@ export const CLAIMS: readonly ClaimEntry[] = [
     text: 'These counts are validated on every PR by the claim-drift gate. If the code changes and a number drifts, the build fails before it can ship.',
     evidence: [LICENSE_SPLIT, CI_GATE],
   },
+  {
+    file: 'proof.ts',
+    exportPath: 'PROOF_DEPLOYERS.heading',
+    text: 'Built for people who deploy, not only demo.',
+    evidence: [
+      {
+        kind: 'url',
+        ref: 'https://revealuistudio.com',
+        note: 'Studio/agency is the reference forward-deploy practice (ADR 2026-07-21)',
+      },
+    ],
+  },
+  {
+    file: 'proof.ts',
+    exportPath: 'PROOF_DEPLOYERS.body',
+    text: 'Some buyers install RevealUI themselves. Some hire us, or their own forward-deployed engineer, to stamp and hand over a fleet. Either way the outcome is the same: a self-hosted runtime where the business and its agents live under one roof, on infrastructure the customer owns.',
+    evidence: [
+      REPO,
+      {
+        kind: 'url',
+        ref: 'https://revealuistudio.com',
+        note: 'hire-us path; Fleet Stamp / Custom Build on agency services',
+      },
+      {
+        kind: 'url',
+        ref: 'https://revealui.com',
+        note: 'self-install product path; canonical ownership sentence',
+      },
+    ],
+  },
+  {
+    file: 'proof.ts',
+    exportPath: 'PROOF_DEPLOYERS.foil',
+    text: 'Cloud agent platforms rent you an outcome. A forward-deployed engagement leaves a runtime the customer runs.',
+    evidence: [
+      REPO,
+      {
+        kind: 'url',
+        ref: 'https://revealuistudio.com',
+        note: 'positioning foil: customer-owned runtime after handoff, not a rented outcome',
+      },
+    ],
+  },
 
   // ── pricing-teaser.ts ────────────────────────────────────────────────────
   {

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -40,6 +40,21 @@ export const PROOF_TRUST = {
   },
 } as const;
 
+// Secondary FDE / deployers band (ADR 2026-07-21 accepted). Nested under Proof
+// so the homepage stays within the ≤7 section hard rule (ADR 2026-07-10).
+// Never a H1 or primary ICP. Copy pack §3 (scenario first, runtime noun).
+export const PROOF_DEPLOYERS = {
+  eyebrow: 'For deployers',
+  heading: 'Built for people who deploy, not only demo.',
+  body: 'Some buyers install RevealUI themselves. Some hire us, or their own forward-deployed engineer, to stamp and hand over a fleet. Either way the outcome is the same: a self-hosted runtime where the business and its agents live under one roof, on infrastructure the customer owns.',
+  foil: 'Cloud agent platforms rent you an outcome. A forward-deployed engagement leaves a runtime the customer runs.',
+  cta: {
+    label: 'Work with Studio',
+    href: SITE.urls.agency,
+    external: true,
+  },
+} as const;
+
 // Live-metrics snapshot badge. Every integer is read from site.ts METRICS, which
 // is pinned to the codebase by the claim-drift gate (build fails on drift). The
 // badge links to that validator so the "live from the repo" claim is checkable.


### PR DESCRIPTION
## Summary

Product **secondary** FDE / deployers module after ADR 2026-07-21 acceptance. Nested under the existing Proof section so the homepage stays within the ≤7 section hard rule (ADR 2026-07-10).

**Does not change** homepage H1, canonical positioning sentence, ICP chips, or pricing identity.

## Copy (from FDE copy pack §3)

- Eyebrow: For deployers
- Heading: Built for people who deploy, not only demo.
- Body + micro-foil (scenario first, runtime noun)
- CTA: Work with Studio → revealuistudio.com

## Evidence

- `claims-evidence` + claim-drift green
- Unit tests on `PROOF_DEPLOYERS` strings (3/3)

## Peer

- Agency FDE hero already on test (agency#93)
- jv ADR accept PR pairs with this
- Avoids VES (#2048) paths

## Owner

```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```
