### PR TITLE
docs(grok): monorepo worktree isolation + GAP-398 residual floor note

### DIFF
--- a/.grok/rules/monorepo.md
+++ b/.grok/rules/monorepo.md
@@ -41,3 +41,11 @@ Shared branch policy is **not** authored here (Plane A). Canon:
 `~/.claude/rules/git.md` + revcon `profiles/revfleet/claude/rules/git.md`.
 Launch: `rfg` (Plane C). Architecture ADR:
 `2026-07-21-harness-policy-runtime-launch-planes`.
+
+## Worktree isolation (HARDLINE)
+
+Multi-step edits: `git worktree add ~/revfleet/.wt/<name> -b <branch> origin/test`.  
+Do not use the shared `~/revfleet/revealui` checkout for concurrent claims.  
+Dirty branch switches are blocked by `dirty-checkout-guard.js`.  
+Full rule: `~/.grok/rules/06-worktree-isolation.md`.  
+Preferred launch: `rfg revealui --worktree=<label>` (injects `--ref test` when omitted).

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -1,5 +1,5 @@
 {
-  "description": "Allowlisted Tier-1 JSX intrinsics in apps/* until burned to presentation components (GAP-398). Each entry needs a non-empty reason.",
+  "description": "Allowlisted Tier-1 JSX intrinsics in apps/* (GAP-398 residual floor). Hard-fail gate: pnpm validate:tier1-presentation -- --hard-fail. Each entry needs a non-empty reason. Intentional floor classes: data charts, Lexical letterform toolbar icons, CMS/content-driven path icons. ADR 2026-05-16 amendment 2026-07-21. Do not empty without new presentation primitives.",
   "entries": [
     {
       "path": "apps/admin/src/components/revealui/sections/stats-with-graph.tsx",


### PR DESCRIPTION
docs(grok): monorepo worktree isolation hardline + residual allowlist note

Pin multi-step product work to origin/test worktrees in project Grok rules.
Clarify GAP-398 residual floor purpose on the tier1 allowlist description
(policy pointer; no host rewrites).
