### PR TITLE
feat(server): GAP-406 WIRE phase 1–2 MCPHypervisor sinks + opt-in spawn

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -50,6 +50,7 @@ import {
   auditStorageSelfTest,
   installAuditStorage,
 } from './lib/audit-storage.js';
+import { wireMcpHypervisorIfEnabled } from './lib/mcp-hypervisor-wire.js';
 import { queryBillingStatusByCustomerId, querySupportExpiry } from './lib/billing-status.js';
 import { createLazyHonoRoute } from './lib/lazy-hono-route.js';
 import { runHostedLicenseCanary } from './lib/license-canary.js';
@@ -1414,6 +1415,8 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
     // Swap in persistent audit storage (replaces default InMemoryAuditStorage).
     assertAuditStorageEnv();
     installAuditStorage();
+    // GAP-406 WIRE phase 1: opt-in MCPHypervisor meter/audit sinks (no spawn).
+    wireMcpHypervisorIfEnabled();
     validateStartup();
     // validateLicenseAtStartup is a no-op in hosted mode (REVEALUI_LICENSE_PRIVATE_KEY
     // present); in self-hosted Forge mode it throws on missing/invalid license,
@@ -1520,5 +1523,7 @@ if (process.env.NODE_ENV === 'production') {
     // round trip — the serverless-safe substitute for the worker's self-test.
     assertAuditStorageEnv();
     installAuditStorage();
+    // GAP-406 WIRE phase 1: opt-in MCPHypervisor meter/audit sinks (no spawn).
+    wireMcpHypervisorIfEnabled();
   }
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -50,10 +50,10 @@ import {
   auditStorageSelfTest,
   installAuditStorage,
 } from './lib/audit-storage.js';
-import { wireMcpHypervisorIfEnabled } from './lib/mcp-hypervisor-wire.js';
 import { queryBillingStatusByCustomerId, querySupportExpiry } from './lib/billing-status.js';
 import { createLazyHonoRoute } from './lib/lazy-hono-route.js';
 import { runHostedLicenseCanary } from './lib/license-canary.js';
+import { wireMcpHypervisorIfEnabled } from './lib/mcp-hypervisor-wire.js';
 import { resolveSelfApiBaseUrl } from './lib/self-api-url.js';
 import {
   validateBillingCatalogAtStartup,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1415,8 +1415,13 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
     // Swap in persistent audit storage (replaces default InMemoryAuditStorage).
     assertAuditStorageEnv();
     installAuditStorage();
-    // GAP-406 WIRE phase 1: opt-in MCPHypervisor meter/audit sinks (no spawn).
-    wireMcpHypervisorIfEnabled();
+    // GAP-406 WIRE: opt-in MCPHypervisor sinks (+ optional process-local spawn).
+    void wireMcpHypervisorIfEnabled().catch((err: unknown) => {
+      logger.error(
+        '[mcp-hypervisor-wire] boot failed',
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    });
     validateStartup();
     // validateLicenseAtStartup is a no-op in hosted mode (REVEALUI_LICENSE_PRIVATE_KEY
     // present); in self-hosted Forge mode it throws on missing/invalid license,
@@ -1523,7 +1528,12 @@ if (process.env.NODE_ENV === 'production') {
     // round trip — the serverless-safe substitute for the worker's self-test.
     assertAuditStorageEnv();
     installAuditStorage();
-    // GAP-406 WIRE phase 1: opt-in MCPHypervisor meter/audit sinks (no spawn).
-    wireMcpHypervisorIfEnabled();
+    // GAP-406 WIRE: opt-in MCPHypervisor sinks (+ optional process-local spawn).
+    void wireMcpHypervisorIfEnabled().catch((err: unknown) => {
+      logger.error(
+        '[mcp-hypervisor-wire] boot failed',
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    });
   }
 }

--- a/apps/server/src/lib/__tests__/mcp-hypervisor-wire.test.ts
+++ b/apps/server/src/lib/__tests__/mcp-hypervisor-wire.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const setUsageMeterSink = vi.fn();
+const setAuditSink = vi.fn();
+const getInstance = vi.fn(() => ({
+  setUsageMeterSink,
+  setAuditSink,
+}));
+
+vi.mock('@revealui/mcp', () => ({
+  MCPHypervisor: {
+    getInstance,
+  },
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../metering.js', () => ({
+  recordUsageMeter: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../mcp-audit.js', () => ({
+  recordMcpToolAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('mcp-hypervisor-wire', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.REVEALUI_MCP_HYPERVISOR;
+  });
+
+  it('is disabled by default', async () => {
+    const { isMcpHypervisorWireEnabled, wireMcpHypervisorIfEnabled } = await import(
+      '../mcp-hypervisor-wire.js'
+    );
+    expect(isMcpHypervisorWireEnabled({})).toBe(false);
+    expect(wireMcpHypervisorIfEnabled({})).toBe(false);
+    expect(getInstance).not.toHaveBeenCalled();
+  });
+
+  it('enables on REVEALUI_MCP_HYPERVISOR=1 and installs sinks', async () => {
+    const { wireMcpHypervisorIfEnabled } = await import('../mcp-hypervisor-wire.js');
+    expect(wireMcpHypervisorIfEnabled({ REVEALUI_MCP_HYPERVISOR: '1' })).toBe(true);
+    expect(getInstance).toHaveBeenCalledOnce();
+    expect(setUsageMeterSink).toHaveBeenCalledOnce();
+    expect(setAuditSink).toHaveBeenCalledOnce();
+  });
+
+  it('maps tenant meter events to usage rows and skips without tenant', async () => {
+    const { meterEventToUsageRow } = await import('../mcp-hypervisor-wire.js');
+    const withTenant = meterEventToUsageRow({
+      kind: 'mcp.tool.call',
+      serverName: 'content',
+      toolName: 'list',
+      tenantId: 'acct_1',
+      duration_ms: 12,
+      success: true,
+    });
+    expect(withTenant).toMatchObject({
+      accountId: 'acct_1',
+      meterName: 'mcp.tool.call',
+      source: 'agent',
+      durationMs: 12,
+      errored: false,
+    });
+
+    expect(
+      meterEventToUsageRow({
+        kind: 'mcp.tool.call',
+        serverName: 'content',
+        toolName: 'list',
+        duration_ms: 3,
+        success: false,
+        error: 'boom',
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/server/src/lib/__tests__/mcp-hypervisor-wire.test.ts
+++ b/apps/server/src/lib/__tests__/mcp-hypervisor-wire.test.ts
@@ -2,9 +2,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const setUsageMeterSink = vi.fn();
 const setAuditSink = vi.fn();
+const registerServer = vi.fn();
+const startServer = vi.fn().mockResolvedValue(undefined);
+const setCredentialResolver = vi.fn();
 const getInstance = vi.fn(() => ({
   setUsageMeterSink,
   setAuditSink,
+  registerServer,
+  startServer,
+  setCredentialResolver,
 }));
 
 vi.mock('@revealui/mcp', () => ({
@@ -25,10 +31,30 @@ vi.mock('../mcp-audit.js', () => ({
   recordMcpToolAudit: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('node:module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:module')>();
+  return {
+    ...actual,
+    createRequire: () => {
+      const req = ((id: string) => {
+        throw new Error(`unexpected require ${id}`);
+      }) as NodeRequire;
+      req.resolve = (id: string) => {
+        if (id.includes('@revealui/mcp')) return '/fake/mcp/dist/cli.js';
+        throw new Error(`unexpected resolve ${id}`);
+      };
+      req.cache = {};
+      req.extensions = {};
+      req.main = undefined;
+      return req;
+    },
+  };
+});
+
 describe('mcp-hypervisor-wire', () => {
   afterEach(() => {
     vi.clearAllMocks();
-    delete process.env.REVEALUI_MCP_HYPERVISOR;
+    vi.resetModules();
   });
 
   it('is disabled by default', async () => {
@@ -36,16 +62,18 @@ describe('mcp-hypervisor-wire', () => {
       '../mcp-hypervisor-wire.js'
     );
     expect(isMcpHypervisorWireEnabled({})).toBe(false);
-    expect(wireMcpHypervisorIfEnabled({})).toBe(false);
+    expect(await wireMcpHypervisorIfEnabled({})).toBe(false);
     expect(getInstance).not.toHaveBeenCalled();
   });
 
-  it('enables on REVEALUI_MCP_HYPERVISOR=1 and installs sinks', async () => {
+  it('enables on REVEALUI_MCP_HYPERVISOR=1 and installs sinks without spawn', async () => {
     const { wireMcpHypervisorIfEnabled } = await import('../mcp-hypervisor-wire.js');
-    expect(wireMcpHypervisorIfEnabled({ REVEALUI_MCP_HYPERVISOR: '1' })).toBe(true);
+    expect(await wireMcpHypervisorIfEnabled({ REVEALUI_MCP_HYPERVISOR: '1' })).toBe(true);
     expect(getInstance).toHaveBeenCalledOnce();
     expect(setUsageMeterSink).toHaveBeenCalledOnce();
     expect(setAuditSink).toHaveBeenCalledOnce();
+    expect(registerServer).not.toHaveBeenCalled();
+    expect(startServer).not.toHaveBeenCalled();
   });
 
   it('maps tenant meter events to usage rows and skips without tenant', async () => {
@@ -76,5 +104,45 @@ describe('mcp-hypervisor-wire', () => {
         error: 'boom',
       }),
     ).toBeNull();
+  });
+
+  it('parseSpawnServerList defaults to contracts,docs and filters unknown', async () => {
+    const { parseSpawnServerList, DEFAULT_SPAWN_SERVERS } = await import(
+      '../mcp-hypervisor-wire.js'
+    );
+    expect(parseSpawnServerList({})).toEqual([...DEFAULT_SPAWN_SERVERS]);
+    expect(
+      parseSpawnServerList({ REVEALUI_MCP_HYPERVISOR_SERVERS: 'contracts,nope,docs' }),
+    ).toEqual(['contracts', 'docs']);
+  });
+
+  it('spawn path registers and starts allowlisted servers', async () => {
+    const { wireMcpHypervisorIfEnabled, buildServerConfig } = await import(
+      '../mcp-hypervisor-wire.js'
+    );
+
+    expect(buildServerConfig('contracts', '/fake/cli.js')).toMatchObject({
+      name: 'contracts',
+      command: process.execPath,
+      args: ['/fake/cli.js', 'contracts'],
+    });
+
+    expect(
+      await wireMcpHypervisorIfEnabled({
+        REVEALUI_MCP_HYPERVISOR: '1',
+        REVEALUI_MCP_HYPERVISOR_SPAWN: '1',
+        REVEALUI_MCP_HYPERVISOR_SERVERS: 'contracts',
+      }),
+    ).toBe(true);
+
+    expect(setCredentialResolver).toHaveBeenCalledOnce();
+    expect(registerServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'contracts',
+        command: process.execPath,
+        args: ['/fake/mcp/dist/cli.js', 'contracts'],
+      }),
+    );
+    expect(startServer).toHaveBeenCalledWith('contracts');
   });
 });

--- a/apps/server/src/lib/mcp-hypervisor-wire.ts
+++ b/apps/server/src/lib/mcp-hypervisor-wire.ts
@@ -1,30 +1,99 @@
 /**
- * GAP-406 WIRE phase 1 — opt-in MCPHypervisor sink wiring on apps/server.
+ * GAP-406 WIRE — opt-in MCPHypervisor wiring on apps/server.
  *
- * When `REVEALUI_MCP_HYPERVISOR=1`, installs usage-meter + integrity-audit sinks
- * on the process singleton. Does **not** spawn MCP server children and does
- * **not** register a credential resolver (those need product design for
- * multi-tenant spawn — later phases of GAP-406).
+ * Phase 1 (`REVEALUI_MCP_HYPERVISOR=1`):
+ *   Install usage-meter + integrity-audit sinks on the process singleton.
  *
- * Default (env unset/false): no-op. Safe for local/dev/serverless without
- * hypervisor traffic.
+ * Phase 2 (`REVEALUI_MCP_HYPERVISOR_SPAWN=1` in addition):
+ *   Register + start process-local first-party MCP servers via `revealui-mcp`.
+ *   Default server list is public introspection only (`contracts,docs`) unless
+ *   `REVEALUI_MCP_HYPERVISOR_SERVERS` overrides (comma-separated allowlist).
+ *   Credential resolver is a stub that returns null (tenant spawn still blocked);
+ *   process-local children inherit `process.env` for any credentials they need.
+ *
+ * Default (env unset): no-op. Safe for local/dev/serverless without hypervisor traffic.
  *
  * @see docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
- * @see .jv/docs/gaps/GAP-406.yml
+ * @see GAP-406
  */
 
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { logger } from '@revealui/core/observability/logger';
-import type { McpAuditEvent, McpMeterEvent } from '@revealui/mcp';
+import type { MCPServerConfig, McpAuditEvent, McpMeterEvent } from '@revealui/mcp';
 import { MCPHypervisor } from '@revealui/mcp';
 import { recordMcpToolAudit } from './mcp-audit.js';
 import { recordUsageMeter } from './metering.js';
 
 const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
 
+/** Servers safe to auto-spawn without product tenant credentials. */
+export const DEFAULT_SPAWN_SERVERS = ['contracts', 'docs'] as const;
+
+/** Full first-party allowlist for REVEALUI_MCP_HYPERVISOR_SERVERS. */
+export const SPAWN_ALLOWLIST = new Set([
+  'contracts',
+  'docs',
+  'revealui-content',
+  'revealui-email',
+  'revealui-memory',
+  'revealui-stripe',
+  'neon',
+  'stripe',
+  'vercel',
+  'playwright',
+  'next-devtools',
+]);
+
+const require = createRequire(import.meta.url);
+
 export function isMcpHypervisorWireEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env.REVEALUI_MCP_HYPERVISOR?.trim().toLowerCase();
   return raw !== undefined && ENABLED_VALUES.has(raw);
+}
+
+export function isMcpHypervisorSpawnEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (!isMcpHypervisorWireEnabled(env)) return false;
+  const raw = env.REVEALUI_MCP_HYPERVISOR_SPAWN?.trim().toLowerCase();
+  return raw !== undefined && ENABLED_VALUES.has(raw);
+}
+
+/**
+ * Parse spawn server names from env. Unknown names are dropped with a warn.
+ */
+export function parseSpawnServerList(env: NodeJS.ProcessEnv = process.env): string[] {
+  const raw = env.REVEALUI_MCP_HYPERVISOR_SERVERS?.trim();
+  const names = raw
+    ? raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [...DEFAULT_SPAWN_SERVERS];
+
+  const out: string[] = [];
+  for (const name of names) {
+    if (!SPAWN_ALLOWLIST.has(name)) {
+      logger.warn('[mcp-hypervisor-wire] skipping unknown spawn server', { name });
+      continue;
+    }
+    out.push(name);
+  }
+  return out;
+}
+
+/**
+ * Resolve the compiled revealui-mcp CLI entry for process.execPath spawn.
+ */
+export function resolveMcpCliPath(): string {
+  return require.resolve('@revealui/mcp/dist/cli.js');
+}
+
+export function buildServerConfig(serverName: string, cliPath: string): MCPServerConfig {
+  return {
+    name: serverName,
+    command: process.execPath,
+    args: [cliPath, serverName],
+  };
 }
 
 /**
@@ -97,10 +166,65 @@ function installAuditSink(hv: MCPHypervisor): void {
 }
 
 /**
- * Wire sinks when enabled. Idempotent enough for double-call (re-sets sinks).
- * Returns true when wiring ran.
+ * Tenant credential resolver stub (phase 2).
+ * Returns null so startServerForTenant fails closed until a real vault-backed
+ * resolver lands. Process-local startServer still inherits process.env.
  */
-export function wireMcpHypervisorIfEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+export function createStubCredentialResolver(): (
+  tenantId: string,
+  serverName: string,
+) => Promise<Record<string, string> | null> {
+  return async (tenantId, serverName) => {
+    logger.debug('[mcp-hypervisor-wire] credential resolver stub (null)', {
+      tenantId,
+      serverName,
+    });
+    return null;
+  };
+}
+
+async function registerAndStartServers(hv: MCPHypervisor, env: NodeJS.ProcessEnv): Promise<void> {
+  const servers = parseSpawnServerList(env);
+  if (servers.length === 0) {
+    logger.warn('[mcp-hypervisor-wire] spawn enabled but server list empty');
+    return;
+  }
+
+  let cliPath: string;
+  try {
+    cliPath = resolveMcpCliPath();
+  } catch (error) {
+    logger.error(
+      '[mcp-hypervisor-wire] cannot resolve @revealui/mcp CLI; skip spawn',
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    return;
+  }
+
+  hv.setCredentialResolver(createStubCredentialResolver());
+
+  for (const name of servers) {
+    const config = buildServerConfig(name, cliPath);
+    hv.registerServer(config);
+    try {
+      await hv.startServer(name);
+      logger.info('[mcp-hypervisor-wire] started process-local MCP server', { name });
+    } catch (error) {
+      logger.warn('[mcp-hypervisor-wire] failed to start MCP server', {
+        name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+/**
+ * Wire sinks (and optional spawn) when enabled.
+ * Returns true when phase-1 wiring ran.
+ */
+export async function wireMcpHypervisorIfEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
   if (!isMcpHypervisorWireEnabled(env)) {
     return false;
   }
@@ -109,8 +233,14 @@ export function wireMcpHypervisorIfEnabled(env: NodeJS.ProcessEnv = process.env)
   installMeterSink(hv);
   installAuditSink(hv);
 
-  logger.info(
-    '[mcp-hypervisor-wire] GAP-406 phase 1: meter + audit sinks installed (no auto-spawn)',
-  );
+  logger.info('[mcp-hypervisor-wire] GAP-406 phase 1: meter + audit sinks installed');
+
+  if (isMcpHypervisorSpawnEnabled(env)) {
+    await registerAndStartServers(hv, env);
+    logger.info('[mcp-hypervisor-wire] GAP-406 phase 2: process-local spawn attempted');
+  } else {
+    logger.info('[mcp-hypervisor-wire] spawn off (set REVEALUI_MCP_HYPERVISOR_SPAWN=1 to enable)');
+  }
+
   return true;
 }

--- a/apps/server/src/lib/mcp-hypervisor-wire.ts
+++ b/apps/server/src/lib/mcp-hypervisor-wire.ts
@@ -1,0 +1,116 @@
+/**
+ * GAP-406 WIRE phase 1 — opt-in MCPHypervisor sink wiring on apps/server.
+ *
+ * When `REVEALUI_MCP_HYPERVISOR=1`, installs usage-meter + integrity-audit sinks
+ * on the process singleton. Does **not** spawn MCP server children and does
+ * **not** register a credential resolver (those need product design for
+ * multi-tenant spawn — later phases of GAP-406).
+ *
+ * Default (env unset/false): no-op. Safe for local/dev/serverless without
+ * hypervisor traffic.
+ *
+ * @see docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+ * @see .jv/docs/gaps/GAP-406.yml
+ */
+
+import { randomUUID } from 'node:crypto';
+import { logger } from '@revealui/core/observability/logger';
+import type { McpAuditEvent, McpMeterEvent } from '@revealui/mcp';
+import { MCPHypervisor } from '@revealui/mcp';
+import { recordMcpToolAudit } from './mcp-audit.js';
+import { recordUsageMeter } from './metering.js';
+
+const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export function isMcpHypervisorWireEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.REVEALUI_MCP_HYPERVISOR?.trim().toLowerCase();
+  return raw !== undefined && ENABLED_VALUES.has(raw);
+}
+
+/**
+ * Map a hypervisor meter event into a `usage_meters` row.
+ * Skips when no tenantId (no account fk) — process-local calls stay unmetered.
+ */
+export function meterEventToUsageRow(
+  event: McpMeterEvent,
+): Parameters<typeof recordUsageMeter>[0] | null {
+  const accountId = event.tenantId?.trim();
+  if (!accountId) {
+    return null;
+  }
+  const id = randomUUID();
+  return {
+    id,
+    accountId,
+    meterName: event.kind,
+    quantity: 1,
+    periodStart: new Date(),
+    periodEnd: null,
+    source: 'agent',
+    idempotencyKey: `hv:${event.serverName}:${event.toolName}:${id}`,
+    durationMs: event.duration_ms,
+    errored: !event.success,
+  };
+}
+
+function installMeterSink(hv: MCPHypervisor): void {
+  hv.setUsageMeterSink(async (event: McpMeterEvent) => {
+    const row = meterEventToUsageRow(event);
+    if (!row) {
+      logger.debug('[mcp-hypervisor-wire] skip meter (no tenantId)', {
+        serverName: event.serverName,
+        toolName: event.toolName,
+      });
+      return;
+    }
+    try {
+      await recordUsageMeter(row);
+    } catch (error) {
+      logger.warn('[mcp-hypervisor-wire] usage meter write failed', {
+        error: error instanceof Error ? error.message : String(error),
+        serverName: event.serverName,
+        toolName: event.toolName,
+      });
+    }
+  });
+}
+
+function installAuditSink(hv: MCPHypervisor): void {
+  hv.setAuditSink(async (event: McpAuditEvent) => {
+    const accountId = event.tenantId?.trim() || null;
+    const userId = accountId ?? 'system:hypervisor';
+    await recordMcpToolAudit({
+      outcome: event.success ? 'invoked' : 'failed',
+      clientName: 'mcp-hypervisor',
+      userId,
+      accountId,
+      tool: `${event.serverName}/${event.toolName}`,
+      argsDigest: event.argsDigest ?? '',
+      scalars: {
+        serverName: event.serverName,
+        toolName: event.toolName,
+      },
+      durationMs: event.duration_ms,
+      reason: event.error,
+    });
+  });
+}
+
+/**
+ * Wire sinks when enabled. Idempotent enough for double-call (re-sets sinks).
+ * Returns true when wiring ran.
+ */
+export function wireMcpHypervisorIfEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (!isMcpHypervisorWireEnabled(env)) {
+    return false;
+  }
+
+  const hv = MCPHypervisor.getInstance();
+  installMeterSink(hv);
+  installAuditSink(hv);
+
+  logger.info(
+    '[mcp-hypervisor-wire] GAP-406 phase 1: meter + audit sinks installed (no auto-spawn)',
+  );
+  return true;
+}

--- a/apps/server/src/lib/mcp-hypervisor-wire.ts
+++ b/apps/server/src/lib/mcp-hypervisor-wire.ts
@@ -20,7 +20,12 @@
 import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { logger } from '@revealui/core/observability/logger';
-import type { MCPServerConfig, McpAuditEvent, McpMeterEvent } from '@revealui/mcp';
+import type {
+  MCPCredentialResolver,
+  MCPServerConfig,
+  McpAuditEvent,
+  McpMeterEvent,
+} from '@revealui/mcp';
 import { MCPHypervisor } from '@revealui/mcp';
 import { recordMcpToolAudit } from './mcp-audit.js';
 import { recordUsageMeter } from './metering.js';
@@ -170,16 +175,15 @@ function installAuditSink(hv: MCPHypervisor): void {
  * Returns null so startServerForTenant fails closed until a real vault-backed
  * resolver lands. Process-local startServer still inherits process.env.
  */
-export function createStubCredentialResolver(): (
-  tenantId: string,
-  serverName: string,
-) => Promise<Record<string, string> | null> {
-  return async (tenantId, serverName) => {
-    logger.debug('[mcp-hypervisor-wire] credential resolver stub (null)', {
-      tenantId,
-      serverName,
-    });
-    return null;
+export function createStubCredentialResolver(): MCPCredentialResolver {
+  return {
+    async resolve(tenantId: string, serverName: string): Promise<Record<string, string> | null> {
+      logger.debug('[mcp-hypervisor-wire] credential resolver stub (null)', {
+        tenantId,
+        serverName,
+      });
+      return null;
+    },
   };
 }
 

--- a/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+++ b/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
@@ -45,16 +45,17 @@ Marketing and package copy still describe the MCP hypervisor as the live agent t
 - Future WIRE PRs must update claims and this ADR status (or supersede) in the same train.
 - Phase 3 parallel work (C3 logger ADR, C5 `createVitestConfig`) is unaffected.
 
-## Progress — GAP-406 WIRE phase 1 (2026-07-24)
+## Progress — GAP-406 WIRE (2026-07-24)
 
-**Partial WIRE of MCPHypervisor only** (sink installation, not process spawn):
+**Partial WIRE of MCPHypervisor** (sinks + opt-in process-local spawn):
 
 | Item | Status |
 |------|--------|
-| Opt-in env `REVEALUI_MCP_HYPERVISOR=1` | Shipped — `apps/server/src/lib/mcp-hypervisor-wire.ts` |
+| Opt-in env `REVEALUI_MCP_HYPERVISOR=1` | Shipped — sinks on process singleton |
 | `setUsageMeterSink` → `usage_meters` | Shipped when `tenantId` present on event |
 | `setAuditSink` → `recordMcpToolAudit` | Shipped |
-| Auto-spawn MCP children / credential resolver | **Not** in phase 1 |
+| Process-local spawn | Phase 2: `REVEALUI_MCP_HYPERVISOR_SPAWN=1`; default servers `contracts,docs`; override via `REVEALUI_MCP_HYPERVISOR_SERVERS` |
+| Credential resolver | Stub returns `null` (tenant spawn closed); process-local children inherit `process.env` |
 | `@revealui/ai/skills` / `observability` app mount | Still incubating |
 
 `validate:incubate-posture` allowlists only `mcp-hypervisor-wire.ts` for Hypervisor imports.

--- a/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+++ b/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
@@ -45,6 +45,20 @@ Marketing and package copy still describe the MCP hypervisor as the live agent t
 - Future WIRE PRs must update claims and this ADR status (or supersede) in the same train.
 - Phase 3 parallel work (C3 logger ADR, C5 `createVitestConfig`) is unaffected.
 
+## Progress — GAP-406 WIRE phase 1 (2026-07-24)
+
+**Partial WIRE of MCPHypervisor only** (sink installation, not process spawn):
+
+| Item | Status |
+|------|--------|
+| Opt-in env `REVEALUI_MCP_HYPERVISOR=1` | Shipped — `apps/server/src/lib/mcp-hypervisor-wire.ts` |
+| `setUsageMeterSink` → `usage_meters` | Shipped when `tenantId` present on event |
+| `setAuditSink` → `recordMcpToolAudit` | Shipped |
+| Auto-spawn MCP children / credential resolver | **Not** in phase 1 |
+| `@revealui/ai/skills` / `observability` app mount | Still incubating |
+
+`validate:incubate-posture` allowlists only `mcp-hypervisor-wire.ts` for Hypervisor imports.
+
 ## Verification
 
 - No production import of `MCPHypervisor.getInstance` / constructor under `apps/` (code-over-docs).

--- a/packages/mcp/src/__tests__/barrel-import-no-side-effects.test.ts
+++ b/packages/mcp/src/__tests__/barrel-import-no-side-effects.test.ts
@@ -1,0 +1,40 @@
+/**
+ * GAP-406 regression: barrel re-exports of launch*Mcp must not start MCP
+ * servers or call process.exit. apps/server loads MCPHypervisor from
+ * `@revealui/mcp`; those re-exports previously executed each launcher's main().
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const LAUNCHERS = [
+  '../servers/neon.js',
+  '../servers/stripe.js',
+  '../servers/vercel.js',
+  '../servers/playwright.js',
+  '../servers/next-devtools.js',
+] as const;
+
+describe('MCP launcher modules (barrel-safe)', () => {
+  it('import without process.exit / auto-main', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit unexpectedly called with ${code}`);
+    }) as never);
+
+    try {
+      for (const path of LAUNCHERS) {
+        await import(path);
+      }
+      // Let any microtask-scheduled main() settle
+      await new Promise((r) => setTimeout(r, 50));
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});
+
+describe('isDirectEntry', () => {
+  it('is false when import.meta.url is not process.argv[1]', async () => {
+    const { isDirectEntry } = await import('../servers/_launcher-utils.js');
+    expect(isDirectEntry('file:///not/the/entry.js')).toBe(false);
+  });
+});

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -7,24 +7,28 @@
  *   revealui-mcp <server>
  *   npx @revealui/mcp <server>
  *
- * Each server module self-starts on import (its own main() runs). The
- * allowlist below is static so no user input ever reaches an import path.
+ * The allowlist is static so no user input ever reaches an import path.
  * code-validator is repo-only (tsx, excluded from the build) and is not
  * listed here.
+ *
+ * External launchers (neon/stripe/vercel/playwright/next-devtools) export
+ * `launch*Mcp` and must not auto-start on import (barrel-safe for GAP-406).
+ * First-party stdio servers still self-start on import of their entry file.
  */
 
 const SERVERS: Record<string, () => Promise<unknown>> = {
   contracts: () => import('./servers/contracts.js'),
   docs: () => import('./servers/docs.js'),
-  neon: () => import('./servers/neon.js'),
-  'next-devtools': () => import('./servers/next-devtools.js'),
-  playwright: () => import('./servers/playwright.js'),
+  neon: () => import('./servers/neon.js').then((m) => m.launchNeonMcp()),
+  'next-devtools': () =>
+    import('./servers/next-devtools.js').then((m) => m.launchNextDevtoolsMcp()),
+  playwright: () => import('./servers/playwright.js').then((m) => m.launchPlaywrightMcp()),
   'revealui-content': () => import('./servers/revealui-content.js'),
   'revealui-email': () => import('./servers/revealui-email.js'),
   'revealui-memory': () => import('./servers/revealui-memory.js'),
   'revealui-stripe': () => import('./servers/revealui-stripe.js'),
-  stripe: () => import('./servers/stripe.js'),
-  vercel: () => import('./servers/vercel.js'),
+  stripe: () => import('./servers/stripe.js').then((m) => m.launchStripeMcp()),
+  vercel: () => import('./servers/vercel.js').then((m) => m.launchVercelMcp()),
 };
 
 const requested = process.argv[2];

--- a/packages/mcp/src/servers/_launcher-utils.ts
+++ b/packages/mcp/src/servers/_launcher-utils.ts
@@ -6,6 +6,8 @@
  * cross-package imports beyond its own declared dependencies.
  */
 
+import { pathToFileURL } from 'node:url';
+
 // =============================================================================
 // Exit Codes
 // =============================================================================
@@ -18,6 +20,31 @@ export const ExitCode = {
 } as const;
 
 export type ExitCode = (typeof ExitCode)[keyof typeof ExitCode];
+
+// =============================================================================
+// Entry detection
+// =============================================================================
+
+/**
+ * True when `importMetaUrl` is the process entry script (direct `node`/`tsx` run).
+ *
+ * Launcher modules export `launch*Mcp` for programmatic use and re-export from
+ * the package barrel. They must not call `main()` on every import — that
+ * `process.exit`s the host process (apps/server, Vitest) when anything loads
+ * `@revealui/mcp` for `MCPHypervisor` (GAP-406 WIRE).
+ *
+ * CLI (`revealui-mcp <server>`) calls `launch*Mcp` explicitly; direct file
+ * runs still auto-start via this check.
+ */
+export function isDirectEntry(importMetaUrl: string): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return importMetaUrl === pathToFileURL(entry).href;
+  } catch {
+    return false;
+  }
+}
 
 // =============================================================================
 // Logger

--- a/packages/mcp/src/servers/neon.ts
+++ b/packages/mcp/src/servers/neon.ts
@@ -11,7 +11,7 @@
 
 import { spawn } from 'node:child_process';
 import { config } from 'dotenv';
-import { createLauncherLogger, ExitCode } from './_launcher-utils.js';
+import { createLauncherLogger, ExitCode, isDirectEntry } from './_launcher-utils.js';
 
 const logger = createLauncherLogger();
 
@@ -97,4 +97,7 @@ async function main() {
   }
 }
 
-main();
+// Direct CLI only — never on package import (barrel re-exports launchNeonMcp).
+if (isDirectEntry(import.meta.url)) {
+  void main();
+}

--- a/packages/mcp/src/servers/next-devtools.ts
+++ b/packages/mcp/src/servers/next-devtools.ts
@@ -12,7 +12,7 @@
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:net';
 import { config } from 'dotenv';
-import { createLauncherLogger, ExitCode } from './_launcher-utils.js';
+import { createLauncherLogger, ExitCode, isDirectEntry } from './_launcher-utils.js';
 
 const logger = createLauncherLogger();
 
@@ -228,4 +228,6 @@ async function main() {
   }
 }
 
-main();
+if (isDirectEntry(import.meta.url)) {
+  void main();
+}

--- a/packages/mcp/src/servers/playwright.ts
+++ b/packages/mcp/src/servers/playwright.ts
@@ -11,7 +11,7 @@
 
 import { spawn } from 'node:child_process';
 import { config } from 'dotenv';
-import { createLauncherLogger, ExitCode } from './_launcher-utils.js';
+import { createLauncherLogger, ExitCode, isDirectEntry } from './_launcher-utils.js';
 
 const logger = createLauncherLogger();
 
@@ -76,4 +76,6 @@ async function main() {
   }
 }
 
-main();
+if (isDirectEntry(import.meta.url)) {
+  void main();
+}

--- a/packages/mcp/src/servers/stripe.ts
+++ b/packages/mcp/src/servers/stripe.ts
@@ -11,7 +11,7 @@
 
 import { spawn } from 'node:child_process';
 import { config } from 'dotenv';
-import { createLauncherLogger, ExitCode } from './_launcher-utils.js';
+import { createLauncherLogger, ExitCode, isDirectEntry } from './_launcher-utils.js';
 
 const logger = createLauncherLogger();
 
@@ -93,4 +93,6 @@ async function main() {
   }
 }
 
-main();
+if (isDirectEntry(import.meta.url)) {
+  void main();
+}

--- a/packages/mcp/src/servers/vercel.ts
+++ b/packages/mcp/src/servers/vercel.ts
@@ -11,7 +11,7 @@
 
 import { spawn } from 'node:child_process';
 import { config } from 'dotenv';
-import { createLauncherLogger, ExitCode } from './_launcher-utils.js';
+import { createLauncherLogger, ExitCode, isDirectEntry } from './_launcher-utils.js';
 
 const logger = createLauncherLogger();
 
@@ -94,4 +94,6 @@ async function main() {
   }
 }
 
-main();
+if (isDirectEntry(import.meta.url)) {
+  void main();
+}

--- a/scripts/validate/incubate-posture.ts
+++ b/scripts/validate/incubate-posture.ts
@@ -16,7 +16,7 @@ import { join, relative } from 'node:path';
 const REPO_ROOT = join(import.meta.dirname, '..', '..');
 const SOURCE_EXT = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
 
-function isExemptAppPath(rel: string): boolean {
+function isExemptAppPath(rel: string, label?: string): boolean {
   const lower = rel.toLowerCase();
   if (lower.includes('__tests__') || lower.includes('/test/') || lower.includes('/tests/')) {
     return true;
@@ -24,6 +24,10 @@ function isExemptAppPath(rel: string): boolean {
   if (lower.endsWith('.test.ts') || lower.endsWith('.test.tsx')) return true;
   if (lower.endsWith('.spec.ts') || lower.endsWith('.spec.tsx')) return true;
   if (lower.includes('/content/') || lower.includes('/public/')) return true;
+  // GAP-406 WIRE phase 1: sole allowed MCPHypervisor consumer (sink wire only).
+  if (label === 'MCPHypervisor' && rel === 'apps/server/src/lib/mcp-hypervisor-wire.ts') {
+    return true;
+  }
   return false;
 }
 
@@ -92,7 +96,6 @@ function main(): void {
 
   for (const file of files) {
     const rel = relative(REPO_ROOT, file).replaceAll('\\', '/');
-    if (isExemptAppPath(rel)) continue;
     let source: string;
     try {
       source = readFileSync(file, 'utf8');
@@ -100,6 +103,7 @@ function main(): void {
       continue;
     }
     for (const rule of FORBIDDEN) {
+      if (isExemptAppPath(rel, rule.label)) continue;
       for (const n of rule.needles) {
         if (source.includes(n)) {
           errors.push(
@@ -116,7 +120,9 @@ function main(): void {
   console.log('================================================================');
 
   if (errors.length === 0) {
-    console.log('  ✓ no apps/* production imports of MCPHypervisor');
+    console.log(
+      '  ✓ no apps/* production imports of MCPHypervisor (except mcp-hypervisor-wire GAP-406 p1)',
+    );
     console.log('  ✓ no apps/* production imports of @revealui/ai/skills');
     console.log('  ✓ no apps/* production imports of @revealui/ai/observability');
     console.log('================================================================\n');


### PR DESCRIPTION
## Summary
**GAP-406 WIRE phases 1–2** for MCPHypervisor residual:

### Phase 1 (sinks)
- `REVEALUI_MCP_HYPERVISOR=1` installs `setUsageMeterSink` + `setAuditSink`
- Meter rows need `tenantId`; audit goes through `recordMcpToolAudit`

### Phase 2 (process-local spawn)
- `REVEALUI_MCP_HYPERVISOR_SPAWN=1` registers/starts first-party servers via `node @revealui/mcp/dist/cli.js <name>`
- Default servers: `contracts,docs` (public introspection)
- Override: `REVEALUI_MCP_HYPERVISOR_SERVERS=contracts,docs,revealui-content,...` (allowlist)
- Credential resolver **stub** returns `null` (tenant spawn still closed); children inherit `process.env`

### Not yet
- Vault-backed multi-tenant credentials
- `@revealui/ai/skills` / `observability` app mount

## Enable
```bash
REVEALUI_MCP_HYPERVISOR=1
REVEALUI_MCP_HYPERVISOR_SPAWN=1
# optional:
# REVEALUI_MCP_HYPERVISOR_SERVERS=contracts,docs
```

## Test plan
- [x] Unit tests (5) green
- [x] incubate-posture allowlist holds
- [x] Pre-push gate
- [ ] CI green