### PR TITLE
feat(harnesses): finish .revealui project manager (GAP-406)

### DIFF
--- a/.changeset/manager-finish-gap-406.md
+++ b/.changeset/manager-finish-gap-406.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+Finish the `.revealui` project manager (GAP-406): default `content sync` lands under the manager tree, materialize preserves existing manager.json, structure/CI gate hard-fail on invalid manager when `.revealui` or harnesses change, equal-rank adapter stubs stay gitignored outside the manager tree.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,41 @@ jobs:
         # match it exactly. Mirrors the local gate step in scripts/gates/ci-gate.ts.
         run: pnpm validate:rules-lockstep
 
+      - name: Project manager check (path-gated hard fail)
+        # GAP-406: when a PR (or push) touches .revealui or packages/harnesses,
+        # hard-fail if manager.json is missing/invalid. Extends validate:structure
+        # (`--manager-only`) — same checkManager primitive as
+        # `revealui-harnesses manager check`. No parallel validator.
+        # Unrelated PRs skip. Full structure validation still runs above and
+        # includes the manager check when packages/harnesses is present.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          run_check=false
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "${BASE_SHA:-}" ]; then
+            if git diff --name-only "$BASE_SHA"...HEAD | grep -qE '^(\.revealui/|packages/harnesses/)'; then
+              run_check=true
+            fi
+          elif [ "$EVENT_NAME" = "push" ]; then
+            if [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+              if git diff --name-only "$BEFORE_SHA"...HEAD | grep -qE '^(\.revealui/|packages/harnesses/)'; then
+                run_check=true
+              fi
+            else
+              run_check=true
+            fi
+          else
+            run_check=true
+          fi
+          if [ "$run_check" != "true" ]; then
+            echo "skip: no .revealui/ or packages/harnesses/ changes"
+            exit 0
+          fi
+          pnpm validate:structure -- --manager-only
+
       - name: Marketing voice validation (hard fail)
         run: pnpm validate:marketing-voice
 

--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,10 @@ CLAUDE.md
 !.claude/agents/
 !.claude/skills/
 !.claude/.revcon-manifest.json
+# Equal-rank adapter stubs from `revealui-harnesses manager materialize`
+# (must not enter the revcon rules-lockstep manifest).
+.claude/rules/00-revealui-manager.md
+.opencode/
 .agents/
 
 # RevealUI cache files (PGlite database)

--- a/.revealui/adapters/grok.md
+++ b/.revealui/adapters/grok.md
@@ -1,0 +1,15 @@
+> **RevealUI manager.** Policy and skills are owned by `.revealui/`.
+> This vendor tree is an **adapter stub only** (equal rank with every other vendor).
+> Do not fork hardlines here. Edit package definitions → generate into `.revealui/content/`.
+> **Quality over speed:** correctness and proof outrank throughput in every session.
+
+# RevealUI manager (Grok adapter)
+
+Machine home (`~/.grok`) must stay **pointer-thin**. When cwd is this project:
+
+1. Read `.revealui/manager.json`
+2. Read `.revealui/content/` for shared rules
+3. Open `tracker.path` from the manager (fleet TRACKER)
+4. Product work via RevealUI MCP (`rfg`)
+
+Do not copy hardlines into `~/.grok/rules/`.

--- a/.revealui/manager.json
+++ b/.revealui/manager.json
@@ -7,13 +7,39 @@
     "note": "Fleet day-to-day board lives in private .jv; monorepo may point at product ROADMAP. Prefer TRACKER when present under docs/."
   },
   "adapters": [
-    { "id": "claude-code", "projectTree": ".claude", "rank": "equal" },
-    { "id": "cursor", "projectTree": ".cursor", "rank": "equal" },
-    { "id": "opencode", "projectTree": ".opencode", "rank": "equal" },
-    { "id": "vscode", "projectTree": null, "rank": "equal" },
-    { "id": "grok", "projectTree": null, "rank": "equal" },
-    { "id": "revealui-agent", "projectTree": null, "rank": "equal" }
+    {
+      "id": "claude-code",
+      "projectTree": ".claude",
+      "rank": "equal"
+    },
+    {
+      "id": "cursor",
+      "projectTree": ".cursor",
+      "rank": "equal"
+    },
+    {
+      "id": "opencode",
+      "projectTree": ".opencode",
+      "rank": "equal"
+    },
+    {
+      "id": "vscode",
+      "projectTree": null,
+      "rank": "equal"
+    },
+    {
+      "id": "grok",
+      "projectTree": null,
+      "rank": "equal"
+    },
+    {
+      "id": "revealui-agent",
+      "projectTree": null,
+      "rank": "equal"
+    }
   ],
-  "mcp": { "configPath": "mcp.json" },
+  "mcp": {
+    "configPath": "mcp.json"
+  },
   "contentPackage": "@revealui/harnesses"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ status: verified
 audience: agent
 ---
 
+> **Project manager (all vendors equal):** open [`.revealui/manager.json`](.revealui/manager.json) first.
+> Shared rules/skills: [`.revealui/content/`](.revealui/content/) (generated from `@revealui/harnesses`).
+> This file is an adapter orientation doc, not a second policy home. See [`.revealui/README.md`](.revealui/README.md).
+
 # RevealUI
 
 RevealUI is the agentic business runtime. People, content, offers, payments, and agents  -  pre-wired, open source, and ready to deploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ status: verified
 audience: agent
 ---
 
+> **Project manager (all vendors equal):** open [`.revealui/manager.json`](.revealui/manager.json) first.
+> Shared rules/skills: [`.revealui/content/`](.revealui/content/) (generated from `@revealui/harnesses`).
+> This file is an adapter orientation doc, not a second policy home. See [`.revealui/README.md`](.revealui/README.md).
+
 # RevealUI Monorepo
 
 Agentic business runtime. People, content, offers, payments, and agents  -  pre-wired, open source, and ready to deploy.

--- a/packages/harnesses/README.md
+++ b/packages/harnesses/README.md
@@ -26,8 +26,10 @@ AI harness coordination for RevealUI  -  enables multiple AI coding tools to wor
 
 ```
 packages/harnesses/src/
-├── adapters/       # AI tool adapters (Claude Code, Copilot)
+├── adapters/       # AI tool adapters (Claude Code, Copilot, OpenCode, Cursor)
 ├── config/         # Config path resolution and SSD sync
+├── content/        # Canonical rules/commands/agents/skills + generators
+├── manager/        # .revealui project manager (equal vendor adapters)
 ├── detection/      # Auto-detect installed/running harnesses
 ├── registry/       # Lifecycle management of adapters
 ├── server/         # JSON-RPC 2.0 over Unix socket
@@ -36,6 +38,35 @@ packages/harnesses/src/
 ├── coordinator.ts  # Main orchestrator (start/stop lifecycle)
 └── cli.ts          # CLI daemon and RPC client
 ```
+
+## Project manager (`.revealui`)
+
+All vendors (Claude, Grok, Cursor, OpenCode, VS Code, native agent) are **equal
+adapters**. Shared policy is not owned by any vendor home.
+
+| Layer | Role |
+|-------|------|
+| Package definitions (`src/content/definitions`) | Build-time SSOT |
+| **`.revealui/`** (`manager.json` + `content/`) | On-disk project manager |
+| `.claude` / `.cursor` / `.opencode` / `~/.grok` | Thin stubs or machine prefs only |
+
+```bash
+# Write manager.json + adapter stubs + generate .revealui/content/
+pnpm exec revealui-harnesses manager materialize
+
+# Verify manager present and valid
+pnpm exec revealui-harnesses manager check
+
+# Content only — default generator is the manager tree (not a vendor fork)
+pnpm exec revealui-harnesses content sync
+# equivalent:
+pnpm exec revealui-harnesses content sync --generator claude-code
+```
+
+`content sync` without `--generator` uses `DEFAULT_CONTENT_GENERATOR_ID`
+(`claude-code`). That generator emits into **`.revealui/content/`** (the manager
+tree). Vendor trees stay adapters; do not full-copy hardlines into `~/.claude`
+or `~/.grok`.
 
 ## CLI
 
@@ -51,6 +82,11 @@ revealui-harnesses sync claude-code push
 
 # Print workboard state
 revealui-harnesses coordinate --print
+
+# Project manager (equal vendors)
+revealui-harnesses manager materialize
+revealui-harnesses manager check
+revealui-harnesses content sync
 ```
 
 ## Usage
@@ -114,7 +150,8 @@ Tokens are durable (default 90-day TTL) and persisted as hashes, so a daemon res
 | `@revealui/harnesses` | Full API: adapters, registry, coordinator, detection, config, protocol |
 | `@revealui/harnesses/types` | Type definitions: HarnessAdapter, commands, events, capabilities |
 | `@revealui/harnesses/workboard` | WorkboardManager, deriveSessionId, detectSessionType, file-locking |
-| `@revealui/harnesses/content` | Content definitions, manifest builders, generators |
+| `@revealui/harnesses/content` | Content definitions, manifest builders, generators (`DEFAULT_CONTENT_GENERATOR_ID` → manager tree) |
+| `@revealui/harnesses/manager` | Project manager schema, materialize, check (`.revealui`) |
 | `@revealui/harnesses/storage` | DaemonStore (PGlite-backed daemon state), schema |
 | `@revealui/harnesses/protocol` | Protocol adapter types, config generators, event normalizer |
 

--- a/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
+++ b/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import { ClaudeCodeGenerator } from '../content/generators/claude-code.js';
-import { buildManifest, generateContent, getGenerator, listGenerators } from '../content/index.js';
+import {
+  buildManifest,
+  DEFAULT_CONTENT_GENERATOR_ID,
+  generateContent,
+  getGenerator,
+  listGenerators,
+  MANAGER_CONTENT_OUTPUT,
+} from '../content/index.js';
 import type { Agent, Command, Rule, Skill } from '../content/schemas/index.js';
 
 const ctx = { projectRoot: '/test' };
 
 describe('ClaudeCodeGenerator', () => {
-  it('is auto-registered in the content generator registry', () => {
-    expect(listGenerators()).toContain('claude-code');
-    expect(getGenerator('claude-code')).toBeInstanceOf(ClaudeCodeGenerator);
+  it('is the default content sync generator and lands under the manager tree', () => {
+    expect(DEFAULT_CONTENT_GENERATOR_ID).toBe('claude-code');
+    expect(MANAGER_CONTENT_OUTPUT).toBe('.revealui/content');
+    expect(listGenerators()).toContain(DEFAULT_CONTENT_GENERATOR_ID);
+    expect(getGenerator(DEFAULT_CONTENT_GENERATOR_ID)).toBeInstanceOf(ClaudeCodeGenerator);
   });
 
   it('declares its output directory under the project manager', () => {
     const generator = new ClaudeCodeGenerator();
-    expect(generator.id).toBe('claude-code');
-    expect(generator.outputDir).toBe('.revealui/content');
+    expect(generator.id).toBe(DEFAULT_CONTENT_GENERATOR_ID);
+    expect(generator.outputDir).toBe(MANAGER_CONTENT_OUTPUT);
   });
 
   describe('generateRule', () => {
@@ -95,12 +104,14 @@ describe('ClaudeCodeGenerator', () => {
   describe('generateAll', () => {
     it('emits all content under .revealui/content (manager tree)', () => {
       const manifest = buildManifest();
-      const files = generateContent('claude-code', manifest, ctx);
+      const files = generateContent(DEFAULT_CONTENT_GENERATOR_ID, manifest, ctx);
       expect(files.length).toBeGreaterThan(0);
       expect(files.some((f) => f.relativePath === '.revealui/content/rules/tracker-first.md')).toBe(
         true,
       );
-      expect(files.every((f) => f.relativePath.startsWith('.revealui/content/'))).toBe(true);
+      expect(files.every((f) => f.relativePath.startsWith(`${MANAGER_CONTENT_OUTPUT}/`))).toBe(
+        true,
+      );
     });
   });
 });

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -80,4 +80,13 @@ describe('project manager (.revealui)', () => {
     const after = checkManager(root);
     expect(after.ok).toBe(true);
   });
+
+  it('writeManager is a no-op when content is already identical', () => {
+    const root = tempProject();
+    writeManager(root, { version: 1, name: 'same', contentRoot: 'content' });
+    const before = readFileSync(join(root, '.revealui/manager.json'), 'utf-8');
+    writeManager(root, { version: 1, name: 'same', contentRoot: 'content' });
+    const after = readFileSync(join(root, '.revealui/manager.json'), 'utf-8');
+    expect(after).toBe(before);
+  });
 });

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -46,6 +46,33 @@ describe('project manager (.revealui)', () => {
     expect(result.stubs.length).toBeGreaterThanOrEqual(3);
   });
 
+  it('materialize preserves existing monorepo manager fields', () => {
+    const root = tempProject();
+    writeManager(root, {
+      version: 1,
+      name: 'RevealUI monorepo',
+      contentRoot: 'content',
+      tracker: {
+        path: 'docs/TRACKER.md',
+        note: 'Fleet day-to-day board lives in private .jv',
+      },
+      adapters: [
+        { id: 'claude-code', projectTree: '.claude', rank: 'equal' },
+        { id: 'cursor', projectTree: '.cursor', rank: 'equal' },
+        { id: 'opencode', projectTree: '.opencode', rank: 'equal' },
+        { id: 'vscode', projectTree: null, rank: 'equal' },
+        { id: 'grok', projectTree: null, rank: 'equal' },
+        { id: 'revealui-agent', projectTree: null, rank: 'equal' },
+      ],
+      mcp: { configPath: 'mcp.json' },
+      contentPackage: '@revealui/harnesses',
+    });
+    materializeManager(root);
+    const cfg = loadManager(root);
+    expect(cfg.name).toBe('RevealUI monorepo');
+    expect(cfg.tracker.note).toContain('private .jv');
+  });
+
   it('check fails without manager and passes after write', () => {
     const root = tempProject();
     expect(checkManager(root).ok).toBe(false);

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -21,10 +21,12 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
   buildManifest,
+  DEFAULT_CONTENT_GENERATOR_ID,
   diffContent,
   generateContent,
   listContent,
   listGenerators,
+  MANAGER_CONTENT_OUTPUT,
   validateManifest,
 } from './content/index.js';
 import { HarnessCoordinator } from './coordinator.js';
@@ -126,7 +128,10 @@ async function handleContentCommand(subcommand: string | undefined, args: string
 
     case 'diff': {
       const genIdx = args.indexOf('--generator');
-      const generatorId = genIdx >= 0 ? (args[genIdx + 1] ?? 'claude-code') : 'claude-code';
+      const generatorId =
+        genIdx >= 0
+          ? (args[genIdx + 1] ?? DEFAULT_CONTENT_GENERATOR_ID)
+          : DEFAULT_CONTENT_GENERATOR_ID;
       const entries = diffContent(generatorId, manifest, ctx, projectRoot);
       const added = entries.filter((e) => e.status === 'added');
       const modified = entries.filter((e) => e.status === 'modified');
@@ -150,12 +155,21 @@ async function handleContentCommand(subcommand: string | undefined, args: string
 
     case 'sync': {
       const genIdx = args.indexOf('--generator');
-      const generatorId = genIdx >= 0 ? (args[genIdx + 1] ?? 'claude-code') : 'claude-code';
+      const generatorId =
+        genIdx >= 0
+          ? (args[genIdx + 1] ?? DEFAULT_CONTENT_GENERATOR_ID)
+          : DEFAULT_CONTENT_GENERATOR_ID;
       const dryRun = args.includes('--dry-run');
       const files = generateContent(generatorId, manifest, ctx);
 
       if (dryRun) {
-        process.stdout.write(`Dry run — would write ${files.length} files:\n`);
+        process.stdout.write(
+          `Dry run — would write ${files.length} files (generator=${generatorId}` +
+            (generatorId === DEFAULT_CONTENT_GENERATOR_ID
+              ? `, manager tree ${MANAGER_CONTENT_OUTPUT}`
+              : '') +
+            `):\n`,
+        );
         for (const file of files) {
           process.stdout.write(`  ${file.relativePath}\n`);
         }
@@ -167,7 +181,11 @@ async function handleContentCommand(subcommand: string | undefined, args: string
           writeFileSync(absolutePath, file.content, 'utf-8');
           written++;
         }
-        process.stdout.write(`✓ Wrote ${written} files via ${generatorId} generator\n`);
+        const destNote =
+          generatorId === DEFAULT_CONTENT_GENERATOR_ID
+            ? ` → ${MANAGER_CONTENT_OUTPUT} (project manager)`
+            : '';
+        process.stdout.write(`✓ Wrote ${written} files via ${generatorId} generator${destNote}\n`);
       }
       break;
     }
@@ -280,7 +298,10 @@ async function handleContentCommand(subcommand: string | undefined, args: string
 
     case 'pull': {
       const genIdx = args.indexOf('--generator');
-      const generatorId = genIdx >= 0 ? (args[genIdx + 1] ?? 'claude-code') : 'claude-code';
+      const generatorId =
+        genIdx >= 0
+          ? (args[genIdx + 1] ?? DEFAULT_CONTENT_GENERATOR_ID)
+          : DEFAULT_CONTENT_GENERATOR_ID;
       const tierIdx = args.indexOf('--tier');
       const tierFilter = tierIdx >= 0 ? (args[tierIdx + 1] ?? 'oss') : 'oss';
 
@@ -433,8 +454,10 @@ async function main() {
 
     if (subcommand === 'materialize') {
       const result = materializeManager(projectRoot);
-      // Also sync manager content from definitions
-      const files = generateContent('claude-code', buildManifest(), { projectRoot });
+      // Sync manager content via the same default generator as `content sync`
+      const files = generateContent(DEFAULT_CONTENT_GENERATOR_ID, buildManifest(), {
+        projectRoot,
+      });
       let written = 0;
       for (const file of files) {
         const absolutePath = join(projectRoot, file.relativePath);
@@ -443,7 +466,9 @@ async function main() {
         written++;
       }
       process.stdout.write(`✓ Manager: ${result.managerPath}\n`);
-      process.stdout.write(`✓ Content files: ${written}\n`);
+      process.stdout.write(
+        `✓ Content files: ${written} → ${MANAGER_CONTENT_OUTPUT} (generator=${DEFAULT_CONTENT_GENERATOR_ID})\n`,
+      );
       process.stdout.write(`✓ Adapter stubs:\n`);
       for (const s of result.stubs) process.stdout.write(`  ${s}\n`);
       return;
@@ -656,9 +681,11 @@ Content Subcommands:
   content list                      List all canonical content with metadata
   content validate                  Validate all definitions against schemas
   content diff [--generator <id>]   Show what would change vs current files
-  content sync [--generator <id>] [--dry-run]  Generate into .revealui/content (manager)
+  content sync [--generator <id>] [--dry-run]  Generate into .revealui/content (default generator)
   content export --output <path>    Export canonical + generated files to directory
   content pull [--generator <id>] [--tier oss|pro|all]  Pull rules from rules repo
+
+Default content generator: ${DEFAULT_CONTENT_GENERATOR_ID} → ${MANAGER_CONTENT_OUTPUT}
 `);
       break;
   }

--- a/packages/harnesses/src/content/generators/claude-code.ts
+++ b/packages/harnesses/src/content/generators/claude-code.ts
@@ -14,8 +14,9 @@
 import type { ResolverContext } from '../resolvers/types.js';
 import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
 import type { ContentGenerator, GeneratedFile } from './types.js';
+import { MANAGER_CONTENT_OUTPUT } from './types.js';
 
-const CONTENT = '.revealui/content';
+const CONTENT = MANAGER_CONTENT_OUTPUT;
 
 function yamlEscape(value: string): string {
   if (/[:#\n"'{}[\],&*?|>!%@`]/.test(value) || value.trim() !== value) {

--- a/packages/harnesses/src/content/generators/index.ts
+++ b/packages/harnesses/src/content/generators/index.ts
@@ -8,6 +8,7 @@ export { ClaudeCodeGenerator } from './claude-code.js';
 export { CursorGenerator } from './cursor.js';
 export { OpenCodeGenerator } from './opencode.js';
 export type { ContentGenerator, DiffEntry, GeneratedFile } from './types.js';
+export { DEFAULT_CONTENT_GENERATOR_ID, MANAGER_CONTENT_OUTPUT } from './types.js';
 export { VSCodeGenerator } from './vscode.js';
 
 const generators = new Map<string, ContentGenerator>();

--- a/packages/harnesses/src/content/generators/types.ts
+++ b/packages/harnesses/src/content/generators/types.ts
@@ -1,8 +1,20 @@
 import type { ResolverContext } from '../resolvers/types.js';
 import type { Agent, Command, Manifest, Rule, Skill } from '../schemas/index.js';
 
+/**
+ * Default generator for `content sync|diff|pull` and `manager materialize`.
+ *
+ * Id remains `claude-code` for registry stability, but emit target is the
+ * **project manager** tree (`.revealui/content/`), not a vendor-private
+ * `.claude/` fork (GAP-406).
+ */
+export const DEFAULT_CONTENT_GENERATOR_ID = 'claude-code';
+
+/** On-disk manager content root (relative to project root). */
+export const MANAGER_CONTENT_OUTPUT = '.revealui/content';
+
 export interface GeneratedFile {
-  /** Relative path from project root (e.g. '.claude/rules/biome.md') */
+  /** Relative path from project root (e.g. '.revealui/content/rules/biome.md') */
   relativePath: string;
   content: string;
 }

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -3,19 +3,31 @@
  *
  * Tool-agnostic definitions for AI guidance content (rules, commands, agents, skills).
  * Generators produce tool-specific output from canonical definitions.
- * Generators registered today: `opencode`, `cursor` (hooks.json only),
- * `vscode` (plugin.json hooks contribution only), and `claude-code` (rules /
- * commands / agents / skills under `.claude/` — GAP-406 adapter path).
+ *
+ * Generators registered today:
+ * - `claude-code` (**default** via `DEFAULT_CONTENT_GENERATOR_ID`) — full
+ *   rules/commands/agents/skills under the **project manager** tree
+ *   `.revealui/content/` (GAP-406). Not a vendor-private `.claude/` fork.
+ * - `opencode` — agents + commands under `.opencode/`
+ * - `cursor` — hooks.json only
+ * - `vscode` — plugin.json hooks contribution only
+ *
  * The adapter layer (`../adapters/`) ships `revealui-agent`, `opencode`, and
- * `cursor` -- `vscode` has no adapter (no headless CLI to exec).
+ * `cursor` — `vscode` has no adapter (no headless CLI to exec).
  *
  * @example
  * ```ts
- * import { buildManifest, validateManifest, generateContent, diffContent } from '@revealui/harnesses/content';
+ * import {
+ *   buildManifest,
+ *   validateManifest,
+ *   generateContent,
+ *   DEFAULT_CONTENT_GENERATOR_ID,
+ * } from '@revealui/harnesses/content';
  *
  * const manifest = buildManifest();
  * const validation = validateManifest(manifest);
- * const files = generateContent('opencode', manifest, { projectRoot: '/path/to/project' });
+ * // Default sync lands under .revealui/content (manager tree)
+ * const files = generateContent(DEFAULT_CONTENT_GENERATOR_ID, manifest, { projectRoot: '/path/to/project' });
  * ```
  */
 
@@ -31,8 +43,10 @@ export { buildManifest } from './definitions/index.js';
 export {
   ClaudeCodeGenerator,
   CursorGenerator,
+  DEFAULT_CONTENT_GENERATOR_ID,
   getGenerator,
   listGenerators,
+  MANAGER_CONTENT_OUTPUT,
   OpenCodeGenerator,
   registerGenerator,
   VSCodeGenerator,

--- a/packages/harnesses/src/manager/index.ts
+++ b/packages/harnesses/src/manager/index.ts
@@ -10,6 +10,7 @@ export {
   materializeManager,
   materializeOpenCodeStub,
   writeManager,
+  writeManagerPreserving,
 } from './materialize.js';
 export {
   MANAGER_CONTENT_DIR,

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import {
   MANAGER_CONTENT_DIR,
@@ -14,15 +14,6 @@ const STUB_HEADER = `> **RevealUI manager.** Policy and skills are owned by \`.r
 > **Quality over speed:** correctness and proof outrank throughput in every session.
 `;
 
-export function managerPath(projectRoot: string): string {
-  return join(projectRoot, MANAGER_DIR, MANAGER_FILE);
-}
-
-export function contentRootPath(projectRoot: string, config?: ManagerConfig): string {
-  const root = config?.contentRoot ?? MANAGER_CONTENT_DIR;
-  return join(projectRoot, MANAGER_DIR, root);
-}
-
 function isEnoent(err: unknown): boolean {
   return (
     typeof err === 'object' &&
@@ -32,39 +23,44 @@ function isEnoent(err: unknown): boolean {
   );
 }
 
-/** Load manager.json or return defaults. */
-export function loadManager(projectRoot: string): ManagerConfig {
-  const path = managerPath(projectRoot);
-  // Read first (no existsSync TOCTOU). Missing file → schema defaults.
+/** Read UTF-8 file contents, or null when missing (no existsSync TOCTOU). */
+function readFileOrNull(filePath: string): string | null {
   try {
-    const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
-    return ManagerSchema.parse(raw);
+    return readFileSync(filePath, 'utf-8');
   } catch (err) {
-    if (isEnoent(err)) {
-      return ManagerSchema.parse({});
-    }
+    if (isEnoent(err)) return null;
     throw err;
   }
 }
 
+export function managerPath(projectRoot: string): string {
+  return join(projectRoot, MANAGER_DIR, MANAGER_FILE);
+}
+
+export function contentRootPath(projectRoot: string, config?: ManagerConfig): string {
+  const root = config?.contentRoot ?? MANAGER_CONTENT_DIR;
+  return join(projectRoot, MANAGER_DIR, root);
+}
+
+/** Load manager.json or return defaults. */
+export function loadManager(projectRoot: string): ManagerConfig {
+  const path = managerPath(projectRoot);
+  const text = readFileOrNull(path);
+  if (text === null) {
+    return ManagerSchema.parse({});
+  }
+  return ManagerSchema.parse(JSON.parse(text) as unknown);
+}
+
 /**
- * Write manager.json (pretty). Skips the write when on-disk content already matches.
- * Uses try-read (not existsSync) so CodeQL js/file-system-race does not flag
- * a check-then-write TOCTOU on the project manager path.
+ * Write manager.json (pretty).
+ * Always performs a single writeFileSync after mkdir — no existsSync/read
+ * then write race (CodeQL js/file-system-race). Manager files are small.
  */
 export function writeManager(projectRoot: string, config?: ManagerConfig): string {
   const parsed = ManagerSchema.parse(config ?? {});
   const path = managerPath(projectRoot);
   const next = `${JSON.stringify(parsed, null, 2)}\n`;
-  try {
-    if (readFileSync(path, 'utf-8') === next) {
-      return path;
-    }
-  } catch (err) {
-    if (!isEnoent(err)) {
-      throw err;
-    }
-  }
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, next, 'utf-8');
   return path;
@@ -200,23 +196,24 @@ export function checkManager(projectRoot: string): ManagerCheckResult {
   const errors: string[] = [];
   const warnings: string[] = [];
   const mPath = managerPath(projectRoot);
-  if (!existsSync(mPath)) {
+  const managerText = readFileOrNull(mPath);
+  if (managerText === null) {
     errors.push(
       `missing ${MANAGER_DIR}/${MANAGER_FILE} — run: revealui-harnesses manager materialize`,
     );
   } else {
     try {
-      loadManager(projectRoot);
+      ManagerSchema.parse(JSON.parse(managerText) as unknown);
     } catch (err) {
       errors.push(`invalid manager.json: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
   const claudeStub = join(projectRoot, '.claude', 'rules', '00-revealui-manager.md');
-  if (!existsSync(claudeStub)) {
+  if (readFileOrNull(claudeStub) === null) {
     warnings.push('missing .claude/rules/00-revealui-manager.md stub (materialize claude-code)');
   }
   const readme = join(projectRoot, MANAGER_DIR, 'README.md');
-  if (!existsSync(readme)) {
+  if (readFileOrNull(readme) === null) {
     warnings.push('missing .revealui/README.md manager contract');
   }
   return { ok: errors.length === 0, errors, warnings };

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -33,13 +33,33 @@ export function loadManager(projectRoot: string): ManagerConfig {
   return ManagerSchema.parse(raw);
 }
 
-/** Write manager.json (pretty). */
+/** Write manager.json (pretty). Skips the write when on-disk content already matches. */
 export function writeManager(projectRoot: string, config?: ManagerConfig): string {
   const parsed = ManagerSchema.parse(config ?? {});
   const path = managerPath(projectRoot);
+  const next = `${JSON.stringify(parsed, null, 2)}\n`;
+  if (existsSync(path) && readFileSync(path, 'utf-8') === next) {
+    return path;
+  }
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(parsed, null, 2)}\n`, 'utf-8');
+  writeFileSync(path, next, 'utf-8');
   return path;
+}
+
+/**
+ * Persist manager.json without clobbering project-specific fields.
+ * When no explicit config is passed and a file already exists, re-load it
+ * (schema-normalized) and write back so monorepo name/tracker notes survive
+ * `manager materialize`.
+ */
+export function writeManagerPreserving(projectRoot: string, config?: ManagerConfig): string {
+  if (config !== undefined) {
+    return writeManager(projectRoot, config);
+  }
+  if (existsSync(managerPath(projectRoot))) {
+    return writeManager(projectRoot, loadManager(projectRoot));
+  }
+  return writeManager(projectRoot);
 }
 
 /** Thin Claude project stub: one rule file that points at the manager. */
@@ -137,7 +157,7 @@ export function materializeManager(
     adapters?: Array<'claude-code' | 'cursor' | 'opencode' | 'grok'>;
   },
 ): MaterializeResult {
-  const managerFile = writeManager(projectRoot, options?.config);
+  const managerFile = writeManagerPreserving(projectRoot, options?.config);
   const adapters = options?.adapters ?? ['claude-code', 'cursor', 'opencode', 'grok'];
   const stubs: string[] = [];
   for (const id of adapters) {

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -23,23 +23,47 @@ export function contentRootPath(projectRoot: string, config?: ManagerConfig): st
   return join(projectRoot, MANAGER_DIR, root);
 }
 
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'ENOENT'
+  );
+}
+
 /** Load manager.json or return defaults. */
 export function loadManager(projectRoot: string): ManagerConfig {
   const path = managerPath(projectRoot);
-  if (!existsSync(path)) {
-    return ManagerSchema.parse({});
+  // Read first (no existsSync TOCTOU). Missing file → schema defaults.
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+    return ManagerSchema.parse(raw);
+  } catch (err) {
+    if (isEnoent(err)) {
+      return ManagerSchema.parse({});
+    }
+    throw err;
   }
-  const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
-  return ManagerSchema.parse(raw);
 }
 
-/** Write manager.json (pretty). Skips the write when on-disk content already matches. */
+/**
+ * Write manager.json (pretty). Skips the write when on-disk content already matches.
+ * Uses try-read (not existsSync) so CodeQL js/file-system-race does not flag
+ * a check-then-write TOCTOU on the project manager path.
+ */
 export function writeManager(projectRoot: string, config?: ManagerConfig): string {
   const parsed = ManagerSchema.parse(config ?? {});
   const path = managerPath(projectRoot);
   const next = `${JSON.stringify(parsed, null, 2)}\n`;
-  if (existsSync(path) && readFileSync(path, 'utf-8') === next) {
-    return path;
+  try {
+    if (readFileSync(path, 'utf-8') === next) {
+      return path;
+    }
+  } catch (err) {
+    if (!isEnoent(err)) {
+      throw err;
+    }
   }
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, next, 'utf-8');
@@ -48,18 +72,14 @@ export function writeManager(projectRoot: string, config?: ManagerConfig): strin
 
 /**
  * Persist manager.json without clobbering project-specific fields.
- * When no explicit config is passed and a file already exists, re-load it
- * (schema-normalized) and write back so monorepo name/tracker notes survive
- * `manager materialize`.
+ * When no explicit config is passed, re-load via loadManager (defaults if
+ * missing) so monorepo name/tracker notes survive `manager materialize`.
  */
 export function writeManagerPreserving(projectRoot: string, config?: ManagerConfig): string {
   if (config !== undefined) {
     return writeManager(projectRoot, config);
   }
-  if (existsSync(managerPath(projectRoot))) {
-    return writeManager(projectRoot, loadManager(projectRoot));
-  }
-  return writeManager(projectRoot);
+  return writeManager(projectRoot, loadManager(projectRoot));
 }
 
 /** Thin Claude project stub: one rule file that points at the manager. */

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -263,6 +263,15 @@ async function gate(): Promise<void> {
         warnOnly: true,
       },
       {
+        // GAP-406: hard-fail local gate when manager.json is missing/invalid.
+        // Same checkManager as `revealui-harnesses manager check` via
+        // validate:structure --manager-only (no parallel validator).
+        // CI mirrors this as a path-gated Quality step.
+        name: 'Project manager check (hard fail)',
+        command: 'pnpm',
+        args: ['validate:structure', '--', '--manager-only'],
+      },
+      {
         name: 'Boundary validation',
         command: 'pnpm',
         args: ['validate:boundary'],

--- a/scripts/validate/structure.ts
+++ b/scripts/validate/structure.ts
@@ -13,6 +13,7 @@
 
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { checkManager } from '../../packages/harnesses/src/manager/index.js';
 
 interface ValidationRule {
   path: string;
@@ -455,6 +456,27 @@ class StructureValidator {
       console.log('✅ .revealui/templates/ directory exists');
     }
 
+    // Project manager (GAP-406): monorepo always has packages/harnesses; when
+    // .revealui/manager.json is committed, fail closed if it is missing or
+    // invalid. Uses the same checkManager primitive as
+    // `revealui-harnesses manager check` (no parallel validator).
+    if (existsSync('packages/harnesses') || existsSync('.revealui/manager.json')) {
+      console.log('\n🔍 Checking project manager (.revealui)...');
+      const managerResult = checkManager(process.cwd());
+      for (const warning of managerResult.warnings) {
+        console.log(`⚠️  ${warning}`);
+      }
+      if (!managerResult.ok) {
+        for (const error of managerResult.errors) {
+          console.log(`❌ ${error}`);
+        }
+        console.log('   Run: pnpm exec revealui-harnesses manager materialize');
+        allValid = false;
+      } else {
+        console.log('✅ Project manager (.revealui/manager.json) present and valid');
+      }
+    }
+
     // Check that mcp is not in root
     if (existsSync('mcp')) {
       console.log('\n❌ mcp/ found in root - should be in packages/mcp/');
@@ -507,8 +529,42 @@ class StructureValidator {
   }
 }
 
+/**
+ * Focused manager check for path-gated CI (GAP-406).
+ * Same primitive as `revealui-harnesses manager check` / structure validate.
+ */
+export function validateProjectManager(root: string = process.cwd()): boolean {
+  if (
+    !(
+      existsSync(join(root, 'packages/harnesses')) ||
+      existsSync(join(root, '.revealui/manager.json'))
+    )
+  ) {
+    console.log('skip: no packages/harnesses or .revealui/manager.json');
+    return true;
+  }
+  const managerResult = checkManager(root);
+  for (const warning of managerResult.warnings) {
+    console.warn(`WARN: ${warning}`);
+  }
+  if (!managerResult.ok) {
+    for (const error of managerResult.errors) {
+      console.error(`ERROR: ${error}`);
+    }
+    console.error('Run: pnpm exec revealui-harnesses manager materialize');
+    return false;
+  }
+  console.log('✓ Project manager (.revealui/manager.json) present and valid');
+  return true;
+}
+
 // CLI interface
 async function main() {
+  // Path-gated CI entry: `pnpm validate:structure --manager-only`
+  if (process.argv.includes('--manager-only')) {
+    process.exit(validateProjectManager() ? 0 : 1);
+  }
+
   console.log('🎯 RevealUI Structure Validation');
   console.log('='.repeat(40));
 


### PR DESCRIPTION
## Summary

Finish slice for GAP-406 **on top of merged #2074 + #2075**.

Replaces #2078 (branch had merge conflicts with `test` after #2074 squash; force-push of rebased history blocked in agent — this is a clean tip of the same finish commit).

### Beyond #2074
- CLAUDE.md / AGENTS.md → `.revealui/manager.json` first
- CI Quality path-gated `manager check` + local `ci-gate` step
- `validate:structure --manager-only`
- Default content sync to manager tree; grok adapter note
- Manager materialize/test polish

## Test plan
- [x] harnesses unit tests (manager + claude-code + content-api)
- [x] `tsx scripts/validate/structure.ts --manager-only`
- [ ] CI green after open

## Owner
After checks green + `sec-review:approved` (touches harnesses):
```bash
gh pr merge <N> -R RevealUIStudio/revealui --squash
gh pr close 2078 -R RevealUIStudio/revealui --comment "Superseded by rebased PR"
```