### PR TITLE
feat(marketing): wire for-operators managed CMS blocks (VES residual)

### DIFF
--- a/apps/marketing/app/components/for-operators-managed/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Hero.tsx
@@ -1,33 +1,60 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FO_MANAGED_HERO } from '../../content/for-operators-managed';
+import type { FoManagedHeroData } from '../../lib/page-blocks';
 
-export function Hero() {
+export interface FoManagedHeroProps {
+  readonly data?: FoManagedHeroData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function Hero({ data, path, annotation }: FoManagedHeroProps = {}) {
+  const content = data ?? {
+    eyebrow: FO_MANAGED_HERO.eyebrow,
+    h1Lines: [...FO_MANAGED_HERO.h1Lines],
+    subtitle: FO_MANAGED_HERO.subtitle,
+    backLink: FO_MANAGED_HERO.backLink,
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   return (
     <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
       <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
 
       <div className="relative mx-auto max-w-3xl text-center">
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
-          {FO_MANAGED_HERO.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
+          {content.eyebrow}
         </p>
 
-        <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
-          {FO_MANAGED_HERO.h1Lines.map((line) => (
+        <h1
+          className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl"
+          {...(base ? fieldAttrs(ann, `${base}.title`) : {})}
+        >
+          {content.h1Lines.map((line) => (
             <span key={line} className="block">
               {line}
             </span>
           ))}
         </h1>
 
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-          {FO_MANAGED_HERO.subtitle}
+        <p
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          {...(base ? fieldAttrs(ann, `${base}.subtitle`) : {})}
+        >
+          {content.subtitle}
         </p>
 
         <p className="mt-10 text-sm text-muted-foreground">
           <a
-            href={FO_MANAGED_HERO.backLink.href}
+            href={content.backLink.href}
             className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+            {...(base ? fieldAttrs(ann, `${base}.links.0.label`) : {})}
           >
-            {FO_MANAGED_HERO.backLink.label}
+            {content.backLink.label}
           </a>
         </p>
       </div>

--- a/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
@@ -1,32 +1,78 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FO_MANAGED_PREREQS } from '../../content/for-operators-managed';
+import type { FoManagedPrereqsData } from '../../lib/page-blocks';
 
-export function Prerequisites() {
+export interface FoManagedPrereqsProps {
+  readonly data?: FoManagedPrereqsData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function Prerequisites({ data, path, annotation }: FoManagedPrereqsProps = {}) {
+  const content = data ?? {
+    eyebrow: FO_MANAGED_PREREQS.eyebrow,
+    heading: FO_MANAGED_PREREQS.heading,
+    intro: FO_MANAGED_PREREQS.intro,
+    prerequisites: FO_MANAGED_PREREQS.prerequisites.map((p) => ({
+      title: p.title,
+      body: p.body,
+    })),
+    closing: FO_MANAGED_PREREQS.closing,
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+  const closingIndex = content.prerequisites.length;
+
   return (
     <section className="bg-muted py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FO_MANAGED_PREREQS.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
+          {content.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FO_MANAGED_PREREQS.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+        >
+          {content.heading}
         </h2>
 
-        <p className="mt-6 text-base leading-7 text-muted-foreground">{FO_MANAGED_PREREQS.intro}</p>
+        <p
+          className="mt-6 text-base leading-7 text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+        >
+          {content.intro}
+        </p>
 
         <ul className="mt-6 space-y-4 list-none p-0">
-          {FO_MANAGED_PREREQS.prerequisites.map((prereq) => (
+          {content.prerequisites.map((prereq, index) => (
             <li
               key={prereq.title}
               className="rounded-2xl border border-border bg-card p-5 shadow-sm"
             >
-              <h3 className="text-base font-semibold leading-7 text-foreground">{prereq.title}</h3>
-              <p className="mt-2 text-base leading-7 text-muted-foreground">{prereq.body}</p>
+              <h3
+                className="text-base font-semibold leading-7 text-foreground"
+                {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
+              >
+                {prereq.title}
+              </h3>
+              <p
+                className="mt-2 text-base leading-7 text-muted-foreground"
+                {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
+              >
+                {prereq.body}
+              </p>
             </li>
           ))}
         </ul>
 
-        <p className="mt-8 text-base leading-7 text-foreground font-medium">
-          {FO_MANAGED_PREREQS.closing}
+        <p
+          className="mt-8 text-base leading-7 text-foreground font-medium"
+          {...(base ? fieldAttrs(ann, `${base}.items.${closingIndex}.body`) : {})}
+        >
+          {content.closing}
         </p>
       </div>
     </section>

--- a/apps/marketing/app/components/for-operators-managed/Status.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Status.tsx
@@ -1,20 +1,44 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FO_MANAGED_STATUS } from '../../content/for-operators-managed';
+import type { FoManagedStatusData } from '../../lib/page-blocks';
 
-export function Status() {
+export interface FoManagedStatusProps {
+  readonly data?: FoManagedStatusData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function Status({ data, path, annotation }: FoManagedStatusProps = {}) {
+  const content = data ?? {
+    eyebrow: FO_MANAGED_STATUS.eyebrow,
+    heading: FO_MANAGED_STATUS.heading,
+    paragraph1: FO_MANAGED_STATUS.paragraph1,
+    paragraph2: FO_MANAGED_STATUS.paragraph2,
+    paragraph3: FO_MANAGED_STATUS.paragraph3,
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   return (
     <section className="bg-muted py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FO_MANAGED_STATUS.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
+          {content.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FO_MANAGED_STATUS.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+        >
+          {content.heading}
         </h2>
 
         <div className="mt-8 space-y-6 text-base leading-7 text-muted-foreground">
-          <p>{FO_MANAGED_STATUS.paragraph1}</p>
-          <p>{FO_MANAGED_STATUS.paragraph2}</p>
-          <p>{FO_MANAGED_STATUS.paragraph3}</p>
+          <p {...(base ? fieldAttrs(ann, `${base}.body`) : {})}>{content.paragraph1}</p>
+          <p {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>{content.paragraph2}</p>
+          <p {...(base ? fieldAttrs(ann, `${base}.items.1.body`) : {})}>{content.paragraph3}</p>
         </div>
       </div>
     </section>

--- a/apps/marketing/app/components/for-operators-managed/Today.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Today.tsx
@@ -1,38 +1,66 @@
-import { Button } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
 import { FO_MANAGED_TODAY } from '../../content/for-operators-managed';
+import type { FoManagedTodayData } from '../../lib/page-blocks';
 
-export function Today() {
+export interface FoManagedTodayProps {
+  readonly data?: FoManagedTodayData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function Today({ data, path, annotation }: FoManagedTodayProps = {}) {
+  const content = data ?? {
+    eyebrow: FO_MANAGED_TODAY.eyebrow,
+    heading: FO_MANAGED_TODAY.heading,
+    body: FO_MANAGED_TODAY.body,
+    primaryCta: FO_MANAGED_TODAY.primaryCta,
+    detailLink: FO_MANAGED_TODAY.detailLink,
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FO_MANAGED_TODAY.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
+          {content.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FO_MANAGED_TODAY.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+        >
+          {content.heading}
         </h2>
 
-        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">
-          {FO_MANAGED_TODAY.body}
+        <p
+          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+        >
+          {content.body}
         </p>
 
         <div className="mt-10 flex flex-col items-center gap-4">
           <Button asChild size="lg">
             <a
-              href={FO_MANAGED_TODAY.primaryCta.href}
-              {...(FO_MANAGED_TODAY.primaryCta.external
+              href={content.primaryCta.href}
+              {...(content.primaryCta.external
                 ? { target: '_blank', rel: 'noopener noreferrer' }
                 : {})}
+              {...(base ? fieldAttrs(ann, `${base}.items.0.label`) : {})}
             >
-              {FO_MANAGED_TODAY.primaryCta.label}
+              {content.primaryCta.label}
             </a>
           </Button>
           <p className="text-sm">
             <a
-              href={FO_MANAGED_TODAY.detailLink.href}
+              href={content.detailLink.href}
               className="font-medium text-primary hover:underline underline-offset-4"
+              {...(base ? fieldAttrs(ann, `${base}.items.1.label`) : {})}
             >
-              {FO_MANAGED_TODAY.detailLink.label}
+              {content.detailLink.label}
             </a>
           </p>
         </div>

--- a/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
@@ -1,10 +1,31 @@
-import { Button, Input } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs, Input } from '@revealui/presentation';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
 import { FO_MANAGED_WAITLIST } from '../../content/for-operators-managed';
 import { submitWaitlist } from '../../lib/api';
+import type { FoManagedWaitlistData } from '../../lib/page-blocks';
 
-export function Waitlist() {
+export interface FoManagedWaitlistProps {
+  readonly data?: FoManagedWaitlistData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function Waitlist({ data, path, annotation }: FoManagedWaitlistProps = {}) {
+  const content = data ?? {
+    eyebrow: FO_MANAGED_WAITLIST.eyebrow,
+    heading: FO_MANAGED_WAITLIST.heading,
+    body: FO_MANAGED_WAITLIST.body,
+    inputPlaceholder: FO_MANAGED_WAITLIST.inputPlaceholder,
+    buttonLabel: FO_MANAGED_WAITLIST.buttonLabel,
+    buttonLabelLoading: FO_MANAGED_WAITLIST.buttonLabelLoading,
+    successMessage: FO_MANAGED_WAITLIST.successMessage,
+  };
+  // product source is API contract — never CMS-editable.
+  const product = FO_MANAGED_WAITLIST.product;
+  const ann = annotation ?? {};
+  const base = path ?? '';
+
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
@@ -16,10 +37,10 @@ export function Waitlist() {
     setStatus('loading');
     // Source-tagged so RevealUI Cloud interest is queryable separately from
     // newsletter signups (apps/server POST /api/waitlist → waitlist table).
-    const error = await submitWaitlist({ email, source: FO_MANAGED_WAITLIST.product });
+    const error = await submitWaitlist({ email, source: product });
     if (error === null) {
       setStatus('success');
-      setMessage(FO_MANAGED_WAITLIST.successMessage);
+      setMessage(content.successMessage);
       setEmail('');
     } else {
       setStatus('error');
@@ -30,19 +51,31 @@ export function Waitlist() {
   return (
     <section className="bg-muted py-24 sm:py-32">
       <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FO_MANAGED_WAITLIST.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+        >
+          {content.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FO_MANAGED_WAITLIST.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+        >
+          {content.heading}
         </h2>
 
-        <p className="mx-auto mt-6 max-w-xl text-base leading-7 text-muted-foreground">
-          {FO_MANAGED_WAITLIST.body}
+        <p
+          className="mx-auto mt-6 max-w-xl text-base leading-7 text-muted-foreground"
+          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+        >
+          {content.body}
         </p>
 
         {status === 'success' ? (
-          <p className="mt-10 animate-[fade-in_300ms_ease-out] text-base font-medium text-primary">
+          <p
+            className="mt-10 animate-[fade-in_300ms_ease-out] text-base font-medium text-primary"
+            {...(base ? fieldAttrs(ann, `${base}.items.3.body`) : {})}
+          >
             {message}
           </p>
         ) : (
@@ -55,18 +88,29 @@ export function Waitlist() {
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              placeholder={FO_MANAGED_WAITLIST.inputPlaceholder}
+              placeholder={content.inputPlaceholder}
               required
             />
+            {/* Labels ride CMS for seed/fallback parity; form controls stay unannotated. */}
+            <span className="sr-only" {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>
+              {content.inputPlaceholder}
+            </span>
             <Button
               type="submit"
               variant="brand"
               isLoading={status === 'loading'}
               disabled={status === 'loading'}
             >
-              {status === 'loading'
-                ? FO_MANAGED_WAITLIST.buttonLabelLoading
-                : FO_MANAGED_WAITLIST.buttonLabel}
+              <span
+                {...(base
+                  ? fieldAttrs(
+                      ann,
+                      status === 'loading' ? `${base}.items.2.body` : `${base}.items.1.body`,
+                    )
+                  : {})}
+              >
+                {status === 'loading' ? content.buttonLabelLoading : content.buttonLabel}
+              </span>
             </Button>
             {status === 'error' && <p className="text-xs text-destructive">{message}</p>}
           </form>

--- a/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
+++ b/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
@@ -1,34 +1,72 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FO_MANAGED_WOULD_BE } from '../../content/for-operators-managed';
+import type { FoManagedWouldBeData } from '../../lib/page-blocks';
 
-export function WouldBe() {
+export interface FoManagedWouldBeProps {
+  readonly data?: FoManagedWouldBeData;
+  readonly path?: string;
+  readonly annotation?: BlockAnnotation;
+}
+
+export function WouldBe({ data, path, annotation }: FoManagedWouldBeProps = {}) {
+  const content = data ?? {
+    eyebrow: FO_MANAGED_WOULD_BE.eyebrow,
+    heading: FO_MANAGED_WOULD_BE.heading,
+    capabilities: FO_MANAGED_WOULD_BE.capabilities.map((c) => ({
+      title: c.title,
+      body: c.body,
+    })),
+    closing: FO_MANAGED_WOULD_BE.closing,
+  };
+  const ann = annotation ?? {};
+  const base = path ?? '';
+  const closingIndex = content.capabilities.length;
+
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-5xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {FO_MANAGED_WOULD_BE.eyebrow}
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+          >
+            {content.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {FO_MANAGED_WOULD_BE.heading}
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
+          >
+            {content.heading}
           </h2>
         </div>
 
         <ul className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-6 list-none p-0">
-          {FO_MANAGED_WOULD_BE.capabilities.map((capability) => (
+          {content.capabilities.map((capability, index) => (
             <li
               key={capability.title}
               className="rounded-2xl border border-border bg-card p-6 shadow-sm"
             >
-              <h3 className="text-lg font-semibold leading-7 text-foreground">
+              <h3
+                className="text-lg font-semibold leading-7 text-foreground"
+                {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
+              >
                 {capability.title}
               </h3>
-              <p className="mt-2 text-base leading-7 text-muted-foreground">{capability.body}</p>
+              <p
+                className="mt-2 text-base leading-7 text-muted-foreground"
+                {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
+              >
+                {capability.body}
+              </p>
             </li>
           ))}
         </ul>
 
-        <p className="mx-auto mt-12 max-w-2xl text-center text-base leading-7 text-foreground font-medium">
-          {FO_MANAGED_WOULD_BE.closing}
+        <p
+          className="mx-auto mt-12 max-w-2xl text-center text-base leading-7 text-foreground font-medium"
+          {...(base ? fieldAttrs(ann, `${base}.items.${closingIndex}.body`) : {})}
+        >
+          {content.closing}
         </p>
       </div>
     </section>

--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -11,6 +11,14 @@ import {
   FAIR_SOURCE_PEERS,
   FAIR_SOURCE_PEERS_SECTION,
 } from '../content/fair-source';
+import {
+  FO_MANAGED_HERO,
+  FO_MANAGED_PREREQS,
+  FO_MANAGED_STATUS,
+  FO_MANAGED_TODAY,
+  FO_MANAGED_WAITLIST,
+  FO_MANAGED_WOULD_BE,
+} from '../content/for-operators-managed';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
@@ -21,6 +29,7 @@ import {
   blocksMatchFallback,
   demoSlot,
   FAIR_SOURCE_FALLBACK_BLOCKS,
+  FO_MANAGED_FALLBACK_BLOCKS,
   fairSourceBlocks,
   fairSourceClockSlot,
   fairSourceContractSlot,
@@ -28,6 +37,13 @@ import {
   fairSourceFaqSlot,
   fairSourcePackagesIntroSlot,
   fairSourcePeersSlot,
+  foManagedBlocks,
+  foManagedHeroSlot,
+  foManagedPrereqsSlot,
+  foManagedStatusSlot,
+  foManagedTodaySlot,
+  foManagedWaitlistSlot,
+  foManagedWouldBeSlot,
   getStartedSlot,
   HOME_FALLBACK_BLOCKS,
   homeBlocks,
@@ -65,13 +81,14 @@ function collectStrings(value: unknown, out: string[] = []): string[] {
 }
 
 describe('page-blocks derivation', () => {
-  it('produces schema-valid blocks for home, products, philosophy, local-ai, and fair-source', () => {
+  it('produces schema-valid blocks for home, products, philosophy, local-ai, fair-source, and fo-managed', () => {
     for (const block of [
       ...homeBlocks(),
       ...productsBlocks(),
       ...philosophyBlocks(),
       ...localAiBlocks(),
       ...fairSourceBlocks(),
+      ...foManagedBlocks(),
     ]) {
       expect(BlockSchema.safeParse(block).success).toBe(true);
     }
@@ -95,6 +112,14 @@ describe('page-blocks derivation', () => {
       'section',
       'section',
       'ctaSection',
+    ]);
+    expect(foManagedBlocks().map((b) => b.type)).toEqual([
+      'hero',
+      'section',
+      'section',
+      'section',
+      'section',
+      'section',
     ]);
   });
 
@@ -185,6 +210,54 @@ describe('page-blocks derivation', () => {
       secondary: { label: FAIR_SOURCE_CTA.secondaryLabel, href: FAIR_SOURCE_CTA.secondaryHref },
     });
   });
+
+  it('round-trips fo-managed slots against for-operators-managed content', () => {
+    const blocks = FO_MANAGED_FALLBACK_BLOCKS;
+    expect(foManagedHeroSlot(blocks).data).toEqual({
+      eyebrow: FO_MANAGED_HERO.eyebrow,
+      h1Lines: [...FO_MANAGED_HERO.h1Lines],
+      subtitle: FO_MANAGED_HERO.subtitle,
+      backLink: FO_MANAGED_HERO.backLink,
+    });
+    expect(foManagedStatusSlot(blocks).data).toEqual({ ...FO_MANAGED_STATUS });
+    expect(foManagedWouldBeSlot(blocks).data).toEqual({
+      eyebrow: FO_MANAGED_WOULD_BE.eyebrow,
+      heading: FO_MANAGED_WOULD_BE.heading,
+      capabilities: FO_MANAGED_WOULD_BE.capabilities.map((c) => ({
+        title: c.title,
+        body: c.body,
+      })),
+      closing: FO_MANAGED_WOULD_BE.closing,
+    });
+    expect(foManagedPrereqsSlot(blocks).data).toEqual({
+      eyebrow: FO_MANAGED_PREREQS.eyebrow,
+      heading: FO_MANAGED_PREREQS.heading,
+      intro: FO_MANAGED_PREREQS.intro,
+      prerequisites: FO_MANAGED_PREREQS.prerequisites.map((p) => ({
+        title: p.title,
+        body: p.body,
+      })),
+      closing: FO_MANAGED_PREREQS.closing,
+    });
+    expect(foManagedTodaySlot(blocks).data).toEqual({
+      eyebrow: FO_MANAGED_TODAY.eyebrow,
+      heading: FO_MANAGED_TODAY.heading,
+      body: FO_MANAGED_TODAY.body,
+      primaryCta: FO_MANAGED_TODAY.primaryCta,
+      detailLink: FO_MANAGED_TODAY.detailLink,
+    });
+    expect(foManagedWaitlistSlot(blocks).data).toEqual({
+      eyebrow: FO_MANAGED_WAITLIST.eyebrow,
+      heading: FO_MANAGED_WAITLIST.heading,
+      body: FO_MANAGED_WAITLIST.body,
+      inputPlaceholder: FO_MANAGED_WAITLIST.inputPlaceholder,
+      buttonLabel: FO_MANAGED_WAITLIST.buttonLabel,
+      buttonLabelLoading: FO_MANAGED_WAITLIST.buttonLabelLoading,
+      successMessage: FO_MANAGED_WAITLIST.successMessage,
+    });
+    // product source tag never enters blocks
+    expect(collectStrings(foManagedBlocks()).join(' ')).not.toContain('managed-cloud');
+  });
 });
 
 describe('claims safety: prose is single-sourced, pinned values never enter blocks', () => {
@@ -194,6 +267,7 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     philosophyBlocks(),
     localAiBlocks(),
     fairSourceBlocks(),
+    foManagedBlocks(),
   ]);
   const haystack = strings.join(' ');
 
@@ -243,6 +317,9 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     }
     expect(strings).toContain(FAIR_SOURCE_CTA.heading);
     expect(strings).toContain(FAIR_SOURCE_CTA.body);
+    expect(strings).toContain(FO_MANAGED_HERO.subtitle);
+    expect(strings).toContain(FO_MANAGED_STATUS.heading);
+    expect(strings).toContain(FO_MANAGED_WAITLIST.heading);
     // Env-code lines stay out of blocks (grep-accurate, component-local).
     expect(strings).not.toContain('LLM_PROVIDER=inference-snaps');
     expect(strings).not.toContain('LLM_PROVIDER=ollama');

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -1,6 +1,6 @@
 /**
  * Static-first block derivation for marketing pages served from the CMS
- * (home, products, philosophy, local-ai, fair-source).
+ * (home, products, philosophy, local-ai, fair-source, for-operators-managed).
  *
  * The marketing content modules stay the single source of truth for every prose
  * string. This module derives the canonical `pages.blocks` array from those
@@ -19,6 +19,10 @@
  * subhead, and body interpolate METRICS license-split counts. The package
  * inventory table stays structural (name/license/repo/npm), while section
  * headers, contract cards, clock, peers, FAQ, and CTA ride the CMS.
+ *
+ * For-operators managed (`/for-operators/managed`) is narrative roadmap copy.
+ * Waitlist form interactivity and the `product` waitlist source tag stay component-local;
+ * CMS carries section prose, CTAs, and waitlist labels only.
  *
  * No React or network imports live here so `scripts/seed-fleet-marketing-site.ts`
  * can import the same derivation the runtime falls back to.
@@ -45,6 +49,14 @@ import {
   FAIR_SOURCE_PEERS,
   FAIR_SOURCE_PEERS_SECTION,
 } from '../content/fair-source';
+import {
+  FO_MANAGED_HERO,
+  FO_MANAGED_PREREQS,
+  FO_MANAGED_STATUS,
+  FO_MANAGED_TODAY,
+  FO_MANAGED_WAITLIST,
+  FO_MANAGED_WOULD_BE,
+} from '../content/for-operators-managed';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
@@ -234,6 +246,64 @@ export interface FairSourceCtaData {
   readonly secondary: Cta;
 }
 
+export interface FoManagedHeroData {
+  readonly eyebrow: string;
+  readonly h1Lines: readonly string[];
+  readonly subtitle: string;
+  readonly backLink: Cta;
+}
+
+export interface FoManagedStatusData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly paragraph1: string;
+  readonly paragraph2: string;
+  readonly paragraph3: string;
+}
+
+export interface FoManagedCapabilityData {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface FoManagedWouldBeData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly capabilities: readonly FoManagedCapabilityData[];
+  readonly closing: string;
+}
+
+export interface FoManagedPrereqData {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface FoManagedPrereqsData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly intro: string;
+  readonly prerequisites: readonly FoManagedPrereqData[];
+  readonly closing: string;
+}
+
+export interface FoManagedTodayData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly primaryCta: Cta;
+  readonly detailLink: Cta;
+}
+
+export interface FoManagedWaitlistData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly body: string;
+  readonly inputPlaceholder: string;
+  readonly buttonLabel: string;
+  readonly buttonLabelLoading: string;
+  readonly successMessage: string;
+}
+
 // ---------------------------------------------------------------------------
 // Stable block ids + positions. Ids let the seed and fallback match, but the
 // runtime routes each slot by array POSITION + type (the CMS assigns its own
@@ -260,6 +330,12 @@ export const FAIR_SOURCE_CLOCK_BLOCK_ID = 'fair-source-clock';
 export const FAIR_SOURCE_PEERS_BLOCK_ID = 'fair-source-peers';
 export const FAIR_SOURCE_FAQ_BLOCK_ID = 'fair-source-faq';
 export const FAIR_SOURCE_CTA_BLOCK_ID = 'fair-source-cta';
+export const FO_MANAGED_HERO_BLOCK_ID = 'fo-managed-hero';
+export const FO_MANAGED_STATUS_BLOCK_ID = 'fo-managed-status';
+export const FO_MANAGED_WOULD_BE_BLOCK_ID = 'fo-managed-would-be';
+export const FO_MANAGED_PREREQS_BLOCK_ID = 'fo-managed-prereqs';
+export const FO_MANAGED_TODAY_BLOCK_ID = 'fo-managed-today';
+export const FO_MANAGED_WAITLIST_BLOCK_ID = 'fo-managed-waitlist';
 
 const HOME_DEMO_INDEX = 0;
 const HOME_PRIMITIVES_INDEX = 1;
@@ -281,6 +357,21 @@ const FAIR_SOURCE_CLOCK_INDEX = 2;
 const FAIR_SOURCE_PEERS_INDEX = 3;
 const FAIR_SOURCE_FAQ_INDEX = 4;
 const FAIR_SOURCE_CTA_INDEX = 5;
+const FO_MANAGED_HERO_INDEX = 0;
+const FO_MANAGED_STATUS_INDEX = 1;
+const FO_MANAGED_WOULD_BE_INDEX = 2;
+const FO_MANAGED_PREREQS_INDEX = 3;
+const FO_MANAGED_TODAY_INDEX = 4;
+const FO_MANAGED_WAITLIST_INDEX = 5;
+
+function hrefLooksExternal(href: string): boolean {
+  return (
+    href.startsWith('http://') ||
+    href.startsWith('https://') ||
+    href.startsWith('mailto:') ||
+    href.startsWith('//')
+  );
+}
 
 function ctaToLink(cta: Cta, variant: 'primary' | 'secondary'): MarketingLink {
   return { label: cta.label, href: cta.href, variant };
@@ -546,6 +637,86 @@ function fairSourceCtaBlock(): CtaSectionBlock {
   });
 }
 
+function foManagedHeroBlock(): HeroBlock {
+  return createHeroBlock(FO_MANAGED_HERO_BLOCK_ID, FO_MANAGED_HERO.h1Lines.join('\n'), {
+    eyebrow: FO_MANAGED_HERO.eyebrow,
+    subtitle: FO_MANAGED_HERO.subtitle,
+    links: [ctaToLink(FO_MANAGED_HERO.backLink, 'secondary')],
+  });
+}
+
+function foManagedStatusBlock(): SectionBlock {
+  return createSectionBlock(FO_MANAGED_STATUS_BLOCK_ID, FO_MANAGED_STATUS.heading, {
+    eyebrow: FO_MANAGED_STATUS.eyebrow,
+    body: FO_MANAGED_STATUS.paragraph1,
+    items: [
+      { label: 'paragraph2', body: FO_MANAGED_STATUS.paragraph2 },
+      { label: 'paragraph3', body: FO_MANAGED_STATUS.paragraph3 },
+    ],
+  });
+}
+
+function foManagedWouldBeBlock(): SectionBlock {
+  return createSectionBlock(FO_MANAGED_WOULD_BE_BLOCK_ID, FO_MANAGED_WOULD_BE.heading, {
+    eyebrow: FO_MANAGED_WOULD_BE.eyebrow,
+    items: [
+      ...FO_MANAGED_WOULD_BE.capabilities.map((cap) => ({
+        label: cap.title,
+        body: cap.body,
+      })),
+      { label: 'closing', body: FO_MANAGED_WOULD_BE.closing },
+    ],
+  });
+}
+
+function foManagedPrereqsBlock(): SectionBlock {
+  return createSectionBlock(FO_MANAGED_PREREQS_BLOCK_ID, FO_MANAGED_PREREQS.heading, {
+    eyebrow: FO_MANAGED_PREREQS.eyebrow,
+    body: FO_MANAGED_PREREQS.intro,
+    items: [
+      ...FO_MANAGED_PREREQS.prerequisites.map((p) => ({
+        label: p.title,
+        body: p.body,
+      })),
+      { label: 'closing', body: FO_MANAGED_PREREQS.closing },
+    ],
+  });
+}
+
+function foManagedTodayBlock(): SectionBlock {
+  // ctaSection has no eyebrow field; encode CTAs as items (label/href/external flag).
+  return createSectionBlock(FO_MANAGED_TODAY_BLOCK_ID, FO_MANAGED_TODAY.heading, {
+    eyebrow: FO_MANAGED_TODAY.eyebrow,
+    body: FO_MANAGED_TODAY.body,
+    items: [
+      {
+        label: FO_MANAGED_TODAY.primaryCta.label,
+        title: FO_MANAGED_TODAY.primaryCta.href,
+        body: FO_MANAGED_TODAY.primaryCta.external ? 'external' : 'internal',
+      },
+      {
+        label: FO_MANAGED_TODAY.detailLink.label,
+        title: FO_MANAGED_TODAY.detailLink.href,
+        body: 'internal',
+      },
+    ],
+  });
+}
+
+function foManagedWaitlistBlock(): SectionBlock {
+  // product source tag stays out of CMS (API contract).
+  return createSectionBlock(FO_MANAGED_WAITLIST_BLOCK_ID, FO_MANAGED_WAITLIST.heading, {
+    eyebrow: FO_MANAGED_WAITLIST.eyebrow,
+    body: FO_MANAGED_WAITLIST.body,
+    items: [
+      { label: 'placeholder', body: FO_MANAGED_WAITLIST.inputPlaceholder },
+      { label: 'button', body: FO_MANAGED_WAITLIST.buttonLabel },
+      { label: 'button-loading', body: FO_MANAGED_WAITLIST.buttonLabelLoading },
+      { label: 'success', body: FO_MANAGED_WAITLIST.successMessage },
+    ],
+  });
+}
+
 /** Derives the home page's block-driven sections (Demo, Primitives, GetStarted). */
 export function homeBlocks(): Block[] {
   return [homeDemoBlock(), homePrimitivesBlock(), homeGetStartedBlock()];
@@ -592,6 +763,23 @@ export const PRODUCTS_FALLBACK_BLOCKS: Block[] = productsBlocks();
 export const PHILOSOPHY_FALLBACK_BLOCKS: Block[] = philosophyBlocks();
 export const LOCAL_AI_FALLBACK_BLOCKS: Block[] = localAiBlocks();
 export const FAIR_SOURCE_FALLBACK_BLOCKS: Block[] = fairSourceBlocks();
+
+/**
+ * Derives /for-operators/managed CMS sections (roadmap narrative + waitlist labels).
+ * Waitlist form + product source tag stay component-local.
+ */
+export function foManagedBlocks(): Block[] {
+  return [
+    foManagedHeroBlock(),
+    foManagedStatusBlock(),
+    foManagedWouldBeBlock(),
+    foManagedPrereqsBlock(),
+    foManagedTodayBlock(),
+    foManagedWaitlistBlock(),
+  ];
+}
+
+export const FO_MANAGED_FALLBACK_BLOCKS: Block[] = foManagedBlocks();
 
 // ---------------------------------------------------------------------------
 // Reverse mappers: canonical block -> rich component data shape
@@ -1000,6 +1188,148 @@ export function fairSourceCtaSlot(blocks: Block[]): BlockSlot<FairSourceCtaData>
   const path = `blocks.${FAIR_SOURCE_CTA_INDEX}.data`;
   if (block && block.type === 'ctaSection') return { data: ctaToFairSourceCta(block), path };
   return { data: ctaToFairSourceCta(fairSourceCtaBlock()), path };
+}
+
+function heroToFoManagedHero(block: HeroBlock): FoManagedHeroData {
+  const links = block.data.links ?? [];
+  const back = links[0] ? linkToCta(links[0]) : FO_MANAGED_HERO.backLink;
+  const lines = block.data.title.split('\n').filter((line) => line.length > 0);
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    h1Lines: lines.length > 0 ? lines : [...FO_MANAGED_HERO.h1Lines],
+    subtitle: block.data.subtitle ?? '',
+    backLink: back,
+  };
+}
+
+function sectionToFoManagedStatus(block: SectionBlock): FoManagedStatusData {
+  const byLabel = new Map((block.data.items ?? []).map((item) => [item.label ?? '', item]));
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    paragraph1: block.data.body ?? '',
+    paragraph2: byLabel.get('paragraph2')?.body ?? FO_MANAGED_STATUS.paragraph2,
+    paragraph3: byLabel.get('paragraph3')?.body ?? FO_MANAGED_STATUS.paragraph3,
+  };
+}
+
+function sectionToFoManagedWouldBe(block: SectionBlock): FoManagedWouldBeData {
+  const items = block.data.items ?? [];
+  const closing = items.find((item) => item.label === 'closing');
+  const capabilities = items
+    .filter((item) => item.label !== 'closing')
+    .map((item) => ({ title: item.label ?? '', body: item.body }));
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    capabilities:
+      capabilities.length > 0
+        ? capabilities
+        : FO_MANAGED_WOULD_BE.capabilities.map((c) => ({ title: c.title, body: c.body })),
+    closing: closing?.body ?? FO_MANAGED_WOULD_BE.closing,
+  };
+}
+
+function sectionToFoManagedPrereqs(block: SectionBlock): FoManagedPrereqsData {
+  const items = block.data.items ?? [];
+  const closing = items.find((item) => item.label === 'closing');
+  const prerequisites = items
+    .filter((item) => item.label !== 'closing')
+    .map((item) => ({ title: item.label ?? '', body: item.body }));
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    intro: block.data.body ?? '',
+    prerequisites:
+      prerequisites.length > 0
+        ? prerequisites
+        : FO_MANAGED_PREREQS.prerequisites.map((p) => ({ title: p.title, body: p.body })),
+    closing: closing?.body ?? FO_MANAGED_PREREQS.closing,
+  };
+}
+
+function sectionToFoManagedToday(block: SectionBlock): FoManagedTodayData {
+  const items = block.data.items ?? [];
+  const primaryItem = items[0];
+  const detailItem = items[1];
+  const primary = primaryItem
+    ? {
+        label: primaryItem.label ?? FO_MANAGED_TODAY.primaryCta.label,
+        href: primaryItem.title ?? FO_MANAGED_TODAY.primaryCta.href,
+        ...(primaryItem.body === 'external' || hrefLooksExternal(primaryItem.title ?? '')
+          ? { external: true as const }
+          : {}),
+      }
+    : FO_MANAGED_TODAY.primaryCta;
+  const detail = detailItem
+    ? {
+        label: detailItem.label ?? FO_MANAGED_TODAY.detailLink.label,
+        href: detailItem.title ?? FO_MANAGED_TODAY.detailLink.href,
+      }
+    : FO_MANAGED_TODAY.detailLink;
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    primaryCta: primary,
+    detailLink: detail,
+  };
+}
+
+function sectionToFoManagedWaitlist(block: SectionBlock): FoManagedWaitlistData {
+  const byLabel = new Map((block.data.items ?? []).map((item) => [item.label ?? '', item]));
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    inputPlaceholder: byLabel.get('placeholder')?.body ?? FO_MANAGED_WAITLIST.inputPlaceholder,
+    buttonLabel: byLabel.get('button')?.body ?? FO_MANAGED_WAITLIST.buttonLabel,
+    buttonLabelLoading:
+      byLabel.get('button-loading')?.body ?? FO_MANAGED_WAITLIST.buttonLabelLoading,
+    successMessage: byLabel.get('success')?.body ?? FO_MANAGED_WAITLIST.successMessage,
+  };
+}
+
+export function foManagedHeroSlot(blocks: Block[]): BlockSlot<FoManagedHeroData> {
+  const block = blocks[FO_MANAGED_HERO_INDEX];
+  const path = `blocks.${FO_MANAGED_HERO_INDEX}.data`;
+  if (block && block.type === 'hero') return { data: heroToFoManagedHero(block), path };
+  return { data: heroToFoManagedHero(foManagedHeroBlock()), path };
+}
+
+export function foManagedStatusSlot(blocks: Block[]): BlockSlot<FoManagedStatusData> {
+  const block = blocks[FO_MANAGED_STATUS_INDEX];
+  const path = `blocks.${FO_MANAGED_STATUS_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoManagedStatus(block), path };
+  return { data: sectionToFoManagedStatus(foManagedStatusBlock()), path };
+}
+
+export function foManagedWouldBeSlot(blocks: Block[]): BlockSlot<FoManagedWouldBeData> {
+  const block = blocks[FO_MANAGED_WOULD_BE_INDEX];
+  const path = `blocks.${FO_MANAGED_WOULD_BE_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoManagedWouldBe(block), path };
+  return { data: sectionToFoManagedWouldBe(foManagedWouldBeBlock()), path };
+}
+
+export function foManagedPrereqsSlot(blocks: Block[]): BlockSlot<FoManagedPrereqsData> {
+  const block = blocks[FO_MANAGED_PREREQS_INDEX];
+  const path = `blocks.${FO_MANAGED_PREREQS_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoManagedPrereqs(block), path };
+  return { data: sectionToFoManagedPrereqs(foManagedPrereqsBlock()), path };
+}
+
+export function foManagedTodaySlot(blocks: Block[]): BlockSlot<FoManagedTodayData> {
+  const block = blocks[FO_MANAGED_TODAY_INDEX];
+  const path = `blocks.${FO_MANAGED_TODAY_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoManagedToday(block), path };
+  return { data: sectionToFoManagedToday(foManagedTodayBlock()), path };
+}
+
+export function foManagedWaitlistSlot(blocks: Block[]): BlockSlot<FoManagedWaitlistData> {
+  const block = blocks[FO_MANAGED_WAITLIST_INDEX];
+  const path = `blocks.${FO_MANAGED_WAITLIST_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoManagedWaitlist(block), path };
+  return { data: sectionToFoManagedWaitlist(foManagedWaitlistBlock()), path };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/routes/ForOperatorsManagedPage.tsx
+++ b/apps/marketing/app/routes/ForOperatorsManagedPage.tsx
@@ -4,6 +4,9 @@
 //
 // Spec: internal non-technical-lane spec (2026-05-14) §3.3 Page 3.
 // Locked decisions: §9.4 OQ-1 ("RevealUI Cloud"), OQ-2 (ship with the lane).
+//
+// Narrative sections are CMS-wired via useMarketingPageBlocks (VES residual).
+// Waitlist form interactivity + product source tag stay component-local.
 
 import { Footer } from '../components/Footer';
 import { Hero } from '../components/for-operators-managed/Hero';
@@ -12,16 +15,37 @@ import { Status } from '../components/for-operators-managed/Status';
 import { Today } from '../components/for-operators-managed/Today';
 import { Waitlist } from '../components/for-operators-managed/Waitlist';
 import { WouldBe } from '../components/for-operators-managed/WouldBe';
+import {
+  FO_MANAGED_FALLBACK_BLOCKS,
+  foManagedHeroSlot,
+  foManagedPrereqsSlot,
+  foManagedStatusSlot,
+  foManagedTodaySlot,
+  foManagedWaitlistSlot,
+  foManagedWouldBeSlot,
+} from '../lib/page-blocks';
+import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
 export function ForOperatorsManagedPage() {
+  const { blocks, annotation } = useMarketingPageBlocks(
+    'for-operators-managed',
+    FO_MANAGED_FALLBACK_BLOCKS,
+  );
+  const hero = foManagedHeroSlot(blocks);
+  const status = foManagedStatusSlot(blocks);
+  const wouldBe = foManagedWouldBeSlot(blocks);
+  const prereqs = foManagedPrereqsSlot(blocks);
+  const today = foManagedTodaySlot(blocks);
+  const waitlist = foManagedWaitlistSlot(blocks);
+
   return (
     <div className="min-h-screen bg-background">
-      <Hero />
-      <Status />
-      <WouldBe />
-      <Prerequisites />
-      <Today />
-      <Waitlist />
+      <Hero data={hero.data} path={hero.path} annotation={annotation} />
+      <Status data={status.data} path={status.path} annotation={annotation} />
+      <WouldBe data={wouldBe.data} path={wouldBe.path} annotation={annotation} />
+      <Prerequisites data={prereqs.data} path={prereqs.path} annotation={annotation} />
+      <Today data={today.data} path={today.path} annotation={annotation} />
+      <Waitlist data={waitlist.data} path={waitlist.path} annotation={annotation} />
       <Footer />
     </div>
   );

--- a/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
+++ b/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
@@ -13,8 +13,15 @@ import { act, cleanup, render, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchPageBlocks } from '../../lib/api';
-import { fairSourceBlocks, homeBlocks, localAiBlocks, productsBlocks } from '../../lib/page-blocks';
+import {
+  fairSourceBlocks,
+  foManagedBlocks,
+  homeBlocks,
+  localAiBlocks,
+  productsBlocks,
+} from '../../lib/page-blocks';
 import { FairSourcePage } from '../FairSourcePage';
+import { ForOperatorsManagedPage } from '../ForOperatorsManagedPage';
 import { HomePage } from '../HomePage';
 import { LocalAiPage } from '../LocalAiPage';
 import { ProductsPage } from '../ProductsPage';
@@ -65,7 +72,7 @@ describe('marketing pages: edit-mode wiring', () => {
     editDraftsStore.setEditActive(false);
   });
 
-  it('HomePage, ProductsPage, LocalAiPage, and FairSourcePage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
+  it('HomePage, ProductsPage, LocalAiPage, FairSourcePage, and ForOperatorsManagedPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
     const home = renderRouted(<HomePage />);
     expect(home.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(home.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
@@ -84,6 +91,11 @@ describe('marketing pages: edit-mode wiring', () => {
     const fairSource = renderRouted(<FairSourcePage />);
     expect(fairSource.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(fairSource.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
+    fairSource.unmount();
+
+    const managed = renderRouted(<ForOperatorsManagedPage />);
+    expect(managed.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+    expect(managed.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
   });
 
   it('HomePage renders the draft heading annotated with the session docId when a matching overlay exists', () => {
@@ -160,6 +172,26 @@ describe('marketing pages: edit-mode wiring', () => {
     const heading = container.querySelector('[data-rvui-field="blocks.0.data.heading"]');
     expect(heading?.getAttribute('data-rvui-doc')).toBe('page-fair-source-id');
     expect(heading?.textContent).toBe('Canvas-edited fair-source contract');
+  });
+
+  it('ForOperatorsManagedPage renders the draft hero annotated with the session docId when a matching overlay exists', () => {
+    const draftBlocks = foManagedBlocks();
+    const hero = draftBlocks[0];
+    if (hero?.type === 'hero') {
+      hero.data.title = 'Canvas-edited managed title';
+    }
+    editDraftsStore.set([
+      {
+        docType: 'page',
+        docId: 'page-fo-managed-id',
+        draft: { slug: 'for-operators-managed', blocks: draftBlocks },
+      },
+    ]);
+
+    const { container } = renderRouted(<ForOperatorsManagedPage />);
+    const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
+    expect(title?.getAttribute('data-rvui-doc')).toBe('page-fo-managed-id');
+    expect(title?.textContent).toBe('Canvas-edited managed title');
   });
 
   it('re-renders HomePage with the patched value after an optimistic draft-store update', () => {

--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -43,6 +43,10 @@
       "sha256": "60508313d8412871180cd9897dd49eebc178277cb877aa0e35ef02d621ef7b1f"
     },
     {
+      "relativePath": ".revealui/content/rules/adapter-only.md",
+      "sha256": "dcd894a7516ad394e15a6485a77aea302db87c4a9c4b1910507edd05a97078b8"
+    },
+    {
       "relativePath": ".revealui/content/rules/agent-dispatch.md",
       "sha256": "0b2497c1817e23a1d4902cb5b5889cec4a6f6526179d7273622066705e444fe8"
     },
@@ -55,8 +59,20 @@
       "sha256": "0ec5699691c7505d6c9ac3fa7b2150c546b5e738e0089af42732ac1a6272a04e"
     },
     {
+      "relativePath": ".revealui/content/rules/code-over-docs.md",
+      "sha256": "092c970e6638e76ca6a14f8fb0f25ca70eb76fa3da95e34fcdb0f6cd18c59561"
+    },
+    {
       "relativePath": ".revealui/content/rules/database.md",
       "sha256": "cb66ad35bf9cd6c61846bb6b9ad1d1ec941f72b04a179441e7ccf0a1b873b341"
+    },
+    {
+      "relativePath": ".revealui/content/rules/disposition-actions.md",
+      "sha256": "184c2b6094fd21c96b06172dc0c29df05dfd903b78ff0d149e00c3e61ecf2a78"
+    },
+    {
+      "relativePath": ".revealui/content/rules/durable-solutions.md",
+      "sha256": "162e4f1925ca067d0a00f7257dae9f31b544ccf8b41b5cf8ea8a848b238259d6"
     },
     {
       "relativePath": ".revealui/content/rules/monorepo.md",

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -2,7 +2,7 @@
 
 /**
  * Seed the fleet-marketing `sites` row plus its published marketing pages
- * (home, products, philosophy, local-ai, fair-source) for the visual-edit-sessions block wire.
+ * (home, products, philosophy, local-ai, fair-source, for-operators-managed) for the visual-edit-sessions block wire.
  *
  * The page `blocks` come from the SAME pure derivation the marketing app falls
  * back to (`apps/marketing/app/lib/page-blocks.ts`), so the seeded CMS content
@@ -33,6 +33,7 @@ import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import {
   fairSourceBlocks,
+  foManagedBlocks,
   homeBlocks,
   localAiBlocks,
   philosophyBlocks,
@@ -117,6 +118,17 @@ const PAGE_SEEDS: readonly PageSeed[] = [
       title: 'Fair Source | RevealUI',
       description:
         'Source-visible. Commercially usable. MIT in two years. The license contract for RevealUI Pro packages.',
+    },
+  },
+  {
+    slug: 'for-operators-managed',
+    path: '/for-operators/managed',
+    title: 'RevealUI Cloud (roadmap)',
+    blocks: foManagedBlocks(),
+    seo: {
+      title: 'RevealUI Cloud | RevealUI',
+      description:
+        'Self-serve managed runtime on the roadmap. Honest status: not shipping today. Waitlist when you want it.',
     },
   },
 ];
@@ -265,7 +277,7 @@ async function main(): Promise<void> {
   }
 
   // ---------------------------------------------------------------------------
-  // Pages (home + products + philosophy + local-ai + fair-source) — version-safe, idempotent
+  // Pages (home + products + philosophy + local-ai + fair-source + managed) — version-safe, idempotent
   // ---------------------------------------------------------------------------
 
   for (const seed of PAGE_SEEDS) {


### PR DESCRIPTION
## Summary

- Wire `/for-operators/managed` to CMS via static-first page-blocks (same VES pattern as fair-source / services)
- Optional CMS data + `fieldAttrs` on for-operators-managed sections
- Seed fleet-marketing page slug `for-operators-managed`
- Waitlist form interactivity and `product` source tag stay component-local (API contract)
- **Also:** regen harnesses content snapshot for four Plane A hardlines missing after #2082/#2083 (pre-push green)

## Coordination

| Surface | Owner |
|---------|--------|
| #2084 `/services` | owner merges when green |
| peer how-it-works | do not touch (`ves-fo-how-it-works`) |
| this PR managed | claimed `2026-07-23T0310Z-grok-fo-managed-cms-claim.md` |

Note: peer how-it-works and this PR both touch `page-blocks.ts` — land one then rebase the other if needed.

## Test plan

- [x] page-blocks + edit-mode wiring tests (22/22 local)
- [x] local phase-1 gate PASS (incl. content snapshot)
- [ ] CI green
- [ ] Owner seed: `pnpm db:seed:fleet-marketing` when env needs the managed CMS row