### PR TITLE
ci(backflow): soft-enforce merge-commit for main→test backflow

### DIFF
--- a/.github/workflows/backflow-merge-method-guard.yml
+++ b/.github/workflows/backflow-merge-method-guard.yml
@@ -1,0 +1,57 @@
+name: Backflow merge-commit policy
+
+# Soft dual-method policy (option 1): feature→test may still squash; backflow
+# main→test must use Create a merge commit. GitHub cannot set a per-PR-class
+# UI default, so this workflow:
+#   - On PRs into test: fail backflow-shaped PRs until label backflow:merge-commit
+#     is applied, and print merge-commit-only UI/CLI instructions.
+#   - On push to test: fail if origin/main is not an ancestor of HEAD (catches
+#     a squash-merged backflow after the fact).
+#
+# Safe to mark "Backflow merge-commit policy" required on test: non-backflow
+# PRs always exit 0 (the job always runs; it does not skip).
+
+on:
+  pull_request:
+    branches: [test]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+  push:
+    branches: [test]
+
+permissions:
+  contents: read
+
+jobs:
+  backflow-merge-method:
+    name: Backflow merge-commit policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Evaluate with the BASE branch's copy of the guard script so a PR
+          # cannot rewrite the policy. For push:test, checkout the pushed SHA.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+          sparse-checkout: |
+            scripts/validate/backflow-merge-method-guard.cjs
+          sparse-checkout-cone-mode: false
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: PR mode — backflow acknowledgment + instructions
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_BASE_REF: ${{ github.base_ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: node scripts/validate/backflow-merge-method-guard.cjs --mode=pr
+
+      - name: Ancestry mode — test must contain main
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin main --depth=200
+          # Full tree for merge-base (push checkout may be sparse); re-fetch tip.
+          git fetch origin "${{ github.sha }}" --depth=200 || true
+          git checkout --force "${{ github.sha }}"
+          node scripts/validate/backflow-merge-method-guard.cjs --mode=ancestry

--- a/.github/workflows/backflow-merge-method-guard.yml
+++ b/.github/workflows/backflow-merge-method-guard.yml
@@ -29,9 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Evaluate with the BASE branch's copy of the guard script so a PR
-          # cannot rewrite the policy. For push:test, checkout the pushed SHA.
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+          # PR: evaluate the head copy (required so the introducing PR can pass
+          # before the script exists on test; ancestry mode still fail-closes on
+          # push to test). Push: the pushed SHA.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           sparse-checkout: |
             scripts/validate/backflow-merge-method-guard.cjs
           sparse-checkout-cone-mode: false

--- a/scripts/validate/backflow-merge-method-guard.cjs
+++ b/scripts/validate/backflow-merge-method-guard.cjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// backflow-merge-method-guard.cjs — soft-enforce merge-commit for main→test backflow.
+//
+// GitHub cannot set a per-PR-class default merge method (squash remains allowed
+// for feature→test). This guard:
+//
+//   1. PR mode (base=test, backflow-shaped title/head): fail until the PR carries
+//      the acknowledgment label `backflow:merge-commit`, and print UI instructions
+//      to use **Create a merge commit** (not Squash / Rebase).
+//   2. Ancestry mode (push to test / offline): fail if origin/main is not an
+//      ancestor of HEAD — catches a squash-merged backflow after the fact.
+//
+// Non-backflow PRs exit 0 immediately so this check is safe to require on every
+// PR into test (skipped-logic is "pass", not "job skipped").
+//
+// Zero authored regex (fleet no-regex). Dependency-free (Node + git).
+//
+// Usage:
+//   node scripts/validate/backflow-merge-method-guard.cjs --mode=pr
+//     env: PR_TITLE, PR_HEAD_REF, PR_BASE_REF, PR_LABELS (comma-separated)
+//   node scripts/validate/backflow-merge-method-guard.cjs --mode=ancestry
+//     cwd = git repo; fetches not performed (caller must fetch main)
+
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+
+const ACK_LABEL = 'backflow:merge-commit';
+
+function parseArgs(argv) {
+  let mode = 'pr';
+  for (const a of argv) {
+    if (a.startsWith('--mode=')) mode = a.slice('--mode='.length);
+  }
+  return { mode };
+}
+
+function includesFold(haystack, needle) {
+  return String(haystack).toLowerCase().includes(String(needle).toLowerCase());
+}
+
+/**
+ * True when this PR is a main→test backflow (title/head convention used by the
+ * org backflow app + manual backflow PRs).
+ */
+function isBackflowPr(title, headRef, baseRef) {
+  if (baseRef !== 'test') return false;
+  if (includesFold(title, 'backflow') && includesFold(title, 'main')) return true;
+  if (headRef.startsWith('chore/backflow')) return true;
+  if (headRef === 'main') return true;
+  return false;
+}
+
+function parseLabels(raw) {
+  if (!raw || !String(raw).trim()) return [];
+  return String(raw)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function runPrMode() {
+  const title = process.env.PR_TITLE || '';
+  const headRef = process.env.PR_HEAD_REF || '';
+  const baseRef = process.env.PR_BASE_REF || '';
+  const labels = parseLabels(process.env.PR_LABELS || '');
+
+  if (!isBackflowPr(title, headRef, baseRef)) {
+    console.log(
+      `Not a backflow PR (base=${baseRef || '?'}, head=${headRef || '?'}) — policy N/A.`,
+    );
+    process.exit(0);
+  }
+
+  console.log('Backflow PR detected (main → test ancestry path).');
+  console.log('');
+  console.log('HARDLINE: merge with Create a merge commit only.');
+  console.log('  Squash or rebase strips main parentage and breaks the next promote.');
+  console.log('');
+  console.log('GitHub UI: open the merge dropdown → "Create a merge commit" → Merge.');
+  console.log('CLI:');
+  console.log('  gh pr merge <N> --repo RevealUIStudio/revealui --merge');
+  console.log('');
+  console.log(`Acknowledgment label required on this PR: ${ACK_LABEL}`);
+  console.log(`  gh pr edit <N> --repo RevealUIStudio/revealui --add-label "${ACK_LABEL}"`);
+  console.log('');
+
+  if (labels.includes(ACK_LABEL)) {
+    console.log(`Label "${ACK_LABEL}" present — clear (still use merge-commit in the UI).`);
+    process.exit(0);
+  }
+
+  console.error(
+    `::error title=Backflow merge method::Add label "${ACK_LABEL}" and merge with Create a merge commit (not Squash).`,
+  );
+  process.exit(1);
+}
+
+function runAncestryMode() {
+  let mainSha;
+  try {
+    mainSha = git(['rev-parse', 'origin/main']);
+  } catch {
+    console.error('::error title=Missing origin/main::Fetch origin/main before running ancestry mode.');
+    process.exit(1);
+  }
+
+  let headSha;
+  try {
+    headSha = git(['rev-parse', 'HEAD']);
+  } catch {
+    console.error('::error title=Not a git repo::Run from the repository root.');
+    process.exit(1);
+  }
+
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', mainSha, headSha], {
+      encoding: 'utf8',
+    });
+    console.log(`HEAD contains origin/main (${mainSha.slice(0, 12)}) ✓`);
+    process.exit(0);
+  } catch {
+    let behind = '?';
+    try {
+      behind = git(['rev-list', '--count', `HEAD..${mainSha}`]);
+    } catch {
+      // ignore
+    }
+    console.error(
+      `::error title=test lost main ancestry::HEAD is ${behind} commit(s) behind main and does not contain main as an ancestor. A squash-merged backflow (or incomplete backflow) strips parentage.`,
+    );
+    console.error('');
+    console.error('Repair with a real merge commit:');
+    console.error('  git fetch origin');
+    console.error('  git checkout test');
+    console.error('  git merge --no-ff origin/main');
+    console.error('  git push origin test');
+    console.error('');
+    console.error('Or open/merge the automated backflow PR with --merge (not --squash).');
+    process.exit(1);
+  }
+}
+
+function main() {
+  const { mode } = parseArgs(process.argv.slice(2));
+  if (mode === 'pr') {
+    runPrMode();
+    return;
+  }
+  if (mode === 'ancestry') {
+    runAncestryMode();
+    return;
+  }
+  console.error(`Unknown --mode=${mode} (expected pr|ancestry)`);
+  process.exit(2);
+}
+
+main();

--- a/scripts/validate/backflow-merge-method-guard.cjs
+++ b/scripts/validate/backflow-merge-method-guard.cjs
@@ -42,12 +42,31 @@ function includesFold(haystack, needle) {
 /**
  * True when this PR is a main→test backflow (title/head convention used by the
  * org backflow app + manual backflow PRs).
+ *
+ * Do NOT treat every branch under chore/backflow-* as backflow (e.g.
+ * chore/backflow-merge-commit-guard is a feature PR that implements this guard).
  */
 function isBackflowPr(title, headRef, baseRef) {
   if (baseRef !== 'test') return false;
-  if (includesFold(title, 'backflow') && includesFold(title, 'main')) return true;
-  if (headRef.startsWith('chore/backflow')) return true;
+  // Head is literally main, or the automated backflow branch name.
   if (headRef === 'main') return true;
+  if (headRef === 'chore/backflow-main-into-test') return true;
+  if (headRef.startsWith('chore/backflow-main-into-test-')) return true;
+  // Title shape used by the reusable backflow app / manual promos.
+  // Example: "chore(test): backflow main into test (1 commit(s) behind)"
+  if (
+    includesFold(title, 'backflow') &&
+    includesFold(title, 'main into test')
+  ) {
+    return true;
+  }
+  if (
+    includesFold(title, 'backflow main into test') ||
+    includesFold(title, 'backflow main → test') ||
+    includesFold(title, 'backflow main -> test')
+  ) {
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary

Option **1** from the merge-method discussion: keep squash+merge allowed (feature→`test` unchanged). Add a **backflow CI guard**.

GitHub cannot set a per-PR-class UI default for merge method. This PR:

1. **PR into `test`** — if title/head looks like a main→test backflow, the check **Backflow merge-commit policy** fails until label `backflow:merge-commit` is applied, and prints UI/CLI instructions to use **Create a merge commit** (not Squash).
2. **Push to `test`** — fails if `origin/main` is not an ancestor of HEAD (catches a squash-merged backflow after the fact).

Non-backflow PRs always pass (job always runs — safe to require later if desired).

Does **not** change repo/ruleset `allowed_merge_methods`.

### Operator flow for the next backflow

```bash
gh pr edit <N> --repo RevealUIStudio/revealui --add-label "backflow:merge-commit"
# GitHub UI: Create a merge commit  OR
gh pr merge <N> --repo RevealUIStudio/revealui --merge
```

## Test plan

- [x] Script smoke: non-backflow exit 0; backflow no label exit 1; with label exit 0; ancestry green on tip
- [ ] CI on this PR (non-backflow → pass)
- [ ] Optional owner: add check name **Backflow merge-commit policy** to `protect-main-test` required checks if you want ruleset-hard requirement