### PR TITLE
chore(dev): add pnpm dogfood:api local server launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,7 +259,8 @@
     "vercel:sync:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply",
     "vercel:drift-check": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --json",
     "vercel:sync:staging": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel-staging.toml",
-    "vercel:sync:staging:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel-staging.toml --apply"
+    "vercel:sync:staging:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel-staging.toml --apply",
+    "dogfood:api": "tsx scripts/dev-tools/dogfood-api.ts"
   },
   "type": "module"
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -275,3 +275,18 @@ When adding a new script:
 - **Validation**: [validate/README.md](./validate/README.md)
 - **Dev Tools**: [dev-tools/README.md](./dev-tools/README.md)
 - **Setup**: [setup/README.md](./setup/README.md)
+
+### Local dogfood (VES + API)
+
+```bash
+pnpm db:migrate                 # if audit_log / schema lag docker
+pnpm dogfood:api                # API :3004 (DB via seed-env, license via revvault)
+# optional if voice gate rejects section/ctaSection after a pull:
+pnpm dogfood:api -- --build-contracts
+
+# apps/admin/.env.local
+# NEXT_PUBLIC_API_URL=http://localhost:3004
+
+pnpm --filter marketing dev     # :3000
+pnpm dev:admin                  # :4000 — restart after changing NEXT_PUBLIC_*
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,6 +78,7 @@ scripts/
 ├── utils/                     # base.ts (shared script helpers)
 ├── seed-fleet-marketing-site.ts       # `pnpm db:seed:fleet-marketing`
 ├── seed-fleet-marketing-home-page.ts  # `pnpm db:seed:fleet-marketing-home`
+├── dev-tools/dogfood-api.ts             # `pnpm dogfood:api` (local server + env)
 ├── gen-brand-assets.cjs               # brand asset generation
 ├── audit-no-submodules.sh
 └── check-client-leaks.sh

--- a/scripts/dev-tools/dogfood-api.ts
+++ b/scripts/dev-tools/dogfood-api.ts
@@ -23,7 +23,7 @@
  *   pnpm dev:admin                # :4000 (after NEXT_PUBLIC_API_URL)
  */
 
-import { spawn, execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
@@ -69,9 +69,9 @@ function buildContracts(): void {
 async function main(): Promise<void> {
   const buildContractsFlag = process.argv.includes('--build-contracts');
 
-  console.log('\n' + '='.repeat(60));
+  console.log(`\n${'='.repeat(60)}`);
   console.log('  Dogfood API (local server :3004)');
-  console.log('='.repeat(60) + '\n');
+  console.log(`${'='.repeat(60)}\n`);
 
   loadSeedEnv(rootDir);
   const url = resolveSeedDatabaseUrl();
@@ -110,8 +110,7 @@ async function main(): Promise<void> {
 
   // Match packages/config default when unset so admin session cookies validate CSRF.
   const secret =
-    process.env.REVEALUI_SECRET ||
-    'INSECURE-DEV-ONLY-CHANGE-ME-SET-REVEALUI_SECRET-IN-PRODUCTION';
+    process.env.REVEALUI_SECRET || 'INSECURE-DEV-ONLY-CHANGE-ME-SET-REVEALUI_SECRET-IN-PRODUCTION';
 
   if (!process.env.NEXT_PUBLIC_API_URL) {
     console.log(
@@ -130,7 +129,9 @@ async function main(): Promise<void> {
       DATABASE_URL: url,
       REVEALUI_LICENSE_PRIVATE_KEY: privateKey,
       REVEALUI_SECRET: secret,
-      SESSION_SECRET: process.env.SESSION_SECRET || secret,
+      // Same value as REVEALUI_SECRET (admin CSRF/session alignment); do not
+      // read process.env.SESSION_SECRET here — biome noUndeclaredEnvVars.
+      SESSION_SECRET: secret,
     },
     stdio: 'inherit',
   });

--- a/scripts/dev-tools/dogfood-api.ts
+++ b/scripts/dev-tools/dogfood-api.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env tsx
+
+/**
+ * Local dogfood API launcher (server on :3004).
+ *
+ * Why this exists (2026-07-22 dogfood):
+ *   - `pnpm --filter server dev` alone fails closed without POSTGRES_URL /
+ *     NODE_ENV / hosted license private key (audit + license startup gates).
+ *   - bare `loadSeedEnv` is enough for DB; license keys live in revvault.
+ *   - Admin canvas calls `NEXT_PUBLIC_API_URL` (default prod). For local VES
+ *     set `NEXT_PUBLIC_API_URL=http://localhost:3004` in apps/admin/.env.local
+ *     and restart admin.
+ *   - Voice gate on fleet-marketing needs a current `@revealui/contracts` dist
+ *     (section / ctaSection prose slots). Pass `--build-contracts` if voice
+ *     rejects unmapped blockTypes after a pull.
+ *
+ * Usage:
+ *   pnpm dogfood:api
+ *   pnpm dogfood:api -- --build-contracts
+ *
+ * Does not start admin or marketing. Pair with:
+ *   pnpm --filter marketing dev   # :3000
+ *   pnpm dev:admin                # :4000 (after NEXT_PUBLIC_API_URL)
+ */
+
+import { spawn, execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  assertSeedDatabaseReady,
+  loadSeedEnv,
+  resolveSeedDatabaseUrl,
+  SeedEnvError,
+} from '../lib/seed-env.js';
+
+const rootDir = process.cwd();
+
+function revvaultGet(path: string): string | null {
+  try {
+    return execFileSync('revvault', ['get', '--full', path], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function contractsDistHasSectionSlots(): boolean {
+  try {
+    const dist = readFileSync(
+      resolve(rootDir, 'packages/contracts/dist/marketing-voice/blocks.js'),
+      'utf8',
+    );
+    return dist.includes('section:') && dist.includes('ctaSection:');
+  } catch {
+    return false;
+  }
+}
+
+function buildContracts(): void {
+  console.log('  i Building @revealui/contracts (voice prose slots)…');
+  execFileSync('pnpm', ['--filter', '@revealui/contracts', 'build'], {
+    cwd: rootDir,
+    stdio: 'inherit',
+  });
+}
+
+async function main(): Promise<void> {
+  const buildContractsFlag = process.argv.includes('--build-contracts');
+
+  console.log('\n' + '='.repeat(60));
+  console.log('  Dogfood API (local server :3004)');
+  console.log('='.repeat(60) + '\n');
+
+  loadSeedEnv(rootDir);
+  const url = resolveSeedDatabaseUrl();
+  if (!url) {
+    throw new SeedEnvError(
+      'No database URL. Point apps/admin/.env.local POSTGRES_URL at docker postgres ' +
+        '(default :5432/revealui), then re-run.',
+    );
+  }
+
+  await assertSeedDatabaseReady();
+  console.log('  + Database reachable (seed-env preflight)');
+
+  if (buildContractsFlag || !contractsDistHasSectionSlots()) {
+    if (!buildContractsFlag) {
+      console.log(
+        '  ! contracts dist missing section/ctaSection slots — rebuilding (stale dist breaks VES voice gate)',
+      );
+    }
+    buildContracts();
+  } else {
+    console.log('  + contracts dist has section/ctaSection voice slots');
+  }
+
+  const privateKey =
+    revvaultGet('revealui/staging/license/private-key') ||
+    revvaultGet('revdev/license-signing-private-key');
+  if (!privateKey) {
+    throw new SeedEnvError(
+      'No REVEALUI_LICENSE_PRIVATE_KEY in revvault ' +
+        '(tried revealui/staging/license/private-key, revdev/license-signing-private-key). ' +
+        'Hosted local mode needs a private key so startup does not require forge LICENSE_KEY.',
+    );
+  }
+  console.log('  + License private key (hosted mode)');
+
+  // Match packages/config default when unset so admin session cookies validate CSRF.
+  const secret =
+    process.env.REVEALUI_SECRET ||
+    'INSECURE-DEV-ONLY-CHANGE-ME-SET-REVEALUI_SECRET-IN-PRODUCTION';
+
+  if (!process.env.NEXT_PUBLIC_API_URL) {
+    console.log(
+      '  ! Reminder: set NEXT_PUBLIC_API_URL=http://localhost:3004 in apps/admin/.env.local and restart admin for canvas',
+    );
+  }
+
+  console.log('  i Starting pnpm --filter server dev …\n');
+
+  const child = spawn('pnpm', ['--filter', 'server', 'dev'], {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      NODE_ENV: process.env.NODE_ENV || 'development',
+      POSTGRES_URL: url,
+      DATABASE_URL: url,
+      REVEALUI_LICENSE_PRIVATE_KEY: privateKey,
+      REVEALUI_SECRET: secret,
+      SESSION_SECRET: process.env.SESSION_SECRET || secret,
+    },
+    stdio: 'inherit',
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    process.exit(code ?? 1);
+  });
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`  x ${msg}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Local VES dogfood repeatedly failed to start the API without a manual env stack (DB URL, hosted license private key, `NODE_ENV`, matching `REVEALUI_SECRET`). Voice gate also rejected fleet-marketing `section` blocks when `@revealui/contracts` dist was stale.

Adds **`pnpm dogfood:api`** → `scripts/dev-tools/dogfood-api.ts`:

- `loadSeedEnv` + `assertSeedDatabaseReady` (same as fleet seeds)
- Hosted license private key from revvault
- Default `REVEALUI_SECRET` aligned with admin config when unset
- Auto-rebuild contracts if dist lacks `section` / `ctaSection` slots
- Reminds about `NEXT_PUBLIC_API_URL=http://localhost:3004` for admin canvas

## Operator

```bash
pnpm dogfood:api
# apps/admin/.env.local:
# NEXT_PUBLIC_API_URL=http://localhost:3004
pnpm --filter marketing dev
pnpm dev:admin
```

## Test plan

- [x] Script typechecks under biome
- [ ] Local: `pnpm dogfood:api` serves `:3004/health`