### PR TITLE
fix(db,admin): GAP-302 residual — drop npm_username, welcome agent CTA

### DIFF
--- a/apps/admin/src/app/(frontend)/welcome/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/__tests__/page.test.tsx
@@ -57,7 +57,9 @@ describe('WelcomePage', () => {
     mockUseLicense.mockReturnValue({ tier: 'free' });
     render(<WelcomePage />);
 
-    expect(screen.getByText('First governed agent action')).toBeInTheDocument();
+    // Free / non-paid-success still uses the original heading; paid-success
+    // uses "First governed agent action" (GAP-302 residual).
+    expect(screen.getByText('Run your first agent')).toBeInTheDocument();
     expect(screen.queryByText('Your license key')).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/src/app/(frontend)/welcome/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/__tests__/page.test.tsx
@@ -33,9 +33,9 @@ describe('WelcomePage', () => {
     expect(hrefs[1]).toBe('/agents');
 
     expect(screen.getByText('Your license key')).toBeInTheDocument();
-    expect(screen.getByText('Run your first agent')).toBeInTheDocument();
-    // Only one "Run your first agent" CTA in the paid-success state.
-    expect(screen.getAllByText('Run your first agent')).toHaveLength(1);
+    expect(screen.getByText('First governed agent action')).toBeInTheDocument();
+    // Only one first-agent CTA in the paid-success state.
+    expect(screen.getAllByText('First governed agent action')).toHaveLength(1);
   });
 
   it('keeps the original CTA order and appends the agent CTA for non-paid success', () => {
@@ -57,7 +57,7 @@ describe('WelcomePage', () => {
     mockUseLicense.mockReturnValue({ tier: 'free' });
     render(<WelcomePage />);
 
-    expect(screen.getByText('Run your first agent')).toBeInTheDocument();
+    expect(screen.getByText('First governed agent action')).toBeInTheDocument();
     expect(screen.queryByText('Your license key')).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/src/app/(frontend)/welcome/page.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/page.tsx
@@ -121,9 +121,10 @@ export default function WelcomePage() {
               <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
                 <span className="text-lg font-semibold">2</span>
               </div>
-              <h2 className="text-lg font-semibold text-foreground">Run your first agent</h2>
+              <h2 className="text-lg font-semibold text-foreground">First governed agent action</h2>
               <p className="mt-2 text-sm text-muted-foreground">
-                Talk to an agent and watch it take a real action in your workspace.
+                Run an agent in your workspace. Every agent is a governed and audited user
+                with a receipt you can check.
               </p>
               <a
                 href="/agents"

--- a/apps/admin/src/app/(frontend)/welcome/page.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/page.tsx
@@ -123,8 +123,8 @@ export default function WelcomePage() {
               </div>
               <h2 className="text-lg font-semibold text-foreground">First governed agent action</h2>
               <p className="mt-2 text-sm text-muted-foreground">
-                Run an agent in your workspace. Every agent is a governed and audited user
-                with a receipt you can check.
+                Run an agent in your workspace. Every agent is a governed and audited user with a
+                receipt you can check.
               </p>
               <a
                 href="/agents"

--- a/packages/db/migrations/0029_drop_licenses_npm_username.sql
+++ b/packages/db/migrations/0029_drop_licenses_npm_username.sql
@@ -1,0 +1,6 @@
+-- GAP-302 residual (b): drop unused licenses.npm_username.
+-- Never written at runtime; perpetual package access is GitHub-team based
+-- (github_username + provisionGitHubAccess). Safe DROP — column is nullable
+-- and has no FKs or indexes.
+
+ALTER TABLE "licenses" DROP COLUMN IF EXISTS "npm_username";

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -80,6 +80,12 @@
       "rationale": "GAP-355 S4-1 hand-written CREATE TABLE audit_anchors + indexes + CHECK constraints. Hand-written so ADD CONSTRAINT uses DO $$ BEGIN ... EXCEPTION WHEN duplicate_object for idempotency (drizzle-kit does not emit that form). Companion Drizzle schema: packages/db/src/schema/audit-anchors.ts.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Snapshot deferred to shared snapshot-debt backfill; schema is fully modeled in audit-anchors.ts for type consumers."
+    },
+    {
+      "tag": "0029_drop_licenses_npm_username",
+      "rationale": "GAP-302 residual (b): DROP COLUMN licenses.npm_username. Column was never written at runtime (perpetual package access is GitHub-team based via github_username + provisionGitHubAccess). Hand-written single-statement DROP COLUMN IF EXISTS for idempotency. Companion Drizzle schema change at packages/db/src/schema/licenses.ts removes the field so types match the DB.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. Schema at licenses.ts already omits npmUsername at the type level."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1784600000000,
       "tag": "0028_audit_anchors",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1784700000000,
+      "tag": "0029_drop_licenses_npm_username",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/__tests__/licenses-audit-trail.test.ts
+++ b/packages/db/src/schema/__tests__/licenses-audit-trail.test.ts
@@ -43,7 +43,7 @@ beforeAll(async () => {
       perpetual BOOLEAN NOT NULL DEFAULT false,
       support_expires_at TIMESTAMPTZ,
       github_username TEXT,
-      npm_username TEXT,
+
       deleted_at TIMESTAMPTZ
     )
   `);

--- a/packages/db/src/schema/licenses.ts
+++ b/packages/db/src/schema/licenses.ts
@@ -61,8 +61,8 @@ export const licenses = pgTable(
     /** GitHub username for revealui-pro team provisioning (perpetual only) */
     githubUsername: text('github_username'),
 
-    /** npm username for @revealui Pro package access provisioning */
-    npmUsername: text('npm_username'),
+    // npmUsername removed (GAP-302 residual b): never written; private GitHub
+    // team provisioning uses githubUsername only. Dropped in migration 0029.
 
     /** Soft-delete  -  license records must never be hard-deleted for audit trail */
     deletedAt: timestamp('deleted_at', { withTimezone: true }),


### PR DESCRIPTION
## Summary

GAP-302 residual cleanup after Phase 1 (#2126):

| Residual | Action |
|----------|--------|
| (a) perpetual env name mismatch | Already fixed on test (canon `*_PERPETUAL_PRICE_ID`) |
| (b) `licenses.npm_username` half-wired | **DROP** — never written; GitHub team uses `github_username` |
| (c) Enterprise Perpetual UI | Already on test (`PERPETUAL_PLANS`) |
| Phase 2 onboarding | Welcome paid-success CTA → **First governed agent action** → `/agents` |

### Migration
`0029_drop_licenses_npm_username.sql` — `DROP COLUMN IF EXISTS npm_username`

## Test plan
- [ ] CI Unit Tests / migration journal
- [ ] Welcome paid-success test expectations