### PR TITLE
docs: fix high DOC-DRIFT countable claims (GAP-407 W2)

### DIFF
--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -42,7 +42,6 @@ jobs:
           sparse-checkout: |
             scripts/validate/security-review-gate.cjs
             scripts/validate/guardrail2-verdict.cjs
-            scripts/validate/security-paths.shared.json
           sparse-checkout-cone-mode: false
 
       - name: Evaluate review gate

--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -42,6 +42,7 @@ jobs:
           sparse-checkout: |
             scripts/validate/security-review-gate.cjs
             scripts/validate/guardrail2-verdict.cjs
+            scripts/validate/security-paths.shared.json
           sparse-checkout-cone-mode: false
 
       - name: Evaluate review gate

--- a/docs/COMPONENT_CATALOG.md
+++ b/docs/COMPONENT_CATALOG.md
@@ -7,11 +7,11 @@ category: reference
 audience: developer
 ---
 
-**Last Updated:** 2026-07-11
+**Last Updated:** 2026-07-22
 **Packages:** `@revealui/presentation`, `@revealui/core`
 **Total Components:** **65 native components in `@revealui/presentation`** (this catalog also documents admin and rich-text UI in `@revealui/core`, listed separately below).
 
-> Counting rule (enforced in CI by `pnpm validate:claims`; canonical source `scripts/validate/claim-drift.ts` `countUIComponents()`, canonical value in `apps/marketing/app/content/site.ts` `METRICS`): the 61 figure counts `.tsx` files directly in `packages/presentation/src/components/`, excluding `_`-prefixed internal helpers. The package's `packages/presentation/src/primitives/` subpath (Box, Flex, Grid, Text, Heading, Slot; 6 files, listed under Primitives below) ships from the same package but is a separate directory the validator does not scan, so it is not part of the 61. `@revealui/core` admin/rich-text counts below are catalog-maintained, not CI-gated.
+> Counting rule (enforced in CI by `pnpm validate:claims`; canonical source `scripts/validate/claim-drift.ts` `countUIComponents()`, canonical value in `apps/marketing/app/content/site.ts` `METRICS`): the **65** figure counts `.tsx` files directly in `packages/presentation/src/components/`, excluding `_`-prefixed internal helpers. The package's `packages/presentation/src/primitives/` subpath (Box, Flex, Grid, Text, Heading, Slot; 6 files, listed under Primitives below) ships from the same package but is a separate directory the validator does not scan, so it is not part of the 65. `@revealui/core` admin/rich-text counts below are catalog-maintained, not CI-gated.
 
 ---
 
@@ -1779,7 +1779,7 @@ Components like Dialog, Combobox, and Listbox use native RevealUI hooks for buil
 
 ## Prop-Table Verification Scope
 
-This pass (2026-07-11) verified every per-component entry in `packages/presentation/src/components/` against real source files (61 files) and added rows for the 25 that had no catalog entry. Full prop tables were spot-verified against TypeScript source for the 10 most-used components (by import frequency across `apps/`): `Label`, `Input`, `Button` (`ButtonCVA`), `Badge`, `Card`, `Select`, `Textarea`, `LinkButton`, `Checkbox`, `Avatar`. Four of those ten had real drift, now fixed: `Button`/`Select` were documented under the wrong export name (see the naming notes on each entry), and `LinkButton`/`Checkbox`/`Avatar`/`Badge` prop tables were missing real props (`glow`, `shine`, `onCheckedChange`, `square`, `initials`, the full color union, `AvatarButton`, `BadgeButton`).
+This pass (2026-07-11) verified every per-component entry in `packages/presentation/src/components/` against real source files (live count is **65** `.tsx` files excluding `_`-prefixed helpers; the pass text originally said 61) and added rows for the 25 that had no catalog entry. Full prop tables were spot-verified against TypeScript source for the 10 most-used components (by import frequency across `apps/`): `Label`, `Input`, `Button` (`ButtonCVA`), `Badge`, `Card`, `Select`, `Textarea`, `LinkButton`, `Checkbox`, `Avatar`. Four of those ten had real drift, now fixed: `Button`/`Select` were documented under the wrong export name (see the naming notes on each entry), and `LinkButton`/`Checkbox`/`Avatar`/`Badge` prop tables were missing real props (`glow`, `shine`, `onCheckedChange`, `square`, `initials`, the full color union, `AvatarButton`, `BadgeButton`).
 
 The remaining detailed entries (`Box`, `Flex`, `Grid`, `Text`, `Heading`, `Slot`, `Input`, `Textarea`, `Radio`, `Switch`, `Label`, `FormLabel`, `Fieldset`, `Combobox`, `Listbox`, `Dropdown`, headless variants, `Table`, `Description List`, `Divider`, `Heading`/`Text` (Component), `Link`, `Navbar`, `Sidebar`, `Pagination`, `Alert`, `Dialog`, `Toast`, layout components, and the `@revealui/core` admin/rich-text entries) are carried forward from the prior pass, not re-verified line-by-line in this sweep. The 25 newly added rows (in the "Additional \<Category\> Components" tables) intentionally carry name + one-line purpose only, no prop tables, so they don't imply a verification depth this pass didn't do.
 

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -5,7 +5,7 @@ title: "Marketing Metrics — Pinned Truth"
 description: "Single source of truth for every metric, count, and status claim used in the marketing app and public-facing copy. Updated when the code changes; validated by claim-drift CI gate."
 category: internal
 audience: maintainer
-last-verified: 2026-06-22
+last-verified: 2026-07-22
 verified-via: pnpm tsx scripts/validate/claim-drift.ts
 ---
 
@@ -21,21 +21,21 @@ If a number appears in marketing copy, it MUST match the value below. If a value
 
 ## 1. Codebase metrics (validated by claim-drift CI gate)
 
-Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-16 (commit `6223dfa21`).
+Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-22 (GAP-407 Session B re-verify).
 
 | Metric | Canonical value | Source of truth (script ref) | Notes |
 |---|---|---|---|
 | Packages in `packages/` | **29** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
 | Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (one app removed per PR #936 + #946 + #947). |
 | Workspaces (monorepo total) | **33** | `countWorkspaces()` (= 29 packages + 4 apps) | |
-| Test files | **1061** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). |
+| Test files | **1122** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). claim-drift allows site.ts METRICS.testFiles within tolerance 100. |
 | UI components in `packages/presentation/` | **65** | `countUIComponents()` | Marketing copy says "65 native React components" or similar. |
 | **MCP servers** | **14** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); confirmed by `packages/mcp/README.md` + `CHANGELOG.md` 12→13 bump. |
-| DB tables (Drizzle pgTable) | **93** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86 (2026-06-22); corrected to 92 (2026-07-16); GAP-300 added `nudge_dismissals`, bringing the live count to 93 on 2026-07-17. `site.ts` METRICS is gate-enforced by claim-drift. |
+| DB tables (Drizzle pgTable) | **96** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86 (2026-06-22); 93 after GAP-300; live count on 2026-07-22 is **96**. `site.ts` METRICS.dbTables is gate-enforced by claim-drift. |
 | Access-control enforcement tests | **60** | `countEnforcementTests()` — `it(`/`test(` in `packages/core/src/__tests__/auth/` + `collections/operations/__tests__/access-enforcement.test.ts` | Quoted by the blog, both security attestations (`INFORMATION_SECURITY_POLICY`, `ASSET_INVENTORY`), `LAUNCH-CHECKLIST`, and marketing primitives. Gate-enforced so all surfaces move together. |
 | License: MIT packages | **23** | `licenseSplit.mit` | |
 | License: FSL-1.1-MIT packages | **5** | `licenseSplit.fsl` | @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services |
-| License: internal/none | **1** | `licenseSplit.internal` | `test` workspace package (private) |
+| License: internal/none | **1** | `licenseSplit.internal` | `@revealui/scripts` (private build tooling; no public license field) |
 
 **Marketing copy rule:** when a number appears, quote it as the canonical value. When a phrase says "more than N" or "N+", use the validated number as N. Don't round, don't approximate, don't add bonus framing like "(plus the adapter)" — the validator enforces the bare integer.
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -6,7 +6,7 @@ status: verified
 audience: user
 ---
 
-> Last verified: 2026-07-11
+> Last verified: 2026-07-22
 
 This page is an honest account of what RevealUI can and can't do right now.
 If you're evaluating RevealUI for a project, read this before the marketing page.
@@ -25,7 +25,7 @@ and a REST API. The heart of RevealUI and the most mature part of the codebase.
 **65 native React components in `@revealui/presentation`** (plus admin and rich-text UI in `@revealui/core`), built on Tailwind CSS v4. No external UI dependencies (no Radix, no Headless UI, no shadcn). Just React hooks, clsx, and CVA. Buttons, forms, modals, tables, toasts, navigation, data display, and layout primitives.
 
 ### Database schema
-**96 PostgreSQL tables** with Drizzle ORM, **72 CHECK constraints** enforced at the database level. NeonDB is the primary database (REST + agent memories via pgvector). Supabase is an optional sidecar today (RAG chunks + a legacy duplicate billing copy); Phase 7 in the roadmap consolidates RAG onto NeonDB pgvector and retires the Supabase dependency. ElectricSQL is an optional sync layer (off by default).
+**96 PostgreSQL tables** with Drizzle ORM, **81 CHECK constraints** enforced at the database level. NeonDB is the sole primary database (REST, agent memories, and RAG via pgvector on Neon). Supabase is not an internal datastore (ADR `2026-05-01-supabase-removal`); it remains only as an optional customer-facing MCP adapter (`packages/mcp/src/servers/supabase.ts`) for installs that choose Supabase as their own backend. ElectricSQL is an optional sync layer (off by default).
 
 ### Rich text editing
 Lexical-based rich text editor with custom nodes, serialization, and a plugin system.
@@ -36,7 +36,7 @@ ElectricSQL integration for real-time data synchronization. Proxy, auth, and sha
 have been verified working between Fly and NeonDB. Off by default — opt-in via env vars when you want it.
 
 ### CLI scaffolding
-**`create-revealui` published to npm at v0.5.12**. `@revealui/cli` is at v0.8.3. Bootstraps a new RevealUI project with working config, database setup, and development server.
+**`create-revealui` published to npm at v0.5.15**. `@revealui/cli` is at v0.9.2. Bootstraps a new RevealUI project with working config, database setup, and development server.
 
 ### CI and code quality
 3-phase CI gate (lint, typecheck, test, build) with an extensive test suite across
@@ -102,14 +102,14 @@ Honest list of things that are not done, not deployed, or not verified.
 
 | Metric | Value | Verified |
 |--------|-------|----------|
-| Workspaces (apps + packages) | 31 | Yes |
+| Workspaces (apps + packages) | 33 | Yes |
 | Apps | 4 (`admin`, `server`, `docs`, `marketing`) | Yes |
-| OSS packages (MIT) | 21 | Yes |
+| OSS packages (MIT) | 23 | Yes |
 | Pro packages (FSL-1.1-MIT) | 5 (`ai`, `engines`, `harnesses`, `mcp`, `services`) | Yes |
 | Internal packages | 1 (`@revealui/scripts`, unlicensed build tooling) | Yes |
-| UI components | 61 in `@revealui/presentation` | Yes |
-| Database tables | 85 | Yes (run `grep -h 'pgTable(' packages/db/src/schema/*.ts \| wc -l`) |
-| CHECK constraints | 72 | Yes (run `grep -rh 'check(' packages/db/src/schema/*.ts \| wc -l`) |
+| UI components | 65 in `@revealui/presentation` | Yes |
+| Database tables | 96 | Yes (run `grep -h 'pgTable(' packages/db/src/schema/*.ts \| wc -l`) |
+| CHECK constraints | 81 | Yes (run `grep -rh 'check(' packages/db/src/schema/*.ts \| wc -l`) |
 | MCP servers | 14 | Yes (run `ls packages/mcp/src/servers/*.ts` and count non-`_` files) |
 | Test cases | run `pnpm test` for current count | Reproducible |
 | Test files | run `find . -name "*.test.ts*" -not -path "*/node_modules/*"` | Reproducible |

--- a/docs/blog/14-claim-drift.md
+++ b/docs/blog/14-claim-drift.md
@@ -22,11 +22,13 @@ It is not malice, it is structure. The claim and the thing it describes have no 
 The first half of the fix is a single source of truth. Every number the marketing site can state lives in one typed object, and no page is allowed to hardcode the integer anywhere else.
 
 ```ts
+// Illustrative shape (numbers are whatever claim-drift counts today;
+// see apps/marketing/app/content/site.ts METRICS for the live values).
 export const METRICS = {
-  packages: 27,        // workspace packages
-  uiComponents: 60,    // components in @revealui/presentation
+  packages: 29,        // workspace packages
+  uiComponents: 65,    // components in @revealui/presentation
   mcpServers: 14,      // first-party MCP servers
-  dbTables: 85,        // Drizzle table declarations
+  dbTables: 96,        // Drizzle table declarations
   // ...
 } as const;
 ```


### PR DESCRIPTION
## Summary

Session B of GAP-407 MD-truth W2 (`revealui/docs/**` only). Read-only audit first against `~/revfleet/archive/audits/2026-07-22-md-truth/`, then DOC-DRIFT fixes with code:line proofs.

### Fixes (DOC-DRIFT only)

| Doc | Drift | Code proof |
|-----|-------|------------|
| `docs/WHAT_WORKS_TODAY.md` | create-revealui 0.5.12→**0.5.15**, cli 0.8.3→**0.9.2** | `packages/create-revealui/package.json`, `packages/cli/package.json` |
| same | workspaces 31→**33**, MIT 21→**23**, UI 61→**65**, tables 85→**96**, CHECK 72→**81** | `pnpm tsx scripts/validate/claim-drift.ts` actuals; `site.ts` METRICS |
| same | Supabase "optional sidecar" | ADR `2026-05-01-supabase-removal`; `packages/db/src/schema/vector.ts` Neon pgvector; `packages/mcp/src/servers/supabase.ts` customer MCP only |
| `docs/MARKETING_METRICS.md` | dbTables 93→**96**, testFiles 1061→**1122**, internal package name | claim-drift counts; `@revealui/scripts` license none |
| `docs/COMPONENT_CATALOG.md` | counting rule still said **61** | `countUIComponents()` = 65 |
| `docs/blog/14-claim-drift.md` | sample METRICS (85/60/27) | illustrative sample updated to live shape |

### Audit artifacts

- Run: `$REVFLEET_ARCHIVE/audits/2026-07-22-md-truth/`
- Pure shards claimed: `shard-042`…`048` + re-filtered `shard-docs-residual` (8 paths from mixed 041/049)
- Coverage: 131/131 `revealui/docs/**` terminal rows in `ledger/coverage.jsonl`
- Findings: `ledger/findings.jsonl` (F-B-0001…0013)

### Out of scope (per session bar)

- **CODE-DRIFT on pricing/security:** none requiring owner words. Pricing docs match `pricing-fallbacks.ts` ($49 / $299 / $1,499).
- No self-merge.

## Test plan

- [ ] `pnpm validate:claims` still green on this branch
- [ ] Spot-check Numbers table in WHAT_WORKS_TODAY vs `pnpm tsx scripts/validate/claim-drift.ts` printed actuals
- [ ] No apps/docs public mirror for these paths (confirmed absent)