### PR TITLE
feat(auth): Phase 3 engines ADR-006 + C11 requireMfa and alerts

### DIFF
--- a/apps/admin/src/__tests__/auth/api-keys-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/api-keys-routes.test.ts
@@ -14,6 +14,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
+  // C11 requireSessionWithMfa: allow MFA gate by default so route unit tests
+  // focus on key crypto/DB behavior (MFA unit-tested in packages/auth).
+  checkSessionMfa: vi.fn(() => ({ allowed: true })),
 }));
 
 vi.mock('@revealui/core/utils/logger', () => ({

--- a/apps/admin/src/__tests__/integration/api/gdpr.test.ts
+++ b/apps/admin/src/__tests__/integration/api/gdpr.test.ts
@@ -14,6 +14,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
+  // C11 requireSessionWithMfa on account_delete: allow gate by default.
+  checkSessionMfa: vi.fn(() => ({ allowed: true })),
 }));
 
 vi.mock('@/lib/utils/revealui-singleton', () => ({

--- a/apps/admin/src/app/api/auth/mfa/backup/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/backup/route.ts
@@ -98,6 +98,7 @@ async function backupHandler(request: NextRequest): Promise<NextResponse> {
     const { token: sessionToken } = await rotateSession(payload.userId, {
       userAgent,
       ipAddress,
+      metadata: { mfaVerified: true },
     });
 
     const response = NextResponse.json({

--- a/apps/admin/src/app/api/auth/mfa/verify/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify/route.ts
@@ -97,6 +97,8 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
     const { token: sessionToken } = await rotateSession(payload.userId, {
       userAgent,
       ipAddress,
+      // Marks this session as MFA step-up complete for requireMfa (C11).
+      metadata: { mfaVerified: true },
     });
 
     const response = NextResponse.json({ success: true });

--- a/apps/admin/src/app/api/gdpr/__tests__/gdpr-routes.test.ts
+++ b/apps/admin/src/app/api/gdpr/__tests__/gdpr-routes.test.ts
@@ -7,7 +7,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetSession = vi.fn();
-const mockCheckSessionMfa = vi.fn(() => ({ allowed: true }));
+const mockCheckSessionMfa = vi.fn((..._args: unknown[]) => ({ allowed: true }));
 const mockGetRevealUIInstance = vi.fn();
 const mockWriteGDPRAuditEntry = vi.fn();
 

--- a/apps/admin/src/app/api/gdpr/__tests__/gdpr-routes.test.ts
+++ b/apps/admin/src/app/api/gdpr/__tests__/gdpr-routes.test.ts
@@ -7,11 +7,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetSession = vi.fn();
+const mockCheckSessionMfa = vi.fn(() => ({ allowed: true }));
 const mockGetRevealUIInstance = vi.fn();
 const mockWriteGDPRAuditEntry = vi.fn();
 
 vi.mock('@revealui/auth/server', () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
+  // C11 requireSessionWithMfa on account_delete: allow gate by default.
+  checkSessionMfa: (...args: unknown[]) => mockCheckSessionMfa(...args),
 }));
 
 vi.mock('@revealui/core/utils/logger', () => ({

--- a/apps/admin/src/app/api/gdpr/delete/route.ts
+++ b/apps/admin/src/app/api/gdpr/delete/route.ts
@@ -1,15 +1,14 @@
 export const runtime = 'nodejs';
 
-import { getSession } from '@revealui/auth/server';
 import { getClient } from '@revealui/db';
 import { appLogs, errorEvents, users } from '@revealui/db/schema';
 import { logger } from '@revealui/utils/logger';
 import { eq } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
+import { requireSessionWithMfa } from '@/lib/auth/require-mfa';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { writeGDPRAuditEntry } from '@/lib/utils/gdpr-audit';
-import { extractRequestContext } from '@/lib/utils/request-context';
 import { getRevealUIInstance } from '@/lib/utils/revealui-singleton';
 
 export const dynamic = 'force-dynamic';
@@ -53,11 +52,18 @@ async function deleteAllUserDocs(
  */
 async function gdprDeleteHandler(request: NextRequest) {
   try {
-    // Require authentication
-    const session = await getSession(request.headers, extractRequestContext(request));
-    if (!session) {
-      return createApplicationErrorResponse('Authentication required', 'UNAUTHORIZED', 401);
+    // Auth + MFA for account deletion (all roles; C11 requireMfa).
+    const gate = await requireSessionWithMfa(request, {
+      operations: ['account_delete'],
+      operation: 'account_delete',
+    });
+    if (!gate.ok) {
+      if (gate.response.status === 401) {
+        return createApplicationErrorResponse('Authentication required', 'UNAUTHORIZED', 401);
+      }
+      return gate.response;
     }
+    const { session } = gate;
 
     const revealui = await getRevealUIInstance();
 

--- a/apps/admin/src/app/api/user/__tests__/api-keys-routes.test.ts
+++ b/apps/admin/src/app/api/user/__tests__/api-keys-routes.test.ts
@@ -7,6 +7,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetSession = vi.fn();
+const mockCheckSessionMfa = vi.fn(() => ({ allowed: true }));
 const mockGetClient = vi.fn();
 const mockEncryptApiKey = vi.fn();
 const mockRedactApiKey = vi.fn();
@@ -14,6 +15,8 @@ const mockDecryptApiKey = vi.fn();
 
 vi.mock('@revealui/auth/server', () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
+  // C11 requireSessionWithMfa: allow MFA gate by default for route unit tests.
+  checkSessionMfa: (...args: unknown[]) => mockCheckSessionMfa(...args),
 }));
 
 vi.mock('@revealui/db', () => ({

--- a/apps/admin/src/app/api/user/__tests__/api-keys-routes.test.ts
+++ b/apps/admin/src/app/api/user/__tests__/api-keys-routes.test.ts
@@ -7,7 +7,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetSession = vi.fn();
-const mockCheckSessionMfa = vi.fn(() => ({ allowed: true }));
+const mockCheckSessionMfa = vi.fn((..._args: unknown[]) => ({ allowed: true }));
 const mockGetClient = vi.fn();
 const mockEncryptApiKey = vi.fn();
 const mockRedactApiKey = vi.fn();

--- a/apps/admin/src/app/api/user/api-keys/route.ts
+++ b/apps/admin/src/app/api/user/api-keys/route.ts
@@ -7,6 +7,7 @@ import { encryptApiKey, redactApiKey } from '@revealui/db/crypto';
 import { deleteApiKeys, getApiKeyMetadata, upsertApiKey } from '@revealui/db/queries/user-api-keys';
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { requireSessionWithMfa } from '@/lib/auth/require-mfa';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 const ApiKeySchema = z.object({
@@ -31,10 +32,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
 /** POST /api/user/api-keys  -  encrypt and upsert an API key */
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const session = await getSession(request.headers, extractRequestContext(request));
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  // Admin/owner roles must have MFA enrolled + verified (C11 requireMfa).
+  const gate = await requireSessionWithMfa(request);
+  if (!gate.ok) return gate.response;
+  const { session } = gate;
 
   let body: unknown;
   try {
@@ -70,10 +71,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
 /** DELETE /api/user/api-keys  -  remove the user's stored key */
 export async function DELETE(request: NextRequest): Promise<NextResponse> {
-  const session = await getSession(request.headers, extractRequestContext(request));
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const gate = await requireSessionWithMfa(request);
+  if (!gate.ok) return gate.response;
+  const { session } = gate;
 
   const db = getClient();
   await deleteApiKeys(db, session.user.id);

--- a/apps/admin/src/lib/auth/require-mfa.ts
+++ b/apps/admin/src/lib/auth/require-mfa.ts
@@ -1,0 +1,39 @@
+/**
+ * Next.js helper: session + MFA enforcement (fleet-redundancy C11).
+ */
+
+import { checkSessionMfa, getSession, type MfaEnforcementOptions } from '@revealui/auth/server';
+import { type NextRequest, NextResponse } from 'next/server';
+import { extractRequestContext } from '@/lib/utils/request-context';
+
+export type MfaGateResult =
+  | { ok: true; session: NonNullable<Awaited<ReturnType<typeof getSession>>> }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Require an authenticated session and MFA for admin/owner (or listed ops).
+ */
+export async function requireSessionWithMfa(
+  request: NextRequest,
+  options?: MfaEnforcementOptions & { operation?: string },
+): Promise<MfaGateResult> {
+  const session = await getSession(request.headers, extractRequestContext(request));
+  if (!session) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    };
+  }
+
+  const mfa = checkSessionMfa(session, options);
+  if (!mfa.allowed) {
+    return {
+      ok: false,
+      response: NextResponse.json(mfa.body ?? { error: 'MFA required' }, {
+        status: mfa.status ?? 403,
+      }),
+    };
+  }
+
+  return { ok: true, session };
+}

--- a/docs/architecture/ADR-006-engines-package-posture.md
+++ b/docs/architecture/ADR-006-engines-package-posture.md
@@ -1,0 +1,49 @@
+---
+title: "ADR-006: @revealui/engines package posture (incubate, not app entry)"
+description: "Fleet-redundancy Phase 3 / C10 — honest status for the five-primitives facade"
+visibility: public
+status: accepted
+audience: developer
+---
+
+**Date:** 2026-07-23  
+**Status:** Accepted  
+**Lane:** fleet-redundancy Phase 3 (C10)  
+**Related:** ADR-003 Fair Source; remediation spec `2026-07-20-fleet-redundancy-remediation` §Phase 3
+
+## Context
+
+`@revealui/engines` was marketed as the unified entry for the five business primitives (`users`, `content`, `products`, `payments`, `agents`). A 2026-06-27 reaudit and 2026-07-23 re-verify found:
+
+- **Zero production app importers** of `@revealui/engines` (apps import `@revealui/auth`, `@revealui/db`, `@revealui/services` directly).
+- Package is `"private": true` and **not published on npm** (already noted in `docs/FAIR_SOURCE.md` / `docs/PRO.md`).
+- References remain in Pro package lists and claims copy as a Fair Source / Pro package.
+
+Keeping silent “the one import” framing while apps bypass the facade is claims and architecture drift.
+
+## Decision
+
+**Option C — Incubate (default).** Do **not** migrate apps onto the facade in this program.
+
+1. **Honest package posture:** engines is an **incubating** unified barrel for future consumers and external kit experiments. It is **not** the required application entry point today.
+2. **Keep the package** in the monorepo under FSL-1.1-MIT; keep `private: true` until a real consumer and publish decision exist.
+3. **Claims / docs:** may list engines as a Pro/FSL package and as optional unified barrel; must **not** claim apps “import the five primitives from `@revealui/engines`” until that is true.
+4. **Optional honesty check (Phase 6):** if marketing claims “engines as the app entry,” fail claim-drift or add a consumer-count check.
+
+### Rejected alternatives
+
+| Option | Why not now |
+|--------|-------------|
+| **A — Adopt** (migrate apps onto engines) | Multi-PR blast radius; no product urgency; apps are healthy on direct imports |
+| **B — Abandon** (delete package / strip from Pro lists) | Package is useful as a composed surface for kits; deletion is premature |
+
+## Consequences
+
+- Apps continue importing leaf packages; no forced refactor.
+- Fleet-redundancy C10 closes as **decision recorded**; no code migration in this ADR.
+- Future “adopt engines” requires a separate ADR with a migration plan and claim updates in the same PR train.
+
+## Verification
+
+- `grep` for production imports of `@revealui/engines` remains empty outside `packages/engines` and tests (code-over-docs).
+- Package README / index comment state incubating posture (same change set as this ADR or immediate follow-up).

--- a/packages/auth/src/server/__tests__/mfa-enforcement.test.ts
+++ b/packages/auth/src/server/__tests__/mfa-enforcement.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { MfaRequest } from '../mfa-enforcement.js';
-import { requireMfa } from '../mfa-enforcement.js';
+import { checkSessionMfa, requireMfa } from '../mfa-enforcement.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -238,5 +238,42 @@ describe('requireMfa', () => {
       expect(result.allowed).toBe(false);
       expect(result.body?.code).toBe('MFA_VERIFY_REQUIRED');
     });
+  });
+});
+
+describe('checkSessionMfa / toMfaSession', () => {
+  it('reads mfaVerified from session.metadata', () => {
+    const result = checkSessionMfa(
+      {
+        user: { id: 'u1', role: 'admin', mfaEnabled: true },
+        session: { metadata: { mfaVerified: true } },
+      },
+      {},
+    );
+    expect(result.allowed).toBe(true);
+  });
+
+  it('blocks admin when metadata lacks mfaVerified', () => {
+    const result = checkSessionMfa(
+      {
+        user: { id: 'u1', role: 'admin', mfaEnabled: true },
+        session: { metadata: null },
+      },
+      {},
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.body?.code).toBe('MFA_VERIFY_REQUIRED');
+  });
+
+  it('blocks owner without MFA enrolled', () => {
+    const result = checkSessionMfa(
+      {
+        user: { id: 'u1', role: 'owner', mfaEnabled: false },
+        session: { metadata: {} },
+      },
+      {},
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.body?.code).toBe('MFA_REQUIRED');
   });
 });

--- a/packages/auth/src/server/audit-bridge.ts
+++ b/packages/auth/src/server/audit-bridge.ts
@@ -8,6 +8,7 @@
 
 import { logger } from '@revealui/core/observability/logger';
 import type { AuditEvent, AuditSystem } from '@revealui/security/server';
+import { evaluateSecurityAlert } from './security-alerts.js';
 
 type AuditEventInput = Omit<AuditEvent, 'id' | 'timestamp'>;
 
@@ -33,16 +34,17 @@ async function getAudit(): Promise<AuditSystem | null> {
  */
 async function logAuditEvent(event: AuditEventInput): Promise<void> {
   const auditSystem = await getAudit();
-  if (!auditSystem) {
-    return;
+  if (auditSystem) {
+    try {
+      await auditSystem.log(event);
+    } catch (error) {
+      logger.error('Failed to write audit event', error instanceof Error ? error : undefined, {
+        type: event.type,
+      });
+    }
   }
-  try {
-    await auditSystem.log(event);
-  } catch (error) {
-    logger.error('Failed to write audit event', error instanceof Error ? error : undefined, {
-      type: event.type,
-    });
-  }
+  // Threshold alerts (failed logins, MFA disable, lockouts, …) — C11 WIRE
+  await evaluateSecurityAlert(event);
 }
 
 /**

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -63,7 +63,7 @@ export type {
   MfaSession,
   MfaSessionUser,
 } from './mfa-enforcement.js';
-export { requireMfa } from './mfa-enforcement.js';
+export { checkSessionMfa, requireMfa, toMfaSession } from './mfa-enforcement.js';
 export {
   buildAuthUrl,
   exchangeCode,

--- a/packages/auth/src/server/mfa-enforcement.ts
+++ b/packages/auth/src/server/mfa-enforcement.ts
@@ -62,7 +62,8 @@ export interface MfaCheckResult {
 // Middleware
 // =============================================================================
 
-const DEFAULT_ROLES = ['admin'];
+/** Admin-level DB roles that require MFA for sensitive operations (C11). */
+const DEFAULT_ROLES = ['admin', 'owner'];
 
 /**
  * Create an MFA enforcement checker.
@@ -139,4 +140,40 @@ export function requireMfa(
 
     return { allowed: true };
   };
+}
+
+/**
+ * Build MFA session shape from getSession / rotateSession results.
+ * `mfaVerified` comes from session.metadata set after MFA login (verify/backup).
+ */
+export function toMfaSession(sessionData: {
+  user: { id: string; role: string; mfaEnabled?: boolean | null };
+  session: { metadata?: Record<string, unknown> | null };
+}): MfaSession {
+  const meta = sessionData.session.metadata ?? null;
+  return {
+    user: {
+      id: sessionData.user.id,
+      role: sessionData.user.role,
+      mfaEnabled: sessionData.user.mfaEnabled === true,
+      mfaVerified: meta?.mfaVerified === true,
+    },
+  };
+}
+
+/**
+ * One-shot MFA check for a SessionData-like object (Next.js / Hono handlers).
+ */
+export function checkSessionMfa(
+  sessionData: {
+    user: { id: string; role: string; mfaEnabled?: boolean | null };
+    session: { metadata?: Record<string, unknown> | null };
+  },
+  options?: MfaEnforcementOptions & { operation?: string },
+): MfaCheckResult {
+  const check = requireMfa(options);
+  return check({
+    session: toMfaSession(sessionData),
+    operation: options?.operation,
+  });
 }

--- a/packages/auth/src/server/security-alerts.ts
+++ b/packages/auth/src/server/security-alerts.ts
@@ -1,0 +1,64 @@
+/**
+ * SecurityAlertService bridge (fleet-redundancy C11).
+ *
+ * Lazy singleton: evaluates auth/security audit events against DEFAULT_THRESHOLDS
+ * and logs via LogAlertHandler. Best-effort — never throws into the login path.
+ */
+
+import { logger } from '@revealui/core/observability/logger';
+import type { AuditEvent, SecurityAlertService } from '@revealui/security';
+
+type AuditEventInput = Omit<AuditEvent, 'id' | 'timestamp'>;
+
+let service: SecurityAlertService | null | undefined;
+
+/**
+ * Lazily construct the process-wide SecurityAlertService, or null if the
+ * security package cannot be loaded (e.g. partial test mocks).
+ */
+async function getAlertService(): Promise<SecurityAlertService | null> {
+  if (service !== undefined) {
+    return service;
+  }
+  try {
+    const {
+      SecurityAlertService: AlertService,
+      DEFAULT_THRESHOLDS,
+      LogAlertHandler,
+    } = await import('@revealui/security');
+    service = new AlertService({
+      thresholds: DEFAULT_THRESHOLDS,
+      handlers: [new LogAlertHandler()],
+    });
+    return service;
+  } catch {
+    service = null;
+    return null;
+  }
+}
+
+/** Reset singleton (tests only). */
+export function resetSecurityAlertService(): void {
+  service = undefined;
+}
+
+/**
+ * Feed an audit-shaped event into SecurityAlertService.evaluateEvent.
+ * Never throws; failures are logged and swallowed.
+ */
+export async function evaluateSecurityAlert(event: AuditEventInput): Promise<void> {
+  try {
+    const alerts = await getAlertService();
+    if (!alerts) return;
+    const full: AuditEvent = {
+      id: crypto.randomUUID(),
+      timestamp: new Date().toISOString(),
+      ...event,
+    };
+    await alerts.evaluateEvent(full);
+  } catch (error) {
+    logger.error('Failed to evaluate security alert', error instanceof Error ? error : undefined, {
+      type: event.type,
+    });
+  }
+}

--- a/packages/auth/src/server/security-alerts.ts
+++ b/packages/auth/src/server/security-alerts.ts
@@ -6,7 +6,9 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
-import type { AuditEvent, SecurityAlertService } from '@revealui/security';
+import type { SecurityAlertService } from '@revealui/security';
+// AuditEvent lives on the server subpath (node:crypto audit module); not on the client-safe barrel.
+import type { AuditEvent } from '@revealui/security/server';
 
 type AuditEventInput = Omit<AuditEvent, 'id' | 'timestamp'>;
 

--- a/packages/auth/src/server/session.ts
+++ b/packages/auth/src/server/session.ts
@@ -360,6 +360,8 @@ export async function rotateSession(
     persistent?: boolean;
     userAgent?: string;
     ipAddress?: string;
+    /** Session metadata (e.g. `{ mfaVerified: true }` after MFA login). */
+    metadata?: Record<string, unknown>;
   },
 ): Promise<{ token: string; session: Session }> {
   try {
@@ -389,6 +391,7 @@ export async function rotateSession(
       persistent: options?.persistent,
       userAgent: options?.userAgent,
       ipAddress: options?.ipAddress,
+      metadata: options?.metadata,
     });
   } catch (err: unknown) {
     if (err instanceof DatabaseError || err instanceof TokenError) {

--- a/packages/engines/src/index.ts
+++ b/packages/engines/src/index.ts
@@ -1,13 +1,18 @@
 /**
- * @revealui/engines — Unified entry point for the five RevealUI business primitives.
+ * @revealui/engines — Optional unified barrel for the five business primitives.
  *
- * Each primitive is available as a namespace import:
+ * **Posture (ADR-006, 2026-07-23):** incubating. Apps and production routes
+ * import leaf packages (`@revealui/auth`, `@revealui/db`, …) directly. This
+ * package is a composed surface for kits / future consumers — not the required
+ * application entry point today. Package is private (not published on npm).
+ *
+ * Namespace import (when you intentionally want the barrel):
  *
  * ```ts
  * import { users, content, products, payments, agents } from '@revealui/engines';
  * ```
  *
- * Or import a specific primitive directly:
+ * Or a specific primitive:
  *
  * ```ts
  * import { signIn, useSession, UserSchema } from '@revealui/engines/users';


### PR DESCRIPTION
## Summary

Fleet-redundancy **Phase 3** first ship: C10 decision + C11 do-now WIRE.

### C10 — engines
- **[ADR-006](docs/architecture/ADR-006-engines-package-posture.md):** incubate `@revealui/engines` (option C), not the app entry
- Package header comment matches posture

### C11 — WIRE
| Item | Change |
|------|--------|
| **requireMfa** | `checkSessionMfa` / `toMfaSession`; default roles `admin`+`owner` |
| **Session MFA** | `rotateSession` accepts `metadata`; MFA verify/backup set `mfaVerified: true` |
| **Admin routes** | `requireSessionWithMfa` on API key write/delete; GDPR delete (all users via `account_delete`) |
| **SecurityAlertService** | `evaluateSecurityAlert` after every audit-bridge event (failed logins, MFA disable, lockouts, …) |

### Tests
- MFA enforcement: **20** green (includes checkSessionMfa)
- Phase-1 gate **PASS**

## Test plan
- [x] auth mfa-enforcement unit tests
- [x] phase-1 gate
- [ ] CI + sec-review label if required