### PR TITLE
docs(packages): md-truth W2 package/app claim fixes (GAP-407)

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -26,7 +26,7 @@ Admin dashboard with content, account billing, and system monitoring  -  powered
 - **Styling**: Tailwind CSS v4
 - **Database**: Drizzle ORM (NeonDB)
 - **Auth**: `@revealui/auth` (bcrypt, sessions, rate limiting)
-- **UI Components**: `@revealui/presentation` (59 native components)
+- **UI Components**: `@revealui/presentation` (65 native components)
 - **Rich Text**: Lexical editor
 - **Payments**: Stripe (checkout, billing portal, webhooks)
 - **Monitoring**: Sentry

--- a/packages/PACKAGE-CONVENTIONS.md
+++ b/packages/PACKAGE-CONVENTIONS.md
@@ -16,7 +16,7 @@ See [CLAUDE.md](../CLAUDE.md) for the full package map and [docs/REFERENCE.md](.
 
 Monorepo-wide naming split, enforced on the `name` field in `package.json`:
 
-- **Apps** (`apps/*`): unscoped  -  `"admin"`, `"api"`, `"docs"`, `"marketing"`, `"studio"`. Never `@revealui/<app>`.
+- **Apps** (`apps/*`): unscoped  -  `"admin"`, `"server"`, `"docs"`, `"marketing"`. Never `@revealui/<app>`.
 - **Packages** (`packages/*`): scoped  -  `"@revealui/core"`, `"@revealui/security"`, etc.
 
 Rationale: apps are deploy targets, not consumable libraries; the `@revealui/` prefix is reserved for things that get published to npm.

--- a/packages/ai/OBSERVABILITY.md
+++ b/packages/ai/OBSERVABILITY.md
@@ -1,6 +1,8 @@
 ---
 title: "RevealUI AI Observability"
-description: "Comprehensive observability system for tracking agent operations, decisions, tool usage, and LLM calls."
+description: "Comprehensive observability system for tracking agent operations, decisions, tool usage, and LLM calls.
+
+> **Published export note:** `package.json` does not currently export `./observability`. Use the monorepo source path (`packages/ai/src/observability`) until a public export is added."
 visibility: internal
 status: verified
 audience: maintainer
@@ -27,7 +29,7 @@ import {
   AgentEventLogger,
   AgentMetricsCollector,
   MemoryEventStorage,
-} from '@revealui/ai/observability'
+} from '../src/observability' // monorepo path; not yet in package.json exports
 
 // Create logger with in-memory storage
 const logger = new AgentEventLogger({
@@ -229,7 +231,7 @@ logger.logError({
 In-memory storage with no persistence:
 
 ```typescript
-import { MemoryEventStorage } from '@revealui/ai/observability'
+import { MemoryEventStorage } from '../src/observability' // monorepo path; not yet in package.json exports
 
 const storage = new MemoryEventStorage()
 const logger = new AgentEventLogger({ storage })
@@ -242,7 +244,7 @@ const logger = new AgentEventLogger({ storage })
 Persist events to browser localStorage:
 
 ```typescript
-import { LocalStorageEventStorage } from '@revealui/ai/observability'
+import { LocalStorageEventStorage } from '../src/observability' // monorepo path; not yet in package.json exports
 
 const storage = new LocalStorageEventStorage('my-app:agent:events')
 const logger = new AgentEventLogger({ storage })
@@ -255,7 +257,7 @@ const logger = new AgentEventLogger({ storage })
 Persist events to JSON files:
 
 ```typescript
-import { FileSystemEventStorage } from '@revealui/ai/observability'
+import { FileSystemEventStorage } from '../src/observability' // monorepo path; not yet in package.json exports
 
 const storage = new FileSystemEventStorage('./logs/agent-events.json')
 const logger = new AgentEventLogger({ storage })
@@ -442,7 +444,7 @@ logger.destroy()
 
 ```typescript
 import { AgentOrchestrator } from '@revealui/ai/orchestration'
-import { AgentEventLogger, AgentMetricsCollector } from '@revealui/ai/observability'
+import { AgentEventLogger, AgentMetricsCollector } from '../src/observability' // monorepo path; not yet in package.json exports
 
 const logger = new AgentEventLogger()
 const metrics = new AgentMetricsCollector(logger)
@@ -492,7 +494,7 @@ class ObservableOrchestrator extends AgentOrchestrator {
 
 ```typescript
 import { LLMClient } from '@revealui/ai/llm'
-import { AgentEventLogger } from '@revealui/ai/observability'
+import { AgentEventLogger } from '../src/observability' // monorepo path; not yet in package.json exports
 
 class ObservableLLMClient extends LLMClient {
   constructor(private logger: AgentEventLogger) {

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -255,7 +255,7 @@ pnpm --filter @revealui/ai test
 POSTGRES_URL="postgresql://..." pnpm --filter @revealui/ai test __tests__/integration
 
 # Production validation
-POSTGRES_URL="postgresql://..." ./scripts/validate-production.sh
+pnpm --filter @revealui/ai test  # production validation script retired; use package tests / gate
 ```
 
 ### Testing Limitations

--- a/packages/ai/TESTING.md
+++ b/packages/ai/TESTING.md
@@ -44,7 +44,7 @@ pnpm --filter @revealui/ai test __tests__/integration/
 
 ### Production Validation
 ```bash
-POSTGRES_URL="postgresql://..." ./scripts/validate-production.sh
+pnpm --filter @revealui/ai test  # production validation script retired; use package tests / gate
 ```
 
 ---
@@ -54,13 +54,13 @@ POSTGRES_URL="postgresql://..." ./scripts/validate-production.sh
 ### Commands
 ```bash
 # Unit tests (always work)
-pnpm --filter @revealui/memory test
+pnpm --filter @revealui/ai test
 
 # Integration tests (require Neon)
-POSTGRES_URL="postgresql://..." pnpm --filter @revealui/memory test __tests__/integration
+POSTGRES_URL="postgresql://..." pnpm --filter @revealui/ai test __tests__/integration
 
 # Production validation
-POSTGRES_URL="postgresql://..." ./scripts/validate-production.sh
+pnpm --filter @revealui/ai test  # production validation script retired; use package tests / gate
 ```
 
 ### Known Issues
@@ -212,7 +212,7 @@ export POSTGRES_URL="postgresql://user:pass@neon-host/dbname"
 pnpm --filter @revealui/db db:push
 
 # 3. Run validation script
-./scripts/validate-production.sh
+pnpm --filter @revealui/ai test
 ```
 
 **Validation Checklist**:
@@ -327,7 +327,7 @@ If staging environment is not available, use this manual checklist:
 - **Drizzle Docs**: https://orm.drizzle.team
 - **Test Files**: `packages/ai/__tests__/integration/`
 - **Helper Functions**: `packages/ai/src/memory/utils/sql-helpers.ts`
-- **Validation Script**: `scripts/validate-production.sh`
+- **Validation**: `pnpm --filter @revealui/ai test` (package suite; no standalone validate-production.sh)
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,7 +28,7 @@ pnpm create revealui@latest my-project --template basic-blog
 - Multiple templates: basic-blog, e-commerce, portfolio, starter, starter-native (Vite + @revealui/router, no Next.js)
 - Automatic environment configuration
 - Database setup (NeonDB, Supabase, or local PostgreSQL)
-- Storage setup (Cloudflare R2, or legacy Vercel Blob)
+- Storage setup (Cloudflare R2, or skip)
 - Payment setup (Stripe)
 - Dev Container and Devbox configuration
 - Git initialization with initial commit

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -82,9 +82,10 @@ The config package validates these environment variables (schema: `packages/conf
 # Database
 POSTGRES_URL=postgresql://user:password@host/database
 
-# RevealUI
+# RevealUI (schema: packages/config/src/schema.ts requiredSchema)
 REVEALUI_SECRET=your_secret_key_here
 REVEALUI_PUBLIC_SERVER_URL=http://localhost:4000
+NEXT_PUBLIC_SERVER_URL=http://localhost:3004
 ```
 
 ### Optional Variables
@@ -112,13 +113,13 @@ NEON_API_KEY=neon_...
 
 ## File Loading Priority
 
-Environment variables are loaded in this order (later overrides earlier):
+File loading is environment-specific (`packages/config/src/loader.ts`). **`process.env` always wins** when values are merged.
 
-1. System environment variables
-2. `.env` (shared defaults, if present)
-3. `.env.local` (local overrides)
-4. `.env.development.local` (development mode)
-5. `.env.production.local` (production mode)
+| Environment | Files loaded |
+|-------------|--------------|
+| **production** | None (process.env only) |
+| **test** | First existing of `.env.test.local`, then `.env.test` |
+| **development** | First existing of `.env.development.local`, then `.env.local`, then `.env` |
 
 ## Validation
 
@@ -170,9 +171,9 @@ pnpm --filter @revealui/config lint
 
 ## Related Documentation
 
-- [Environment Variables Guide](../../docs/ENVIRONMENT_VARIABLES_GUIDE.md) - Complete environment setup
+- [Environment Variables Guide](../../docs/ENVIRONMENT-VARIABLES-GUIDE.md) - Complete environment setup
 - [Quick Start](../../docs/QUICK_START.md) - Initial setup instructions
-- [MCP Guide](../../docs/MCP.md) - MCP server configuration
+- [MCP Guide](../mcp/README.md) - MCP server configuration
 
 ## License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,7 +27,7 @@ Part of the [RevealUI monorepo](https://github.com/RevealUIStudio/revealui)  -  
 - **Plugins**  -  Extensible plugin system (form builder, nested docs, redirects)
 - **Feature Gating**  -  Tier-based licensing (free, pro, max, enterprise) with JWT license keys
 - **Database**  -  PostgreSQL adapters (NeonDB + PGlite for testing), connection pooling, SSL/TLS
-- **Storage**  -  Pluggable storage interface (Cloudflare R2 primary; Vercel Blob legacy adapter retained during migration)
+- **Storage**  -  Pluggable storage interface (Cloudflare R2 sole non-mock backend; mock adapter for tests)
 
 ## Installation
 
@@ -145,7 +145,7 @@ if (isFeatureEnabled('ai')) {
 | `@revealui/core/database` | Database adapters |
 | `@revealui/core/database/ssl-config` | SSL/TLS config |
 | `@revealui/core/database/type-adapter` | Type adapter utilities |
-| `@revealui/core/storage` | Storage adapters (R2 + legacy Vercel Blob) |
+| `@revealui/core/storage` | Storage adapters (R2 + mock for tests) |
 | `@revealui/core/plugins` | Plugin system |
 | `@revealui/core/features` | Feature flags |
 | `@revealui/core/license` | License validation |

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -140,7 +140,7 @@ await db.insert(users).values({
 
 ## Design Principles
 
-- **Unified**: One schema definition (85 tables) drives types, queries, and migrations across all apps
+- **Unified**: One schema definition (96 tables) drives types, queries, and migrations across all apps
 - **Orthogonal**: Schema files are cleanly separated by domain (cms, users, agents, vector, crdt) with no cross-domain entanglement
 - **Sovereign**: Your database, your schema, your migrations  -  no hosted schema service in the loop
 
@@ -148,7 +148,6 @@ await db.insert(users).values({
 
 - [Migration Discipline](./docs/migrations-discipline.md) - How migrations work and rules to prevent silent failures
 - [Database Guide](../../docs/DATABASE.md) - Complete database setup and configuration
-- [Database Management](../../docs/DATABASE_MANAGEMENT.md) - Operations and maintenance
 - [Drizzle ORM Docs](https://orm.drizzle.team/) - Official Drizzle documentation
 
 ## License

--- a/packages/db/migrations/README.md
+++ b/packages/db/migrations/README.md
@@ -12,7 +12,7 @@ This directory contains versioned SQL migrations managed by Drizzle Kit.
 
 ## Current Migrations
 
-18 migrations applied (0000–0017). See `meta/_journal.json` for the canonical list.
+28 migrations applied (0000–0027). See `meta/_journal.json` for the canonical list.
 
 | Migration tag | Description |
 |---------------|-------------|
@@ -34,8 +34,18 @@ This directory contains versioned SQL migrations managed by Drizzle Kit.
 | `0015_users_stripe_deletion_status` | Users Stripe deletion status |
 | `0016_drop_revealcoin_tables` | Drop RevealCoin tables |
 | `0017_webhook_idempotency_state` | Webhook idempotency state |
+| `0018_eager_killmonger` | Schema additions |
+| `0019_clean_thor_girl` | Schema additions |
+| `0020_productive_scarecrow` | Schema additions |
+| `0021_knowledge_graph` | Knowledge graph tables |
+| `0022_kg_search_text` | Knowledge graph search text |
+| `0023_entitlement_trialing_last_event` | Entitlement trial last event |
+| `0024_widen_provider_check_anthropic_openai` | Provider check widening |
+| `0025_add_nudge_dismissals` | Nudge dismissals |
+| `0026_audit_log_append_only` | Audit log append-only |
+| `0027_open_storm` | Schema additions |
 
-**Total Tables:** 85 (see `packages/db/package.json` description)
+**Total Tables:** 96 (recount `pgTable(` under `packages/db/src/schema`; keep in lockstep with `pnpm validate:claims`)
 
 ## Migration Strategy
 
@@ -76,7 +86,7 @@ Drizzle Kit does not generate automatic rollback migrations. For schema changes 
 ## Adding New Tables
 
 1. Define table in `packages/db/src/schema/*.ts`
-2. Export from appropriate schema file (rest.ts or vector.ts)
+2. Export from appropriate schema file
 3. Build package: `pnpm build`
 4. Generate migration: `pnpm db:generate`
 5. Review generated SQL in `migrations/`

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/db",
   "version": "0.9.0",
-  "description": "Drizzle ORM schema (85 tables) for RevealUI on NeonDB (Postgres). Ships with RevealUI.",
+  "description": "Drizzle ORM schema (96 tables) for RevealUI on NeonDB (Postgres). Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {
     "@neondatabase/serverless": "catalog:",

--- a/packages/harnesses/README.md
+++ b/packages/harnesses/README.md
@@ -15,7 +15,7 @@ AI harness coordination for RevealUI  -  enables multiple AI coding tools to wor
 
 ## Features
 
-- **Multi-Harness Coordination**: Claude Code, Cursor, Copilot adapters with conflict detection
+- **Multi-Harness Coordination**: Cursor, OpenCode, and RevealUI agent adapters with conflict detection; Claude Code / VS Code via hooks and content generators
 - **Workboard Protocol**: Shared `.claude/workboard.md` for session tracking and file reservations
 - **Auto-Detection**: Discovers installed harnesses via PATH and running processes
 - **JSON-RPC 2.0 Server**: Unix domain socket IPC for harness-to-harness communication

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -66,12 +66,8 @@ packages/mcp/
 │   ├── servers/          # MCP server implementations (run `ls packages/mcp/src/servers/` for the current list)
 │   │   ├── code-validator.ts   ← AI code standards enforcer
 │   │   └── …                   ← Neon, Next.js DevTools, Playwright, RevealUI-*, Stripe, Supabase, Vercel
-│   ├── config/           # Configuration utilities
-│   │   ├── index.ts
-│   │   ├── config.json
-│   │   └── README.md
-│   └── adapters/         # Database adapters
-│       └── db.ts
+│   ├── config/           # Configuration utilities (index.ts, config.json)
+│   └── adapters/         # Database adapters (db.ts)
 ├── configs/              # Template configurations
 │   ├── claude-template.json
 │   └── README.md
@@ -105,7 +101,7 @@ tsx packages/mcp/src/servers/code-validator.ts
 Deploy and manage Vercel projects.
 
 ```bash
-pnpm mcp:vercel
+tsx packages/mcp/src/servers/vercel.ts
 ```
 
 ### 3. Stripe
@@ -114,7 +110,7 @@ pnpm mcp:vercel
 Payment processing and billing operations.
 
 ```bash
-pnpm mcp:stripe
+tsx packages/mcp/src/servers/stripe.ts
 ```
 
 ### 4. Neon
@@ -123,7 +119,7 @@ pnpm mcp:stripe
 Database operations and SQL queries.
 
 ```bash
-pnpm mcp:neon
+tsx packages/mcp/src/servers/neon.ts
 ```
 
 ### 5. Supabase
@@ -132,7 +128,7 @@ pnpm mcp:neon
 Supabase project management and CRUD operations.
 
 ```bash
-pnpm mcp:supabase
+tsx packages/mcp/src/servers/supabase.ts
 ```
 
 ### 6. Playwright
@@ -141,7 +137,7 @@ pnpm mcp:supabase
 Browser automation and web scraping.
 
 ```bash
-pnpm mcp:playwright
+tsx packages/mcp/src/servers/playwright.ts
 ```
 
 ### 7. Next.js DevTools
@@ -150,7 +146,7 @@ pnpm mcp:playwright
 Next.js 16+ runtime diagnostics and automation.
 
 ```bash
-pnpm mcp:next-devtools
+tsx packages/mcp/src/servers/next-devtools.ts
 ```
 
 ### 8. Contracts Introspection
@@ -218,18 +214,23 @@ pnpm typecheck
 pnpm lint
 ```
 
-## Package Scripts (Root)
+## Running servers
+
+There are no root `pnpm mcp:*` script aliases. Start a server with `tsx` against the file under `src/servers/` (underscore-prefixed files are helpers, not counted servers):
 
 ```bash
-# Start individual MCP servers
-pnpm mcp:vercel
-pnpm mcp:stripe
-pnpm mcp:neon
-pnpm mcp:supabase
-pnpm mcp:playwright
-pnpm mcp:next-devtools
+# Examples (from monorepo root)
+tsx packages/mcp/src/servers/code-validator.ts
+tsx packages/mcp/src/servers/vercel.ts
+tsx packages/mcp/src/servers/stripe.ts
+tsx packages/mcp/src/servers/neon.ts
+tsx packages/mcp/src/servers/supabase.ts
+tsx packages/mcp/src/servers/playwright.ts
+tsx packages/mcp/src/servers/next-devtools.ts
+tsx packages/mcp/src/servers/contracts.ts
+tsx packages/mcp/src/servers/docs.ts
 
-# Setup MCP configuration
+# Copy Claude config template
 pnpm setup:mcp
 ```
 

--- a/packages/mcp/configs/README.md
+++ b/packages/mcp/configs/README.md
@@ -32,12 +32,12 @@ Template for Claude Code / Claude Desktop
 | Server | Command | Description |
 |--------|---------|-------------|
 | code-validator | `tsx packages/mcp/src/servers/code-validator.ts` | Validates code against standards |
-| vercel | `pnpm mcp:vercel` | Vercel deployment |
-| stripe | `pnpm mcp:stripe` | Payment processing |
-| neon | `pnpm mcp:neon` | Database operations |
-| supabase | `pnpm mcp:supabase` | Supabase management |
-| playwright | `pnpm mcp:playwright` | Browser automation |
-| next-devtools | `pnpm mcp:next-devtools` | Next.js debugging |
+| vercel | `tsx packages/mcp/src/servers/vercel.ts` | Vercel deployment |
+| stripe | `tsx packages/mcp/src/servers/stripe.ts` | Payment processing |
+| neon | `tsx packages/mcp/src/servers/neon.ts` | Database operations |
+| supabase | `tsx packages/mcp/src/servers/supabase.ts` | Supabase management |
+| playwright | `tsx packages/mcp/src/servers/playwright.ts` | Browser automation |
+| next-devtools | `tsx packages/mcp/src/servers/next-devtools.ts` | Next.js debugging |
 
 ## Quick Setup Script
 

--- a/packages/mcp/configs/claude-template.json
+++ b/packages/mcp/configs/claude-template.json
@@ -3,49 +3,63 @@
   "mcpServers": {
     "revealui-code-validator": {
       "command": "tsx",
-      "args": ["<REPO_PATH>/packages/mcp/src/servers/code-validator.ts"],
+      "args": [
+        "<REPO_PATH>/packages/mcp/src/servers/code-validator.ts"
+      ],
       "cwd": "<REPO_PATH>",
       "description": "Code validation - prevents AI-generated technical debt",
       "enabled": true
     },
     "revealui-vercel": {
-      "command": "pnpm",
-      "args": ["mcp:vercel"],
+      "command": "tsx",
+      "args": [
+        "packages/mcp/src/servers/vercel.ts"
+      ],
       "cwd": "<REPO_PATH>",
       "description": "Vercel deployment and storage management",
       "enabled": false
     },
     "revealui-stripe": {
-      "command": "pnpm",
-      "args": ["mcp:stripe"],
+      "command": "tsx",
+      "args": [
+        "packages/mcp/src/servers/stripe.ts"
+      ],
       "cwd": "<REPO_PATH>",
       "description": "Stripe payment processing",
       "enabled": false
     },
     "revealui-neon": {
-      "command": "pnpm",
-      "args": ["mcp:neon"],
+      "command": "tsx",
+      "args": [
+        "packages/mcp/src/servers/neon.ts"
+      ],
       "cwd": "<REPO_PATH>",
       "description": "NeonDB database operations",
       "enabled": false
     },
     "revealui-supabase": {
-      "command": "pnpm",
-      "args": ["mcp:supabase"],
+      "command": "tsx",
+      "args": [
+        "packages/mcp/src/servers/supabase.ts"
+      ],
       "cwd": "<REPO_PATH>",
       "description": "Supabase project management",
       "enabled": false
     },
     "revealui-playwright": {
-      "command": "pnpm",
-      "args": ["mcp:playwright"],
+      "command": "tsx",
+      "args": [
+        "packages/mcp/src/servers/playwright.ts"
+      ],
       "cwd": "<REPO_PATH>",
       "description": "Browser automation",
       "enabled": false
     },
     "revealui-next-devtools": {
-      "command": "pnpm",
-      "args": ["mcp:next-devtools"],
+      "command": "tsx",
+      "args": [
+        "packages/mcp/src/servers/next-devtools.ts"
+      ],
       "cwd": "<REPO_PATH>",
       "description": "Next.js debugging",
       "enabled": false

--- a/packages/mcp/configs/claude-template.json
+++ b/packages/mcp/configs/claude-template.json
@@ -3,63 +3,49 @@
   "mcpServers": {
     "revealui-code-validator": {
       "command": "tsx",
-      "args": [
-        "<REPO_PATH>/packages/mcp/src/servers/code-validator.ts"
-      ],
+      "args": ["<REPO_PATH>/packages/mcp/src/servers/code-validator.ts"],
       "cwd": "<REPO_PATH>",
       "description": "Code validation - prevents AI-generated technical debt",
       "enabled": true
     },
     "revealui-vercel": {
       "command": "tsx",
-      "args": [
-        "packages/mcp/src/servers/vercel.ts"
-      ],
+      "args": ["packages/mcp/src/servers/vercel.ts"],
       "cwd": "<REPO_PATH>",
       "description": "Vercel deployment and storage management",
       "enabled": false
     },
     "revealui-stripe": {
       "command": "tsx",
-      "args": [
-        "packages/mcp/src/servers/stripe.ts"
-      ],
+      "args": ["packages/mcp/src/servers/stripe.ts"],
       "cwd": "<REPO_PATH>",
       "description": "Stripe payment processing",
       "enabled": false
     },
     "revealui-neon": {
       "command": "tsx",
-      "args": [
-        "packages/mcp/src/servers/neon.ts"
-      ],
+      "args": ["packages/mcp/src/servers/neon.ts"],
       "cwd": "<REPO_PATH>",
       "description": "NeonDB database operations",
       "enabled": false
     },
     "revealui-supabase": {
       "command": "tsx",
-      "args": [
-        "packages/mcp/src/servers/supabase.ts"
-      ],
+      "args": ["packages/mcp/src/servers/supabase.ts"],
       "cwd": "<REPO_PATH>",
       "description": "Supabase project management",
       "enabled": false
     },
     "revealui-playwright": {
       "command": "tsx",
-      "args": [
-        "packages/mcp/src/servers/playwright.ts"
-      ],
+      "args": ["packages/mcp/src/servers/playwright.ts"],
       "cwd": "<REPO_PATH>",
       "description": "Browser automation",
       "enabled": false
     },
     "revealui-next-devtools": {
       "command": "tsx",
-      "args": [
-        "packages/mcp/src/servers/next-devtools.ts"
-      ],
+      "args": ["packages/mcp/src/servers/next-devtools.ts"],
       "cwd": "<REPO_PATH>",
       "description": "Next.js debugging",
       "enabled": false

--- a/packages/mcp/docs/INDEX.md
+++ b/packages/mcp/docs/INDEX.md
@@ -46,7 +46,7 @@ packages/mcp/
 │   ├── README.md         # Main guide
 │   ├── SETUP.md          # Setup instructions
 │   └── servers/          # Per-server docs
-├── migrations/           # Database migrations
+├── (schema lives in `@revealui/db` migrations, not this package)           # Database migrations
 └── package.json
 ```
 

--- a/packages/mcp/docs/README.md
+++ b/packages/mcp/docs/README.md
@@ -49,7 +49,7 @@ All servers are **free** and run locally as npm packages.
 
 ---
 
-**Prerequisites**: Complete [QUICK_START.md](./QUICK_START.md) first for basic setup.
+**Prerequisites**: Complete [QUICK_START.md](../../docs/QUICK_START.md) first for basic setup.
 
 ## MCP-Specific Setup
 
@@ -82,15 +82,15 @@ See [Getting API Keys](#getting-api-keys) section below for instructions.
 
 ```bash
 # Start all servers
-pnpm mcp:all
+# start each server with tsx packages/mcp/src/servers/<name>.ts (no mcp:all alias)
 
 # Or start individually
-pnpm mcp:vercel
-pnpm mcp:stripe
-pnpm mcp:neon
-pnpm mcp:supabase
-pnpm mcp:playwright
-pnpm mcp:next-devtools
+tsx packages/mcp/src/servers/vercel.ts
+tsx packages/mcp/src/servers/stripe.ts
+tsx packages/mcp/src/servers/neon.ts
+tsx packages/mcp/src/servers/supabase.ts
+tsx packages/mcp/src/servers/playwright.ts
+tsx packages/mcp/src/servers/next-devtools.ts
 ```
 
 ---
@@ -221,7 +221,7 @@ pnpm mcp:next-devtools
 3. Copy the key (starts with `neon_`)
 4. Add to `.env`: `NEON_API_KEY=neon_xxx...`
 
-**Detailed guide**: See [NEON_API_KEY_SETUP.md](./ENVIRONMENT_VARIABLES_GUIDE.md)
+**Detailed guide**: See [NEON_API_KEY_SETUP.md](../../docs/ENVIRONMENT-VARIABLES-GUIDE.md)
 
 ### Supabase Credentials
 
@@ -546,10 +546,10 @@ pnpm dev
 **Step 2: Start Next.js DevTools MCP Server (Optional)**
 ```bash
 # In another terminal
-pnpm mcp:next-devtools
+tsx packages/mcp/src/servers/next-devtools.ts
 
 # Or start all MCP servers
-pnpm mcp:all
+# start each server with tsx packages/mcp/src/servers/<name>.ts (no mcp:all alias)
 ```
 
 **Note:** Cursor manages MCP servers automatically, so manual startup is only for testing.
@@ -606,7 +606,7 @@ Complete automated setup with error detection and fixing.
 ### "Connection refused" Error
 
 **Solution:**
-- Ensure MCP servers are running: `pnpm mcp:all`
+- Ensure MCP servers are running: `# start each server with tsx packages/mcp/src/servers/<name>.ts (no mcp:all alias)`
 - Check if port conflicts exist
 - Verify Cursor has restarted after configuration
 
@@ -673,7 +673,7 @@ Complete automated setup with error detection and fixing.
 If you want to test manually:
 ```bash
 # Check if script works
-pnpm mcp:next-devtools
+tsx packages/mcp/src/servers/next-devtools.ts
 
 # Should start MCP server (will run until stopped)
 ```
@@ -686,19 +686,19 @@ pnpm mcp:next-devtools
 
 ```bash
 # Test each server (will timeout after 3 seconds - this is normal)
-timeout 3 pnpm mcp:vercel     # Should show "Starting Vercel MCP Server..."
-timeout 3 pnpm mcp:stripe     # Should show "Starting Stripe MCP Server..."
-timeout 3 pnpm mcp:neon       # Will fail if NEON_API_KEY not set
-timeout 3 pnpm mcp:supabase   # Will fail if SUPABASE_URL not set
-timeout 3 pnpm mcp:playwright # Should show "Starting Playwright MCP Server..."
-timeout 3 pnpm mcp:next-devtools # Should show "Starting Next.js DevTools MCP..."
+timeout 3 tsx packages/mcp/src/servers/vercel.ts     # Should show "Starting Vercel MCP Server..."
+timeout 3 tsx packages/mcp/src/servers/stripe.ts     # Should show "Starting Stripe MCP Server..."
+timeout 3 tsx packages/mcp/src/servers/neon.ts       # Will fail if NEON_API_KEY not set
+timeout 3 tsx packages/mcp/src/servers/supabase.ts   # Will fail if SUPABASE_URL not set
+timeout 3 tsx packages/mcp/src/servers/playwright.ts # Should show "Starting Playwright MCP Server..."
+timeout 3 tsx packages/mcp/src/servers/next-devtools.ts # Should show "Starting Next.js DevTools MCP..."
 ```
 
 ### Verify All Servers Start
 
 ```bash
 # Start all servers (Ctrl+C to stop)
-pnpm mcp:all
+# start each server with tsx packages/mcp/src/servers/<name>.ts (no mcp:all alias)
 
 # Expected output:
 # [0] ✅ Vercel MCP Server running
@@ -714,7 +714,7 @@ pnpm mcp:all
 Use this checklist to verify everything is working:
 
 - [ ] CMS dev server running (`cd apps/admin && pnpm dev`)
-- [ ] Next.js DevTools MCP running (`pnpm mcp:next-devtools`)
+- [ ] Next.js DevTools MCP running (`tsx packages/mcp/src/servers/next-devtools.ts`)
 - [ ] MCP endpoint accessible (`curl http://localhost:4000/_next/mcp`)
 - [ ] Can discover servers (ask: "what servers are running?")
 - [ ] Can query errors (ask: "what errors are in my app?")
@@ -769,9 +769,9 @@ All MCP servers are **completely free**:
 - [MCP Fixes 2025](./MCP_FIXES_2025.md) - Recent MCP updates and fixes
 - [Next.js DevTools Demo](./NEXTJS_DEVTOOLS_MCP_DEMO.md) - Demo and examples
 - [MCP Demo Interaction](./demo-mcp-interaction.md) - Interaction examples
-- [Neon API Key Setup](./ENVIRONMENT_VARIABLES_GUIDE.md) - Detailed Neon setup
+- [Neon API Key Setup](../../docs/ENVIRONMENT-VARIABLES-GUIDE.md) - Detailed Neon setup
 - [Supabase IPv4/IPv6](./DATABASE.md) - Network compatibility
-- [Environment Variables Guide](./ENVIRONMENT_VARIABLES_GUIDE.md) - Configuration
+- [Environment Variables Guide](../../docs/ENVIRONMENT-VARIABLES-GUIDE.md) - Configuration
 - [Master Index](../INDEX.md) - Complete documentation index
 
 ---

--- a/packages/mcp/docs/SETUP.md
+++ b/packages/mcp/docs/SETUP.md
@@ -118,7 +118,7 @@ Validates code content against RevealUI standards.
       "message": "Use logger instead of console.*",
       "line": 1,
       "column": 1,
-      "suggestedFix": "import { logger } from '@revealui/core/logger'..."
+      "suggestedFix": "import { logger } from '@revealui/core/observability/logger'..."
     }
   ],
   "errors": 1,

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -32,8 +32,8 @@ Peer dependencies: `hono` (>=4.3.6), `zod` (>=4.0.0)
 | `OpenAPIHono` | Class | Extended Hono app with OpenAPI route registration |
 | `createRoute` | Function | Define a typed route with request/response schemas |
 | `zValidator` | Middleware | Validate request body/query/params against Zod schemas |
-| `$` | Helper | Shorthand for OpenAPI schema references |
-| `extendZodWithOpenApi` | Function | Add `.openapi()` method to Zod types (re-exported from `@asteasolutions/zod-to-openapi`) |
+| `$` | Helper | Cast a Hono instance to `OpenAPIHono` after chaining (identity type helper; not a schema `$ref` shorthand) |
+| `extendZodWithOpenApi` | Function | Add `.openapi()` method to Zod types (native implementation in this package) |
 | `z` | Re-export | Zod instance for convenience |
 
 ### Types
@@ -89,6 +89,6 @@ See the internal contracts-protocol-pyramid ADR (2026-05-03) §"Phase 3" for the
 ## Related
 
 - Pairs well with `@revealui/contracts` for shared Zod schemas between API and clients
-- Built on `@asteasolutions/zod-to-openapi` for Zod → OpenAPI schema generation
+- Native Zod → OpenAPI extension (no `@asteasolutions/zod-to-openapi` dependency)
 - Supports OpenAPI 3.0 and 3.1 spec output
 - Contracts mirror consumes `@revealui/mcp/contracts-server` (F8 Phase 1 of the protocol-pyramid ADR)

--- a/packages/presentation/README.md
+++ b/packages/presentation/README.md
@@ -1,6 +1,6 @@
 ---
 title: "@revealui/presentation"
-description: "61 native UI components for RevealUI - built with React 19 and Tailwind CSS v4. No external UI library dependencies (ships its own `cn`/`cva`; only `tailwind-merge` is a runtime..."
+description: "65 native UI components for RevealUI - built with React 19 and Tailwind CSS v4. No external UI library dependencies (ships its own `cn`/`cva`; only `tailwind-merge` is a runtime..."
 visibility: public
 status: verified
 audience: user
@@ -8,11 +8,11 @@ audience: user
 
 # @revealui/presentation
 
-61 native UI components for RevealUI  -  built with React 19 and Tailwind CSS v4. No external UI library dependencies (ships its own `cn`/`cva`; only `tailwind-merge` is a runtime dep).
+65 native UI components for RevealUI  -  built with React 19 and Tailwind CSS v4. No external UI library dependencies (ships its own `cn`/`cva`; only `tailwind-merge` is a runtime dep).
 
 ## Features
 
-- **61 Components**  -  Forms, data display, feedback, navigation, media, and layout
+- **65 Components**  -  Forms, data display, feedback, navigation, media, and layout
 - **6 Primitives**  -  Low-level building blocks (Box, Flex, Grid, Heading, Text, Slot)
 - **16 Hooks**  -  Focus trap, click outside, popover, roving tabindex, scroll lock, and more
 - **Headless + Styled**  -  Many components ship both unstyled (headless) and styled (CVA) variants
@@ -34,12 +34,13 @@ import { Box, Flex } from '@revealui/presentation/primitives'
 import { useClickOutside, useFocusTrap } from '@revealui/presentation/hooks'
 ```
 
-## Components (61)
+## Components (65)
 
 ### Layout
 | Component | Description |
 |-----------|-------------|
 | AuthLayout | Authentication page layout |
+| SplitAuthLayout | Split authentication page layout |
 | SidebarLayout | Sidebar + content layout |
 | StackedLayout | Stacked page layout |
 | Navbar | Top navigation bar |
@@ -48,7 +49,7 @@ import { useClickOutside, useFocusTrap } from '@revealui/presentation/hooks'
 ### Form Controls
 | Component | Description |
 |-----------|-------------|
-| Button / ButtonCVA | Action trigger (headless + styled) |
+| Button (ButtonCVA alias) | Action trigger (owned CVA button; not dual-headless) |
 | Input / InputCVA | Text input (headless + styled) |
 | Textarea / TextareaCVA | Multi-line text (headless + styled) |
 | Checkbox / CheckboxCVA | Checkbox (headless + styled) |
@@ -59,6 +60,8 @@ import { useClickOutside, useFocusTrap } from '@revealui/presentation/hooks'
 | Switch | Toggle switch |
 | Label / FormLabel | Form labels |
 | Fieldset | Form field grouping |
+| FormField | Form field wrapper |
+| LinkButton | Link-styled button |
 
 ### Data Display
 | Component | Description |
@@ -105,6 +108,13 @@ import { useClickOutside, useFocusTrap } from '@revealui/presentation/hooks'
 | CodeBlock | Syntax-highlighted code |
 | Kbd / KbdShortcut | Keyboard shortcut display |
 | Link | Styled anchor |
+| PricingTable | Pricing tiers table |
+| ReceiptCard | Receipt / audit-style card |
+| AuditLine | Single audit receipt line |
+| StatusDot | Status indicator dot |
+| VerdictChip | Verdict / decision chip |
+| BrandMark / Wordmark | Brand mark and wordmark |
+| BuiltWithRevealUI | Built-with badge |
 
 ## Primitives (6)
 
@@ -153,47 +163,36 @@ import { useClickOutside, useFocusTrap } from '@revealui/presentation/hooks'
 
 ## Styled vs headless components (the `*CVA` convention)
 
-Several form controls ship **two** implementations under a deliberate, package-wide naming
-convention. The bare name is the headless (Catalyst) component; the `*CVA` suffix is the
-styled, brand-token-driven one:
+**Most components are a single styled implementation.** A few form controls still ship dual
+exports: the bare name is the headless (Catalyst) primitive; the `*CVA` suffix is the
+token-driven styled variant.
 
 | Headless (bare name) | Styled (`*CVA`) | Source files |
 |----------------------|-----------------|--------------|
-| `Button`   | `ButtonCVA`   | `button-headless.tsx`, `Button.tsx` |
 | `Input`    | `InputCVA`    | `input-headless.tsx`, `Input.tsx` |
 | `Textarea` | `TextareaCVA` | `textarea-headless.tsx`, `Textarea.tsx` |
 | `Checkbox` | `CheckboxCVA` | `checkbox-headless.tsx`, `Checkbox.tsx` |
 | `Select`   | `SelectCVA`   | `select-headless.tsx`, `Select.tsx` |
 
-- **Headless (bare name):** a richly composable Catalyst-style primitive with its own
-  `color` / `outline` / `plain` palette system. These also power internal composites (for
-  example, `Dropdown` is built on the headless `Button`).
-- **Styled (`*CVA`):** references the semantic design tokens (`bg-primary`, `--ring`, and so
-  on), so it re-themes automatically with the active brand. `ButtonCVA` is the canonical app
-  button, imported by marketing, admin, and docs.
+**Button is not dual.** `Button` is the owned brand-token button (`Button.tsx`).
+`ButtonCVA` is a deprecated alias of `Button` for older call sites. There is no
+`button-headless.tsx`.
 
-**Which do I use?** Reach for the styled `*CVA` component for app CTAs and forms. It is
-brand-aware and needs no palette wiring. Drop to the headless component only when you need
-Catalyst-style composition or a deliberately fixed, non-brand palette. The two are not
-interchangeable: `Button` (headless) and `ButtonCVA` (styled) are different components with
-different prop APIs, and the convention holds across all five families above.
+### `Button` props
 
-### `ButtonCVA` props
+Two orthogonal axes (see `packages/presentation/src/components/Button.tsx`):
 
-`variant` (`primary`, `secondary`, `destructive`, `outline`, `ghost`, `link`), `size` (`sm`,
-`default`, `lg`, `icon`, `clear`), `asChild`, `isLoading`, plus:
-
-- automatic icon spacing (`gap-2`) and `svg` shrink / pointer-events protection, so an icon
-  and a label compose without manual margins;
-- `glow`: opt-in brand-glow halo for emphasis CTAs, driven by the `--rvui-shadow-glow` token;
-- `shine`: opt-in subtle light sweep on hover.
+- `variant`: semantic colour intent — `brand` | `neutral` | `success` | `warning` | `danger`
+- `appearance`: visual weight — `solid` | `outline` | `ghost` | `link`
+- `size`: `sm` | `default` | `lg` | `icon` | `clear`
+- plus `asChild`, `isLoading`, `glow`, `shine`
 
 ```tsx
-import { ButtonCVA } from '@revealui/presentation/server'
+import { Button } from '@revealui/presentation'
 
-<ButtonCVA variant="primary" glow>Get started</ButtonCVA>
-<ButtonCVA variant="primary" size="lg" shine>Upgrade</ButtonCVA>
-<ButtonCVA isLoading>Saving...</ButtonCVA>
+<Button variant="brand" appearance="solid" glow>Get started</Button>
+<Button variant="brand" appearance="solid" size="lg" shine>Upgrade</Button>
+<Button isLoading>Saving...</Button>
 ```
 
 ## Development
@@ -219,7 +218,7 @@ pnpm dev
 ## When to Use This
 
 - You need accessible, styled UI components (buttons, forms, cards, dialogs) for a RevealUI app
-- You want headless + styled variants so you can choose between full control and quick defaults
+- You want token-driven components, with headless + `*CVA` duals on selected form controls
 - You need React hooks for common UI patterns (focus trap, click outside, popover positioning)
 - **Not** for CMS admin UI  -  `@revealui/core/admin` provides the admin dashboard
 - **Not** for rich text editing  -  use `@revealui/core/richtext/client` (Lexical-based)
@@ -228,7 +227,7 @@ pnpm dev
 
 - **Sovereign**: No external UI library dependencies (no Radix, no shadcn). Ships its own `cn` + `cva` implementations; only `tailwind-merge` is a runtime dep for class conflict resolution
 - **Orthogonal**: Components, primitives, and hooks are independent subpath exports with no cross-cutting entanglement
-- **Justifiable**: Every component ships headless and styled variants because different contexts need different levels of control
+- **Justifiable**: Selected form controls ship headless + styled duals; most components are a single owned implementation
 
 ## Related
 

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -73,8 +73,8 @@ Runtime dependencies: `@revealui/contracts`, `@revealui/utils`, `parse5` (HTML s
 | `EnvelopeEncryption` | Class | Envelope encryption (data key + master key) |
 | `FieldEncryption` | Class | Encrypt/decrypt individual database fields |
 | `KeyRotationManager` | Class | Scheduled key rotation with re-encryption |
-| `DataMasking` | Class | Mask sensitive data for display (email, phone, SSN) |
-| `TokenGenerator` | Class | Secure random token generation |
+| `DataMasking` | Object helpers | Mask sensitive data for display (email, phone, SSN) |
+| `TokenGenerator` | Object helpers | Secure random token generation |
 
 ### Security Alerting
 
@@ -97,7 +97,7 @@ Server-only (`@revealui/security/server`).
 | `createAuditMiddleware` | Function | Hono middleware for automatic request auditing |
 | `InMemoryAuditStorage` | Class | In-memory storage for testing |
 
-### GDPR Compliance
+### GDPR (server-only — import from `@revealui/security/server`) Compliance
 
 | Export | Type | Purpose |
 |--------|------|---------|

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -18,11 +18,11 @@ External service integrations for RevealUI  -  Stripe (billing + circuit breaker
 - **Stripe Integration**: Payment processing and billing operations with circuit breaker
 - **Email**: Transactional email helpers
 - **Type-safe**: Full TypeScript support
-- **Server & Client**: Separate exports for server-side and client-side usage
+- **Server surface**: Root and `./server` export the same server Stripe/email helpers (no distinct client Stripe bundle)
 
 ## Installation
 
-This package is private and only used within the RevealUI monorepo via `workspace:*` references.
+This package is published (`publishConfig.access: public`) and consumed in the monorepo via `workspace:*` references.
 
 ## Usage
 
@@ -117,7 +117,7 @@ pnpm --filter @revealui/services test:coverage
 
 ## Related Documentation
 
-- [Environment Variables Guide](../../docs/ENVIRONMENT_VARIABLES_GUIDE.md) - Service API keys setup
+- [Environment Variables Guide](../../docs/ENVIRONMENT-VARIABLES-GUIDE.md) - Service API keys setup
 - [Architecture](../../docs/ARCHITECTURE.md) - Service integration patterns
 
 ## License

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -153,9 +153,9 @@ Offline mutation replay with configurable conflict strategies:
 import { resolveConflict, coalesceMutations, replayMutations } from '@revealui/sync'
 ```
 
-- `resolveConflict(conflict, strategy)` — resolve a detected conflict using `last-write-wins`, `merge`, or `reject`
+- `resolveConflict(conflict, strategy)` — resolve a detected conflict using `last-write-wins`, `server-wins`, or `manual` (`packages/sync/src/conflict-resolution.ts`)
 - `coalesceMutations(mutations)` — deduplicate and squash offline mutations before replay
-- `replayMutations(mutations, executor)` — replay a queue of offline mutations against the server
+- `replayMutations(mutations, strategy?)` — replay a queue of offline mutations (default strategy `last-write-wins`)
 
 ## Collaboration (Yjs)
 

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -202,10 +202,10 @@ describe('API Integration', () => {
 ## Test Coverage
 
 Coverage thresholds:
-- **Statements**: ≥ 70%
-- **Branches**: ≥ 60%
-- **Functions**: ≥ 70%
-- **Lines**: ≥ 70%
+- **Statements**: ≥ 35% (`packages/test/vitest.config.ts`)
+- **Branches**: ≥ 30%
+- **Functions**: ≥ 25%
+- **Lines**: ≥ 35%
 
 Run coverage report:
 ```bash


### PR DESCRIPTION
## Summary

Session **C** of GAP-407 MD truth W2 (packages + apps markdown only).

Supersedes #2079 (that branch’s merge history polluted the PR file list with Session A harnesses manager paths; this cut is docs-only from current `origin/test`).

## DOC-DRIFT fixed (vs code)

| Area | Fix |
|------|-----|
| `@revealui/db` | 85→**96** tables; migrations 18→**28**; package.json description |
| `@revealui/presentation` | 61→**65** components; Button single CVA + real variant/appearance axes |
| `apps/admin` | presentation count 59→**65** |
| Package conventions | apps list uses `server` (not `api`/`studio`) |
| core / cli | storage **R2-only** |
| `@revealui/mcp` | no `pnpm mcp:*`; launch via `tsx packages/mcp/src/servers/*.ts` |
| `@revealui/ai` | observability export honesty; filter `@revealui/ai`; no validate-production.sh |
| sync / config / openapi / harnesses README / test / services / security | API, load priority, adapter roster, thresholds, wording |

## Out of scope

- `packages/harnesses` **manager/source** (Session A) — only README claim text here
- `apps/docs/public/**` mirrors (Session B `docs/` SoT + `copy-docs.sh`)

## Test plan

- [ ] Counts: `pgTable(` under `packages/db/src/schema` → 96
- [ ] Presentation component `.tsx` (non-`_`) count → 65
- [ ] No `packages/harnesses/src/**` in this PR
- [ ] CI green; security review gate should pass or HOLD only on README path substrings if any (not manager code)