### PR TITLE
fix(harnesses): GAP-390 keep SIGKILL timer ref'd on drain

### DIFF
--- a/packages/harnesses/src/coordinator.ts
+++ b/packages/harnesses/src/coordinator.ts
@@ -150,9 +150,10 @@ export class HarnessCoordinator {
       this.httpGateway = null;
     }
 
-    // Stop all spawned agent processes
+    // Stop all spawned agent processes (GAP-390: wait for SIGKILL grace so
+    // SIGTERM-ignoring children are not orphaned on event-loop drain).
     if (this.spawner) {
-      await this.spawner.stopAll();
+      await this.spawner.stopAllAndWait();
       this.spawner = null;
     }
     this.inference = null;

--- a/packages/harnesses/src/server/__tests__/spawner-service.test.ts
+++ b/packages/harnesses/src/server/__tests__/spawner-service.test.ts
@@ -102,4 +102,32 @@ describe('SpawnerService termination (D6)', () => {
     await exited;
     expect(service.list()[0]?.status).not.toBe('running');
   });
+
+  it('stopAllAndWait SIGKILLs a SIGTERM-ignoring child (GAP-390 drain)', async () => {
+    service = new SpawnerService({ terminationGraceMs: 100 });
+    service.spawn('wedged', 'Ollama', 'model', 'prompt');
+    await waitReady(service);
+    const pid = service.list()[0]?.pid;
+    expect(pid).toBeTypeOf('number');
+
+    const start = Date.now();
+    await service.stopAllAndWait();
+    // Grace elapsed then SIGKILL; must not resolve early as if unref-drained.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+    expect(service.list()[0]?.status).toBe('stopped');
+
+    // Child is actually dead (ESRCH on signal 0).
+    expect(() => process.kill(pid as number, 0)).toThrow();
+  });
+
+  it('intentional stop of SIGTERM-ignorer maps to stopped not errored', async () => {
+    service = new SpawnerService({ terminationGraceMs: 80 });
+    const id = service.spawn('wedged', 'Ollama', 'model', 'prompt');
+    await waitReady(service);
+
+    const exited = onceExit(service);
+    service.stop(id);
+    await exited;
+    expect(service.list()[0]?.status).toBe('stopped');
+  });
 });

--- a/packages/harnesses/src/server/spawner-service.ts
+++ b/packages/harnesses/src/server/spawner-service.ts
@@ -58,6 +58,11 @@ interface AgentProcess {
   status: 'running' | 'stopped' | 'errored';
   /** Pending SIGKILL escalation timer, set while a SIGTERM grace window is open. */
   graceTimer?: ReturnType<typeof setTimeout>;
+  /**
+   * True once an intentional terminate() was requested. Maps SIGKILL / non-zero
+   * close during grace to status 'stopped' rather than 'errored' (GAP-390).
+   */
+  terminating?: boolean;
 }
 
 /**
@@ -150,7 +155,12 @@ export class SpawnerService extends EventEmitter {
         clearTimeout(proc.graceTimer);
         proc.graceTimer = undefined;
       }
-      proc.status = code === 0 ? 'stopped' : 'errored';
+      // Intentional terminate (incl. SIGKILL after grace) → stopped, not errored.
+      if (proc.terminating || code === 0) {
+        proc.status = 'stopped';
+      } else {
+        proc.status = 'errored';
+      }
       this.emit('exit', { sessionId, code } satisfies AgentExitEvent);
     });
 
@@ -168,6 +178,8 @@ export class SpawnerService extends EventEmitter {
    * the status transition is event-driven (the child's `close` handler sets the
    * terminal status), so `list()` keeps reporting `running` until the process
    * actually exits.
+   *
+   * If a grace window is already open, returns without re-arming (idempotent).
    */
   stop(sessionId: string): void {
     const proc = this.sessions.get(sessionId);
@@ -205,8 +217,8 @@ export class SpawnerService extends EventEmitter {
   /**
    * Request termination of all running agents (called on daemon shutdown).
    * Same SIGTERM → grace → SIGKILL escalation as `stop`, with event-driven
-   * status, so shutdown neither wedges a child that ignores SIGTERM nor lies
-   * about its status.
+   * status. Prefer `stopAllAndWait()` on the shutdown path so SIGKILL can land
+   * before the process exits (GAP-390).
    */
   stopAll(): void {
     for (const [, proc] of this.sessions) {
@@ -217,13 +229,54 @@ export class SpawnerService extends EventEmitter {
   }
 
   /**
+   * Terminate every running agent and resolve only after each has exited
+   * (or the grace window elapsed and SIGKILL was sent). Holds the event loop
+   * until then so a draining daemon does not orphan SIGTERM-ignoring children
+   * (GAP-390).
+   */
+  async stopAllAndWait(): Promise<void> {
+    const pendingIds: string[] = [];
+    for (const [sessionId, proc] of this.sessions) {
+      if (proc.status === 'running') pendingIds.push(sessionId);
+    }
+    if (pendingIds.length === 0) return;
+
+    const waits = pendingIds.map(
+      (sessionId) =>
+        new Promise<void>((resolve) => {
+          const onExit = (event: AgentExitEvent): void => {
+            if (event.sessionId === sessionId) {
+              this.off('exit', onExit);
+              resolve();
+            }
+          };
+          this.on('exit', onExit);
+          // Race: already closed between snapshot and listener.
+          const proc = this.sessions.get(sessionId);
+          if (!proc || proc.status !== 'running') {
+            this.off('exit', onExit);
+            resolve();
+          }
+        }),
+    );
+
+    this.stopAll();
+    await Promise.all(waits);
+  }
+
+  /**
    * Send SIGTERM and arm a bounded SIGKILL escalation. Status is left `running`;
    * the child's `close` handler owns the terminal transition. Idempotent while a
-   * grace window is already open. The escalation timer is unref'd so it can never
-   * keep the process alive or fire after exit.
+   * grace window is already open.
+   *
+   * GAP-390: the escalation timer stays **ref'd** so it holds the event loop
+   * through the grace window. `close` clears it, so a clean exit never keeps
+   * the process alive past the child's death. Do not `unref()` — that let
+   * stopAll + event-loop drain skip SIGKILL entirely.
    */
   private terminate(proc: AgentProcess): void {
     if (proc.graceTimer) return;
+    proc.terminating = true;
     proc.child.kill('SIGTERM');
     const timer = setTimeout(() => {
       proc.graceTimer = undefined;
@@ -231,7 +284,6 @@ export class SpawnerService extends EventEmitter {
         proc.child.kill('SIGKILL');
       }
     }, this.config.terminationGraceMs);
-    timer.unref?.();
     proc.graceTimer = timer;
   }
 }


### PR DESCRIPTION
## Summary

GAP-390: SpawnerService SIGKILL escalation no longer dies with the event loop on shutdown.

- Remove `timer.unref()` on the SIGTERM→SIGKILL grace timer
- Add `stopAllAndWait()` that resolves after every child exits (or is SIGKILLed)
- Coordinator `stop()` awaits `stopAllAndWait()` so drain cannot orphan wedged children
- Intentional terminate maps close status to `stopped` (not `errored`)
- Tests: SIGTERM-ignorer dead after `stopAllAndWait`; status `stopped`

## Test plan

- [x] `pnpm --filter @revealui/harnesses test` (476 tests)
- [ ] CI on PR

## Notes

Closes INIT-002 Phase 3c residual. Pair with jv GAP-390 close after merge.