### PR TITLE
fix(ai): close US-origin snap residual install and doc paths

### DIFF
--- a/apps/admin/src/seed.ts
+++ b/apps/admin/src/seed.ts
@@ -203,7 +203,7 @@ const sampleContent = {
       title: 'VISION',
       name: 'Agentic Business Runtime',
       description:
-        'You build the product. Agents extend it. Bring your own model: default ships open-weight (Llama 4, Gemma 3, Qwen 3, DeepSeek R1) so the inference bill does not scale with usage; switch to Claude or GPT in one config line. The runtime is provider-agnostic.',
+        'You build the product. Agents extend it. Bring your own model: default ships open-weight US-origin models (Nemotron 3 Nano, Gemma 3/4) so the inference bill does not scale with usage; switch to Claude or GPT in one config line. The runtime is provider-agnostic.',
       alt: 'RevealUI agentic vision',
     },
   ],

--- a/apps/docs/public/docs-pro/ai/index.md
+++ b/apps/docs/public/docs-pro/ai/index.md
@@ -30,7 +30,7 @@ ollama pull gemma4:e2b
 ollama pull nomic-embed-text
 
 # OR planned path (run + manage the snap yourself for now)
-sudo snap install gemma3
+sudo snap install nemotron-3-nano
 ```
 
 ```typescript

--- a/apps/docs/public/docs-pro/inference/index.md
+++ b/apps/docs/public/docs-pro/inference/index.md
@@ -55,7 +55,7 @@ When `INFERENCE_SNAPS_BASE_URL` is set, the LLM client auto-detects it as the pr
 | Path | Runtime | Cost | Use Case |
 |------|---------|------|----------|
 | **Ollama** (default) | Local GGUF models | Free (your hardware) | Flexible  -  any open source GGUF model (Gemma 4, Qwen, Mistral) |
-| **Ubuntu Inference Snaps** (planned) | Canonical snap runtime | Free (your hardware) | Local production  -  Gemma 3, Nemotron-Nano, DeepSeek-R1, Qwen-VL |
+| **Ubuntu Inference Snaps** (planned) | Canonical snap runtime | Free (your hardware) | Local production  -  US-origin: Nemotron 3 Nano/Omni, Gemma 3/4 |
 | **Groq** | Cloud, your own key | Pay Groq directly | Fast cloud inference, opt-in via `GROQ_API_KEY` |
 | **Anthropic** | Cloud, your own key | Pay Anthropic directly | Bring your own key, opt-in via `ANTHROPIC_API_KEY` |
 | **OpenAI** | Cloud, your own key | Pay OpenAI directly | Bring your own key, opt-in via `OPENAI_API_KEY` |

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -414,7 +414,7 @@ const SERVICES_STRIPE: EvidenceRef = {
 const LLM_CLIENT: EvidenceRef = {
   kind: 'code',
   ref: 'packages/ai/src/llm/client.ts',
-  note: 'createLLMClientFromEnv default provider inference-snaps, defaultModel gemma3, port 9090; LLMProviderType union groq/ollama/huggingface/inference-snaps',
+  note: 'createLLMClientFromEnv default provider inference-snaps, defaultModel nemotron-3-nano, port 9090; US-origin allowlist; LLMProviderType union groq/ollama/huggingface/inference-snaps',
 };
 const OLLAMA: EvidenceRef = {
   kind: 'code',
@@ -2612,7 +2612,7 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'local-ai.ts',
     exportPath: 'LOCAL_AI_SECTION.snippet.lines[0].note',
-    text: 'gemma3 on your box, port 9090 (default runner)',
+    text: 'nemotron-3-nano on your box, port 9090 (default runner)',
     evidence: [LLM_CLIENT],
   },
   {

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -2737,6 +2737,12 @@ export const CLAIMS: readonly ClaimEntry[] = [
   },
   {
     file: 'local-ai.ts',
+    exportPath: 'PROVIDER_SWITCH.modes.local.model',
+    text: 'nemotron-3-nano, open-weight (US-origin)',
+    evidence: [LLM_CLIENT, OPEN_WEIGHT],
+  },
+  {
+    file: 'local-ai.ts',
     exportPath: 'PROVIDER_SWITCH.modes.local.cost',
     text: 'Your inference cost, no per-token fee',
     evidence: [OPEN_WEIGHT],

--- a/apps/marketing/app/content/local-ai.ts
+++ b/apps/marketing/app/content/local-ai.ts
@@ -17,7 +17,7 @@
 // cost + sovereignty + good-enough-for-most-work economics, NEVER on parity,
 // "free", "turnkey", or "faster". Frontier stays the opt-in escalation. The
 // provider snippet is grep-accurate to packages/ai/src/llm/client.ts
-// (LLM_PROVIDER; inference-snaps default gemma3 :9090, ollama gemma4 :11434).
+// (LLM_PROVIDER; inference-snaps default nemotron-3-nano :9090, ollama gemma4 :11434).
 // Positioning guardrail (Phase C): ownership stays the lead; local AI is its proof.
 //
 // claims-ratchet 2026-07-12: frontier-mode provider naming scoped to the shipped
@@ -57,7 +57,7 @@ export const LOCAL_AI_SECTION = {
     lines: [
       {
         code: 'LLM_PROVIDER=inference-snaps',
-        note: 'gemma3 on your box, port 9090 (default runner)',
+        note: 'nemotron-3-nano on your box, port 9090 (default runner)',
       },
       { code: 'LLM_PROVIDER=ollama', note: 'gemma4 on your box, port 11434' },
     ],
@@ -152,7 +152,7 @@ export const PROVIDER_SWITCH = {
     local: {
       label: 'Local',
       badge: 'default',
-      model: 'gemma3, open-weight',
+      model: 'nemotron-3-nano, open-weight (US-origin)',
       locus: 'Runs on your own box',
       cost: 'Your inference cost, no per-token fee',
       config: 'LLM_PROVIDER=inference-snaps',

--- a/apps/server/src/routes/__tests__/agent-stream-success.test.ts
+++ b/apps/server/src/routes/__tests__/agent-stream-success.test.ts
@@ -70,6 +70,10 @@ vi.mock('@revealui/ai', () => {
     createCoreLoggerSink: vi.fn().mockReturnValue(() => {}),
     createUsageMeterSink: vi.fn().mockReturnValue(() => {}),
     createToolsFromMcpClient: vi.fn().mockResolvedValue([]),
+    // US-origin Inference Snaps hardline (agent-stream sampling allowlist)
+    US_ORIGIN_INFERENCE_SNAP_IDS: ['nemotron-3-nano', 'nemotron-3-nano-omni', 'gemma3', 'gemma4'],
+    DEFAULT_US_ORIGIN_INFERENCE_SNAP: 'nemotron-3-nano',
+    createSamplingHandler: vi.fn().mockReturnValue(async () => ({ model: 'nemotron-3-nano' })),
   };
 });
 

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -370,17 +370,10 @@ app.openapi(agentStreamRoute, async (c) => {
 
     // A.2a: Sampling handler allowlist. MCP servers may request any model
     // via `modelPreferences.hints`; we filter those hints to this list so
-    // servers can't silently route us to expensive models. Models outside
-    // the list fall back to `defaultModel`. Conservative set — extend when
-    // specific models are validated + cost-bounded.
-    const samplingAllowedModels = [
-      'gemma3',
-      'gemma3:e2b',
-      'gemma3:e4b',
-      'deepseek-r1',
-      'qwen3',
-    ] as const;
-    const samplingDefaultModel = process.env.LLM_MODEL ?? 'gemma3';
+    // servers can't silently route us off the product US-origin snap set.
+    // SSOT: @revealui/ai US_ORIGIN_INFERENCE_SNAP_IDS.
+    const samplingAllowedModels = [...aiMod.US_ORIGIN_INFERENCE_SNAP_IDS];
+    const samplingDefaultModel = process.env.LLM_MODEL ?? aiMod.DEFAULT_US_ORIGIN_INFERENCE_SNAP;
 
     for (const server of serverIds) {
       try {

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -15,7 +15,7 @@ AI agents, LLM providers, CRDT memory, and the A2A protocol for RevealUI Pro.
 
 - **Agents**  -  long-running task agents with persistent state
 - **Memory**  -  four-store cognitive memory (episodic, working, semantic, procedural)
-- **Bring your own model**  -  default ships open-weight (Llama 4, Gemma 3, Qwen 3, DeepSeek R1) via Ubuntu Inference Snaps or Ollama so the inference bill does not scale with usage; switch to Claude, GPT, or any provider in one config line
+- **Bring your own model**  -  default ships open-weight US-origin models (Nemotron 3 Nano, Gemma 3/4) via Ubuntu Inference Snaps or Ollama so the inference bill does not scale with usage; switch to Claude, GPT, or any provider in one config line
 - **Streaming**  -  SSE-based token streaming via `StreamingAgentRuntime` and `useAgentStream`
 - **Orchestration**  -  multi-agent coordination with the A2A protocol
 - **MCP integration**  -  tool use via Model Context Protocol
@@ -33,11 +33,10 @@ pnpm add @revealui/ai
 Install a model via Ubuntu Inference Snaps (canonical default — install + run yourself today; Studio lifecycle pending):
 
 ```bash
-sudo snap install gemma3             # default — general + vision (~8 GB, Apache 2.0)
-# or: sudo snap install deepseek-r1            # reasoning, chain-of-thought
-# or: sudo snap install qwen-vl                # vision-language, document parsing
-# or: sudo snap install nemotron-3-nano        # text-only, lightweight (~4 GB)
-# or: sudo snap install nemotron-3-nano-omni   # multimodal — text/image/video/audio in, text out
+sudo snap install nemotron-3-nano    # default — NVIDIA US-origin general + tools
+# or: sudo snap install gemma4                 # Google US-origin general + vision + tools
+# or: sudo snap install gemma3                 # Google US-origin (allowlisted)
+# or: sudo snap install nemotron-3-nano-omni   # NVIDIA multimodal
 ```
 
 ```typescript
@@ -106,11 +105,12 @@ const memory = {
 
 | Snap | Type | Use Case |
 | ---- | ---- | -------- |
-| `gemma3` | General + vision | **Default**  -  vision-capable, Apache 2.0 (~8 GB) |
-| `deepseek-r1` | Reasoning | Complex analysis, chain-of-thought |
-| `qwen-vl` | Vision-language | Document parsing, visual Q&A |
-| `nemotron-3-nano` | General (text-only) | Lightweight alternative for low-resource hosts (~4 GB) |
-| `nemotron-3-nano-omni` | Multimodal | Text/image/video/audio in, text out |
+| `nemotron-3-nano` | General + tools (NVIDIA, US) | **Default** product snap |
+| `nemotron-3-nano-omni` | Multimodal (NVIDIA, US) | Text/image/video/audio in |
+| `gemma4` | General + vision + tools (Google, US) | Strong general alternative |
+| `gemma3` | General + vision (Google, US) | Allowlisted legacy snap |
+
+Non-US snaps in Canonical's catalog (DeepSeek, Qwen, GLM) are rejected in product code unless `REVEALUI_ALLOW_NON_US_MODELS=1`.
 
 Install: `sudo snap install <name>`. Each snap serves an OpenAI-compatible API at `http://localhost:<port>/v1`.
 
@@ -151,7 +151,7 @@ For the planned recommended path (when you're ready to install + run a Canonical
 
 ```bash
 # Install your first model (default)
-sudo snap install gemma3
+sudo snap install nemotron-3-nano
 
 # Check status
 gemma3 status

--- a/docs/LOCAL_FIRST.md
+++ b/docs/LOCAL_FIRST.md
@@ -60,11 +60,10 @@ The Nix flake activates: Node 24, pnpm 10, Biome, and all build dependencies are
 Inference snaps are the canonical local-AI path for RevealUI. Canonical's snap-packaged model serving provides hardware-aware engine selection, signed packages, and zero configuration. Today, you install + run the snap yourself; Studio lifecycle management (start / stop / health / model discovery) is on the roadmap.
 
 ```bash
-sudo snap install gemma3             # default — general + vision (~8 GB, Apache 2.0)
-# or: sudo snap install deepseek-r1            # reasoning
-# or: sudo snap install qwen-vl                # vision-language
-# or: sudo snap install nemotron-3-nano        # text-only, lightweight (~4 GB)
-# or: sudo snap install nemotron-3-nano-omni   # multimodal — text/image/video/audio
+sudo snap install nemotron-3-nano    # default — NVIDIA US-origin general + tools
+# or: sudo snap install gemma4                 # Google US-origin general + vision + tools
+# or: sudo snap install gemma3                 # Google US-origin (allowlisted)
+# or: sudo snap install nemotron-3-nano-omni   # NVIDIA multimodal
 ```
 
 Verify the snap is running:

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -131,7 +131,7 @@ Customer-stamped Fleet kits are NOT fleet products — they are per-customer bra
 
 ## 6. Open-weight inference defaults (per memory)
 
-Canonical defaults (when "open-model AI" is mentioned in marketing): Gemma 4, Phi-4-mini (via Ollama), DeepSeek-R1, Qwen-VL, Nemotron-3-nano, Nemotron-3-omni (via Ubuntu Inference Snaps).
+Canonical defaults (when "open-model AI" is mentioned in marketing): Nemotron-3-nano (default), Nemotron-3-omni, Gemma 3/4 (via Ubuntu Inference Snaps; US-origin allowlist); Phi-4-mini and other US open weights via Ollama.
 
 **Hard rule per memory `project_suite_roadmap`:** Anthropic SDK is NEVER imported by RevealUI runtime code. Marketing copy may say "Claude / Anthropic" as one of the supported model providers (the Claude API integration runs out-of-band) but never as the default. Default is open-weight.
 

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -854,7 +854,7 @@ RevealUI AI defaults to open source models running on your own hardware. It neve
 
 | Path | Runtime | Current state | Tracking |
 |------|---------|---------------|----------|
-| **Ubuntu Inference Snaps** | Canonical snap runtime | CLI install works today for Gemma3, DeepSeek-R1, Qwen-VL, Nemotron-Nano (`sudo snap install <model>`). Setting `INFERENCE_SNAPS_BASE_URL` wires an already-running snap service to the LLM client. Studio lifecycle management (start / stop / health / model discovery) is **not shipped**. | Integration issue to be filed; tracked internally as CR-9 P1-04 |
+| **Ubuntu Inference Snaps** | Canonical snap runtime | CLI install works today for US-origin snaps: Nemotron-3-nano (default), Gemma 3/4, Nemotron Omni (`sudo snap install <model>`). Setting `INFERENCE_SNAPS_BASE_URL` wires an already-running snap service to the LLM client. Studio lifecycle management (start / stop / health / model discovery) is **not shipped**. | Integration issue to be filed; tracked internally as CR-9 P1-04 |
 
 ## Server-side usage
 

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -51,7 +51,7 @@ RevealUI's AI agents run on open source models locally. The recommended path is 
 
 ```bash
 # Install a model (one command)
-sudo snap install gemma3
+sudo snap install nemotron-3-nano
 
 # Check status
 gemma3 status
@@ -79,7 +79,7 @@ cd RevealUI
 direnv allow        # Nix builds and activates the full dev environment
 
 # Install a model via inference snaps (recommended)
-sudo snap install gemma3
+sudo snap install nemotron-3-nano
 
 # Or use Ollama
 ollama pull gemma4:e2b
@@ -99,7 +99,7 @@ flake.nix
 └── devShell
     └── nodejs, pnpm, biome          # Standard RevealUI toolchain
 
-sudo snap install gemma3             # Or: ollama pull gemma4:e2b
+sudo snap install nemotron-3-nano    # Or: ollama pull gemma4:e2b
 └── OpenAI-compatible API served locally
 
 @revealui/ai                         # Agent orchestration routes to local model

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -433,7 +433,7 @@ The `@revealui/ai` package is loaded dynamically. If the license is free, the im
 
 RevealUI defaults to open-weight models (no API key, no cloud bill, no vendor lock-in). Cloud providers (Groq, HuggingFace, and OpenAI-compatible endpoints) are opt-in via environment variables. The inference path is auto-detected:
 
-1. **Ubuntu Inference Snaps** (recommended)  -  Canonical snap runtime (Gemma3, DeepSeek-R1, Qwen-VL, Nemotron-Nano)
+1. **Ubuntu Inference Snaps** (recommended)  -  Canonical snap runtime (US-origin allowlist: Nemotron-3-nano, Gemma 3/4, Nemotron Omni)
 2. **Ollama** (fallback)  -  Any open source GGUF model (chat: `gemma4:e2b`, embeddings: `nomic-embed-text`)
 
 ### CRDT-based memory system

--- a/docs/guides/technology-stack.md
+++ b/docs/guides/technology-stack.md
@@ -66,7 +66,7 @@ The runtime is provider-agnostic by contract and ships with no default AI vendor
 |---|---|
 | **Ollama** | Local model runner — the standard developer-machine path. |
 | **Ubuntu Inference Snaps** | Snap-packaged model runtimes — recommended for production on Ubuntu hosts. |
-| **Canonical model catalog** | Gemma 3/4, DeepSeek R1, Qwen VL, Nemotron — Apache-2.0 preferred. |
+| **Canonical model catalog (product)** | Nemotron 3 Nano/Omni, Gemma 3/4 (US-origin allowlist). |
 | **Pluggable provider adapters** | Claude, OpenAI, and others available as opt-in adapters — never bundled. |
 
 ## Deployment targets

--- a/packages/ai/src/tools/mcp-sampling.ts
+++ b/packages/ai/src/tools/mcp-sampling.ts
@@ -21,7 +21,7 @@
  *
  * const llm = new InferenceSnapsProvider({
  *   baseURL: 'http://localhost:9090/v1',
- *   model: 'gemma3',
+ *   model: 'nemotron-3-nano',
  * });
  *
  * const client = new McpClient({
@@ -29,8 +29,8 @@
  *   transport: { kind: 'streamable-http', url: 'https://example.com/mcp' },
  *   samplingHandler: createSamplingHandler({
  *     llm,
- *     defaultModel: 'gemma3',
- *     allowedModels: ['gemma3', 'deepseek-r1'],
+ *     defaultModel: 'nemotron-3-nano',
+ *     allowedModels: ['nemotron-3-nano', 'gemma4', 'gemma3'],
  *   }),
  * });
  * await client.connect();

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -14,7 +14,7 @@ const TextPartSchema = z.object({
 });
 
 /** Image content part  -  base64 data URL or HTTPS URL.
- *  Used with vision-capable models (inference-snaps gemma3/qwen-vl, GPT-4o, etc.) */
+ *  Used with vision-capable models (inference-snaps gemma4/omni, GPT-4o, etc.) */
 const ImagePartSchema = z.object({
   type: z.literal('image_url'),
   image_url: z.object({
@@ -32,7 +32,7 @@ export type ContentPart = z.infer<typeof ContentPartSchema>;
  *
  * Content may be a plain string or a multipart array (text + images).
  * Multipart content is passed through to OpenAI-compatible providers,
- * enabling vision models such as gemma3, qwen-vl, and GPT-4o.
+ * enabling vision models such as gemma4, nemotron-3-nano-omni, and GPT-4o.
  */
 export const ChatMessageSchema = z.object({
   role: z.enum(['user', 'assistant', 'system']),

--- a/packages/harnesses/src/__tests__/inference-service-snaps.test.ts
+++ b/packages/harnesses/src/__tests__/inference-service-snaps.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Product Inference Snap catalog must stay on the US-origin allowlist.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { PRODUCT_INFERENCE_SNAPS } from '../server/inference-service.js';
+
+const US_ORIGIN_IDS = ['nemotron-3-nano', 'nemotron-3-nano-omni', 'gemma3', 'gemma4'] as const;
+
+const FORBIDDEN = ['deepseek-r1', 'qwen-vl', 'qwen3', 'qwen3-coder', 'glm-4-7-flash'];
+
+describe('PRODUCT_INFERENCE_SNAPS', () => {
+  it('lists only US-origin snap ids (lockstep with @revealui/ai allowlist)', () => {
+    const names = PRODUCT_INFERENCE_SNAPS.map(([name]) => name);
+    expect(names).toEqual(expect.arrayContaining([...US_ORIGIN_IDS]));
+    expect(names).toHaveLength(US_ORIGIN_IDS.length);
+    for (const id of US_ORIGIN_IDS) {
+      expect(names).toContain(id);
+    }
+  });
+
+  it('does not offer PRC-origin catalog snaps for install', () => {
+    const names = PRODUCT_INFERENCE_SNAPS.map(([name]) => name);
+    for (const banned of FORBIDDEN) {
+      expect(names).not.toContain(banned);
+    }
+  });
+
+  it('defaults product id remains nemotron-3-nano first (install UX order)', () => {
+    expect(PRODUCT_INFERENCE_SNAPS[0]?.[0]).toBe('nemotron-3-nano');
+  });
+
+  it('matches the SSOT ids in @revealui/ai us-origin-snaps.ts', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const sot = join(here, '../../../ai/src/llm/providers/us-origin-snaps.ts');
+    const source = readFileSync(sot, 'utf8');
+    for (const id of PRODUCT_INFERENCE_SNAPS.map(([name]) => name)) {
+      expect(source).toContain(`'${id}'`);
+    }
+  });
+});

--- a/packages/harnesses/src/server/inference-service.ts
+++ b/packages/harnesses/src/server/inference-service.ts
@@ -38,13 +38,19 @@ export interface SnapModel {
 
 // ── Configuration ───────────────────────────────────────────────────
 
-const KNOWN_SNAPS: Array<[string, string]> = [
-  ['gemma3', 'General + vision  -  default; image understanding, multimodal (Apache 2.0)'],
-  ['deepseek-r1', 'Reasoning  -  complex analysis, chain-of-thought'],
-  ['qwen-vl', 'Vision-language  -  document parsing, visual Q&A'],
-  ['nemotron-3-nano', 'General (text-only)  -  lightweight alternative for low-resource hosts'],
-  ['nemotron-3-nano-omni', 'Multimodal  -  text/image/video/audio in, text out'],
-];
+/**
+ * Product install/list catalog for Inference Snaps.
+ * Must stay lockstep with `@revealui/ai` `US_ORIGIN_INFERENCE_SNAP_IDS`
+ * (US-origin hardline; PRC catalog snaps are not product-installable here).
+ */
+export const PRODUCT_INFERENCE_SNAPS: ReadonlyArray<readonly [string, string]> = [
+  ['nemotron-3-nano', 'NVIDIA (US)  -  general + tools; product default'],
+  ['nemotron-3-nano-omni', 'NVIDIA (US)  -  multimodal (text/image/video/audio in)'],
+  ['gemma4', 'Google (US)  -  general + vision + tools'],
+  ['gemma3', 'Google (US)  -  general + vision (allowlisted)'],
+] as const;
+
+const KNOWN_SNAPS = PRODUCT_INFERENCE_SNAPS;
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -224,6 +230,8 @@ export class InferenceService {
   }
 
   async snapRemove(snapName: string): Promise<void> {
+    const known = KNOWN_SNAPS.some(([name]) => name === snapName);
+    if (!known) throw new Error(`Unknown inference snap: ${snapName}`);
     await execFileAsync('sudo', ['snap', 'remove', snapName], { timeout: 60_000 });
   }
 }


### PR DESCRIPTION
## Summary

Closes residual surfaces after the US-origin Inference Snaps hardline ([#2132](https://github.com/RevealUIStudio/revealui/pull/2132)):

### Code
- **`@revealui/harnesses` `InferenceService`:** product install catalog is US-origin only (`nemotron-3-nano` first, omni, gemma4, gemma3). Dropped deepseek/qwen. `snapRemove` now validates the same allowlist.
- **`agent-stream` sampling:** uses `US_ORIGIN_INFERENCE_SNAP_IDS` + `DEFAULT_US_ORIGIN_INFERENCE_SNAP` from `@revealui/ai` (no hard-coded deepseek/qwen).
- Lockstep test: harnesses catalog must match `us-origin-snaps.ts`.

### Docs / marketing
- AI, LOCAL_FIRST, PRO, blogs, technology-stack, marketing local-ai + claims-evidence defaults → Nemotron; Gemma still allowed.
- Explicit: non-US Canonical catalog snaps rejected unless operator escape.

### Companion
- [revdev#313](https://github.com/RevealUIStudio/revdev/pull/313) — Studio Tauri + mock list
- jv#719 ADR left to peer (CI)

## Test plan
- [x] `vitest` harnesses `inference-service-snaps.test.ts` (4 passed)
- [x] `pnpm validate:claims-evidence`
- [x] pre-push gate PASS
- [ ] CI on PR

## Owner actions
Merge when green (non-security residual):
```bash
gh pr merge <N> --repo RevealUIStudio/revealui --merge
gh pr merge 313 --repo RevealUIStudio/revdev --merge
```