### PR TITLE
feat(security): Merkle root builder and anchor root sign (GAP-355 S4-2)

### DIFF
--- a/packages/security/src/__tests__/audit-merkle.test.ts
+++ b/packages/security/src/__tests__/audit-merkle.test.ts
@@ -1,0 +1,146 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  assertContiguousSeq,
+  auditAnchorSignableBytes,
+  buildInclusionProof,
+  buildMerkleRootFromSignatures,
+  hashAuditSignatureLeaf,
+  signAuditAnchorRoot,
+  verifyAuditAnchorRoot,
+  verifyInclusionProof,
+} from '../audit-merkle.js';
+import { Ed25519AuditRowSigner } from '../audit-signing.js';
+
+function makeKeypair(): { privateKeyPem: string; publicKeyPem: string } {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  return {
+    privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    publicKeyPem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+  };
+}
+
+describe('audit Merkle (GAP-355 Stage 4 S4-2)', () => {
+  let priv: string;
+  let pub: string;
+  let signer: Ed25519AuditRowSigner;
+
+  beforeAll(() => {
+    const kp = makeKeypair();
+    priv = kp.privateKeyPem;
+    pub = kp.publicKeyPem;
+    signer = new Ed25519AuditRowSigner(priv, 'kid-merkle');
+  });
+
+  it('hashes leaves deterministically', () => {
+    const a = hashAuditSignatureLeaf('v1.ed25519.kid.sigA');
+    const b = hashAuditSignatureLeaf('v1.ed25519.kid.sigA');
+    const c = hashAuditSignatureLeaf('v1.ed25519.kid.sigB');
+    expect(a).toBe(b);
+    expect(a).toHaveLength(64);
+    expect(a).not.toBe(c);
+  });
+
+  it('rejects empty signature leaf', () => {
+    expect(() => hashAuditSignatureLeaf('')).toThrow(/non-empty/);
+  });
+
+  it('assertContiguousSeq accepts tight ranges and rejects gaps', () => {
+    expect(() => assertContiguousSeq([10, 11, 12])).not.toThrow();
+    expect(() => assertContiguousSeq([10, 12])).toThrow(/gap/);
+    expect(() => assertContiguousSeq([])).toThrow(/empty/);
+  });
+
+  it('builds a stable root for ordered signatures', () => {
+    const sigs = ['sig-1', 'sig-2', 'sig-3', 'sig-4'];
+    const a = buildMerkleRootFromSignatures(sigs);
+    const b = buildMerkleRootFromSignatures(sigs);
+    expect(a.root).toBe(b.root);
+    expect(a.leafCount).toBe(4);
+    expect(a.leafHashes).toHaveLength(4);
+  });
+
+  it('root changes when any leaf signature changes (tamper)', () => {
+    const base = buildMerkleRootFromSignatures(['a', 'b', 'c']);
+    const tampered = buildMerkleRootFromSignatures(['a', 'b-X', 'c']);
+    expect(tampered.root).not.toBe(base.root);
+  });
+
+  it('root changes when leaf order changes', () => {
+    const a = buildMerkleRootFromSignatures(['x', 'y', 'z']);
+    const b = buildMerkleRootFromSignatures(['z', 'y', 'x']);
+    expect(a.root).not.toBe(b.root);
+  });
+
+  it('single leaf root equals the leaf hash', () => {
+    const sig = 'only-one';
+    const { root, leafHashes } = buildMerkleRootFromSignatures([sig]);
+    expect(root).toBe(leafHashes[0]);
+    expect(root).toBe(hashAuditSignatureLeaf(sig));
+  });
+
+  it('inclusion proof verifies for every leaf index', () => {
+    const sigs = ['s0', 's1', 's2', 's3', 's4']; // odd count exercises duplicate-last
+    const { root, leafHashes } = buildMerkleRootFromSignatures(sigs);
+    for (let i = 0; i < leafHashes.length; i++) {
+      const proof = buildInclusionProof(leafHashes, i);
+      const leaf = leafHashes[i];
+      expect(leaf).toBeDefined();
+      expect(verifyInclusionProof(leaf as string, proof, root)).toBe(true);
+    }
+  });
+
+  it('inclusion proof fails for wrong leaf or wrong root', () => {
+    const { root, leafHashes } = buildMerkleRootFromSignatures(['p', 'q', 'r']);
+    const proof = buildInclusionProof(leafHashes, 1);
+    expect(verifyInclusionProof(leafHashes[0] as string, proof, root)).toBe(false);
+    expect(verifyInclusionProof(leafHashes[1] as string, proof, '0'.repeat(64))).toBe(false);
+  });
+
+  it('signs and verifies an anchor root with range binding', () => {
+    const sigs = ['row-sig-1', 'row-sig-2', 'row-sig-3'];
+    assertContiguousSeq([100, 101, 102]);
+    const { root, leafCount } = buildMerkleRootFromSignatures(sigs);
+    const anchor = {
+      tenant: 'acct_demo',
+      seqFrom: 100,
+      seqTo: 102,
+      leafCount,
+      root,
+    };
+    const { value } = signAuditAnchorRoot(signer, anchor);
+    expect(value.startsWith('v1.ed25519.kid-merkle.')).toBe(true);
+    expect(
+      verifyAuditAnchorRoot(anchor, value, (kid) => (kid === 'kid-merkle' ? pub : null)).valid,
+    ).toBe(true);
+  });
+
+  it('anchor verify fails when root or range is tampered', () => {
+    const { root, leafCount } = buildMerkleRootFromSignatures(['a', 'b']);
+    const anchor = {
+      tenant: 't1',
+      seqFrom: 1,
+      seqTo: 2,
+      leafCount,
+      root,
+    };
+    const { value } = signAuditAnchorRoot(signer, anchor);
+    const resolve = (kid: string) => (kid === 'kid-merkle' ? pub : null);
+    expect(verifyAuditAnchorRoot({ ...anchor, root: 'a'.repeat(64) }, value, resolve).valid).toBe(
+      false,
+    );
+    expect(verifyAuditAnchorRoot({ ...anchor, tenant: 'other' }, value, resolve).valid).toBe(false);
+  });
+
+  it('anchor signable rejects leafCount that does not match seq span', () => {
+    expect(() =>
+      auditAnchorSignableBytes({
+        tenant: 't',
+        seqFrom: 1,
+        seqTo: 3,
+        leafCount: 2,
+        root: 'b'.repeat(64),
+      }),
+    ).toThrow(/leafCount/);
+  });
+});

--- a/packages/security/src/audit-merkle.ts
+++ b/packages/security/src/audit-merkle.ts
@@ -1,0 +1,243 @@
+/**
+ * Merkle roots over signed audit_log rows (GAP-355 Stage 4 S4-2).
+ *
+ * Leaves are SHA-256 digests of each row's **signature** string (already
+ * integrity-bearing), ordered by `seq` ascending. Binary tree: when a level
+ * has an odd count, the last node is duplicated (Bitcoin-style) so every
+ * parent has two children. Root is lower-case hex of the SHA-256 of the
+ * concatenated child digests (raw 32-byte digests, not hex).
+ *
+ * Root signing reuses Stage 3 `AuditRowSigner` / Ed25519 envelope
+ * (`v1.ed25519.<kid>.<sig>`) over a JCS payload binding tenant + seq range +
+ * leaf count + root hex.
+ *
+ * Worker sweep (S4-3), API proof (S4-4), and offline CLI (S4-5) consume this
+ * library; this module does not touch the database.
+ */
+
+import { createHash } from 'node:crypto';
+import type { AuditRowSigner } from './audit-signing.js';
+import { type PublicKeyResolver, verifyEd25519AuditSignature } from './audit-signing.js';
+import { canonicalizeJcs } from './jcs.js';
+
+/** Lower-case hex SHA-256 of the UTF-8 signature column value. */
+export function hashAuditSignatureLeaf(signature: string): string {
+  if (signature.length === 0) {
+    throw new Error('hashAuditSignatureLeaf: signature must be non-empty');
+  }
+  return createHash('sha256').update(signature, 'utf8').digest('hex');
+}
+
+/** SHA-256(left || right) where left/right are 32-byte digests (hex in, hex out). */
+export function hashMerklePair(leftHex: string, rightHex: string): string {
+  const left = Buffer.from(leftHex, 'hex');
+  const right = Buffer.from(rightHex, 'hex');
+  if (left.length !== 32 || right.length !== 32) {
+    throw new Error('hashMerklePair: expected 32-byte hex digests');
+  }
+  return createHash('sha256').update(left).update(right).digest('hex');
+}
+
+/**
+ * Fail closed if `seq` values are not strictly increasing by 1 with no gaps.
+ * Used by the worker before building a batch (design §4 step 3).
+ */
+export function assertContiguousSeq(seqs: readonly number[]): void {
+  if (seqs.length === 0) {
+    throw new Error('assertContiguousSeq: empty seq list');
+  }
+  for (let i = 1; i < seqs.length; i++) {
+    const prev = seqs[i - 1];
+    const cur = seqs[i];
+    if (prev === undefined || cur === undefined) {
+      throw new Error('assertContiguousSeq: undefined seq');
+    }
+    if (!(Number.isInteger(prev) && Number.isInteger(cur))) {
+      throw new Error('assertContiguousSeq: seq must be integers');
+    }
+    if (cur !== prev + 1) {
+      throw new Error(
+        `assertContiguousSeq: gap or reorder at index ${i}: ${prev} → ${cur} (need ${prev + 1})`,
+      );
+    }
+  }
+}
+
+export interface MerkleBuildResult {
+  /** Lower-case hex Merkle root. */
+  root: string;
+  /** Leaf digests in input order (same length as input signatures). */
+  leafHashes: string[];
+  leafCount: number;
+}
+
+/**
+ * Build a binary Merkle root over signature strings (leaf = SHA-256(signature)).
+ * Empty input throws (anchors require leaf_count > 0).
+ */
+export function buildMerkleRootFromSignatures(signatures: readonly string[]): MerkleBuildResult {
+  if (signatures.length === 0) {
+    throw new Error('buildMerkleRootFromSignatures: need at least one signature');
+  }
+  const leafHashes = signatures.map((s) => hashAuditSignatureLeaf(s));
+  let level = leafHashes.slice();
+  while (level.length > 1) {
+    const next: string[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      const left = level[i];
+      if (left === undefined) {
+        throw new Error('buildMerkleRootFromSignatures: internal level gap');
+      }
+      const right = level[i + 1] ?? left; // odd: duplicate last
+      next.push(hashMerklePair(left, right));
+    }
+    level = next;
+  }
+  const root = level[0];
+  if (!root) {
+    throw new Error('buildMerkleRootFromSignatures: empty root');
+  }
+  return { root, leafHashes, leafCount: leafHashes.length };
+}
+
+export interface InclusionProof {
+  /** Index of the leaf among the batch (0-based). */
+  leafIndex: number;
+  leafCount: number;
+  /**
+   * Sibling digests from leaf toward root. For each step, `isRightSibling`
+   * means the sibling is on the right of the current node (i.e. current is left).
+   */
+  path: Array<{ siblingHex: string; isRightSibling: boolean }>;
+}
+
+/**
+ * Build an inclusion proof for `leafIndex` given the full ordered leaf hash list
+ * (must match the list used to build the root).
+ */
+export function buildInclusionProof(
+  leafHashes: readonly string[],
+  leafIndex: number,
+): InclusionProof {
+  if (leafHashes.length === 0) {
+    throw new Error('buildInclusionProof: empty leaves');
+  }
+  if (!Number.isInteger(leafIndex) || leafIndex < 0 || leafIndex >= leafHashes.length) {
+    throw new Error(`buildInclusionProof: leafIndex ${leafIndex} out of range`);
+  }
+
+  const path: InclusionProof['path'] = [];
+  let level = leafHashes.slice();
+  let index = leafIndex;
+
+  while (level.length > 1) {
+    const isLeft = index % 2 === 0;
+    const pairIndex = isLeft ? index + 1 : index - 1;
+    // Odd last leaf: paired with itself
+    const siblingIndex = pairIndex >= level.length ? index : pairIndex;
+    const siblingHex = level[siblingIndex];
+    if (!siblingHex) {
+      throw new Error('buildInclusionProof: missing sibling');
+    }
+    path.push({ siblingHex, isRightSibling: isLeft });
+
+    const next: string[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      const left = level[i];
+      if (left === undefined) throw new Error('buildInclusionProof: internal gap');
+      const right = level[i + 1] ?? left;
+      next.push(hashMerklePair(left, right));
+    }
+    level = next;
+    index = Math.floor(index / 2);
+  }
+
+  return { leafIndex, leafCount: leafHashes.length, path };
+}
+
+/**
+ * Recompute root from a leaf digest + inclusion proof. Returns true iff it
+ * matches `expectedRoot`.
+ */
+export function verifyInclusionProof(
+  leafHex: string,
+  proof: InclusionProof,
+  expectedRoot: string,
+): boolean {
+  if (leafHex.length !== 64 || expectedRoot.length !== 64) {
+    return false;
+  }
+  let current = leafHex;
+  for (const step of proof.path) {
+    if (step.isRightSibling) {
+      current = hashMerklePair(current, step.siblingHex);
+    } else {
+      current = hashMerklePair(step.siblingHex, current);
+    }
+  }
+  return current === expectedRoot;
+}
+
+// ── Root signing (binds range + root) ─────────────────────────────────
+
+export interface AuditAnchorSignable {
+  tenant: string;
+  seqFrom: number;
+  seqTo: number;
+  leafCount: number;
+  root: string;
+}
+
+/** Canonical bytes signed for an anchor root (shared by sign + verify). */
+export function auditAnchorSignableBytes(anchor: AuditAnchorSignable): Uint8Array {
+  if (anchor.tenant.length === 0) {
+    throw new Error('auditAnchorSignableBytes: tenant required');
+  }
+  if (!(Number.isInteger(anchor.seqFrom) && Number.isInteger(anchor.seqTo))) {
+    throw new Error('auditAnchorSignableBytes: seq must be integers');
+  }
+  if (anchor.seqTo < anchor.seqFrom) {
+    throw new Error('auditAnchorSignableBytes: seqTo < seqFrom');
+  }
+  if (!Number.isInteger(anchor.leafCount) || anchor.leafCount <= 0) {
+    throw new Error('auditAnchorSignableBytes: leafCount must be positive integer');
+  }
+  if (!/^[0-9a-f]{64}$/.test(anchor.root)) {
+    throw new Error('auditAnchorSignableBytes: root must be 64-char lowercase hex');
+  }
+  const expectedLeaves = anchor.seqTo - anchor.seqFrom + 1;
+  if (anchor.leafCount !== expectedLeaves) {
+    throw new Error(
+      `auditAnchorSignableBytes: leafCount ${anchor.leafCount} != seq span ${expectedLeaves}`,
+    );
+  }
+  const canonical = canonicalizeJcs({
+    tenant: anchor.tenant,
+    seqFrom: anchor.seqFrom,
+    seqTo: anchor.seqTo,
+    leafCount: anchor.leafCount,
+    root: anchor.root,
+  });
+  return new TextEncoder().encode(canonical);
+}
+
+/** Sign an anchor payload; returns the Stage-3 style envelope string. */
+export function signAuditAnchorRoot(
+  signer: AuditRowSigner,
+  anchor: AuditAnchorSignable,
+): { value: string } {
+  return signer.sign(auditAnchorSignableBytes(anchor));
+}
+
+/** Verify an anchor root signature envelope. */
+export function verifyAuditAnchorRoot(
+  anchor: AuditAnchorSignable,
+  rootSignature: string,
+  resolvePublicKey: PublicKeyResolver,
+): { valid: boolean; kid?: string; reason?: string } {
+  return verifyEd25519AuditSignature(
+    auditAnchorSignableBytes(anchor),
+    rootSignature,
+    resolvePublicKey,
+  );
+}

--- a/packages/security/src/server.ts
+++ b/packages/security/src/server.ts
@@ -33,6 +33,23 @@ export {
   createAuditMiddleware,
   InMemoryAuditStorage,
 } from './audit.js';
+// Merkle roots over row signatures (GAP-355 Stage 4 S4-2)
+export type {
+  AuditAnchorSignable,
+  InclusionProof,
+  MerkleBuildResult,
+} from './audit-merkle.js';
+export {
+  assertContiguousSeq,
+  auditAnchorSignableBytes,
+  buildInclusionProof,
+  buildMerkleRootFromSignatures,
+  hashAuditSignatureLeaf,
+  hashMerklePair,
+  signAuditAnchorRoot,
+  verifyAuditAnchorRoot,
+  verifyInclusionProof,
+} from './audit-merkle.js';
 // Env-composed audit signer + public-key resolution (GAP-355 Stage 3, D4/D5)
 export type {
   AuditRowSignerFn,


### PR DESCRIPTION
## Summary

**GAP-355 Stage 4 S4-2** — Merkle builder + root sign (library only).

- `@revealui/security/server`: `audit-merkle.ts`
  - leaf = SHA-256 of row **signature** string
  - binary Merkle (odd level: duplicate last leaf)
  - inclusion proof build + verify
  - `assertContiguousSeq` for worker batch invariant
  - `signAuditAnchorRoot` / `verifyAuditAnchorRoot` over JCS `{ tenant, seqFrom, seqTo, leafCount, root }` using Stage 3 `AuditRowSigner` envelope
- 12 unit tests (tamper root, order, inclusion, range binding)

**Not in this PR:** worker job (S4-3), API (S4-4), CLI (S4-5), copy (S4-6).

Grounded on Stage 4 design + S4-1 `audit_anchors` schema (#2101).

## Security

Non-author guardrail-2 required before merge. Owner merges.

## Test plan

- [x] `pnpm --filter @revealui/security test` (742 tests green, including audit-merkle)
- [x] pre-push phase-1 gate PASS
- [ ] Non-author security review on crypto paths

## Non-claims

- #2100 P3/C11, #2102 supabase MCP
- S4-3+ surfaces

## Owner

```bash
# after non-author verdict + any sec-review label if required:
gh pr merge <N> --squash
```