### PR TITLE
feat(server,ai): GAP-406 WIRE phase 3–4 vault creds + skills/observability

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -489,6 +489,14 @@ LLM_ENABLE_SEMANTIC_CACHE=true
 # ELECTRIC_API_KEY=                      # ElectricSQL API key
 # PGVECTOR_ENABLED=false                 # Enable pgvector in MCP
 
+# GAP-406 WIRE — MCPHypervisor + AI skills/observability (all default off)
+# REVEALUI_MCP_HYPERVISOR=1              # install meter/audit sinks + vault credential resolver
+# REVEALUI_MCP_HYPERVISOR_SPAWN=1        # also start process-local servers (needs HYPERVISOR=1)
+# REVEALUI_MCP_HYPERVISOR_SERVERS=contracts,docs  # optional allowlist override
+# Tenant MCP env in revvault: mcp/<tenantId>/<serverName>/env  (JSON string map)
+# REVEALUI_AI_SKILLS=1                   # AgentSkillProvider on agent-stream
+# REVEALUI_AI_OBSERVABILITY=1            # AgentEventLogger on agent-stream
+
 # =============================================================================
 # APP-SPECIFIC VARIABLES
 # =============================================================================

--- a/apps/server/src/lib/__tests__/ai-observability-wire.test.ts
+++ b/apps/server/src/lib/__tests__/ai-observability-wire.test.ts
@@ -6,9 +6,7 @@ vi.mock('@revealui/core/observability/logger', () => ({
 
 const AgentEventLogger = vi.fn(function AgentEventLogger(
   this: { maxEvents?: number },
-  opts?: {
-    maxEvents?: number;
-  },
+  opts?: { maxEvents?: number },
 ) {
   this.maxEvents = opts?.maxEvents;
   return this;
@@ -29,13 +27,13 @@ describe('ai-observability-wire', () => {
       '../ai-observability-wire.js'
     );
     expect(isAiObservabilityWireEnabled({})).toBe(false);
-    expect(createAgentEventLoggerIfEnabled({})).toBeNull();
+    await expect(createAgentEventLoggerIfEnabled({})).resolves.toBeNull();
     expect(AgentEventLogger).not.toHaveBeenCalled();
   });
 
   it('creates logger when REVEALUI_AI_OBSERVABILITY=1', async () => {
     const { createAgentEventLoggerIfEnabled } = await import('../ai-observability-wire.js');
-    const eventLogger = createAgentEventLoggerIfEnabled({ REVEALUI_AI_OBSERVABILITY: '1' });
+    const eventLogger = await createAgentEventLoggerIfEnabled({ REVEALUI_AI_OBSERVABILITY: '1' });
     expect(eventLogger).not.toBeNull();
     expect(AgentEventLogger).toHaveBeenCalledWith({ maxEvents: 1000 });
   });

--- a/apps/server/src/lib/__tests__/ai-observability-wire.test.ts
+++ b/apps/server/src/lib/__tests__/ai-observability-wire.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const AgentEventLogger = vi.fn(function AgentEventLogger(
+  this: { maxEvents?: number },
+  opts?: {
+    maxEvents?: number;
+  },
+) {
+  this.maxEvents = opts?.maxEvents;
+  return this;
+});
+
+vi.mock('@revealui/ai/observability', () => ({
+  AgentEventLogger,
+}));
+
+describe('ai-observability-wire', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('is disabled by default', async () => {
+    const { isAiObservabilityWireEnabled, createAgentEventLoggerIfEnabled } = await import(
+      '../ai-observability-wire.js'
+    );
+    expect(isAiObservabilityWireEnabled({})).toBe(false);
+    expect(createAgentEventLoggerIfEnabled({})).toBeNull();
+    expect(AgentEventLogger).not.toHaveBeenCalled();
+  });
+
+  it('creates logger when REVEALUI_AI_OBSERVABILITY=1', async () => {
+    const { createAgentEventLoggerIfEnabled } = await import('../ai-observability-wire.js');
+    const eventLogger = createAgentEventLoggerIfEnabled({ REVEALUI_AI_OBSERVABILITY: '1' });
+    expect(eventLogger).not.toBeNull();
+    expect(AgentEventLogger).toHaveBeenCalledWith({ maxEvents: 1000 });
+  });
+});

--- a/apps/server/src/lib/__tests__/ai-skills-wire.test.ts
+++ b/apps/server/src/lib/__tests__/ai-skills-wire.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+const createAgentSkillProvider = vi.fn(() => ({ injectSkillInstructions: vi.fn() }));
+const SkillActivator = vi.fn(function SkillActivator(this: unknown) {
+  return this;
+});
+
+vi.mock('@revealui/ai/skills', () => ({
+  createAgentSkillProvider,
+  globalSkillRegistry: { name: 'global' },
+  SkillActivator,
+}));
+
+describe('ai-skills-wire', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('is disabled by default', async () => {
+    const { isAiSkillsWireEnabled, createSkillProviderIfEnabled } = await import(
+      '../ai-skills-wire.js'
+    );
+    expect(isAiSkillsWireEnabled({})).toBe(false);
+    expect(createSkillProviderIfEnabled({})).toBeNull();
+    expect(createAgentSkillProvider).not.toHaveBeenCalled();
+  });
+
+  it('builds provider when REVEALUI_AI_SKILLS=1', async () => {
+    const { createSkillProviderIfEnabled } = await import('../ai-skills-wire.js');
+    const provider = createSkillProviderIfEnabled({ REVEALUI_AI_SKILLS: '1' });
+    expect(provider).not.toBeNull();
+    expect(SkillActivator).toHaveBeenCalledOnce();
+    expect(createAgentSkillProvider).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/server/src/lib/__tests__/ai-skills-wire.test.ts
+++ b/apps/server/src/lib/__tests__/ai-skills-wire.test.ts
@@ -26,13 +26,13 @@ describe('ai-skills-wire', () => {
       '../ai-skills-wire.js'
     );
     expect(isAiSkillsWireEnabled({})).toBe(false);
-    expect(createSkillProviderIfEnabled({})).toBeNull();
+    await expect(createSkillProviderIfEnabled({})).resolves.toBeNull();
     expect(createAgentSkillProvider).not.toHaveBeenCalled();
   });
 
   it('builds provider when REVEALUI_AI_SKILLS=1', async () => {
     const { createSkillProviderIfEnabled } = await import('../ai-skills-wire.js');
-    const provider = createSkillProviderIfEnabled({ REVEALUI_AI_SKILLS: '1' });
+    const provider = await createSkillProviderIfEnabled({ REVEALUI_AI_SKILLS: '1' });
     expect(provider).not.toBeNull();
     expect(SkillActivator).toHaveBeenCalledOnce();
     expect(createAgentSkillProvider).toHaveBeenCalledOnce();

--- a/apps/server/src/lib/__tests__/mcp-hypervisor-wire.test.ts
+++ b/apps/server/src/lib/__tests__/mcp-hypervisor-wire.test.ts
@@ -13,10 +13,28 @@ const getInstance = vi.fn(() => ({
   setCredentialResolver,
 }));
 
+const memoryStore = new Map<string, string>();
+const memoryVault = {
+  async get(path: string) {
+    return memoryStore.get(path);
+  },
+  async set(path: string, value: string) {
+    memoryStore.set(path, value);
+  },
+  async delete(path: string) {
+    memoryStore.delete(path);
+  },
+  async list(prefix: string) {
+    return [...memoryStore.keys()].filter((k) => k.startsWith(prefix));
+  },
+};
+
 vi.mock('@revealui/mcp', () => ({
   MCPHypervisor: {
     getInstance,
   },
+  createRevvaultVault: () => memoryVault,
+  createMemoryVault: () => memoryVault,
 }));
 
 vi.mock('@revealui/core/observability/logger', () => ({
@@ -55,6 +73,7 @@ describe('mcp-hypervisor-wire', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    memoryStore.clear();
   });
 
   it('is disabled by default', async () => {
@@ -66,12 +85,13 @@ describe('mcp-hypervisor-wire', () => {
     expect(getInstance).not.toHaveBeenCalled();
   });
 
-  it('enables on REVEALUI_MCP_HYPERVISOR=1 and installs sinks without spawn', async () => {
+  it('enables on REVEALUI_MCP_HYPERVISOR=1 and installs sinks + vault resolver', async () => {
     const { wireMcpHypervisorIfEnabled } = await import('../mcp-hypervisor-wire.js');
     expect(await wireMcpHypervisorIfEnabled({ REVEALUI_MCP_HYPERVISOR: '1' })).toBe(true);
     expect(getInstance).toHaveBeenCalledOnce();
     expect(setUsageMeterSink).toHaveBeenCalledOnce();
     expect(setAuditSink).toHaveBeenCalledOnce();
+    expect(setCredentialResolver).toHaveBeenCalledOnce();
     expect(registerServer).not.toHaveBeenCalled();
     expect(startServer).not.toHaveBeenCalled();
   });
@@ -144,5 +164,28 @@ describe('mcp-hypervisor-wire', () => {
       }),
     );
     expect(startServer).toHaveBeenCalledWith('contracts');
+  });
+
+  it('vault credential resolver returns env map from mcp/tenant/server/env', async () => {
+    const { createVaultCredentialResolver, mcpTenantEnvVaultPath } = await import(
+      '../mcp-hypervisor-wire.js'
+    );
+    const path = mcpTenantEnvVaultPath('tenant1', 'neon');
+    await memoryVault.set(path, JSON.stringify({ NEON_API_KEY: 'nk_test' }));
+
+    const resolver = createVaultCredentialResolver({ vault: memoryVault });
+    await expect(resolver.resolve('tenant1', 'neon')).resolves.toEqual({
+      NEON_API_KEY: 'nk_test',
+    });
+    await expect(resolver.resolve('tenant1', 'missing-server')).resolves.toBeNull();
+    await expect(resolver.resolve('bad/id', 'neon')).resolves.toBeNull();
+  });
+
+  it('parseTenantEnvBlob rejects non-string values', async () => {
+    const { parseTenantEnvBlob } = await import('../mcp-hypervisor-wire.js');
+    expect(parseTenantEnvBlob('{"A":"ok"}')).toEqual({ A: 'ok' });
+    expect(parseTenantEnvBlob('{"A":1}')).toBeNull();
+    expect(parseTenantEnvBlob('[]')).toBeNull();
+    expect(parseTenantEnvBlob('not-json')).toBeNull();
   });
 });

--- a/apps/server/src/lib/ai-observability-wire.ts
+++ b/apps/server/src/lib/ai-observability-wire.ts
@@ -2,14 +2,15 @@
  * GAP-406 WIRE phase 4 — opt-in `@revealui/ai/observability` mount for apps/server.
  *
  * `REVEALUI_AI_OBSERVABILITY=1` (or true/yes/on): creates an in-process
- * {@link AgentEventLogger} for agent-stream instrumentation.
+ * AgentEventLogger for agent-stream instrumentation.
  * Default (unset): null.
+ *
+ * Pro package is loaded via dynamic import (boundary: optional Fair Source).
  *
  * @see docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
  * @see GAP-406
  */
 
-import { AgentEventLogger } from '@revealui/ai/observability';
 import { logger } from '@revealui/core/observability/logger';
 
 const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
@@ -19,17 +20,35 @@ export function isAiObservabilityWireEnabled(env: NodeJS.ProcessEnv = process.en
   return raw !== undefined && ENABLED_VALUES.has(raw);
 }
 
+export interface AgentEventLoggerLike {
+  logDecision(event: {
+    timestamp: number;
+    agentId: string;
+    sessionId: string;
+    reasoning: string;
+    context?: Record<string, unknown>;
+  }): void;
+}
+
 /**
- * Create an agent event logger when enabled. Returns null when off.
+ * Create an agent event logger when enabled. Returns null when off or package missing.
  */
-export function createAgentEventLoggerIfEnabled(
+export async function createAgentEventLoggerIfEnabled(
   env: NodeJS.ProcessEnv = process.env,
-): AgentEventLogger | null {
+): Promise<AgentEventLoggerLike | null> {
   if (!isAiObservabilityWireEnabled(env)) {
     return null;
   }
 
-  const eventLogger = new AgentEventLogger({ maxEvents: 1000 });
-  logger.info('[ai-observability-wire] GAP-406 phase 4: AgentEventLogger ready (in-memory)');
-  return eventLogger;
+  try {
+    const obs = await import('@revealui/ai/observability');
+    const eventLogger = new obs.AgentEventLogger({ maxEvents: 1000 });
+    logger.info('[ai-observability-wire] GAP-406 phase 4: AgentEventLogger ready (in-memory)');
+    return eventLogger;
+  } catch (error) {
+    logger.warn('[ai-observability-wire] failed to load @revealui/ai/observability', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 }

--- a/apps/server/src/lib/ai-observability-wire.ts
+++ b/apps/server/src/lib/ai-observability-wire.ts
@@ -1,0 +1,35 @@
+/**
+ * GAP-406 WIRE phase 4 — opt-in `@revealui/ai/observability` mount for apps/server.
+ *
+ * `REVEALUI_AI_OBSERVABILITY=1` (or true/yes/on): creates an in-process
+ * {@link AgentEventLogger} for agent-stream instrumentation.
+ * Default (unset): null.
+ *
+ * @see docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+ * @see GAP-406
+ */
+
+import { AgentEventLogger } from '@revealui/ai/observability';
+import { logger } from '@revealui/core/observability/logger';
+
+const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export function isAiObservabilityWireEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.REVEALUI_AI_OBSERVABILITY?.trim().toLowerCase();
+  return raw !== undefined && ENABLED_VALUES.has(raw);
+}
+
+/**
+ * Create an agent event logger when enabled. Returns null when off.
+ */
+export function createAgentEventLoggerIfEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): AgentEventLogger | null {
+  if (!isAiObservabilityWireEnabled(env)) {
+    return null;
+  }
+
+  const eventLogger = new AgentEventLogger({ maxEvents: 1000 });
+  logger.info('[ai-observability-wire] GAP-406 phase 4: AgentEventLogger ready (in-memory)');
+  return eventLogger;
+}

--- a/apps/server/src/lib/ai-skills-wire.ts
+++ b/apps/server/src/lib/ai-skills-wire.ts
@@ -1,0 +1,37 @@
+/**
+ * GAP-406 WIRE phase 4 — opt-in `@revealui/ai/skills` mount for apps/server.
+ *
+ * `REVEALUI_AI_SKILLS=1` (or true/yes/on): builds an {@link AgentSkillProvider}
+ * over the process {@link globalSkillRegistry} for agent runtime injection.
+ * Default (unset): null — no skills import cost when disabled.
+ *
+ * @see docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+ * @see GAP-406
+ */
+
+import type { AgentSkillProvider } from '@revealui/ai/skills';
+import { createAgentSkillProvider, globalSkillRegistry, SkillActivator } from '@revealui/ai/skills';
+import { logger } from '@revealui/core/observability/logger';
+
+const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export function isAiSkillsWireEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.REVEALUI_AI_SKILLS?.trim().toLowerCase();
+  return raw !== undefined && ENABLED_VALUES.has(raw);
+}
+
+/**
+ * Build a skill provider when enabled. Returns null when off.
+ */
+export function createSkillProviderIfEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): AgentSkillProvider | null {
+  if (!isAiSkillsWireEnabled(env)) {
+    return null;
+  }
+
+  const activator = new SkillActivator({ registry: globalSkillRegistry });
+  const provider = createAgentSkillProvider(activator);
+  logger.info('[ai-skills-wire] GAP-406 phase 4: AgentSkillProvider ready (global registry)');
+  return provider;
+}

--- a/apps/server/src/lib/ai-skills-wire.ts
+++ b/apps/server/src/lib/ai-skills-wire.ts
@@ -1,16 +1,16 @@
 /**
  * GAP-406 WIRE phase 4 — opt-in `@revealui/ai/skills` mount for apps/server.
  *
- * `REVEALUI_AI_SKILLS=1` (or true/yes/on): builds an {@link AgentSkillProvider}
- * over the process {@link globalSkillRegistry} for agent runtime injection.
- * Default (unset): null — no skills import cost when disabled.
+ * `REVEALUI_AI_SKILLS=1` (or true/yes/on): builds an AgentSkillProvider over the
+ * process globalSkillRegistry for agent runtime injection.
+ * Default (unset): null — no skills load when disabled.
+ *
+ * Pro package is loaded via dynamic import (boundary: optional Fair Source).
  *
  * @see docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
  * @see GAP-406
  */
 
-import type { AgentSkillProvider } from '@revealui/ai/skills';
-import { createAgentSkillProvider, globalSkillRegistry, SkillActivator } from '@revealui/ai/skills';
 import { logger } from '@revealui/core/observability/logger';
 
 const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
@@ -21,17 +21,25 @@ export function isAiSkillsWireEnabled(env: NodeJS.ProcessEnv = process.env): boo
 }
 
 /**
- * Build a skill provider when enabled. Returns null when off.
+ * Build a skill provider when enabled. Returns null when off or package missing.
  */
-export function createSkillProviderIfEnabled(
+export async function createSkillProviderIfEnabled(
   env: NodeJS.ProcessEnv = process.env,
-): AgentSkillProvider | null {
+): Promise<unknown | null> {
   if (!isAiSkillsWireEnabled(env)) {
     return null;
   }
 
-  const activator = new SkillActivator({ registry: globalSkillRegistry });
-  const provider = createAgentSkillProvider(activator);
-  logger.info('[ai-skills-wire] GAP-406 phase 4: AgentSkillProvider ready (global registry)');
-  return provider;
+  try {
+    const skills = await import('@revealui/ai/skills');
+    const activator = new skills.SkillActivator({ registry: skills.globalSkillRegistry });
+    const provider = skills.createAgentSkillProvider(activator);
+    logger.info('[ai-skills-wire] GAP-406 phase 4: AgentSkillProvider ready (global registry)');
+    return provider;
+  } catch (error) {
+    logger.warn('[ai-skills-wire] failed to load @revealui/ai/skills', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
 }

--- a/apps/server/src/lib/mcp-hypervisor-wire.ts
+++ b/apps/server/src/lib/mcp-hypervisor-wire.ts
@@ -3,13 +3,19 @@
  *
  * Phase 1 (`REVEALUI_MCP_HYPERVISOR=1`):
  *   Install usage-meter + integrity-audit sinks on the process singleton.
+ *   Install vault-backed credential resolver (phase 3).
  *
  * Phase 2 (`REVEALUI_MCP_HYPERVISOR_SPAWN=1` in addition):
  *   Register + start process-local first-party MCP servers via `revealui-mcp`.
  *   Default server list is public introspection only (`contracts,docs`) unless
  *   `REVEALUI_MCP_HYPERVISOR_SERVERS` overrides (comma-separated allowlist).
- *   Credential resolver is a stub that returns null (tenant spawn still blocked);
- *   process-local children inherit `process.env` for any credentials they need.
+ *   Process-local children inherit `process.env` for host credentials.
+ *
+ * Phase 3 (with phase 1):
+ *   Credential resolver reads `mcp/<tenantId>/<serverName>/env` (JSON object of
+ *   env vars) from a Vault (default revvault). Missing path → null (no tenant
+ *   env). Tenant spawn still merges process.env in the hypervisor today;
+ *   isolation tightening is a follow-up.
  *
  * Default (env unset): no-op. Safe for local/dev/serverless without hypervisor traffic.
  *
@@ -25,12 +31,16 @@ import type {
   MCPServerConfig,
   McpAuditEvent,
   McpMeterEvent,
+  Vault,
 } from '@revealui/mcp';
-import { MCPHypervisor } from '@revealui/mcp';
+import { createRevvaultVault, MCPHypervisor } from '@revealui/mcp';
 import { recordMcpToolAudit } from './mcp-audit.js';
 import { recordUsageMeter } from './metering.js';
 
 const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+/** Safe tenant/server path segment (matches MCP remote-client SAFE_ID_RE). */
+const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
 /** Servers safe to auto-spawn without product tenant credentials. */
 export const DEFAULT_SPAWN_SERVERS = ['contracts', 'docs'] as const;
@@ -171,9 +181,40 @@ function installAuditSink(hv: MCPHypervisor): void {
 }
 
 /**
- * Tenant credential resolver stub (phase 2).
- * Returns null so startServerForTenant fails closed until a real vault-backed
- * resolver lands. Process-local startServer still inherits process.env.
+ * Canonical revvault path for process-env credentials for a tenant MCP server.
+ * Value must be a JSON object of string env keys → string values.
+ */
+export function mcpTenantEnvVaultPath(tenantId: string, serverName: string): string {
+  return `mcp/${tenantId}/${serverName}/env`;
+}
+
+/**
+ * Parse vault blob into env map. Rejects non-objects and non-string values.
+ */
+export function parseTenantEnvBlob(raw: string): Record<string, string> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof key !== 'string' || key.length === 0) continue;
+    if (typeof value !== 'string') {
+      return null;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Tenant credential resolver stub (phase 2 / tests).
+ * Always returns null (no tenant env). Prefer {@link createVaultCredentialResolver}.
  */
 export function createStubCredentialResolver(): MCPCredentialResolver {
   return {
@@ -183,6 +224,69 @@ export function createStubCredentialResolver(): MCPCredentialResolver {
         serverName,
       });
       return null;
+    },
+  };
+}
+
+export interface VaultCredentialResolverOptions {
+  /** Injected vault (tests use memory vault). Default: revvault CLI vault. */
+  vault?: Vault;
+}
+
+/**
+ * Vault-backed credential resolver (GAP-406 phase 3).
+ *
+ * Reads `mcp/<tenantId>/<serverName>/env` as JSON `Record<string, string>`.
+ * Returns null when path missing, ids unsafe, server not allowlisted, blob
+ * invalid, or vault errors (logged).
+ */
+export function createVaultCredentialResolver(
+  options: VaultCredentialResolverOptions = {},
+): MCPCredentialResolver {
+  const vault = options.vault ?? createRevvaultVault();
+
+  return {
+    async resolve(tenantId: string, serverName: string): Promise<Record<string, string> | null> {
+      if (!(SAFE_ID_RE.test(tenantId) && SAFE_ID_RE.test(serverName))) {
+        logger.warn('[mcp-hypervisor-wire] reject unsafe tenant/server id for vault resolve', {
+          tenantId,
+          serverName,
+        });
+        return null;
+      }
+      if (!SPAWN_ALLOWLIST.has(serverName)) {
+        logger.debug('[mcp-hypervisor-wire] server not on spawn allowlist; no vault env', {
+          serverName,
+        });
+        return null;
+      }
+
+      const path = mcpTenantEnvVaultPath(tenantId, serverName);
+      let raw: string | undefined;
+      try {
+        raw = await vault.get(path);
+      } catch (error) {
+        logger.warn('[mcp-hypervisor-wire] vault get failed for tenant env', {
+          path,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+
+      if (raw === undefined || raw.trim() === '') {
+        logger.debug('[mcp-hypervisor-wire] no vault env for tenant server', { path });
+        return null;
+      }
+
+      const envMap = parseTenantEnvBlob(raw);
+      if (!envMap) {
+        logger.warn('[mcp-hypervisor-wire] invalid vault env JSON (expect object of strings)', {
+          path,
+        });
+        return null;
+      }
+
+      return envMap;
     },
   };
 }
@@ -205,8 +309,6 @@ async function registerAndStartServers(hv: MCPHypervisor, env: NodeJS.ProcessEnv
     return;
   }
 
-  hv.setCredentialResolver(createStubCredentialResolver());
-
   for (const name of servers) {
     const config = buildServerConfig(name, cliPath);
     hv.registerServer(config);
@@ -223,11 +325,12 @@ async function registerAndStartServers(hv: MCPHypervisor, env: NodeJS.ProcessEnv
 }
 
 /**
- * Wire sinks (and optional spawn) when enabled.
+ * Wire sinks, vault credential resolver, and optional spawn when enabled.
  * Returns true when phase-1 wiring ran.
  */
 export async function wireMcpHypervisorIfEnabled(
   env: NodeJS.ProcessEnv = process.env,
+  options: VaultCredentialResolverOptions = {},
 ): Promise<boolean> {
   if (!isMcpHypervisorWireEnabled(env)) {
     return false;
@@ -236,8 +339,11 @@ export async function wireMcpHypervisorIfEnabled(
   const hv = MCPHypervisor.getInstance();
   installMeterSink(hv);
   installAuditSink(hv);
+  hv.setCredentialResolver(createVaultCredentialResolver(options));
 
-  logger.info('[mcp-hypervisor-wire] GAP-406 phase 1: meter + audit sinks installed');
+  logger.info(
+    '[mcp-hypervisor-wire] GAP-406 phase 1+3: meter + audit sinks + vault credential resolver',
+  );
 
   if (isMcpHypervisorSpawnEnabled(env)) {
     await registerAndStartServers(hv, env);

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -558,8 +558,8 @@ Workspace: ${workspaceId}`,
   };
 
   // GAP-406 phase 4: opt-in skills + agent event logger (env-gated wire modules).
-  const skillProvider = createSkillProviderIfEnabled();
-  const agentEventLogger = createAgentEventLoggerIfEnabled();
+  const skillProvider = await createSkillProviderIfEnabled();
+  const agentEventLogger = await createAgentEventLoggerIfEnabled();
   if (agentEventLogger) {
     agentEventLogger.logDecision({
       timestamp: Date.now(),

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -570,10 +570,12 @@ Workspace: ${workspaceId}`,
     });
   }
 
+  // skillProvider is loaded via dynamic import (boundary); cast through never
+  // so RuntimeConfig accepts it without a static @revealui/ai/skills type import.
   const runtime = new streamingRuntimeMod.StreamingAgentRuntime({
     maxIterations: 10,
     timeout: 120_000,
-    ...(skillProvider ? { skillProvider } : {}),
+    ...(skillProvider ? { skillProvider: skillProvider as never } : {}),
   });
 
   const auditStore = createAuditStore(getClient());

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -30,6 +30,8 @@ import {
 } from '../lib/agent-run-sessions.js';
 import { recordAgentMcpToolAudit } from '../lib/agent-tool-audit.js';
 import { applyAgentToolGovernance } from '../lib/agent-tool-governance.js';
+import { createAgentEventLoggerIfEnabled } from '../lib/ai-observability-wire.js';
+import { createSkillProviderIfEnabled } from '../lib/ai-skills-wire.js';
 import { createAuditStore } from '../lib/audit-signer.js';
 import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
 import { recordUsageMeter } from '../lib/metering.js';
@@ -555,9 +557,23 @@ Workspace: ${workspaceId}`,
     description: body.instruction,
   };
 
+  // GAP-406 phase 4: opt-in skills + agent event logger (env-gated wire modules).
+  const skillProvider = createSkillProviderIfEnabled();
+  const agentEventLogger = createAgentEventLoggerIfEnabled();
+  if (agentEventLogger) {
+    agentEventLogger.logDecision({
+      timestamp: Date.now(),
+      agentId: mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent',
+      sessionId: runSession.sessionId,
+      reasoning: `agent_stream_start mode=${mode}`,
+      context: { mode },
+    });
+  }
+
   const runtime = new streamingRuntimeMod.StreamingAgentRuntime({
     maxIterations: 10,
     timeout: 120_000,
+    ...(skillProvider ? { skillProvider } : {}),
   });
 
   const auditStore = createAuditStore(getClient());

--- a/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+++ b/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
@@ -47,7 +47,7 @@ Marketing and package copy still describe the MCP hypervisor as the live agent t
 
 ## Progress — GAP-406 WIRE (2026-07-24)
 
-**Partial WIRE of MCPHypervisor** (sinks + opt-in process-local spawn):
+**WIRE train** (opt-in; default process still no-op when env unset):
 
 | Item | Status |
 |------|--------|
@@ -55,15 +55,16 @@ Marketing and package copy still describe the MCP hypervisor as the live agent t
 | `setUsageMeterSink` → `usage_meters` | Shipped when `tenantId` present on event |
 | `setAuditSink` → `recordMcpToolAudit` | Shipped |
 | Process-local spawn | Phase 2: `REVEALUI_MCP_HYPERVISOR_SPAWN=1`; default servers `contracts,docs`; override via `REVEALUI_MCP_HYPERVISOR_SERVERS` |
-| Credential resolver | Stub returns `null` (tenant spawn closed); process-local children inherit `process.env` |
-| `@revealui/ai/skills` / `observability` app mount | Still incubating |
+| Credential resolver | Phase 3: vault path `mcp/<tenant>/<server>/env` (JSON env map); missing → null |
+| `@revealui/ai/skills` | Phase 4: `REVEALUI_AI_SKILLS=1` → `AgentSkillProvider` on agent-stream runtime |
+| `@revealui/ai/observability` | Phase 4: `REVEALUI_AI_OBSERVABILITY=1` → `AgentEventLogger` on agent-stream start |
 
-`validate:incubate-posture` allowlists only `mcp-hypervisor-wire.ts` for Hypervisor imports.
+`validate:incubate-posture` allowlists wire modules under `apps/server/src/lib/*-wire.ts` (and agent-stream consumer for skills/observability).
 
 ## Verification
 
-- No production import of `MCPHypervisor.getInstance` / constructor under `apps/` (code-over-docs).
-- No production import of `@revealui/ai/skills` or `@revealui/ai/observability` under `apps/`.
-- File headers and package README/index comments state incubating posture (same change set).
-- **Phase 6 gate:** `pnpm validate:incubate-posture` (CI phase 1 + Quality job) fails if apps mount these surfaces without a WIRE train. Standing ticket: GAP-406.
+- Production mounts of incubating surfaces go only through allowlisted GAP-406 wire modules (env-gated).
+- Package headers still note library surfaces; app default remains off without env flags.
+- **Phase 6 gate:** `pnpm validate:incubate-posture` fails on non-allowlisted app imports. Standing ticket: GAP-406 (close when residual product follow-ups done or abandoned).
 - **Clone advisory:** `pnpm audit:clones` reports exact multi-file clones under `packages/` (optional prevention; advisory exit 0).
+- **Follow-up (not this train):** tenant spawn env isolation (avoid host `process.env` merge); deeper skill catalog install; durable event storage for observability.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -105,6 +105,11 @@
       "import": "./dist/skills/registry/index.js",
       "default": "./dist/skills/registry/index.js"
     },
+    "./observability": {
+      "types": "./dist/observability/index.d.ts",
+      "import": "./dist/observability/index.js",
+      "default": "./dist/observability/index.js"
+    },
     "./llm/cache-utils": {
       "types": "./dist/llm/cache-utils.d.ts",
       "import": "./dist/llm/cache-utils.js",

--- a/packages/ai/src/observability/export.ts
+++ b/packages/ai/src/observability/export.ts
@@ -76,7 +76,7 @@ export function exportToCSV(events: AnyAgentEvent[]): string {
     const row: string[] = [];
 
     for (const column of columns) {
-      const value = (event as Record<string, unknown>)[column];
+      const value = (event as unknown as Record<string, unknown>)[column];
       if (value === undefined || value === null) {
         row.push('');
       } else if (typeof value === 'string' && (value.includes(',') || value.includes('"'))) {

--- a/packages/ai/src/observability/instrumentation.ts
+++ b/packages/ai/src/observability/instrumentation.ts
@@ -101,7 +101,7 @@ export function logTaskDelegation(
   logger.logDecision({
     timestamp: Date.now(),
     agentId: selectedAgent.id,
-    sessionId: task.sessionId,
+    sessionId: 'session',
     taskId: task.id,
     reasoning,
     chosenTool: selectedAgent.name,
@@ -132,10 +132,10 @@ export async function instrumentTaskExecution<T extends AgentResult>(
     logger.logToolCall({
       timestamp: Date.now(),
       agentId,
-      sessionId: task.sessionId,
+      sessionId: 'session',
       taskId: task.id,
       toolName: `task:${task.type}`,
-      params: task.input as Record<string, unknown>,
+      params: (task.parameters ?? {}) as Record<string, unknown>,
       result: result.output,
       durationMs,
       success: result.success,
@@ -149,7 +149,7 @@ export async function instrumentTaskExecution<T extends AgentResult>(
     logger.logError({
       timestamp: Date.now(),
       agentId,
-      sessionId: task.sessionId,
+      sessionId: 'session',
       taskId: task.id,
       message: `Task execution failed: ${task.type}`,
       stack: error instanceof Error ? error.stack : undefined,
@@ -252,7 +252,7 @@ export const LLMCostCalculators = {
       'gpt-3.5-turbo': { input: 0.5, output: 1.5 },
     };
 
-    const price = prices[model] || prices['gpt-3.5-turbo'];
+    const price = prices[model] ?? prices['gpt-3.5-turbo'] ?? { input: 0.5, output: 1.5 };
     return (
       (usage.promptTokens / 1_000_000) * price.input +
       (usage.completionTokens / 1_000_000) * price.output
@@ -270,7 +270,7 @@ export const LLMCostCalculators = {
       'claude-3-haiku': { input: 0.25, output: 1.25 },
     };
 
-    const price = prices[model] || prices['claude-3-sonnet'];
+    const price = prices[model] ?? prices['claude-3-sonnet'] ?? { input: 3, output: 15 };
     return (
       (usage.promptTokens / 1_000_000) * price.input +
       (usage.completionTokens / 1_000_000) * price.output

--- a/packages/ai/src/observability/instrumentation.ts
+++ b/packages/ai/src/observability/instrumentation.ts
@@ -89,6 +89,32 @@ export function instrumentAgent(
 }
 
 /**
+ * Optional observability fields callers may attach to a Task (not on core Task).
+ */
+type TaskObservabilityFields = Task & {
+  sessionId?: string;
+  input?: unknown;
+};
+
+function taskSessionId(task: Task): string {
+  const sessionId = (task as TaskObservabilityFields).sessionId;
+  return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : 'session';
+}
+
+function taskInputParams(task: Task): Record<string, unknown> {
+  const extended = task as TaskObservabilityFields;
+  if (
+    extended.input !== undefined &&
+    extended.input !== null &&
+    typeof extended.input === 'object' &&
+    !Array.isArray(extended.input)
+  ) {
+    return extended.input as Record<string, unknown>;
+  }
+  return (task.parameters ?? {}) as Record<string, unknown>;
+}
+
+/**
  * Instrument a task delegation decision
  */
 export function logTaskDelegation(
@@ -101,7 +127,7 @@ export function logTaskDelegation(
   logger.logDecision({
     timestamp: Date.now(),
     agentId: selectedAgent.id,
-    sessionId: 'session',
+    sessionId: taskSessionId(task),
     taskId: task.id,
     reasoning,
     chosenTool: selectedAgent.name,
@@ -123,6 +149,7 @@ export async function instrumentTaskExecution<T extends AgentResult>(
   executor: () => Promise<T>,
 ): Promise<T> {
   const startTime = Date.now();
+  const sessionId = taskSessionId(task);
 
   try {
     const result = await executor();
@@ -132,10 +159,10 @@ export async function instrumentTaskExecution<T extends AgentResult>(
     logger.logToolCall({
       timestamp: Date.now(),
       agentId,
-      sessionId: 'session',
+      sessionId,
       taskId: task.id,
       toolName: `task:${task.type}`,
-      params: (task.parameters ?? {}) as Record<string, unknown>,
+      params: taskInputParams(task),
       result: result.output,
       durationMs,
       success: result.success,
@@ -149,7 +176,7 @@ export async function instrumentTaskExecution<T extends AgentResult>(
     logger.logError({
       timestamp: Date.now(),
       agentId,
-      sessionId: 'session',
+      sessionId,
       taskId: task.id,
       message: `Task execution failed: ${task.type}`,
       stack: error instanceof Error ? error.stack : undefined,

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -18,6 +18,7 @@
     "src/**/*.test.tsx",
     "src/**/*.spec.ts",
     "src/**/*.spec.tsx",
-    "src/observability/**/*"
+    "src/observability/examples.ts",
+    "src/observability/__tests__/**"
   ]
 }

--- a/scripts/validate/incubate-posture.ts
+++ b/scripts/validate/incubate-posture.ts
@@ -28,17 +28,13 @@ function isExemptAppPath(rel: string, label?: string): boolean {
   if (label === 'MCPHypervisor' && rel === 'apps/server/src/lib/mcp-hypervisor-wire.ts') {
     return true;
   }
-  if (
-    label === '@revealui/ai/skills' &&
-    (rel === 'apps/server/src/lib/ai-skills-wire.ts' ||
-      rel === 'apps/server/src/routes/agent-stream.ts')
-  ) {
+  // Dynamic import() strings still match needles; wire modules are the WIRE path.
+  if (label === '@revealui/ai/skills' && rel === 'apps/server/src/lib/ai-skills-wire.ts') {
     return true;
   }
   if (
     label === '@revealui/ai/observability' &&
-    (rel === 'apps/server/src/lib/ai-observability-wire.ts' ||
-      rel === 'apps/server/src/routes/agent-stream.ts')
+    rel === 'apps/server/src/lib/ai-observability-wire.ts'
   ) {
     return true;
   }

--- a/scripts/validate/incubate-posture.ts
+++ b/scripts/validate/incubate-posture.ts
@@ -24,8 +24,22 @@ function isExemptAppPath(rel: string, label?: string): boolean {
   if (lower.endsWith('.test.ts') || lower.endsWith('.test.tsx')) return true;
   if (lower.endsWith('.spec.ts') || lower.endsWith('.spec.tsx')) return true;
   if (lower.includes('/content/') || lower.includes('/public/')) return true;
-  // GAP-406 WIRE phase 1: sole allowed MCPHypervisor consumer (sink wire only).
+  // GAP-406 WIRE: sole allowed app mounts (env-gated wire modules + consumers).
   if (label === 'MCPHypervisor' && rel === 'apps/server/src/lib/mcp-hypervisor-wire.ts') {
+    return true;
+  }
+  if (
+    label === '@revealui/ai/skills' &&
+    (rel === 'apps/server/src/lib/ai-skills-wire.ts' ||
+      rel === 'apps/server/src/routes/agent-stream.ts')
+  ) {
+    return true;
+  }
+  if (
+    label === '@revealui/ai/observability' &&
+    (rel === 'apps/server/src/lib/ai-observability-wire.ts' ||
+      rel === 'apps/server/src/routes/agent-stream.ts')
+  ) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary

GAP-406 C11 residual after p1–p2 (#2131):

1. **Phase 3 — vault credential resolver** on `REVEALUI_MCP_HYPERVISOR=1`
   - Reads `mcp/<tenantId>/<serverName>/env` (JSON env map) via revvault
   - Installed with sinks (not only spawn path)
2. **Phase 4 — opt-in AI mounts** (dynamic Pro imports for boundary compliance)
   - `REVEALUI_AI_SKILLS=1` → `AgentSkillProvider` on agent-stream
   - `REVEALUI_AI_OBSERVABILITY=1` → `AgentEventLogger` on stream start
3. **Package:** export + compile `@revealui/ai/observability` (was tsconfig-excluded)
4. **ADR-007** progress + `.env.template` flags + incubate-posture allowlists

Default remains off when env flags unset.

## Test plan

- [x] `pnpm --filter server exec vitest run` wire unit tests (11)
- [x] `pnpm validate:incubate-posture`
- [x] `pnpm validate:boundary`
- [x] Pre-push phase 1 gate

## Owner

```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```