### PR TITLE
feat(validate): Phase 6 incubate-posture + packages clone audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Console audit
         run: pnpm audit:console
 
+      # Phase 6 prevention: exact clone report under packages/ (advisory only)
+      - name: Exact clone audit (packages/, advisory)
+        continue-on-error: true
+        run: pnpm audit:clones
+
       - name: Structure validation
         run: pnpm validate:structure
 
@@ -86,6 +91,9 @@ jobs:
 
       - name: Boundary validation (hard fail)
         run: pnpm validate:boundary
+
+      - name: Incubate posture (ADR-007, hard fail)
+        run: pnpm validate:incubate-posture
 
       - name: Claim drift validation (hard fail)
         run: pnpm validate:claims

--- a/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+++ b/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
@@ -50,3 +50,5 @@ Marketing and package copy still describe the MCP hypervisor as the live agent t
 - No production import of `MCPHypervisor.getInstance` / constructor under `apps/` (code-over-docs).
 - No production import of `@revealui/ai/skills` or `@revealui/ai/observability` under `apps/`.
 - File headers and package README/index comments state incubating posture (same change set).
+- **Phase 6 gate:** `pnpm validate:incubate-posture` (CI phase 1 + Quality job) fails if apps mount these surfaces without a WIRE train. Standing ticket: GAP-406.
+- **Clone advisory:** `pnpm audit:clones` reports exact multi-file clones under `packages/` (optional prevention; advisory exit 0).

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
   },
   "scripts": {
     "audit:any": "tsx scripts/analyze/audit-any-types.ts",
+    "audit:clones": "tsx scripts/analyze/audit-clones.ts",
     "audit:console": "tsx scripts/analyze/audit-console.ts",
     "audit:emdash": "tsx scripts/analyze/audit-emdash.ts",
     "audit:palette-text": "tsx scripts/analyze/audit-text-palette.ts",
@@ -228,6 +229,7 @@
     "validate:artifacts": "tsx scripts/validate/build-artifacts.ts",
     "validate:boundary": "tsx scripts/validate/boundary.ts",
     "validate:gitignore": "tsx scripts/validate/gitignore-pro.ts",
+    "validate:incubate-posture": "tsx scripts/validate/incubate-posture.ts",
     "validate:structure": "tsx scripts/validate/structure.ts",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",

--- a/scripts/analyze/audit-clones.ts
+++ b/scripts/analyze/audit-clones.ts
@@ -19,7 +19,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { existsSync, readdirSync, readFileSync, statSync, type Dirent, type Stats } from 'node:fs';
+import { type Dirent, existsSync, readdirSync, readFileSync, type Stats, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const REPO_ROOT = process.cwd();
@@ -145,7 +145,13 @@ function main(): void {
       groups.push(paths.sort());
     }
   }
-  groups.sort((a, b) => b.length - a.length || a[0]!.localeCompare(b[0]!));
+  groups.sort((a, b) => {
+    const byLen = b.length - a.length;
+    if (byLen !== 0) return byLen;
+    const a0 = a[0] ?? '';
+    const b0 = b[0] ?? '';
+    return a0.localeCompare(b0);
+  });
 
   console.log('\n================================================================');
   console.log('  Exact clone audit (packages/) — Phase 6 prevention');

--- a/scripts/analyze/audit-clones.ts
+++ b/scripts/analyze/audit-clones.ts
@@ -88,6 +88,7 @@ function walk(dir: string, out: string[]): void {
       walk(join(dir, e.name), out);
       continue;
     }
+    if (!e.isFile()) continue;
     if (shouldSkipFile(e.name)) continue;
     out.push(join(dir, e.name));
   }
@@ -109,25 +110,20 @@ function main(): void {
   let skippedSmall = 0;
 
   for (const file of files) {
-    let st: Stats;
-    try {
-      st = statSync(file);
-    } catch {
-      continue;
-    }
-    if (!st.isFile() || st.size < minBytes) {
-      skippedSmall++;
-      continue;
-    }
-    // Cap read size for pathological huge files
-    if (st.size > 2_000_000) continue;
-
+    // Single read — avoid stat+read TOCTOU (CodeQL js/file-system-race).
     let buf: Buffer;
     try {
       buf = readFileSync(file);
     } catch {
       continue;
     }
+    const size = buf.byteLength;
+    if (size < minBytes) {
+      skippedSmall++;
+      continue;
+    }
+    // Cap pathological huge files (already in memory once; skip hashing only)
+    if (size > 2_000_000) continue;
     // Skip likely-binary
     if (buf.includes(0)) continue;
 

--- a/scripts/analyze/audit-clones.ts
+++ b/scripts/analyze/audit-clones.ts
@@ -19,7 +19,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { type Dirent, existsSync, readdirSync, readFileSync } from 'node:fs';
+import { type Dirent, readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const REPO_ROOT = process.cwd();
@@ -71,6 +71,11 @@ function shouldSkipFile(name: string): boolean {
   return SKIP_FILE_SUFFIXES.some((s) => lower.endsWith(s));
 }
 
+/**
+ * Collect candidate paths. Directory-only branching uses Dirent.isDirectory();
+ * non-directories are queued without isFile()/stat — content is validated only
+ * via a single readFileSync (avoids CodeQL js/file-system-race).
+ */
 function walk(dir: string, out: string[]): void {
   let entries: Dirent[];
   try {
@@ -79,59 +84,68 @@ function walk(dir: string, out: string[]): void {
     return;
   }
   for (const e of entries) {
-    if (e.name.startsWith('.') && e.name !== '.env.example') {
-      // skip hidden dirs/files except explicit examples
-      if (e.isDirectory()) continue;
-    }
     if (e.isDirectory()) {
       if (SKIP_DIR_NAMES.has(e.name)) continue;
+      if (e.name.startsWith('.')) continue;
       walk(join(dir, e.name), out);
       continue;
     }
-    if (!e.isFile()) continue;
+    if (e.name.startsWith('.') && e.name !== '.env.example') continue;
     if (shouldSkipFile(e.name)) continue;
     out.push(join(dir, e.name));
   }
 }
 
+function hashFile(path: string): { ok: true; hash: string; size: number } | { ok: false } {
+  let buf: Buffer;
+  try {
+    // Single open/read — no prior exists/stat/isFile on this path.
+    buf = readFileSync(path);
+  } catch {
+    return { ok: false };
+  }
+  if (buf.includes(0)) {
+    return { ok: false };
+  }
+  return {
+    ok: true,
+    size: buf.byteLength,
+    hash: createHash('sha256').update(buf).digest('hex'),
+  };
+}
+
 function main(): void {
   const { fail, minBytes } = parseArgs(process.argv.slice(2));
 
-  if (!existsSync(PACKAGES_ROOT)) {
-    console.error('[audit-clones] packages/ missing');
-    process.exit(2);
-  }
-
   const files: string[] = [];
   walk(PACKAGES_ROOT, files);
+  if (files.length === 0) {
+    // packages/ missing or empty — treat as setup error only if root walk failed hard
+    try {
+      readdirSync(PACKAGES_ROOT);
+    } catch {
+      console.error('[audit-clones] packages/ missing or unreadable');
+      process.exit(2);
+    }
+  }
 
   const byHash = new Map<string, string[]>();
   let scanned = 0;
   let skippedSmall = 0;
 
   for (const file of files) {
-    // Single read — avoid stat+read TOCTOU (CodeQL js/file-system-race).
-    let buf: Buffer;
-    try {
-      buf = readFileSync(file);
-    } catch {
-      continue;
-    }
-    const size = buf.byteLength;
-    if (size < minBytes) {
+    const result = hashFile(file);
+    if (!result.ok) continue;
+    if (result.size < minBytes) {
       skippedSmall++;
       continue;
     }
-    // Cap pathological huge files (already in memory once; skip hashing only)
-    if (size > 2_000_000) continue;
-    // Skip likely-binary
-    if (buf.includes(0)) continue;
+    if (result.size > 2_000_000) continue;
 
-    const hash = createHash('sha256').update(buf).digest('hex');
     const rel = relative(REPO_ROOT, file).replaceAll('\\', '/');
-    const list = byHash.get(hash) ?? [];
+    const list = byHash.get(result.hash) ?? [];
     list.push(rel);
-    byHash.set(hash, list);
+    byHash.set(result.hash, list);
     scanned++;
   }
 

--- a/scripts/analyze/audit-clones.ts
+++ b/scripts/analyze/audit-clones.ts
@@ -19,7 +19,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync, type Dirent, type Stats } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const REPO_ROOT = process.cwd();
@@ -72,7 +72,7 @@ function shouldSkipFile(name: string): boolean {
 }
 
 function walk(dir: string, out: string[]): void {
-  let entries;
+  let entries: Dirent[];
   try {
     entries = readdirSync(dir, { withFileTypes: true });
   } catch {
@@ -109,7 +109,7 @@ function main(): void {
   let skippedSmall = 0;
 
   for (const file of files) {
-    let st;
+    let st: Stats;
     try {
       st = statSync(file);
     } catch {

--- a/scripts/analyze/audit-clones.ts
+++ b/scripts/analyze/audit-clones.ts
@@ -19,7 +19,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { type Dirent, existsSync, readdirSync, readFileSync, type Stats, statSync } from 'node:fs';
+import { type Dirent, existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const REPO_ROOT = process.cwd();

--- a/scripts/analyze/audit-clones.ts
+++ b/scripts/analyze/audit-clones.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env tsx
+/**
+ * Exact clone audit for packages/ (fleet-redundancy Phase 6 prevention).
+ *
+ * Optional clone detector: content-hash identical files under packages/
+ * (excludes dist, generated, lockfiles, binary-ish assets). Near-duplicate
+ * detection (classic jscpd token clones) is intentionally out of scope —
+ * exact clones are the durable, dependency-free signal that half-sweeps
+ * and copy-paste leave behind.
+ *
+ * Exit codes:
+ *   0 — always by default (advisory). Use --fail to exit 1 when any clone group exists.
+ *   2 — tool/setup error
+ *
+ * Usage:
+ *   pnpm audit:clones
+ *   pnpm audit:clones -- --fail
+ *   pnpm audit:clones -- --min-bytes=80
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+const PACKAGES_ROOT = join(REPO_ROOT, 'packages');
+
+const SKIP_DIR_NAMES = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  '.turbo',
+  '.git',
+  'generated',
+  '__snapshots__',
+]);
+
+const SKIP_FILE_SUFFIXES = [
+  '.map',
+  '.min.js',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+  '.pdf',
+  '.lock',
+];
+
+function parseArgs(argv: string[]): { fail: boolean; minBytes: number } {
+  let fail = false;
+  let minBytes = 40;
+  for (const a of argv) {
+    if (a === '--fail') fail = true;
+    if (a.startsWith('--min-bytes=')) {
+      const n = Number(a.slice('--min-bytes='.length));
+      if (Number.isFinite(n) && n >= 0) minBytes = n;
+    }
+  }
+  return { fail, minBytes };
+}
+
+function shouldSkipFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  return SKIP_FILE_SUFFIXES.some((s) => lower.endsWith(s));
+}
+
+function walk(dir: string, out: string[]): void {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.name.startsWith('.') && e.name !== '.env.example') {
+      // skip hidden dirs/files except explicit examples
+      if (e.isDirectory()) continue;
+    }
+    if (e.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(e.name)) continue;
+      walk(join(dir, e.name), out);
+      continue;
+    }
+    if (shouldSkipFile(e.name)) continue;
+    out.push(join(dir, e.name));
+  }
+}
+
+function main(): void {
+  const { fail, minBytes } = parseArgs(process.argv.slice(2));
+
+  if (!existsSync(PACKAGES_ROOT)) {
+    console.error('[audit-clones] packages/ missing');
+    process.exit(2);
+  }
+
+  const files: string[] = [];
+  walk(PACKAGES_ROOT, files);
+
+  const byHash = new Map<string, string[]>();
+  let scanned = 0;
+  let skippedSmall = 0;
+
+  for (const file of files) {
+    let st;
+    try {
+      st = statSync(file);
+    } catch {
+      continue;
+    }
+    if (!st.isFile() || st.size < minBytes) {
+      skippedSmall++;
+      continue;
+    }
+    // Cap read size for pathological huge files
+    if (st.size > 2_000_000) continue;
+
+    let buf: Buffer;
+    try {
+      buf = readFileSync(file);
+    } catch {
+      continue;
+    }
+    // Skip likely-binary
+    if (buf.includes(0)) continue;
+
+    const hash = createHash('sha256').update(buf).digest('hex');
+    const rel = relative(REPO_ROOT, file).replaceAll('\\', '/');
+    const list = byHash.get(hash) ?? [];
+    list.push(rel);
+    byHash.set(hash, list);
+    scanned++;
+  }
+
+  const groups: string[][] = [];
+  for (const paths of byHash.values()) {
+    if (paths.length >= 2) {
+      groups.push(paths.sort());
+    }
+  }
+  groups.sort((a, b) => b.length - a.length || a[0]!.localeCompare(b[0]!));
+
+  console.log('\n================================================================');
+  console.log('  Exact clone audit (packages/) — Phase 6 prevention');
+  console.log('================================================================');
+  console.log(`  Scanned: ${scanned} files (≥ ${minBytes} bytes)`);
+  console.log(`  Skipped small: ${skippedSmall}`);
+  console.log(`  Clone groups: ${groups.length}`);
+
+  const maxReport = 25;
+  for (const g of groups.slice(0, maxReport)) {
+    console.log(`\n  [${g.length}× identical]`);
+    for (const p of g) {
+      console.log(`    - ${p}`);
+    }
+  }
+  if (groups.length > maxReport) {
+    console.log(`\n  … ${groups.length - maxReport} more group(s) omitted`);
+  }
+
+  if (groups.length === 0) {
+    console.log('\n  ✓ No exact multi-file clones under packages/');
+  } else {
+    console.log(
+      '\n  Advisory: exact clones often mean extend-before-create debt. Prefer shared helpers over copy-paste.',
+    );
+  }
+  console.log('================================================================\n');
+
+  if (fail && groups.length > 0) {
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -327,6 +327,12 @@ async function gate(): Promise<void> {
         args: ['validate:gitignore'],
       },
       {
+        // ADR-007: C11 incubators stay unmounted from apps until WIRE (GAP-406)
+        name: 'Incubate posture (hard fail)',
+        command: 'pnpm',
+        args: ['validate:incubate-posture'],
+      },
+      {
         name: 'Claim drift (hard fail)',
         command: 'pnpm',
         args: ['validate:claims'],

--- a/scripts/validate/incubate-posture.ts
+++ b/scripts/validate/incubate-posture.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+/**
+ * C11 incubate posture gate (ADR-007 / fleet-redundancy Phase 6).
+ *
+ * Surfaces that must stay unmounted from apps until a dedicated WIRE ticket:
+ * - MCPHypervisor (packages/mcp)
+ * - @revealui/ai/skills
+ * - @revealui/ai/observability
+ *
+ * Exit 0 = incubate holds. Exit 1 = app production path imports incubating surface.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const SOURCE_EXT = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+
+function isExemptAppPath(rel: string): boolean {
+  const lower = rel.toLowerCase();
+  if (lower.includes('__tests__') || lower.includes('/test/') || lower.includes('/tests/')) {
+    return true;
+  }
+  if (lower.endsWith('.test.ts') || lower.endsWith('.test.tsx')) return true;
+  if (lower.endsWith('.spec.ts') || lower.endsWith('.spec.tsx')) return true;
+  if (lower.includes('/content/') || lower.includes('/public/')) return true;
+  return false;
+}
+
+function walkFiles(dir: string, out: string[]): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (
+      entry.name === 'node_modules' ||
+      entry.name === 'dist' ||
+      entry.name === '.next' ||
+      entry.name === 'coverage'
+    ) {
+      continue;
+    }
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(full, out);
+      continue;
+    }
+    const ext = entry.name.includes('.') ? `.${entry.name.split('.').pop()}` : '';
+    if (SOURCE_EXT.has(ext)) out.push(full);
+  }
+}
+
+// Import/require forms only (comments may name the type without mounting it).
+const FORBIDDEN: { label: string; needles: string[] }[] = [
+  {
+    label: 'MCPHypervisor',
+    needles: [
+      "from '@revealui/mcp/hypervisor'",
+      'from "@revealui/mcp/hypervisor"',
+      "from '@revealui/mcp/src/hypervisor",
+      'from "@revealui/mcp/src/hypervisor',
+      "require('@revealui/mcp/hypervisor'",
+      'require("@revealui/mcp/hypervisor"',
+      // named import of the class from package root
+      'MCPHypervisor } from',
+      'MCPHypervisor, ',
+      '{ MCPHypervisor',
+    ],
+  },
+  {
+    label: '@revealui/ai/skills',
+    needles: [
+      "from '@revealui/ai/skills'",
+      'from "@revealui/ai/skills"',
+      "from '@revealui/ai/skills/",
+      'from "@revealui/ai/skills/',
+    ],
+  },
+  {
+    label: '@revealui/ai/observability',
+    needles: [
+      "from '@revealui/ai/observability'",
+      'from "@revealui/ai/observability"',
+      "from '@revealui/ai/observability/",
+      'from "@revealui/ai/observability/',
+    ],
+  },
+];
+
+function main(): void {
+  const errors: string[] = [];
+  const files: string[] = [];
+  walkFiles(join(REPO_ROOT, 'apps'), files);
+
+  for (const file of files) {
+    const rel = relative(REPO_ROOT, file).replaceAll('\\', '/');
+    if (isExemptAppPath(rel)) continue;
+    let source: string;
+    try {
+      source = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const rule of FORBIDDEN) {
+      for (const n of rule.needles) {
+        if (source.includes(n)) {
+          errors.push(
+            `${rel}: imports incubating surface ${rule.label} (ADR-007; needs WIRE ticket first)`,
+          );
+          break;
+        }
+      }
+    }
+  }
+
+  console.log('\n================================================================');
+  console.log('  C11 incubate posture (ADR-007)');
+  console.log('================================================================');
+
+  if (errors.length === 0) {
+    console.log('  ✓ no apps/* production imports of MCPHypervisor');
+    console.log('  ✓ no apps/* production imports of @revealui/ai/skills');
+    console.log('  ✓ no apps/* production imports of @revealui/ai/observability');
+    console.log('================================================================\n');
+    process.exit(0);
+  }
+
+  for (const e of errors) {
+    console.log(`  ✗ ${e}`);
+  }
+  console.log('================================================================\n');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary
Fleet-redundancy **Phase 6 prevention** residual:

1. **`pnpm validate:incubate-posture`** (hard fail, CI Quality + local gate) — ADR-007: apps must not import MCPHypervisor / `@revealui/ai/skills` / `@revealui/ai/observability` until a WIRE train.
2. **`pnpm audit:clones`** — exact multi-file content clones under `packages/` (advisory; CI `continue-on-error`). Durable alternative to flaky token-level jscpd for the optional Phase 6 clone signal.
3. ADR-007 verification notes + standing **GAP-406** on jv.

## Test plan
- [x] `pnpm validate:incubate-posture` PASS
- [x] `pnpm audit:clones` reports groups, exit 0
- [x] Pre-push phase-1 gate PASS
- [ ] CI green on `test`