### PR TITLE
chore(env): quiet fetch origin/test on direnv enter

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,9 +6,10 @@
 # Secrets are NOT exported here — use with-secrets / revvault at point of use.
 #
 # Fleet methodology (banner + shell helpers):
-#   free surfaces → ~/revfleet/.jv/docs/TRACKER.md  (`tracker`)
-#   workboard     → ~/revfleet/.jv/.claude/workboard.md  (`wb`)
+#   free surfaces → fleet TRACKER doc (`tracker`)
+#   workboard     → canonical fleet workboard (`wb`)
 #   git base      → origin/test, PR target test
+#   keep tip      → `sync-test` (revkit) after fetch; direnv only fetches
 #
 # Setup:
 #   1. direnv allow
@@ -28,6 +29,15 @@ use flake
 # Watch for changes to Nix files (auto-reload environment)
 watch_file flake.nix
 watch_file flake.lock
+
+# Refresh remote-tracking tip so the shell banner's "behind origin/test" is
+# honest. Never merges (dirty trees / mid-rebase stay untouched). Skip with
+# REVEALUI_SKIP_FETCH_TEST=1 or when offline (errors ignored).
+if [ "${REVEALUI_SKIP_FETCH_TEST:-}" != "1" ] && command -v git >/dev/null 2>&1; then
+  if git rev-parse --git-dir >/dev/null 2>&1; then
+    git fetch origin test --quiet 2>/dev/null || true
+  fi
+fi
 
 # Load .envrc.local early — it provides REVVAULT_IDENTITY and REVVAULT_STORE
 # which revvault needs to decrypt secrets. Must come before any revvault calls.


### PR DESCRIPTION
## Summary

On direnv enter, quietly `git fetch origin test` so the Nix shell banner can report an honest **behind origin/test** count.

- Never merges or switches branches
- Failures ignored (offline / no network)
- Opt out: `REVEALUI_SKIP_FETCH_TEST=1`

Pairs with revkit `sync-test` for the actual fast-forward.

## Test plan
- [ ] Enter revealui with direnv; `git rev-parse origin/test` is recent without a manual fetch
- [ ] Dirty worktree unchanged
- [ ] `REVEALUI_SKIP_FETCH_TEST=1 direnv reload` skips fetch