### PR TITLE
feat(ai): hardline US-origin Inference Snaps allowlist

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -414,8 +414,11 @@ REVEALUI_CORS_ORIGINS=http://localhost:3000,http://localhost:4000
 
 # LLM Model Selection
 # Optional - provider-specific model name
-# Examples: gemma3 (inference-snaps), qwen/qwen3-32b (groq), gemma4:e2b (ollama)
-# LLM_MODEL=gemma3
+# Examples: nemotron-3-nano (inference-snaps US-origin default), gemma4 (also allowlisted),
+#   qwen/qwen3-32b (groq cloud), gemma4:e2b (ollama).
+# Non-US snaps (deepseek-r1, qwen-*, glm-*) are rejected for inference-snaps unless
+# REVEALUI_ALLOW_NON_US_MODELS=1 (operator escape only; never seed).
+# LLM_MODEL=nemotron-3-nano
 
 # Enable Anthropic Prompt Caching (90% cost savings on repeated context)
 # Cache TTL: 5 minutes, automatically caches system prompts and tools

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ No assembly required. Define your data once. Humans manage it through the dashbo
 The Agents primitive ships with open-model defaults. No proprietary API keys required, no API bill that scales with usage.
 
 - **Ollama** — local model runner; the standard developer-machine path.
-- **Ubuntu Inference Snaps** — Apache-2.0-preferred model runtimes for production. `sudo snap install gemma3` (or `deepseek-r1`, `qwen-vl`, `nemotron-3-nano`, `nemotron-3-nano-omni`).
+- **Ubuntu Inference Snaps** — US-origin model runtimes for production. `sudo snap install nemotron-3-nano` (or `gemma4`, `gemma3`, `nemotron-3-nano-omni`). Non-US catalog snaps are rejected in product code.
 - **Pluggable provider adapters** — Claude, OpenAI, and others available as opt-in adapters. The fleet runtime never imports any provider SDK by default; you wire whichever model you want.
 
 Verifiable: `git grep -l "@anthropic-ai/sdk" packages/` returns nothing inside `@revealui/*` packages. The runtime is provider-agnostic by contract.
@@ -127,7 +127,7 @@ The [Pro tier](https://revealui.com/pro) adds AI agents and automation that work
 
 - **AI agent system** _(beta — works in staging, production usage is early)_: build and deploy purpose-built agents for your workflows
 - **MCP framework:** hypervisor, adapter framework, and tool discovery for connecting agents to external services
-- **Open-model inference:** Ubuntu Inference Snaps (canonical default — Studio lifecycle pending), Ollama, and open source models via the RevealUI harness. `sudo snap install gemma3` for instant local AI (or any of `deepseek-r1`, `qwen-vl`, `nemotron-3-nano`, `nemotron-3-nano-omni`). No proprietary APIs, no vendor lock-in, zero API bills
+- **Open-model inference:** Ubuntu Inference Snaps (canonical default — Studio lifecycle pending), Ollama, and open source models via the RevealUI harness. `sudo snap install nemotron-3-nano` for US-origin local AI (or `gemma4` / `nemotron-3-nano-omni`). No proprietary APIs, no vendor lock-in, zero API bills
 - **Task history:** every agent action logged, auditable, and visible in the dashboard
 - **Editor config sync:** generate and sync settings for Zed, VS Code, Cursor, and Antigravity
 

--- a/apps/docs/public/docs-pro/inference/index.md
+++ b/apps/docs/public/docs-pro/inference/index.md
@@ -7,27 +7,30 @@ RevealUI AI defaults to open-model inference (Snaps, Ollama). Groq, Anthropic, O
 **Inference Snaps** from Canonical are the planned recommended path for local AI with RevealUI. Today, you install + run the snap yourself, then point RevealUI at it via `INFERENCE_SNAPS_BASE_URL`. Studio lifecycle management (start / stop / health / model discovery) is on the roadmap; until that ships, treat Snap operations as standalone (Ollama is the practical default for most users today).
 
 ```bash
-# Install the default model
-sudo snap install gemma3
+# Install the default model (US-origin allowlist)
+sudo snap install nemotron-3-nano
 
 # Check status and endpoint
-gemma3 status
+nemotron-3-nano status
 
 # Optional: change the HTTP port (default 9090)
-gemma3 set http.port=9090
+nemotron-3-nano set http.port=9090
 ```
 
 The snap serves an OpenAI-compatible API at `http://localhost:<port>/v1`  -  the RevealUI AI provider uses this directly with zero additional configuration.
 
-### Available Models
+### Product allowlist (US-origin only)
 
-| Snap | Type | RAM | Use Case |
-|------|------|-----|----------|
-| `gemma3` | General + vision | ~8 GB | **Default**  -  vision-capable, Apache 2.0 |
-| `deepseek-r1` | Reasoning | ~16 GB | Complex analysis, chain-of-thought |
-| `qwen-vl` | Vision-language | ~8 GB | Document parsing, visual Q&A |
-| `nemotron-3-nano` | General (text-only) | ~4 GB | Lightweight alternative for low-resource hosts |
-| `nemotron-3-nano-omni` | Multimodal | ~4 GB | Text/image/video/audio in, text out |
+RevealUI rejects non-US snap model IDs at provider construction. Canonical's
+catalog may still list other models; product code will not use them unless the
+operator sets `REVEALUI_ALLOW_NON_US_MODELS=1` (never seed this).
+
+| Snap | Origin | Type | Use Case |
+|------|--------|------|----------|
+| `nemotron-3-nano` | NVIDIA (US) | General + tools | **Default** |
+| `nemotron-3-nano-omni` | NVIDIA (US) | Multimodal | Text/image/video/audio in |
+| `gemma4` | Google (US) | General + vision + tools | Strong general alternative |
+| `gemma3` | Google (US) | General + vision | Legacy allowlisted snap |
 
 ### Configuration
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -68,8 +68,9 @@ ADMIN_URL=http://localhost:4000
 # --- Open-model inference (Apache 2.0 — zero commercial fees) ---
 
 # Ubuntu Inference Snaps (canonical default — zero config, one command install; Studio lifecycle pending)
-# Install: sudo snap install gemma3 --beta
+# Install: sudo snap install nemotron-3-nano
 # INFERENCE_SNAPS_BASE_URL=http://localhost:9090/v1
+# LLM_MODEL=nemotron-3-nano   # US-origin allowlist only
 # LLM_PROVIDER=inference-snaps
 
 # Ollama (local inference: https://ollama.com — fully offline, zero cost)

--- a/docs/architecture/ai-stack.md
+++ b/docs/architecture/ai-stack.md
@@ -16,7 +16,7 @@ All LLM access flows through `LLMClient`, a factory that wraps inference backend
 
 | Path | Chat | Embeddings | Key Env Var | Notes |
 |------|------|-----------|-------------|-------|
-| **Ubuntu Inference Snaps** | yes | depends on model | `INFERENCE_SNAPS_BASE_URL` | Canonical snap runtime  -  Gemma3, DeepSeek-R1, Qwen-VL, Nemotron-Nano |
+| **Ubuntu Inference Snaps** | yes | depends on model | `INFERENCE_SNAPS_BASE_URL` | Canonical snap runtime  -  US-origin allowlist only: Nemotron 3 Nano/Omni, Gemma 3/4 |
 | **Ollama** | yes | yes | `OLLAMA_BASE_URL` | Any open source GGUF model. Chat: `gemma4:e2b`, Embed: `nomic-embed-text` |
 
 ### Auto-Detection Priority

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -50,7 +50,7 @@ A coordination layer that lets multiple AI coding tools (Claude Code, Cursor, Ai
 
 ## Inference Snaps
 
-Canonical's silicon-optimized snap-packaged LLMs running on Ubuntu. The **canonical default** open-model inference path for RevealUI per memory `project_canonical_inference_snap_stack`. Today the snap *provider* in `@revealui/ai` works (point `INFERENCE_SNAPS_BASE_URL` at a running snap and route LLM calls); Studio lifecycle management (auto-install, start/stop, health, model discovery) is **not yet shipped** — install + run snaps yourself. Catalog (May 2026): `gemma3`, `deepseek-r1`, `nemotron-3-nano`, `nemotron-3-nano-omni`, `qwen-vl`. See [`./AI`](./AI.md).
+Canonical's silicon-optimized snap-packaged LLMs running on Ubuntu. The **canonical default** open-model inference path for RevealUI per memory `project_canonical_inference_snap_stack`. Today the snap *provider* in `@revealui/ai` works (point `INFERENCE_SNAPS_BASE_URL` at a running snap and route LLM calls); Studio lifecycle management (auto-install, start/stop, health, model discovery) is **not yet shipped** — install + run snaps yourself. Product US-origin allowlist (2026-07): `nemotron-3-nano` (default), `nemotron-3-nano-omni`, `gemma3`, `gemma4`. Non-US catalog snaps are fail-closed. See [`./AI`](./AI.md).
 
 ## JWT
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -39,29 +39,41 @@ The recommended on-prem / on-device stack pairs `@revealui/ai` with a
                                                     ▲
                                                     │
                                          Canonical Inference Snap
-                                         (DeepSeek R1, Qwen 2.5 VL,
-                                          Gemma 3, Nemotron Nano —
+                                         (US-origin allowlist only:
+                                          Nemotron 3 Nano / Omni, Gemma 3/4 —
                                           silicon-optimized on Intel/
                                           Ampere/NVIDIA/NPU)
 ```
 
+**US-origin hardline:** product Inference Snaps usage allows only
+`nemotron-3-nano`, `nemotron-3-nano-omni`, `gemma3`, and `gemma4`.
+Non-US snaps in Canonical's catalog (`deepseek-r1`, `qwen-*`, `glm-*`) are
+rejected at provider construction. Operator escape (never seed):
+`REVEALUI_ALLOW_NON_US_MODELS=1`.
+
 Quick setup:
 
 ```bash
-sudo snap install gemma3               # or deepseek-r1, qwen-vl, etc.
-gemma3 set http.port=9090
-gemma3 status                          # confirms base URL
+sudo snap install nemotron-3-nano      # default; or gemma4 / nemotron-3-nano-omni
+nemotron-3-nano set http.port=9090
+nemotron-3-nano status                 # confirms base URL
 ```
 
 ```typescript
 import { InferenceSnapsProvider, LLMClient } from '@revealui/ai'
 
-const provider = new InferenceSnapsProvider({
+const client = new LLMClient({
+  provider: 'inference-snaps',
+  apiKey: 'inference-snaps',
   baseURL: 'http://localhost:9090/v1',
-  model: 'gemma3',
+  model: 'nemotron-3-nano', // default when omitted
 })
 
-const client = new LLMClient({ provider })
+// Or the provider alone:
+const provider = new InferenceSnapsProvider({
+  baseURL: 'http://localhost:9090/v1',
+  model: 'gemma4',
+})
 ```
 
 Groq, Anthropic, OpenAI, and HuggingFace remain supported as pluggable,
@@ -189,7 +201,7 @@ import { InferenceSnapsProvider, createSamplingHandler } from '@revealui/ai'
 
 const llm = new InferenceSnapsProvider({
   baseURL: 'http://localhost:9090/v1',
-  model: 'gemma3',
+  model: 'nemotron-3-nano',
 })
 
 const client = new McpClient({
@@ -197,8 +209,9 @@ const client = new McpClient({
   transport: { kind: 'streamable-http', url: 'https://example.com/mcp' },
   samplingHandler: createSamplingHandler({
     llm,
-    defaultModel: 'gemma3',
-    allowedModels: ['gemma3', 'deepseek-r1'],  // strongly recommended
+    defaultModel: 'nemotron-3-nano',
+    // Keep sampling hints on the US-origin allowlist (provider also enforces).
+    allowedModels: ['nemotron-3-nano', 'gemma4', 'gemma3'],
     onSamplingRequest: (info) => {
       // metering / audit trail
       metrics.incr('mcp.sampling', { model: info.model })

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -62,6 +62,7 @@ export * from './llm/provider-health.js';
 export * from './llm/providers/base.js';
 export * from './llm/providers/inference-snaps.js';
 export * from './llm/providers/openai-compat.js';
+export * from './llm/providers/us-origin-snaps.js';
 export * from './llm/resolve.js';
 export * from './llm/token-counter.js';
 export * from './llm/workspace-provider-config.js';

--- a/packages/ai/src/llm/__tests__/env-factory.test.ts
+++ b/packages/ai/src/llm/__tests__/env-factory.test.ts
@@ -44,6 +44,7 @@ const PROVIDER_ENV_KEYS = [
   'LLM_MODEL',
   'LLM_TEMPERATURE',
   'LLM_MAX_TOKENS',
+  'REVEALUI_ALLOW_NON_US_MODELS',
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -183,6 +184,18 @@ describe('createLLMClientFromEnv — auto-detect for new providers (appended aft
   });
 
   it('falls back to the inference-snaps localhost default with no provider env', () => {
+    expect(providerOf(createLLMClientFromEnv())).toBe('inference-snaps');
+  });
+
+  it('rejects non-US LLM_MODEL for inference-snaps (US-origin hardline)', () => {
+    process.env.LLM_PROVIDER = 'inference-snaps';
+    process.env.LLM_MODEL = 'deepseek-r1';
+    expect(() => createLLMClientFromEnv()).toThrow(/US-origin allowlist/);
+  });
+
+  it('accepts allowlisted LLM_MODEL for inference-snaps', () => {
+    process.env.LLM_PROVIDER = 'inference-snaps';
+    process.env.LLM_MODEL = 'gemma4';
     expect(providerOf(createLLMClientFromEnv())).toBe('inference-snaps');
   });
 });

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -38,6 +38,7 @@ import {
 import { OllamaProvider, type OllamaProviderConfig } from './providers/ollama.js';
 import { OpenAIProvider, type OpenAIProviderConfig } from './providers/openai.js';
 import { type OpenAICompatConfig, OpenAICompatProvider } from './providers/openai-compat.js';
+import { DEFAULT_US_ORIGIN_INFERENCE_SNAP } from './providers/us-origin-snaps.js';
 import { XaiProvider, type XaiProviderConfig } from './providers/xai.js';
 import { type CacheStats, ResponseCache, type ResponseCacheOptions } from './response-cache.js';
 import {
@@ -638,11 +639,12 @@ export class LLMClient {
  * (Anthropic + OpenAI ride their OpenAI-compatible endpoints).
  *
  * Canonical Inference Snaps is the reference local provider on Ubuntu — offline,
- * silicon-optimized, no API key required. See `providers/inference-snaps.ts` for
- * install docs (`sudo snap install gemma3`, etc.).
+ * silicon-optimized, no API key required. Product usage is **US-origin snaps
+ * only** (nemotron-3-nano default; gemma3/4 also allowlisted). See
+ * `providers/us-origin-snaps.ts` and `providers/inference-snaps.ts`.
  *
  * Provider defaults:
- *   inference-snaps → gemma3            (base URL defaults to http://localhost:9090/v1)
+ *   inference-snaps → nemotron-3-nano   (base URL defaults to http://localhost:9090/v1)
  *   groq            → qwen/qwen3-32b
  *   ollama          → gemma4:e2b        (base URL defaults to http://localhost:11434)
  *   anthropic       → claude-sonnet-4-6 (base URL defaults to https://api.anthropic.com/v1)
@@ -716,8 +718,9 @@ export function createLLMClientFromEnv(): LLMClient {
     apiKey = 'inference-snaps'; // inference-snaps ignores the API key
     // Defaults to Canonical's Inference Snap local service on port 9090; override
     // via INFERENCE_SNAPS_BASE_URL when the snap listens on a non-default port.
+    // Model defaults to the US-origin allowlist default (asserted in provider ctor).
     baseURL = process.env.INFERENCE_SNAPS_BASE_URL ?? 'http://localhost:9090/v1';
-    defaultModel = 'gemma3';
+    defaultModel = DEFAULT_US_ORIGIN_INFERENCE_SNAP;
   }
 
   if (!apiKey) {

--- a/packages/ai/src/llm/providers/__tests__/us-origin-snaps.test.ts
+++ b/packages/ai/src/llm/providers/__tests__/us-origin-snaps.test.ts
@@ -1,0 +1,144 @@
+/**
+ * US-origin Inference Snap allowlist — fail-closed hardline.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LLMClient } from '../../client.js';
+import { InferenceSnapsProvider } from '../inference-snaps.js';
+import {
+  assertUsOriginInferenceSnap,
+  DEFAULT_US_ORIGIN_INFERENCE_SNAP,
+  isNonUsModelsEscapeEnabled,
+  isUsOriginInferenceSnap,
+  NON_US_MODELS_ESCAPE_ENV,
+  NonUsOriginInferenceSnapError,
+  US_ORIGIN_INFERENCE_SNAP_IDS,
+} from '../us-origin-snaps.js';
+
+const TEST_URL = 'http://localhost:9999/v1';
+
+const savedEscape = process.env[NON_US_MODELS_ESCAPE_ENV];
+
+beforeEach(() => {
+  delete process.env[NON_US_MODELS_ESCAPE_ENV];
+});
+
+afterEach(() => {
+  if (savedEscape === undefined) {
+    delete process.env[NON_US_MODELS_ESCAPE_ENV];
+  } else {
+    process.env[NON_US_MODELS_ESCAPE_ENV] = savedEscape;
+  }
+});
+
+describe('isUsOriginInferenceSnap', () => {
+  it.each([...US_ORIGIN_INFERENCE_SNAP_IDS])('allows %s', (id) => {
+    expect(isUsOriginInferenceSnap(id)).toBe(true);
+  });
+
+  it('is case-insensitive and trims', () => {
+    expect(isUsOriginInferenceSnap('  Gemma4  ')).toBe(true);
+  });
+
+  it.each(['deepseek-r1', 'qwen-vl', 'qwen3', 'qwen3-coder', 'qwen3-6', 'glm-4-7-flash'])(
+    'rejects %s',
+    (id) => {
+      expect(isUsOriginInferenceSnap(id)).toBe(false);
+    },
+  );
+});
+
+describe('assertUsOriginInferenceSnap', () => {
+  it('defaults to nemotron-3-nano when model is omitted', () => {
+    expect(assertUsOriginInferenceSnap(undefined)).toBe(DEFAULT_US_ORIGIN_INFERENCE_SNAP);
+    expect(assertUsOriginInferenceSnap('')).toBe(DEFAULT_US_ORIGIN_INFERENCE_SNAP);
+  });
+
+  it('returns allowlisted models unchanged (trimmed)', () => {
+    expect(assertUsOriginInferenceSnap(' gemma4 ')).toBe('gemma4');
+  });
+
+  it('throws NonUsOriginInferenceSnapError for PRC snaps', () => {
+    expect(() => assertUsOriginInferenceSnap('deepseek-r1')).toThrow(NonUsOriginInferenceSnapError);
+    expect(() => assertUsOriginInferenceSnap('qwen3-coder')).toThrow(/US-origin allowlist/);
+  });
+
+  it('allows non-US when allowNonUs is true', () => {
+    expect(assertUsOriginInferenceSnap('deepseek-r1', { allowNonUs: true })).toBe('deepseek-r1');
+  });
+
+  it('allows non-US when REVEALUI_ALLOW_NON_US_MODELS=1', () => {
+    process.env[NON_US_MODELS_ESCAPE_ENV] = '1';
+    expect(isNonUsModelsEscapeEnabled()).toBe(true);
+    expect(assertUsOriginInferenceSnap('qwen-vl')).toBe('qwen-vl');
+  });
+
+  it('allows non-US when REVEALUI_ALLOW_NON_US_MODELS=true', () => {
+    process.env[NON_US_MODELS_ESCAPE_ENV] = 'true';
+    expect(assertUsOriginInferenceSnap('glm-4-7-flash')).toBe('glm-4-7-flash');
+  });
+});
+
+describe('InferenceSnapsProvider construction', () => {
+  it('constructs with default US-origin model', () => {
+    expect(() => new InferenceSnapsProvider({ baseURL: TEST_URL })).not.toThrow();
+  });
+
+  it('constructs with each allowlisted model', () => {
+    for (const model of US_ORIGIN_INFERENCE_SNAP_IDS) {
+      expect(() => new InferenceSnapsProvider({ baseURL: TEST_URL, model })).not.toThrow();
+    }
+  });
+
+  it('rejects deepseek-r1 at construction', () => {
+    expect(() => new InferenceSnapsProvider({ baseURL: TEST_URL, model: 'deepseek-r1' })).toThrow(
+      NonUsOriginInferenceSnapError,
+    );
+  });
+
+  it('rejects non-US embedModel even when chat model is allowlisted', () => {
+    expect(
+      () =>
+        new InferenceSnapsProvider({
+          baseURL: TEST_URL,
+          model: 'gemma3',
+          embedModel: 'qwen-vl',
+        }),
+    ).toThrow(/qwen-vl/);
+  });
+
+  it('constructs non-US model when allowNonUsModels is set', () => {
+    expect(
+      () =>
+        new InferenceSnapsProvider({
+          baseURL: TEST_URL,
+          model: 'deepseek-r1',
+          allowNonUsModels: true,
+        }),
+    ).not.toThrow();
+  });
+});
+
+describe('LLMClient + createProvider path', () => {
+  it('rejects non-US model via LLMClient inference-snaps branch', () => {
+    expect(
+      () =>
+        new LLMClient({
+          provider: 'inference-snaps',
+          apiKey: 'inference-snaps',
+          baseURL: TEST_URL,
+          model: 'deepseek-r1',
+        }),
+    ).toThrow(NonUsOriginInferenceSnapError);
+  });
+
+  it('accepts default US-origin model via LLMClient', () => {
+    expect(
+      () =>
+        new LLMClient({
+          provider: 'inference-snaps',
+          apiKey: 'inference-snaps',
+          baseURL: TEST_URL,
+        }),
+    ).not.toThrow();
+  });
+});

--- a/packages/ai/src/llm/providers/inference-snaps.ts
+++ b/packages/ai/src/llm/providers/inference-snaps.ts
@@ -4,23 +4,24 @@
  * Local inference via Canonical's inference-snaps OpenAI-compatible API.
  * No API key required. Zero cost, fully offline, hardware-optimized.
  *
- * Supported models (snaps), per Canonical's official catalog at
- * https://documentation.ubuntu.com/inference-snaps/reference/snaps/ :
- *   gemma3                 -  general LLM + vision (text/image in, text out)
- *   deepseek-r1            -  reasoning LLM (chat completions)
- *   qwen-vl                -  vision-language model (image + text)
- *   nemotron-3-nano        -  general LLM (reasoning + non-reasoning, text only)
- *   nemotron-3-nano-omni   -  multimodal (text/image/video/audio in, text out)
+ * Product hardline: US-origin snap models only (see us-origin-snaps.ts).
+ * Allowlisted snaps (install these):
+ *   nemotron-3-nano        -  NVIDIA general + tools (default)
+ *   nemotron-3-nano-omni   -  NVIDIA multimodal
+ *   gemma3 / gemma4        -  Google general + vision + tools
+ *
+ * Canonical also publishes non-US snaps (deepseek-r1, qwen-*, glm-*). Those
+ * are rejected at construction unless REVEALUI_ALLOW_NON_US_MODELS=1.
  *
  * Install a model:
- *   sudo snap install gemma3
- *   gemma3 set http.port=9090   # optional: change port (default varies)
- *   gemma3 status               # shows base URL and available models
+ *   sudo snap install nemotron-3-nano
+ *   nemotron-3-nano set http.port=9090   # optional: change port
+ *   nemotron-3-nano status              # shows base URL and available models
  *
  * Set env vars:
  *   INFERENCE_SNAPS_BASE_URL=http://localhost:9090/v1
- *   LLM_MODEL=gemma3            # must match the snap name / model ID
- *   LLM_EMBED_MODEL=gemma3      # optional: model for embeddings
+ *   LLM_MODEL=nemotron-3-nano   # must match an allowlisted snap model ID
+ *   LLM_EMBED_MODEL=nemotron-3-nano
  *
  * Docs: https://documentation.ubuntu.com/inference-snaps
  */
@@ -38,15 +39,27 @@ import type {
   ReasonerCapabilities,
 } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
+import {
+  assertUsOriginInferenceSnap,
+  DEFAULT_US_ORIGIN_INFERENCE_SNAP,
+} from './us-origin-snaps.js';
 
 export interface InferenceSnapsProviderConfig extends Omit<LLMProviderConfig, 'apiKey'> {
   apiKey?: string;
   /** Base URL of the inference-snaps service, e.g. http://localhost:9090/v1 */
   baseURL: string;
-  /** Chat/vision model name  -  must match the snap's model ID (e.g. 'gemma3', 'deepseek-r1') */
+  /**
+   * Chat/vision model name — must match an allowlisted snap model ID
+   * (e.g. 'nemotron-3-nano', 'gemma4'). See US_ORIGIN_INFERENCE_SNAP_IDS.
+   */
   model?: string;
   /** Embedding model name. Defaults to the chat model when omitted. */
   embedModel?: string;
+  /**
+   * Bypass US-origin allowlist for this instance (operator/tests only).
+   * Prefer the process env REVEALUI_ALLOW_NON_US_MODELS=1 when needed.
+   */
+  allowNonUsModels?: boolean;
 }
 
 export class InferenceSnapsProvider implements LLMProvider {
@@ -56,20 +69,21 @@ export class InferenceSnapsProvider implements LLMProvider {
 
   constructor(config: InferenceSnapsProviderConfig) {
     this.baseURL = config.baseURL;
-    // Use the same model for embeddings unless explicitly overridden
-    this.embedModel = config.embedModel ?? config.model ?? 'gemma3';
+    const assertOpts = { allowNonUs: config.allowNonUsModels === true };
+    const model = assertUsOriginInferenceSnap(config.model, assertOpts);
+    this.embedModel = assertUsOriginInferenceSnap(config.embedModel ?? model, assertOpts);
     this.inner = new OpenAICompatProvider({
       ...config,
       // inference-snaps ignores the API key; OpenAI client requires a non-empty value
       apiKey: config.apiKey ?? 'inference-snaps',
       baseURL: config.baseURL,
-      model: config.model ?? 'gemma3',
+      model,
     });
   }
 
   capabilities(): ReasonerCapabilities {
-    // Profile for the default model (gemma3, text-only). Per-model capability
-    // negotiation (e.g. qwen-vl vision, deepseek-r1 reasoningEffort) is a follow-up.
+    // Profile for the default US-origin model (text + tools). Per-model capability
+    // negotiation (e.g. nemotron-3-nano-omni vision) is a follow-up.
     return {
       providerTag: 'inference-snaps',
       tools: true,
@@ -117,3 +131,5 @@ export class InferenceSnapsProvider implements LLMProvider {
     return Array.isArray(text) ? embeddings : (embeddings[0] as Embedding);
   }
 }
+
+export { DEFAULT_US_ORIGIN_INFERENCE_SNAP };

--- a/packages/ai/src/llm/providers/us-origin-snaps.ts
+++ b/packages/ai/src/llm/providers/us-origin-snaps.ts
@@ -92,7 +92,7 @@ export function assertUsOriginInferenceSnap(
   const allowNonUs =
     options?.allowNonUs === true || isNonUsModelsEscapeEnabled(options?.env ?? process.env);
 
-  if (!allowNonUs && !isUsOriginInferenceSnap(resolved)) {
+  if (!(allowNonUs || isUsOriginInferenceSnap(resolved))) {
     throw new NonUsOriginInferenceSnapError(resolved);
   }
 

--- a/packages/ai/src/llm/providers/us-origin-snaps.ts
+++ b/packages/ai/src/llm/providers/us-origin-snaps.ts
@@ -1,0 +1,100 @@
+/**
+ * US-origin Inference Snap allowlist (product hardline).
+ *
+ * Canonical's snap catalog includes PRC-origin models (DeepSeek, Qwen, GLM).
+ * RevealUI product local inference is **US-origin weights only**, fail-closed.
+ *
+ * Definition: open weights published by an organization whose ultimate parent
+ * is incorporated in the United States. Packaging (Canonical snaps) is not origin.
+ *
+ * Allowlist today (Canonical catalog, 2026-07):
+ *   - nemotron-3-nano / nemotron-3-nano-omni — NVIDIA
+ *   - gemma3 / gemma4 — Google (Alphabet)
+ *
+ * Escape (operator-only, never seed, always loud in the error path):
+ *   REVEALUI_ALLOW_NON_US_MODELS=1
+ *
+ * Companion ADR: .jv docs/decisions/2026-07-24-us-origin-inference-snaps.md
+ */
+
+/** Snap model IDs permitted for product Inference Snaps usage. */
+export const US_ORIGIN_INFERENCE_SNAP_IDS = [
+  'nemotron-3-nano',
+  'nemotron-3-nano-omni',
+  'gemma3',
+  'gemma4',
+] as const;
+
+export type UsOriginInferenceSnapId = (typeof US_ORIGIN_INFERENCE_SNAP_IDS)[number];
+
+/** Default chat/embed model when none is specified. */
+export const DEFAULT_US_ORIGIN_INFERENCE_SNAP: UsOriginInferenceSnapId = 'nemotron-3-nano';
+
+/** Operator escape env var. Never set in customer seed or CI green paths. */
+export const NON_US_MODELS_ESCAPE_ENV = 'REVEALUI_ALLOW_NON_US_MODELS';
+
+export class NonUsOriginInferenceSnapError extends Error {
+  readonly code = 'NON_US_ORIGIN_INFERENCE_SNAP' as const;
+  readonly modelId: string;
+
+  constructor(modelId: string) {
+    super(
+      `Inference Snap model "${modelId}" is not on the US-origin allowlist ` +
+        `(${US_ORIGIN_INFERENCE_SNAP_IDS.join(', ')}). ` +
+        'Product local inference is US-origin snaps only. ' +
+        `Install: sudo snap install ${DEFAULT_US_ORIGIN_INFERENCE_SNAP}. ` +
+        `Operator escape (audited, never seed): ${NON_US_MODELS_ESCAPE_ENV}=1`,
+    );
+    this.name = 'NonUsOriginInferenceSnapError';
+    this.modelId = modelId;
+  }
+}
+
+/** Normalize a snap model id for allowlist comparison. */
+export function normalizeInferenceSnapModelId(modelId: string): string {
+  return modelId.trim().toLowerCase();
+}
+
+/** True when the model id is on the US-origin product allowlist. */
+export function isUsOriginInferenceSnap(modelId: string): boolean {
+  const id = normalizeInferenceSnapModelId(modelId);
+  return (US_ORIGIN_INFERENCE_SNAP_IDS as readonly string[]).includes(id);
+}
+
+/** True when the operator escape hatch is enabled. */
+export function isNonUsModelsEscapeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = env[NON_US_MODELS_ESCAPE_ENV];
+  return value === '1' || value === 'true';
+}
+
+export interface AssertUsOriginInferenceSnapOptions {
+  /** Force-allow non-US models (tests / explicit callers). Overrides env when true. */
+  allowNonUs?: boolean;
+  /** Env source for the escape hatch (defaults to process.env). */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Resolve and enforce the US-origin allowlist.
+ *
+ * @returns the model id to use (default when empty/undefined)
+ * @throws {NonUsOriginInferenceSnapError} when model is off-allowlist and escape is off
+ */
+export function assertUsOriginInferenceSnap(
+  modelId: string | undefined,
+  options?: AssertUsOriginInferenceSnapOptions,
+): string {
+  const resolved =
+    modelId !== undefined && modelId.trim() !== ''
+      ? modelId.trim()
+      : DEFAULT_US_ORIGIN_INFERENCE_SNAP;
+
+  const allowNonUs =
+    options?.allowNonUs === true || isNonUsModelsEscapeEnabled(options?.env ?? process.env);
+
+  if (!allowNonUs && !isUsOriginInferenceSnap(resolved)) {
+    throw new NonUsOriginInferenceSnapError(resolved);
+  }
+
+  return resolved;
+}

--- a/packages/ai/test-response-cache.ts
+++ b/packages/ai/test-response-cache.ts
@@ -19,7 +19,7 @@ async function testResponseCaching() {
   const client = new LLMClient({
     provider: 'inference-snaps',
     apiKey: 'inference-snaps',
-    model: process.env.LLM_MODEL || 'gemma3',
+    model: process.env.LLM_MODEL || 'nemotron-3-nano',
     baseURL: process.env.INFERENCE_SNAPS_BASE_URL,
     enableResponseCache: true,
     responseCacheOptions: {
@@ -92,7 +92,7 @@ async function testResponseCaching() {
         '\n   Hint: Inference Snaps must be reachable at',
         process.env.INFERENCE_SNAPS_BASE_URL ?? 'http://localhost:9090/v1',
       );
-      console.error('   Install: sudo snap install gemma3 (or your model of choice).');
+      console.error('   Install: sudo snap install nemotron-3-nano (US-origin allowlist).');
     }
     process.exit(1);
   }

--- a/packages/ai/test-semantic-cache.ts
+++ b/packages/ai/test-semantic-cache.ts
@@ -18,7 +18,7 @@ async function testSemanticCaching() {
   const client = new LLMClient({
     provider: 'inference-snaps',
     apiKey: 'inference-snaps',
-    model: process.env.LLM_MODEL || 'gemma3',
+    model: process.env.LLM_MODEL || 'nemotron-3-nano',
     baseURL: process.env.INFERENCE_SNAPS_BASE_URL,
     enableSemanticCache: true,
     semanticCacheOptions: {


### PR DESCRIPTION
## Summary

Product hardline: **Ubuntu Inference Snaps usage is US-origin models only**, fail-closed in `@revealui/ai`.

- New SSOT: `US_ORIGIN_INFERENCE_SNAP_IDS` in `packages/ai/src/llm/providers/us-origin-snaps.ts`
- Allowlist: `nemotron-3-nano` (default), `nemotron-3-nano-omni`, `gemma3`, `gemma4`
- Rejected at provider construction: DeepSeek, Qwen, GLM, any off-list id
- Operator escape only: `REVEALUI_ALLOW_NON_US_MODELS=1` (never seeded)
- Docs/env defaults updated off PRC catalog recommendations

Companion ADR (private): `.jv` `docs/decisions/2026-07-24-us-origin-inference-snaps.md`

## Why

Canonical’s snap catalog mixes US and PRC-origin weights. Packaging is not origin. Without code enforcement, `LLM_MODEL=deepseek-r1` silently breaks a jurisdiction hardline.

## Test plan

- [x] `pnpm exec vitest run src/llm/providers/__tests__/us-origin-snaps.test.ts src/llm/__tests__/env-factory.test.ts` (47 passed)
- [x] capabilities suite still green
- [ ] CI gate on PR
- [ ] Optional: install `nemotron-3-nano` and smoke `createLLMClientFromEnv`

## Residual (not this PR)

- Marketing blog posts that still list DeepSeek/Qwen as recommended local defaults
- Studio install UI if it enumerates full Canonical catalog
- GAP-296 capability re-tests should use allowlisted snaps

## Owner actions

None required beyond review/merge when green (non-security product policy; standard disposition).