### PR TITLE
docs(c11): ADR-007 incubate MCPHypervisor and ai skills/obs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 | @revealui/ai | AI agents, CRDT memory, LLM providers, orchestration |
 | @revealui/engines | Unified entry point for the five business primitives (private workspace package) |
 | @revealui/harnesses | AI harness adapters, workboard coordination, JSON-RPC |
-| @revealui/mcp | MCP hypervisor, adapter framework, tool discovery |
+| @revealui/mcp | MCP servers + adapters; process hypervisor incubating (ADR-007) |
 | @revealui/services | Stripe (payment processing + circuit breaker), email (Gmail API delivery) |
 
 ### Internal Package (no license, build tooling) — 1

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -3065,13 +3065,13 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'marketplace.ts',
     exportPath: 'MARKETPLACE_DISCOVERY_STEPS[0].description',
-    text: 'Agents find available tools through the MCP hypervisor. Each server advertises its capabilities and required permissions.',
+    text: 'Agents attach MCP servers that advertise tools and required permissions through the open protocol.',
     evidence: [HYPERVISOR],
   },
   {
     file: 'marketplace.ts',
     exportPath: 'MARKETPLACE_DISCOVERY_STEPS[1].description',
-    text: 'The MCP hypervisor routes the call to the right server.',
+    text: 'Each call targets the matching MCP server. A multi-server process hypervisor is available in source when you wire multi-hosting.',
     evidence: [HYPERVISOR],
   },
   {

--- a/apps/marketing/app/content/marketplace.ts
+++ b/apps/marketing/app/content/marketplace.ts
@@ -55,12 +55,13 @@ export const MARKETPLACE_DISCOVERY_STEPS: readonly DiscoveryStep[] = [
     step: '1',
     title: 'Discover',
     description:
-      'Agents find available tools through the MCP hypervisor. Each server advertises its capabilities and required permissions.',
+      'Agents attach MCP servers that advertise tools and required permissions through the open protocol.',
   },
   {
     step: '2',
     title: 'Route',
-    description: 'The MCP hypervisor routes the call to the right server.',
+    description:
+      'Each call targets the matching MCP server. A multi-server process hypervisor is available in source when you wire multi-hosting.',
   },
   {
     step: '3',

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -52,7 +52,7 @@ Project conventions are loaded from [`CLAUDE.md`](../CLAUDE.md) at the repo root
 
 ### MCP servers
 
-The repo ships custom MCP servers under `packages/mcp/src/servers/`. They're consumed both by the framework's runtime hypervisor and by external agents (Claude Desktop, Claude Code, Zed). See [`packages/mcp/README.md`](../packages/mcp/README.md) for the current adapter set, and `apps/admin`'s MCP integration for in-product usage.
+The repo ships custom MCP servers under `packages/mcp/src/servers/`. External agents (Claude Desktop, Claude Code, Zed) attach them via config. The multi-server process hypervisor remains incubating in source (ADR-007). See [`packages/mcp/README.md`](../packages/mcp/README.md) for the current adapter set, and `apps/admin`'s MCP integration for in-product usage.
 
 The previous `.cursor/mcp-config.json` configuration file is not present in this repo.
 

--- a/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+++ b/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
@@ -1,0 +1,52 @@
+---
+title: "ADR-007: C11 unwired subsystems — incubate MCPHypervisor, ai skills, ai observability"
+description: "Fleet-redundancy Phase 3 / C11 residual — honest status for built-but-unwired MCP and AI surfaces"
+visibility: public
+status: accepted
+audience: developer
+---
+
+**Date:** 2026-07-23  
+**Status:** Accepted  
+**Lane:** fleet-redundancy Phase 3 (C11 residual INCUBATE)  
+**Related:** ADR-006 engines posture; remediation spec `2026-07-20-fleet-redundancy-remediation` §C11
+
+## Context
+
+Fleet-redundancy C11 triaged built-but-unwired subsystems. DELETE/WIRE subsets shipped (requireMfa, SecurityAlertService, legacy Supabase MCP deleted, cache edge, paywall server adapters, core in-memory tracing). Residual surfaces still present in tree:
+
+| Surface | Code | App runtime path (2026-07-23) |
+|---------|------|-------------------------------|
+| `MCPHypervisor` | `packages/mcp/src/hypervisor.ts` | No app constructs or starts the singleton; tools/tests + optional AI adapter interface only |
+| `@revealui/ai/skills` | `packages/ai/src/skills/` | Exported; no app imports the skills registry/loaders as a product path |
+| `@revealui/ai/observability` | `packages/ai/src/observability/` | Exported; package-internal / tests, not app-mounted |
+
+Marketing and package copy still describe the MCP hypervisor as the live agent tool path. That overstates current wiring (code-over-docs).
+
+## Decision
+
+**Incubate (do not wire, do not delete) in this program.**
+
+1. **Keep the code.** Hypervisor, skills, and AI observability remain in the monorepo under their existing licenses (FSL for mcp/ai). They are valid library surfaces for future WIRE tickets and external kits.
+2. **Honest posture:** each surface is **incubating / not app-mounted**. Product and admin paths that need MCP or agent tooling today use explicit launchers, `revealui-mcp`, or app-local wiring — not a process-wide hypervisor bootstrap.
+3. **Claims / docs:** may name hypervisor, skills, and AI observability as **framework capabilities that exist in source**. Must **not** claim production apps “run the MCP hypervisor” or “load agent skills via `@revealui/ai/skills`” until a consumer path is greppable in `apps/`.
+4. **No silent wire.** Mounting the hypervisor at app startup, or registering skill catalogs in product routes, is a separate WIRE ticket with product acceptance — not a side effect of this ADR.
+
+### Rejected for this residual
+
+| Option | Why not now |
+|--------|-------------|
+| **WIRE** (start hypervisor in server/admin) | Product design + credential resolver + metering ownership; multi-session |
+| **DELETE** | Large tested surface; AI adapter still types against a tool source; premature |
+
+## Consequences
+
+- C11 residual INCUBATE closes as **decision recorded + honesty markers**.
+- Future WIRE PRs must update claims and this ADR status (or supersede) in the same train.
+- Phase 3 parallel work (C3 logger ADR, C5 `createVitestConfig`) is unaffected.
+
+## Verification
+
+- No production import of `MCPHypervisor.getInstance` / constructor under `apps/` (code-over-docs).
+- No production import of `@revealui/ai/skills` or `@revealui/ai/observability` under `apps/`.
+- File headers and package README/index comments state incubating posture (same change set).

--- a/docs/features/mcp.yml
+++ b/docs/features/mcp.yml
@@ -16,7 +16,8 @@ api-surface:
     endpoint: "MCPHypervisor singleton — manages N running MCP server processes"
     openapi: false
     tested: true
-    notes: "Spawns stdio processes, health checks every 60s, tool namespacing (@@mcp_server_tool)"
+    status: incubating
+    notes: "ADR-007 C11: library kept and tested; not app-mounted at boot. Spawns stdio processes, health checks every 60s, tool namespacing (@@mcp_server_tool). Prefer revealui-mcp launchers until WIRE."
   adapter:
     endpoint: "MCPAdapter abstract class — base for service-specific adapters"
     openapi: false
@@ -57,7 +58,7 @@ package-exports:
   ".": "dist/index.js — license check, re-exports all modules"
   "./adapter": "dist/servers/adapter.js — MCPAdapter base class"
   "./contracts": "dist/contracts.js — Zod schemas"
-  "./hypervisor": "dist/hypervisor.js — MCPHypervisor singleton"
+  "./hypervisor": "dist/hypervisor.js — MCPHypervisor singleton (incubating; ADR-007)"
   "./db": "dist/adapters/db.js — PGlite/PostgreSQL + CRDT"
   "./config": "dist/config/index.js — MCP environment config"
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -67,11 +67,11 @@ The customer's right to use the Pro tier features of a RevealUI runtime. Encoded
 
 ## MCP — Model Context Protocol
 
-The protocol agents use to discover and invoke external tools (Stripe, Neon, Vercel, Playwright, Slack, Linear, etc.). RevealUI ships an MCP **hypervisor** that hosts multiple MCP servers behind one process. See `packages/mcp` and [`./PRO`](./PRO.md) for the canonical server list.
+The protocol agents use to discover and invoke external tools (Stripe, Neon, Vercel, Playwright, Slack, Linear, etc.). RevealUI ships first-party MCP servers plus an **incubating** multi-server process **hypervisor** in source (not app-mounted by default; ADR-007). See `packages/mcp` and [`./PRO`](./PRO.md) for the canonical server list.
 
 ## MCP server
 
-A specific tool integration exposed via [MCP](#mcp---model-context-protocol). E.g., `stripe-mcp`, `neon-mcp`. Distinct from the **MCP hypervisor** that hosts them. RevealUI's marketplace lets customers wire third-party MCP servers (e.g., a customer's own Supabase MCP server) without forking the hypervisor.
+A specific tool integration exposed via [MCP](#mcp---model-context-protocol). E.g., `stripe-mcp`, `neon-mcp`. Distinct from the optional multi-server **MCP hypervisor** library that can host them when wired. RevealUI's marketplace path is for attaching third-party MCP servers without forking the framework.
 
 ## Operator
 

--- a/packages/ai/src/observability/index.ts
+++ b/packages/ai/src/observability/index.ts
@@ -1,6 +1,10 @@
 /**
  * @revealui/ai - Observability
  *
+ * **INCUBATING (fleet-redundancy C11 / ADR-007).** Agent event/metrics helpers
+ * are available as a library. No RevealUI app currently mounts this surface as
+ * the product observability path; prefer explicit wiring under a WIRE ticket.
+ *
  * Agent operation tracking, logging, and metrics collection.
  */
 

--- a/packages/ai/src/skills/index.ts
+++ b/packages/ai/src/skills/index.ts
@@ -1,6 +1,10 @@
 /**
  * Agent Skills
  *
+ * **INCUBATING (fleet-redundancy C11 / ADR-007).** Library exports for skill
+ * install/activation remain. No RevealUI app currently mounts the skills
+ * registry as a product path; wire only under a dedicated WIRE ticket.
+ *
  * Implementation of the Agent Skills open standard (skills.sh).
  * Allows RevealUI agents to install and use skill packages.
  *

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -20,6 +20,7 @@ Centralized MCP server infrastructure, configuration, and documentation for Reve
 This package contains everything MCP-related:
 
 - **13 MCP Servers** - Code Validator, Contracts Introspection, RevealUI Docs, Neon, Next.js DevTools, Playwright, RevealUI Content, RevealUI Email, RevealUI Memory, RevealUI Stripe, Stripe, Vercel, and the Adapter base (BaseAdapter with retry and idempotency, plus the Vercel/Stripe/Neon adapter subclasses). This roster matches the CI counter in `scripts/validate/claim-drift.ts` (adapter counted, the underscore-prefixed email-provider utility not); the count is enforced by `pnpm validate:claims`. Of the 13, eight are RevealUI-authored and five are first-party launchers that start vendor MCP server packages.
+- **MCPHypervisor (incubating)** - Multi-server process manager in source (`src/hypervisor.ts`). Not started by apps at boot today (ADR-007). Use `revealui-mcp` / per-server launchers for day-to-day attach.
 - **Configuration Templates** - For Claude Code / Claude Desktop
 - **Utilities** - Config management, database adapters
 - **Documentation** - Complete guides and per-server docs

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/mcp",
   "version": "0.8.1",
-  "description": "Model Context Protocol framework — MCP server hypervisor, adapter pattern, tool discovery, and adapters for Stripe, Vercel, Neon, and related upstream servers.",
+  "description": "Model Context Protocol framework — first-party server launchers, adapter pattern, tool discovery, and an incubating multi-server hypervisor (not app-mounted by default; ADR-007).",
   "repository": {
     "type": "git",
     "url": "https://github.com/RevealUIStudio/revealui.git",

--- a/packages/mcp/src/hypervisor.ts
+++ b/packages/mcp/src/hypervisor.ts
@@ -1,6 +1,11 @@
 /**
  * MCP Hypervisor
  *
+ * **INCUBATING (fleet-redundancy C11 / ADR-007).** Library surface is kept and
+ * tested. No RevealUI app currently constructs or starts this singleton at
+ * process boot. Prefer explicit `revealui-mcp` / per-server launchers until a
+ * dedicated WIRE ticket mounts the hypervisor with credential + metering ownership.
+ *
  * Manages N running MCP server processes, pings them for liveness, and
  * dynamically exposes their tools at runtime. Inspired by the
  * MCPCompatibilityLayer/MCPHypervisor pattern from AnythingLLM.


### PR DESCRIPTION
## Summary
Closes fleet-redundancy C11 residual **INCUBATE** (same shape as ADR-006 engines).

## ADR-007
- **MCPHypervisor**, `@revealui/ai/skills`, `@revealui/ai/observability`: keep code, do not wire, do not delete
- Apps must not claim these are mounted product paths until greppable under `apps/`

## Honesty surface
- File headers on hypervisor + ai skills/obs barrels
- Marketplace discovery steps no longer imply a live app hypervisor
- claims-evidence, glossary, mcp.yml, package description aligned

## Verify
- [x] `pnpm validate:claims` / `validate:claims-evidence`
- [x] `pnpm validate:doc-currency`
- [x] local phase-1 gate PASS