### PR TITLE
fix(services): DbCircuitBreaker composes resilience store (P2-D)

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -13,6 +13,7 @@
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
     "@revealui/db": "workspace:*",
+    "@revealui/resilience": "workspace:*",
     "@revealui/utils": "workspace:*",
     "@vercel/node": "^5.8.22",
     "drizzle-orm": "catalog:",

--- a/packages/services/src/stripe/db-circuit-breaker.ts
+++ b/packages/services/src/stripe/db-circuit-breaker.ts
@@ -1,23 +1,26 @@
 /**
  * DB-Backed Circuit Breaker
  *
- * Stores circuit state in NeonDB so all API instances share the same view.
+ * Shared multi-instance circuit for Stripe (and similar) operations.
  *
- * Architecture:
- *   - Local in-memory cache (5s TTL)  -  fast read path, no DB hit per request
- *   - DB write only on state transitions (open/closed/half-open changes)
- *   - Fail-open on DB errors: if we can't read state, we let the call through
+ * Architecture (fleet-redundancy P2-D):
+ *   - State machine thresholds align with `@revealui/resilience` CircuitBreaker
+ *   - Durable state via CircuitBreakerStore (default: NeonCircuitBreakerStore)
+ *   - Local in-memory cache (5s TTL) — fast read path, no store hit per request
+ *   - Store write only on state transitions (open/closed/half-open changes)
+ *   - Fail-open on store errors: if we can't read state, we let the call through
  *     rather than blocking all traffic because the circuit state store is down
  */
 
 import { createLogger } from '@revealui/core/observability/logger';
-import { getClient } from '@revealui/db';
-import { circuitBreakerState } from '@revealui/db/schema';
-import { eq } from 'drizzle-orm';
+import type {
+  CircuitBreakerSnapshot,
+  CircuitBreakerStore,
+  CircuitState,
+} from '@revealui/resilience';
+import { NeonCircuitBreakerStore } from './neon-circuit-breaker-store.js';
 
 const logger = createLogger({ service: 'DbCircuitBreaker' });
-
-type CircuitState = 'closed' | 'open' | 'half-open';
 
 interface CachedState {
   state: CircuitState;
@@ -49,14 +52,43 @@ const DEFAULT_CONFIG: DbCircuitBreakerConfig = {
 // Module-level cache shared across all instances in the same process
 const localCache = new Map<string, CachedState>();
 
+const defaultStore: CircuitBreakerStore = new NeonCircuitBreakerStore();
+
+function toSnapshot(s: CachedState): CircuitBreakerSnapshot {
+  return {
+    state: s.state,
+    failureCount: s.failureCount,
+    successCount: s.successCount,
+    consecutiveFailures: s.failureCount,
+    consecutiveSuccesses: s.successCount,
+    lastFailureAt: s.lastFailureAt,
+    lastSuccessAt: 0,
+    stateChangedAt: s.stateChangedAt,
+  };
+}
+
+function fromSnapshot(snap: CircuitBreakerSnapshot): CachedState {
+  return {
+    state: snap.state,
+    failureCount: snap.consecutiveFailures || snap.failureCount,
+    successCount: snap.consecutiveSuccesses || snap.successCount,
+    lastFailureAt: snap.lastFailureAt,
+    stateChangedAt: snap.stateChangedAt,
+    cachedAt: Date.now(),
+  };
+}
+
 export class DbCircuitBreaker {
   private readonly config: DbCircuitBreakerConfig;
+  private readonly store: CircuitBreakerStore;
 
   constructor(
     private readonly serviceName: string,
     config: Partial<DbCircuitBreakerConfig> = {},
+    store: CircuitBreakerStore = defaultStore,
   ) {
     this.config = { ...DEFAULT_CONFIG, ...config };
+    this.store = store;
   }
 
   /**
@@ -102,7 +134,7 @@ export class DbCircuitBreaker {
           stateChangedAt: Date.now(),
         });
       } else {
-        // Update local cache only  -  no DB write until threshold is reached
+        // Update local cache only  -  no store write until threshold is reached
         localCache.set(this.serviceName, {
           ...s,
           successCount: newSuccesses,
@@ -113,7 +145,7 @@ export class DbCircuitBreaker {
     }
 
     if (s.state === 'closed' && s.failureCount > 0) {
-      // Reset sub-threshold failure counter locally (no DB write needed)
+      // Reset sub-threshold failure counter locally (no store write needed)
       localCache.set(this.serviceName, { ...s, failureCount: 0 });
     }
   }
@@ -136,7 +168,7 @@ export class DbCircuitBreaker {
         stateChangedAt: Date.now(),
       });
     } else {
-      // Sub-threshold: update local counter without hitting DB
+      // Sub-threshold: update local counter without hitting the store
       localCache.set(this.serviceName, {
         ...s,
         failureCount: newFailures,
@@ -159,7 +191,7 @@ export class DbCircuitBreaker {
     await this.writeState(fresh);
   }
 
-  /** Clear only the local cache (forces next read to hit DB). For testing. */
+  /** Clear only the local cache (forces next read to hit the store). For testing. */
   clearLocalCache(): void {
     localCache.delete(this.serviceName);
   }
@@ -171,26 +203,14 @@ export class DbCircuitBreaker {
     if (cached && Date.now() - cached.cachedAt < this.config.cacheTtlMs) {
       return cached;
     }
-    return this.readFromDb();
+    return this.readFromStore();
   }
 
-  private async readFromDb(): Promise<CachedState> {
+  private async readFromStore(): Promise<CachedState> {
     try {
-      const db = getClient();
-      const [row] = await db
-        .select()
-        .from(circuitBreakerState)
-        .where(eq(circuitBreakerState.serviceName, this.serviceName));
-
-      const state: CachedState = row
-        ? {
-            state: row.state as CircuitState,
-            failureCount: row.failureCount,
-            successCount: row.successCount,
-            lastFailureAt: row.lastFailureAt?.getTime() ?? 0,
-            stateChangedAt: row.stateChangedAt.getTime(),
-            cachedAt: Date.now(),
-          }
+      const snap = await this.store.load(this.serviceName);
+      const state: CachedState = snap
+        ? fromSnapshot(snap)
         : {
             state: 'closed',
             failureCount: 0,
@@ -203,8 +223,8 @@ export class DbCircuitBreaker {
       localCache.set(this.serviceName, state);
       return state;
     } catch {
-      // Fail-open: if DB is unreachable, default to closed so Stripe calls proceed.
-      // We log a warning but don't block traffic over a missing circuit state row.
+      // Fail-open: if the store is unreachable, default to closed so Stripe
+      // calls proceed. Log a warning but do not block traffic.
       logger.warn(
         `DbCircuitBreaker: failed to read state for '${this.serviceName}', defaulting to closed`,
       );
@@ -222,37 +242,14 @@ export class DbCircuitBreaker {
   }
 
   private async writeState(s: CachedState): Promise<void> {
-    const now = new Date();
     // Optimistically update local cache first so subsequent in-process
-    // calls see the new state without waiting for the DB round-trip to complete.
+    // calls see the new state without waiting for the store round-trip.
     localCache.set(this.serviceName, { ...s, cachedAt: Date.now() });
 
     try {
-      const db = getClient();
-      await db
-        .insert(circuitBreakerState)
-        .values({
-          serviceName: this.serviceName,
-          state: s.state,
-          failureCount: s.failureCount,
-          successCount: s.successCount,
-          lastFailureAt: s.lastFailureAt ? new Date(s.lastFailureAt) : null,
-          stateChangedAt: new Date(s.stateChangedAt),
-          updatedAt: now,
-        })
-        .onConflictDoUpdate({
-          target: circuitBreakerState.serviceName,
-          set: {
-            state: s.state,
-            failureCount: s.failureCount,
-            successCount: s.successCount,
-            lastFailureAt: s.lastFailureAt ? new Date(s.lastFailureAt) : null,
-            stateChangedAt: new Date(s.stateChangedAt),
-            updatedAt: now,
-          },
-        });
+      await this.store.save(this.serviceName, toSnapshot(s));
     } catch (err) {
-      // Non-fatal: local cache has the new state; DB will catch up on next write.
+      // Non-fatal: local cache has the new state; store will catch up on next write.
       logger.warn(`DbCircuitBreaker: failed to persist state for '${this.serviceName}'`, {
         error: err instanceof Error ? err.message : String(err),
         newState: s.state,

--- a/packages/services/src/stripe/neon-circuit-breaker-store.ts
+++ b/packages/services/src/stripe/neon-circuit-breaker-store.ts
@@ -1,0 +1,88 @@
+/**
+ * Neon-backed CircuitBreakerStore (fleet-redundancy P2-D).
+ *
+ * Implements the pluggable store interface from `@revealui/resilience` so
+ * DbCircuitBreaker does not own a parallel persistence layer. Maps the shared
+ * `circuit_breaker_state` table (Neon/Drizzle) onto CircuitBreakerSnapshot.
+ */
+
+import { getClient } from '@revealui/db';
+import { circuitBreakerState } from '@revealui/db/schema';
+import type { CircuitBreakerSnapshot, CircuitBreakerStore } from '@revealui/resilience';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Circuit breaker state store backed by the fleet Neon `circuit_breaker_state`
+ * table. All API instances share the same durable view.
+ */
+export class NeonCircuitBreakerStore implements CircuitBreakerStore {
+  async load(name: string): Promise<CircuitBreakerSnapshot | null> {
+    const db = getClient();
+    const [row] = await db
+      .select()
+      .from(circuitBreakerState)
+      .where(eq(circuitBreakerState.serviceName, name));
+
+    if (!row) return null;
+
+    // Schema stores consecutive failures/successes in failureCount/successCount.
+    return {
+      state: row.state as CircuitBreakerSnapshot['state'],
+      failureCount: row.failureCount,
+      successCount: row.successCount,
+      consecutiveFailures: row.failureCount,
+      consecutiveSuccesses: row.successCount,
+      lastFailureAt: row.lastFailureAt?.getTime() ?? 0,
+      lastSuccessAt: 0,
+      stateChangedAt: row.stateChangedAt.getTime(),
+    };
+  }
+
+  async save(name: string, snapshot: CircuitBreakerSnapshot): Promise<void> {
+    const now = new Date();
+    const failureCount = snapshot.consecutiveFailures || snapshot.failureCount;
+    const successCount = snapshot.consecutiveSuccesses || snapshot.successCount;
+    const db = getClient();
+
+    await db
+      .insert(circuitBreakerState)
+      .values({
+        serviceName: name,
+        state: snapshot.state,
+        failureCount,
+        successCount,
+        lastFailureAt: snapshot.lastFailureAt ? new Date(snapshot.lastFailureAt) : null,
+        stateChangedAt: new Date(snapshot.stateChangedAt),
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: circuitBreakerState.serviceName,
+        set: {
+          state: snapshot.state,
+          failureCount,
+          successCount,
+          lastFailureAt: snapshot.lastFailureAt ? new Date(snapshot.lastFailureAt) : null,
+          stateChangedAt: new Date(snapshot.stateChangedAt),
+          updatedAt: now,
+        },
+      });
+  }
+
+  async remove(name: string): Promise<boolean> {
+    const db = getClient();
+    const deleted = await db
+      .delete(circuitBreakerState)
+      .where(eq(circuitBreakerState.serviceName, name))
+      .returning({ serviceName: circuitBreakerState.serviceName });
+    return deleted.length > 0;
+  }
+
+  async clear(): Promise<void> {
+    const db = getClient();
+    await db.delete(circuitBreakerState);
+  }
+
+  async close(): Promise<void> {
+    // Caller owns the shared Drizzle client lifecycle.
+  }
+}

--- a/packages/services/src/stripe/neon-circuit-breaker-store.ts
+++ b/packages/services/src/stripe/neon-circuit-breaker-store.ts
@@ -70,10 +70,11 @@ export class NeonCircuitBreakerStore implements CircuitBreakerStore {
 
   async remove(name: string): Promise<boolean> {
     const db = getClient();
+    // Neon HTTP client types require bare `.returning()` (no column selection map).
     const deleted = await db
       .delete(circuitBreakerState)
       .where(eq(circuitBreakerState.serviceName, name))
-      .returning({ serviceName: circuitBreakerState.serviceName });
+      .returning();
     return deleted.length > 0;
   }
 

--- a/packages/services/src/stripe/stripeClient.ts
+++ b/packages/services/src/stripe/stripeClient.ts
@@ -83,7 +83,7 @@ const RETRY_CONFIG = {
 
 /**
  * Shared DB-backed circuit breaker for all Stripe operations.
- * State is persisted to NeonDB so all API instances share the same view.
+ * State machine + Neon CircuitBreakerStore (@revealui/resilience, P2-D).
  * Local 5-second cache keeps the read path fast.
  */
 const stripeCircuitBreaker = new DbCircuitBreaker('stripe', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,7 +370,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -573,7 +573,7 @@ importers:
         version: 10.67.0(react@19.2.7)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react:
         specifier: '>=19.2.4'
         version: 19.2.7
@@ -1608,6 +1608,9 @@ importers:
       '@revealui/db':
         specifier: workspace:*
         version: link:../db
+      '@revealui/resilience':
+        specifier: workspace:*
+        version: link:../resilience
       '@revealui/utils':
         specifier: workspace:*
         version: link:../utils
@@ -11996,7 +11999,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@2.0.0(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7


### PR DESCRIPTION
## Summary

Fleet-redundancy **P2-D**: stop forking a private Neon circuit-breaker persistence path. Compose the pluggable store from `@revealui/resilience`.

### Changes
| Piece | Role |
|-------|------|
| **`NeonCircuitBreakerStore`** | Implements `CircuitBreakerStore` on `circuit_breaker_state` (Drizzle/Neon) |
| **`DbCircuitBreaker`** | Uses the store for load/save; keeps thresholds, 5s local cache, fail-open |
| **`@revealui/resilience`** | New workspace dependency of `@revealui/services` |
| Types | Reuses resilience `CircuitState` / `CircuitBreakerSnapshot` |

### Unchanged
- Public API: `isOpen` / `recordSuccess` / `recordFailure` / `reset`
- Stripe thresholds: failure 5, success 2, reset 30s
- `protectedStripe` call path

### Tests
- `__tests__/circuit-breaker.test.ts`: **15/15** green (state transitions + protectedStripe)
- Local phase-1 gate **PASS**

### Spec
`docs/specs/2026-07-20-fleet-redundancy-remediation.md` §P2-D

## Test plan
- [x] services circuit-breaker unit suite
- [x] phase-1 gate
- [ ] CI on PR