### PR TITLE
feat(harnesses): definition ↔ generator content snapshot drift CI (GAP-406)

### DIFF
--- a/packages/harnesses/README.md
+++ b/packages/harnesses/README.md
@@ -61,12 +61,23 @@ pnpm exec revealui-harnesses manager check
 pnpm exec revealui-harnesses content sync
 # equivalent:
 pnpm exec revealui-harnesses content sync --generator claude-code
+
+# Definition ↔ committed generator snapshot (CI lock, GAP-406)
+pnpm --filter @revealui/harnesses content:snapshot:check
+# After editing content/definitions/**, refresh hashes:
+pnpm --filter @revealui/harnesses content:snapshot:write
+# Local disk vs definitions (when .revealui/content exists):
+pnpm exec revealui-harnesses content diff --check
 ```
 
 `content sync` without `--generator` uses `DEFAULT_CONTENT_GENERATOR_ID`
 (`claude-code`). That generator emits into **`.revealui/content/`** (the manager
 tree). Vendor trees stay adapters; do not full-copy hardlines into `~/.claude`
 or `~/.grok`.
+
+Committed SHA-256 locks live in `content-snapshots/<generatorId>.json`. Unit
+tests and the local CI gate fail when definitions change without refreshing
+those files in the same PR.
 
 ## CLI
 

--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -1,0 +1,130 @@
+{
+  "version": 1,
+  "generatorId": "claude-code",
+  "files": [
+    {
+      "relativePath": ".revealui/content/agents/builder.md",
+      "sha256": "23f88ef81bb1f491b72d28ee8547efb347ef62e01ecabb1953852e3c00704dcc"
+    },
+    {
+      "relativePath": ".revealui/content/agents/docs-sync.md",
+      "sha256": "a11efaa434d85d473240a0dddd1406484a0a5c192f4257c7cf84d9cfe2da7a93"
+    },
+    {
+      "relativePath": ".revealui/content/agents/gate-runner.md",
+      "sha256": "ef0f23bb19408a779c48e31d16ea8319d51850c78d5c0e1266d9b038fc1db1a9"
+    },
+    {
+      "relativePath": ".revealui/content/agents/linter.md",
+      "sha256": "05c4ed2419edc0b6c9158b61fbf89883c39ad9d918944202bccf834cef91df1d"
+    },
+    {
+      "relativePath": ".revealui/content/agents/security-reviewer.md",
+      "sha256": "d381b193ce8243ab97fe94ee536b8be3327dc33ea566908c43e571012580e3aa"
+    },
+    {
+      "relativePath": ".revealui/content/agents/tester.md",
+      "sha256": "835e1cf0da42614d375b4e671aa5c635044a5e306c07df89dbcd94078c08c329"
+    },
+    {
+      "relativePath": ".revealui/content/commands/audit.md",
+      "sha256": "599f5e84841b49adc751fea3deaa193477b7c8670afa2b28aaf35b11d8733771"
+    },
+    {
+      "relativePath": ".revealui/content/commands/gate.md",
+      "sha256": "70a9f25da6147d06cd9108db6e1e86c27e42791cbddf290989696ff367791a2f"
+    },
+    {
+      "relativePath": ".revealui/content/commands/new-package.md",
+      "sha256": "f7a9cec2fe1eafbb13ce7c0c96f98bedab85a864085d7facd20a9b8ed17b8c2c"
+    },
+    {
+      "relativePath": ".revealui/content/commands/stripe-best-practices.md",
+      "sha256": "60508313d8412871180cd9897dd49eebc178277cb877aa0e35ef02d621ef7b1f"
+    },
+    {
+      "relativePath": ".revealui/content/rules/agent-dispatch.md",
+      "sha256": "0b2497c1817e23a1d4902cb5b5889cec4a6f6526179d7273622066705e444fe8"
+    },
+    {
+      "relativePath": ".revealui/content/rules/biome.md",
+      "sha256": "053ac61189b299d733a99935c8b34285cc970c26b5b0b7d2ee7dc70ad1082d71"
+    },
+    {
+      "relativePath": ".revealui/content/rules/code-analysis-policy.md",
+      "sha256": "0ec5699691c7505d6c9ac3fa7b2150c546b5e738e0089af42732ac1a6272a04e"
+    },
+    {
+      "relativePath": ".revealui/content/rules/database.md",
+      "sha256": "cb66ad35bf9cd6c61846bb6b9ad1d1ec941f72b04a179441e7ccf0a1b873b341"
+    },
+    {
+      "relativePath": ".revealui/content/rules/monorepo.md",
+      "sha256": "1fa60d068a0f0b6429cf13bd2821b9a92503187770e2b3ffe2065d4406c0e4f7"
+    },
+    {
+      "relativePath": ".revealui/content/rules/parameterization.md",
+      "sha256": "bfe4e287ca33926d9ee04f9eec6490ddffb04058594a4a9e1a20a5eb9e82e9e1"
+    },
+    {
+      "relativePath": ".revealui/content/rules/quality-over-speed.md",
+      "sha256": "7481acbbdcde46aa7c02ecdb7a72b60f9d270be8777e1ae8c0172dd1a0ff5277"
+    },
+    {
+      "relativePath": ".revealui/content/rules/skills-usage.md",
+      "sha256": "8607d1d76c2800137808a5a5e72185ad2a632a0fb1553b59d55b3246b412d647"
+    },
+    {
+      "relativePath": ".revealui/content/rules/tailwind.md",
+      "sha256": "498578c8bc2c7d3370667efd6a60d17c09903ab774659ce5a031b3acdb70e6d3"
+    },
+    {
+      "relativePath": ".revealui/content/rules/tracker-first.md",
+      "sha256": "a31d4380657565bcb45e65c34458de01e77d0f547b9304e627f6764d90f55f1c"
+    },
+    {
+      "relativePath": ".revealui/content/rules/unused-declarations.md",
+      "sha256": "34382001e3bf3eb36d655006542a8fe109b1210413676e8ac80bbb810d432f84"
+    },
+    {
+      "relativePath": ".revealui/content/skills/db-migrate/SKILL.md",
+      "sha256": "415ca913640e24181be20dc1b7867c4a61fbec617c15e54ca5b6887306fd560d"
+    },
+    {
+      "relativePath": ".revealui/content/skills/preflight/SKILL.md",
+      "sha256": "14db3848cd2a89f04e56b1dab1a82197a3c030fe292cd6d6baa6fff1cf960b1b"
+    },
+    {
+      "relativePath": ".revealui/content/skills/revealui-conventions/SKILL.md",
+      "sha256": "178e4c7365a0fbaf708b9e32e36f6b514c1f4bba5dbef00ad6545549036fe8f0"
+    },
+    {
+      "relativePath": ".revealui/content/skills/revealui-db/SKILL.md",
+      "sha256": "e323d7a738c88c3431df034ce1a773a60c90ea28f8820b9641db53ef95cc92b0"
+    },
+    {
+      "relativePath": ".revealui/content/skills/revealui-debugging/SKILL.md",
+      "sha256": "e78d583b7bd0574107f6d3fc5e4ee20d2db53ea3f4b0a12d5ff428d169bb0ad8"
+    },
+    {
+      "relativePath": ".revealui/content/skills/revealui-review/SKILL.md",
+      "sha256": "9e7d85e7b028e9668c36a31723abc8ede637dcfac65236aa8b0c135c91fdc895"
+    },
+    {
+      "relativePath": ".revealui/content/skills/revealui-safety/SKILL.md",
+      "sha256": "b0e1146445f425c9c1d4f0e1fa3170ad2ccb573a5816d8a977d2994e631efdd9"
+    },
+    {
+      "relativePath": ".revealui/content/skills/revealui-tdd/SKILL.md",
+      "sha256": "fdb25f906b7613b3dd24c95f9b3e581557c042c82a1acf2c0bfa91d039bb5e4e"
+    },
+    {
+      "relativePath": ".revealui/content/skills/revealui-testing/SKILL.md",
+      "sha256": "30e26f6bd81af5edf702e9079c09cd978c3ee8ef6a5e918906ee61d18b20e556"
+    },
+    {
+      "relativePath": ".revealui/content/skills/tailwind-4-docs/SKILL.md",
+      "sha256": "af697a576ad14aa59a7dff9864b2a95ee9a08bc18b2625eda76e7357be98bb13"
+    }
+  ]
+}

--- a/packages/harnesses/content-snapshots/cursor.json
+++ b/packages/harnesses/content-snapshots/cursor.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "generatorId": "cursor",
+  "files": [
+    {
+      "relativePath": ".cursor/hooks.json",
+      "sha256": "b372095f362cf16864ed62b8307e613bcbef3a73df428abd3f1289cf7497d915"
+    }
+  ]
+}

--- a/packages/harnesses/content-snapshots/opencode.json
+++ b/packages/harnesses/content-snapshots/opencode.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "generatorId": "opencode",
+  "files": [
+    {
+      "relativePath": ".opencode/agents/builder.md",
+      "sha256": "ff56efad6e406a37f74f219ff7b968a6dfa93f91c1bdc777a82bf26add65d3b8"
+    },
+    {
+      "relativePath": ".opencode/agents/docs-sync.md",
+      "sha256": "9ee6323a1f307d4dda338405ba33f1007d6fea02be7e589befc456dbf0668616"
+    },
+    {
+      "relativePath": ".opencode/agents/gate-runner.md",
+      "sha256": "5e0a5f04999866b27dac38487350908b880b955698b50c41adbb93ea567664f3"
+    },
+    {
+      "relativePath": ".opencode/agents/linter.md",
+      "sha256": "a010a690b016d807bba0408a84887c37cd0632c23d79b55b41c6a06705f2b34f"
+    },
+    {
+      "relativePath": ".opencode/agents/security-reviewer.md",
+      "sha256": "27b8070965ea218c309fddee8db196e2b1e663cbfcca0d8ad5a4b961c2f523c6"
+    },
+    {
+      "relativePath": ".opencode/agents/tester.md",
+      "sha256": "09b1670b5027fb97d07e2752e0b2fbdc4fc5fc2fb02fc8252fad266931aa4c44"
+    },
+    {
+      "relativePath": ".opencode/commands/audit.md",
+      "sha256": "2894e093ee9d1442f3ba5c7f082b90358e337e2bab1f37be5b1a860cef69ed7d"
+    },
+    {
+      "relativePath": ".opencode/commands/gate.md",
+      "sha256": "151d065e5db72875eb1dc27c4457c310ad54847004a9ca5d37e1715a50f8e94f"
+    },
+    {
+      "relativePath": ".opencode/commands/new-package.md",
+      "sha256": "1f1a31766b225b75582af388f891600a6749cbb532e71ad018dcf133b3dc4d14"
+    },
+    {
+      "relativePath": ".opencode/commands/stripe-best-practices.md",
+      "sha256": "558ae6a7f17ae42c33ecfd6c69c803ccb1a84a49cad0ab113433172ed686495a"
+    }
+  ]
+}

--- a/packages/harnesses/content-snapshots/vscode.json
+++ b/packages/harnesses/content-snapshots/vscode.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "generatorId": "vscode",
+  "files": [
+    {
+      "relativePath": ".revealui/vscode-plugin/plugin.json",
+      "sha256": "8a87582710e2358645496b1776a5edea3f6618d1d9ec5338431118f7b7abd6b8"
+    }
+  ]
+}

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -75,6 +75,7 @@
   },
   "files": [
     "dist",
+    "content-snapshots",
     "LICENSE"
   ],
   "funding": {
@@ -96,7 +97,9 @@
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "content:snapshot:check": "vitest run src/__tests__/content-snapshot.test.ts",
+    "content:snapshot:write": "tsx scripts/write-content-snapshots.mts"
   },
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/harnesses/scripts/write-content-snapshots.mts
+++ b/packages/harnesses/scripts/write-content-snapshots.mts
@@ -1,0 +1,10 @@
+/**
+ * Refresh committed generator content snapshots (GAP-406).
+ * Run: pnpm --filter @revealui/harnesses content:snapshot:write
+ */
+import { writeAllContentSnapshots } from '../src/content/snapshot.ts';
+
+const paths = writeAllContentSnapshots();
+for (const p of paths) {
+  process.stdout.write(`wrote ${p}\n`);
+}

--- a/packages/harnesses/src/__tests__/content-snapshot.test.ts
+++ b/packages/harnesses/src/__tests__/content-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';

--- a/packages/harnesses/src/__tests__/content-snapshot.test.ts
+++ b/packages/harnesses/src/__tests__/content-snapshot.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildContentSnapshot,
+  buildManifest,
+  checkAllContentSnapshots,
+  checkContentSnapshot,
+  DEFAULT_CONTENT_GENERATOR_ID,
+  getContentSnapshotsDir,
+  hashContent,
+  listGenerators,
+  loadContentSnapshot,
+  snapshotPathFor,
+  writeContentSnapshot,
+} from '../content/index.js';
+
+describe('content snapshot (definition ↔ generator lock, GAP-406)', () => {
+  const temps: string[] = [];
+
+  afterEach(() => {
+    for (const d of temps) {
+      rmSync(d, { recursive: true, force: true });
+    }
+    temps.length = 0;
+  });
+
+  it('buildContentSnapshot is deterministic for the default generator', () => {
+    const a = buildContentSnapshot(DEFAULT_CONTENT_GENERATOR_ID);
+    const b = buildContentSnapshot(DEFAULT_CONTENT_GENERATOR_ID);
+    expect(a).toEqual(b);
+    expect(a.files.length).toBeGreaterThan(0);
+    expect(a.generatorId).toBe(DEFAULT_CONTENT_GENERATOR_ID);
+    expect(a.files[0]?.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('hashContent is stable for a fixed string', () => {
+    expect(hashContent('hello\n')).toBe(hashContent('hello\n'));
+    expect(hashContent('hello\n')).not.toBe(hashContent('hello'));
+  });
+
+  it('checkContentSnapshot reports hash-mismatch and missing paths', () => {
+    const live = buildContentSnapshot(DEFAULT_CONTENT_GENERATOR_ID);
+    const broken = {
+      ...live,
+      files: live.files.map((f, i) => (i === 0 ? { ...f, sha256: '0'.repeat(64) } : f)),
+    };
+    const mismatch = checkContentSnapshot(broken);
+    expect(mismatch.ok).toBe(false);
+    expect(mismatch.drifts.some((d) => d.kind === 'hash-mismatch')).toBe(true);
+
+    const missingGenerate = {
+      ...live,
+      files: [
+        ...live.files,
+        { relativePath: '.revealui/content/rules/does-not-exist.md', sha256: 'a'.repeat(64) },
+      ],
+    };
+    const missing = checkContentSnapshot(missingGenerate);
+    expect(missing.ok).toBe(false);
+    expect(missing.drifts.some((d) => d.kind === 'missing-in-generate')).toBe(true);
+  });
+
+  it('write + load round-trips a snapshot on disk', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'content-snap-'));
+    temps.push(dir);
+    const snap = buildContentSnapshot('cursor');
+    const path = join(dir, 'cursor.json');
+    writeContentSnapshot(path, snap);
+    const loaded = loadContentSnapshot(path);
+    expect(loaded).toEqual(snap);
+    expect(checkContentSnapshot(loaded).ok).toBe(true);
+  });
+
+  it('committed snapshots cover every registered generator (CI lock)', () => {
+    const dir = getContentSnapshotsDir();
+    const all = checkAllContentSnapshots({ snapshotsDir: dir });
+    if (!all.ok) {
+      const detail = [
+        ...all.errors,
+        ...all.results
+          .filter((r) => !r.ok)
+          .flatMap((r) =>
+            r.drifts.slice(0, 10).map((d) => `${r.generatorId}: ${d.kind} ${d.relativePath}`),
+          ),
+      ].join('\n');
+      throw new Error(
+        `Content snapshot drift. Run: pnpm --filter @revealui/harnesses content:snapshot:write\n${detail}`,
+      );
+    }
+    expect(all.results.map((r) => r.generatorId).sort()).toEqual(listGenerators().sort());
+    for (const r of all.results) {
+      expect(r.fileCount).toBeGreaterThan(0);
+      expect(snapshotPathFor(r.generatorId, dir)).toContain(r.generatorId);
+    }
+  });
+
+  it('snapshot file count tracks manifest for claude-code rules+cmds+agents+skills', () => {
+    const manifest = buildManifest();
+    const snap = buildContentSnapshot(DEFAULT_CONTENT_GENERATOR_ID, { manifest });
+    const expected =
+      manifest.rules.length +
+      manifest.commands.length +
+      manifest.agents.length +
+      manifest.skills.length;
+    expect(snap.files.length).toBe(expected);
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -21,13 +21,18 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
   buildManifest,
+  checkAllContentSnapshots,
+  checkContentSnapshot,
   DEFAULT_CONTENT_GENERATOR_ID,
   diffContent,
   generateContent,
   listContent,
   listGenerators,
+  loadContentSnapshot,
   MANAGER_CONTENT_OUTPUT,
+  snapshotPathFor,
   validateManifest,
+  writeAllContentSnapshots,
 } from './content/index.js';
 import { HarnessCoordinator } from './coordinator.js';
 import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
@@ -132,6 +137,7 @@ async function handleContentCommand(subcommand: string | undefined, args: string
         genIdx >= 0
           ? (args[genIdx + 1] ?? DEFAULT_CONTENT_GENERATOR_ID)
           : DEFAULT_CONTENT_GENERATOR_ID;
+      const check = args.includes('--check');
       const entries = diffContent(generatorId, manifest, ctx, projectRoot);
       const added = entries.filter((e) => e.status === 'added');
       const modified = entries.filter((e) => e.status === 'modified');
@@ -149,6 +155,71 @@ async function handleContentCommand(subcommand: string | undefined, args: string
           for (const e of modified) process.stdout.write(`  ~ ${e.relativePath}\n`);
         }
         process.stdout.write(`Unchanged: ${unchanged.length}\n`);
+        if (check) {
+          process.stderr.write(
+            'content diff --check: disk output drifts from definitions (run content sync)\n',
+          );
+          process.exit(1);
+        }
+      }
+      break;
+    }
+
+    case 'snapshot': {
+      // GAP-406: definition ↔ committed generator snapshot lock.
+      // --write refreshes content-snapshots/*.json; --check fails CI on drift.
+      const write = args.includes('--write');
+      const check = args.includes('--check') || !write;
+      const genIdx = args.indexOf('--generator');
+      const onlyGen = genIdx >= 0 ? (args[genIdx + 1] ?? undefined) : undefined;
+
+      if (write) {
+        const paths = writeAllContentSnapshots(onlyGen ? { generatorIds: [onlyGen] } : undefined);
+        process.stdout.write(`✓ Wrote ${paths.length} content snapshot(s):\n`);
+        for (const p of paths) process.stdout.write(`  ${p}\n`);
+        if (!check) break;
+      }
+
+      if (check) {
+        if (onlyGen) {
+          const path = snapshotPathFor(onlyGen);
+          const expected = loadContentSnapshot(path);
+          const result = checkContentSnapshot(expected);
+          if (!result.ok) {
+            process.stderr.write(
+              `✗ Content snapshot drift for ${onlyGen} (${result.drifts.length} file(s))\n`,
+            );
+            for (const d of result.drifts.slice(0, 40)) {
+              process.stderr.write(`  ${d.kind}: ${d.relativePath}\n`);
+            }
+            process.stderr.write(
+              'Refresh: pnpm exec revealui-harnesses content snapshot --write\n',
+            );
+            process.exit(1);
+          }
+          process.stdout.write(
+            `✓ Content snapshot OK for ${onlyGen} (${result.fileCount} files)\n`,
+          );
+        } else {
+          const all = checkAllContentSnapshots();
+          for (const err of all.errors) process.stderr.write(`ERROR: ${err}\n`);
+          for (const r of all.results) {
+            if (r.ok) {
+              process.stdout.write(`✓ ${r.generatorId}: ${r.fileCount} files match snapshot\n`);
+            } else {
+              process.stderr.write(`✗ ${r.generatorId}: ${r.drifts.length} drift(s)\n`);
+              for (const d of r.drifts.slice(0, 20)) {
+                process.stderr.write(`  ${d.kind}: ${d.relativePath}\n`);
+              }
+            }
+          }
+          if (!all.ok) {
+            process.stderr.write(
+              'Refresh: pnpm exec revealui-harnesses content snapshot --write\n',
+            );
+            process.exit(1);
+          }
+        }
       }
       break;
     }
@@ -680,7 +751,8 @@ Commands:
 Content Subcommands:
   content list                      List all canonical content with metadata
   content validate                  Validate all definitions against schemas
-  content diff [--generator <id>]   Show what would change vs current files
+  content diff [--generator <id>] [--check]  Disk vs definitions (exit 1 with --check on drift)
+  content snapshot [--check|--write] [--generator <id>]  Definition ↔ committed snapshot (GAP-406)
   content sync [--generator <id>] [--dry-run]  Generate into .revealui/content (default generator)
   content export --output <path>    Export canonical + generated files to directory
   content pull [--generator <id>] [--tier oss|pro|all]  Pull rules from rules repo

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -64,6 +64,24 @@ export {
   RuleSchema,
   SkillSchema,
 } from './schemas/index.js';
+export type {
+  ContentSnapshot,
+  ContentSnapshotFile,
+  SnapshotCheckResult,
+  SnapshotDrift,
+} from './snapshot.js';
+export {
+  buildContentSnapshot,
+  CONTENT_SNAPSHOT_VERSION,
+  checkAllContentSnapshots,
+  checkContentSnapshot,
+  getContentSnapshotsDir,
+  hashContent,
+  loadContentSnapshot,
+  snapshotPathFor,
+  writeAllContentSnapshots,
+  writeContentSnapshot,
+} from './snapshot.js';
 
 export interface ValidationResult {
   valid: boolean;

--- a/packages/harnesses/src/content/snapshot.ts
+++ b/packages/harnesses/src/content/snapshot.ts
@@ -1,0 +1,255 @@
+/**
+ * Definition ↔ generated-content snapshot (GAP-406 residual).
+ *
+ * Package definitions under `content/definitions/` are the authoring SSOT.
+ * Generators produce tool-specific trees (manager `.revealui/content/`, etc.).
+ * Committed hashes under `content-snapshots/` lock that emit surface so CI
+ * fails when definitions change without refreshing the snapshot.
+ *
+ * Disk drift (local materialize vs definitions) remains `diffContent` /
+ * `content diff --check`. This module is the **committed** golden lock.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildManifest } from './definitions/index.js';
+import { getGenerator, listGenerators } from './generators/index.js';
+import type { Manifest } from './schemas/manifest.js';
+
+function generateForSnapshot(
+  generatorId: string,
+  manifest: Manifest,
+  projectRoot: string,
+): { relativePath: string; content: string }[] {
+  const generator = getGenerator(generatorId);
+  if (!generator) {
+    throw new Error(
+      `Unknown generator "${generatorId}". Available: ${listGenerators().join(', ')}`,
+    );
+  }
+  return generator.generateAll(manifest, { projectRoot });
+}
+
+export const CONTENT_SNAPSHOT_VERSION = 1 as const;
+
+export interface ContentSnapshotFile {
+  relativePath: string;
+  sha256: string;
+}
+
+export interface ContentSnapshot {
+  version: typeof CONTENT_SNAPSHOT_VERSION;
+  generatorId: string;
+  /** Sorted by relativePath (stable for git diffs). */
+  files: ContentSnapshotFile[];
+}
+
+export interface SnapshotDrift {
+  relativePath: string;
+  kind: 'missing-in-snapshot' | 'missing-in-generate' | 'hash-mismatch';
+  expectedSha256?: string;
+  actualSha256?: string;
+}
+
+export interface SnapshotCheckResult {
+  ok: boolean;
+  generatorId: string;
+  drifts: SnapshotDrift[];
+  fileCount: number;
+}
+
+/** Directory holding committed `*.json` snapshots (package root). */
+export function getContentSnapshotsDir(): string {
+  // src/content/snapshot.ts → packageRoot/content-snapshots
+  // dist/content/snapshot.js → packageRoot/content-snapshots
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, '..', '..', 'content-snapshots');
+}
+
+export function snapshotPathFor(generatorId: string, snapshotsDir?: string): string {
+  const dir = snapshotsDir ?? getContentSnapshotsDir();
+  return join(dir, `${generatorId}.json`);
+}
+
+export function hashContent(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+/**
+ * Build a snapshot from live definitions + generator (does not read disk).
+ * Uses a fixed synthetic projectRoot so path-sensitive generators stay stable.
+ */
+export function buildContentSnapshot(
+  generatorId: string,
+  options?: { manifest?: Manifest; projectRoot?: string },
+): ContentSnapshot {
+  const manifest = options?.manifest ?? buildManifest();
+  const projectRoot = options?.projectRoot ?? '/revealui-content-snapshot';
+  const files = generateForSnapshot(generatorId, manifest, projectRoot);
+  const entries: ContentSnapshotFile[] = files
+    .map((f) => ({
+      relativePath: f.relativePath,
+      sha256: hashContent(f.content),
+    }))
+    .sort((a, b) =>
+      a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+    );
+
+  return {
+    version: CONTENT_SNAPSHOT_VERSION,
+    generatorId,
+    files: entries,
+  };
+}
+
+export function loadContentSnapshot(filePath: string): ContentSnapshot {
+  const raw = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`Invalid content snapshot (not an object): ${filePath}`);
+  }
+  const obj = raw as Record<string, unknown>;
+  if (obj.version !== CONTENT_SNAPSHOT_VERSION) {
+    throw new Error(
+      `Unsupported content snapshot version ${String(obj.version)} in ${filePath} (want ${CONTENT_SNAPSHOT_VERSION})`,
+    );
+  }
+  if (typeof obj.generatorId !== 'string' || obj.generatorId.length === 0) {
+    throw new Error(`Content snapshot missing generatorId: ${filePath}`);
+  }
+  if (!Array.isArray(obj.files)) {
+    throw new Error(`Content snapshot missing files[]: ${filePath}`);
+  }
+  const files: ContentSnapshotFile[] = [];
+  for (const item of obj.files) {
+    if (!item || typeof item !== 'object') {
+      throw new Error(`Invalid snapshot file entry in ${filePath}`);
+    }
+    const f = item as Record<string, unknown>;
+    if (typeof f.relativePath !== 'string' || typeof f.sha256 !== 'string') {
+      throw new Error(`Snapshot file entry needs relativePath + sha256 in ${filePath}`);
+    }
+    if (f.sha256.length !== 64) {
+      throw new Error(`Snapshot sha256 must be 64 hex chars (${f.relativePath})`);
+    }
+    files.push({ relativePath: f.relativePath, sha256: f.sha256 });
+  }
+  return {
+    version: CONTENT_SNAPSHOT_VERSION,
+    generatorId: obj.generatorId,
+    files,
+  };
+}
+
+export function writeContentSnapshot(filePath: string, snapshot: ContentSnapshot): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const body = `${JSON.stringify(snapshot, null, 2)}\n`;
+  writeFileSync(filePath, body, 'utf8');
+}
+
+/** Compare an expected snapshot to freshly generated output. */
+export function checkContentSnapshot(
+  expected: ContentSnapshot,
+  options?: { manifest?: Manifest; projectRoot?: string },
+): SnapshotCheckResult {
+  const actual = buildContentSnapshot(expected.generatorId, options);
+  const expectedMap = new Map(expected.files.map((f) => [f.relativePath, f.sha256]));
+  const actualMap = new Map(actual.files.map((f) => [f.relativePath, f.sha256]));
+  const drifts: SnapshotDrift[] = [];
+
+  for (const [path, sha] of actualMap) {
+    const exp = expectedMap.get(path);
+    if (exp === undefined) {
+      drifts.push({
+        relativePath: path,
+        kind: 'missing-in-snapshot',
+        actualSha256: sha,
+      });
+    } else if (exp !== sha) {
+      drifts.push({
+        relativePath: path,
+        kind: 'hash-mismatch',
+        expectedSha256: exp,
+        actualSha256: sha,
+      });
+    }
+  }
+  for (const [path, sha] of expectedMap) {
+    if (!actualMap.has(path)) {
+      drifts.push({
+        relativePath: path,
+        kind: 'missing-in-generate',
+        expectedSha256: sha,
+      });
+    }
+  }
+
+  drifts.sort((a, b) =>
+    a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+  );
+
+  return {
+    ok: drifts.length === 0,
+    generatorId: expected.generatorId,
+    drifts,
+    fileCount: actual.files.length,
+  };
+}
+
+/**
+ * Check all generators that have a committed snapshot file.
+ * Generators without a snapshot file are reported as errors (fail closed).
+ */
+export function checkAllContentSnapshots(options?: {
+  snapshotsDir?: string;
+  manifest?: Manifest;
+  projectRoot?: string;
+}): { ok: boolean; results: SnapshotCheckResult[]; errors: string[] } {
+  const dir = options?.snapshotsDir ?? getContentSnapshotsDir();
+  const results: SnapshotCheckResult[] = [];
+  const errors: string[] = [];
+  const generators = listGenerators().sort();
+
+  for (const id of generators) {
+    const path = snapshotPathFor(id, dir);
+    try {
+      const expected = loadContentSnapshot(path);
+      if (expected.generatorId !== id) {
+        errors.push(
+          `Snapshot ${path} has generatorId=${expected.generatorId}, expected file stem ${id}`,
+        );
+        continue;
+      }
+      results.push(checkContentSnapshot(expected, options));
+    } catch (err) {
+      errors.push(
+        `Missing or invalid snapshot for generator "${id}" at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  const ok = errors.length === 0 && results.every((r) => r.ok);
+  return { ok, results, errors };
+}
+
+/** Write snapshots for one or all registered generators. */
+export function writeAllContentSnapshots(options?: {
+  snapshotsDir?: string;
+  generatorIds?: string[];
+  manifest?: Manifest;
+  projectRoot?: string;
+}): string[] {
+  const dir = options?.snapshotsDir ?? getContentSnapshotsDir();
+  const ids = options?.generatorIds ?? listGenerators().sort();
+  const written: string[] = [];
+  for (const id of ids) {
+    const snap = buildContentSnapshot(id, options);
+    const path = snapshotPathFor(id, dir);
+    writeContentSnapshot(path, snap);
+    written.push(path);
+  }
+  return written;
+}

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -36,15 +36,19 @@ export type {
 } from './content/index.js';
 // Content layer (canonical content definitions and generators)
 export {
+  buildContentSnapshot,
   buildManifest,
   ClaudeCodeGenerator,
   CursorGenerator,
+  checkAllContentSnapshots,
+  checkContentSnapshot,
   diffContent,
   generateContent,
   listContent,
   OpenCodeGenerator,
   VSCodeGenerator,
   validateManifest,
+  writeAllContentSnapshots,
 } from './content/index.js';
 export type { CoordinatorOptions } from './coordinator.js';
 // Coordinator

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -272,6 +272,14 @@ async function gate(): Promise<void> {
         args: ['validate:structure', '--', '--manager-only'],
       },
       {
+        // GAP-406 residual: definition ↔ committed generator snapshot lock.
+        // Fails when package definitions change without refreshing
+        // packages/harnesses/content-snapshots/*.json (unit tests also cover this).
+        name: 'Harnesses content snapshot (hard fail)',
+        command: 'pnpm',
+        args: ['--filter', '@revealui/harnesses', 'content:snapshot:check'],
+      },
+      {
         name: 'Boundary validation',
         command: 'pnpm',
         args: ['validate:boundary'],


### PR DESCRIPTION
## Summary
Implements the GAP-406 residual **definition ↔ generated snapshot drift CI**.

Package definitions under `packages/harnesses/src/content/definitions/` remain the authoring SSOT. Generators emit tool-specific trees (manager `.revealui/content/`, OpenCode, Cursor, VS Code). Committed SHA-256 locks under `packages/harnesses/content-snapshots/<generatorId>.json` fail CI when definitions change without refreshing the lock.

### What landed
- `content/snapshot.ts` — build / check / write snapshot helpers
- Committed snapshots for all generators: `claude-code`, `cursor`, `opencode`, `vscode`
- CLI: `content snapshot --check|--write [--generator id]`, `content diff --check`
- Package scripts: `content:snapshot:check`, `content:snapshot:write`
- Unit tests prove green lock + red on hash mismatch
- Local `ci-gate` phase-1 hard fail: **Harnesses content snapshot**
- README operator docs

### Operator workflow after editing definitions
```bash
pnpm --filter @revealui/harnesses content:snapshot:write
# commit the updated content-snapshots/*.json with the definition change
```

### Note for stacked GAP-406 PRs
If [#2082](https://github.com/RevealUIStudio/revealui/pull/2082) (hardline definitions) merges after this, re-run `content:snapshot:write` on that branch (or a follow-up) so the new rules appear in the lock.

## Test plan
- [x] `pnpm exec vitest run src/__tests__/content-snapshot.test.ts` (pass)
- [x] Mutate snapshot hash → test fails with hash-mismatch
- [x] Local phase-1 gate including new hard fail (PASS on push)
- [ ] CI unit tests + security-review gate (path: packages/harnesses)

## Related
GAP-406 residual · pairs with #2082 hardlines (snapshot refresh required when those land)