### PR TITLE
feat(server): free-pro-gate upgrade_intent on requireFeature denials

### DIFF
--- a/apps/server/src/lib/nudges/__tests__/triggers.test.ts
+++ b/apps/server/src/lib/nudges/__tests__/triggers.test.ts
@@ -65,6 +65,13 @@ describe('buildCandidates — tier gating', () => {
       'pro-read-receipts',
     );
   });
+
+  it('free-pro-gate appears only for free tier once upgrade intent is recorded', () => {
+    const withIntent: NudgeSignals = { ...BASE_SIGNALS, hasUpgradeIntent: true };
+    expect(ids(buildCandidates('free', withIntent))).toContain('free-pro-gate');
+    expect(ids(buildCandidates('pro', withIntent))).not.toContain('free-pro-gate');
+    expect(ids(buildCandidates('free', BASE_SIGNALS))).not.toContain('free-pro-gate');
+  });
 });
 
 describe('buildCandidates — retirement on milestone event', () => {

--- a/apps/server/src/lib/nudges/definitions.ts
+++ b/apps/server/src/lib/nudges/definitions.ts
@@ -6,10 +6,9 @@
  * one of them. Copy is VERBATIM from §7 — do not paraphrase headline,
  * body, or CTA text when editing this file.
  *
- * Live trigger evaluators: free-first-*, pro-first-action, pro-read-receipts,
- * max-local-inference, max-export-audit, ent-second-tenant.
- * Still deferred: free-pro-gate (needs security-reviewed requireFeature write),
- * pro-license-wire (self-hosted env), pro-connect-data (MCP map),
+ * Live trigger evaluators: free-first-*, free-pro-gate, pro-first-action,
+ * pro-read-receipts, max-local-inference, max-export-audit, ent-second-tenant.
+ * Still deferred: pro-license-wire (self-hosted env), pro-connect-data (MCP),
  * max-enable-memory (no toggle).
  */
 
@@ -133,6 +132,7 @@ export const NUDGE_DEFINITIONS: Record<NudgeId, NudgeDefinition> = {
 export const IMPLEMENTED_NUDGE_IDS: readonly NudgeId[] = [
   'free-first-reply',
   'free-first-content',
+  'free-pro-gate',
   'pro-first-action',
   'pro-read-receipts',
   'max-local-inference',

--- a/apps/server/src/lib/nudges/milestone-meters.ts
+++ b/apps/server/src/lib/nudges/milestone-meters.ts
@@ -14,11 +14,7 @@ import { AUDIT_EXPORT_METER_NAME } from './triggers.js';
 /** First successful GET /admin/audit list (viewed the trail once). */
 export const AUDIT_VIEW_METER_NAME = 'audit_view';
 
-/**
- * Free-tier Pro gate denial (knowingly hit a paid feature).
- * Writer lives with requireFeature (security-reviewed surface); constant
- * reserved so a follow-up PR can record without redefining the name.
- */
+/** Free-tier Pro gate denial (knowingly hit a paid feature via requireFeature). */
 export const UPGRADE_INTENT_METER_NAME = 'upgrade_intent';
 
 export { AUDIT_EXPORT_METER_NAME };

--- a/apps/server/src/lib/nudges/triggers.ts
+++ b/apps/server/src/lib/nudges/triggers.ts
@@ -74,10 +74,9 @@ export function buildCandidates(tier: LicenseTier, signals: NudgeSignals): Nudge
     if (signals.userChatMessageCount >= 3 && !signals.hasPageOrProduct) {
       candidates.push({ id: 'free-first-content', milestone: 'hour24' });
     }
-    // free-pro-gate deferred: recording upgrade_intent requires requireFeature
-    // instrumentation in middleware/license.ts (security-review path). Ship
-    // when a security-reviewed PR lands that write; signal field stays for
-    // that follow-up.
+    if (signals.hasUpgradeIntent) {
+      candidates.push({ id: 'free-pro-gate', milestone: 'day7' });
+    }
   }
 
   if (tier === 'pro' || tier === 'max' || tier === 'enterprise') {

--- a/apps/server/src/middleware/license.ts
+++ b/apps/server/src/middleware/license.ts
@@ -24,6 +24,10 @@ import { trackX402PaymentRequired } from '@revealui/core/observability/metrics';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import {
+  recordMilestoneMeterFirstSafe,
+  UPGRADE_INTENT_METER_NAME,
+} from '../lib/nudges/milestone-meters.js';
+import {
   buildPaymentRequired,
   encodePaymentRequired,
   getAdvertisedCurrencyLabel,
@@ -230,6 +234,19 @@ export const requireFeature = (
     if (!enabled) {
       const requiredTier = getRequiredTier(feature);
       const x402 = getX402Config();
+
+      // GAP-300 free-pro-gate: free-tier callers who knowingly hit a paid gate.
+      // First-ever usage_meters row only (idempotent). Never blocks the denial.
+      // Does not change which requests are allowed/denied.
+      if (currentTier === 'free') {
+        const accountId =
+          requestEntitlements?.accountId ??
+          (c.get('entitlements') as { accountId?: string | null } | undefined)?.accountId;
+        recordMilestoneMeterFirstSafe(accountId, UPGRADE_INTENT_METER_NAME, {
+          feature,
+          path: new URL(c.req.url).pathname,
+        });
+      }
 
       if (x402.enabled) {
         // Check if agent already paid via x402


### PR DESCRIPTION
## Summary

GAP-300 residual: enable **free-pro-gate** by recording a first-ever `upgrade_intent` usage meter when a **free-tier** caller is denied by `requireFeature`.

## Security notes (gate will HOLD until clearance)

Touches `apps/server/src/middleware/license.ts` (SECURITY_PATHS).

| Property | Behavior |
|----------|----------|
| Allow/deny | **Unchanged** — meter write is after the feature is already known disabled |
| Scope | `currentTier === 'free'` only |
| Idempotency | `nudge:upgrade_intent:first:${accountId}` via existing `recordUsageMeter` |
| Failure mode | Best-effort; denial response always returns |
| Data | No secrets; accountId + feature name in warn logs only on meter failure |

**Not a privilege escalation path.** Does not widen feature access.

## Product effect

- Free users who hit a paid gate once get the free-pro-gate §7 nudge (when selection runs).
- Live triggers become **8 of 11** (same count as planned after #2053 + this).

## Tests

`pnpm --filter server exec vitest run src/lib/nudges` — 40/40.

## Owner actions (required for merge)

1. Non-author security review with guardrail-2 marker (or explicit approve).
2. Clear the security review gate:

```bash
gh pr edit 2055 -R RevealUIStudio/revealui --add-label sec-review:approved
# or merge after APPROVED reviewDecision
gh pr merge 2055 -R RevealUIStudio/revealui --squash
```

(Replace PR number if different.)

## Out of scope

GAP-240 signup flip, lifecycle email arming, remaining deferred nudges (license-wire / MCP / memory toggle).
