### PR TITLE
feat(validate): Phase 6 engines incubate posture gate (ADR-006)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ feature/* ──PR──▶ test ──PR──▶ main
 | Package | Purpose |
 |---------|---------|
 | @revealui/ai | AI agents, CRDT memory, LLM providers, orchestration |
-| @revealui/engines | Unified entry point for the five business primitives (private workspace package) |
+| @revealui/engines | Incubating optional barrel for the five primitives (not the app entry; private workspace package) |
 | @revealui/harnesses | AI harness adapters, workboard coordination, JSON-RPC |
 | @revealui/mcp | MCP servers + adapters; process hypervisor incubating (ADR-007) |
 | @revealui/services | Stripe (payment processing + circuit breaker), email (Gmail API delivery) |

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The RevealUI Studio agency site (revealuistudio.com) lives in [RevealUIStudio/ag
 | Package                                                 | Purpose                                           |
 | ------------------------------------------------------- | ------------------------------------------------- |
 | [`@revealui/ai`](packages/ai)                           | AI agents, CRDT memory, LLM providers             |
-| [`@revealui/engines`](packages/engines)                 | Unified entry point for the five primitives (private) |
+| [`@revealui/engines`](packages/engines)                 | Incubating optional barrel for the five primitives (not the app entry; private) |
 | [`@revealui/harnesses`](packages/harnesses)             | AI harness adapters and workboard coordination    |
 | [`@revealui/mcp`](packages/mcp)                         | MCP hypervisor, adapter framework, tool discovery |
 | [`@revealui/services`](packages/services)               | Stripe (billing + circuit breaker), transactional email (Gmail API) |

--- a/docs/architecture/ADR-006-engines-package-posture.md
+++ b/docs/architecture/ADR-006-engines-package-posture.md
@@ -46,4 +46,5 @@ Keeping silent “the one import” framing while apps bypass the facade is clai
 ## Verification
 
 - `grep` for production imports of `@revealui/engines` remains empty outside `packages/engines` and tests (code-over-docs).
+- **Phase 6 gate:** `pnpm validate:engines-posture` (CI phase 1) fails on app importers, non-private package.json, or surface docs that call engines the unified app entry without incubating/optional language.
 - Package README / index comment state incubating posture (same change set as this ADR or immediate follow-up).

--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
     "validate:artifacts": "tsx scripts/validate/build-artifacts.ts",
     "validate:boundary": "tsx scripts/validate/boundary.ts",
     "validate:gitignore": "tsx scripts/validate/gitignore-pro.ts",
+    "validate:engines-posture": "tsx scripts/validate/engines-posture.ts",
     "validate:structure": "tsx scripts/validate/structure.ts",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -327,6 +327,12 @@ async function gate(): Promise<void> {
         args: ['validate:gitignore'],
       },
       {
+        // ADR-006: engines incubate posture (no app entry claim / no app importers)
+        name: 'Engines posture (hard fail)',
+        command: 'pnpm',
+        args: ['validate:engines-posture'],
+      },
+      {
         name: 'Claim drift (hard fail)',
         command: 'pnpm',
         args: ['validate:claims'],

--- a/scripts/validate/engines-posture.ts
+++ b/scripts/validate/engines-posture.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env tsx
+/**
+ * Engines package posture gate (ADR-006 / fleet-redundancy Phase 6).
+ *
+ * Enforces incubate posture for `@revealui/engines`:
+ * 1. No production importers under apps/ (apps use direct package imports).
+ * 2. package.json remains `"private": true`.
+ * 3. Surface docs (CLAUDE.md, README.md) do not call engines "the" unified
+ *    app entry without incubating/optional language.
+ *
+ * Exit 0 = posture holds. Exit 1 = drift.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const ENGINES_PKG = join(REPO_ROOT, 'packages', 'engines', 'package.json');
+
+const SOURCE_EXT = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+
+/** Paths under apps/ that may mention engines (tests / docs samples only). */
+function isExemptAppPath(rel: string): boolean {
+  const lower = rel.toLowerCase();
+  if (lower.includes('__tests__') || lower.includes('/test/') || lower.includes('/tests/')) {
+    return true;
+  }
+  if (lower.endsWith('.test.ts') || lower.endsWith('.test.tsx')) return true;
+  if (lower.endsWith('.spec.ts') || lower.endsWith('.spec.tsx')) return true;
+  // Public marketing/docs content may list engines as a Pro package name.
+  if (lower.includes('/content/') || lower.includes('/public/')) return true;
+  return false;
+}
+
+function walkFiles(dir: string, out: string[]): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '.next') {
+      continue;
+    }
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(full, out);
+      continue;
+    }
+    const ext = entry.name.includes('.') ? `.${entry.name.split('.').pop()}` : '';
+    if (SOURCE_EXT.has(ext)) {
+      out.push(full);
+    }
+  }
+}
+
+function hasEnginesImport(source: string): boolean {
+  // No regex (repo no-regex posture): substring checks on common import forms.
+  const needles = [
+    "from '@revealui/engines'",
+    'from "@revealui/engines"',
+    "from '@revealui/engines/",
+    'from "@revealui/engines/',
+    "require('@revealui/engines'",
+    'require("@revealui/engines"',
+  ];
+  return needles.some((n) => source.includes(n));
+}
+
+function checkPrivatePackage(): string[] {
+  const errors: string[] = [];
+  if (!existsSync(ENGINES_PKG)) {
+    errors.push('packages/engines/package.json missing');
+    return errors;
+  }
+  const pj = JSON.parse(readFileSync(ENGINES_PKG, 'utf8')) as {
+    private?: boolean;
+    name?: string;
+  };
+  if (pj.private !== true) {
+    errors.push(
+      'packages/engines/package.json must set "private": true (ADR-006 incubate; not published)',
+    );
+  }
+  if (pj.name !== '@revealui/engines') {
+    errors.push(`unexpected package name: ${pj.name ?? '(missing)'}`);
+  }
+  return errors;
+}
+
+function checkAppImporters(): string[] {
+  const errors: string[] = [];
+  const appsRoot = join(REPO_ROOT, 'apps');
+  const files: string[] = [];
+  walkFiles(appsRoot, files);
+
+  for (const file of files) {
+    const rel = relative(REPO_ROOT, file).replaceAll('\\', '/');
+    if (isExemptAppPath(rel)) continue;
+    let source: string;
+    try {
+      source = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (hasEnginesImport(source)) {
+      errors.push(
+        `production app import of @revealui/engines: ${rel} (ADR-006: apps use direct packages until adopt decision)`,
+      );
+    }
+  }
+  return errors;
+}
+
+/**
+ * Surface docs that historically over-claimed "unified entry".
+ * Each listed file must not contain a bare "Unified entry point" engines line
+ * without incubating/optional language on the same line.
+ */
+function checkSurfaceDocHonesty(): string[] {
+  const errors: string[] = [];
+  const files = ['CLAUDE.md', 'README.md', 'AGENTS.md'];
+
+  for (const rel of files) {
+    const full = join(REPO_ROOT, rel);
+    if (!existsSync(full) || !statSync(full).isFile()) continue;
+    const lines = readFileSync(full, 'utf8').split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? '';
+      if (!line.includes('@revealui/engines') && !line.includes('engines]')) {
+        // README table uses packages/engines link text
+        if (!(rel === 'README.md' && line.includes('packages/engines'))) {
+          continue;
+        }
+      }
+      const lower = line.toLowerCase();
+      const claimsUnified =
+        lower.includes('unified entry') ||
+        lower.includes('the entry point for the five') ||
+        lower.includes('required application entry');
+      if (!claimsUnified) continue;
+
+      const honest =
+        lower.includes('incubat') ||
+        lower.includes('optional') ||
+        lower.includes('not the app entry') ||
+        lower.includes('not the required');
+
+      if (!honest) {
+        errors.push(
+          `${rel}:${i + 1}: engines described as unified entry without incubating/optional language (ADR-006)`,
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+function main(): void {
+  const errors = [...checkPrivatePackage(), ...checkAppImporters(), ...checkSurfaceDocHonesty()];
+
+  console.log('\n================================================================');
+  console.log('  Engines package posture (ADR-006)');
+  console.log('================================================================');
+
+  if (errors.length === 0) {
+    console.log('  ✓ private workspace package');
+    console.log('  ✓ no production apps/* importers');
+    console.log('  ✓ surface docs use incubating/optional language where relevant');
+    console.log('================================================================\n');
+    process.exit(0);
+  }
+
+  for (const e of errors) {
+    console.log(`  ✗ ${e}`);
+  }
+  console.log('================================================================\n');
+  process.exit(1);
+}
+
+main();

--- a/scripts/validate/engines-posture.ts
+++ b/scripts/validate/engines-posture.ts
@@ -144,11 +144,11 @@ function checkSurfaceDocHonesty(): string[] {
     const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i] ?? '';
-      if (!line.includes('@revealui/engines') && !line.includes('engines]')) {
-        // README table uses packages/engines link text
-        if (!(rel === 'README.md' && line.includes('packages/engines'))) {
-          continue;
-        }
+      if (
+        !(line.includes('@revealui/engines') || line.includes('engines]')) &&
+        !(rel === 'README.md' && line.includes('packages/engines'))
+      ) {
+        continue;
       }
       const lower = line.toLowerCase();
       const claimsUnified =

--- a/scripts/validate/engines-posture.ts
+++ b/scripts/validate/engines-posture.ts
@@ -11,7 +11,7 @@
  * Exit 0 = posture holds. Exit 1 = drift.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..');
@@ -33,17 +33,29 @@ function isExemptAppPath(rel: string): boolean {
 }
 
 function walkFiles(dir: string, out: string[]): void {
-  if (!existsSync(dir)) return;
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '.next') {
+  // No existsSync→readdir TOCTOU: attempt readdir and skip on failure.
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (name === 'node_modules' || name === 'dist' || name === '.next') {
       continue;
     }
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
+    const full = join(dir, name);
+    let isDir = false;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (isDir) {
       walkFiles(full, out);
       continue;
     }
-    const ext = entry.name.includes('.') ? `.${entry.name.split('.').pop()}` : '';
+    const ext = name.includes('.') ? `.${name.split('.').pop()}` : '';
     if (SOURCE_EXT.has(ext)) {
       out.push(full);
     }
@@ -65,11 +77,14 @@ function hasEnginesImport(source: string): boolean {
 
 function checkPrivatePackage(): string[] {
   const errors: string[] = [];
-  if (!existsSync(ENGINES_PKG)) {
+  let raw: string;
+  try {
+    raw = readFileSync(ENGINES_PKG, 'utf8');
+  } catch {
     errors.push('packages/engines/package.json missing');
     return errors;
   }
-  const pj = JSON.parse(readFileSync(ENGINES_PKG, 'utf8')) as {
+  const pj = JSON.parse(raw) as {
     private?: boolean;
     name?: string;
   };
@@ -119,8 +134,14 @@ function checkSurfaceDocHonesty(): string[] {
 
   for (const rel of files) {
     const full = join(REPO_ROOT, rel);
-    if (!existsSync(full) || !statSync(full).isFile()) continue;
-    const lines = readFileSync(full, 'utf8').split('\n');
+    // Single open: avoid existsSync/statSync then read (CodeQL TOCTOU).
+    let content: string;
+    try {
+      content = readFileSync(full, 'utf8');
+    } catch {
+      continue;
+    }
+    const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i] ?? '';
       if (!line.includes('@revealui/engines') && !line.includes('engines]')) {

--- a/scripts/validate/engines-posture.ts
+++ b/scripts/validate/engines-posture.ts
@@ -144,10 +144,11 @@ function checkSurfaceDocHonesty(): string[] {
     const lines = content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i] ?? '';
-      if (
-        !(line.includes('@revealui/engines') || line.includes('engines]')) &&
-        !(rel === 'README.md' && line.includes('packages/engines'))
-      ) {
+      const mentionsEngines =
+        line.includes('@revealui/engines') ||
+        line.includes('engines]') ||
+        (rel === 'README.md' && line.includes('packages/engines'));
+      if (!mentionsEngines) {
         continue;
       }
       const lower = line.toLowerCase();


### PR DESCRIPTION
## Summary
Fleet-redundancy **Phase 6** (prevention): enforce ADR-006 incubate posture for `@revealui/engines`.

- **`pnpm validate:engines-posture`** / CI phase 1 hard fail:
  - `packages/engines` stays `"private": true`
  - no production `apps/*` importers of `@revealui/engines`
  - CLAUDE.md / README must not call engines the unified app entry without incubating/optional language
- Honest package table rows in CLAUDE.md + README
- ADR-006 verification notes the gate

Phase 5 residual (vitest/biome): monorepo already on `createVitestConfig` (intentional self-contained holdouts only); biome remains root + `@revealui/dev/biome` (no separate package needed).

## Test plan
- [x] `pnpm validate:engines-posture` PASS
- [x] Pre-push phase-1 gate PASS (includes Engines posture)
- [ ] CI green on `test` base