### PR TITLE
feat(server): wire max-export-audit nudge via audit export meter

### DIFF
--- a/apps/server/src/lib/nudges/__tests__/triggers.test.ts
+++ b/apps/server/src/lib/nudges/__tests__/triggers.test.ts
@@ -7,6 +7,7 @@ const BASE_SIGNALS: NudgeSignals = {
   hasPageOrProduct: false,
   hasAgentAction: false,
   hasInferenceConfig: false,
+  hasAuditExport: false,
   accountAgeMs: 0,
   siteCount: 0,
 };
@@ -42,6 +43,14 @@ describe('buildCandidates — tier gating', () => {
     const signals: NudgeSignals = { ...BASE_SIGNALS, siteCount: 1, accountAgeMs: DAY_7_MS };
     expect(ids(buildCandidates('max', signals))).not.toContain('ent-second-tenant');
     expect(ids(buildCandidates('enterprise', signals))).toContain('ent-second-tenant');
+  });
+
+  it('max-export-audit appears for max and enterprise once day-7+ and never for free/pro', () => {
+    const signals: NudgeSignals = { ...BASE_SIGNALS, accountAgeMs: DAY_7_MS };
+    expect(ids(buildCandidates('free', signals))).not.toContain('max-export-audit');
+    expect(ids(buildCandidates('pro', signals))).not.toContain('max-export-audit');
+    expect(ids(buildCandidates('max', signals))).toContain('max-export-audit');
+    expect(ids(buildCandidates('enterprise', signals))).toContain('max-export-audit');
   });
 });
 
@@ -118,6 +127,19 @@ describe('buildCandidates — retirement on milestone event', () => {
     expect(ids(dueWithOneSite)).toContain('ent-second-tenant');
     expect(ids(secondSiteLanded)).not.toContain('ent-second-tenant');
   });
+
+  it('max-export-audit waits for day 7 and retires after an audit export meter row', () => {
+    const tooEarly = buildCandidates('max', { ...BASE_SIGNALS, accountAgeMs: DAY_7_MS - 1 });
+    const due = buildCandidates('max', { ...BASE_SIGNALS, accountAgeMs: DAY_7_MS });
+    const exported = buildCandidates('max', {
+      ...BASE_SIGNALS,
+      accountAgeMs: DAY_7_MS,
+      hasAuditExport: true,
+    });
+    expect(ids(tooEarly)).not.toContain('max-export-audit');
+    expect(ids(due)).toContain('max-export-audit');
+    expect(ids(exported)).not.toContain('max-export-audit');
+  });
 });
 
 describe('buildCandidates — priority tags match the milestone order', () => {
@@ -128,12 +150,14 @@ describe('buildCandidates — priority tags match the milestone order', () => {
       hasPageOrProduct: false,
       hasAgentAction: false,
       hasInferenceConfig: false,
+      hasAuditExport: false,
       accountAgeMs: DAY_7_MS,
       siteCount: 1,
     };
     const byId = new Map(buildCandidates('enterprise', signals).map((c) => [c.id, c.milestone]));
     expect(byId.get('pro-first-action')).toBe('hour1');
     expect(byId.get('max-local-inference')).toBe('hour24');
+    expect(byId.get('max-export-audit')).toBe('day7');
     expect(byId.get('ent-second-tenant')).toBe('day7');
   });
 });

--- a/apps/server/src/lib/nudges/definitions.ts
+++ b/apps/server/src/lib/nudges/definitions.ts
@@ -7,11 +7,11 @@
  * body, or CTA text when editing this file.
  *
  * Not every nudge has a live trigger evaluator (see ./triggers.ts):
- * five of the eleven have no observable signal in the schema today
+ * five of the eleven still lack an observable signal
  * (upgrade-intent, self-hosted license activation, audit-trail-viewed,
- * MCP connection state, an AI-memory enable toggle) and are excluded
- * from selection rather than approximated. See the PR description for
- * the id-by-id rationale.
+ * MCP connection state, an AI-memory enable toggle) and stay excluded
+ * from selection rather than approximated. max-export-audit is live via
+ * usage_meters meter_name=audit_export (source=user) written on export.
  */
 
 export type NudgeId =
@@ -136,5 +136,6 @@ export const IMPLEMENTED_NUDGE_IDS: readonly NudgeId[] = [
   'free-first-content',
   'pro-first-action',
   'max-local-inference',
+  'max-export-audit',
   'ent-second-tenant',
 ];

--- a/apps/server/src/lib/nudges/signals.ts
+++ b/apps/server/src/lib/nudges/signals.ts
@@ -7,7 +7,8 @@
  *   - conversations/messages  -  free-tier local chat (aiLocal surface)
  *   - pages/products          -  content existence, scoped via site ownership
  *   - account_entitlements    -  tier resolution (mirrors account-entitlement.ts)
- *   - usage_meters            -  governed agent actions (source='agent')
+ *   - usage_meters            -  governed agent actions (source='agent');
+ *                                audit exports (meter_name=audit_export, source='user')
  *   - workspace_inference_configs  -  per-site inference config
  *   - sites                   -  tenant count for the Enterprise nudge
  */
@@ -28,7 +29,7 @@ import {
   workspaceInferenceConfigs,
 } from '@revealui/db/schema';
 import { and, count, eq, isNull } from 'drizzle-orm';
-import type { NudgeSignals } from './triggers.js';
+import { AUDIT_EXPORT_METER_NAME, type NudgeSignals } from './triggers.js';
 
 function isHealthyStatus(status: string | null): boolean {
   return status === 'active' || status === 'trialing';
@@ -130,6 +131,22 @@ async function hasAgentAction(db: DatabaseClient, accountId: string | null): Pro
   return !!row;
 }
 
+async function hasAuditExport(db: DatabaseClient, accountId: string | null): Promise<boolean> {
+  if (!accountId) return false;
+  const [row] = await db
+    .select({ id: usageMeters.id })
+    .from(usageMeters)
+    .where(
+      and(
+        eq(usageMeters.accountId, accountId),
+        eq(usageMeters.source, 'user'),
+        eq(usageMeters.meterName, AUDIT_EXPORT_METER_NAME),
+      ),
+    )
+    .limit(1);
+  return !!row;
+}
+
 async function hasInferenceConfig(db: DatabaseClient, userId: string): Promise<boolean> {
   const [row] = await db
     .select({ id: workspaceInferenceConfigs.id })
@@ -167,6 +184,7 @@ export async function fetchNudgeContext(db: DatabaseClient, userId: string): Pro
     userChatMessageCount,
     pageOrProduct,
     agentAction,
+    auditExport,
     inferenceConfig,
     ageMs,
     siteCount,
@@ -175,6 +193,7 @@ export async function fetchNudgeContext(db: DatabaseClient, userId: string): Pro
     countUserChatMessages(db, userId),
     hasPageOrProduct(db, userId),
     hasAgentAction(db, accountId),
+    hasAuditExport(db, accountId),
     hasInferenceConfig(db, userId),
     accountAgeMs(db, userId),
     countSites(db, userId),
@@ -187,6 +206,7 @@ export async function fetchNudgeContext(db: DatabaseClient, userId: string): Pro
       userChatMessageCount,
       hasPageOrProduct: pageOrProduct,
       hasAgentAction: agentAction,
+      hasAuditExport: auditExport,
       hasInferenceConfig: inferenceConfig,
       accountAgeMs: ageMs,
       siteCount,

--- a/apps/server/src/lib/nudges/triggers.ts
+++ b/apps/server/src/lib/nudges/triggers.ts
@@ -6,9 +6,8 @@
  * tier gating and milestone-retirement are unit-testable without mocking
  * a database.
  *
- * Only the five nudges with an observable signal in the schema today are
- * evaluated here — see ../../../../../.jv PR description (or the GAP-300
- * PR body) for which ids are deferred and why.
+ * Implemented triggers live here; remaining deferred ids still need real
+ * signals (see definitions.ts IMPLEMENTED_NUDGE_IDS + #1929 rationale).
  */
 
 import type { LicenseTier } from '@revealui/core/license';
@@ -25,11 +24,19 @@ export interface NudgeSignals {
   hasAgentAction: boolean;
   /** True once any site owned by the user has a workspace inference config. */
   hasInferenceConfig: boolean;
+  /**
+   * True once the account has exported the audit log
+   * (usage_meters.meter_name = audit_export, source = user).
+   */
+  hasAuditExport: boolean;
   /** Milliseconds since the user's account was created. */
   accountAgeMs: number;
   /** Count of non-deleted sites owned by the user. */
   siteCount: number;
 }
+
+/** Meter name written by GET /admin/audit/export for the max-export-audit nudge. */
+export const AUDIT_EXPORT_METER_NAME = 'audit_export';
 
 export const HOUR_24_MS = 24 * 60 * 60 * 1000;
 export const DAY_7_MS = 7 * 24 * 60 * 60 * 1000;
@@ -62,6 +69,9 @@ export function buildCandidates(tier: LicenseTier, signals: NudgeSignals): Nudge
   if (tier === 'max' || tier === 'enterprise') {
     if (!signals.hasInferenceConfig && signals.accountAgeMs >= HOUR_24_MS) {
       candidates.push({ id: 'max-local-inference', milestone: 'hour24' });
+    }
+    if (!signals.hasAuditExport && signals.accountAgeMs >= DAY_7_MS) {
+      candidates.push({ id: 'max-export-audit', milestone: 'day7' });
     }
   }
 

--- a/apps/server/src/routes/admin/observability.ts
+++ b/apps/server/src/routes/admin/observability.ts
@@ -15,12 +15,23 @@
  *                               recent failures) (CR8-P2-01 phase D)
  */
 
+import { randomUUID } from 'node:crypto';
+import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import type { DatabaseClient } from '@revealui/db/client';
-import { appLogs, auditLog, errorEvents, jobs, processedWebhookEvents } from '@revealui/db/schema';
+import {
+  accountMemberships,
+  appLogs,
+  auditLog,
+  errorEvents,
+  jobs,
+  processedWebhookEvents,
+} from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, count, desc, eq, gte, lte, type SQL, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { recordUsageMeter } from '../../lib/metering.js';
+import { AUDIT_EXPORT_METER_NAME } from '../../lib/nudges/triggers.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString } from '../_helpers/serialize.js';
 
@@ -414,7 +425,8 @@ function csvEscape(value: unknown): string {
 }
 
 app.get('/audit/export', async (c) => {
-  requireAdmin(c.get('user'));
+  const user = c.get('user');
+  requireAdmin(user);
 
   const parsed = AuditExportQuery.safeParse(Object.fromEntries(new URL(c.req.url).searchParams));
   if (!parsed.success) {
@@ -441,6 +453,35 @@ app.get('/audit/export', async (c) => {
     .where(where)
     .orderBy(desc(auditLog.timestamp))
     .limit(AUDIT_EXPORT_MAX_ROWS);
+
+  // GAP-300: record a real export signal for max-export-audit (best-effort).
+  // Never block the download if metering fails.
+  if (user?.id) {
+    try {
+      const [membership] = await db
+        .select({ accountId: accountMemberships.accountId })
+        .from(accountMemberships)
+        .where(and(eq(accountMemberships.userId, user.id), eq(accountMemberships.status, 'active')))
+        .limit(1);
+      if (membership?.accountId) {
+        const now = new Date();
+        await recordUsageMeter({
+          id: randomUUID(),
+          accountId: membership.accountId,
+          meterName: AUDIT_EXPORT_METER_NAME,
+          quantity: 1,
+          periodStart: now,
+          source: 'user',
+          idempotencyKey: `audit_export:${membership.accountId}:${now.toISOString()}`,
+        });
+      }
+    } catch (err) {
+      logger.warn('audit export: failed to record usage meter (export still delivered)', {
+        userId: user.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
 
   const filenameStamp = new Date().toISOString().replace(/[:.]/g, '-');
 


### PR DESCRIPTION
## Summary

GAP-300 residual after the §7 surface (#1929) and FDE train: unlock deferred nudge **`max-export-audit`** with a **real** signal (no invented view tracking).

On successful `GET /admin/audit/export`, best-effort write:

- `usage_meters.meter_name = audit_export`
- `source = user`
- account resolved via active membership

Nudge evaluation: Max/Enterprise, day-7+, no prior export meter → show §7 copy; retires after first export.

Metering failures **never** block the download (warn log only).

## Why this residual

Content-truth recommended residual was GAP-300 flow/instrumentation (not copy strings). Most of the journey map is already shipped (lastActiveAt writer, welcome CTAs, checklist agents-first, activation analytics, lifecycle emails disarmed pending owner mailbox). This is one of the five remaining deferred triggers that can ship by extending existing `usage_meters` + `recordUsageMeter` (extend-before-create).

Still deferred (need real signals elsewhere): free-pro-gate, pro-license-wire, pro-read-receipts, pro-connect-data, max-enable-memory.

Owner-gated (not this PR): lifecycle email arming, GAP-240 signup flip, thesis lede edit.

## Tests

`pnpm --filter server exec vitest run src/lib/nudges` — 37/37.

## Peer

- Claim: workboard note `2026-07-21T21-grok-gap300-residual.md`
- Avoids #2051 VES philosophy routes

## Owner

```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```
