### PR TITLE
feat(dev): createVitestConfig factory + first package cohort

### DIFF
--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -1,91 +1,69 @@
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    pool: 'forks',
-    maxWorkers: 2,
-    hookTimeout: 30000,
-    exclude: [
-      'node_modules/**',
-      '.direnv/**',
-      '.claude/**',
-      // Integration tests requiring Payloadadmin + database  -  run via pnpm test:integration
-      'src/__tests__/auth/access-control.test.ts',
-      'src/__tests__/auth/authentication.test.ts',
-    ],
-    setupFiles: [path.resolve(__dirname, './src/__tests__/setup.ts')],
-    env: {
-      // CRITICAL: Skip env validation during tests
-      SKIP_ENV_VALIDATION: 'true',
-      NODE_ENV: 'test',
-      REVEALUI_SECRET: 'test-secret-key-for-testing-only-32chars',
-      REVEALUI_PUBLIC_SERVER_URL: 'http://localhost:4000',
-      // Force in-memory storage by unsetting database URLs that may leak from direnv/nix shell
-      POSTGRES_URL: '',
-      DATABASE_URL: '',
-      SKIP_ONINIT: 'true',
-    },
-    server: {
-      deps: {
-        // Inline all @revealui/* workspace packages so Vite's resolver (and
-        // alias map) applies to their transitive imports too. Without this,
-        // Node.js native ESM loads them directly and the @revealui/config
-        // alias is bypassed, causing "Cannot find module ./loader" errors
-        // from the extensionless imports that tsc emits under moduleResolution:bundler.
-        inline: [/@revealui\//],
-      },
-    },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: [
-        'node_modules/**',
-        'src/__tests__/**',
-        '**/*.test.ts',
-        '**/*.spec.ts',
-        'dist/**',
-        '.next/**',
-      ],
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
-      },
-    },
+export default createVitestConfig({
+  environment: 'jsdom',
+  hookTimeout: 30_000,
+  exclude: [
+    'node_modules/**',
+    '.direnv/**',
+    '.claude/**',
+    'src/__tests__/auth/access-control.test.ts',
+    'src/__tests__/auth/authentication.test.ts',
+  ],
+  coverageExclude: [
+    'node_modules/**',
+    'src/__tests__/**',
+    '**/*.test.ts',
+    '**/*.spec.ts',
+    'dist/**',
+    '.next/**',
+  ],
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
-  resolve: {
-    alias: {
-      // Force workspace package resolution for @revealui/* packages.
-      // Without these, pnpm may resolve to a stale published version in the
-      // store (e.g. @revealui/config@0.2.0) whose dist/index.js contains
-      // extensionless relative imports that Node ESM rejects at test-time.
-      // Pointing directly at source lets Vitest's transform handle them.
-      // IMPORTANT: subpath aliases must come BEFORE the broad prefix alias or
-      // Vite appends the subpath suffix to the file path → ENOTDIR.
-      '@revealui/config/revealui': path.resolve(
-        __dirname,
-        '../../packages/config/src/revealui.config.ts',
-      ),
-      '@revealui/config': path.resolve(__dirname, '../../packages/config/src/index.ts'),
-      '@revealui/auth/server': path.resolve(__dirname, '../../packages/auth/src/server/index.ts'),
-      '@': path.resolve(__dirname, './src'),
-      '@reveal-config': path.resolve(__dirname, './revealui.config.ts'),
-      '@/collections': path.resolve(__dirname, './src/lib/collections'),
-      '@/blocks': path.resolve(__dirname, './src/lib/blocks'),
-      '@/components': path.resolve(__dirname, './src/lib/components'),
-      '@/access': path.resolve(__dirname, './src/lib/access'),
-      '@/hooks': path.resolve(__dirname, './src/lib/hooks'),
-      '@/fields': path.resolve(__dirname, './src/lib/fields'),
-      '@/globals': path.resolve(__dirname, './src/lib/globals'),
-      '@/heros': path.resolve(__dirname, './src/lib/heros'),
-      '@/lib': path.resolve(__dirname, './src/lib'),
-      // tsconfig paths alias used by Media components (ImageMedia); reached in
-      // tests since RenderBlocks renders hero blocks via RenderHero.
-      cssVariables: path.resolve(__dirname, './cssVariables.js'),
+  overrides: {
+    test: {
+      setupFiles: [path.resolve(__dirname, './src/__tests__/setup.ts')],
+      env: {
+        SKIP_ENV_VALIDATION: 'true',
+        NODE_ENV: 'test',
+        REVEALUI_SECRET: 'test-secret-key-for-testing-only-32chars',
+        REVEALUI_PUBLIC_SERVER_URL: 'http://localhost:4000',
+        POSTGRES_URL: '',
+        DATABASE_URL: '',
+        SKIP_ONINIT: 'true',
+      },
+      server: {
+        deps: {
+          inline: [/@revealui\//],
+        },
+      },
+    },
+    resolve: {
+      alias: {
+        '@revealui/config/revealui': path.resolve(
+          __dirname,
+          '../../packages/config/src/revealui.config.ts',
+        ),
+        '@revealui/config': path.resolve(__dirname, '../../packages/config/src/index.ts'),
+        '@revealui/auth/server': path.resolve(__dirname, '../../packages/auth/src/server/index.ts'),
+        '@': path.resolve(__dirname, './src'),
+        '@reveal-config': path.resolve(__dirname, './revealui.config.ts'),
+        '@/collections': path.resolve(__dirname, './src/lib/collections'),
+        '@/blocks': path.resolve(__dirname, './src/lib/blocks'),
+        '@/components': path.resolve(__dirname, './src/lib/components'),
+        '@/access': path.resolve(__dirname, './src/lib/access'),
+        '@/hooks': path.resolve(__dirname, './src/lib/hooks'),
+        '@/fields': path.resolve(__dirname, './src/lib/fields'),
+        '@/globals': path.resolve(__dirname, './src/lib/globals'),
+        '@/heros': path.resolve(__dirname, './src/lib/heros'),
+        '@/lib': path.resolve(__dirname, './src/lib'),
+        cssVariables: path.resolve(__dirname, './cssVariables.js'),
+      },
     },
   },
 });

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -10,6 +10,12 @@ export default createVitestConfig({
   testTimeout: 30_000,
   hookTimeout: 30_000,
   maxWorkers: 1,
+  // Tests live under app/ and __tests__/ (not packages/src default).
+  include: [
+    'app/**/*.{test,spec}.{ts,tsx}',
+    '__tests__/**/*.{test,spec}.{ts,tsx}',
+    'scripts/**/*.{test,spec}.{ts,tsx}',
+  ],
   coverageExclude: [
     'app/components/showcase/registry.ts',
     'app/showcase/**/*.showcase.tsx',

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,53 +1,42 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./__tests__/setup.ts'],
-    // Keep this package narrow under monorepo fan-out instead of raising global repo settings.
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
-    pool: 'forks',
-    maxWorkers: 1,
-    minWorkers: 1,
-    coverage: {
-      provider: 'v8',
-      // Showcase entries and the registry that loads them are pure configuration
-      // (lazy-import loaders + JSX render functions consumed by the docs site at
-      // runtime). They have no testable behaviour as units — they are exercised
-      // by clicking through the showcase routes, which the docs E2E suite covers
-      // separately. Excluding them keeps the unit coverage gate honest about
-      // logic-bearing code (DocLayout, hooks, utils, components/showcase/Shell).
-      exclude: [
-        'app/components/showcase/registry.ts',
-        'app/showcase/**/*.showcase.tsx',
-        // Default vitest excludes (preserved when we override exclude)
-        'coverage/**',
-        'dist/**',
-        'node_modules/**',
-        '**/__tests__/**',
-        '**/*.test.{ts,tsx}',
-        '**/*.spec.{ts,tsx}',
-        'vitest.config.ts',
-      ],
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
-      },
-    },
+export default createVitestConfig({
+  environment: 'jsdom',
+  testTimeout: 30_000,
+  hookTimeout: 30_000,
+  maxWorkers: 1,
+  coverageExclude: [
+    'app/components/showcase/registry.ts',
+    'app/showcase/**/*.showcase.tsx',
+    'coverage/**',
+    'dist/**',
+    'node_modules/**',
+    '**/__tests__/**',
+    '**/*.test.{ts,tsx}',
+    '**/*.spec.{ts,tsx}',
+    'vitest.config.ts',
+  ],
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './app'),
+  overrides: {
+    plugins: [react()],
+    test: {
+      setupFiles: ['./__tests__/setup.ts'],
+      minWorkers: 1,
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './app'),
+      },
     },
   },
 });

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import react from '@vitejs/plugin-react';
 import { createVitestConfig } from '@revealui/dev/vitest';
+import react from '@vitejs/plugin-react';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/apps/marketing/vitest.config.ts
+++ b/apps/marketing/vitest.config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import react from '@vitejs/plugin-react';
 import { createVitestConfig } from '@revealui/dev/vitest';
+import react from '@vitejs/plugin-react';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/apps/marketing/vitest.config.ts
+++ b/apps/marketing/vitest.config.ts
@@ -1,39 +1,33 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
-    pool: 'forks',
-    maxWorkers: 1,
-    minWorkers: 1,
-    coverage: {
-      provider: 'v8',
-      exclude: [
-        'coverage/**',
-        'dist/**',
-        'node_modules/**',
-        '**/__tests__/**',
-        '**/*.test.{ts,tsx}',
-        '**/*.spec.{ts,tsx}',
-        'vitest.config.ts',
-      ],
-      // Marketing is mostly presentational pages — strict coverage thresholds
-      // don't match the surface profile. Coverage report still generated for
-      // trend visibility; coverage:check --fail-on-zero is the real gate.
+export default createVitestConfig({
+  environment: 'jsdom',
+  testTimeout: 30_000,
+  hookTimeout: 30_000,
+  maxWorkers: 1,
+  coverageExclude: [
+    'coverage/**',
+    'dist/**',
+    'node_modules/**',
+    '**/__tests__/**',
+    '**/*.test.{ts,tsx}',
+    '**/*.spec.{ts,tsx}',
+    'vitest.config.ts',
+  ],
+  overrides: {
+    plugins: [react()],
+    test: {
+      minWorkers: 1,
     },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './app'),
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './app'),
+      },
     },
   },
 });

--- a/apps/marketing/vitest.config.ts
+++ b/apps/marketing/vitest.config.ts
@@ -10,6 +10,8 @@ export default createVitestConfig({
   testTimeout: 30_000,
   hookTimeout: 30_000,
   maxWorkers: 1,
+  // Tests live under app/ (not packages/src default).
+  include: ['app/**/*.{test,spec}.{ts,tsx}'],
   coverageExclude: [
     'coverage/**',
     'dist/**',

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,7 +37,8 @@
     "tsup": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@revealui/dev": "workspace:*"
   },
   "engines": {
     "node": ">=24.13.0"

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,74 +1,59 @@
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  resolve: {
-    alias: [
-      { find: '@', replacement: path.resolve(__dirname, './src') },
-      // Resolve workspace packages from source to avoid Vite SSR export* re-export breakage.
-      // Classes lose constructor identity when passed through export * chains in SSR mode.
-      // Subpath aliases MUST precede the bare '@revealui/security' alias: Vite's
-      // string `find` is a prefix match, so the bare alias would rewrite
-      // '@revealui/security/server' to '.../src/index.ts/server' (ENOTDIR). Map
-      // each published subpath to its own source entry.
-      {
-        find: '@revealui/security/server',
-        replacement: path.resolve(__dirname, '../../packages/security/src/server.ts'),
-      },
-      {
-        find: '@revealui/security/sanitize',
-        replacement: path.resolve(__dirname, '../../packages/security/src/sanitize.ts'),
-      },
-      {
-        find: '@revealui/security',
-        replacement: path.resolve(__dirname, '../../packages/security/src/index.ts'),
-      },
-      // tsup's binary loader inlines .ttf into the production bundle, but
-      // vitest can't evaluate the binary as a JS module. Alias to a tiny
-      // stub so any test that transitively imports og.ts doesn't crash
-      // collection. The `^.+` anchor is critical: a bare `\.ttf$` would
-      // match only the extension substring and concatenate the replacement
-      // onto the rest of the path; anchoring matches the full module ID so
-      // the replacement takes over completely.
-      //
-      // No `.wasm` alias needed — og.ts reads the resvg WASM at runtime via
-      // `readFileSync`, not via ESM import (see apps/server/src/routes/og.ts).
-      { find: /^.+\.ttf$/, replacement: path.resolve(__dirname, './__tests__/binary-stub.ts') },
-    ],
+export default createVitestConfig({
+  testTimeout: 15_000,
+  hookTimeout: 30_000,
+  include: ['__tests__/**/*.test.ts', '**/*.test.ts'],
+  exclude: [
+    '**/node_modules/**',
+    '**/dist/**',
+    '**/.direnv/**',
+    '**/.claude/**',
+    '.direnv/**',
+    '.claude/**',
+    '**/*-integration.test.ts',
+  ],
+  coverageExclude: [
+    'node_modules/**',
+    '**/*.test.ts',
+    '**/*.spec.ts',
+    'dist/**',
+    '**/__tests__/**',
+  ],
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
-  test: {
-    include: ['__tests__/**/*.test.ts', '**/*.test.ts'],
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/.direnv/**',
-      '**/.claude/**',
-      '.direnv/**',
-      '.claude/**',
-      '**/*-integration.test.ts',
-    ],
-    environment: 'node',
-    globals: true,
-    pool: 'forks',
-    maxWorkers: 2,
-    testTimeout: 15000,
-    // hookTimeout > testTimeout: PGlite createTestDb() bootstrap in beforeAll runs all migrations (9-19s observed)
-    hookTimeout: 30000,
-    env: {
-      NODE_ENV: 'test',
-      // Force in-memory storage by unsetting database URLs that may leak from direnv/nix shell
-      POSTGRES_URL: '',
-      DATABASE_URL: '',
+  overrides: {
+    resolve: {
+      alias: [
+        { find: '@', replacement: path.resolve(__dirname, './src') },
+        {
+          find: '@revealui/security/server',
+          replacement: path.resolve(__dirname, '../../packages/security/src/server.ts'),
+        },
+        {
+          find: '@revealui/security/sanitize',
+          replacement: path.resolve(__dirname, '../../packages/security/src/sanitize.ts'),
+        },
+        {
+          find: '@revealui/security',
+          replacement: path.resolve(__dirname, '../../packages/security/src/index.ts'),
+        },
+        {
+          find: /^.+\.ttf$/,
+          replacement: path.resolve(__dirname, './__tests__/binary-stub.ts'),
+        },
+      ],
     },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: ['node_modules/**', '**/*.test.ts', '**/*.spec.ts', 'dist/**', '**/__tests__/**'],
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
+    test: {
+      env: {
+        NODE_ENV: 'test',
+        POSTGRES_URL: '',
+        DATABASE_URL: '',
       },
     },
   },

--- a/packages/ai/vitest.config.ts
+++ b/packages/ai/vitest.config.ts
@@ -1,51 +1,35 @@
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    hookTimeout: 90_000,
-    testTimeout: 90_000,
-    environment: 'node',
-    include: ['src/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      'src/__tests__/integration/**', // Skip - need Neon database
-    ],
-    environmentMatchGlobs: [
-      // Use jsdom for client-side React hook tests
-      ['src/client/**/*.test.ts', 'jsdom'],
-    ],
-    coverage: {
-      provider: 'v8',
-      // Standardized reporters: text (CI logs), json (programmatic), html (local dev), lcov (Codecov)
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/__tests__/**', 'dist/**'],
-      thresholds: {
-        statements: 50,
-        branches: 35,
-        functions: 50,
-        lines: 50,
-      },
-    },
+export default createVitestConfig({
+  hookTimeout: 90_000,
+  testTimeout: 90_000,
+  include: ['src/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
+  exclude: ['**/node_modules/**', '**/dist/**', 'src/__tests__/integration/**'],
+  coverageExclude: ['src/**/*.test.ts', 'src/**/__tests__/**', 'dist/**'],
+  thresholds: {
+    statements: 50,
+    branches: 35,
+    functions: 50,
+    lines: 50,
   },
-  resolve: {
-    alias: {
-      '@revealui/db/schema/vector': path.resolve(__dirname, '../db/dist/schema/vector.js'),
-      '@revealui/db/schema/rag': path.resolve(__dirname, '../db/dist/schema/rag.js'),
-      '@revealui/db/schema': path.resolve(__dirname, '../db/dist/schema/index.js'),
-      '@revealui/db/client': path.resolve(__dirname, '../db/dist/client/index.js'),
-      '@revealui/db/crypto': path.resolve(__dirname, '../db/dist/crypto.js'),
-      '@revealui/db/validation': path.resolve(__dirname, '../db/dist/validation/cross-db.js'),
-      '@revealui/db': path.resolve(__dirname, '../db/dist/index.js'),
-      '@revealui/contracts': path.resolve(__dirname, '../contracts/src'),
-      // More-specific first: package exports map ./admin → dist/client/admin.
-      // A bare @revealui/core → src alias would resolve
-      // @revealui/core/admin/utils/csrf to src/admin/... (missing client/).
-      '@revealui/core/admin': path.resolve(__dirname, '../core/src/client/admin'),
-      '@revealui/core': path.resolve(__dirname, '../core/src'),
+  overrides: {
+    test: {
+      environmentMatchGlobs: [['src/client/**/*.test.ts', 'jsdom']],
+    },
+    resolve: {
+      alias: {
+        '@revealui/db/schema/vector': path.resolve(__dirname, '../db/dist/schema/vector.js'),
+        '@revealui/db/schema/rag': path.resolve(__dirname, '../db/dist/schema/rag.js'),
+        '@revealui/db/schema': path.resolve(__dirname, '../db/dist/schema/index.js'),
+        '@revealui/db/client': path.resolve(__dirname, '../db/dist/client/index.js'),
+        '@revealui/db/crypto': path.resolve(__dirname, '../db/dist/crypto.js'),
+        '@revealui/db/validation': path.resolve(__dirname, '../db/dist/validation/cross-db.js'),
+        '@revealui/db': path.resolve(__dirname, '../db/dist/index.js'),
+        '@revealui/contracts': path.resolve(__dirname, '../contracts/src'),
+        '@revealui/core/admin': path.resolve(__dirname, '../core/src/client/admin'),
+        '@revealui/core': path.resolve(__dirname, '../core/src'),
+      },
     },
   },
 });

--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -1,31 +1,24 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    environmentMatchGlobs: [['**/*.test.tsx', 'happy-dom']],
-    pool: 'forks',
-    fileParallelism: false,
-    maxWorkers: 1,
-    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
-    env: {
-      REVEALUI_SECRET: 'test-secret-key-for-testing-only-32chars',
-      // Force in-memory storage by unsetting database URLs that may leak from direnv/nix shell
-      POSTGRES_URL: '',
-      DATABASE_URL: '',
-      NODE_ENV: 'test',
-    },
-    coverage: {
-      provider: 'v8',
-      // Standardized reporters: text (CI logs), json (programmatic), html (local dev), lcov (Codecov)
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/__tests__/**'],
-      thresholds: {
-        lines: 75,
-        functions: 75,
-        branches: 65,
-        statements: 75,
+export default createVitestConfig({
+  maxWorkers: 1,
+  include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  coverageExclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/__tests__/**'],
+  thresholds: {
+    lines: 75,
+    functions: 75,
+    branches: 65,
+    statements: 75,
+  },
+  overrides: {
+    test: {
+      environmentMatchGlobs: [['**/*.test.tsx', 'happy-dom']],
+      fileParallelism: false,
+      env: {
+        REVEALUI_SECRET: 'test-secret-key-for-testing-only-32chars',
+        POSTGRES_URL: '',
+        DATABASE_URL: '',
+        NODE_ENV: 'test',
       },
     },
   },

--- a/packages/cache/vitest.config.ts
+++ b/packages/cache/vitest.config.ts
@@ -1,23 +1,11 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    hookTimeout: 30000,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
-      },
-    },
+export default createVitestConfig({
+  hookTimeout: 30_000,
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,8 @@
     "@types/node": "catalog:",
     "@types/semver": "^7.7.1",
     "tsup": "^8.5.1",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "@revealui/dev": "workspace:*"
   },
   "engines": {
     "node": ">=24.13.0"

--- a/packages/cli/templates/starter-native/vitest.config.ts
+++ b/packages/cli/templates/starter-native/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Customer starter template: keep a self-contained config (no monorepo-only deps).
 export default defineConfig({
   test: {
     environment: 'jsdom',

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,34 +1,30 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    testTimeout: 15_000,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**', '**/templates/**'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json-summary', 'html'],
-      include: ['src/**/*.{ts,tsx}'],
-      exclude: [
-        'src/**/*.test.ts',
-        'src/**/*.spec.ts',
-        'src/**/__tests__/**',
-        'src/cli.ts',
-        'src/index.ts',
-        'dist/**',
-        'node_modules/**',
-        'templates/**',
-      ],
-      all: true,
-      thresholds: {
-        lines: 45,
-        functions: 55,
-        branches: 35,
-        statements: 45,
+export default createVitestConfig({
+  testTimeout: 15_000,
+  exclude: ['**/node_modules/**', '**/dist/**', '**/templates/**'],
+  coverageInclude: ['src/**/*.{ts,tsx}'],
+  coverageReporters: ['text', 'json-summary', 'html'],
+  coverageExclude: [
+    'src/**/*.test.ts',
+    'src/**/*.spec.ts',
+    'src/**/__tests__/**',
+    'src/cli.ts',
+    'src/index.ts',
+    'dist/**',
+    'node_modules/**',
+    'templates/**',
+  ],
+  thresholds: {
+    lines: 45,
+    functions: 55,
+    branches: 35,
+    statements: 45,
+  },
+  overrides: {
+    test: {
+      coverage: {
+        all: true,
       },
     },
   },

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,24 +1,11 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    coverage: {
-      provider: 'v8',
-      // Standardized reporters: text (CI logs), json (programmatic), html (local dev), lcov (Codecov)
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-      thresholds: {
-        lines: 50,
-        functions: 35,
-        branches: 20,
-        statements: 50,
-      },
-    },
+export default createVitestConfig({
+  coverageExclude: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+  thresholds: {
+    lines: 50,
+    functions: 35,
+    branches: 20,
+    statements: 50,
   },
 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,42 +1,32 @@
 import * as path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    hookTimeout: 30000,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
-    env: {
-      // Force in-memory storage by unsetting database URLs that may leak from direnv/nix shell
-      POSTGRES_URL: '',
-      DATABASE_URL: '',
-    },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.ts'],
-      exclude: [
-        'src/**/*.test.ts',
-        'src/**/*.spec.ts',
-        'src/**/__tests__/**',
-        'dist/**',
-        'node_modules/**',
-      ],
-      thresholds: {
-        lines: 70,
-        functions: 70,
-        branches: 65,
-        statements: 70,
+export default createVitestConfig({
+  hookTimeout: 30_000,
+  coverageExclude: [
+    'src/**/*.test.ts',
+    'src/**/*.spec.ts',
+    'src/**/__tests__/**',
+    'dist/**',
+    'node_modules/**',
+  ],
+  thresholds: {
+    lines: 70,
+    functions: 70,
+    branches: 65,
+    statements: 70,
+  },
+  overrides: {
+    test: {
+      env: {
+        POSTGRES_URL: '',
+        DATABASE_URL: '',
       },
     },
-  },
-  resolve: {
-    alias: {
-      '@revealui/contracts': path.resolve(__dirname, '../contracts/src'),
+    resolve: {
+      alias: {
+        '@revealui/contracts': path.resolve(__dirname, '../contracts/src'),
+      },
     },
   },
 });

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,44 +1,36 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    fileParallelism: false,
-    maxWorkers: 1,
-    pool: 'forks',
-    hookTimeout: 30000,
-    env: {
-      // Force in-memory storage by unsetting database URLs that may leak from direnv/nix shell
-      POSTGRES_URL: '',
-      DATABASE_URL: '',
-    },
-    include: ['src/**/*.test.ts', '__tests__/**/*.test.ts'],
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**', // Exclude compiled tests - only run source tests
-    ],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov', 'html', 'json-summary'],
-      reportsDirectory: './coverage',
-      include: ['src/**/*.ts'],
-      exclude: [
-        'src/**/*.test.ts',
-        'src/**/*.spec.ts',
-        'src/**/__tests__/**',
-        'src/**/test-fixtures.ts',
-        'src/types/database.ts', // Generated file
-        'src/**/index.ts', // Barrel files — pure re-exports, no runtime logic
-        'src/**/types.ts', // Type-only modules (TS `export type`, zero runtime)
-        'src/scripts/**', // CLI entry points (shebang scripts) — run manually, tested via pnpm db:cleanup / db:backfill
-        'dist/**',
-      ],
-      thresholds: {
-        lines: 55,
-        functions: 40,
-        branches: 50,
-        statements: 55,
+export default createVitestConfig({
+  maxWorkers: 1,
+  hookTimeout: 30_000,
+  include: ['src/**/*.test.ts', '__tests__/**/*.test.ts'],
+  coverageReporters: ['text', 'lcov', 'html', 'json-summary'],
+  coverageExclude: [
+    'src/**/*.test.ts',
+    'src/**/*.spec.ts',
+    'src/**/__tests__/**',
+    'src/**/test-fixtures.ts',
+    'src/types/database.ts',
+    'src/**/index.ts',
+    'src/**/types.ts',
+    'src/scripts/**',
+    'dist/**',
+  ],
+  thresholds: {
+    lines: 55,
+    functions: 40,
+    branches: 50,
+    statements: 55,
+  },
+  overrides: {
+    test: {
+      fileParallelism: false,
+      env: {
+        POSTGRES_URL: '',
+        DATABASE_URL: '',
+      },
+      coverage: {
+        reportsDirectory: './coverage',
       },
     },
   },

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -40,6 +40,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./vite": "./src/vite/vite.shared.ts",
+    "./vitest": "./src/vitest/create-config.ts",
     "./tailwind": "./src/tailwind/tailwind.config.ts",
     "./tailwind/create-config": "./src/tailwind/create-config.ts",
     "./postcss": "./src/postcss/postcss.config.ts",
@@ -54,7 +55,13 @@
     "./editors": "./src/editors/index.ts"
   },
   "peerDependencies": {
-    "vite": ">=5.0.0"
+    "vite": ">=5.0.0",
+    "vitest": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/packages/dev/src/__tests__/create-vitest-config.test.ts
+++ b/packages/dev/src/__tests__/create-vitest-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { createVitestConfig } from '../vitest/create-config.js';
+
+describe('createVitestConfig', () => {
+  it('applies node package defaults', () => {
+    const config = createVitestConfig();
+    expect(config.test?.globals).toBe(true);
+    expect(config.test?.environment).toBe('node');
+    expect(config.test?.pool).toBe('forks');
+    expect(config.test?.maxWorkers).toBe(2);
+    expect(config.test?.include).toEqual(['src/**/*.test.ts', 'src/**/*.spec.ts']);
+    expect(config.test?.exclude).toEqual(['**/node_modules/**', '**/dist/**']);
+  });
+
+  it('includes standard coverage reporters and omits thresholds by default', () => {
+    const config = createVitestConfig();
+    const coverage = config.test?.coverage as {
+      provider?: string;
+      reporter?: string[];
+      thresholds?: unknown;
+    };
+    expect(coverage?.provider).toBe('v8');
+    expect(coverage?.reporter).toEqual(['text', 'json', 'html', 'lcov']);
+    expect(coverage?.thresholds).toBeUndefined();
+  });
+
+  it('accepts parameterized thresholds', () => {
+    const thresholds = { lines: 70, functions: 65, branches: 65, statements: 70 };
+    const config = createVitestConfig({ thresholds });
+    const coverage = config.test?.coverage as { thresholds?: typeof thresholds };
+    expect(coverage?.thresholds).toEqual(thresholds);
+  });
+
+  it('can disable coverage entirely', () => {
+    const config = createVitestConfig({ coverage: false });
+    expect(config.test?.coverage).toBeUndefined();
+  });
+
+  it('merges overrides for env and aliases', () => {
+    const config = createVitestConfig({
+      overrides: {
+        test: {
+          env: { NODE_ENV: 'test' },
+        },
+        resolve: {
+          alias: { '@': './src' },
+        },
+      },
+    });
+    expect(config.test?.env).toMatchObject({ NODE_ENV: 'test' });
+    expect(config.test?.globals).toBe(true);
+    expect(config.resolve?.alias).toBeDefined();
+  });
+
+  it('honors environment and timeout options', () => {
+    const config = createVitestConfig({
+      environment: 'jsdom',
+      hookTimeout: 30_000,
+      testTimeout: 60_000,
+      maxWorkers: 1,
+    });
+    expect(config.test?.environment).toBe('jsdom');
+    expect(config.test?.hookTimeout).toBe(30_000);
+    expect(config.test?.testTimeout).toBe(60_000);
+    expect(config.test?.maxWorkers).toBe(1);
+  });
+});

--- a/packages/dev/src/__tests__/create-vitest-config.test.ts
+++ b/packages/dev/src/__tests__/create-vitest-config.test.ts
@@ -8,7 +8,12 @@ describe('createVitestConfig', () => {
     expect(config.test?.environment).toBe('node');
     expect(config.test?.pool).toBe('forks');
     expect(config.test?.maxWorkers).toBe(2);
-    expect(config.test?.include).toEqual(['src/**/*.test.ts', 'src/**/*.spec.ts']);
+    expect(config.test?.include).toEqual([
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+      'src/**/*.spec.ts',
+      'src/**/*.spec.tsx',
+    ]);
     expect(config.test?.exclude).toEqual(['**/node_modules/**', '**/dist/**']);
   });
 

--- a/packages/dev/src/__tests__/integration/configs.integration.test.ts
+++ b/packages/dev/src/__tests__/integration/configs.integration.test.ts
@@ -108,6 +108,23 @@ describe('Dev Package Configs Integration', () => {
     });
   });
 
+  describe('Vitest Config Factory', () => {
+    it('should import createVitestConfig', async () => {
+      const { createVitestConfig } = await import('@revealui/dev/vitest');
+      expect(typeof createVitestConfig).toBe('function');
+    });
+
+    it('should produce a node package default config', async () => {
+      const { createVitestConfig } = await import('@revealui/dev/vitest');
+      const config = createVitestConfig({
+        thresholds: { lines: 50, functions: 50, branches: 40, statements: 50 },
+      });
+      expect(config.test?.environment).toBe('node');
+      expect(config.test?.pool).toBe('forks');
+      expect(config.test?.globals).toBe(true);
+    });
+  });
+
   describe('Biome Config', () => {
     it('should import biome config', async () => {
       const config = await import('@revealui/dev/biome');

--- a/packages/dev/src/vitest/create-config.ts
+++ b/packages/dev/src/vitest/create-config.ts
@@ -14,7 +14,7 @@
  * })
  * ```
  */
-import { defineConfig, mergeConfig, type UserConfig } from 'vitest/config';
+import { defineConfig, mergeConfig, type ViteUserConfig } from 'vitest/config';
 
 /** Coverage thresholds — all four keys required when set (matches gate habit). */
 export interface VitestCoverageThresholds {
@@ -57,7 +57,7 @@ export interface CreateVitestConfigOptions {
    * Deep-merged onto the factory result via `mergeConfig`. Use for resolve
    * aliases, `define`, `env`, multi-project setups, etc.
    */
-  overrides?: UserConfig;
+  overrides?: ViteUserConfig;
 }
 
 const DEFAULT_INCLUDE = ['src/**/*.test.ts', 'src/**/*.spec.ts'] as const;
@@ -75,7 +75,7 @@ const DEFAULT_COVERAGE_REPORTERS = ['text', 'json', 'html', 'lcov'] as const;
  *
  * Returns the result of `defineConfig` so configs can `export default` it.
  */
-export function createVitestConfig(options: CreateVitestConfigOptions = {}): UserConfig {
+export function createVitestConfig(options: CreateVitestConfigOptions = {}): ViteUserConfig {
   const {
     environment = 'node',
     maxWorkers = 2,
@@ -91,7 +91,7 @@ export function createVitestConfig(options: CreateVitestConfigOptions = {}): Use
     overrides,
   } = options;
 
-  const base: UserConfig = {
+  const base: ViteUserConfig = {
     test: {
       globals: true,
       environment,

--- a/packages/dev/src/vitest/create-config.ts
+++ b/packages/dev/src/vitest/create-config.ts
@@ -60,7 +60,12 @@ export interface CreateVitestConfigOptions {
   overrides?: ViteUserConfig;
 }
 
-const DEFAULT_INCLUDE = ['src/**/*.test.ts', 'src/**/*.spec.ts'] as const;
+const DEFAULT_INCLUDE = [
+  'src/**/*.test.ts',
+  'src/**/*.test.tsx',
+  'src/**/*.spec.ts',
+  'src/**/*.spec.tsx',
+] as const;
 const DEFAULT_EXCLUDE = ['**/node_modules/**', '**/dist/**'] as const;
 const DEFAULT_COVERAGE_INCLUDE = ['src/**/*.ts'] as const;
 const DEFAULT_COVERAGE_EXCLUDE = [

--- a/packages/dev/src/vitest/create-config.ts
+++ b/packages/dev/src/vitest/create-config.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared Vitest config factory for RevealUI monorepo packages.
+ *
+ * Fleet-redundancy C5 / P2-F: one factory for the common node-package shape
+ * (globals, forks pool, coverage reporters). Per-package thresholds and
+ * includes stay parameterized so coverage gates do not silently drop.
+ *
+ * @example
+ * ```ts
+ * import { createVitestConfig } from '@revealui/dev/vitest'
+ *
+ * export default createVitestConfig({
+ *   thresholds: { lines: 60, functions: 60, branches: 55, statements: 60 },
+ * })
+ * ```
+ */
+import { defineConfig, mergeConfig, type UserConfig } from 'vitest/config';
+
+/** Coverage thresholds — all four keys required when set (matches gate habit). */
+export interface VitestCoverageThresholds {
+  lines: number;
+  functions: number;
+  branches: number;
+  statements: number;
+}
+
+export interface CreateVitestConfigOptions {
+  /** Vitest environment. Default: `'node'`. */
+  environment?: 'node' | 'jsdom' | 'happy-dom' | 'edge-runtime';
+  /** maxWorkers for the forks pool. Default: `2`. */
+  maxWorkers?: number;
+  /** hookTimeout ms. Default: Vitest default (omit). */
+  hookTimeout?: number;
+  /** testTimeout ms. Default: Vitest default (omit). */
+  testTimeout?: number;
+  /** Test include globs. Default: src unit/spec files. */
+  include?: string[];
+  /** Test exclude globs. Default: node_modules and dist. */
+  exclude?: string[];
+  /** When false, omit coverage block. Default: true. */
+  coverage?: boolean;
+  /** Coverage include globs. Default: src TypeScript files. */
+  coverageInclude?: string[];
+  /** Coverage exclude globs. Default: tests and __tests__ trees. */
+  coverageExclude?: string[];
+  /**
+   * Coverage thresholds. When omitted, no thresholds key is written
+   * (packages opt in explicitly so gates stay intentional).
+   */
+  thresholds?: VitestCoverageThresholds;
+  /**
+   * Coverage reporters. Default:
+   * `['text', 'json', 'html', 'lcov']`
+   */
+  coverageReporters?: string[];
+  /**
+   * Deep-merged onto the factory result via `mergeConfig`. Use for resolve
+   * aliases, `define`, `env`, multi-project setups, etc.
+   */
+  overrides?: UserConfig;
+}
+
+const DEFAULT_INCLUDE = ['src/**/*.test.ts', 'src/**/*.spec.ts'] as const;
+const DEFAULT_EXCLUDE = ['**/node_modules/**', '**/dist/**'] as const;
+const DEFAULT_COVERAGE_INCLUDE = ['src/**/*.ts'] as const;
+const DEFAULT_COVERAGE_EXCLUDE = [
+  'src/**/*.test.ts',
+  'src/**/*.spec.ts',
+  'src/**/__tests__/**',
+] as const;
+const DEFAULT_COVERAGE_REPORTERS = ['text', 'json', 'html', 'lcov'] as const;
+
+/**
+ * Build a Vitest `UserConfig` for a monorepo package.
+ *
+ * Returns the result of `defineConfig` so configs can `export default` it.
+ */
+export function createVitestConfig(options: CreateVitestConfigOptions = {}): UserConfig {
+  const {
+    environment = 'node',
+    maxWorkers = 2,
+    hookTimeout,
+    testTimeout,
+    include = [...DEFAULT_INCLUDE],
+    exclude = [...DEFAULT_EXCLUDE],
+    coverage = true,
+    coverageInclude = [...DEFAULT_COVERAGE_INCLUDE],
+    coverageExclude = [...DEFAULT_COVERAGE_EXCLUDE],
+    thresholds,
+    coverageReporters = [...DEFAULT_COVERAGE_REPORTERS],
+    overrides,
+  } = options;
+
+  const base: UserConfig = {
+    test: {
+      globals: true,
+      environment,
+      pool: 'forks',
+      maxWorkers,
+      include,
+      exclude,
+      ...(hookTimeout !== undefined ? { hookTimeout } : {}),
+      ...(testTimeout !== undefined ? { testTimeout } : {}),
+      ...(coverage
+        ? {
+            coverage: {
+              provider: 'v8' as const,
+              reporter: coverageReporters,
+              include: coverageInclude,
+              exclude: coverageExclude,
+              ...(thresholds ? { thresholds } : {}),
+            },
+          }
+        : {}),
+    },
+  };
+
+  if (!overrides) {
+    return defineConfig(base);
+  }
+
+  return defineConfig(mergeConfig(base, overrides));
+}

--- a/packages/dev/vitest.config.ts
+++ b/packages/dev/vitest.config.ts
@@ -1,57 +1,81 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from './src/vitest/create-config.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export default defineConfig({
-  resolve: {
-    alias: [
-      // More-specific subpath aliases must come before the broad prefix alias.
-      // These mirror the package.json "exports" map so tests can import 'dev/*'
-      // without the package being installed in node_modules.
-      {
-        find: 'dev/tailwind/create-config',
-        replacement: path.resolve(__dirname, './src/tailwind/create-config.ts'),
-      },
-      {
-        find: 'dev/tailwind',
-        replacement: path.resolve(__dirname, './src/tailwind/tailwind.config.ts'),
-      },
-      {
-        find: 'dev/postcss',
-        replacement: path.resolve(__dirname, './src/postcss/postcss.config.ts'),
-      },
-      { find: 'dev/vite', replacement: path.resolve(__dirname, './src/vite/vite.shared.ts') },
-      { find: 'dev/biome', replacement: path.resolve(__dirname, './src/biome/biome.config.ts') },
-      {
-        find: 'dev/code-validator',
-        replacement: path.resolve(__dirname, './src/code-validator/index.ts'),
-      },
-    ],
+// Self-reference source path so tests resolve before package exports are wired.
+export default createVitestConfig({
+  include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+  coverageExclude: [
+    'node_modules/**',
+    '**/*.test.ts',
+    '**/*.spec.ts',
+    'dist/**',
+    '**/__tests__/**',
+  ],
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
-  test: {
-    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
-    environment: 'node',
-    globals: true,
-    env: {
-      VITEST: 'true',
-      NODE_ENV: 'test',
+  overrides: {
+    resolve: {
+      alias: [
+        {
+          find: 'dev/tailwind/create-config',
+          replacement: path.resolve(__dirname, './src/tailwind/create-config.ts'),
+        },
+        {
+          find: 'dev/tailwind',
+          replacement: path.resolve(__dirname, './src/tailwind/tailwind.config.ts'),
+        },
+        {
+          find: 'dev/postcss',
+          replacement: path.resolve(__dirname, './src/postcss/postcss.config.ts'),
+        },
+        { find: 'dev/vite', replacement: path.resolve(__dirname, './src/vite/vite.shared.ts') },
+        {
+          find: 'dev/vitest',
+          replacement: path.resolve(__dirname, './src/vitest/create-config.ts'),
+        },
+        { find: 'dev/biome', replacement: path.resolve(__dirname, './src/biome/biome.config.ts') },
+        {
+          find: 'dev/code-validator',
+          replacement: path.resolve(__dirname, './src/code-validator/index.ts'),
+        },
+        {
+          find: '@revealui/dev/vitest',
+          replacement: path.resolve(__dirname, './src/vitest/create-config.ts'),
+        },
+        {
+          find: '@revealui/dev/tailwind/create-config',
+          replacement: path.resolve(__dirname, './src/tailwind/create-config.ts'),
+        },
+        {
+          find: '@revealui/dev/tailwind',
+          replacement: path.resolve(__dirname, './src/tailwind/tailwind.config.ts'),
+        },
+        {
+          find: '@revealui/dev/postcss',
+          replacement: path.resolve(__dirname, './src/postcss/postcss.config.ts'),
+        },
+        {
+          find: '@revealui/dev/vite',
+          replacement: path.resolve(__dirname, './src/vite/vite.shared.ts'),
+        },
+        {
+          find: '@revealui/dev/biome',
+          replacement: path.resolve(__dirname, './src/biome/biome.config.ts'),
+        },
+      ],
     },
-    pool: 'forks',
-    maxWorkers: 2,
-    coverage: {
-      provider: 'v8',
-      // Standardized reporters: text (CI logs), json (programmatic), html (local dev), lcov (Codecov)
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: ['node_modules/**', '**/*.test.ts', '**/*.spec.ts', 'dist/**', '**/__tests__/**'],
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
+    test: {
+      env: {
+        VITEST: 'true',
+        NODE_ENV: 'test',
       },
     },
   },

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -1,21 +1,16 @@
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    pool: 'forks',
-    maxWorkers: 2,
-    setupFiles: ['./src/__tests__/setup.ts'],
-    testTimeout: 15_000,
-    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.ts', 'src/**/*.tsx'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/__tests__/**'],
+export default createVitestConfig({
+  environment: 'jsdom',
+  testTimeout: 15_000,
+  include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  coverageInclude: ['src/**/*.ts', 'src/**/*.tsx'],
+  coverageExclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/__tests__/**'],
+  overrides: {
+    plugins: [react()],
+    test: {
+      setupFiles: ['./src/__tests__/setup.ts'],
     },
   },
 });

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -1,5 +1,5 @@
-import react from '@vitejs/plugin-react';
 import { createVitestConfig } from '@revealui/dev/vitest';
+import react from '@vitejs/plugin-react';
 
 export default createVitestConfig({
   environment: 'jsdom',

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -18,6 +18,11 @@
   "peerDependencies": {
     "typescript": "^6.0.2"
   },
+  "devDependencies": {
+    "@revealui/dev": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./users": "./src/users/index.ts",

--- a/packages/engines/vitest.config.ts
+++ b/packages/engines/vitest.config.ts
@@ -1,8 +1,6 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-  },
+export default createVitestConfig({
+  // Engines facade is thin; no coverage thresholds enforced yet.
+  coverage: false,
 });

--- a/packages/harnesses/vitest.config.ts
+++ b/packages/harnesses/vitest.config.ts
@@ -1,35 +1,24 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    hookTimeout: 90_000,
-    testTimeout: 90_000,
-    environment: 'node',
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.ts'],
-      exclude: [
-        'src/**/*.test.ts',
-        'src/**/*.spec.ts',
-        'src/**/__tests__/**',
-        'src/types/**',
-        'src/workboard/workboard-protocol.ts',
-        'src/workboard/index.ts',
-        'src/cli.ts',
-        'src/detection/process-detector.ts',
-        'dist/**',
-        'node_modules/**',
-      ],
-      thresholds: {
-        statements: 40,
-        branches: 25,
-        functions: 40,
-        lines: 40,
-      },
-    },
+export default createVitestConfig({
+  hookTimeout: 90_000,
+  testTimeout: 90_000,
+  coverageExclude: [
+    'src/**/*.test.ts',
+    'src/**/*.spec.ts',
+    'src/**/__tests__/**',
+    'src/types/**',
+    'src/workboard/workboard-protocol.ts',
+    'src/workboard/index.ts',
+    'src/cli.ts',
+    'src/detection/process-detector.ts',
+    'dist/**',
+    'node_modules/**',
+  ],
+  thresholds: {
+    statements: 40,
+    branches: 25,
+    functions: 40,
+    lines: 40,
   },
 });

--- a/packages/knowledge-graph/vitest.config.ts
+++ b/packages/knowledge-graph/vitest.config.ts
@@ -1,19 +1,8 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json'],
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/cli/**'],
-    },
-  },
+export default createVitestConfig({
+  testTimeout: 30_000,
+  hookTimeout: 30_000,
+  coverageReporters: ['text', 'json'],
+  coverageExclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/cli/**'],
 });

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,7 +31,8 @@
     "@electric-sql/pglite": "catalog:",
     "pg": "catalog:",
     "typescript": "catalog:",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "@revealui/dev": "workspace:*"
   },
   "engines": {
     "node": ">=24.13.0"

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,25 +1,17 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  resolve: {
-    conditions: ['import', 'module', 'browser', 'default'],
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    hookTimeout: 30000,
-    include: ['__tests__/**/*.test.ts', 'src/**/*.test.ts'],
-    env: {
-      // Set NODE_ENV to 'test' to skip integration tests that require database setup
-      // Integration tests will check for TEST_DATABASE_URL and skip if not present
-      NODE_ENV: 'test',
+export default createVitestConfig({
+  hookTimeout: 30_000,
+  include: ['__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+  coverageExclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/__tests__/**'],
+  overrides: {
+    resolve: {
+      conditions: ['import', 'module', 'browser', 'default'],
     },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/__tests__/**'],
+    test: {
+      env: {
+        NODE_ENV: 'test',
+      },
     },
   },
 });

--- a/packages/openapi/vitest.config.ts
+++ b/packages/openapi/vitest.config.ts
@@ -1,12 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
-  },
-});
+export default createVitestConfig();

--- a/packages/presentation/vitest.config.ts
+++ b/packages/presentation/vitest.config.ts
@@ -1,27 +1,23 @@
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    pool: 'forks',
-    maxWorkers: 2,
-    setupFiles: ['./src/__tests__/setup.ts'],
-    testTimeout: 15_000,
-    coverage: {
-      provider: 'v8',
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
-      },
-    },
+export default createVitestConfig({
+  environment: 'jsdom',
+  testTimeout: 15_000,
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+  overrides: {
+    test: {
+      setupFiles: ['./src/__tests__/setup.ts'],
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
   },
 });

--- a/packages/resilience/vitest.config.ts
+++ b/packages/resilience/vitest.config.ts
@@ -1,23 +1,11 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    hookTimeout: 30000,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
-      },
-    },
+export default createVitestConfig({
+  hookTimeout: 30_000,
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
 });

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -26,7 +26,8 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "tsup": "^8.5.1",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "@revealui/dev": "workspace:*"
   },
   "engines": {
     "node": ">=24.13.0"

--- a/packages/router/vitest.config.ts
+++ b/packages/router/vitest.config.ts
@@ -1,19 +1,11 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    pool: 'forks',
-    maxWorkers: 2,
-    coverage: {
-      provider: 'v8',
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
-      },
-    },
+export default createVitestConfig({
+  environment: 'jsdom',
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
 });

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -9,7 +9,8 @@
     "ret": "^0.5.0"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "catalog:"
+    "@electric-sql/pglite": "catalog:",
+    "@revealui/dev": "workspace:*"
   },
   "exports": {
     ".": "./index.ts",

--- a/packages/scripts/vitest.config.ts
+++ b/packages/scripts/vitest.config.ts
@@ -4,6 +4,8 @@ import { createVitestConfig } from '@revealui/dev/vitest';
 export default createVitestConfig({
   hookTimeout: 30_000,
   coverage: false,
+  // Tests live at package-root __tests__/ (not under src/).
+  include: ['__tests__/**/*.{test,spec}.{ts,tsx}'],
   overrides: {
     resolve: {
       alias: {

--- a/packages/scripts/vitest.config.ts
+++ b/packages/scripts/vitest.config.ts
@@ -1,15 +1,14 @@
 import { resolve } from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    hookTimeout: 30000,
-    globals: true,
-    environment: 'node',
-  },
-  resolve: {
-    alias: {
-      '@revealui/contracts/security': resolve(__dirname, '../contracts/src/security/index.ts'),
+export default createVitestConfig({
+  hookTimeout: 30_000,
+  coverage: false,
+  overrides: {
+    resolve: {
+      alias: {
+        '@revealui/contracts/security': resolve(__dirname, '../contracts/src/security/index.ts'),
+      },
     },
   },
 });

--- a/packages/security/vitest.config.ts
+++ b/packages/security/vitest.config.ts
@@ -1,23 +1,10 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
-    coverage: {
-      provider: 'v8',
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/__tests__/**'],
-      thresholds: {
-        lines: 70,
-        functions: 65,
-        branches: 65,
-        statements: 70,
-      },
-    },
+export default createVitestConfig({
+  thresholds: {
+    lines: 70,
+    functions: 65,
+    branches: 65,
+    statements: 70,
   },
 });

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -1,47 +1,35 @@
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      services: path.resolve(__dirname, './src'),
-      'services/server': path.resolve(__dirname, './src/index.ts'),
-    },
+export default createVitestConfig({
+  include: ['__tests__/**/*.test.ts', '**/*.test.ts'],
+  coverageExclude: [
+    'node_modules/**',
+    '**/*.test.ts',
+    '**/*.spec.ts',
+    'dist/**',
+    '**/__tests__/**',
+  ],
+  thresholds: {
+    statements: 65,
+    branches: 50,
+    functions: 70,
+    lines: 65,
   },
-  define: {
-    // Mock import.meta.env for webhook tests
-    // This replaces import.meta.env.STRIPE_WEBHOOK_SECRET at build time
-    'import.meta.env.STRIPE_WEBHOOK_SECRET': JSON.stringify(
-      process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test_secret',
-    ),
-    'import.meta.env.STRIPE_WEBHOOK_SECRET_LIVE': JSON.stringify(
-      process.env.STRIPE_WEBHOOK_SECRET_LIVE || undefined,
-    ),
-  },
-  test: {
-    include: ['__tests__/**/*.test.ts', '**/*.test.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**'],
-    environment: 'node',
-    globals: true,
-    pool: 'forks',
-    maxWorkers: 2,
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: ['node_modules/**', '**/*.test.ts', '**/*.spec.ts', 'dist/**', '**/__tests__/**'],
-      thresholds: {
-        // Honest bar restored 2026-05-23. #1032 removed the revealcoin module +
-        // its 1,656 lines of tests, which had masked pre-existing gaps in
-        // src/email/index.ts and src/stripe/payment-intent.ts; #1043 had
-        // temporarily lowered the floors to current-actuals as a stopgap. This
-        // PR adds payment-intent + email-service failure-path tests, bringing
-        // package coverage to ~87.5/82.8/79/87.9 — so the pre-#1032 bar is
-        // restored rather than left lowered (closes GAP-211).
-        statements: 65,
-        branches: 50,
-        functions: 70,
-        lines: 65,
+  overrides: {
+    resolve: {
+      alias: {
+        services: path.resolve(__dirname, './src'),
+        'services/server': path.resolve(__dirname, './src/index.ts'),
       },
+    },
+    define: {
+      'import.meta.env.STRIPE_WEBHOOK_SECRET': JSON.stringify(
+        process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test_secret',
+      ),
+      'import.meta.env.STRIPE_WEBHOOK_SECRET_LIVE': JSON.stringify(
+        process.env.STRIPE_WEBHOOK_SECRET_LIVE || undefined,
+      ),
     },
   },
 });

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -30,7 +30,8 @@
     "@types/node": "catalog:",
     "tsup": "^8.5.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@revealui/dev": "workspace:*"
   },
   "engines": {
     "node": ">=24.13.0"

--- a/packages/setup/vitest.config.ts
+++ b/packages/setup/vitest.config.ts
@@ -1,19 +1,10 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    coverage: {
-      provider: 'v8',
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
-      },
-    },
+export default createVitestConfig({
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
 });

--- a/packages/sync/vitest.config.ts
+++ b/packages/sync/vitest.config.ts
@@ -1,42 +1,32 @@
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'jsdom', // React hooks need DOM
-    setupFiles: ['./src/test-setup.ts'],
-    // Increased timeout to prevent worker init failures under full monorepo parallel load
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
-    // Forks give each test file its own process, preventing jsdom/yjs shared-state
-    // contention when turbo runs 29 packages in parallel during CI gate
-    pool: 'forks',
-    maxWorkers: 2,
-    env: {
-      // Force in-memory storage by unsetting database URLs that may leak from direnv/nix shell
-      POSTGRES_URL: '',
-      DATABASE_URL: '',
-    },
-    maxConcurrency: 1,
-    coverage: {
-      provider: 'v8',
-      // Standardized reporters: text (CI logs), json (programmatic), html (local dev), lcov (Codecov)
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.ts', 'src/**/*.tsx'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
-      thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 55,
-        statements: 60,
-      },
-    },
+export default createVitestConfig({
+  environment: 'jsdom',
+  testTimeout: 30_000,
+  hookTimeout: 30_000,
+  coverageInclude: ['src/**/*.ts', 'src/**/*.tsx'],
+  coverageExclude: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  thresholds: {
+    lines: 60,
+    functions: 60,
+    branches: 55,
+    statements: 60,
   },
-  resolve: {
-    alias: {
-      '@revealui/db': path.resolve(__dirname, '../db/src'),
-      '@revealui/contracts': path.resolve(__dirname, '../contracts/src'),
+  overrides: {
+    test: {
+      setupFiles: ['./src/test-setup.ts'],
+      env: {
+        POSTGRES_URL: '',
+        DATABASE_URL: '',
+      },
+      maxConcurrency: 1,
+    },
+    resolve: {
+      alias: {
+        '@revealui/db': path.resolve(__dirname, '../db/src'),
+        '@revealui/contracts': path.resolve(__dirname, '../contracts/src'),
+      },
     },
   },
 });

--- a/packages/test/vitest.config.ts
+++ b/packages/test/vitest.config.ts
@@ -1,54 +1,42 @@
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      // Point to actual revealui package
-      '@revealui/core': path.resolve(__dirname, '../core/src'),
-      // Allow importing from apps
-      '@admin': path.resolve(__dirname, '../../apps/admin/src'),
-      '@api': path.resolve(__dirname, '../../apps/server/src'),
-    },
+export default createVitestConfig({
+  maxWorkers: 1,
+  hookTimeout: 30_000,
+  exclude: ['src/integration/**', 'src/integration-pro/**', '**/e2e/**', '**/node_modules/**'],
+  coverageExclude: [
+    'node_modules/**',
+    '**/*.test.ts',
+    '**/*.spec.ts',
+    'dist/**',
+    '**/__tests__/**',
+    '**/e2e/**',
+  ],
+  thresholds: {
+    lines: 35,
+    functions: 25,
+    branches: 30,
+    statements: 35,
   },
-  esbuild: {
-    // Let esbuild infer loader from file extension (.ts vs .tsx)
-    // This prevents treating TypeScript generics as JSX in .ts files
-    include: /\.(ts|tsx)$/,
-  },
-  test: {
-    // Exclude E2E tests (run separately with Playwright)
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    exclude: ['src/integration/**', 'src/integration-pro/**', '**/e2e/**', '**/node_modules/**'], // Exclude integration tests - they use separate configs
-    environment: 'node',
-    fileParallelism: false,
-    maxWorkers: 1,
-    globals: true,
-    env: {
-      VITEST: 'true',
-      NODE_ENV: 'test',
-      // Force in-memory storage by unsetting database URLs that may leak from direnv/nix shell
-      POSTGRES_URL: '',
-      DATABASE_URL: '',
+  overrides: {
+    resolve: {
+      alias: {
+        '@revealui/core': path.resolve(__dirname, '../core/src'),
+        '@admin': path.resolve(__dirname, '../../apps/admin/src'),
+        '@api': path.resolve(__dirname, '../../apps/server/src'),
+      },
     },
-    pool: 'forks',
-    hookTimeout: 30000,
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: [
-        'node_modules/**',
-        '**/*.test.ts',
-        '**/*.spec.ts',
-        'dist/**',
-        '**/__tests__/**',
-        '**/e2e/**',
-      ],
-      thresholds: {
-        lines: 35,
-        functions: 25,
-        branches: 30,
-        statements: 35,
+    esbuild: {
+      include: /\.(ts|tsx)$/,
+    },
+    test: {
+      fileParallelism: false,
+      env: {
+        VITEST: 'true',
+        NODE_ENV: 'test',
+        POSTGRES_URL: '',
+        DATABASE_URL: '',
       },
     },
   },

--- a/packages/tokens/vitest.config.ts
+++ b/packages/tokens/vitest.config.ts
@@ -1,17 +1,3 @@
-import { defineConfig } from 'vitest/config';
+import { createVitestConfig } from '@revealui/dev/vitest';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    pool: 'forks',
-    maxWorkers: 2,
-    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
-    },
-  },
-});
+export default createVitestConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1222,9 +1222,16 @@ importers:
       '@revealui/services':
         specifier: workspace:*
         version: link:../services
+    devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../dev
       typescript:
-        specifier: ^6.0.2
+        specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
       '@revealui/ai':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,6 +714,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../../packages/dev
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.5
@@ -897,6 +900,9 @@ importers:
         specifier: ^0.2.17
         version: 0.2.17
     devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../dev
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.5
@@ -1333,6 +1339,9 @@ importers:
       '@electric-sql/pglite':
         specifier: 'catalog:'
         version: 0.5.4
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../dev
       pg:
         specifier: 'catalog:'
         version: 8.22.0
@@ -1513,6 +1522,9 @@ importers:
         specifier: 4.12.27
         version: 4.12.27
     devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../dev
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1556,6 +1568,9 @@ importers:
       '@electric-sql/pglite':
         specifier: 'catalog:'
         version: 0.5.4
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../dev
 
   packages/security:
     dependencies:
@@ -1682,6 +1697,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../dev
       '@types/inquirer':
         specifier: ^9.0.9
         version: 9.0.10


### PR DESCRIPTION
## Summary
Fleet-redundancy **C5 / P2-F**: shared Vitest config factory for monorepo packages.

### Factory
- `@revealui/dev/vitest` → `createVitestConfig(options?)`
- Defaults: `globals`, `node`, `forks`, `maxWorkers: 2`, standard coverage reporters
- Parameterized: `thresholds`, `hookTimeout`, `environment`, `include`/`exclude`, `overrides` (via `mergeConfig`)

### First cohort (spec: first 5, plus security)
| Package | Notes |
|---------|--------|
| `@revealui/openapi` | defaults |
| `@revealui/tokens` | defaults |
| `@revealui/engines` | `coverage: false` (thin facade) |
| `@revealui/cache` | thresholds + hookTimeout |
| `@revealui/resilience` | thresholds + hookTimeout |
| `@revealui/security` | package thresholds |

### Verify
- [x] `@revealui/dev` tests: 53 passed
- [x] migrated packages that resolve in worktree: tokens, cache, resilience, security green
- [x] openapi one-file fail is pre-existing (`@revealui/mcp/contracts-server` dist missing without full monorepo build)
- [x] local phase-1 gate PASS

### Follow-up
Batch remaining ~20 `vitest.config.ts` files onto the factory (Phase 5 fleet rollout).