### PR TITLE
feat(marketing): wire fair-source CMS blocks (VES residual)

### DIFF
--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -1,5 +1,16 @@
 import { BlockSchema } from '@revealui/contracts/content';
 import { describe, expect, it } from 'vitest';
+import {
+  FAIR_SOURCE_CLOCK_SECTION,
+  FAIR_SOURCE_CONTRACT_CARDS,
+  FAIR_SOURCE_CONTRACT_SECTION,
+  FAIR_SOURCE_CTA,
+  FAIR_SOURCE_FAQ_SECTION,
+  FAIR_SOURCE_FAQS,
+  FAIR_SOURCE_PACKAGES_SECTION,
+  FAIR_SOURCE_PEERS,
+  FAIR_SOURCE_PEERS_SECTION,
+} from '../content/fair-source';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
@@ -9,6 +20,14 @@ import { METRICS } from '../content/site';
 import {
   blocksMatchFallback,
   demoSlot,
+  FAIR_SOURCE_FALLBACK_BLOCKS,
+  fairSourceBlocks,
+  fairSourceClockSlot,
+  fairSourceContractSlot,
+  fairSourceCtaSlot,
+  fairSourceFaqSlot,
+  fairSourcePackagesIntroSlot,
+  fairSourcePeersSlot,
   getStartedSlot,
   HOME_FALLBACK_BLOCKS,
   homeBlocks,
@@ -46,12 +65,13 @@ function collectStrings(value: unknown, out: string[] = []): string[] {
 }
 
 describe('page-blocks derivation', () => {
-  it('produces schema-valid blocks for home, products, philosophy, and local-ai', () => {
+  it('produces schema-valid blocks for home, products, philosophy, local-ai, and fair-source', () => {
     for (const block of [
       ...homeBlocks(),
       ...productsBlocks(),
       ...philosophyBlocks(),
       ...localAiBlocks(),
+      ...fairSourceBlocks(),
     ]) {
       expect(BlockSchema.safeParse(block).success).toBe(true);
     }
@@ -63,6 +83,14 @@ describe('page-blocks derivation', () => {
     expect(philosophyBlocks().map((b) => b.type)).toEqual(['hero', 'section', 'ctaSection']);
     expect(localAiBlocks().map((b) => b.type)).toEqual([
       'hero',
+      'section',
+      'section',
+      'section',
+      'ctaSection',
+    ]);
+    expect(fairSourceBlocks().map((b) => b.type)).toEqual([
+      'section',
+      'section',
       'section',
       'section',
       'section',
@@ -113,6 +141,50 @@ describe('page-blocks derivation', () => {
     });
     expect(localAiCtaSlot(blocks).data).toEqual(LOCAL_AI_PAGE.cta);
   });
+
+  it('round-trips fair-source slots against the static content module', () => {
+    const blocks = FAIR_SOURCE_FALLBACK_BLOCKS;
+    expect(fairSourceContractSlot(blocks).data).toEqual({
+      eyebrow: FAIR_SOURCE_CONTRACT_SECTION.eyebrow,
+      heading: FAIR_SOURCE_CONTRACT_SECTION.heading,
+      cards: FAIR_SOURCE_CONTRACT_CARDS.map((c) => ({
+        kind: c.kind,
+        title: c.title,
+        body: c.body,
+      })),
+    });
+    const packagesIntro = fairSourcePackagesIntroSlot(blocks).data;
+    expect(packagesIntro.eyebrow).toBe(FAIR_SOURCE_PACKAGES_SECTION.eyebrow);
+    expect(packagesIntro.heading).toBe(FAIR_SOURCE_PACKAGES_SECTION.heading);
+    expect(packagesIntro.body).toContain(FAIR_SOURCE_PACKAGES_SECTION.body.privatePackage);
+    expect(packagesIntro.footerCommand).toBe(FAIR_SOURCE_PACKAGES_SECTION.footer.command);
+    expect(fairSourceClockSlot(blocks).data).toEqual({
+      eyebrow: FAIR_SOURCE_CLOCK_SECTION.eyebrow,
+      heading: FAIR_SOURCE_CLOCK_SECTION.heading,
+      body: FAIR_SOURCE_CLOCK_SECTION.body,
+      steps: FAIR_SOURCE_CLOCK_SECTION.steps.map((s) => ({
+        title: s.title,
+        body: s.body,
+        color: s.color,
+      })),
+    });
+    expect(fairSourcePeersSlot(blocks).data).toEqual({
+      eyebrow: FAIR_SOURCE_PEERS_SECTION.eyebrow,
+      heading: FAIR_SOURCE_PEERS_SECTION.heading,
+      peers: FAIR_SOURCE_PEERS.map((p) => ({ name: p.name, note: p.note, url: p.url })),
+    });
+    expect(fairSourceFaqSlot(blocks).data).toEqual({
+      eyebrow: FAIR_SOURCE_FAQ_SECTION.eyebrow,
+      heading: FAIR_SOURCE_FAQ_SECTION.heading,
+      items: FAIR_SOURCE_FAQS.map((f) => ({ question: f.question, answer: f.answer })),
+    });
+    expect(fairSourceCtaSlot(blocks).data).toEqual({
+      heading: FAIR_SOURCE_CTA.heading,
+      body: FAIR_SOURCE_CTA.body,
+      primary: { label: FAIR_SOURCE_CTA.primaryLabel, href: FAIR_SOURCE_CTA.primaryHref },
+      secondary: { label: FAIR_SOURCE_CTA.secondaryLabel, href: FAIR_SOURCE_CTA.secondaryHref },
+    });
+  });
 });
 
 describe('claims safety: prose is single-sourced, pinned values never enter blocks', () => {
@@ -121,6 +193,7 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     productsBlocks(),
     philosophyBlocks(),
     localAiBlocks(),
+    fairSourceBlocks(),
   ]);
   const haystack = strings.join(' ');
 
@@ -163,6 +236,13 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     }
     expect(strings).toContain(LOCAL_AI_PAGE.marketProof.heading);
     expect(strings).toContain(LOCAL_AI_SECTION.snippet.caption);
+    expect(strings).toContain(FAIR_SOURCE_CONTRACT_SECTION.heading);
+    for (const card of FAIR_SOURCE_CONTRACT_CARDS) {
+      expect(strings).toContain(card.title);
+      expect(strings).toContain(card.body);
+    }
+    expect(strings).toContain(FAIR_SOURCE_CTA.heading);
+    expect(strings).toContain(FAIR_SOURCE_CTA.body);
     // Env-code lines stay out of blocks (grep-accurate, component-local).
     expect(strings).not.toContain('LLM_PROVIDER=inference-snaps');
     expect(strings).not.toContain('LLM_PROVIDER=ollama');
@@ -174,6 +254,7 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     // The pro price lives only on the pricing surfaces, never in a block.
     expect(haystack).not.toContain(SUBSCRIPTION_PRICE_FALLBACKS.pro.price);
     // Metric counters are rendered from METRICS in TSX, never as block prose.
+    // Fair-source hero (which interpolates METRICS) is intentionally not in blocks.
     for (const metric of [METRICS.packages, METRICS.dbTables, METRICS.mcpServers]) {
       expect(strings).not.toContain(String(metric));
     }
@@ -258,6 +339,7 @@ describe('blocksMatchFallback shape guard', () => {
     expect(blocksMatchFallback(homeBlocks(), HOME_FALLBACK_BLOCKS)).toBe(true);
     expect(blocksMatchFallback(productsBlocks(), PRODUCTS_FALLBACK_BLOCKS)).toBe(true);
     expect(blocksMatchFallback(philosophyBlocks(), PHILOSOPHY_FALLBACK_BLOCKS)).toBe(true);
+    expect(blocksMatchFallback(fairSourceBlocks(), FAIR_SOURCE_FALLBACK_BLOCKS)).toBe(true);
   });
 
   it('rejects empty, wrong-length, and wrong-type arrays', () => {

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -1,6 +1,6 @@
 /**
  * Static-first block derivation for marketing pages served from the CMS
- * (home, products, philosophy, local-ai).
+ * (home, products, philosophy, local-ai, fair-source).
  *
  * The marketing content modules stay the single source of truth for every prose
  * string. This module derives the canonical `pages.blocks` array from those
@@ -14,6 +14,11 @@
  * numbers, prices, product versions, colors, and icon paths never leave the TSX.
  * Interactive widgets (ProviderSwitch, FrontierPathway) and env-code snippets
  * stay component-local so grep-accurate config lines never go through CMS.
+ *
+ * Fair Source hero stays component-local for the same reason: its headline,
+ * subhead, and body interpolate METRICS license-split counts. The package
+ * inventory table stays structural (name/license/repo/npm), while section
+ * headers, contract cards, clock, peers, FAQ, and CTA ride the CMS.
  *
  * No React or network imports live here so `scripts/seed-fleet-marketing-site.ts`
  * can import the same derivation the runtime falls back to.
@@ -29,6 +34,17 @@ import {
   type MarketingLink,
   type SectionBlock,
 } from '@revealui/contracts/content';
+import {
+  FAIR_SOURCE_CLOCK_SECTION,
+  FAIR_SOURCE_CONTRACT_CARDS,
+  FAIR_SOURCE_CONTRACT_SECTION,
+  FAIR_SOURCE_CTA,
+  FAIR_SOURCE_FAQ_SECTION,
+  FAIR_SOURCE_FAQS,
+  FAIR_SOURCE_PACKAGES_SECTION,
+  FAIR_SOURCE_PEERS,
+  FAIR_SOURCE_PEERS_SECTION,
+} from '../content/fair-source';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
@@ -160,6 +176,64 @@ export interface LocalAiCtaData {
   readonly secondary: Cta;
 }
 
+export interface FairSourceContractCardData {
+  readonly kind: 'yes' | 'no';
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface FairSourceContractData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly cards: readonly FairSourceContractCardData[];
+}
+
+export interface FairSourcePackagesIntroData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly footer: string;
+  readonly footerCommand: string;
+}
+
+export interface FairSourceClockStepData {
+  readonly title: string;
+  readonly body: string;
+  readonly color: 'emerald' | 'amber';
+}
+
+export interface FairSourceClockData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly steps: readonly FairSourceClockStepData[];
+}
+
+export interface FairSourcePeerData {
+  readonly name: string;
+  readonly note: string;
+  readonly url: string;
+}
+
+export interface FairSourcePeersData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly peers: readonly FairSourcePeerData[];
+}
+
+export interface FairSourceFaqData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly items: readonly FaqItemData[];
+}
+
+export interface FairSourceCtaData {
+  readonly heading: string;
+  readonly body: string;
+  readonly primary: Cta;
+  readonly secondary: Cta;
+}
+
 // ---------------------------------------------------------------------------
 // Stable block ids + positions. Ids let the seed and fallback match, but the
 // runtime routes each slot by array POSITION + type (the CMS assigns its own
@@ -180,6 +254,12 @@ export const LOCAL_AI_PILLARS_BLOCK_ID = 'local-ai-pillars';
 export const LOCAL_AI_MARKET_PROOF_BLOCK_ID = 'local-ai-market-proof';
 export const LOCAL_AI_NOTES_BLOCK_ID = 'local-ai-notes';
 export const LOCAL_AI_CTA_BLOCK_ID = 'local-ai-cta';
+export const FAIR_SOURCE_CONTRACT_BLOCK_ID = 'fair-source-contract';
+export const FAIR_SOURCE_PACKAGES_INTRO_BLOCK_ID = 'fair-source-packages-intro';
+export const FAIR_SOURCE_CLOCK_BLOCK_ID = 'fair-source-clock';
+export const FAIR_SOURCE_PEERS_BLOCK_ID = 'fair-source-peers';
+export const FAIR_SOURCE_FAQ_BLOCK_ID = 'fair-source-faq';
+export const FAIR_SOURCE_CTA_BLOCK_ID = 'fair-source-cta';
 
 const HOME_DEMO_INDEX = 0;
 const HOME_PRIMITIVES_INDEX = 1;
@@ -195,6 +275,12 @@ const LOCAL_AI_PILLARS_INDEX = 1;
 const LOCAL_AI_MARKET_PROOF_INDEX = 2;
 const LOCAL_AI_NOTES_INDEX = 3;
 const LOCAL_AI_CTA_INDEX = 4;
+const FAIR_SOURCE_CONTRACT_INDEX = 0;
+const FAIR_SOURCE_PACKAGES_INTRO_INDEX = 1;
+const FAIR_SOURCE_CLOCK_INDEX = 2;
+const FAIR_SOURCE_PEERS_INDEX = 3;
+const FAIR_SOURCE_FAQ_INDEX = 4;
+const FAIR_SOURCE_CTA_INDEX = 5;
 
 function ctaToLink(cta: Cta, variant: 'primary' | 'secondary'): MarketingLink {
   return { label: cta.label, href: cta.href, variant };
@@ -368,6 +454,98 @@ function localAiCtaBlock(): CtaSectionBlock {
   });
 }
 
+function fairSourceContractBlock(): SectionBlock {
+  return createSectionBlock(FAIR_SOURCE_CONTRACT_BLOCK_ID, FAIR_SOURCE_CONTRACT_SECTION.heading, {
+    eyebrow: FAIR_SOURCE_CONTRACT_SECTION.eyebrow,
+    items: FAIR_SOURCE_CONTRACT_CARDS.map((card) => ({
+      label: card.title,
+      title: card.kind,
+      body: card.body,
+    })),
+  });
+}
+
+function fairSourcePackagesIntroBlock(): SectionBlock {
+  // Package inventory table stays structural in FairSourcePage (name/license/repo).
+  // Header + footer prose ride the CMS; private package name is embedded in body.
+  const body = [
+    FAIR_SOURCE_PACKAGES_SECTION.body.prefix,
+    FAIR_SOURCE_PACKAGES_SECTION.body.privatePackage,
+    FAIR_SOURCE_PACKAGES_SECTION.body.suffix,
+  ].join(' ');
+  const footer = [
+    FAIR_SOURCE_PACKAGES_SECTION.footer.prefix,
+    FAIR_SOURCE_PACKAGES_SECTION.footer.command,
+    FAIR_SOURCE_PACKAGES_SECTION.footer.suffix,
+  ].join(' ');
+  return createSectionBlock(
+    FAIR_SOURCE_PACKAGES_INTRO_BLOCK_ID,
+    FAIR_SOURCE_PACKAGES_SECTION.heading,
+    {
+      eyebrow: FAIR_SOURCE_PACKAGES_SECTION.eyebrow,
+      body,
+      items: [
+        { label: 'footer', body: footer },
+        {
+          label: 'footer-command',
+          body: FAIR_SOURCE_PACKAGES_SECTION.footer.command,
+        },
+      ],
+    },
+  );
+}
+
+function fairSourceClockBlock(): SectionBlock {
+  return createSectionBlock(FAIR_SOURCE_CLOCK_BLOCK_ID, FAIR_SOURCE_CLOCK_SECTION.heading, {
+    eyebrow: FAIR_SOURCE_CLOCK_SECTION.eyebrow,
+    body: FAIR_SOURCE_CLOCK_SECTION.body,
+    items: FAIR_SOURCE_CLOCK_SECTION.steps.map((step) => ({
+      label: step.title,
+      title: step.color,
+      body: step.body,
+    })),
+  });
+}
+
+function fairSourcePeersBlock(): SectionBlock {
+  return createSectionBlock(FAIR_SOURCE_PEERS_BLOCK_ID, FAIR_SOURCE_PEERS_SECTION.heading, {
+    eyebrow: FAIR_SOURCE_PEERS_SECTION.eyebrow,
+    items: FAIR_SOURCE_PEERS.map((peer) => ({
+      label: peer.name,
+      title: peer.url,
+      body: peer.note,
+    })),
+  });
+}
+
+function fairSourceFaqBlock(): SectionBlock {
+  return createSectionBlock(FAIR_SOURCE_FAQ_BLOCK_ID, FAIR_SOURCE_FAQ_SECTION.heading, {
+    eyebrow: FAIR_SOURCE_FAQ_SECTION.eyebrow,
+    items: FAIR_SOURCE_FAQS.map((item) => ({
+      label: item.question,
+      body: item.answer,
+    })),
+  });
+}
+
+function fairSourceCtaBlock(): CtaSectionBlock {
+  return createCtaSectionBlock(FAIR_SOURCE_CTA_BLOCK_ID, FAIR_SOURCE_CTA.heading, {
+    body: FAIR_SOURCE_CTA.body,
+    links: [
+      {
+        label: FAIR_SOURCE_CTA.primaryLabel,
+        href: FAIR_SOURCE_CTA.primaryHref,
+        variant: 'primary',
+      },
+      {
+        label: FAIR_SOURCE_CTA.secondaryLabel,
+        href: FAIR_SOURCE_CTA.secondaryHref,
+        variant: 'secondary',
+      },
+    ],
+  });
+}
+
 /** Derives the home page's block-driven sections (Demo, Primitives, GetStarted). */
 export function homeBlocks(): Block[] {
   return [homeDemoBlock(), homePrimitivesBlock(), homeGetStartedBlock()];
@@ -394,10 +572,26 @@ export function localAiBlocks(): Block[] {
   ];
 }
 
+/**
+ * Derives the fair-source page's CMS-driven sections.
+ * Hero (metric-bearing) and package inventory table stay component-local.
+ */
+export function fairSourceBlocks(): Block[] {
+  return [
+    fairSourceContractBlock(),
+    fairSourcePackagesIntroBlock(),
+    fairSourceClockBlock(),
+    fairSourcePeersBlock(),
+    fairSourceFaqBlock(),
+    fairSourceCtaBlock(),
+  ];
+}
+
 export const HOME_FALLBACK_BLOCKS: Block[] = homeBlocks();
 export const PRODUCTS_FALLBACK_BLOCKS: Block[] = productsBlocks();
 export const PHILOSOPHY_FALLBACK_BLOCKS: Block[] = philosophyBlocks();
 export const LOCAL_AI_FALLBACK_BLOCKS: Block[] = localAiBlocks();
+export const FAIR_SOURCE_FALLBACK_BLOCKS: Block[] = fairSourceBlocks();
 
 // ---------------------------------------------------------------------------
 // Reverse mappers: canonical block -> rich component data shape
@@ -685,6 +879,127 @@ export function localAiCtaSlot(blocks: Block[]): BlockSlot<LocalAiCtaData> {
   const path = `blocks.${LOCAL_AI_CTA_INDEX}.data`;
   if (block && block.type === 'ctaSection') return { data: ctaToLocalAiCta(block), path };
   return { data: ctaToLocalAiCta(localAiCtaBlock()), path };
+}
+
+function sectionToFairSourceContract(block: SectionBlock): FairSourceContractData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    cards: (block.data.items ?? []).map((item) => ({
+      kind: item.title === 'no' ? 'no' : 'yes',
+      title: item.label ?? '',
+      body: item.body,
+    })),
+  };
+}
+
+function sectionToFairSourcePackagesIntro(block: SectionBlock): FairSourcePackagesIntroData {
+  const items = block.data.items ?? [];
+  const footerItem = items.find((item) => item.label === 'footer');
+  const commandItem = items.find((item) => item.label === 'footer-command');
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    footer: footerItem?.body ?? '',
+    footerCommand: commandItem?.body ?? FAIR_SOURCE_PACKAGES_SECTION.footer.command,
+  };
+}
+
+function sectionToFairSourceClock(block: SectionBlock): FairSourceClockData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    steps: (block.data.items ?? []).map((item) => ({
+      title: item.label ?? '',
+      body: item.body,
+      color: item.title === 'amber' ? 'amber' : 'emerald',
+    })),
+  };
+}
+
+function sectionToFairSourcePeers(block: SectionBlock): FairSourcePeersData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    peers: (block.data.items ?? []).map((item) => ({
+      name: item.label ?? '',
+      note: item.body,
+      url: item.title ?? '',
+    })),
+  };
+}
+
+function sectionToFairSourceFaq(block: SectionBlock): FairSourceFaqData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    items: (block.data.items ?? []).map((item) => ({
+      question: item.label ?? '',
+      answer: item.body,
+    })),
+  };
+}
+
+function ctaToFairSourceCta(block: CtaSectionBlock): FairSourceCtaData {
+  const links = block.data.links ?? [];
+  return {
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    primary: links[0]
+      ? linkToCta(links[0])
+      : { label: FAIR_SOURCE_CTA.primaryLabel, href: FAIR_SOURCE_CTA.primaryHref },
+    secondary: links[1]
+      ? linkToCta(links[1])
+      : { label: FAIR_SOURCE_CTA.secondaryLabel, href: FAIR_SOURCE_CTA.secondaryHref },
+  };
+}
+
+export function fairSourceContractSlot(blocks: Block[]): BlockSlot<FairSourceContractData> {
+  const block = blocks[FAIR_SOURCE_CONTRACT_INDEX];
+  const path = `blocks.${FAIR_SOURCE_CONTRACT_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFairSourceContract(block), path };
+  return { data: sectionToFairSourceContract(fairSourceContractBlock()), path };
+}
+
+export function fairSourcePackagesIntroSlot(
+  blocks: Block[],
+): BlockSlot<FairSourcePackagesIntroData> {
+  const block = blocks[FAIR_SOURCE_PACKAGES_INTRO_INDEX];
+  const path = `blocks.${FAIR_SOURCE_PACKAGES_INTRO_INDEX}.data`;
+  if (block && block.type === 'section') {
+    return { data: sectionToFairSourcePackagesIntro(block), path };
+  }
+  return { data: sectionToFairSourcePackagesIntro(fairSourcePackagesIntroBlock()), path };
+}
+
+export function fairSourceClockSlot(blocks: Block[]): BlockSlot<FairSourceClockData> {
+  const block = blocks[FAIR_SOURCE_CLOCK_INDEX];
+  const path = `blocks.${FAIR_SOURCE_CLOCK_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFairSourceClock(block), path };
+  return { data: sectionToFairSourceClock(fairSourceClockBlock()), path };
+}
+
+export function fairSourcePeersSlot(blocks: Block[]): BlockSlot<FairSourcePeersData> {
+  const block = blocks[FAIR_SOURCE_PEERS_INDEX];
+  const path = `blocks.${FAIR_SOURCE_PEERS_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFairSourcePeers(block), path };
+  return { data: sectionToFairSourcePeers(fairSourcePeersBlock()), path };
+}
+
+export function fairSourceFaqSlot(blocks: Block[]): BlockSlot<FairSourceFaqData> {
+  const block = blocks[FAIR_SOURCE_FAQ_INDEX];
+  const path = `blocks.${FAIR_SOURCE_FAQ_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFairSourceFaq(block), path };
+  return { data: sectionToFairSourceFaq(fairSourceFaqBlock()), path };
+}
+
+export function fairSourceCtaSlot(blocks: Block[]): BlockSlot<FairSourceCtaData> {
+  const block = blocks[FAIR_SOURCE_CTA_INDEX];
+  const path = `blocks.${FAIR_SOURCE_CTA_INDEX}.data`;
+  if (block && block.type === 'ctaSection') return { data: ctaToFairSourceCta(block), path };
+  return { data: ctaToFairSourceCta(fairSourceCtaBlock()), path };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -1,23 +1,423 @@
-import { Button, IconCheckCircle, IconPlus, IconXCircle } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  Button,
+  fieldAttrs,
+  IconCheckCircle,
+  IconPlus,
+  IconXCircle,
+} from '@revealui/presentation';
 import { useEffect } from 'react';
 import { Footer } from '../components/Footer';
 import {
-  FAIR_SOURCE_CLOCK_SECTION,
-  FAIR_SOURCE_CONTRACT_CARDS,
-  FAIR_SOURCE_CONTRACT_SECTION,
-  FAIR_SOURCE_CTA,
-  FAIR_SOURCE_FAQ_SECTION,
-  FAIR_SOURCE_FAQS,
   FAIR_SOURCE_HERO,
   FAIR_SOURCE_PACKAGES,
-  FAIR_SOURCE_PACKAGES_SECTION,
   FAIR_SOURCE_PAGE_TITLE,
-  FAIR_SOURCE_PEERS,
-  FAIR_SOURCE_PEERS_SECTION,
 } from '../content/fair-source';
 import { buildOgUrl } from '../lib/og';
+import {
+  FAIR_SOURCE_FALLBACK_BLOCKS,
+  type FairSourceClockData,
+  type FairSourceContractData,
+  type FairSourceCtaData,
+  type FairSourceFaqData,
+  type FairSourcePackagesIntroData,
+  type FairSourcePeersData,
+  fairSourceClockSlot,
+  fairSourceContractSlot,
+  fairSourceCtaSlot,
+  fairSourceFaqSlot,
+  fairSourcePackagesIntroSlot,
+  fairSourcePeersSlot,
+} from '../lib/page-blocks';
+import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
+interface AnnotatedSectionProps {
+  path: string;
+  annotation: BlockAnnotation;
+}
+
+interface ContractProps extends AnnotatedSectionProps {
+  data: FairSourceContractData;
+}
+
+function FairSourceContract({ data, path, annotation }: ContractProps) {
+  return (
+    <section className="bg-background py-16 sm:py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {data.eyebrow}
+          </p>
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
+          </h2>
+        </div>
+
+        <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2">
+          {data.cards.map((c, index) => (
+            <div
+              key={c.title}
+              className={`rounded-2xl p-6 ring-1 transition ${
+                c.kind === 'yes'
+                  ? 'bg-primary/10 ring-primary/20'
+                  : 'bg-amber-500/15 ring-amber-500/30'
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                {c.kind === 'yes' ? (
+                  <IconCheckCircle size="md" className="mt-0.5 flex-shrink-0 text-primary" />
+                ) : (
+                  <IconXCircle
+                    size="md"
+                    className="mt-0.5 flex-shrink-0 text-amber-800 dark:text-amber-200"
+                  />
+                )}
+                <div>
+                  <h3
+                    className="text-lg font-semibold text-foreground"
+                    {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+                  >
+                    {c.title}
+                  </h3>
+                  <p
+                    className="mt-2 text-sm leading-6 text-muted-foreground"
+                    {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+                  >
+                    {c.body}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface PackagesIntroProps extends AnnotatedSectionProps {
+  data: FairSourcePackagesIntroData;
+}
+
+function FairSourcePackagesIntro({ data, path, annotation }: PackagesIntroProps) {
+  // Inventory table stays structural (name / license / repo / npm). Only the
+  // section header + footer prose are CMS-driven so metric/package inventory
+  // claims never leave the claim-covered content modules + static table.
+  return (
+    <section className="bg-secondary py-16 sm:py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {data.eyebrow}
+          </p>
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
+          </h2>
+          <p
+            className="mt-6 text-base leading-7 text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.body`)}
+          >
+            {data.body}
+          </p>
+        </div>
+
+        <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-card ring-1 ring-border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              <tr>
+                <th className="px-6 py-3">Package</th>
+                <th className="px-6 py-3">Purpose</th>
+                <th className="px-6 py-3">License</th>
+                <th className="px-6 py-3">Source</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {FAIR_SOURCE_PACKAGES.map((p) => (
+                <tr key={p.name}>
+                  <td className="px-6 py-4 font-mono text-sm font-semibold text-foreground">
+                    {p.name}
+                  </td>
+                  <td className="px-6 py-4 text-muted-foreground">{p.purpose}</td>
+                  <td className="px-6 py-4">
+                    <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
+                      {p.license}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 text-sm">
+                    <a
+                      href={p.repo}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:text-primary/80"
+                    >
+                      GitHub
+                    </a>
+                    <span className="px-2 text-muted-foreground/40">·</span>
+                    <a
+                      href={p.npm}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:text-primary/80"
+                    >
+                      npm
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p
+          className="mx-auto mt-6 max-w-2xl text-center text-sm text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.items.0.body`)}
+        >
+          {data.footer.includes(data.footerCommand) ? (
+            <>
+              {data.footer.slice(0, data.footer.indexOf(data.footerCommand))}
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                {data.footerCommand}
+              </code>
+              {data.footer.slice(
+                data.footer.indexOf(data.footerCommand) + data.footerCommand.length,
+              )}
+            </>
+          ) : (
+            data.footer
+          )}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+interface ClockProps extends AnnotatedSectionProps {
+  data: FairSourceClockData;
+}
+
+function FairSourceClock({ data, path, annotation }: ClockProps) {
+  return (
+    <section className="bg-background py-16 sm:py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {data.eyebrow}
+          </p>
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
+          </h2>
+          <p
+            className="mt-6 text-base leading-7 text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.body`)}
+          >
+            {data.body}
+          </p>
+        </div>
+
+        <div className="mx-auto mt-12 max-w-3xl">
+          <ol className="relative border-l-2 border-primary/20 pl-8">
+            {data.steps.map((step, index) => (
+              <li key={step.title} className="mb-8 last:mb-0">
+                <span
+                  className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-background ${
+                    step.color === 'emerald' ? 'bg-primary' : 'bg-amber-600'
+                  }`}
+                >
+                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
+                </span>
+                <h3
+                  className="font-semibold text-foreground"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+                >
+                  {step.title}
+                </h3>
+                <p
+                  className="mt-1 text-sm text-muted-foreground"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+                >
+                  {step.body}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface PeersProps extends AnnotatedSectionProps {
+  data: FairSourcePeersData;
+}
+
+function FairSourcePeers({ data, path, annotation }: PeersProps) {
+  return (
+    <section className="bg-secondary py-16 sm:py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {data.eyebrow}
+          </p>
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
+          </h2>
+        </div>
+
+        <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
+          {data.peers.map((p, index) => (
+            <a
+              key={p.name}
+              href={p.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-2xl bg-card p-6 ring-1 ring-border no-underline transition hover:ring-border/60"
+            >
+              <h3
+                className="text-lg font-semibold text-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+              >
+                {p.name}
+              </h3>
+              <p
+                className="mt-2 text-sm leading-6 text-muted-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+              >
+                {p.note}
+              </p>
+              <p className="mt-3 text-xs font-medium text-primary">Read their post &rarr;</p>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface FaqProps extends AnnotatedSectionProps {
+  data: FairSourceFaqData;
+}
+
+function FairSourceFaq({ data, path, annotation }: FaqProps) {
+  return (
+    <section className="bg-background py-16 sm:py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...fieldAttrs(annotation, `${path}.eyebrow`)}
+          >
+            {data.eyebrow}
+          </p>
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...fieldAttrs(annotation, `${path}.heading`)}
+          >
+            {data.heading}
+          </h2>
+        </div>
+
+        <div className="mx-auto mt-12 max-w-3xl divide-y divide-border">
+          {data.items.map((f, index) => (
+            <details key={f.question} className="group py-6">
+              <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
+                <h3
+                  className="text-lg font-semibold leading-7 text-foreground"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+                >
+                  {f.question}
+                </h3>
+                <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
+                  <IconPlus size="sm" label="Toggle" />
+                </span>
+              </summary>
+              <div
+                className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+              >
+                {f.answer}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface CtaProps extends AnnotatedSectionProps {
+  data: FairSourceCtaData;
+}
+
+function FairSourceCta({ data, path, annotation }: CtaProps) {
+  return (
+    <section className="bg-card py-16 sm:py-24">
+      <div className="mx-auto max-w-2xl px-6 lg:px-8 text-center">
+        <h2
+          className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...fieldAttrs(annotation, `${path}.heading`)}
+        >
+          {data.heading}
+        </h2>
+        <p
+          className="mt-6 text-lg leading-8 text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.body`)}
+        >
+          {data.body}
+        </p>
+        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <Button asChild size="lg" variant="brand">
+            <a href={data.primary.href} {...fieldAttrs(annotation, `${path}.links.0.label`)}>
+              {data.primary.label}
+            </a>
+          </Button>
+          <Button asChild appearance="outline" variant="neutral" size="lg">
+            <a href={data.secondary.href} {...fieldAttrs(annotation, `${path}.links.1.label`)}>
+              {data.secondary.label}
+            </a>
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * /fair-source license deep dive. Metric-bearing hero and package inventory
+ * table stay static (claims safety). Narrative sections are CMS-wired via
+ * useMarketingPageBlocks (VES residual).
+ */
 export function FairSourcePage() {
+  const { blocks, annotation } = useMarketingPageBlocks('fair-source', FAIR_SOURCE_FALLBACK_BLOCKS);
+  const contract = fairSourceContractSlot(blocks);
+  const packagesIntro = fairSourcePackagesIntroSlot(blocks);
+  const clock = fairSourceClockSlot(blocks);
+  const peers = fairSourcePeersSlot(blocks);
+  const faq = fairSourceFaqSlot(blocks);
+  const cta = fairSourceCtaSlot(blocks);
+
   // Per-page OG tag override. Vite SPAs can update <head> at runtime; the
   // crawler signal value is lower than SSR, but most modern crawlers
   // (Twitterbot, Slackbot, Discordbot, LinkedIn, OpenGraph spec consumers)
@@ -31,7 +431,7 @@ export function FairSourcePage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Hero */}
+      {/* Hero — static: headline/subhead/body interpolate METRICS counts */}
       <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-16 sm:pt-28 sm:pb-20 lg:px-8">
         <div
           aria-hidden="true"
@@ -68,236 +468,16 @@ export function FairSourcePage() {
         </div>
       </section>
 
-      {/* The contract */}
-      <section className="bg-background py-16 sm:py-24">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-              {FAIR_SOURCE_CONTRACT_SECTION.eyebrow}
-            </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {FAIR_SOURCE_CONTRACT_SECTION.heading}
-            </h2>
-          </div>
-
-          <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2">
-            {FAIR_SOURCE_CONTRACT_CARDS.map((c) => (
-              <div
-                key={c.title}
-                className={`rounded-2xl p-6 ring-1 transition ${
-                  c.kind === 'yes'
-                    ? 'bg-primary/10 ring-primary/20'
-                    : 'bg-amber-500/15 ring-amber-500/30'
-                }`}
-              >
-                <div className="flex items-start gap-3">
-                  {c.kind === 'yes' ? (
-                    <IconCheckCircle size="md" className="mt-0.5 flex-shrink-0 text-primary" />
-                  ) : (
-                    <IconXCircle
-                      size="md"
-                      className="mt-0.5 flex-shrink-0 text-amber-800 dark:text-amber-200"
-                    />
-                  )}
-                  <div>
-                    <h3 className="text-lg font-semibold text-foreground">{c.title}</h3>
-                    <p className="mt-2 text-sm leading-6 text-muted-foreground">{c.body}</p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Which packages */}
-      <section className="bg-secondary py-16 sm:py-24">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-              {FAIR_SOURCE_PACKAGES_SECTION.eyebrow}
-            </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {FAIR_SOURCE_PACKAGES_SECTION.heading}
-            </h2>
-            <p className="mt-6 text-base leading-7 text-muted-foreground">
-              {FAIR_SOURCE_PACKAGES_SECTION.body.prefix}{' '}
-              <code className="rounded bg-muted px-1 py-0.5 font-mono text-sm text-foreground">
-                {FAIR_SOURCE_PACKAGES_SECTION.body.privatePackage}
-              </code>{' '}
-              {FAIR_SOURCE_PACKAGES_SECTION.body.suffix}
-            </p>
-          </div>
-
-          <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-card ring-1 ring-border">
-            <table className="w-full text-left text-sm">
-              <thead className="bg-muted text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                <tr>
-                  <th className="px-6 py-3">Package</th>
-                  <th className="px-6 py-3">Purpose</th>
-                  <th className="px-6 py-3">License</th>
-                  <th className="px-6 py-3">Source</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {FAIR_SOURCE_PACKAGES.map((p) => (
-                  <tr key={p.name}>
-                    <td className="px-6 py-4 font-mono text-sm font-semibold text-foreground">
-                      {p.name}
-                    </td>
-                    <td className="px-6 py-4 text-muted-foreground">{p.purpose}</td>
-                    <td className="px-6 py-4">
-                      <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
-                        {p.license}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-sm">
-                      <a
-                        href={p.repo}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:text-primary/80"
-                      >
-                        GitHub
-                      </a>
-                      <span className="px-2 text-muted-foreground/40">·</span>
-                      <a
-                        href={p.npm}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:text-primary/80"
-                      >
-                        npm
-                      </a>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <p className="mx-auto mt-6 max-w-2xl text-center text-sm text-muted-foreground">
-            {FAIR_SOURCE_PACKAGES_SECTION.footer.prefix}{' '}
-            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-              {FAIR_SOURCE_PACKAGES_SECTION.footer.command}
-            </code>
-            {FAIR_SOURCE_PACKAGES_SECTION.footer.suffix}
-          </p>
-        </div>
-      </section>
-
-      {/* The two-year clock */}
-      <section className="bg-background py-16 sm:py-24">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-              {FAIR_SOURCE_CLOCK_SECTION.eyebrow}
-            </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {FAIR_SOURCE_CLOCK_SECTION.heading}
-            </h2>
-            <p className="mt-6 text-base leading-7 text-muted-foreground">
-              {FAIR_SOURCE_CLOCK_SECTION.body}
-            </p>
-          </div>
-
-          <div className="mx-auto mt-12 max-w-3xl">
-            <ol className="relative border-l-2 border-primary/20 pl-8">
-              {FAIR_SOURCE_CLOCK_SECTION.steps.map((step) => (
-                <li key={step.title} className="mb-8 last:mb-0">
-                  <span
-                    className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-background ${
-                      step.color === 'emerald' ? 'bg-primary' : 'bg-amber-600'
-                    }`}
-                  >
-                    <span className="h-1.5 w-1.5 rounded-full bg-white" />
-                  </span>
-                  <h3 className="font-semibold text-foreground">{step.title}</h3>
-                  <p className="mt-1 text-sm text-muted-foreground">{step.body}</p>
-                </li>
-              ))}
-            </ol>
-          </div>
-        </div>
-      </section>
-
-      {/* In good company */}
-      <section className="bg-secondary py-16 sm:py-24">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-              {FAIR_SOURCE_PEERS_SECTION.eyebrow}
-            </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {FAIR_SOURCE_PEERS_SECTION.heading}
-            </h2>
-          </div>
-
-          <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
-            {FAIR_SOURCE_PEERS.map((p) => (
-              <a
-                key={p.name}
-                href={p.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-2xl bg-card p-6 ring-1 ring-border no-underline transition hover:ring-border/60"
-              >
-                <h3 className="text-lg font-semibold text-foreground">{p.name}</h3>
-                <p className="mt-2 text-sm leading-6 text-muted-foreground">{p.note}</p>
-                <p className="mt-3 text-xs font-medium text-primary">Read their post &rarr;</p>
-              </a>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* FAQ */}
-      <section className="bg-background py-16 sm:py-24">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-              {FAIR_SOURCE_FAQ_SECTION.eyebrow}
-            </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {FAIR_SOURCE_FAQ_SECTION.heading}
-            </h2>
-          </div>
-
-          <div className="mx-auto mt-12 max-w-3xl divide-y divide-border">
-            {FAIR_SOURCE_FAQS.map((f) => (
-              <details key={f.question} className="group py-6">
-                <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                  <h3 className="text-lg font-semibold leading-7 text-foreground">{f.question}</h3>
-                  <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
-                    <IconPlus size="sm" label="Toggle" />
-                  </span>
-                </summary>
-                <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">
-                  {f.answer}
-                </div>
-              </details>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="bg-card py-16 sm:py-24">
-        <div className="mx-auto max-w-2xl px-6 lg:px-8 text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {FAIR_SOURCE_CTA.heading}
-          </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{FAIR_SOURCE_CTA.body}</p>
-          <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Button asChild size="lg" variant="brand">
-              <a href={FAIR_SOURCE_CTA.primaryHref}>{FAIR_SOURCE_CTA.primaryLabel}</a>
-            </Button>
-            <Button asChild appearance="outline" variant="neutral" size="lg">
-              <a href={FAIR_SOURCE_CTA.secondaryHref}>{FAIR_SOURCE_CTA.secondaryLabel}</a>
-            </Button>
-          </div>
-        </div>
-      </section>
-
+      <FairSourceContract data={contract.data} path={contract.path} annotation={annotation} />
+      <FairSourcePackagesIntro
+        data={packagesIntro.data}
+        path={packagesIntro.path}
+        annotation={annotation}
+      />
+      <FairSourceClock data={clock.data} path={clock.path} annotation={annotation} />
+      <FairSourcePeers data={peers.data} path={peers.path} annotation={annotation} />
+      <FairSourceFaq data={faq.data} path={faq.path} annotation={annotation} />
+      <FairSourceCta data={cta.data} path={cta.path} annotation={annotation} />
       <Footer />
     </div>
   );

--- a/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
+++ b/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
@@ -13,7 +13,8 @@ import { act, cleanup, render, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchPageBlocks } from '../../lib/api';
-import { homeBlocks, localAiBlocks, productsBlocks } from '../../lib/page-blocks';
+import { fairSourceBlocks, homeBlocks, localAiBlocks, productsBlocks } from '../../lib/page-blocks';
+import { FairSourcePage } from '../FairSourcePage';
 import { HomePage } from '../HomePage';
 import { LocalAiPage } from '../LocalAiPage';
 import { ProductsPage } from '../ProductsPage';
@@ -64,7 +65,7 @@ describe('marketing pages: edit-mode wiring', () => {
     editDraftsStore.setEditActive(false);
   });
 
-  it('HomePage, ProductsPage, and LocalAiPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
+  it('HomePage, ProductsPage, LocalAiPage, and FairSourcePage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
     const home = renderRouted(<HomePage />);
     expect(home.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(home.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
@@ -78,6 +79,11 @@ describe('marketing pages: edit-mode wiring', () => {
     const localAi = renderRouted(<LocalAiPage />);
     expect(localAi.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(localAi.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
+    localAi.unmount();
+
+    const fairSource = renderRouted(<FairSourcePage />);
+    expect(fairSource.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+    expect(fairSource.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
   });
 
   it('HomePage renders the draft heading annotated with the session docId when a matching overlay exists', () => {
@@ -134,6 +140,26 @@ describe('marketing pages: edit-mode wiring', () => {
     const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
     expect(title?.getAttribute('data-rvui-doc')).toBe('page-local-ai-id');
     expect(title?.textContent).toBe('Canvas-edited local-ai title');
+  });
+
+  it('FairSourcePage renders the draft contract heading annotated with the session docId when a matching overlay exists', () => {
+    const draftBlocks = fairSourceBlocks();
+    const contract = draftBlocks[0];
+    if (contract?.type === 'section') {
+      contract.data.heading = 'Canvas-edited fair-source contract';
+    }
+    editDraftsStore.set([
+      {
+        docType: 'page',
+        docId: 'page-fair-source-id',
+        draft: { slug: 'fair-source', blocks: draftBlocks },
+      },
+    ]);
+
+    const { container } = renderRouted(<FairSourcePage />);
+    const heading = container.querySelector('[data-rvui-field="blocks.0.data.heading"]');
+    expect(heading?.getAttribute('data-rvui-doc')).toBe('page-fair-source-id');
+    expect(heading?.textContent).toBe('Canvas-edited fair-source contract');
   });
 
   it('re-renders HomePage with the patched value after an optimistic draft-store update', () => {

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -2,7 +2,7 @@
 
 /**
  * Seed the fleet-marketing `sites` row plus its published marketing pages
- * (home, products, philosophy, local-ai) for the visual-edit-sessions block wire.
+ * (home, products, philosophy, local-ai, fair-source) for the visual-edit-sessions block wire.
  *
  * The page `blocks` come from the SAME pure derivation the marketing app falls
  * back to (`apps/marketing/app/lib/page-blocks.ts`), so the seeded CMS content
@@ -32,6 +32,7 @@
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import {
+  fairSourceBlocks,
   homeBlocks,
   localAiBlocks,
   philosophyBlocks,
@@ -105,6 +106,17 @@ const PAGE_SEEDS: readonly PageSeed[] = [
       title: 'Local-first AI | RevealUI',
       description:
         'Run your AI on infrastructure you own. Open-weight default, frontier one config line away.',
+    },
+  },
+  {
+    slug: 'fair-source',
+    path: '/fair-source',
+    title: 'Fair Source',
+    blocks: fairSourceBlocks(),
+    seo: {
+      title: 'Fair Source | RevealUI',
+      description:
+        'Source-visible. Commercially usable. MIT in two years. The license contract for RevealUI Pro packages.',
     },
   },
 ];
@@ -253,7 +265,7 @@ async function main(): Promise<void> {
   }
 
   // ---------------------------------------------------------------------------
-  // Pages (home + products + philosophy + local-ai) — version-safe, idempotent
+  // Pages (home + products + philosophy + local-ai + fair-source) — version-safe, idempotent
   // ---------------------------------------------------------------------------
 
   for (const seed of PAGE_SEEDS) {


### PR DESCRIPTION
## Summary

VES residual free surface: CMS-wire `/fair-source` the same static-first way as local-ai / philosophy.

- Derive narrative blocks from `content/fair-source.ts` in `page-blocks.ts` (contract, packages intro, clock, peers, FAQ, CTA)
- Render via `useMarketingPageBlocks` + `fieldAttrs` on `FairSourcePage`
- Seed `fair-source` page in `seed-fleet-marketing-site.ts`
- Tests: page-blocks round-trip + claims safety (metrics stay out of blocks) + edit-mode wiring

**Kept static (claims safety):** metric-bearing hero (METRICS license-split counts) and package inventory table (name/license/repo/npm).

## Test plan

- [x] `pnpm --filter marketing exec vitest run app/lib/page-blocks.test.ts app/routes/__tests__/edit-mode-wiring.test.tsx` (20/20)
- [x] marketing build via turbo filter
- [ ] Owner: `pnpm db:seed:fleet-marketing` when ready to land `/fair-source` in CMS

## Out of scope

- `/services` CMS wire (next residual)
- GAP-406/407 harness surfaces
- Media/CTA field editors, MCP content.session.*