### PR TITLE
fix(core): ValidationError taxonomy (fleet-redundancy P2-A)

### DIFF
--- a/packages/core/src/collections/operations/fieldValidation.ts
+++ b/packages/core/src/collections/operations/fieldValidation.ts
@@ -7,8 +7,8 @@
  *
  * A field's `validate(value, { value, data, siblingData, operation, req })`
  * returns `true` when the value is valid, or a non-empty string error message
- * when it is not. On the first failure the engine throws a ValidationError
- * (HTTP 400) carrying that message, so the write is rejected at ingress.
+ * when it is not. On the first failure the engine throws the canonical ValidationError
+ * (HTTP 400, `instanceof`) carrying that message, so the write is rejected at ingress.
  *
  * Enforcement note: this is one of the engine's ingress checks and runs for
  * EVERY collection written through create()/update(). For public page/post
@@ -19,27 +19,11 @@
 
 import type { Field } from '@revealui/contracts/admin';
 import type { RevealCollectionConfig, RevealRequest } from '../../types/index.js';
+import { ValidationError } from '../../utils/errors.js';
 import { flattenFields } from '../../utils/type-guards.js';
 
-/**
- * Thrown when a field's `validate` predicate rejects a value.
- *
- * Carries `status`/`statusCode` 400 so transports surface it as a client error
- * with the validator's message intact (core `rest.ts` reads `status`; the
- * server error middleware can branch on `name === 'ValidationError'`), rather
- * than the generic 500 that a bare Error would produce.
- */
-export class ValidationError extends Error {
-  readonly status = 400;
-  readonly statusCode = 400;
-  readonly field?: string;
-
-  constructor(message: string, field?: string) {
-    super(message);
-    this.name = 'ValidationError';
-    this.field = field;
-  }
-}
+/** Re-export canonical domain ValidationError for collection call sites/tests. */
+export { ValidationError };
 
 /**
  * Executes every field's `validate` predicate for the fields present in `data`.

--- a/packages/core/src/error-handling/__tests__/error-reporter.test.ts
+++ b/packages/core/src/error-handling/__tests__/error-reporter.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ValidationError as DomainValidationError } from '../../utils/errors.js';
+import { ClientValidationError, NetworkError } from '../error-boundary.js';
 import type { Breadcrumb, ErrorReporter, UserContext } from '../error-reporter.js';
 import {
   ConsoleErrorReporter,
@@ -512,8 +514,7 @@ describe('ErrorReportingSystem', () => {
     });
 
     it('should classify NetworkError as warning level', () => {
-      const error = new Error('network issue');
-      error.name = 'NetworkError';
+      const error = new NetworkError('network issue');
       system.captureError(error);
 
       expect(mockReporter.captureError).toHaveBeenCalledWith(
@@ -522,14 +523,34 @@ describe('ErrorReportingSystem', () => {
       );
     });
 
-    it('should classify ValidationError as warning level', () => {
-      const error = new Error('invalid input');
-      error.name = 'ValidationError';
+    it('should classify ClientValidationError as warning level', () => {
+      const error = new ClientValidationError('invalid input');
       system.captureError(error);
 
       expect(mockReporter.captureError).toHaveBeenCalledWith(
         error,
         expect.objectContaining({ level: 'warning' }),
+      );
+    });
+
+    it('should classify domain ValidationError as warning level', () => {
+      const error = new DomainValidationError('invalid email', 'email', 'bad');
+      system.captureError(error);
+
+      expect(mockReporter.captureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ level: 'warning' }),
+      );
+    });
+
+    it('should not treat name-only ValidationError spoof as warning', () => {
+      const error = new Error('spoofed');
+      error.name = 'ValidationError';
+      system.captureError(error);
+
+      expect(mockReporter.captureError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ level: 'error' }),
       );
     });
 

--- a/packages/core/src/error-handling/__tests__/validation-error-taxonomy.test.ts
+++ b/packages/core/src/error-handling/__tests__/validation-error-taxonomy.test.ts
@@ -1,0 +1,53 @@
+/**
+ * P2-A fleet-redundancy: ValidationError taxonomy.
+ * Domain vs client classes must not share instanceof identity or name-guard paths.
+ */
+import { describe, expect, it } from 'vitest';
+import { ValidationError as FieldIngressValidationError } from '../../collections/operations/fieldValidation.js';
+import { ValidationError as DomainValidationError } from '../../utils/errors.js';
+import {
+  ValidationError as BoundaryValidationAlias,
+  ClientValidationError,
+  isClientValidationError,
+  isValidationError,
+} from '../error-boundary.js';
+
+describe('ValidationError taxonomy (P2-A)', () => {
+  it('domain and client classes are distinct constructors', () => {
+    const domain = new DomainValidationError('bad', 'email', 'x');
+    const client = new ClientValidationError('bad', { email: 'required' });
+
+    expect(domain).toBeInstanceOf(DomainValidationError);
+    expect(client).toBeInstanceOf(ClientValidationError);
+    expect(domain).not.toBeInstanceOf(ClientValidationError);
+    expect(client).not.toBeInstanceOf(DomainValidationError);
+    expect(domain.name).toBe('ValidationError');
+    expect(client.name).toBe('ClientValidationError');
+  });
+
+  it('field-ingress re-exports the domain class', () => {
+    const err = new FieldIngressValidationError('Unsafe URL scheme', 'url');
+    expect(err).toBeInstanceOf(DomainValidationError);
+    expect(err.status).toBe(400);
+    expect(err.statusCode).toBe(400);
+  });
+
+  it('isClientValidationError is instanceof-only (no name spoof)', () => {
+    const spoof = new Error('spoof');
+    spoof.name = 'ValidationError';
+    const spoofClient = new Error('spoof');
+    spoofClient.name = 'ClientValidationError';
+
+    expect(isClientValidationError(spoof)).toBe(false);
+    expect(isClientValidationError(spoofClient)).toBe(false);
+    expect(isValidationError(spoof)).toBe(false);
+    expect(isClientValidationError(new ClientValidationError('ok'))).toBe(true);
+    expect(isValidationError(new BoundaryValidationAlias('ok'))).toBe(true);
+  });
+
+  it('domain ValidationError is not a client validation error', () => {
+    const domain = new DomainValidationError('bad', 'f', 1);
+    expect(isClientValidationError(domain)).toBe(false);
+    expect(isValidationError(domain)).toBe(false);
+  });
+});

--- a/packages/core/src/error-handling/error-boundary.tsx
+++ b/packages/core/src/error-handling/error-boundary.tsx
@@ -386,15 +386,28 @@ export class NetworkError extends Error {
   }
 }
 
-export class ValidationError extends Error {
+/**
+ * Client-side form / UI validation error (field-map payload).
+ *
+ * Not the same class as domain `ValidationError` in `utils/errors.ts`.
+ * Renamed from ValidationError (P2-A fleet-redundancy) so `instanceof` and
+ * `name` no longer collide with API/field-ingress errors.
+ */
+export class ClientValidationError extends Error {
   constructor(
     message: string,
     public fields?: Record<string, string>,
   ) {
     super(message);
-    this.name = 'ValidationError';
+    this.name = 'ClientValidationError';
   }
 }
+
+/**
+ * @deprecated Use {@link ClientValidationError}. Alias kept for one minor.
+ */
+export const ValidationError = ClientValidationError;
+export type ValidationError = ClientValidationError;
 
 export class AuthenticationError extends Error {
   constructor(message: string) {
@@ -420,10 +433,13 @@ export function isNetworkError(error: unknown): error is NetworkError {
   return error instanceof NetworkError || (error instanceof Error && error.name === 'NetworkError');
 }
 
-export function isValidationError(error: unknown): error is ValidationError {
-  return (
-    error instanceof ValidationError || (error instanceof Error && error.name === 'ValidationError')
-  );
+export function isClientValidationError(error: unknown): error is ClientValidationError {
+  return error instanceof ClientValidationError;
+}
+
+/** @deprecated Prefer {@link isClientValidationError}; still instanceof-only (no name check). */
+export function isValidationError(error: unknown): error is ClientValidationError {
+  return isClientValidationError(error);
 }
 
 export function isAuthenticationError(error: unknown): error is AuthenticationError {

--- a/packages/core/src/error-handling/error-reporter.ts
+++ b/packages/core/src/error-handling/error-reporter.ts
@@ -5,7 +5,8 @@
  */
 
 import { logger } from '../observability/logger.js';
-import type { ErrorInfo } from './error-boundary.js';
+import { ValidationError as DomainValidationError } from '../utils/errors.js';
+import { ClientValidationError, type ErrorInfo, NetworkError } from './error-boundary.js';
 
 export interface ErrorReport {
   error: Error;
@@ -278,11 +279,13 @@ export class ErrorReportingSystem implements ErrorReporter {
       return 'error';
     }
 
-    if (error.name === 'NetworkError') {
+    // instanceof only — name checks false-positive across dual ValidationError
+    // classes (P2-A fleet-redundancy).
+    if (error instanceof NetworkError) {
       return 'warning';
     }
 
-    if (error.name === 'ValidationError') {
+    if (error instanceof ClientValidationError || error instanceof DomainValidationError) {
       return 'warning';
     }
 

--- a/packages/core/src/error-handling/index.ts
+++ b/packages/core/src/error-handling/index.ts
@@ -52,10 +52,12 @@ export type {
 // Error boundaries
 export {
   AuthenticationError,
+  ClientValidationError,
   ErrorBoundary,
   ErrorBoundaryWithRetry,
   getErrorSeverity,
   isAuthenticationError,
+  isClientValidationError,
   isNetworkError,
   isNotFoundError,
   isValidationError,

--- a/packages/core/src/utils/__tests__/errors.test.ts
+++ b/packages/core/src/utils/__tests__/errors.test.ts
@@ -49,6 +49,15 @@ describe('Error Classes', () => {
       expect(err.field).toBe('email');
       expect(err.value).toBe('bad@');
       expect(err.name).toBe('ValidationError');
+      expect(err.status).toBe(400);
+      expect(err.statusCode).toBe(400);
+    });
+
+    it('allows optional value for field-ingress throws', () => {
+      const err = new ValidationError('Unsafe URL scheme', 'url');
+      expect(err.field).toBe('url');
+      expect(err.value).toBeUndefined();
+      expect(err).toBeInstanceOf(ValidationError);
     });
   });
 

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -24,14 +24,27 @@ export class ApplicationError extends Error {
 }
 
 /**
- * Validation Error
- * Use for input validation failures, schema validation failures
+ * Validation Error (canonical domain / API / field-ingress class)
+ *
+ * Single source for server-side validation failures. Carries HTTP 400 via
+ * `status` / `statusCode` so REST and middleware treat field-ingress and
+ * API validation the same. Distinct from `ClientValidationError` in the
+ * React error-boundary module (client form field map).
+ *
+ * Always branch with `instanceof ValidationError` — never `name ===
+ * 'ValidationError'`, which false-positives against other classes that
+ * historically shared the same name.
  */
 export class ValidationError extends Error {
+  /** HTTP status for transports that read `error.status` (e.g. rest.ts). */
+  readonly status = 400;
+  /** Alias for handlers that read `statusCode`. */
+  readonly statusCode = 400;
+
   constructor(
     message: string,
     public field: string,
-    public value: unknown,
+    public value?: unknown,
     public context?: Record<string, unknown>,
   ) {
     super(message);

--- a/packages/test/src/integration/services/error-reporting.integration.test.ts
+++ b/packages/test/src/integration/services/error-reporting.integration.test.ts
@@ -16,6 +16,7 @@
  * - Error filtering and sampling
  */
 
+import { NetworkError } from '@revealui/core/error-handling';
 import {
   type Breadcrumb,
   type ErrorReport,
@@ -156,14 +157,7 @@ describe('Error Reporting System Integration Tests', () => {
     it('should determine error level based on error type', () => {
       const typeError = new TypeError('Type error');
       const referenceError = new ReferenceError('Reference error');
-
-      // Create custom error types
-      class NetworkError extends Error {
-        constructor(message: string) {
-          super(message);
-          this.name = 'NetworkError';
-        }
-      }
+      // Real NetworkError class — name-only spoofs no longer map to warning (P2-A).
       const networkError = new NetworkError('Network error');
 
       errorReporter.captureError(typeError);
@@ -174,7 +168,7 @@ describe('Error Reporting System Integration Tests', () => {
       expect(mockReporter.capturedErrors[0]?.context?.level).toBe('error');
       expect(mockReporter.capturedErrors[1]?.context?.level).toBe('error');
 
-      // NetworkError should be 'warning' level
+      // NetworkError should be 'warning' level (instanceof)
       expect(mockReporter.capturedErrors[2]?.context?.level).toBe('warning');
     });
   });


### PR DESCRIPTION
## Summary

Fleet-redundancy **P2-A** (lane unpaused jv#611): stop three `ValidationError` classes from sharing `name === 'ValidationError'` (false-positive guards).

### Changes
| Surface | Before | After |
|---------|--------|--------|
| `utils/errors.ts` | Domain class, no HTTP status | Canonical **domain** class + `status`/`statusCode` 400 |
| `fieldValidation.ts` | Local duplicate class | Re-exports / throws domain `ValidationError` |
| `error-boundary.tsx` | Client class also named `ValidationError` | **`ClientValidationError`** (`name: ClientValidationError`); deprecated `ValidationError` alias |
| Guards / reporter | `name === 'ValidationError'` | **`instanceof` only** |

### Tests
- `validation-error-taxonomy.test.ts` — class identity, field re-export, name-spoof fails closed
- Updated error-reporter + errors unit tests
- **172** tests green in the touched suite

### Spec
`docs/specs/2026-07-20-fleet-redundancy-remediation.md` §P2-A

## Test plan
- [x] `pnpm exec vitest run` on errors / fieldValidation / error-handling / taxonomy / error-reporter
- [ ] CI gate on PR