### PR TITLE
feat(harnesses): export Plane A hardlines as package definitions (GAP-406)

### DIFF
--- a/packages/harnesses/src/__tests__/content-api.test.ts
+++ b/packages/harnesses/src/__tests__/content-api.test.ts
@@ -7,7 +7,7 @@ describe('Content Public API', () => {
       const manifest = buildManifest();
       expect(manifest.version).toBe(1);
       expect(manifest.generatedAt).toBeTruthy();
-      expect(manifest.rules.length).toBe(11);
+      expect(manifest.rules.length).toBe(15);
       expect(manifest.commands.length).toBe(4);
       expect(manifest.agents.length).toBe(6);
       expect(manifest.skills.length).toBe(10);
@@ -47,18 +47,18 @@ describe('Content Public API', () => {
   describe('listContent', () => {
     it('returns correct counts', () => {
       const summary = listContent();
-      expect(summary.rules).toBe(11);
+      expect(summary.rules).toBe(15);
       expect(summary.commands).toBe(4);
       expect(summary.agents).toBe(6);
       expect(summary.skills).toBe(10);
       expect(summary.preambles).toBe(4);
-      expect(summary.total).toBe(31);
+      expect(summary.total).toBe(35);
     });
 
     it('accepts an explicit manifest', () => {
       const manifest = buildManifest();
       const summary = listContent(manifest);
-      expect(summary.total).toBe(31);
+      expect(summary.total).toBe(35);
     });
   });
 

--- a/packages/harnesses/src/content/definitions/preambles/index.ts
+++ b/packages/harnesses/src/content/definitions/preambles/index.ts
@@ -5,7 +5,15 @@ export const preambles: PreambleTier[] = [
     tier: 1,
     name: 'Identity',
     description: 'Always injected  -  core project identity and structure',
-    ruleIds: ['monorepo', 'tracker-first', 'quality-over-speed'],
+    ruleIds: [
+      'monorepo',
+      'tracker-first',
+      'quality-over-speed',
+      'code-over-docs',
+      'durable-solutions',
+      'disposition-actions',
+      'adapter-only',
+    ],
   },
   {
     tier: 2,

--- a/packages/harnesses/src/content/definitions/rules/adapter-only.ts
+++ b/packages/harnesses/src/content/definitions/rules/adapter-only.ts
@@ -1,0 +1,52 @@
+import type { Rule } from '../../schemas/rule.js';
+
+/**
+ * Claude/Grok/Cursor/etc. are adapters only; no full hardline mirrors (GAP-406).
+ */
+export const adapterOnlyRule: Rule = {
+  id: 'adapter-only',
+  tier: 'oss',
+  name: 'Adapter Only',
+  description:
+    'Harness homes consume RevealUI-native policy and TRACKER; they must not full-copy shared hardlines',
+  scope: 'global',
+  preambleTier: 1,
+  tags: ['harness', 'hardline', 'manager', 'adapters'],
+  content: `# Adapter Only (no dual-home mirrors)
+
+Claude Code, Grok, Cursor, OpenCode, VS Code, and product agents are **adapters**.
+Shared policy, product tools, coordination, and day-to-day backlog live in the
+RevealUI native layer. Adapters communicate with that layer; they do not re-author
+shared hardlines.
+
+## Authority order
+
+1. **Project manager** — \`./.revealui/manager.json\` (+ \`.revealui/content/\`)
+2. **Package definitions** — \`@revealui/harnesses\` content definitions (this rule set)
+3. **Fleet TRACKER** — free-surface board (\`docs/TRACKER.md\` / private planning tree)
+4. **Adapter homes** — thin pointers, vendor tool names, TUI ops only
+
+## Rules
+
+1. **No new full hardline body** under vendor homes (\`~/.claude/rules\` forks of
+   shared policy, \`~/.grok/rules\` full copies). Pointers only for shared policy.
+2. **Equal-rank vendors.** No adapter outranks another under the manager.
+3. **Product I/O** goes through RevealUI MCP (governed user + receipts), not
+   per-harness side channels for product actions.
+4. **Session orientation** uses the shared tracker/manager check (one script),
+   not dual banners re-authored per adapter.
+5. **Quality over speed** still applies; thinning mirrors is not an excuse to
+   skip proof.
+
+## Illegal mirror (stop / thin)
+
+A vendor rule file that restates a full Plane A hardline body instead of citing
+the package definition or machine-global owner is an illegal mirror. Fix by
+thinning to a pointer, not by copying more prose.
+
+## References
+
+- ADR harness policy / runtime / launch planes
+- GAP-406, GAP-318, tracker-first, quality-over-speed
+`,
+};

--- a/packages/harnesses/src/content/definitions/rules/code-over-docs.ts
+++ b/packages/harnesses/src/content/definitions/rules/code-over-docs.ts
@@ -1,0 +1,50 @@
+import type { Rule } from '../../schemas/rule.js';
+
+/**
+ * Source of truth is always the source code (owner hardline 2026-07-09).
+ * Package-portable form for equal-rank adapters via manager content.
+ */
+export const codeOverDocsRule: Rule = {
+  id: 'code-over-docs',
+  tier: 'oss',
+  name: 'Code Over Docs',
+  description:
+    'Source code defines system behavior; docs describe it. On disagreement, trust code and fix the doc.',
+  scope: 'global',
+  preambleTier: 1,
+  tags: ['docs', 'sdlc', 'hardline', 'truth'],
+  content: `# Code Over Docs
+
+The source code is the single source of truth. Documentation (READMEs, specs,
+plans, handoffs, ADRs, comments, gap files, memory) *describes* the system; the
+code *defines* it. When any doc and the code disagree, the code is correct and
+the doc is stale.
+
+## Apply every session
+
+1. **Verify against code before acting.** Never implement, review, plan, or
+   report from a doc claim alone. Load-bearing claims need \`file:line\` in
+   actual source (or a test that exercises the path).
+2. **On disagreement: trust code, then fix the doc.** A doc↔code conflict is a
+   doc bug. Do not "fix" working code to match stale prose without an explicit
+   decision that the doc's behavior is the intended one.
+3. **Doc-tier authority is subordinate.** Handoff / plan tiers resolve
+   doc-vs-doc conflicts only. Code outranks all tiers on factual system
+   behavior.
+4. **Prioritize code work over doc work.** Correct code outranks nicer prose
+   about code. Doc sweeps ride behind the code fixes they describe.
+5. **Comments are docs too.** Stale headers or comments are drift; the code
+   path below them is what you trust.
+
+## Explicitly rejected
+
+- Treating gap files, handoffs, or ADRs as proof of runtime behavior
+- Marking exhaustive / md-truth claims verified without reading the file body
+- Shipping doc-only "fixes" that leave wrong code unchanged
+
+## References
+
+- Sibling: quality-over-speed, durable-solutions, tracker-first
+- Exhaustive / md-truth programs prove claims against code, not against docs
+`,
+};

--- a/packages/harnesses/src/content/definitions/rules/disposition-actions.ts
+++ b/packages/harnesses/src/content/definitions/rules/disposition-actions.ts
@@ -1,0 +1,58 @@
+import type { Rule } from '../../schemas/rule.js';
+
+/**
+ * Agents propose; owners dispose (owner hardline 2026-07-10).
+ */
+export const dispositionActionsRule: Rule = {
+  id: 'disposition-actions',
+  tier: 'oss',
+  name: 'Disposition Actions',
+  description:
+    'Agent work is proposal-shaped by default; merge, gate labels, force-push, and repo mutation need named owner authorization',
+  scope: 'global',
+  preambleTier: 1,
+  tags: ['git', 'security', 'hardline', 'governance'],
+  content: `# Disposition Actions — Propose, Don't Dispose
+
+Agent work is **proposal-shaped by default**. A proposal produces an artifact
+someone else can act on; a disposition consummates an outcome. Proposals never
+need special authorization; dispositions always do.
+
+## Always safe (proposal-shaped)
+
+- Reading, grepping, auditing; empirical tests in session scratch
+- Posting review or verdict comments on PRs
+- Creating worktrees, committing to fresh branches, pushing feature branches
+- Opening PRs, filing gaps, authoring specs and lane docs
+
+## Disposition-shaped (requires named in-session owner authorization)
+
+- Merging any PR the agent authored this session
+- Merging any PR whose subject matter is security (design docs included)
+- Applying gate-clearing labels (\`sec-review:approved\` and siblings)
+- Deleting remote branches
+- Mutating repo settings, rulesets, required checks, Actions secrets, webhooks
+- Force pushes, history rewrites, removing another session's worktree
+
+A blanket preference in memory ("merge green PRs") does **not** cover
+security-classed items. Only named in-session words or a standing settings
+allow rule do.
+
+## Never bundle a disposition with anything else
+
+One disposition action per shell command, alone. Mid-bundle blocks leave half-
+executed state.
+
+## When a PR is ready and no authorization exists
+
+Stop at the open PR. List the exact one-line owner command under owner actions.
+Do not re-send a blocked command or accomplish the disposition through another
+tool.
+
+## References
+
+- Sibling: tracker-first, quality-over-speed, durable-solutions
+- Adapter glue may deny merge/force at the permission layer; this rule is the
+  policy body adapters must not re-author in full.
+`,
+};

--- a/packages/harnesses/src/content/definitions/rules/durable-solutions.ts
+++ b/packages/harnesses/src/content/definitions/rules/durable-solutions.ts
@@ -1,0 +1,55 @@
+import type { Rule } from '../../schemas/rule.js';
+
+/**
+ * Long-term root-cause fixes only; hotfixes are registered debt (owner 2026-07-21).
+ */
+export const durableSolutionsRule: Rule = {
+  id: 'durable-solutions',
+  tier: 'oss',
+  name: 'Durable Solutions',
+  description:
+    'Prefer long-term root-cause fixes in the owning layer; register any unavoidable hotfix the same turn',
+  scope: 'global',
+  preambleTier: 1,
+  tags: ['sdlc', 'hardline', 'hotfix', 'quality'],
+  content: `# Durable Solutions
+
+Prefer long-term durable solutions. Fix root causes in the owning layer (shared
+lib, env bootstrap, policy, product primitive) so the failure class cannot
+recur. Session-local patches, one-off shell recipes, and "works on my machine"
+overrides are not done unless the owner accepts a **registered hotfix**.
+
+## Rules
+
+1. **Durable first.** Extend the real primitive; do not invent a parallel path.
+2. **Hotfixes are debt.** Allowed only when production or a peer must be
+   unblocked *now*. Register the same turn with symptom, temporary shape,
+   durable target, paths, and optional gap id.
+3. **Every hotfix has a destination.** Pending entries surface at session
+   boundaries until converted.
+4. **Unregistered hotfixes are policy violations** (same class as orphan temp
+   scripts).
+
+## Non-durable shapes (register or refuse)
+
+| Shape | Examples |
+|-------|----------|
+| Env / machine only | Editing gitignored \`.env.local\` without fixing loaders |
+| Session-only | Scratch scripts left for the owner; undocumented escapes |
+| Symptom patch | Catch-and-ignore without root fix |
+| Parallel path | Second seed script or resolver "just for X" |
+| Silent demotion | "We'll harden later" with no registry entry |
+
+## Durable shapes
+
+- Shared module / rule / hook / CI gate that fails closed for the class
+- Documented escape hatches with explicit env flags
+- Gaps/ADRs when the durable fix needs multi-session design
+- Tests that lock the durable behavior (prove red, then green)
+
+## References
+
+- Sibling: extend-before-create, quality-over-speed, code-over-docs
+- Operator registry (Studio): \`hotfix.js register\` / \`resolve\` / \`audit\`
+`,
+};

--- a/packages/harnesses/src/content/definitions/rules/index.ts
+++ b/packages/harnesses/src/content/definitions/rules/index.ts
@@ -1,8 +1,12 @@
 import type { Rule } from '../../schemas/rule.js';
+import { adapterOnlyRule } from './adapter-only.js';
 import { agentDispatchRule } from './agent-dispatch.js';
 import { biomeRule } from './biome.js';
 import { codeAnalysisPolicyRule } from './code-analysis-policy.js';
+import { codeOverDocsRule } from './code-over-docs.js';
 import { databaseRule } from './database.js';
+import { dispositionActionsRule } from './disposition-actions.js';
+import { durableSolutionsRule } from './durable-solutions.js';
 import { monorepoRule } from './monorepo.js';
 import { parameterizationRule } from './parameterization.js';
 import { qualityOverSpeedRule } from './quality-over-speed.js';
@@ -12,10 +16,14 @@ import { trackerFirstRule } from './tracker-first.js';
 import { unusedDeclarationsRule } from './unused-declarations.js';
 
 export const rules: Rule[] = [
+  adapterOnlyRule,
   agentDispatchRule,
   biomeRule,
   codeAnalysisPolicyRule,
+  codeOverDocsRule,
   databaseRule,
+  dispositionActionsRule,
+  durableSolutionsRule,
   monorepoRule,
   parameterizationRule,
   qualityOverSpeedRule,


### PR DESCRIPTION
## Summary
Add package-portable hardline definitions under `@revealui/harnesses` so equal-rank adapters consume one authoring home (GAP-406):

- `code-over-docs`
- `durable-solutions`
- `disposition-actions`
- `adapter-only`

Also assign them to preamble tier 1 (Identity) with existing `tracker-first` / `quality-over-speed`.

## Test plan
- [x] `pnpm exec vitest run src/__tests__/content-api.test.ts` (14 pass)
- [x] `claude-code-content-generator` + `content-schemas` tests
- [x] Local phase-1 gate on push (PASS)

## Related
GAP-406 residual · pairs with jv orientation script + claude-config shared SessionStart call