### PR TITLE
feat(marketing): wire for-operators how-it-works CMS blocks

### DIFF
--- a/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
@@ -1,36 +1,63 @@
-import { Button } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
 import { FO_HIW_CLOSING } from '../../content/for-operators-how-it-works';
+import type { FoHiwCtaData } from '../../lib/page-blocks';
 
-export function ClosingCta() {
+interface ClosingCtaProps {
+  data?: FoHiwCtaData;
+  path?: string;
+  annotation?: BlockAnnotation;
+}
+
+export function ClosingCta({
+  data = {
+    heading: FO_HIW_CLOSING.heading,
+    body: FO_HIW_CLOSING.body,
+    primaryCta: FO_HIW_CLOSING.primaryCta,
+    backLink: FO_HIW_CLOSING.backLink,
+  },
+  path,
+  annotation,
+}: ClosingCtaProps) {
+  const field = (suffix: string) =>
+    annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
+
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-        <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FO_HIW_CLOSING.heading}
+        <h2
+          className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...field('heading')}
+        >
+          {data.heading}
         </h2>
-        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">
-          {FO_HIW_CLOSING.body}
+        <p
+          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground"
+          {...field('body')}
+        >
+          {data.body}
         </p>
 
         <div className="mt-10 flex justify-center">
           <Button asChild size="lg">
             <a
-              href={FO_HIW_CLOSING.primaryCta.href}
-              {...(FO_HIW_CLOSING.primaryCta.external
+              href={data.primaryCta.href}
+              {...(data.primaryCta.external
                 ? { target: '_blank', rel: 'noopener noreferrer' }
                 : {})}
+              {...field('links.0.label')}
             >
-              {FO_HIW_CLOSING.primaryCta.label}
+              {data.primaryCta.label}
             </a>
           </Button>
         </div>
 
         <p className="mt-6 text-sm text-muted-foreground">
           <a
-            href={FO_HIW_CLOSING.backLink.href}
+            href={data.backLink.href}
             className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+            {...field('links.1.label')}
           >
-            {FO_HIW_CLOSING.backLink.label}
+            {data.backLink.label}
           </a>
         </p>
       </div>

--- a/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
@@ -1,30 +1,60 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FO_HIW_STEPS } from '../../content/for-operators-how-it-works';
+import type { FoHiwStepsData } from '../../lib/page-blocks';
 
-export function EngagementSteps() {
+interface EngagementStepsProps {
+  data?: FoHiwStepsData;
+  path?: string;
+  annotation?: BlockAnnotation;
+}
+
+export function EngagementSteps({ data = FO_HIW_STEPS, path, annotation }: EngagementStepsProps) {
+  const field = (suffix: string) =>
+    annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
+
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-5xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {FO_HIW_STEPS.eyebrow}
+          <p
+            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            {...field('eyebrow')}
+          >
+            {data.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {FO_HIW_STEPS.heading}
+          <h2
+            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            {...field('heading')}
+          >
+            {data.heading}
           </h2>
         </div>
 
         <ol className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-6 list-none p-0">
-          {FO_HIW_STEPS.steps.map((step) => (
+          {data.steps.map((step, index) => (
             <li
               key={step.number}
               className="grid grid-cols-[auto_1fr] gap-6 rounded-2xl border border-border bg-card p-6 shadow-sm"
             >
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 font-mono text-base font-semibold text-primary">
+              <div
+                className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 font-mono text-base font-semibold text-primary"
+                {...field(`items.${index}.label`)}
+              >
                 {step.number}
               </div>
               <div>
-                <h3 className="text-lg font-semibold leading-7 text-foreground">{step.title}</h3>
-                <p className="mt-2 text-base leading-7 text-muted-foreground">{step.body}</p>
+                <h3
+                  className="text-lg font-semibold leading-7 text-foreground"
+                  {...field(`items.${index}.title`)}
+                >
+                  {step.title}
+                </h3>
+                <p
+                  className="mt-2 text-base leading-7 text-muted-foreground"
+                  {...field(`items.${index}.body`)}
+                >
+                  {step.body}
+                </p>
               </div>
             </li>
           ))}

--- a/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
@@ -1,33 +1,71 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FO_HIW_FEAR } from '../../content/for-operators-how-it-works';
+import type { FoHiwFearData } from '../../lib/page-blocks';
 
-export function FearRemoval() {
+interface FearRemovalProps {
+  data?: FoHiwFearData;
+  path?: string;
+  annotation?: BlockAnnotation;
+}
+
+export function FearRemoval({ data = FO_HIW_FEAR, path, annotation }: FearRemovalProps) {
+  const field = (suffix: string) =>
+    annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
+
+  // Item layout: paragraph2, then options, then closing (matches foHiwFearBlock).
+  const optionStart = 1;
+  const closingIndex = optionStart + data.options.length;
+
   return (
     <section className="bg-muted py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FO_HIW_FEAR.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...field('eyebrow')}
+        >
+          {data.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FO_HIW_FEAR.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...field('heading')}
+        >
+          {data.heading}
         </h2>
 
-        <p className="mt-8 text-base leading-7 text-muted-foreground">{FO_HIW_FEAR.paragraph1}</p>
-        <p className="mt-4 text-base leading-7 text-muted-foreground">{FO_HIW_FEAR.paragraph2}</p>
+        <p className="mt-8 text-base leading-7 text-muted-foreground" {...field('body')}>
+          {data.paragraph1}
+        </p>
+        <p className="mt-4 text-base leading-7 text-muted-foreground" {...field('items.0.body')}>
+          {data.paragraph2}
+        </p>
 
         <ul className="mt-6 space-y-4 list-none p-0">
-          {FO_HIW_FEAR.options.map((option) => (
+          {data.options.map((option, index) => (
             <li
               key={option.title}
               className="rounded-2xl border border-border bg-card p-5 shadow-sm"
             >
-              <h3 className="text-base font-semibold leading-7 text-foreground">{option.title}</h3>
-              <p className="mt-1 text-base leading-7 text-muted-foreground">{option.body}</p>
+              <h3
+                className="text-base font-semibold leading-7 text-foreground"
+                {...field(`items.${optionStart + index}.title`)}
+              >
+                {option.title}
+              </h3>
+              <p
+                className="mt-1 text-base leading-7 text-muted-foreground"
+                {...field(`items.${optionStart + index}.body`)}
+              >
+                {option.body}
+              </p>
             </li>
           ))}
         </ul>
 
-        <p className="mt-8 text-base leading-7 text-foreground font-medium">
-          {FO_HIW_FEAR.closing}
+        <p
+          className="mt-8 text-base leading-7 text-foreground font-medium"
+          {...field(`items.${closingIndex}.body`)}
+        >
+          {data.closing}
         </p>
       </div>
     </section>

--- a/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
@@ -1,47 +1,78 @@
-import { Button } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
 import { FO_HIW_HERO } from '../../content/for-operators-how-it-works';
+import type { FoHiwHeroData } from '../../lib/page-blocks';
 
-export function Hero() {
+interface HeroProps {
+  data?: FoHiwHeroData;
+  path?: string;
+  annotation?: BlockAnnotation;
+}
+
+export function Hero({
+  data = {
+    eyebrow: FO_HIW_HERO.eyebrow,
+    h1Lines: FO_HIW_HERO.h1Lines,
+    subtitle: FO_HIW_HERO.subtitle,
+    primaryCta: FO_HIW_HERO.primaryCta,
+    backLink: FO_HIW_HERO.backLink,
+  },
+  path,
+  annotation,
+}: HeroProps) {
+  const field = (suffix: string) =>
+    annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
+
   return (
     <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
       <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
 
       <div className="relative mx-auto max-w-3xl text-center">
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
-          {FO_HIW_HERO.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6"
+          {...field('eyebrow')}
+        >
+          {data.eyebrow}
         </p>
 
-        <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
-          {FO_HIW_HERO.h1Lines.map((line) => (
+        <h1
+          className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl"
+          {...field('title')}
+        >
+          {data.h1Lines.map((line) => (
             <span key={line} className="block">
               {line}
             </span>
           ))}
         </h1>
 
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-          {FO_HIW_HERO.subtitle}
+        <p
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          {...field('subtitle')}
+        >
+          {data.subtitle}
         </p>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
           <Button asChild size="lg" className="w-full sm:w-auto">
             <a
-              href={FO_HIW_HERO.primaryCta.href}
-              {...(FO_HIW_HERO.primaryCta.external
+              href={data.primaryCta.href}
+              {...(data.primaryCta.external
                 ? { target: '_blank', rel: 'noopener noreferrer' }
                 : {})}
+              {...field('links.0.label')}
             >
-              {FO_HIW_HERO.primaryCta.label}
+              {data.primaryCta.label}
             </a>
           </Button>
         </div>
 
         <p className="mt-8 text-sm text-muted-foreground">
           <a
-            href={FO_HIW_HERO.backLink.href}
+            href={data.backLink.href}
             className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+            {...field('links.1.label')}
           >
-            {FO_HIW_HERO.backLink.label}
+            {data.backLink.label}
           </a>
         </p>
       </div>

--- a/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
@@ -1,32 +1,66 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FO_HIW_OWNERSHIP } from '../../content/for-operators-how-it-works';
+import type { FoHiwOwnershipData } from '../../lib/page-blocks';
 
-export function Ownership() {
+interface OwnershipProps {
+  data?: FoHiwOwnershipData;
+  path?: string;
+  annotation?: BlockAnnotation;
+}
+
+export function Ownership({ data = FO_HIW_OWNERSHIP, path, annotation }: OwnershipProps) {
+  const field = (suffix: string) =>
+    annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
+
+  const diffIndex = data.claims.length;
+
   return (
     <section className="bg-background py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FO_HIW_OWNERSHIP.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...field('eyebrow')}
+        >
+          {data.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FO_HIW_OWNERSHIP.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...field('heading')}
+        >
+          {data.heading}
         </h2>
 
-        <p className="mt-6 text-base leading-7 text-muted-foreground">{FO_HIW_OWNERSHIP.intro}</p>
+        <p className="mt-6 text-base leading-7 text-muted-foreground" {...field('body')}>
+          {data.intro}
+        </p>
 
         <ul className="mt-6 space-y-4 list-none p-0">
-          {FO_HIW_OWNERSHIP.claims.map((claim) => (
+          {data.claims.map((claim, index) => (
             <li
               key={claim.title}
               className="rounded-2xl border border-border bg-card p-5 shadow-sm"
             >
-              <h3 className="text-base font-semibold leading-7 text-foreground">{claim.title}</h3>
-              <p className="mt-1 text-base leading-7 text-muted-foreground">{claim.body}</p>
+              <h3
+                className="text-base font-semibold leading-7 text-foreground"
+                {...field(`items.${index}.title`)}
+              >
+                {claim.title}
+              </h3>
+              <p
+                className="mt-1 text-base leading-7 text-muted-foreground"
+                {...field(`items.${index}.body`)}
+              >
+                {claim.body}
+              </p>
             </li>
           ))}
         </ul>
 
-        <p className="mt-8 text-base leading-7 text-foreground font-medium">
-          {FO_HIW_OWNERSHIP.differentiator}
+        <p
+          className="mt-8 text-base leading-7 text-foreground font-medium"
+          {...field(`items.${diffIndex}.body`)}
+        >
+          {data.differentiator}
         </p>
       </div>
     </section>

--- a/apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx
@@ -1,21 +1,38 @@
+import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { FO_HIW_TIMELINE } from '../../content/for-operators-how-it-works';
+import type { FoHiwTimelineData } from '../../lib/page-blocks';
 
-export function Timeline() {
+interface TimelineProps {
+  data?: FoHiwTimelineData;
+  path?: string;
+  annotation?: BlockAnnotation;
+}
+
+export function Timeline({ data = FO_HIW_TIMELINE, path, annotation }: TimelineProps) {
+  const field = (suffix: string) =>
+    annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
+
   return (
     <section className="bg-muted py-24 sm:py-32">
       <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-          {FO_HIW_TIMELINE.eyebrow}
+        <p
+          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+          {...field('eyebrow')}
+        >
+          {data.eyebrow}
         </p>
-        <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-          {FO_HIW_TIMELINE.heading}
+        <h2
+          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          {...field('heading')}
+        >
+          {data.heading}
         </h2>
 
-        <p className="mt-6 text-base leading-7 text-muted-foreground">
-          {FO_HIW_TIMELINE.paragraph1}
+        <p className="mt-6 text-base leading-7 text-muted-foreground" {...field('body')}>
+          {data.paragraph1}
         </p>
-        <p className="mt-4 text-base leading-7 text-muted-foreground">
-          {FO_HIW_TIMELINE.paragraph2}
+        <p className="mt-4 text-base leading-7 text-muted-foreground" {...field('items.0.body')}>
+          {data.paragraph2}
         </p>
       </div>
     </section>

--- a/apps/marketing/app/lib/page-blocks.test.ts
+++ b/apps/marketing/app/lib/page-blocks.test.ts
@@ -20,6 +20,14 @@ import {
   FOR_OPERATORS_PROOF,
   FOR_OPERATORS_WHAT_YOU_GET,
 } from '../content/for-operators';
+import {
+  FO_HIW_CLOSING,
+  FO_HIW_FEAR,
+  FO_HIW_HERO,
+  FO_HIW_OWNERSHIP,
+  FO_HIW_STEPS,
+  FO_HIW_TIMELINE,
+} from '../content/for-operators-how-it-works';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
@@ -30,6 +38,7 @@ import {
   blocksMatchFallback,
   demoSlot,
   FAIR_SOURCE_FALLBACK_BLOCKS,
+  FO_HIW_FALLBACK_BLOCKS,
   fairSourceBlocks,
   fairSourceClockSlot,
   fairSourceContractSlot,
@@ -37,6 +46,13 @@ import {
   fairSourceFaqSlot,
   fairSourcePackagesIntroSlot,
   fairSourcePeersSlot,
+  foHiwBlocks,
+  foHiwCtaSlot,
+  foHiwFearSlot,
+  foHiwHeroSlot,
+  foHiwOwnershipSlot,
+  foHiwStepsSlot,
+  foHiwTimelineSlot,
   getStartedSlot,
   HOME_FALLBACK_BLOCKS,
   homeBlocks,
@@ -83,7 +99,7 @@ function collectStrings(value: unknown, out: string[] = []): string[] {
 }
 
 describe('page-blocks derivation', () => {
-  it('produces schema-valid blocks for home, products, philosophy, local-ai, fair-source, and services', () => {
+  it('produces schema-valid blocks for home, products, philosophy, local-ai, fair-source, services, and fo-hiw', () => {
     for (const block of [
       ...homeBlocks(),
       ...productsBlocks(),
@@ -91,6 +107,7 @@ describe('page-blocks derivation', () => {
       ...localAiBlocks(),
       ...fairSourceBlocks(),
       ...servicesBlocks(),
+      ...foHiwBlocks(),
     ]) {
       expect(BlockSchema.safeParse(block).success).toBe(true);
     }
@@ -118,6 +135,14 @@ describe('page-blocks derivation', () => {
     expect(servicesBlocks().map((b) => b.type)).toEqual([
       'hero',
       'section',
+      'section',
+      'section',
+      'section',
+      'section',
+      'ctaSection',
+    ]);
+    expect(foHiwBlocks().map((b) => b.type)).toEqual([
+      'hero',
       'section',
       'section',
       'section',
@@ -275,6 +300,68 @@ describe('page-blocks derivation', () => {
     });
     expect(blocksMatchFallback(servicesBlocks(), SERVICES_FALLBACK_BLOCKS)).toBe(true);
   });
+
+  it('round-trips fo-hiw slots against the for-operators-how-it-works content module', () => {
+    const blocks = FO_HIW_FALLBACK_BLOCKS;
+    expect(foHiwHeroSlot(blocks).data).toEqual({
+      eyebrow: FO_HIW_HERO.eyebrow,
+      h1Lines: [...FO_HIW_HERO.h1Lines],
+      subtitle: FO_HIW_HERO.subtitle,
+      primaryCta: {
+        label: FO_HIW_HERO.primaryCta.label,
+        href: FO_HIW_HERO.primaryCta.href,
+        external: true,
+      },
+      backLink: {
+        label: FO_HIW_HERO.backLink.label,
+        href: FO_HIW_HERO.backLink.href,
+      },
+    });
+    expect(foHiwStepsSlot(blocks).data).toEqual({
+      eyebrow: FO_HIW_STEPS.eyebrow,
+      heading: FO_HIW_STEPS.heading,
+      steps: FO_HIW_STEPS.steps.map((s) => ({
+        number: s.number,
+        title: s.title,
+        body: s.body,
+      })),
+    });
+    expect(foHiwFearSlot(blocks).data).toEqual({
+      eyebrow: FO_HIW_FEAR.eyebrow,
+      heading: FO_HIW_FEAR.heading,
+      paragraph1: FO_HIW_FEAR.paragraph1,
+      paragraph2: FO_HIW_FEAR.paragraph2,
+      options: FO_HIW_FEAR.options.map((o) => ({ title: o.title, body: o.body })),
+      closing: FO_HIW_FEAR.closing,
+    });
+    expect(foHiwOwnershipSlot(blocks).data).toEqual({
+      eyebrow: FO_HIW_OWNERSHIP.eyebrow,
+      heading: FO_HIW_OWNERSHIP.heading,
+      intro: FO_HIW_OWNERSHIP.intro,
+      claims: FO_HIW_OWNERSHIP.claims.map((c) => ({ title: c.title, body: c.body })),
+      differentiator: FO_HIW_OWNERSHIP.differentiator,
+    });
+    expect(foHiwTimelineSlot(blocks).data).toEqual({
+      eyebrow: FO_HIW_TIMELINE.eyebrow,
+      heading: FO_HIW_TIMELINE.heading,
+      paragraph1: FO_HIW_TIMELINE.paragraph1,
+      paragraph2: FO_HIW_TIMELINE.paragraph2,
+    });
+    expect(foHiwCtaSlot(blocks).data).toEqual({
+      heading: FO_HIW_CLOSING.heading,
+      body: FO_HIW_CLOSING.body,
+      primaryCta: {
+        label: FO_HIW_CLOSING.primaryCta.label,
+        href: FO_HIW_CLOSING.primaryCta.href,
+        external: true,
+      },
+      backLink: {
+        label: FO_HIW_CLOSING.backLink.label,
+        href: FO_HIW_CLOSING.backLink.href,
+      },
+    });
+    expect(blocksMatchFallback(foHiwBlocks(), FO_HIW_FALLBACK_BLOCKS)).toBe(true);
+  });
 });
 
 describe('claims safety: prose is single-sourced, pinned values never enter blocks', () => {
@@ -285,6 +372,7 @@ describe('claims safety: prose is single-sourced, pinned values never enter bloc
     localAiBlocks(),
     fairSourceBlocks(),
     servicesBlocks(),
+    foHiwBlocks(),
   ]);
   const haystack = strings.join(' ');
 

--- a/apps/marketing/app/lib/page-blocks.ts
+++ b/apps/marketing/app/lib/page-blocks.ts
@@ -1,6 +1,6 @@
 /**
  * Static-first block derivation for marketing pages served from the CMS
- * (home, products, philosophy, local-ai, fair-source, services).
+ * (home, products, philosophy, local-ai, fair-source, services, for-operators-how-it-works).
  *
  * The marketing content modules stay the single source of truth for every prose
  * string. This module derives the canonical `pages.blocks` array from those
@@ -24,6 +24,9 @@
  * and the FAQ (answers interpolate ladder prices) stay component-local from
  * `for-operators` + contracts pricing anchors. CMS carries hero through proof
  * narrative, the pricing section header, and the closing CTA.
+ *
+ * For-operators how-it-works (`/for-operators/how-it-works`) is fully narrative
+ * (no dollar figures per content module). All six sections ride the CMS.
  *
  * No React or network imports live here so `scripts/seed-fleet-marketing-site.ts`
  * can import the same derivation the runtime falls back to.
@@ -59,6 +62,14 @@ import {
   FOR_OPERATORS_PROOF,
   FOR_OPERATORS_WHAT_YOU_GET,
 } from '../content/for-operators';
+import {
+  FO_HIW_CLOSING,
+  FO_HIW_FEAR,
+  FO_HIW_HERO,
+  FO_HIW_OWNERSHIP,
+  FO_HIW_STEPS,
+  FO_HIW_TIMELINE,
+} from '../content/for-operators-how-it-works';
 import { HOME_DEMO, HOME_FAQ, HOME_GET_STARTED } from '../content/home';
 import { LOCAL_AI_PAGE, LOCAL_AI_SECTION } from '../content/local-ai';
 import { PHILOSOPHY } from '../content/philosophy';
@@ -314,6 +325,67 @@ export interface ServicesCtaData {
   };
 }
 
+export interface FoHiwHeroData {
+  readonly eyebrow: string;
+  readonly h1Lines: readonly string[];
+  readonly subtitle: string;
+  readonly primaryCta: Cta;
+  readonly backLink: Cta;
+}
+
+export interface FoHiwStepData {
+  readonly number: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface FoHiwStepsData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly steps: readonly FoHiwStepData[];
+}
+
+export interface FoHiwFearOptionData {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface FoHiwFearData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly paragraph1: string;
+  readonly paragraph2: string;
+  readonly options: readonly FoHiwFearOptionData[];
+  readonly closing: string;
+}
+
+export interface FoHiwOwnershipClaimData {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface FoHiwOwnershipData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly intro: string;
+  readonly claims: readonly FoHiwOwnershipClaimData[];
+  readonly differentiator: string;
+}
+
+export interface FoHiwTimelineData {
+  readonly eyebrow: string;
+  readonly heading: string;
+  readonly paragraph1: string;
+  readonly paragraph2: string;
+}
+
+export interface FoHiwCtaData {
+  readonly heading: string;
+  readonly body: string;
+  readonly primaryCta: Cta;
+  readonly backLink: Cta;
+}
+
 // ---------------------------------------------------------------------------
 // Stable block ids + positions. Ids let the seed and fallback match, but the
 // runtime routes each slot by array POSITION + type (the CMS assigns its own
@@ -347,6 +419,12 @@ export const SERVICES_PRICING_INTRO_BLOCK_ID = 'services-pricing-intro';
 export const SERVICES_DISCOVERY_BLOCK_ID = 'services-discovery';
 export const SERVICES_PROOF_BLOCK_ID = 'services-proof';
 export const SERVICES_CTA_BLOCK_ID = 'services-cta';
+export const FO_HIW_HERO_BLOCK_ID = 'fo-hiw-hero';
+export const FO_HIW_STEPS_BLOCK_ID = 'fo-hiw-steps';
+export const FO_HIW_FEAR_BLOCK_ID = 'fo-hiw-fear';
+export const FO_HIW_OWNERSHIP_BLOCK_ID = 'fo-hiw-ownership';
+export const FO_HIW_TIMELINE_BLOCK_ID = 'fo-hiw-timeline';
+export const FO_HIW_CTA_BLOCK_ID = 'fo-hiw-cta';
 
 const HOME_DEMO_INDEX = 0;
 const HOME_PRIMITIVES_INDEX = 1;
@@ -375,6 +453,12 @@ const SERVICES_PRICING_INTRO_INDEX = 3;
 const SERVICES_DISCOVERY_INDEX = 4;
 const SERVICES_PROOF_INDEX = 5;
 const SERVICES_CTA_INDEX = 6;
+const FO_HIW_HERO_INDEX = 0;
+const FO_HIW_STEPS_INDEX = 1;
+const FO_HIW_FEAR_INDEX = 2;
+const FO_HIW_OWNERSHIP_INDEX = 3;
+const FO_HIW_TIMELINE_INDEX = 4;
+const FO_HIW_CTA_INDEX = 5;
 
 function hrefLooksExternal(href: string): boolean {
   return (
@@ -745,6 +829,77 @@ function servicesCtaBlock(): CtaSectionBlock {
   });
 }
 
+function foHiwHeroBlock(): HeroBlock {
+  return createHeroBlock(FO_HIW_HERO_BLOCK_ID, FO_HIW_HERO.h1Lines.join('\n'), {
+    eyebrow: FO_HIW_HERO.eyebrow,
+    subtitle: FO_HIW_HERO.subtitle,
+    links: [
+      ctaToLink(FO_HIW_HERO.primaryCta, 'primary'),
+      ctaToLink(FO_HIW_HERO.backLink, 'secondary'),
+    ],
+  });
+}
+
+function foHiwStepsBlock(): SectionBlock {
+  return createSectionBlock(FO_HIW_STEPS_BLOCK_ID, FO_HIW_STEPS.heading, {
+    eyebrow: FO_HIW_STEPS.eyebrow,
+    items: FO_HIW_STEPS.steps.map((step) => ({
+      label: step.number,
+      title: step.title,
+      body: step.body,
+    })),
+  });
+}
+
+function foHiwFearBlock(): SectionBlock {
+  return createSectionBlock(FO_HIW_FEAR_BLOCK_ID, FO_HIW_FEAR.heading, {
+    eyebrow: FO_HIW_FEAR.eyebrow,
+    body: FO_HIW_FEAR.paragraph1,
+    items: [
+      { label: 'paragraph2', body: FO_HIW_FEAR.paragraph2 },
+      ...FO_HIW_FEAR.options.map((opt) => ({
+        label: 'option',
+        title: opt.title,
+        body: opt.body,
+      })),
+      { label: 'closing', body: FO_HIW_FEAR.closing },
+    ],
+  });
+}
+
+function foHiwOwnershipBlock(): SectionBlock {
+  return createSectionBlock(FO_HIW_OWNERSHIP_BLOCK_ID, FO_HIW_OWNERSHIP.heading, {
+    eyebrow: FO_HIW_OWNERSHIP.eyebrow,
+    body: FO_HIW_OWNERSHIP.intro,
+    items: [
+      ...FO_HIW_OWNERSHIP.claims.map((claim) => ({
+        label: 'claim',
+        title: claim.title,
+        body: claim.body,
+      })),
+      { label: 'differentiator', body: FO_HIW_OWNERSHIP.differentiator },
+    ],
+  });
+}
+
+function foHiwTimelineBlock(): SectionBlock {
+  return createSectionBlock(FO_HIW_TIMELINE_BLOCK_ID, FO_HIW_TIMELINE.heading, {
+    eyebrow: FO_HIW_TIMELINE.eyebrow,
+    body: FO_HIW_TIMELINE.paragraph1,
+    items: [{ label: 'paragraph2', body: FO_HIW_TIMELINE.paragraph2 }],
+  });
+}
+
+function foHiwCtaBlock(): CtaSectionBlock {
+  return createCtaSectionBlock(FO_HIW_CTA_BLOCK_ID, FO_HIW_CLOSING.heading, {
+    body: FO_HIW_CLOSING.body,
+    links: [
+      ctaToLink(FO_HIW_CLOSING.primaryCta, 'primary'),
+      ctaToLink(FO_HIW_CLOSING.backLink, 'secondary'),
+    ],
+  });
+}
+
 /** Derives the home page's block-driven sections (Demo, Primitives, GetStarted). */
 export function homeBlocks(): Block[] {
   return [homeDemoBlock(), homePrimitivesBlock(), homeGetStartedBlock()];
@@ -802,12 +957,25 @@ export function servicesBlocks(): Block[] {
   ];
 }
 
+/** Derives /for-operators/how-it-works CMS sections (fully narrative). */
+export function foHiwBlocks(): Block[] {
+  return [
+    foHiwHeroBlock(),
+    foHiwStepsBlock(),
+    foHiwFearBlock(),
+    foHiwOwnershipBlock(),
+    foHiwTimelineBlock(),
+    foHiwCtaBlock(),
+  ];
+}
+
 export const HOME_FALLBACK_BLOCKS: Block[] = homeBlocks();
 export const PRODUCTS_FALLBACK_BLOCKS: Block[] = productsBlocks();
 export const PHILOSOPHY_FALLBACK_BLOCKS: Block[] = philosophyBlocks();
 export const LOCAL_AI_FALLBACK_BLOCKS: Block[] = localAiBlocks();
 export const FAIR_SOURCE_FALLBACK_BLOCKS: Block[] = fairSourceBlocks();
 export const SERVICES_FALLBACK_BLOCKS: Block[] = servicesBlocks();
+export const FO_HIW_FALLBACK_BLOCKS: Block[] = foHiwBlocks();
 
 // ---------------------------------------------------------------------------
 // Reverse mappers: canonical block -> rich component data shape
@@ -1385,6 +1553,138 @@ export function servicesCtaSlot(blocks: Block[]): BlockSlot<ServicesCtaData> {
   const path = `blocks.${SERVICES_CTA_INDEX}.data`;
   if (block && block.type === 'ctaSection') return { data: ctaToServicesCta(block), path };
   return { data: ctaToServicesCta(servicesCtaBlock()), path };
+}
+
+function heroToFoHiwHero(block: HeroBlock): FoHiwHeroData {
+  const links = block.data.links ?? [];
+  const primary = links[0]
+    ? {
+        ...linkToCta(links[0]),
+        ...(hrefLooksExternal(links[0].href) ? { external: true as const } : {}),
+      }
+    : FO_HIW_HERO.primaryCta;
+  const back = links[1] ? linkToCta(links[1]) : FO_HIW_HERO.backLink;
+  const lines = block.data.title.split('\n').filter((line) => line.length > 0);
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    h1Lines: lines.length > 0 ? lines : [...FO_HIW_HERO.h1Lines],
+    subtitle: block.data.subtitle ?? '',
+    primaryCta: primary,
+    backLink: back,
+  };
+}
+
+function sectionToFoHiwSteps(block: SectionBlock): FoHiwStepsData {
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    steps: (block.data.items ?? []).map((item) => ({
+      number: item.label ?? '',
+      title: item.title ?? '',
+      body: item.body,
+    })),
+  };
+}
+
+function sectionToFoHiwFear(block: SectionBlock): FoHiwFearData {
+  const items = block.data.items ?? [];
+  const p2 = items.find((item) => item.label === 'paragraph2');
+  const closing = items.find((item) => item.label === 'closing');
+  const options = items
+    .filter((item) => item.label === 'option')
+    .map((item) => ({ title: item.title ?? '', body: item.body }));
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    paragraph1: block.data.body ?? '',
+    paragraph2: p2?.body ?? FO_HIW_FEAR.paragraph2,
+    options: options.length > 0 ? options : [...FO_HIW_FEAR.options],
+    closing: closing?.body ?? FO_HIW_FEAR.closing,
+  };
+}
+
+function sectionToFoHiwOwnership(block: SectionBlock): FoHiwOwnershipData {
+  const items = block.data.items ?? [];
+  const differentiator = items.find((item) => item.label === 'differentiator');
+  const claims = items
+    .filter((item) => item.label === 'claim')
+    .map((item) => ({ title: item.title ?? '', body: item.body }));
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    intro: block.data.body ?? '',
+    claims: claims.length > 0 ? claims : [...FO_HIW_OWNERSHIP.claims],
+    differentiator: differentiator?.body ?? FO_HIW_OWNERSHIP.differentiator,
+  };
+}
+
+function sectionToFoHiwTimeline(block: SectionBlock): FoHiwTimelineData {
+  const p2 = (block.data.items ?? []).find((item) => item.label === 'paragraph2');
+  return {
+    eyebrow: block.data.eyebrow ?? '',
+    heading: block.data.heading,
+    paragraph1: block.data.body ?? '',
+    paragraph2: p2?.body ?? FO_HIW_TIMELINE.paragraph2,
+  };
+}
+
+function ctaToFoHiwCta(block: CtaSectionBlock): FoHiwCtaData {
+  const links = block.data.links ?? [];
+  const primary = links[0]
+    ? {
+        ...linkToCta(links[0]),
+        ...(hrefLooksExternal(links[0].href) ? { external: true as const } : {}),
+      }
+    : FO_HIW_CLOSING.primaryCta;
+  const back = links[1] ? linkToCta(links[1]) : FO_HIW_CLOSING.backLink;
+  return {
+    heading: block.data.heading,
+    body: block.data.body ?? '',
+    primaryCta: primary,
+    backLink: back,
+  };
+}
+
+export function foHiwHeroSlot(blocks: Block[]): BlockSlot<FoHiwHeroData> {
+  const block = blocks[FO_HIW_HERO_INDEX];
+  const path = `blocks.${FO_HIW_HERO_INDEX}.data`;
+  if (block && block.type === 'hero') return { data: heroToFoHiwHero(block), path };
+  return { data: heroToFoHiwHero(foHiwHeroBlock()), path };
+}
+
+export function foHiwStepsSlot(blocks: Block[]): BlockSlot<FoHiwStepsData> {
+  const block = blocks[FO_HIW_STEPS_INDEX];
+  const path = `blocks.${FO_HIW_STEPS_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoHiwSteps(block), path };
+  return { data: sectionToFoHiwSteps(foHiwStepsBlock()), path };
+}
+
+export function foHiwFearSlot(blocks: Block[]): BlockSlot<FoHiwFearData> {
+  const block = blocks[FO_HIW_FEAR_INDEX];
+  const path = `blocks.${FO_HIW_FEAR_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoHiwFear(block), path };
+  return { data: sectionToFoHiwFear(foHiwFearBlock()), path };
+}
+
+export function foHiwOwnershipSlot(blocks: Block[]): BlockSlot<FoHiwOwnershipData> {
+  const block = blocks[FO_HIW_OWNERSHIP_INDEX];
+  const path = `blocks.${FO_HIW_OWNERSHIP_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoHiwOwnership(block), path };
+  return { data: sectionToFoHiwOwnership(foHiwOwnershipBlock()), path };
+}
+
+export function foHiwTimelineSlot(blocks: Block[]): BlockSlot<FoHiwTimelineData> {
+  const block = blocks[FO_HIW_TIMELINE_INDEX];
+  const path = `blocks.${FO_HIW_TIMELINE_INDEX}.data`;
+  if (block && block.type === 'section') return { data: sectionToFoHiwTimeline(block), path };
+  return { data: sectionToFoHiwTimeline(foHiwTimelineBlock()), path };
+}
+
+export function foHiwCtaSlot(blocks: Block[]): BlockSlot<FoHiwCtaData> {
+  const block = blocks[FO_HIW_CTA_INDEX];
+  const path = `blocks.${FO_HIW_CTA_INDEX}.data`;
+  if (block && block.type === 'ctaSection') return { data: ctaToFoHiwCta(block), path };
+  return { data: ctaToFoHiwCta(foHiwCtaBlock()), path };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/routes/ForOperatorsHowItWorksPage.tsx
+++ b/apps/marketing/app/routes/ForOperatorsHowItWorksPage.tsx
@@ -1,7 +1,7 @@
 // Page 2 of the operator lane — process description that removes the fear
 // by making the engagement concrete and bounded.
 // Spec: internal non-technical-lane spec (2026-05-14) §3.3 Page 2.
-// Phase 4 of the spec's §8 sequence.
+// CMS-wired via useMarketingPageBlocks (VES residual; same pattern as fair-source).
 
 import { Footer } from '../components/Footer';
 import { ClosingCta } from '../components/for-operators-how-it-works/ClosingCta';
@@ -10,16 +10,37 @@ import { FearRemoval } from '../components/for-operators-how-it-works/FearRemova
 import { Hero } from '../components/for-operators-how-it-works/Hero';
 import { Ownership } from '../components/for-operators-how-it-works/Ownership';
 import { Timeline } from '../components/for-operators-how-it-works/Timeline';
+import {
+  FO_HIW_FALLBACK_BLOCKS,
+  foHiwCtaSlot,
+  foHiwFearSlot,
+  foHiwHeroSlot,
+  foHiwOwnershipSlot,
+  foHiwStepsSlot,
+  foHiwTimelineSlot,
+} from '../lib/page-blocks';
+import { useMarketingPageBlocks } from '../lib/use-page-blocks';
 
 export function ForOperatorsHowItWorksPage() {
+  const { blocks, annotation } = useMarketingPageBlocks(
+    'for-operators-how-it-works',
+    FO_HIW_FALLBACK_BLOCKS,
+  );
+  const hero = foHiwHeroSlot(blocks);
+  const steps = foHiwStepsSlot(blocks);
+  const fear = foHiwFearSlot(blocks);
+  const ownership = foHiwOwnershipSlot(blocks);
+  const timeline = foHiwTimelineSlot(blocks);
+  const cta = foHiwCtaSlot(blocks);
+
   return (
     <div className="min-h-screen bg-background">
-      <Hero />
-      <EngagementSteps />
-      <FearRemoval />
-      <Ownership />
-      <Timeline />
-      <ClosingCta />
+      <Hero data={hero.data} path={hero.path} annotation={annotation} />
+      <EngagementSteps data={steps.data} path={steps.path} annotation={annotation} />
+      <FearRemoval data={fear.data} path={fear.path} annotation={annotation} />
+      <Ownership data={ownership.data} path={ownership.path} annotation={annotation} />
+      <Timeline data={timeline.data} path={timeline.path} annotation={annotation} />
+      <ClosingCta data={cta.data} path={cta.path} annotation={annotation} />
       <Footer />
     </div>
   );

--- a/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
+++ b/apps/marketing/app/routes/__tests__/edit-mode-wiring.test.tsx
@@ -15,12 +15,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchPageBlocks } from '../../lib/api';
 import {
   fairSourceBlocks,
+  foHiwBlocks,
   homeBlocks,
   localAiBlocks,
   productsBlocks,
   servicesBlocks,
 } from '../../lib/page-blocks';
 import { FairSourcePage } from '../FairSourcePage';
+import { ForOperatorsHowItWorksPage } from '../ForOperatorsHowItWorksPage';
 import { HomePage } from '../HomePage';
 import { LocalAiPage } from '../LocalAiPage';
 import { ProductsPage } from '../ProductsPage';
@@ -72,7 +74,7 @@ describe('marketing pages: edit-mode wiring', () => {
     editDraftsStore.setEditActive(false);
   });
 
-  it('HomePage, ProductsPage, LocalAiPage, FairSourcePage, and ServicesPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
+  it('HomePage, ProductsPage, LocalAiPage, FairSourcePage, ServicesPage, and ForOperatorsHowItWorksPage emit zero data-rvui-* attributes with no active draft (regression pin)', () => {
     const home = renderRouted(<HomePage />);
     expect(home.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(home.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
@@ -96,6 +98,11 @@ describe('marketing pages: edit-mode wiring', () => {
     const services = renderRouted(<ServicesPage />);
     expect(services.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
     expect(services.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
+    services.unmount();
+
+    const hiw = renderRouted(<ForOperatorsHowItWorksPage />);
+    expect(hiw.container.querySelectorAll('[data-rvui-field]')).toHaveLength(0);
+    expect(hiw.container.querySelectorAll('[data-rvui-doc]')).toHaveLength(0);
   });
 
   it('HomePage renders the draft heading annotated with the session docId when a matching overlay exists', () => {
@@ -192,6 +199,26 @@ describe('marketing pages: edit-mode wiring', () => {
     const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
     expect(title?.getAttribute('data-rvui-doc')).toBe('page-services-id');
     expect(title?.textContent).toBe('Canvas-edited services title');
+  });
+
+  it('ForOperatorsHowItWorksPage renders the draft hero annotated with the session docId when a matching overlay exists', () => {
+    const draftBlocks = foHiwBlocks();
+    const hero = draftBlocks[0];
+    if (hero?.type === 'hero') {
+      hero.data.title = 'Canvas-edited how-it-works title';
+    }
+    editDraftsStore.set([
+      {
+        docType: 'page',
+        docId: 'page-fo-hiw-id',
+        draft: { slug: 'for-operators-how-it-works', blocks: draftBlocks },
+      },
+    ]);
+
+    const { container } = renderRouted(<ForOperatorsHowItWorksPage />);
+    const title = container.querySelector('[data-rvui-field="blocks.0.data.title"]');
+    expect(title?.getAttribute('data-rvui-doc')).toBe('page-fo-hiw-id');
+    expect(title?.textContent).toBe('Canvas-edited how-it-works title');
   });
 
   it('re-renders HomePage with the patched value after an optimistic draft-store update', () => {

--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -43,6 +43,10 @@
       "sha256": "60508313d8412871180cd9897dd49eebc178277cb877aa0e35ef02d621ef7b1f"
     },
     {
+      "relativePath": ".revealui/content/rules/adapter-only.md",
+      "sha256": "dcd894a7516ad394e15a6485a77aea302db87c4a9c4b1910507edd05a97078b8"
+    },
+    {
       "relativePath": ".revealui/content/rules/agent-dispatch.md",
       "sha256": "0b2497c1817e23a1d4902cb5b5889cec4a6f6526179d7273622066705e444fe8"
     },
@@ -55,8 +59,20 @@
       "sha256": "0ec5699691c7505d6c9ac3fa7b2150c546b5e738e0089af42732ac1a6272a04e"
     },
     {
+      "relativePath": ".revealui/content/rules/code-over-docs.md",
+      "sha256": "092c970e6638e76ca6a14f8fb0f25ca70eb76fa3da95e34fcdb0f6cd18c59561"
+    },
+    {
       "relativePath": ".revealui/content/rules/database.md",
       "sha256": "cb66ad35bf9cd6c61846bb6b9ad1d1ec941f72b04a179441e7ccf0a1b873b341"
+    },
+    {
+      "relativePath": ".revealui/content/rules/disposition-actions.md",
+      "sha256": "184c2b6094fd21c96b06172dc0c29df05dfd903b78ff0d149e00c3e61ecf2a78"
+    },
+    {
+      "relativePath": ".revealui/content/rules/durable-solutions.md",
+      "sha256": "162e4f1925ca067d0a00f7257dae9f31b544ccf8b41b5cf8ea8a848b238259d6"
     },
     {
       "relativePath": ".revealui/content/rules/monorepo.md",

--- a/scripts/seed-fleet-marketing-site.ts
+++ b/scripts/seed-fleet-marketing-site.ts
@@ -2,8 +2,8 @@
 
 /**
  * Seed the fleet-marketing `sites` row plus its published marketing pages
- * (home, products, philosophy, local-ai, fair-source, services) for the
- * visual-edit-sessions block wire.
+ * (home, products, philosophy, local-ai, fair-source, services,
+ * for-operators-how-it-works) for the visual-edit-sessions block wire.
  *
  * The page `blocks` come from the SAME pure derivation the marketing app falls
  * back to (`apps/marketing/app/lib/page-blocks.ts`), so the seeded CMS content
@@ -34,6 +34,7 @@ import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 import {
   fairSourceBlocks,
+  foHiwBlocks,
   homeBlocks,
   localAiBlocks,
   philosophyBlocks,
@@ -130,6 +131,17 @@ const PAGE_SEEDS: readonly PageSeed[] = [
       title: 'Services | RevealUI',
       description:
         'Done-for-you software with AI built in. Discovery, fixed-scope engagement, delivered by the team that builds the runtime.',
+    },
+  },
+  {
+    slug: 'for-operators-how-it-works',
+    path: '/for-operators/how-it-works',
+    title: 'How the engagement works',
+    blocks: foHiwBlocks(),
+    seo: {
+      title: 'How the engagement works | RevealUI',
+      description:
+        'Discovery, fixed-scope proposal, build, and handoff. Weeks, not quarters. How RevealUI Studio delivers operator software.',
     },
   },
 ];
@@ -278,7 +290,7 @@ async function main(): Promise<void> {
   }
 
   // ---------------------------------------------------------------------------
-  // Pages (home + products + philosophy + local-ai + fair-source + services) — version-safe, idempotent
+  // Pages (home + products + philosophy + local-ai + fair-source + services + how-it-works) — version-safe, idempotent
   // ---------------------------------------------------------------------------
 
   for (const seed of PAGE_SEEDS) {


### PR DESCRIPTION
## Summary

Supersedes **#2085** (rebased onto `test` after #2084 services merge; conflict resolution).

- Wire `/for-operators/how-it-works` to CMS (VES residual; same pattern as fair-source / services)
- Coexists with services CMS on `page-blocks` + seed
- Seed slug `for-operators-how-it-works`
- Gate snapshot refresh commit may already be on `test`; included if still needed

## Test plan

- [x] page-blocks + edit-mode: 24/24 after rebase
- [x] Pre-push gate (this push)

## Owner

- Close #2085 as superseded when this is open
- Merge when green; then `pnpm db:seed:fleet-marketing`