### PR TITLE
feat(marketing): wire services CMS blocks (VES residual)

### DIFF
--- a/apps/marketing/app/components/for-operators/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators/ClosingCta.tsx
@@ -1,39 +1,67 @@
-import { Button } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
 import { FOR_OPERATORS_CLOSING } from '../../content/for-operators';
+import type { ServicesCtaData } from '../../lib/page-blocks';
 
-export function ClosingCta() {
+export interface ClosingCtaProps {
+  readonly data?: ServicesCtaData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function ClosingCta({ data, path, annotation }: ClosingCtaProps = {}) {
+  const content = data ?? {
+    heading: FOR_OPERATORS_CLOSING.heading,
+    body: FOR_OPERATORS_CLOSING.body,
+    primaryCta: FOR_OPERATORS_CLOSING.primaryCta,
+    emailFallback: { ...FOR_OPERATORS_CLOSING.emailFallback },
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   return (
     <section className="bg-muted py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-        <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FOR_OPERATORS_CLOSING.heading}
+        <h2
+          className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+        >
+          {content.heading}
         </h2>
-        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">
-          {FOR_OPERATORS_CLOSING.body}
+        <p
+          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+        >
+          {content.body}
         </p>
 
         <div className="mt-10 flex justify-center">
           <Button asChild size="lg">
             <a
-              href={FOR_OPERATORS_CLOSING.primaryCta.href}
-              {...(FOR_OPERATORS_CLOSING.primaryCta.external
+              href={content.primaryCta.href}
+              {...(content.primaryCta.external
                 ? { target: '_blank', rel: 'noopener noreferrer' }
                 : {})}
+              {...(base ? fieldAttrs(ann, `${base}.links.0.label`) : {})}
             >
-              {FOR_OPERATORS_CLOSING.primaryCta.label}
+              {content.primaryCta.label}
             </a>
           </Button>
         </div>
 
         <p className="mt-6 text-sm text-muted-foreground">
-          {FOR_OPERATORS_CLOSING.emailFallback.prefix}
+          <span {...(base ? fieldAttrs(ann, `${base}.snippet.lines.0`) : {})}>
+            {content.emailFallback.prefix}
+          </span>
           <a
-            href={`mailto:${FOR_OPERATORS_CLOSING.emailFallback.address}`}
+            href={`mailto:${content.emailFallback.address}`}
             className="font-medium text-primary hover:underline underline-offset-4"
+            {...(base ? fieldAttrs(ann, `${base}.snippet.lines.1`) : {})}
           >
-            {FOR_OPERATORS_CLOSING.emailFallback.address}
+            {content.emailFallback.address}
           </a>
-          {FOR_OPERATORS_CLOSING.emailFallback.suffix}
+          <span {...(base ? fieldAttrs(ann, `${base}.snippet.lines.2`) : {})}>
+            {content.emailFallback.suffix}
+          </span>
         </p>
       </div>
     </section>

--- a/apps/marketing/app/components/for-operators/DiscoveryScopeShip.tsx
+++ b/apps/marketing/app/components/for-operators/DiscoveryScopeShip.tsx
@@ -1,24 +1,51 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FOR_OPERATORS_DISCOVERY } from '../../content/for-operators';
+import type { ServicesDiscoveryData } from '../../lib/page-blocks';
 
-export function DiscoveryScopeShip() {
+export interface DiscoveryScopeShipProps {
+  readonly data?: ServicesDiscoveryData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function DiscoveryScopeShip({ data, path, annotation }: DiscoveryScopeShipProps = {}) {
+  const content = data ?? {
+    eyebrow: FOR_OPERATORS_DISCOVERY.eyebrow,
+    heading: FOR_OPERATORS_DISCOVERY.heading,
+    body: FOR_OPERATORS_DISCOVERY.body,
+    link: FOR_OPERATORS_DISCOVERY.link,
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FOR_OPERATORS_DISCOVERY.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
+          {content.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FOR_OPERATORS_DISCOVERY.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+        >
+          {content.heading}
         </h2>
-        <p className="mt-6 text-base leading-7 text-muted-foreground">
-          {FOR_OPERATORS_DISCOVERY.body}
+        <p
+          className="mt-6 text-base leading-7 text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+        >
+          {content.body}
         </p>
         <p className="mt-8">
           <a
-            href={FOR_OPERATORS_DISCOVERY.link.href}
+            href={content.link.href}
             className="font-medium text-primary hover:underline underline-offset-4"
+            {...(base ? fieldAttrs(ann, `${base}.items.0.label`) : {})}
           >
-            {FOR_OPERATORS_DISCOVERY.link.label}
+            {content.link.label}
           </a>
         </p>
       </div>

--- a/apps/marketing/app/components/for-operators/EngagementPricing.tsx
+++ b/apps/marketing/app/components/for-operators/EngagementPricing.tsx
@@ -1,20 +1,49 @@
-import { Button } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
 import { FOR_OPERATORS_PRICING } from '../../content/for-operators';
+import type { ServicesPricingIntroData } from '../../lib/page-blocks';
 
-export function EngagementPricing() {
-  const { eyebrow, heading, body, rungs } = FOR_OPERATORS_PRICING;
+export interface EngagementPricingProps {
+  /**
+   * CMS-driven section header only. Engagement ladder rungs (titles, prices,
+   * bodies, CTAs) stay component-local from for-operators + contracts.
+   */
+  readonly data?: ServicesPricingIntroData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function EngagementPricing({ data, path, annotation }: EngagementPricingProps = {}) {
+  const intro = data ?? {
+    eyebrow: FOR_OPERATORS_PRICING.eyebrow,
+    heading: FOR_OPERATORS_PRICING.heading,
+    body: FOR_OPERATORS_PRICING.body,
+  };
+  const { rungs } = FOR_OPERATORS_PRICING;
+  const ann = annotation ?? {};
+  const base = path ?? '';
 
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {eyebrow}
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+          >
+            {intro.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {heading}
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+          >
+            {intro.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{body}</p>
+          <p
+            className="mt-6 text-lg leading-8 text-muted-foreground"
+            {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+          >
+            {intro.body}
+          </p>
         </div>
 
         <ul className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3 list-none p-0">

--- a/apps/marketing/app/components/for-operators/Faq.tsx
+++ b/apps/marketing/app/components/for-operators/Faq.tsx
@@ -1,29 +1,61 @@
-import { IconPlus } from '@revealui/presentation';
+import { type BlockAnnotation, fieldAttrs, IconPlus } from '@revealui/presentation';
 import { FOR_OPERATORS_FAQ } from '../../content/for-operators';
+import type { ServicesFaqData } from '../../lib/page-blocks';
 
-export function Faq() {
+export interface FaqProps {
+  readonly data?: ServicesFaqData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function Faq({ data, path, annotation }: FaqProps = {}) {
+  const content = data ?? {
+    eyebrow: FOR_OPERATORS_FAQ.eyebrow,
+    heading: FOR_OPERATORS_FAQ.heading,
+    items: FOR_OPERATORS_FAQ.items.map((item) => ({
+      question: item.question,
+      answer: item.answer,
+    })),
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {FOR_OPERATORS_FAQ.eyebrow}
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+          >
+            {content.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {FOR_OPERATORS_FAQ.heading}
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+          >
+            {content.heading}
           </h2>
         </div>
 
         <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
-          {FOR_OPERATORS_FAQ.items.map((item) => (
+          {content.items.map((item, index) => (
             <details key={item.question} className="group py-6">
               <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                <h3 className="text-lg font-semibold leading-7 text-foreground">{item.question}</h3>
+                <h3
+                  className="text-lg font-semibold leading-7 text-foreground"
+                  {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
+                >
+                  {item.question}
+                </h3>
                 <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
                   <IconPlus size="sm" label="Toggle" />
                 </span>
               </summary>
-              <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">
+              <div
+                className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
+                {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
+              >
                 {item.answer}
               </div>
             </details>

--- a/apps/marketing/app/components/for-operators/Faq.tsx
+++ b/apps/marketing/app/components/for-operators/Faq.tsx
@@ -1,61 +1,33 @@
-import { type BlockAnnotation, fieldAttrs, IconPlus } from '@revealui/presentation';
+import { IconPlus } from '@revealui/presentation';
 import { FOR_OPERATORS_FAQ } from '../../content/for-operators';
-import type { ServicesFaqData } from '../../lib/page-blocks';
 
-export interface FaqProps {
-  readonly data?: ServicesFaqData;
-  readonly path?: string;
-  readonly annotation?: BlockAnnotation;
-}
-
-export function Faq({ data, path, annotation }: FaqProps = {}) {
-  const content = data ?? {
-    eyebrow: FOR_OPERATORS_FAQ.eyebrow,
-    heading: FOR_OPERATORS_FAQ.heading,
-    items: FOR_OPERATORS_FAQ.items.map((item) => ({
-      question: item.question,
-      answer: item.answer,
-    })),
-  };
-  const ann = annotation ?? {};
-  const base = path ?? '';
-
+/**
+ * Services FAQ stays component-local (not CMS). The cost answer interpolates
+ * engagement ladder prices from contracts; claims-safety forbids prices in blocks.
+ */
+export function Faq() {
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-          >
-            {content.eyebrow}
+          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+            {FOR_OPERATORS_FAQ.eyebrow}
           </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-          >
-            {content.heading}
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {FOR_OPERATORS_FAQ.heading}
           </h2>
         </div>
 
         <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
-          {content.items.map((item, index) => (
+          {FOR_OPERATORS_FAQ.items.map((item) => (
             <details key={item.question} className="group py-6">
               <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                <h3
-                  className="text-lg font-semibold leading-7 text-foreground"
-                  {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
-                >
-                  {item.question}
-                </h3>
+                <h3 className="text-lg font-semibold leading-7 text-foreground">{item.question}</h3>
                 <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
                   <IconPlus size="sm" label="Toggle" />
                 </span>
               </summary>
-              <div
-                className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
-                {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
-              >
+              <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">
                 {item.answer}
               </div>
             </details>

--- a/apps/marketing/app/components/for-operators/Hero.tsx
+++ b/apps/marketing/app/components/for-operators/Hero.tsx
@@ -1,47 +1,77 @@
-import { Button } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
 import { FOR_OPERATORS_HERO } from '../../content/for-operators';
+import type { ServicesHeroData } from '../../lib/page-blocks';
 
-export function Hero() {
+export interface ServicesHeroProps {
+  /** CMS-driven data; defaults to the static content module. */
+  readonly data?: ServicesHeroData;
+  /** Dot-path into the page blocks array (e.g. `blocks.0.data`). */
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function Hero({ data, path, annotation }: ServicesHeroProps = {}) {
+  const content = data ?? {
+    eyebrow: FOR_OPERATORS_HERO.eyebrow,
+    h1Lines: [...FOR_OPERATORS_HERO.h1Lines],
+    subtitle: FOR_OPERATORS_HERO.subtitle,
+    primaryCta: FOR_OPERATORS_HERO.primaryCta,
+    reverseLink: FOR_OPERATORS_HERO.reverseLink,
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   return (
     <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
       <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
 
       <div className="relative mx-auto max-w-3xl text-center">
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
-          {FOR_OPERATORS_HERO.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
+          {content.eyebrow}
         </p>
 
-        <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
-          {FOR_OPERATORS_HERO.h1Lines.map((line) => (
+        <h1
+          className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl"
+          {...(base ? fieldAttrs(ann, `${base}.title`) : {})}
+        >
+          {content.h1Lines.map((line) => (
             <span key={line} className="block">
               {line}
             </span>
           ))}
         </h1>
 
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-          {FOR_OPERATORS_HERO.subtitle}
+        <p
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          {...(base ? fieldAttrs(ann, `${base}.subtitle`) : {})}
+        >
+          {content.subtitle}
         </p>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
           <Button asChild size="lg" className="w-full sm:w-auto">
             <a
-              href={FOR_OPERATORS_HERO.primaryCta.href}
-              {...(FOR_OPERATORS_HERO.primaryCta.external
+              href={content.primaryCta.href}
+              {...(content.primaryCta.external
                 ? { target: '_blank', rel: 'noopener noreferrer' }
                 : {})}
+              {...(base ? fieldAttrs(ann, `${base}.links.0.label`) : {})}
             >
-              {FOR_OPERATORS_HERO.primaryCta.label}
+              {content.primaryCta.label}
             </a>
           </Button>
         </div>
 
         <p className="mt-8 text-sm text-muted-foreground">
           <a
-            href={FOR_OPERATORS_HERO.reverseLink.href}
+            href={content.reverseLink.href}
             className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+            {...(base ? fieldAttrs(ann, `${base}.links.1.label`) : {})}
           >
-            {FOR_OPERATORS_HERO.reverseLink.label}
+            {content.reverseLink.label}
           </a>
         </p>
       </div>

--- a/apps/marketing/app/components/for-operators/HowWeDeliver.tsx
+++ b/apps/marketing/app/components/for-operators/HowWeDeliver.tsx
@@ -1,31 +1,59 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FOR_OPERATORS_HOW_WE_DELIVER } from '../../content/for-operators';
+import type { ServicesHowWeDeliverData } from '../../lib/page-blocks';
 
-export function HowWeDeliver() {
-  const { eyebrow, heading, paragraph1, paragraph2, paragraph3 } = FOR_OPERATORS_HOW_WE_DELIVER;
+export interface HowWeDeliverProps {
+  readonly data?: ServicesHowWeDeliverData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function HowWeDeliver({ data, path, annotation }: HowWeDeliverProps = {}) {
+  const content = data ?? {
+    eyebrow: FOR_OPERATORS_HOW_WE_DELIVER.eyebrow,
+    heading: FOR_OPERATORS_HOW_WE_DELIVER.heading,
+    paragraph1: FOR_OPERATORS_HOW_WE_DELIVER.paragraph1,
+    paragraph2: { ...FOR_OPERATORS_HOW_WE_DELIVER.paragraph2 },
+    paragraph3: FOR_OPERATORS_HOW_WE_DELIVER.paragraph3,
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+  const { eyebrow, heading, paragraph1, paragraph2, paragraph3 } = content;
 
   return (
     <section className="bg-muted py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
           {eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+        >
           {heading}
         </h2>
 
         <div className="mt-8 space-y-6 text-base leading-7 text-muted-foreground">
-          <p>{paragraph1}</p>
+          <p {...(base ? fieldAttrs(ann, `${base}.body`) : {})}>{paragraph1}</p>
           <p>
-            {paragraph2.before}
+            <span {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>
+              {paragraph2.before}
+            </span>
             <a
               href={paragraph2.linkHref}
               className="font-medium text-primary hover:underline underline-offset-4"
+              {...(base ? fieldAttrs(ann, `${base}.items.1.body`) : {})}
             >
               {paragraph2.linkLabel}
             </a>
-            {paragraph2.after}
+            <span {...(base ? fieldAttrs(ann, `${base}.items.2.body`) : {})}>
+              {paragraph2.after}
+            </span>
           </p>
-          <p>{paragraph3}</p>
+          <p {...(base ? fieldAttrs(ann, `${base}.items.3.body`) : {})}>{paragraph3}</p>
         </div>
       </div>
     </section>

--- a/apps/marketing/app/components/for-operators/Proof.tsx
+++ b/apps/marketing/app/components/for-operators/Proof.tsx
@@ -1,35 +1,78 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FOR_OPERATORS_PROOF } from '../../content/for-operators';
+import type { ServicesProofData } from '../../lib/page-blocks';
 
-export function Proof() {
+export interface ProofProps {
+  readonly data?: ServicesProofData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function Proof({ data, path, annotation }: ProofProps = {}) {
+  const content = data ?? {
+    eyebrow: FOR_OPERATORS_PROOF.eyebrow,
+    heading: FOR_OPERATORS_PROOF.heading,
+    body: FOR_OPERATORS_PROOF.body,
+    bulletIntro: FOR_OPERATORS_PROOF.bulletIntro,
+    bullets: [...FOR_OPERATORS_PROOF.bullets],
+    links: [...FOR_OPERATORS_PROOF.links],
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+  // Block layout: items[0]=bullet-intro, then bullets, then links.
+  const introItemIndex = 0;
+  const firstBulletIndex = 1;
+  const firstLinkIndex = firstBulletIndex + content.bullets.length;
+
   return (
     <section className="bg-muted py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FOR_OPERATORS_PROOF.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
+          {content.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FOR_OPERATORS_PROOF.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+        >
+          {content.heading}
         </h2>
 
-        <p className="mt-6 text-base leading-7 text-muted-foreground">{FOR_OPERATORS_PROOF.body}</p>
+        <p
+          className="mt-6 text-base leading-7 text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+        >
+          {content.body}
+        </p>
 
-        <p className="mt-6 text-base leading-7 text-muted-foreground">
-          {FOR_OPERATORS_PROOF.bulletIntro}
+        <p
+          className="mt-6 text-base leading-7 text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.items.${introItemIndex}.body`) : {})}
+        >
+          {content.bulletIntro}
         </p>
 
         <ul className="mt-4 space-y-3 list-disc pl-6 text-base leading-7 text-muted-foreground marker:text-primary">
-          {FOR_OPERATORS_PROOF.bullets.map((bullet) => (
-            <li key={bullet}>{bullet}</li>
+          {content.bullets.map((bullet, index) => (
+            <li
+              key={bullet}
+              {...(base ? fieldAttrs(ann, `${base}.items.${firstBulletIndex + index}.body`) : {})}
+            >
+              {bullet}
+            </li>
           ))}
         </ul>
 
         <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-sm">
-          {FOR_OPERATORS_PROOF.links.map((link) => (
+          {content.links.map((link, index) => (
             <a
               key={link.href}
               href={link.href}
               {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
               className="font-medium text-primary hover:underline underline-offset-4"
+              {...(base ? fieldAttrs(ann, `${base}.items.${firstLinkIndex + index}.label`) : {})}
             >
               {link.label}
             </a>

--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -1,30 +1,66 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FOR_OPERATORS_WHAT_YOU_GET } from '../../content/for-operators';
+import type { ServicesWhatYouGetData } from '../../lib/page-blocks';
 import { CenteredCardGrid } from '../CenteredCardGrid';
 
-export function WhatYouGet() {
+export interface WhatYouGetProps {
+  readonly data?: ServicesWhatYouGetData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function WhatYouGet({ data, path, annotation }: WhatYouGetProps = {}) {
+  const content = data ?? {
+    eyebrow: FOR_OPERATORS_WHAT_YOU_GET.eyebrow,
+    heading: FOR_OPERATORS_WHAT_YOU_GET.heading,
+    body: FOR_OPERATORS_WHAT_YOU_GET.body,
+    cards: FOR_OPERATORS_WHAT_YOU_GET.cards.map((c) => ({ title: c.title, body: c.body })),
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {FOR_OPERATORS_WHAT_YOU_GET.eyebrow}
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+          >
+            {content.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {FOR_OPERATORS_WHAT_YOU_GET.heading}
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+          >
+            {content.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">
-            {FOR_OPERATORS_WHAT_YOU_GET.body}
+          <p
+            className="mt-6 text-lg leading-8 text-muted-foreground"
+            {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+          >
+            {content.body}
           </p>
         </div>
 
         <CenteredCardGrid className="mx-auto mt-16 max-w-5xl">
-          {FOR_OPERATORS_WHAT_YOU_GET.cards.map((card) => (
+          {content.cards.map((card, index) => (
             <div
               key={card.title}
               className="w-full rounded-2xl border border-border bg-card p-6 shadow-sm sm:w-[calc(50%-0.75rem)] lg:w-[calc(33.333%-1rem)]"
             >
-              <h3 className="text-lg font-semibold leading-7 text-foreground">{card.title}</h3>
-              <p className="mt-3 text-base leading-7 text-muted-foreground">{card.body}</p>
+              <h3
+                className="text-lg font-semibold leading-7 text-foreground"
+                {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
+              >
+                {card.title}
+              </h3>
+              <p
+                className="mt-3 text-base leading-7 text-muted-foreground"
+                {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
+              >
+                {card.body}
+              </p>
             </div>
           ))}
         </CenteredCardGrid>

--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -11,6 +11,16 @@ import {
   FAIR_SOURCE_PEERS,
   FAIR_SOURCE_PEERS_SECTION,
 } from '../content/fair-source';
+import {
+  FOR_OPERATORS_CLOSING,
+  FOR_OPERATORS_DISCOVERY,
+  FOR_OPERATORS_FAQ,
+  FOR_OPERATORS_HERO,
+  FOR_OPERATORS_HOW_WE_DELIVER,
+  FOR_OPERATORS_PRICING,
+  FOR_OPERATORS_PROOF,
+  FOR_OPERATORS_WHAT_YOU_GET,
+} from '../content/for-operators';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
@@ -49,6 +59,16 @@ import {
   productsCtaSlot,
   productsFaqSlot,
   productsHeroSlot,
+  SERVICES_FALLBACK_BLOCKS,
+  servicesBlocks,
+  servicesCtaSlot,
+  servicesDiscoverySlot,
+  servicesFaqSlot,
+  servicesHeroSlot,
+  servicesHowWeDeliverSlot,
+  servicesPricingIntroSlot,
+  servicesProofSlot,
+  servicesWhatYouGetSlot,
 } from './page-blocks';
 import { SUBSCRIPTION_PRICE_FALLBACKS } from './pricing-fallbacks';
 
@@ -65,13 +85,14 @@ function collectStrings(value: unknown, out: string[] = []): string[] {
 }
 
 describe('page-blocks derivation', () => {
-  it('produces schema-valid blocks for home, products, philosophy, local-ai, and fair-source', () => {
+  it('produces schema-valid blocks for home, products, philosophy, local-ai, fair-source, and services', () => {
     for (const block of [
       ...homeBlocks(),
       ...productsBlocks(),
       ...philosophyBlocks(),
       ...localAiBlocks(),
       ...fairSourceBlocks(),
+      ...servicesBlocks(),
     ]) {
       expect(BlockSchema.safeParse(block).success).toBe(true);
     }
@@ -89,6 +110,16 @@ describe('page-blocks derivation', () => {
       'ctaSection',
     ]);
     expect(fairSourceBlocks().map((b) => b.type)).toEqual([
+      'section',
+      'section',
+      'section',
+      'section',
+      'section',
+      'ctaSection',
+    ]);
+    expect(servicesBlocks().map((b) => b.type)).toEqual([
+      'hero',
+      'section',
       'section',
       'section',
       'section',
@@ -185,6 +216,73 @@ describe('page-blocks derivation', () => {
       secondary: { label: FAIR_SOURCE_CTA.secondaryLabel, href: FAIR_SOURCE_CTA.secondaryHref },
     });
   });
+
+  it('round-trips services slots against the for-operators content module', () => {
+    const blocks = SERVICES_FALLBACK_BLOCKS;
+    expect(servicesHeroSlot(blocks).data).toEqual({
+      eyebrow: FOR_OPERATORS_HERO.eyebrow,
+      h1Lines: [...FOR_OPERATORS_HERO.h1Lines],
+      subtitle: FOR_OPERATORS_HERO.subtitle,
+      primaryCta: {
+        label: FOR_OPERATORS_HERO.primaryCta.label,
+        href: FOR_OPERATORS_HERO.primaryCta.href,
+        external: true,
+      },
+      reverseLink: {
+        label: FOR_OPERATORS_HERO.reverseLink.label,
+        href: FOR_OPERATORS_HERO.reverseLink.href,
+      },
+    });
+    expect(servicesWhatYouGetSlot(blocks).data).toEqual({
+      eyebrow: FOR_OPERATORS_WHAT_YOU_GET.eyebrow,
+      heading: FOR_OPERATORS_WHAT_YOU_GET.heading,
+      body: FOR_OPERATORS_WHAT_YOU_GET.body,
+      cards: FOR_OPERATORS_WHAT_YOU_GET.cards.map((c) => ({ title: c.title, body: c.body })),
+    });
+    expect(servicesHowWeDeliverSlot(blocks).data).toEqual(FOR_OPERATORS_HOW_WE_DELIVER);
+    expect(servicesPricingIntroSlot(blocks).data).toEqual({
+      eyebrow: FOR_OPERATORS_PRICING.eyebrow,
+      heading: FOR_OPERATORS_PRICING.heading,
+      body: FOR_OPERATORS_PRICING.body,
+    });
+    expect(servicesDiscoverySlot(blocks).data).toEqual({
+      eyebrow: FOR_OPERATORS_DISCOVERY.eyebrow,
+      heading: FOR_OPERATORS_DISCOVERY.heading,
+      body: FOR_OPERATORS_DISCOVERY.body,
+      link: {
+        label: FOR_OPERATORS_DISCOVERY.link.label,
+        href: FOR_OPERATORS_DISCOVERY.link.href,
+      },
+    });
+    expect(servicesProofSlot(blocks).data).toEqual({
+      eyebrow: FOR_OPERATORS_PROOF.eyebrow,
+      heading: FOR_OPERATORS_PROOF.heading,
+      body: FOR_OPERATORS_PROOF.body,
+      bulletIntro: FOR_OPERATORS_PROOF.bulletIntro,
+      bullets: [...FOR_OPERATORS_PROOF.bullets],
+      links: FOR_OPERATORS_PROOF.links.map((l) => ({
+        label: l.label,
+        href: l.href,
+        ...(l.external ? { external: true } : {}),
+      })),
+    });
+    expect(servicesFaqSlot(blocks).data).toEqual({
+      eyebrow: FOR_OPERATORS_FAQ.eyebrow,
+      heading: FOR_OPERATORS_FAQ.heading,
+      items: FOR_OPERATORS_FAQ.items.map((i) => ({ question: i.question, answer: i.answer })),
+    });
+    expect(servicesCtaSlot(blocks).data).toEqual({
+      heading: FOR_OPERATORS_CLOSING.heading,
+      body: FOR_OPERATORS_CLOSING.body,
+      primaryCta: {
+        label: FOR_OPERATORS_CLOSING.primaryCta.label,
+        href: FOR_OPERATORS_CLOSING.primaryCta.href,
+        external: true,
+      },
+      emailFallback: { ...FOR_OPERATORS_CLOSING.emailFallback },
+    });
+    expect(blocksMatchFallback(servicesBlocks(), SERVICES_FALLBACK_BLOCKS)).toBe(true);
+  });
 });
 
 describe('claims safety: prose is single-sourced, pinned values never enter blocks', () => {
@@ -194,6 +292,7 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     philosophyBlocks(),
     localAiBlocks(),
     fairSourceBlocks(),
+    servicesBlocks(),
   ]);
   const haystack = strings.join(' ');
 
@@ -243,6 +342,10 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     }
     expect(strings).toContain(FAIR_SOURCE_CTA.heading);
     expect(strings).toContain(FAIR_SOURCE_CTA.body);
+    expect(strings).toContain(FOR_OPERATORS_HERO.subtitle);
+    expect(strings).toContain(FOR_OPERATORS_WHAT_YOU_GET.heading);
+    expect(strings).toContain(FOR_OPERATORS_PRICING.heading);
+    expect(strings).toContain(FOR_OPERATORS_CLOSING.heading);
     // Env-code lines stay out of blocks (grep-accurate, component-local).
     expect(strings).not.toContain('LLM_PROVIDER=inference-snaps');
     expect(strings).not.toContain('LLM_PROVIDER=ollama');
@@ -253,6 +356,16 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     expect(haystack).not.toContain(PRODUCTS_FLAGSHIP.version);
     // The pro price lives only on the pricing surfaces, never in a block.
     expect(haystack).not.toContain(SUBSCRIPTION_PRICE_FALLBACKS.pro.price);
+    // Services engagement ladder rungs stay component-local: pricing intro is
+    // header-only (FAQ prose may still mention dollar anchors).
+    const pricingIntro = servicesBlocks().find((b) => b.id === 'services-pricing-intro');
+    expect(pricingIntro?.type).toBe('section');
+    if (pricingIntro?.type === 'section') {
+      expect(pricingIntro.data.items ?? []).toHaveLength(0);
+      for (const rung of FOR_OPERATORS_PRICING.rungs) {
+        expect(pricingIntro.data.body ?? '').not.toContain(rung.price);
+      }
+    }
     // Metric counters are rendered from METRICS in TSX, never as block prose.
     // Fair-source hero (which interpolates METRICS) is intentionally not in blocks.
     for (const metric of [METRICS.packages, METRICS.dbTables, METRICS.mcpServers]) {

--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -14,7 +14,6 @@ import {
 import {
   FOR_OPERATORS_CLOSING,
   FOR_OPERATORS_DISCOVERY,
-  FOR_OPERATORS_FAQ,
   FOR_OPERATORS_HERO,
   FOR_OPERATORS_HOW_WE_DELIVER,
   FOR_OPERATORS_PRICING,
@@ -63,7 +62,6 @@ import {
   servicesBlocks,
   servicesCtaSlot,
   servicesDiscoverySlot,
-  servicesFaqSlot,
   servicesHeroSlot,
   servicesHowWeDeliverSlot,
   servicesPricingIntroSlot,
@@ -119,7 +117,6 @@ describe('page-blocks derivation', () => {
     ]);
     expect(servicesBlocks().map((b) => b.type)).toEqual([
       'hero',
-      'section',
       'section',
       'section',
       'section',
@@ -265,11 +262,6 @@ describe('page-blocks derivation', () => {
         href: l.href,
         ...(l.external ? { external: true } : {}),
       })),
-    });
-    expect(servicesFaqSlot(blocks).data).toEqual({
-      eyebrow: FOR_OPERATORS_FAQ.eyebrow,
-      heading: FOR_OPERATORS_FAQ.heading,
-      items: FOR_OPERATORS_FAQ.items.map((i) => ({ question: i.question, answer: i.answer })),
     });
     expect(servicesCtaSlot(blocks).data).toEqual({
       heading: FOR_OPERATORS_CLOSING.heading,

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -1,6 +1,6 @@
 /**
  * Static-first block derivation for marketing pages served from the CMS
- * (home, products, philosophy, local-ai, fair-source).
+ * (home, products, philosophy, local-ai, fair-source, services).
  *
  * The marketing content modules stay the single source of truth for every prose
  * string. This module derives the canonical `pages.blocks` array from those
@@ -19,6 +19,10 @@
  * subhead, and body interpolate METRICS license-split counts. The package
  * inventory table stays structural (name/license/repo/npm), while section
  * headers, contract cards, clock, peers, FAQ, and CTA ride the CMS.
+ *
+ * Services (`/services`) engagement ladder rungs (titles, prices, bodies, CTAs)
+ * stay component-local from `for-operators` + contracts pricing anchors. CMS
+ * carries hero through FAQ/CTA narrative and the pricing section header only.
  *
  * No React or network imports live here so `scripts/seed-fleet-marketing-site.ts`
  * can import the same derivation the runtime falls back to.
@@ -45,6 +49,16 @@ import {
   FAIR_SOURCE_PEERS,
   FAIR_SOURCE_PEERS_SECTION,
 } from '../content/fair-source';
+import {
+  FOR_OPERATORS_CLOSING,
+  FOR_OPERATORS_DISCOVERY,
+  FOR_OPERATORS_FAQ,
+  FOR_OPERATORS_HERO,
+  FOR_OPERATORS_HOW_WE_DELIVER,
+  FOR_OPERATORS_PRICING,
+  FOR_OPERATORS_PROOF,
+  FOR_OPERATORS_WHAT_YOU_GET,
+} from '../content/for-operators';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
@@ -234,6 +248,78 @@ export interface FairSourceCtaData {
   readonly secondary: Cta;
 }
 
+export interface ServicesHeroData {
+  readonly eyebrow: string;
+  readonly h1Lines: readonly string[];
+  readonly subtitle: string;
+  readonly primaryCta: Cta;
+  readonly reverseLink: Cta;
+}
+
+export interface ServicesCardData {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface ServicesWhatYouGetData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly cards: readonly ServicesCardData[];
+}
+
+export interface ServicesHowWeDeliverData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly paragraph1: string;
+  readonly paragraph2: {
+    readonly before: string;
+    readonly linkLabel: string;
+    readonly linkHref: string;
+    readonly after: string;
+  };
+  readonly paragraph3: string;
+}
+
+export interface ServicesPricingIntroData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+}
+
+export interface ServicesDiscoveryData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly link: Cta;
+}
+
+export interface ServicesProofData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly bulletIntro: string;
+  readonly bullets: readonly string[];
+  readonly links: readonly Cta[];
+}
+
+export interface ServicesFaqData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly items: readonly FaqItemData[];
+}
+
+export interface ServicesCtaData {
+  readonly heading: string;
+  readonly body: string;
+  readonly primaryCta: Cta;
+  readonly emailFallback: {
+    readonly prefix: string;
+    readonly address: string;
+    readonly suffix: string;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Stable block ids + positions. Ids let the seed and fallback match, but the
 // runtime routes each slot by array POSITION + type (the CMS assigns its own
@@ -260,6 +346,14 @@ export const FAIR_SOURCE_CLOCK_BLOCK_ID = 'fair-source-clock';
 export const FAIR_SOURCE_PEERS_BLOCK_ID = 'fair-source-peers';
 export const FAIR_SOURCE_FAQ_BLOCK_ID = 'fair-source-faq';
 export const FAIR_SOURCE_CTA_BLOCK_ID = 'fair-source-cta';
+export const SERVICES_HERO_BLOCK_ID = 'services-hero';
+export const SERVICES_WHAT_YOU_GET_BLOCK_ID = 'services-what-you-get';
+export const SERVICES_HOW_WE_DELIVER_BLOCK_ID = 'services-how-we-deliver';
+export const SERVICES_PRICING_INTRO_BLOCK_ID = 'services-pricing-intro';
+export const SERVICES_DISCOVERY_BLOCK_ID = 'services-discovery';
+export const SERVICES_PROOF_BLOCK_ID = 'services-proof';
+export const SERVICES_FAQ_BLOCK_ID = 'services-faq';
+export const SERVICES_CTA_BLOCK_ID = 'services-cta';
 
 const HOME_DEMO_INDEX = 0;
 const HOME_PRIMITIVES_INDEX = 1;
@@ -281,6 +375,23 @@ const FAIR_SOURCE_CLOCK_INDEX = 2;
 const FAIR_SOURCE_PEERS_INDEX = 3;
 const FAIR_SOURCE_FAQ_INDEX = 4;
 const FAIR_SOURCE_CTA_INDEX = 5;
+const SERVICES_HERO_INDEX = 0;
+const SERVICES_WHAT_YOU_GET_INDEX = 1;
+const SERVICES_HOW_WE_DELIVER_INDEX = 2;
+const SERVICES_PRICING_INTRO_INDEX = 3;
+const SERVICES_DISCOVERY_INDEX = 4;
+const SERVICES_PROOF_INDEX = 5;
+const SERVICES_FAQ_INDEX = 6;
+const SERVICES_CTA_INDEX = 7;
+
+function hrefLooksExternal(href: string): boolean {
+  return (
+    href.startsWith('http://') ||
+    href.startsWith('https://') ||
+    href.startsWith('mailto:') ||
+    href.startsWith('//')
+  );
+}
 
 function ctaToLink(cta: Cta, variant: 'primary' | 'secondary'): MarketingLink {
   return { label: cta.label, href: cta.href, variant };
@@ -546,6 +657,112 @@ function fairSourceCtaBlock(): CtaSectionBlock {
   });
 }
 
+function servicesHeroBlock(): HeroBlock {
+  // h1Lines ride title as newline-joined so reverse can restore line breaks.
+  return createHeroBlock(SERVICES_HERO_BLOCK_ID, FOR_OPERATORS_HERO.h1Lines.join('\n'), {
+    eyebrow: FOR_OPERATORS_HERO.eyebrow,
+    subtitle: FOR_OPERATORS_HERO.subtitle,
+    links: [
+      ctaToLink(FOR_OPERATORS_HERO.primaryCta, 'primary'),
+      ctaToLink(FOR_OPERATORS_HERO.reverseLink, 'secondary'),
+    ],
+  });
+}
+
+function servicesWhatYouGetBlock(): SectionBlock {
+  return createSectionBlock(SERVICES_WHAT_YOU_GET_BLOCK_ID, FOR_OPERATORS_WHAT_YOU_GET.heading, {
+    eyebrow: FOR_OPERATORS_WHAT_YOU_GET.eyebrow,
+    body: FOR_OPERATORS_WHAT_YOU_GET.body,
+    items: FOR_OPERATORS_WHAT_YOU_GET.cards.map((card) => ({
+      label: card.title,
+      body: card.body,
+    })),
+  });
+}
+
+function servicesHowWeDeliverBlock(): SectionBlock {
+  const p2 = FOR_OPERATORS_HOW_WE_DELIVER.paragraph2;
+  return createSectionBlock(
+    SERVICES_HOW_WE_DELIVER_BLOCK_ID,
+    FOR_OPERATORS_HOW_WE_DELIVER.heading,
+    {
+      eyebrow: FOR_OPERATORS_HOW_WE_DELIVER.eyebrow,
+      body: FOR_OPERATORS_HOW_WE_DELIVER.paragraph1,
+      items: [
+        { label: 'paragraph2-before', body: p2.before },
+        { label: 'paragraph2-link', title: p2.linkHref, body: p2.linkLabel },
+        { label: 'paragraph2-after', body: p2.after },
+        { label: 'paragraph3', body: FOR_OPERATORS_HOW_WE_DELIVER.paragraph3 },
+      ],
+    },
+  );
+}
+
+function servicesPricingIntroBlock(): SectionBlock {
+  // Engagement ladder rungs stay in EngagementPricing (prices from contracts).
+  return createSectionBlock(SERVICES_PRICING_INTRO_BLOCK_ID, FOR_OPERATORS_PRICING.heading, {
+    eyebrow: FOR_OPERATORS_PRICING.eyebrow,
+    body: FOR_OPERATORS_PRICING.body,
+  });
+}
+
+function servicesDiscoveryBlock(): SectionBlock {
+  return createSectionBlock(SERVICES_DISCOVERY_BLOCK_ID, FOR_OPERATORS_DISCOVERY.heading, {
+    eyebrow: FOR_OPERATORS_DISCOVERY.eyebrow,
+    body: FOR_OPERATORS_DISCOVERY.body,
+    items: [
+      {
+        label: FOR_OPERATORS_DISCOVERY.link.label,
+        title: FOR_OPERATORS_DISCOVERY.link.href,
+        body: '',
+      },
+    ],
+  });
+}
+
+function servicesProofBlock(): SectionBlock {
+  return createSectionBlock(SERVICES_PROOF_BLOCK_ID, FOR_OPERATORS_PROOF.heading, {
+    eyebrow: FOR_OPERATORS_PROOF.eyebrow,
+    body: FOR_OPERATORS_PROOF.body,
+    items: [
+      { label: 'bullet-intro', body: FOR_OPERATORS_PROOF.bulletIntro },
+      ...FOR_OPERATORS_PROOF.bullets.map((bullet) => ({
+        label: 'bullet',
+        body: bullet,
+      })),
+      ...FOR_OPERATORS_PROOF.links.map((link) => ({
+        label: link.label,
+        title: link.href,
+        body: link.external ? 'external' : 'internal',
+      })),
+    ],
+  });
+}
+
+function servicesFaqBlock(): SectionBlock {
+  return createSectionBlock(SERVICES_FAQ_BLOCK_ID, FOR_OPERATORS_FAQ.heading, {
+    eyebrow: FOR_OPERATORS_FAQ.eyebrow,
+    items: FOR_OPERATORS_FAQ.items.map((item) => ({
+      label: item.question,
+      body: item.answer,
+    })),
+  });
+}
+
+function servicesCtaBlock(): CtaSectionBlock {
+  return createCtaSectionBlock(SERVICES_CTA_BLOCK_ID, FOR_OPERATORS_CLOSING.heading, {
+    body: FOR_OPERATORS_CLOSING.body,
+    links: [ctaToLink(FOR_OPERATORS_CLOSING.primaryCta, 'primary')],
+    snippet: {
+      lines: [
+        FOR_OPERATORS_CLOSING.emailFallback.prefix,
+        FOR_OPERATORS_CLOSING.emailFallback.address,
+        FOR_OPERATORS_CLOSING.emailFallback.suffix,
+      ],
+    },
+  });
+}
+
 /** Derives the home page's block-driven sections (Demo, Primitives, GetStarted). */
 export function homeBlocks(): Block[] {
   return [homeDemoBlock(), homePrimitivesBlock(), homeGetStartedBlock()];
@@ -587,11 +804,29 @@ export function fairSourceBlocks(): Block[] {
   ];
 }
 
+/**
+ * Derives the /services page CMS-driven sections from for-operators content.
+ * Engagement ladder rungs stay component-local (price anchors).
+ */
+export function servicesBlocks(): Block[] {
+  return [
+    servicesHeroBlock(),
+    servicesWhatYouGetBlock(),
+    servicesHowWeDeliverBlock(),
+    servicesPricingIntroBlock(),
+    servicesDiscoveryBlock(),
+    servicesProofBlock(),
+    servicesFaqBlock(),
+    servicesCtaBlock(),
+  ];
+}
+
 export const HOME_FALLBACK_BLOCKS: Block[] = homeBlocks();
 export const PRODUCTS_FALLBACK_BLOCKS: Block[] = productsBlocks();
 export const PHILOSOPHY_FALLBACK_BLOCKS: Block[] = philosophyBlocks();
 export const LOCAL_AI_FALLBACK_BLOCKS: Block[] = localAiBlocks();
 export const FAIR_SOURCE_FALLBACK_BLOCKS: Block[] = fairSourceBlocks();
+export const SERVICES_FALLBACK_BLOCKS: Block[] = servicesBlocks();
 
 // ---------------------------------------------------------------------------
 // Reverse mappers: canonical block -> rich component data shape
@@ -1000,6 +1235,193 @@ export function fairSourceCtaSlot(blocks: Block[]): BlockSlot<FairSourceCtaData>
   const path = `blocks.${FAIR_SOURCE_CTA_INDEX}.data`;
   if (block && block.type === 'ctaSection') return { data: ctaToFairSourceCta(block), path };
   return { data: ctaToFairSourceCta(fairSourceCtaBlock()), path };
+}
+
+function heroToServicesHero(block: HeroBlock): ServicesHeroData {
+  const links = block.data.links ?? [];
+  const primary = links[0]
+    ? {
+        ...linkToCta(links[0]),
+        ...(hrefLooksExternal(links[0].href) ? { external: true as const } : {}),
+      }
+    : FOR_OPERATORS_HERO.primaryCta;
+  const reverse = links[1] ? linkToCta(links[1]) : FOR_OPERATORS_HERO.reverseLink;
+  const lines = block.data.title.split('\n').filter((line) => line.length > 0);
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    h1Lines: lines.length > 0 ? lines : [...FOR_OPERATORS_HERO.h1Lines],
+    subtitle: block.data.subtitle ?? '',
+    primaryCta: primary,
+    reverseLink: reverse,
+  };
+}
+
+function sectionToServicesWhatYouGet(block: SectionBlock): ServicesWhatYouGetData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    cards: (block.data.items ?? []).map((item) => ({
+      title: item.label ?? '',
+      body: item.body,
+    })),
+  };
+}
+
+function sectionToServicesHowWeDeliver(block: SectionBlock): ServicesHowWeDeliverData {
+  const byLabel = new Map((block.data.items ?? []).map((item) => [item.label ?? '', item]));
+  const p2 = FOR_OPERATORS_HOW_WE_DELIVER.paragraph2;
+  const linkItem = byLabel.get('paragraph2-link');
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    paragraph1: block.data.body ?? '',
+    paragraph2: {
+      before: byLabel.get('paragraph2-before')?.body ?? p2.before,
+      linkLabel: linkItem?.body ?? p2.linkLabel,
+      linkHref: linkItem?.title ?? p2.linkHref,
+      after: byLabel.get('paragraph2-after')?.body ?? p2.after,
+    },
+    paragraph3: byLabel.get('paragraph3')?.body ?? FOR_OPERATORS_HOW_WE_DELIVER.paragraph3,
+  };
+}
+
+function sectionToServicesPricingIntro(block: SectionBlock): ServicesPricingIntroData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+  };
+}
+
+function sectionToServicesDiscovery(block: SectionBlock): ServicesDiscoveryData {
+  const linkItem = (block.data.items ?? [])[0];
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    link: {
+      label: linkItem?.label ?? FOR_OPERATORS_DISCOVERY.link.label,
+      href: linkItem?.title ?? FOR_OPERATORS_DISCOVERY.link.href,
+    },
+  };
+}
+
+function sectionToServicesProof(block: SectionBlock): ServicesProofData {
+  const items = block.data.items ?? [];
+  const intro = items.find((item) => item.label === 'bullet-intro');
+  const bullets = items.filter((item) => item.label === 'bullet').map((item) => item.body);
+  const links = items
+    .filter((item) => item.label !== 'bullet-intro' && item.label !== 'bullet')
+    .map((item) => ({
+      label: item.label ?? '',
+      href: item.title ?? '',
+      ...(item.body === 'external' || hrefLooksExternal(item.title ?? '')
+        ? { external: true as const }
+        : {}),
+    }));
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    bulletIntro: intro?.body ?? FOR_OPERATORS_PROOF.bulletIntro,
+    bullets: bullets.length > 0 ? bullets : [...FOR_OPERATORS_PROOF.bullets],
+    links: links.length > 0 ? links : [...FOR_OPERATORS_PROOF.links],
+  };
+}
+
+function sectionToServicesFaq(block: SectionBlock): ServicesFaqData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    items: (block.data.items ?? []).map((item) => ({
+      question: item.label ?? '',
+      answer: item.body,
+    })),
+  };
+}
+
+function ctaToServicesCta(block: CtaSectionBlock): ServicesCtaData {
+  const links = block.data.links ?? [];
+  const lines = block.data.snippet?.lines ?? [];
+  const primary = links[0]
+    ? {
+        ...linkToCta(links[0]),
+        ...(hrefLooksExternal(links[0].href) ? { external: true as const } : {}),
+      }
+    : FOR_OPERATORS_CLOSING.primaryCta;
+  return {
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    primaryCta: primary,
+    emailFallback: {
+      prefix: lines[0] ?? FOR_OPERATORS_CLOSING.emailFallback.prefix,
+      address: lines[1] ?? FOR_OPERATORS_CLOSING.emailFallback.address,
+      suffix: lines[2] ?? FOR_OPERATORS_CLOSING.emailFallback.suffix,
+    },
+  };
+}
+
+export function servicesHeroSlot(blocks: Block[]): BlockSlot<ServicesHeroData> {
+  const block = blocks[SERVICES_HERO_INDEX];
+  const path = `blocks.${SERVICES_HERO_INDEX}.data`;
+  if (block && block.type === 'hero') return { data: heroToServicesHero(block), path };
+  return { data: heroToServicesHero(servicesHeroBlock()), path };
+}
+
+export function servicesWhatYouGetSlot(blocks: Block[]): BlockSlot<ServicesWhatYouGetData> {
+  const block = blocks[SERVICES_WHAT_YOU_GET_INDEX];
+  const path = `blocks.${SERVICES_WHAT_YOU_GET_INDEX}.data`;
+  if (block && block.type === 'section') {
+    return { data: sectionToServicesWhatYouGet(block), path };
+  }
+  return { data: sectionToServicesWhatYouGet(servicesWhatYouGetBlock()), path };
+}
+
+export function servicesHowWeDeliverSlot(blocks: Block[]): BlockSlot<ServicesHowWeDeliverData> {
+  const block = blocks[SERVICES_HOW_WE_DELIVER_INDEX];
+  const path = `blocks.${SERVICES_HOW_WE_DELIVER_INDEX}.data`;
+  if (block && block.type === 'section') {
+    return { data: sectionToServicesHowWeDeliver(block), path };
+  }
+  return { data: sectionToServicesHowWeDeliver(servicesHowWeDeliverBlock()), path };
+}
+
+export function servicesPricingIntroSlot(blocks: Block[]): BlockSlot<ServicesPricingIntroData> {
+  const block = blocks[SERVICES_PRICING_INTRO_INDEX];
+  const path = `blocks.${SERVICES_PRICING_INTRO_INDEX}.data`;
+  if (block && block.type === 'section') {
+    return { data: sectionToServicesPricingIntro(block), path };
+  }
+  return { data: sectionToServicesPricingIntro(servicesPricingIntroBlock()), path };
+}
+
+export function servicesDiscoverySlot(blocks: Block[]): BlockSlot<ServicesDiscoveryData> {
+  const block = blocks[SERVICES_DISCOVERY_INDEX];
+  const path = `blocks.${SERVICES_DISCOVERY_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToServicesDiscovery(block), path };
+  return { data: sectionToServicesDiscovery(servicesDiscoveryBlock()), path };
+}
+
+export function servicesProofSlot(blocks: Block[]): BlockSlot<ServicesProofData> {
+  const block = blocks[SERVICES_PROOF_INDEX];
+  const path = `blocks.${SERVICES_PROOF_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToServicesProof(block), path };
+  return { data: sectionToServicesProof(servicesProofBlock()), path };
+}
+
+export function servicesFaqSlot(blocks: Block[]): BlockSlot<ServicesFaqData> {
+  const block = blocks[SERVICES_FAQ_INDEX];
+  const path = `blocks.${SERVICES_FAQ_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToServicesFaq(block), path };
+  return { data: sectionToServicesFaq(servicesFaqBlock()), path };
+}
+
+export function servicesCtaSlot(blocks: Block[]): BlockSlot<ServicesCtaData> {
+  const block = blocks[SERVICES_CTA_INDEX];
+  const path = `blocks.${SERVICES_CTA_INDEX}.data`;
+  if (block && block.type === 'ctaSection') return { data: ctaToServicesCta(block), path };
+  return { data: ctaToServicesCta(servicesCtaBlock()), path };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -21,8 +21,9 @@
  * headers, contract cards, clock, peers, FAQ, and CTA ride the CMS.
  *
  * Services (`/services`) engagement ladder rungs (titles, prices, bodies, CTAs)
- * stay component-local from `for-operators` + contracts pricing anchors. CMS
- * carries hero through FAQ/CTA narrative and the pricing section header only.
+ * and the FAQ (answers interpolate ladder prices) stay component-local from
+ * `for-operators` + contracts pricing anchors. CMS carries hero through proof
+ * narrative, the pricing section header, and the closing CTA.
  *
  * No React or network imports live here so `scripts/seed-fleet-marketing-site.ts`
  * can import the same derivation the runtime falls back to.
@@ -52,7 +53,6 @@ import {
 import {
   FOR_OPERATORS_CLOSING,
   FOR_OPERATORS_DISCOVERY,
-  FOR_OPERATORS_FAQ,
   FOR_OPERATORS_HERO,
   FOR_OPERATORS_HOW_WE_DELIVER,
   FOR_OPERATORS_PRICING,
@@ -303,12 +303,6 @@ export interface ServicesProofData {
   readonly links: readonly Cta[];
 }
 
-export interface ServicesFaqData {
-  readonly eyebrow: string;
-  readonly heading: string;
-  readonly items: readonly FaqItemData[];
-}
-
 export interface ServicesCtaData {
   readonly heading: string;
   readonly body: string;
@@ -352,7 +346,6 @@ export const SERVICES_HOW_WE_DELIVER_BLOCK_ID = 'services-how-we-deliver';
 export const SERVICES_PRICING_INTRO_BLOCK_ID = 'services-pricing-intro';
 export const SERVICES_DISCOVERY_BLOCK_ID = 'services-discovery';
 export const SERVICES_PROOF_BLOCK_ID = 'services-proof';
-export const SERVICES_FAQ_BLOCK_ID = 'services-faq';
 export const SERVICES_CTA_BLOCK_ID = 'services-cta';
 
 const HOME_DEMO_INDEX = 0;
@@ -381,8 +374,7 @@ const SERVICES_HOW_WE_DELIVER_INDEX = 2;
 const SERVICES_PRICING_INTRO_INDEX = 3;
 const SERVICES_DISCOVERY_INDEX = 4;
 const SERVICES_PROOF_INDEX = 5;
-const SERVICES_FAQ_INDEX = 6;
-const SERVICES_CTA_INDEX = 7;
+const SERVICES_CTA_INDEX = 6;
 
 function hrefLooksExternal(href: string): boolean {
   return (
@@ -739,16 +731,6 @@ function servicesProofBlock(): SectionBlock {
   });
 }
 
-function servicesFaqBlock(): SectionBlock {
-  return createSectionBlock(SERVICES_FAQ_BLOCK_ID, FOR_OPERATORS_FAQ.heading, {
-    eyebrow: FOR_OPERATORS_FAQ.eyebrow,
-    items: FOR_OPERATORS_FAQ.items.map((item) => ({
-      label: item.question,
-      body: item.answer,
-    })),
-  });
-}
-
 function servicesCtaBlock(): CtaSectionBlock {
   return createCtaSectionBlock(SERVICES_CTA_BLOCK_ID, FOR_OPERATORS_CLOSING.heading, {
     body: FOR_OPERATORS_CLOSING.body,
@@ -806,7 +788,7 @@ export function fairSourceBlocks(): Block[] {
 
 /**
  * Derives the /services page CMS-driven sections from for-operators content.
- * Engagement ladder rungs stay component-local (price anchors).
+ * Engagement ladder rungs and FAQ stay component-local (price anchors).
  */
 export function servicesBlocks(): Block[] {
   return [
@@ -816,7 +798,6 @@ export function servicesBlocks(): Block[] {
     servicesPricingIntroBlock(),
     servicesDiscoveryBlock(),
     servicesProofBlock(),
-    servicesFaqBlock(),
     servicesCtaBlock(),
   ];
 }
@@ -1330,17 +1311,6 @@ function sectionToServicesProof(block: SectionBlock): ServicesProofData {
   };
 }
 
-function sectionToServicesFaq(block: SectionBlock): ServicesFaqData {
-  return {
-    eyebrow: block.data.eyebrow ?? '',
-    heading: block.data.heading,
-    items: (block.data.items ?? []).map((item) => ({
-      question: item.label ?? '',
-      answer: item.body,
-    })),
-  };
-}
-
 function ctaToServicesCta(block: CtaSectionBlock): ServicesCtaData {
   const links = block.data.links ?? [];
   const lines = block.data.snippet?.lines ?? [];
@@ -1408,13 +1378,6 @@ export function servicesProofSlot(blocks: Block[]): BlockSlot<ServicesProofData>
   const path = `blocks.${SERVICES_PROOF_INDEX}.data`;
   if (block && block.type === 'section') return { data: sectionToServicesProof(block), path };
   return { data: sectionToServicesProof(servicesProofBlock()), path };
-}
-
-export function servicesFaqSlot(blocks: Block[]): BlockSlot<ServicesFaqData> {
-  const block = blocks[SERVICES_FAQ_INDEX];
-  const path = `blocks.${SERVICES_FAQ_INDEX}.data`;
-  if (block && block.type === 'section') return { data: sectionToServicesFaq(block), path };
-  return { data: sectionToServicesFaq(servicesFaqBlock()), path };
 }
 
 export function servicesCtaSlot(blocks: Block[]): BlockSlot<ServicesCtaData> {

--- a/apps/marketing/app/routes/ServicesPage.tsx
+++ b/apps/marketing/app/routes/ServicesPage.tsx
@@ -7,25 +7,55 @@ import { Hero as ServicesHero } from '../components/for-operators/Hero';
 import { HowWeDeliver } from '../components/for-operators/HowWeDeliver';
 import { Proof as ServicesProof } from '../components/for-operators/Proof';
 import { WhatYouGet } from '../components/for-operators/WhatYouGet';
+import {
+  SERVICES_FALLBACK_BLOCKS,
+  servicesCtaSlot,
+  servicesDiscoverySlot,
+  servicesFaqSlot,
+  servicesHeroSlot,
+  servicesHowWeDeliverSlot,
+  servicesPricingIntroSlot,
+  servicesProofSlot,
+  servicesWhatYouGetSlot,
+} from '../lib/page-blocks';
+import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
 /**
  * Done-for-you services landing: `/services`. The operator pitch used to be
  * only reachable as the homepage's non-technical audience view; it now also
  * has its own URL, using the standalone for-operators Hero (eyebrow + reverse
  * link back to `/`) that predates the in-hero audience toggle. `?for=non-
- * technical` on `/` still serves the same underlying content as an alias.
+ * technical` on `/` still serves the same underlying content as a static alias
+ * (CMS wire lives only here).
+ *
+ * Narrative sections are CMS-wired via useMarketingPageBlocks (VES residual).
+ * Engagement ladder rungs stay component-local (price anchors from contracts).
  */
 export function ServicesPage() {
+  const { blocks, annotation } = useMarketingPageBlocks('services', SERVICES_FALLBACK_BLOCKS);
+  const hero = servicesHeroSlot(blocks);
+  const whatYouGet = servicesWhatYouGetSlot(blocks);
+  const howWeDeliver = servicesHowWeDeliverSlot(blocks);
+  const pricingIntro = servicesPricingIntroSlot(blocks);
+  const discovery = servicesDiscoverySlot(blocks);
+  const proof = servicesProofSlot(blocks);
+  const faq = servicesFaqSlot(blocks);
+  const cta = servicesCtaSlot(blocks);
+
   return (
     <div className="min-h-screen bg-background">
-      <ServicesHero />
-      <WhatYouGet />
-      <HowWeDeliver />
-      <EngagementPricing />
-      <DiscoveryScopeShip />
-      <ServicesProof />
-      <ServicesFaq />
-      <ClosingCta />
+      <ServicesHero data={hero.data} path={hero.path} annotation={annotation} />
+      <WhatYouGet data={whatYouGet.data} path={whatYouGet.path} annotation={annotation} />
+      <HowWeDeliver data={howWeDeliver.data} path={howWeDeliver.path} annotation={annotation} />
+      <EngagementPricing
+        data={pricingIntro.data}
+        path={pricingIntro.path}
+        annotation={annotation}
+      />
+      <DiscoveryScopeShip data={discovery.data} path={discovery.path} annotation={annotation} />
+      <ServicesProof data={proof.data} path={proof.path} annotation={annotation} />
+      <ServicesFaq data={faq.data} path={faq.path} annotation={annotation} />
+      <ClosingCta data={cta.data} path={cta.path} annotation={annotation} />
       <Footer />
     </div>
   );

--- a/apps/marketing/app/routes/ServicesPage.tsx
+++ b/apps/marketing/app/routes/ServicesPage.tsx
@@ -11,7 +11,6 @@ import {
   SERVICES_FALLBACK_BLOCKS,
   servicesCtaSlot,
   servicesDiscoverySlot,
-  servicesFaqSlot,
   servicesHeroSlot,
   servicesHowWeDeliverSlot,
   servicesPricingIntroSlot,
@@ -21,15 +20,10 @@ import {
 import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
 /**
- * Done-for-you services landing: `/services`. The operator pitch used to be
- * only reachable as the homepage's non-technical audience view; it now also
- * has its own URL, using the standalone for-operators Hero (eyebrow + reverse
- * link back to `/`) that predates the in-hero audience toggle. `?for=non-
- * technical` on `/` still serves the same underlying content as a static alias
- * (CMS wire lives only here).
- *
- * Narrative sections are CMS-wired via useMarketingPageBlocks (VES residual).
- * Engagement ladder rungs stay component-local (price anchors from contracts).
+ * Done-for-you services landing: `/services`. Narrative sections are CMS-wired
+ * via useMarketingPageBlocks (VES residual, same pattern as fair-source).
+ * Engagement ladder rungs and FAQ stay static (answers interpolate price
+ * anchors from contracts). `?for=non-technical` on `/` is a static alias.
  */
 export function ServicesPage() {
   const { blocks, annotation } = useMarketingPageBlocks('services', SERVICES_FALLBACK_BLOCKS);
@@ -39,7 +33,6 @@ export function ServicesPage() {
   const pricingIntro = servicesPricingIntroSlot(blocks);
   const discovery = servicesDiscoverySlot(blocks);
   const proof = servicesProofSlot(blocks);
-  const faq = servicesFaqSlot(blocks);
   const cta = servicesCtaSlot(blocks);
 
   return (
@@ -54,7 +47,7 @@ export function ServicesPage() {
       />
       <DiscoveryScopeShip data={discovery.data} path={discovery.path} annotation={annotation} />
       <ServicesProof data={proof.data} path={proof.path} annotation={annotation} />
-      <ServicesFaq data={faq.data} path={faq.path} annotation={annotation} />
+      <ServicesFaq />
       <ClosingCta data={cta.data} path={cta.path} annotation={annotation} />
       <Footer />
     </div>

--- a/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
+++ b/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
@@ -13,11 +13,18 @@ import { act, cleanup, render, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchPageBlocks } from '../../lib/api';
-import { fairSourceBlocks, homeBlocks, localAiBlocks, productsBlocks } from '../../lib/page-blocks';
+import {
+  fairSourceBlocks,
+  homeBlocks,
+  localAiBlocks,
+  productsBlocks,
+  servicesBlocks,
+} from '../../lib/page-blocks';
 import { FairSourcePage } from '../FairSourcePage';
 import { HomePage } from '../HomePage';
 import { LocalAiPage } from '../LocalAiPage';
 import { ProductsPage } from '../ProductsPage';
+import { ServicesPage } from '../ServicesPage';
 
 vi.mock('../../lib/api', () => ({ fetchPageBlocks: vi.fn() }));
 
@@ -65,7 +72,7 @@ describe('marketing pages: edit-mode wiring', () => {
     editDraftsStore.setEditActive(false);
   });
 
-  it('HomePage, ProductsPage, LocalAiPage, and FairSourcePage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
+  it('HomePage, ProductsPage, LocalAiPage, FairSourcePage, and ServicesPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
     const home = renderRouted(<HomePage />);
     expect(home.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(home.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
@@ -84,6 +91,11 @@ describe('marketing pages: edit-mode wiring', () => {
     const fairSource = renderRouted(<FairSourcePage />);
     expect(fairSource.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(fairSource.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
+    fairSource.unmount();
+
+    const services = renderRouted(<ServicesPage />);
+    expect(services.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+    expect(services.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
   });
 
   it('HomePage renders the draft heading annotated with the session docId when a matching overlay exists', () => {
@@ -160,6 +172,26 @@ describe('marketing pages: edit-mode wiring', () => {
     const heading = container.querySelector('[data-rvui-field="blocks.0.data.heading"]');
     expect(heading?.getAttribute('data-rvui-doc')).toBe('page-fair-source-id');
     expect(heading?.textContent).toBe('Canvas-edited fair-source contract');
+  });
+
+  it('ServicesPage renders the draft hero annotated with the session docId when a matching overlay exists', () => {
+    const draftBlocks = servicesBlocks();
+    const hero = draftBlocks[0];
+    if (hero?.type === 'hero') {
+      hero.data.title = 'Canvas-edited services title';
+    }
+    editDraftsStore.set([
+      {
+        docType: 'page',
+        docId: 'page-services-id',
+        draft: { slug: 'services', blocks: draftBlocks },
+      },
+    ]);
+
+    const { container } = renderRouted(<ServicesPage />);
+    const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
+    expect(title?.getAttribute('data-rvui-doc')).toBe('page-services-id');
+    expect(title?.textContent).toBe('Canvas-edited services title');
   });
 
   it('re-renders HomePage with the patched value after an optimistic draft-store update', () => {

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -2,7 +2,8 @@
 
 /**
  * Seed the fleet-marketing `sites` row plus its published marketing pages
- * (home, products, philosophy, local-ai, fair-source) for the visual-edit-sessions block wire.
+ * (home, products, philosophy, local-ai, fair-source, services) for the
+ * visual-edit-sessions block wire.
  *
  * The page `blocks` come from the SAME pure derivation the marketing app falls
  * back to (`apps/marketing/app/lib/page-blocks.ts`), so the seeded CMS content
@@ -37,6 +38,7 @@ import {
   localAiBlocks,
   philosophyBlocks,
   productsBlocks,
+  servicesBlocks,
 } from '../apps/marketing/app/lib/page-blocks';
 import {
   assertSeedDatabaseReady,
@@ -117,6 +119,17 @@ const PAGE_SEEDS: readonly PageSeed[] = [
       title: 'Fair Source | RevealUI',
       description:
         'Source-visible. Commercially usable. MIT in two years. The license contract for RevealUI Pro packages.',
+    },
+  },
+  {
+    slug: 'services',
+    path: '/services',
+    title: 'Services',
+    blocks: servicesBlocks(),
+    seo: {
+      title: 'Services | RevealUI',
+      description:
+        'Done-for-you software with AI built in. Discovery, fixed-scope engagement, delivered by the team that builds the runtime.',
     },
   },
 ];
@@ -265,7 +278,7 @@ async function main(): Promise<void> {
   }
 
   // ---------------------------------------------------------------------------
-  // Pages (home + products + philosophy + local-ai + fair-source) — version-safe, idempotent
+  // Pages (home + products + philosophy + local-ai + fair-source + services) — version-safe, idempotent
   // ---------------------------------------------------------------------------
 
   for (const seed of PAGE_SEEDS) {


### PR DESCRIPTION
## Summary

- Wire `/services` to CMS via the same static-first pattern as fair-source (#2077) and local-ai
- Derive narrative blocks from `content/for-operators.ts` in `page-blocks.ts` (hero, what-you-get, how-we-deliver, pricing intro, discovery, proof, closing CTA)
- Pass optional CMS data + `fieldAttrs` into for-operators section components (Home `?for=non-technical` still works without props)
- Seed fleet-marketing `services` page; extend page-blocks + edit-mode wiring tests

## Non-goals (claims safety)

- Engagement ladder **rungs** stay component-local (price anchors from contracts)
- **FAQ** stays component-local (cost answer interpolates ladder prices; blocks must not carry `$…`)
- Home `?for=non-technical` stays a static alias (no CMS slug)

## Peer coordination

- Peer owns GAP-406 (#2083 / jv#606) — no path overlap
- Claim: `.jv/.claude/workboard.d/notes/2026-07-23T0230Z-grok-services-cms-claim.md`

## Test plan

- [x] `pnpm exec vitest run app/lib/page-blocks.test.ts app/routes/__tests__/edit-mode-wiring.test.tsx` (22/22)
- [x] `pnpm --filter marketing typecheck`
- [x] Pre-push gate phase 1 PASS

## Owner

Merge when green (`--squash` or merge-commit per repo settings). No security path.