### PR TITLE
fix(ci): security-review-gate sparse checkout includes shared paths JSON

### DIFF
--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -39,9 +39,13 @@ jobs:
           # files, labels, comments, and reviews all come from the API, so the
           # checkout exists only to supply this script code.
           ref: ${{ github.event.pull_request.base.sha }}
+          # GAP-404: gate loads SECURITY_PATHS from security-paths.shared.json
+          # at module load. Sparse list must include that JSON or the job
+          # crashes ENOENT before it can classify the PR (revealui#2074).
           sparse-checkout: |
             scripts/validate/security-review-gate.cjs
             scripts/validate/guardrail2-verdict.cjs
+            scripts/validate/security-paths.shared.json
           sparse-checkout-cone-mode: false
 
       - name: Evaluate review gate


### PR DESCRIPTION
## Summary

**Not a security HOLD** on #2074 — the gate job crashes before it can judge the PR.

### Failure

```
ENOENT: open '.../scripts/validate/security-paths.shared.json'
```

Workflow checks out **base** (`test`) with a sparse list that only had:

- `security-review-gate.cjs`
- `guardrail2-verdict.cjs`

GAP-404 (#2073) made the gate `readFileSync` `security-paths.shared.json` at load time, but the sparse list was not updated.

### Fix

Add `scripts/validate/security-paths.shared.json` to the sparse-checkout list.

### Why this PR first

The gate evaluates using **base** scripts. This must land on `test` before #2074 (and every other PR) can get a real gate verdict again.

## Test plan

- [x] File exists on `origin/test` at the path the gate opens
- [ ] After merge: re-run Security review gate on #2074 — should evaluate (HOLD if sensitive without verdict, or pass if not sensitive), not ENOENT

## Owner

```bash
gh pr merge <N> -R RevealUIStudio/revealui --squash
# then re-run checks on #2074
gh pr checks 2074 -R RevealUIStudio/revealui
```