### PR TITLE
feat(marketing): restore full locked form on product hero subtitle

### DIFF
--- a/apps/marketing/app/__tests__/hero-variant.test.ts
+++ b/apps/marketing/app/__tests__/hero-variant.test.ts
@@ -26,4 +26,13 @@ describe('selectHomeHero', () => {
   it('matches the corpus §4.1 H1 lock verbatim', () => {
     expect(HOME_HERO_FOUNDATION.h1).toBe('The foundation your business runs on.');
   });
+
+  it('keeps the full locked positioning form on both hero variants', () => {
+    expect(HOME_HERO.subtitle.sentence1).toContain('under one roof');
+    expect(HOME_HERO.subtitle.sentence2).toBe(
+      'Every agent is a governed and audited user that lives on your infrastructure.',
+    );
+    expect(HOME_HERO.subtitle.support).toBe('It runs on any AI provider you choose.');
+    expect(HOME_HERO_FOUNDATION.subtitle.sentence2).toBe(HOME_HERO.subtitle.sentence2);
+  });
 });

--- a/apps/marketing/app/__tests__/use-audience-head.test.ts
+++ b/apps/marketing/app/__tests__/use-audience-head.test.ts
@@ -93,7 +93,7 @@ describe('useAudienceHead — technical audience', () => {
     expect(
       document.querySelector<HTMLMetaElement>('meta[property="og:description"]')?.content,
     ).toBe(
-      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client.',
+      'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof. Every agent is a governed and audited user that lives on your infrastructure.',
     );
   });
 

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -43,7 +43,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
       </h1>
 
       <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
-        {hero.subtitle.sentence1} {hero.subtitle.support}
+        {hero.subtitle.sentence1} {hero.subtitle.sentence2} {hero.subtitle.support}
       </p>
 
       <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -557,6 +557,30 @@ export const CLAIMS: readonly ClaimEntry[] = [
   },
   {
     file: 'home.ts',
+    exportPath: 'HOME_HERO.subtitle.sentence2',
+    text: 'Every agent is a governed and audited user that lives on your infrastructure.',
+    evidence: [
+      AGENT_ROUTES,
+      RBAC_ABAC,
+      TIER_GATES,
+      AUDIT_LOG_SCHEMA,
+      AUDIT_SIGNING,
+      AUDIT_SIGNING_TEST,
+      {
+        kind: 'code',
+        ref: 'packages/auth/src/server/auth.ts',
+        note: 'agents authenticate as first-class principals under the same session/auth surface as human users',
+      },
+      {
+        kind: 'test',
+        ref: 'packages/core/src/collections/operations/__tests__/access-enforcement.test.ts#authenticated() allows when user is present',
+        note: 'identity-gated access: a principal must authenticate before protected operations; agents use the same gate surface as human users',
+      },
+      SELF_HOST,
+    ],
+  },
+  {
+    file: 'home.ts',
     exportPath: 'HOME_HERO.subtitle.support',
     text: 'It runs on any AI provider you choose.',
     evidence: [PROVIDERS, OPEN_WEIGHT],

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -3,10 +3,11 @@
 //   app/components/GetStarted.tsx (Phase 1c extraction).
 // Per the internal marketing-overhaul plan §4.4.
 // 2026-07-09: homepage funnel declutter (internal marketing funnel audit). Hero
-// subtitle now carries the canonical positioning sentence + foil; the "What
-// ships today" grid, the audience Fork, and the Objections section moved out
-// (their 3 strongest metrics live in the Proof section; the two objection
-// cards became the first two FAQ items below).
+// subtitle carries the canonical positioning sentences; receipt foil lives on
+// the ReceiptCard. The "What ships today" grid, audience Fork, and Objections
+// section moved out (metrics in Proof; objections in FAQ).
+// 2026-07-23: hero subtitle restored to the full 2026-07-09 locked form
+// (sentence1 + sentence2 + support). Foil stays on ReceiptCard.
 // 2026-07-10: frontend-excellence Phase 1 (11->7 section cut, ADR
 // 2026-07-10-frontend-design-direction). HOME_ACTORS and HOME_THESIS_BAND
 // removed (thin vocabulary/pull-quote content, no longer rendered anywhere);
@@ -28,9 +29,13 @@ import type { Cta, FaqItem } from './types';
 export const HOME_HERO = {
   eyebrow: 'Open source. Self-hostable.',
   h1: 'Run your whole business on one runtime you own.',
+  // Locked public form (copy-voice.md + ADR 2026-07-09 / 2026-07-21): two
+  // positioning sentences + support. Receipt foil is NOT in the subtitle; it
+  // is the ReceiptCard caption under this hero.
   subtitle: {
     sentence1:
       'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof.',
+    sentence2: 'Every agent is a governed and audited user that lives on your infrastructure.',
     support: 'It runs on any AI provider you choose.',
   },
   cta: {

--- a/apps/marketing/app/lib/use-audience-head.ts
+++ b/apps/marketing/app/lib/use-audience-head.ts
@@ -30,16 +30,17 @@ const SEO: Record<Audience, AudienceSeo> = {
   },
   technical: {
     title: 'RevealUI | Run your whole business on one runtime you own.',
+    // Mirrors HOME_HERO subtitle (canonical 2026-07-09 form, no em dashes).
     description:
-      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client.',
+      'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof. Every agent is a governed and audited user that lives on your infrastructure. It runs on any AI provider you choose.',
     ogTitle: 'RevealUI | Run your whole business on one runtime you own.',
     ogDescription:
-      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client.',
+      'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof. Every agent is a governed and audited user that lives on your infrastructure.',
     ogImage:
       'https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own.',
     twitterTitle: 'RevealUI | Run your whole business on one runtime you own.',
     twitterDescription:
-      'Auth, content, products, and payments, pre-wired into one open-source runtime you self-host. Ship one product or stamp a branded copy per client.',
+      'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof. Every agent is a governed and audited user that lives on your infrastructure.',
     twitterImage:
       'https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own.',
   },


### PR DESCRIPTION
## Summary

Completes the **locked 2026-07-09 product positioning form** on the technical homepage hero (owner choice: complete locked form, not FDE H1 override).

**Before:** subtitle was only roof sentence + provider support.  
**After:** roof sentence + *Every agent is a governed and audited user that lives on your infrastructure.* + support.

Also aligns technical audience meta/OG descriptions with that form. Receipt foil stays on the ReceiptCard. H1 and foundation A/B unchanged. ADR 2026-07-21 FDE layer rules respected (no FDE product H1).

## Files

- `apps/marketing/app/content/home.ts` — `subtitle.sentence2`
- `apps/marketing/app/components/landing/Hero.tsx` — render all three subtitle parts
- `apps/marketing/app/content/claims-evidence.ts` — indexed claim + test proofs
- `apps/marketing/app/lib/use-audience-head.ts` — technical SEO descriptions
- tests for hero variant + audience head

## Test plan

- [x] marketing unit tests (hero-variant, use-audience-head)
- [x] `pnpm validate:claims`
- [ ] CI green
- [ ] Spot-check `/?audience=technical` (or default technical) hero body