### PR TITLE
feat(ai,server,ci): GAP-355 S5-4 agent audit chokepoint inventory

### DIFF
--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -195,6 +195,34 @@ app.openapi(agentStreamRoute, async (c) => {
 
   const workspaceId = body.workspaceId ?? c.get('tenant')?.id ?? 'default';
   const mode = body.mode ?? 'admin';
+  const streamAgentId = mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent';
+  const accountId = getEntitlementsFromContext(c).accountId;
+  const runSession = createAgentRunSession(user.id);
+  // Late-bound task id for tool-audit rows (task object is built after tools).
+  const taskRef: { id: string } = { id: `task-${Date.now()}` };
+
+  // GAP-355 S5-4: integrity audit for non-MCP tools (admin CMS + coding).
+  const streamToolAudit =
+    (namespace: string) =>
+    async (event: {
+      toolName: string;
+      success: boolean;
+      duration_ms: number;
+      error?: string;
+    }): Promise<void> => {
+      await recordAgentMcpToolAudit({
+        namespace,
+        toolName: event.toolName,
+        success: event.success,
+        durationMs: event.duration_ms,
+        ...(event.error !== undefined ? { error: event.error } : {}),
+        sessionId: runSession.sessionId,
+        accountId,
+        userId: user.id,
+        agentId: streamAgentId,
+        taskId: taskRef.id,
+      });
+    };
 
   // Load admin tools so the agent can manage content, media, users, globals
   let cmsTools: unknown[] = [];
@@ -219,7 +247,10 @@ app.openapi(agentStreamRoute, async (c) => {
       const { createInternalAdminClient } = await import('../lib/internal-admin-client.js');
       const apiClient = createInternalAdminClient(apiBase, sessionToken);
 
-      cmsTools = cmsToolsMod.createAdminTools({ apiClient });
+      cmsTools = cmsToolsMod.createAdminTools({
+        apiClient,
+        onToolAudit: streamToolAudit('admin-cms'),
+      });
     }
   } catch {
     // admin tools unavailable  -  agent will work without them
@@ -244,12 +275,19 @@ app.openapi(agentStreamRoute, async (c) => {
           projectRoot: string;
           allowedPaths?: string[];
           include?: string[];
+          onToolAudit?: (event: {
+            toolName: string;
+            success: boolean;
+            duration_ms: number;
+            error?: string;
+          }) => void | Promise<void>;
         }) => unknown[];
         codingTools = createCodingTools({
           projectRoot,
           allowedPaths: process.env.CODING_ALLOWED_PATHS?.split(','),
           // Local (free tier): only read-only tools (no file_write, file_edit, shell_exec, git_ops)
           ...(isLocalOnly && { include: readOnlyCodingTools }),
+          onToolAudit: streamToolAudit('coding'),
         });
       }
     } catch {
@@ -273,11 +311,7 @@ app.openapi(agentStreamRoute, async (c) => {
   // `streamSSE()` starts can write into the stream once it exists.
   const mcpClients: McpClient[] = [];
   const tenant = c.get('tenant')?.id;
-  const accountId = getEntitlementsFromContext(c).accountId;
-  const runSession = createAgentRunSession(user.id);
   const streamRef: { current: SSEStreamingApi | undefined } = { current: undefined };
-  // Late-bound task id for tool-audit rows (task object is built after MCP tools).
-  const taskRef: { id: string } = { id: `task-${Date.now()}` };
 
   const loggerSink = aiMod.createCoreLoggerSink();
   const meterSink = accountId
@@ -501,7 +535,6 @@ Workspace: ${workspaceId}`,
     timeout: 120_000,
   });
 
-  const streamAgentId = mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent';
   const auditStore = createAuditStore(getClient());
 
   return streamSSE(c, async (stream) => {

--- a/package.json
+++ b/package.json
@@ -247,6 +247,7 @@
     "validate:empty-catch": "tsx scripts/validate/empty-catch.ts",
     "validate:as-never-values": "tsx scripts/validate/as-never-values.ts",
     "validate:audit-one-door": "tsx scripts/validate/audit-log-single-door.ts",
+    "validate:agent-audit-chokepoints": "tsx scripts/validate/agent-audit-chokepoints.ts",
     "validate:kek-rotation": "vitest run scripts/security/__tests__/rotate-kek.test.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
     "validate:prod-env": "tsx scripts/validate/prod-env.ts",

--- a/packages/ai/src/__tests__/tools/integrity-audit.test.ts
+++ b/packages/ai/src/__tests__/tools/integrity-audit.test.ts
@@ -1,0 +1,74 @@
+/**
+ * GAP-355 S5-4 — wrapToolWithIntegrityAudit fail-closed contract.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import type { Tool } from '../../tools/base.js';
+import {
+  maybeWrapToolsWithIntegrityAudit,
+  wrapToolWithIntegrityAudit,
+} from '../../tools/integrity-audit.js';
+
+function makeTool(execute: Tool['execute'], name = 'demo_tool'): Tool {
+  return {
+    name,
+    description: 'demo',
+    parameters: z.object({}),
+    execute,
+  };
+}
+
+describe('wrapToolWithIntegrityAudit', () => {
+  it('awaits audit after a successful execute', async () => {
+    const order: string[] = [];
+    const tool = makeTool(async () => {
+      order.push('exec');
+      return { success: true, data: { ok: true } };
+    });
+
+    const wrapped = wrapToolWithIntegrityAudit(tool, async (e) => {
+      order.push('audit');
+      expect(e).toMatchObject({ toolName: 'demo_tool', success: true });
+    });
+
+    const result = await wrapped.execute({});
+    expect(result.success).toBe(true);
+    expect(order).toEqual(['exec', 'audit']);
+  });
+
+  it('fails closed when audit throws after success', async () => {
+    const tool = makeTool(async () => ({ success: true, data: {} }));
+    const wrapped = wrapToolWithIntegrityAudit(tool, async () => {
+      throw new Error('audit write failed');
+    });
+
+    await expect(wrapped.execute({})).rejects.toThrow(/audit write failed/);
+  });
+
+  it('returns tool failure when audit throws on an already-failed call', async () => {
+    const tool = makeTool(async () => ({ success: false, error: 'nope' }));
+    const wrapped = wrapToolWithIntegrityAudit(tool, async () => {
+      throw new Error('audit write failed');
+    });
+
+    await expect(wrapped.execute({})).resolves.toEqual({
+      success: false,
+      error: 'nope',
+    });
+  });
+
+  it('maybeWrapToolsWithIntegrityAudit is a no-op without a handler', () => {
+    const tool = makeTool(async () => ({ success: true }));
+    const out = maybeWrapToolsWithIntegrityAudit([tool], undefined);
+    expect(out[0]).toBe(tool);
+  });
+
+  it('maybeWrapToolsWithIntegrityAudit wraps when handler present', async () => {
+    const onToolAudit = vi.fn(async () => undefined);
+    const tool = makeTool(async () => ({ success: true }));
+    const [wrapped] = maybeWrapToolsWithIntegrityAudit([tool], onToolAudit);
+    await wrapped?.execute({});
+    expect(onToolAudit).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
+++ b/packages/ai/src/__tests__/tools/mcp-client-adapter.test.ts
@@ -9,6 +9,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   createToolsFromMcpClient,
+  discoverMCPTools,
+  type MCPToolSource,
   type McpCallToolResultLike,
   type McpClientLike,
   type McpGetPromptResultLike,
@@ -924,8 +926,8 @@ describe('createToolsFromMcpClient — onToolAudit', () => {
     });
   });
 
-  it('does not call onToolAudit for resource/prompt meta-tools', async () => {
-    const onToolAudit = vi.fn(async () => undefined);
+  it('audits resource/prompt meta-tools (S5-4b live residual close)', async () => {
+    const audited: string[] = [];
     const client = makeFullClient({
       resources: [{ uri: 'x://1', name: 'one' }],
       resourceContents: { 'x://1': [{ uri: 'x://1', text: 'body' }] },
@@ -938,7 +940,11 @@ describe('createToolsFromMcpClient — onToolAudit', () => {
     const tools = await createToolsFromMcpClient(client, {
       namespace: 'srv',
       include: { tools: false, resources: true, prompts: true },
-      onToolAudit,
+      onToolAudit: async (e) => {
+        audited.push(e.toolName);
+        expect(e.kind).toBe('mcp.tool.call');
+        expect(e.success).toBe(true);
+      },
     });
 
     for (const tool of tools) {
@@ -951,7 +957,26 @@ describe('createToolsFromMcpClient — onToolAudit', () => {
       }
     }
 
-    expect(onToolAudit).not.toHaveBeenCalled();
+    expect(audited.sort()).toEqual(
+      ['get_prompt', 'list_prompts', 'list_resources', 'read_resource'].sort(),
+    );
+  });
+
+  it('fails closed when onToolAudit throws after read_resource success', async () => {
+    const client = makeFullClient({
+      resources: [{ uri: 'x://1', name: 'one' }],
+      resourceContents: { 'x://1': [{ uri: 'x://1', text: 'body' }] },
+    });
+
+    const tools = await createToolsFromMcpClient(client, {
+      namespace: 'srv',
+      include: { tools: false, resources: true, prompts: false },
+      onToolAudit: async () => {
+        throw new Error('audit write failed');
+      },
+    });
+    const readTool = tools.find((t) => t.name.endsWith('__read_resource'));
+    await expect(readTool?.execute({ uri: 'x://1' })).rejects.toThrow(/audit write failed/);
   });
 
   it('works without onToolAudit — success path unchanged', async () => {
@@ -963,5 +988,62 @@ describe('createToolsFromMcpClient — onToolAudit', () => {
     const tools = await createToolsFromMcpClient(client, { namespace: 'srv' });
     const result = await tools[0]?.execute({});
     expect(result?.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverMCPTools — legacy hypervisor path integrity (S5-4b)
+// ---------------------------------------------------------------------------
+
+describe('discoverMCPTools — onToolAudit', () => {
+  function makeSource(
+    callHandler: (server: string, tool: string, args: unknown) => Promise<unknown>,
+  ): MCPToolSource {
+    return {
+      getAllTools: () => [
+        {
+          namespacedName: '@@mcp_srv_ping',
+          serverName: 'srv',
+          tool: {
+            name: 'ping',
+            description: 'ping',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        },
+      ],
+      callTool: callHandler,
+    };
+  }
+
+  it('awaits onToolAudit after a successful legacy tool call', async () => {
+    const order: string[] = [];
+    const source = makeSource(async () => {
+      order.push('rpc');
+      return { ok: true };
+    });
+    const tools = discoverMCPTools(source, {
+      onToolAudit: async (e) => {
+        order.push('audit');
+        expect(e).toMatchObject({
+          kind: 'mcp.tool.call',
+          namespace: 'srv',
+          toolName: 'ping',
+          success: true,
+        });
+      },
+    });
+    const result = await tools[0]?.execute({});
+    expect(result?.success).toBe(true);
+    expect(order).toEqual(['rpc', 'audit']);
+  });
+
+  it('fails closed when audit throws after success', async () => {
+    const source = makeSource(async () => ({ ok: true }));
+    const tools = discoverMCPTools(source, {
+      onToolAudit: async () => {
+        throw new Error('audit write failed');
+      },
+    });
+    await expect(tools[0]?.execute({})).rejects.toThrow(/audit write failed/);
   });
 });

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -83,6 +83,7 @@ export * from './templates/index.js';
 export * from './tools/base.js';
 export * from './tools/deduplicator.js';
 export * from './tools/document-summarizer.js';
+export * from './tools/integrity-audit.js';
 export * from './tools/mcp-adapter.js';
 export * from './tools/mcp-elicitation.js';
 export * from './tools/mcp-events.js';

--- a/packages/ai/src/orchestration/runtime.ts
+++ b/packages/ai/src/orchestration/runtime.ts
@@ -14,6 +14,7 @@ import type { ApprovalCallback, Tool, ToolResult } from '../tools/base.js';
 import { ToolCallDeduplicator } from '../tools/deduplicator.js';
 import type { MCPToolSource, McpClientLike } from '../tools/mcp-adapter.js';
 import { createToolsFromMcpClient, discoverMCPTools } from '../tools/mcp-adapter.js';
+import type { McpToolCallEvent } from '../tools/mcp-events.js';
 import { createWebSearchTool } from '../tools/web/duck-duck-go.js';
 import type { Agent, AgentResult, Task } from './agent.js';
 
@@ -71,6 +72,12 @@ export interface RuntimeConfig {
    */
   mcpClients?: ReadonlyArray<{ name: string; client: McpClientLike }>;
   /**
+   * GAP-355 integrity audit for MCP tools discovered at run time.
+   * Passed into `createToolsFromMcpClient` and `discoverMCPTools` so library
+   * consumers (not only agent-stream) fail closed when a receipt cannot land.
+   */
+  onToolAudit?: (event: McpToolCallEvent) => void | Promise<void>;
+  /**
    * Optional skill provider. When set, activated skills are injected into the
    * system prompt before the first LLM call, giving the agent contextual
    * instructions from the matching skill packages.
@@ -116,6 +123,7 @@ export class AgentRuntime {
       enableCache: config.enableCache ?? true, // Enable by default for cost savings
       mcpToolSource: config.mcpToolSource,
       mcpClients: config.mcpClients,
+      onToolAudit: config.onToolAudit,
       skillProvider: config.skillProvider,
       thinkingLevel: config.thinkingLevel,
       modelTier: config.modelTier,
@@ -173,13 +181,21 @@ export class AgentRuntime {
     //   - Standard `McpClient` instances (Stage 5.1a, preferred)
     //   - `MCPToolSource` / hypervisor (legacy, deprecated but supported)
     const mcpTools: Tool[] = [];
+    const onToolAudit = this.config.onToolAudit;
     if (this.config.mcpToolSource) {
-      mcpTools.push(...discoverMCPTools(this.config.mcpToolSource));
+      mcpTools.push(
+        ...discoverMCPTools(this.config.mcpToolSource, {
+          ...(onToolAudit !== undefined ? { onToolAudit } : {}),
+        }),
+      );
     }
     if (this.config.mcpClients && this.config.mcpClients.length > 0) {
       for (const { name, client } of this.config.mcpClients) {
         try {
-          const fromClient = await createToolsFromMcpClient(client, { namespace: name });
+          const fromClient = await createToolsFromMcpClient(client, {
+            namespace: name,
+            ...(onToolAudit !== undefined ? { onToolAudit } : {}),
+          });
           mcpTools.push(...fromClient);
         } catch {
           // empty-catch-ok: an unhealthy MCP client shouldn't fail the whole task — other clients + base tools still apply

--- a/packages/ai/src/tools/admin/factory.ts
+++ b/packages/ai/src/tools/admin/factory.ts
@@ -5,6 +5,10 @@
 
 import type { Tool } from '../base.js';
 import {
+  maybeWrapToolsWithIntegrityAudit,
+  type ToolIntegrityAuditHandler,
+} from '../integrity-audit.js';
+import {
   createDocumentTool,
   deleteDocumentTool,
   findDocumentsTool,
@@ -106,6 +110,12 @@ export interface AdminToolsConfig {
 
   /** Current user context (for permission checks) */
   user?: UserContext;
+
+  /**
+   * GAP-355 S5-4 integrity audit. When set, every tool execute is awaited and
+   * successful results fail closed if the audit write throws.
+   */
+  onToolAudit?: ToolIntegrityAuditHandler;
 }
 
 /**
@@ -113,7 +123,7 @@ export interface AdminToolsConfig {
  * This factory function creates functional tools by injecting the actual API implementation
  */
 export function createAdminTools(config: AdminToolsConfig): Tool[] {
-  const { apiClient, collections, globals, user } = config;
+  const { apiClient, collections, globals, user, onToolAudit } = config;
 
   // Clone tools and inject API client implementation
   const tools: Tool[] = [];
@@ -623,5 +633,5 @@ export function createAdminTools(config: AdminToolsConfig): Tool[] {
     },
   });
 
-  return tools;
+  return maybeWrapToolsWithIntegrityAudit(tools, onToolAudit);
 }

--- a/packages/ai/src/tools/coding/index.ts
+++ b/packages/ai/src/tools/coding/index.ts
@@ -5,6 +5,10 @@
  */
 
 import type { Tool } from '../base.js';
+import {
+  maybeWrapToolsWithIntegrityAudit,
+  type ToolIntegrityAuditHandler,
+} from '../integrity-audit.js';
 import { fileEditTool } from './file-edit.js';
 import { fileGlobTool } from './file-glob.js';
 import { fileGrepTool } from './file-grep.js';
@@ -64,6 +68,11 @@ export interface CodingToolsConfig {
     | 'test_runner'
     | 'lint_fix'
   >;
+  /**
+   * GAP-355 S5-4 integrity audit. When set, every tool execute is awaited and
+   * successful results fail closed if the audit write throws.
+   */
+  onToolAudit?: ToolIntegrityAuditHandler;
 }
 
 /** All coding tools in registration order */
@@ -96,12 +105,15 @@ export function createCodingTools(config: CodingToolsConfig): Tool[] {
   configureSafety(safetyConfig);
 
   // Filter tools if include list is provided
+  let tools: Tool[];
   if (config.include) {
     const includeSet = new Set(config.include);
-    return ALL_CODING_TOOLS.filter((t) =>
+    tools = ALL_CODING_TOOLS.filter((t) =>
       includeSet.has(t.name as CodingToolsConfig['include'] extends Array<infer U> ? U : never),
     );
+  } else {
+    tools = [...ALL_CODING_TOOLS];
   }
 
-  return [...ALL_CODING_TOOLS];
+  return maybeWrapToolsWithIntegrityAudit(tools, config.onToolAudit);
 }

--- a/packages/ai/src/tools/integrity-audit.ts
+++ b/packages/ai/src/tools/integrity-audit.ts
@@ -1,0 +1,84 @@
+/**
+ * Tool integrity audit wrapper (GAP-355 Stage 5 S5-4).
+ *
+ * Same fail-closed contract as `createToolsFromMcpClient({ onToolAudit })`:
+ * after a successful tool execution, await the audit hook and rethrow so an
+ * unrecorded success cannot complete. On tool failure, prefer the tool error
+ * if a secondary audit write fails.
+ *
+ * Used for admin CMS + coding tools that are not MCP server tools.
+ */
+
+import type { Tool, ToolResult } from './base.js';
+
+/** Summary event for one tool execution (no raw args / results). */
+export interface ToolIntegrityAuditEvent {
+  toolName: string;
+  success: boolean;
+  duration_ms: number;
+  error?: string;
+}
+
+export type ToolIntegrityAuditHandler = (event: ToolIntegrityAuditEvent) => void | Promise<void>;
+
+/**
+ * Wrap a tool so each `execute` emits an integrity audit event.
+ * Returns a new tool object; does not mutate the input.
+ */
+export function wrapToolWithIntegrityAudit(
+  tool: Tool,
+  onToolAudit: ToolIntegrityAuditHandler,
+): Tool {
+  return {
+    ...tool,
+    async execute(params: unknown): Promise<ToolResult> {
+      const started = Date.now();
+      let result: ToolResult;
+
+      try {
+        result = await tool.execute(params);
+      } catch (error) {
+        const errorText = error instanceof Error ? error.message : String(error);
+        try {
+          await onToolAudit({
+            toolName: tool.name,
+            success: false,
+            duration_ms: Date.now() - started,
+            error: errorText,
+          });
+        } catch {
+          // Prefer the original tool exception over a secondary audit failure.
+        }
+        throw error;
+      }
+
+      const event: ToolIntegrityAuditEvent = {
+        toolName: tool.name,
+        success: result.success,
+        duration_ms: Date.now() - started,
+        ...(result.error !== undefined ? { error: result.error } : {}),
+      };
+
+      if (result.success) {
+        await onToolAudit(event);
+        return result;
+      }
+
+      try {
+        await onToolAudit(event);
+      } catch {
+        // Prefer the tool failure over a secondary audit failure.
+      }
+      return result;
+    },
+  };
+}
+
+/** Map over a tool list when a handler is provided; otherwise return as-is. */
+export function maybeWrapToolsWithIntegrityAudit(
+  tools: Tool[],
+  onToolAudit: ToolIntegrityAuditHandler | undefined,
+): Tool[] {
+  if (!onToolAudit) return tools;
+  return tools.map((tool) => wrapToolWithIntegrityAudit(tool, onToolAudit));
+}

--- a/packages/ai/src/tools/mcp-adapter.ts
+++ b/packages/ai/src/tools/mcp-adapter.ts
@@ -198,11 +198,11 @@ export interface CreateToolsFromMcpClientOptions {
    */
   onEvent?: McpEventSink;
   /**
-   * Integrity audit hook (GAP-355 Stage 5). Fires once per **server tool**
-   * call with the same summary shape as `mcp.tool.call` events. Unlike
+   * Integrity audit hook (GAP-355 Stage 5). Fires once per server tool **and**
+   * resource/prompt meta-tool call with the `mcp.tool.call` summary shape
+   * (`toolName` is the bare primitive name, e.g. `read_resource`). Unlike
    * `onEvent`, this is **awaited** and **rethrows** so a failed audit write
-   * fails the tool execution (fail-closed). Resource/prompt meta-tools are
-   * not audited here (inventory residual S5-4).
+   * fails the tool execution (fail-closed).
    */
   onToolAudit?: (event: McpToolCallEvent) => void | Promise<void>;
 }
@@ -321,6 +321,36 @@ async function awaitToolAudit(ctx: BuildToolContext, event: McpToolCallEvent): P
 }
 
 /**
+ * Build an integrity event and await it. Success path rethrows audit failures;
+ * failure path prefers the original tool/meta-tool error.
+ */
+async function finishToolIntegrity(
+  ctx: BuildToolContext,
+  toolName: string,
+  started: number,
+  success: boolean,
+  error?: string,
+): Promise<void> {
+  const event: McpToolCallEvent = {
+    kind: 'mcp.tool.call',
+    namespace: ctx.namespace,
+    toolName,
+    duration_ms: Date.now() - started,
+    success,
+    ...(error !== undefined ? { error } : {}),
+  };
+  if (success) {
+    await awaitToolAudit(ctx, event);
+    return;
+  }
+  try {
+    await awaitToolAudit(ctx, event);
+  } catch {
+    // Prefer the tool / meta-tool failure over a secondary audit failure.
+  }
+}
+
+/**
  * Build the request-options object passed to `client.callTool()` /
  * `readResource()` / etc. Wraps the ctx's `onProgress` with the
  * specific tool name + namespace so every emitted event is attributable.
@@ -413,28 +443,28 @@ function buildListResourcesTool(client: McpClientLike, ctx: BuildToolContext): T
 
     async execute(): Promise<ToolResult> {
       const started = Date.now();
+      let ok = false;
+      let errorText: string | undefined;
+      let resources: ReadonlyArray<McpResourceDescriptor> = [];
       try {
-        const resources =
+        resources =
           (await client.listResources?.(buildRequestOptions(ctx, 'list_resources'))) ?? [];
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.resource.list',
-          namespace: ctx.namespace,
-          duration_ms: Date.now() - started,
-          success: true,
-          resourceCount: resources.length,
-        });
-        return { success: true, data: serializeMCPResult(resources) };
+        ok = true;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.resource.list',
-          namespace: ctx.namespace,
-          duration_ms: Date.now() - started,
-          success: false,
-          error: message,
-        });
-        return { success: false, error: message };
+        errorText = error instanceof Error ? error.message : String(error);
       }
+
+      emitMcpEvent(ctx.onEvent, {
+        kind: 'mcp.resource.list',
+        namespace: ctx.namespace,
+        duration_ms: Date.now() - started,
+        success: ok,
+        ...(ok ? { resourceCount: resources.length } : {}),
+        ...(errorText !== undefined ? { error: errorText } : {}),
+      });
+      await finishToolIntegrity(ctx, 'list_resources', started, ok, errorText);
+      if (ok) return { success: true, data: serializeMCPResult(resources) };
+      return { success: false, error: errorText ?? 'list_resources failed' };
     },
 
     getMetadata() {
@@ -461,34 +491,34 @@ function buildReadResourceTool(client: McpClientLike, ctx: BuildToolContext): To
     async execute(params: unknown): Promise<ToolResult> {
       const { uri } = paramsSchema.parse(params);
       const started = Date.now();
+      let ok = false;
+      let errorText: string | undefined;
+      let contents: ReadonlyArray<McpResourceContentLike> = [];
       try {
-        const contents =
+        contents =
           (await client.readResource?.(uri, buildRequestOptions(ctx, 'read_resource'))) ?? [];
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.resource.read',
-          namespace: ctx.namespace,
-          uri,
-          duration_ms: Date.now() - started,
-          success: true,
-        });
-        const joinedText = flattenResourceText(contents);
-        const base: ToolResult = {
-          success: true,
-          data: serializeMCPResult(contents),
-        };
-        return joinedText !== undefined ? { ...base, content: joinedText } : base;
+        ok = true;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.resource.read',
-          namespace: ctx.namespace,
-          uri,
-          duration_ms: Date.now() - started,
-          success: false,
-          error: message,
-        });
-        return { success: false, error: message };
+        errorText = error instanceof Error ? error.message : String(error);
       }
+
+      emitMcpEvent(ctx.onEvent, {
+        kind: 'mcp.resource.read',
+        namespace: ctx.namespace,
+        uri,
+        duration_ms: Date.now() - started,
+        success: ok,
+        ...(errorText !== undefined ? { error: errorText } : {}),
+      });
+      await finishToolIntegrity(ctx, 'read_resource', started, ok, errorText);
+      if (!ok) return { success: false, error: errorText ?? 'read_resource failed' };
+
+      const joinedText = flattenResourceText(contents);
+      const base: ToolResult = {
+        success: true,
+        data: serializeMCPResult(contents),
+      };
+      return joinedText !== undefined ? { ...base, content: joinedText } : base;
     },
 
     getMetadata() {
@@ -511,28 +541,27 @@ function buildListPromptsTool(client: McpClientLike, ctx: BuildToolContext): Too
 
     async execute(): Promise<ToolResult> {
       const started = Date.now();
+      let ok = false;
+      let errorText: string | undefined;
+      let prompts: ReadonlyArray<McpPromptDescriptor> = [];
       try {
-        const prompts =
-          (await client.listPrompts?.(buildRequestOptions(ctx, 'list_prompts'))) ?? [];
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.prompt.list',
-          namespace: ctx.namespace,
-          duration_ms: Date.now() - started,
-          success: true,
-          promptCount: prompts.length,
-        });
-        return { success: true, data: serializeMCPResult(prompts) };
+        prompts = (await client.listPrompts?.(buildRequestOptions(ctx, 'list_prompts'))) ?? [];
+        ok = true;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.prompt.list',
-          namespace: ctx.namespace,
-          duration_ms: Date.now() - started,
-          success: false,
-          error: message,
-        });
-        return { success: false, error: message };
+        errorText = error instanceof Error ? error.message : String(error);
       }
+
+      emitMcpEvent(ctx.onEvent, {
+        kind: 'mcp.prompt.list',
+        namespace: ctx.namespace,
+        duration_ms: Date.now() - started,
+        success: ok,
+        ...(ok ? { promptCount: prompts.length } : {}),
+        ...(errorText !== undefined ? { error: errorText } : {}),
+      });
+      await finishToolIntegrity(ctx, 'list_prompts', started, ok, errorText);
+      if (ok) return { success: true, data: serializeMCPResult(prompts) };
+      return { success: false, error: errorText ?? 'list_prompts failed' };
     },
 
     getMetadata() {
@@ -563,45 +592,39 @@ function buildGetPromptTool(client: McpClientLike, ctx: BuildToolContext): Tool 
     async execute(params: unknown): Promise<ToolResult> {
       const { name, args } = paramsSchema.parse(params);
       const started = Date.now();
+      let ok = false;
+      let errorText: string | undefined;
+      let result: McpGetPromptResultLike | undefined;
       try {
-        const result = await client.getPrompt?.(name, args, buildRequestOptions(ctx, 'get_prompt'));
+        result = await client.getPrompt?.(name, args, buildRequestOptions(ctx, 'get_prompt'));
         if (!result) {
-          const msg = 'client does not implement getPrompt';
-          emitMcpEvent(ctx.onEvent, {
-            kind: 'mcp.prompt.get',
-            namespace: ctx.namespace,
-            promptName: name,
-            duration_ms: Date.now() - started,
-            success: false,
-            error: msg,
-          });
-          return { success: false, error: msg };
+          errorText = 'client does not implement getPrompt';
+        } else {
+          ok = true;
         }
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.prompt.get',
-          namespace: ctx.namespace,
-          promptName: name,
-          duration_ms: Date.now() - started,
-          success: true,
-        });
-        const joinedText = flattenPromptMessages(result.messages);
-        const base: ToolResult = {
-          success: true,
-          data: serializeMCPResult(result),
-        };
-        return joinedText !== undefined ? { ...base, content: joinedText } : base;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        emitMcpEvent(ctx.onEvent, {
-          kind: 'mcp.prompt.get',
-          namespace: ctx.namespace,
-          promptName: name,
-          duration_ms: Date.now() - started,
-          success: false,
-          error: message,
-        });
-        return { success: false, error: message };
+        errorText = error instanceof Error ? error.message : String(error);
       }
+
+      emitMcpEvent(ctx.onEvent, {
+        kind: 'mcp.prompt.get',
+        namespace: ctx.namespace,
+        promptName: name,
+        duration_ms: Date.now() - started,
+        success: ok,
+        ...(errorText !== undefined ? { error: errorText } : {}),
+      });
+      await finishToolIntegrity(ctx, 'get_prompt', started, ok, errorText);
+      if (!(ok && result)) {
+        return { success: false, error: errorText ?? 'get_prompt failed' };
+      }
+
+      const joinedText = flattenPromptMessages(result.messages);
+      const base: ToolResult = {
+        success: true,
+        data: serializeMCPResult(result),
+      };
+      return joinedText !== undefined ? { ...base, content: joinedText } : base;
     },
 
     getMetadata() {
@@ -742,6 +765,16 @@ export function serializeMCPResult(value: unknown): unknown {
   return JSON.parse(JSON.stringify(value, replacer));
 }
 
+/** Options for the legacy hypervisor discovery path (GAP-355 integrity). */
+export interface DiscoverMCPToolsOptions {
+  /**
+   * Integrity audit hook (awaited, fail-closed on success). Same contract as
+   * `createToolsFromMcpClient({ onToolAudit })`. `namespace` on the event is
+   * the MCP server name from the hypervisor source.
+   */
+  onToolAudit?: (event: McpToolCallEvent) => void | Promise<void>;
+}
+
 /**
  * Discover all tools from a running MCPHypervisor (or any MCPToolSource)
  * and return them as RevealUI Tool instances.
@@ -749,17 +782,20 @@ export function serializeMCPResult(value: unknown): unknown {
  * Tool names use the hypervisor's namespacing (@@mcp_{server}_{tool}) so
  * collisions across servers are impossible.
  *
+ * @deprecated Prefer `createToolsFromMcpClient` (Stage 5.1a). Kept for
+ *   AgentRuntime `mcpToolSource` compatibility.
+ *
  * @example
  * ```typescript
  * import { MCPHypervisor } from '@revealui/mcp'
  * import { discoverMCPTools } from '@revealui/ai'
  *
  * const hypervisor = MCPHypervisor.getInstance()
- * const tools = discoverMCPTools(hypervisor)
+ * const tools = discoverMCPTools(hypervisor, { onToolAudit })
  * agent.tools.push(...tools)
  * ```
  */
-export function discoverMCPTools(source: MCPToolSource): Tool[] {
+export function discoverMCPTools(source: MCPToolSource, options?: DiscoverMCPToolsOptions): Tool[] {
   return source.getAllTools().map(({ namespacedName, serverName, tool }) => {
     const zodSchema = jsonSchemaToZod(tool.inputSchema);
 
@@ -771,19 +807,49 @@ export function discoverMCPTools(source: MCPToolSource): Tool[] {
       async execute(params: unknown): Promise<ToolResult> {
         // Validate params against the schema
         const validated = zodSchema.parse(params);
+        const started = Date.now();
+        let toolSucceeded = false;
+        let payload: unknown;
+        let errorText: string | undefined;
 
         try {
-          const callResult = await source.callTool(serverName, tool.name, validated);
+          payload = await source.callTool(serverName, tool.name, validated);
+          toolSucceeded = true;
+        } catch (error) {
+          errorText = error instanceof Error ? error.message : String(error);
+        }
+
+        const event: McpToolCallEvent = {
+          kind: 'mcp.tool.call',
+          namespace: serverName,
+          toolName: tool.name,
+          duration_ms: Date.now() - started,
+          success: toolSucceeded,
+          ...(errorText !== undefined ? { error: errorText } : {}),
+        };
+
+        if (toolSucceeded) {
+          // Integrity outside the RPC try so audit throws fail closed.
+          if (options?.onToolAudit) {
+            await options.onToolAudit(event);
+          }
           return {
             success: true,
-            data: serializeMCPResult(callResult),
-          };
-        } catch (error) {
-          return {
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
+            data: serializeMCPResult(payload),
           };
         }
+
+        if (options?.onToolAudit) {
+          try {
+            await options.onToolAudit(event);
+          } catch {
+            // Prefer the tool failure over a secondary audit failure.
+          }
+        }
+        return {
+          success: false,
+          error: errorText ?? 'Tool failed',
+        };
       },
 
       getMetadata() {

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -414,6 +414,12 @@ async function gate(): Promise<void> {
         args: ['validate:audit-one-door'],
       },
       {
+        // GAP-355 S5-4: named agent emit chokepoints must still wire integrity audit.
+        name: 'agent audit chokepoints (hard fail)',
+        command: 'pnpm',
+        args: ['validate:agent-audit-chokepoints'],
+      },
+      {
         name: 'Stripe-client consolidation (hard fail)',
         command: 'pnpm',
         args: ['validate:stripe-client'],

--- a/scripts/validate/agent-audit-chokepoints.json
+++ b/scripts/validate/agent-audit-chokepoints.json
@@ -9,7 +9,12 @@
     {
       "id": "mcp-adapter-onToolAudit",
       "file": "packages/ai/src/tools/mcp-adapter.ts",
-      "mustContain": ["onToolAudit", "awaitToolAudit", "finishToolIntegrity", "DiscoverMCPToolsOptions"]
+      "mustContain": [
+        "onToolAudit",
+        "awaitToolAudit",
+        "finishToolIntegrity",
+        "DiscoverMCPToolsOptions"
+      ]
     },
     {
       "id": "agent-runtime-onToolAudit",

--- a/scripts/validate/agent-audit-chokepoints.json
+++ b/scripts/validate/agent-audit-chokepoints.json
@@ -1,0 +1,69 @@
+{
+  "$comment": "GAP-355 Stage 5 S5-4 — mechanical checklist that named agent audit chokepoints still call the door. Strings are literal substring matches (no regex). Residual inventory lives in .jv gap-specs/GAP-355-stage5-agent-emit-design.md.",
+  "chokepoints": [
+    {
+      "id": "hypervisor-setAuditSink",
+      "file": "packages/mcp/src/hypervisor.ts",
+      "mustContain": ["setAuditSink", "emitAudit", "fail-closed"]
+    },
+    {
+      "id": "mcp-adapter-onToolAudit",
+      "file": "packages/ai/src/tools/mcp-adapter.ts",
+      "mustContain": ["onToolAudit", "awaitToolAudit"]
+    },
+    {
+      "id": "tool-integrity-wrapper",
+      "file": "packages/ai/src/tools/integrity-audit.ts",
+      "mustContain": ["wrapToolWithIntegrityAudit", "ToolIntegrityAuditEvent"]
+    },
+    {
+      "id": "admin-tools-onToolAudit",
+      "file": "packages/ai/src/tools/admin/factory.ts",
+      "mustContain": ["onToolAudit", "maybeWrapToolsWithIntegrityAudit"]
+    },
+    {
+      "id": "coding-tools-onToolAudit",
+      "file": "packages/ai/src/tools/coding/index.ts",
+      "mustContain": ["onToolAudit", "maybeWrapToolsWithIntegrityAudit"]
+    },
+    {
+      "id": "agent-dispatcher-task-lifecycle",
+      "file": "apps/server/src/lib/agent-dispatcher.ts",
+      "mustContain": ["agent:task:started", "agent:task:completed", "createAuditStore"]
+    },
+    {
+      "id": "agent-stream-mcp-and-native-tools",
+      "file": "apps/server/src/routes/agent-stream.ts",
+      "mustContain": [
+        "recordAgentMcpToolAudit",
+        "onToolAudit",
+        "agent:task:started",
+        "streamToolAudit"
+      ]
+    },
+    {
+      "id": "agent-tool-audit-adapter",
+      "file": "apps/server/src/lib/agent-tool-audit.ts",
+      "mustContain": ["recordAgentMcpToolAudit", "createAuditStore", "agent:tool:called"]
+    },
+    {
+      "id": "governed-mcp-tool-audit",
+      "file": "apps/server/src/lib/mcp-audit.ts",
+      "mustContain": ["recordMcpToolAudit", "createAuditStore"]
+    }
+  ],
+  "residuals": [
+    {
+      "id": "hypervisor-no-apps-server-install",
+      "note": "MCPHypervisor.setAuditSink has unit tests but no apps/server boot-time install; production agent path uses createToolsFromMcpClient + onToolAudit."
+    },
+    {
+      "id": "discoverMCPTools-legacy",
+      "note": "packages/ai discoverMCPTools (hypervisor legacy path) does not take onToolAudit; prefer createToolsFromMcpClient."
+    },
+    {
+      "id": "resource-prompt-meta-tools",
+      "note": "MCP resource/prompt meta-tools are not covered by onToolAudit (inventory residual; server tools only)."
+    }
+  ]
+}

--- a/scripts/validate/agent-audit-chokepoints.json
+++ b/scripts/validate/agent-audit-chokepoints.json
@@ -9,7 +9,12 @@
     {
       "id": "mcp-adapter-onToolAudit",
       "file": "packages/ai/src/tools/mcp-adapter.ts",
-      "mustContain": ["onToolAudit", "awaitToolAudit"]
+      "mustContain": ["onToolAudit", "awaitToolAudit", "finishToolIntegrity", "DiscoverMCPToolsOptions"]
+    },
+    {
+      "id": "agent-runtime-onToolAudit",
+      "file": "packages/ai/src/orchestration/runtime.ts",
+      "mustContain": ["onToolAudit", "createToolsFromMcpClient", "discoverMCPTools"]
     },
     {
       "id": "tool-integrity-wrapper",
@@ -55,15 +60,7 @@
   "residuals": [
     {
       "id": "hypervisor-no-apps-server-install",
-      "note": "MCPHypervisor.setAuditSink has unit tests but no apps/server boot-time install; production agent path uses createToolsFromMcpClient + onToolAudit."
-    },
-    {
-      "id": "discoverMCPTools-legacy",
-      "note": "packages/ai discoverMCPTools (hypervisor legacy path) does not take onToolAudit; prefer createToolsFromMcpClient."
-    },
-    {
-      "id": "resource-prompt-meta-tools",
-      "note": "MCP resource/prompt meta-tools are not covered by onToolAudit (inventory residual; server tools only)."
+      "note": "MCPHypervisor.setAuditSink has unit tests but no apps/server boot-time install. Accept residual: wire setAuditSink only at a real hypervisor construction site, not a fake boot install. Prod agent-stream uses createToolsFromMcpClient + onToolAudit."
     }
   ]
 }

--- a/scripts/validate/agent-audit-chokepoints.ts
+++ b/scripts/validate/agent-audit-chokepoints.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env tsx
+// console-allowed
+
+/**
+ * GAP-355 Stage 5 S5-4 — agent audit chokepoint checklist.
+ *
+ * Ensures named agent execution surfaces still carry the integrity audit
+ * wiring (substring presence in source files). Complements
+ * `audit-log-single-door.ts` (which guards WHO may insert audit_log) by
+ * guarding WHERE agent paths must call the door.
+ *
+ * Config: scripts/validate/agent-audit-chokepoints.json
+ * Matching is literal `includes` only (no authored regex).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+const CONFIG_PATH = join(REPO_ROOT, 'scripts/validate/agent-audit-chokepoints.json');
+
+interface Chokepoint {
+  id: string;
+  file: string;
+  mustContain: string[];
+}
+
+interface Residual {
+  id: string;
+  note: string;
+}
+
+interface Config {
+  chokepoints: Chokepoint[];
+  residuals?: Residual[];
+}
+
+function loadConfig(): Config {
+  if (!existsSync(CONFIG_PATH)) {
+    throw new Error(`Missing config: ${CONFIG_PATH}`);
+  }
+  return JSON.parse(readFileSync(CONFIG_PATH, 'utf8')) as Config;
+}
+
+function main(): number {
+  const config = loadConfig();
+  const failures: string[] = [];
+
+  out('============================================================');
+  out('GAP-355 Stage 5 — agent audit chokepoint checklist');
+  out('============================================================');
+
+  for (const cp of config.chokepoints) {
+    const abs = join(REPO_ROOT, cp.file);
+    if (!existsSync(abs)) {
+      failures.push(`[${cp.id}] missing file: ${cp.file}`);
+      out(`  ✗ ${cp.id} — file missing (${cp.file})`);
+      continue;
+    }
+    const src = readFileSync(abs, 'utf8');
+    const missing = cp.mustContain.filter((needle) => !src.includes(needle));
+    if (missing.length > 0) {
+      failures.push(`[${cp.id}] missing markers in ${cp.file}: ${missing.join(', ')}`);
+      out(`  ✗ ${cp.id} — missing: ${missing.join(', ')}`);
+    } else {
+      out(`  ✓ ${cp.id}`);
+    }
+  }
+
+  if (config.residuals && config.residuals.length > 0) {
+    out('');
+    out('Documented residuals (informational):');
+    for (const r of config.residuals) {
+      out(`  · ${r.id}: ${r.note}`);
+    }
+  }
+
+  out('');
+  if (failures.length > 0) {
+    out(`Result: FAIL (${failures.length} chokepoint(s))`);
+    for (const f of failures) out(`  - ${f}`);
+    return 1;
+  }
+
+  out(`Result: PASS (${config.chokepoints.length} chokepoints)`);
+  return 0;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

GAP-355 Stage 5 **S5-4 + S5-4b**: residual tool inventory, CI checklist, and live-path integrity gaps closed after S5-1+S5-2 (#2117).

### S5-4
- `wrapToolWithIntegrityAudit` for admin CMS + coding tools
- agent-stream wires `admin-cms` / `coding` namespaces → ONE DOOR
- `pnpm validate:agent-audit-chokepoints` (phase-1 hard fail)

### S5-4b (suggested residual close)
- MCP **resource/prompt meta-tools** audited via `finishToolIntegrity` (fail-closed; audit throw not swallowed by tool try/catch)
- `discoverMCPTools({ onToolAudit })` for legacy hypervisor adapter
- `AgentRuntime` config `onToolAudit` threaded into both MCP discovery paths

### Accepted residual
- **Hypervisor `setAuditSink`**: no apps/server boot install. Wire only when a real host constructs `MCPHypervisor` (no fake install). Prod agent-stream uses typed MCP client path.

**S5-3:** already satisfied by #2117 dispatcher lifecycle.  
**S5-5:** claims still require deliberate policy before any foil expansion.

## Security
Audit integrity path. **Non-author guardrail-2 before merge.** Proposal-shaped; owner merges.

## Test plan
- [x] `pnpm validate:agent-audit-chokepoints` PASS (10)
- [x] integrity-audit unit tests (5)
- [x] mcp-client-adapter tests (52) including meta-tool + discoverMCPTools fail-closed
- [x] pre-push phase-1 gate
- [ ] CI green on this PR
- [ ] Non-author security review