### PR TITLE
feat(ai,server): GAP-355 S6-3 agent-stream pre-authorize wrap

### DIFF
--- a/apps/server/src/lib/__tests__/agent-tool-governance.test.ts
+++ b/apps/server/src/lib/__tests__/agent-tool-governance.test.ts
@@ -1,0 +1,113 @@
+/**
+ * GAP-355 S6-3 — applyAgentToolGovernance soft-fail + deny audit.
+ * authorizeAgentTool is mocked so this suite does not need a full core build.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveStreamPrincipal } from '../agent-principal.js';
+import { applyAgentToolGovernance, type GovernableTool } from '../agent-tool-governance.js';
+
+const mockAppend = vi.fn().mockResolvedValue(undefined);
+const mockAuthorize = vi.fn();
+
+vi.mock('../audit-signer.js', () => ({
+  createAuditStore: () => ({
+    append: mockAppend,
+  }),
+}));
+
+vi.mock('@revealui/db', () => ({
+  getClient: () => ({}),
+}));
+
+vi.mock('@revealui/core/security', () => ({
+  classifyAuditWriteFailure: () => 'unknown',
+  recordAuditWriteResult: vi.fn(),
+  AuthorizationSystem: class {
+    registerRole() {}
+    hasPermission() {
+      return false;
+    }
+  },
+}));
+
+vi.mock('../agent-tool-access.js', () => ({
+  authorizeAgentTool: (...args: unknown[]) => mockAuthorize(...args),
+}));
+
+function makeTool(name: string, execute: GovernableTool['execute']): GovernableTool {
+  return {
+    name,
+    execute,
+  };
+}
+
+describe('applyAgentToolGovernance', () => {
+  beforeEach(() => {
+    mockAppend.mockClear();
+    mockAuthorize.mockReset();
+  });
+
+  it('denies when authorize returns false and records agent:tool:denied', async () => {
+    mockAuthorize.mockReturnValue({
+      allowed: false,
+      reason: 'exec_requires_grant',
+      permissionKey: 'agent:tool:shell_exec',
+      class: 'exec',
+      surface: 'coding',
+    });
+    const execute = vi.fn(async () => ({ success: true }));
+    const principal = resolveStreamPrincipal({
+      mode: 'coding',
+      userId: 'user-1',
+      userRole: 'owner',
+    });
+    const [wrapped] = applyAgentToolGovernance([makeTool('shell_exec', execute)], {
+      principal,
+      namespace: 'coding',
+      sessionId: 'sess-1',
+      accountId: 'acct-1',
+      userId: 'user-1',
+      taskId: 'task-1',
+    });
+
+    const result = (await wrapped?.execute({})) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/exec_requires_grant/);
+    expect(execute).not.toHaveBeenCalled();
+    expect(mockAppend).toHaveBeenCalledOnce();
+    const row = mockAppend.mock.calls[0]?.[0] as {
+      eventType: string;
+      payload: Record<string, unknown>;
+    };
+    expect(row.eventType).toBe('agent:tool:denied');
+    expect(row.payload.reason).toBe('exec_requires_grant');
+    expect(row.payload.tool).toBe('shell_exec');
+  });
+
+  it('allows and executes when authorize returns true', async () => {
+    mockAuthorize.mockReturnValue({
+      allowed: true,
+      reason: 'allowed',
+      permissionKey: 'agent:tool:file_read',
+      class: 'read',
+      surface: 'coding',
+    });
+    const execute = vi.fn(async () => ({ success: true, data: 'ok' }));
+    const principal = resolveStreamPrincipal({
+      mode: 'coding',
+      userId: 'user-1',
+      userRole: 'owner',
+    });
+    const [wrapped] = applyAgentToolGovernance([makeTool('file_read', execute)], {
+      principal,
+      namespace: 'coding',
+      userId: 'user-1',
+    });
+
+    const result = await wrapped?.execute({});
+    expect(result).toEqual({ success: true, data: 'ok' });
+    expect(execute).toHaveBeenCalledOnce();
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/lib/agent-tool-audit.ts
+++ b/apps/server/src/lib/agent-tool-audit.ts
@@ -73,3 +73,58 @@ export async function recordAgentMcpToolAudit(input: AgentMcpToolAuditInput): Pr
     throw err;
   }
 }
+
+export interface AgentToolDeniedAuditInput {
+  toolName: string;
+  reason: string;
+  namespace?: string;
+  sessionId?: string;
+  accountId?: string | null;
+  userId?: string | null;
+  agentId?: string;
+  taskId?: string;
+  db?: Database;
+}
+
+/**
+ * Append agent:tool:denied (GAP-355 Stage 6 S6-3). Soft-fail path on stream —
+ * callers may swallow throw so the model still receives a deny ToolResult.
+ */
+export async function recordAgentToolDenied(input: AgentToolDeniedAuditInput): Promise<void> {
+  const id = randomUUID();
+  const eventType = 'agent:tool:denied';
+  const agentId = input.agentId ?? 'agent-stream';
+
+  const payload: Record<string, unknown> = {
+    tool: input.toolName,
+    reason: input.reason,
+    success: false,
+  };
+  if (input.namespace !== undefined) payload.namespace = input.namespace;
+  if (input.userId !== undefined) payload.userId = input.userId;
+  if (input.accountId !== undefined) payload.accountId = input.accountId;
+
+  try {
+    await createAuditStore(input.db ?? getClient()).append({
+      id,
+      timestamp: new Date(),
+      eventType,
+      severity: 'warn',
+      agentId,
+      ...(input.taskId !== undefined ? { taskId: input.taskId } : {}),
+      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+      payload,
+      policyViolations: [input.reason],
+      tenant: input.accountId ?? null,
+    });
+    recordAuditWriteResult({ ok: true, eventId: id, eventType });
+  } catch (err) {
+    recordAuditWriteResult({
+      ok: false,
+      reason: classifyAuditWriteFailure(err),
+      eventId: id,
+      eventType,
+    });
+    throw err;
+  }
+}

--- a/apps/server/src/lib/agent-tool-governance.ts
+++ b/apps/server/src/lib/agent-tool-governance.ts
@@ -14,11 +14,13 @@ import type { AgentPrincipal } from './agent-principal.js';
 import { authorizeAgentTool } from './agent-tool-access.js';
 import { recordAgentToolDenied } from './agent-tool-audit.js';
 
-/** Minimal tool shape (matches @revealui/ai Tool execute contract). */
+/**
+ * Minimal tool shape (structurally satisfied by `@revealui/ai` Tool).
+ * No index signature — keeps `Tool[]` assignable without casts.
+ */
 export interface GovernableTool {
   name: string;
   execute: (params: unknown) => Promise<unknown>;
-  [key: string]: unknown;
 }
 
 export interface AgentToolGovernanceContext {
@@ -32,9 +34,10 @@ export interface AgentToolGovernanceContext {
 
 /**
  * Wrap tools so each execute is pre-authorized. Soft-fail denials do not throw.
+ * Preserves extra tool fields via spread; return type stays the input element type.
  */
 export function applyAgentToolGovernance<T extends GovernableTool>(
-  tools: T[],
+  tools: readonly T[],
   ctx: AgentToolGovernanceContext,
 ): T[] {
   const { principal } = ctx;
@@ -66,6 +69,6 @@ export function applyAgentToolGovernance<T extends GovernableTool>(
         }
         return originalExecute(params);
       },
-    } as T;
-  });
+    };
+  }) as T[];
 }

--- a/apps/server/src/lib/agent-tool-governance.ts
+++ b/apps/server/src/lib/agent-tool-governance.ts
@@ -1,0 +1,71 @@
+/**
+ * Apply Stage 6 pre-authorize wraps to in-process agent tools (S6-3).
+ *
+ * Uses authorizeAgentTool (S6-2) + soft-fail denial + recordAgentToolDenied.
+ * Implemented here (not a static `@revealui/ai` import) so apps/server stays
+ * free of a hard Pro-package dependency at module load; the wrap contract
+ * matches `packages/ai` `wrapToolWithGovernance`.
+ *
+ * Pass only admin/coding tools — not MCP `mcp_*` tools (unknown would deny;
+ * remote MCP is gated separately).
+ */
+
+import type { AgentPrincipal } from './agent-principal.js';
+import { authorizeAgentTool } from './agent-tool-access.js';
+import { recordAgentToolDenied } from './agent-tool-audit.js';
+
+/** Minimal tool shape (matches @revealui/ai Tool execute contract). */
+export interface GovernableTool {
+  name: string;
+  execute: (params: unknown) => Promise<unknown>;
+  [key: string]: unknown;
+}
+
+export interface AgentToolGovernanceContext {
+  principal: AgentPrincipal;
+  namespace: string;
+  sessionId?: string;
+  accountId?: string | null;
+  userId?: string | null;
+  taskId?: string;
+}
+
+/**
+ * Wrap tools so each execute is pre-authorized. Soft-fail denials do not throw.
+ */
+export function applyAgentToolGovernance<T extends GovernableTool>(
+  tools: T[],
+  ctx: AgentToolGovernanceContext,
+): T[] {
+  const { principal } = ctx;
+  return tools.map((tool) => {
+    const originalExecute = tool.execute.bind(tool);
+    return {
+      ...tool,
+      async execute(params: unknown): Promise<unknown> {
+        const decision = authorizeAgentTool(principal, tool.name);
+        if (!decision.allowed) {
+          try {
+            await recordAgentToolDenied({
+              toolName: tool.name,
+              reason: decision.reason,
+              namespace: ctx.namespace,
+              sessionId: ctx.sessionId,
+              accountId: ctx.accountId,
+              userId: ctx.userId,
+              agentId: principal.agentId,
+              taskId: ctx.taskId,
+            });
+          } catch {
+            // Soft-fail: still return denial if deny-audit fails.
+          }
+          return {
+            success: false,
+            error: `Permission denied (${decision.reason}): ${tool.name}`,
+          };
+        }
+        return originalExecute(params);
+      },
+    } as T;
+  });
+}

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -22,12 +22,14 @@ import {
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
 import { type SSEStreamingApi, streamSSE } from 'hono/streaming';
+import { resolveStreamPrincipal } from '../lib/agent-principal.js';
 import {
   awaitElicitationResponse,
   createAgentRunSession,
   deleteAgentRunSession,
 } from '../lib/agent-run-sessions.js';
 import { recordAgentMcpToolAudit } from '../lib/agent-tool-audit.js';
+import { applyAgentToolGovernance } from '../lib/agent-tool-governance.js';
 import { createAuditStore } from '../lib/audit-signer.js';
 import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
 import { recordUsageMeter } from '../lib/metering.js';
@@ -195,11 +197,21 @@ app.openapi(agentStreamRoute, async (c) => {
 
   const workspaceId = body.workspaceId ?? c.get('tenant')?.id ?? 'default';
   const mode = body.mode ?? 'admin';
-  const streamAgentId = mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent';
   const accountId = getEntitlementsFromContext(c).accountId;
+  const tenantId = c.get('tenant')?.id ?? null;
   const runSession = createAgentRunSession(user.id);
   // Late-bound task id for tool-audit rows (task object is built after tools).
   const taskRef: { id: string } = { id: `task-${Date.now()}` };
+
+  // GAP-355 S6-1: server-derived principal for pre-authorize (never client input).
+  const streamPrincipal = resolveStreamPrincipal({
+    mode,
+    userId: user.id,
+    userRole: user.role,
+    tenantId,
+    accountId,
+  });
+  const streamAgentId = streamPrincipal.agentId;
 
   // GAP-355 S5-4: integrity audit for non-MCP tools (admin CMS + coding).
   const streamToolAudit =
@@ -219,10 +231,19 @@ app.openapi(agentStreamRoute, async (c) => {
         sessionId: runSession.sessionId,
         accountId,
         userId: user.id,
-        agentId: streamAgentId,
+        agentId: streamPrincipal.agentId,
         taskId: taskRef.id,
       });
     };
+
+  const governanceCtx = (namespace: string) => ({
+    principal: streamPrincipal,
+    namespace,
+    sessionId: runSession.sessionId,
+    accountId,
+    userId: user.id,
+    taskId: taskRef.id,
+  });
 
   // Load admin tools so the agent can manage content, media, users, globals
   let cmsTools: unknown[] = [];
@@ -247,10 +268,13 @@ app.openapi(agentStreamRoute, async (c) => {
       const { createInternalAdminClient } = await import('../lib/internal-admin-client.js');
       const apiClient = createInternalAdminClient(apiBase, sessionToken);
 
-      cmsTools = cmsToolsMod.createAdminTools({
+      // Integrity (S5) inside factory; governance (S6) wraps outside so deny
+      // never executes the tool.
+      const rawAdmin = cmsToolsMod.createAdminTools({
         apiClient,
         onToolAudit: streamToolAudit('admin-cms'),
       });
+      cmsTools = applyAgentToolGovernance(rawAdmin, governanceCtx('admin-cms'));
     }
   } catch {
     // admin tools unavailable  -  agent will work without them
@@ -282,13 +306,14 @@ app.openapi(agentStreamRoute, async (c) => {
             error?: string;
           }) => void | Promise<void>;
         }) => unknown[];
-        codingTools = createCodingTools({
+        const rawCoding = createCodingTools({
           projectRoot,
           allowedPaths: process.env.CODING_ALLOWED_PATHS?.split(','),
           // Local (free tier): only read-only tools (no file_write, file_edit, shell_exec, git_ops)
           ...(isLocalOnly && { include: readOnlyCodingTools }),
           onToolAudit: streamToolAudit('coding'),
-        });
+        }) as Array<{ name: string; execute: (params: unknown) => Promise<unknown> }>;
+        codingTools = applyAgentToolGovernance(rawCoding, governanceCtx('coding'));
       }
     } catch {
       // Coding tools unavailable  -  agent will work with admin tools only

--- a/packages/ai/src/__tests__/tools/governance.test.ts
+++ b/packages/ai/src/__tests__/tools/governance.test.ts
@@ -1,0 +1,70 @@
+/**
+ * GAP-355 S6-3 — wrapToolWithGovernance soft-fail pre-authorize.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import type { Tool } from '../../tools/base.js';
+import { wrapToolWithGovernance } from '../../tools/governance.js';
+
+function makeTool(execute: Tool['execute'], name = 'demo_tool'): Tool {
+  return {
+    name,
+    description: 'demo',
+    parameters: z.object({}),
+    execute,
+  };
+}
+
+describe('wrapToolWithGovernance', () => {
+  it('does not execute when authorize denies; returns soft-fail ToolResult', async () => {
+    const execute = vi.fn(async () => ({ success: true, data: {} }));
+    const onDenied = vi.fn(async () => undefined);
+    const tool = makeTool(execute);
+
+    const wrapped = wrapToolWithGovernance(tool, {
+      authorize: () => ({ allowed: false, reason: 'exec_requires_grant' }),
+      onDenied,
+    });
+
+    const result = await wrapped.execute({});
+    expect(result).toEqual({
+      success: false,
+      error: 'Permission denied (exec_requires_grant): demo_tool',
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expect(onDenied).toHaveBeenCalledWith({
+      toolName: 'demo_tool',
+      reason: 'exec_requires_grant',
+    });
+  });
+
+  it('executes when authorize allows', async () => {
+    const execute = vi.fn(async () => ({ success: true, data: { ok: true } }));
+    const tool = makeTool(execute);
+
+    const wrapped = wrapToolWithGovernance(tool, {
+      authorize: () => ({ allowed: true, reason: 'allowed' }),
+    });
+
+    const result = await wrapped.execute({});
+    expect(result).toEqual({ success: true, data: { ok: true } });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it('still soft-fails when onDenied throws', async () => {
+    const execute = vi.fn(async () => ({ success: true }));
+    const tool = makeTool(execute);
+
+    const wrapped = wrapToolWithGovernance(tool, {
+      authorize: () => ({ allowed: false, reason: 'unknown_tool' }),
+      onDenied: async () => {
+        throw new Error('audit failed');
+      },
+    });
+
+    const result = await wrapped.execute({});
+    expect(result.success).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -83,6 +83,7 @@ export * from './templates/index.js';
 export * from './tools/base.js';
 export * from './tools/deduplicator.js';
 export * from './tools/document-summarizer.js';
+export * from './tools/governance.js';
 export * from './tools/integrity-audit.js';
 export * from './tools/mcp-adapter.js';
 export * from './tools/mcp-elicitation.js';

--- a/packages/ai/src/tools/governance.ts
+++ b/packages/ai/src/tools/governance.ts
@@ -1,0 +1,70 @@
+/**
+ * Tool governance wrapper (GAP-355 Stage 6 S6-3).
+ *
+ * Pre-authorize before side effects; soft-fail (return ToolResult error) when
+ * denied so the model can recover. Compose outside integrity audit wraps:
+ *   governance(integrity(realTool))
+ * so authorize runs first and denied tools never execute or integrity-audit success.
+ *
+ * MCP server tools are not wrapped here (remote / governed-MCP gated).
+ */
+
+import type { Tool, ToolResult } from './base.js';
+
+export interface ToolAuthorizeDecision {
+  allowed: boolean;
+  /** Machine-readable deny reason (e.g. exec_requires_grant). */
+  reason: string;
+}
+
+export type ToolAuthorizeFn = (toolName: string) => ToolAuthorizeDecision;
+
+export type ToolDeniedHandler = (info: {
+  toolName: string;
+  reason: string;
+}) => void | Promise<void>;
+
+export interface WrapToolWithGovernanceOptions {
+  authorize: ToolAuthorizeFn;
+  /**
+   * Called when authorize denies. Soft-fail: errors here do not rethrow —
+   * the tool still returns a denial ToolResult (owner: soft fail UX).
+   */
+  onDenied?: ToolDeniedHandler;
+}
+
+/**
+ * Wrap a tool so execute is gated by authorize. Denied → no execute.
+ * Returns a new tool object; does not mutate the input.
+ */
+export function wrapToolWithGovernance(tool: Tool, options: WrapToolWithGovernanceOptions): Tool {
+  return {
+    ...tool,
+    async execute(params: unknown): Promise<ToolResult> {
+      const decision = options.authorize(tool.name);
+      if (!decision.allowed) {
+        try {
+          await options.onDenied?.({
+            toolName: tool.name,
+            reason: decision.reason,
+          });
+        } catch {
+          // Soft-fail: still return denial to the model if deny-audit fails.
+        }
+        return {
+          success: false,
+          error: `Permission denied (${decision.reason}): ${tool.name}`,
+        };
+      }
+      return tool.execute(params);
+    },
+  };
+}
+
+/** Map a tool list through wrapToolWithGovernance. */
+export function wrapToolsWithGovernance(
+  tools: Tool[],
+  options: WrapToolWithGovernanceOptions,
+): Tool[] {
+  return tools.map((tool) => wrapToolWithGovernance(tool, options));
+}

--- a/scripts/validate/agent-audit-chokepoints.json
+++ b/scripts/validate/agent-audit-chokepoints.json
@@ -48,13 +48,36 @@
         "recordAgentMcpToolAudit",
         "onToolAudit",
         "agent:task:started",
-        "streamToolAudit"
+        "streamToolAudit",
+        "resolveStreamPrincipal",
+        "applyAgentToolGovernance"
       ]
     },
     {
       "id": "agent-tool-audit-adapter",
       "file": "apps/server/src/lib/agent-tool-audit.ts",
-      "mustContain": ["recordAgentMcpToolAudit", "createAuditStore", "agent:tool:called"]
+      "mustContain": [
+        "recordAgentMcpToolAudit",
+        "recordAgentToolDenied",
+        "createAuditStore",
+        "agent:tool:called",
+        "agent:tool:denied"
+      ]
+    },
+    {
+      "id": "agent-tool-governance-wrap",
+      "file": "apps/server/src/lib/agent-tool-governance.ts",
+      "mustContain": ["applyAgentToolGovernance", "authorizeAgentTool", "recordAgentToolDenied"]
+    },
+    {
+      "id": "agent-tool-access-matrix",
+      "file": "apps/server/src/lib/agent-tool-access.ts",
+      "mustContain": ["authorizeAgentTool", "agent:tool:"]
+    },
+    {
+      "id": "tool-governance-wrapper",
+      "file": "packages/ai/src/tools/governance.ts",
+      "mustContain": ["wrapToolWithGovernance", "Permission denied"]
     },
     {
       "id": "governed-mcp-tool-audit",


### PR DESCRIPTION
## Summary

GAP-355 Stage 6 **S6-3**: wire pre-authorize on agent-stream for admin CMS + coding tools.

### Behavior
1. `resolveStreamPrincipal` at stream open (server-derived; never client input)
2. `applyAgentToolGovernance` wraps admin/coding tools **outside** integrity audit
3. Deny → soft-fail `ToolResult` + `agent:tool:denied` audit (no execute)
4. Allow → execute → Stage 5 integrity audit as before
5. MCP `mcp_*` tools **not** wrapped (remote / governed-MCP gated)

### Also
- `packages/ai` `wrapToolWithGovernance` (library form; server uses structural apply to avoid static Pro import)
- `recordAgentToolDenied` on ONE DOOR
- Chokepoint checklist extended (13 markers)

### Owner countersigns honored
- Admin: agent ∩ human (via S6-2 matrix)
- Exec: deny until grant
- Soft-fail deny UX

### Residual
- Ticket dispatcher / job path wire = **S6-4**
- Claims still hold foil (S6-6)

## Security
Agent authorization path. **Non-author guardrail-2 before merge.** Proposal-shaped; owner merges.

## Test plan
- [x] governance unit tests (3)
- [x] agent-tool-governance unit tests (2)
- [x] validate:agent-audit-chokepoints PASS
- [x] pre-push phase-1 gate
- [ ] CI green
- [ ] Non-author security review