### PR TITLE
feat(security): offline audit-anchor verify CLI (GAP-355 S4-5)

### DIFF
--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -507,7 +507,8 @@ const CLAIMS_PAGE_ROUTE: EvidenceRef = {
 };
 // ── audit-log signing (GAP-355 Stage 3): the log is signed with a key anyone
 // can check, verifiable offline without our secret. Scoped to the log, not
-// "every agent action" (Stage 5). ─────────────────────────────────────────────
+// "every agent action" (Stage 5). Stage 4 adds Merkle roots + offline anchor
+// CLI (S4-5) for customers who hold a delivered root. ─────────────────────────
 const AUDIT_ROW_SIGNER: EvidenceRef = {
   kind: 'code',
   ref: 'packages/security/src/audit-signing.ts',
@@ -517,6 +518,31 @@ const AUDIT_SIGN_ROUNDTRIP: EvidenceRef = {
   kind: 'test',
   ref: 'apps/server/src/lib/__tests__/audit-signing-roundtrip.pglite.test.ts#a canonically-signed row verifies OFFLINE after the jsonb + timestamptz round trip',
   note: 'a row written through the one door verifies offline from the jsonb + timestamptz readback using only the public key',
+};
+const AUDIT_MERKLE: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/security/src/audit-merkle.ts',
+  note: 'Stage 4: per-tenant Merkle roots over row signature leaves; inclusion proofs recompute the root offline',
+};
+const AUDIT_ANCHOR_VERIFY: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/security/src/audit-anchor-verify.ts',
+  note: 'Stage 4 S4-5: pure offline verify of root signature + optional inclusion proof (no network)',
+};
+const AUDIT_ANCHOR_VERIFY_CLI: EvidenceRef = {
+  kind: 'command',
+  ref: 'pnpm verify:audit-anchor -- --public-key <pem> --anchor <json> [--proof <json>]',
+  note: 'Stage 4 offline CLI (scripts/security/verify-audit-anchor.ts); exit 0 iff checks pass',
+};
+const AUDIT_ANCHOR_SCHEMA: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/db/src/schema/audit-anchors.ts',
+  note: 'audit_anchors stores delivered roots + root_signature for customer hold',
+};
+const AUDIT_ANCHOR_VERIFY_TEST: EvidenceRef = {
+  kind: 'test',
+  ref: 'packages/security/src/__tests__/audit-anchor-verify.test.ts#accepts root + inclusion proof for one leaf',
+  note: 'root signature + inclusion path verify offline with only the public key',
 };
 
 export const CLAIMS: readonly ClaimEntry[] = [
@@ -3294,7 +3320,15 @@ export const CLAIMS: readonly ClaimEntry[] = [
     file: 'claims.ts',
     exportPath: 'CLAIMS_SIGNED_LEDGER_NOTE.body',
     text: 'Every action in the audit log is signed with a key you can check yourself. Verifying a record does not require our secret.',
-    evidence: [AUDIT_ROW_SIGNER, AUDIT_SIGN_ROUNDTRIP],
+    evidence: [
+      AUDIT_ROW_SIGNER,
+      AUDIT_SIGN_ROUNDTRIP,
+      AUDIT_MERKLE,
+      AUDIT_ANCHOR_VERIFY,
+      AUDIT_ANCHOR_VERIFY_CLI,
+      AUDIT_ANCHOR_SCHEMA,
+      AUDIT_ANCHOR_VERIFY_TEST,
+    ],
   },
   {
     file: 'claims.ts',

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "test:integration": "tsx scripts/dev-tools/run-integration-tests.ts",
     "typecheck:all": "turbo run typecheck --concurrency=3",
     "verify:audit-signatures": "tsx scripts/security/verify-audit-signatures.ts",
+    "verify:audit-anchor": "tsx scripts/security/verify-audit-anchor.ts",
     "validate:artifacts": "tsx scripts/validate/build-artifacts.ts",
     "validate:boundary": "tsx scripts/validate/boundary.ts",
     "validate:gitignore": "tsx scripts/validate/gitignore-pro.ts",

--- a/packages/security/src/__tests__/audit-anchor-verify.test.ts
+++ b/packages/security/src/__tests__/audit-anchor-verify.test.ts
@@ -1,0 +1,125 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { verifyAuditAnchorOffline } from '../audit-anchor-verify.js';
+import {
+  buildInclusionProof,
+  buildMerkleRootFromSignatures,
+  hashAuditSignatureLeaf,
+  signAuditAnchorRoot,
+} from '../audit-merkle.js';
+import { Ed25519AuditRowSigner } from '../audit-signing.js';
+
+// Ed25519AuditRowSigner is in audit-signing (re-export path used by verify tests)
+
+function makeKeypair(): { privateKeyPem: string; publicKeyPem: string } {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  return {
+    privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    publicKeyPem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+  };
+}
+
+describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
+  it('accepts a valid root-only verification', () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const sigs = ['a', 'b', 'c'];
+    const { root, leafCount } = buildMerkleRootFromSignatures(sigs);
+    const anchorBase = {
+      tenant: 'acct_t',
+      seqFrom: 10,
+      seqTo: 12,
+      leafCount,
+      root,
+    };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
+
+    const result = verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: { ...anchorBase, rootSignature },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.checks.some((c) => c.includes('VALID'))).toBe(true);
+  });
+
+  it('rejects a tampered root', () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const { root, leafCount } = buildMerkleRootFromSignatures(['x', 'y']);
+    const anchorBase = {
+      tenant: 'acct_t',
+      seqFrom: 1,
+      seqTo: 2,
+      leafCount,
+      root,
+    };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
+
+    const result = verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: {
+        ...anchorBase,
+        root: 'a'.repeat(64),
+        rootSignature,
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts root + inclusion proof for one leaf', () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const sigs = ['s0', 's1', 's2', 's3'];
+    const { root, leafCount, leafHashes } = buildMerkleRootFromSignatures(sigs);
+    const anchorBase = {
+      tenant: 'acct_t',
+      seqFrom: 100,
+      seqTo: 103,
+      leafCount,
+      root,
+    };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
+    const leafIndex = 2;
+    const proof = buildInclusionProof(leafHashes, leafIndex);
+
+    const result = verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: { ...anchorBase, rootSignature },
+      inclusion: {
+        seq: 102,
+        signature: 's2',
+        leafHash: hashAuditSignatureLeaf('s2'),
+        proof,
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.checks.some((c) => c.includes('inclusion proof VALID'))).toBe(true);
+  });
+
+  it('rejects inclusion proof for wrong leaf signature', () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const sigs = ['s0', 's1'];
+    const { root, leafCount, leafHashes } = buildMerkleRootFromSignatures(sigs);
+    const anchorBase = {
+      tenant: 'acct_t',
+      seqFrom: 1,
+      seqTo: 2,
+      leafCount,
+      root,
+    };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
+    const proof = buildInclusionProof(leafHashes, 0);
+
+    const result = verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: { ...anchorBase, rootSignature },
+      inclusion: {
+        seq: 1,
+        signature: 'WRONG',
+        proof,
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/security/src/audit-anchor-verify.ts
+++ b/packages/security/src/audit-anchor-verify.ts
@@ -1,0 +1,156 @@
+/**
+ * Offline audit-anchor verification (GAP-355 Stage 4 S4-5).
+ *
+ * Pure library: no network, no database. Customers (and `verify-audit-anchor`
+ * CLI) pass a published SPKI public key, a root record (from API download or
+ * export), and optionally an inclusion proof for one row signature.
+ *
+ * Exit contract for CLI consumers:
+ *   - root signature must verify over JCS { tenant, seqFrom, seqTo, leafCount, root }
+ *   - if proof present: leaf = SHA-256(signature), inclusion path must recompute root
+ */
+
+import {
+  type AuditAnchorSignable,
+  hashAuditSignatureLeaf,
+  type InclusionProof,
+  verifyAuditAnchorRoot,
+  verifyInclusionProof,
+} from './audit-merkle.js';
+import type { PublicKeyResolver } from './audit-signing.js';
+
+export interface OfflineAnchorRecord extends AuditAnchorSignable {
+  /** Stage-3 style envelope: v1.ed25519.<kid>.<sig> */
+  rootSignature: string;
+}
+
+export interface OfflineInclusionProofInput {
+  /** Audit log seq covered by the anchor range. */
+  seq: number;
+  /** Row signature string (leaf preimage). */
+  signature: string;
+  /** Merkle inclusion path (from API / proof export). */
+  proof: InclusionProof;
+  /** Optional leaf hash; if set, must match SHA-256(signature). */
+  leafHash?: string;
+}
+
+export interface OfflineVerifyInput {
+  /** SPKI PEM public key that verifies the root (and any kid in the envelope). */
+  publicKeyPem: string;
+  anchor: OfflineAnchorRecord;
+  inclusion?: OfflineInclusionProofInput;
+}
+
+export interface OfflineVerifyResult {
+  ok: boolean;
+  /** Human-readable checks (pass or fail). */
+  checks: string[];
+  kid?: string;
+}
+
+function singleKeyResolver(publicKeyPem: string): PublicKeyResolver {
+  return (_kid: string) => publicKeyPem;
+}
+
+/**
+ * Verify an anchor root signature and optional inclusion proof offline.
+ * Never throws for expected invalid crypto; returns ok:false + reasons.
+ */
+export function verifyAuditAnchorOffline(input: OfflineVerifyInput): OfflineVerifyResult {
+  const checks: string[] = [];
+  const { publicKeyPem, anchor, inclusion } = input;
+
+  if (!(publicKeyPem.includes('BEGIN PUBLIC KEY') || publicKeyPem.includes('BEGIN'))) {
+    // Allow raw PEM without forcing exact header wording; empty is hard fail.
+    if (publicKeyPem.trim().length === 0) {
+      return { ok: false, checks: ['public key PEM is empty'] };
+    }
+  }
+
+  let anchorSignable: AuditAnchorSignable;
+  try {
+    anchorSignable = {
+      tenant: anchor.tenant,
+      seqFrom: anchor.seqFrom,
+      seqTo: anchor.seqTo,
+      leafCount: anchor.leafCount,
+      root: anchor.root,
+    };
+    // Validate shape via auditAnchorSignableBytes rules by calling verify path
+  } catch (err) {
+    return {
+      ok: false,
+      checks: [`invalid anchor shape: ${err instanceof Error ? err.message : String(err)}`],
+    };
+  }
+
+  let rootResult: { valid: boolean; kid?: string; reason?: string };
+  try {
+    rootResult = verifyAuditAnchorRoot(
+      anchorSignable,
+      anchor.rootSignature,
+      singleKeyResolver(publicKeyPem),
+    );
+  } catch (err) {
+    return {
+      ok: false,
+      checks: [`root signature verify threw: ${err instanceof Error ? err.message : String(err)}`],
+    };
+  }
+
+  if (!rootResult.valid) {
+    checks.push(`root signature INVALID: ${rootResult.reason ?? 'unknown'}`);
+    return { ok: false, checks, kid: rootResult.kid };
+  }
+  checks.push(
+    `root signature VALID (tenant=${anchor.tenant} seq=${anchor.seqFrom}..${anchor.seqTo} leaves=${anchor.leafCount})`,
+  );
+
+  if (!inclusion) {
+    checks.push('no inclusion proof provided (root-only verify)');
+    return { ok: true, checks, kid: rootResult.kid };
+  }
+
+  // Inclusion proof path
+  if (inclusion.seq < anchor.seqFrom || inclusion.seq > anchor.seqTo) {
+    checks.push(
+      `inclusion seq ${inclusion.seq} outside anchor range ${anchor.seqFrom}..${anchor.seqTo}`,
+    );
+    return { ok: false, checks, kid: rootResult.kid };
+  }
+
+  const expectedLeafIndex = inclusion.seq - anchor.seqFrom;
+  if (inclusion.proof.leafIndex !== expectedLeafIndex) {
+    checks.push(`proof.leafIndex ${inclusion.proof.leafIndex} != seq-seqFrom ${expectedLeafIndex}`);
+    return { ok: false, checks, kid: rootResult.kid };
+  }
+  if (inclusion.proof.leafCount !== anchor.leafCount) {
+    checks.push(
+      `proof.leafCount ${inclusion.proof.leafCount} != anchor.leafCount ${anchor.leafCount}`,
+    );
+    return { ok: false, checks, kid: rootResult.kid };
+  }
+
+  let leafHex: string;
+  try {
+    leafHex = hashAuditSignatureLeaf(inclusion.signature);
+  } catch (err) {
+    checks.push(`leaf hash failed: ${err instanceof Error ? err.message : String(err)}`);
+    return { ok: false, checks, kid: rootResult.kid };
+  }
+
+  if (inclusion.leafHash && inclusion.leafHash !== leafHex) {
+    checks.push('provided leafHash does not match SHA-256(signature)');
+    return { ok: false, checks, kid: rootResult.kid };
+  }
+
+  const pathOk = verifyInclusionProof(leafHex, inclusion.proof, anchor.root);
+  if (!pathOk) {
+    checks.push('inclusion proof does NOT recompute to stored Merkle root');
+    return { ok: false, checks, kid: rootResult.kid };
+  }
+
+  checks.push(`inclusion proof VALID for seq=${inclusion.seq} leafIndex=${expectedLeafIndex}`);
+  return { ok: true, checks, kid: rootResult.kid };
+}

--- a/packages/security/src/server.ts
+++ b/packages/security/src/server.ts
@@ -33,6 +33,14 @@ export {
   createAuditMiddleware,
   InMemoryAuditStorage,
 } from './audit.js';
+// Offline anchor verify (GAP-355 Stage 4 S4-5)
+export type {
+  OfflineAnchorRecord,
+  OfflineInclusionProofInput,
+  OfflineVerifyInput,
+  OfflineVerifyResult,
+} from './audit-anchor-verify.js';
+export { verifyAuditAnchorOffline } from './audit-anchor-verify.js';
 // Merkle roots over row signatures (GAP-355 Stage 4 S4-2)
 export type {
   AuditAnchorSignable,

--- a/scripts/security/bin/revealui-verify-audit
+++ b/scripts/security/bin/revealui-verify-audit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# GAP-355 Stage 4 S4-5 — offline Merkle anchor verifier (no network).
+# Prefer: pnpm verify:audit-anchor -- …
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+exec pnpm --dir "$ROOT" exec tsx scripts/security/verify-audit-anchor.ts "$@"

--- a/scripts/security/verify-audit-anchor.ts
+++ b/scripts/security/verify-audit-anchor.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env tsx
+
+/**
+ * Offline audit-anchor verifier (GAP-355 Stage 4 S4-5).
+ *
+ * Verifies a customer-held Merkle root (and optional inclusion proof) with
+ * ONLY the published SPKI public key. **No network. No database.**
+ *
+ * Inputs are JSON files (or stdin for anchor when --anchor -).
+ *
+ * Usage:
+ *   pnpm verify:audit-anchor -- \
+ *     --public-key ./audit-public.pem \
+ *     --anchor ./anchor.json \
+ *     [--proof ./proof.json]
+ *
+ *   # or package-style:
+ *   pnpm exec tsx scripts/security/verify-audit-anchor.ts --help
+ *
+ * anchor.json (from GET /api/audit/anchors/:id or export):
+ *   {
+ *     "tenant": "acct_…",
+ *     "seqFrom": 1,
+ *     "seqTo": 10,
+ *     "leafCount": 10,
+ *     "root": "<64-char hex>",
+ *     "rootSignature": "v1.ed25519.<kid>.<sig>"
+ *   }
+ *
+ * proof.json (from GET /api/audit/anchors/:id/proof?seq=N):
+ *   {
+ *     "seq": 5,
+ *     "signature": "<row signature string>",
+ *     "leafHash": "<optional hex>",
+ *     "proof": { "leafIndex": 4, "leafCount": 10, "path": […] }
+ *   }
+ *
+ * Exit: 0 if all checks pass; 1 if any check fails or args are invalid.
+ */
+
+import { createPrivateKey, createPublicKey } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import {
+  type OfflineAnchorRecord,
+  type OfflineInclusionProofInput,
+  verifyAuditAnchorOffline,
+} from '@revealui/security/server';
+
+interface Args {
+  publicKeyPath?: string;
+  publicKeyPem?: string;
+  anchorPath?: string;
+  proofPath?: string;
+  help?: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {};
+  let i = 0;
+  while (i < argv.length) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') {
+      args.help = true;
+      i += 1;
+    } else if (a === '--public-key' || a === '-p') {
+      args.publicKeyPath = argv[i + 1];
+      i += 2;
+    } else if (a === '--public-key-pem') {
+      args.publicKeyPem = argv[i + 1];
+      i += 2;
+    } else if (a === '--anchor' || a === '-a') {
+      args.anchorPath = argv[i + 1];
+      i += 2;
+    } else if (a === '--proof') {
+      args.proofPath = argv[i + 1];
+      i += 2;
+    } else {
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  process.stdout.write(`verify-audit-anchor — offline Merkle root + inclusion proof check (GAP-355 S4-5)
+
+Usage:
+  pnpm verify:audit-anchor -- --public-key <pem-file> --anchor <json> [--proof <json>]
+
+Options:
+  --public-key, -p   Path to SPKI PEM public key (or use REVEALUI_AUDIT_PUBLIC_KEY)
+  --public-key-pem   Inline SPKI PEM string
+  --anchor, -a       Path to anchor JSON (root + rootSignature + range)
+  --proof            Optional path to inclusion proof JSON for one seq
+  --help, -h         This help
+
+Exit codes:
+  0  all checks passed
+  1  verification failed or bad arguments
+
+No network. No database.
+`);
+}
+
+function resolvePublicKeyPem(args: Args): string | null {
+  if (args.publicKeyPem) return args.publicKeyPem;
+  if (args.publicKeyPath) return readFileSync(args.publicKeyPath, 'utf8');
+  const fromEnv = process.env.REVEALUI_AUDIT_PUBLIC_KEY;
+  if (fromEnv) return fromEnv;
+  const privatePem = process.env.REVEALUI_AUDIT_SIGNING_KEY;
+  if (privatePem) {
+    return createPublicKey(createPrivateKey(privatePem))
+      .export({ type: 'spki', format: 'pem' })
+      .toString();
+  }
+  return null;
+}
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown;
+}
+
+function asAnchor(raw: unknown): OfflineAnchorRecord {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('anchor JSON must be an object');
+  }
+  const o = raw as Record<string, unknown>;
+  const tenant = String(o.tenant ?? '');
+  const seqFrom = Number(o.seqFrom);
+  const seqTo = Number(o.seqTo);
+  const leafCount = Number(o.leafCount);
+  const root = String(o.root ?? '');
+  const rootSignature = String(o.rootSignature ?? '');
+  if (!(tenant && root && rootSignature)) {
+    throw new Error('anchor requires tenant, root, rootSignature, seqFrom, seqTo, leafCount');
+  }
+  return { tenant, seqFrom, seqTo, leafCount, root, rootSignature };
+}
+
+function asProof(raw: unknown): OfflineInclusionProofInput {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('proof JSON must be an object');
+  }
+  const o = raw as Record<string, unknown>;
+  const seq = Number(o.seq);
+  const signature = String(o.signature ?? '');
+  const proof = o.proof;
+  if (!(signature && proof) || typeof proof !== 'object') {
+    throw new Error('proof requires seq, signature, and proof path object');
+  }
+  const leafHash = o.leafHash != null ? String(o.leafHash) : undefined;
+  return {
+    seq,
+    signature,
+    leafHash,
+    proof: proof as OfflineInclusionProofInput['proof'],
+  };
+}
+
+function main(): number {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+
+  const publicKeyPem = resolvePublicKeyPem(args);
+  if (!publicKeyPem) {
+    process.stderr.write(
+      'error: provide --public-key <pem>, --public-key-pem, or REVEALUI_AUDIT_PUBLIC_KEY\n',
+    );
+    return 1;
+  }
+  if (!args.anchorPath) {
+    process.stderr.write('error: --anchor <json> is required\n');
+    return 1;
+  }
+
+  let anchor: OfflineAnchorRecord;
+  let inclusion: OfflineInclusionProofInput | undefined;
+  try {
+    anchor = asAnchor(readJsonFile(args.anchorPath));
+    if (args.proofPath) {
+      inclusion = asProof(readJsonFile(args.proofPath));
+    }
+  } catch (err) {
+    process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+
+  const result = verifyAuditAnchorOffline({
+    publicKeyPem,
+    anchor,
+    inclusion,
+  });
+
+  for (const line of result.checks) {
+    process.stdout.write(`${result.ok ? 'ok' : 'fail'}: ${line}\n`);
+  }
+  if (result.kid) {
+    process.stdout.write(`kid: ${result.kid}\n`);
+  }
+  process.stdout.write(result.ok ? 'RESULT: PASS\n' : 'RESULT: FAIL\n');
+  return result.ok ? 0 : 1;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

**GAP-355 Stage 4 S4-5** — offline verify CLI + claims-evidence.

### Library
- `@revealui/security/server`: `verifyAuditAnchorOffline`
  - Verifies root signature (JCS range binding)
  - Optional inclusion proof for one row signature
  - **No network, no DB**

### CLI
```bash
pnpm verify:audit-anchor -- \
  --public-key ./audit-public.pem \
  --anchor ./anchor.json \
  [--proof ./proof.json]
```
- Wrapper: `scripts/security/bin/revealui-verify-audit`
- Exit 0 = PASS, 1 = FAIL

### Claims-evidence
Stage 4 refs attached to existing signed-ledger claim (Merkle, offline verify, schema, CLI, tests). Does **not** lift marketing foil embargos (S4-6).

### Tests
- 4 new unit tests in `audit-anchor-verify.test.ts`
- Full `@revealui/security` suite 746 green
- Pre-push phase-1 gate PASS

## Non-claims
- #2106 S4-4 (peer finishing)
- S4-6 marketing embargos

## Security
Non-author guardrail-2 if gate flags security paths; owner merges.

## Owner
```bash
gh pr merge <N> --squash
```