### PR TITLE
fix(seed): admin seed package exports + seed-env under direnv

### DIFF
--- a/apps/admin/src/seed.ts
+++ b/apps/admin/src/seed.ts
@@ -9,6 +9,9 @@
  *
  * All seed operations are idempotent (checks for existing entries before creating).
  *
+ * Env: uses scripts/lib/seed-env.ts (same as fleet-marketing) so direnv/Nix
+ * passwordless POSTGRES_URL defaults are demoted and apps/admin/.env.local wins.
+ *
  * Usage:
  *   pnpm db:seed                    # Seed everything
  *   pnpm db:seed -- --pages-only    # Seed pages only
@@ -20,6 +23,15 @@ import { getRevealUI } from '@revealui/core';
 import { getClient } from '@revealui/db';
 import { sites, users } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
+import {
+  assertSeedDatabaseReady,
+  loadSeedEnv,
+  SeedEnvError,
+} from '../../../scripts/lib/seed-env.ts';
+
+// pnpm db:seed:admin runs from monorepo root; seed-env loads apps/admin/.env.local
+// and demotes passwordless direnv/Nix POSTGRES_URL placeholders.
+loadSeedEnv(process.cwd());
 
 const logger = {
   header: (msg: string) =>
@@ -287,6 +299,9 @@ async function main() {
     logger.header('RevealUI Seed');
     logger.info('Initializing admin...\n');
 
+    const { target } = await assertSeedDatabaseReady();
+    logger.info(`Database ${target.host}:${target.port}/${target.database}\n`);
+
     const revealuiConfig = await config;
     const revealui = await getRevealUI({ config: revealuiConfig });
 
@@ -312,6 +327,10 @@ async function main() {
     logger.info('   2. Visit / to see the home page');
     logger.info('   3. Add images via Media collection\n');
   } catch (error) {
+    if (error instanceof SeedEnvError) {
+      logger.error(error.message);
+      process.exit(1);
+    }
     logger.error(`Fatal error: ${error instanceof Error ? error.message : String(error)}`);
     if (error instanceof Error && error.stack) {
       logger.error(`Stack: ${error.stack}`);

--- a/apps/admin/src/seed.ts
+++ b/apps/admin/src/seed.ts
@@ -27,7 +27,7 @@ import {
   assertSeedDatabaseReady,
   loadSeedEnv,
   SeedEnvError,
-} from '../../../scripts/lib/seed-env.ts';
+} from '../../../scripts/lib/seed-env.js';
 
 // pnpm db:seed:admin runs from monorepo root; seed-env loads apps/admin/.env.local
 // and demotes passwordless direnv/Nix POSTGRES_URL placeholders.

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../packages/dev/src/ts/nextjs.json",
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -21,10 +25,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@/types": ["./src/types/index.ts"],
-      "@reveal-config": ["./revealui.config.ts"],
-      "cssVariables": ["./cssVariables.js"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@/types": [
+        "./src/types/index.ts"
+      ],
+      "@reveal-config": [
+        "./revealui.config.ts"
+      ],
+      "cssVariables": [
+        "./cssVariables.js"
+      ]
     },
     "target": "ES2022"
   },
@@ -39,5 +51,9 @@
   "typeAcquisition": {
     "enable": false
   },
-  "exclude": ["node_modules", ".next/types/validator.ts"]
+  "exclude": [
+    "node_modules",
+    ".next/types/validator.ts",
+    "src/seed.ts"
+  ]
 }

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../packages/dev/src/ts/nextjs.json",
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -25,18 +21,10 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@/types": [
-        "./src/types/index.ts"
-      ],
-      "@reveal-config": [
-        "./revealui.config.ts"
-      ],
-      "cssVariables": [
-        "./cssVariables.js"
-      ]
+      "@/*": ["./src/*"],
+      "@/types": ["./src/types/index.ts"],
+      "@reveal-config": ["./revealui.config.ts"],
+      "cssVariables": ["./cssVariables.js"]
     },
     "target": "ES2022"
   },
@@ -51,9 +39,5 @@
   "typeAcquisition": {
     "enable": false
   },
-  "exclude": [
-    "node_modules",
-    ".next/types/validator.ts",
-    "src/seed.ts"
-  ]
+  "exclude": ["node_modules", ".next/types/validator.ts", "src/seed.ts"]
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -47,123 +47,153 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./a2a": {
       "types": "./dist/a2a/index.d.ts",
-      "import": "./dist/a2a/index.js"
+      "import": "./dist/a2a/index.js",
+      "default": "./dist/a2a/index.js"
     },
     "./memory": {
       "types": "./dist/memory/index.d.ts",
-      "import": "./dist/memory/index.js"
+      "import": "./dist/memory/index.js",
+      "default": "./dist/memory/index.js"
     },
     "./memory/stores": {
       "types": "./dist/memory/stores/index.d.ts",
-      "import": "./dist/memory/stores/index.js"
+      "import": "./dist/memory/stores/index.js",
+      "default": "./dist/memory/stores/index.js"
     },
     "./memory/vector": {
       "types": "./dist/memory/vector/index.d.ts",
-      "import": "./dist/memory/vector/index.js"
+      "import": "./dist/memory/vector/index.js",
+      "default": "./dist/memory/vector/index.js"
     },
     "./memory/persistence": {
       "types": "./dist/memory/persistence/index.d.ts",
-      "import": "./dist/memory/persistence/index.js"
+      "import": "./dist/memory/persistence/index.js",
+      "default": "./dist/memory/persistence/index.js"
     },
     "./memory/agent": {
       "types": "./dist/memory/agent/index.d.ts",
-      "import": "./dist/memory/agent/index.js"
+      "import": "./dist/memory/agent/index.js",
+      "default": "./dist/memory/agent/index.js"
     },
     "./memory/services": {
       "types": "./dist/memory/services/index.d.ts",
-      "import": "./dist/memory/services/index.js"
+      "import": "./dist/memory/services/index.js",
+      "default": "./dist/memory/services/index.js"
     },
     "./embeddings": {
       "types": "./dist/embeddings/index.d.ts",
-      "import": "./dist/embeddings/index.js"
+      "import": "./dist/embeddings/index.js",
+      "default": "./dist/embeddings/index.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
-      "import": "./dist/client/index.js"
+      "import": "./dist/client/index.js",
+      "default": "./dist/client/index.js"
     },
     "./skills": {
       "types": "./dist/skills/index.d.ts",
-      "import": "./dist/skills/index.js"
+      "import": "./dist/skills/index.js",
+      "default": "./dist/skills/index.js"
     },
     "./skills/registry": {
       "types": "./dist/skills/registry/index.d.ts",
-      "import": "./dist/skills/registry/index.js"
+      "import": "./dist/skills/registry/index.js",
+      "default": "./dist/skills/registry/index.js"
     },
     "./llm/cache-utils": {
       "types": "./dist/llm/cache-utils.d.ts",
-      "import": "./dist/llm/cache-utils.js"
+      "import": "./dist/llm/cache-utils.js",
+      "default": "./dist/llm/cache-utils.js"
     },
     "./llm/client": {
       "types": "./dist/llm/client.d.ts",
-      "import": "./dist/llm/client.js"
+      "import": "./dist/llm/client.js",
+      "default": "./dist/llm/client.js"
     },
     "./llm/key-validator": {
       "types": "./dist/llm/key-validator.d.ts",
-      "import": "./dist/llm/key-validator.js"
+      "import": "./dist/llm/key-validator.js",
+      "default": "./dist/llm/key-validator.js"
     },
     "./llm/server": {
       "types": "./dist/llm/server.d.ts",
-      "import": "./dist/llm/server.js"
+      "import": "./dist/llm/server.js",
+      "default": "./dist/llm/server.js"
     },
     "./llm/providers/base": {
       "types": "./dist/llm/providers/base.d.ts",
-      "import": "./dist/llm/providers/base.js"
+      "import": "./dist/llm/providers/base.js",
+      "default": "./dist/llm/providers/base.js"
     },
     "./llm/response-cache": {
       "types": "./dist/llm/response-cache.d.ts",
-      "import": "./dist/llm/response-cache.js"
+      "import": "./dist/llm/response-cache.js",
+      "default": "./dist/llm/response-cache.js"
     },
     "./llm/semantic-cache": {
       "types": "./dist/llm/semantic-cache.d.ts",
-      "import": "./dist/llm/semantic-cache.js"
+      "import": "./dist/llm/semantic-cache.js",
+      "default": "./dist/llm/semantic-cache.js"
     },
     "./tools/admin": {
       "types": "./dist/tools/admin/index.d.ts",
-      "import": "./dist/tools/admin/index.js"
+      "import": "./dist/tools/admin/index.js",
+      "default": "./dist/tools/admin/index.js"
     },
     "./tools/registry": {
       "types": "./dist/tools/registry.d.ts",
-      "import": "./dist/tools/registry.js"
+      "import": "./dist/tools/registry.js",
+      "default": "./dist/tools/registry.js"
     },
     "./ingestion": {
       "types": "./dist/ingestion/index.d.ts",
-      "import": "./dist/ingestion/index.js"
+      "import": "./dist/ingestion/index.js",
+      "default": "./dist/ingestion/index.js"
     },
     "./orchestration/runtime": {
       "types": "./dist/orchestration/runtime.d.ts",
-      "import": "./dist/orchestration/runtime.js"
+      "import": "./dist/orchestration/runtime.js",
+      "default": "./dist/orchestration/runtime.js"
     },
     "./orchestration/streaming-runtime": {
       "types": "./dist/orchestration/streaming-runtime.d.ts",
-      "import": "./dist/orchestration/streaming-runtime.js"
+      "import": "./dist/orchestration/streaming-runtime.js",
+      "default": "./dist/orchestration/streaming-runtime.js"
     },
     "./orchestration/agent": {
       "types": "./dist/orchestration/agent.d.ts",
-      "import": "./dist/orchestration/agent.js"
+      "import": "./dist/orchestration/agent.js",
+      "default": "./dist/orchestration/agent.js"
     },
     "./tools/coding": {
       "types": "./dist/tools/coding/index.d.ts",
-      "import": "./dist/tools/coding/index.js"
+      "import": "./dist/tools/coding/index.js",
+      "default": "./dist/tools/coding/index.js"
     },
     "./inference": {
       "types": "./dist/inference/index.d.ts",
-      "import": "./dist/inference/index.js"
+      "import": "./dist/inference/index.js",
+      "default": "./dist/inference/index.js"
     },
     "./inference/context-budget": {
       "types": "./dist/inference/context-budget.d.ts",
-      "import": "./dist/inference/context-budget.js"
+      "import": "./dist/inference/context-budget.js",
+      "default": "./dist/inference/context-budget.js"
     },
     "./inference/tool-result-compressor": {
       "types": "./dist/inference/tool-result-compressor.d.ts",
-      "import": "./dist/inference/tool-result-compressor.js"
+      "import": "./dist/inference/tool-result-compressor.js",
+      "default": "./dist/inference/tool-result-compressor.js"
     },
     "./inference/task-decomposer": {
       "types": "./dist/inference/task-decomposer.d.ts",
-      "import": "./dist/inference/task-decomposer.js"
+      "import": "./dist/inference/task-decomposer.js",
+      "default": "./dist/inference/task-decomposer.js"
     }
   },
   "files": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -38,15 +38,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./server": {
       "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js"
+      "import": "./dist/server/index.js",
+      "default": "./dist/server/index.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",
-      "import": "./dist/react/index.js"
+      "import": "./dist/react/index.js",
+      "default": "./dist/react/index.js"
     }
   },
   "files": [

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -20,11 +20,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./adapters": {
       "types": "./dist/adapters/index.d.ts",
-      "import": "./dist/adapters/index.js"
+      "import": "./dist/adapters/index.js",
+      "default": "./dist/adapters/index.js"
     }
   },
   "files": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,8 @@
   "exports": {
     ".": {
       "types": "./dist/cli.d.ts",
-      "import": "./dist/cli.js"
+      "import": "./dist/cli.js",
+      "default": "./dist/cli.js"
     }
   },
   "files": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,19 +19,23 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./revealui": {
       "types": "./dist/revealui.config.d.ts",
-      "import": "./dist/revealui.config.js"
+      "import": "./dist/revealui.config.js",
+      "default": "./dist/revealui.config.js"
     },
     "./mcp": {
       "types": "./dist/mcp.d.ts",
-      "import": "./dist/mcp.js"
+      "import": "./dist/mcp.js",
+      "default": "./dist/mcp.js"
     },
     "./stripe-mode": {
       "types": "./dist/stripe-mode.d.ts",
-      "import": "./dist/stripe-mode.js"
+      "import": "./dist/stripe-mode.js",
+      "default": "./dist/stripe-mode.js"
     }
   },
   "files": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -28,103 +28,128 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./foundation": {
       "types": "./dist/foundation/index.d.ts",
-      "import": "./dist/foundation/index.js"
+      "import": "./dist/foundation/index.js",
+      "default": "./dist/foundation/index.js"
     },
     "./representation": {
       "types": "./dist/representation/index.d.ts",
-      "import": "./dist/representation/index.js"
+      "import": "./dist/representation/index.js",
+      "default": "./dist/representation/index.js"
     },
     "./entities": {
       "types": "./dist/entities/index.d.ts",
-      "import": "./dist/entities/index.js"
+      "import": "./dist/entities/index.js",
+      "default": "./dist/entities/index.js"
     },
     "./content": {
       "types": "./dist/content/index.d.ts",
-      "import": "./dist/content/index.js"
+      "import": "./dist/content/index.js",
+      "default": "./dist/content/index.js"
     },
     "./admin": {
       "types": "./dist/admin/index.d.ts",
-      "import": "./dist/admin/index.js"
+      "import": "./dist/admin/index.js",
+      "default": "./dist/admin/index.js"
     },
     "./agents": {
       "types": "./dist/agents/index.d.ts",
-      "import": "./dist/agents/index.js"
+      "import": "./dist/agents/index.js",
+      "default": "./dist/agents/index.js"
     },
     "./database": {
       "types": "./dist/database/index.d.ts",
-      "import": "./dist/database/index.js"
+      "import": "./dist/database/index.js",
+      "default": "./dist/database/index.js"
     },
     "./marketing-voice": {
       "types": "./dist/marketing-voice/index.d.ts",
-      "import": "./dist/marketing-voice/index.js"
+      "import": "./dist/marketing-voice/index.js",
+      "default": "./dist/marketing-voice/index.js"
     },
     "./actions": {
       "types": "./dist/actions/index.d.ts",
-      "import": "./dist/actions/index.js"
+      "import": "./dist/actions/index.js",
+      "default": "./dist/actions/index.js"
     },
     "./core": {
       "types": "./dist/cms/index.d.ts",
-      "import": "./dist/cms/index.js"
+      "import": "./dist/cms/index.js",
+      "default": "./dist/cms/index.js"
     },
     "./core/contracts": {
       "types": "./dist/cms/index.d.ts",
-      "import": "./dist/cms/index.js"
+      "import": "./dist/cms/index.js",
+      "default": "./dist/cms/index.js"
     },
     "./blocks": {
       "types": "./dist/content/index.d.ts",
-      "import": "./dist/content/index.js"
+      "import": "./dist/content/index.js",
+      "default": "./dist/content/index.js"
     },
     "./pricing": {
       "types": "./dist/pricing.d.ts",
-      "import": "./dist/pricing.js"
+      "import": "./dist/pricing.js",
+      "default": "./dist/pricing.js"
     },
     "./generated": {
       "types": "./dist/generated/database.d.ts",
-      "import": "./dist/generated/database.js"
+      "import": "./dist/generated/database.js",
+      "default": "./dist/generated/database.js"
     },
     "./generated/database": {
       "types": "./dist/generated/database.d.ts",
-      "import": "./dist/generated/database.js"
+      "import": "./dist/generated/database.js",
+      "default": "./dist/generated/database.js"
     },
     "./generated/zod-schemas": {
       "types": "./dist/generated/zod-schemas.d.ts",
-      "import": "./dist/generated/zod-schemas.js"
+      "import": "./dist/generated/zod-schemas.js",
+      "default": "./dist/generated/zod-schemas.js"
     },
     "./generated/contracts": {
       "types": "./dist/generated/contracts.d.ts",
-      "import": "./dist/generated/contracts.js"
+      "import": "./dist/generated/contracts.js",
+      "default": "./dist/generated/contracts.js"
     },
     "./content-validation": {
       "types": "./dist/content-validation.d.ts",
-      "import": "./dist/content-validation.js"
+      "import": "./dist/content-validation.js",
+      "default": "./dist/content-validation.js"
     },
     "./security": {
       "types": "./dist/security/index.d.ts",
-      "import": "./dist/security/index.js"
+      "import": "./dist/security/index.js",
+      "default": "./dist/security/index.js"
     },
     "./secrets": {
       "types": "./dist/secrets/index.d.ts",
-      "import": "./dist/secrets/index.js"
+      "import": "./dist/secrets/index.js",
+      "default": "./dist/secrets/index.js"
     },
     "./a2a": {
       "types": "./dist/a2a/index.d.ts",
-      "import": "./dist/a2a/index.js"
+      "import": "./dist/a2a/index.js",
+      "default": "./dist/a2a/index.js"
     },
     "./api/auth": {
       "types": "./dist/api/auth.d.ts",
-      "import": "./dist/api/auth.js"
+      "import": "./dist/api/auth.js",
+      "default": "./dist/api/auth.js"
     },
     "./api/chat": {
       "types": "./dist/api/chat.d.ts",
-      "import": "./dist/api/chat.js"
+      "import": "./dist/api/chat.js",
+      "default": "./dist/api/chat.js"
     },
     "./api/gdpr": {
       "types": "./dist/api/gdpr.d.ts",
-      "import": "./dist/api/gdpr.js"
+      "import": "./dist/api/gdpr.js",
+      "default": "./dist/api/gdpr.js"
     }
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,279 +46,348 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./license": {
       "types": "./dist/license.d.ts",
-      "import": "./dist/license.js"
+      "import": "./dist/license.js",
+      "default": "./dist/license.js"
     },
     "./revforge-license": {
       "types": "./dist/revforge-license.d.ts",
-      "import": "./dist/revforge-license.js"
+      "import": "./dist/revforge-license.js",
+      "default": "./dist/revforge-license.js"
     },
     "./features": {
       "types": "./dist/features.d.ts",
-      "import": "./dist/features.js"
+      "import": "./dist/features.js",
+      "default": "./dist/features.js"
     },
     "./server": {
       "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js"
+      "import": "./dist/server/index.js",
+      "default": "./dist/server/index.js"
     },
     "./types": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/types/index.js"
+      "import": "./dist/types/index.js",
+      "default": "./dist/types/index.js"
     },
     "./types/core": {
       "types": "./dist/types/core.d.ts",
-      "import": "./dist/types/core.js"
+      "import": "./dist/types/core.js",
+      "default": "./dist/types/core.js"
     },
     "./types/schema": {
       "types": "./dist/types/schema.d.ts",
-      "import": "./dist/types/schema.js"
+      "import": "./dist/types/schema.js",
+      "default": "./dist/types/schema.js"
     },
     "./types/generated": {
       "types": "./dist/types/generated.d.ts",
-      "import": "./dist/types/generated.js"
+      "import": "./dist/types/generated.js",
+      "default": "./dist/types/generated.js"
     },
     "./types/admin": {
       "types": "./dist/types/admin.d.ts",
-      "import": "./dist/types/admin.js"
+      "import": "./dist/types/admin.js",
+      "default": "./dist/types/admin.js"
     },
     "./types/frontend": {
       "types": "./dist/types/frontend.d.ts",
-      "import": "./dist/types/frontend.js"
+      "import": "./dist/types/frontend.js",
+      "default": "./dist/types/frontend.js"
     },
     "./generated": {
       "types": "./dist/generated/index.d.ts",
-      "import": "./dist/generated/index.js"
+      "import": "./dist/generated/index.js",
+      "default": "./dist/generated/index.js"
     },
     "./generated/types": {
       "types": "./dist/generated/types/index.d.ts",
-      "import": "./dist/generated/types/index.js"
+      "import": "./dist/generated/types/index.js",
+      "default": "./dist/generated/types/index.js"
     },
     "./generated/types/admin": {
       "types": "./dist/generated/types/admin.d.ts",
-      "import": "./dist/generated/types/admin.js"
+      "import": "./dist/generated/types/admin.js",
+      "default": "./dist/generated/types/admin.js"
     },
     "./generated/types/neon": {
       "types": "./dist/generated/types/neon.d.ts",
-      "import": "./dist/generated/types/neon.js"
+      "import": "./dist/generated/types/neon.js",
+      "default": "./dist/generated/types/neon.js"
     },
     "./config": {
       "types": "./dist/config/index.d.ts",
-      "import": "./dist/config/index.js"
+      "import": "./dist/config/index.js",
+      "default": "./dist/config/index.js"
     },
     "./database": {
       "types": "./dist/database/index.d.ts",
-      "import": "./dist/database/index.js"
+      "import": "./dist/database/index.js",
+      "default": "./dist/database/index.js"
     },
     "./database/ssl-config": {
       "types": "./dist/database/ssl-config.d.ts",
-      "import": "./dist/database/ssl-config.js"
+      "import": "./dist/database/ssl-config.js",
+      "default": "./dist/database/ssl-config.js"
     },
     "./database/type-adapter": {
       "types": "./dist/database/type-adapter.d.ts",
-      "import": "./dist/database/type-adapter.js"
+      "import": "./dist/database/type-adapter.js",
+      "default": "./dist/database/type-adapter.js"
     },
     "./storage": {
       "types": "./dist/storage/index.d.ts",
-      "import": "./dist/storage/index.js"
+      "import": "./dist/storage/index.js",
+      "default": "./dist/storage/index.js"
     },
     "./auth": {
       "types": "./dist/auth/index.d.ts",
-      "import": "./dist/auth/index.js"
+      "import": "./dist/auth/index.js",
+      "default": "./dist/auth/index.js"
     },
     "./admin": {
       "types": "./dist/client/admin/index.d.ts",
-      "import": "./dist/client/admin/index.js"
+      "import": "./dist/client/admin/index.js",
+      "default": "./dist/client/admin/index.js"
     },
     "./admin/utils/serializeConfig": {
       "types": "./dist/client/admin/utils/serializeConfig.d.ts",
-      "import": "./dist/client/admin/utils/serializeConfig.js"
+      "import": "./dist/client/admin/utils/serializeConfig.js",
+      "default": "./dist/client/admin/utils/serializeConfig.js"
     },
     "./admin/utils/apiClient": {
       "types": "./dist/client/admin/utils/apiClient.d.ts",
-      "import": "./dist/client/admin/utils/apiClient.js"
+      "import": "./dist/client/admin/utils/apiClient.js",
+      "default": "./dist/client/admin/utils/apiClient.js"
     },
     "./richtext": {
       "types": "./dist/richtext/index.d.ts",
-      "import": "./dist/richtext/index.js"
+      "import": "./dist/richtext/index.js",
+      "default": "./dist/richtext/index.js"
     },
     "./richtext/client": {
       "types": "./dist/client/richtext/index.d.ts",
-      "import": "./dist/client/richtext/index.js"
+      "import": "./dist/client/richtext/index.js",
+      "default": "./dist/client/richtext/index.js"
     },
     "./richtext/react": {
       "types": "./dist/richtext/exports/react/index.d.ts",
-      "import": "./dist/richtext/exports/react/index.js"
+      "import": "./dist/richtext/exports/react/index.js",
+      "default": "./dist/richtext/exports/react/index.js"
     },
     "./richtext/html": {
       "types": "./dist/richtext/exports/html/index.d.ts",
-      "import": "./dist/richtext/exports/html/index.js"
+      "import": "./dist/richtext/exports/html/index.js",
+      "default": "./dist/richtext/exports/html/index.js"
     },
     "./richtext/rsc": {
       "types": "./dist/richtext/exports/server/rsc.d.tsx",
-      "import": "./dist/richtext/exports/server/rsc.js"
+      "import": "./dist/richtext/exports/server/rsc.js",
+      "default": "./dist/richtext/exports/server/rsc.js"
     },
     "./translations": {
       "types": "./dist/translations/index.d.ts",
-      "import": "./dist/translations/index.js"
+      "import": "./dist/translations/index.js",
+      "default": "./dist/translations/index.js"
     },
     "./ui": {
       "types": "./dist/client/ui/index.d.tsx",
-      "import": "./dist/client/ui/index.js"
+      "import": "./dist/client/ui/index.js",
+      "default": "./dist/client/ui/index.js"
     },
     "./plugins": {
       "types": "./dist/plugins/index.d.ts",
-      "import": "./dist/plugins/index.js"
+      "import": "./dist/plugins/index.js",
+      "default": "./dist/plugins/index.js"
     },
     "./api/rest": {
       "types": "./dist/api/rest.d.ts",
-      "import": "./dist/api/rest.js"
+      "import": "./dist/api/rest.js",
+      "default": "./dist/api/rest.js"
     },
     "./api/compression": {
       "types": "./dist/api/compression.d.ts",
-      "import": "./dist/api/compression.js"
+      "import": "./dist/api/compression.js",
+      "default": "./dist/api/compression.js"
     },
     "./api/payload-optimization": {
       "types": "./dist/api/payload-optimization.d.ts",
-      "import": "./dist/api/payload-optimization.js"
+      "import": "./dist/api/payload-optimization.js",
+      "default": "./dist/api/payload-optimization.js"
     },
     "./api/rate-limit": {
       "types": "./dist/api/rate-limit.d.ts",
-      "import": "./dist/api/rate-limit.js"
+      "import": "./dist/api/rate-limit.js",
+      "default": "./dist/api/rate-limit.js"
     },
     "./api/response-cache": {
       "types": "./dist/api/response-cache.d.ts",
-      "import": "./dist/api/response-cache.js"
+      "import": "./dist/api/response-cache.js",
+      "default": "./dist/api/response-cache.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
-      "import": "./dist/client/index.js"
+      "import": "./dist/client/index.js",
+      "default": "./dist/client/index.js"
     },
     "./client/ui": {
       "types": "./dist/client/ui/index.d.ts",
-      "import": "./dist/client/ui/index.js"
+      "import": "./dist/client/ui/index.js",
+      "default": "./dist/client/ui/index.js"
     },
     "./client/admin": {
       "types": "./dist/client/admin/index.d.ts",
-      "import": "./dist/client/admin/index.js"
+      "import": "./dist/client/admin/index.js",
+      "default": "./dist/client/admin/index.js"
     },
     "./client/richtext": {
       "types": "./dist/client/richtext/index.d.ts",
-      "import": "./dist/client/richtext/index.js"
+      "import": "./dist/client/richtext/index.js",
+      "default": "./dist/client/richtext/index.js"
     },
     "./types/interfaces/app": {
       "types": "./dist/types/interfaces/app.d.ts",
-      "import": "./dist/types/interfaces/app.js"
+      "import": "./dist/types/interfaces/app.js",
+      "default": "./dist/types/interfaces/app.js"
     },
     "./nextjs": {
       "types": "./dist/nextjs/index.d.ts",
-      "import": "./dist/nextjs/index.js"
+      "import": "./dist/nextjs/index.js",
+      "default": "./dist/nextjs/index.js"
     },
     "./nextjs/withRevealUI": {
       "types": "./dist/nextjs/withRevealUI.d.ts",
-      "import": "./dist/nextjs/withRevealUI.js"
+      "import": "./dist/nextjs/withRevealUI.js",
+      "default": "./dist/nextjs/withRevealUI.js"
     },
     "./utils/logger": {
       "types": "./dist/utils/logger.d.ts",
-      "import": "./dist/utils/logger.js"
+      "import": "./dist/utils/logger.js",
+      "default": "./dist/utils/logger.js"
     },
     "./utils/logger/client": {
       "types": "./dist/utils/logger-client.d.ts",
-      "import": "./dist/utils/logger-client.js"
+      "import": "./dist/utils/logger-client.js",
+      "default": "./dist/utils/logger-client.js"
     },
     "./utils/logger/server": {
       "types": "./dist/utils/logger-server.d.ts",
-      "import": "./dist/utils/logger-server.js"
+      "import": "./dist/utils/logger-server.js",
+      "default": "./dist/utils/logger-server.js"
     },
     "./security": {
       "types": "./dist/security/index.d.ts",
-      "import": "./dist/security/index.js"
+      "import": "./dist/security/index.js",
+      "default": "./dist/security/index.js"
     },
     "./license-encryption": {
       "types": "./dist/license-encryption.d.ts",
-      "import": "./dist/license-encryption.js"
+      "import": "./dist/license-encryption.js",
+      "default": "./dist/license-encryption.js"
     },
     "./observability": {
       "types": "./dist/observability/index.d.ts",
-      "import": "./dist/observability/index.js"
+      "import": "./dist/observability/index.js",
+      "default": "./dist/observability/index.js"
     },
     "./observability/logger": {
       "types": "./dist/observability/logger.d.ts",
-      "import": "./dist/observability/logger.js"
+      "import": "./dist/observability/logger.js",
+      "default": "./dist/observability/logger.js"
     },
     "./observability/metrics": {
       "types": "./dist/observability/metrics.d.ts",
-      "import": "./dist/observability/metrics.js"
+      "import": "./dist/observability/metrics.js",
+      "default": "./dist/observability/metrics.js"
     },
     "./observability/alerts": {
       "types": "./dist/observability/alerts.d.ts",
-      "import": "./dist/observability/alerts.js"
+      "import": "./dist/observability/alerts.js",
+      "default": "./dist/observability/alerts.js"
     },
     "./utils/cache": {
       "types": "./dist/utils/cache.d.ts",
-      "import": "./dist/utils/cache.js"
+      "import": "./dist/utils/cache.js",
+      "default": "./dist/utils/cache.js"
     },
     "./utils/deep-clone": {
       "types": "./dist/utils/deep-clone.d.ts",
-      "import": "./dist/utils/deep-clone.js"
+      "import": "./dist/utils/deep-clone.js",
+      "default": "./dist/utils/deep-clone.js"
     },
     "./utils/errors": {
       "types": "./dist/utils/errors.d.ts",
-      "import": "./dist/utils/errors.js"
+      "import": "./dist/utils/errors.js",
+      "default": "./dist/utils/errors.js"
     },
     "./jobs": {
       "types": "./dist/jobs/index.d.ts",
-      "import": "./dist/jobs/index.js"
+      "import": "./dist/jobs/index.js",
+      "default": "./dist/jobs/index.js"
     },
     "./monitoring": {
       "types": "./dist/monitoring/index.d.ts",
-      "import": "./dist/monitoring/index.js"
+      "import": "./dist/monitoring/index.js",
+      "default": "./dist/monitoring/index.js"
     },
     "./monitoring/process-registry": {
       "types": "./dist/monitoring/process-registry.d.ts",
-      "import": "./dist/monitoring/process-registry.js"
+      "import": "./dist/monitoring/process-registry.js",
+      "default": "./dist/monitoring/process-registry.js"
     },
     "./monitoring/query-monitor": {
       "types": "./dist/monitoring/query-monitor.d.ts",
-      "import": "./dist/monitoring/query-monitor.js"
+      "import": "./dist/monitoring/query-monitor.js",
+      "default": "./dist/monitoring/query-monitor.js"
     },
     "./utils/error-responses": {
       "types": "./dist/utils/error-responses.d.ts",
-      "import": "./dist/utils/error-responses.js"
+      "import": "./dist/utils/error-responses.js",
+      "default": "./dist/utils/error-responses.js"
     },
     "./utils/request-context": {
       "types": "./dist/utils/request-context.d.ts",
-      "import": "./dist/utils/request-context.js"
+      "import": "./dist/utils/request-context.js",
+      "default": "./dist/utils/request-context.js"
     },
     "./error-handling": {
       "types": "./dist/error-handling/index.d.ts",
-      "import": "./dist/error-handling/index.js"
+      "import": "./dist/error-handling/index.js",
+      "default": "./dist/error-handling/index.js"
     },
     "./error-handling/error-reporter": {
       "types": "./dist/error-handling/error-reporter.d.ts",
-      "import": "./dist/error-handling/error-reporter.js"
+      "import": "./dist/error-handling/error-reporter.js",
+      "default": "./dist/error-handling/error-reporter.js"
     },
     "./caching": {
       "types": "./dist/caching/index.d.ts",
-      "import": "./dist/caching/index.js"
+      "import": "./dist/caching/index.js",
+      "default": "./dist/caching/index.js"
     },
     "./cache/query-cache": {
       "types": "./dist/cache/query-cache.d.ts",
-      "import": "./dist/cache/query-cache.js"
+      "import": "./dist/cache/query-cache.js",
+      "default": "./dist/cache/query-cache.js"
     },
     "./optimization/code-splitting": {
       "types": "./dist/optimization/code-splitting.d.ts",
-      "import": "./dist/optimization/code-splitting.js"
+      "import": "./dist/optimization/code-splitting.js",
+      "default": "./dist/optimization/code-splitting.js"
     },
     "./richtext/lexical": {
       "types": "./dist/richtext/lexical.d.ts",
-      "import": "./dist/richtext/lexical.js"
+      "import": "./dist/richtext/lexical.js",
+      "default": "./dist/richtext/lexical.js"
     },
     "./admin/i18n/en": {
       "types": "./dist/client/admin/i18n/en.d.ts",
-      "import": "./dist/client/admin/i18n/en.js"
+      "import": "./dist/client/admin/i18n/en.js",
+      "default": "./dist/client/admin/i18n/en.js"
     }
   },
   "files": [

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -24,231 +24,288 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./core": {
       "types": "./dist/client/index.d.ts",
-      "import": "./dist/client/index.js"
+      "import": "./dist/client/index.js",
+      "default": "./dist/client/index.js"
     },
     "./orm": {
       "types": "./dist/orm.d.ts",
-      "import": "./dist/orm.js"
+      "import": "./dist/orm.js",
+      "default": "./dist/orm.js"
     },
     "./schema": {
       "types": "./dist/schema/index.d.ts",
-      "import": "./dist/schema/index.js"
+      "import": "./dist/schema/index.js",
+      "default": "./dist/schema/index.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
-      "import": "./dist/client/index.js"
+      "import": "./dist/client/index.js",
+      "default": "./dist/client/index.js"
     },
     "./validation": {
       "types": "./dist/validation/cross-db.d.ts",
-      "import": "./dist/validation/cross-db.js"
+      "import": "./dist/validation/cross-db.js",
+      "default": "./dist/validation/cross-db.js"
     },
     "./cleanup": {
       "types": "./dist/cleanup/index.d.ts",
-      "import": "./dist/cleanup/index.js"
+      "import": "./dist/cleanup/index.js",
+      "default": "./dist/cleanup/index.js"
     },
     "./types": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/types/index.js"
+      "import": "./dist/types/index.js",
+      "default": "./dist/types/index.js"
     },
     "./schema/agents": {
       "types": "./dist/schema/agents.d.ts",
-      "import": "./dist/schema/agents.js"
+      "import": "./dist/schema/agents.js",
+      "default": "./dist/schema/agents.js"
     },
     "./schema/crdt-operations": {
       "types": "./dist/schema/crdt-operations.d.ts",
-      "import": "./dist/schema/crdt-operations.js"
+      "import": "./dist/schema/crdt-operations.js",
+      "default": "./dist/schema/crdt-operations.js"
     },
     "./schema/node-ids": {
       "types": "./dist/schema/node-ids.d.ts",
-      "import": "./dist/schema/node-ids.js"
+      "import": "./dist/schema/node-ids.js",
+      "default": "./dist/schema/node-ids.js"
     },
     "./schema/pages": {
       "types": "./dist/schema/pages.d.ts",
-      "import": "./dist/schema/pages.js"
+      "import": "./dist/schema/pages.js",
+      "default": "./dist/schema/pages.js"
     },
     "./schema/rate-limits": {
       "types": "./dist/schema/rate-limits.d.ts",
-      "import": "./dist/schema/rate-limits.js"
+      "import": "./dist/schema/rate-limits.js",
+      "default": "./dist/schema/rate-limits.js"
     },
     "./schema/sites": {
       "types": "./dist/schema/sites.d.ts",
-      "import": "./dist/schema/sites.js"
+      "import": "./dist/schema/sites.js",
+      "default": "./dist/schema/sites.js"
     },
     "./schema/tenants": {
       "types": "./dist/schema/tenants.d.ts",
-      "import": "./dist/schema/tenants.js"
+      "import": "./dist/schema/tenants.js",
+      "default": "./dist/schema/tenants.js"
     },
     "./schema/users": {
       "types": "./dist/schema/users.d.ts",
-      "import": "./dist/schema/users.js"
+      "import": "./dist/schema/users.js",
+      "default": "./dist/schema/users.js"
     },
     "./schema/password-reset-tokens": {
       "types": "./dist/schema/password-reset-tokens.d.ts",
-      "import": "./dist/schema/password-reset-tokens.js"
+      "import": "./dist/schema/password-reset-tokens.js",
+      "default": "./dist/schema/password-reset-tokens.js"
     },
     "./schema/admin": {
       "types": "./dist/schema/admin.d.ts",
-      "import": "./dist/schema/admin.js"
+      "import": "./dist/schema/admin.js",
+      "default": "./dist/schema/admin.js"
     },
     "./schema/licenses": {
       "types": "./dist/schema/licenses.d.ts",
-      "import": "./dist/schema/licenses.js"
+      "import": "./dist/schema/licenses.js",
+      "default": "./dist/schema/licenses.js"
     },
     "./schema/api-keys": {
       "types": "./dist/schema/api-keys.d.ts",
-      "import": "./dist/schema/api-keys.js"
+      "import": "./dist/schema/api-keys.js",
+      "default": "./dist/schema/api-keys.js"
     },
     "./schema/audit-log": {
       "types": "./dist/schema/audit-log.d.ts",
-      "import": "./dist/schema/audit-log.js"
+      "import": "./dist/schema/audit-log.js",
+      "default": "./dist/schema/audit-log.js"
     },
     "./schema/app-logs": {
       "types": "./dist/schema/app-logs.d.ts",
-      "import": "./dist/schema/app-logs.js"
+      "import": "./dist/schema/app-logs.js",
+      "default": "./dist/schema/app-logs.js"
     },
     "./schema/error-events": {
       "types": "./dist/schema/error-events.d.ts",
-      "import": "./dist/schema/error-events.js"
+      "import": "./dist/schema/error-events.js",
+      "default": "./dist/schema/error-events.js"
     },
     "./schema/code-provenance": {
       "types": "./dist/schema/code-provenance.d.ts",
-      "import": "./dist/schema/code-provenance.js"
+      "import": "./dist/schema/code-provenance.js",
+      "default": "./dist/schema/code-provenance.js"
     },
     "./schema/tickets": {
       "types": "./dist/schema/tickets.d.ts",
-      "import": "./dist/schema/tickets.js"
+      "import": "./dist/schema/tickets.js",
+      "default": "./dist/schema/tickets.js"
     },
     "./schema/vector": {
       "types": "./dist/schema/vector.d.ts",
-      "import": "./dist/schema/vector.js"
+      "import": "./dist/schema/vector.js",
+      "default": "./dist/schema/vector.js"
     },
     "./schema/rag": {
       "types": "./dist/schema/rag.d.ts",
-      "import": "./dist/schema/rag.js"
+      "import": "./dist/schema/rag.js",
+      "default": "./dist/schema/rag.js"
     },
     "./schema/knowledge-graph": {
       "types": "./dist/schema/knowledge-graph.d.ts",
-      "import": "./dist/schema/knowledge-graph.js"
+      "import": "./dist/schema/knowledge-graph.js",
+      "default": "./dist/schema/knowledge-graph.js"
     },
     "./generated/zod-schemas": {
       "types": "./dist/generated/zod-schemas.d.ts",
-      "import": "./dist/generated/zod-schemas.js"
+      "import": "./dist/generated/zod-schemas.js",
+      "default": "./dist/generated/zod-schemas.js"
     },
     "./queries/tickets": {
       "types": "./dist/queries/tickets.d.ts",
-      "import": "./dist/queries/tickets.js"
+      "import": "./dist/queries/tickets.js",
+      "default": "./dist/queries/tickets.js"
     },
     "./queries/boards": {
       "types": "./dist/queries/boards.d.ts",
-      "import": "./dist/queries/boards.js"
+      "import": "./dist/queries/boards.js",
+      "default": "./dist/queries/boards.js"
     },
     "./queries/ticket-comments": {
       "types": "./dist/queries/ticket-comments.d.ts",
-      "import": "./dist/queries/ticket-comments.js"
+      "import": "./dist/queries/ticket-comments.js",
+      "default": "./dist/queries/ticket-comments.js"
     },
     "./queries/ticket-labels": {
       "types": "./dist/queries/ticket-labels.d.ts",
-      "import": "./dist/queries/ticket-labels.js"
+      "import": "./dist/queries/ticket-labels.js",
+      "default": "./dist/queries/ticket-labels.js"
     },
     "./queries/code-provenance": {
       "types": "./dist/queries/code-provenance.d.ts",
-      "import": "./dist/queries/code-provenance.js"
+      "import": "./dist/queries/code-provenance.js",
+      "default": "./dist/queries/code-provenance.js"
     },
     "./queries/posts": {
       "types": "./dist/queries/posts.d.ts",
-      "import": "./dist/queries/posts.js"
+      "import": "./dist/queries/posts.js",
+      "default": "./dist/queries/posts.js"
     },
     "./queries/globals": {
       "types": "./dist/queries/globals.d.ts",
-      "import": "./dist/queries/globals.js"
+      "import": "./dist/queries/globals.js",
+      "default": "./dist/queries/globals.js"
     },
     "./queries/media": {
       "types": "./dist/queries/media.d.ts",
-      "import": "./dist/queries/media.js"
+      "import": "./dist/queries/media.js",
+      "default": "./dist/queries/media.js"
     },
     "./queries/sites": {
       "types": "./dist/queries/sites.d.ts",
-      "import": "./dist/queries/sites.js"
+      "import": "./dist/queries/sites.js",
+      "default": "./dist/queries/sites.js"
     },
     "./queries/pages": {
       "types": "./dist/queries/pages.d.ts",
-      "import": "./dist/queries/pages.js"
+      "import": "./dist/queries/pages.js",
+      "default": "./dist/queries/pages.js"
     },
     "./queries/edit-sessions": {
       "types": "./dist/queries/edit-sessions.d.ts",
-      "import": "./dist/queries/edit-sessions.js"
+      "import": "./dist/queries/edit-sessions.js",
+      "default": "./dist/queries/edit-sessions.js"
     },
     "./queries/users": {
       "types": "./dist/queries/users.d.ts",
-      "import": "./dist/queries/users.js"
+      "import": "./dist/queries/users.js",
+      "default": "./dist/queries/users.js"
     },
     "./queries/sessions": {
       "types": "./dist/queries/sessions.d.ts",
-      "import": "./dist/queries/sessions.js"
+      "import": "./dist/queries/sessions.js",
+      "default": "./dist/queries/sessions.js"
     },
     "./queries/passkeys": {
       "types": "./dist/queries/passkeys.d.ts",
-      "import": "./dist/queries/passkeys.js"
+      "import": "./dist/queries/passkeys.js",
+      "default": "./dist/queries/passkeys.js"
     },
     "./queries/user-api-keys": {
       "types": "./dist/queries/user-api-keys.d.ts",
-      "import": "./dist/queries/user-api-keys.js"
+      "import": "./dist/queries/user-api-keys.js",
+      "default": "./dist/queries/user-api-keys.js"
     },
     "./queries/oauth-accounts": {
       "types": "./dist/queries/oauth-accounts.d.ts",
-      "import": "./dist/queries/oauth-accounts.js"
+      "import": "./dist/queries/oauth-accounts.js",
+      "default": "./dist/queries/oauth-accounts.js"
     },
     "./queries/conversations": {
       "types": "./dist/queries/conversations.d.ts",
-      "import": "./dist/queries/conversations.js"
+      "import": "./dist/queries/conversations.js",
+      "default": "./dist/queries/conversations.js"
     },
     "./queries/products": {
       "types": "./dist/queries/products.d.ts",
-      "import": "./dist/queries/products.js"
+      "import": "./dist/queries/products.js",
+      "default": "./dist/queries/products.js"
     },
     "./queries/orders": {
       "types": "./dist/queries/orders.d.ts",
-      "import": "./dist/queries/orders.js"
+      "import": "./dist/queries/orders.js",
+      "default": "./dist/queries/orders.js"
     },
     "./schema/products": {
       "types": "./dist/schema/products.d.ts",
-      "import": "./dist/schema/products.js"
+      "import": "./dist/schema/products.js",
+      "default": "./dist/schema/products.js"
     },
     "./schema/yjs-documents": {
       "types": "./dist/schema/yjs-documents.d.ts",
-      "import": "./dist/schema/yjs-documents.js"
+      "import": "./dist/schema/yjs-documents.js",
+      "default": "./dist/schema/yjs-documents.js"
     },
     "./schema/collab-edits": {
       "types": "./dist/schema/collab-edits.d.ts",
-      "import": "./dist/schema/collab-edits.js"
+      "import": "./dist/schema/collab-edits.js",
+      "default": "./dist/schema/collab-edits.js"
     },
     "./log-transport": {
       "types": "./dist/log-transport.d.ts",
-      "import": "./dist/log-transport.js"
+      "import": "./dist/log-transport.js",
+      "default": "./dist/log-transport.js"
     },
     "./crypto": {
       "types": "./dist/crypto.d.ts",
-      "import": "./dist/crypto.js"
+      "import": "./dist/crypto.js",
+      "default": "./dist/crypto.js"
     },
     "./validation/cross-db": {
       "types": "./dist/validation/cross-db.d.ts",
-      "import": "./dist/validation/cross-db.js"
+      "import": "./dist/validation/cross-db.js",
+      "default": "./dist/validation/cross-db.js"
     },
     "./saga": {
       "types": "./dist/saga/index.d.ts",
-      "import": "./dist/saga/index.js"
+      "import": "./dist/saga/index.js",
+      "default": "./dist/saga/index.js"
     },
     "./jobs": {
       "types": "./dist/jobs/index.d.ts",
-      "import": "./dist/jobs/index.js"
+      "import": "./dist/jobs/index.js",
+      "default": "./dist/jobs/index.js"
     },
     "./pool": {
       "types": "./dist/pool.d.ts",
-      "import": "./dist/pool.js"
+      "import": "./dist/pool.js",
+      "default": "./dist/pool.js"
     }
   },
   "files": [

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -15,15 +15,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./runtime": {
       "types": "./dist/runtime/index.d.ts",
-      "import": "./dist/runtime/index.js"
+      "import": "./dist/runtime/index.js",
+      "default": "./dist/runtime/index.js"
     },
     "./canvas": {
       "types": "./dist/canvas/index.d.ts",
-      "import": "./dist/canvas/index.js"
+      "import": "./dist/canvas/index.js",
+      "default": "./dist/canvas/index.js"
     }
   },
   "files": [

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -29,35 +29,43 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./types": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/types/index.js"
+      "import": "./dist/types/index.js",
+      "default": "./dist/types/index.js"
     },
     "./workboard": {
       "types": "./dist/workboard/index.d.ts",
-      "import": "./dist/workboard/index.js"
+      "import": "./dist/workboard/index.js",
+      "default": "./dist/workboard/index.js"
     },
     "./content": {
       "types": "./dist/content/index.d.ts",
-      "import": "./dist/content/index.js"
+      "import": "./dist/content/index.js",
+      "default": "./dist/content/index.js"
     },
     "./storage": {
       "types": "./dist/storage/index.d.ts",
-      "import": "./dist/storage/index.js"
+      "import": "./dist/storage/index.js",
+      "default": "./dist/storage/index.js"
     },
     "./goals": {
       "types": "./dist/goals/index.d.ts",
-      "import": "./dist/goals/index.js"
+      "import": "./dist/goals/index.js",
+      "default": "./dist/goals/index.js"
     },
     "./protocol": {
       "types": "./dist/protocol/index.d.ts",
-      "import": "./dist/protocol/index.js"
+      "import": "./dist/protocol/index.js",
+      "default": "./dist/protocol/index.js"
     },
     "./hooks": {
       "types": "./dist/hooks/index.d.ts",
-      "import": "./dist/hooks/index.js"
+      "import": "./dist/hooks/index.js",
+      "default": "./dist/hooks/index.js"
     }
   },
   "files": [

--- a/packages/knowledge-graph/package.json
+++ b/packages/knowledge-graph/package.json
@@ -17,27 +17,33 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./ontology": {
       "types": "./dist/ontology/index.d.ts",
-      "import": "./dist/ontology/index.js"
+      "import": "./dist/ontology/index.js",
+      "default": "./dist/ontology/index.js"
     },
     "./ingest": {
       "types": "./dist/ingest/index.d.ts",
-      "import": "./dist/ingest/index.js"
+      "import": "./dist/ingest/index.js",
+      "default": "./dist/ingest/index.js"
     },
     "./search": {
       "types": "./dist/search/index.d.ts",
-      "import": "./dist/search/index.js"
+      "import": "./dist/search/index.js",
+      "default": "./dist/search/index.js"
     },
     "./extractors": {
       "types": "./dist/extractors/index.d.ts",
-      "import": "./dist/extractors/index.js"
+      "import": "./dist/extractors/index.js",
+      "default": "./dist/extractors/index.js"
     },
     "./ddl": {
       "types": "./dist/db/ddl.d.ts",
-      "import": "./dist/db/ddl.js"
+      "import": "./dist/db/ddl.js",
+      "default": "./dist/db/ddl.js"
     }
   },
   "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,91 +39,113 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./adapter": {
       "types": "./dist/servers/adapter.d.ts",
-      "import": "./dist/servers/adapter.js"
+      "import": "./dist/servers/adapter.js",
+      "default": "./dist/servers/adapter.js"
     },
     "./author": {
       "types": "./dist/author/index.d.ts",
-      "import": "./dist/author/index.js"
+      "import": "./dist/author/index.js",
+      "default": "./dist/author/index.js"
     },
     "./author/scaffold": {
       "types": "./dist/author/scaffold.d.ts",
-      "import": "./dist/author/scaffold.js"
+      "import": "./dist/author/scaffold.js",
+      "default": "./dist/author/scaffold.js"
     },
     "./author/test": {
       "types": "./dist/author/test.d.ts",
-      "import": "./dist/author/test.js"
+      "import": "./dist/author/test.js",
+      "default": "./dist/author/test.js"
     },
     "./author/publish": {
       "types": "./dist/author/publish.d.ts",
-      "import": "./dist/author/publish.js"
+      "import": "./dist/author/publish.js",
+      "default": "./dist/author/publish.js"
     },
     "./contracts": {
       "types": "./dist/contracts.d.ts",
-      "import": "./dist/contracts.js"
+      "import": "./dist/contracts.js",
+      "default": "./dist/contracts.js"
     },
     "./contracts-server": {
       "types": "./dist/servers/factories/contracts.d.ts",
-      "import": "./dist/servers/factories/contracts.js"
+      "import": "./dist/servers/factories/contracts.js",
+      "default": "./dist/servers/factories/contracts.js"
     },
     "./revealui-content-factory": {
       "types": "./dist/servers/factories/revealui-content.d.ts",
-      "import": "./dist/servers/factories/revealui-content.js"
+      "import": "./dist/servers/factories/revealui-content.js",
+      "default": "./dist/servers/factories/revealui-content.js"
     },
     "./docs-server": {
       "types": "./dist/servers/factories/docs.d.ts",
-      "import": "./dist/servers/factories/docs.js"
+      "import": "./dist/servers/factories/docs.js",
+      "default": "./dist/servers/factories/docs.js"
     },
     "./kg-server": {
       "types": "./dist/servers/factories/knowledge-graph.d.ts",
-      "import": "./dist/servers/factories/knowledge-graph.js"
+      "import": "./dist/servers/factories/knowledge-graph.js",
+      "default": "./dist/servers/factories/knowledge-graph.js"
     },
     "./hypervisor": {
       "types": "./dist/hypervisor.d.ts",
-      "import": "./dist/hypervisor.js"
+      "import": "./dist/hypervisor.js",
+      "default": "./dist/hypervisor.js"
     },
     "./db": {
       "types": "./dist/adapters/db.d.ts",
-      "import": "./dist/adapters/db.js"
+      "import": "./dist/adapters/db.js",
+      "default": "./dist/adapters/db.js"
     },
     "./config": {
       "types": "./dist/config/index.d.ts",
-      "import": "./dist/config/index.js"
+      "import": "./dist/config/index.js",
+      "default": "./dist/config/index.js"
     },
     "./pipeline": {
       "types": "./dist/pipeline.d.ts",
-      "import": "./dist/pipeline.js"
+      "import": "./dist/pipeline.js",
+      "default": "./dist/pipeline.js"
     },
     "./rate-limiter": {
       "types": "./dist/rate-limiter.d.ts",
-      "import": "./dist/rate-limiter.js"
+      "import": "./dist/rate-limiter.js",
+      "default": "./dist/rate-limiter.js"
     },
     "./telemetry": {
       "types": "./dist/telemetry.d.ts",
-      "import": "./dist/telemetry.js"
+      "import": "./dist/telemetry.js",
+      "default": "./dist/telemetry.js"
     },
     "./auth": {
       "types": "./dist/auth.d.ts",
-      "import": "./dist/auth.js"
+      "import": "./dist/auth.js",
+      "default": "./dist/auth.js"
     },
     "./streamable-http": {
       "types": "./dist/streamable-http.d.ts",
-      "import": "./dist/streamable-http.js"
+      "import": "./dist/streamable-http.js",
+      "default": "./dist/streamable-http.js"
     },
     "./oauth": {
       "types": "./dist/oauth.d.ts",
-      "import": "./dist/oauth.js"
+      "import": "./dist/oauth.js",
+      "default": "./dist/oauth.js"
     },
     "./client": {
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.js"
+      "import": "./dist/client.js",
+      "default": "./dist/client.js"
     },
     "./remote-client": {
       "types": "./dist/remote-client.d.ts",
-      "import": "./dist/remote-client.js"
+      "import": "./dist/remote-client.js",
+      "default": "./dist/remote-client.js"
     }
   },
   "files": [

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -31,7 +31,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/paywall/package.json
+++ b/packages/paywall/package.json
@@ -38,27 +38,33 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./server/hono": {
       "types": "./dist/server/hono.d.ts",
-      "import": "./dist/server/hono.js"
+      "import": "./dist/server/hono.js",
+      "default": "./dist/server/hono.js"
     },
     "./server/next": {
       "types": "./dist/server/next.d.ts",
-      "import": "./dist/server/next.js"
+      "import": "./dist/server/next.js",
+      "default": "./dist/server/next.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
-      "import": "./dist/client/index.js"
+      "import": "./dist/client/index.js",
+      "default": "./dist/client/index.js"
     },
     "./stripe": {
       "types": "./dist/stripe/index.d.ts",
-      "import": "./dist/stripe/index.js"
+      "import": "./dist/stripe/index.js",
+      "default": "./dist/stripe/index.js"
     },
     "./x402": {
       "types": "./dist/x402/index.d.ts",
-      "import": "./dist/x402/index.js"
+      "import": "./dist/x402/index.js",
+      "default": "./dist/x402/index.js"
     }
   },
   "files": [

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -40,27 +40,33 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./server": {
       "types": "./dist/server.d.ts",
-      "import": "./dist/server.js"
+      "import": "./dist/server.js",
+      "default": "./dist/server.js"
     },
     "./client": {
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.js"
+      "import": "./dist/client.js",
+      "default": "./dist/client.js"
     },
     "./components": {
       "types": "./dist/components/index.d.ts",
-      "import": "./dist/components/index.js"
+      "import": "./dist/components/index.js",
+      "default": "./dist/components/index.js"
     },
     "./primitives": {
       "types": "./dist/primitives/index.d.ts",
-      "import": "./dist/primitives/index.js"
+      "import": "./dist/primitives/index.js",
+      "default": "./dist/primitives/index.js"
     },
     "./hooks": {
       "types": "./dist/hooks/index.d.ts",
-      "import": "./dist/hooks/index.js"
+      "import": "./dist/hooks/index.js",
+      "default": "./dist/hooks/index.js"
     },
     "./tokens.css": "./dist/tokens.css",
     "./design-context/MANIFEST.sha256": "./dist/design-context/MANIFEST.sha256",
@@ -68,7 +74,8 @@
     "./design-context/tokens.css": "./dist/design-context/tokens.css",
     "./animations": {
       "types": "./dist/animations/index.d.ts",
-      "import": "./dist/animations/index.js"
+      "import": "./dist/animations/index.js",
+      "default": "./dist/animations/index.js"
     }
   },
   "files": [

--- a/packages/resilience/package.json
+++ b/packages/resilience/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -34,11 +34,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./server": {
       "types": "./dist/server.d.ts",
-      "import": "./dist/server.js"
+      "import": "./dist/server.js",
+      "default": "./dist/server.js"
     }
   },
   "files": [

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -22,15 +22,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./server": {
       "types": "./dist/server.d.ts",
-      "import": "./dist/server.js"
+      "import": "./dist/server.js",
+      "default": "./dist/server.js"
     },
     "./sanitize": {
       "types": "./dist/sanitize.d.ts",
-      "import": "./dist/sanitize.js"
+      "import": "./dist/sanitize.js",
+      "default": "./dist/sanitize.js"
     }
   },
   "files": [

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -40,27 +40,33 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./server": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./email": {
       "types": "./dist/email/index.d.ts",
-      "import": "./dist/email/index.js"
+      "import": "./dist/email/index.js",
+      "default": "./dist/email/index.js"
     },
     "./stripe/mode": {
       "types": "./dist/stripe/mode.d.ts",
-      "import": "./dist/stripe/mode.js"
+      "import": "./dist/stripe/mode.js",
+      "default": "./dist/stripe/mode.js"
     },
     "./stripe/payment-intent": {
       "types": "./dist/stripe/payment-intent.d.ts",
-      "import": "./dist/stripe/payment-intent.js"
+      "import": "./dist/stripe/payment-intent.js",
+      "default": "./dist/stripe/payment-intent.js"
     },
     "./stripe/stripeClient": {
       "types": "./dist/stripe/stripeClient.d.ts",
-      "import": "./dist/stripe/stripeClient.js"
+      "import": "./dist/stripe/stripeClient.js",
+      "default": "./dist/stripe/stripeClient.js"
     }
   },
   "files": [

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -38,31 +38,38 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./environment": {
       "types": "./dist/environment/index.d.ts",
-      "import": "./dist/environment/index.js"
+      "import": "./dist/environment/index.js",
+      "default": "./dist/environment/index.js"
     },
     "./utils": {
       "types": "./dist/utils/index.d.ts",
-      "import": "./dist/utils/index.js"
+      "import": "./dist/utils/index.js",
+      "default": "./dist/utils/index.js"
     },
     "./validators": {
       "types": "./dist/validators/index.d.ts",
-      "import": "./dist/validators/index.js"
+      "import": "./dist/validators/index.js",
+      "default": "./dist/validators/index.js"
     },
     "./bootstrap": {
       "types": "./dist/bootstrap/index.d.ts",
-      "import": "./dist/bootstrap/index.js"
+      "import": "./dist/bootstrap/index.js",
+      "default": "./dist/bootstrap/index.js"
     },
     "./system-tune": {
       "types": "./dist/system-tune/index.d.ts",
-      "import": "./dist/system-tune/index.js"
+      "import": "./dist/system-tune/index.js",
+      "default": "./dist/system-tune/index.js"
     },
     "./revvault": {
       "types": "./dist/revvault/index.d.ts",
-      "import": "./dist/revvault/index.js"
+      "import": "./dist/revvault/index.js",
+      "default": "./dist/revvault/index.js"
     }
   },
   "files": [

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -32,19 +32,23 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./provider": {
       "types": "./dist/provider/index.d.ts",
-      "import": "./dist/provider/index.js"
+      "import": "./dist/provider/index.js",
+      "default": "./dist/provider/index.js"
     },
     "./collab": {
       "types": "./dist/collab/index.d.ts",
-      "import": "./dist/collab/index.js"
+      "import": "./dist/collab/index.js",
+      "default": "./dist/collab/index.js"
     },
     "./collab/server": {
       "types": "./dist/collab/server-index.d.ts",
-      "import": "./dist/collab/server-index.js"
+      "import": "./dist/collab/server-index.js",
+      "default": "./dist/collab/server-index.js"
     }
   },
   "files": [

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -38,15 +38,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./integration/setup": {
       "types": "./dist/integration/setup.d.ts",
-      "import": "./dist/integration/setup.js"
+      "import": "./dist/integration/setup.js",
+      "default": "./dist/integration/setup.js"
     },
     "./integration/test-database": {
       "types": "./dist/integration/test-database.d.ts",
-      "import": "./dist/integration/test-database.js"
+      "import": "./dist/integration/test-database.js",
+      "default": "./dist/integration/test-database.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -18,7 +18,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./tokens.css": "./dist/tokens.css",
     "./design-context/MANIFEST.sha256": "./design-context/MANIFEST.sha256",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,19 +19,23 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./logger": {
       "types": "./dist/logger/index.d.ts",
-      "import": "./dist/logger/index.js"
+      "import": "./dist/logger/index.js",
+      "default": "./dist/logger/index.js"
     },
     "./database": {
       "types": "./dist/database/index.d.ts",
-      "import": "./dist/database/index.js"
+      "import": "./dist/database/index.js",
+      "default": "./dist/database/index.js"
     },
     "./validation": {
       "types": "./dist/validation/index.d.ts",
-      "import": "./dist/validation/index.js"
+      "import": "./dist/validation/index.js",
+      "default": "./dist/validation/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

`pnpm db:seed` / `pnpm db:seed:admin` failed with:

```text
ERR_PACKAGE_PATH_NOT_EXPORTED: No "exports" main defined in @revealui/config
```

**Cause:** `tsx --tsconfig apps/admin/tsconfig.json` resolves packages through Node’s CJS resolver. Workspace packages only declared `"import"` (no `"default"`), so resolution fails under Node 24.

**Durable fix:**
1. Add `"default"` matching each `"import"` on all `packages/*` export maps (non-breaking; ESM consumers unchanged).
2. Run admin seed through `scripts/lib/seed-env.ts` (demote passwordless direnv URLs; load `apps/admin/.env.local`) so DB connect matches fleet-marketing.

## Test plan

- [x] Simulated direnv `POSTGRES_URL=postgresql://postgres@localhost:5432/postgres` + `pnpm db:seed:admin` reaches DB `localhost:5432/revealui` and completes (exit 0)
- [x] `pnpm db:seed:fleet-marketing` already green on #2060
- [ ] CI Quality / Unit Tests

## Note

Collection create permission warnings (`Access denied`, missing `contents`/`events`) are separate from the module-resolution bug; seed script still exits 0 after idempotent skips/errors per item.