### PR TITLE
feat(harnesses): finish .revealui project manager (GAP-406)

### DIFF
--- a/.changeset/manager-finish-gap-406.md
+++ b/.changeset/manager-finish-gap-406.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+Finish the `.revealui` project manager (GAP-406): default `content sync` lands under the manager tree, materialize preserves existing manager.json, structure/CI gate hard-fail on invalid manager when `.revealui` or harnesses change, equal-rank adapter stubs stay gitignored outside the manager tree.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,41 @@ jobs:
         # match it exactly. Mirrors the local gate step in scripts/gates/ci-gate.ts.
         run: pnpm validate:rules-lockstep
 
+      - name: Project manager check (path-gated hard fail)
+        # GAP-406: when a PR (or push) touches .revealui or packages/harnesses,
+        # hard-fail if manager.json is missing/invalid. Extends validate:structure
+        # (`--manager-only`) — same checkManager primitive as
+        # `revealui-harnesses manager check`. No parallel validator.
+        # Unrelated PRs skip. Full structure validation still runs above and
+        # includes the manager check when packages/harnesses is present.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          run_check=false
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "${BASE_SHA:-}" ]; then
+            if git diff --name-only "$BASE_SHA"...HEAD | grep -qE '^(\.revealui/|packages/harnesses/)'; then
+              run_check=true
+            fi
+          elif [ "$EVENT_NAME" = "push" ]; then
+            if [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+              if git diff --name-only "$BEFORE_SHA"...HEAD | grep -qE '^(\.revealui/|packages/harnesses/)'; then
+                run_check=true
+              fi
+            else
+              run_check=true
+            fi
+          else
+            run_check=true
+          fi
+          if [ "$run_check" != "true" ]; then
+            echo "skip: no .revealui/ or packages/harnesses/ changes"
+            exit 0
+          fi
+          pnpm validate:structure -- --manager-only
+
       - name: Marketing voice validation (hard fail)
         run: pnpm validate:marketing-voice
 

--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,10 @@ CLAUDE.md
 !.claude/agents/
 !.claude/skills/
 !.claude/.revcon-manifest.json
+# Equal-rank adapter stubs from `revealui-harnesses manager materialize`
+# (must not enter the revcon rules-lockstep manifest).
+.claude/rules/00-revealui-manager.md
+.opencode/
 .agents/
 
 # RevealUI cache files (PGlite database)

--- a/.gitignore
+++ b/.gitignore
@@ -178,9 +178,15 @@ CLAUDE.md
 # RevealUI cache files (PGlite database)
 .revealui/cache/
 
-# RevealUI local configuration (but allow skills to be committed)
+# RevealUI local configuration (but allow manager contract + skills)
 .revealui/*
 !.revealui/skills/
+!.revealui/templates/
+!.revealui/code-standards.json
+!.revealui/README.md
+!.revealui/manager.json
+!.revealui/adapters/
+!.revealui/adapters/**
 # =============================================================================
 # Nix Development Environment
 # =============================================================================

--- a/.revealui/README.md
+++ b/.revealui/README.md
@@ -2,6 +2,14 @@
 
 This directory is the **RevealUI project manager**. Claude, Grok, Cursor, OpenCode, VS Code, and the native RevealUI agent all have **the same rank**: they are adapters that **reference** this tree. None of them is a second policy home.
 
+## Quality over speed (standing order)
+
+**Quality is always the primary metric** for code, config, and documentation.
+Concurrent sessions, cheaper inference, and faster hardware may arrive later;
+rushed dual-home shortcuts and unproven docs do not get a pass. Prefer a smaller
+correct slice over a larger weak one. Full bar: content rule \`quality-over-speed\`
+(from \`@revealui/harnesses\`).
+
 ## Authority
 
 | Layer | Role |

--- a/.revealui/README.md
+++ b/.revealui/README.md
@@ -1,0 +1,59 @@
+# `.revealui` — project manager (all vendors equal)
+
+This directory is the **RevealUI project manager**. Claude, Grok, Cursor, OpenCode, VS Code, and the native RevealUI agent all have **the same rank**: they are adapters that **reference** this tree. None of them is a second policy home.
+
+## Authority
+
+| Layer | Role |
+|-------|------|
+| `@revealui/harnesses` package definitions | Build-time SSOT for rules/skills/commands/agents |
+| **`.revealui/` (this tree)** | On-disk manager for the project |
+| `.claude` / `.cursor` / `.opencode` / `~/.grok` | Thin adapter stubs or machine prefs only |
+
+## Layout
+
+```text
+.revealui/
+  manager.json          # adapters[], contentRoot, tracker path, mcp config path
+  content/              # generated rules, commands, agents, skills
+  adapters/             # optional vendor notes (e.g. grok.md)
+  code-standards.json   # code validator standards
+  skills/               # committed skill pack (may merge with content/ over time)
+  templates/            # package.json script templates
+  vscode-plugin/        # VS Code agent plugin (already under manager)
+  README.md             # this file
+```
+
+## Commands
+
+```bash
+# Write manager.json + generate content/ + equal-rank adapter stubs
+pnpm exec revealui-harnesses manager materialize
+
+# Verify manager present
+pnpm exec revealui-harnesses manager check
+
+# Generate content only (into .revealui/content)
+pnpm exec revealui-harnesses content sync --generator claude-code
+```
+
+## What adapters must do
+
+1. Open **`manager.json`** when entering the project.  
+2. Load shared policy from **`content/`**.  
+3. Use **tracker.path** for day-to-day free surfaces (fleet: `docs/TRACKER.md`).  
+4. Product I/O via **RevealUI MCP** (token from revvault / `rfg`) — not vendor side channels.  
+5. **Do not** full-copy hardlines into `~/.claude` or `~/.grok`.
+
+## Machine vs project
+
+| Root | Role |
+|------|------|
+| `./.revealui` | **This** manager (project) |
+| `~/.revealui` | Operator secrets (revvault) + harness config backup — not product policy |
+
+## Related
+
+- GAP-406 (adapter-only + manager)  
+- ADR `2026-07-21-harness-policy-runtime-launch-planes`  
+- ADR `2026-07-22-single-fleet-tracker`

--- a/.revealui/adapters/grok.md
+++ b/.revealui/adapters/grok.md
@@ -1,0 +1,15 @@
+> **RevealUI manager.** Policy and skills are owned by `.revealui/`.
+> This vendor tree is an **adapter stub only** (equal rank with every other vendor).
+> Do not fork hardlines here. Edit package definitions → generate into `.revealui/content/`.
+> **Quality over speed:** correctness and proof outrank throughput in every session.
+
+# RevealUI manager (Grok adapter)
+
+Machine home (`~/.grok`) must stay **pointer-thin**. When cwd is this project:
+
+1. Read `.revealui/manager.json`
+2. Read `.revealui/content/` for shared rules
+3. Open `tracker.path` from the manager (fleet TRACKER)
+4. Product work via RevealUI MCP (`rfg`)
+
+Do not copy hardlines into `~/.grok/rules/`.

--- a/.revealui/manager.json
+++ b/.revealui/manager.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "name": "RevealUI monorepo",
+  "contentRoot": "content",
+  "tracker": {
+    "path": "docs/TRACKER.md",
+    "note": "Fleet day-to-day board lives in private .jv; monorepo may point at product ROADMAP. Prefer TRACKER when present under docs/."
+  },
+  "adapters": [
+    { "id": "claude-code", "projectTree": ".claude", "rank": "equal" },
+    { "id": "cursor", "projectTree": ".cursor", "rank": "equal" },
+    { "id": "opencode", "projectTree": ".opencode", "rank": "equal" },
+    { "id": "vscode", "projectTree": null, "rank": "equal" },
+    { "id": "grok", "projectTree": null, "rank": "equal" },
+    { "id": "revealui-agent", "projectTree": null, "rank": "equal" }
+  ],
+  "mcp": { "configPath": "mcp.json" },
+  "contentPackage": "@revealui/harnesses"
+}

--- a/.revealui/manager.json
+++ b/.revealui/manager.json
@@ -7,13 +7,39 @@
     "note": "Fleet day-to-day board lives in private .jv; monorepo may point at product ROADMAP. Prefer TRACKER when present under docs/."
   },
   "adapters": [
-    { "id": "claude-code", "projectTree": ".claude", "rank": "equal" },
-    { "id": "cursor", "projectTree": ".cursor", "rank": "equal" },
-    { "id": "opencode", "projectTree": ".opencode", "rank": "equal" },
-    { "id": "vscode", "projectTree": null, "rank": "equal" },
-    { "id": "grok", "projectTree": null, "rank": "equal" },
-    { "id": "revealui-agent", "projectTree": null, "rank": "equal" }
+    {
+      "id": "claude-code",
+      "projectTree": ".claude",
+      "rank": "equal"
+    },
+    {
+      "id": "cursor",
+      "projectTree": ".cursor",
+      "rank": "equal"
+    },
+    {
+      "id": "opencode",
+      "projectTree": ".opencode",
+      "rank": "equal"
+    },
+    {
+      "id": "vscode",
+      "projectTree": null,
+      "rank": "equal"
+    },
+    {
+      "id": "grok",
+      "projectTree": null,
+      "rank": "equal"
+    },
+    {
+      "id": "revealui-agent",
+      "projectTree": null,
+      "rank": "equal"
+    }
   ],
-  "mcp": { "configPath": "mcp.json" },
+  "mcp": {
+    "configPath": "mcp.json"
+  },
   "contentPackage": "@revealui/harnesses"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ status: verified
 audience: agent
 ---
 
+> **Project manager (all vendors equal):** open [`.revealui/manager.json`](.revealui/manager.json) first.
+> Shared rules/skills: [`.revealui/content/`](.revealui/content/) (generated from `@revealui/harnesses`).
+> This file is an adapter orientation doc, not a second policy home. See [`.revealui/README.md`](.revealui/README.md).
+
 # RevealUI
 
 RevealUI is the agentic business runtime. People, content, offers, payments, and agents  -  pre-wired, open source, and ready to deploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ status: verified
 audience: agent
 ---
 
+> **Project manager (all vendors equal):** open [`.revealui/manager.json`](.revealui/manager.json) first.
+> Shared rules/skills: [`.revealui/content/`](.revealui/content/) (generated from `@revealui/harnesses`).
+> This file is an adapter orientation doc, not a second policy home. See [`.revealui/README.md`](.revealui/README.md).
+
 # RevealUI Monorepo
 
 Agentic business runtime. People, content, offers, payments, and agents  -  pre-wired, open source, and ready to deploy.

--- a/packages/harnesses/README.md
+++ b/packages/harnesses/README.md
@@ -26,8 +26,10 @@ AI harness coordination for RevealUI  -  enables multiple AI coding tools to wor
 
 ```
 packages/harnesses/src/
-├── adapters/       # AI tool adapters (Claude Code, Copilot)
+├── adapters/       # AI tool adapters (Claude Code, Copilot, OpenCode, Cursor)
 ├── config/         # Config path resolution and SSD sync
+├── content/        # Canonical rules/commands/agents/skills + generators
+├── manager/        # .revealui project manager (equal vendor adapters)
 ├── detection/      # Auto-detect installed/running harnesses
 ├── registry/       # Lifecycle management of adapters
 ├── server/         # JSON-RPC 2.0 over Unix socket
@@ -36,6 +38,35 @@ packages/harnesses/src/
 ├── coordinator.ts  # Main orchestrator (start/stop lifecycle)
 └── cli.ts          # CLI daemon and RPC client
 ```
+
+## Project manager (`.revealui`)
+
+All vendors (Claude, Grok, Cursor, OpenCode, VS Code, native agent) are **equal
+adapters**. Shared policy is not owned by any vendor home.
+
+| Layer | Role |
+|-------|------|
+| Package definitions (`src/content/definitions`) | Build-time SSOT |
+| **`.revealui/`** (`manager.json` + `content/`) | On-disk project manager |
+| `.claude` / `.cursor` / `.opencode` / `~/.grok` | Thin stubs or machine prefs only |
+
+```bash
+# Write manager.json + adapter stubs + generate .revealui/content/
+pnpm exec revealui-harnesses manager materialize
+
+# Verify manager present and valid
+pnpm exec revealui-harnesses manager check
+
+# Content only — default generator is the manager tree (not a vendor fork)
+pnpm exec revealui-harnesses content sync
+# equivalent:
+pnpm exec revealui-harnesses content sync --generator claude-code
+```
+
+`content sync` without `--generator` uses `DEFAULT_CONTENT_GENERATOR_ID`
+(`claude-code`). That generator emits into **`.revealui/content/`** (the manager
+tree). Vendor trees stay adapters; do not full-copy hardlines into `~/.claude`
+or `~/.grok`.
 
 ## CLI
 
@@ -51,6 +82,11 @@ revealui-harnesses sync claude-code push
 
 # Print workboard state
 revealui-harnesses coordinate --print
+
+# Project manager (equal vendors)
+revealui-harnesses manager materialize
+revealui-harnesses manager check
+revealui-harnesses content sync
 ```
 
 ## Usage
@@ -114,7 +150,8 @@ Tokens are durable (default 90-day TTL) and persisted as hashes, so a daemon res
 | `@revealui/harnesses` | Full API: adapters, registry, coordinator, detection, config, protocol |
 | `@revealui/harnesses/types` | Type definitions: HarnessAdapter, commands, events, capabilities |
 | `@revealui/harnesses/workboard` | WorkboardManager, deriveSessionId, detectSessionType, file-locking |
-| `@revealui/harnesses/content` | Content definitions, manifest builders, generators |
+| `@revealui/harnesses/content` | Content definitions, manifest builders, generators (`DEFAULT_CONTENT_GENERATOR_ID` → manager tree) |
+| `@revealui/harnesses/manager` | Project manager schema, materialize, check (`.revealui`) |
 | `@revealui/harnesses/storage` | DaemonStore (PGlite-backed daemon state), schema |
 | `@revealui/harnesses/protocol` | Protocol adapter types, config generators, event normalizer |
 

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -47,6 +47,11 @@
       "import": "./dist/content/index.js",
       "default": "./dist/content/index.js"
     },
+    "./manager": {
+      "types": "./dist/manager/index.d.ts",
+      "import": "./dist/manager/index.js",
+      "default": "./dist/manager/index.js"
+    },
     "./storage": {
       "types": "./dist/storage/index.d.ts",
       "import": "./dist/storage/index.js",

--- a/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
+++ b/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
@@ -11,14 +11,14 @@ describe('ClaudeCodeGenerator', () => {
     expect(getGenerator('claude-code')).toBeInstanceOf(ClaudeCodeGenerator);
   });
 
-  it('declares its output directory', () => {
+  it('declares its output directory under the project manager', () => {
     const generator = new ClaudeCodeGenerator();
     expect(generator.id).toBe('claude-code');
-    expect(generator.outputDir).toBe('.claude');
+    expect(generator.outputDir).toBe('.revealui/content');
   });
 
   describe('generateRule', () => {
-    it('writes markdown under .claude/rules/', () => {
+    it('writes markdown under .revealui/content/rules/', () => {
       const rule: Rule = {
         id: 'tracker-first',
         name: 'Tracker First',
@@ -31,13 +31,13 @@ describe('ClaudeCodeGenerator', () => {
       };
       const files = new ClaudeCodeGenerator().generateRule(rule, ctx);
       expect(files).toHaveLength(1);
-      expect(files[0]?.relativePath).toBe('.claude/rules/tracker-first.md');
+      expect(files[0]?.relativePath).toBe('.revealui/content/rules/tracker-first.md');
       expect(files[0]?.content).toContain('Open docs/TRACKER.md first');
     });
   });
 
   describe('generateCommand', () => {
-    it('writes frontmatter markdown under .claude/commands/', () => {
+    it('writes frontmatter markdown under .revealui/content/commands/', () => {
       const cmd: Command = {
         id: 'gate',
         name: 'Gate',
@@ -47,14 +47,14 @@ describe('ClaudeCodeGenerator', () => {
         content: 'Run lint, typecheck, and tests.',
       };
       const [file] = new ClaudeCodeGenerator().generateCommand(cmd, ctx);
-      expect(file?.relativePath).toBe('.claude/commands/gate.md');
+      expect(file?.relativePath).toBe('.revealui/content/commands/gate.md');
       expect(file?.content).toContain('description: Run the quality gate');
       expect(file?.content).toContain('Run lint, typecheck, and tests.');
     });
   });
 
   describe('generateAgent', () => {
-    it('writes frontmatter markdown under .claude/agents/', () => {
+    it('writes frontmatter markdown under .revealui/content/agents/', () => {
       const agent: Agent = {
         id: 'reviewer',
         name: 'Reviewer',
@@ -65,14 +65,14 @@ describe('ClaudeCodeGenerator', () => {
         content: 'You review code for quality.',
       };
       const [file] = new ClaudeCodeGenerator().generateAgent(agent, ctx);
-      expect(file?.relativePath).toBe('.claude/agents/reviewer.md');
+      expect(file?.relativePath).toBe('.revealui/content/agents/reviewer.md');
       expect(file?.content).toContain('name: Reviewer');
       expect(file?.content).toContain('tools: Read, Grep');
     });
   });
 
   describe('generateSkill', () => {
-    it('writes SKILL.md under .claude/skills/<id>/', () => {
+    it('writes SKILL.md under .revealui/content/skills/<id>/', () => {
       const skill: Skill = {
         id: 'tdd',
         name: 'TDD',
@@ -86,19 +86,21 @@ describe('ClaudeCodeGenerator', () => {
         content: 'Write tests first.',
       };
       const [file] = new ClaudeCodeGenerator().generateSkill(skill, ctx);
-      expect(file?.relativePath).toBe('.claude/skills/tdd/SKILL.md');
+      expect(file?.relativePath).toBe('.revealui/content/skills/tdd/SKILL.md');
       expect(file?.content).toContain('name: TDD');
       expect(file?.content).toContain('Write tests first.');
     });
   });
 
   describe('generateAll', () => {
-    it('emits rules, commands, agents, and skills from the canonical manifest', () => {
+    it('emits all content under .revealui/content (manager tree)', () => {
       const manifest = buildManifest();
       const files = generateContent('claude-code', manifest, ctx);
       expect(files.length).toBeGreaterThan(0);
-      expect(files.some((f) => f.relativePath === '.claude/rules/tracker-first.md')).toBe(true);
-      expect(files.every((f) => f.relativePath.startsWith('.claude/'))).toBe(true);
+      expect(files.some((f) => f.relativePath === '.revealui/content/rules/tracker-first.md')).toBe(
+        true,
+      );
+      expect(files.every((f) => f.relativePath.startsWith('.revealui/content/'))).toBe(true);
     });
   });
 });

--- a/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
+++ b/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import { ClaudeCodeGenerator } from '../content/generators/claude-code.js';
-import { buildManifest, generateContent, getGenerator, listGenerators } from '../content/index.js';
+import {
+  buildManifest,
+  DEFAULT_CONTENT_GENERATOR_ID,
+  generateContent,
+  getGenerator,
+  listGenerators,
+  MANAGER_CONTENT_OUTPUT,
+} from '../content/index.js';
 import type { Agent, Command, Rule, Skill } from '../content/schemas/index.js';
 
 const ctx = { projectRoot: '/test' };
 
 describe('ClaudeCodeGenerator', () => {
-  it('is auto-registered in the content generator registry', () => {
-    expect(listGenerators()).toContain('claude-code');
-    expect(getGenerator('claude-code')).toBeInstanceOf(ClaudeCodeGenerator);
+  it('is the default content sync generator and lands under the manager tree', () => {
+    expect(DEFAULT_CONTENT_GENERATOR_ID).toBe('claude-code');
+    expect(MANAGER_CONTENT_OUTPUT).toBe('.revealui/content');
+    expect(listGenerators()).toContain(DEFAULT_CONTENT_GENERATOR_ID);
+    expect(getGenerator(DEFAULT_CONTENT_GENERATOR_ID)).toBeInstanceOf(ClaudeCodeGenerator);
   });
 
   it('declares its output directory under the project manager', () => {
     const generator = new ClaudeCodeGenerator();
-    expect(generator.id).toBe('claude-code');
-    expect(generator.outputDir).toBe('.revealui/content');
+    expect(generator.id).toBe(DEFAULT_CONTENT_GENERATOR_ID);
+    expect(generator.outputDir).toBe(MANAGER_CONTENT_OUTPUT);
   });
 
   describe('generateRule', () => {
@@ -95,12 +104,14 @@ describe('ClaudeCodeGenerator', () => {
   describe('generateAll', () => {
     it('emits all content under .revealui/content (manager tree)', () => {
       const manifest = buildManifest();
-      const files = generateContent('claude-code', manifest, ctx);
+      const files = generateContent(DEFAULT_CONTENT_GENERATOR_ID, manifest, ctx);
       expect(files.length).toBeGreaterThan(0);
       expect(files.some((f) => f.relativePath === '.revealui/content/rules/tracker-first.md')).toBe(
         true,
       );
-      expect(files.every((f) => f.relativePath.startsWith('.revealui/content/'))).toBe(true);
+      expect(files.every((f) => f.relativePath.startsWith(`${MANAGER_CONTENT_OUTPUT}/`))).toBe(
+        true,
+      );
     });
   });
 });

--- a/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
+++ b/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { ClaudeCodeGenerator } from '../content/generators/claude-code.js';
+import { buildManifest, generateContent, getGenerator, listGenerators } from '../content/index.js';
+import type { Agent, Command, Rule, Skill } from '../content/schemas/index.js';
+
+const ctx = { projectRoot: '/test' };
+
+describe('ClaudeCodeGenerator', () => {
+  it('is auto-registered in the content generator registry', () => {
+    expect(listGenerators()).toContain('claude-code');
+    expect(getGenerator('claude-code')).toBeInstanceOf(ClaudeCodeGenerator);
+  });
+
+  it('declares its output directory', () => {
+    const generator = new ClaudeCodeGenerator();
+    expect(generator.id).toBe('claude-code');
+    expect(generator.outputDir).toBe('.claude');
+  });
+
+  describe('generateRule', () => {
+    it('writes markdown under .claude/rules/', () => {
+      const rule: Rule = {
+        id: 'tracker-first',
+        name: 'Tracker First',
+        description: 'Open TRACKER first',
+        scope: 'project',
+        preambleTier: 1,
+        tier: 'oss',
+        tags: ['coordination'],
+        content: '# Tracker First\n\nOpen docs/TRACKER.md first.\n',
+      };
+      const files = new ClaudeCodeGenerator().generateRule(rule, ctx);
+      expect(files).toHaveLength(1);
+      expect(files[0]?.relativePath).toBe('.claude/rules/tracker-first.md');
+      expect(files[0]?.content).toContain('Open docs/TRACKER.md first');
+    });
+  });
+
+  describe('generateCommand', () => {
+    it('writes frontmatter markdown under .claude/commands/', () => {
+      const cmd: Command = {
+        id: 'gate',
+        name: 'Gate',
+        description: 'Run the quality gate',
+        tier: 'oss',
+        disableModelInvocation: false,
+        content: 'Run lint, typecheck, and tests.',
+      };
+      const [file] = new ClaudeCodeGenerator().generateCommand(cmd, ctx);
+      expect(file?.relativePath).toBe('.claude/commands/gate.md');
+      expect(file?.content).toContain('description: Run the quality gate');
+      expect(file?.content).toContain('Run lint, typecheck, and tests.');
+    });
+  });
+
+  describe('generateAgent', () => {
+    it('writes frontmatter markdown under .claude/agents/', () => {
+      const agent: Agent = {
+        id: 'reviewer',
+        name: 'Reviewer',
+        description: 'Reviews code',
+        tier: 'oss',
+        isolation: 'none',
+        tools: ['Read', 'Grep'],
+        content: 'You review code for quality.',
+      };
+      const [file] = new ClaudeCodeGenerator().generateAgent(agent, ctx);
+      expect(file?.relativePath).toBe('.claude/agents/reviewer.md');
+      expect(file?.content).toContain('name: Reviewer');
+      expect(file?.content).toContain('tools: Read, Grep');
+    });
+  });
+
+  describe('generateSkill', () => {
+    it('writes SKILL.md under .claude/skills/<id>/', () => {
+      const skill: Skill = {
+        id: 'tdd',
+        name: 'TDD',
+        description: 'Test-driven development',
+        tier: 'oss',
+        disableModelInvocation: false,
+        skipFrontmatter: false,
+        filePatterns: [],
+        bashPatterns: [],
+        references: {},
+        content: 'Write tests first.',
+      };
+      const [file] = new ClaudeCodeGenerator().generateSkill(skill, ctx);
+      expect(file?.relativePath).toBe('.claude/skills/tdd/SKILL.md');
+      expect(file?.content).toContain('name: TDD');
+      expect(file?.content).toContain('Write tests first.');
+    });
+  });
+
+  describe('generateAll', () => {
+    it('emits rules, commands, agents, and skills from the canonical manifest', () => {
+      const manifest = buildManifest();
+      const files = generateContent('claude-code', manifest, ctx);
+      expect(files.length).toBeGreaterThan(0);
+      expect(files.some((f) => f.relativePath === '.claude/rules/tracker-first.md')).toBe(true);
+      expect(files.every((f) => f.relativePath.startsWith('.claude/'))).toBe(true);
+    });
+  });
+});

--- a/packages/harnesses/src/__tests__/content-api.test.ts
+++ b/packages/harnesses/src/__tests__/content-api.test.ts
@@ -7,7 +7,7 @@ describe('Content Public API', () => {
       const manifest = buildManifest();
       expect(manifest.version).toBe(1);
       expect(manifest.generatedAt).toBeTruthy();
-      expect(manifest.rules.length).toBe(9);
+      expect(manifest.rules.length).toBe(10);
       expect(manifest.commands.length).toBe(4);
       expect(manifest.agents.length).toBe(6);
       expect(manifest.skills.length).toBe(10);
@@ -47,18 +47,18 @@ describe('Content Public API', () => {
   describe('listContent', () => {
     it('returns correct counts', () => {
       const summary = listContent();
-      expect(summary.rules).toBe(9);
+      expect(summary.rules).toBe(10);
       expect(summary.commands).toBe(4);
       expect(summary.agents).toBe(6);
       expect(summary.skills).toBe(10);
       expect(summary.preambles).toBe(4);
-      expect(summary.total).toBe(29);
+      expect(summary.total).toBe(30);
     });
 
     it('accepts an explicit manifest', () => {
       const manifest = buildManifest();
       const summary = listContent(manifest);
-      expect(summary.total).toBe(29);
+      expect(summary.total).toBe(30);
     });
   });
 

--- a/packages/harnesses/src/__tests__/content-api.test.ts
+++ b/packages/harnesses/src/__tests__/content-api.test.ts
@@ -7,7 +7,7 @@ describe('Content Public API', () => {
       const manifest = buildManifest();
       expect(manifest.version).toBe(1);
       expect(manifest.generatedAt).toBeTruthy();
-      expect(manifest.rules.length).toBe(10);
+      expect(manifest.rules.length).toBe(11);
       expect(manifest.commands.length).toBe(4);
       expect(manifest.agents.length).toBe(6);
       expect(manifest.skills.length).toBe(10);
@@ -47,18 +47,18 @@ describe('Content Public API', () => {
   describe('listContent', () => {
     it('returns correct counts', () => {
       const summary = listContent();
-      expect(summary.rules).toBe(10);
+      expect(summary.rules).toBe(11);
       expect(summary.commands).toBe(4);
       expect(summary.agents).toBe(6);
       expect(summary.skills).toBe(10);
       expect(summary.preambles).toBe(4);
-      expect(summary.total).toBe(30);
+      expect(summary.total).toBe(31);
     });
 
     it('accepts an explicit manifest', () => {
       const manifest = buildManifest();
       const summary = listContent(manifest);
-      expect(summary.total).toBe(30);
+      expect(summary.total).toBe(31);
     });
   });
 

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -46,6 +46,33 @@ describe('project manager (.revealui)', () => {
     expect(result.stubs.length).toBeGreaterThanOrEqual(3);
   });
 
+  it('materialize preserves existing monorepo manager fields', () => {
+    const root = tempProject();
+    writeManager(root, {
+      version: 1,
+      name: 'RevealUI monorepo',
+      contentRoot: 'content',
+      tracker: {
+        path: 'docs/TRACKER.md',
+        note: 'Fleet day-to-day board lives in private .jv',
+      },
+      adapters: [
+        { id: 'claude-code', projectTree: '.claude', rank: 'equal' },
+        { id: 'cursor', projectTree: '.cursor', rank: 'equal' },
+        { id: 'opencode', projectTree: '.opencode', rank: 'equal' },
+        { id: 'vscode', projectTree: null, rank: 'equal' },
+        { id: 'grok', projectTree: null, rank: 'equal' },
+        { id: 'revealui-agent', projectTree: null, rank: 'equal' },
+      ],
+      mcp: { configPath: 'mcp.json' },
+      contentPackage: '@revealui/harnesses',
+    });
+    materializeManager(root);
+    const cfg = loadManager(root);
+    expect(cfg.name).toBe('RevealUI monorepo');
+    expect(cfg.tracker.note).toContain('private .jv');
+  });
+
   it('check fails without manager and passes after write', () => {
     const root = tempProject();
     expect(checkManager(root).ok).toBe(false);

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  checkManager,
+  loadManager,
+  materializeManager,
+  ManagerSchema,
+  writeManager,
+} from '../manager/index.js';
+
+describe('project manager (.revealui)', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  function tempProject(): string {
+    const d = mkdtempSync(join(tmpdir(), 'revealui-manager-'));
+    dirs.push(d);
+    return d;
+  }
+
+  it('parses default manager config', () => {
+    const cfg = ManagerSchema.parse({});
+    expect(cfg.version).toBe(1);
+    expect(cfg.contentRoot).toBe('content');
+    expect(cfg.adapters.some((a) => a.id === 'claude-code' && a.rank === 'equal')).toBe(true);
+    expect(cfg.adapters.every((a) => a.rank === 'equal')).toBe(true);
+  });
+
+  it('materialize writes manager.json and equal adapter stubs', () => {
+    const root = tempProject();
+    const result = materializeManager(root);
+    expect(result.managerPath).toContain('.revealui/manager.json');
+    const cfg = loadManager(root);
+    expect(cfg.version).toBe(1);
+    const stub = readFileSync(join(root, '.claude/rules/00-revealui-manager.md'), 'utf-8');
+    expect(stub).toContain('.revealui/manager.json');
+    expect(stub).toContain('equal');
+    expect(result.stubs.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('check fails without manager and passes after write', () => {
+    const root = tempProject();
+    expect(checkManager(root).ok).toBe(false);
+    writeManager(root);
+    const after = checkManager(root);
+    expect(after.ok).toBe(true);
+  });
+});

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -5,8 +5,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   checkManager,
   loadManager,
-  materializeManager,
   ManagerSchema,
+  materializeManager,
   writeManager,
 } from '../manager/index.js';
 

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -21,10 +21,12 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
   buildManifest,
+  DEFAULT_CONTENT_GENERATOR_ID,
   diffContent,
   generateContent,
   listContent,
   listGenerators,
+  MANAGER_CONTENT_OUTPUT,
   validateManifest,
 } from './content/index.js';
 import { HarnessCoordinator } from './coordinator.js';
@@ -126,7 +128,10 @@ async function handleContentCommand(subcommand: string | undefined, args: string
 
     case 'diff': {
       const genIdx = args.indexOf('--generator');
-      const generatorId = genIdx >= 0 ? (args[genIdx + 1] ?? 'claude-code') : 'claude-code';
+      const generatorId =
+        genIdx >= 0
+          ? (args[genIdx + 1] ?? DEFAULT_CONTENT_GENERATOR_ID)
+          : DEFAULT_CONTENT_GENERATOR_ID;
       const entries = diffContent(generatorId, manifest, ctx, projectRoot);
       const added = entries.filter((e) => e.status === 'added');
       const modified = entries.filter((e) => e.status === 'modified');
@@ -150,12 +155,21 @@ async function handleContentCommand(subcommand: string | undefined, args: string
 
     case 'sync': {
       const genIdx = args.indexOf('--generator');
-      const generatorId = genIdx >= 0 ? (args[genIdx + 1] ?? 'claude-code') : 'claude-code';
+      const generatorId =
+        genIdx >= 0
+          ? (args[genIdx + 1] ?? DEFAULT_CONTENT_GENERATOR_ID)
+          : DEFAULT_CONTENT_GENERATOR_ID;
       const dryRun = args.includes('--dry-run');
       const files = generateContent(generatorId, manifest, ctx);
 
       if (dryRun) {
-        process.stdout.write(`Dry run — would write ${files.length} files:\n`);
+        process.stdout.write(
+          `Dry run — would write ${files.length} files (generator=${generatorId}` +
+            (generatorId === DEFAULT_CONTENT_GENERATOR_ID
+              ? `, manager tree ${MANAGER_CONTENT_OUTPUT}`
+              : '') +
+            `):\n`,
+        );
         for (const file of files) {
           process.stdout.write(`  ${file.relativePath}\n`);
         }
@@ -167,7 +181,11 @@ async function handleContentCommand(subcommand: string | undefined, args: string
           writeFileSync(absolutePath, file.content, 'utf-8');
           written++;
         }
-        process.stdout.write(`✓ Wrote ${written} files via ${generatorId} generator\n`);
+        const destNote =
+          generatorId === DEFAULT_CONTENT_GENERATOR_ID
+            ? ` → ${MANAGER_CONTENT_OUTPUT} (project manager)`
+            : '';
+        process.stdout.write(`✓ Wrote ${written} files via ${generatorId} generator${destNote}\n`);
       }
       break;
     }
@@ -280,7 +298,10 @@ async function handleContentCommand(subcommand: string | undefined, args: string
 
     case 'pull': {
       const genIdx = args.indexOf('--generator');
-      const generatorId = genIdx >= 0 ? (args[genIdx + 1] ?? 'claude-code') : 'claude-code';
+      const generatorId =
+        genIdx >= 0
+          ? (args[genIdx + 1] ?? DEFAULT_CONTENT_GENERATOR_ID)
+          : DEFAULT_CONTENT_GENERATOR_ID;
       const tierIdx = args.indexOf('--tier');
       const tierFilter = tierIdx >= 0 ? (args[tierIdx + 1] ?? 'oss') : 'oss';
 
@@ -433,8 +454,10 @@ async function main() {
 
     if (subcommand === 'materialize') {
       const result = materializeManager(projectRoot);
-      // Also sync manager content from definitions
-      const files = generateContent('claude-code', buildManifest(), { projectRoot });
+      // Sync manager content via the same default generator as `content sync`
+      const files = generateContent(DEFAULT_CONTENT_GENERATOR_ID, buildManifest(), {
+        projectRoot,
+      });
       let written = 0;
       for (const file of files) {
         const absolutePath = join(projectRoot, file.relativePath);
@@ -443,7 +466,9 @@ async function main() {
         written++;
       }
       process.stdout.write(`✓ Manager: ${result.managerPath}\n`);
-      process.stdout.write(`✓ Content files: ${written}\n`);
+      process.stdout.write(
+        `✓ Content files: ${written} → ${MANAGER_CONTENT_OUTPUT} (generator=${DEFAULT_CONTENT_GENERATOR_ID})\n`,
+      );
       process.stdout.write(`✓ Adapter stubs:\n`);
       for (const s of result.stubs) process.stdout.write(`  ${s}\n`);
       return;
@@ -656,9 +681,11 @@ Content Subcommands:
   content list                      List all canonical content with metadata
   content validate                  Validate all definitions against schemas
   content diff [--generator <id>]   Show what would change vs current files
-  content sync [--generator <id>] [--dry-run]  Generate into .revealui/content (manager)
+  content sync [--generator <id>] [--dry-run]  Generate into .revealui/content (default generator)
   content export --output <path>    Export canonical + generated files to directory
   content pull [--generator <id>] [--tier oss|pro|all]  Pull rules from rules repo
+
+Default content generator: ${DEFAULT_CONTENT_GENERATOR_ID} → ${MANAGER_CONTENT_OUTPUT}
 `);
       break;
   }

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -29,6 +29,7 @@ import {
 } from './content/index.js';
 import { HarnessCoordinator } from './coordinator.js';
 import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
+import { checkManager, materializeManager } from './manager/index.js';
 import { WorkboardManager } from './workboard/workboard-manager.js';
 
 const DATA_DIR = join(homedir(), '.local', 'share', 'revealui');
@@ -424,6 +425,44 @@ async function main() {
     return;
   }
 
+  if (command === 'manager') {
+    const [subcommand] = args;
+    const projectIdx = args.indexOf('--project');
+    const projectRoot =
+      projectIdx >= 0 ? (args[projectIdx + 1] ?? DEFAULT_PROJECT) : DEFAULT_PROJECT;
+
+    if (subcommand === 'materialize') {
+      const result = materializeManager(projectRoot);
+      // Also sync manager content from definitions
+      const files = generateContent('claude-code', buildManifest(), { projectRoot });
+      let written = 0;
+      for (const file of files) {
+        const absolutePath = join(projectRoot, file.relativePath);
+        mkdirSync(dirname(absolutePath), { recursive: true });
+        writeFileSync(absolutePath, file.content, 'utf-8');
+        written++;
+      }
+      process.stdout.write(`✓ Manager: ${result.managerPath}\n`);
+      process.stdout.write(`✓ Content files: ${written}\n`);
+      process.stdout.write(`✓ Adapter stubs:\n`);
+      for (const s of result.stubs) process.stdout.write(`  ${s}\n`);
+      return;
+    }
+
+    if (subcommand === 'check') {
+      const result = checkManager(projectRoot);
+      for (const w of result.warnings) process.stderr.write(`WARN: ${w}\n`);
+      for (const e of result.errors) process.stderr.write(`ERROR: ${e}\n`);
+      if (!result.ok) process.exit(1);
+      process.stdout.write(`✓ Manager OK at ${join(projectRoot, '.revealui', 'manager.json')}\n`);
+      return;
+    }
+
+    process.stderr.write(`Unknown manager subcommand: ${subcommand ?? '(none)'}\n`);
+    process.stderr.write(`Available: materialize, check\n`);
+    process.exit(1);
+  }
+
   switch (command) {
     case 'start': {
       const projectIdx = args.indexOf('--project');
@@ -610,12 +649,14 @@ Commands:
   coordinate --init [<path>]        Register + start daemon
   hook <cursor|claude-code|vscode>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
   content <subcommand>              Manage canonical content definitions
+  manager materialize [--project p] Write .revealui/manager.json + content + equal adapter stubs
+  manager check [--project p]       Verify project manager present and valid
 
 Content Subcommands:
   content list                      List all canonical content with metadata
   content validate                  Validate all definitions against schemas
   content diff [--generator <id>]   Show what would change vs current files
-  content sync [--generator <id>] [--dry-run]  Generate and write files
+  content sync [--generator <id>] [--dry-run]  Generate into .revealui/content (manager)
   content export --output <path>    Export canonical + generated files to directory
   content pull [--generator <id>] [--tier oss|pro|all]  Pull rules from rules repo
 `);

--- a/packages/harnesses/src/content/definitions/preambles/index.ts
+++ b/packages/harnesses/src/content/definitions/preambles/index.ts
@@ -5,7 +5,7 @@ export const preambles: PreambleTier[] = [
     tier: 1,
     name: 'Identity',
     description: 'Always injected  -  core project identity and structure',
-    ruleIds: ['monorepo', 'tracker-first'],
+    ruleIds: ['monorepo', 'tracker-first', 'quality-over-speed'],
   },
   {
     tier: 2,

--- a/packages/harnesses/src/content/definitions/preambles/index.ts
+++ b/packages/harnesses/src/content/definitions/preambles/index.ts
@@ -5,7 +5,7 @@ export const preambles: PreambleTier[] = [
     tier: 1,
     name: 'Identity',
     description: 'Always injected  -  core project identity and structure',
-    ruleIds: ['monorepo'],
+    ruleIds: ['monorepo', 'tracker-first'],
   },
   {
     tier: 2,

--- a/packages/harnesses/src/content/definitions/rules/index.ts
+++ b/packages/harnesses/src/content/definitions/rules/index.ts
@@ -5,6 +5,7 @@ import { codeAnalysisPolicyRule } from './code-analysis-policy.js';
 import { databaseRule } from './database.js';
 import { monorepoRule } from './monorepo.js';
 import { parameterizationRule } from './parameterization.js';
+import { qualityOverSpeedRule } from './quality-over-speed.js';
 import { skillsUsageRule } from './skills-usage.js';
 import { tailwindRule } from './tailwind.js';
 import { trackerFirstRule } from './tracker-first.js';
@@ -17,6 +18,7 @@ export const rules: Rule[] = [
   databaseRule,
   monorepoRule,
   parameterizationRule,
+  qualityOverSpeedRule,
   skillsUsageRule,
   tailwindRule,
   trackerFirstRule,

--- a/packages/harnesses/src/content/definitions/rules/index.ts
+++ b/packages/harnesses/src/content/definitions/rules/index.ts
@@ -7,6 +7,7 @@ import { monorepoRule } from './monorepo.js';
 import { parameterizationRule } from './parameterization.js';
 import { skillsUsageRule } from './skills-usage.js';
 import { tailwindRule } from './tailwind.js';
+import { trackerFirstRule } from './tracker-first.js';
 import { unusedDeclarationsRule } from './unused-declarations.js';
 
 export const rules: Rule[] = [
@@ -18,5 +19,6 @@ export const rules: Rule[] = [
   parameterizationRule,
   skillsUsageRule,
   tailwindRule,
+  trackerFirstRule,
   unusedDeclarationsRule,
 ];

--- a/packages/harnesses/src/content/definitions/rules/quality-over-speed.ts
+++ b/packages/harnesses/src/content/definitions/rules/quality-over-speed.ts
@@ -1,0 +1,49 @@
+import type { Rule } from '../../schemas/rule.js';
+
+/**
+ * Owner standing order: quality over speed for code, config, and documentation.
+ * Hardware and price improve over time; rushed work does not age well.
+ */
+export const qualityOverSpeedRule: Rule = {
+  id: 'quality-over-speed',
+  tier: 'oss',
+  name: 'Quality Over Speed',
+  description:
+    'Prefer correctness, proof, and durable design over throughput; never trade quality for concurrent session velocity',
+  scope: 'global',
+  preambleTier: 1,
+  tags: ['quality', 'sdlc', 'hardline'],
+  content: `# Quality Over Speed (standing order)
+
+**Quality is always the primary metric** for code, config, and documentation.
+Speed is a lagging benefit of good systems and better hardware/pricing — not a
+reason to ship weak work, thin proofs, or dual-home shortcuts.
+
+## Apply every session (including concurrent multi-agent work)
+
+1. **Correctness first.** Prove red→green where tests apply. Prefer root-cause
+   durable fixes over hotfixes (register any unavoidable hotfix the same turn).
+2. **Proof over pace.** Claims about system behavior need \`code:line\` or test
+   evidence (code-over-docs). Doc edits without proof are incomplete.
+3. **One solid change beats three rushed ones.** Do not expand scope to "finish
+   the wave" if quality drops. Stop at a clean PR boundary.
+4. **Concurrency does not lower the bar.** Parallel sessions still use exclusive
+   shards/worktrees, full gates for risk level, and no self-merge of security or
+   unreviewed work. Faster calendar time is worthless if two agents thrash the
+   same surface or invent parallel queues.
+5. **Manager + adapters.** Shared policy lives under \`.revealui\` / package
+   definitions. Do not mirror hardlines into vendor homes "to go faster."
+
+## Explicitly rejected
+
+- Skipping tests, audits, or claim proof to close a session sooner
+- Partial file reads marked verified in exhaustive / md-truth ledgers
+- Dual-writing the same rule into Claude and Grok homes
+- Merging or force-pushing to "unblock" without owner disposition when required
+
+## When pressed for speed
+
+Reduce **scope**, not **quality**. Ship a smaller correct slice; leave the rest
+as TRACKER gaps/lanes with acceptance criteria intact.
+`,
+};

--- a/packages/harnesses/src/content/definitions/rules/tracker-first.ts
+++ b/packages/harnesses/src/content/definitions/rules/tracker-first.ts
@@ -1,0 +1,40 @@
+import type { Rule } from '../../schemas/rule.js';
+
+/**
+ * Session orientation: single fleet TRACKER is the day-to-day board.
+ * Adapters open TRACKER first; they do not invent parallel queues (GAP-406 / GAP-318).
+ */
+export const trackerFirstRule: Rule = {
+  id: 'tracker-first',
+  tier: 'oss',
+  name: 'Tracker First',
+  description:
+    'Open docs/TRACKER.md first; gaps and lanes are the only execution units; no dual-home backlogs',
+  scope: 'project',
+  preambleTier: 1,
+  tags: ['coordination', 'tracker', 'sdlc'],
+  content: `# Tracker First (all models / providers)
+
+Open the fleet **TRACKER** before inventing work:
+
+\`docs/TRACKER.md\` (generated from \`docs/initiatives/*.yml\` via \`node scripts/initiatives-render.js\`)
+
+## Rules
+
+1. **Day-to-day free surfaces live only on TRACKER.** Gaps and lanes are the execution units; initiatives group them.
+2. **Do not invent parallel queues** in harness homes (\`~/.claude\`, \`~/.grok\`), root \`TODO.md\`, or chat-only lists.
+3. **CURRENT-HANDOFF** is session deltas only. **MASTER_PLAN** is strategy only.
+4. **Product I/O** goes through RevealUI MCP (governed user + receipts), not per-harness side channels.
+5. Shared policy is authored once (Plane A / \`@revealui/harnesses\` content definitions). Adapters **consume**; they do not full-copy hardlines.
+
+## Claim work
+
+Register a workboard note for an existing gap or lane id from TRACKER. Status lives on the gap YAML or lane plan — never hand-copied into TRACKER tables.
+
+## References
+
+- ADR \`2026-07-22-single-fleet-tracker\`
+- ADR \`2026-07-21-harness-policy-runtime-launch-planes\`
+- GAP-318, GAP-406
+`,
+};

--- a/packages/harnesses/src/content/generators/claude-code.ts
+++ b/packages/harnesses/src/content/generators/claude-code.ts
@@ -1,0 +1,120 @@
+/**
+ * Claude Code Content Generator
+ *
+ * Emits adapter trees from canonical harness content definitions so Claude
+ * Code is a *consumer*, not a second authoring home (GAP-406 / ADR 2026-07-21).
+ *
+ * Surfaces (Claude Code project layout):
+ *   - rules:    `.claude/rules/<id>.md`
+ *   - commands: `.claude/commands/<id>.md`  (slash commands; YAML frontmatter)
+ *   - agents:   `.claude/agents/<id>.md`
+ *   - skills:   `.claude/skills/<id>/SKILL.md`
+ *
+ * Hooks and settings.json are out of scope here — they remain machine-global
+ * adapter config (claude-config) or protocol normalizers, same split as
+ * Cursor's hooks-only generator vs MCP config normalizer.
+ */
+
+import type { ResolverContext } from '../resolvers/types.js';
+import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
+import type { ContentGenerator, GeneratedFile } from './types.js';
+
+function yamlEscape(value: string): string {
+  // Keep frontmatter simple: quote when special chars present
+  if (/[:#\n"'{}[\],&*?|>!%@`]/.test(value) || value.trim() !== value) {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+export class ClaudeCodeGenerator implements ContentGenerator {
+  readonly id = 'claude-code';
+  readonly outputDir = '.claude';
+
+  generateRule(rule: Rule, _ctx: ResolverContext): GeneratedFile[] {
+    // Rule content is already full markdown (definitions own the heading).
+    const body = rule.content.endsWith('\n') ? rule.content : `${rule.content}\n`;
+    return [
+      {
+        relativePath: `.claude/rules/${rule.id}.md`,
+        content: body,
+      },
+    ];
+  }
+
+  generateCommand(cmd: Command, _ctx: ResolverContext): GeneratedFile[] {
+    const frontmatter = ['---', `description: ${yamlEscape(cmd.description)}`];
+    if (cmd.argumentHint) frontmatter.push(`argument-hint: ${yamlEscape(cmd.argumentHint)}`);
+    if (cmd.disableModelInvocation) frontmatter.push('disable-model-invocation: true');
+    frontmatter.push('---');
+    const body = cmd.content.endsWith('\n') ? cmd.content : `${cmd.content}\n`;
+    return [
+      {
+        relativePath: `.claude/commands/${cmd.id}.md`,
+        content: `${frontmatter.join('\n')}\n\n${body}`,
+      },
+    ];
+  }
+
+  generateAgent(agent: Agent, _ctx: ResolverContext): GeneratedFile[] {
+    const frontmatter = [
+      '---',
+      `name: ${yamlEscape(agent.name)}`,
+      `description: ${yamlEscape(agent.description)}`,
+    ];
+    if (agent.tools.length > 0) {
+      frontmatter.push(`tools: ${agent.tools.join(', ')}`);
+    }
+    frontmatter.push('---');
+    const body = agent.content.endsWith('\n') ? agent.content : `${agent.content}\n`;
+    return [
+      {
+        relativePath: `.claude/agents/${agent.id}.md`,
+        content: `${frontmatter.join('\n')}\n\n${body}`,
+      },
+    ];
+  }
+
+  generateSkill(skill: Skill, _ctx: ResolverContext): GeneratedFile[] {
+    if (skill.skipFrontmatter) {
+      const body = skill.content.endsWith('\n') ? skill.content : `${skill.content}\n`;
+      return [
+        {
+          relativePath: `.claude/skills/${skill.id}/SKILL.md`,
+          content: body,
+        },
+      ];
+    }
+    const frontmatter = [
+      '---',
+      `name: ${yamlEscape(skill.name)}`,
+      `description: ${yamlEscape(skill.description)}`,
+    ];
+    if (skill.disableModelInvocation) frontmatter.push('disable-model-invocation: true');
+    frontmatter.push('---');
+    const body = skill.content.endsWith('\n') ? skill.content : `${skill.content}\n`;
+    return [
+      {
+        relativePath: `.claude/skills/${skill.id}/SKILL.md`,
+        content: `${frontmatter.join('\n')}\n\n${body}`,
+      },
+    ];
+  }
+
+  generateAll(manifest: Manifest, ctx: ResolverContext): GeneratedFile[] {
+    const files: GeneratedFile[] = [];
+    for (const rule of manifest.rules) {
+      files.push(...this.generateRule(rule, ctx));
+    }
+    for (const cmd of manifest.commands) {
+      files.push(...this.generateCommand(cmd, ctx));
+    }
+    for (const agent of manifest.agents) {
+      files.push(...this.generateAgent(agent, ctx));
+    }
+    for (const skill of manifest.skills) {
+      files.push(...this.generateSkill(skill, ctx));
+    }
+    return files;
+  }
+}

--- a/packages/harnesses/src/content/generators/claude-code.ts
+++ b/packages/harnesses/src/content/generators/claude-code.ts
@@ -14,8 +14,9 @@
 import type { ResolverContext } from '../resolvers/types.js';
 import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
 import type { ContentGenerator, GeneratedFile } from './types.js';
+import { MANAGER_CONTENT_OUTPUT } from './types.js';
 
-const CONTENT = '.revealui/content';
+const CONTENT = MANAGER_CONTENT_OUTPUT;
 
 function yamlEscape(value: string): string {
   if (/[:#\n"'{}[\],&*?|>!%@`]/.test(value) || value.trim() !== value) {

--- a/packages/harnesses/src/content/generators/claude-code.ts
+++ b/packages/harnesses/src/content/generators/claude-code.ts
@@ -1,43 +1,43 @@
 /**
- * Claude Code Content Generator
+ * Claude Code / manager content generator (GAP-406)
  *
- * Emits adapter trees from canonical harness content definitions so Claude
- * Code is a *consumer*, not a second authoring home (GAP-406 / ADR 2026-07-21).
+ * Primary emit lands under the **project manager** tree:
+ *   `.revealui/content/{rules,commands,agents,skills}/`
  *
- * Surfaces (Claude Code project layout):
- *   - rules:    `.claude/rules/<id>.md`
- *   - commands: `.claude/commands/<id>.md`  (slash commands; YAML frontmatter)
- *   - agents:   `.claude/agents/<id>.md`
- *   - skills:   `.claude/skills/<id>/SKILL.md`
+ * Vendor homes (`.claude`, `.cursor`, …) are **equal-rank adapters**.
+ * Thin stubs that *reference* the manager are produced by
+ * `revealui-harnesses manager materialize` — not by forking policy here.
  *
- * Hooks and settings.json are out of scope here — they remain machine-global
- * adapter config (claude-config) or protocol normalizers, same split as
- * Cursor's hooks-only generator vs MCP config normalizer.
+ * Package definitions in `@revealui/harnesses` remain build-time SSOT.
  */
 
 import type { ResolverContext } from '../resolvers/types.js';
 import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
 import type { ContentGenerator, GeneratedFile } from './types.js';
 
+const CONTENT = '.revealui/content';
+
 function yamlEscape(value: string): string {
-  // Keep frontmatter simple: quote when special chars present
   if (/[:#\n"'{}[\],&*?|>!%@`]/.test(value) || value.trim() !== value) {
     return JSON.stringify(value);
   }
   return value;
 }
 
+function ensureNl(body: string): string {
+  return body.endsWith('\n') ? body : `${body}\n`;
+}
+
 export class ClaudeCodeGenerator implements ContentGenerator {
   readonly id = 'claude-code';
-  readonly outputDir = '.claude';
+  /** Manager content root — not a vendor-private tree. */
+  readonly outputDir = CONTENT;
 
   generateRule(rule: Rule, _ctx: ResolverContext): GeneratedFile[] {
-    // Rule content is already full markdown (definitions own the heading).
-    const body = rule.content.endsWith('\n') ? rule.content : `${rule.content}\n`;
     return [
       {
-        relativePath: `.claude/rules/${rule.id}.md`,
-        content: body,
+        relativePath: `${CONTENT}/rules/${rule.id}.md`,
+        content: ensureNl(rule.content),
       },
     ];
   }
@@ -47,11 +47,10 @@ export class ClaudeCodeGenerator implements ContentGenerator {
     if (cmd.argumentHint) frontmatter.push(`argument-hint: ${yamlEscape(cmd.argumentHint)}`);
     if (cmd.disableModelInvocation) frontmatter.push('disable-model-invocation: true');
     frontmatter.push('---');
-    const body = cmd.content.endsWith('\n') ? cmd.content : `${cmd.content}\n`;
     return [
       {
-        relativePath: `.claude/commands/${cmd.id}.md`,
-        content: `${frontmatter.join('\n')}\n\n${body}`,
+        relativePath: `${CONTENT}/commands/${cmd.id}.md`,
+        content: `${frontmatter.join('\n')}\n\n${ensureNl(cmd.content)}`,
       },
     ];
   }
@@ -66,22 +65,20 @@ export class ClaudeCodeGenerator implements ContentGenerator {
       frontmatter.push(`tools: ${agent.tools.join(', ')}`);
     }
     frontmatter.push('---');
-    const body = agent.content.endsWith('\n') ? agent.content : `${agent.content}\n`;
     return [
       {
-        relativePath: `.claude/agents/${agent.id}.md`,
-        content: `${frontmatter.join('\n')}\n\n${body}`,
+        relativePath: `${CONTENT}/agents/${agent.id}.md`,
+        content: `${frontmatter.join('\n')}\n\n${ensureNl(agent.content)}`,
       },
     ];
   }
 
   generateSkill(skill: Skill, _ctx: ResolverContext): GeneratedFile[] {
     if (skill.skipFrontmatter) {
-      const body = skill.content.endsWith('\n') ? skill.content : `${skill.content}\n`;
       return [
         {
-          relativePath: `.claude/skills/${skill.id}/SKILL.md`,
-          content: body,
+          relativePath: `${CONTENT}/skills/${skill.id}/SKILL.md`,
+          content: ensureNl(skill.content),
         },
       ];
     }
@@ -92,11 +89,10 @@ export class ClaudeCodeGenerator implements ContentGenerator {
     ];
     if (skill.disableModelInvocation) frontmatter.push('disable-model-invocation: true');
     frontmatter.push('---');
-    const body = skill.content.endsWith('\n') ? skill.content : `${skill.content}\n`;
     return [
       {
-        relativePath: `.claude/skills/${skill.id}/SKILL.md`,
-        content: `${frontmatter.join('\n')}\n\n${body}`,
+        relativePath: `${CONTENT}/skills/${skill.id}/SKILL.md`,
+        content: `${frontmatter.join('\n')}\n\n${ensureNl(skill.content)}`,
       },
     ];
   }

--- a/packages/harnesses/src/content/generators/index.ts
+++ b/packages/harnesses/src/content/generators/index.ts
@@ -1,8 +1,10 @@
+import { ClaudeCodeGenerator } from './claude-code.js';
 import { CursorGenerator } from './cursor.js';
 import { OpenCodeGenerator } from './opencode.js';
 import type { ContentGenerator } from './types.js';
 import { VSCodeGenerator } from './vscode.js';
 
+export { ClaudeCodeGenerator } from './claude-code.js';
 export { CursorGenerator } from './cursor.js';
 export { OpenCodeGenerator } from './opencode.js';
 export type { ContentGenerator, DiffEntry, GeneratedFile } from './types.js';
@@ -31,3 +33,4 @@ export function listGenerators(): string[] {
 registerGenerator(new OpenCodeGenerator());
 registerGenerator(new CursorGenerator());
 registerGenerator(new VSCodeGenerator());
+registerGenerator(new ClaudeCodeGenerator());

--- a/packages/harnesses/src/content/generators/index.ts
+++ b/packages/harnesses/src/content/generators/index.ts
@@ -8,6 +8,7 @@ export { ClaudeCodeGenerator } from './claude-code.js';
 export { CursorGenerator } from './cursor.js';
 export { OpenCodeGenerator } from './opencode.js';
 export type { ContentGenerator, DiffEntry, GeneratedFile } from './types.js';
+export { DEFAULT_CONTENT_GENERATOR_ID, MANAGER_CONTENT_OUTPUT } from './types.js';
 export { VSCodeGenerator } from './vscode.js';
 
 const generators = new Map<string, ContentGenerator>();

--- a/packages/harnesses/src/content/generators/types.ts
+++ b/packages/harnesses/src/content/generators/types.ts
@@ -1,8 +1,20 @@
 import type { ResolverContext } from '../resolvers/types.js';
 import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
 
+/**
+ * Default generator for `content sync|diff|pull` and `manager materialize`.
+ *
+ * Id remains `claude-code` for registry stability, but emit target is the
+ * **project manager** tree (`.revealui/content/`), not a vendor-private
+ * `.claude/` fork (GAP-406).
+ */
+export const DEFAULT_CONTENT_GENERATOR_ID = 'claude-code';
+
+/** On-disk manager content root (relative to project root). */
+export const MANAGER_CONTENT_OUTPUT = '.revealui/content';
+
 export interface GeneratedFile {
-  /** Relative path from project root (e.g. '.claude/rules/biome.md') */
+  /** Relative path from project root (e.g. '.revealui/content/rules/biome.md') */
   relativePath: string;
   content: string;
 }

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -3,19 +3,31 @@
  *
  * Tool-agnostic definitions for AI guidance content (rules, commands, agents, skills).
  * Generators produce tool-specific output from canonical definitions.
- * Generators registered today: `opencode`, `cursor` (hooks.json only),
- * `vscode` (plugin.json hooks contribution only), and `claude-code` (rules /
- * commands / agents / skills under `.claude/` — GAP-406 adapter path).
+ *
+ * Generators registered today:
+ * - `claude-code` (**default** via `DEFAULT_CONTENT_GENERATOR_ID`) — full
+ *   rules/commands/agents/skills under the **project manager** tree
+ *   `.revealui/content/` (GAP-406). Not a vendor-private `.claude/` fork.
+ * - `opencode` — agents + commands under `.opencode/`
+ * - `cursor` — hooks.json only
+ * - `vscode` — plugin.json hooks contribution only
+ *
  * The adapter layer (`../adapters/`) ships `revealui-agent`, `opencode`, and
- * `cursor` -- `vscode` has no adapter (no headless CLI to exec).
+ * `cursor` — `vscode` has no adapter (no headless CLI to exec).
  *
  * @example
  * ```ts
- * import { buildManifest, validateManifest, generateContent, diffContent } from '@revealui/harnesses/content';
+ * import {
+ *   buildManifest,
+ *   validateManifest,
+ *   generateContent,
+ *   DEFAULT_CONTENT_GENERATOR_ID,
+ * } from '@revealui/harnesses/content';
  *
  * const manifest = buildManifest();
  * const validation = validateManifest(manifest);
- * const files = generateContent('opencode', manifest, { projectRoot: '/path/to/project' });
+ * // Default sync lands under .revealui/content (manager tree)
+ * const files = generateContent(DEFAULT_CONTENT_GENERATOR_ID, manifest, { projectRoot: '/path/to/project' });
  * ```
  */
 
@@ -31,8 +43,10 @@ export { buildManifest } from './definitions/index.js';
 export {
   ClaudeCodeGenerator,
   CursorGenerator,
+  DEFAULT_CONTENT_GENERATOR_ID,
   getGenerator,
   listGenerators,
+  MANAGER_CONTENT_OUTPUT,
   OpenCodeGenerator,
   registerGenerator,
   VSCodeGenerator,

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -3,13 +3,11 @@
  *
  * Tool-agnostic definitions for AI guidance content (rules, commands, agents, skills).
  * Generators produce tool-specific output from canonical definitions.
- * `opencode` (`./generators/opencode.ts`), `cursor` (`./generators/cursor.ts`,
- * hooks.json only -- see that file's doc comment), and `vscode`
- * (`./generators/vscode.ts`, plugin.json hooks contribution only) are
- * registered today. The adapter layer (`../adapters/`) ships
- * `revealui-agent`, `opencode`, and `cursor` -- `vscode` has no adapter (no
- * headless CLI to exec; see `./generators/vscode.ts`'s doc comment). A
- * Claude Code generator is not implemented.
+ * Generators registered today: `opencode`, `cursor` (hooks.json only),
+ * `vscode` (plugin.json hooks contribution only), and `claude-code` (rules /
+ * commands / agents / skills under `.claude/` — GAP-406 adapter path).
+ * The adapter layer (`../adapters/`) ships `revealui-agent`, `opencode`, and
+ * `cursor` -- `vscode` has no adapter (no headless CLI to exec).
  *
  * @example
  * ```ts
@@ -31,6 +29,7 @@ import { type Manifest, ManifestSchema } from './schemas/manifest.js';
 
 export { buildManifest } from './definitions/index.js';
 export {
+  ClaudeCodeGenerator,
   CursorGenerator,
   getGenerator,
   listGenerators,

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -47,15 +47,6 @@ export {
   validateManifest,
 } from './content/index.js';
 export type { CoordinatorOptions } from './coordinator.js';
-// Project manager (.revealui) — equal vendor adapters reference this tree
-export type { ManagerCheckResult, ManagerConfig, MaterializeResult } from './manager/index.js';
-export {
-  checkManager,
-  loadManager,
-  materializeManager,
-  ManagerSchema,
-  writeManager,
-} from './manager/index.js';
 // Coordinator
 export { HarnessCoordinator } from './coordinator.js';
 // Detection
@@ -123,6 +114,15 @@ export {
   normalizeVSCodeHookEvent,
   runHookCommand,
 } from './hooks/index.js';
+// Project manager (.revealui) — equal vendor adapters reference this tree
+export type { ManagerCheckResult, ManagerConfig, MaterializeResult } from './manager/index.js';
+export {
+  checkManager,
+  loadManager,
+  ManagerSchema,
+  materializeManager,
+  writeManager,
+} from './manager/index.js';
 // Harness Protocol (was VAUGHN until 2026-05-18; see docs/HARNESS_PROTOCOL.md)
 export type {
   ClaudeCodeSettings,

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -37,6 +37,7 @@ export type {
 // Content layer (canonical content definitions and generators)
 export {
   buildManifest,
+  ClaudeCodeGenerator,
   CursorGenerator,
   diffContent,
   generateContent,
@@ -46,6 +47,15 @@ export {
   validateManifest,
 } from './content/index.js';
 export type { CoordinatorOptions } from './coordinator.js';
+// Project manager (.revealui) — equal vendor adapters reference this tree
+export type { ManagerCheckResult, ManagerConfig, MaterializeResult } from './manager/index.js';
+export {
+  checkManager,
+  loadManager,
+  materializeManager,
+  ManagerSchema,
+  writeManager,
+} from './manager/index.js';
 // Coordinator
 export { HarnessCoordinator } from './coordinator.js';
 // Detection

--- a/packages/harnesses/src/manager/index.ts
+++ b/packages/harnesses/src/manager/index.ts
@@ -1,0 +1,20 @@
+export {
+  checkManager,
+  contentRootPath,
+  loadManager,
+  materializeClaudeStub,
+  materializeCursorStub,
+  materializeGrokPointer,
+  materializeManager,
+  materializeOpenCodeStub,
+  managerPath,
+  writeManager,
+} from './materialize.js';
+export type { ManagerCheckResult, MaterializeResult } from './materialize.js';
+export {
+  MANAGER_CONTENT_DIR,
+  MANAGER_DIR,
+  MANAGER_FILE,
+  type ManagerConfig,
+  ManagerSchema,
+} from './schema.js';

--- a/packages/harnesses/src/manager/index.ts
+++ b/packages/harnesses/src/manager/index.ts
@@ -10,6 +10,7 @@ export {
   materializeManager,
   materializeOpenCodeStub,
   writeManager,
+  writeManagerPreserving,
 } from './materialize.js';
 export {
   MANAGER_CONTENT_DIR,

--- a/packages/harnesses/src/manager/index.ts
+++ b/packages/harnesses/src/manager/index.ts
@@ -1,16 +1,16 @@
+export type { ManagerCheckResult, MaterializeResult } from './materialize.js';
 export {
   checkManager,
   contentRootPath,
   loadManager,
+  managerPath,
   materializeClaudeStub,
   materializeCursorStub,
   materializeGrokPointer,
   materializeManager,
   materializeOpenCodeStub,
-  managerPath,
   writeManager,
 } from './materialize.js';
-export type { ManagerCheckResult, MaterializeResult } from './materialize.js';
 export {
   MANAGER_CONTENT_DIR,
   MANAGER_DIR,

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -1,0 +1,182 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  MANAGER_CONTENT_DIR,
+  MANAGER_DIR,
+  MANAGER_FILE,
+  type ManagerConfig,
+  ManagerSchema,
+} from './schema.js';
+
+const STUB_HEADER = `> **RevealUI manager.** Policy and skills are owned by \`.revealui/\`.
+> This vendor tree is an **adapter stub only** (equal rank with every other vendor).
+> Do not fork hardlines here. Edit package definitions → generate into \`.revealui/content/\`.
+`;
+
+export function managerPath(projectRoot: string): string {
+  return join(projectRoot, MANAGER_DIR, MANAGER_FILE);
+}
+
+export function contentRootPath(projectRoot: string, config?: ManagerConfig): string {
+  const root = config?.contentRoot ?? MANAGER_CONTENT_DIR;
+  return join(projectRoot, MANAGER_DIR, root);
+}
+
+/** Load manager.json or return defaults. */
+export function loadManager(projectRoot: string): ManagerConfig {
+  const path = managerPath(projectRoot);
+  if (!existsSync(path)) {
+    return ManagerSchema.parse({});
+  }
+  const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+  return ManagerSchema.parse(raw);
+}
+
+/** Write manager.json (pretty). */
+export function writeManager(projectRoot: string, config?: ManagerConfig): string {
+  const parsed = ManagerSchema.parse(config ?? {});
+  const path = managerPath(projectRoot);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(parsed, null, 2)}\n`, 'utf-8');
+  return path;
+}
+
+/** Thin Claude project stub: one rule file that points at the manager. */
+export function materializeClaudeStub(projectRoot: string): string {
+  const rel = join('.claude', 'rules', '00-revealui-manager.md');
+  const abs = join(projectRoot, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  const body = `${STUB_HEADER}
+# RevealUI manager (Claude adapter)
+
+1. Open **\`.revealui/manager.json\`** for project authority.
+2. Shared rules/skills: **\`.revealui/content/\`** (generated from \`@revealui/harnesses\`).
+3. Day-to-day free surfaces: path in \`manager.json\` → \`tracker.path\` (fleet: \`docs/TRACKER.md\`).
+4. Product I/O: RevealUI MCP only (device token via \`rfg\` / revvault) — not vendor side channels.
+5. Equal vendors: Claude is not more authoritative than Grok, Cursor, or OpenCode.
+
+See \`.revealui/README.md\`.
+`;
+  writeFileSync(abs, body, 'utf-8');
+  return rel;
+}
+
+/** Thin Cursor stub note under .cursor if tree exists or always create pointer. */
+export function materializeCursorStub(projectRoot: string): string {
+  const rel = join('.cursor', 'revealui-manager.md');
+  const abs = join(projectRoot, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(
+    abs,
+    `${STUB_HEADER}
+# RevealUI manager (Cursor adapter)
+
+Authority: \`.revealui/manager.json\` + \`.revealui/content/\`.
+Hooks may call \`revealui-harnesses hook cursor\`; policy text is not owned here.
+`,
+    'utf-8',
+  );
+  return rel;
+}
+
+/** OpenCode: short AGENTS fragment note under .opencode */
+export function materializeOpenCodeStub(projectRoot: string): string {
+  const rel = join('.opencode', 'revealui-manager.md');
+  const abs = join(projectRoot, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(
+    abs,
+    `${STUB_HEADER}
+# RevealUI manager (OpenCode adapter)
+
+Authority: \`.revealui/manager.json\` + \`.revealui/content/\`.
+`,
+    'utf-8',
+  );
+  return rel;
+}
+
+/**
+ * Grok has no project tree by default — emit a project AGENTS pointer fragment
+ * under .revealui so machine ~/.grok can tell operators to open it.
+ */
+export function materializeGrokPointer(projectRoot: string): string {
+  const rel = join(MANAGER_DIR, 'adapters', 'grok.md');
+  const abs = join(projectRoot, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(
+    abs,
+    `${STUB_HEADER}
+# RevealUI manager (Grok adapter)
+
+Machine home (\`~/.grok\`) must stay **pointer-thin**. When cwd is this project:
+
+1. Read \`.revealui/manager.json\`
+2. Read \`.revealui/content/\` for shared rules
+3. Open \`tracker.path\` from the manager (fleet TRACKER)
+4. Product work via RevealUI MCP (\`rfg\`)
+
+Do not copy hardlines into \`~/.grok/rules/\`.
+`,
+    'utf-8',
+  );
+  return rel;
+}
+
+export interface MaterializeResult {
+  managerPath: string;
+  stubs: string[];
+}
+
+/** Write manager.json + equal-rank adapter stubs. */
+export function materializeManager(
+  projectRoot: string,
+  options?: {
+    config?: ManagerConfig;
+    adapters?: Array<'claude-code' | 'cursor' | 'opencode' | 'grok'>;
+  },
+): MaterializeResult {
+  const managerFile = writeManager(projectRoot, options?.config);
+  const adapters = options?.adapters ?? ['claude-code', 'cursor', 'opencode', 'grok'];
+  const stubs: string[] = [];
+  for (const id of adapters) {
+    if (id === 'claude-code') stubs.push(materializeClaudeStub(projectRoot));
+    else if (id === 'cursor') stubs.push(materializeCursorStub(projectRoot));
+    else if (id === 'opencode') stubs.push(materializeOpenCodeStub(projectRoot));
+    else if (id === 'grok') stubs.push(materializeGrokPointer(projectRoot));
+  }
+  return { managerPath: managerFile, stubs };
+}
+
+export interface ManagerCheckResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/** Fail if manager missing or Claude tree looks like a full policy fork without stub. */
+export function checkManager(projectRoot: string): ManagerCheckResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const mPath = managerPath(projectRoot);
+  if (!existsSync(mPath)) {
+    errors.push(
+      `missing ${MANAGER_DIR}/${MANAGER_FILE} — run: revealui-harnesses manager materialize`,
+    );
+  } else {
+    try {
+      loadManager(projectRoot);
+    } catch (err) {
+      errors.push(`invalid manager.json: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  const claudeStub = join(projectRoot, '.claude', 'rules', '00-revealui-manager.md');
+  if (!existsSync(claudeStub)) {
+    warnings.push('missing .claude/rules/00-revealui-manager.md stub (materialize claude-code)');
+  }
+  const readme = join(projectRoot, MANAGER_DIR, 'README.md');
+  if (!existsSync(readme)) {
+    warnings.push('missing .revealui/README.md manager contract');
+  }
+  return { ok: errors.length === 0, errors, warnings };
+}

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -11,6 +11,7 @@ import {
 const STUB_HEADER = `> **RevealUI manager.** Policy and skills are owned by \`.revealui/\`.
 > This vendor tree is an **adapter stub only** (equal rank with every other vendor).
 > Do not fork hardlines here. Edit package definitions → generate into \`.revealui/content/\`.
+> **Quality over speed:** correctness and proof outrank throughput in every session.
 `;
 
 export function managerPath(projectRoot: string): string {

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -33,13 +33,33 @@ export function loadManager(projectRoot: string): ManagerConfig {
   return ManagerSchema.parse(raw);
 }
 
-/** Write manager.json (pretty). */
+/** Write manager.json (pretty). Skips the write when on-disk content already matches. */
 export function writeManager(projectRoot: string, config?: ManagerConfig): string {
   const parsed = ManagerSchema.parse(config ?? {});
   const path = managerPath(projectRoot);
+  const next = `${JSON.stringify(parsed, null, 2)}\n`;
+  if (existsSync(path) && readFileSync(path, 'utf-8') === next) {
+    return path;
+  }
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(parsed, null, 2)}\n`, 'utf-8');
+  writeFileSync(path, next, 'utf-8');
   return path;
+}
+
+/**
+ * Persist manager.json without clobbering project-specific fields.
+ * When no explicit config is passed and a file already exists, re-load it
+ * (schema-normalized) and write back so monorepo name/tracker notes survive
+ * `manager materialize`.
+ */
+export function writeManagerPreserving(projectRoot: string, config?: ManagerConfig): string {
+  if (config !== undefined) {
+    return writeManager(projectRoot, config);
+  }
+  if (existsSync(managerPath(projectRoot))) {
+    return writeManager(projectRoot, loadManager(projectRoot));
+  }
+  return writeManager(projectRoot);
 }
 
 /** Thin Claude project stub: one rule file that points at the manager. */
@@ -137,7 +157,7 @@ export function materializeManager(
     adapters?: Array<'claude-code' | 'cursor' | 'opencode' | 'grok'>;
   },
 ): MaterializeResult {
-  const managerFile = writeManager(projectRoot, options?.config);
+  const managerFile = writeManagerPreserving(projectRoot, options?.config);
   const adapters = options?.adapters ?? ['claude-code', 'cursor', 'opencode', 'grok'];
   const stubs: string[] = [];
   for (const id of adapters) {

--- a/packages/harnesses/src/manager/schema.ts
+++ b/packages/harnesses/src/manager/schema.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+/**
+ * Project manager manifest (`.revealui/manager.json`).
+ *
+ * Equal vendor authority: Claude, Grok, Cursor, OpenCode, VSCode all
+ * *reference* this tree; none is the policy SSOT (GAP-406).
+ */
+export const ManagerSchema = z.object({
+  version: z.literal(1).default(1),
+  /** Human-readable project name */
+  name: z.string().min(1).default('RevealUI project'),
+  /** Relative content root under .revealui */
+  contentRoot: z.string().default('content'),
+  /** Day-to-day free surfaces (fleet uses .jv TRACKER; products may override) */
+  tracker: z
+    .object({
+      path: z.string().default('docs/TRACKER.md'),
+      note: z.string().optional(),
+    })
+    .default({ path: 'docs/TRACKER.md' }),
+  /** Adapters that may materialize thin stubs pointing here */
+  adapters: z
+    .array(
+      z.object({
+        id: z.enum(['claude-code', 'cursor', 'opencode', 'vscode', 'grok', 'revealui-agent']),
+        /** Vendor tree relative to project root (null = machine-home only) */
+        projectTree: z.string().nullable().default(null),
+        /** Equal rank — no adapter is more authoritative than another */
+        rank: z.literal('equal').default('equal'),
+      }),
+    )
+    .default([
+      { id: 'claude-code', projectTree: '.claude', rank: 'equal' },
+      { id: 'cursor', projectTree: '.cursor', rank: 'equal' },
+      { id: 'opencode', projectTree: '.opencode', rank: 'equal' },
+      { id: 'vscode', projectTree: null, rank: 'equal' },
+      { id: 'grok', projectTree: null, rank: 'equal' },
+      { id: 'revealui-agent', projectTree: null, rank: 'equal' },
+    ]),
+  mcp: z
+    .object({
+      /** Path to mcp config with env-var token refs only (never secrets) */
+      configPath: z.string().default('mcp.json'),
+    })
+    .default({ configPath: 'mcp.json' }),
+  /** Package that owns definitions (build-time SSOT) */
+  contentPackage: z.string().default('@revealui/harnesses'),
+});
+
+export type ManagerConfig = z.infer<typeof ManagerSchema>;
+
+export const MANAGER_DIR = '.revealui';
+export const MANAGER_FILE = 'manager.json';
+export const MANAGER_CONTENT_DIR = 'content';

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'src/workboard/index.ts',
     'src/types/index.ts',
     'src/content/index.ts',
+    'src/manager/index.ts',
     'src/storage/index.ts',
     'src/goals/index.ts',
     'src/hooks/index.ts',

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -263,6 +263,15 @@ async function gate(): Promise<void> {
         warnOnly: true,
       },
       {
+        // GAP-406: hard-fail local gate when manager.json is missing/invalid.
+        // Same checkManager as `revealui-harnesses manager check` via
+        // validate:structure --manager-only (no parallel validator).
+        // CI mirrors this as a path-gated Quality step.
+        name: 'Project manager check (hard fail)',
+        command: 'pnpm',
+        args: ['validate:structure', '--', '--manager-only'],
+      },
+      {
         name: 'Boundary validation',
         command: 'pnpm',
         args: ['validate:boundary'],

--- a/scripts/validate/structure.ts
+++ b/scripts/validate/structure.ts
@@ -13,6 +13,7 @@
 
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { checkManager } from '../../packages/harnesses/src/manager/index.js';
 
 interface ValidationRule {
   path: string;
@@ -455,6 +456,27 @@ class StructureValidator {
       console.log('✅ .revealui/templates/ directory exists');
     }
 
+    // Project manager (GAP-406): monorepo always has packages/harnesses; when
+    // .revealui/manager.json is committed, fail closed if it is missing or
+    // invalid. Uses the same checkManager primitive as
+    // `revealui-harnesses manager check` (no parallel validator).
+    if (existsSync('packages/harnesses') || existsSync('.revealui/manager.json')) {
+      console.log('\n🔍 Checking project manager (.revealui)...');
+      const managerResult = checkManager(process.cwd());
+      for (const warning of managerResult.warnings) {
+        console.log(`⚠️  ${warning}`);
+      }
+      if (!managerResult.ok) {
+        for (const error of managerResult.errors) {
+          console.log(`❌ ${error}`);
+        }
+        console.log('   Run: pnpm exec revealui-harnesses manager materialize');
+        allValid = false;
+      } else {
+        console.log('✅ Project manager (.revealui/manager.json) present and valid');
+      }
+    }
+
     // Check that mcp is not in root
     if (existsSync('mcp')) {
       console.log('\n❌ mcp/ found in root - should be in packages/mcp/');
@@ -507,8 +529,42 @@ class StructureValidator {
   }
 }
 
+/**
+ * Focused manager check for path-gated CI (GAP-406).
+ * Same primitive as `revealui-harnesses manager check` / structure validate.
+ */
+export function validateProjectManager(root: string = process.cwd()): boolean {
+  if (
+    !(
+      existsSync(join(root, 'packages/harnesses')) ||
+      existsSync(join(root, '.revealui/manager.json'))
+    )
+  ) {
+    console.log('skip: no packages/harnesses or .revealui/manager.json');
+    return true;
+  }
+  const managerResult = checkManager(root);
+  for (const warning of managerResult.warnings) {
+    console.warn(`WARN: ${warning}`);
+  }
+  if (!managerResult.ok) {
+    for (const error of managerResult.errors) {
+      console.error(`ERROR: ${error}`);
+    }
+    console.error('Run: pnpm exec revealui-harnesses manager materialize');
+    return false;
+  }
+  console.log('✓ Project manager (.revealui/manager.json) present and valid');
+  return true;
+}
+
 // CLI interface
 async function main() {
+  // Path-gated CI entry: `pnpm validate:structure --manager-only`
+  if (process.argv.includes('--manager-only')) {
+    process.exit(validateProjectManager() ? 0 : 1);
+  }
+
   console.log('🎯 RevealUI Structure Validation');
   console.log('='.repeat(40));
 


### PR DESCRIPTION
## Summary

Finishes GAP-406 so `.revealui` is the **project manager** and all vendors (Claude, Grok, Cursor, OpenCode, VS Code, native agent) are **equal adapters**.

Includes the foundation from #2074 (manager schema, materialize/check, content → `.revealui/content`, tracker-first + quality-over-speed) plus this finish slice:

- **`content sync` default** uses `DEFAULT_CONTENT_GENERATOR_ID` (`claude-code`) → **`.revealui/content/`** (manager tree, not a vendor fork)
- **`manager materialize`** preserves existing monorepo `manager.json` fields (name, tracker note)
- **CI / local gate**: `validate:structure --manager-only` (same `checkManager` primitive as `revealui-harnesses manager check`); path-gated hard-fail in Quality when `.revealui/` or `packages/harnesses/` change
- **Thin CLAUDE.md / AGENTS.md** tops point at `.revealui/manager.json`
- Adapter stubs under `.claude`/`.opencode` stay **gitignored** (rules-lockstep safe); Grok pointer committed under `.revealui/adapters/`
- Documented in `packages/harnesses/README.md`

Does **not** re-author hardlines into `~/.claude` or `~/.grok`.

## Test plan

- [x] `node packages/harnesses/dist/cli.js manager materialize` (preserves monorepo name/note)
- [x] `node packages/harnesses/dist/cli.js manager check`
- [x] `pnpm validate:structure -- --manager-only`
- [x] `pnpm --filter @revealui/harnesses exec vitest run src/__tests__/manager.test.ts src/__tests__/claude-code-content-generator.test.ts src/__tests__/content-api.test.ts` (25 tests)
- [ ] CI Quality path-gated manager check when this PR lands

## Supersedes

Open PR #2074 (`feat/harnesses-claude-generator`) is the foundation of this branch. Prefer merging **this** PR and closing #2074.

## Owner

```bash
gh pr merge <N> -R RevealUIStudio/revealui --squash   # when green; named auth required
```