### PR TITLE
fix(scripts): durable seed env — refuse probe DB, resolve owner, fail loud

### DIFF
--- a/scripts/electric-latency-probe/README.md
+++ b/scripts/electric-latency-probe/README.md
@@ -1,54 +1,37 @@
----
-title: "Electric Latency Probe"
-description: "Measures end-to-end propagation latency through the local admin app:"
-visibility: internal
-status: verified
-audience: contributor
----
+# Electric latency probe
 
-# Electric Latency Probe
+Isolated stack for measuring ElectricSQL shape-sync latency against a throwaway
+Postgres. **Ephemeral only** — never the long-lived admin / fleet-marketing
+database.
 
-Measures end-to-end propagation latency through the local admin app:
-write → DB → Electric → shape stream → subscriber callback.
+| Service | Host port | Identity |
+|---------|-----------|----------|
+| Postgres | **5434** | user/db `revealui` / `revealui_probe` |
+| Electric | **5133** | local only |
 
-Produces a small notes file with a median + p95 number you can quote
-in a meeting, with a header that identifies which backend was measured.
+Fleet seeds (`pnpm db:seed:fleet-marketing`, etc.) **refuse** this target unless
+`REVEALUI_ALLOW_PROBE_DB=1` (see `scripts/lib/seed-env.ts`).
 
-## Why local, not prod
+## Durable rule (do not re-break local dev)
 
-- The first Forge customer's deployment is local-box, not cloud. The honest
-  number is the local number; the cloud path adds Vercel→Electric
-  and Electric→Neon hops that the customer won't experience.
-- Avoids writing 50 POSTs into a prod shape other subscribers read.
-- Secrets posture: the script pulls from revvault rather than
-  env-vars you have to paste anywhere.
+**Never leave the probe URL in `apps/admin/.env.local`.**
 
-## One-time setup (~10 min)
+That file is the durable admin database pointer (and is loaded by seed scripts).
+Swapping it to port 5434 for a probe run, then forgetting to restore, makes every
+later seed/bootstrap fail with a cryptic connection error against a dead port.
 
-### 1. Store the config values in revvault
+Use **session-scoped env** or a **separate probe env file** (below). Do not
+`sed` the durable `.env.local` as the primary workflow.
 
-Revvault is the single source of truth for all secrets. See
-`~/.claude/rules/secrets.md` for the hard rule.
+## Runbook
 
-```bash
-# Electric service URL — LOCAL running Electric (see step 2). Do NOT use prod.
-echo "http://localhost:5133" | revvault set revealui/dev/electric/service-url
+### 1. Prerequisites
 
-# The admin app base URL (usually localhost:4000 in dev).
-echo "http://localhost:4000" | revvault set revealui/dev/admin-base-url
+- Docker
+- A cookie for an authenticated admin session (see step 5) stored in revvault:
+  `revealui/dev/admin-session-cookie`
 
-# Session cookie — deferred to step 5 (requires signed-in browser session).
-```
-
-(Electric's shared secret, if any, is handled server-side by the admin
-proxy — the probe doesn't need its own copy in revvault.)
-
-All command blocks below assume your shell is at the repo root.
-
-### 2. Bring up the probe stack (postgres + electric)
-
-Isolated compose in this directory. Uses ports 5434 (postgres) and 5133
-(electric) — doesn't collide with any other compose.
+### 2. Bring up the probe stack
 
 ```bash
 docker compose -f scripts/electric-latency-probe/docker-compose.yml up -d
@@ -56,104 +39,86 @@ docker compose -f scripts/electric-latency-probe/docker-compose.yml ps
 # Both services should report "healthy" within ~30s.
 ```
 
-### 3. Apply the schema to the probe postgres
-
-Drizzle migrations create the tables the probe writes to (`shared_facts`,
-etc.). Run once after bringing up the stack:
+### 3. Apply schema to the probe postgres (session env only)
 
 ```bash
-DATABASE_URL='postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable' \
+export PROBE_DATABASE_URL='postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable'
+
+DATABASE_URL="$PROBE_DATABASE_URL" POSTGRES_URL="$PROBE_DATABASE_URL" \
   pnpm --filter @revealui/db db:migrate
 ```
 
-### 4. Point admin at the probe DB for this session
+### 4. Point **this shell** (or a probe-only env file) at the probe DB
 
-The admin app's `.env.local` usually points at cloud. For the probe run,
-swap `DATABASE_URL` to the probe DB. Back up first so the swap is reversible:
+**Preferred — session env (no file mutation):**
 
 ```bash
-cp apps/admin/.env.local apps/admin/.env.local.backup
+export DATABASE_URL="$PROBE_DATABASE_URL"
+export POSTGRES_URL="$PROBE_DATABASE_URL"
+export ELECTRIC_SERVICE_URL='http://localhost:5133'
 
-# Replace the DATABASE_URL line:
-sed -i 's|^DATABASE_URL=.*|DATABASE_URL=postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable|' \
-  apps/admin/.env.local
-
-# Add the probe Electric URL (or edit if present):
-grep -q '^ELECTRIC_SERVICE_URL=' apps/admin/.env.local \
-  && sed -i 's|^ELECTRIC_SERVICE_URL=.*|ELECTRIC_SERVICE_URL=http://localhost:5133|' apps/admin/.env.local \
-  || echo 'ELECTRIC_SERVICE_URL=http://localhost:5133' >> apps/admin/.env.local
+pnpm dev:admin
+# admin uses the process env for this terminal only
 ```
 
-Restore after the probe run:
-`cp apps/admin/.env.local.backup apps/admin/.env.local && rm apps/admin/.env.local.backup`.
+**Alternate — probe-only env file (never overwrite durable .env.local):**
 
-### 5. Start admin, sign in, store session cookie
+```bash
+# Create once; gitignored via .env*.local
+cat > apps/admin/.env.probe.local <<'EOF'
+DATABASE_URL=postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable
+POSTGRES_URL=postgres://revealui:revealui@localhost:5434/revealui_probe?sslmode=disable
+ELECTRIC_SERVICE_URL=http://localhost:5133
+EOF
+
+# Load only for the probe session (example):
+set -a && source apps/admin/.env.probe.local && set +a
+pnpm dev:admin
+```
+
+**Forbidden as the durable workflow:** permanently rewriting
+`apps/admin/.env.local` with a `sed` that points at 5434. If you must edit a
+file for an old tool, take a timestamped backup and restore in the same shell
+session before you leave:
+
+```bash
+# Discouraged; only if a tool cannot accept env overrides
+cp apps/admin/.env.local "apps/admin/.env.local.bak.$(date +%Y%m%d%H%M%S)"
+# …edit…
+# restore before any fleet seed / normal admin work:
+# cp apps/admin/.env.local.bak.<timestamp> apps/admin/.env.local
+```
+
+### 5. Sign in and store session cookie
 
 ```bash
 pnpm dev:admin
-# admin now serving on http://localhost:4000
+# http://localhost:4000
 ```
-
-In a browser:
 
 1. Open `http://localhost:4000/admin`
-2. Create an account (fresh probe DB has no users)
-3. Devtools → Application → Cookies → `localhost:4000` → copy the value
-   of `revealui-session`
-4. Store it in revvault:
-
-```bash
-echo '<cookie_value>' | revvault set revealui/dev/admin-session-cookie
-```
+2. Create an account on the **probe** DB (fresh each volume)
+3. Devtools → Cookies → copy `revealui-session`
+4. `echo '<cookie_value>' | revvault set revealui/dev/admin-session-cookie`
 
 ### 6. Run the probe
 
 ```bash
+# Still with PROBE_DATABASE_URL / ELECTRIC_SERVICE_URL in this shell
 pnpm exec tsx scripts/electric-latency-probe/probe.ts
-
-# Output file:
-#   scripts/electric-latency-probe/latency-notes-<timestamp>.md
+# → scripts/electric-latency-probe/latency-notes-<timestamp>.md
 ```
 
 ### 7. Teardown
 
 ```bash
-# Restore admin env
-cp apps/admin/.env.local.backup apps/admin/.env.local && rm apps/admin/.env.local.backup
-
-# Bring down the probe stack (-v removes the postgres volume → fresh DB next time)
 docker compose -f scripts/electric-latency-probe/docker-compose.yml down -v
+unset DATABASE_URL POSTGRES_URL ELECTRIC_SERVICE_URL PROBE_DATABASE_URL
+# Confirm durable admin env still points at docker-compose :5432 or Neon — not 5434
 ```
 
-## Known gotchas — verify before first run
+## Known gotchas
 
-- [ ] **AI feature gate.** The shared-facts mutation route may run through
-      `checkAIFeatureGate`. If it rejects without a license key, the first
-      write fails with 403 and the probe exits before warmup completes.
-      Resolve by issuing a dev license or bypassing the gate for
-      localhost in dev mode.
-- [ ] **session_id uniqueness.** Probe uses a UUID prefixed `probe-`,
-      visible in the notes file header. Low clash risk; flagged for
-      traceability only.
-
-## What it measures (two timings per write)
-
-- **mutation_accepted_to_subscriber_ms** — wall-clock from
-  `POST /api/sync/shared-facts` returning 201 (server has committed
-  the row) to the subscriber's callback firing with the new row.
-  **This is the number you quote in the room.**
-- **commit_confirmed_to_subscriber_ms** — wall-clock from the `fetch`
-  call starting to the subscriber's callback firing. Includes the
-  mutation route's own latency (auth, validation, DB insert, network).
-  **Diagnostic only.** Use to decompose if the room number regresses.
-
-Output has both, labeled unambiguously.
-
-## What it does NOT measure
-
-- Concurrent load. All writes are serial. Don't quote the measured
-  number as an upper bound on propagation under concurrent writes —
-  the real number at 50 concurrent agents is unknown and not addressed
-  by this script. If someone asks, say exactly that.
-- The Vercel → Electric → Neon cloud path. Prod would have that
-  plus CDN caching behavior we don't simulate here.
+- [ ] **AI feature gate.** Shared-facts mutation may require a dev license.
+- [ ] **session_id uniqueness.** Probe uses a UUID prefixed `probe-`.
+- [ ] **Fleet seed refusal.** If you see `Seed refused the electric-latency-probe database`, your durable env still points at 5434; fix `apps/admin/.env.local` or export a real `POSTGRES_URL` before re-running `pnpm db:seed:fleet-marketing`.

--- a/scripts/lib/__tests__/seed-env.test.ts
+++ b/scripts/lib/__tests__/seed-env.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  assertSeedDatabaseReady,
+  isProbeDatabaseUrl,
+  parseDbTarget,
+  redactDatabaseUrl,
+  resolveSeedOwnerEmailCandidates,
+  SeedEnvError,
+} from '../seed-env.js';
+
+describe('parseDbTarget / redact / probe detect', () => {
+  it('parses postgres URLs without exposing password', () => {
+    const target = parseDbTarget(
+      'postgres://revealui:secret@localhost:5434/revealui_probe?sslmode=disable',
+    );
+    expect(target).toEqual({
+      host: 'localhost',
+      port: '5434',
+      database: 'revealui_probe',
+      user: 'revealui',
+    });
+    const redacted = redactDatabaseUrl(
+      'postgres://revealui:secret@localhost:5434/revealui_probe?sslmode=disable',
+    );
+    expect(redacted).not.toContain('secret');
+    expect(redacted).toContain('****');
+  });
+
+  it('flags the electric-latency-probe identity by port or db name', () => {
+    expect(
+      isProbeDatabaseUrl('postgres://revealui:x@localhost:5434/revealui_probe?sslmode=disable'),
+    ).toBe(true);
+    expect(isProbeDatabaseUrl('postgresql://u:p@localhost:5434/anything')).toBe(true);
+    expect(isProbeDatabaseUrl('postgresql://u:p@localhost:5432/revealui_probe')).toBe(true);
+    expect(isProbeDatabaseUrl('postgresql://u:p@localhost:5432/revealui')).toBe(false);
+  });
+});
+
+describe('resolveSeedOwnerEmailCandidates', () => {
+  const prev = process.env.REVEALUI_SEED_OWNER_EMAIL;
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.REVEALUI_SEED_OWNER_EMAIL;
+    else process.env.REVEALUI_SEED_OWNER_EMAIL = prev;
+  });
+
+  it('prefers env override, then revvault, then founder default', () => {
+    delete process.env.REVEALUI_SEED_OWNER_EMAIL;
+    expect(resolveSeedOwnerEmailCandidates({ revvaultEmail: 'ops@example.com' })).toEqual([
+      'ops@example.com',
+      'founder@revealui.com',
+    ]);
+
+    process.env.REVEALUI_SEED_OWNER_EMAIL = 'seed-owner@example.com';
+    expect(resolveSeedOwnerEmailCandidates({ revvaultEmail: 'ops@example.com' })).toEqual([
+      'seed-owner@example.com',
+      'ops@example.com',
+      'founder@revealui.com',
+    ]);
+  });
+});
+
+describe('assertSeedDatabaseReady', () => {
+  const prevAllow = process.env.REVEALUI_ALLOW_PROBE_DB;
+  const prevPg = process.env.POSTGRES_URL;
+  const prevDb = process.env.DATABASE_URL;
+
+  afterEach(() => {
+    if (prevAllow === undefined) delete process.env.REVEALUI_ALLOW_PROBE_DB;
+    else process.env.REVEALUI_ALLOW_PROBE_DB = prevAllow;
+    if (prevPg === undefined) delete process.env.POSTGRES_URL;
+    else process.env.POSTGRES_URL = prevPg;
+    if (prevDb === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDb;
+  });
+
+  it('refuses the probe database with a SeedEnvError', async () => {
+    process.env.POSTGRES_URL =
+      'postgres://revealui:x@localhost:5434/revealui_probe?sslmode=disable';
+    delete process.env.REVEALUI_ALLOW_PROBE_DB;
+
+    await expect(
+      assertSeedDatabaseReady({
+        connect: async () => {
+          /* should not be called */
+        },
+      }),
+    ).rejects.toBeInstanceOf(SeedEnvError);
+
+    await expect(
+      assertSeedDatabaseReady({
+        connect: async () => {
+          /* should not be called */
+        },
+      }),
+    ).rejects.toThrow(/electric-latency-probe|5434|revealui_probe/);
+  });
+
+  it('allows probe when REVEALUI_ALLOW_PROBE_DB=1 and connect succeeds', async () => {
+    process.env.POSTGRES_URL =
+      'postgres://revealui:x@localhost:5434/revealui_probe?sslmode=disable';
+    process.env.REVEALUI_ALLOW_PROBE_DB = '1';
+    let connected = false;
+    const result = await assertSeedDatabaseReady({
+      connect: async () => {
+        connected = true;
+      },
+    });
+    expect(connected).toBe(true);
+    expect(result.target.port).toBe('5434');
+  });
+
+  it('surfaces unreachable databases with host:port/db', async () => {
+    process.env.POSTGRES_URL = 'postgresql://u:p@127.0.0.1:5432/revealui';
+    await expect(
+      assertSeedDatabaseReady({
+        connect: async () => {
+          throw new Error('connect ECONNREFUSED');
+        },
+      }),
+    ).rejects.toThrow(/127\.0\.0\.1:5432\/revealui/);
+  });
+});

--- a/scripts/lib/seed-env.ts
+++ b/scripts/lib/seed-env.ts
@@ -1,0 +1,247 @@
+/**
+ * Shared environment bootstrap for fleet seed scripts.
+ *
+ * Durable rules (do not re-discover the hard way):
+ * 1. Load local dotenv files without overriding a URL already in process.env
+ *    (so `POSTGRES_URL=… pnpm db:seed:fleet-marketing` always wins).
+ * 2. Prefer POSTGRES_URL over DATABASE_URL (same as @revealui/db getClient).
+ * 3. Refuse the electric-latency-probe database (port 5434 / db revealui_probe)
+ *    for fleet seeds unless REVEALUI_ALLOW_PROBE_DB=1 — that DB is ephemeral and
+ *    must never be the silent target of marketing seed / bootstrap.
+ * 4. Fail loud with a redacted host:port/db when the URL is missing or unreachable.
+ *
+ * Owner resolution for site.ownerId is separate (see resolveSeedOwnerEmail).
+ */
+
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { config } from 'dotenv';
+
+const require = createRequire(import.meta.url);
+
+const DEFAULT_ENV_FILES = [
+  '.env',
+  '.env.development.local',
+  '.env.local',
+  'apps/server/.env.vercel',
+  'apps/admin/.env.local',
+] as const;
+
+/** Well-known electric-latency-probe compose identity (scripts/electric-latency-probe/). */
+export const PROBE_DB_PORT = '5434';
+export const PROBE_DB_NAME = 'revealui_probe';
+
+export interface ParsedDbTarget {
+  readonly host: string;
+  readonly port: string;
+  readonly database: string;
+  readonly user: string;
+}
+
+/**
+ * Parse a Postgres URL for logging / probe detection. Never returns the password.
+ * Accepts both `postgres://` and `postgresql://`.
+ */
+export function parseDbTarget(raw: string): ParsedDbTarget | null {
+  try {
+    const normalized = raw.startsWith('postgres:') ? raw.replace(/^postgres(ql)?:/i, 'http:') : raw;
+    const url = new URL(normalized);
+    const database = url.pathname.replace(/^\//, '').split('?')[0] ?? '';
+    return {
+      host: url.hostname || 'localhost',
+      port: url.port || '5432',
+      database,
+      user: decodeURIComponent(url.username || ''),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Redact password from a connection string for logs. */
+export function redactDatabaseUrl(raw: string): string {
+  try {
+    const normalized = raw.startsWith('postgres:') ? raw.replace(/^postgres(ql)?:/i, 'http:') : raw;
+    const url = new URL(normalized);
+    if (url.password) url.password = '****';
+    return url
+      .toString()
+      .replace(/^http:/, raw.startsWith('postgresql:') ? 'postgresql:' : 'postgres:');
+  } catch {
+    return '[unparseable database url]';
+  }
+}
+
+/**
+ * True when the URL targets the electric-latency-probe stack.
+ * Probe identity is port 5434 and/or database name `revealui_probe`.
+ */
+export function isProbeDatabaseUrl(raw: string): boolean {
+  const target = parseDbTarget(raw);
+  if (!target) return false;
+  if (target.port === PROBE_DB_PORT) return true;
+  if (target.database === PROBE_DB_NAME) return true;
+  return false;
+}
+
+/**
+ * Load dotenv files into process.env (no override of already-set vars).
+ * Then promote DATABASE_URL → POSTGRES_URL when only the former is set so
+ * seed scripts and getClient share one resolution order.
+ */
+export function loadSeedEnv(
+  rootDir: string,
+  envFiles: readonly string[] = DEFAULT_ENV_FILES,
+): void {
+  for (const envFile of envFiles) {
+    config({ path: resolve(rootDir, envFile), override: false });
+  }
+
+  if (!process.env.POSTGRES_URL && process.env.DATABASE_URL) {
+    process.env.POSTGRES_URL = process.env.DATABASE_URL;
+  }
+}
+
+/** Resolved connection string after loadSeedEnv (POSTGRES_URL preferred). */
+export function resolveSeedDatabaseUrl(): string | undefined {
+  const candidates = [process.env.POSTGRES_URL, process.env.DATABASE_URL];
+  return candidates.find((v): v is string => typeof v === 'string' && v.length > 0);
+}
+
+export class SeedEnvError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SeedEnvError';
+  }
+}
+
+/**
+ * Fail closed when the configured URL is missing, is the probe DB, or cannot
+ * accept a connection. Call after loadSeedEnv(), before getClient().
+ *
+ * Escape hatch (tests / intentional probe work only):
+ *   REVEALUI_ALLOW_PROBE_DB=1
+ */
+export async function assertSeedDatabaseReady(options?: {
+  allowProbe?: boolean;
+  connect?: (url: string) => Promise<void>;
+}): Promise<{ url: string; target: ParsedDbTarget }> {
+  const url = resolveSeedDatabaseUrl();
+  if (!url) {
+    throw new SeedEnvError(
+      'No database URL for seed. Set POSTGRES_URL (preferred) or DATABASE_URL to the ' +
+        'local docker-compose Postgres (default host port 5432) or your Neon branch. ' +
+        'Example local: POSTGRES_URL=postgresql://…@127.0.0.1:5432/revealui',
+    );
+  }
+
+  const allowProbe = options?.allowProbe === true || process.env.REVEALUI_ALLOW_PROBE_DB === '1';
+
+  if (isProbeDatabaseUrl(url) && !allowProbe) {
+    const target = parseDbTarget(url);
+    throw new SeedEnvError(
+      [
+        'Seed refused the electric-latency-probe database.',
+        target
+          ? `  target: ${target.host}:${target.port}/${target.database}`
+          : `  url: ${redactDatabaseUrl(url)}`,
+        'That stack is ephemeral (scripts/electric-latency-probe/, port 5434 / db revealui_probe)',
+        'and must not receive fleet-marketing or admin seed writes.',
+        '',
+        'Fix (durable):',
+        '  1. Point apps/admin/.env.local DATABASE_URL / POSTGRES_URL at docker-compose Postgres',
+        '     (default host port 5432, not 5434) or your real Neon URL from revvault.',
+        '  2. Never leave the probe URL in .env.local after a latency probe — use a session',
+        '     env override or apps/admin/.env.probe.local (see probe README).',
+        '  3. Escape hatch only for intentional probe work: REVEALUI_ALLOW_PROBE_DB=1',
+      ].join('\n'),
+    );
+  }
+
+  const target = parseDbTarget(url);
+  if (!target) {
+    throw new SeedEnvError(
+      `Database URL is unparseable: ${redactDatabaseUrl(url)}. Expected a postgres:// or postgresql:// URL.`,
+    );
+  }
+
+  const connect =
+    options?.connect ??
+    (async (connectionString: string) => {
+      const { default: pg } = await import('pg');
+      const client = new pg.Client({
+        connectionString,
+        connectionTimeoutMillis: 4_000,
+      });
+      try {
+        await client.connect();
+        await client.query('select 1');
+      } finally {
+        await client.end().catch(() => {
+          /* ignore close errors */
+        });
+      }
+    });
+
+  try {
+    await connect(url);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new SeedEnvError(
+      [
+        `Database unreachable at ${target.host}:${target.port}/${target.database}.`,
+        `  ${detail}`,
+        '',
+        'Check:',
+        '  - docker compose postgres is up on the host port in your URL (default 5432)',
+        '  - POSTGRES_URL is not a stale probe (5434 / revealui_probe)',
+        '  - credentials match the running container',
+      ].join('\n'),
+    );
+  }
+
+  return { url, target };
+}
+
+/**
+ * Resolve which user email owns the fleet-marketing site row.
+ *
+ * Order (first that yields a non-empty string):
+ *   1. REVEALUI_SEED_OWNER_EMAIL (explicit operator override)
+ *   2. revealui/{env}/admin/bootstrap/email via revvault when available
+ *   3. founder@revealui.com (historical seed default)
+ *
+ * The seed then looks up that email in `users`. If missing, it may fall back to
+ * the first active owner/admin (see seed script).
+ */
+export function resolveSeedOwnerEmailCandidates(options?: {
+  env?: string;
+  revvaultEmail?: string | null;
+}): string[] {
+  const out: string[] = [];
+  const push = (value: string | undefined | null): void => {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (trimmed.length > 0 && !out.includes(trimmed)) out.push(trimmed);
+  };
+
+  push(process.env.REVEALUI_SEED_OWNER_EMAIL);
+  push(options?.revvaultEmail);
+  push('founder@revealui.com');
+  return out;
+}
+
+/**
+ * Best-effort read of the bootstrap email from revvault (no throw).
+ * Uses the same path layout as `pnpm admin:bootstrap`.
+ */
+export function tryReadBootstrapEmailFromRevvault(env = 'dev'): string | null {
+  try {
+    // Lazy require so seed scripts still run when @revealui/setup is not built.
+    const { readRevvaultSecret } = require('@revealui/setup/revvault') as {
+      readRevvaultSecret: (path: string) => string | null;
+    };
+    return readRevvaultSecret(`revealui/${env}/admin/bootstrap/email`);
+  } catch {
+    return null;
+  }
+}

--- a/scripts/seed-fleet-marketing-home-page.ts
+++ b/scripts/seed-fleet-marketing-home-page.ts
@@ -17,23 +17,17 @@
  * Usage:
  *   pnpm tsx scripts/seed-fleet-marketing-home-page.ts
  *   pnpm tsx scripts/seed-fleet-marketing-home-page.ts -- --dry-run
+ *
+ * Database resolution: see scripts/lib/seed-env.ts (POSTGRES_URL preferred;
+ * electric-latency-probe DB refused unless REVEALUI_ALLOW_PROBE_DB=1).
  */
 
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
-import { config } from 'dotenv';
+import { assertSeedDatabaseReady, loadSeedEnv, SeedEnvError } from './lib/seed-env.js';
 
 const rootDir = resolve(import.meta.dirname, '..');
-
-for (const envFile of [
-  '.env',
-  '.env.development.local',
-  '.env.local',
-  'apps/server/.env.vercel',
-  'apps/admin/.env.local',
-]) {
-  config({ path: resolve(rootDir, envFile), override: false });
-}
+loadSeedEnv(rootDir);
 
 const SITE_ID = 'fleet-marketing';
 const HOME_SLUG = 'home';
@@ -52,6 +46,10 @@ async function main(): Promise<void> {
   if (dryRun) {
     log.warn('DRY RUN — no writes will be made');
   }
+
+  const { url, target } = await assertSeedDatabaseReady();
+  log.info(`Database ${target.host}:${target.port}/${target.database}`);
+  process.env.POSTGRES_URL = url;
 
   const { getClient } = await import('@revealui/db/client');
   const { pages, sites } = await import('@revealui/db/schema');
@@ -183,6 +181,10 @@ async function main(): Promise<void> {
 try {
   await main();
 } catch (error) {
+  if (error instanceof SeedEnvError) {
+    log.error(error.message);
+    process.exit(1);
+  }
   log.error(`Fatal: ${error instanceof Error ? error.message : String(error)}`);
   process.exit(1);
 }

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -12,39 +12,42 @@
  * Idempotent: the site row is inserted once; each page is inserted if missing,
  * updated (with an optimistic version guard) only when its blocks changed, and
  * skipped when its blocks already match. Soft-deleted pages are surfaced, never
- * silently resurrected. Fails fast if the founder user or the site row is
- * missing (bootstrap + site seed must run first).
+ * silently resurrected.
+ *
+ * Database / owner resolution (durable — see scripts/lib/seed-env.ts):
+ *   - POSTGRES_URL preferred over DATABASE_URL; process env wins over dotenv files
+ *   - electric-latency-probe DB (5434 / revealui_probe) is refused unless
+ *     REVEALUI_ALLOW_PROBE_DB=1
+ *   - Site owner email: REVEALUI_SEED_OWNER_EMAIL → revvault bootstrap email →
+ *     founder@revealui.com → first active owner/admin user
  *
  * Usage:
- *   pnpm tsx scripts/seed-fleet-marketing-site.ts
+ *   pnpm db:seed:fleet-marketing
  *   pnpm tsx scripts/seed-fleet-marketing-site.ts -- --dry-run
+ *   POSTGRES_URL=postgresql://…@127.0.0.1:5432/revealui pnpm db:seed:fleet-marketing
  *
  * Spec: the internal visual-edit-sessions spec (2026-07-02); Phase A.2 row A2.
  */
 
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
-import { config } from 'dotenv';
 import {
   homeBlocks,
   philosophyBlocks,
   productsBlocks,
 } from '../apps/marketing/app/lib/page-blocks';
+import {
+  assertSeedDatabaseReady,
+  loadSeedEnv,
+  resolveSeedOwnerEmailCandidates,
+  SeedEnvError,
+  tryReadBootstrapEmailFromRevvault,
+} from './lib/seed-env.js';
 
 const rootDir = resolve(import.meta.dirname, '..');
-
-for (const envFile of [
-  '.env',
-  '.env.development.local',
-  '.env.local',
-  'apps/server/.env.vercel',
-  'apps/admin/.env.local',
-]) {
-  config({ path: resolve(rootDir, envFile), override: false });
-}
+loadSeedEnv(rootDir);
 
 const SITE_ID = 'fleet-marketing';
-const FOUNDER_EMAIL = 'founder@revealui.com';
 
 const log = {
   info: (msg: string) => console.log(`  i ${msg}`),
@@ -102,30 +105,85 @@ async function main(): Promise<void> {
     log.warn('DRY RUN — no writes will be made');
   }
 
+  const { url, target } = await assertSeedDatabaseReady();
+  log.info(`Database ${target.host}:${target.port}/${target.database} (POSTGRES_URL preferred)`);
+  // Ensure getClient sees the same URL we validated.
+  process.env.POSTGRES_URL = url;
+
   const { getClient } = await import('@revealui/db/client');
   const { users, sites, pages } = await import('@revealui/db/schema');
-  const { and, eq } = await import('drizzle-orm');
+  const { and, eq, inArray } = await import('drizzle-orm');
 
   const db = getClient('rest');
 
   // ---------------------------------------------------------------------------
-  // Site row
+  // Site row — owner resolution (env → revvault bootstrap email → founder → role)
   // ---------------------------------------------------------------------------
 
-  const founderRows = await db
-    .select({ id: users.id })
-    .from(users)
-    .where(eq(users.email, FOUNDER_EMAIL))
-    .limit(1);
+  const revvaultEmail = tryReadBootstrapEmailFromRevvault(
+    process.env.REVEALUI_ENV === 'production' || process.env.NODE_ENV === 'production'
+      ? 'prod'
+      : 'dev',
+  );
+  const emailCandidates = resolveSeedOwnerEmailCandidates({ revvaultEmail });
 
-  if (founderRows.length === 0) {
-    log.error(`Founder user not found: ${FOUNDER_EMAIL}`);
-    log.error('Run pnpm admin:bootstrap (or pnpm db:seed:admin) first, then re-run this script.');
-    process.exit(1);
+  let ownerId: string | undefined;
+  let ownerEmail: string | undefined;
+  let ownerSource: string | undefined;
+
+  for (const email of emailCandidates) {
+    const rows = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+    if (rows.length > 0 && rows[0].email) {
+      ownerId = rows[0].id;
+      ownerEmail = rows[0].email;
+      ownerSource =
+        email === process.env.REVEALUI_SEED_OWNER_EMAIL
+          ? 'REVEALUI_SEED_OWNER_EMAIL'
+          : email === revvaultEmail
+            ? 'revvault bootstrap email'
+            : 'seed default founder@revealui.com';
+      break;
+    }
   }
 
-  const ownerId = founderRows[0].id;
-  log.info(`Resolved ownerId for ${FOUNDER_EMAIL}: ${ownerId}`);
+  if (!(ownerId && ownerEmail)) {
+    const roleRows = await db
+      .select({ id: users.id, email: users.email, role: users.role })
+      .from(users)
+      .where(inArray(users.role, ['owner', 'admin']))
+      .limit(5);
+    const usable = roleRows.find((r) => typeof r.email === 'string' && r.email.length > 0);
+    if (usable?.email) {
+      log.warn(
+        `No seed owner matched ${emailCandidates.join(' | ')}. ` +
+          `Using first ${usable.role} user ${usable.email}. ` +
+          'Set REVEALUI_SEED_OWNER_EMAIL or run pnpm admin:bootstrap for a stable owner.',
+      );
+      ownerId = usable.id;
+      ownerEmail = usable.email;
+      ownerSource = `fallback role=${usable.role}`;
+    }
+  }
+
+  if (!(ownerId && ownerEmail)) {
+    throw new SeedEnvError(
+      [
+        'No site owner user found for fleet-marketing seed.',
+        `  looked for emails: ${emailCandidates.join(', ')}`,
+        '  also looked for any user with role owner|admin',
+        '',
+        'Fix:',
+        '  pnpm admin:bootstrap -- --env=dev --force --no-seed',
+        '  # or: REVEALUI_SEED_OWNER_EMAIL=<existing-user-email> pnpm db:seed:fleet-marketing',
+      ].join('\n'),
+    );
+  }
+
+  log.info(`Resolved ownerId for ${ownerEmail} (${ownerSource}): ${ownerId}`);
 
   const existingSite = await db
     .select({ id: sites.id, slug: sites.slug, status: sites.status })
@@ -284,6 +342,10 @@ async function main(): Promise<void> {
 try {
   await main();
 } catch (error) {
+  if (error instanceof SeedEnvError) {
+    log.error(error.message);
+    process.exit(1);
+  }
   log.error(`Fatal: ${error instanceof Error ? error.message : String(error)}`);
   if (error instanceof Error && error.stack) {
     log.error(error.stack);


### PR DESCRIPTION
## Summary

Long-term fix for fleet seed / local DB footguns (electric-latency-probe leftovers).

### Root cause
`scripts/electric-latency-probe/README.md` taught operators to `sed` `apps/admin/.env.local` to `localhost:5434/revealui_probe`. Leaving that in place made every later `pnpm db:seed:fleet-marketing` hit a dead port with a cryptic Drizzle error. Seed also hard-required `founder@revealui.com` even when a local owner already existed.

### Durable solution
1. **`scripts/lib/seed-env.ts`** — shared seed bootstrap:
   - dotenv without clobbering process env
   - prefer `POSTGRES_URL` over `DATABASE_URL`
   - **refuse probe identity** (port `5434` or db `revealui_probe`) unless `REVEALUI_ALLOW_PROBE_DB=1`
   - connectivity preflight with **redacted** host:port/db
   - owner email candidates: `REVEALUI_SEED_OWNER_EMAIL` → revvault bootstrap email → `founder@revealui.com` → first active owner/admin
2. Wire **both** fleet-marketing seed scripts through it.
3. **Probe README** rewritten: session env or `.env.probe.local` only — never permanent rewrite of durable `.env.local`.
4. Unit tests for probe detection, owner candidates, refuse/allow paths.

### Local machine (not in PR)
`apps/admin/.env.local` on this workstation was already corrected 5434/probe → 5432/revealui (gitignored).

## Test plan
- [x] `vitest run scripts/lib/__tests__/seed-env.test.ts` (6)
- [x] Probe URL dry-run: refused with clear message
- [x] Live docker 5432 dry-run: connects + resolves owner
- [x] pre-push phase-1 gate PASS

## Notes
Not security-sensitive (seed scripts + docs). Escape hatch `REVEALUI_ALLOW_PROBE_DB=1` is intentional for probe-only work.
