### PR TITLE
ci(sync): schedule Vercel secret-path name-diff drift check (GAP-258 P0-8)

### DIFF
--- a/.github/workflows/secret-path-drift.yml
+++ b/.github/workflows/secret-path-drift.yml
@@ -1,0 +1,55 @@
+name: Secret Path Drift
+
+# Read-only Vercel env NAME-diff vs scripts/sync/revvault-vercel.toml (GAP-258 P0-8).
+# NOT a per-PR gate (live API + tokens are a PR-gate anti-pattern) — schedule +
+# workflow_dispatch only. Orphan / missing only; shape-violation stays local
+# (`pnpm vercel:drift-check` + revvault, age identity never in Actions).
+#
+# Requires repo secret VERCEL_TOKEN (already used by deploy workflows; read-only
+# list is enough). Job no-ops (passes) when the token is unset.
+
+on:
+  schedule:
+    - cron: "41 14 * * 1" # Mondays 14:41 UTC (offset from stripe-catalog-check)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "24"
+  PNPM_VERSION: "10.28.2"
+  PNPM_INSTALL_FLAGS: "--frozen-lockfile"
+
+jobs:
+  secret-path-drift:
+    name: Secret path drift (Vercel names)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install ${{ env.PNPM_INSTALL_FLAGS }}
+
+      - name: Vercel env name-diff (read-only)
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_TOKEN:-}" ]; then
+            echo "VERCEL_TOKEN not set; skipping live secret-path name-diff."
+            exit 0
+          fi
+          pnpm secret-path:drift:live

--- a/package.json
+++ b/package.json
@@ -260,6 +260,7 @@
     "kek:rotate": "tsx scripts/security/rotate-kek.ts",
     "vercel:sync": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml",
     "vercel:sync:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply",
+    "secret-path:drift:live": "tsx scripts/sync/secret-path-drift.ts --live-vercel",
     "vercel:drift-check": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --json",
     "vercel:sync:staging": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel-staging.toml",
     "vercel:sync:staging:apply": "VERCEL_TOKEN=$(revvault get revealui/prod/api-keys/vercel-token) revvault sync vercel --manifest scripts/sync/revvault-vercel-staging.toml --apply",

--- a/scripts/sync/__tests__/secret-path-drift.test.ts
+++ b/scripts/sync/__tests__/secret-path-drift.test.ts
@@ -3,12 +3,15 @@
  * `revvault sync ... --json` fixture — no revvault, no network, no secret values.
  */
 import { describe, expect, it } from 'vitest';
+import { collectVercelProjects } from '../parse-manifests.js';
 import {
   classifyVercelDrift,
+  classifyVercelNameDrift,
   type DriftFinding,
   KNOWN_DRIFT,
   knownKey,
   parseSyncDiffJsonl,
+  parseVercelNamesJson,
   partitionFindings,
 } from '../secret-path-drift.js';
 
@@ -113,5 +116,50 @@ describe('KNOWN_DRIFT allowlist explicitly tracks the 2026-07-11 live findings',
         reason: null,
       });
     }
+  });
+});
+
+describe('classifyVercelNameDrift (CI name-diff path)', () => {
+  const projects = collectVercelProjects(`
+[projects.demo]
+project_id = "prj_demo"
+skip = ["NODE_ENV", "STRIPE_LIVE_MODE"]
+
+[projects.demo.vars]
+STRIPE_SECRET_KEY = { path = "revealui/prod/stripe/secret-key", sensitive = true }
+POSTGRES_URL = "revealui/prod/db/postgres-url"
+`);
+
+  it('parses project_id, skip, and vars from the manifest', () => {
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.slug).toBe('demo');
+    expect(projects[0]?.projectId).toBe('prj_demo');
+    expect(projects[0]?.skip).toEqual(['NODE_ENV', 'STRIPE_LIVE_MODE']);
+    expect(projects[0]?.vars.get('POSTGRES_URL')).toBe('revealui/prod/db/postgres-url');
+  });
+
+  it('reports orphan + missing; never orphans skip names', () => {
+    const live = new Map<string, string[]>([
+      ['demo', ['STRIPE_SECRET_KEY', 'BRAND_NEW', 'NODE_ENV']],
+    ]);
+    const findings = classifyVercelNameDrift(projects, live);
+    const byCat = (c: string) =>
+      findings
+        .filter((f) => f.category === c)
+        .map((f) => f.key)
+        .sort();
+    expect(byCat('orphan')).toEqual(['BRAND_NEW']);
+    expect(byCat('missing')).toEqual(['POSTGRES_URL']);
+    expect(findings.find((f) => f.key === 'NODE_ENV')).toBeUndefined();
+    expect(findings.find((f) => f.category === 'shape-violation')).toBeUndefined();
+  });
+
+  it('parseVercelNamesJson builds the live map', () => {
+    const map = parseVercelNamesJson(
+      JSON.stringify({
+        projects: [{ project: 'demo', names: ['A', 'B'] }],
+      }),
+    );
+    expect(map.get('demo')).toEqual(['A', 'B']);
   });
 });

--- a/scripts/sync/parse-manifests.ts
+++ b/scripts/sync/parse-manifests.ts
@@ -54,3 +54,49 @@ export function collectVars(
   }
   return out;
 }
+
+/**
+ * One Vercel project block from the sync manifest (slug + project_id + skip + vars).
+ * Used by the scheduled name-diff drift check (GAP-258 P0-8): live env NAMES from
+ * the Vercel API vs declared vars — no vault decrypt, no secret values.
+ */
+export interface VercelProjectSpec {
+  slug: string;
+  projectId: string;
+  /** Env names intentionally not managed by revvault (never orphans). */
+  skip: readonly string[];
+  /** Declared var name → vault path. */
+  vars: ReadonlyMap<string, string>;
+}
+
+/**
+ * Parse `[projects.<slug>]` blocks for Vercel name-diff classification.
+ * Projects without a usable `project_id` string are skipped (fail soft for that block).
+ */
+export function collectVercelProjects(tomlText: string): VercelProjectSpec[] {
+  const parsed = parseToml(tomlText) as Record<string, unknown>;
+  const container = parsed.projects;
+  if (container === undefined || container === null || typeof container !== 'object') return [];
+  const out: VercelProjectSpec[] = [];
+  for (const [slug, block] of Object.entries(container as Record<string, unknown>)) {
+    if (block === null || typeof block !== 'object') continue;
+    const b = block as Record<string, unknown>;
+    if (typeof b.project_id !== 'string' || b.project_id.length === 0) continue;
+    const skip: string[] = [];
+    if (Array.isArray(b.skip)) {
+      for (const s of b.skip) {
+        if (typeof s === 'string' && s.length > 0) skip.push(s);
+      }
+    }
+    const vars = new Map<string, string>();
+    if (b.vars !== undefined && b.vars !== null && typeof b.vars === 'object') {
+      for (const [name, value] of Object.entries(b.vars as Record<string, unknown>)) {
+        const parsedVar = readVarPath(value);
+        if (parsedVar === null) continue;
+        vars.set(name, parsedVar.path);
+      }
+    }
+    out.push({ slug, projectId: b.project_id, skip, vars });
+  }
+  return out;
+}

--- a/scripts/sync/secret-path-drift.ts
+++ b/scripts/sync/secret-path-drift.ts
@@ -1,30 +1,33 @@
 /**
  * Secret-path LIVE-drift checker (read-only).
  *
- * Consumes the JSON output of `revvault sync vercel --json` (and, optionally,
- * `flyctl secrets list --json`) and classifies each live env var against the
- * canonical secret spec (`SECRET_PATHS`, via the lockstep-guaranteed manifest
- * mapping in parse-manifests.ts) into:
+ * Two input modes (both never print secret VALUES):
  *
- *   • orphan          — live in Vercel/Fly but NOT in the vault/spec (DiffAction Orphan)
- *   • missing         — in the vault/spec but absent live            (DiffAction Add)
- *   • shape-violation — present live but corrupt: empty / at-rest ciphertext (DiffAction DropShape)
+ * 1. **revvault sync JSONL** (`--vercel-json`) — full Orphan/Add/DropShape from a
+ *    local `revvault sync vercel --json` capture (owner machine; needs age identity).
+ * 2. **Vercel name-diff** (`--live-vercel` or `--vercel-names-json`) — orphan/missing
+ *    only, from env-var NAMES listed by the Vercel API (or a fixture). This is the
+ *    CI-safe path for GAP-258 P0-8: no vault decrypt, no age identity in Actions.
+ *    Shape-violation stays a local/owner check.
  *
- * NEVER writes, NEVER applies, NEVER prints a secret VALUE — the sync `--json`
- * emits env-var NAMES + action + reason only. This process itself takes no token
- * and makes no network call; the workflow feeds it the captured `--json` files.
- * Token-gating + the live `revvault`/`flyctl` invocation live in
- * .github/workflows/secret-path-drift.yml.
+ * Classification vs the lockstep-guaranteed manifest (`parse-manifests.ts`):
+ *
+ *   • orphan          — live but NOT in the manifest vars (or revvault Orphan)
+ *   • missing         — in the manifest vars but absent live (or revvault Add)
+ *   • shape-violation — revvault DropShape only (not available in name-diff mode)
  *
  * KNOWN, already-tracked drift is allow-listed (surfaced as KNOWN, does not fail
  * the run); any NEW drift fails the run so it is triaged before it compounds —
  * the doc-currency-baseline pattern.
+ *
+ * Scheduled workflow: `.github/workflows/secret-path-drift.yml` (no-op if
+ * `VERCEL_TOKEN` unset).
  */
 
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { collectVars } from './parse-manifests.js';
+import { collectVars, collectVercelProjects, type VercelProjectSpec } from './parse-manifests.js';
 import { DECLARED_PATHS } from './secret-paths.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -150,6 +153,115 @@ export function classifyVercelDrift(
   return findings;
 }
 
+/**
+ * Name-only classification (CI path): live env keys vs declared manifest vars.
+ * `skip` names are never orphans (intentionally Vercel-direct / platform-managed).
+ * No shape-violation — values are never fetched.
+ */
+export function classifyVercelNameDrift(
+  projects: readonly VercelProjectSpec[],
+  liveNamesBySlug: ReadonlyMap<string, readonly string[]>,
+): DriftFinding[] {
+  const findings: DriftFinding[] = [];
+  for (const proj of projects) {
+    const surface = `vercel:${proj.slug}`;
+    const live = new Set(liveNamesBySlug.get(proj.slug) ?? []);
+    const skip = new Set(proj.skip);
+    for (const name of live) {
+      if (skip.has(name)) continue;
+      if (!proj.vars.has(name)) {
+        findings.push({
+          surface,
+          key: name,
+          category: 'orphan',
+          reason: 'live on Vercel, not in manifest vars',
+        });
+      }
+    }
+    for (const [name, path] of proj.vars) {
+      if (!live.has(name)) {
+        findings.push({
+          surface,
+          key: name,
+          category: 'missing',
+          reason: 'in manifest vars, absent on Vercel (production target)',
+          path,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+/** Fixture / offline shape for `--vercel-names-json`. */
+export interface VercelNamesDoc {
+  projects: Array<{ project: string; names: string[] }>;
+}
+
+export function parseVercelNamesJson(text: string): Map<string, string[]> {
+  const obj = JSON.parse(text) as VercelNamesDoc;
+  const map = new Map<string, string[]>();
+  if (!obj || !Array.isArray(obj.projects)) {
+    throw new Error('vercel-names-json: expected { projects: [{ project, names }] }');
+  }
+  for (const p of obj.projects) {
+    if (typeof p.project !== 'string' || !Array.isArray(p.names)) continue;
+    map.set(
+      p.project,
+      p.names.filter((n): n is string => typeof n === 'string' && n.length > 0),
+    );
+  }
+  return map;
+}
+
+/**
+ * Fetch production env-var NAMES for a Vercel project (no values used).
+ * Uses the public list endpoint; decrypt is never requested.
+ */
+export async function fetchVercelProductionEnvNames(
+  token: string,
+  projectId: string,
+): Promise<string[]> {
+  const names = new Set<string>();
+  let url: string | null =
+    `https://api.vercel.com/v10/projects/${encodeURIComponent(projectId)}/env?limit=100`;
+  while (url) {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(
+        `Vercel env list failed for ${projectId}: HTTP ${res.status} ${body.slice(0, 200)}`,
+      );
+    }
+    const data = (await res.json()) as {
+      envs?: Array<{ key?: string; target?: string[] | string }>;
+      pagination?: { next?: number | null };
+    };
+    for (const env of data.envs ?? []) {
+      if (typeof env.key !== 'string' || env.key.length === 0) continue;
+      const targets = Array.isArray(env.target)
+        ? env.target
+        : typeof env.target === 'string'
+          ? [env.target]
+          : [];
+      // Name-diff CI scopes to production (manifest targets = production-only).
+      if (targets.length === 0 || targets.includes('production')) {
+        names.add(env.key);
+      }
+    }
+    // Vercel pagination: next is a timestamp cursor when more pages exist.
+    const next = data.pagination?.next;
+    if (typeof next === 'number' && next > 0) {
+      url = `https://api.vercel.com/v10/projects/${encodeURIComponent(projectId)}/env?limit=100&until=${next}`;
+    } else {
+      url = null;
+    }
+  }
+  return [...names].sort();
+}
+
 interface FlySecret {
   Name?: string;
 }
@@ -214,42 +326,13 @@ function argValue(argv: string[], flag: string): string | undefined {
   return i !== -1 && i + 1 < argv.length ? argv[i + 1] : undefined;
 }
 
-function main(): void {
-  const argv = process.argv.slice(2);
-  const vercelJsonPath = argValue(argv, '--vercel-json');
-  const flyJsonPath = argValue(argv, '--fly-json');
-  if (!vercelJsonPath) {
-    process.stderr.write('usage: secret-path-drift --vercel-json <file> [--fly-json <file>]\n');
-    process.exit(2);
-  }
-
-  const nameToPath = manifestNamePathIndex();
-  const findings: DriftFinding[] = [];
-
-  const vercelDocs = parseSyncDiffJsonl(readFileSync(vercelJsonPath, 'utf8'));
-  findings.push(...classifyVercelDrift(vercelDocs, nameToPath));
-
-  if (flyJsonPath) {
-    let flyLive: string[] = [];
-    try {
-      const parsed = JSON.parse(readFileSync(flyJsonPath, 'utf8')) as FlySecret[];
-      flyLive = parsed.map((s) => s.Name).filter((n): n is string => typeof n === 'string');
-    } catch {
-      process.stderr.write(
-        'secret-path-drift: --fly-json unreadable/empty — Fly surface skipped\n',
-      );
-    }
-    if (flyLive.length > 0) findings.push(...classifyFlyDrift(flyLive, nameToPath));
-  }
-
-  // Belt-and-suspenders: a non-orphan live key whose manifest path is undeclared
-  // would mean manifest↔spec drift the per-PR lockstep somehow missed.
+function reportAndExit(findings: DriftFinding[], projectsScanned: number, mode: string): void {
   const undeclared = findings.filter((f) => f.path !== undefined && !DECLARED_PATHS.has(f.path));
-
   const { fresh, known } = partitionFindings(findings);
 
   process.stdout.write('── secret-path live-drift check (read-only) ──\n');
-  process.stdout.write(`vercel projects scanned: ${vercelDocs.length}\n\n`);
+  process.stdout.write(`mode: ${mode}\n`);
+  process.stdout.write(`vercel projects scanned: ${projectsScanned}\n\n`);
 
   if (known.length > 0) {
     process.stdout.write(`KNOWN drift (${known.length}, tracked — not failing):\n`);
@@ -282,6 +365,85 @@ function main(): void {
     for (const f of undeclared) process.stdout.write(`  ${f.surface} ${f.key} → ${f.path}\n`);
   }
   process.exit(1);
+}
+
+async function runLiveVercel(): Promise<void> {
+  const token = process.env.VERCEL_TOKEN;
+  if (!token || token.length === 0) {
+    process.stdout.write('VERCEL_TOKEN not set; skipping live Vercel name-diff (no-op pass).\n');
+    process.exit(0);
+  }
+  const projects = collectVercelProjects(readFileSync(VERCEL_MANIFEST, 'utf8'));
+  if (projects.length === 0) {
+    process.stderr.write('secret-path-drift: no projects with project_id in prod manifest\n');
+    process.exit(2);
+  }
+  // De-dupe by projectId (staging reuses prod IDs in a separate manifest).
+  const byId = new Map<string, VercelProjectSpec>();
+  for (const p of projects) {
+    if (!byId.has(p.projectId)) byId.set(p.projectId, p);
+  }
+  const unique = [...byId.values()];
+  const liveNamesBySlug = new Map<string, string[]>();
+  for (const p of unique) {
+    process.stdout.write(`fetching production env names: ${p.slug} (${p.projectId})\n`);
+    const names = await fetchVercelProductionEnvNames(token, p.projectId);
+    liveNamesBySlug.set(p.slug, names);
+  }
+  const findings = classifyVercelNameDrift(unique, liveNamesBySlug);
+  reportAndExit(findings, unique.length, 'vercel-name-diff (live API)');
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--live-vercel')) {
+    runLiveVercel().catch((err) => {
+      process.stderr.write(
+        `secret-path-drift --live-vercel failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    });
+    return;
+  }
+
+  const namesJsonPath = argValue(argv, '--vercel-names-json');
+  if (namesJsonPath) {
+    const projects = collectVercelProjects(readFileSync(VERCEL_MANIFEST, 'utf8'));
+    const live = parseVercelNamesJson(readFileSync(namesJsonPath, 'utf8'));
+    const findings = classifyVercelNameDrift(projects, live);
+    reportAndExit(findings, projects.length, 'vercel-name-diff (fixture)');
+    return;
+  }
+
+  const vercelJsonPath = argValue(argv, '--vercel-json');
+  const flyJsonPath = argValue(argv, '--fly-json');
+  if (!vercelJsonPath) {
+    process.stderr.write(
+      'usage: secret-path-drift --live-vercel | --vercel-names-json <file> | --vercel-json <file> [--fly-json <file>]\n',
+    );
+    process.exit(2);
+  }
+
+  const nameToPath = manifestNamePathIndex();
+  const findings: DriftFinding[] = [];
+
+  const vercelDocs = parseSyncDiffJsonl(readFileSync(vercelJsonPath, 'utf8'));
+  findings.push(...classifyVercelDrift(vercelDocs, nameToPath));
+
+  if (flyJsonPath) {
+    let flyLive: string[] = [];
+    try {
+      const parsed = JSON.parse(readFileSync(flyJsonPath, 'utf8')) as FlySecret[];
+      flyLive = parsed.map((s) => s.Name).filter((n): n is string => typeof n === 'string');
+    } catch {
+      process.stderr.write(
+        'secret-path-drift: --fly-json unreadable/empty — Fly surface skipped\n',
+      );
+    }
+    if (flyLive.length > 0) findings.push(...classifyFlyDrift(flyLive, nameToPath));
+  }
+
+  reportAndExit(findings, vercelDocs.length, 'revvault-sync-json');
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/sync/secret-path-drift.ts
+++ b/scripts/sync/secret-path-drift.ts
@@ -201,7 +201,7 @@ export interface VercelNamesDoc {
 export function parseVercelNamesJson(text: string): Map<string, string[]> {
   const obj = JSON.parse(text) as VercelNamesDoc;
   const map = new Map<string, string[]>();
-  if (!obj || !Array.isArray(obj.projects)) {
+  if (!(obj && Array.isArray(obj.projects))) {
     throw new Error('vercel-names-json: expected { projects: [{ project, names }] }');
   }
   for (const p of obj.projects) {


### PR DESCRIPTION
## Summary

Closes the **GAP-258 P0-8 residual**: scheduled live drift without putting the age identity in CI.

| Piece | Detail |
|-------|--------|
| `collectVercelProjects` | Parse `project_id` / `skip` / `vars` from `revvault-vercel.toml` |
| `classifyVercelNameDrift` | orphan + missing only (no values, no DropShape) |
| `--live-vercel` | Fetches production env **names** via Vercel API |
| Workflow | `.github/workflows/secret-path-drift.yml` — schedule Mon 14:41 UTC + dispatch; **no-op if `VERCEL_TOKEN` unset** |

Shape-violation stays owner-local: `pnpm vercel:drift-check` (revvault + age).

### Architecture (extends existing checker)

Does **not** clone the lane-plan “revvault in CI” model (not viable — vault decrypt). Matches the 2026-07-11 finding: Vercel-API name-diff only.

### Tests

- 10 unit tests green (name-diff + existing revvault JSONL fixtures)
- `VERCEL_TOKEN` unset → exit 0 no-op

## Test plan

- [x] `pnpm exec vitest run scripts/sync/__tests__/secret-path-drift.test.ts`
- [x] `env -u VERCEL_TOKEN pnpm secret-path:drift:live` no-op
- [ ] After merge: Actions → Secret Path Drift → Run workflow (with `VERCEL_TOKEN`)
- [ ] First live run: triage any NEW orphan/missing into `KNOWN_DRIFT` or vault

## Owner

Security-sensitive (workflow under security paths). Needs non-author clearance / `sec-review:approved` then merge:

```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```