### PR TITLE
feat(marketing): wire /philosophy to CMS block stream for VES

### DIFF
--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -1,6 +1,7 @@
 import { BlockSchema } from '@revealui/contracts/content';
 import { describe, expect, it } from 'vitest';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
+import { PHILOSOPHY } from '../content/philosophy';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../content/primitives';
 import { PRODUCTS_CTA_SECTION, PRODUCTS_FLAGSHIP, PRODUCTS_PAGE_HERO } from '../content/products';
 import { METRICS } from '../content/site';
@@ -10,7 +11,12 @@ import {
   getStartedSlot,
   HOME_FALLBACK_BLOCKS,
   homeBlocks,
+  PHILOSOPHY_FALLBACK_BLOCKS,
   PRODUCTS_FALLBACK_BLOCKS,
+  philosophyBlocks,
+  philosophyBodySlot,
+  philosophyCtaSlot,
+  philosophyHeroSlot,
   primitivesSlot,
   productsBlocks,
   productsCtaSlot,
@@ -32,8 +38,8 @@ function collectStrings(value: unknown, out: string[] = []): string[] {
 }
 
 describe('page-blocks derivation', () => {
-  it('produces schema-valid blocks for both pages', () => {
-    for (const block of [...homeBlocks(), ...productsBlocks()]) {
+  it('produces schema-valid blocks for home, products, and philosophy', () => {
+    for (const block of [...homeBlocks(), ...productsBlocks(), ...philosophyBlocks()]) {
       expect(BlockSchema.safeParse(block).success).toBe(true);
     }
   });
@@ -41,11 +47,24 @@ describe('page-blocks derivation', () => {
   it('derives the expected block types per page in order', () => {
     expect(homeBlocks().map((b) => b.type)).toEqual(['section', 'section', 'ctaSection']);
     expect(productsBlocks().map((b) => b.type)).toEqual(['hero', 'section', 'ctaSection']);
+    expect(philosophyBlocks().map((b) => b.type)).toEqual(['hero', 'section', 'ctaSection']);
+  });
+
+  it('round-trips philosophy slots against the static content module', () => {
+    const blocks = PHILOSOPHY_FALLBACK_BLOCKS;
+    expect(philosophyHeroSlot(blocks).data).toEqual({
+      eyebrow: PHILOSOPHY.eyebrow,
+      h1: PHILOSOPHY.h1,
+    });
+    expect(philosophyBodySlot(blocks).data.sections.map((s) => s.body)).toEqual(
+      PHILOSOPHY.sections.map((s) => s.body),
+    );
+    expect(philosophyCtaSlot(blocks).data).toEqual(PHILOSOPHY.cta);
   });
 });
 
 describe('claims safety: prose is single-sourced, pinned values never enter blocks', () => {
-  const strings = collectStrings([homeBlocks(), productsBlocks()]);
+  const strings = collectStrings([homeBlocks(), productsBlocks(), philosophyBlocks()]);
   const haystack = strings.join(' ');
 
   it('carries the copy sentences byte-identical to the content modules', () => {
@@ -72,6 +91,13 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     }
     expect(strings).toContain(PRODUCTS_CTA_SECTION.heading);
     expect(strings).toContain(PRODUCTS_CTA_SECTION.body);
+    expect(strings).toContain(PHILOSOPHY.eyebrow);
+    expect(strings).toContain(PHILOSOPHY.h1);
+    for (const section of PHILOSOPHY.sections) {
+      expect(strings).toContain(section.body);
+    }
+    expect(strings).toContain(PHILOSOPHY.cta.primary.label);
+    expect(strings).toContain(PHILOSOPHY.cta.secondary.label);
   });
 
   it('never carries metric-derived numbers, prices, or product versions', () => {
@@ -163,6 +189,7 @@ describe('blocksMatchFallback shape guard', () => {
   it('accepts an array with matching length + per-position types', () => {
     expect(blocksMatchFallback(homeBlocks(), HOME_FALLBACK_BLOCKS)).toBe(true);
     expect(blocksMatchFallback(productsBlocks(), PRODUCTS_FALLBACK_BLOCKS)).toBe(true);
+    expect(blocksMatchFallback(philosophyBlocks(), PHILOSOPHY_FALLBACK_BLOCKS)).toBe(true);
   });
 
   it('rejects empty, wrong-length, and wrong-type arrays', () => {

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -1,12 +1,12 @@
 /**
- * Static-first block derivation for the marketing home + products pages.
+ * Static-first block derivation for marketing pages served from the CMS
+ * (home, products, philosophy).
  *
- * The marketing content modules (content/home.ts, content/primitives.ts,
- * content/products.ts) stay the single source of truth for every prose string.
- * This module derives the canonical `pages.blocks` array from those modules with
- * the `@revealui/contracts` factories — a PURE transform, so the CMS block stream
- * and the static fallback can never carry a different sentence than the
- * claim-covered modules do.
+ * The marketing content modules stay the single source of truth for every prose
+ * string. This module derives the canonical `pages.blocks` array from those
+ * modules with the `@revealui/contracts` factories — a PURE transform, so the
+ * CMS block stream and the static fallback can never carry a different sentence
+ * than the claim-covered modules do.
  *
  * The reverse mappers reconstruct each marketing component's own rich data shape
  * from a block, so the styled marketing components keep their look while their
@@ -28,6 +28,7 @@ import {
   type SectionBlock,
 } from '@revealui/contracts/content';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
+import { PHILOSOPHY } from '../content/philosophy';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../content/primitives';
 import { PRODUCTS_CTA_SECTION, PRODUCTS_PAGE_HERO } from '../content/products';
 import type { Cta } from '../content/types';
@@ -92,6 +93,27 @@ export interface ProductsCtaData {
   readonly cta: { readonly docs: Cta; readonly pricing: Cta };
 }
 
+export type PhilosophyParagraphRole = 'lead' | 'body' | 'footer';
+
+export interface PhilosophyParagraphData {
+  readonly role: PhilosophyParagraphRole;
+  readonly body: string;
+}
+
+export interface PhilosophyHeroData {
+  readonly eyebrow: string;
+  readonly h1: string;
+}
+
+export interface PhilosophyBodyData {
+  readonly sections: readonly PhilosophyParagraphData[];
+}
+
+export interface PhilosophyCtaData {
+  readonly primary: Cta;
+  readonly secondary: Cta;
+}
+
 // ---------------------------------------------------------------------------
 // Stable block ids + positions. Ids let the seed and fallback match, but the
 // runtime routes each slot by array POSITION + type (the CMS assigns its own
@@ -104,6 +126,9 @@ export const HOME_GET_STARTED_BLOCK_ID = 'home-get-started';
 export const PRODUCTS_HERO_BLOCK_ID = 'products-hero';
 export const PRODUCTS_FAQ_BLOCK_ID = 'products-faq';
 export const PRODUCTS_CTA_BLOCK_ID = 'products-cta';
+export const PHILOSOPHY_HERO_BLOCK_ID = 'philosophy-hero';
+export const PHILOSOPHY_BODY_BLOCK_ID = 'philosophy-body';
+export const PHILOSOPHY_CTA_BLOCK_ID = 'philosophy-cta';
 
 const HOME_DEMO_INDEX = 0;
 const HOME_PRIMITIVES_INDEX = 1;
@@ -111,6 +136,9 @@ const HOME_GET_STARTED_INDEX = 2;
 const PRODUCTS_HERO_INDEX = 0;
 const PRODUCTS_FAQ_INDEX = 1;
 const PRODUCTS_CTA_INDEX = 2;
+const PHILOSOPHY_HERO_INDEX = 0;
+const PHILOSOPHY_BODY_INDEX = 1;
+const PHILOSOPHY_CTA_INDEX = 2;
 
 function ctaToLink(cta: Cta, variant: 'primary' | 'secondary'): MarketingLink {
   return { label: cta.label, href: cta.href, variant };
@@ -188,6 +216,41 @@ function productsCtaBlock(): CtaSectionBlock {
   });
 }
 
+function philosophyHeroBlock(): HeroBlock {
+  return createHeroBlock(PHILOSOPHY_HERO_BLOCK_ID, PHILOSOPHY.h1, {
+    eyebrow: PHILOSOPHY.eyebrow,
+  });
+}
+
+function philosophyParagraphRole(
+  section: (typeof PHILOSOPHY.sections)[number],
+): PhilosophyParagraphRole {
+  if ('lead' in section && section.lead) return 'lead';
+  if ('footer' in section && section.footer) return 'footer';
+  return 'body';
+}
+
+function philosophyBodyBlock(): SectionBlock {
+  // Heading is structural (not rendered as a second H1); paragraphs carry the
+  // manifesto copy. Role is stored in item.label so reverse-map can restore
+  // lead/footer styling without inventing new block types.
+  return createSectionBlock(PHILOSOPHY_BODY_BLOCK_ID, 'Manifesto', {
+    items: PHILOSOPHY.sections.map((section) => ({
+      label: philosophyParagraphRole(section),
+      body: section.body,
+    })),
+  });
+}
+
+function philosophyCtaBlock(): CtaSectionBlock {
+  return createCtaSectionBlock(PHILOSOPHY_CTA_BLOCK_ID, 'Next', {
+    links: [
+      ctaToLink(PHILOSOPHY.cta.primary, 'primary'),
+      ctaToLink(PHILOSOPHY.cta.secondary, 'secondary'),
+    ],
+  });
+}
+
 /** Derives the home page's block-driven sections (Demo, Primitives, GetStarted). */
 export function homeBlocks(): Block[] {
   return [homeDemoBlock(), homePrimitivesBlock(), homeGetStartedBlock()];
@@ -198,8 +261,14 @@ export function productsBlocks(): Block[] {
   return [productsHeroBlock(), productsFaqBlock(), productsCtaBlock()];
 }
 
+/** Derives the philosophy page's block-driven sections (Hero, body, CTA). */
+export function philosophyBlocks(): Block[] {
+  return [philosophyHeroBlock(), philosophyBodyBlock(), philosophyCtaBlock()];
+}
+
 export const HOME_FALLBACK_BLOCKS: Block[] = homeBlocks();
 export const PRODUCTS_FALLBACK_BLOCKS: Block[] = productsBlocks();
+export const PHILOSOPHY_FALLBACK_BLOCKS: Block[] = philosophyBlocks();
 
 // ---------------------------------------------------------------------------
 // Reverse mappers: canonical block -> rich component data shape
@@ -264,6 +333,31 @@ function heroToProductsHero(block: HeroBlock): ProductsHeroData {
   return {
     h1: block.data.title,
     subtitle: block.data.subtitle ?? '',
+  };
+}
+
+function heroToPhilosophyHero(block: HeroBlock): PhilosophyHeroData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    h1: block.data.title,
+  };
+}
+
+function sectionToPhilosophyBody(block: SectionBlock): PhilosophyBodyData {
+  return {
+    sections: (block.data.items ?? []).map((item) => {
+      const label = item.label ?? 'body';
+      const role: PhilosophyParagraphRole = label === 'lead' || label === 'footer' ? label : 'body';
+      return { role, body: item.body };
+    }),
+  };
+}
+
+function ctaToPhilosophyCta(block: CtaSectionBlock): PhilosophyCtaData {
+  const links = block.data.links ?? [];
+  return {
+    primary: links[0] ? linkToCta(links[0]) : PHILOSOPHY.cta.primary,
+    secondary: links[1] ? linkToCta(links[1]) : PHILOSOPHY.cta.secondary,
   };
 }
 
@@ -345,6 +439,27 @@ export function productsCtaSlot(blocks: Block[]): BlockSlot<ProductsCtaData> {
   const path = `blocks.${PRODUCTS_CTA_INDEX}.data`;
   if (block && block.type === 'ctaSection') return { data: ctaToProductsCta(block), path };
   return { data: ctaToProductsCta(productsCtaBlock()), path };
+}
+
+export function philosophyHeroSlot(blocks: Block[]): BlockSlot<PhilosophyHeroData> {
+  const block = blocks[PHILOSOPHY_HERO_INDEX];
+  const path = `blocks.${PHILOSOPHY_HERO_INDEX}.data`;
+  if (block && block.type === 'hero') return { data: heroToPhilosophyHero(block), path };
+  return { data: heroToPhilosophyHero(philosophyHeroBlock()), path };
+}
+
+export function philosophyBodySlot(blocks: Block[]): BlockSlot<PhilosophyBodyData> {
+  const block = blocks[PHILOSOPHY_BODY_INDEX];
+  const path = `blocks.${PHILOSOPHY_BODY_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToPhilosophyBody(block), path };
+  return { data: sectionToPhilosophyBody(philosophyBodyBlock()), path };
+}
+
+export function philosophyCtaSlot(blocks: Block[]): BlockSlot<PhilosophyCtaData> {
+  const block = blocks[PHILOSOPHY_CTA_INDEX];
+  const path = `blocks.${PHILOSOPHY_CTA_INDEX}.data`;
+  if (block && block.type === 'ctaSection') return { data: ctaToPhilosophyCta(block), path };
+  return { data: ctaToPhilosophyCta(philosophyCtaBlock()), path };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -1,66 +1,125 @@
-import { Button } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
-import { PHILOSOPHY } from '../content/philosophy';
+import {
+  PHILOSOPHY_FALLBACK_BLOCKS,
+  type PhilosophyBodyData,
+  type PhilosophyCtaData,
+  type PhilosophyHeroData,
+  philosophyBodySlot,
+  philosophyCtaSlot,
+  philosophyHeroSlot,
+} from '../lib/page-blocks';
+import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
-export function PhilosophyPage() {
+interface PhilosophyHeroProps {
+  data: PhilosophyHeroData;
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+function PhilosophyHero({ data, path, annotation }: PhilosophyHeroProps) {
   return (
-    <div className="min-h-screen bg-background">
-      <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-violet-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <div className="mx-auto max-w-3xl">
-          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
-            {PHILOSOPHY.eyebrow}
-          </p>
-          <h1 className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-            {PHILOSOPHY.h1}
-          </h1>
-        </div>
-      </section>
+    <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-violet-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        <p
+          className="text-sm font-semibold uppercase tracking-wide text-primary"
+          {...fieldAttrs(annotation, `${path}.eyebrow`)}
+        >
+          {data.eyebrow}
+        </p>
+        <h1
+          className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+          {...fieldAttrs(annotation, `${path}.title`)}
+        >
+          {data.h1}
+        </h1>
+      </div>
+    </section>
+  );
+}
 
-      <section className="px-6 py-16 sm:py-24 lg:px-8">
-        <div className="mx-auto max-w-3xl space-y-8">
-          {PHILOSOPHY.sections.map((section, index) => {
-            if ('lead' in section && section.lead) {
-              return (
-                <p
-                  key={index}
-                  className="text-2xl font-medium leading-relaxed text-foreground sm:text-3xl"
-                >
-                  {section.body}
-                </p>
-              );
-            }
-            if ('footer' in section && section.footer) {
-              return (
-                <p
-                  key={index}
-                  className="mt-12 border-t border-border pt-8 text-base font-medium text-muted-foreground"
-                >
-                  {section.body}
-                </p>
-              );
-            }
+interface PhilosophyBodyProps {
+  data: PhilosophyBodyData;
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+function PhilosophyBody({ data, path, annotation }: PhilosophyBodyProps) {
+  return (
+    <section className="px-6 py-16 sm:py-24 lg:px-8">
+      <div className="mx-auto max-w-3xl space-y-8">
+        {data.sections.map((section, index) => {
+          if (section.role === 'lead') {
             return (
-              <p key={index} className="text-lg leading-8 text-muted-foreground">
+              <p
+                key={`lead-${index}`}
+                className="text-2xl font-medium leading-relaxed text-foreground sm:text-3xl"
+                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+              >
                 {section.body}
               </p>
             );
-          })}
-        </div>
-      </section>
+          }
+          if (section.role === 'footer') {
+            return (
+              <p
+                key={`footer-${index}`}
+                className="mt-12 border-t border-border pt-8 text-base font-medium text-muted-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+              >
+                {section.body}
+              </p>
+            );
+          }
+          return (
+            <p
+              key={`body-${index}`}
+              className="text-lg leading-8 text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+            >
+              {section.body}
+            </p>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
 
-      <section className="px-6 pb-24 sm:pb-32 lg:px-8">
-        <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
-          <Button asChild size="lg" variant="brand">
-            <a href={PHILOSOPHY.cta.primary.href}>{PHILOSOPHY.cta.primary.label}</a>
-          </Button>
-          <Button asChild size="lg" appearance="outline" variant="neutral">
-            <a href={PHILOSOPHY.cta.secondary.href} target="_blank" rel="noopener noreferrer">
-              {PHILOSOPHY.cta.secondary.label}
-            </a>
-          </Button>
-        </div>
-      </section>
+interface PhilosophyCtaProps {
+  data: PhilosophyCtaData;
+}
 
+function PhilosophyCta({ data }: PhilosophyCtaProps) {
+  // Link labels are editable via the ctaSection block's links in a later
+  // media/CTA canvas slice; for now labels ride the block data used by seed.
+  return (
+    <section className="px-6 pb-24 sm:pb-32 lg:px-8">
+      <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
+        <Button asChild size="lg" variant="brand">
+          <a href={data.primary.href}>{data.primary.label}</a>
+        </Button>
+        <Button asChild size="lg" appearance="outline" variant="neutral">
+          <a href={data.secondary.href} target="_blank" rel="noopener noreferrer">
+            {data.secondary.label}
+          </a>
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+export function PhilosophyPage() {
+  const { blocks, annotation } = useMarketingPageBlocks('philosophy', PHILOSOPHY_FALLBACK_BLOCKS);
+  const hero = philosophyHeroSlot(blocks);
+  const body = philosophyBodySlot(blocks);
+  const cta = philosophyCtaSlot(blocks);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <PhilosophyHero data={hero.data} path={hero.path} annotation={annotation} />
+      <PhilosophyBody data={body.data} path={body.path} annotation={annotation} />
+      <PhilosophyCta data={cta.data} />
       <Footer />
     </div>
   );

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env tsx
 
 /**
- * Seed the fleet-marketing `sites` row plus its `home` and `products` pages
- * (Phase A.2 + the visual-edit-sessions block wire).
+ * Seed the fleet-marketing `sites` row plus its published marketing pages
+ * (home, products, philosophy) for the visual-edit-sessions block wire.
  *
  * The page `blocks` come from the SAME pure derivation the marketing app falls
  * back to (`apps/marketing/app/lib/page-blocks.ts`), so the seeded CMS content
@@ -25,7 +25,11 @@
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import { config } from 'dotenv';
-import { homeBlocks, productsBlocks } from '../apps/marketing/app/lib/page-blocks';
+import {
+  homeBlocks,
+  philosophyBlocks,
+  productsBlocks,
+} from '../apps/marketing/app/lib/page-blocks';
 
 const rootDir = resolve(import.meta.dirname, '..');
 
@@ -76,6 +80,16 @@ const PAGE_SEEDS: readonly PageSeed[] = [
     seo: {
       title: 'The RevFleet product family',
       description: 'Seven products on one foundation, all built and operated by RevealUI Studio.',
+    },
+  },
+  {
+    slug: 'philosophy',
+    path: '/philosophy',
+    title: 'Philosophy',
+    blocks: philosophyBlocks(),
+    seo: {
+      title: 'Philosophy | RevealUI',
+      description: 'Software that compounds. Why RevealUI exists.',
     },
   },
 ];
@@ -169,7 +183,7 @@ async function main(): Promise<void> {
   }
 
   // ---------------------------------------------------------------------------
-  // Pages (home + products) — version-safe, idempotent
+  // Pages (home + products + philosophy) — version-safe, idempotent
   // ---------------------------------------------------------------------------
 
   for (const seed of PAGE_SEEDS) {


### PR DESCRIPTION
## Summary

Wires `/philosophy` into the same CMS static-first block stream used by home and products for Visual Edit Sessions.

- `page-blocks.ts`: `philosophyBlocks()` + hero/body/cta slots derived from `content/philosophy.ts`
- `PhilosophyPage.tsx`: `useMarketingPageBlocks('philosophy', …)` + `data-rvui-*` annotations on manifesto prose
- `seed-fleet-marketing-site.ts`: adds the philosophy page seed (idempotent)

Claims-safe: only prose from the content module enters blocks (no metrics/prices). Fallback stays byte-identical when CMS is empty/unreachable.

## Test plan

- [x] `page-blocks.test.ts` 11/11
- [x] marketing production build
- [x] pre-push phase-1 gate PASS
- [ ] Owner: re-run `pnpm tsx scripts/seed-fleet-marketing-site.ts` after merge to materialize the philosophy row

## Notes

Not security-sensitive (marketing app + seed script only). Next routes after this: fair-source (careful with METRICS in hero), then others without pricing lockstep coupling.
