### PR TITLE
docs(harnesses): durable-solutions control-layer ownership (GAP-405)

### DIFF
--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -72,7 +72,7 @@
     },
     {
       "relativePath": ".revealui/content/rules/durable-solutions.md",
-      "sha256": "162e4f1925ca067d0a00f7257dae9f31b544ccf8b41b5cf8ea8a848b238259d6"
+      "sha256": "291a6b958224a478fa33f0c398ca56336e3112ce5df3a9a7539ddfb7eea01696"
     },
     {
       "relativePath": ".revealui/content/rules/monorepo.md",

--- a/packages/harnesses/src/content/definitions/rules/durable-solutions.ts
+++ b/packages/harnesses/src/content/definitions/rules/durable-solutions.ts
@@ -49,7 +49,10 @@ overrides are not done unless the owner accepts a **registered hotfix**.
 
 ## References
 
-- Sibling: extend-before-create, quality-over-speed, code-over-docs
-- Operator registry (Studio): \`hotfix.js register\` / \`resolve\` / \`audit\`
+- Sibling: extend-before-create, quality-over-speed, code-over-docs, adapter-only
+- **Control layer:** hotfix register / resolve / audit is owned by RevealUI
+  (\`@revealui/harnesses\` / project manager). Adapters surface it; they do not
+  re-author a second registry (GAP-405). Studio \`hotfix.js\` is transitional
+  bootstrap until cutover.
 `,
 };


### PR DESCRIPTION
## Summary

Align `@revealui/harnesses` durable-solutions rule references with the control-layer decision: hotfix registry is RevealUI-owned; Studio `hotfix.js` is transitional bootstrap (GAP-405 / jv#648).

## Test plan
- [x] `pnpm --filter @revealui/harnesses content:snapshot:check`