### PR TITLE
feat(mcp,ai,server): GAP-355 Stage 5 S5-1+S5-2 agent audit emit

### DIFF
--- a/apps/server/src/lib/agent-dispatcher.ts
+++ b/apps/server/src/lib/agent-dispatcher.ts
@@ -53,6 +53,7 @@ export async function buildDispatcher(
   const aiMod = await import('@revealui/ai').catch(() => null);
   if (!aiMod) return null;
 
+  const auditStore = createAuditStore(db);
   let llmClient: unknown;
   try {
     // Resolve the client through the single GAP-360 resolver. A durable audit
@@ -61,7 +62,7 @@ export async function buildDispatcher(
     llmClient = await aiMod.resolveLLMClientForRequest(resolution.userId, db, {
       isHosted: resolution.isHosted,
       workspaceId: resolution.workspaceId,
-      auditStore: createAuditStore(db),
+      auditStore,
     });
   } catch (err) {
     if ((err as { code?: unknown } | null)?.code === 'LLM_NOT_CONFIGURED') throw err;
@@ -95,11 +96,79 @@ export async function buildDispatcher(
   // Type assertions: TicketAgentDispatcher comes from the Pro package via
   // dynamic import; the runtime shape matches Dispatcher.
   type DispatcherConfig = ConstructorParameters<typeof aiMod.TicketAgentDispatcher>[0];
-  return new aiMod.TicketAgentDispatcher({
+  const inner = new aiMod.TicketAgentDispatcher({
     llmClient: llmClient as DispatcherConfig['llmClient'],
     apiClient,
     ticketClient,
   }) as unknown as Dispatcher;
+
+  // GAP-355 Stage 5: wrap dispatch with task lifecycle audit rows (ONE DOOR).
+  // Fail closed if start cannot be recorded. Tenant = workspaceId when present.
+  const tenant = resolution.workspaceId ?? null;
+
+  return {
+    async dispatch(ticket, options) {
+      const startId = crypto.randomUUID();
+      await auditStore.append({
+        id: startId,
+        timestamp: new Date(),
+        eventType: 'agent:task:started',
+        severity: 'info',
+        agentId: 'ticket-agent-dispatcher',
+        taskId: ticket.id,
+        sessionId: options?.dispatchId,
+        payload: {
+          title: ticket.title,
+          userId: resolution.userId,
+          isHosted: resolution.isHosted,
+        },
+        policyViolations: [],
+        tenant,
+      });
+
+      try {
+        const result = await inner.dispatch(ticket, options);
+        await auditStore.append({
+          id: crypto.randomUUID(),
+          timestamp: new Date(),
+          eventType: result.success ? 'agent:task:completed' : 'agent:task:failed',
+          severity: result.success ? 'info' : 'warn',
+          agentId: 'ticket-agent-dispatcher',
+          taskId: ticket.id,
+          sessionId: options?.dispatchId,
+          payload: {
+            success: result.success,
+            tokensUsed: result.metadata?.tokensUsed,
+            executionTime: result.metadata?.executionTime,
+          },
+          policyViolations: [],
+          tenant,
+        });
+        return result;
+      } catch (err) {
+        try {
+          await auditStore.append({
+            id: crypto.randomUUID(),
+            timestamp: new Date(),
+            eventType: 'agent:task:failed',
+            severity: 'warn',
+            agentId: 'ticket-agent-dispatcher',
+            taskId: ticket.id,
+            sessionId: options?.dispatchId,
+            payload: {
+              success: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            policyViolations: [],
+            tenant,
+          });
+        } catch {
+          // Prefer original dispatch error if completion audit also fails
+        }
+        throw err;
+      }
+    },
+  };
 }
 
 /**

--- a/apps/server/src/lib/agent-tool-audit.ts
+++ b/apps/server/src/lib/agent-tool-audit.ts
@@ -1,0 +1,75 @@
+/**
+ * Agent MCP tool audit writer (GAP-355 Stage 5 S5-2).
+ *
+ * Maps agent-stream MCP tool-call summaries onto the ONE DOOR
+ * (`createAuditStore` → signed `audit_log` rows). Throws when the write
+ * fails so the adapter can fail closed after a successful tool RPC.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { classifyAuditWriteFailure, recordAuditWriteResult } from '@revealui/core/security';
+import { getClient } from '@revealui/db';
+import type { Database } from '@revealui/db/client';
+import { createAuditStore } from './audit-signer.js';
+
+export interface AgentMcpToolAuditInput {
+  /** MCP server namespace (tenant server id). */
+  namespace: string;
+  toolName: string;
+  success: boolean;
+  durationMs: number;
+  error?: string;
+  /** Session / run id for the agent stream. */
+  sessionId?: string;
+  /** Account tenant for Stage 4 anchoring when known. */
+  accountId?: string | null;
+  /** Authenticated user driving the agent. */
+  userId?: string | null;
+  agentId?: string;
+  taskId?: string;
+  db?: Database;
+}
+
+/**
+ * Append one agent MCP tool receipt. Throws on write failure (fail-closed).
+ */
+export async function recordAgentMcpToolAudit(input: AgentMcpToolAuditInput): Promise<void> {
+  const id = randomUUID();
+  const eventType = 'agent:tool:called';
+  const severity = input.success ? 'info' : 'warn';
+  const agentId = input.agentId ?? `agent-stream:${input.namespace}`;
+
+  const payload: Record<string, unknown> = {
+    namespace: input.namespace,
+    tool: input.toolName,
+    success: input.success,
+    durationMs: input.durationMs,
+  };
+  if (input.error !== undefined) payload.error = input.error;
+  if (input.userId !== undefined) payload.userId = input.userId;
+  if (input.accountId !== undefined) payload.accountId = input.accountId;
+
+  try {
+    await createAuditStore(input.db ?? getClient()).append({
+      id,
+      timestamp: new Date(),
+      eventType,
+      severity,
+      agentId,
+      ...(input.taskId !== undefined ? { taskId: input.taskId } : {}),
+      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+      payload,
+      policyViolations: [],
+      tenant: input.accountId ?? null,
+    });
+    recordAuditWriteResult({ ok: true, eventId: id, eventType });
+  } catch (err) {
+    recordAuditWriteResult({
+      ok: false,
+      reason: classifyAuditWriteFailure(err),
+      eventId: id,
+      eventType,
+    });
+    throw err;
+  }
+}

--- a/apps/server/src/routes/__tests__/agent-tasks.test.ts
+++ b/apps/server/src/routes/__tests__/agent-tasks.test.ts
@@ -56,6 +56,24 @@ import agentTasksApp from '../agent-tasks.js';
 const mb = vi.mocked(boardQueries);
 const mt = vi.mocked(ticketQueries);
 
+/** Rows written via mockDbInsert, keyed by drizzle table name (GAP-355 audit vs memory). */
+const insertedByTable = {
+  agentMemories: [] as Array<Record<string, unknown>>,
+  auditLog: [] as Array<Record<string, unknown>>,
+};
+
+/** Read `Symbol(drizzle:Name)` without importing schema tables (keeps the test light). */
+function drizzleTableName(table: unknown): string | undefined {
+  if (!table || typeof table !== 'object') return undefined;
+  for (const sym of Object.getOwnPropertySymbols(table)) {
+    if (String(sym) === 'Symbol(drizzle:Name)') {
+      const name = (table as Record<symbol, unknown>)[sym];
+      return typeof name === 'string' ? name : undefined;
+    }
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Env setup  -  provide a fake API key so buildDispatcher returns a dispatcher
 // ---------------------------------------------------------------------------
@@ -63,8 +81,19 @@ const mt = vi.mocked(ticketQueries);
 beforeEach(() => {
   vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test');
   vi.stubEnv('ADMIN_URL', 'http://localhost:4000');
+  insertedByTable.agentMemories.length = 0;
+  insertedByTable.auditLog.length = 0;
   mockDbInsert.mockClear();
-  mockDbInsert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+  // GAP-355 S5: TicketAgentDispatcher path also inserts audit_log (start + complete/fail).
+  // Capture every insert by table so memory assertions are not polluted by audit rows.
+  mockDbInsert.mockImplementation((table: unknown) => ({
+    values: vi.fn(async (row: unknown) => {
+      const payload = row as Record<string, unknown>;
+      const name = drizzleTableName(table);
+      if (name === 'agent_memories') insertedByTable.agentMemories.push(payload);
+      if (name === 'audit_log') insertedByTable.auditLog.push(payload);
+    }),
+  }));
 });
 
 afterEach(() => {
@@ -242,24 +271,24 @@ describe('POST /  -  submit agent task', () => {
   });
 
   it('persists agent output to agent_memories table on success', async () => {
-    const mockValues = vi.fn().mockResolvedValue(undefined);
-    mockDbInsert.mockReturnValueOnce({ values: mockValues });
-
     mb.getBoardById.mockResolvedValue(makeBoard() as never);
     mt.createTicket.mockResolvedValue(makeTicket() as never);
     mt.getTicketById.mockResolvedValue(makeTicket({ status: 'done' }) as never);
     const app = createApp();
     await app.request('/', post({ instruction: 'Publish blog post', boardId: 'board-1' }));
 
-    // db.insert(agentMemories) must have been called once with the agent output
-    expect(mockDbInsert).toHaveBeenCalledOnce();
-    const insertedRow = mockValues.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(insertedRow).toBeDefined();
+    // Memory insert is independent of GAP-355 task audit_log rows (start + complete).
+    expect(insertedByTable.agentMemories).toHaveLength(1);
+    const insertedRow = insertedByTable.agentMemories[0] as Record<string, unknown>;
     expect(insertedRow.content).toBe('Agent completed the task.');
     expect(insertedRow.type).toBe('decision');
     expect(typeof insertedRow.agentId).toBe('string');
     expect(insertedRow.agentId as string).toContain('ticket-agent-');
     expect((insertedRow.metadata as Record<string, unknown>).success).toBe(true);
+
+    // Lifecycle audit: started + completed via ONE DOOR
+    const eventTypes = insertedByTable.auditLog.map((r) => r.eventType);
+    expect(eventTypes).toEqual(['agent:task:started', 'agent:task:completed']);
   });
 
   it('does not insert agent_memories when agent returns no output', async () => {
@@ -271,7 +300,12 @@ describe('POST /  -  submit agent task', () => {
     const app = createApp();
     await app.request('/', post({ instruction: 'Publish blog post', boardId: 'board-1' }));
 
-    expect(mockDbInsert).not.toHaveBeenCalled();
+    expect(insertedByTable.agentMemories).toHaveLength(0);
+    // Task still audited even when there is no memory payload
+    expect(insertedByTable.auditLog.map((r) => r.eventType)).toEqual([
+      'agent:task:started',
+      'agent:task:completed',
+    ]);
   });
 
   it('marks ticket blocked when agent fails', async () => {

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -27,6 +27,7 @@ import {
   createAgentRunSession,
   deleteAgentRunSession,
 } from '../lib/agent-run-sessions.js';
+import { recordAgentMcpToolAudit } from '../lib/agent-tool-audit.js';
 import { createAuditStore } from '../lib/audit-signer.js';
 import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
 import { recordUsageMeter } from '../lib/metering.js';
@@ -275,6 +276,8 @@ app.openapi(agentStreamRoute, async (c) => {
   const accountId = getEntitlementsFromContext(c).accountId;
   const runSession = createAgentRunSession(user.id);
   const streamRef: { current: SSEStreamingApi | undefined } = { current: undefined };
+  // Late-bound task id for tool-audit rows (task object is built after MCP tools).
+  const taskRef: { id: string } = { id: `task-${Date.now()}` };
 
   const loggerSink = aiMod.createCoreLoggerSink();
   const meterSink = accountId
@@ -418,6 +421,21 @@ app.openapi(agentStreamRoute, async (c) => {
         const mcpTools = await aiMod.createToolsFromMcpClient(built.client, {
           namespace: server,
           onEvent,
+          // GAP-355 S5-2: integrity audit (awaited, fail-closed on success).
+          onToolAudit: async (event) => {
+            await recordAgentMcpToolAudit({
+              namespace: event.namespace,
+              toolName: event.toolName,
+              success: event.success,
+              durationMs: event.duration_ms,
+              ...(event.error !== undefined ? { error: event.error } : {}),
+              sessionId: runSession.sessionId,
+              accountId,
+              userId: user.id,
+              agentId: mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent',
+              taskId: taskRef.id,
+            });
+          },
         });
         mcpClients.push(built.client);
         allTools.push(...mcpTools);
@@ -473,7 +491,7 @@ Workspace: ${workspaceId}`,
   };
 
   const task = {
-    id: `task-${Date.now()}`,
+    id: taskRef.id,
     type: 'instruction',
     description: body.instruction,
   };
@@ -482,6 +500,9 @@ Workspace: ${workspaceId}`,
     maxIterations: 10,
     timeout: 120_000,
   });
+
+  const streamAgentId = mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent';
+  const auditStore = createAuditStore(getClient());
 
   return streamSSE(c, async (stream) => {
     const controller = new AbortController();
@@ -503,6 +524,39 @@ Workspace: ${workspaceId}`,
       }),
     });
 
+    // GAP-355 S5-2: task start — fail closed if we cannot record.
+    try {
+      await auditStore.append({
+        id: crypto.randomUUID(),
+        timestamp: new Date(),
+        eventType: 'agent:task:started',
+        severity: 'info',
+        agentId: streamAgentId,
+        taskId: task.id,
+        sessionId: runSession.sessionId,
+        payload: {
+          mode,
+          userId: user.id,
+          instructionPreview: body.instruction.slice(0, 200),
+        },
+        policyViolations: [],
+        tenant: accountId ?? null,
+      });
+    } catch (startAuditErr) {
+      await stream.writeSSE({
+        data: JSON.stringify({
+          type: 'error',
+          error:
+            startAuditErr instanceof Error
+              ? `Audit start failed: ${startAuditErr.message}`
+              : 'Audit start failed',
+        }),
+        event: 'error',
+      });
+      return;
+    }
+
+    let taskOk = false;
     try {
       // llmClient is typed as unknown because it comes from dynamically imported Pro packages;
       // the runtime type is LLMClient when present.
@@ -518,7 +572,11 @@ Workspace: ${workspaceId}`,
           event: chunk.type,
         });
 
-        if (chunk.type === 'done' || chunk.type === 'error') break;
+        if (chunk.type === 'done') {
+          taskOk = true;
+          break;
+        }
+        if (chunk.type === 'error') break;
       }
     } catch (error) {
       await stream.writeSSE({
@@ -529,6 +587,22 @@ Workspace: ${workspaceId}`,
         event: 'error',
       });
     } finally {
+      try {
+        await auditStore.append({
+          id: crypto.randomUUID(),
+          timestamp: new Date(),
+          eventType: taskOk ? 'agent:task:completed' : 'agent:task:failed',
+          severity: taskOk ? 'info' : 'warn',
+          agentId: streamAgentId,
+          taskId: task.id,
+          sessionId: runSession.sessionId,
+          payload: { success: taskOk, mode },
+          policyViolations: [],
+          tenant: accountId ?? null,
+        });
+      } catch {
+        // Completion audit best-effort after stream ends
+      }
       // Tear down any MCP clients we connected at handler entry so
       // sockets + OAuth-refresh timers don't leak across requests.
       for (const client of mcpClients) {

--- a/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
@@ -831,3 +831,137 @@ describe('createToolsFromMcpClient — onEvent', () => {
     expect(sink).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GAP-355 Stage 5 S5-2 — onToolAudit integrity hook (awaited, fail-closed)
+// ---------------------------------------------------------------------------
+
+describe('createToolsFromMcpClient — onToolAudit', () => {
+  it('awaits onToolAudit after a successful server tool call', async () => {
+    const order: string[] = [];
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => {
+        order.push('rpc');
+        return { content: [{ type: 'text', text: 'ok' }] };
+      },
+    );
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onToolAudit: async (e) => {
+        order.push('audit');
+        expect(e).toMatchObject({
+          kind: 'mcp.tool.call',
+          namespace: 'srv',
+          toolName: 'noop',
+          success: true,
+        });
+      },
+    });
+    const result = await tools[0]?.execute({});
+
+    expect(result?.success).toBe(true);
+    expect(order).toEqual(['rpc', 'audit']);
+  });
+
+  it('fails closed: successful tool RPC + audit throw does not return success', async () => {
+    const client = makeClient(
+      [{ name: 'write_thing', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [{ type: 'text', text: 'written' }] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onToolAudit: async () => {
+        throw new Error('audit write failed');
+      },
+    });
+
+    await expect(tools[0]?.execute({})).rejects.toThrow(/audit write failed/);
+  });
+
+  it('still returns tool failure when audit throws on an already-failed call', async () => {
+    const client = makeClient(
+      [{ name: 'flaky', inputSchema: { type: 'object', properties: {} } }],
+      async () => {
+        throw new Error('transport broke');
+      },
+    );
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onToolAudit: async () => {
+        throw new Error('audit write failed');
+      },
+    });
+    const result = await tools[0]?.execute({});
+
+    expect(result).toEqual({ success: false, error: 'transport broke' });
+  });
+
+  it('audits isError tool results without failing the ToolResult shape', async () => {
+    const audited: Array<Record<string, unknown>> = [];
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ isError: true, content: [{ type: 'text', text: 'server rejected' }] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      onToolAudit: async (e) => {
+        audited.push(e as unknown as Record<string, unknown>);
+      },
+    });
+    const result = await tools[0]?.execute({});
+
+    expect(result).toEqual({ success: false, error: 'server rejected' });
+    expect(audited).toHaveLength(1);
+    expect(audited[0]).toMatchObject({
+      success: false,
+      toolName: 'noop',
+      error: 'server rejected',
+    });
+  });
+
+  it('does not call onToolAudit for resource/prompt meta-tools', async () => {
+    const onToolAudit = vi.fn(async () => undefined);
+    const client = makeFullClient({
+      resources: [{ uri: 'x://1', name: 'one' }],
+      resourceContents: { 'x://1': [{ uri: 'x://1', text: 'body' }] },
+      prompts: [{ name: 'greet' }],
+      promptResults: {
+        greet: { messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }] },
+      },
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      include: { tools: false, resources: true, prompts: true },
+      onToolAudit,
+    });
+
+    for (const tool of tools) {
+      if (tool.name.endsWith('__read_resource')) {
+        await tool.execute({ uri: 'x://1' });
+      } else if (tool.name.endsWith('__get_prompt')) {
+        await tool.execute({ name: 'greet' });
+      } else {
+        await tool.execute({});
+      }
+    }
+
+    expect(onToolAudit).not.toHaveBeenCalled();
+  });
+
+  it('works without onToolAudit — success path unchanged', async () => {
+    const client = makeClient(
+      [{ name: 'noop', inputSchema: { type: 'object', properties: {} } }],
+      async () => ({ content: [] }),
+    );
+
+    const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
+    const result = await tools[0]?.execute({});
+    expect(result?.success).toBe(true);
+  });
+});

--- a/packages/ai/src/tools/mcp-adapter.ts
+++ b/packages/ai/src/tools/mcp-adapter.ts
@@ -23,7 +23,7 @@
 
 import { z } from 'zod/v4';
 import type { Tool, ToolResult } from './base.js';
-import { emitMcpEvent, type McpEventSink } from './mcp-events.js';
+import { emitMcpEvent, type McpEventSink, type McpToolCallEvent } from './mcp-events.js';
 
 export interface MCPTool {
   name: string;
@@ -197,6 +197,14 @@ export interface CreateToolsFromMcpClientOptions {
    * Safe to pass a throwing sink — adapter swallows sink errors.
    */
   onEvent?: McpEventSink;
+  /**
+   * Integrity audit hook (GAP-355 Stage 5). Fires once per **server tool**
+   * call with the same summary shape as `mcp.tool.call` events. Unlike
+   * `onEvent`, this is **awaited** and **rethrows** so a failed audit write
+   * fails the tool execution (fail-closed). Resource/prompt meta-tools are
+   * not audited here (inventory residual S5-4).
+   */
+  onToolAudit?: (event: McpToolCallEvent) => void | Promise<void>;
 }
 
 /** Spec-shaped `Progress` notification subset. */
@@ -263,6 +271,7 @@ export async function createToolsFromMcpClient(
     ...(options.onProgress !== undefined ? { onProgress: options.onProgress } : {}),
     ...(options.signal !== undefined ? { signal: options.signal } : {}),
     ...(options.onEvent !== undefined ? { onEvent: options.onEvent } : {}),
+    ...(options.onToolAudit !== undefined ? { onToolAudit: options.onToolAudit } : {}),
   };
 
   const tools: Tool[] = [];
@@ -302,6 +311,13 @@ interface BuildToolContext {
   onProgress?: (event: McpProgressEvent) => void;
   signal?: AbortSignal;
   onEvent?: McpEventSink;
+  onToolAudit?: (event: McpToolCallEvent) => void | Promise<void>;
+}
+
+/** Await integrity audit; rethrow so unrecorded tool success cannot complete. */
+async function awaitToolAudit(ctx: BuildToolContext, event: McpToolCallEvent): Promise<void> {
+  if (!ctx.onToolAudit) return;
+  await ctx.onToolAudit(event);
 }
 
 /**
@@ -338,6 +354,10 @@ function buildServerTool(
     async execute(params: unknown): Promise<ToolResult> {
       const validated = zodSchema.parse(params);
       const started = Date.now();
+      let toolSucceeded = false;
+      let errorText: string | undefined;
+      let payload: unknown;
+
       try {
         const result = await client.callTool(
           descriptor.name,
@@ -345,38 +365,37 @@ function buildServerTool(
           buildRequestOptions(ctx, descriptor.name),
         );
         if (result.isError) {
-          const errorText = extractErrorText(result);
-          emitMcpEvent(ctx.onEvent, {
-            kind: 'mcp.tool.call',
-            namespace: ctx.namespace,
-            toolName: descriptor.name,
-            duration_ms: Date.now() - started,
-            success: false,
-            error: errorText,
-          });
-          return { success: false, error: errorText };
+          errorText = extractErrorText(result);
+        } else {
+          toolSucceeded = true;
+          payload = result.structuredContent ?? result.content;
         }
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.tool.call',
-          namespace: ctx.namespace,
-          toolName: descriptor.name,
-          duration_ms: Date.now() - started,
-          success: true,
-        });
-        const payload = result.structuredContent ?? result.content;
-        return { success: true, data: serializeMCPResult(payload) };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.tool.call',
-          namespace: ctx.namespace,
-          toolName: descriptor.name,
-          duration_ms: Date.now() - started,
-          success: false,
-          error: message,
-        });
-        return { success: false, error: message };
+        errorText = error instanceof Error ? error.message : String(error);
       }
+
+      const event: McpToolCallEvent = {
+        kind: 'mcp.tool.call',
+        namespace: ctx.namespace,
+        toolName: descriptor.name,
+        duration_ms: Date.now() - started,
+        success: toolSucceeded,
+        ...(errorText !== undefined ? { error: errorText } : {}),
+      };
+      emitMcpEvent(ctx.onEvent, event);
+
+      if (toolSucceeded) {
+        // Integrity: unrecorded success must not complete as success.
+        await awaitToolAudit(ctx, event);
+        return { success: true, data: serializeMCPResult(payload) };
+      }
+
+      try {
+        await awaitToolAudit(ctx, event);
+      } catch {
+        // Prefer the tool failure over a secondary audit failure.
+      }
+      return { success: false, error: errorText ?? 'Tool failed' };
     },
 
     getMetadata() {

--- a/packages/mcp/src/__tests__/hypervisor.test.ts
+++ b/packages/mcp/src/__tests__/hypervisor.test.ts
@@ -634,6 +634,92 @@ describe('MCPHypervisor', () => {
   });
 
   // ===========================================================================
+  // GAP-355 Stage 5 — integrity audit sink
+  // ===========================================================================
+
+  describe('setAuditSink() + emitAudit', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('awaits audit sink after successful callTool', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      const order: string[] = [];
+      hv.setAuditSink(async () => {
+        order.push('audit');
+      });
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'do_thing', { x: 1 }).then(() => {
+        order.push('resolved');
+      });
+
+      const req = JSON.parse(String(mockProcess.stdin.write.mock.calls[0]?.[0] ?? '').trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ok: true } })}\n`),
+      );
+
+      await toolPromise;
+      expect(order).toEqual(['audit', 'resolved']);
+    });
+
+    it('fails the successful tool call when audit sink throws (fail-closed)', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      hv.setAuditSink(async () => {
+        throw new Error('audit write failed');
+      });
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'do_thing', {});
+
+      const req = JSON.parse(String(mockProcess.stdin.write.mock.calls[0]?.[0] ?? '').trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ok: true } })}\n`),
+      );
+
+      await expect(toolPromise).rejects.toThrow(/audit write failed/);
+    });
+
+    it('setAuditSink(null) disables integrity auditing', async () => {
+      vi.useFakeTimers();
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer(testConfig);
+      const { stdoutCb } = await startServerWithFakeTimers(hv);
+
+      const sink = vi.fn(async () => {
+        throw new Error('should not run');
+      });
+      hv.setAuditSink(sink);
+      hv.setAuditSink(null);
+
+      mockProcess.stdin.write.mockClear();
+      const toolPromise = hv.callTool('test-server', 'do_thing', {});
+
+      const req = JSON.parse(String(mockProcess.stdin.write.mock.calls[0]?.[0] ?? '').trim()) as {
+        id: number;
+      };
+      stdoutCb(
+        Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ok: true } })}\n`),
+      );
+
+      await expect(toolPromise).resolves.toBeDefined();
+      expect(sink).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
   // Stage 6.2 — usage metering sink
   // ===========================================================================
 

--- a/packages/mcp/src/audit-sink.ts
+++ b/packages/mcp/src/audit-sink.ts
@@ -1,0 +1,37 @@
+/**
+ * MCP hypervisor audit sink (GAP-355 Stage 5).
+ *
+ * Consumer-wired integrity hook for tool-call boundaries. Unlike
+ * `setUsageMeterSink` (fire-and-forget, never fails the call), the audit sink
+ * is **awaited**. When installed, sink failures **fail the tool call** so an
+ * action that cannot be recorded does not complete successfully.
+ *
+ * `@revealui/mcp` stays free of `@revealui/db`. Apps wire the sink to
+ * `DrizzleAuditStore` / `recordMcpToolAudit` at process boot.
+ */
+
+/**
+ * Event fired once per hypervisor tool-call boundary (success or failure).
+ * Mirrors `McpMeterEvent` plus an optional args digest (never raw args).
+ */
+export interface McpAuditEvent {
+  kind: 'mcp.tool.call';
+  serverName: string;
+  toolName: string;
+  /** Set when the call went through `callToolForTenant`. */
+  tenantId?: string;
+  duration_ms: number;
+  success: boolean;
+  error?: string;
+  /**
+   * Optional sha256 hex of canonical args. Callers that can hash safely may
+   * set this; the hypervisor leaves it unset (no raw arg capture).
+   */
+  argsDigest?: string;
+}
+
+/**
+ * Integrity audit sink. Must resolve before the tool call is treated as
+ * successfully audited. Throwing or rejecting fails the call path.
+ */
+export type McpAuditSink = (event: McpAuditEvent) => void | Promise<void>;

--- a/packages/mcp/src/hypervisor.ts
+++ b/packages/mcp/src/hypervisor.ts
@@ -22,6 +22,7 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import { registerCleanupHandler } from '@revealui/core/monitoring';
 import { logger } from '@revealui/core/observability/logger';
+import type { McpAuditEvent, McpAuditSink } from './audit-sink.js';
 import type { McpMeterEvent, McpMeterSink } from './metering.js';
 
 // =============================================================================
@@ -145,6 +146,8 @@ export class MCPHypervisor {
   private tenantServers: Map<string, ServerEntry> = new Map();
   private credentialResolver: MCPCredentialResolver | null = null;
   private meterSink: McpMeterSink | null = null;
+  /** GAP-355 Stage 5: integrity audit sink (awaited; fail-closed when set). */
+  private auditSink: McpAuditSink | null = null;
   private requestCounter = 0;
   private pendingRequests: Map<
     number,
@@ -475,6 +478,13 @@ export class MCPHypervisor {
         duration_ms: durationMs,
         success: true,
       });
+      await this.emitAudit({
+        kind: 'mcp.tool.call',
+        serverName,
+        toolName,
+        duration_ms: durationMs,
+        success: true,
+      });
 
       return result;
     } catch (error) {
@@ -494,6 +504,22 @@ export class MCPHypervisor {
         success: false,
         error: error instanceof Error ? error.message : String(error),
       });
+      try {
+        await this.emitAudit({
+          kind: 'mcp.tool.call',
+          serverName,
+          toolName,
+          duration_ms: durationMs,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } catch (auditErr) {
+        // Prefer the tool failure; still surface audit failure if tool path succeeded...
+        // here the tool already failed, so attach audit fail only as secondary log.
+        logger.warn('[MCPHypervisor] audit sink failed after tool error; rethrowing tool error', {
+          auditError: auditErr instanceof Error ? auditErr.message : String(auditErr),
+        });
+      }
       throw error;
     }
   }
@@ -542,6 +568,18 @@ export class MCPHypervisor {
   }
 
   /**
+   * Install an integrity audit sink (GAP-355 Stage 5). Unlike usage metering,
+   * the sink is **awaited**. When non-null, a throw/reject from the sink after
+   * a successful tool call **fails the call** (fail-closed: unrecorded action
+   * does not complete as success).
+   *
+   * Pass `null` to disable.
+   */
+  setAuditSink(sink: McpAuditSink | null): void {
+    this.auditSink = sink;
+  }
+
+  /**
    * Fire the consumer-wired metering sink. Swallows errors so
    * observability can never corrupt a successful tool call.
    *
@@ -566,6 +604,17 @@ export class MCPHypervisor {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  /**
+   * Await the integrity audit sink. Propagates errors (fail-closed).
+   *
+   * @internal
+   */
+  private async emitAudit(event: McpAuditEvent): Promise<void> {
+    const sink = this.auditSink;
+    if (!sink) return;
+    await sink(event);
   }
 
   // ---------------------------------------------------------------------------
@@ -757,6 +806,14 @@ export class MCPHypervisor {
         duration_ms: durationMs,
         success: true,
       });
+      await this.emitAudit({
+        kind: 'mcp.tool.call',
+        serverName,
+        toolName,
+        tenantId,
+        duration_ms: durationMs,
+        success: true,
+      });
 
       return result;
     } catch (error) {
@@ -778,6 +835,21 @@ export class MCPHypervisor {
         success: false,
         error: error instanceof Error ? error.message : String(error),
       });
+      try {
+        await this.emitAudit({
+          kind: 'mcp.tool.call',
+          serverName,
+          toolName,
+          tenantId,
+          duration_ms: durationMs,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } catch (auditErr) {
+        logger.warn('[MCPHypervisor] audit sink failed after tool error; rethrowing tool error', {
+          auditError: auditErr instanceof Error ? auditErr.message : String(auditErr),
+        });
+      }
       throw error;
     }
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -22,6 +22,8 @@ export {
   type McpDocumentOperationsRow,
   type QueryResult,
 } from './adapters/db.js';
+// Usage metering (Stage 6.2 — tool-call boundary hook, consumer-wired sink)
+export type { McpAuditEvent, McpAuditSink } from './audit-sink.js';
 // Auth bridge (JWT claims validation + tool authorization)
 export {
   authorizeToolCall,
@@ -106,7 +108,6 @@ export {
   type MCPTool,
   type NamespacedTool,
 } from './hypervisor.js';
-// Usage metering (Stage 6.2 — tool-call boundary hook, consumer-wired sink)
 export type { McpMeterEvent, McpMeterSink } from './metering.js';
 // OAuth 2.1 client provider (Stage 2 PR-2.1 — revvault-backed credential storage)
 export {


### PR DESCRIPTION
## Summary

GAP-355 Stage 5 (AUDIT THE AGENTS) — first two product PRs on one branch.

### S5-1 — Hypervisor + dispatcher
- `MCPHypervisor.setAuditSink`: awaited integrity sink; fail-closed after successful tool RPC
- `agent-dispatcher`: `agent:task:started` / `completed` / `failed` via ONE DOOR (`createAuditStore`)

### S5-2 — agent-stream MCP tools
- `createToolsFromMcpClient({ onToolAudit })`: awaited; success path rethrows on audit failure
- `recordAgentMcpToolAudit` → signed `audit_log` rows (`agent:tool:called`)
- agent-stream wires `onToolAudit` + task start (fail-closed) / complete|fail (best-effort after stream)
- tenant = accountId when known

### Tests
- hypervisor `setAuditSink` unit tests
- mcp-client-adapter `onToolAudit` fail-closed / residual (no meta-tool audit)

## Design
`.jv/docs/gap-specs/GAP-355-stage5-agent-emit-design.md` (private)

## Residual (later PRs)
- **S5-3**: deeper dispatcher/tool coverage if still gaps
- **S5-4**: admin CMS tools inventory + resource/prompt meta-tool audit decision
- **S5-5**: marketing claims only after inventory green

## Security
Sensitive (audit integrity, agent tool path). **Non-author guardrail-2 review required before merge.** Proposal-shaped: owner merges when green.

## Test plan
- [x] `pnpm --filter @revealui/ai exec vitest run src/__tests__/tools/mcp-client-adapter.test.ts` (49 pass)
- [x] hypervisor setAuditSink tests
- [x] pre-push phase-1 gate + audit ONE DOOR
- [ ] CI green on this PR
- [ ] Non-author security review