### PR TITLE
feat(ves): P2 local-ai wire + canvas fields, theme, session MCP

### DIFF
--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -1,6 +1,7 @@
 import { BlockSchema } from '@revealui/contracts/content';
 import { describe, expect, it } from 'vitest';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
+import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../content/primitives';
 import { PRODUCTS_CTA_SECTION, PRODUCTS_FLAGSHIP, PRODUCTS_PAGE_HERO } from '../content/products';
@@ -11,6 +12,13 @@ import {
   getStartedSlot,
   HOME_FALLBACK_BLOCKS,
   homeBlocks,
+  LOCAL_AI_FALLBACK_BLOCKS,
+  localAiBlocks,
+  localAiCtaSlot,
+  localAiHeroSlot,
+  localAiMarketProofSlot,
+  localAiNotesSlot,
+  localAiPillarsSlot,
   PHILOSOPHY_FALLBACK_BLOCKS,
   PRODUCTS_FALLBACK_BLOCKS,
   philosophyBlocks,
@@ -38,8 +46,13 @@ function collectStrings(value: unknown, out: string[] = []): string[] {
 }
 
 describe('page-blocks derivation', () => {
-  it('produces schema-valid blocks for home, products, and philosophy', () => {
-    for (const block of [...homeBlocks(), ...productsBlocks(), ...philosophyBlocks()]) {
+  it('produces schema-valid blocks for home, products, philosophy, and local-ai', () => {
+    for (const block of [
+      ...homeBlocks(),
+      ...productsBlocks(),
+      ...philosophyBlocks(),
+      ...localAiBlocks(),
+    ]) {
       expect(BlockSchema.safeParse(block).success).toBe(true);
     }
   });
@@ -48,6 +61,13 @@ describe('page-blocks derivation', () => {
     expect(homeBlocks().map((b) => b.type)).toEqual(['section', 'section', 'ctaSection']);
     expect(productsBlocks().map((b) => b.type)).toEqual(['hero', 'section', 'ctaSection']);
     expect(philosophyBlocks().map((b) => b.type)).toEqual(['hero', 'section', 'ctaSection']);
+    expect(localAiBlocks().map((b) => b.type)).toEqual([
+      'hero',
+      'section',
+      'section',
+      'section',
+      'ctaSection',
+    ]);
   });
 
   it('round-trips philosophy slots against the static content module', () => {
@@ -61,10 +81,47 @@ describe('page-blocks derivation', () => {
     );
     expect(philosophyCtaSlot(blocks).data).toEqual(PHILOSOPHY.cta);
   });
+
+  it('round-trips local-ai slots against the static content module', () => {
+    const blocks = LOCAL_AI_FALLBACK_BLOCKS;
+    expect(localAiHeroSlot(blocks).data).toEqual({
+      eyebrow: LOCAL_AI_PAGE.eyebrow,
+      h1: LOCAL_AI_PAGE.h1,
+      lead: LOCAL_AI_PAGE.lead,
+    });
+    expect(localAiPillarsSlot(blocks).data.pillars).toEqual(
+      LOCAL_AI_PAGE.pillars.map((p) => ({ title: p.title, body: p.body })),
+    );
+    expect(localAiMarketProofSlot(blocks).data).toEqual({
+      eyebrow: LOCAL_AI_PAGE.marketProof.eyebrow,
+      heading: LOCAL_AI_PAGE.marketProof.heading,
+      body: LOCAL_AI_PAGE.marketProof.body,
+      adopters: LOCAL_AI_PAGE.marketProof.adopters.map((a) => ({
+        name: a.name,
+        detail: a.detail,
+        source: a.source,
+      })),
+      disclaimer: LOCAL_AI_PAGE.marketProof.disclaimer,
+    });
+    expect(localAiNotesSlot(blocks).data).toEqual({
+      dogfood: LOCAL_AI_SECTION.dogfood,
+      honesty: LOCAL_AI_PAGE.honesty,
+      roadmapHeading: LOCAL_AI_PAGE.roadmap.heading,
+      roadmapBody: LOCAL_AI_PAGE.roadmap.body,
+      roadmapHref: LOCAL_AI_PAGE.roadmap.href,
+      snippetCaption: LOCAL_AI_SECTION.snippet.caption,
+    });
+    expect(localAiCtaSlot(blocks).data).toEqual(LOCAL_AI_PAGE.cta);
+  });
 });
 
 describe('claims safety: prose is single-sourced, pinned values never enter blocks', () => {
-  const strings = collectStrings([homeBlocks(), productsBlocks(), philosophyBlocks()]);
+  const strings = collectStrings([
+    homeBlocks(),
+    productsBlocks(),
+    philosophyBlocks(),
+    localAiBlocks(),
+  ]);
   const haystack = strings.join(' ');
 
   it('carries the copy sentences byte-identical to the content modules', () => {
@@ -98,6 +155,17 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     }
     expect(strings).toContain(PHILOSOPHY.cta.primary.label);
     expect(strings).toContain(PHILOSOPHY.cta.secondary.label);
+    expect(strings).toContain(LOCAL_AI_PAGE.h1);
+    expect(strings).toContain(LOCAL_AI_PAGE.lead);
+    for (const pillar of LOCAL_AI_PAGE.pillars) {
+      expect(strings).toContain(pillar.title);
+      expect(strings).toContain(pillar.body);
+    }
+    expect(strings).toContain(LOCAL_AI_PAGE.marketProof.heading);
+    expect(strings).toContain(LOCAL_AI_SECTION.snippet.caption);
+    // Env-code lines stay out of blocks (grep-accurate, component-local).
+    expect(strings).not.toContain('LLM_PROVIDER=inference-snaps');
+    expect(strings).not.toContain('LLM_PROVIDER=ollama');
   });
 
   it('never carries metric-derived numbers, prices, or product versions', () => {

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -1,6 +1,6 @@
 /**
  * Static-first block derivation for marketing pages served from the CMS
- * (home, products, philosophy).
+ * (home, products, philosophy, local-ai).
  *
  * The marketing content modules stay the single source of truth for every prose
  * string. This module derives the canonical `pages.blocks` array from those
@@ -12,6 +12,8 @@
  * from a block, so the styled marketing components keep their look while their
  * prose can be overridden by the CMS. Only prose lives in blocks: metric-derived
  * numbers, prices, product versions, colors, and icon paths never leave the TSX.
+ * Interactive widgets (ProviderSwitch, FrontierPathway) and env-code snippets
+ * stay component-local so grep-accurate config lines never go through CMS.
  *
  * No React or network imports live here so `scripts/seed-fleet-marketing-site.ts`
  * can import the same derivation the runtime falls back to.
@@ -28,6 +30,7 @@ import {
   type SectionBlock,
 } from '@revealui/contracts/content';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
+import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../content/primitives';
 import { PRODUCTS_CTA_SECTION, PRODUCTS_PAGE_HERO } from '../content/products';
@@ -114,6 +117,49 @@ export interface PhilosophyCtaData {
   readonly secondary: Cta;
 }
 
+export interface LocalAiHeroData {
+  readonly eyebrow: string;
+  readonly h1: string;
+  readonly lead: string;
+}
+
+export interface LocalAiPillarData {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface LocalAiPillarsData {
+  readonly pillars: readonly LocalAiPillarData[];
+}
+
+export interface LocalAiAdopterData {
+  readonly name: string;
+  readonly detail: string;
+  readonly source: string;
+}
+
+export interface LocalAiMarketProofData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly adopters: readonly LocalAiAdopterData[];
+  readonly disclaimer: string;
+}
+
+export interface LocalAiNotesData {
+  readonly dogfood: string;
+  readonly honesty: string;
+  readonly roadmapHeading: string;
+  readonly roadmapBody: string;
+  readonly roadmapHref: string;
+  readonly snippetCaption: string;
+}
+
+export interface LocalAiCtaData {
+  readonly primary: Cta;
+  readonly secondary: Cta;
+}
+
 // ---------------------------------------------------------------------------
 // Stable block ids + positions. Ids let the seed and fallback match, but the
 // runtime routes each slot by array POSITION + type (the CMS assigns its own
@@ -129,6 +175,11 @@ export const PRODUCTS_CTA_BLOCK_ID = 'products-cta';
 export const PHILOSOPHY_HERO_BLOCK_ID = 'philosophy-hero';
 export const PHILOSOPHY_BODY_BLOCK_ID = 'philosophy-body';
 export const PHILOSOPHY_CTA_BLOCK_ID = 'philosophy-cta';
+export const LOCAL_AI_HERO_BLOCK_ID = 'local-ai-hero';
+export const LOCAL_AI_PILLARS_BLOCK_ID = 'local-ai-pillars';
+export const LOCAL_AI_MARKET_PROOF_BLOCK_ID = 'local-ai-market-proof';
+export const LOCAL_AI_NOTES_BLOCK_ID = 'local-ai-notes';
+export const LOCAL_AI_CTA_BLOCK_ID = 'local-ai-cta';
 
 const HOME_DEMO_INDEX = 0;
 const HOME_PRIMITIVES_INDEX = 1;
@@ -139,6 +190,11 @@ const PRODUCTS_CTA_INDEX = 2;
 const PHILOSOPHY_HERO_INDEX = 0;
 const PHILOSOPHY_BODY_INDEX = 1;
 const PHILOSOPHY_CTA_INDEX = 2;
+const LOCAL_AI_HERO_INDEX = 0;
+const LOCAL_AI_PILLARS_INDEX = 1;
+const LOCAL_AI_MARKET_PROOF_INDEX = 2;
+const LOCAL_AI_NOTES_INDEX = 3;
+const LOCAL_AI_CTA_INDEX = 4;
 
 function ctaToLink(cta: Cta, variant: 'primary' | 'secondary'): MarketingLink {
   return { label: cta.label, href: cta.href, variant };
@@ -251,6 +307,67 @@ function philosophyCtaBlock(): CtaSectionBlock {
   });
 }
 
+function localAiHeroBlock(): HeroBlock {
+  return createHeroBlock(LOCAL_AI_HERO_BLOCK_ID, LOCAL_AI_PAGE.h1, {
+    eyebrow: LOCAL_AI_PAGE.eyebrow,
+    subtitle: LOCAL_AI_PAGE.lead,
+  });
+}
+
+function localAiPillarsBlock(): SectionBlock {
+  // Structural heading (not rendered as a second H1 on the page).
+  return createSectionBlock(LOCAL_AI_PILLARS_BLOCK_ID, 'Pillars', {
+    items: LOCAL_AI_PAGE.pillars.map((pillar) => ({
+      label: pillar.title,
+      body: pillar.body,
+    })),
+  });
+}
+
+function localAiMarketProofBlock(): SectionBlock {
+  return createSectionBlock(LOCAL_AI_MARKET_PROOF_BLOCK_ID, LOCAL_AI_PAGE.marketProof.heading, {
+    eyebrow: LOCAL_AI_PAGE.marketProof.eyebrow,
+    body: LOCAL_AI_PAGE.marketProof.body,
+    items: [
+      ...LOCAL_AI_PAGE.marketProof.adopters.map((adopter) => ({
+        label: adopter.name,
+        title: adopter.source,
+        body: adopter.detail,
+      })),
+      {
+        label: 'disclaimer',
+        body: LOCAL_AI_PAGE.marketProof.disclaimer,
+      },
+    ],
+  });
+}
+
+function localAiNotesBlock(): SectionBlock {
+  // Dogfood, honesty, roadmap, and the snippet caption (prose only). Env-code
+  // lines stay in LocalAiPage so they remain grep-accurate to packages/ai.
+  return createSectionBlock(LOCAL_AI_NOTES_BLOCK_ID, 'Notes', {
+    items: [
+      { label: 'dogfood', body: LOCAL_AI_SECTION.dogfood },
+      { label: 'honesty', body: LOCAL_AI_PAGE.honesty },
+      {
+        label: 'roadmap',
+        title: LOCAL_AI_PAGE.roadmap.heading,
+        body: LOCAL_AI_PAGE.roadmap.body,
+      },
+      { label: 'snippet-caption', body: LOCAL_AI_SECTION.snippet.caption },
+    ],
+  });
+}
+
+function localAiCtaBlock(): CtaSectionBlock {
+  return createCtaSectionBlock(LOCAL_AI_CTA_BLOCK_ID, 'Next', {
+    links: [
+      ctaToLink(LOCAL_AI_PAGE.cta.primary, 'primary'),
+      ctaToLink(LOCAL_AI_PAGE.cta.secondary, 'secondary'),
+    ],
+  });
+}
+
 /** Derives the home page's block-driven sections (Demo, Primitives, GetStarted). */
 export function homeBlocks(): Block[] {
   return [homeDemoBlock(), homePrimitivesBlock(), homeGetStartedBlock()];
@@ -266,9 +383,21 @@ export function philosophyBlocks(): Block[] {
   return [philosophyHeroBlock(), philosophyBodyBlock(), philosophyCtaBlock()];
 }
 
+/** Derives the local-ai page's block-driven sections (hero through CTA). */
+export function localAiBlocks(): Block[] {
+  return [
+    localAiHeroBlock(),
+    localAiPillarsBlock(),
+    localAiMarketProofBlock(),
+    localAiNotesBlock(),
+    localAiCtaBlock(),
+  ];
+}
+
 export const HOME_FALLBACK_BLOCKS: Block[] = homeBlocks();
 export const PRODUCTS_FALLBACK_BLOCKS: Block[] = productsBlocks();
 export const PHILOSOPHY_FALLBACK_BLOCKS: Block[] = philosophyBlocks();
+export const LOCAL_AI_FALLBACK_BLOCKS: Block[] = localAiBlocks();
 
 // ---------------------------------------------------------------------------
 // Reverse mappers: canonical block -> rich component data shape
@@ -350,6 +479,67 @@ function sectionToPhilosophyBody(block: SectionBlock): PhilosophyBodyData {
       const role: PhilosophyParagraphRole = label === 'lead' || label === 'footer' ? label : 'body';
       return { role, body: item.body };
     }),
+  };
+}
+
+function heroToLocalAiHero(block: HeroBlock): LocalAiHeroData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    h1: block.data.title,
+    lead: block.data.subtitle ?? '',
+  };
+}
+
+function sectionToLocalAiPillars(block: SectionBlock): LocalAiPillarsData {
+  return {
+    pillars: (block.data.items ?? []).map((item) => ({
+      title: item.label ?? '',
+      body: item.body,
+    })),
+  };
+}
+
+function sectionToLocalAiMarketProof(block: SectionBlock): LocalAiMarketProofData {
+  const items = block.data.items ?? [];
+  const disclaimerItem = items.find((item) => item.label === 'disclaimer');
+  const adopters = items
+    .filter((item) => item.label !== 'disclaimer')
+    .map((item) => ({
+      name: item.label ?? '',
+      detail: item.body,
+      source: item.title ?? '',
+    }));
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    adopters,
+    disclaimer: disclaimerItem?.body ?? LOCAL_AI_PAGE.marketProof.disclaimer,
+  };
+}
+
+function sectionToLocalAiNotes(block: SectionBlock): LocalAiNotesData {
+  const byLabel = new Map((block.data.items ?? []).map((item) => [item.label ?? '', item]));
+  const dogfood = byLabel.get('dogfood')?.body ?? LOCAL_AI_SECTION.dogfood;
+  const honesty = byLabel.get('honesty')?.body ?? LOCAL_AI_PAGE.honesty;
+  const roadmap = byLabel.get('roadmap');
+  const snippet = byLabel.get('snippet-caption');
+  return {
+    dogfood,
+    honesty,
+    roadmapHeading: roadmap?.title ?? LOCAL_AI_PAGE.roadmap.heading,
+    roadmapBody: roadmap?.body ?? LOCAL_AI_PAGE.roadmap.body,
+    // href is structural navigation, not CMS prose.
+    roadmapHref: LOCAL_AI_PAGE.roadmap.href,
+    snippetCaption: snippet?.body ?? LOCAL_AI_SECTION.snippet.caption,
+  };
+}
+
+function ctaToLocalAiCta(block: CtaSectionBlock): LocalAiCtaData {
+  const links = block.data.links ?? [];
+  return {
+    primary: links[0] ? linkToCta(links[0]) : LOCAL_AI_PAGE.cta.primary,
+    secondary: links[1] ? linkToCta(links[1]) : LOCAL_AI_PAGE.cta.secondary,
   };
 }
 
@@ -460,6 +650,41 @@ export function philosophyCtaSlot(blocks: Block[]): BlockSlot<PhilosophyCtaData>
   const path = `blocks.${PHILOSOPHY_CTA_INDEX}.data`;
   if (block && block.type === 'ctaSection') return { data: ctaToPhilosophyCta(block), path };
   return { data: ctaToPhilosophyCta(philosophyCtaBlock()), path };
+}
+
+export function localAiHeroSlot(blocks: Block[]): BlockSlot<LocalAiHeroData> {
+  const block = blocks[LOCAL_AI_HERO_INDEX];
+  const path = `blocks.${LOCAL_AI_HERO_INDEX}.data`;
+  if (block && block.type === 'hero') return { data: heroToLocalAiHero(block), path };
+  return { data: heroToLocalAiHero(localAiHeroBlock()), path };
+}
+
+export function localAiPillarsSlot(blocks: Block[]): BlockSlot<LocalAiPillarsData> {
+  const block = blocks[LOCAL_AI_PILLARS_INDEX];
+  const path = `blocks.${LOCAL_AI_PILLARS_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToLocalAiPillars(block), path };
+  return { data: sectionToLocalAiPillars(localAiPillarsBlock()), path };
+}
+
+export function localAiMarketProofSlot(blocks: Block[]): BlockSlot<LocalAiMarketProofData> {
+  const block = blocks[LOCAL_AI_MARKET_PROOF_INDEX];
+  const path = `blocks.${LOCAL_AI_MARKET_PROOF_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToLocalAiMarketProof(block), path };
+  return { data: sectionToLocalAiMarketProof(localAiMarketProofBlock()), path };
+}
+
+export function localAiNotesSlot(blocks: Block[]): BlockSlot<LocalAiNotesData> {
+  const block = blocks[LOCAL_AI_NOTES_INDEX];
+  const path = `blocks.${LOCAL_AI_NOTES_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToLocalAiNotes(block), path };
+  return { data: sectionToLocalAiNotes(localAiNotesBlock()), path };
+}
+
+export function localAiCtaSlot(blocks: Block[]): BlockSlot<LocalAiCtaData> {
+  const block = blocks[LOCAL_AI_CTA_INDEX];
+  const path = `blocks.${LOCAL_AI_CTA_INDEX}.data`;
+  if (block && block.type === 'ctaSection') return { data: ctaToLocalAiCta(block), path };
+  return { data: ctaToLocalAiCta(localAiCtaBlock()), path };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -1,141 +1,286 @@
-import { Button } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import { FrontierPathway } from '../components/landing/FrontierPathway';
 import { ProviderSwitch } from '../components/landing/ProviderSwitch';
-import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
+import { LOCAL_AI_SECTION } from '../content/local-ai';
+import {
+  LOCAL_AI_FALLBACK_BLOCKS,
+  type LocalAiCtaData,
+  type LocalAiHeroData,
+  type LocalAiMarketProofData,
+  type LocalAiNotesData,
+  type LocalAiPillarsData,
+  localAiCtaSlot,
+  localAiHeroSlot,
+  localAiMarketProofSlot,
+  localAiNotesSlot,
+  localAiPillarsSlot,
+} from '../lib/page-blocks';
+import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
 // index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette
 // remap); this renders cobalt today, not emerald.
 const SNIPPET_CODE_CLASS_NAME = 'text-emerald-400'; // adherence-ignore: emerald-utility - zero visual change, see comment above
 
+interface LocalAiHeroProps {
+  data: LocalAiHeroData;
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+function LocalAiHero({ data, path, annotation }: LocalAiHeroProps) {
+  return (
+    <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-violet-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        <p
+          className="text-sm font-semibold uppercase tracking-wide text-primary"
+          {...fieldAttrs(annotation, `${path}.eyebrow`)}
+        >
+          {data.eyebrow}
+        </p>
+        <h1
+          className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+          {...fieldAttrs(annotation, `${path}.title`)}
+        >
+          {data.h1}
+        </h1>
+        <p
+          className="mt-6 text-lg leading-8 text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.subtitle`)}
+        >
+          {data.lead}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+interface LocalAiPillarsProps {
+  data: LocalAiPillarsData;
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+function LocalAiPillars({ data, path, annotation }: LocalAiPillarsProps) {
+  return (
+    <section className="px-6 py-16 sm:py-20 lg:px-8">
+      <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
+        {data.pillars.map((pillar, index) => (
+          <div key={`pillar-${index}`} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+            <h2
+              className="text-lg font-semibold text-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+            >
+              {pillar.title}
+            </h2>
+            <p
+              className="mt-3 text-sm leading-6 text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+            >
+              {pillar.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+interface LocalAiSnippetProps {
+  caption: string;
+  captionPath: string;
+  annotation: BlockAnnotation;
+}
+
+function LocalAiSnippet({ caption, captionPath, annotation }: LocalAiSnippetProps) {
+  return (
+    <section className="px-6 pb-8 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        <div className="rounded-2xl bg-foreground p-6 ring-1 ring-background/10">
+          <ul className="space-y-2 font-mono text-sm list-none p-0">
+            {LOCAL_AI_SECTION.snippet.lines.map((line) => (
+              <li
+                key={line.code}
+                className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3"
+              >
+                <code className={SNIPPET_CODE_CLASS_NAME}>{line.code}</code>
+                <span className="text-background/60"># {line.note}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <p className="mt-3 text-sm text-muted-foreground" {...fieldAttrs(annotation, captionPath)}>
+          {caption}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+interface LocalAiMarketProofProps {
+  data: LocalAiMarketProofData;
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+function LocalAiMarketProof({ data, path, annotation }: LocalAiMarketProofProps) {
+  return (
+    <section className="px-6 py-16 sm:py-20 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-primary"
+          {...fieldAttrs(annotation, `${path}.eyebrow`)}
+        >
+          {data.eyebrow}
+        </p>
+        <h2
+          className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
+          {...fieldAttrs(annotation, `${path}.heading`)}
+        >
+          {data.heading}
+        </h2>
+        <p
+          className="mt-4 text-base leading-7 text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.body`)}
+        >
+          {data.body}
+        </p>
+        <ul className="mt-8 space-y-4 list-none p-0">
+          {data.adopters.map((adopter, index) => (
+            <li key={`adopter-${index}`} className="rounded-xl bg-secondary p-5 ring-1 ring-border">
+              <p className="text-base text-foreground">
+                <span
+                  className="font-semibold"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+                >
+                  {adopter.name}
+                </span>{' '}
+                <span {...fieldAttrs(annotation, `${path}.items.${index}.body`)}>
+                  {adopter.detail}
+                </span>
+              </p>
+              <p
+                className="mt-1 text-xs text-muted-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.title`)}
+              >
+                {adopter.source}
+              </p>
+            </li>
+          ))}
+        </ul>
+        <p
+          className="mt-6 text-sm italic leading-6 text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.items.${data.adopters.length}.body`)}
+        >
+          {data.disclaimer}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+interface LocalAiNotesProps {
+  data: LocalAiNotesData;
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+function LocalAiNotes({ data, path, annotation }: LocalAiNotesProps) {
+  // Item indices match localAiNotesBlock order: dogfood, honesty, roadmap, snippet-caption.
+  return (
+    <section className="px-6 pb-16 lg:px-8">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <p
+          className="text-base leading-7 text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.items.0.body`)}
+        >
+          {data.dogfood}
+        </p>
+        <div className="rounded-xl border border-border bg-card p-5">
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.items.2.title`)}
+          >
+            {data.roadmapHeading}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            <span {...fieldAttrs(annotation, `${path}.items.2.body`)}>{data.roadmapBody}</span>{' '}
+            <a href={data.roadmapHref} className="font-medium text-primary hover:underline">
+              See the roadmap
+            </a>
+            .
+          </p>
+        </div>
+        <p
+          className="border-t border-border pt-6 text-sm leading-6 text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.items.1.body`)}
+        >
+          {data.honesty}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+interface LocalAiCtaProps {
+  data: LocalAiCtaData;
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+function LocalAiCta({ data, path, annotation }: LocalAiCtaProps) {
+  return (
+    <section className="px-6 pb-24 sm:pb-32 lg:px-8">
+      <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
+        <Button asChild size="lg" variant="brand">
+          <a href={data.primary.href} {...fieldAttrs(annotation, `${path}.links.0.label`)}>
+            {data.primary.label}
+          </a>
+        </Button>
+        <Button asChild size="lg" appearance="outline" variant="neutral">
+          <a
+            href={data.secondary.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            {...fieldAttrs(annotation, `${path}.links.1.label`)}
+          >
+            {data.secondary.label}
+          </a>
+        </Button>
+      </div>
+    </section>
+  );
+}
+
 /**
  * Standalone /local-ai page (positioning decision c: standalone, not folded in).
- * Consolidates the economics, in-boundary sovereignty, and frontier-pathway
- * lines, the §4(c) named-adopter MARKET proof (industry adopters of open/local
- * models, not RevealUI customers), and the air-gap roadmap. The opencode pathway
- * is gated to Phase E (corpus §4.13) and ships there, not here. One primary CTA.
- * Guardrail: ownership stays the lead; local AI is its proof, not a reordering of
- * the locked positioning stack.
+ * Prose sections are CMS-wired via useMarketingPageBlocks (VES P2). Interactive
+ * ProviderSwitch / FrontierPathway and env-code snippet lines stay static.
  */
 export function LocalAiPage() {
+  const { blocks, annotation } = useMarketingPageBlocks('local-ai', LOCAL_AI_FALLBACK_BLOCKS);
+  const hero = localAiHeroSlot(blocks);
+  const pillars = localAiPillarsSlot(blocks);
+  const marketProof = localAiMarketProofSlot(blocks);
+  const notes = localAiNotesSlot(blocks);
+  const cta = localAiCtaSlot(blocks);
+
   return (
     <div className="min-h-screen bg-background">
-      <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-violet-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <div className="mx-auto max-w-3xl">
-          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
-            {LOCAL_AI_PAGE.eyebrow}
-          </p>
-          <h1 className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-            {LOCAL_AI_PAGE.h1}
-          </h1>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{LOCAL_AI_PAGE.lead}</p>
-        </div>
-      </section>
-
-      {/* Three pillars: sovereignty, economics, pathway. */}
-      <section className="px-6 py-16 sm:py-20 lg:px-8">
-        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
-          {LOCAL_AI_PAGE.pillars.map((pillar) => (
-            <div key={pillar.title} className="rounded-2xl bg-card p-6 ring-1 ring-border">
-              <h2 className="text-lg font-semibold text-foreground">{pillar.title}</h2>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">{pillar.body}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* One-config-line provider snippet, shared with the home section. */}
-      <section className="px-6 pb-8 lg:px-8">
-        <div className="mx-auto max-w-3xl">
-          <div className="rounded-2xl bg-foreground p-6 ring-1 ring-background/10">
-            <ul className="space-y-2 font-mono text-sm list-none p-0">
-              {LOCAL_AI_SECTION.snippet.lines.map((line) => (
-                <li
-                  key={line.code}
-                  className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3"
-                >
-                  <code className={SNIPPET_CODE_CLASS_NAME}>{line.code}</code>
-                  <span className="text-background/60"># {line.note}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <p className="mt-3 text-sm text-muted-foreground">{LOCAL_AI_SECTION.snippet.caption}</p>
-        </div>
-      </section>
-
-      {/* Provider-switch interactive + frontier-pathway visual (Phase D). */}
+      <LocalAiHero data={hero.data} path={hero.path} annotation={annotation} />
+      <LocalAiPillars data={pillars.data} path={pillars.path} annotation={annotation} />
+      <LocalAiSnippet
+        caption={notes.data.snippetCaption}
+        captionPath={`${notes.path}.items.3.body`}
+        annotation={annotation}
+      />
       <section className="px-6 pb-8 lg:px-8">
         <ProviderSwitch />
         <FrontierPathway />
       </section>
-
-      {/* §4(c) market proof: industry adopters of open/local models, not customers. */}
-      <section className="px-6 py-16 sm:py-20 lg:px-8">
-        <div className="mx-auto max-w-3xl">
-          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
-            {LOCAL_AI_PAGE.marketProof.eyebrow}
-          </p>
-          <h2 className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-            {LOCAL_AI_PAGE.marketProof.heading}
-          </h2>
-          <p className="mt-4 text-base leading-7 text-muted-foreground">
-            {LOCAL_AI_PAGE.marketProof.body}
-          </p>
-          <ul className="mt-8 space-y-4 list-none p-0">
-            {LOCAL_AI_PAGE.marketProof.adopters.map((adopter) => (
-              <li key={adopter.name} className="rounded-xl bg-secondary p-5 ring-1 ring-border">
-                <p className="text-base text-foreground">
-                  <span className="font-semibold">{adopter.name}</span> {adopter.detail}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">{adopter.source}</p>
-              </li>
-            ))}
-          </ul>
-          <p className="mt-6 text-sm italic leading-6 text-muted-foreground">
-            {LOCAL_AI_PAGE.marketProof.disclaimer}
-          </p>
-        </div>
-      </section>
-
-      {/* Dogfood proof + honesty qualification + air-gap roadmap. */}
-      <section className="px-6 pb-16 lg:px-8">
-        <div className="mx-auto max-w-3xl space-y-6">
-          <p className="text-base leading-7 text-muted-foreground">{LOCAL_AI_SECTION.dogfood}</p>
-          <div className="rounded-xl border border-border bg-card p-5">
-            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-              {LOCAL_AI_PAGE.roadmap.heading}
-            </p>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              {LOCAL_AI_PAGE.roadmap.body}{' '}
-              <a
-                href={LOCAL_AI_PAGE.roadmap.href}
-                className="font-medium text-primary hover:underline"
-              >
-                See the roadmap
-              </a>
-              .
-            </p>
-          </div>
-          <p className="border-t border-border pt-6 text-sm leading-6 text-muted-foreground">
-            {LOCAL_AI_PAGE.honesty}
-          </p>
-        </div>
-      </section>
-
-      <section className="px-6 pb-24 sm:pb-32 lg:px-8">
-        <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
-          <Button asChild size="lg" variant="brand">
-            <a href={LOCAL_AI_PAGE.cta.primary.href}>{LOCAL_AI_PAGE.cta.primary.label}</a>
-          </Button>
-          <Button asChild size="lg" appearance="outline" variant="neutral">
-            <a href={LOCAL_AI_PAGE.cta.secondary.href} target="_blank" rel="noopener noreferrer">
-              {LOCAL_AI_PAGE.cta.secondary.label}
-            </a>
-          </Button>
-        </div>
-      </section>
-
+      <LocalAiMarketProof data={marketProof.data} path={marketProof.path} annotation={annotation} />
+      <LocalAiNotes data={notes.data} path={notes.path} annotation={annotation} />
+      <LocalAiCta data={cta.data} path={cta.path} annotation={annotation} />
       <Footer />
     </div>
   );

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -88,20 +88,32 @@ function PhilosophyBody({ data, path, annotation }: PhilosophyBodyProps) {
 
 interface PhilosophyCtaProps {
   data: PhilosophyCtaData;
+  path: string;
+  annotation: BlockAnnotation;
 }
 
-function PhilosophyCta({ data }: PhilosophyCtaProps) {
-  // Link labels are editable via the ctaSection block's links in a later
-  // media/CTA canvas slice; for now labels ride the block data used by seed.
+function PhilosophyCta({ data, path, annotation }: PhilosophyCtaProps) {
   return (
     <section className="px-6 pb-24 sm:pb-32 lg:px-8">
       <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
         <Button asChild size="lg" variant="brand">
-          <a href={data.primary.href}>{data.primary.label}</a>
+          <a
+            href={data.primary.href}
+            {...fieldAttrs(annotation, `${path}.links.0.href`)}
+            data-rvui-value={data.primary.href}
+          >
+            <span {...fieldAttrs(annotation, `${path}.links.0.label`)}>{data.primary.label}</span>
+          </a>
         </Button>
         <Button asChild size="lg" appearance="outline" variant="neutral">
-          <a href={data.secondary.href} target="_blank" rel="noopener noreferrer">
-            {data.secondary.label}
+          <a
+            href={data.secondary.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            {...fieldAttrs(annotation, `${path}.links.1.href`)}
+            data-rvui-value={data.secondary.href}
+          >
+            <span {...fieldAttrs(annotation, `${path}.links.1.label`)}>{data.secondary.label}</span>
           </a>
         </Button>
       </div>
@@ -119,7 +131,7 @@ export function PhilosophyPage() {
     <div className="min-h-screen bg-background">
       <PhilosophyHero data={hero.data} path={hero.path} annotation={annotation} />
       <PhilosophyBody data={body.data} path={body.path} annotation={annotation} />
-      <PhilosophyCta data={cta.data} />
+      <PhilosophyCta data={cta.data} path={cta.path} annotation={annotation} />
       <Footer />
     </div>
   );

--- a/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
+++ b/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
@@ -13,8 +13,9 @@ import { act, cleanup, render, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchPageBlocks } from '../../lib/api';
-import { homeBlocks, productsBlocks } from '../../lib/page-blocks';
+import { homeBlocks, localAiBlocks, productsBlocks } from '../../lib/page-blocks';
 import { HomePage } from '../HomePage';
+import { LocalAiPage } from '../LocalAiPage';
 import { ProductsPage } from '../ProductsPage';
 
 vi.mock('../../lib/api', () => ({ fetchPageBlocks: vi.fn() }));
@@ -63,7 +64,7 @@ describe('marketing pages: edit-mode wiring', () => {
     editDraftsStore.setEditActive(false);
   });
 
-  it('HomePage and ProductsPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
+  it('HomePage, ProductsPage, and LocalAiPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
     const home = renderRouted(<HomePage />);
     expect(home.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(home.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
@@ -72,6 +73,11 @@ describe('marketing pages: edit-mode wiring', () => {
     const products = renderRouted(<ProductsPage />);
     expect(products.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(products.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
+    products.unmount();
+
+    const localAi = renderRouted(<LocalAiPage />);
+    expect(localAi.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+    expect(localAi.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
   });
 
   it('HomePage renders the draft heading annotated with the session docId when a matching overlay exists', () => {
@@ -108,6 +114,26 @@ describe('marketing pages: edit-mode wiring', () => {
     const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
     expect(title?.getAttribute('data-rvui-doc')).toBe('page-products-id');
     expect(title?.textContent).toBe('Canvas-edited hero title');
+  });
+
+  it('LocalAiPage renders the draft hero annotated with the session docId when a matching overlay exists', () => {
+    const draftBlocks = localAiBlocks();
+    const hero = draftBlocks[0];
+    if (hero?.type === 'hero') {
+      hero.data.title = 'Canvas-edited local-ai title';
+    }
+    editDraftsStore.set([
+      {
+        docType: 'page',
+        docId: 'page-local-ai-id',
+        draft: { slug: 'local-ai', blocks: draftBlocks },
+      },
+    ]);
+
+    const { container } = renderRouted(<LocalAiPage />);
+    const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
+    expect(title?.getAttribute('data-rvui-doc')).toBe('page-local-ai-id');
+    expect(title?.textContent).toBe('Canvas-edited local-ai title');
   });
 
   it('re-renders HomePage with the patched value after an optimistic draft-store update', () => {

--- a/apps/server/src/lib/mcp-tool-access.ts
+++ b/apps/server/src/lib/mcp-tool-access.ts
@@ -24,13 +24,18 @@ import { AuthorizationSystem } from '@revealui/core/security';
 /** Server-derived account tier (mirrors `EntitlementContext['tier']`). */
 export type McpTier = 'free' | 'pro' | 'max' | 'enterprise';
 
-/** The governed tool surface (Phase 1 scope: the five read tools). */
+/** The governed tool surface (content reads + VES session propose tools). */
 export const MCP_TOOL_NAMES = [
   'revealui_list_sites',
   'revealui_list_content',
   'revealui_get_content',
   'revealui_site_stats',
   'revealui_list_users',
+  'revealui_session_list',
+  'revealui_session_open',
+  'revealui_session_get',
+  'revealui_session_patch',
+  'revealui_page_read',
 ] as const;
 export type McpToolName = (typeof MCP_TOOL_NAMES)[number];
 
@@ -39,6 +44,14 @@ const CONTENT_READ_TOOLS: readonly McpToolName[] = [
   'revealui_list_content',
   'revealui_get_content',
   'revealui_site_stats',
+  'revealui_page_read',
+];
+/** VES session tools — agents may propose; humans publish outside MCP. */
+const SESSION_PROPOSE_TOOLS: readonly McpToolName[] = [
+  'revealui_session_list',
+  'revealui_session_open',
+  'revealui_session_get',
+  'revealui_session_patch',
 ];
 const ADMIN_TOOLS: readonly McpToolName[] = ['revealui_list_users'];
 
@@ -50,12 +63,12 @@ function toolPermissionKey(toolName: string): string {
 
 /** Which tools each role may execute (RBAC grants). */
 const ROLE_TOOL_GRANTS: Record<string, readonly McpToolName[]> = {
-  owner: [...CONTENT_READ_TOOLS, ...ADMIN_TOOLS],
-  admin: [...CONTENT_READ_TOOLS, ...ADMIN_TOOLS],
-  editor: CONTENT_READ_TOOLS,
+  owner: [...CONTENT_READ_TOOLS, ...SESSION_PROPOSE_TOOLS, ...ADMIN_TOOLS],
+  admin: [...CONTENT_READ_TOOLS, ...SESSION_PROPOSE_TOOLS, ...ADMIN_TOOLS],
+  editor: [...CONTENT_READ_TOOLS, ...SESSION_PROPOSE_TOOLS],
   viewer: CONTENT_READ_TOOLS,
-  agent: CONTENT_READ_TOOLS,
-  contributor: CONTENT_READ_TOOLS,
+  agent: [...CONTENT_READ_TOOLS, ...SESSION_PROPOSE_TOOLS],
+  contributor: [...CONTENT_READ_TOOLS, ...SESSION_PROPOSE_TOOLS],
 };
 
 /** Which tiers may see/execute each tool (tier gate). `list_users` is pro-gated. */
@@ -67,6 +80,11 @@ const TOOL_TIER_GATE: Record<McpToolName, ReadonlySet<McpTier>> = {
   revealui_get_content: ALL_TIERS,
   revealui_site_stats: ALL_TIERS,
   revealui_list_users: PAID_TIERS,
+  revealui_session_list: ALL_TIERS,
+  revealui_session_open: ALL_TIERS,
+  revealui_session_get: ALL_TIERS,
+  revealui_session_patch: ALL_TIERS,
+  revealui_page_read: ALL_TIERS,
 };
 
 // A dedicated engine instance registered with the exact tool-permission keys.

--- a/apps/server/src/routes/content/sessions.ts
+++ b/apps/server/src/routes/content/sessions.ts
@@ -56,13 +56,34 @@ interface SessionUser {
   role: string;
 }
 
-/** Require an authenticated user holding content:update. Throws 401 / 403. */
+/**
+ * Open / list / patch / discard: human editors (`content:update`) or agents
+ * proposing into a session (`content:propose`). Publish stays human-only via
+ * `requireContentPublisher`.
+ */
 function requireContentEditor(user: SessionUser | undefined): SessionUser {
   if (!user) {
     throw new HTTPException(401, { message: 'Authentication required' });
   }
+  const canUpdate = authorizationSystem.hasPermission([user.role], 'content', 'update');
+  const canPropose = authorizationSystem.hasPermission([user.role], 'content', 'propose');
+  if (!(canUpdate || canPropose)) {
+    throw new HTTPException(403, {
+      message: 'Permission denied: content:update or content:propose',
+    });
+  }
+  return user;
+}
+
+/** Publish remains a human (or editor) act — never content:propose alone. */
+function requireContentPublisher(user: SessionUser | undefined): SessionUser {
+  if (!user) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
   if (!authorizationSystem.hasPermission([user.role], 'content', 'update')) {
-    throw new HTTPException(403, { message: 'Permission denied: content:update' });
+    throw new HTTPException(403, {
+      message: 'Permission denied: content:update required to publish',
+    });
   }
   return user;
 }
@@ -89,7 +110,15 @@ function actorKindFor(user: SessionUser): 'human' | 'agent' {
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 const UNPATCHABLE_ROOT_HINT =
-  "not a writable root (writable: 'title', 'seo', 'blocks.<i>.data...')";
+  "not a writable root (writable: 'title', 'seo', 'theme', 'blocks.<i>.data...')";
+
+/** Allowlisted design-token CSS variables (matches @revealui/editor field-kind). */
+const EDITABLE_THEME_TOKEN_NAMES = new Set([
+  '--rvui-brand',
+  '--rvui-brand-glow',
+  '--rvui-accent',
+  '--rvui-radius-md',
+]);
 
 function isArrayIndex(segment: string): boolean {
   if (segment.length === 0) return false;
@@ -179,6 +208,50 @@ function applyDraftPatch(draft: Record<string, unknown>, path: string, value: un
       return;
     }
     setThroughExisting(draft, segments, 0, value, false);
+    return;
+  }
+
+  if (root === 'theme') {
+    // P2 token theming: draft.theme is a map of allowlisted --rvui-* CSS vars.
+    if (segments.length === 1) {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new HTTPException(400, { message: 'theme must be an object of token → value' });
+      }
+      const next: Record<string, string> = {};
+      for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+        if (!EDITABLE_THEME_TOKEN_NAMES.has(key)) {
+          throw pathError(key, 'not an allowlisted design token');
+        }
+        if (typeof val !== 'string') {
+          throw new HTTPException(400, { message: `theme.${key} must be a string` });
+        }
+        if (val.includes(';') || val.includes('{') || val.includes('}')) {
+          throw new HTTPException(400, { message: `theme.${key} contains illegal CSS` });
+        }
+        next[key] = val;
+      }
+      draft.theme = next;
+      return;
+    }
+    if (segments.length !== 2) {
+      throw pathError(segments.slice(1).join('.'), 'theme paths are theme.<token> only');
+    }
+    const token = segments[1];
+    if (!token || !EDITABLE_THEME_TOKEN_NAMES.has(token)) {
+      throw pathError(token ?? 'theme', 'not an allowlisted design token');
+    }
+    if (typeof value !== 'string') {
+      throw new HTTPException(400, { message: `theme.${token} must be a string` });
+    }
+    if (value.includes(';') || value.includes('{') || value.includes('}')) {
+      throw new HTTPException(400, { message: `theme.${token} contains illegal CSS` });
+    }
+    const existing =
+      typeof draft.theme === 'object' && draft.theme !== null && !Array.isArray(draft.theme)
+        ? { ...(draft.theme as Record<string, string>) }
+        : {};
+    existing[token] = value;
+    draft.theme = existing;
     return;
   }
 
@@ -890,7 +963,8 @@ app.openapi(
   }),
   async (c) => {
     const db = c.get('db');
-    const user = requireContentEditor(c.get('user'));
+    // Publish is human/editor only — agents with content:propose cannot publish.
+    const user = requireContentPublisher(c.get('user'));
     const { id } = c.req.valid('param');
 
     const session = await sessionQueries.getEditSessionById(db, id);

--- a/packages/editor/src/canvas/EditSessionCanvas.tsx
+++ b/packages/editor/src/canvas/EditSessionCanvas.tsx
@@ -19,7 +19,19 @@
 
 import { Button, cn } from '@revealui/presentation';
 import { type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
-import { type ClickMessage, isClickMessage, RVUI_APPLY_PATCH } from '../protocol.js';
+import {
+  type ClickMessage,
+  isClickMessage,
+  RVUI_APPLY_PATCH,
+  RVUI_SET_THEME,
+} from '../protocol.js';
+import {
+  EDITABLE_THEME_TOKENS,
+  type EditableThemeToken,
+  type FieldKind,
+  fieldKindFromPath,
+  isEditableThemeToken,
+} from './field-kind.js';
 
 const BREAKPOINTS = {
   desktop: { label: 'Desktop', width: 1280 },
@@ -107,16 +119,35 @@ interface ActiveField {
 }
 
 // -----------------------------------------------------------------------------
-// Field editor popover
+// Field editor popover (text | url | media)
 // -----------------------------------------------------------------------------
+
+interface MediaItem {
+  id: string;
+  url: string;
+  filename: string;
+  alt: string | null;
+}
 
 interface FieldEditorPopoverProps {
   field: ActiveField;
+  kind: FieldKind;
+  media: readonly MediaItem[];
+  mediaLoading: boolean;
   onCommit: (value: string) => void;
   onClose: () => void;
+  onRefreshMedia: () => void;
 }
 
-function FieldEditorPopover({ field, onCommit, onClose }: FieldEditorPopoverProps): ReactElement {
+function FieldEditorPopover({
+  field,
+  kind,
+  media,
+  mediaLoading,
+  onCommit,
+  onClose,
+  onRefreshMedia,
+}: FieldEditorPopoverProps): ReactElement {
   const [value, setValue] = useState(field.value);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -125,6 +156,10 @@ function FieldEditorPopover({ field, onCommit, onClose }: FieldEditorPopoverProp
       if (timer.current) clearTimeout(timer.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (kind === 'media') onRefreshMedia();
+  }, [kind, onRefreshMedia]);
 
   const scheduleAutosave = useCallback(
     (next: string) => {
@@ -140,27 +175,95 @@ function FieldEditorPopover({ field, onCommit, onClose }: FieldEditorPopoverProp
     onClose();
   }, [onCommit, onClose, value]);
 
+  const pickMedia = useCallback(
+    (url: string) => {
+      setValue(url);
+      if (timer.current) clearTimeout(timer.current);
+      onCommit(url);
+      onClose();
+    },
+    [onClose, onCommit],
+  );
+
+  const kindLabel = kind === 'media' ? 'Edit image' : kind === 'url' ? 'Edit link' : 'Edit field';
+
   return (
     <div
       role="dialog"
-      aria-label="Edit field"
-      className="fixed z-50 rounded-md border border-neutral-700 bg-neutral-900 p-2 shadow-lg"
+      aria-label={kindLabel}
+      className="fixed z-50 max-h-[70vh] overflow-auto rounded-md border border-neutral-700 bg-neutral-900 p-2 shadow-lg"
       style={{
         top: Math.max(field.rect.top + field.rect.height + 4, 0),
         left: Math.max(field.rect.left, 0),
-        minWidth: 240,
+        minWidth: kind === 'media' ? 320 : 240,
+        maxWidth: 420,
       }}
     >
-      <textarea
-        aria-label="Field value"
-        className="block w-full resize-y rounded border border-neutral-600 bg-neutral-800 p-1 text-sm text-neutral-100"
-        rows={3}
-        value={value}
-        onChange={(e) => {
-          setValue(e.target.value);
-          scheduleAutosave(e.target.value);
-        }}
-      />
+      {kind === 'url' ? (
+        <input
+          type="url"
+          aria-label="Link URL"
+          className="block w-full rounded border border-neutral-600 bg-neutral-800 p-1.5 text-sm text-neutral-100"
+          value={value}
+          placeholder="https://…"
+          onChange={(e) => {
+            setValue(e.target.value);
+            scheduleAutosave(e.target.value);
+          }}
+        />
+      ) : kind === 'media' ? (
+        <div className="space-y-2">
+          <input
+            type="url"
+            aria-label="Image URL"
+            className="block w-full rounded border border-neutral-600 bg-neutral-800 p-1.5 text-sm text-neutral-100"
+            value={value}
+            placeholder="https://… or pick below"
+            onChange={(e) => {
+              setValue(e.target.value);
+              scheduleAutosave(e.target.value);
+            }}
+          />
+          <p className="text-xs text-neutral-400">Media library</p>
+          {mediaLoading ? (
+            <p className="text-xs text-neutral-500">Loading…</p>
+          ) : media.length === 0 ? (
+            <p className="text-xs text-neutral-500">
+              No media yet. Paste a URL or upload in admin.
+            </p>
+          ) : (
+            <ul className="grid max-h-48 grid-cols-3 gap-1">
+              {media.map((item) => (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    className="block w-full overflow-hidden rounded border border-neutral-700 hover:border-primary"
+                    onClick={() => pickMedia(item.url)}
+                    title={item.alt ?? item.filename}
+                  >
+                    <img
+                      src={item.url}
+                      alt={item.alt ?? item.filename}
+                      className="aspect-square h-16 w-full object-cover"
+                    />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : (
+        <textarea
+          aria-label="Field value"
+          className="block w-full resize-y rounded border border-neutral-600 bg-neutral-800 p-1 text-sm text-neutral-100"
+          rows={3}
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            scheduleAutosave(e.target.value);
+          }}
+        />
+      )}
       <div className="mt-2 flex justify-end gap-2">
         <Button size="sm" appearance="outline" onClick={onClose}>
           Cancel
@@ -169,6 +272,41 @@ function FieldEditorPopover({ field, onCommit, onClose }: FieldEditorPopoverProp
           Save
         </Button>
       </div>
+    </div>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Theme token panel (D8 — allowlisted --rvui-* only)
+// -----------------------------------------------------------------------------
+
+interface ThemePanelProps {
+  tokens: Record<EditableThemeToken, string>;
+  onChange: (token: EditableThemeToken, value: string) => void;
+  onApply: () => void;
+}
+
+function ThemePanel({ tokens, onChange, onApply }: ThemePanelProps): ReactElement {
+  return (
+    <div className="mb-3 space-y-2 border-t border-neutral-800 pt-2">
+      <h2 className="text-xs font-semibold uppercase text-neutral-400">Theme tokens</h2>
+      <p className="text-[10px] leading-snug text-neutral-500">
+        Brand tokens only. Arbitrary CSS is rejected.
+      </p>
+      {EDITABLE_THEME_TOKENS.map((token) => (
+        <label key={token} className="block text-[10px] text-neutral-400">
+          {token}
+          <input
+            type="text"
+            className="mt-0.5 block w-full rounded border border-neutral-700 bg-neutral-900 px-1 py-0.5 font-mono text-xs text-neutral-100"
+            value={tokens[token] ?? ''}
+            onChange={(e) => onChange(token, e.target.value)}
+          />
+        </label>
+      ))}
+      <Button size="sm" appearance="outline" onClick={onApply}>
+        Apply theme
+      </Button>
     </div>
   );
 }
@@ -191,6 +329,13 @@ export function EditSessionCanvas({
   const [activeField, setActiveField] = useState<ActiveField | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [media, setMedia] = useState<MediaItem[]>([]);
+  const [mediaLoading, setMediaLoading] = useState(false);
+  const [themeTokens, setThemeTokens] = useState<Record<EditableThemeToken, string>>(() => {
+    const init = {} as Record<EditableThemeToken, string>;
+    for (const t of EDITABLE_THEME_TOKENS) init[t] = '';
+    return init;
+  });
 
   const doFetch = useCallback<Fetcher>(
     (path, init = {}) => {
@@ -277,8 +422,56 @@ export function EditSessionCanvas({
     setDocs(detail.data.docs);
   }, [doFetch, sessionId]);
 
+  const refreshMedia = useCallback(async () => {
+    setMediaLoading(true);
+    try {
+      const res = await doFetch('/api/content/media?limit=48');
+      if (!res.ok) {
+        setMedia([]);
+        return;
+      }
+      const body = (await res.json()) as { data?: MediaItem[] };
+      setMedia(Array.isArray(body.data) ? body.data : []);
+    } catch {
+      setMedia([]);
+    } finally {
+      setMediaLoading(false);
+    }
+  }, [doFetch]);
+
   const targetDocId = previewPageId ?? docs.find((d) => d.docType === 'page')?.docId ?? null;
   const blockList = blockMetaFromDocs(docs, targetDocId);
+  const activeFieldKind: FieldKind = activeField ? fieldKindFromPath(activeField.field) : 'text';
+
+  const applyThemeToPreview = useCallback(() => {
+    if (!marketingOrigin) return;
+    const tokens: Record<string, string> = {};
+    for (const key of EDITABLE_THEME_TOKENS) {
+      const value = themeTokens[key]?.trim();
+      if (value) tokens[key] = value;
+    }
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: RVUI_SET_THEME, tokens },
+      marketingOrigin,
+    );
+    // Persist allowlisted tokens on the draft under theme.* (session path).
+    if (targetDocId && Object.keys(tokens).length > 0) {
+      void (async () => {
+        for (const [key, value] of Object.entries(tokens)) {
+          if (!isEditableThemeToken(key)) continue;
+          await doFetch(`/api/content/sessions/${sessionId}/docs/page/${targetDocId}`, {
+            method: 'PATCH',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ path: `theme.${key}`, value }),
+          });
+        }
+        setNotice('Theme applied to preview and saved on the draft.');
+        await refreshDocs();
+      })();
+    } else {
+      setNotice('Theme applied to preview (no page draft to persist yet).');
+    }
+  }, [doFetch, marketingOrigin, refreshDocs, sessionId, targetDocId, themeTokens]);
 
   const commitPatch = useCallback(
     async (doc: string, field: string, value: string) => {
@@ -467,24 +660,54 @@ export function EditSessionCanvas({
               ))}
             </ul>
           )}
-          <Button
-            size="sm"
-            appearance="outline"
-            disabled={!targetDocId}
-            onClick={() =>
-              void commitBlockOp({
-                op: 'blocks.insert',
-                index: blockList.length,
-                block: {
-                  id: `text-${crypto.randomUUID()}`,
-                  type: 'text',
-                  data: { content: 'New text block' },
-                },
-              })
-            }
-          >
-            Add text block
-          </Button>
+          <div className="flex flex-col gap-1">
+            <Button
+              size="sm"
+              appearance="outline"
+              disabled={!targetDocId}
+              onClick={() =>
+                void commitBlockOp({
+                  op: 'blocks.insert',
+                  index: blockList.length,
+                  block: {
+                    id: `text-${crypto.randomUUID()}`,
+                    type: 'text',
+                    data: { content: 'New text block' },
+                  },
+                })
+              }
+            >
+              Add text block
+            </Button>
+            <Button
+              size="sm"
+              appearance="outline"
+              disabled={!targetDocId}
+              onClick={() =>
+                void commitBlockOp({
+                  op: 'blocks.insert',
+                  index: blockList.length,
+                  block: {
+                    id: `image-${crypto.randomUUID()}`,
+                    type: 'image',
+                    data: {
+                      src: 'https://placehold.co/800x450/png?text=Image',
+                      alt: 'Placeholder image',
+                      loading: 'lazy',
+                    },
+                  },
+                })
+              }
+            >
+              Add image block
+            </Button>
+          </div>
+
+          <ThemePanel
+            tokens={themeTokens}
+            onChange={(token, value) => setThemeTokens((prev) => ({ ...prev, [token]: value }))}
+            onApply={applyThemeToPreview}
+          />
         </aside>
 
         <div className="min-h-0 flex-1 overflow-auto rounded-md border border-neutral-800 bg-neutral-950">
@@ -505,8 +728,12 @@ export function EditSessionCanvas({
       {activeField ? (
         <FieldEditorPopover
           field={activeField}
+          kind={activeFieldKind}
+          media={media}
+          mediaLoading={mediaLoading}
           onCommit={(value) => commitPatch(activeField.doc, activeField.field, value)}
           onClose={() => setActiveField(null)}
+          onRefreshMedia={() => void refreshMedia()}
         />
       ) : null}
     </div>

--- a/packages/editor/src/canvas/EditSessionCanvas.tsx
+++ b/packages/editor/src/canvas/EditSessionCanvas.tsx
@@ -81,15 +81,22 @@ interface PreviewPageCandidate {
 
 /**
  * Choose which published page a fresh (empty) session should land the iframe on.
- * Prefers the VES Phase-1 marketing slice (`home`, then `products`), else the
- * first published page. Pure helper so canvas tests can lock the order.
+ * Prefers the VES marketing slice (`home`, then `products`, then `philosophy`,
+ * then `local-ai`), else the first published page. Pure helper so canvas tests
+ * can lock the order.
  */
 export function pickDefaultPreviewPageId(
   pages: readonly PreviewPageCandidate[],
 ): string | undefined {
   if (pages.length === 0) return undefined;
   const bySlug = (slug: string): string | undefined => pages.find((p) => p.slug === slug)?.id;
-  return bySlug('home') ?? bySlug('products') ?? pages[0]?.id;
+  return (
+    bySlug('home') ??
+    bySlug('products') ??
+    bySlug('philosophy') ??
+    bySlug('local-ai') ??
+    pages[0]?.id
+  );
 }
 
 interface ActiveField {

--- a/packages/editor/src/canvas/__tests__/field-kind.test.ts
+++ b/packages/editor/src/canvas/__tests__/field-kind.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EDITABLE_THEME_TOKENS,
+  fieldKindFromPath,
+  fieldPathLeaf,
+  isEditableThemeToken,
+} from '../field-kind.js';
+
+describe('fieldKindFromPath', () => {
+  it('classifies prose paths as text', () => {
+    expect(fieldKindFromPath('blocks.0.data.heading')).toBe('text');
+    expect(fieldKindFromPath('blocks.1.data.items.0.body')).toBe('text');
+    expect(fieldKindFromPath('blocks.2.data.links.0.label')).toBe('text');
+  });
+
+  it('classifies href paths as url', () => {
+    expect(fieldKindFromPath('blocks.2.data.links.0.href')).toBe('url');
+    expect(fieldKindFromPath('cta.href')).toBe('url');
+  });
+
+  it('classifies image src paths as media', () => {
+    expect(fieldKindFromPath('blocks.3.data.src')).toBe('media');
+    expect(fieldKindFromPath('blocks.0.data.imageSrc')).toBe('media');
+  });
+});
+
+describe('fieldPathLeaf', () => {
+  it('returns the last segment', () => {
+    expect(fieldPathLeaf('blocks.0.data.heading')).toBe('heading');
+    expect(fieldPathLeaf('href')).toBe('href');
+  });
+});
+
+describe('theme token allowlist', () => {
+  it('accepts only the editable brand tokens', () => {
+    expect(EDITABLE_THEME_TOKENS.length).toBeGreaterThan(0);
+    expect(isEditableThemeToken('--rvui-brand')).toBe(true);
+    expect(isEditableThemeToken('--color-primary')).toBe(false);
+    expect(isEditableThemeToken('background')).toBe(false);
+  });
+});

--- a/packages/editor/src/canvas/field-kind.ts
+++ b/packages/editor/src/canvas/field-kind.ts
@@ -1,0 +1,44 @@
+/**
+ * Infer which field editor the canvas should open from a data-rvui-field path.
+ * Zero authored regex: leaf segment + endsWith checks only.
+ */
+
+export type FieldKind = 'text' | 'url' | 'media';
+
+/** Allowlisted design-token CSS variables the theme panel may set (D8). */
+export const EDITABLE_THEME_TOKENS = [
+  '--rvui-brand',
+  '--rvui-brand-glow',
+  '--rvui-accent',
+  '--rvui-radius-md',
+] as const;
+
+export type EditableThemeToken = (typeof EDITABLE_THEME_TOKENS)[number];
+
+export function isEditableThemeToken(name: string): name is EditableThemeToken {
+  return (EDITABLE_THEME_TOKENS as readonly string[]).includes(name);
+}
+
+/**
+ * Leaf of a dotted path (`blocks.2.data.links.0.href` → `href`).
+ */
+export function fieldPathLeaf(field: string): string {
+  const lastDot = field.lastIndexOf('.');
+  if (lastDot === -1) return field;
+  return field.slice(lastDot + 1);
+}
+
+/**
+ * Classify a field path for the canvas popover.
+ * - media: image/src URLs that should pick from the media library
+ * - url: href/link destinations (typed URL, no media library)
+ * - text: everything else (prose / labels)
+ */
+export function fieldKindFromPath(field: string): FieldKind {
+  const leaf = fieldPathLeaf(field);
+  if (leaf === 'src' || leaf === 'imageSrc' || leaf === 'imageUrl') return 'media';
+  if (leaf === 'href' || leaf === 'url' || leaf === 'link') return 'url';
+  if (field.endsWith('.src') || field.endsWith('.imageSrc')) return 'media';
+  if (field.endsWith('.href')) return 'url';
+  return 'text';
+}

--- a/packages/editor/src/canvas/index.ts
+++ b/packages/editor/src/canvas/index.ts
@@ -10,3 +10,11 @@ export {
   type Fetcher,
   pickDefaultPreviewPageId,
 } from './EditSessionCanvas.js';
+export {
+  EDITABLE_THEME_TOKENS,
+  type EditableThemeToken,
+  type FieldKind,
+  fieldKindFromPath,
+  fieldPathLeaf,
+  isEditableThemeToken,
+} from './field-kind.js';

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -18,6 +18,7 @@ export {
   isClickMessage,
   isPatchAppliedMessage,
   isReadyMessage,
+  isSetThemeMessage,
   type PatchAppliedMessage,
   type ReadyMessage,
   type RuntimeToCanvasMessage,
@@ -25,4 +26,6 @@ export {
   RVUI_CLICK,
   RVUI_PATCH_APPLIED,
   RVUI_READY,
+  RVUI_SET_THEME,
+  type SetThemeMessage,
 } from './protocol.js';

--- a/packages/editor/src/protocol.ts
+++ b/packages/editor/src/protocol.ts
@@ -18,6 +18,8 @@ export const RVUI_CLICK = 'rvui:click';
 export const RVUI_PATCH_APPLIED = 'rvui:patch-applied';
 /** Canvas -> runtime: apply a committed field value optimistically. */
 export const RVUI_APPLY_PATCH = 'rvui:apply-patch';
+/** Canvas -> runtime: apply allowlisted design-token CSS variables (P2 theming). */
+export const RVUI_SET_THEME = 'rvui:set-theme';
 
 export interface FieldRect {
   top: number;
@@ -55,8 +57,14 @@ export interface ApplyPatchMessage {
   value: string;
 }
 
+export interface SetThemeMessage {
+  type: typeof RVUI_SET_THEME;
+  /** CSS custom property map; runtime applies only known --rvui-* keys. */
+  tokens: Record<string, string>;
+}
+
 export type RuntimeToCanvasMessage = ReadyMessage | ClickMessage | PatchAppliedMessage;
-export type CanvasToRuntimeMessage = ApplyPatchMessage;
+export type CanvasToRuntimeMessage = ApplyPatchMessage | SetThemeMessage;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -104,6 +112,16 @@ export function isApplyPatchMessage(value: unknown): value is ApplyPatchMessage 
     typeof value.field === 'string' &&
     typeof value.value === 'string'
   );
+}
+
+export function isSetThemeMessage(value: unknown): value is SetThemeMessage {
+  if (!(isRecord(value) && value.type === RVUI_SET_THEME && isRecord(value.tokens))) {
+    return false;
+  }
+  for (const [key, val] of Object.entries(value.tokens)) {
+    if (typeof key !== 'string' || typeof val !== 'string') return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/editor/src/runtime/index.ts
+++ b/packages/editor/src/runtime/index.ts
@@ -27,6 +27,7 @@ import {
   type ApplyPatchMessage,
   devWarn,
   isApplyPatchMessage,
+  isSetThemeMessage,
   RVUI_CLICK,
   RVUI_PATCH_APPLIED,
   RVUI_READY,
@@ -211,9 +212,23 @@ export async function initEditRuntime(
     post({ type: RVUI_PATCH_APPLIED, doc: msg.doc, field: msg.field });
   };
 
+  const applyThemeTokens = (tokens: Record<string, string>): void => {
+    const root = document.documentElement;
+    for (const [key, value] of Object.entries(tokens)) {
+      // Only accept design-token names (D8); reject arbitrary CSS injection.
+      if (!key.startsWith('--rvui-')) continue;
+      if (value.includes(';') || value.includes('{') || value.includes('}')) continue;
+      root.style.setProperty(key, value);
+    }
+  };
+
   const onMessage = (event: MessageEvent): void => {
     if (event.origin !== adminOrigin) {
       devWarn(`dropped message from foreign origin: ${event.origin}`);
+      return;
+    }
+    if (isSetThemeMessage(event.data)) {
+      applyThemeTokens(event.data.tokens);
       return;
     }
     if (!isApplyPatchMessage(event.data)) {
@@ -231,12 +246,17 @@ export async function initEditRuntime(
     const doc = el.getAttribute('data-rvui-doc');
     const field = el.getAttribute('data-rvui-field');
     if (!(doc && field)) return;
+    // Prefer attribute values for link/image fields so the canvas gets href/src.
+    const attrValue =
+      el.getAttribute('href') ??
+      el.getAttribute('src') ??
+      (el instanceof HTMLElement ? el.dataset.rvuiValue : null);
     post({
       type: RVUI_CLICK,
       doc,
       field,
       rect: rectOf(el),
-      currentValue: el.textContent ?? '',
+      currentValue: attrValue ?? el.textContent ?? '',
     });
   };
 

--- a/packages/mcp/src/servers/factories/revealui-content.ts
+++ b/packages/mcp/src/servers/factories/revealui-content.ts
@@ -260,6 +260,30 @@ async function apiGet(
   return body;
 }
 
+async function apiJson(
+  baseUrl: string,
+  apiKey: string,
+  method: 'POST' | 'PATCH',
+  path: string,
+  payload: unknown,
+): Promise<unknown> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: apiHeaders(apiKey),
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json();
+  if (!res.ok) {
+    throw new ApiRequestError(
+      (body as { error?: string; message?: string }).error ??
+        (body as { message?: string }).message ??
+        `API ${res.status}`,
+      res.status,
+    );
+  }
+  return body;
+}
+
 // ---------------------------------------------------------------------------
 // Tool argument schemas (Zod 4)
 // ---------------------------------------------------------------------------
@@ -299,6 +323,43 @@ export const ListUsersArgsSchema = z
 export const SiteStatsArgsSchema = z
   .object({
     site_id: z.string().optional(),
+  })
+  .strict();
+
+/** VES edit-session tools (propose-only; no publish). */
+export const SessionListArgsSchema = z
+  .object({
+    site_id: z.string().optional(),
+    status: z.enum(['open', 'published', 'discarded']).optional(),
+  })
+  .strict();
+
+export const SessionOpenArgsSchema = z
+  .object({
+    site_id: z.string().min(1),
+    title: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const SessionPatchArgsSchema = z
+  .object({
+    session_id: z.string().min(1),
+    page_id: z.string().min(1),
+    path: z.string().min(1),
+    value: z.unknown(),
+  })
+  .strict();
+
+export const SessionGetArgsSchema = z
+  .object({
+    session_id: z.string().min(1),
+  })
+  .strict();
+
+export const PageReadArgsSchema = z
+  .object({
+    site_id: z.string().min(1),
+    page_id: z.string().min(1),
   })
   .strict();
 
@@ -379,6 +440,75 @@ const TOOLS: Tool[] = [
           description: 'Site ID to fetch stats for (omit for global stats)',
         },
       },
+    },
+  },
+  // --- Visual edit sessions (VES P2) — propose patches; never publish ---
+  {
+    name: 'revealui_session_list',
+    description: 'List edit sessions for a site (open / published / discarded).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        site_id: { type: 'string', description: 'Site ID (e.g. fleet-marketing)' },
+        status: {
+          type: 'string',
+          description: 'Filter: open | published | discarded',
+        },
+      },
+    },
+  },
+  {
+    name: 'revealui_session_open',
+    description:
+      'Open a new edit session on a site. Agents may propose into sessions; only humans publish.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        site_id: { type: 'string', description: 'Site ID' },
+        title: { type: 'string', description: 'Optional session title' },
+      },
+      required: ['site_id'],
+    },
+  },
+  {
+    name: 'revealui_session_get',
+    description: 'Get an edit session with its draft docs and recent events.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        session_id: { type: 'string', description: 'Edit session ID' },
+      },
+      required: ['session_id'],
+    },
+  },
+  {
+    name: 'revealui_session_patch',
+    description:
+      'Propose a field patch into an open edit session (path + value). Voice rules apply for fleet-marketing. Does not publish.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        session_id: { type: 'string' },
+        page_id: { type: 'string', description: 'Page document id' },
+        path: {
+          type: 'string',
+          description: 'Dot path, e.g. blocks.0.data.heading or theme.--rvui-brand',
+        },
+        value: { description: 'New value (string, number, object, …)' },
+      },
+      required: ['session_id', 'page_id', 'path', 'value'],
+    },
+  },
+  {
+    name: 'revealui_page_read',
+    description: 'Read a published page (blocks + SEO) for a site.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        site_id: { type: 'string' },
+        page_id: { type: 'string' },
+      },
+      required: ['site_id', 'page_id'],
     },
   },
 ];
@@ -965,6 +1095,58 @@ export function createRevealuiContentServer(options?: CreateRevealuiContentServe
           // site_id is accepted for forward-compat; readiness is process-global.
           void parsed.value.site_id;
           data = await apiGet(apiUrl, apiKey, '/health/ready', {});
+          break;
+        }
+
+        case 'revealui_session_list': {
+          const parsed = validateToolArgs(SessionListArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
+          const params: Record<string, string> = {};
+          if (parsed.value.site_id) params.siteId = parsed.value.site_id;
+          if (parsed.value.status) params.status = parsed.value.status;
+          data = await apiGet(apiUrl, apiKey, '/api/content/sessions', params);
+          break;
+        }
+
+        case 'revealui_session_open': {
+          const parsed = validateToolArgs(SessionOpenArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
+          data = await apiJson(apiUrl, apiKey, 'POST', '/api/content/sessions', {
+            siteId: parsed.value.site_id,
+            title: parsed.value.title,
+          });
+          break;
+        }
+
+        case 'revealui_session_get': {
+          const parsed = validateToolArgs(SessionGetArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
+          data = await apiGet(apiUrl, apiKey, `/api/content/sessions/${parsed.value.session_id}`);
+          break;
+        }
+
+        case 'revealui_session_patch': {
+          const parsed = validateToolArgs(SessionPatchArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
+          const { session_id, page_id, path, value } = parsed.value;
+          data = await apiJson(
+            apiUrl,
+            apiKey,
+            'PATCH',
+            `/api/content/sessions/${session_id}/docs/page/${page_id}`,
+            { path, value },
+          );
+          break;
+        }
+
+        case 'revealui_page_read': {
+          const parsed = validateToolArgs(PageReadArgsSchema, rawArgs, toolName);
+          if (!parsed.ok) return denied(parsed.error);
+          data = await apiGet(
+            apiUrl,
+            apiKey,
+            `/api/content/sites/${parsed.value.site_id}/pages/${parsed.value.page_id}`,
+          );
           break;
         }
 

--- a/packages/security/src/authorization.ts
+++ b/packages/security/src/authorization.ts
@@ -347,11 +347,14 @@ export const CommonRoles: Record<string, Role> = {
   agent: {
     id: 'agent',
     name: 'AI Agent',
-    description: 'Can execute tasks and read content',
+    description:
+      'Can execute tasks, read content, and propose draft patches into edit sessions (not publish)',
     permissions: [
       { resource: 'tasks', action: 'create' },
       { resource: 'tasks', action: 'read' },
       { resource: 'content', action: 'read' },
+      // VES P2 D5: agents propose into sessions; publish stays content:update-only.
+      { resource: 'content', action: 'propose' },
       { resource: 'rag', action: 'read' },
       { resource: 'rag', action: 'create' },
     ],

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -2,7 +2,7 @@
 
 /**
  * Seed the fleet-marketing `sites` row plus its published marketing pages
- * (home, products, philosophy) for the visual-edit-sessions block wire.
+ * (home, products, philosophy, local-ai) for the visual-edit-sessions block wire.
  *
  * The page `blocks` come from the SAME pure derivation the marketing app falls
  * back to (`apps/marketing/app/lib/page-blocks.ts`), so the seeded CMS content
@@ -33,6 +33,7 @@ import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import {
   homeBlocks,
+  localAiBlocks,
   philosophyBlocks,
   productsBlocks,
 } from '../apps/marketing/app/lib/page-blocks';
@@ -93,6 +94,17 @@ const PAGE_SEEDS: readonly PageSeed[] = [
     seo: {
       title: 'Philosophy | RevealUI',
       description: 'Software that compounds. Why RevealUI exists.',
+    },
+  },
+  {
+    slug: 'local-ai',
+    path: '/local-ai',
+    title: 'Local-first AI',
+    blocks: localAiBlocks(),
+    seo: {
+      title: 'Local-first AI | RevealUI',
+      description:
+        'Run your AI on infrastructure you own. Open-weight default, frontier one config line away.',
     },
   },
 ];
@@ -241,7 +253,7 @@ async function main(): Promise<void> {
   }
 
   // ---------------------------------------------------------------------------
-  // Pages (home + products + philosophy) — version-safe, idempotent
+  // Pages (home + products + philosophy + local-ai) — version-safe, idempotent
   // ---------------------------------------------------------------------------
 
   for (const seed of PAGE_SEEDS) {


### PR DESCRIPTION
## Summary

VES **P2 program slice** (systematic order) on top of the marketing CMS block stream.

### Shipped in this PR

| Order | Item | Status |
|------:|------|--------|
| 1 | `/local-ai` CMS block stream + seed + fieldAttrs | done |
| 2 | Canvas field kinds: **text / url / media** (library picker) | done |
| 3 | Add **image** block + media library load from `GET /api/content/media` | done |
| 4 | **Theme tokens** panel (`--rvui-brand` allowlist) + runtime `rvui:set-theme` + draft `theme.*` path | done |
| 5 | Agents: `content:propose`; publish requires `content:update` | done |
| 6 | MCP: `revealui_session_list/open/get/patch` + `revealui_page_read` (no publish) | done |
| 7 | Philosophy CTA href/label click-to-edit | done |

### Explicitly still later (not blocking this PR)

- Full CMS wire for **fair-source**, **services**, remaining operator pages (pricing stays deferred for lockstep)
- Rich media **upload** from canvas (picker uses library; upload stays admin media UI)
- Full P2 prod dogfood / acceptance walk
- `content.session.comment` / `publish_request` event tools (patch + human publish covers the loop)

## Test plan

- [x] editor: field-kind + EditSessionCanvas tests
- [x] marketing: page-blocks + edit-mode-wiring
- [x] pre-push phase-1 gate
- [ ] Owner: re-seed `pnpm db:seed:fleet-marketing`, canvas edit local-ai + link + image + theme, agent session.patch via MCP with device token

## Owner merge

```bash
gh pr merge 2068 --repo RevealUIStudio/revealui --squash
```