### PR TITLE
fix(a11y): label pricing cost-calculator sliders for WCAG

### DIFF
--- a/apps/marketing/app/components/landing/CostCalculator.tsx
+++ b/apps/marketing/app/components/landing/CostCalculator.tsx
@@ -34,14 +34,19 @@ function LabeledSlider({
   display: string;
   onChange: (v: number) => void;
 }) {
+  // Pass `label` + `valueLabel` into Slider so the range input is associated
+  // via htmlFor/id (axe "label" / WCAG 4.1.2). valueLabel keeps marketing
+  // units (products+, $k) without decoupling the accessible name.
   return (
-    <div className="block">
-      <span className="mb-2 flex items-baseline justify-between">
-        <span className="text-sm font-medium text-foreground">{label}</span>
-        <span className="font-mono text-sm text-primary">{display}</span>
-      </span>
-      <Slider value={value} min={min} max={max} step={step} onChange={onChange} />
-    </div>
+    <Slider
+      label={label}
+      valueLabel={display}
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      onChange={onChange}
+    />
   );
 }
 

--- a/packages/presentation/src/__tests__/components/slider.test.tsx
+++ b/packages/presentation/src/__tests__/components/slider.test.tsx
@@ -37,10 +37,22 @@ describe('Slider', () => {
   it('shows label when provided', () => {
     render(<Slider label="Volume" />);
     expect(screen.getByText('Volume')).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Volume' })).toBeInTheDocument();
+  });
+
+  it('exposes a fallback accessible name when no label is provided', () => {
+    render(<Slider />);
+    expect(screen.getByRole('slider', { name: 'Slider' })).toBeInTheDocument();
   });
 
   it('shows current value when showValue is true', () => {
     render(<Slider defaultValue={42} showValue />);
     expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('shows a custom valueLabel when provided', () => {
+    render(<Slider label="MRR" value={10000} valueLabel="$10k" />);
+    expect(screen.getByRole('slider', { name: 'MRR' })).toBeInTheDocument();
+    expect(screen.getByText('$10k')).toBeInTheDocument();
   });
 });

--- a/packages/presentation/src/components/slider.tsx
+++ b/packages/presentation/src/components/slider.tsx
@@ -14,6 +14,8 @@ export function Slider({
   disabled = false,
   label,
   showValue = false,
+  /** Formatted value shown opposite the label (e.g. "$10k"). Overrides raw showValue. */
+  valueLabel,
   className,
 }: {
   value?: number;
@@ -25,6 +27,7 @@ export function Slider({
   disabled?: boolean;
   label?: string;
   showValue?: boolean;
+  valueLabel?: string;
   className?: string;
 }) {
   const [internalValue, setInternalValue] = useState(defaultValue);
@@ -41,17 +44,22 @@ export function Slider({
   );
 
   const percentage = ((value - min) / (max - min)) * 100;
+  const rightDisplay = valueLabel ?? (showValue ? String(value) : null);
 
   return (
     <div className={cn('w-full', className)}>
-      {(label || showValue) && (
+      {(label || rightDisplay) && (
         <div className="mb-2 flex items-center justify-between">
           {label && (
             <label htmlFor={id} className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
               {label}
             </label>
           )}
-          {showValue && <span className="text-sm text-zinc-500 dark:text-zinc-400">{value}</span>}
+          {rightDisplay && (
+            <span className="text-sm text-zinc-500 dark:text-zinc-400" aria-hidden={Boolean(label)}>
+              {rightDisplay}
+            </span>
+          )}
         </div>
       )}
       <input
@@ -63,6 +71,9 @@ export function Slider({
         value={value}
         disabled={disabled}
         onChange={handleChange}
+        // When no visible label is provided, still expose a name for AT / axe.
+        // With `label` set, the <label htmlFor> association is the primary name.
+        aria-label={label ? undefined : 'Slider'}
         style={{ '--slider-pct': `${percentage}%` } as React.CSSProperties}
         className={cn(
           'h-2 w-full cursor-pointer appearance-none rounded-full outline-none',


### PR DESCRIPTION
## Summary

Fixes promotion #2069 **Accessibility (E2E)** failure on `/pricing`:

```
label (critical): Ensure every form element has a label
selectors: #_r_0_, #_r_1_, #_r_2_  (CostCalculator range inputs)
```

`CostCalculator` rendered a visual label next to `@revealui/presentation` `Slider` but never passed `label`, so the `<input type="range">` had no accessible name.

### Fix
- Wire `label` + `valueLabel` (formatted display) into `Slider`
- `Slider`: support `valueLabel`; fallback `aria-label="Slider"` when unlabeled
- Unit tests for name association + valueLabel

## Test plan
- [x] `vitest` presentation `slider.test.tsx` (9)
- [ ] CI Accessibility E2E on this PR
- [ ] Re-run / auto-update promotion #2069 after merge to `test`

Closes the a11y hold on the release train.