### PR TITLE
feat(core,admin,server): GAP-260 P4-1 REVEALUI_DEPLOYMENT_MODE

### DIFF
--- a/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/page.tsx
@@ -1,18 +1,19 @@
 /**
  * Settings, API Keys — server shell.
  *
- * Resolves the GAP-360 hosted flag server-side (same signal as
- * `app/api/chat/route.ts:315` — `REVEALUI_LICENSE_PRIVATE_KEY` presence)
+ * Resolves the GAP-360 hosted flag server-side via detectDeploymentMode
+ * (GAP-260 P4-1: REVEALUI_DEPLOYMENT_MODE, fallback private-key presence)
  * and the provider list to offer, then hands both down to the client page.
  * The boolean crosses the server/client boundary; the env var itself never
  * does.
  */
 
+import { isHostedDeployment } from '@revealui/core/deployment-mode';
 import { visibleProviders } from '@/lib/settings/api-key-providers';
 import ApiKeysPageClient from './api-keys-client';
 
 export default async function ApiKeysPage() {
-  const isHosted = !!process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+  const isHosted = isHostedDeployment(process.env);
 
   // @revealui/ai is an optional Pro peer dependency of apps/admin — dynamic
   // import + catch, matching every other consumer (src/lib/ai/pro-stub.ts).

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -105,9 +105,9 @@ export async function GET(
     // Enforce user limit for new OAuth signups (CR5-2).
     // Only check if this OAuth identity doesn't already map to a user. The
     // deployment-license cap is a self-hosted (Forge) concept; hosted admission
-    // is per-account, so a deployment-global seat cap must not gate hosted OAuth
-    // onboarding (mirrors the password sign-up route + apps/server validate-startup).
-    const isSelfHostedForge = !process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    // is per-account (GAP-260 P4-1 MODE / detectDeploymentMode).
+    const { detectDeploymentMode } = await import('@revealui/core/deployment-mode');
+    const isSelfHostedForge = detectDeploymentMode(process.env) === 'forge';
     try {
       await initializeLicense();
       const maxUsers = getMaxUsers();

--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -116,11 +116,10 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
 
       // The deployment-license user cap is a self-hosted (Forge) concept and must
       // NOT gate hosted onboarding. A global active-user count would cap the whole
-      // control plane at the free seat count. Mirrors apps/server validate-startup
-      // and the password sign-up route: license-signing-key presence ⇒ hosted
-      // multi-tenant mode, where admission is governed per-account, not by a
-      // deployment-global seat count.
-      const isSelfHostedForge = !process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+      // control plane at the free seat count. Mode: REVEALUI_DEPLOYMENT_MODE
+      // (GAP-260 P4-1) with private-key fallback — hosted is per-account admission.
+      const { detectDeploymentMode } = await import('@revealui/core/deployment-mode');
+      const isSelfHostedForge = detectDeploymentMode(process.env) === 'forge';
       // Enforce user limit based on license tier (R5-H11 fix  -  was missing from passkey flow)
       try {
         await initializeLicense();

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -109,10 +109,10 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
 
     // The deployment-license user cap is a self-hosted (Forge) concept and must
     // NOT gate hosted onboarding (it would cap the whole control plane at the
-    // free seat count). Mode detection mirrors apps/server validate-startup:
-    // license-signing-key presence ⇒ hosted multi-tenant deployment, where
-    // admission is governed per-account rather than by a deployment-global cap.
-    const isSelfHostedForge = !process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    // free seat count). Mode: REVEALUI_DEPLOYMENT_MODE (GAP-260 P4-1), fallback
+    // private-key presence — hosted multi-tenant uses per-account admission.
+    const { detectDeploymentMode } = await import('@revealui/core/deployment-mode');
+    const isSelfHostedForge = detectDeploymentMode(process.env) === 'forge';
     // Track whether this is the first user  -  they get admin role automatically.
     let isFirstUser = false;
     try {

--- a/apps/admin/src/app/api/chat/route.ts
+++ b/apps/admin/src/app/api/chat/route.ts
@@ -307,12 +307,13 @@ export async function POST(request: NextRequest) {
 
     // Resolve the LLM client via the GAP-360 resolver: per-account BYOK on
     // hosted, env on self-hosted. userId is the authenticated session user
-    // (§6.1). Hosted detection mirrors the deployment signal used elsewhere
-    // (REVEALUI_LICENSE_PRIVATE_KEY presence, matching instrumentation.ts).
+    // (§6.1). Hosted detection: REVEALUI_DEPLOYMENT_MODE (GAP-260 P4-1),
+    // fallback private-key presence (matching instrumentation.ts).
     // NOTE (§6.4 / GAP-338): the admin process has no durable audit sink yet,
     // so no auditStore is wired — byok:key:accessed does not persist here until
     // GAP-338 closes. Recorded limitation, not a Phase-1 blocker.
-    const isHosted = !!process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+    const { isHostedDeployment } = await import('@revealui/core/deployment-mode');
+    const isHosted = isHostedDeployment(process.env);
     let resolvedClient: ChatLLMClient;
     try {
       if (aiDeps.resolveLLMClientForRequest) {

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -32,11 +32,11 @@ export async function register() {
   }
 
   // ── Forge boot license enforcement ─────────────────────────────────
-  // Mirrors apps/server/src/lib/validate-startup.ts → validateLicenseAtStartup.
-  // Hosted SaaS (REVEALUI_LICENSE_PRIVATE_KEY present) is a no-op; self-
-  // hosted Forge customer mode hard-fails the runtime on missing/invalid
-  // license so Docker restart-loops instead of serving traffic without a
-  // valid studio-issued JWT.
+  // Mirrors apps/server validateLicenseAtStartup / detectDeploymentMode.
+  // Hosted SaaS (REVEALUI_DEPLOYMENT_MODE=hosted, or legacy private-key
+  // presence) is a no-op; Forge hard-fails on missing/invalid customer JWT.
+  // GAP-260 P4-1: MODE is the durable signal so admin can boot hosted with
+  // the signing private key ABSENT (signer isolation).
   //
   // We use process.exit(1) rather than `throw` because Next.js's
   // instrumentation.ts contract is "never throw — it kills the entire
@@ -46,7 +46,8 @@ export async function register() {
   // TODO: extract this block to @revealui/core/revforge-license-boot once
   // the same pattern is needed in a third app. Today (api + admin) the
   // ~25-line duplication is preferable to a new package boundary.
-  if (process.env.SKIP_ENV_VALIDATION !== 'true' && !process.env.REVEALUI_LICENSE_PRIVATE_KEY) {
+  const { detectDeploymentMode } = await import('@revealui/core/deployment-mode');
+  if (process.env.SKIP_ENV_VALIDATION !== 'true' && detectDeploymentMode(process.env) === 'forge') {
     const failures: string[] = [];
     if (!process.env.REVEALUI_LICENSE_KEY) {
       failures.push(

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -644,6 +644,29 @@ describe('detectDeploymentMode', () => {
   it('returns "forge" for empty-string private key (treated as unset)', () => {
     expect(detectDeploymentMode({ REVEALUI_LICENSE_PRIVATE_KEY: '' })).toBe('forge');
   });
+
+  it('returns "hosted" when REVEALUI_DEPLOYMENT_MODE=hosted without private key (GAP-260 P4-1)', () => {
+    expect(detectDeploymentMode({ REVEALUI_DEPLOYMENT_MODE: 'hosted' })).toBe('hosted');
+  });
+});
+
+describe('validateStartup — hosted MODE without private key', () => {
+  it('accepts production hosted with MODE=hosted and no private key', () => {
+    const env = {
+      ...validLiveProdEnv(),
+      REVEALUI_DEPLOYMENT_MODE: 'hosted',
+    };
+    delete env.REVEALUI_LICENSE_PRIVATE_KEY;
+    expect(() => validateStartup(env)).not.toThrow();
+  });
+
+  it('rejects MODE=forge when private key is present', () => {
+    const env = {
+      ...validLiveProdEnv(),
+      REVEALUI_DEPLOYMENT_MODE: 'forge',
+    };
+    expect(() => validateStartup(env)).toThrow(/MODE=forge/);
+  });
 });
 
 describe('validateStartup — forge mode', () => {

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -6,6 +6,12 @@ import {
   classifyStripeSecretKey,
 } from '@revealui/config/stripe-mode';
 import {
+  type DeploymentMode,
+  type DetectDeploymentModeOptions,
+  deploymentModeKeyConsistencyError,
+  detectDeploymentMode as detectDeploymentModeCore,
+} from '@revealui/core/deployment-mode';
+import {
   computeKeyId,
   hostMatchesLicensedDomains,
   validateLicenseKey,
@@ -16,6 +22,8 @@ import { eq } from 'drizzle-orm';
 import { REQUIRED_ALWAYS_GROUPS, REQUIRED_IN_PRODUCTION_HOSTED } from './required-env.js';
 
 export type EnvMap = Record<string, string | undefined>;
+/** Re-export SSOT type (GAP-260 P4-1). */
+export type { DeploymentMode };
 
 /**
  * Row shape returned by the billing_catalog lookup. Exported so tests can
@@ -77,23 +85,6 @@ export function findBillingCatalogGaps(rows: BillingCatalogRow[]): {
 }
 
 /**
- * Where this RevealUI deployment runs.
- *
- * - `hosted`: revealui.com SaaS. We sign per-subscriber license JWTs, so
- *   `REVEALUI_LICENSE_PRIVATE_KEY` is set; entitlement is DB-driven via
- *   `account_entitlements` rows. Strict Stripe + HTTPS posture.
- * - `forge`: self-hosted Forge customer kit (Docker stack from
- *   `forge/stamp.sh`). Customer consumes a studio-issued JWT in
- *   `REVEALUI_LICENSE_KEY` against the master public key in
- *   `REVEALUI_LICENSE_PUBLIC_KEY`. No Stripe, no signing key, can run on
- *   `http://localhost`.
- *
- * Detection is by presence of the signing key: only the studio's hosted
- * deployment has it.
- */
-export type DeploymentMode = 'forge' | 'hosted';
-
-/**
  * Options that change validation behavior across runtime vs pre-deploy contexts.
  *
  * - `lenient` (default false): treats empty-string values as "present, sensitive
@@ -127,11 +118,22 @@ function isPresent(env: EnvMap, key: string, lenient: boolean): boolean {
   return Boolean(env[key]);
 }
 
+/**
+ * Where this RevealUI deployment runs (GAP-260 P4-1).
+ *
+ * - `hosted`: revealui.com SaaS. Entitlement is DB-driven; may or may not hold
+ *   the signing private key locally (signer isolation may put it elsewhere).
+ * - `forge`: self-hosted customer kit. Studio-issued JWT + public key; no mint.
+ *
+ * Prefer explicit `REVEALUI_DEPLOYMENT_MODE=hosted|forge`. During the dual-run
+ * window, falls back to private-key presence (legacy). SSOT implementation:
+ * `@revealui/core/deployment-mode`.
+ */
 export function detectDeploymentMode(
   env: EnvMap,
-  { lenient = false }: ValidateOptions = {},
+  options: DetectDeploymentModeOptions = {},
 ): DeploymentMode {
-  return isPresent(env, 'REVEALUI_LICENSE_PRIVATE_KEY', lenient) ? 'hosted' : 'forge';
+  return detectDeploymentModeCore(env, options);
 }
 
 const REQUIRED_IN_PRODUCTION_FORGE = [
@@ -249,8 +251,20 @@ export function validateStartup(
   }
 
   const mode = detectDeploymentMode(env, { lenient });
+  const modeConsistency = deploymentModeKeyConsistencyError(env, { lenient });
+  if (modeConsistency) {
+    throw new Error(`STARTUP VALIDATION FAILED: ${modeConsistency}`);
+  }
   const required = mode === 'forge' ? REQUIRED_IN_PRODUCTION_FORGE : REQUIRED_IN_PRODUCTION_HOSTED;
-  const missingProd = required.filter((key) => !isPresent(env, key, lenient));
+  // Hosted list historically required the private key because mint lived in-process.
+  // With REVEALUI_DEPLOYMENT_MODE=hosted, private key may be absent (signer isolation).
+  const requiredFiltered =
+    mode === 'hosted' &&
+    (env.REVEALUI_DEPLOYMENT_MODE ?? '').trim().toLowerCase() === 'hosted' &&
+    !isPresent(env, 'REVEALUI_LICENSE_PRIVATE_KEY', lenient)
+      ? required.filter((key) => key !== 'REVEALUI_LICENSE_PRIVATE_KEY')
+      : required;
+  const missingProd = requiredFiltered.filter((key) => !isPresent(env, key, lenient));
   if (missingProd.length > 0) {
     throw new Error(
       `STARTUP VALIDATION FAILED (${mode} mode): Missing production-required env vars: ${missingProd.join(', ')}.`,

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -305,6 +305,11 @@ revealui/env/license   # Multi-key bundle for local dev: REVEALUI_LICENSE_PRIVAT
 # value-move is gated on a computeKeyId readback. Adversarial verification of the target is in flight.
 ```
 
+**Deployment mode (GAP-260 P4-1):** set `REVEALUI_DEPLOYMENT_MODE=hosted` or `forge` on each
+runtime (api + admin). Prefer explicit MODE over private-key sniffing so hosted admin can boot
+without the signing private key (signer isolation). When MODE is unset, runtimes still fall
+back to "private key present → hosted". `MODE=forge` with a private key present fails boot.
+
 ### LLM / AI providers
 
 ```

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -455,9 +455,10 @@ export async function signUp(
     // exists from signup. Best-effort: the Stripe billing webhook
     // (ensureHostedAccount) is idempotent on an active membership and backfills
     // this if it fails here, so a transient error never blocks signup. Skipped on
-    // self-hosted (Forge) deployments — single-tenant, no per-user accounts (mode
-    // detected by the license signing key, as in apps/server validate-startup).
-    if (process.env.REVEALUI_LICENSE_PRIVATE_KEY) {
+    // self-hosted (Forge) deployments — single-tenant, no per-user accounts
+    // (GAP-260 P4-1: REVEALUI_DEPLOYMENT_MODE, fallback private-key presence).
+    const { isHostedDeployment } = await import('@revealui/core/deployment-mode');
+    if (isHostedDeployment(process.env)) {
       try {
         const accountId = crypto.randomUUID();
         const now = new Date();

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -120,9 +120,11 @@ const optionalSchema = z.object({
     .max(3650, 'Must not exceed 3650 days (10 years)')
     .default(90),
 
-  // License key signing (RSA-2048 PEM)
+  // License key signing (Ed25519 PEM)
   REVEALUI_LICENSE_PRIVATE_KEY: z.string().optional(),
   REVEALUI_LICENSE_PUBLIC_KEY: z.string().optional(),
+  // GAP-260 P4-1: explicit hosted vs forge posture (fallback: private-key presence)
+  REVEALUI_DEPLOYMENT_MODE: z.enum(['hosted', 'forge']).optional(),
 
   // Email provider  -  Gmail REST API (preferred, edge-compatible)
   GOOGLE_SERVICE_ACCOUNT_EMAIL: z.string().email().optional(),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,11 @@
       "import": "./dist/license.js",
       "default": "./dist/license.js"
     },
+    "./deployment-mode": {
+      "types": "./dist/deployment-mode.d.ts",
+      "import": "./dist/deployment-mode.js",
+      "default": "./dist/deployment-mode.js"
+    },
     "./revforge-license": {
       "types": "./dist/revforge-license.d.ts",
       "import": "./dist/revforge-license.js",

--- a/packages/core/src/__tests__/deployment-mode.test.ts
+++ b/packages/core/src/__tests__/deployment-mode.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deploymentModeKeyConsistencyError,
+  detectDeploymentMode,
+  isHostedDeployment,
+} from '../deployment-mode.js';
+
+describe('detectDeploymentMode', () => {
+  it('prefers REVEALUI_DEPLOYMENT_MODE=hosted over missing private key', () => {
+    expect(detectDeploymentMode({ REVEALUI_DEPLOYMENT_MODE: 'hosted' })).toBe('hosted');
+  });
+
+  it('prefers REVEALUI_DEPLOYMENT_MODE=forge even when private key is set', () => {
+    // Consistency error is separate; detection still honors explicit MODE.
+    expect(
+      detectDeploymentMode({
+        REVEALUI_DEPLOYMENT_MODE: 'forge',
+        REVEALUI_LICENSE_PRIVATE_KEY: 'pem',
+      }),
+    ).toBe('forge');
+  });
+
+  it('is case-insensitive and trims MODE', () => {
+    expect(detectDeploymentMode({ REVEALUI_DEPLOYMENT_MODE: '  HOSTED  ' })).toBe('hosted');
+    expect(detectDeploymentMode({ REVEALUI_DEPLOYMENT_MODE: 'Forge' })).toBe('forge');
+  });
+
+  it('falls back to private-key presence when MODE is unset', () => {
+    expect(detectDeploymentMode({ REVEALUI_LICENSE_PRIVATE_KEY: 'any' })).toBe('hosted');
+    expect(detectDeploymentMode({})).toBe('forge');
+    expect(detectDeploymentMode({ REVEALUI_LICENSE_PRIVATE_KEY: '' })).toBe('forge');
+  });
+
+  it('ignores unknown MODE values and falls back to key presence', () => {
+    expect(detectDeploymentMode({ REVEALUI_DEPLOYMENT_MODE: 'saas' })).toBe('forge');
+    expect(
+      detectDeploymentMode({
+        REVEALUI_DEPLOYMENT_MODE: 'saas',
+        REVEALUI_LICENSE_PRIVATE_KEY: 'k',
+      }),
+    ).toBe('hosted');
+  });
+
+  it('lenient treats empty private key as present for fallback', () => {
+    expect(detectDeploymentMode({ REVEALUI_LICENSE_PRIVATE_KEY: '' }, { lenient: true })).toBe(
+      'hosted',
+    );
+  });
+});
+
+describe('isHostedDeployment', () => {
+  it('returns true for hosted MODE without private key', () => {
+    expect(isHostedDeployment({ REVEALUI_DEPLOYMENT_MODE: 'hosted' })).toBe(true);
+  });
+});
+
+describe('deploymentModeKeyConsistencyError', () => {
+  it('errors when MODE=forge and private key is present', () => {
+    const msg = deploymentModeKeyConsistencyError({
+      REVEALUI_DEPLOYMENT_MODE: 'forge',
+      REVEALUI_LICENSE_PRIVATE_KEY: 'pem',
+    });
+    expect(msg).toMatch(/MODE=forge/);
+  });
+
+  it('allows MODE=hosted without private key (signer isolation)', () => {
+    expect(deploymentModeKeyConsistencyError({ REVEALUI_DEPLOYMENT_MODE: 'hosted' })).toBeNull();
+  });
+
+  it('is a no-op when MODE is unset', () => {
+    expect(deploymentModeKeyConsistencyError({ REVEALUI_LICENSE_PRIVATE_KEY: 'pem' })).toBeNull();
+  });
+});

--- a/packages/core/src/deployment-mode.ts
+++ b/packages/core/src/deployment-mode.ts
@@ -1,0 +1,83 @@
+/**
+ * Deployment mode detection (GAP-260 P4-1).
+ *
+ * Hosted SaaS vs self-hosted Forge must not be inferred only from the presence
+ * of the license signing private key. That coupling bricks admin when the key
+ * is removed for signer isolation (private key leaves admin / lives only in
+ * license-signer).
+ *
+ * Preference order:
+ * 1. Explicit `REVEALUI_DEPLOYMENT_MODE=hosted|forge` (case-insensitive trim)
+ * 2. Fallback (overlap window): private key present → hosted, else forge
+ *
+ * Sign-capable surfaces still require the private key at mint time; this module
+ * only answers "which product posture is this process".
+ */
+
+export type DeploymentMode = 'forge' | 'hosted';
+
+export type DeploymentModeEnv = Record<string, string | undefined>;
+
+export interface DetectDeploymentModeOptions {
+  /**
+   * When true, empty-string env values count as "present" (Vercel Sensitive
+   * pull semantics). When false (default), empty string is treated as missing.
+   */
+  lenient?: boolean;
+}
+
+function isPresent(env: DeploymentModeEnv, key: string, lenient: boolean): boolean {
+  if (lenient) return env[key] !== undefined;
+  return Boolean(env[key]);
+}
+
+/**
+ * Resolve deployment mode from env.
+ *
+ * Explicit MODE always wins when set to `hosted` or `forge`. Any other
+ * non-empty MODE value is ignored (falls through to key-presence) so a typo
+ * does not hard-brick boot during the dual-run window; production boot
+ * validators may still warn separately.
+ */
+export function detectDeploymentMode(
+  env: DeploymentModeEnv,
+  { lenient = false }: DetectDeploymentModeOptions = {},
+): DeploymentMode {
+  const raw = (env.REVEALUI_DEPLOYMENT_MODE ?? '').trim().toLowerCase();
+  if (raw === 'hosted' || raw === 'forge') {
+    return raw;
+  }
+  return isPresent(env, 'REVEALUI_LICENSE_PRIVATE_KEY', lenient) ? 'hosted' : 'forge';
+}
+
+/** Convenience: true when the process is in hosted SaaS posture. */
+export function isHostedDeployment(
+  env: DeploymentModeEnv = process.env as DeploymentModeEnv,
+  options?: DetectDeploymentModeOptions,
+): boolean {
+  return detectDeploymentMode(env, options) === 'hosted';
+}
+
+/**
+ * Consistency check for CI / pre-deploy: forge mode must not also carry the
+ * signing private key (confused deputy). Hosted without private key is allowed
+ * (signer isolation target).
+ *
+ * Returns an error message or null when OK.
+ */
+export function deploymentModeKeyConsistencyError(
+  env: DeploymentModeEnv,
+  { lenient = false }: DetectDeploymentModeOptions = {},
+): string | null {
+  const raw = (env.REVEALUI_DEPLOYMENT_MODE ?? '').trim().toLowerCase();
+  if (raw !== 'hosted' && raw !== 'forge') return null;
+  const hasPriv = isPresent(env, 'REVEALUI_LICENSE_PRIVATE_KEY', lenient);
+  if (raw === 'forge' && hasPriv) {
+    return (
+      'REVEALUI_DEPLOYMENT_MODE=forge but REVEALUI_LICENSE_PRIVATE_KEY is set. ' +
+      'Forge kits must not hold the studio signing key. Remove the private key ' +
+      'or set MODE=hosted.'
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

GAP-260 **P4-1** (first unblocked build after P2-1 census): explicit `REVEALUI_DEPLOYMENT_MODE=hosted|forge`.

### Why
Hosted vs forge was inferred only from `REVEALUI_LICENSE_PRIVATE_KEY` presence. That bricks admin when the private key is removed for signer isolation (P4-2+).

### Changes
- `@revealui/core/deployment-mode` — SSOT `detectDeploymentMode` / `isHostedDeployment` / consistency check
- Server `validate-startup` uses SSOT; **MODE=hosted without private key** allowed; **MODE=forge + private key** fails boot
- Admin instrumentation + auth seat caps + BYOK hosted flag use MODE
- Config schema + SECRETS.md note

### P2-1 census (closed)
- **RevDev daemon does not mint** (public baked / issue scripts offline only)
- Sign-capable remain: api license + webhooks + offline stampers

### Not in this PR
P2-2 env split, license-signer, mint cutover, private key drop, jti denylist

### Owner ops after merge
Set `REVEALUI_DEPLOYMENT_MODE=hosted` on Vercel api + admin (preview first). Dual-run: omit MODE and keep private key until proven.

## Test plan
- [x] core `deployment-mode` unit tests (10)
- [x] local pre-push phase-1 gate PASS
- [ ] CI Unit Tests / Typecheck

## Owner
```bash
gh pr merge <N> -R RevealUIStudio/revealui --merge
```