### PR TITLE
fix(core): single readCsrfToken for browser clients (P2-C)

### DIFF
--- a/packages/ai/src/client/hooks/useAgentStream.ts
+++ b/packages/ai/src/client/hooks/useAgentStream.ts
@@ -22,6 +22,7 @@
 
 'use client';
 
+import { readCsrfToken } from '@revealui/core/admin/utils/csrf';
 import { useCallback, useRef, useState } from 'react';
 
 /**
@@ -138,32 +139,6 @@ const INITIAL_STATE: UseAgentStreamState = {
   sessionId: null,
   pendingElicitations: [],
 };
-
-/**
- * Read the JS-readable `revealui-csrf` cookie. The api's csrfMiddleware
- * (`apps/server/src/middleware/csrf.ts`) requires it as an `X-CSRF-Token`
- * header on any session-cookie-bearing unsafe request; the admin proxy
- * issues it on page load. Returns undefined outside the browser or when
- * the cookie is absent/empty. Mirrors the cookie-read in `@revealui/core`'s
- * admin APIClient (`request()`).
- */
-function readCsrfToken(): string | undefined {
-  if (typeof document === 'undefined') return undefined;
-  for (const part of document.cookie.split(';')) {
-    const eqIdx = part.indexOf('=');
-    if (eqIdx === -1) continue;
-    if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      const raw = part.slice(eqIdx + 1).trim();
-      if (!raw) return undefined;
-      try {
-        return decodeURIComponent(raw);
-      } catch {
-        return raw;
-      }
-    }
-  }
-  return undefined;
-}
 
 export function useAgentStream(): UseAgentStreamReturn {
   const [state, setState] = useState<UseAgentStreamState>(INITIAL_STATE);

--- a/packages/ai/vitest.config.ts
+++ b/packages/ai/vitest.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
       '@revealui/db/validation': path.resolve(__dirname, '../db/dist/validation/cross-db.js'),
       '@revealui/db': path.resolve(__dirname, '../db/dist/index.js'),
       '@revealui/contracts': path.resolve(__dirname, '../contracts/src'),
+      // More-specific first: package exports map ./admin → dist/client/admin.
+      // A bare @revealui/core → src alias would resolve
+      // @revealui/core/admin/utils/csrf to src/admin/... (missing client/).
+      '@revealui/core/admin': path.resolve(__dirname, '../core/src/client/admin'),
       '@revealui/core': path.resolve(__dirname, '../core/src'),
     },
   },

--- a/packages/auth/src/react/csrf.ts
+++ b/packages/auth/src/react/csrf.ts
@@ -1,33 +1,10 @@
 /**
  * CSRF Double-Submit Token Helper
  *
- * Shared by the react auth hooks (`usePasskey`, `useMFA`, `useSignOut`) whose
- * POSTs target the RevealUI admin proxy's CSRF-gated endpoints.
+ * Re-exports the canonical browser cookie reader from
+ * `@revealui/core/admin/utils/csrf` (fleet-redundancy P2-C). Shared by the
+ * react auth hooks (`usePasskey`, `useMFA`, `useSignOut`) whose POSTs target
+ * the RevealUI admin proxy's CSRF-gated endpoints.
  */
 
-/**
- * Read the JS-readable `revealui-csrf` cookie. The RevealUI admin proxy
- * (`apps/admin/src/proxy.ts`) requires it as an `X-CSRF-Token` header on any
- * session-cookie-bearing unsafe request, and may re-issue the cookie on any
- * response — so call this immediately before each fetch rather than once per
- * flow. Returns undefined outside the browser or when the cookie is
- * absent/empty. Mirrors the cookie-read in `@revealui/core`'s admin APIClient
- * (`request()`) and `@revealui/ai`'s `useAgentStream`.
- */
-export function readCsrfToken(): string | undefined {
-  if (typeof document === 'undefined') return undefined;
-  for (const part of document.cookie.split(';')) {
-    const eqIdx = part.indexOf('=');
-    if (eqIdx === -1) continue;
-    if (part.slice(0, eqIdx).trim() === 'revealui-csrf') {
-      const raw = part.slice(eqIdx + 1).trim();
-      if (!raw) return undefined;
-      try {
-        return decodeURIComponent(raw);
-      } catch {
-        return raw;
-      }
-    }
-  }
-  return undefined;
-}
+export { readCsrfToken } from '@revealui/core/admin/utils/csrf';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -164,6 +164,11 @@
       "import": "./dist/client/admin/utils/apiClient.js",
       "default": "./dist/client/admin/utils/apiClient.js"
     },
+    "./admin/utils/csrf": {
+      "types": "./dist/client/admin/utils/csrf.d.ts",
+      "import": "./dist/client/admin/utils/csrf.js",
+      "default": "./dist/client/admin/utils/csrf.js"
+    },
     "./richtext": {
       "types": "./dist/richtext/index.d.ts",
       "import": "./dist/richtext/index.js",

--- a/packages/core/src/client/admin/utils/csrf.ts
+++ b/packages/core/src/client/admin/utils/csrf.ts
@@ -1,12 +1,15 @@
 /**
- * CSRF helpers for the admin client.
+ * CSRF helpers for browser clients (admin, auth hooks, agent stream).
+ *
+ * Single source of truth for reading the JS-readable `revealui-csrf` cookie
+ * (fleet-redundancy P2-C). Consumers: this package's admin APIClient,
+ * `@revealui/auth/react` (re-export), `@revealui/ai` useAgentStream.
  *
  * The admin proxy and the api server's csrfMiddleware require any unsafe
- * request carrying a `revealui-session` cookie to echo the JS-readable
- * `revealui-csrf` cookie as an `X-CSRF-Token` header. The token is re-read
- * immediately before each request because the proxy re-issues the cookie
- * whenever it no longer validates against the current session (e.g. after
- * re-login or session rotation).
+ * request carrying a `revealui-session` cookie to echo this cookie as an
+ * `X-CSRF-Token` header. Re-read immediately before each request because
+ * the proxy re-issues the cookie when it no longer validates against the
+ * current session (e.g. after re-login or session rotation).
  */
 
 /**


### PR DESCRIPTION
## Summary

Fleet-redundancy **P2-C**: one `readCsrfToken` implementation for all browser clients.

### Layout
| Package | Role |
|---------|------|
| **`@revealui/core/admin/utils/csrf`** | **Canonical** `readCsrfToken` (+ `postSignOut`); existing unit tests |
| **`@revealui/auth/react`** | Re-exports from core (hooks unchanged) |
| **`@revealui/ai` `useAgentStream`** | Imports from core; private copy deleted |

### Also
- New package export: `./admin/utils/csrf` (same pattern as `apiClient`)

### Tests
- core csrf unit: **11** green
- auth react hooks: **63** green
- Local phase-1 gate **PASS**

### Spec
`docs/specs/2026-07-20-fleet-redundancy-remediation.md` §P2-C

## Test plan
- [x] csrf unit + auth react suite
- [x] phase-1 gate
- [ ] CI on PR