### PR TITLE
feat(ai,server): GAP-355 S6-4 dispatcher and job tool governance

### DIFF
--- a/apps/server/src/jobs/agent-dispatch.ts
+++ b/apps/server/src/jobs/agent-dispatch.ts
@@ -66,6 +66,13 @@ export interface AgentDispatchPayload extends Record<string, unknown> {
    */
   userId: string;
   /**
+   * Authenticated dispatcher's role at enqueue (GAP-355 S6-4). Server-captured
+   * from the session — never client-supplied as an untrusted field alone.
+   */
+  userRole?: string;
+  /** Account id at enqueue for audit tenant / principal. */
+  accountId?: string | null;
+  /**
    * Correlation id from the originating POST request. All logs from the
    * handler carry this so POST / worker / status-poll share a trace.
    */
@@ -135,8 +142,11 @@ export async function agentDispatchHandler(
 
   const dispatcher = await buildDispatcher(db, data.tenantId, {
     userId: dispatcherUserId,
+    userRole: data.userRole ?? null,
+    accountId: data.accountId ?? null,
     isHosted,
     workspaceId: data.tenantId,
+    asJob: true,
   });
   if (!dispatcher) {
     throw new Error(

--- a/apps/server/src/lib/__tests__/agent-tool-access.test.ts
+++ b/apps/server/src/lib/__tests__/agent-tool-access.test.ts
@@ -169,4 +169,26 @@ describe('authorizeAgentTool — dispatch principal', () => {
     });
     expect(authorizeAgentTool(p, 'file_read').allowed).toBe(true);
   });
+
+  it('allows ticket sidecars under admin ∩ for editor', () => {
+    const p = resolveDispatchPrincipal({
+      ticketId: 't1',
+      userId: 'u',
+      userRole: 'editor',
+    });
+    expect(authorizeAgentTool(p, 'add_ticket_comment').allowed).toBe(true);
+    expect(authorizeAgentTool(p, 'update_ticket_status').allowed).toBe(true);
+  });
+
+  it('denies ticket sidecars for viewer human role (∩)', () => {
+    const p = resolveDispatchPrincipal({
+      ticketId: 't1',
+      userId: 'u',
+      userRole: 'viewer',
+    });
+    expect(authorizeAgentTool(p, 'add_ticket_comment')).toMatchObject({
+      allowed: false,
+      reason: 'user_role_denied',
+    });
+  });
 });

--- a/apps/server/src/lib/agent-dispatcher.ts
+++ b/apps/server/src/lib/agent-dispatcher.ts
@@ -14,6 +14,8 @@
 import type { Database } from '@revealui/db/client';
 import * as commentQueries from '@revealui/db/queries/ticket-comments';
 import * as ticketQueries from '@revealui/db/queries/tickets';
+import { resolveDispatchPrincipal, resolveJobPrincipal } from './agent-principal.js';
+import { applyAgentToolGovernance } from './agent-tool-governance.js';
 import { createAuditStore } from './audit-signer.js';
 
 export interface DispatcherResult {
@@ -43,6 +45,19 @@ export interface DispatcherResolution {
   userId: string | null;
   isHosted: boolean;
   workspaceId?: string;
+  /**
+   * Authenticated dispatcher's role (`users.role`). Required for admin ∩
+   * human role checks (GAP-355 S6-4). When omitted, principal is agent-only
+   * and admin tools soft-deny.
+   */
+  userRole?: string | null;
+  /** Account for audit tenant / Stage 4 anchoring when known. */
+  accountId?: string | null;
+  /**
+   * When true, principal kind is `job` (durable queue). Default `dispatch`
+   * for synchronous POST.
+   */
+  asJob?: boolean;
 }
 
 export async function buildDispatcher(
@@ -93,13 +108,43 @@ export async function buildDispatcher(
   const adminBaseUrl = process.env.ADMIN_URL ?? process.env.NEXT_PUBLIC_ADMIN_URL;
   const apiClient = buildCMSClient(adminBaseUrl);
 
+  // GAP-355 S6-4: pre-authorize admin/ticket tools at dispatch via wrapTools.
+  type DispatcherConfig = ConstructorParameters<typeof aiMod.TicketAgentDispatcher>[0];
+
+  const wrapTools: NonNullable<DispatcherConfig['wrapTools']> = (tools, ctx) => {
+    const principal = resolution.asJob
+      ? resolveJobPrincipal({
+          agentId: `ticket-agent-${ctx.ticketId}`,
+          userId: resolution.userId,
+          userRole: resolution.userRole,
+          tenantId: resolution.workspaceId ?? null,
+          accountId: resolution.accountId ?? null,
+        })
+      : resolveDispatchPrincipal({
+          ticketId: ctx.ticketId,
+          userId: resolution.userId,
+          userRole: resolution.userRole,
+          workspaceId: resolution.workspaceId,
+          accountId: resolution.accountId,
+        });
+
+    return applyAgentToolGovernance(tools, {
+      principal,
+      namespace: resolution.asJob ? 'ticket-job' : 'ticket-dispatch',
+      sessionId: ctx.dispatchId,
+      accountId: resolution.accountId ?? null,
+      userId: resolution.userId,
+      taskId: ctx.ticketId,
+    }) as typeof tools;
+  };
+
   // Type assertions: TicketAgentDispatcher comes from the Pro package via
   // dynamic import; the runtime shape matches Dispatcher.
-  type DispatcherConfig = ConstructorParameters<typeof aiMod.TicketAgentDispatcher>[0];
   const inner = new aiMod.TicketAgentDispatcher({
     llmClient: llmClient as DispatcherConfig['llmClient'],
     apiClient,
     ticketClient,
+    wrapTools,
   }) as unknown as Dispatcher;
 
   // GAP-355 Stage 5: wrap dispatch with task lifecycle audit rows (ONE DOOR).
@@ -108,19 +153,37 @@ export async function buildDispatcher(
 
   return {
     async dispatch(ticket, options) {
+      const principal = resolution.asJob
+        ? resolveJobPrincipal({
+            agentId: `ticket-agent-${ticket.id}`,
+            userId: resolution.userId,
+            userRole: resolution.userRole,
+            tenantId: resolution.workspaceId ?? null,
+            accountId: resolution.accountId ?? null,
+          })
+        : resolveDispatchPrincipal({
+            ticketId: ticket.id,
+            userId: resolution.userId,
+            userRole: resolution.userRole,
+            workspaceId: resolution.workspaceId,
+            accountId: resolution.accountId,
+          });
+
       const startId = crypto.randomUUID();
       await auditStore.append({
         id: startId,
         timestamp: new Date(),
         eventType: 'agent:task:started',
         severity: 'info',
-        agentId: 'ticket-agent-dispatcher',
+        agentId: principal.agentId,
         taskId: ticket.id,
         sessionId: options?.dispatchId,
         payload: {
           title: ticket.title,
           userId: resolution.userId,
           isHosted: resolution.isHosted,
+          roles: principal.roles,
+          kind: principal.kind,
         },
         policyViolations: [],
         tenant,
@@ -133,7 +196,7 @@ export async function buildDispatcher(
           timestamp: new Date(),
           eventType: result.success ? 'agent:task:completed' : 'agent:task:failed',
           severity: result.success ? 'info' : 'warn',
-          agentId: 'ticket-agent-dispatcher',
+          agentId: principal.agentId,
           taskId: ticket.id,
           sessionId: options?.dispatchId,
           payload: {
@@ -152,7 +215,7 @@ export async function buildDispatcher(
             timestamp: new Date(),
             eventType: 'agent:task:failed',
             severity: 'warn',
-            agentId: 'ticket-agent-dispatcher',
+            agentId: principal.agentId,
             taskId: ticket.id,
             sessionId: options?.dispatchId,
             payload: {

--- a/apps/server/src/lib/agent-tool-access.ts
+++ b/apps/server/src/lib/agent-tool-access.ts
@@ -63,6 +63,9 @@ export const AGENT_TOOL_CATALOG: readonly AgentToolMeta[] = [
   { name: 'create_user', surface: 'admin', class: 'admin-pii' },
   { name: 'update_user', surface: 'admin', class: 'admin-pii' },
   { name: 'delete_user', surface: 'admin', class: 'admin-pii' },
+  // Ticket agent sidecars (S6-4 — TicketAgentDispatcher)
+  { name: 'update_ticket_status', surface: 'admin', class: 'mutate' },
+  { name: 'add_ticket_comment', surface: 'admin', class: 'mutate' },
   // Coding
   { name: 'file_read', surface: 'coding', class: 'read' },
   { name: 'file_glob', surface: 'coding', class: 'read' },
@@ -74,6 +77,9 @@ export const AGENT_TOOL_CATALOG: readonly AgentToolMeta[] = [
   { name: 'git_ops', surface: 'coding', class: 'exec' },
   { name: 'test_runner', surface: 'coding', class: 'exec' },
   { name: 'lint_fix', surface: 'coding', class: 'exec' },
+  // Dispatch extras (read-class; no shell)
+  { name: 'web_scrape', surface: 'coding', class: 'read' },
+  { name: 'document_summarize', surface: 'coding', class: 'read' },
 ] as const;
 
 const TOOL_BY_NAME = new Map(AGENT_TOOL_CATALOG.map((t) => [t.name, t]));

--- a/apps/server/src/routes/agent-tasks.ts
+++ b/apps/server/src/routes/agent-tasks.ts
@@ -40,6 +40,7 @@ import type { AgentDispatchOutput, AgentDispatchPayload } from '../jobs/agent-di
 import { buildDispatcher, type Dispatcher } from '../lib/agent-dispatcher.js';
 import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
 import { detectDeploymentMode, type EnvMap } from '../lib/validate-startup.js';
+import { getEntitlementsFromContext } from '../middleware/entitlements.js';
 
 type Variables = {
   db: DatabaseClient;
@@ -85,7 +86,8 @@ const LLMNotConfiguredSchema = z.object({
 async function buildDispatcherOr409(
   db: DatabaseClient,
   tenantId: string | undefined,
-  userId: string,
+  user: { id: string; role: string },
+  accountId?: string | null,
 ): Promise<
   | { ok: true; dispatcher: Dispatcher | null }
   | {
@@ -95,7 +97,9 @@ async function buildDispatcherOr409(
 > {
   try {
     const dispatcher = await buildDispatcher(db, tenantId, {
-      userId,
+      userId: user.id,
+      userRole: user.role,
+      accountId: accountId ?? null,
       isHosted: detectDeploymentMode(process.env as EnvMap) === 'hosted',
       workspaceId: tenantId,
     });
@@ -217,7 +221,14 @@ app.openapi(
 
     // --- Durable dispatch path (flag on) ---
     if (isDurableDispatchEnabled()) {
-      const outcome = await runDurableDispatch(db, ticket, user, tenant, c.get('requestId'));
+      const outcome = await runDurableDispatch(
+        db,
+        ticket,
+        user,
+        tenant,
+        c.get('requestId'),
+        getEntitlementsFromContext(c).accountId,
+      );
       if (outcome.kind === 'complete') {
         return c.json(
           {
@@ -248,7 +259,12 @@ app.openapi(
     }
 
     // --- Legacy sync path (flag off) ---
-    const built = await buildDispatcherOr409(db, tenant?.id, user.id);
+    const built = await buildDispatcherOr409(
+      db,
+      tenant?.id,
+      user,
+      getEntitlementsFromContext(c).accountId,
+    );
     if (!built.ok) {
       await ticketQueries.updateTicket(db, ticket.id, { status: 'open' });
       return c.json(built.body, 409);
@@ -342,7 +358,14 @@ app.openapi(
     // --- Durable dispatch path ---
     if (isDurableDispatchEnabled()) {
       await ticketQueries.updateTicket(db, ticketId, { status: 'in_progress' });
-      const outcome = await runDurableDispatch(db, ticket, user, tenant, c.get('requestId'));
+      const outcome = await runDurableDispatch(
+        db,
+        ticket,
+        user,
+        tenant,
+        c.get('requestId'),
+        getEntitlementsFromContext(c).accountId,
+      );
       if (outcome.kind === 'complete') {
         return c.json(
           {
@@ -371,7 +394,12 @@ app.openapi(
     }
 
     // --- Legacy sync path ---
-    const built = await buildDispatcherOr409(db, tenant?.id, user.id);
+    const built = await buildDispatcherOr409(
+      db,
+      tenant?.id,
+      user,
+      getEntitlementsFromContext(c).accountId,
+    );
     if (!built.ok) {
       return c.json(built.body, 409);
     }
@@ -514,9 +542,10 @@ type DispatchOutcome =
 async function runDurableDispatch(
   db: DatabaseClient,
   ticket: { id: string },
-  user: { id: string },
+  user: { id: string; role: string },
   tenant: { id: string } | undefined,
   requestId: string | undefined,
+  accountId?: string | null,
 ): Promise<DispatchOutcome> {
   const jobId = jobIdForTicket(ticket.id);
 
@@ -526,6 +555,8 @@ async function runDurableDispatch(
       ticketId: ticket.id,
       tenantId: tenant?.id,
       userId: user.id,
+      userRole: user.role,
+      accountId: accountId ?? null,
       requestId,
     },
     { idempotencyKey: jobId, retryLimit: 3 },

--- a/packages/ai/src/orchestration/ticket-agent.ts
+++ b/packages/ai/src/orchestration/ticket-agent.ts
@@ -22,6 +22,7 @@ import type {
   GlobalMetadata,
 } from '../tools/admin/factory.js';
 import { createAdminTools } from '../tools/admin/factory.js';
+import type { Tool } from '../tools/base.js';
 import { createDocumentSummarizerTool } from '../tools/document-summarizer.js';
 import type { TicketMutationClient } from '../tools/ticket-tools.js';
 import { createTicketTools } from '../tools/ticket-tools.js';
@@ -72,6 +73,13 @@ export interface TicketAgentConfig {
 
   /** Timeout in ms (default: 120_000) */
   timeout?: number;
+
+  /**
+   * Optional tool transform after the tool set is assembled (GAP-355 S6-4).
+   * Server injects pre-authorize wraps without `@revealui/ai` importing server.
+   * Called once per dispatch with the ticket id and optional dispatchId.
+   */
+  wrapTools?: (tools: Tool[], ctx: { ticketId: string; dispatchId?: string }) => Tool[];
 }
 
 /**
@@ -170,7 +178,13 @@ export class TicketAgentDispatcher {
     const extraTools = db
       ? [webScraperTool, createDocumentSummarizerTool(db, this.config.llmClient)]
       : [webScraperTool];
-    const tools = [...cmsTools, ...ticketTools, ...extraTools];
+    let tools: Tool[] = [...cmsTools, ...ticketTools, ...extraTools];
+    if (this.config.wrapTools) {
+      tools = this.config.wrapTools(tools, {
+        ticketId: ticket.id,
+        ...(options.dispatchId !== undefined ? { dispatchId: options.dispatchId } : {}),
+      });
+    }
 
     // The runtime does not call agent.memory  -  satisfy the interface with a stub when no
     // shared memory instance is provided. Cast is safe: only runtime touches this field.

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,6 +1,9 @@
 import { createVitestConfig } from '@revealui/dev/vitest';
 
 export default createVitestConfig({
+  // PGlite cold start (knowledge-graph-factory + rate-limit-store) regularly
+  // exceeds vitest's 5s default on CI runners; match @revealui/knowledge-graph.
+  testTimeout: 30_000,
   hookTimeout: 30_000,
   include: ['__tests__/**/*.test.ts', 'src/**/*.test.ts'],
   coverageExclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/__tests__/**'],

--- a/scripts/validate/agent-audit-chokepoints.json
+++ b/scripts/validate/agent-audit-chokepoints.json
@@ -39,7 +39,14 @@
     {
       "id": "agent-dispatcher-task-lifecycle",
       "file": "apps/server/src/lib/agent-dispatcher.ts",
-      "mustContain": ["agent:task:started", "agent:task:completed", "createAuditStore"]
+      "mustContain": [
+        "agent:task:started",
+        "agent:task:completed",
+        "createAuditStore",
+        "wrapTools",
+        "applyAgentToolGovernance",
+        "resolveDispatchPrincipal"
+      ]
     },
     {
       "id": "agent-stream-mcp-and-native-tools",


### PR DESCRIPTION
## Summary

GAP-355 Stage 6 **S6-4**: pre-authorize ticket dispatch (sync + durable job) the same way as agent-stream.

### Changes
- `TicketAgentDispatcher`: optional `wrapTools(tools, { ticketId, dispatchId })` after tool assembly
- `buildDispatcher`: injects `applyAgentToolGovernance` with `resolveDispatchPrincipal` / `resolveJobPrincipal` (`asJob` for queue)
- Task lifecycle audit rows use principal `agentId` + roles/kind in start payload
- Catalog: `update_ticket_status`, `add_ticket_comment`, `web_scrape`, `document_summarize`
- Enqueue payload: `userRole`, `accountId` (server-captured)
- `agent-tasks` passes session user role + entitlement accountId

### Not in this PR
- S6-5 authorize CI checklist expansion (chokepoint markers already require wrapTools on dispatcher)
- S6-6 claims (hold foil)

## Security
Agent authz on dispatch path. **Non-author guardrail-2.** Owner merges.

## Test plan
- [x] agent-tool-access tests (23) including ticket sidecars ∩
- [x] validate:agent-audit-chokepoints
- [x] pre-push phase-1
- [ ] CI green
- [ ] Non-author security review