### PR TITLE
refactor(core): C3 D2-D4 logger consolidation onto utils

### DIFF
--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -2059,7 +2059,7 @@ To add new validation rules:
 
 ## Overview
 
-RevealUI has a comprehensive logging system already implemented in `@revealui/core` (`packages/core/src/utils/logger-client.ts:70`). This guide shows how to use it instead of `console.log`.
+RevealUI has a comprehensive logging system implemented in `@revealui/utils/logger` and re-exported from `@revealui/core` (`packages/core/src/observability/logger.ts:1`, ADR-008). This guide shows how to use it instead of `console.log`.
 
 ## Quick Start
 

--- a/docs/architecture/ADR-008-core-logger-consolidation.md
+++ b/docs/architecture/ADR-008-core-logger-consolidation.md
@@ -100,7 +100,10 @@ That path remains a **thin facade** over utils (plus core-only middleware helper
 - Legacy core logger modules carry a short header pointing at ADR-008 (no behavior change).
 - Fleet-redundancy plan next-action no longer lists “write C3 ADR” as open design.
 
-## Verification (future D2–D4)
+## Verification (D2–D4 — landed)
 
-- `grep` for `instance/logger` and `utils/logger-server` under `packages/core/src` (excluding tests and deprecation shims) trends to zero.
-- Client-bundle safety gate remains green (no server logger on client graphs).
+- **D2:** Production free-function call sites no longer import `instance/logger` for logging; they use `observability/logger`. `instance/logger` remains as a **varargs adapter** over utils for `RevealUIInstance.logger` / public `RevealUILogger` API only.
+- **D3:** `utils/logger-server` is a thin request-id enricher over utils (not a second ConsoleLogger). Monitoring + `@revealui/core/server` keep that path for Node-only request-id injection (cannot live in the client-safe observability barrel).
+- **D4:** `utils/logger-client` + `utils/logger` barrel re-export `@revealui/utils/logger`. One structured implementation; legacy files are facades/adapters only.
+- **Production silencing:** hard-silence of info/warn in production is retired; product logs follow utils `LOG_LEVEL` (default `info`). Documented product decision for this consolidation.
+- Client-bundle safety gate must stay green (no `logger-server` / `request-context` on client graphs).

--- a/packages/core/src/__tests__/api/rest.test.ts
+++ b/packages/core/src/__tests__/api/rest.test.ts
@@ -19,8 +19,8 @@ import type {
 // Mock the logger to suppress output during tests
 // ---------------------------------------------------------------------------
 
-vi.mock('../../instance/logger.js', () => ({
-  defaultLogger: {
+vi.mock('../../observability/logger.js', () => ({
+  logger: {
     error: vi.fn(),
     warn: vi.fn(),
     info: vi.fn(),

--- a/packages/core/src/api/rest.ts
+++ b/packages/core/src/api/rest.ts
@@ -7,7 +7,7 @@
  * Do NOT import in client-side code or edge runtime.
  */
 
-import { defaultLogger } from '../instance/logger.js';
+import { logger } from '../observability/logger.js';
 import type {
   Config,
   PopulateType,
@@ -374,7 +374,7 @@ async function handleCollectionOperation(
     const status =
       'status' in (error as { status?: number }) ? (error as { status: number }).status : 500;
     // Log error with context for debugging
-    defaultLogger.error('RevealUI Collection API Error:', {
+    logger.error('RevealUI Collection API Error:', {
       collection,
       method: request.method,
       error:
@@ -452,7 +452,7 @@ async function handleGlobalOperation(
     const status =
       'status' in (error as { status?: number }) ? (error as { status: number }).status : 500;
     // Log error with context for debugging
-    defaultLogger.error('RevealUI Global API Error:', {
+    logger.error('RevealUI Global API Error:', {
       global,
       method: request.method,
       error:
@@ -553,7 +553,7 @@ export async function handleRESTRequest(
     const message = error instanceof Error ? error.message : 'Internal server error';
 
     // Log error with context for debugging
-    defaultLogger.error('RevealUI REST API Error:', {
+    logger.error('RevealUI REST API Error:', {
       message,
       path: url.pathname,
       method: request.method,

--- a/packages/core/src/collections/operations/__tests__/concurrency.test.ts
+++ b/packages/core/src/collections/operations/__tests__/concurrency.test.ts
@@ -29,8 +29,8 @@ vi.mock('bcryptjs', () => ({
 }));
 
 // Mock defaultLogger
-vi.mock('../../../instance/logger', () => ({
-  defaultLogger: { warn: vi.fn() },
+vi.mock('../../../observability/logger', () => ({
+  logger: { warn: vi.fn() },
 }));
 
 describe('Collection CRUD concurrency', () => {

--- a/packages/core/src/collections/operations/__tests__/concurrent-access.test.ts
+++ b/packages/core/src/collections/operations/__tests__/concurrent-access.test.ts
@@ -35,8 +35,8 @@ vi.mock('bcryptjs', () => ({
 }));
 
 // Mock defaultLogger
-vi.mock('../../../instance/logger', () => ({
-  defaultLogger: { warn: vi.fn() },
+vi.mock('../../../observability/logger', () => ({
+  logger: { warn: vi.fn() },
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/collections/operations/__tests__/update.test.ts
+++ b/packages/core/src/collections/operations/__tests__/update.test.ts
@@ -26,8 +26,8 @@ vi.mock('bcryptjs', () => ({
 }));
 
 // Mock defaultLogger
-vi.mock('../../../instance/logger', () => ({
-  defaultLogger: {
+vi.mock('../../../observability/logger', () => ({
+  logger: {
     warn: vi.fn(),
   },
 }));

--- a/packages/core/src/collections/operations/update.ts
+++ b/packages/core/src/collections/operations/update.ts
@@ -5,7 +5,7 @@
  */
 
 import bcrypt from 'bcryptjs';
-import { defaultLogger } from '../../instance/logger.js';
+import { logger } from '../../observability/logger.js';
 import type {
   QueryableDatabaseAdapter,
   RevealCollectionConfig,
@@ -257,10 +257,9 @@ export async function update(
           }
         } catch (error) {
           // Log JSON parse error for debugging
-          defaultLogger.warn(
-            `[CollectionOperations] Failed to parse _json for ${tableName}.id=${id}:`,
-            error,
-          );
+          logger.warn(`[CollectionOperations] Failed to parse _json for ${tableName}.id=${id}`, {
+            error: error instanceof Error ? { message: error.message, name: error.name } : error,
+          });
           existingJson = {};
         }
       }

--- a/packages/core/src/database/__tests__/universal-postgres.test.ts
+++ b/packages/core/src/database/__tests__/universal-postgres.test.ts
@@ -48,15 +48,6 @@ vi.mock('@electric-sql/pglite', () => ({
 
 // --- Mock internal modules ---
 
-vi.mock('../../instance/logger.js', () => ({
-  defaultLogger: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
-
 vi.mock('../../observability/logger.js', () => ({
   logger: {
     info: vi.fn(),

--- a/packages/core/src/database/safe-parse.ts
+++ b/packages/core/src/database/safe-parse.ts
@@ -7,7 +7,7 @@
  * out prevents crashes from unexpected driver behavior or schema migrations.
  */
 
-import { defaultLogger } from '../instance/logger.js';
+import { logger } from '../observability/logger.js';
 import type { RevealDocument } from '../types/index.js';
 
 /**
@@ -22,14 +22,14 @@ import type { RevealDocument } from '../types/index.js';
  */
 export function safeParseRevealDocument(row: unknown): RevealDocument | null {
   if (row === null || typeof row !== 'object') {
-    defaultLogger.warn('Database row is not an object  -  skipping', { row });
+    logger.warn('Database row is not an object  -  skipping', { row });
     return null;
   }
 
   const r = row as Record<string, unknown>;
 
   if (typeof r.id !== 'string' && typeof r.id !== 'number') {
-    defaultLogger.warn('Database row missing required id field  -  skipping', {
+    logger.warn('Database row missing required id field  -  skipping', {
       keys: Object.keys(r),
     });
     return null;

--- a/packages/core/src/database/universal-postgres.ts
+++ b/packages/core/src/database/universal-postgres.ts
@@ -13,7 +13,6 @@
  */
 
 import type { Field } from '@revealui/contracts/admin';
-import { defaultLogger } from '../instance/logger.js';
 import { logger } from '../observability/logger.js';
 import type { DatabaseAdapter, DatabaseResult, QueryableDatabaseAdapter } from '../types/index.js';
 import { safeParseRevealDocuments } from './safe-parse.js';
@@ -191,9 +190,9 @@ export function universalPostgresAdapter(
         try {
           await client.query('ROLLBACK');
         } catch (rollbackErr) {
-          defaultLogger.error(
-            `${providerLabel} transaction rollback failed after error:`,
-            rollbackErr,
+          logger.error(
+            `${providerLabel} transaction rollback failed after error`,
+            rollbackErr instanceof Error ? rollbackErr : new Error(String(rollbackErr)),
           );
         }
         throw error;
@@ -279,7 +278,10 @@ export function universalPostgresAdapter(
               client.release();
             }
           } catch (error) {
-            defaultLogger.error('Neon database query error:', error);
+            logger.error(
+              'Neon database query error',
+              error instanceof Error ? error : new Error(String(error)),
+            );
             throw error;
           }
         };
@@ -338,7 +340,10 @@ export function universalPostgresAdapter(
                 client.release();
               }
             } catch (error) {
-              defaultLogger.error('Supabase database query error:', error);
+              logger.error(
+                'Supabase database query error',
+                error instanceof Error ? error : new Error(String(error)),
+              );
               throw error;
             }
           };
@@ -407,7 +412,10 @@ export function universalPostgresAdapter(
               client.release();
             }
           } catch (error) {
-            defaultLogger.error('PostgreSQL query error:', error);
+            logger.error(
+              'PostgreSQL query error',
+              error instanceof Error ? error : new Error(String(error)),
+            );
             throw error;
           }
         };
@@ -442,7 +450,10 @@ export function universalPostgresAdapter(
           // Clear promises after successful execution
           pendingCreations.length = 0;
         } catch (error) {
-          defaultLogger.error('Failed to create tables:', error);
+          logger.error(
+            'Failed to create tables',
+            error instanceof Error ? error : new Error(String(error)),
+          );
           throw error;
         }
       }
@@ -451,7 +462,10 @@ export function universalPostgresAdapter(
       try {
         await queryFn('SELECT 1', []);
       } catch (error) {
-        defaultLogger.error(`Failed to connect to ${provider} database:`, error);
+        logger.error(
+          `Failed to connect to ${provider} database`,
+          error instanceof Error ? error : new Error(String(error)),
+        );
         throw error;
       }
     },
@@ -490,7 +504,10 @@ export function universalPostgresAdapter(
             '[PGlite] Table creation failed',
             error instanceof Error ? error : new Error(String(error)),
           );
-          defaultLogger.error('Failed to create tables before query:', error);
+          logger.error(
+            'Failed to create tables before query',
+            error instanceof Error ? error : new Error(String(error)),
+          );
           throw error;
         }
       }
@@ -512,7 +529,10 @@ export function universalPostgresAdapter(
           await Promise.all(pendingCreations);
           pendingCreations.length = 0;
         } catch (error) {
-          defaultLogger.error('Failed to create tables before transaction:', error);
+          logger.error(
+            'Failed to create tables before transaction',
+            error instanceof Error ? error : new Error(String(error)),
+          );
           throw error;
         }
       }
@@ -617,8 +637,11 @@ export function universalPostgresAdapter(
                   error instanceof Error ? error : new Error(String(error)),
                   { workerId: getWorkerID(), tableName },
                 );
-                defaultLogger.error(`Failed to create table ${tableName}:`, error);
-                defaultLogger.error('SQL:', createTableSQL);
+                logger.error(
+                  `Failed to create table ${tableName}`,
+                  error instanceof Error ? error : new Error(String(error)),
+                  { sql: createTableSQL },
+                );
                 throw error;
               }
             })();
@@ -710,8 +733,11 @@ export function universalPostgresAdapter(
               } catch (error) {
                 // Remove from created set on failure so it can be retried
                 workerCreatedTables.delete(tableName);
-                defaultLogger.error(`Failed to create global table ${tableName}:`, error);
-                defaultLogger.error('SQL:', createTableSQL);
+                logger.error(
+                  `Failed to create global table ${tableName}`,
+                  error instanceof Error ? error : new Error(String(error)),
+                  { sql: createTableSQL },
+                );
                 throw error;
               }
             })();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,7 +153,9 @@ export {
 } from './richtext/index.js';
 // Storage adapters
 export { objectStorage } from './storage/object-storage.js';
-// Note: Logger class is exported from ./revealui.ts (instance/logger.js), not from utils/logger.js
+// Note: Instance-shaped Logger (RevealUILogger adapter) is exported from
+// ./revealui.ts (instance/logger.js). Structured utils logger is re-exported
+// below from ./utils/logger.js (ADR-008: both backed by @revealui/utils/logger).
 export { LRUCache, type LRUCacheOptions } from './utils/cache.js';
 // Deep clone utility
 export { deepClone } from './utils/deep-clone.js';
@@ -178,7 +180,7 @@ export {
   RateLimitError,
   ValidationError,
 } from './utils/errors.js';
-// Utilities
+// Structured logger (utils-backed client barrel — ADR-008 D4)
 export {
   createLogger,
   type LogContext,

--- a/packages/core/src/instance/logger.ts
+++ b/packages/core/src/instance/logger.ts
@@ -1,13 +1,23 @@
 /**
- * RevealUI Logger (legacy instance path)
+ * RevealUI Logger (instance API adapter)
  *
- * @deprecated Prefer `@revealui/core/observability/logger` (facade over
- * `@revealui/utils/logger`). See ADR-008. Migration is D2 in that ADR;
- * this module remains for existing core call sites until then.
+ * ADR-008 D2/D4: implementation is a thin adapter over `@revealui/utils/logger`.
+ * The varargs `RevealUILogger` shape stays for `RevealUIInstance.logger` and
+ * public re-exports from `revealui.ts`. Prefer structured imports for new code:
  *
- * Production-safe logging utility for RevealUI framework operations.
- * Info/warn messages are no-ops in production to avoid console pollution.
+ *   import { logger } from '@revealui/core/observability/logger'
+ *
+ * Production silencing: follows utils `LOG_LEVEL` (default `info`). Legacy
+ * hard-silence of info/warn in production is intentionally retired (documented
+ * in the D2 PR). setup/scripts CLI loggers are out of scope.
  */
+
+import {
+  createLogger as createUtilsLogger,
+  logger as utilsLogger,
+  type LogContext,
+  type Logger as UtilsLogger,
+} from '@revealui/utils/logger';
 
 export interface RevealUILogger {
   info: (...args: unknown[]) => void;
@@ -16,44 +26,97 @@ export interface RevealUILogger {
   debug: (...args: unknown[]) => void;
 }
 
+function toMessageAndContext(args: unknown[]): {
+  message: string;
+  context?: LogContext;
+  error?: Error;
+} {
+  if (args.length === 0) {
+    return { message: '' };
+  }
+
+  const [first, ...rest] = args;
+  const message =
+    typeof first === 'string' ? first : first instanceof Error ? first.message : String(first);
+
+  if (rest.length === 0) {
+    if (first instanceof Error) {
+      return { message, error: first };
+    }
+    return { message };
+  }
+
+  if (rest.length === 1) {
+    const only = rest[0];
+    if (only instanceof Error) {
+      return { message, error: only };
+    }
+    if (only !== null && typeof only === 'object' && !Array.isArray(only)) {
+      return { message, context: only as LogContext };
+    }
+    return { message, context: { detail: only } };
+  }
+
+  return { message, context: { args: rest } };
+}
+
 /**
- * Production-safe logger implementation
- * Info/warn messages are completely silenced in production
+ * Adapts structured utils logger to the historical varargs instance API.
  */
 export class Logger implements RevealUILogger {
+  private readonly backend: UtilsLogger;
+
+  constructor(backend: UtilsLogger = utilsLogger) {
+    this.backend = backend;
+  }
+
   info(...args: unknown[]): void {
-    // Info messages are never logged in production
-    if (process.env.NODE_ENV !== 'production') {
-      console.log('[RevealUI]', ...args);
+    const { message, context, error } = toMessageAndContext(args);
+    if (error) {
+      this.backend.info(message, { ...context, error: error.message, stack: error.stack });
+      return;
     }
+    this.backend.info(message, context);
   }
 
   warn(...args: unknown[]): void {
-    // Warning messages are never logged in production
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn('[RevealUI]', ...args);
+    const { message, context, error } = toMessageAndContext(args);
+    if (error) {
+      this.backend.warn(message, { ...context, error: error.message, stack: error.stack });
+      return;
     }
+    this.backend.warn(message, context);
   }
 
   error(...args: unknown[]): void {
-    console.error('[RevealUI]', ...args);
+    const { message, context, error } = toMessageAndContext(args);
+    if (error) {
+      this.backend.error(message, error, context);
+      return;
+    }
+    this.backend.error(message, context);
   }
 
   debug(...args: unknown[]): void {
-    if (process.env.NODE_ENV !== 'production') {
-      console.debug('[RevealUI]', ...args);
+    const { message, context, error } = toMessageAndContext(args);
+    if (error) {
+      this.backend.debug(message, { ...context, error: error.message, stack: error.stack });
+      return;
     }
+    this.backend.debug(message, context);
   }
 }
 
 /**
- * Creates a new logger instance
+ * Creates a new instance-shaped logger (utils-backed).
  */
 export function createLogger(): RevealUILogger {
-  return new Logger();
+  return new Logger(createUtilsLogger({ component: 'revealui-instance' }));
 }
 
 /**
- * Default logger instance
+ * Default instance-shaped logger (utils-backed).
+ *
+ * @deprecated Prefer `import { logger } from '@revealui/core/observability/logger'`.
  */
 export const defaultLogger: RevealUILogger = new Logger();

--- a/packages/core/src/instance/logger.ts
+++ b/packages/core/src/instance/logger.ts
@@ -14,9 +14,9 @@
 
 import {
   createLogger as createUtilsLogger,
-  logger as utilsLogger,
   type LogContext,
   type Logger as UtilsLogger,
+  logger as utilsLogger,
 } from '@revealui/utils/logger';
 
 export interface RevealUILogger {

--- a/packages/core/src/license.ts
+++ b/packages/core/src/license.ts
@@ -16,7 +16,7 @@
 // other modules in the auth route bundle during page data collection.
 import { z } from 'zod';
 import { decryptLicenseKey } from './license-encryption.js';
-import { logger } from './utils/logger.js';
+import { logger } from './observability/logger.js';
 
 async function getJose() {
   return await import('jose');

--- a/packages/core/src/relationships/analyzer.ts
+++ b/packages/core/src/relationships/analyzer.ts
@@ -1,4 +1,4 @@
-import { defaultLogger } from '../instance/logger.js';
+import { logger } from '../observability/logger.js';
 import type { RevealCollectionConfig, RevealGlobalConfig, RevealUIField } from '../types/index.js';
 import type { RelationshipMetadata } from '../types/query.js';
 
@@ -89,7 +89,7 @@ export function getRelationshipFields(
   const validation = validateRelationshipMetadata(relationships);
   if (!validation.valid) {
     for (const error of validation.errors) {
-      defaultLogger.warn(`[RelationshipAnalyzer] ${error}`);
+      logger.warn(`[RelationshipAnalyzer] ${error}`);
     }
   }
 

--- a/packages/core/src/storage/__tests__/object-storage.test.ts
+++ b/packages/core/src/storage/__tests__/object-storage.test.ts
@@ -8,8 +8,8 @@ const mockPut = vi.fn();
 const mockDel = vi.fn();
 const mockList = vi.fn();
 
-vi.mock('../../instance/logger.js', () => ({
-  defaultLogger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+vi.mock('../../observability/logger.js', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
 import { objectStorage } from '../object-storage.js';

--- a/packages/core/src/storage/object-storage.ts
+++ b/packages/core/src/storage/object-storage.ts
@@ -18,7 +18,7 @@
  * Do NOT import in client-side code or edge runtime.
  */
 
-import { defaultLogger } from '../instance/logger.js';
+import { logger } from '../observability/logger.js';
 import type { Plugin } from '../types/index.js';
 import type { StorageProvider } from './types.js';
 
@@ -104,7 +104,10 @@ export function objectStorage(config: ObjectStorageConfig): Plugin {
                         height: file.height,
                       };
                     } catch (error) {
-                      defaultLogger.error('Object storage upload error:', error);
+                      logger.error(
+                        'Object storage upload error',
+                        error instanceof Error ? error : new Error(String(error)),
+                      );
                       throw error;
                     }
                   },
@@ -119,7 +122,10 @@ export function objectStorage(config: ObjectStorageConfig): Plugin {
 
                       await getProvider().del(keyOrUrl);
                     } catch (error) {
-                      defaultLogger.error('Object storage delete error:', error);
+                      logger.error(
+                        'Object storage delete error',
+                        error instanceof Error ? error : new Error(String(error)),
+                      );
                       throw error;
                     }
                   },

--- a/packages/core/src/utils/__tests__/json-parsing.test.ts
+++ b/packages/core/src/utils/__tests__/json-parsing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../instance/logger.js', () => ({
-  defaultLogger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+vi.mock('../../observability/logger.js', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
 import {

--- a/packages/core/src/utils/json-parsing.ts
+++ b/packages/core/src/utils/json-parsing.ts
@@ -5,7 +5,7 @@
  * Handles the _json column pattern used for storing complex field types.
  */
 
-import { defaultLogger } from '../instance/logger.js';
+import { logger } from '../observability/logger.js';
 import type { RevealDocument } from '../types/index.js';
 
 /**
@@ -78,7 +78,9 @@ export function deserializeJsonFields(
       }
     } catch (error) {
       // Invalid JSON - log for debugging but continue
-      defaultLogger.warn(`Failed to parse _json in ${tableName || 'unknown'}:`, error);
+      logger.warn(`Failed to parse _json in ${tableName || 'unknown'}`, {
+        error: error instanceof Error ? { message: error.message, name: error.name } : error,
+      });
     }
   }
 

--- a/packages/core/src/utils/logger-client.ts
+++ b/packages/core/src/utils/logger-client.ts
@@ -1,81 +1,24 @@
 /**
- * Client-Safe Logger (legacy core path)
+ * Client-safe logger entry (ADR-008 D4)
  *
- * @deprecated Prefer `@revealui/core/observability/logger` or
- * `@revealui/utils/logger` per ADR-008. This module stays client-safe (no
- * async_hooks) until D3/D4 collapses core logger surfaces.
+ * Re-exports `@revealui/utils/logger` (no Node async_hooks). Prefer
+ * `@revealui/core/observability/logger` for packages that already depend on core.
  *
- * Production-safe logging utility that works in both client and server contexts.
- * Does not depend on Node.js APIs (no async_hooks, no crypto).
- * Info/warn messages are no-ops in production to avoid console pollution.
- *
- * NOTE: No 'use client' directive here. This is a plain utility module, not a
- * React component. Adding 'use client' causes Next.js to create a reference
- * proxy when imported from server code (API routes), stripping all methods.
+ * Package export: `@revealui/core/utils/logger/client`
  */
 
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+export type {
+  LogContext,
+  LogEntry,
+  LoggerConfig,
+  LogLevel,
+} from '@revealui/utils/logger';
 
-export interface LogContext {
-  [key: string]: unknown;
-}
-
-export interface Logger {
-  debug(message: string, context?: LogContext): void;
-  info(message: string, context?: LogContext): void;
-  warn(message: string, context?: LogContext): void;
-  error(message: string, context?: LogContext): void;
-}
-
-/**
- * Client-safe logger implementation
- * Simple console-based logging without Node.js dependencies
- */
-class ClientLogger implements Logger {
-  private formatMessage(level: LogLevel, message: string, context?: LogContext): string {
-    const timestamp = new Date().toISOString();
-    const prefix = `[${timestamp}] [RevealUI] [${level.toUpperCase()}]`;
-
-    if (context && Object.keys(context).length > 0) {
-      return `${prefix} ${message} ${JSON.stringify(context)}`;
-    }
-
-    return `${prefix} ${message}`;
-  }
-
-  debug(message: string, context?: LogContext): void {
-    if (process.env.NODE_ENV !== 'production') {
-      console.debug(this.formatMessage('debug', message, context));
-    }
-  }
-
-  info(message: string, context?: LogContext): void {
-    if (process.env.NODE_ENV !== 'production') {
-      console.info(this.formatMessage('info', message, context));
-    }
-  }
-
-  warn(message: string, context?: LogContext): void {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(this.formatMessage('warn', message, context));
-    }
-  }
-
-  error(message: string, context?: LogContext): void {
-    console.error(this.formatMessage('error', message, context));
-  }
-}
-
-/**
- * Create a client-safe logger instance
- *
- * @returns Logger instance safe for client-side use
- */
-export function createLogger(): Logger {
-  return new ClientLogger();
-}
-
-/**
- * Default client-safe logger instance
- */
-export const logger = createLogger();
+export {
+  createLogger,
+  Logger,
+  logAudit,
+  logError,
+  logger,
+  logQuery,
+} from '@revealui/utils/logger';

--- a/packages/core/src/utils/logger-server.ts
+++ b/packages/core/src/utils/logger-server.ts
@@ -15,10 +15,10 @@
 
 import {
   createLogger as createUtilsLogger,
-  Logger as UtilsLoggerClass,
   type LogContext,
-  type Logger as UtilsLogger,
   type LogLevel,
+  type Logger as UtilsLogger,
+  Logger as UtilsLoggerClass,
 } from '@revealui/utils/logger';
 import { getRequestId } from './request-context.js';
 

--- a/packages/core/src/utils/logger-server.ts
+++ b/packages/core/src/utils/logger-server.ts
@@ -1,99 +1,69 @@
 /**
- * Server Logger Utility (legacy core path)
+ * Server logger with request-id enrichment (ADR-008 D3/D4)
  *
- * @deprecated Prefer `@revealui/core/observability/logger` (utils-backed)
- * per ADR-008. Request-id enrichment must be preserved in D3 migration.
+ * Thin facade over `@revealui/utils/logger` that injects `requestId` from
+ * AsyncLocalStorage (`request-context`) on every log call. Not a second
+ * logger implementation.
  *
- * Server-side logging utility for RevealUI framework.
- * Supports different log levels and structured output.
- * Automatically includes request ID from request context when available.
+ * WARNING: Uses Node.js APIs (async_hooks via request-context). Do not import
+ * from browser / RSC client graphs. Client code: `@revealui/core/utils/logger`
+ * or `@revealui/core/observability/logger`.
  *
- * WARNING: This module uses Node.js APIs (async_hooks via request-context).
- * For client-safe logging, use './logger-client.js' instead. Never import
- * this file from browser/RSC client graphs.
+ * Package export: `@revealui/core/utils/logger/server`
+ * Also re-exported from `@revealui/core/server`.
  */
 
+import {
+  createLogger as createUtilsLogger,
+  Logger as UtilsLoggerClass,
+  type LogContext,
+  type Logger as UtilsLogger,
+  type LogLevel,
+} from '@revealui/utils/logger';
 import { getRequestId } from './request-context.js';
 
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+export type { LogContext, LogLevel };
+export type Logger = Pick<UtilsLogger, 'debug' | 'info' | 'warn' | 'error'>;
 
-export interface LogContext {
-  [key: string]: unknown;
+function withRequestId(context?: LogContext): LogContext | undefined {
+  const requestId = getRequestId();
+  if (!requestId) {
+    return context;
+  }
+  return { requestId, ...context };
 }
 
-export interface Logger {
-  debug(message: string, context?: LogContext): void;
-  info(message: string, context?: LogContext): void;
-  warn(message: string, context?: LogContext): void;
-  error(message: string, context?: LogContext): void;
-}
-
-class ConsoleLogger implements Logger {
-  private minLevel: LogLevel;
-
-  constructor(minLevel: LogLevel = 'info') {
-    this.minLevel = minLevel;
-  }
-
-  private shouldLog(level: LogLevel): boolean {
-    const levels: LogLevel[] = ['debug', 'info', 'warn', 'error'];
-    return levels.indexOf(level) >= levels.indexOf(this.minLevel);
-  }
-
-  private formatMessage(level: LogLevel, message: string, context?: LogContext): string {
-    const timestamp = new Date().toISOString();
-    const prefix = `[${timestamp}] [${level.toUpperCase()}]`;
-
-    // Automatically include request ID if available
-    const requestId = getRequestId();
-    const enrichedContext = requestId ? { requestId, ...context } : context;
-
-    if (enrichedContext && Object.keys(enrichedContext).length > 0) {
-      return `${prefix} ${message} ${JSON.stringify(enrichedContext)}`;
-    }
-
-    return `${prefix} ${message}`;
-  }
-
-  debug(message: string, context?: LogContext): void {
-    if (process.env.NODE_ENV !== 'production') {
-      console.debug(this.formatMessage('debug', message, context));
-    }
-  }
-
-  info(message: string, context?: LogContext): void {
-    if (process.env.NODE_ENV !== 'production') {
-      console.info(this.formatMessage('info', message, context));
-    }
-  }
-
-  warn(message: string, context?: LogContext): void {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(this.formatMessage('warn', message, context));
-    }
-  }
-
-  error(message: string, context?: LogContext): void {
-    if (this.shouldLog('error')) {
-      console.error(this.formatMessage('error', message, context));
-    }
-  }
+function wrap(backend: UtilsLogger): Logger {
+  return {
+    debug(message: string, context?: LogContext): void {
+      backend.debug(message, withRequestId(context));
+    },
+    info(message: string, context?: LogContext): void {
+      backend.info(message, withRequestId(context));
+    },
+    warn(message: string, context?: LogContext): void {
+      backend.warn(message, withRequestId(context));
+    },
+    error(message: string, context?: LogContext): void {
+      backend.error(message, withRequestId(context));
+    },
+  };
 }
 
 /**
- * Create a logger instance
+ * Create a server logger that enriches context with the active request ID.
  *
- * @param minLevel - Minimum log level to output (default: 'info')
- * @returns Logger instance
+ * @param minLevel - Optional minimum level (maps to utils `level` config)
  */
 export function createLogger(minLevel?: LogLevel): Logger {
-  // In production, can be extended to use structured logging services
-  // For now, use console-based logger
-  const level = minLevel || (process.env.LOG_LEVEL as LogLevel) || 'info';
-  return new ConsoleLogger(level);
+  const level = minLevel || (process.env.LOG_LEVEL as LogLevel | undefined) || 'info';
+  const backend = new UtilsLoggerClass({
+    level,
+  }).child({ component: 'core-server' });
+  return wrap(backend);
 }
 
 /**
- * Default logger instance
+ * Default server logger (request-id enriching).
  */
-export const logger = createLogger();
+export const logger: Logger = wrap(createUtilsLogger({ component: 'core-server' }));

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,13 +1,25 @@
 /**
- * Logger Utility - Default Export (legacy core barrel → client logger)
+ * Logger barrel (client-safe) — ADR-008 D4
  *
- * @deprecated Prefer `@revealui/core/observability/logger` per ADR-008.
- * This barrel re-exports the client-safe logger only (no async_hooks).
+ * Re-exports `@revealui/utils/logger`. Prefer
+ * `@revealui/core/observability/logger` for new core-dependent code.
  *
- * For server-side logging with request context (until D3):
- *   import { logger } from '@revealui/core/server'
- *   import { logger } from '@revealui/core/utils/logger/server'
+ * Server + request-id: `@revealui/core/server` or
+ * `@revealui/core/utils/logger/server`.
  */
 
-export type { LogContext, Logger, LogLevel } from './logger-client.js';
-export { createLogger, logger } from './logger-client.js';
+export type {
+  LogContext,
+  LogEntry,
+  LoggerConfig,
+  LogLevel,
+} from '@revealui/utils/logger';
+
+export {
+  createLogger,
+  Logger,
+  logAudit,
+  logError,
+  logger,
+  logQuery,
+} from '@revealui/utils/logger';


### PR DESCRIPTION
## Summary
Fleet-redundancy **C3 D2–D4** (implements ADR-008):

- **D2:** Production call sites use `@revealui/core/observability/logger`. `instance/logger` remains only as a **varargs adapter** over `@revealui/utils/logger` for `RevealUIInstance.logger` / public `RevealUILogger`.
- **D3:** `utils/logger-server` is a thin **request-id enricher** over utils (monitoring + `@revealui/core/server`). Not a second ConsoleLogger.
- **D4:** `logger-client` + `utils/logger` barrel re-export utils (client-safe). One structured implementation.
- **Product decision:** production hard-silence of info/warn is retired; product logs follow utils `LOG_LEVEL` (default `info`). setup/scripts CLI loggers unchanged (ADR non-goal).
- Citation fix in `docs/STANDARDS.md` for shortened logger-client file.

## Test plan
- [x] `@revealui/core` unit suite green locally (2750 tests)
- [x] Pre-push phase-1 gate PASS
- [ ] CI green on `test` base
- [ ] Client-bundle safety remains green (server logger not on client graphs)

Companion jv: plan residual next-action → Phase 5.