### PR TITLE
ci(security): drop residual pull_request trigger on review gate (GAP-376)

### DIFF
--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -1,4 +1,4 @@
-# Security review gate — review-before-merge enforcement (GAP-376 cutover).
+# Security review gate — review-before-merge enforcement (GAP-376 complete).
 #
 # Provenance: pull_request_target runs the WORKFLOW DEFINITION from the BASE
 # ref, so a PR cannot rewrite this file for its own evaluation. Scripts still
@@ -10,16 +10,11 @@
 #   A1 — check-run attaches to PR head SHA (#2110)
 #   A2 — payload/verdict parity with prior pull_request gate (#2110)
 #   A3 — workflow-edit self-pass fails on _target base copy (#2113 closed)
+# Cutover: #2114. Residual pull_request dual-trigger removed in this file.
 #
-# Rename-in-place: job name stays "Security review gate" so the protect-main-
-# test ruleset required context needs no owner edit.
-#
-# Dual-trigger residual (intentional, short-lived): pull_request remains so
-# this cutover PR (and the first post-land residual) still report the required
-# context from the merge-ref path. A follow-up PR removes pull_request only;
-# after that, _target alone is the enforcement path. pull_request_review has
-# no _target form — re-eval via labels until org-migration companion (design
-# §Review-trigger).
+# Job name stays "Security review gate" (ruleset required context; rename-
+# in-place). pull_request_review has no _target form — re-eval via labels
+# until org-migration companion (design §Review-trigger).
 #
 # Permissions stay least-privilege: pull_request_target defaults are wider.
 
@@ -27,10 +22,6 @@ name: Security Review Gate
 
 on:
   pull_request_target:
-    branches: [test, main]
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-  # Residual dual-trigger — remove in follow-up PR after this lands on test.
-  pull_request:
     branches: [test, main]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 


### PR DESCRIPTION
## Summary

Follow-up to #2114. Removes the intentional dual-trigger residual so **only** `pull_request_target` runs the Security review gate.

| Before (#2114) | After (this PR) |
|----------------|-----------------|
| `pull_request_target` + `pull_request` | **`pull_request_target` only** |
| Job name `Security review gate` | unchanged (ruleset OK) |

### Why this is safe to merge

While this PR is open, the **base** branch still has `pull_request_target` with job name `Security review gate` (#2114). That base workflow evaluates this PR (HOLD without verdict → clear with `sec-review:approved`). Head cannot rewrite the base definition.

After land: head workflow edits (A3 class) cannot self-pass the required check.

### GAP-376 status after this lands

| Rollout step | Status |
|--------------|--------|
| Shadow | #2112 |
| A1–A3 | #2110 / #2113 |
| Cutover | #2114 |
| Retire `pull_request` | **this PR** |
| `pull_request_review` companion | deferred (org-migration) |

## Test plan

- [ ] Security review gate HOLDs (security path) via base `_target`
- [ ] Provenance log: `event_name=pull_request_target`, `workflow_ref=…@refs/heads/test`
- [ ] No `pull_request` Security Review Gate run for this PR after land (only `_target`)

## Owner actions

```bash
gh api -X POST repos/RevealUIStudio/revealui/issues/<N>/labels -f name='sec-review:approved'
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```