### PR TITLE
feat(billing): self-serve Enterprise subscription checkout (GAP-302 Phase 1)

### DIFF
--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -77,12 +77,14 @@ function BillingContent() {
   const perpetual = searchParams.get('perpetual');
   const credits = searchParams.get('credits');
   const renewal = searchParams.get('renewal');
-  // ?upgrade=pro|max deep link (marketing pricing cards via /signup?plan=).
-  // Unknown values are ignored. Enterprise upgrades go through the manual
-  // button below (proration confirm), never the auto-trigger.
+  // ?upgrade=pro|max|enterprise deep link (marketing pricing cards via /signup?plan=).
+  // Unknown values are ignored. GAP-302 Phase 1: enterprise uses the same
+  // auto-checkout path as pro/max (server resolves catalog price).
   const upgradeParam = searchParams.get('upgrade');
-  const upgrade: 'pro' | 'max' | null =
-    upgradeParam === 'pro' || upgradeParam === 'max' ? upgradeParam : null;
+  const upgrade: 'pro' | 'max' | 'enterprise' | null =
+    upgradeParam === 'pro' || upgradeParam === 'max' || upgradeParam === 'enterprise'
+      ? upgradeParam
+      : null;
   const { data: session, isLoading: sessionLoading } = useSession();
   const [subscription, setSubscription] = useState<SubscriptionData | null>(null);
   const [usage, setUsage] = useState<UsageData | null>(null);
@@ -172,14 +174,16 @@ function BillingContent() {
   }, [session, sessionLoading, fetchSubscription, router]);
 
   const handleCheckout = useCallback(
-    async (target: 'pro' | 'max' = 'pro') => {
+    async (target: 'pro' | 'max' | 'enterprise' = 'pro') => {
       setActionLoading(true);
       setError(null);
       try {
         const priceId =
-          target === 'max'
-            ? process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID
-            : process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID;
+          target === 'enterprise'
+            ? process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID
+            : target === 'max'
+              ? process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID
+              : process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID;
         const res = await apiFetch(`${apiUrl}/api/billing/checkout`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -204,7 +208,7 @@ function BillingContent() {
     [apiUrl],
   );
 
-  // Auto-redirect to checkout on signup with ?upgrade=pro|max, and for churned
+  // Auto-redirect to checkout on signup with ?upgrade=pro|max|enterprise, and for churned
   // users (expired/canceled) arriving with explicit upgrade intent. Never fires
   // for active or trialing subscribers.
   useEffect(() => {

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -46,10 +46,11 @@ export function SignupForm({ apiUrl }: SignupFormProps) {
 function SignupContent({ apiUrl }: SignupFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  // Paid-tier deep link from the marketing pricing cards (?plan=pro|max).
+  // Paid-tier deep link from the marketing pricing cards (?plan=pro|max|enterprise).
   // Unknown values are ignored rather than forwarded to the billing page.
   const planParam = searchParams.get('plan');
-  const plan: 'pro' | 'max' | null = planParam === 'pro' || planParam === 'max' ? planParam : null;
+  const plan: 'pro' | 'max' | 'enterprise' | null =
+    planParam === 'pro' || planParam === 'max' || planParam === 'enterprise' ? planParam : null;
   const {
     register: registerPasskey,
     isLoading: isPasskeyLoading,
@@ -243,7 +244,8 @@ function SignupContent({ apiUrl }: SignupFormProps) {
 
       {plan ? (
         <p className="text-sm text-muted-foreground">
-          Sign up to start your free 7-day {plan === 'pro' ? 'Pro' : 'Max'} trial.
+          Sign up to start your free 7-day{' '}
+          {plan === 'pro' ? 'Pro' : plan === 'max' ? 'Max' : 'Enterprise'} trial.
         </p>
       ) : (
         <p className="text-sm text-muted-foreground">

--- a/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/signup/__tests__/SignupForm.test.tsx
@@ -115,7 +115,7 @@ describe('SignupForm post-signup routing', () => {
     expect(screen.queryByText('Check your inbox')).not.toBeInTheDocument();
   });
 
-  it.each(['pro', 'max'] as const)(
+  it.each(['pro', 'max', 'enterprise'] as const)(
     'routes an auto-verified user with ?plan=%s into the billing upgrade flow',
     async (plan) => {
       mockPlanParam = plan;

--- a/apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/verify-email-route.test.ts
@@ -291,7 +291,7 @@ describe('GET /api/auth/verify-email', () => {
     expect((res as MockRes).cookies.get('revealui-role')?.value).toBe('admin');
   });
 
-  it('ignores an unrecognized upgrade value (no open redirect)', async () => {
+  it('routes enterprise upgrade into billing checkout (GAP-302 Phase 1)', async () => {
     mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
     mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
     mockRotateSession.mockResolvedValue({
@@ -302,8 +302,22 @@ describe('GET /api/auth/verify-email', () => {
     const GET = await loadRoute();
     const res = await GET(makeRequest('valid-token', 'enterprise'));
 
+    expect((res as MockRes).url).toContain('/account/billing?upgrade=enterprise');
+  });
+
+  it('ignores an unrecognized upgrade value (no open redirect)', async () => {
+    mockGetUserByVerificationToken.mockResolvedValue({ id: 'u1', emailVerified: false });
+    mockUpdateUser.mockResolvedValue({ id: 'u1', role: 'viewer', emailVerified: true });
+    mockRotateSession.mockResolvedValue({
+      token: 'session-token-abc',
+      session: { id: 'sess1', userId: 'u1' },
+    });
+
+    const GET = await loadRoute();
+    const res = await GET(makeRequest('valid-token', 'enterprise-deluxe'));
+
     expect((res as MockRes).url).toContain('/welcome');
-    expect((res as MockRes).url).not.toContain('enterprise');
+    expect((res as MockRes).url).not.toContain('enterprise-deluxe');
   });
 
   it('redirects with error on unexpected DB failure, and creates no session', async () => {

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -63,7 +63,8 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
     }
 
     const rawPlan = request.nextUrl.searchParams.get('plan');
-    const plan: 'pro' | 'max' | null = rawPlan === 'pro' || rawPlan === 'max' ? rawPlan : null;
+    const plan: 'pro' | 'max' | 'enterprise' | null =
+      rawPlan === 'pro' || rawPlan === 'max' || rawPlan === 'enterprise' ? rawPlan : null;
 
     let body: unknown;
     try {

--- a/apps/admin/src/app/api/auth/verify-email/route.ts
+++ b/apps/admin/src/app/api/auth/verify-email/route.ts
@@ -30,9 +30,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const token = request.nextUrl.searchParams.get('token');
   const rawUpgrade = request.nextUrl.searchParams.get('upgrade');
   // Whitelist to known checkout plans  -  never forward an arbitrary value
-  // into a redirect destination.
-  const upgrade: 'pro' | 'max' | null =
-    rawUpgrade === 'pro' || rawUpgrade === 'max' ? rawUpgrade : null;
+  // into a redirect destination. GAP-302 Phase 1: enterprise self-serve.
+  const upgrade: 'pro' | 'max' | 'enterprise' | null =
+    rawUpgrade === 'pro' || rawUpgrade === 'max' || rawUpgrade === 'enterprise' ? rawUpgrade : null;
   const baseUrl = request.nextUrl.origin;
 
   if (!token) {

--- a/apps/admin/src/lib/email/verification.ts
+++ b/apps/admin/src/lib/email/verification.ts
@@ -14,7 +14,7 @@ import { sendEmail } from './index';
 export async function sendVerificationEmail(
   email: string,
   token: string,
-  plan?: 'pro' | 'max',
+  plan?: 'pro' | 'max' | 'enterprise',
 ): Promise<{ success: boolean; error?: string }> {
   const baseUrl = config.reveal.serverURL;
 

--- a/apps/admin/src/lib/utils/__tests__/auth-redirect.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/auth-redirect.test.ts
@@ -11,15 +11,24 @@ const reader = (params: Record<string, string | null>) => ({
 });
 
 describe('parseUpgrade', () => {
-  it('accepts the known checkout plans', () => {
+  it('accepts the known checkout plans including enterprise (GAP-302 Phase 1)', () => {
     expect(parseUpgrade('pro')).toBe('pro');
     expect(parseUpgrade('max')).toBe('max');
+    expect(parseUpgrade('enterprise')).toBe('enterprise');
   });
 
   it('rejects unknown values and null', () => {
-    expect(parseUpgrade('enterprise')).toBeNull();
+    expect(parseUpgrade('enterprise-deluxe')).toBeNull();
     expect(parseUpgrade('')).toBeNull();
     expect(parseUpgrade(null)).toBeNull();
+  });
+});
+
+describe('resolveAuthDest enterprise', () => {
+  it('routes enterprise upgrade to billing checkout intent', () => {
+    expect(resolveAuthDest({ upgrade: 'enterprise', redirect: null, fallback: '/welcome' })).toBe(
+      '/account/billing?upgrade=enterprise',
+    );
   });
 });
 

--- a/apps/admin/src/lib/utils/auth-redirect.ts
+++ b/apps/admin/src/lib/utils/auth-redirect.ts
@@ -2,11 +2,13 @@
 
 import { safeInternalRedirect } from '@/lib/utils/safe-internal-redirect';
 
-export type UpgradePlan = 'pro' | 'max';
+/** Paid self-serve checkout plans (subscription). GAP-302 Phase 1 adds enterprise. */
+export type UpgradePlan = 'pro' | 'max' | 'enterprise';
 
-/** Narrow a raw ?upgrade= value to a known checkout plan, or null. */
+/** Narrow a raw ?upgrade= / ?plan= value to a known checkout plan, or null. */
 export function parseUpgrade(raw: string | null): UpgradePlan | null {
-  return raw === 'pro' || raw === 'max' ? raw : null;
+  if (raw === 'pro' || raw === 'max' || raw === 'enterprise') return raw;
+  return null;
 }
 
 /** A URLSearchParams-like reader (matches Next's useSearchParams() return). */

--- a/packages/contracts/src/__tests__/pricing.test.ts
+++ b/packages/contracts/src/__tests__/pricing.test.ts
@@ -111,6 +111,14 @@ describe('SUBSCRIPTION_TIERS', () => {
     expect(highlighted[0].id).toBe('pro');
   });
 
+  // GAP-302 Phase 1: Enterprise subscription is self-serve (not mailto).
+  it('enterprise subscription CTA is self-serve signup, not mailto', () => {
+    const enterprise = SUBSCRIPTION_TIERS.find((t) => t.id === 'enterprise')!;
+    expect(enterprise.ctaHref.startsWith('mailto:')).toBe(false);
+    expect(enterprise.ctaHref).toBe('/signup?plan=enterprise');
+    expect(enterprise.features.some((f) => f.includes('coming soon'))).toBe(true);
+  });
+
   it('free tier has no period', () => {
     const free = SUBSCRIPTION_TIERS.find((t) => t.id === 'free')!;
     expect(free.period).toBeUndefined();

--- a/packages/contracts/src/pricing.ts
+++ b/packages/contracts/src/pricing.ts
@@ -202,14 +202,19 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Unlimited users/editors',
       'Session-based auth + OAuth',
       'Full inference suite (all open models)',
+      // Honesty (GAP-302): x402 remains off by default (X402_ENABLED); label it.
       'x402 agent payments (USDC, coming soon)',
       'Unlimited agent tasks',
       'Slack support (4h SLA)',
       'Annual pricing available',
       'Full source code access',
+      // whiteLabel / SSO-as-enterprise-sold-feature: not advertised until shipped
+      // (see packages/core features whiteLabel force-false + GAP-302 honesty bar).
     ],
-    cta: 'Contact Sales',
-    ctaHref: 'mailto:support@revealui.com?subject=Enterprise%20Tier%20Inquiry',
+    // Self-serve subscription checkout (GAP-302 Phase 1). Server resolves
+    // enterprise price from billing catalog; signup deep-link carries plan.
+    cta: 'Start your 7-day free trial',
+    ctaHref: '/signup?plan=enterprise',
     highlighted: false,
   },
 ];


### PR DESCRIPTION
## Summary

**GAP-302 Phase 1** — Enterprise subscription is self-serve end to end (no mailto).

| Change | Detail |
|--------|--------|
| Marketing CTA | `/signup?plan=enterprise` (was `mailto:support@…`) |
| `UpgradePlan` | `pro \| max \| enterprise` |
| Signup / sign-up API / verify-email | Accept `plan`/`upgrade=enterprise` |
| Billing page | Auto-checkout + `handleCheckout('enterprise')` (catalog price; optional `NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID`) |
| Honesty | x402 remains **coming soon**; no SSO/whiteLabel sold as shipped |

### Flow
`/pricing` → Enterprise trial CTA → `/signup?plan=enterprise` → verify email carries `upgrade=enterprise` → `/account/billing?upgrade=enterprise` → `POST /api/billing/checkout` `{ tier: 'enterprise' }` (server already accepted this).

### Non-goals (still open on GAP-302)
- Phase 2 post-checkout onboarding
- Perpetual tier residual mailtos / env-name fix (Phase 3 residual)
- Enterprise Perpetual self-serve UI

### Tests
- `@revealui/contracts` pricing: 42 passed (enterprise CTA assertion)
- auth-redirect + SignupForm tests updated (CI will run full admin suite; local admin vitest needs package builds)

### Non-claims
- Peer GAP-355 S5 train (#2123 etc.)

## Test plan
- [x] contracts pricing.test.ts
- [x] local gate phase 1 --changed
- [ ] CI green
- [ ] Staging: anonymous → pricing → Enterprise → Stripe test checkout