### PR TITLE
feat(harnesses): materialize Cursor/OpenCode content via manager (GAP-406)

### DIFF
--- a/packages/harnesses/README.md
+++ b/packages/harnesses/README.md
@@ -51,8 +51,10 @@ adapters**. Shared policy is not owned by any vendor home.
 | `.claude` / `.cursor` / `.opencode` / `~/.grok` | Thin stubs or machine prefs only |
 
 ```bash
-# Write manager.json + adapter stubs + generate .revealui/content/
+# Write manager.json + equal adapter content (manager tree + Cursor/OpenCode surfaces)
 pnpm exec revealui-harnesses manager materialize
+# writes: .revealui/manager.json + .revealui/content/* + .cursor/hooks.json
+#          + .opencode/{agents,commands}/* + equal adapter stubs
 
 # Verify manager present and valid
 pnpm exec revealui-harnesses manager check

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { MANAGER_MATERIALIZE_GENERATORS, writeManagerAdapterContent } from '../content/index.js';
 import {
   checkManager,
   loadManager,
@@ -44,6 +45,51 @@ describe('project manager (.revealui)', () => {
     expect(stub).toContain('.revealui/manager.json');
     expect(stub).toContain('equal');
     expect(result.stubs.length).toBeGreaterThanOrEqual(3);
+    const cursorStub = readFileSync(join(root, '.cursor/revealui-manager.md'), 'utf-8');
+    expect(cursorStub).toContain('.revealui/content/');
+    expect(cursorStub).toContain('Equal');
+    const opencodeStub = readFileSync(join(root, '.opencode/revealui-manager.md'), 'utf-8');
+    expect(opencodeStub).toContain('.revealui/manager.json');
+    expect(opencodeStub).toContain('equal');
+  });
+
+  it('writeManagerAdapterContent emits manager content + cursor hooks + opencode surfaces', () => {
+    const root = tempProject();
+    materializeManager(root);
+    const written = writeManagerAdapterContent(root);
+    expect(MANAGER_MATERIALIZE_GENERATORS).toEqual(['claude-code', 'cursor', 'opencode']);
+    expect(written.byGenerator['claude-code']).toBeGreaterThan(0);
+    expect(written.byGenerator.cursor).toBe(1);
+    expect(written.byGenerator.opencode).toBeGreaterThan(0);
+    expect(written.total).toBe(
+      written.byGenerator['claude-code'] +
+        written.byGenerator.cursor +
+        written.byGenerator.opencode,
+    );
+
+    const hooks = JSON.parse(readFileSync(join(root, '.cursor/hooks.json'), 'utf-8')) as {
+      version: number;
+      hooks: Record<string, Array<{ command: string; type: string }>>;
+    };
+    expect(hooks.version).toBe(1);
+    expect(hooks.hooks.sessionStart?.[0]?.command).toContain('revealui-harnesses hook cursor');
+
+    // Manager content (claude-code generator) still lands under .revealui/content
+    const contentRule = readFileSync(
+      join(root, '.revealui/content/rules/code-over-docs.md'),
+      'utf-8',
+    );
+    expect(contentRule.length).toBeGreaterThan(20);
+
+    // OpenCode gets at least one agent or command under .opencode
+    const opencodePaths = written.paths.filter((p) => p.startsWith('.opencode/'));
+    expect(opencodePaths.length).toBeGreaterThan(0);
+
+    const check = checkManager(root);
+    expect(check.ok).toBe(true);
+    expect(check.warnings.filter((w) => w.includes('cursor') || w.includes('opencode'))).toEqual(
+      [],
+    );
   });
 
   it('materialize preserves existing monorepo manager fields', () => {

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -30,9 +30,11 @@ import {
   listGenerators,
   loadContentSnapshot,
   MANAGER_CONTENT_OUTPUT,
+  MANAGER_MATERIALIZE_GENERATORS,
   snapshotPathFor,
   validateManifest,
   writeAllContentSnapshots,
+  writeManagerAdapterContent,
 } from './content/index.js';
 import { HarnessCoordinator } from './coordinator.js';
 import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
@@ -525,21 +527,23 @@ async function main() {
 
     if (subcommand === 'materialize') {
       const result = materializeManager(projectRoot);
-      // Sync manager content via the same default generator as `content sync`
-      const files = generateContent(DEFAULT_CONTENT_GENERATOR_ID, buildManifest(), {
-        projectRoot,
-      });
-      let written = 0;
-      for (const file of files) {
-        const absolutePath = join(projectRoot, file.relativePath);
-        mkdirSync(dirname(absolutePath), { recursive: true });
-        writeFileSync(absolutePath, file.content, 'utf-8');
-        written++;
-      }
+      // Equal-rank adapters: manager content + Cursor hooks + OpenCode agents/commands
+      const content = writeManagerAdapterContent(projectRoot);
       process.stdout.write(`✓ Manager: ${result.managerPath}\n`);
       process.stdout.write(
-        `✓ Content files: ${written} → ${MANAGER_CONTENT_OUTPUT} (generator=${DEFAULT_CONTENT_GENERATOR_ID})\n`,
+        `✓ Content files: ${content.total} (${MANAGER_MATERIALIZE_GENERATORS.join(', ')})\n`,
       );
+      for (const [genId, count] of Object.entries(content.byGenerator)) {
+        const dest =
+          genId === DEFAULT_CONTENT_GENERATOR_ID
+            ? ` → ${MANAGER_CONTENT_OUTPUT}`
+            : genId === 'cursor'
+              ? ' → .cursor/'
+              : genId === 'opencode'
+                ? ' → .opencode/'
+                : '';
+        process.stdout.write(`  ${genId}: ${count}${dest}\n`);
+      }
       process.stdout.write(`✓ Adapter stubs:\n`);
       for (const s of result.stubs) process.stdout.write(`  ${s}\n`);
       return;
@@ -745,7 +749,7 @@ Commands:
   coordinate --init [<path>]        Register + start daemon
   hook <cursor|claude-code|vscode>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
   content <subcommand>              Manage canonical content definitions
-  manager materialize [--project p] Write .revealui/manager.json + content + equal adapter stubs
+  manager materialize [--project p] Write manager.json + .revealui/content + Cursor/OpenCode surfaces + equal stubs
   manager check [--project p]       Verify project manager present and valid
 
 Content Subcommands:

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -9,8 +9,12 @@
  *   rules/commands/agents/skills under the **project manager** tree
  *   `.revealui/content/` (GAP-406). Not a vendor-private `.claude/` fork.
  * - `opencode` — agents + commands under `.opencode/`
- * - `cursor` — hooks.json only
+ * - `cursor` — hooks.json only (vendor-native surface; policy still in manager)
  * - `vscode` — plugin.json hooks contribution only
+ *
+ * `manager materialize` runs `writeManagerAdapterContent` so Cursor/OpenCode
+ * vendor surfaces are emitted on the **same path** as manager content (equal
+ * adapters), not only as orphaned hooks-tree tooling.
  *
  * The adapter layer (`../adapters/`) ships `revealui-agent`, `opencode`, and
  * `cursor` — `vscode` has no adapter (no headless CLI to exec).
@@ -82,6 +86,11 @@ export {
   writeAllContentSnapshots,
   writeContentSnapshot,
 } from './snapshot.js';
+export type { WriteManagerAdapterContentResult } from './write-manager-adapters.js';
+export {
+  MANAGER_MATERIALIZE_GENERATORS,
+  writeManagerAdapterContent,
+} from './write-manager-adapters.js';
 
 export interface ValidationResult {
   valid: boolean;

--- a/packages/harnesses/src/content/write-manager-adapters.ts
+++ b/packages/harnesses/src/content/write-manager-adapters.ts
@@ -1,0 +1,69 @@
+/**
+ * Write equal-rank adapter generator output as part of manager materialize (GAP-406).
+ *
+ * - `claude-code` (default) → `.revealui/content/` (policy SSOT on disk)
+ * - `cursor` → `.cursor/hooks.json` (vendor-native hooks only)
+ * - `opencode` → `.opencode/{agents,commands}/`
+ *
+ * Vendor trees remain thin adapters; hardlines stay in package definitions +
+ * manager content. Hooks/agents/commands that must live under vendor paths
+ * still emit via this one materialize path so Cursor/OpenCode are not
+ * "hooks-tree only" orphans outside the manager.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { buildManifest } from './definitions/index.js';
+import { getGenerator } from './generators/index.js';
+import { DEFAULT_CONTENT_GENERATOR_ID } from './generators/types.js';
+import type { Manifest } from './schemas/manifest.js';
+
+/**
+ * Generators run by `manager materialize` for equal project-tree adapters.
+ * Order: manager content first, then vendor-native surfaces.
+ */
+export const MANAGER_MATERIALIZE_GENERATORS: readonly string[] = [
+  DEFAULT_CONTENT_GENERATOR_ID,
+  'cursor',
+  'opencode',
+];
+
+export interface WriteManagerAdapterContentResult {
+  byGenerator: Record<string, number>;
+  total: number;
+  paths: string[];
+}
+
+/**
+ * Generate + write files for each manager-materialize generator under projectRoot.
+ */
+export function writeManagerAdapterContent(
+  projectRoot: string,
+  options?: { generatorIds?: readonly string[]; manifest?: Manifest },
+): WriteManagerAdapterContentResult {
+  const generatorIds = options?.generatorIds ?? MANAGER_MATERIALIZE_GENERATORS;
+  const manifest = options?.manifest ?? buildManifest();
+  const byGenerator: Record<string, number> = {};
+  const paths: string[] = [];
+  let total = 0;
+
+  for (const id of generatorIds) {
+    const generator = getGenerator(id);
+    if (!generator) {
+      throw new Error(
+        `Unknown generator "${id}" during manager materialize. Available: check listGenerators()`,
+      );
+    }
+    const files = generator.generateAll(manifest, { projectRoot });
+    for (const file of files) {
+      const absolutePath = join(projectRoot, file.relativePath);
+      mkdirSync(dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, file.content, 'utf-8');
+      paths.push(file.relativePath);
+    }
+    byGenerator[id] = files.length;
+    total += files.length;
+  }
+
+  return { byGenerator, total, paths };
+}

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -98,7 +98,7 @@ See \`.revealui/README.md\`.
   return rel;
 }
 
-/** Thin Cursor stub note under .cursor if tree exists or always create pointer. */
+/** Thin Cursor stub: equal-rank adapter pointing at the project manager. */
 export function materializeCursorStub(projectRoot: string): string {
   const rel = join('.cursor', 'revealui-manager.md');
   const abs = join(projectRoot, rel);
@@ -108,15 +108,23 @@ export function materializeCursorStub(projectRoot: string): string {
     `${STUB_HEADER}
 # RevealUI manager (Cursor adapter)
 
-Authority: \`.revealui/manager.json\` + \`.revealui/content/\`.
-Hooks may call \`revealui-harnesses hook cursor\`; policy text is not owned here.
+1. Open **\`.revealui/manager.json\`** for project authority.
+2. Shared rules/skills: **\`.revealui/content/\`** (generated from \`@revealui/harnesses\`).
+3. Day-to-day free surfaces: path in \`manager.json\` → \`tracker.path\` (fleet: \`docs/TRACKER.md\`).
+4. Product I/O: RevealUI MCP only (device token via \`rfg\` / revvault) — not vendor side channels.
+5. Equal vendors: Cursor is not more authoritative than Claude, Grok, or OpenCode.
+
+\`manager materialize\` also emits \`.cursor/hooks.json\` (command hooks → \`revealui-harnesses hook cursor\`).
+Do not fork hardline policy under \`.cursor/rules/\`; edit package definitions instead.
+
+See \`.revealui/README.md\`.
 `,
     'utf-8',
   );
   return rel;
 }
 
-/** OpenCode: short AGENTS fragment note under .opencode */
+/** Thin OpenCode stub: equal-rank adapter pointing at the project manager. */
 export function materializeOpenCodeStub(projectRoot: string): string {
   const rel = join('.opencode', 'revealui-manager.md');
   const abs = join(projectRoot, rel);
@@ -126,7 +134,16 @@ export function materializeOpenCodeStub(projectRoot: string): string {
     `${STUB_HEADER}
 # RevealUI manager (OpenCode adapter)
 
-Authority: \`.revealui/manager.json\` + \`.revealui/content/\`.
+1. Open **\`.revealui/manager.json\`** for project authority.
+2. Shared rules/skills: **\`.revealui/content/\`** (generated from \`@revealui/harnesses\`).
+3. Day-to-day free surfaces: path in \`manager.json\` → \`tracker.path\` (fleet: \`docs/TRACKER.md\`).
+4. Product I/O: RevealUI MCP only (device token via \`rfg\` / revvault) — not vendor side channels.
+5. Equal vendors: OpenCode is not more authoritative than Claude, Grok, or Cursor.
+
+\`manager materialize\` also emits \`.opencode/agents/\` and \`.opencode/commands/\` from package definitions.
+Policy text is not owned under \`.opencode/\`.
+
+See \`.revealui/README.md\`.
 `,
     'utf-8',
   );
@@ -191,7 +208,7 @@ export interface ManagerCheckResult {
   warnings: string[];
 }
 
-/** Fail if manager missing or Claude tree looks like a full policy fork without stub. */
+/** Fail if manager missing; warn if equal-rank adapter stubs/surfaces lag materialize. */
 export function checkManager(projectRoot: string): ManagerCheckResult {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -211,6 +228,20 @@ export function checkManager(projectRoot: string): ManagerCheckResult {
   const claudeStub = join(projectRoot, '.claude', 'rules', '00-revealui-manager.md');
   if (readFileOrNull(claudeStub) === null) {
     warnings.push('missing .claude/rules/00-revealui-manager.md stub (materialize claude-code)');
+  }
+  const cursorStub = join(projectRoot, '.cursor', 'revealui-manager.md');
+  if (readFileOrNull(cursorStub) === null) {
+    warnings.push('missing .cursor/revealui-manager.md stub (materialize cursor)');
+  }
+  const cursorHooks = join(projectRoot, '.cursor', 'hooks.json');
+  if (readFileOrNull(cursorHooks) === null) {
+    warnings.push(
+      'missing .cursor/hooks.json (manager materialize writes cursor generator output)',
+    );
+  }
+  const opencodeStub = join(projectRoot, '.opencode', 'revealui-manager.md');
+  if (readFileOrNull(opencodeStub) === null) {
+    warnings.push('missing .opencode/revealui-manager.md stub (materialize opencode)');
   }
   const readme = join(projectRoot, MANAGER_DIR, 'README.md');
   if (readFileOrNull(readme) === null) {


### PR DESCRIPTION
## Summary

Closes the GAP-406 residual **Cursor/OpenCode full content path via manager**.

`revealui-harnesses manager materialize` now emits **equal-rank** adapter surfaces in one path:

| Generator | Destination |
|-----------|-------------|
| `claude-code` (default) | `.revealui/content/*` |
| `cursor` | `.cursor/hooks.json` |
| `opencode` | `.opencode/{agents,commands}/*` |

Plus equal adapter stubs (Claude / Cursor / OpenCode / Grok). Cursor and OpenCode stubs now match Claude's manager orientation (TRACKER, MCP, equal vendors).

`manager check` warns when Cursor/OpenCode stubs or hooks lag materialize.

## Why

Policy already lives under the project manager (`.revealui/content`). Cursor/OpenCode were still "hooks-tree primary" orphans for vendor-native files. Materialize is the single equal-adapter path.

## Test plan

- [x] `pnpm --filter @revealui/harnesses test` (503 tests green, including new manager materialize coverage)
- [ ] Owner: merge when green
- [ ] Optional follow-up: re-run `manager materialize` on monorepo if you want committed `.cursor/hooks.json` / `.opencode/*` refresh (not required for package fix)

## Non-claims

- GAP-355 Stage 4 (peer countersign)
- fleet-redundancy P2-D #2097
- VES CMS (already on test)

## Owner

```bash
gh pr merge <N> --squash
```