### PR TITLE
feat(ci): GAP-355 S6-5 agent authorize chokepoint checklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "validate:as-never-values": "tsx scripts/validate/as-never-values.ts",
     "validate:audit-one-door": "tsx scripts/validate/audit-log-single-door.ts",
     "validate:agent-audit-chokepoints": "tsx scripts/validate/agent-audit-chokepoints.ts",
+    "validate:agent-authorize-chokepoints": "tsx scripts/validate/agent-authorize-chokepoints.ts",
     "validate:kek-rotation": "vitest run scripts/security/__tests__/rotate-kek.test.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
     "validate:prod-env": "tsx scripts/validate/prod-env.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -432,6 +432,12 @@ async function gate(): Promise<void> {
         args: ['validate:agent-audit-chokepoints'],
       },
       {
+        // GAP-355 S6-5: named agent chokepoints must still pre-authorize tools.
+        name: 'agent authorize chokepoints (hard fail)',
+        command: 'pnpm',
+        args: ['validate:agent-authorize-chokepoints'],
+      },
+      {
         name: 'Stripe-client consolidation (hard fail)',
         command: 'pnpm',
         args: ['validate:stripe-client'],

--- a/scripts/validate/agent-authorize-chokepoints.json
+++ b/scripts/validate/agent-authorize-chokepoints.json
@@ -1,0 +1,71 @@
+{
+  "$comment": "GAP-355 Stage 6 S6-5 — mechanical checklist that named agent execution chokepoints still pre-authorize tools (deny-by-default). Sibling to agent-audit-chokepoints.json (integrity audit). Literal substring matches only (no regex). Design: .jv gap-specs/GAP-355-stage6-govern-agents-design.md.",
+  "chokepoints": [
+    {
+      "id": "agent-principal-resolvers",
+      "file": "apps/server/src/lib/agent-principal.ts",
+      "mustContain": [
+        "AgentPrincipal",
+        "resolveStreamPrincipal",
+        "resolveDispatchPrincipal",
+        "resolveJobPrincipal"
+      ]
+    },
+    {
+      "id": "agent-tool-access-matrix",
+      "file": "apps/server/src/lib/agent-tool-access.ts",
+      "mustContain": ["authorizeAgentTool", "agent:tool:"]
+    },
+    {
+      "id": "agent-tool-governance-wrap",
+      "file": "apps/server/src/lib/agent-tool-governance.ts",
+      "mustContain": [
+        "applyAgentToolGovernance",
+        "authorizeAgentTool",
+        "recordAgentToolDenied"
+      ]
+    },
+    {
+      "id": "tool-governance-wrapper",
+      "file": "packages/ai/src/tools/governance.ts",
+      "mustContain": ["wrapToolWithGovernance", "Permission denied"]
+    },
+    {
+      "id": "agent-stream-pre-authorize",
+      "file": "apps/server/src/routes/agent-stream.ts",
+      "mustContain": [
+        "resolveStreamPrincipal",
+        "applyAgentToolGovernance"
+      ]
+    },
+    {
+      "id": "agent-dispatcher-pre-authorize",
+      "file": "apps/server/src/lib/agent-dispatcher.ts",
+      "mustContain": [
+        "resolveDispatchPrincipal",
+        "resolveJobPrincipal",
+        "applyAgentToolGovernance"
+      ]
+    },
+    {
+      "id": "agent-dispatch-job-uses-dispatcher",
+      "file": "apps/server/src/jobs/agent-dispatch.ts",
+      "mustContain": ["buildDispatcher", "userRole"]
+    },
+    {
+      "id": "agent-tool-denied-receipt",
+      "file": "apps/server/src/lib/agent-tool-audit.ts",
+      "mustContain": ["recordAgentToolDenied", "agent:tool:denied"]
+    }
+  ],
+  "residuals": [
+    {
+      "id": "governed-mcp-uses-mcp-tool-access",
+      "note": "Governed /api/mcp remains on mcp-tool-access (role+tier), not authorizeAgentTool. Intentional gold path — do not dual-gate without a design pass."
+    },
+    {
+      "id": "s6-6-claims-hold",
+      "note": "S6-6 marketing foil remains owner-gated until Stage 6 product acceptance is fully green."
+    }
+  ]
+}

--- a/scripts/validate/agent-authorize-chokepoints.json
+++ b/scripts/validate/agent-authorize-chokepoints.json
@@ -19,11 +19,7 @@
     {
       "id": "agent-tool-governance-wrap",
       "file": "apps/server/src/lib/agent-tool-governance.ts",
-      "mustContain": [
-        "applyAgentToolGovernance",
-        "authorizeAgentTool",
-        "recordAgentToolDenied"
-      ]
+      "mustContain": ["applyAgentToolGovernance", "authorizeAgentTool", "recordAgentToolDenied"]
     },
     {
       "id": "tool-governance-wrapper",
@@ -33,19 +29,12 @@
     {
       "id": "agent-stream-pre-authorize",
       "file": "apps/server/src/routes/agent-stream.ts",
-      "mustContain": [
-        "resolveStreamPrincipal",
-        "applyAgentToolGovernance"
-      ]
+      "mustContain": ["resolveStreamPrincipal", "applyAgentToolGovernance"]
     },
     {
       "id": "agent-dispatcher-pre-authorize",
       "file": "apps/server/src/lib/agent-dispatcher.ts",
-      "mustContain": [
-        "resolveDispatchPrincipal",
-        "resolveJobPrincipal",
-        "applyAgentToolGovernance"
-      ]
+      "mustContain": ["resolveDispatchPrincipal", "resolveJobPrincipal", "applyAgentToolGovernance"]
     },
     {
       "id": "agent-dispatch-job-uses-dispatcher",

--- a/scripts/validate/agent-authorize-chokepoints.ts
+++ b/scripts/validate/agent-authorize-chokepoints.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env tsx
+// console-allowed
+
+/**
+ * GAP-355 Stage 6 S6-5 — agent authorize chokepoint checklist.
+ *
+ * Ensures named agent execution surfaces still pre-authorize tools
+ * (substring presence in source files). Sibling of
+ * `agent-audit-chokepoints.ts` (integrity audit after execute): this gate
+ * guards WHERE authorize / governance wrap must remain.
+ *
+ * Config: scripts/validate/agent-authorize-chokepoints.json
+ * Matching is literal `includes` only (no authored regex).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+const CONFIG_PATH = join(REPO_ROOT, 'scripts/validate/agent-authorize-chokepoints.json');
+
+interface Chokepoint {
+  id: string;
+  file: string;
+  mustContain: string[];
+}
+
+interface Residual {
+  id: string;
+  note: string;
+}
+
+interface Config {
+  chokepoints: Chokepoint[];
+  residuals?: Residual[];
+}
+
+function loadConfig(): Config {
+  if (!existsSync(CONFIG_PATH)) {
+    throw new Error(`Missing config: ${CONFIG_PATH}`);
+  }
+  return JSON.parse(readFileSync(CONFIG_PATH, 'utf8')) as Config;
+}
+
+function main(): number {
+  const config = loadConfig();
+  const failures: string[] = [];
+
+  out('============================================================');
+  out('GAP-355 Stage 6 — agent authorize chokepoint checklist');
+  out('============================================================');
+
+  for (const cp of config.chokepoints) {
+    const abs = join(REPO_ROOT, cp.file);
+    if (!existsSync(abs)) {
+      failures.push(`[${cp.id}] missing file: ${cp.file}`);
+      out(`  ✗ ${cp.id} — file missing (${cp.file})`);
+      continue;
+    }
+    const src = readFileSync(abs, 'utf8');
+    const missing = cp.mustContain.filter((needle) => !src.includes(needle));
+    if (missing.length > 0) {
+      failures.push(`[${cp.id}] missing markers in ${cp.file}: ${missing.join(', ')}`);
+      out(`  ✗ ${cp.id} — missing: ${missing.join(', ')}`);
+    } else {
+      out(`  ✓ ${cp.id}`);
+    }
+  }
+
+  if (config.residuals && config.residuals.length > 0) {
+    out('');
+    out('Documented residuals (informational):');
+    for (const r of config.residuals) {
+      out(`  · ${r.id}: ${r.note}`);
+    }
+  }
+
+  out('');
+  if (failures.length > 0) {
+    out(`Result: FAIL (${failures.length} chokepoint(s))`);
+    for (const f of failures) out(`  - ${f}`);
+    return 1;
+  }
+
+  out(`Result: PASS (${config.chokepoints.length} chokepoints)`);
+  return 0;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

GAP-355 **Stage 6 S6-5** — CI checklist that named agent execution chokepoints still **pre-authorize** tools (sibling to Stage 5 `agent-audit-chokepoints`).

### Added
- `scripts/validate/agent-authorize-chokepoints.ts` + `.json` (literal substring markers; no regex)
- `pnpm validate:agent-authorize-chokepoints`
- Phase-1 `ci-gate` hard-fail entry next to agent-audit chokepoints

### Chokepoints covered (8)
| id | Surface |
|----|---------|
| agent-principal-resolvers | stream / dispatch / job principal constructors |
| agent-tool-access-matrix | `authorizeAgentTool` |
| agent-tool-governance-wrap | `applyAgentToolGovernance` + deny audit |
| tool-governance-wrapper | `packages/ai` `wrapToolWithGovernance` |
| agent-stream-pre-authorize | stream principal + governance wrap |
| agent-dispatcher-pre-authorize | dispatch + job principal + governance |
| agent-dispatch-job-uses-dispatcher | durable job → `buildDispatcher` |
| agent-tool-denied-receipt | `agent:tool:denied` |

### Residuals (documented in JSON)
- Governed MCP stays on `mcp-tool-access` (intentional)
- S6-6 claims foil remains owner-gated

### Non-goals
- No product authorize logic changes (S6-1…S6-4 already on `test` via #2128/#2130/#2135)
- Does not expand marketing claims

## Test plan
- [x] `tsx scripts/validate/agent-authorize-chokepoints.ts` → PASS (8)
- [x] S5 audit checklist still PASS (13)
- [ ] CI Quality / Unit Tests on PR

## Owner
```bash
gh pr merge <N> -R RevealUIStudio/revealui --merge
```

Design: `.jv` `docs/gap-specs/GAP-355-stage6-govern-agents-design.md` §5 S6-5.