### PR TITLE
feat(harnesses): control-layer hotfix→durable registry (GAP-405)

### DIFF
--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -72,7 +72,7 @@
     },
     {
       "relativePath": ".revealui/content/rules/durable-solutions.md",
-      "sha256": "291a6b958224a478fa33f0c398ca56336e3112ce5df3a9a7539ddfb7eea01696"
+      "sha256": "e540263e4ca28d21ae5a9842ad358ba29325fd6bdc256e8caa2693a6a956fb65"
     },
     {
       "relativePath": ".revealui/content/rules/monorepo.md",

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -71,6 +71,11 @@
       "types": "./dist/hooks/index.d.ts",
       "import": "./dist/hooks/index.js",
       "default": "./dist/hooks/index.js"
+    },
+    "./hotfix": {
+      "types": "./dist/hotfix/index.d.ts",
+      "import": "./dist/hotfix/index.js",
+      "default": "./dist/hotfix/index.js"
     }
   },
   "files": [

--- a/packages/harnesses/src/__tests__/hotfix-registry.test.ts
+++ b/packages/harnesses/src/__tests__/hotfix-registry.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  loadManifest,
+  pendingEntries,
+  promoteHotfix,
+  registerHotfix,
+  resolveHotfix,
+  sweepResolved,
+} from '../hotfix/index.js';
+
+const dirs: string[] = [];
+
+function tempStore(): { controlPath: string; legacyPath: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'rvui-hotfix-'));
+  dirs.push(dir);
+  return {
+    controlPath: join(dir, 'manifest.json'),
+    legacyPath: join(dir, 'legacy-manifest.json'),
+  };
+}
+
+afterEach(() => {
+  // temp dirs left for OS cleanup; no global env pollution
+});
+
+describe('hotfix control-layer registry', () => {
+  it('registers pending debt and lists it', () => {
+    const paths = tempStore();
+    const e = registerHotfix(
+      {
+        title: 'seed env bypass',
+        symptom: 'seed fails under direnv',
+        temporary: 'env -u POSTGRES_URL',
+        durable: 'demote incomplete URLs in seed-env',
+        paths: ['scripts/seed-env.ts'],
+        gap: 'GAP-405',
+      },
+      paths,
+    );
+    expect(e.status).toBe('pending');
+    expect(e.id).toMatch(/^seed-env-bypass-/);
+    const pending = pendingEntries(loadManifest(paths));
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.durable).toContain('seed-env');
+  });
+
+  it('resolves with pr and clears pending', () => {
+    const paths = tempStore();
+    const e = registerHotfix(
+      {
+        title: 't',
+        symptom: 's',
+        temporary: 'tmp',
+        durable: 'fix root',
+      },
+      paths,
+    );
+    resolveHotfix(e.id, { pr: 'https://github.com/org/repo/pull/1' }, paths);
+    expect(pendingEntries(loadManifest(paths))).toHaveLength(0);
+    const again = loadManifest(paths).entries[0];
+    expect(again?.status).toBe('resolved');
+    expect(again?.pr).toContain('/pull/1');
+  });
+
+  it('promotes gap without resolving', () => {
+    const paths = tempStore();
+    const e = registerHotfix(
+      {
+        title: 'x',
+        symptom: 's',
+        temporary: 't',
+        durable: 'd',
+      },
+      paths,
+    );
+    promoteHotfix(e.id, 'GAP-999', paths);
+    const m = loadManifest(paths);
+    expect(m.entries[0]?.gap).toBe('GAP-999');
+    expect(m.entries[0]?.status).toBe('pending');
+  });
+
+  it('migrates legacy claude store once into control path', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rvui-hotfix-mig-'));
+    dirs.push(dir);
+    const controlPath = join(dir, 'control.json');
+    const legacyPath = join(dir, 'legacy.json');
+    writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            id: 'legacy-1',
+            title: 'old',
+            symptom: 's',
+            temporary: 't',
+            durable: 'd',
+            paths: [],
+            repo: null,
+            gap: null,
+            pr: null,
+            session: '0',
+            created: new Date().toISOString(),
+            status: 'pending',
+            resolved: null,
+            resolveNote: null,
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const m = loadManifest({ controlPath, legacyPath, migrate: true });
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0]?.id).toBe('legacy-1');
+    // second load from control path without re-import
+    const m2 = loadManifest({ controlPath, legacyPath: join(dir, 'missing.json'), migrate: true });
+    expect(m2.entries[0]?.id).toBe('legacy-1');
+  });
+
+  it('sweep keeps pending and recent resolved', () => {
+    const paths = tempStore();
+    const e = registerHotfix(
+      {
+        title: 'keep',
+        symptom: 's',
+        temporary: 't',
+        durable: 'd',
+      },
+      paths,
+    );
+    resolveHotfix(e.id, { note: 'fixed' }, paths);
+    const r = sweepResolved(paths);
+    expect(r.remaining).toBe(1);
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -38,6 +38,7 @@ import {
 } from './content/index.js';
 import { HarnessCoordinator } from './coordinator.js';
 import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
+import { runHotfixCli } from './hotfix/cli.js';
 import { checkManager, materializeManager } from './manager/index.js';
 import { WorkboardManager } from './workboard/workboard-manager.js';
 
@@ -519,6 +520,11 @@ async function main() {
     return;
   }
 
+  if (command === 'hotfix') {
+    const code = runHotfixCli(args);
+    process.exit(code);
+  }
+
   if (command === 'manager') {
     const [subcommand] = args;
     const projectIdx = args.indexOf('--project');
@@ -751,6 +757,7 @@ Commands:
   content <subcommand>              Manage canonical content definitions
   manager materialize [--project p] Write manager.json + .revealui/content + Cursor/OpenCode surfaces + equal stubs
   manager check [--project p]       Verify project manager present and valid
+  hotfix <subcommand>               Durable-debt registry (long-term fixes only; GAP-405)
 
 Content Subcommands:
   content list                      List all canonical content with metadata
@@ -760,6 +767,12 @@ Content Subcommands:
   content sync [--generator <id>] [--dry-run]  Generate into .revealui/content (default generator)
   content export --output <path>    Export canonical + generated files to directory
   content pull [--generator <id>] [--tier oss|pro|all]  Pull rules from rules repo
+
+Hotfix Subcommands (prefer durable root-cause fixes; register only as debt):
+  hotfix check | list | store | audit [root] | sweep
+  hotfix register --title T --symptom S --temporary X --durable D
+  hotfix resolve <id> --pr URL | --note TEXT
+  hotfix promote <id> --gap GAP-N
 
 Default content generator: ${DEFAULT_CONTENT_GENERATOR_ID} → ${MANAGER_CONTENT_OUTPUT}
 `);

--- a/packages/harnesses/src/content/definitions/rules/durable-solutions.ts
+++ b/packages/harnesses/src/content/definitions/rules/durable-solutions.ts
@@ -47,12 +47,22 @@ overrides are not done unless the owner accepts a **registered hotfix**.
 - Gaps/ADRs when the durable fix needs multi-session design
 - Tests that lock the durable behavior (prove red, then green)
 
+## CLI (control layer)
+
+\`\`\`bash
+revealui-harnesses hotfix check
+revealui-harnesses hotfix list
+revealui-harnesses hotfix audit [path]
+# Only if a temporary patch is unavoidable (admits debt):
+revealui-harnesses hotfix register --title … --symptom … --temporary … --durable …
+revealui-harnesses hotfix resolve <id> --pr <url>
+\`\`\`
+
+Store: \`~/.local/share/revealui/hotfixes/manifest.json\` (not vendor homes).
+
 ## References
 
 - Sibling: extend-before-create, quality-over-speed, code-over-docs, adapter-only
-- **Control layer:** hotfix register / resolve / audit is owned by RevealUI
-  (\`@revealui/harnesses\` / project manager). Adapters surface it; they do not
-  re-author a second registry (GAP-405). Studio \`hotfix.js\` is transitional
-  bootstrap until cutover.
+- GAP-405 — registry + adapter cutover; no dual Claude/Grok mirrors
 `,
 };

--- a/packages/harnesses/src/hotfix/cli.ts
+++ b/packages/harnesses/src/hotfix/cli.ts
@@ -1,0 +1,185 @@
+/**
+ * CLI handler for `revealui-harnesses hotfix …`
+ */
+
+import { controlManifestPath } from './paths.js';
+import {
+  ageDays,
+  auditHotfixes,
+  formatAuditReport,
+  formatCheckLines,
+  pendingEntries,
+  promoteHotfix,
+  registerHotfix,
+  resolveHotfix,
+  sweepResolved,
+} from './registry.js';
+import { loadManifest } from './store.js';
+
+function parseArgs(argv: string[]): {
+  _: string[];
+  title?: string;
+  symptom?: string;
+  temporary?: string;
+  durable?: string;
+  paths?: string;
+  repo?: string;
+  gap?: string;
+  pr?: string;
+  note?: string;
+  id?: string;
+} {
+  const opts: ReturnType<typeof parseArgs> = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i] ?? '';
+    if (a === '--title') opts.title = argv[++i];
+    else if (a === '--symptom') opts.symptom = argv[++i];
+    else if (a === '--temporary') opts.temporary = argv[++i];
+    else if (a === '--durable') opts.durable = argv[++i];
+    else if (a === '--paths') opts.paths = argv[++i];
+    else if (a === '--repo') opts.repo = argv[++i];
+    else if (a === '--gap') opts.gap = argv[++i];
+    else if (a === '--pr') opts.pr = argv[++i];
+    else if (a === '--note') opts.note = argv[++i];
+    else if (a === '--id') opts.id = argv[++i];
+    else if (a.startsWith('--')) {
+      throw new Error(`hotfix: unknown flag ${a}`);
+    } else opts._.push(a);
+  }
+  return opts;
+}
+
+function usage(): string {
+  return `Usage (RevealUI control layer — long-term durable solutions only):
+  revealui-harnesses hotfix register --title T --symptom S --temporary X --durable D [--paths p1,p2] [--repo R] [--gap GAP-N] [--id id]
+  revealui-harnesses hotfix resolve  <id> --pr URL | --note TEXT
+  revealui-harnesses hotfix promote  <id> --gap GAP-N
+  revealui-harnesses hotfix list | check | audit [root] | sweep | store
+
+Policy: prefer a durable root-cause fix in the owning primitive. register admits
+debt; convert with resolve when the durable fix lands. Store: ${controlManifestPath()}
+`;
+}
+
+/**
+ * Run hotfix subcommand. Returns process exit code (0 ok, 1 error).
+ * Writes to stdout/stderr.
+ */
+export function runHotfixCli(argv: string[]): number {
+  const [cmd, ...rest] = argv;
+  try {
+    const opts = parseArgs(rest);
+    const target = opts._[0];
+
+    switch (cmd) {
+      case 'register': {
+        process.stdout.write(
+          'hotfix: WARNING — register is admitted debt. Prefer durable root-cause fixes.\n',
+        );
+        const paths = opts.paths
+          ? String(opts.paths)
+              .split(',')
+              .map((p) => p.trim())
+              .filter(Boolean)
+          : [];
+        const e = registerHotfix({
+          title: opts.title ?? '',
+          symptom: opts.symptom ?? '',
+          temporary: opts.temporary ?? '',
+          durable: opts.durable ?? '',
+          paths,
+          repo: opts.repo ?? null,
+          gap: opts.gap ?? null,
+          id: opts.id,
+        });
+        process.stdout.write(`hotfix: registered ${e.id}\n`);
+        process.stdout.write(`  temporary: ${e.temporary}\n`);
+        process.stdout.write(`  durable:   ${e.durable}\n`);
+        process.stdout.write(
+          `  marker:    // HOTFIX(${e.id}): ${e.title} → durable: ${e.durable}\n`,
+        );
+        process.stdout.write(
+          `  when durable lands: revealui-harnesses hotfix resolve ${e.id} --pr <url>\n`,
+        );
+        process.stdout.write(`  store: ${controlManifestPath()}\n`);
+        return 0;
+      }
+      case 'resolve': {
+        if (!target) {
+          process.stderr.write('hotfix: resolve <id> --pr <url> | --note <text>\n');
+          return 1;
+        }
+        const e = resolveHotfix(target, { pr: opts.pr, note: opts.note });
+        process.stdout.write(`hotfix: ${e.id} resolved (durable conversion recorded)\n`);
+        if (e.pr) process.stdout.write(`  pr: ${e.pr}\n`);
+        if (e.resolveNote) process.stdout.write(`  note: ${e.resolveNote}\n`);
+        return 0;
+      }
+      case 'promote': {
+        if (!target) {
+          process.stderr.write('hotfix: promote <id> --gap GAP-NNN\n');
+          return 1;
+        }
+        const e = promoteHotfix(target, opts.gap ?? '');
+        process.stdout.write(`hotfix: ${e.id} linked to ${e.gap} (still pending until resolve)\n`);
+        return 0;
+      }
+      case 'check': {
+        for (const line of formatCheckLines()) process.stdout.write(`${line}\n`);
+        return 0;
+      }
+      case 'list': {
+        const m = loadManifest();
+        if (m.entries.length === 0) {
+          process.stdout.write('hotfix: no tracked hotfixes\n');
+          process.stdout.write(`  store: ${controlManifestPath()}\n`);
+          return 0;
+        }
+        for (const e of m.entries) {
+          const age = ageDays(e.created).toFixed(1);
+          process.stdout.write(
+            `${e.status.padEnd(9)} ${e.id}  (${age}d)  ${e.title}` +
+              (e.gap ? `  [${e.gap}]` : '') +
+              '\n',
+          );
+          process.stdout.write(`          temporary: ${e.temporary}\n`);
+          process.stdout.write(`          durable:   ${e.durable}\n`);
+          if (e.paths.length) {
+            process.stdout.write(`          paths:     ${e.paths.join(', ')}\n`);
+          }
+          if (e.pr) process.stdout.write(`          pr:        ${e.pr}\n`);
+        }
+        process.stdout.write(`  store: ${controlManifestPath()}\n`);
+        return 0;
+      }
+      case 'audit': {
+        const report = auditHotfixes(target);
+        for (const line of formatAuditReport(report)) process.stdout.write(`${line}\n`);
+        return 0;
+      }
+      case 'sweep': {
+        const r = sweepResolved();
+        process.stdout.write(
+          `hotfix: sweep pruned ${r.pruned} old resolved entr(ies); ${r.remaining} tracked\n`,
+        );
+        return 0;
+      }
+      case 'store': {
+        process.stdout.write(`${controlManifestPath()}\n`);
+        process.stdout.write(`pending: ${pendingEntries().length}\n`);
+        return 0;
+      }
+      case 'help':
+      case undefined:
+        process.stdout.write(usage());
+        return 0;
+      default:
+        process.stderr.write(`hotfix: unknown command ${cmd}\n`);
+        process.stderr.write(usage());
+        return 1;
+    }
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+}

--- a/packages/harnesses/src/hotfix/cli.ts
+++ b/packages/harnesses/src/hotfix/cli.ts
@@ -30,21 +30,27 @@ function parseArgs(argv: string[]): {
   id?: string;
 } {
   const opts: ReturnType<typeof parseArgs> = { _: [] };
-  for (let i = 0; i < argv.length; i++) {
+  let i = 0;
+  while (i < argv.length) {
     const a = argv[i] ?? '';
-    if (a === '--title') opts.title = argv[++i];
-    else if (a === '--symptom') opts.symptom = argv[++i];
-    else if (a === '--temporary') opts.temporary = argv[++i];
-    else if (a === '--durable') opts.durable = argv[++i];
-    else if (a === '--paths') opts.paths = argv[++i];
-    else if (a === '--repo') opts.repo = argv[++i];
-    else if (a === '--gap') opts.gap = argv[++i];
-    else if (a === '--pr') opts.pr = argv[++i];
-    else if (a === '--note') opts.note = argv[++i];
-    else if (a === '--id') opts.id = argv[++i];
+    const next = (): string => {
+      i += 1;
+      return argv[i] ?? '';
+    };
+    if (a === '--title') opts.title = next();
+    else if (a === '--symptom') opts.symptom = next();
+    else if (a === '--temporary') opts.temporary = next();
+    else if (a === '--durable') opts.durable = next();
+    else if (a === '--paths') opts.paths = next();
+    else if (a === '--repo') opts.repo = next();
+    else if (a === '--gap') opts.gap = next();
+    else if (a === '--pr') opts.pr = next();
+    else if (a === '--note') opts.note = next();
+    else if (a === '--id') opts.id = next();
     else if (a.startsWith('--')) {
       throw new Error(`hotfix: unknown flag ${a}`);
     } else opts._.push(a);
+    i += 1;
   }
   return opts;
 }

--- a/packages/harnesses/src/hotfix/index.ts
+++ b/packages/harnesses/src/hotfix/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Hotfix → durable registry (RevealUI control layer).
+ *
+ * Prefer durable root-cause fixes. Use this registry only when a temporary
+ * patch is unavoidable and must be converted.
+ */
+
+export { runHotfixCli } from './cli.js';
+export {
+  controlHotfixDir,
+  controlManifestPath,
+  legacyClaudeManifestPath,
+  revealuiDataDir,
+} from './paths.js';
+export {
+  ageDays,
+  auditHotfixes,
+  ENTRY_RETENTION_DAYS,
+  findEntry,
+  formatAuditReport,
+  formatCheckLines,
+  OVERDUE_DAYS,
+  pendingEntries,
+  promoteHotfix,
+  registerHotfix,
+  resolveHotfix,
+  slugify,
+  sweepResolved,
+} from './registry.js';
+export { loadManifest, saveManifest } from './store.js';
+export type {
+  AuditHit,
+  AuditReport,
+  HotfixEntry,
+  HotfixManifest,
+  HotfixStatus,
+  RegisterHotfixInput,
+  ResolveHotfixInput,
+} from './types.js';

--- a/packages/harnesses/src/hotfix/paths.ts
+++ b/packages/harnesses/src/hotfix/paths.ts
@@ -1,0 +1,32 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Same data root as harness daemon sock / DB (`cli.ts` DATA_DIR). */
+export function revealuiDataDir(): string {
+  return join(homedir(), '.local', 'share', 'revealui');
+}
+
+/** Canonical control-layer hotfix registry directory. */
+export function controlHotfixDir(): string {
+  return join(revealuiDataDir(), 'hotfixes');
+}
+
+export function controlManifestPath(): string {
+  return join(controlHotfixDir(), 'manifest.json');
+}
+
+/**
+ * Legacy Studio-adapter store (pre-cutover). Read for one-time migration only;
+ * never write here after cutover.
+ */
+export function legacyClaudeManifestPath(): string {
+  return join(homedir(), '.claude', 'hotfixes', 'manifest.json');
+}
+
+export function ensureControlHotfixDir(): void {
+  const dir = controlHotfixDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+}

--- a/packages/harnesses/src/hotfix/registry.ts
+++ b/packages/harnesses/src/hotfix/registry.ts
@@ -1,0 +1,328 @@
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { extname, join, relative, resolve } from 'node:path';
+import { controlManifestPath } from './paths.js';
+import { loadManifest, saveManifest } from './store.js';
+import type {
+  AuditHit,
+  AuditReport,
+  HotfixEntry,
+  HotfixManifest,
+  RegisterHotfixInput,
+  ResolveHotfixInput,
+} from './types.js';
+
+/** Days after which a still-pending entry is overdue. */
+export const OVERDUE_DAYS = 7;
+export const ENTRY_RETENTION_DAYS = 90;
+
+const MARKER_PATTERNS = [
+  /HOTFIX\(([A-Za-z0-9._:-]+)\)/,
+  /HOTFIX:\s*(.+)$/,
+  /FIXME\(durable\)/,
+  /@hotfix\b/,
+];
+
+const SCAN_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.md',
+  '.yml',
+  '.yaml',
+  '.sh',
+  '.toml',
+]);
+
+const SKIP_DIR_NAMES = new Set([
+  'node_modules',
+  '.git',
+  '.turbo',
+  'dist',
+  'build',
+  '.next',
+  'coverage',
+  'opensrc',
+  '.direnv',
+  '.pgdata',
+  'vendor',
+]);
+
+export function ageDays(iso: string): number {
+  return (Date.now() - Date.parse(iso)) / 86400000;
+}
+
+export function findEntry(m: HotfixManifest, key: string): HotfixEntry | undefined {
+  return m.entries.find((e) => e.id === key || e.title === key);
+}
+
+export function slugify(title: string): string {
+  return (
+    String(title)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 40) || 'hotfix'
+  );
+}
+
+export function pendingEntries(m?: HotfixManifest): HotfixEntry[] {
+  const manifest = m ?? loadManifest();
+  return manifest.entries.filter((e) => e.status === 'pending');
+}
+
+/**
+ * Register admitted debt. Prefer durable root-cause fixes instead of calling
+ * this — registration is not success; conversion is.
+ */
+export function registerHotfix(
+  input: RegisterHotfixInput,
+  options?: { controlPath?: string; legacyPath?: string },
+): HotfixEntry {
+  if (!input.title?.trim()) {
+    throw new Error('hotfix: register requires --title');
+  }
+  if (!input.symptom?.trim() || !input.temporary?.trim() || !input.durable?.trim()) {
+    throw new Error('hotfix: register requires --symptom, --temporary, and --durable');
+  }
+
+  const m = loadManifest(options);
+  const id = input.id?.trim() || `${slugify(input.title)}-${Date.now().toString(36)}`;
+  if (findEntry(m, id)) {
+    throw new Error(`hotfix: id already exists: ${id}`);
+  }
+
+  const entry: HotfixEntry = {
+    id,
+    title: input.title.trim(),
+    symptom: input.symptom.trim(),
+    temporary: input.temporary.trim(),
+    durable: input.durable.trim(),
+    paths: input.paths ?? [],
+    repo: input.repo ?? null,
+    gap: input.gap ?? null,
+    pr: null,
+    session: String(process.ppid || 0),
+    created: new Date().toISOString(),
+    status: 'pending',
+    resolved: null,
+    resolveNote: null,
+  };
+  m.entries.push(entry);
+  saveManifest(m, options);
+  return entry;
+}
+
+export function resolveHotfix(
+  key: string,
+  input: ResolveHotfixInput,
+  options?: { controlPath?: string; legacyPath?: string },
+): HotfixEntry {
+  const m = loadManifest(options);
+  const e = findEntry(m, key);
+  if (!e) throw new Error(`hotfix: no entry for: ${key}`);
+  if (e.status === 'resolved') return e;
+  if (!input.pr && !input.note) {
+    throw new Error('hotfix: resolve requires --pr <url> and/or --note <text>');
+  }
+  e.status = 'resolved';
+  e.resolved = new Date().toISOString();
+  e.pr = input.pr || e.pr;
+  e.resolveNote = input.note || null;
+  saveManifest(m, options);
+  return e;
+}
+
+export function promoteHotfix(
+  key: string,
+  gap: string,
+  options?: { controlPath?: string; legacyPath?: string },
+): HotfixEntry {
+  if (!gap?.trim()) throw new Error('hotfix: promote requires --gap GAP-NNN');
+  const m = loadManifest(options);
+  const e = findEntry(m, key);
+  if (!e) throw new Error(`hotfix: no entry for: ${key}`);
+  e.gap = gap.trim();
+  saveManifest(m, options);
+  return e;
+}
+
+export function sweepResolved(options?: { controlPath?: string; legacyPath?: string }): {
+  pruned: number;
+  remaining: number;
+} {
+  const m = loadManifest(options);
+  const before = m.entries.length;
+  m.entries = m.entries.filter((e) => {
+    if (e.status !== 'resolved' || !e.resolved) return true;
+    return ageDays(e.resolved) <= ENTRY_RETENTION_DAYS;
+  });
+  saveManifest(m, options);
+  return { pruned: before - m.entries.length, remaining: m.entries.length };
+}
+
+function walkFiles(root: string, out: string[], depth: number): void {
+  if (depth > 12) return;
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of entries) {
+    if (ent.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(ent.name)) continue;
+      if (ent.name.startsWith('.') && ent.name !== '.claude' && ent.name !== '.jv') continue;
+      walkFiles(join(root, ent.name), out, depth + 1);
+      continue;
+    }
+    if (!SCAN_EXTENSIONS.has(extname(ent.name))) continue;
+    out.push(join(root, ent.name));
+  }
+}
+
+function scanFile(filePath: string): AuditHit[] {
+  let text: string;
+  try {
+    text = readFileSync(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+  if (text.length > 1_500_000) return [];
+  const hits: AuditHit[] = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    if (!line.includes('HOTFIX') && !line.includes('FIXME(durable)') && !line.includes('@hotfix')) {
+      continue;
+    }
+    for (const re of MARKER_PATTERNS) {
+      const m = line.match(re);
+      if (m) {
+        hits.push({
+          file: filePath,
+          line: i + 1,
+          text: line.trim().slice(0, 200),
+          id: m[1] && !m[1].includes(' ') ? m[1] : null,
+        });
+        break;
+      }
+    }
+  }
+  return hits;
+}
+
+export function auditHotfixes(
+  rootArg?: string,
+  options?: { controlPath?: string; legacyPath?: string },
+): AuditReport {
+  const root = resolve(rootArg || process.cwd());
+  const m = loadManifest(options);
+  const pending = m.entries.filter((e) => e.status === 'pending');
+  const byId = new Map(m.entries.map((e) => [e.id, e]));
+
+  const files: string[] = [];
+  walkFiles(root, files, 0);
+  const markers: AuditHit[] = [];
+  for (const f of files) {
+    for (const h of scanFile(f)) markers.push(h);
+  }
+
+  let unregisteredCount = 0;
+  for (const h of markers) {
+    if (!(h.id && byId.has(h.id))) unregisteredCount++;
+  }
+
+  let recentCommits: string[] = [];
+  try {
+    const out = execFileSync(
+      'git',
+      ['-C', root, 'log', '--oneline', '-30', '--grep=hotfix', '-i'],
+      { encoding: 'utf8', timeout: 3000 },
+    ).trim();
+    if (out) recentCommits = out.split('\n').slice(0, 10);
+  } catch {
+    /* not a git repo */
+  }
+
+  return {
+    root,
+    pending,
+    total: m.entries.length,
+    markers,
+    unregisteredCount,
+    recentCommits,
+  };
+}
+
+/** Format session-boundary check (warn-only; always informational). */
+export function formatCheckLines(m?: HotfixManifest): string[] {
+  const pending = pendingEntries(m);
+  if (pending.length === 0) return [];
+  const overdue = pending.filter((e) => ageDays(e.created) > OVERDUE_DAYS);
+  const lines: string[] = [
+    `[hotfix] ${pending.length} hotfix(es) awaiting durable conversion` +
+      (overdue.length ? ` (${overdue.length} overdue >${OVERDUE_DAYS}d)` : '') +
+      ':',
+  ];
+  for (const e of pending) {
+    const days = ageDays(e.created).toFixed(1);
+    const flag = ageDays(e.created) > OVERDUE_DAYS ? ' OVERDUE' : '';
+    lines.push(`  ${e.id}${flag} — ${e.title} — ${days}d`);
+    lines.push(`    temporary: ${e.temporary}`);
+    lines.push(`    durable:   ${e.durable}`);
+    if (e.gap) lines.push(`    gap:       ${e.gap}`);
+    lines.push(`    → revealui-harnesses hotfix resolve ${e.id} --pr <url>`);
+  }
+  lines.push(
+    '[hotfix] hardline: long-term durable solutions only (RevealUI control layer / durable-solutions)',
+  );
+  lines.push(`[hotfix] store: ${controlManifestPath()}`);
+  return lines;
+}
+
+export function formatAuditReport(report: AuditReport): string[] {
+  const lines: string[] = [
+    `[hotfix audit] root=${report.root}`,
+    `[hotfix audit] registry: ${report.pending.length} pending / ${report.total} total`,
+    `[hotfix audit] store: ${controlManifestPath()}`,
+  ];
+  for (const e of report.pending) {
+    const days = ageDays(e.created).toFixed(1);
+    const over = ageDays(e.created) > OVERDUE_DAYS ? ' OVERDUE' : '';
+    lines.push(`  pending${over} ${e.id} (${days}d) — ${e.title}`);
+    lines.push(`    → durable: ${e.durable}`);
+  }
+  lines.push(`[hotfix audit] markers found: ${report.markers.length}`);
+  const byId = new Map(loadManifest().entries.map((e) => [e.id, e] as const));
+  for (const h of report.markers) {
+    const rel = relative(report.root, h.file) || h.file;
+    if (h.id && byId.has(h.id)) {
+      const e = byId.get(h.id);
+      lines.push(`  marked  ${rel}:${h.line}  id=${h.id}  status=${e?.status}`);
+    } else if (h.id) {
+      lines.push(`  ORPHAN  ${rel}:${h.line}  id=${h.id} (not in registry)`);
+      lines.push(`    ${h.text}`);
+    } else {
+      lines.push(`  MARKER  ${rel}:${h.line}`);
+      lines.push(`    ${h.text}`);
+      lines.push(
+        '    → prefer a durable root-cause fix; if unavoidable: revealui-harnesses hotfix register …',
+      );
+    }
+  }
+  if (report.recentCommits.length > 0) {
+    lines.push('[hotfix audit] recent commits matching /hotfix/i:');
+    for (const line of report.recentCommits) lines.push(`  ${line}`);
+  }
+  if (report.pending.length === 0 && report.markers.length === 0) {
+    lines.push('[hotfix audit] clean — no pending debt, no markers');
+  } else if (report.unregisteredCount > 0) {
+    lines.push(`[hotfix audit] ${report.unregisteredCount} marker(s) need register or id link`);
+  }
+  lines.push('[hotfix audit] hardline: long-term durable solutions only (control layer)');
+  return lines;
+}

--- a/packages/harnesses/src/hotfix/registry.ts
+++ b/packages/harnesses/src/hotfix/registry.ts
@@ -85,7 +85,7 @@ export function registerHotfix(
   if (!input.title?.trim()) {
     throw new Error('hotfix: register requires --title');
   }
-  if (!input.symptom?.trim() || !input.temporary?.trim() || !input.durable?.trim()) {
+  if (!(input.symptom?.trim() && input.temporary?.trim() && input.durable?.trim())) {
     throw new Error('hotfix: register requires --symptom, --temporary, and --durable');
   }
 
@@ -125,7 +125,7 @@ export function resolveHotfix(
   const e = findEntry(m, key);
   if (!e) throw new Error(`hotfix: no entry for: ${key}`);
   if (e.status === 'resolved') return e;
-  if (!input.pr && !input.note) {
+  if (!(input.pr || input.note)) {
     throw new Error('hotfix: resolve requires --pr <url> and/or --note <text>');
   }
   e.status = 'resolved';
@@ -166,7 +166,7 @@ export function sweepResolved(options?: { controlPath?: string; legacyPath?: str
 
 function walkFiles(root: string, out: string[], depth: number): void {
   if (depth > 12) return;
-  let entries;
+  let entries: ReturnType<typeof readdirSync>;
   try {
     entries = readdirSync(root, { withFileTypes: true });
   } catch {
@@ -196,7 +196,7 @@ function scanFile(filePath: string): AuditHit[] {
   const lines = text.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? '';
-    if (!line.includes('HOTFIX') && !line.includes('FIXME(durable)') && !line.includes('@hotfix')) {
+    if (!(line.includes('HOTFIX') || line.includes('FIXME(durable)') || line.includes('@hotfix'))) {
       continue;
     }
     for (const re of MARKER_PATTERNS) {

--- a/packages/harnesses/src/hotfix/registry.ts
+++ b/packages/harnesses/src/hotfix/registry.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { extname, join, relative, resolve } from 'node:path';
 import { controlManifestPath } from './paths.js';
 import { loadManifest, saveManifest } from './store.js';
@@ -166,21 +166,29 @@ export function sweepResolved(options?: { controlPath?: string; legacyPath?: str
 
 function walkFiles(root: string, out: string[], depth: number): void {
   if (depth > 12) return;
-  let entries: ReturnType<typeof readdirSync>;
+  let names: string[];
   try {
-    entries = readdirSync(root, { withFileTypes: true });
+    // string names (not Dirent) — Node 24 Dirent generics break tsup dts otherwise
+    names = readdirSync(root);
   } catch {
     return;
   }
-  for (const ent of entries) {
-    if (ent.isDirectory()) {
-      if (SKIP_DIR_NAMES.has(ent.name)) continue;
-      if (ent.name.startsWith('.') && ent.name !== '.claude' && ent.name !== '.jv') continue;
-      walkFiles(join(root, ent.name), out, depth + 1);
+  for (const name of names) {
+    const full = join(root, name);
+    let isDir = false;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
       continue;
     }
-    if (!SCAN_EXTENSIONS.has(extname(ent.name))) continue;
-    out.push(join(root, ent.name));
+    if (isDir) {
+      if (SKIP_DIR_NAMES.has(name)) continue;
+      if (name.startsWith('.') && name !== '.claude' && name !== '.jv') continue;
+      walkFiles(full, out, depth + 1);
+      continue;
+    }
+    if (!SCAN_EXTENSIONS.has(extname(name))) continue;
+    out.push(full);
   }
 }
 

--- a/packages/harnesses/src/hotfix/store.ts
+++ b/packages/harnesses/src/hotfix/store.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { controlManifestPath, ensureControlHotfixDir, legacyClaudeManifestPath } from './paths.js';
+import type { HotfixManifest } from './types.js';
+
+const EMPTY: HotfixManifest = { version: 1, entries: [] };
+
+function parseManifest(raw: string): HotfixManifest | null {
+  try {
+    const data = JSON.parse(raw) as HotfixManifest;
+    if (data && Array.isArray(data.entries)) {
+      return { version: 1, store: data.store, entries: data.entries };
+    }
+  } catch {
+    /* corrupt */
+  }
+  return null;
+}
+
+/**
+ * Load control-layer manifest. If missing/empty, one-time import from the
+ * legacy `~/.claude/hotfixes` adapter store (does not delete legacy).
+ */
+export function loadManifest(options?: {
+  controlPath?: string;
+  legacyPath?: string;
+  migrate?: boolean;
+}): HotfixManifest {
+  const controlPath = options?.controlPath ?? controlManifestPath();
+  const legacyPath = options?.legacyPath ?? legacyClaudeManifestPath();
+  const migrate = options?.migrate !== false;
+
+  if (existsSync(controlPath)) {
+    const parsed = parseManifest(readFileSync(controlPath, 'utf8'));
+    if (parsed) return parsed;
+  }
+
+  if (migrate && existsSync(legacyPath)) {
+    const legacy = parseManifest(readFileSync(legacyPath, 'utf8'));
+    if (legacy && legacy.entries.length > 0) {
+      const migrated: HotfixManifest = {
+        version: 1,
+        store: controlPath,
+        entries: legacy.entries,
+      };
+      saveManifest(migrated, { controlPath });
+      return migrated;
+    }
+  }
+
+  return { ...EMPTY, store: controlPath, entries: [] };
+}
+
+export function saveManifest(m: HotfixManifest, options?: { controlPath?: string }): void {
+  const controlPath = options?.controlPath ?? controlManifestPath();
+  ensureControlHotfixDir();
+  const out: HotfixManifest = {
+    version: 1,
+    store: controlPath,
+    entries: m.entries,
+  };
+  writeFileSync(controlPath, `${JSON.stringify(out, null, 2)}\n`, 'utf8');
+}

--- a/packages/harnesses/src/hotfix/types.ts
+++ b/packages/harnesses/src/hotfix/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Hotfix → durable conversion registry (RevealUI control layer).
+ *
+ * Long-term durable solutions only. A registry entry is admitted debt, not a
+ * preferred workflow. Prefer root-cause fixes in the owning primitive.
+ */
+
+export type HotfixStatus = 'pending' | 'resolved';
+
+export interface HotfixEntry {
+  id: string;
+  title: string;
+  symptom: string;
+  temporary: string;
+  durable: string;
+  paths: string[];
+  repo: string | null;
+  gap: string | null;
+  pr: string | null;
+  session: string;
+  created: string;
+  status: HotfixStatus;
+  resolved: string | null;
+  resolveNote: string | null;
+}
+
+export interface HotfixManifest {
+  version: 1;
+  /** Control-layer store path this manifest was last written to. */
+  store?: string;
+  entries: HotfixEntry[];
+}
+
+export interface RegisterHotfixInput {
+  title: string;
+  symptom: string;
+  temporary: string;
+  durable: string;
+  paths?: string[];
+  repo?: string | null;
+  gap?: string | null;
+  id?: string;
+}
+
+export interface ResolveHotfixInput {
+  pr?: string;
+  note?: string;
+}
+
+export interface AuditHit {
+  file: string;
+  line: number;
+  text: string;
+  id: string | null;
+}
+
+export interface AuditReport {
+  root: string;
+  pending: HotfixEntry[];
+  total: number;
+  markers: AuditHit[];
+  unregisteredCount: number;
+  recentCommits: string[];
+}

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     'src/storage/index.ts',
     'src/goals/index.ts',
     'src/hooks/index.ts',
+    'src/hotfix/index.ts',
   ],
   format: ['esm'],
   dts: true,


### PR DESCRIPTION
## Summary

**GAP-405 control layer:** RevealUI owns the hotfix→durable registry.

| Item | Detail |
|------|--------|
| Store | `~/.local/share/revealui/hotfixes/manifest.json` |
| CLI | `revealui-harnesses hotfix {register,resolve,promote,list,check,audit,sweep,store}` |
| Policy | Long-term durable solutions only; register admits debt |
| Migration | One-time import from legacy `~/.claude/hotfixes` if control store empty |

Adapters must thin-forward; dual SSOT retired.

## Test plan
- [x] hotfix-registry unit tests (5)
- [x] content snapshot
- [x] local gate phase 1