### PR TITLE
fix(validate): count test files via git ls-files (GAP-399)

### DIFF
--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -43,6 +43,10 @@
       "sha256": "60508313d8412871180cd9897dd49eebc178277cb877aa0e35ef02d621ef7b1f"
     },
     {
+      "relativePath": ".revealui/content/rules/adapter-only.md",
+      "sha256": "dcd894a7516ad394e15a6485a77aea302db87c4a9c4b1910507edd05a97078b8"
+    },
+    {
       "relativePath": ".revealui/content/rules/agent-dispatch.md",
       "sha256": "0b2497c1817e23a1d4902cb5b5889cec4a6f6526179d7273622066705e444fe8"
     },
@@ -55,8 +59,20 @@
       "sha256": "0ec5699691c7505d6c9ac3fa7b2150c546b5e738e0089af42732ac1a6272a04e"
     },
     {
+      "relativePath": ".revealui/content/rules/code-over-docs.md",
+      "sha256": "092c970e6638e76ca6a14f8fb0f25ca70eb76fa3da95e34fcdb0f6cd18c59561"
+    },
+    {
       "relativePath": ".revealui/content/rules/database.md",
       "sha256": "cb66ad35bf9cd6c61846bb6b9ad1d1ec941f72b04a179441e7ccf0a1b873b341"
+    },
+    {
+      "relativePath": ".revealui/content/rules/disposition-actions.md",
+      "sha256": "184c2b6094fd21c96b06172dc0c29df05dfd903b78ff0d149e00c3e61ecf2a78"
+    },
+    {
+      "relativePath": ".revealui/content/rules/durable-solutions.md",
+      "sha256": "162e4f1925ca067d0a00f7257dae9f31b544ccf8b41b5cf8ea8a848b238259d6"
     },
     {
       "relativePath": ".revealui/content/rules/monorepo.md",

--- a/scripts/validate/__tests__/claim-drift.test.ts
+++ b/scripts/validate/__tests__/claim-drift.test.ts
@@ -10,12 +10,14 @@ import {
   countDirs,
   countEnforcementTests,
   countTestFiles,
+  countTrackedFiles,
   extractRevealuiPackages,
   findIncompleteProList,
   findLicenseSplitAntiPattern,
   isRoadmapDeclaredFile,
   makeIgnoredPathPredicate,
   parseGitIgnoredOutput,
+  TEST_FILE_SUFFIXES,
   WALK_EXCLUDED_DIRS,
 } from '../claim-drift.ts';
 
@@ -290,6 +292,77 @@ describe('countTestFiles', () => {
     // File-granular skip: exactly the listed file, nothing else.
     const isIgnored = makeIgnoredPathPredicate(tmp, new Set(['docs/STALE_REPORT.test.ts']));
     expect(countTestFiles(tmp, isIgnored)).toBe(1);
+  });
+
+  it('GAP-399: walker skips a nested .wt/ full-checkout phantom (name exclusion)', () => {
+    fs.mkdirSync(path.join(tmp, 'packages', 'core'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'packages', 'core', 'real.test.ts'), '');
+    // Incident shape: a peer worktree nested under the main checkout root
+    // (fleet convention .wt/<label>) carrying a full second copy of tests.
+    const phantom = path.join(tmp, '.wt', 'peer-session', 'packages', 'core');
+    fs.mkdirSync(phantom, { recursive: true });
+    fs.writeFileSync(path.join(phantom, 'phantom.test.ts'), '');
+    fs.writeFileSync(path.join(phantom, 'another.spec.tsx'), '');
+    // Without the durable name exclusion this would be 3.
+    expect(countTestFiles(tmp)).toBe(1);
+  });
+});
+
+describe('countTrackedFiles (GAP-399 durable path)', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-drift-git-ls-'));
+    execFileSync('git', ['init', '-q'], { cwd: tmp });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: tmp });
+    execFileSync('git', ['config', 'user.name', 'claim-drift fixture'], { cwd: tmp });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function commitTracked(rel: string, body = ''): void {
+    const full = path.join(tmp, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+    execFileSync('git', ['add', rel], { cwd: tmp });
+    execFileSync('git', ['commit', '-q', '-m', `add ${rel}`], { cwd: tmp });
+  }
+
+  it('counts only index-tracked test files (ignores untracked .wt/ phantoms)', () => {
+    commitTracked('packages/core/real.test.ts');
+    // Untracked nested worktree copy — never enters the index.
+    const phantom = path.join(tmp, '.wt', 'peer', 'packages', 'core');
+    fs.mkdirSync(phantom, { recursive: true });
+    fs.writeFileSync(path.join(phantom, 'phantom.test.ts'), '');
+    fs.writeFileSync(path.join(phantom, 'extra.spec.ts'), '');
+
+    const match = (rel: string) => TEST_FILE_SUFFIXES.some((s) => rel.endsWith(s));
+    expect(countTrackedFiles(tmp, match)).toBe(1);
+    // Filesystem walk without exclusions would see 3; durable path stays at 1.
+  });
+
+  it('returns null when the path is not a git work tree', () => {
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-drift-nogit-'));
+    try {
+      expect(countTrackedFiles(bare, () => true)).toBeNull();
+    } finally {
+      fs.rmSync(bare, { recursive: true, force: true });
+    }
+  });
+
+  it('repo-root countTestFiles matches git ls-files (tracked-files basis)', () => {
+    // Integration check against the real monorepo: both paths must agree so
+    // the durable switch cannot silently drift from the walk-era baseline
+    // when no nested .wt/ is present.
+    const repoRoot = path.resolve(import.meta.dirname, '../../..');
+    const viaDefault = countTestFiles(repoRoot);
+    const viaGit = countTrackedFiles(repoRoot, (rel) =>
+      TEST_FILE_SUFFIXES.some((s) => rel.endsWith(s)),
+    );
+    expect(viaGit).not.toBeNull();
+    expect(viaDefault).toBe(viaGit);
   });
 });
 

--- a/scripts/validate/claim-drift.ts
+++ b/scripts/validate/claim-drift.ts
@@ -44,13 +44,20 @@ const CAPABILITY_BASELINE_PATH = path.join(
 );
 
 // ---------------------------------------------------------------------------
-// Walker exclusions
+// Walker exclusions + tracked-file counts
 //
-// Two layers keep stale local artifacts from skewing local validator runs vs
-// the clean checkout CI sees (incident 2026-06-11: a stale opensrc/ cache
-// held 53 third-party *.test.ts files, inflating countTestFiles() from 961
-// to 1014 — past the ±100 testFiles tolerance — so the local gate
-// hard-failed while CI stayed green):
+// Whole-repo METRICS (test files) prefer `git ls-files` (see countTestFiles /
+// countTrackedFiles) so nested agent worktrees under `.wt/` never inflate
+// counts (GAP-399). Filesystem walkers remain for fixtures, git-less trees,
+// and scoped collectors (packages/, apps/, presentation components, mcp
+// servers, db schema) which only readdir a single known directory and cannot
+// double-count a nested full checkout.
+//
+// Two layers still protect walk-based paths and claim scans when git is
+// unavailable (incident 2026-06-11: a stale opensrc/ cache held 53 third-party
+// *.test.ts files, inflating countTestFiles() from 961 to 1014 — past the
+// ±100 testFiles tolerance — so the local gate hard-failed while CI stayed
+// green):
 //
 // 1. WALK_EXCLUDED_DIRS — directory NAMES the walkers below must never
 //    enter, matched per entry at any depth. This is the only protection when
@@ -60,17 +67,14 @@ const CAPABILITY_BASELINE_PATH = path.join(
 //    assert every entry except .git has a covering .gitignore line AND that
 //    no entry shadows git-tracked files (e.g. screenshots/ is gitignored yet
 //    apps/marketing/public/screenshots is tracked, so it must NOT be listed
-//    here).
+//    here). Includes `.wt` and `.worktrees` for the walk fallback.
 //
-// 2. The git-derived ignored-path set (below) — one lazy `git ls-files` pass
-//    covering what a name set cannot express: path-shaped ignores (the
-//    generated docs mirrors apps/docs/public/docs/ + apps/docs/dist/docs/
-//    written by apps/docs/scripts/copy-docs.sh, where a local docs build
-//    duplicates every scan hit under the generated copy) and pattern-shaped
-//    file ignores inside scanned dirs (docs/*VERIFICATION*.md /
-//    docs/*REPORT*.md report artifacts carrying stale counts). It also
-//    honors nested .gitignore files (apps/docs/.gitignore `public/*/`),
-//    which the name set and its sync-guard test never see.
+// 2. The git-derived ignored-path set (below) — one lazy `git ls-files`
+//    --others --ignored pass covering what a name set cannot express:
+//    path-shaped ignores (the generated docs mirrors apps/docs/public/docs/
+//    + apps/docs/dist/docs/ written by apps/docs/scripts/copy-docs.sh) and
+//    pattern-shaped file ignores inside scanned dirs (docs/*VERIFICATION*.md
+//    / docs/*REPORT*.md). It also honors nested .gitignore files.
 // ---------------------------------------------------------------------------
 
 /** Exported for tests. */
@@ -252,16 +256,67 @@ function countApps(): number {
   return countDirs(path.join(ROOT, 'apps'));
 }
 
+/** Suffixes counted as test files (METRICS.testFiles). Exported for tests. */
+export const TEST_FILE_SUFFIXES: readonly string[] = [
+  '.test.ts',
+  '.test.tsx',
+  '.spec.ts',
+  '.spec.tsx',
+  '.e2e.ts',
+] as const;
+
+function hasTestFileSuffix(filePath: string): boolean {
+  return TEST_FILE_SUFFIXES.some((suffix) => filePath.endsWith(suffix));
+}
+
+/**
+ * Count matching tracked files via `git ls-files` (index paths for THIS
+ * worktree only). Returns null when git is unavailable so callers can fall
+ * back to a filesystem walk.
+ *
+ * GAP-399: peer worktrees under `.wt/` (or any future scratch dir) are full
+ * working trees on disk. A readdir walk from the main checkout double-counts
+ * every test file. `git ls-files` lists only this worktree's tracked paths,
+ * so nested checkouts never inflate the count — even if a name is missing
+ * from WALK_EXCLUDED_DIRS. Prefer this over directory walks for whole-repo
+ * METRICS. Exported for tests.
+ */
+export function countTrackedFiles(
+  root: string,
+  match: (repoRelativePath: string) => boolean,
+): number | null {
+  try {
+    const raw = execFileSync('git', ['ls-files', '-z'], {
+      cwd: root,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    let count = 0;
+    for (const entry of raw.split('\0')) {
+      if (entry.length === 0) continue;
+      // Normalize to forward slashes (git always emits them).
+      if (match(entry)) count++;
+    }
+    return count;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Count test files across the repo. Path-injectable + exported for tests
  * (mirrors countEnforcementTests); tests may also inject a skip-predicate.
+ *
+ * Default path (real repo root, no custom predicate): `git ls-files` so
+ * nested `.wt/` worktrees cannot inflate METRICS.testFiles (GAP-399).
+ * Fixtures and custom predicates keep the filesystem walk.
  */
 export function countTestFiles(base: string = ROOT, isIgnored?: IgnoredPathPredicate): number {
-  return countByGlob(
-    base,
-    ['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx', '.e2e.ts'],
-    isIgnored,
-  );
+  if (base === ROOT && isIgnored === undefined) {
+    const tracked = countTrackedFiles(ROOT, hasTestFileSuffix);
+    if (tracked !== null) return tracked;
+  }
+  return countByGlob(base, [...TEST_FILE_SUFFIXES], isIgnored);
 }
 
 function countUIComponents(): number {


### PR DESCRIPTION
## Summary

- **GAP-399:** `METRICS.testFiles` in `claim-drift.ts` now counts via `git ls-files` (this worktree's tracked paths only). Nested peer checkouts under `.wt/` no longer inflate the claim-drift gate when pushing from a main checkout that has worktrees nested under the repo root.
- Keep the readdir walk (with existing `.wt` / `.worktrees` name exclusions) as the fixture / git-less fallback.
- Audit note: other METRICS collectors (`packages/`, `apps/`, UI components, MCP servers, DB schema) are single-directory reads and cannot double-count a nested full checkout.
- **Tip hygiene (required for pre-push):** refresh `@revealui/harnesses` claude-code content snapshot for four GAP-406 hardlines missing from the #2083 lock (`adapter-only`, `code-over-docs`, `disposition-actions`, `durable-solutions`). Unblocks phase-1 hard-fail for any PR on current tip.

## Test plan

- [x] `pnpm exec vitest run scripts/validate/__tests__/claim-drift.test.ts` — GAP-399 cases green (nested `.wt/` walker + `git ls-files` phantom fixture + repo-root agreement)
- [x] Planted 50 phantom `*.test.ts` under `.wt/gap399-prove/` → `countTestFiles()` stayed at 1125
- [x] `pnpm validate:claims` exit 0
- [x] `pnpm --filter @revealui/harnesses content:snapshot:check` green after snapshot refresh
- [x] Pre-push phase-1 gate PASS

## Out of scope / peer non-collision

- Does not touch marketing CMS / #2086 / #2087 fo routes
- Does not close GAP-192 (AST refactor of claim patterns)
- Pre-existing `WALK_EXCLUDED_DIRS` unit assertions about `.claude` (tracked + walker-excluded) remain red when the suite is run manually; scripts/validate tests are not on turbo `pnpm test` CI path

## Owner

Merge when green (not self-merged).

Closes nothing in product until GAP-399 status is flipped in `.jv` (follow-up).