### PR TITLE
feat(server): audit anchor worker sweep (GAP-355 S4-3)

### DIFF
--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { planContiguousBatch, type SignedAuditRow } from '../audit-anchor-batch.js';
+
+describe('planContiguousBatch (GAP-355 S4-3)', () => {
+  it('returns null for empty input', () => {
+    expect(planContiguousBatch(0, [])).toBeNull();
+  });
+
+  it('accepts a contiguous batch when lastAnchored is 0', () => {
+    const rows: SignedAuditRow[] = [
+      { seq: 5, signature: 's5' },
+      { seq: 6, signature: 's6' },
+      { seq: 7, signature: 's7' },
+    ];
+    expect(planContiguousBatch(0, rows)).toEqual(rows);
+  });
+
+  it('requires next seq = last+1 when lastAnchored > 0', () => {
+    const rows: SignedAuditRow[] = [
+      { seq: 12, signature: 's12' },
+      { seq: 13, signature: 's13' },
+    ];
+    expect(planContiguousBatch(10, rows)).toBeNull();
+    expect(planContiguousBatch(11, rows)).toEqual(rows);
+  });
+
+  it('takes longest contiguous prefix when a mid-batch gap appears', () => {
+    const rows: SignedAuditRow[] = [
+      { seq: 1, signature: 'a' },
+      { seq: 2, signature: 'b' },
+      { seq: 4, signature: 'c' },
+    ];
+    expect(planContiguousBatch(0, rows)).toEqual([
+      { seq: 1, signature: 'a' },
+      { seq: 2, signature: 'b' },
+    ]);
+  });
+});

--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -1,5 +1,56 @@
-import { describe, expect, it } from 'vitest';
+/**
+ * GAP-355 S4-3 — unit (batch planner) + PGlite integration (sweep).
+ */
+
+import { generateKeyPairSync } from 'node:crypto';
+import {
+  type AuditSignable,
+  auditSignableBytes,
+  Ed25519AuditRowSigner,
+  verifyAuditAnchorRoot,
+} from '@revealui/core/security';
+import { type AuditEntry, type AuditRowSignerFn, DrizzleAuditStore } from '@revealui/db';
+import type { Database } from '@revealui/db/client';
+import { auditAnchors } from '@revealui/db/schema';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
 import { planContiguousBatch, type SignedAuditRow } from '../audit-anchor-batch.js';
+import { runAuditAnchorSweep } from '../audit-anchor-sweep.js';
+
+const KID = 'kid-s4-3';
+
+function makeKeypair(): { privateKeyPem: string; publicKeyPem: string } {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  });
+  return { privateKeyPem: privateKey, publicKeyPem: publicKey };
+}
+
+function canonicalSignerFn(privateKeyPem: string): AuditRowSignerFn {
+  const signer = new Ed25519AuditRowSigner(privateKeyPem, KID);
+  return (row: AuditSignable) => signer.sign(auditSignableBytes(row)).value;
+}
+
+function makeEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    id: `row-${Math.random().toString(36).slice(2)}`,
+    timestamp: new Date('2026-07-23T10:00:00.000Z'),
+    eventType: 'agent:tool:called',
+    severity: 'info',
+    agentId: 'agent-1',
+    taskId: undefined,
+    sessionId: 'sess-1',
+    payload: { tool: 'read' },
+    policyViolations: [],
+    tenant: 'acct_max',
+    ...overrides,
+  };
+}
 
 describe('planContiguousBatch (GAP-355 S4-3)', () => {
   it('returns null for empty input', () => {
@@ -34,5 +85,202 @@ describe('planContiguousBatch (GAP-355 S4-3)', () => {
       { seq: 1, signature: 'a' },
       { seq: 2, signature: 'b' },
     ]);
+  });
+});
+
+describe('runAuditAnchorSweep (PGlite)', () => {
+  let testDb: TestDb;
+  let db: Database;
+  let priv: string;
+  let pub: string;
+  let cryptoSigner: Ed25519AuditRowSigner;
+
+  beforeEach(async () => {
+    testDb = await createTestDb();
+    db = testDb.drizzle as unknown as Database;
+    const kp = makeKeypair();
+    priv = kp.privateKeyPem;
+    pub = kp.publicKeyPem;
+    cryptoSigner = new Ed25519AuditRowSigner(priv, KID);
+  });
+
+  afterEach(async () => {
+    await testDb.close();
+  });
+
+  async function appendSigned(n: number, tenant: string, ts: Date): Promise<void> {
+    const store = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    for (let i = 0; i < n; i++) {
+      await store.append(
+        makeEntry({
+          id: `row-${tenant}-${ts.getTime()}-${i}`,
+          tenant,
+          timestamp: new Date(ts.getTime() + i * 1000),
+        }),
+      );
+    }
+  }
+
+  it('inserts a verifiable anchor when batch size is reached', async () => {
+    await appendSigned(3, 'acct_max', new Date('2026-07-23T12:00:00.000Z'));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 3,
+      maxLagMs: 60 * 60 * 1000,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.anchorsInserted).toBe(1);
+    expect(result.errors).toEqual([]);
+
+    const anchors = await db.select().from(auditAnchors).where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(anchors).toHaveLength(1);
+    const a = anchors[0];
+    if (!a) throw new Error('missing anchor');
+    expect(a.leafCount).toBe(3);
+    expect(a.seqFrom).toBe(1);
+    expect(a.seqTo).toBe(3);
+
+    const verify = verifyAuditAnchorRoot(
+      {
+        tenant: a.tenant,
+        seqFrom: a.seqFrom,
+        seqTo: a.seqTo,
+        leafCount: a.leafCount,
+        root: a.root,
+      },
+      a.rootSignature,
+      (kid) => (kid === KID ? pub : null),
+    );
+    expect(verify.valid).toBe(true);
+  });
+
+  it('waits when under batch size and under max lag', async () => {
+    await appendSigned(2, 'acct_max', new Date('2026-07-23T12:00:00.000Z'));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 256,
+      maxLagMs: 60 * 60 * 1000,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:30.000Z'), // 30s < 1h
+    });
+
+    expect(result.anchorsInserted).toBe(0);
+    expect(result.tenantsWaiting).toBe(1);
+    const anchors = await db.select().from(auditAnchors);
+    expect(anchors).toHaveLength(0);
+  });
+
+  it('anchors a partial batch when max lag is exceeded', async () => {
+    await appendSigned(2, 'acct_max', new Date('2026-07-23T10:00:00.000Z'));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 256,
+      maxLagMs: 60 * 60 * 1000,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T11:05:00.000Z'), // > 1h past first row
+    });
+
+    expect(result.anchorsInserted).toBe(1);
+    const anchors = await db.select().from(auditAnchors);
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.leafCount).toBe(2);
+  });
+
+  it('skips tenants without auditLog entitlement', async () => {
+    await appendSigned(3, 'acct_free', new Date('2026-07-23T12:00:00.000Z'));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 3,
+      canAnchorTenant: async () => false,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.anchorsInserted).toBe(0);
+    expect(result.tenantsSkipped).toBe(1);
+    expect(await db.select().from(auditAnchors)).toHaveLength(0);
+  });
+
+  it('counts null-tenant signed rows and never anchors them', async () => {
+    const store = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    await store.append(makeEntry({ tenant: null, id: 'null-tenant-1' }));
+    await store.append(makeEntry({ tenant: 'acct_max', id: 't1' }));
+    await store.append(makeEntry({ tenant: 'acct_max', id: 't2' }));
+    await store.append(makeEntry({ tenant: 'acct_max', id: 't3' }));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 3,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.nullTenantSignedRows).toBe(1);
+    const anchors = await db.select().from(auditAnchors);
+    expect(anchors.every((a) => a.tenant !== null && a.tenant.length > 0)).toBe(true);
+    // null-tenant row is not in any anchor range as a tenant key
+    expect(anchors.some((a) => a.tenant === '')).toBe(false);
+  });
+
+  it('skips when signed seqs jump after last anchor (unsigned hole)', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db); // no signer → signature null
+    await signedStore.append(makeEntry({ id: 's1', tenant: 'acct_max' }));
+    await unsignedStore.append(makeEntry({ id: 'u2', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's3', tenant: 'acct_max' }));
+
+    // First pass anchors contiguous prefix [seq 1] only (size/lag ready).
+    const first = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 1,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+    expect(first.anchorsInserted).toBe(1);
+
+    // last=1; next signed is seq 3 (seq 2 unsigned). Gap → no further insert.
+    const second = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 1,
+      maxLagMs: 1,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T15:00:00.000Z'),
+    });
+    expect(second.anchorsInserted).toBe(0);
+    const anchors = await db.select().from(auditAnchors).where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.seqTo).toBe(1);
+  });
+
+  it('no-ops without a signer (unsigned mode)', async () => {
+    await appendSigned(3, 'acct_max', new Date('2026-07-23T12:00:00.000Z'));
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: null,
+      batchSize: 3,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+    });
+    expect(result.anchorsInserted).toBe(0);
+    expect(await db.select().from(auditAnchors)).toHaveLength(0);
   });
 });

--- a/apps/server/src/jobs/audit-anchor-batch.ts
+++ b/apps/server/src/jobs/audit-anchor-batch.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure batch planning for GAP-355 Stage 4 S4-3 (no I/O, no package side-effects).
+ */
+
+export interface SignedAuditRow {
+  seq: number;
+  signature: string;
+}
+
+function isContiguous(seqs: readonly number[]): boolean {
+  if (seqs.length === 0) return false;
+  for (let i = 1; i < seqs.length; i++) {
+    const prev = seqs[i - 1];
+    const cur = seqs[i];
+    if (prev === undefined || cur === undefined || cur !== prev + 1) return false;
+  }
+  return true;
+}
+
+/**
+ * Given last anchored seq (0 if none) and ordered candidate rows, return the
+ * contiguous prefix to anchor, or null when the batch must be skipped (gap).
+ */
+export function planContiguousBatch(
+  lastAnchoredSeq: number,
+  rows: readonly SignedAuditRow[],
+): SignedAuditRow[] | null {
+  if (rows.length === 0) return null;
+  const first = rows[0];
+  if (!first) return null;
+  if (lastAnchoredSeq > 0 && first.seq !== lastAnchoredSeq + 1) {
+    return null; // gap: do not skip ahead
+  }
+  if (isContiguous(rows.map((r) => r.seq))) {
+    return [...rows];
+  }
+  // Longest contiguous prefix from the start
+  const prefix: SignedAuditRow[] = [first];
+  for (let i = 1; i < rows.length; i++) {
+    const prev = prefix[prefix.length - 1];
+    const cur = rows[i];
+    if (!(prev && cur) || cur.seq !== prev.seq + 1) break;
+    prefix.push(cur);
+  }
+  return prefix.length >= 1 ? prefix : null;
+}

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -1,54 +1,102 @@
 /**
  * GAP-355 Stage 4 S4-3 — Fly worker sweep: per-tenant Merkle anchors.
  *
- * For each non-null tenant with new signed audit_log rows after the last
- * anchor, build a contiguous batch, Merkle-root the signature leaves, sign
- * the root (Stage 3 Ed25519), insert audit_anchors. Failures never delete
- * audit rows (append-only). Null-tenant rows are never anchored (§9).
+ * For each non-null tenant with Max+ `auditLog` and new signed audit_log
+ * rows after the last anchor, when the batch is **ready** (size ≥ N or
+ * age ≥ max lag), build a contiguous batch, Merkle-root the signature
+ * leaves, sign the root (Stage 3 Ed25519), insert audit_anchors, and
+ * meter `audit_anchor`. Failures never delete audit rows (append-only).
+ * Null-tenant rows are never anchored (§9); volume is gauged each tick.
  *
  * Gated by AUDIT_ANCHOR_SWEEP_ENABLED=true on the worker process.
  */
 
-import { createPrivateKey, createPublicKey } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
+import { isFeatureEnabled } from '@revealui/core/features';
 import { logger } from '@revealui/core/observability/logger';
+import { metrics } from '@revealui/core/observability/metrics';
 import {
   assertContiguousSeq,
   buildMerkleRootFromSignatures,
-  deriveAuditKid,
-  Ed25519AuditRowSigner,
+  createAuditRowSignerFromEnv,
+  type Ed25519AuditRowSigner,
   signAuditAnchorRoot,
 } from '@revealui/core/security';
 import { getClient } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
 import { auditAnchors, auditLog } from '@revealui/db/schema';
-import { and, asc, eq, gt, isNotNull, max } from 'drizzle-orm';
+import { and, asc, count, eq, gt, isNotNull, isNull, max } from 'drizzle-orm';
+import { accountHasAuditLogFeature } from '../lib/account-entitlement.js';
+import { recordUsageMeter } from '../lib/metering.js';
 import { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
 
 export { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
 
-/** Default batch size (design: 512). Override with AUDIT_ANCHOR_BATCH_SIZE. */
-export const DEFAULT_ANCHOR_BATCH_SIZE = 512;
+/** Countersigned default batch size (§9). Override: AUDIT_ANCHOR_BATCH_SIZE. */
+export const DEFAULT_ANCHOR_BATCH_SIZE = 256;
 
-/** Default poll interval 1h. Override with AUDIT_ANCHOR_INTERVAL_MS. */
-export const DEFAULT_ANCHOR_INTERVAL_MS = 60 * 60 * 1000;
+/**
+ * Max lag before a partial batch anchors (§9: 1h since first unanchored
+ * signed row). Override: AUDIT_ANCHOR_MAX_LAG_MS.
+ */
+export const DEFAULT_ANCHOR_MAX_LAG_MS = 60 * 60 * 1000;
+
+/**
+ * How often the worker polls for ready batches (not the lag itself).
+ * Override: AUDIT_ANCHOR_INTERVAL_MS.
+ */
+export const DEFAULT_ANCHOR_POLL_MS = 60 * 1000;
+
+/** Usage meter name after successful root insert (design §4 step 7 / §9). */
+export const AUDIT_ANCHOR_METER_NAME = 'audit_anchor';
+
+// Process-wide metrics (registered once; Prometheus via /metrics on worker).
+const mAnchorsCreated = metrics.counter(
+  'revealui_audit_anchors_created_total',
+  'Merkle audit anchors successfully inserted',
+);
+const mGaps = metrics.counter(
+  'revealui_audit_anchor_seq_gaps_total',
+  'Tenant batches skipped because of a non-contiguous seq gap',
+);
+const mEntitlementSkip = metrics.counter(
+  'revealui_audit_anchor_entitlement_skip_total',
+  'Tenants skipped because auditLog (Max+) was not enabled',
+);
+const mErrors = metrics.counter(
+  'revealui_audit_anchor_errors_total',
+  'Anchor sweep tenant failures',
+);
+const mNullTenant = metrics.gauge(
+  'revealui_audit_null_tenant_signed_rows',
+  'Signed audit_log rows with null tenant (never anchored in Stage 4)',
+);
+const mWaiting = metrics.counter(
+  'revealui_audit_anchor_waiting_total',
+  'Tenants with unanchored rows still under batch-size and max-lag thresholds',
+);
 
 export interface AnchorSweepResult {
   tenantsConsidered: number;
   anchorsInserted: number;
   tenantsSkipped: number;
+  tenantsWaiting: number;
+  nullTenantSignedRows: number;
   errors: string[];
 }
 
-function resolveRootSigner(
-  env: Record<string, string | undefined> = process.env,
-): Ed25519AuditRowSigner | null {
-  const privateKeyPem = env.REVEALUI_AUDIT_SIGNING_KEY?.trim();
-  if (!privateKeyPem) return null;
-  const privateKey = createPrivateKey(privateKeyPem);
-  const publicKey = createPublicKey(privateKey);
-  const override = env.REVEALUI_AUDIT_SIGNING_KID?.trim();
-  const kid = override && override.length > 0 ? override : deriveAuditKid(publicKey);
-  return new Ed25519AuditRowSigner(privateKeyPem, kid);
+export interface AnchorSweepOptions {
+  db?: Database;
+  env?: Record<string, string | undefined>;
+  batchSize?: number;
+  maxLagMs?: number;
+  /** Injected for tests; default: account entitlement + process license fallback. */
+  canAnchorTenant?: (tenant: string) => Promise<boolean>;
+  signer?: Ed25519AuditRowSigner | null;
+  /** Injected now() for lag tests. */
+  now?: () => Date;
+  /** When false, skip usage_meters write (tests without accounts table rows). */
+  recordMeter?: boolean;
 }
 
 function batchSizeFromEnv(env: Record<string, string | undefined>): number {
@@ -58,24 +106,53 @@ function batchSizeFromEnv(env: Record<string, string | undefined>): number {
   return Number.isInteger(n) && n > 0 ? n : DEFAULT_ANCHOR_BATCH_SIZE;
 }
 
+function maxLagFromEnv(env: Record<string, string | undefined>): number {
+  const raw = env.AUDIT_ANCHOR_MAX_LAG_MS?.trim();
+  if (!raw) return DEFAULT_ANCHOR_MAX_LAG_MS;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_ANCHOR_MAX_LAG_MS;
+}
+
+function pollMsFromEnv(env: Record<string, string | undefined>): number {
+  const raw = env.AUDIT_ANCHOR_INTERVAL_MS?.trim();
+  if (!raw) return DEFAULT_ANCHOR_POLL_MS;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_ANCHOR_POLL_MS;
+}
+
+function resolveRootSigner(env: Record<string, string | undefined>): Ed25519AuditRowSigner | null {
+  const { cryptoSigner, mode } = createAuditRowSignerFromEnv(env);
+  if (mode !== 'signed' || !cryptoSigner) return null;
+  return cryptoSigner;
+}
+
+async function defaultCanAnchorTenant(db: Database, tenant: string): Promise<boolean> {
+  if (await accountHasAuditLogFeature(db, tenant)) return true;
+  // Forge / process license: Max+ singleton unlocks all tenants.
+  return isFeatureEnabled('auditLog');
+}
+
 /**
  * One sweep pass across all tenants that have non-null tenant + signed rows.
  */
-export async function runAuditAnchorSweep(options?: {
-  db?: Database;
-  env?: Record<string, string | undefined>;
-  batchSize?: number;
-  signer?: Ed25519AuditRowSigner | null;
-}): Promise<AnchorSweepResult> {
-  const env = options?.env ?? process.env;
-  const db = options?.db ?? getClient();
-  const batchSize = options?.batchSize ?? batchSizeFromEnv(env);
-  const signer = options?.signer !== undefined ? options.signer : resolveRootSigner(env);
+export async function runAuditAnchorSweep(
+  options: AnchorSweepOptions = {},
+): Promise<AnchorSweepResult> {
+  const env = options.env ?? process.env;
+  const db = options.db ?? getClient();
+  const batchSize = options.batchSize ?? batchSizeFromEnv(env);
+  const maxLagMs = options.maxLagMs ?? maxLagFromEnv(env);
+  const signer = options.signer !== undefined ? options.signer : resolveRootSigner(env);
+  const now = options.now ?? (() => new Date());
+  const canAnchor = options.canAnchorTenant ?? ((t: string) => defaultCanAnchorTenant(db, t));
+  const doMeter = options.recordMeter !== false;
 
   const result: AnchorSweepResult = {
     tenantsConsidered: 0,
     anchorsInserted: 0,
     tenantsSkipped: 0,
+    tenantsWaiting: 0,
+    nullTenantSignedRows: 0,
     errors: [],
   };
 
@@ -84,7 +161,19 @@ export async function runAuditAnchorSweep(options?: {
     return result;
   }
 
-  // Distinct non-null tenants with at least one signed row
+  // §9: null-tenant volume metric (never anchored in Stage 4).
+  const [nullRow] = await db
+    .select({ c: count() })
+    .from(auditLog)
+    .where(and(isNull(auditLog.tenant), isNotNull(auditLog.signature)));
+  result.nullTenantSignedRows = Number(nullRow?.c ?? 0);
+  mNullTenant.set(result.nullTenantSignedRows);
+  if (result.nullTenantSignedRows > 0) {
+    logger.warn(
+      `audit-anchor-sweep: ${result.nullTenantSignedRows} signed audit_log row(s) have null tenant (skipped)`,
+    );
+  }
+
   const tenantRows = await db
     .selectDistinct({ tenant: auditLog.tenant })
     .from(auditLog)
@@ -94,12 +183,30 @@ export async function runAuditAnchorSweep(options?: {
     if (!tenant) continue;
     result.tenantsConsidered++;
     try {
-      const inserted = await anchorTenantBatch(db, signer, tenant, batchSize);
-      if (inserted) result.anchorsInserted++;
-      else result.tenantsSkipped++;
+      if (!(await canAnchor(tenant))) {
+        mEntitlementSkip.inc();
+        result.tenantsSkipped++;
+        continue;
+      }
+
+      const outcome = await anchorTenantBatch(
+        db,
+        signer,
+        tenant,
+        batchSize,
+        maxLagMs,
+        now,
+        doMeter,
+      );
+      if (outcome === 'inserted') result.anchorsInserted++;
+      else if (outcome === 'waiting') {
+        result.tenantsWaiting++;
+        mWaiting.inc();
+      } else result.tenantsSkipped++;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       result.errors.push(`${tenant}: ${msg}`);
+      mErrors.inc();
       logger.error(
         `audit-anchor-sweep: tenant ${tenant} failed`,
         err instanceof Error ? err : new Error(msg),
@@ -119,18 +226,24 @@ async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
   return typeof m === 'number' && Number.isFinite(m) ? m : 0;
 }
 
+type TenantOutcome = 'inserted' | 'waiting' | 'skipped';
+
 async function anchorTenantBatch(
   db: Database,
   signer: Ed25519AuditRowSigner,
   tenant: string,
   batchSize: number,
-): Promise<boolean> {
+  maxLagMs: number,
+  now: () => Date,
+  doMeter: boolean,
+): Promise<TenantOutcome> {
   const last = await lastAnchoredSeq(db, tenant);
 
   const candidates = await db
     .select({
       seq: auditLog.seq,
       signature: auditLog.signature,
+      timestamp: auditLog.timestamp,
     })
     .from(auditLog)
     .where(and(eq(auditLog.tenant, tenant), isNotNull(auditLog.signature), gt(auditLog.seq, last)))
@@ -138,19 +251,32 @@ async function anchorTenantBatch(
     .limit(batchSize);
 
   const signed: SignedAuditRow[] = [];
+  let oldestTs: Date | null = null;
   for (const row of candidates) {
     if (row.signature === null || row.signature === undefined) continue;
     signed.push({ seq: row.seq, signature: row.signature });
+    if (oldestTs === null) oldestTs = row.timestamp;
   }
+
+  if (signed.length === 0) return 'skipped';
 
   const batch = planContiguousBatch(last, signed);
   if (!batch || batch.length === 0) {
-    if (signed.length > 0 && last > 0 && signed[0] && signed[0].seq !== last + 1) {
+    if (signed[0] && (last === 0 || signed[0].seq !== last + 1)) {
+      mGaps.inc();
       logger.warn(
         `audit-anchor-sweep: gap for tenant=${tenant} lastAnchored=${last} nextSeq=${signed[0].seq} — skip`,
       );
     }
-    return false;
+    return 'skipped';
+  }
+
+  // Size primary; time is max lag for a partial batch (§9).
+  const readyBySize = batch.length >= batchSize;
+  const ageMs = oldestTs ? now().getTime() - oldestTs.getTime() : 0;
+  const readyByLag = batch.length >= 1 && ageMs >= maxLagMs;
+  if (!(readyBySize || readyByLag)) {
+    return 'waiting';
   }
 
   const seqs = batch.map((r) => r.seq);
@@ -159,7 +285,7 @@ async function anchorTenantBatch(
   const { root, leafCount } = buildMerkleRootFromSignatures(signatures);
   const seqFrom = batch[0]?.seq;
   const seqTo = batch[batch.length - 1]?.seq;
-  if (seqFrom === undefined || seqTo === undefined) return false;
+  if (seqFrom === undefined || seqTo === undefined) return 'skipped';
 
   const { value: rootSignature } = signAuditAnchorRoot(signer, {
     tenant,
@@ -178,20 +304,46 @@ async function anchorTenantBatch(
     leafCount,
   });
 
+  mAnchorsCreated.inc();
   logger.info(
     `audit-anchor-sweep: anchored tenant=${tenant} seq=${seqFrom}..${seqTo} leaves=${leafCount}`,
   );
-  return true;
+
+  if (doMeter) {
+    try {
+      const periodStart = now();
+      await recordUsageMeter({
+        id: randomUUID(),
+        accountId: tenant,
+        meterName: AUDIT_ANCHOR_METER_NAME,
+        quantity: 1,
+        periodStart,
+        source: 'system',
+        idempotencyKey: `audit_anchor:${tenant}:${seqFrom}:${seqTo}`,
+      });
+    } catch (err) {
+      // Meter is best-effort after insert; missing accounts FK must not roll back anchors.
+      logger.warn(`audit-anchor-sweep: meter write failed for tenant=${tenant}`, {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return 'inserted';
 }
 
 let sweepTimer: ReturnType<typeof setInterval> | null = null;
+let bootTimer: ReturnType<typeof setTimeout> | null = null;
 
 /**
- * Start the interval loop on the Fly worker. No-op when disabled.
+ * Start the poll loop on the Fly worker. No-op when disabled.
+ *
  * Env:
  *   AUDIT_ANCHOR_SWEEP_ENABLED=true
- *   AUDIT_ANCHOR_INTERVAL_MS (default 3600000)
- *   AUDIT_ANCHOR_BATCH_SIZE (default 512)
+ *   AUDIT_ANCHOR_INTERVAL_MS (default 60000 — poll cadence)
+ *   AUDIT_ANCHOR_BATCH_SIZE (default 256)
+ *   AUDIT_ANCHOR_MAX_LAG_MS (default 3600000 — partial-batch age trigger)
+ *   REVEALUI_AUDIT_SIGNING_KEY (required for any insert)
  */
 export function startAuditAnchorSweep(env: Record<string, string | undefined> = process.env): void {
   if (env.AUDIT_ANCHOR_SWEEP_ENABLED !== 'true') {
@@ -199,29 +351,30 @@ export function startAuditAnchorSweep(env: Record<string, string | undefined> = 
     return;
   }
 
-  const intervalRaw = env.AUDIT_ANCHOR_INTERVAL_MS?.trim();
-  const intervalMs =
-    intervalRaw && Number.isInteger(Number(intervalRaw)) && Number(intervalRaw) > 0
-      ? Number(intervalRaw)
-      : DEFAULT_ANCHOR_INTERVAL_MS;
+  const intervalMs = pollMsFromEnv(env);
 
   const tick = () => {
     void runAuditAnchorSweep({ env }).then((r) => {
       logger.info(
-        `audit-anchor-sweep: tick tenants=${r.tenantsConsidered} inserted=${r.anchorsInserted} skipped=${r.tenantsSkipped} errors=${r.errors.length}`,
+        `audit-anchor-sweep: tick tenants=${r.tenantsConsidered} inserted=${r.anchorsInserted} ` +
+          `waiting=${r.tenantsWaiting} skipped=${r.tenantsSkipped} nullTenant=${r.nullTenantSignedRows} ` +
+          `errors=${r.errors.length}`,
       );
     });
   };
 
   // Fire once soon after boot, then on interval
-  setTimeout(tick, 15_000);
+  bootTimer = setTimeout(tick, 15_000);
+  if (typeof bootTimer === 'object' && bootTimer !== null && 'unref' in bootTimer) {
+    (bootTimer as NodeJS.Timeout).unref?.();
+  }
   sweepTimer = setInterval(tick, intervalMs);
-  // Allow process to exit in tests if this is the only handle
   if (typeof sweepTimer === 'object' && sweepTimer !== null && 'unref' in sweepTimer) {
     (sweepTimer as NodeJS.Timeout).unref?.();
   }
   logger.info(
-    `audit-anchor-sweep: started intervalMs=${intervalMs} batchSize=${batchSizeFromEnv(env)}`,
+    `audit-anchor-sweep: started pollMs=${intervalMs} batchSize=${batchSizeFromEnv(env)} ` +
+      `maxLagMs=${maxLagFromEnv(env)}`,
   );
 }
 
@@ -230,5 +383,9 @@ export function stopAuditAnchorSweep(): void {
   if (sweepTimer) {
     clearInterval(sweepTimer);
     sweepTimer = null;
+  }
+  if (bootTimer) {
+    clearTimeout(bootTimer);
+    bootTimer = null;
   }
 }

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -1,0 +1,234 @@
+/**
+ * GAP-355 Stage 4 S4-3 — Fly worker sweep: per-tenant Merkle anchors.
+ *
+ * For each non-null tenant with new signed audit_log rows after the last
+ * anchor, build a contiguous batch, Merkle-root the signature leaves, sign
+ * the root (Stage 3 Ed25519), insert audit_anchors. Failures never delete
+ * audit rows (append-only). Null-tenant rows are never anchored (§9).
+ *
+ * Gated by AUDIT_ANCHOR_SWEEP_ENABLED=true on the worker process.
+ */
+
+import { createPrivateKey, createPublicKey } from 'node:crypto';
+import { logger } from '@revealui/core/observability/logger';
+import {
+  assertContiguousSeq,
+  buildMerkleRootFromSignatures,
+  deriveAuditKid,
+  Ed25519AuditRowSigner,
+  signAuditAnchorRoot,
+} from '@revealui/core/security';
+import { getClient } from '@revealui/db';
+import type { Database } from '@revealui/db/client';
+import { auditAnchors, auditLog } from '@revealui/db/schema';
+import { and, asc, eq, gt, isNotNull, max } from 'drizzle-orm';
+import { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
+
+export { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
+
+/** Default batch size (design: 512). Override with AUDIT_ANCHOR_BATCH_SIZE. */
+export const DEFAULT_ANCHOR_BATCH_SIZE = 512;
+
+/** Default poll interval 1h. Override with AUDIT_ANCHOR_INTERVAL_MS. */
+export const DEFAULT_ANCHOR_INTERVAL_MS = 60 * 60 * 1000;
+
+export interface AnchorSweepResult {
+  tenantsConsidered: number;
+  anchorsInserted: number;
+  tenantsSkipped: number;
+  errors: string[];
+}
+
+function resolveRootSigner(
+  env: Record<string, string | undefined> = process.env,
+): Ed25519AuditRowSigner | null {
+  const privateKeyPem = env.REVEALUI_AUDIT_SIGNING_KEY?.trim();
+  if (!privateKeyPem) return null;
+  const privateKey = createPrivateKey(privateKeyPem);
+  const publicKey = createPublicKey(privateKey);
+  const override = env.REVEALUI_AUDIT_SIGNING_KID?.trim();
+  const kid = override && override.length > 0 ? override : deriveAuditKid(publicKey);
+  return new Ed25519AuditRowSigner(privateKeyPem, kid);
+}
+
+function batchSizeFromEnv(env: Record<string, string | undefined>): number {
+  const raw = env.AUDIT_ANCHOR_BATCH_SIZE?.trim();
+  if (!raw) return DEFAULT_ANCHOR_BATCH_SIZE;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_ANCHOR_BATCH_SIZE;
+}
+
+/**
+ * One sweep pass across all tenants that have non-null tenant + signed rows.
+ */
+export async function runAuditAnchorSweep(options?: {
+  db?: Database;
+  env?: Record<string, string | undefined>;
+  batchSize?: number;
+  signer?: Ed25519AuditRowSigner | null;
+}): Promise<AnchorSweepResult> {
+  const env = options?.env ?? process.env;
+  const db = options?.db ?? getClient();
+  const batchSize = options?.batchSize ?? batchSizeFromEnv(env);
+  const signer = options?.signer !== undefined ? options.signer : resolveRootSigner(env);
+
+  const result: AnchorSweepResult = {
+    tenantsConsidered: 0,
+    anchorsInserted: 0,
+    tenantsSkipped: 0,
+    errors: [],
+  };
+
+  if (!signer) {
+    logger.info('audit-anchor-sweep: skipped (no REVEALUI_AUDIT_SIGNING_KEY — unsigned mode)');
+    return result;
+  }
+
+  // Distinct non-null tenants with at least one signed row
+  const tenantRows = await db
+    .selectDistinct({ tenant: auditLog.tenant })
+    .from(auditLog)
+    .where(and(isNotNull(auditLog.tenant), isNotNull(auditLog.signature)));
+
+  for (const { tenant } of tenantRows) {
+    if (!tenant) continue;
+    result.tenantsConsidered++;
+    try {
+      const inserted = await anchorTenantBatch(db, signer, tenant, batchSize);
+      if (inserted) result.anchorsInserted++;
+      else result.tenantsSkipped++;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      result.errors.push(`${tenant}: ${msg}`);
+      logger.error(
+        `audit-anchor-sweep: tenant ${tenant} failed`,
+        err instanceof Error ? err : new Error(msg),
+      );
+    }
+  }
+
+  return result;
+}
+
+async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
+  const rows = await db
+    .select({ m: max(auditAnchors.seqTo) })
+    .from(auditAnchors)
+    .where(eq(auditAnchors.tenant, tenant));
+  const m = rows[0]?.m;
+  return typeof m === 'number' && Number.isFinite(m) ? m : 0;
+}
+
+async function anchorTenantBatch(
+  db: Database,
+  signer: Ed25519AuditRowSigner,
+  tenant: string,
+  batchSize: number,
+): Promise<boolean> {
+  const last = await lastAnchoredSeq(db, tenant);
+
+  const candidates = await db
+    .select({
+      seq: auditLog.seq,
+      signature: auditLog.signature,
+    })
+    .from(auditLog)
+    .where(and(eq(auditLog.tenant, tenant), isNotNull(auditLog.signature), gt(auditLog.seq, last)))
+    .orderBy(asc(auditLog.seq))
+    .limit(batchSize);
+
+  const signed: SignedAuditRow[] = [];
+  for (const row of candidates) {
+    if (row.signature === null || row.signature === undefined) continue;
+    signed.push({ seq: row.seq, signature: row.signature });
+  }
+
+  const batch = planContiguousBatch(last, signed);
+  if (!batch || batch.length === 0) {
+    if (signed.length > 0 && last > 0 && signed[0] && signed[0].seq !== last + 1) {
+      logger.warn(
+        `audit-anchor-sweep: gap for tenant=${tenant} lastAnchored=${last} nextSeq=${signed[0].seq} — skip`,
+      );
+    }
+    return false;
+  }
+
+  const seqs = batch.map((r) => r.seq);
+  assertContiguousSeq(seqs);
+  const signatures = batch.map((r) => r.signature);
+  const { root, leafCount } = buildMerkleRootFromSignatures(signatures);
+  const seqFrom = batch[0]?.seq;
+  const seqTo = batch[batch.length - 1]?.seq;
+  if (seqFrom === undefined || seqTo === undefined) return false;
+
+  const { value: rootSignature } = signAuditAnchorRoot(signer, {
+    tenant,
+    seqFrom,
+    seqTo,
+    leafCount,
+    root,
+  });
+
+  await db.insert(auditAnchors).values({
+    tenant,
+    seqFrom,
+    seqTo,
+    root,
+    rootSignature,
+    leafCount,
+  });
+
+  logger.info(
+    `audit-anchor-sweep: anchored tenant=${tenant} seq=${seqFrom}..${seqTo} leaves=${leafCount}`,
+  );
+  return true;
+}
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the interval loop on the Fly worker. No-op when disabled.
+ * Env:
+ *   AUDIT_ANCHOR_SWEEP_ENABLED=true
+ *   AUDIT_ANCHOR_INTERVAL_MS (default 3600000)
+ *   AUDIT_ANCHOR_BATCH_SIZE (default 512)
+ */
+export function startAuditAnchorSweep(env: Record<string, string | undefined> = process.env): void {
+  if (env.AUDIT_ANCHOR_SWEEP_ENABLED !== 'true') {
+    logger.info('audit-anchor-sweep: not started (set AUDIT_ANCHOR_SWEEP_ENABLED=true to enable)');
+    return;
+  }
+
+  const intervalRaw = env.AUDIT_ANCHOR_INTERVAL_MS?.trim();
+  const intervalMs =
+    intervalRaw && Number.isInteger(Number(intervalRaw)) && Number(intervalRaw) > 0
+      ? Number(intervalRaw)
+      : DEFAULT_ANCHOR_INTERVAL_MS;
+
+  const tick = () => {
+    void runAuditAnchorSweep({ env }).then((r) => {
+      logger.info(
+        `audit-anchor-sweep: tick tenants=${r.tenantsConsidered} inserted=${r.anchorsInserted} skipped=${r.tenantsSkipped} errors=${r.errors.length}`,
+      );
+    });
+  };
+
+  // Fire once soon after boot, then on interval
+  setTimeout(tick, 15_000);
+  sweepTimer = setInterval(tick, intervalMs);
+  // Allow process to exit in tests if this is the only handle
+  if (typeof sweepTimer === 'object' && sweepTimer !== null && 'unref' in sweepTimer) {
+    (sweepTimer as NodeJS.Timeout).unref?.();
+  }
+  logger.info(
+    `audit-anchor-sweep: started intervalMs=${intervalMs} batchSize=${batchSizeFromEnv(env)}`,
+  );
+}
+
+/** Test / shutdown helper. */
+export function stopAuditAnchorSweep(): void {
+  if (sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}

--- a/apps/server/src/lib/account-entitlement.ts
+++ b/apps/server/src/lib/account-entitlement.ts
@@ -89,3 +89,50 @@ export async function accountHasAiFeature(db: Database, userId: string | null): 
 
   return features.ai === true;
 }
+
+/**
+ * Whether `accountId` (audit_log.tenant) currently has the Max+ `auditLog`
+ * feature — the gate for GAP-355 Stage 4 anchor job + receipt API.
+ *
+ * Fail-closed: missing/grace-expired entitlement → false.
+ * Process-level license is NOT consulted here; the sweep caller may fall
+ * back to `isFeatureEnabled('auditLog')` for Forge singleton license.
+ */
+export async function accountHasAuditLogFeature(
+  db: Database,
+  accountId: string | null,
+): Promise<boolean> {
+  if (!accountId) return false;
+
+  const [entitlement] = await db
+    .select({
+      tier: accountEntitlements.tier,
+      status: accountEntitlements.status,
+      graceUntil: accountEntitlements.graceUntil,
+      features: accountEntitlements.features,
+    })
+    .from(accountEntitlements)
+    .where(
+      and(
+        eq(accountEntitlements.accountId, accountId),
+        eq(accountEntitlements.mode, getConfiguredStripeMode()),
+      ),
+    )
+    .limit(1);
+
+  if (!entitlement) return false;
+
+  const status = entitlement.status ?? null;
+  const graceUntil = entitlement.graceUntil ?? null;
+  const graceActive = graceUntil != null && graceUntil.getTime() > Date.now();
+  const graceExpired = status !== null && !isHealthyStatus(status) && !graceActive;
+  if (graceExpired) return false;
+
+  const tier = (entitlement.tier as 'free' | 'pro' | 'max' | 'enterprise' | undefined) ?? 'free';
+  const features =
+    entitlement.features && Object.keys(entitlement.features).length > 0
+      ? featureRecord(entitlement.features)
+      : featureRecord(getFeaturesForTier(tier));
+
+  return features.auditLog === true;
+}

--- a/apps/server/src/worker.ts
+++ b/apps/server/src/worker.ts
@@ -43,6 +43,7 @@ import { serve } from '@hono/node-server';
 import { initializeLicense } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
 import app, { initAlerting, terminalWs } from './index.js';
+import { startAuditAnchorSweep } from './jobs/audit-anchor-sweep.js';
 import {
   assertAuditStorageEnv,
   auditStorageSelfTest,
@@ -104,6 +105,10 @@ if (process.env.REVMARKET_EXECUTOR_ENABLED === 'true') {
 } else {
   logger.info('RVMarket executor not started (set REVMARKET_EXECUTOR_ENABLED=true to enable)');
 }
+
+// GAP-355 Stage 4 S4-3: per-tenant Merkle anchor sweep (Fly worker only).
+// Default OFF — set AUDIT_ANCHOR_SWEEP_ENABLED=true when signing key is live.
+startAuditAnchorSweep();
 
 const port = Number(process.env.WORKER_PORT || process.env.PORT) || 8080;
 const server = serve({ fetch: app.fetch, port });

--- a/packages/security/src/audit-signer-env.ts
+++ b/packages/security/src/audit-signer-env.ts
@@ -30,8 +30,13 @@ export type AuditSignerEnv = Record<string, string | undefined>;
 export type AuditRowSignerFn = (row: AuditSignable) => string;
 
 export interface AuditSignerResolution {
-  /** The composed signer, or `undefined` in unsigned mode. */
+  /** The composed row signer, or `undefined` in unsigned mode. */
   readonly signer: AuditRowSignerFn | undefined;
+  /**
+   * The raw Ed25519 signer for non-row payloads (GAP-355 S4-3 anchor roots).
+   * Same instance the row `signer` closes over; signed mode only.
+   */
+  readonly cryptoSigner: Ed25519AuditRowSigner | undefined;
   /** `signed` when a valid key was present, `unsigned` otherwise. */
   readonly mode: 'signed' | 'unsigned';
   /** The resolved key id (signed mode only). */
@@ -68,11 +73,18 @@ function resolveKid(env: AuditSignerEnv, publicKey: KeyObject): string {
  */
 export function createAuditRowSignerFromEnv(env: AuditSignerEnv): AuditSignerResolution {
   const privateKeyPem = env.REVEALUI_AUDIT_SIGNING_KEY?.trim();
-  if (!privateKeyPem) return { signer: undefined, mode: 'unsigned' };
+  if (!privateKeyPem) {
+    return { signer: undefined, cryptoSigner: undefined, mode: 'unsigned' };
+  }
   const publicKey = createPublicKey(createPrivateKey(privateKeyPem));
   const kid = resolveKid(env, publicKey);
-  const signer = new Ed25519AuditRowSigner(privateKeyPem, kid);
-  return { signer: (row) => signer.sign(auditSignableBytes(row)).value, mode: 'signed', kid };
+  const cryptoSigner = new Ed25519AuditRowSigner(privateKeyPem, kid);
+  return {
+    signer: (row) => cryptoSigner.sign(auditSignableBytes(row)).value,
+    cryptoSigner,
+    mode: 'signed',
+    kid,
+  };
 }
 
 /** The published audit public key (spec D4): what `GET /api/audit/public-key` returns. */


### PR DESCRIPTION
## Summary

**GAP-355 Stage 4 S4-3** — Worker sweep job + metrics (Fly worker only).

Completes the open PR train step after S4-1 schema (#2101) and S4-2 Merkle library (#2103).

### What shipped

- `apps/server/src/jobs/audit-anchor-sweep.ts` + `audit-anchor-batch.ts`
  - Poll loop on `worker.ts` when `AUDIT_ANCHOR_SWEEP_ENABLED=true`
  - Per non-null tenant with Max+ `auditLog` (account entitlements; Forge falls back to process license)
  - Batch **ready** when size ≥ **256** **or** age of first unanchored signed row ≥ **1h** (§9)
  - Contiguous `seq` only; gaps → warn + skip (no skip-ahead)
  - Merkle root over signature leaves + Ed25519 root sign (`cryptoSigner` from `createAuditRowSignerFromEnv`)
  - Insert `audit_anchors`; meter `audit_anchor` (best-effort after insert)
  - Prometheus counters/gauge: created, gaps, entitlement skips, errors, null-tenant volume, waiting
- `accountHasAuditLogFeature(db, accountId)` for worker-side Max+ gate
- PGlite tests: size, lag, wait, entitlement skip, null tenant, unsigned hole gap, no signer

### Env

| Var | Default | Role |
|-----|---------|------|
| `AUDIT_ANCHOR_SWEEP_ENABLED` | off | must be `true` to start |
| `AUDIT_ANCHOR_BATCH_SIZE` | 256 | size primary |
| `AUDIT_ANCHOR_MAX_LAG_MS` | 3600000 | partial-batch age trigger |
| `AUDIT_ANCHOR_INTERVAL_MS` | 60000 | poll cadence |
| `REVEALUI_AUDIT_SIGNING_KEY` | — | required for any insert |

### Not in this PR

- S4-4 API list/proof
- S4-5 offline CLI
- S4-6 copy embargos
- Email/webhook delivery (Stage 4.1)

## Security

Non-author guardrail-2 required before merge. Owner merges.

## Test plan

- [x] `pnpm --filter server exec vitest run src/jobs/__tests__/audit-anchor-sweep.test.ts` (11 green)
- [x] pre-push phase-1 gate PASS
- [ ] CI green
- [ ] Non-author security review on crypto/worker paths

## Owner

```bash
gh pr merge 2104 --squash
```