### PR TITLE
fix(ai): accept Inference Snap engine model id variants

### DIFF
--- a/packages/ai/src/llm/providers/__tests__/us-origin-snaps.test.ts
+++ b/packages/ai/src/llm/providers/__tests__/us-origin-snaps.test.ts
@@ -45,6 +45,18 @@ describe('isUsOriginInferenceSnap', () => {
       expect(isUsOriginInferenceSnap(id)).toBe(false);
     },
   );
+
+  it('allows Canonical engine model ids under an allowlisted snap prefix', () => {
+    expect(isUsOriginInferenceSnap('nemotron-3-nano-30b-a3b-q4-k-m')).toBe(true);
+    expect(isUsOriginInferenceSnap('nemotron-3-nano-omni-vision')).toBe(true);
+    expect(isUsOriginInferenceSnap('gemma4:it')).toBe(true);
+  });
+
+  it('does not treat unrelated prefixes as allowlisted snaps', () => {
+    // Must not match by loose substring (e.g. "nano" alone)
+    expect(isUsOriginInferenceSnap('not-nemotron-3-nano')).toBe(false);
+    expect(isUsOriginInferenceSnap('deepseek-r1-nemotron-3-nano')).toBe(false);
+  });
 });
 
 describe('assertUsOriginInferenceSnap', () => {

--- a/packages/ai/src/llm/providers/us-origin-snaps.ts
+++ b/packages/ai/src/llm/providers/us-origin-snaps.ts
@@ -55,10 +55,22 @@ export function normalizeInferenceSnapModelId(modelId: string): string {
   return modelId.trim().toLowerCase();
 }
 
-/** True when the model id is on the US-origin product allowlist. */
+/**
+ * True when the model id is on the US-origin product allowlist.
+ *
+ * Accepts exact snap ids (`nemotron-3-nano`) and engine-served variants that
+ * Canonical publishes under the same snap (e.g.
+ * `nemotron-3-nano-30b-a3b-q4-k-m`, `gemma4:e2b` style suffixes with `-` or `:`).
+ * Match longest snap id first so `nemotron-3-nano-omni` wins over `nemotron-3-nano`.
+ */
 export function isUsOriginInferenceSnap(modelId: string): boolean {
   const id = normalizeInferenceSnapModelId(modelId);
-  return (US_ORIGIN_INFERENCE_SNAP_IDS as readonly string[]).includes(id);
+  const snaps = [...US_ORIGIN_INFERENCE_SNAP_IDS].sort((a, b) => b.length - a.length);
+  for (const snap of snaps) {
+    if (id === snap) return true;
+    if (id.startsWith(`${snap}-`) || id.startsWith(`${snap}:`)) return true;
+  }
+  return false;
 }
 
 /** True when the operator escape hatch is enabled. */


### PR DESCRIPTION
## Summary

Live smoke against Canonical Inference Snaps showed the OpenAI-compatible **engine** model id is not the bare snap name (e.g. `nemotron-3-nano-30b-a3b-q4-k-m`, `gemma3-4b-it-q4-0`). Exact allowlist matching rejected those ids even though the weights are US-origin (NVIDIA / Google).

### Fix
`isUsOriginInferenceSnap` accepts:
- exact allowlisted snap ids (`nemotron-3-nano`, `gemma3`, …)
- engine variants with prefix `${snap}-` or `${snap}:` (longest snap id first so `nemotron-3-nano-omni` wins)

Still rejects PRC catalog names (`deepseek-r1`, `qwen-*`, `glm-*`, etc.).

### Context
Companion to the US-origin hardline (#2132 / #2133). Discovered during operator smoke on WSL.

## Test plan
- [x] `vitest` `us-origin-snaps` (26 tests) including engine-id cases
- [x] Live: `nemotron-3-nano-30b-a3b-q4-k-m` allowlisted after fix; deepseek still rejected
- [ ] CI on PR