### PR TITLE
feat(server): GAP-355 S6-1+S6-2 AgentPrincipal and authorizeAgentTool

### DIFF
--- a/apps/server/src/lib/__tests__/agent-principal.test.ts
+++ b/apps/server/src/lib/__tests__/agent-principal.test.ts
@@ -1,0 +1,181 @@
+/**
+ * GAP-355 Stage 6 S6-1 — AgentPrincipal resolvers (pure unit tests).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type AgentPrincipal,
+  principalHasGrant,
+  principalRoleList,
+  resolveDispatchPrincipal,
+  resolveJobPrincipal,
+  resolveMcpBoundPrincipal,
+  resolveStreamPrincipal,
+} from '../agent-principal.js';
+
+function assertFrozen(principal: AgentPrincipal): void {
+  expect(Object.isFrozen(principal)).toBe(true);
+  expect(Object.isFrozen(principal.roles)).toBe(true);
+  expect(Object.isFrozen(principal.grants)).toBe(true);
+}
+
+describe('resolveStreamPrincipal', () => {
+  it('builds admin-stream-agent with user + agent roles', () => {
+    const p = resolveStreamPrincipal({
+      mode: 'admin',
+      userId: 'user-1',
+      userRole: 'editor',
+      tenantId: 'tenant-a',
+      accountId: 'acct-1',
+    });
+    expect(p).toMatchObject({
+      agentId: 'admin-stream-agent',
+      kind: 'stream',
+      tenantId: 'tenant-a',
+      accountId: 'acct-1',
+      actingUserId: 'user-1',
+      roles: ['editor', 'agent'],
+      grants: [],
+    });
+    assertFrozen(p);
+  });
+
+  it('builds coding-stream-agent for coding mode', () => {
+    const p = resolveStreamPrincipal({
+      mode: 'coding',
+      userId: 'user-2',
+      userRole: 'owner',
+    });
+    expect(p.agentId).toBe('coding-stream-agent');
+    expect(p.roles).toEqual(['owner', 'agent']);
+    expect(p.tenantId).toBeNull();
+    expect(p.accountId).toBeNull();
+  });
+
+  it('dedupes agent role when userRole is already agent', () => {
+    const p = resolveStreamPrincipal({
+      mode: 'admin',
+      userId: 'u',
+      userRole: 'agent',
+    });
+    expect(p.roles).toEqual(['agent']);
+  });
+
+  it('preserves explicit grants', () => {
+    const p = resolveStreamPrincipal({
+      mode: 'coding',
+      userId: 'u',
+      userRole: 'admin',
+      grants: [{ resource: 'agent:tool:coding:shell_exec', action: 'execute' }],
+    });
+    expect(p.grants).toEqual([{ resource: 'agent:tool:coding:shell_exec', action: 'execute' }]);
+    expect(principalHasGrant(p, 'agent:tool:coding:shell_exec', 'execute')).toBe(true);
+  });
+
+  it('throws when userId is empty', () => {
+    expect(() =>
+      resolveStreamPrincipal({ mode: 'admin', userId: '  ', userRole: 'admin' }),
+    ).toThrow(/userId/);
+  });
+});
+
+describe('resolveDispatchPrincipal', () => {
+  it('scopes agentId to ticket when present', () => {
+    const p = resolveDispatchPrincipal({
+      ticketId: 'ticket-42',
+      userId: 'user-1',
+      userRole: 'admin',
+      workspaceId: 'ws-1',
+      accountId: 'acct-1',
+    });
+    expect(p).toMatchObject({
+      agentId: 'ticket-agent-ticket-42',
+      kind: 'dispatch',
+      tenantId: 'ws-1',
+      accountId: 'acct-1',
+      actingUserId: 'user-1',
+      roles: ['admin', 'agent'],
+    });
+    assertFrozen(p);
+  });
+
+  it('falls back to ticket-agent-dispatcher without ticketId', () => {
+    const p = resolveDispatchPrincipal({
+      userId: null,
+      userRole: null,
+    });
+    expect(p.agentId).toBe('ticket-agent-dispatcher');
+    expect(p.actingUserId).toBeNull();
+    expect(p.roles).toEqual(['agent']);
+  });
+});
+
+describe('resolveJobPrincipal', () => {
+  it('builds a job principal', () => {
+    const p = resolveJobPrincipal({
+      agentId: 'ticket-agent-ticket-9',
+      userId: 'owner-1',
+      userRole: 'owner',
+      tenantId: 't1',
+      accountId: 'a1',
+    });
+    expect(p.kind).toBe('job');
+    expect(p.agentId).toBe('ticket-agent-ticket-9');
+    expect(p.roles).toEqual(['owner', 'agent']);
+    assertFrozen(p);
+  });
+
+  it('throws when agentId is empty', () => {
+    expect(() => resolveJobPrincipal({ agentId: '' })).toThrow(/agentId/);
+  });
+});
+
+describe('resolveMcpBoundPrincipal', () => {
+  it('prefixes agentId with mcp:', () => {
+    const p = resolveMcpBoundPrincipal({
+      clientName: 'opencode',
+      userId: 'user-1',
+      userRole: 'editor',
+      accountId: 'acct-1',
+    });
+    expect(p).toMatchObject({
+      agentId: 'mcp:opencode',
+      kind: 'mcp-bound',
+      actingUserId: 'user-1',
+      roles: ['editor', 'agent'],
+      accountId: 'acct-1',
+    });
+    assertFrozen(p);
+  });
+
+  it('uses unknown client when name blank', () => {
+    const p = resolveMcpBoundPrincipal({
+      clientName: '  ',
+      userId: 'user-1',
+      userRole: 'viewer',
+    });
+    expect(p.agentId).toBe('mcp:unknown');
+  });
+});
+
+describe('principalHasGrant / principalRoleList', () => {
+  it('principalHasGrant is false when grants empty', () => {
+    const p = resolveStreamPrincipal({
+      mode: 'admin',
+      userId: 'u',
+      userRole: 'admin',
+    });
+    expect(principalHasGrant(p, 'anything', 'execute')).toBe(false);
+  });
+
+  it('principalRoleList returns a mutable copy', () => {
+    const p = resolveStreamPrincipal({
+      mode: 'admin',
+      userId: 'u',
+      userRole: 'admin',
+    });
+    const list = principalRoleList(p);
+    list.push('mutated');
+    expect(p.roles).toEqual(['admin', 'agent']);
+  });
+});

--- a/apps/server/src/lib/__tests__/agent-tool-access.test.ts
+++ b/apps/server/src/lib/__tests__/agent-tool-access.test.ts
@@ -1,0 +1,172 @@
+/**
+ * GAP-355 Stage 6 S6-2 — authorizeAgentTool policy matrix.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type AgentPrincipal,
+  resolveDispatchPrincipal,
+  resolveStreamPrincipal,
+} from '../agent-principal.js';
+import {
+  agentToolPermissionKey,
+  authorizeAgentTool,
+  getAgentToolMeta,
+  listExecToolNames,
+} from '../agent-tool-access.js';
+
+function stream(role: string, grants?: AgentPrincipal['grants']): AgentPrincipal {
+  return resolveStreamPrincipal({
+    mode: 'coding',
+    userId: 'user-1',
+    userRole: role,
+    grants,
+  });
+}
+
+describe('agentToolPermissionKey', () => {
+  it('prefixes exact tool names', () => {
+    expect(agentToolPermissionKey('shell_exec')).toBe('agent:tool:shell_exec');
+  });
+});
+
+describe('getAgentToolMeta', () => {
+  it('classifies known tools', () => {
+    expect(getAgentToolMeta('file_read')).toMatchObject({
+      surface: 'coding',
+      class: 'read',
+    });
+    expect(getAgentToolMeta('list_users')).toMatchObject({
+      surface: 'admin',
+      class: 'admin-pii',
+    });
+    expect(getAgentToolMeta('shell_exec')?.class).toBe('exec');
+  });
+
+  it('returns undefined for unknown tools', () => {
+    expect(getAgentToolMeta('not_a_real_tool')).toBeUndefined();
+  });
+});
+
+describe('authorizeAgentTool — deny by default', () => {
+  it('denies unknown tools', () => {
+    const r = authorizeAgentTool(stream('owner'), 'mcp_fake__tool');
+    expect(r).toMatchObject({
+      allowed: false,
+      reason: 'unknown_tool',
+      permissionKey: null,
+    });
+  });
+});
+
+describe('authorizeAgentTool — coding exec requires grant', () => {
+  for (const name of listExecToolNames()) {
+    it(`denies ${name} without explicit grant even for owner`, () => {
+      const r = authorizeAgentTool(stream('owner'), name);
+      expect(r).toMatchObject({
+        allowed: false,
+        reason: 'exec_requires_grant',
+        class: 'exec',
+      });
+    });
+
+    it(`allows ${name} with explicit grant`, () => {
+      const r = authorizeAgentTool(
+        stream('viewer', [{ resource: agentToolPermissionKey(name), action: 'execute' }]),
+        name,
+      );
+      expect(r).toMatchObject({
+        allowed: true,
+        reason: 'explicit_grant',
+        class: 'exec',
+      });
+    });
+  }
+});
+
+describe('authorizeAgentTool — coding read/mutate', () => {
+  it('allows file_read for agent+viewer roles', () => {
+    const r = authorizeAgentTool(stream('viewer'), 'file_read');
+    expect(r.allowed).toBe(true);
+    expect(r.reason).toBe('allowed');
+  });
+
+  it('allows file_write for editor (agent has mutate coding)', () => {
+    const r = authorizeAgentTool(stream('editor'), 'file_write');
+    expect(r.allowed).toBe(true);
+  });
+
+  it('denies file_write for viewer (agent role alone would allow mutate, viewer human is N/A for coding)', () => {
+    // Coding surface does not apply human ∩ — agent role includes mutate.
+    // Viewer principal roles = [viewer, agent]; roleAllows with full roles passes
+    // because agent has file_write. That is intentional for coding (not admin ∩).
+    const r = authorizeAgentTool(stream('viewer'), 'file_write');
+    expect(r.allowed).toBe(true);
+  });
+});
+
+describe('authorizeAgentTool — admin ∩ human role', () => {
+  it('allows list_collections for editor (both agent and editor have read admin)', () => {
+    const r = authorizeAgentTool(
+      resolveStreamPrincipal({ mode: 'admin', userId: 'u', userRole: 'editor' }),
+      'list_collections',
+    );
+    expect(r).toMatchObject({ allowed: true, reason: 'allowed', surface: 'admin' });
+  });
+
+  it('denies list_users for editor (admin-pii is owner/admin only on human side)', () => {
+    const r = authorizeAgentTool(
+      resolveStreamPrincipal({ mode: 'admin', userId: 'u', userRole: 'editor' }),
+      'list_users',
+    );
+    // agent role also lacks admin-pii → agent_role_denied first
+    expect(r.allowed).toBe(false);
+    expect(['agent_role_denied', 'user_role_denied']).toContain(r.reason);
+  });
+
+  it('allows list_users for owner', () => {
+    const r = authorizeAgentTool(
+      resolveStreamPrincipal({ mode: 'admin', userId: 'u', userRole: 'owner' }),
+      'list_users',
+    );
+    expect(r.allowed).toBe(true);
+  });
+
+  it('denies delete_document when only agent role would pass but human is viewer', () => {
+    const r = authorizeAgentTool(
+      resolveStreamPrincipal({ mode: 'admin', userId: 'u', userRole: 'viewer' }),
+      'delete_document',
+    );
+    // agent has mutate admin; viewer human does not → user_role_denied
+    expect(r).toMatchObject({
+      allowed: false,
+      reason: 'user_role_denied',
+      surface: 'admin',
+    });
+  });
+
+  it('denies admin tools when principal has no human role (agent-only)', () => {
+    const p = resolveDispatchPrincipal({
+      userId: null,
+      userRole: null,
+    });
+    expect(p.roles).toEqual(['agent']);
+    const r = authorizeAgentTool(p, 'list_collections');
+    // agent allows read admin, but no human role for ∩
+    expect(r).toMatchObject({
+      allowed: false,
+      reason: 'no_human_role',
+    });
+  });
+});
+
+describe('authorizeAgentTool — dispatch principal', () => {
+  it('allows coding file_read for dispatch agent with admin human role', () => {
+    const p = resolveDispatchPrincipal({
+      ticketId: 't1',
+      userId: 'u',
+      userRole: 'admin',
+    });
+    expect(authorizeAgentTool(p, 'file_read').allowed).toBe(true);
+  });
+});

--- a/apps/server/src/lib/agent-principal.ts
+++ b/apps/server/src/lib/agent-principal.ts
@@ -1,0 +1,205 @@
+/**
+ * Agent principal (GAP-355 Stage 6 S6-1).
+ *
+ * A server-derived identity for an in-process agent run. Resolved once at run
+ * start and threaded into tool factories / authorize adapters (S6-2+). Never
+ * trusted from client tool arguments.
+ *
+ * Stage 5 receipts record what happened; Stage 6 principals decide what may
+ * happen. This module is types + pure resolvers only — no HTTP wiring yet.
+ *
+ * @see .jv/docs/gap-specs/GAP-355-stage6-govern-agents-design.md §4.1
+ */
+
+/** How the agent run was started. */
+export type AgentPrincipalKind = 'stream' | 'dispatch' | 'mcp-bound' | 'job';
+
+/** Optional explicit grant (AGENT mode / future scope grants). */
+export interface AgentGrant {
+  resource: string;
+  action: string;
+}
+
+/**
+ * Server-derived agent identity for RBAC evaluation.
+ *
+ * Owner countersign (2026-07-24): admin tools use **agent grants ∩ user
+ * permissions** — `roles` therefore includes both the acting human role and
+ * the `agent` role when known.
+ */
+export interface AgentPrincipal {
+  /** Stable id for audit rows (e.g. coding-stream-agent, ticket-agent-<id>). */
+  agentId: string;
+  kind: AgentPrincipalKind;
+  tenantId: string | null;
+  accountId: string | null;
+  /** Human who initiated or owns the run; null for unattended jobs when unknown. */
+  actingUserId: string | null;
+  /**
+   * Roles for RBAC. Deduped. In-process agents always include `agent` when a
+   * human role is present so policy matrices can key off either.
+   */
+  roles: readonly string[];
+  /** Explicit grants; empty means role-only evaluation (default). */
+  grants: readonly AgentGrant[];
+}
+
+// ─── Pure helpers ───────────────────────────────────────────────────────────
+
+function uniqueRoles(roles: ReadonlyArray<string | null | undefined>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const r of roles) {
+    if (!r) continue;
+    const trimmed = r.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function freezePrincipal(principal: AgentPrincipal): AgentPrincipal {
+  return Object.freeze({
+    ...principal,
+    roles: Object.freeze([...principal.roles]),
+    grants: Object.freeze(principal.grants.map((g) => Object.freeze({ ...g }))),
+  });
+}
+
+/**
+ * Roles used for agent-side RBAC (copy of principal.roles).
+ */
+export function principalRoleList(principal: AgentPrincipal): string[] {
+  return [...principal.roles];
+}
+
+/**
+ * True when the principal carries an explicit grant for resource+action.
+ * Empty grants ⇒ false (role-only mode; S6-2 authorize uses roles).
+ */
+export function principalHasGrant(
+  principal: AgentPrincipal,
+  resource: string,
+  action: string,
+): boolean {
+  return principal.grants.some((g) => g.resource === resource && g.action === action);
+}
+
+// ─── Resolvers (one per kind) ───────────────────────────────────────────────
+
+export interface ResolveStreamPrincipalInput {
+  /** agent-stream body.mode */
+  mode: 'admin' | 'coding';
+  userId: string;
+  /** Session user role from auth (e.g. owner, admin, editor). */
+  userRole: string;
+  tenantId?: string | null;
+  accountId?: string | null;
+  grants?: readonly AgentGrant[];
+}
+
+/**
+ * Principal for POST /api/agent-stream (admin or coding mode).
+ */
+export function resolveStreamPrincipal(input: ResolveStreamPrincipalInput): AgentPrincipal {
+  if (!input.userId.trim()) {
+    throw new Error('resolveStreamPrincipal: userId is required');
+  }
+  const agentId = input.mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent';
+  return freezePrincipal({
+    agentId,
+    kind: 'stream',
+    tenantId: input.tenantId ?? null,
+    accountId: input.accountId ?? null,
+    actingUserId: input.userId,
+    roles: uniqueRoles([input.userRole, 'agent']),
+    grants: input.grants ? [...input.grants] : [],
+  });
+}
+
+export interface ResolveDispatchPrincipalInput {
+  /** Ticket id when known (scopes agentId for audit correlation). */
+  ticketId?: string | null;
+  userId: string | null;
+  userRole?: string | null;
+  /** Workspace / board tenant when known. */
+  workspaceId?: string | null;
+  accountId?: string | null;
+  grants?: readonly AgentGrant[];
+}
+
+/**
+ * Principal for TicketAgentDispatcher / sync dispatch paths.
+ * agentId matches Stage 5 audit convention when ticketId is set.
+ */
+export function resolveDispatchPrincipal(input: ResolveDispatchPrincipalInput): AgentPrincipal {
+  const ticketId = input.ticketId?.trim();
+  const agentId = ticketId ? `ticket-agent-${ticketId}` : 'ticket-agent-dispatcher';
+  return freezePrincipal({
+    agentId,
+    kind: 'dispatch',
+    tenantId: input.workspaceId ?? null,
+    accountId: input.accountId ?? null,
+    actingUserId: input.userId,
+    roles: uniqueRoles([input.userRole, 'agent']),
+    grants: input.grants ? [...input.grants] : [],
+  });
+}
+
+export interface ResolveJobPrincipalInput {
+  agentId: string;
+  userId?: string | null;
+  userRole?: string | null;
+  tenantId?: string | null;
+  accountId?: string | null;
+  grants?: readonly AgentGrant[];
+}
+
+/**
+ * Principal for durable job workers (e.g. agent-dispatch queue).
+ */
+export function resolveJobPrincipal(input: ResolveJobPrincipalInput): AgentPrincipal {
+  if (!input.agentId.trim()) {
+    throw new Error('resolveJobPrincipal: agentId is required');
+  }
+  return freezePrincipal({
+    agentId: input.agentId.trim(),
+    kind: 'job',
+    tenantId: input.tenantId ?? null,
+    accountId: input.accountId ?? null,
+    actingUserId: input.userId ?? null,
+    roles: uniqueRoles([input.userRole, 'agent']),
+    grants: input.grants ? [...input.grants] : [],
+  });
+}
+
+export interface ResolveMcpBoundPrincipalInput {
+  /** MCP client name from handshake (becomes agentId prefix). */
+  clientName: string;
+  userId: string;
+  userRole: string;
+  tenantId?: string | null;
+  accountId?: string | null;
+  grants?: readonly AgentGrant[];
+}
+
+/**
+ * Principal for a bearer-bound MCP client acting as a governed user/agent.
+ * Complements mcp-tool-access (which already gates by role+tier).
+ */
+export function resolveMcpBoundPrincipal(input: ResolveMcpBoundPrincipalInput): AgentPrincipal {
+  if (!input.userId.trim()) {
+    throw new Error('resolveMcpBoundPrincipal: userId is required');
+  }
+  const client = input.clientName.trim() || 'unknown';
+  return freezePrincipal({
+    agentId: `mcp:${client}`,
+    kind: 'mcp-bound',
+    tenantId: input.tenantId ?? null,
+    accountId: input.accountId ?? null,
+    actingUserId: input.userId,
+    roles: uniqueRoles([input.userRole, 'agent']),
+    grants: input.grants ? [...input.grants] : [],
+  });
+}

--- a/apps/server/src/lib/agent-tool-access.ts
+++ b/apps/server/src/lib/agent-tool-access.ts
@@ -1,0 +1,256 @@
+/**
+ * In-process agent tool authorization (GAP-355 Stage 6 S6-2).
+ *
+ * Deny-by-default policy for admin CMS + coding tools used by agent-stream /
+ * dispatcher. Mirrors the shape of `mcp-tool-access.ts` (exact permission
+ * keys + dedicated AuthorizationSystem instance) but targets
+ * `agent:tool:<name>` resources and `AgentPrincipal` identities.
+ *
+ * Owner countersigns (2026-07-24):
+ *  1. Admin tools: **agent role ∩ human role** must both allow the tool.
+ *  2. Coding exec (shell_exec, git_ops, test_runner, lint_fix): **deny
+ *     until explicit principal grant**.
+ *  3. Soft-fail UX is S6-3's job; this module only returns allow/deny.
+ *
+ * MCP server tools (`mcp_*`) are NOT listed here — they are gated by the
+ * remote server + governed MCP path; S6-3 skips this authorize for them.
+ *
+ * @see .jv/docs/gap-specs/GAP-355-stage6-govern-agents-design.md §4.3–4.5
+ */
+
+import { AuthorizationSystem } from '@revealui/core/security';
+import type { AgentPrincipal } from './agent-principal.js';
+import { principalHasGrant } from './agent-principal.js';
+
+const EXECUTE_ACTION = 'execute';
+
+/** Permission resource for one in-process agent tool. */
+export function agentToolPermissionKey(toolName: string): string {
+  return `agent:tool:${toolName}`;
+}
+
+export type AgentToolClass = 'read' | 'propose' | 'mutate' | 'exec' | 'admin-pii';
+export type AgentToolSurface = 'admin' | 'coding';
+
+export interface AgentToolMeta {
+  name: string;
+  surface: AgentToolSurface;
+  class: AgentToolClass;
+}
+
+/** Catalog of known in-process tools (admin factory + coding package). */
+export const AGENT_TOOL_CATALOG: readonly AgentToolMeta[] = [
+  // Admin — collections
+  { name: 'list_collections', surface: 'admin', class: 'read' },
+  { name: 'find_documents', surface: 'admin', class: 'read' },
+  { name: 'get_document', surface: 'admin', class: 'read' },
+  { name: 'create_document', surface: 'admin', class: 'mutate' },
+  { name: 'update_document', surface: 'admin', class: 'mutate' },
+  { name: 'delete_document', surface: 'admin', class: 'mutate' },
+  // Admin — globals
+  { name: 'list_globals', surface: 'admin', class: 'read' },
+  { name: 'get_global', surface: 'admin', class: 'read' },
+  { name: 'update_global', surface: 'admin', class: 'mutate' },
+  // Admin — media
+  { name: 'list_media', surface: 'admin', class: 'read' },
+  { name: 'get_media', surface: 'admin', class: 'read' },
+  { name: 'upload_media', surface: 'admin', class: 'mutate' },
+  { name: 'update_media', surface: 'admin', class: 'mutate' },
+  { name: 'delete_media', surface: 'admin', class: 'mutate' },
+  // Admin — users
+  { name: 'get_current_user', surface: 'admin', class: 'read' },
+  { name: 'list_users', surface: 'admin', class: 'admin-pii' },
+  { name: 'create_user', surface: 'admin', class: 'admin-pii' },
+  { name: 'update_user', surface: 'admin', class: 'admin-pii' },
+  { name: 'delete_user', surface: 'admin', class: 'admin-pii' },
+  // Coding
+  { name: 'file_read', surface: 'coding', class: 'read' },
+  { name: 'file_glob', surface: 'coding', class: 'read' },
+  { name: 'file_grep', surface: 'coding', class: 'read' },
+  { name: 'project_context', surface: 'coding', class: 'read' },
+  { name: 'file_write', surface: 'coding', class: 'mutate' },
+  { name: 'file_edit', surface: 'coding', class: 'mutate' },
+  { name: 'shell_exec', surface: 'coding', class: 'exec' },
+  { name: 'git_ops', surface: 'coding', class: 'exec' },
+  { name: 'test_runner', surface: 'coding', class: 'exec' },
+  { name: 'lint_fix', surface: 'coding', class: 'exec' },
+] as const;
+
+const TOOL_BY_NAME = new Map(AGENT_TOOL_CATALOG.map((t) => [t.name, t]));
+
+export function getAgentToolMeta(toolName: string): AgentToolMeta | undefined {
+  return TOOL_BY_NAME.get(toolName);
+}
+
+// ─── Role matrices (exact keys only; no globs) ──────────────────────────────
+
+const ADMIN_READ = AGENT_TOOL_CATALOG.filter(
+  (t) => t.surface === 'admin' && t.class === 'read',
+).map((t) => t.name);
+
+const ADMIN_MUTATE = AGENT_TOOL_CATALOG.filter(
+  (t) => t.surface === 'admin' && t.class === 'mutate',
+).map((t) => t.name);
+
+const ADMIN_PII = AGENT_TOOL_CATALOG.filter(
+  (t) => t.surface === 'admin' && t.class === 'admin-pii',
+).map((t) => t.name);
+
+const CODING_READ = AGENT_TOOL_CATALOG.filter(
+  (t) => t.surface === 'coding' && t.class === 'read',
+).map((t) => t.name);
+
+const CODING_MUTATE = AGENT_TOOL_CATALOG.filter(
+  (t) => t.surface === 'coding' && t.class === 'mutate',
+).map((t) => t.name);
+
+/** Exec tools are never role-granted; explicit principal.grants only. */
+const CODING_EXEC = AGENT_TOOL_CATALOG.filter(
+  (t) => t.surface === 'coding' && t.class === 'exec',
+).map((t) => t.name);
+
+/**
+ * Per-role tool name grants (registered on the dedicated authz engine).
+ * Exec tools intentionally absent from every role.
+ */
+const ROLE_TOOL_GRANTS: Record<string, readonly string[]> = {
+  owner: [...ADMIN_READ, ...ADMIN_MUTATE, ...ADMIN_PII, ...CODING_READ, ...CODING_MUTATE],
+  admin: [...ADMIN_READ, ...ADMIN_MUTATE, ...ADMIN_PII, ...CODING_READ, ...CODING_MUTATE],
+  editor: [...ADMIN_READ, ...ADMIN_MUTATE, ...CODING_READ, ...CODING_MUTATE],
+  contributor: [...ADMIN_READ, ...ADMIN_MUTATE, ...CODING_READ],
+  viewer: [...ADMIN_READ, ...CODING_READ],
+  // agent role: no admin-pii, no exec; mutate coding yes for paid stream agents
+  agent: [...ADMIN_READ, ...ADMIN_MUTATE, ...CODING_READ, ...CODING_MUTATE],
+};
+
+const agentAuthz = new AuthorizationSystem();
+for (const [roleId, tools] of Object.entries(ROLE_TOOL_GRANTS)) {
+  agentAuthz.registerRole({
+    id: roleId,
+    name: roleId,
+    permissions: tools.map((tool) => ({
+      resource: agentToolPermissionKey(tool),
+      action: EXECUTE_ACTION,
+    })),
+  });
+}
+
+// ─── Authorize ──────────────────────────────────────────────────────────────
+
+export type AgentToolAuthzReason =
+  | 'allowed'
+  | 'explicit_grant'
+  | 'unknown_tool'
+  | 'exec_requires_grant'
+  | 'agent_role_denied'
+  | 'user_role_denied'
+  | 'no_human_role';
+
+export interface AgentToolAuthzResult {
+  allowed: boolean;
+  reason: AgentToolAuthzReason;
+  /** `agent:tool:<name>` when the tool is catalogued. */
+  permissionKey: string | null;
+  class: AgentToolClass | null;
+  surface: AgentToolSurface | null;
+}
+
+function roleAllows(roles: readonly string[], permissionKey: string): boolean {
+  if (roles.length === 0) return false;
+  return agentAuthz.hasPermission([...roles], permissionKey, EXECUTE_ACTION);
+}
+
+/**
+ * Deny-by-default authorization for one in-process agent tool.
+ *
+ * Order:
+ *  1. Unknown tool → deny
+ *  2. Explicit principal grant → allow (covers exec + exceptions)
+ *  3. Exec class without grant → deny
+ *  4. Agent role must allow (via `agent` in principal.roles or other roles)
+ *  5. Admin surface: human role (roles minus `agent`) must also allow (∩)
+ */
+export function authorizeAgentTool(
+  principal: AgentPrincipal,
+  toolName: string,
+): AgentToolAuthzResult {
+  const meta = getAgentToolMeta(toolName);
+  if (!meta) {
+    return {
+      allowed: false,
+      reason: 'unknown_tool',
+      permissionKey: null,
+      class: null,
+      surface: null,
+    };
+  }
+
+  const permissionKey = agentToolPermissionKey(toolName);
+
+  if (principalHasGrant(principal, permissionKey, EXECUTE_ACTION)) {
+    return {
+      allowed: true,
+      reason: 'explicit_grant',
+      permissionKey,
+      class: meta.class,
+      surface: meta.surface,
+    };
+  }
+
+  if (meta.class === 'exec') {
+    return {
+      allowed: false,
+      reason: 'exec_requires_grant',
+      permissionKey,
+      class: meta.class,
+      surface: meta.surface,
+    };
+  }
+
+  // Agent-side of the matrix: evaluate with full principal.roles (includes agent).
+  if (!roleAllows(principal.roles, permissionKey)) {
+    return {
+      allowed: false,
+      reason: 'agent_role_denied',
+      permissionKey,
+      class: meta.class,
+      surface: meta.surface,
+    };
+  }
+
+  // Admin surface: ∩ with human role alone (owner countersign).
+  if (meta.surface === 'admin') {
+    const humanRoles = principal.roles.filter((r) => r !== 'agent');
+    if (humanRoles.length === 0) {
+      return {
+        allowed: false,
+        reason: 'no_human_role',
+        permissionKey,
+        class: meta.class,
+        surface: meta.surface,
+      };
+    }
+    if (!roleAllows(humanRoles, permissionKey)) {
+      return {
+        allowed: false,
+        reason: 'user_role_denied',
+        permissionKey,
+        class: meta.class,
+        surface: meta.surface,
+      };
+    }
+  }
+
+  return {
+    allowed: true,
+    reason: 'allowed',
+    permissionKey,
+    class: meta.class,
+    surface: meta.surface,
+  };
+}
+
+/** Test helper: known exec tool names. */
+export function listExecToolNames(): readonly string[] {
+  return CODING_EXEC;
+}


### PR DESCRIPTION
## Summary

GAP-355 Stage 6 **S6-1 + S6-2** (design countersigned 2026-07-24).

### S6-1 — principal
- `apps/server/src/lib/agent-principal.ts`
- Resolvers: stream / dispatch / job / mcp-bound
- Frozen principals; roles = human + `agent`

### S6-2 — authorize
- `apps/server/src/lib/agent-tool-access.ts`
- Catalog of admin + coding tools → `agent:tool:<name>`
- Deny-by-default via dedicated `AuthorizationSystem` (same pattern as mcp-tool-access)
- **Admin:** agent role ∩ human role (owner countersign)
- **Coding exec** (`shell_exec`, `git_ops`, `test_runner`, `lint_fix`): deny until explicit `principal.grants`
- Soft-fail UX + stream wire = **S6-3** (not this PR)

### Tests
- 13 principal + 21 authorize = 34 unit tests

## Security
Agent authz identity + policy matrix. **Non-author guardrail-2 before merge.** Proposal-shaped; owner merges.

## Test plan
- [x] agent-principal + agent-tool-access unit tests
- [x] pre-push phase-1 gate
- [ ] CI green
- [ ] Non-author security review