### PR TITLE
feat(secrets): GAP-260 P2-2 split env/license public vs license-signing

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -258,7 +258,8 @@ revealui/env/backup
 revealui/env/cms-url
 revealui/env/core
 revealui/env/cron
-revealui/env/license        # REVEALUI_LICENSE_PRIVATE_KEY + REVEALUI_LICENSE_PUBLIC_KEY
+revealui/env/license          # REVEALUI_LICENSE_PUBLIC_KEY only (GAP-260 P2-2 public)
+revealui/env/license-signing  # REVEALUI_LICENSE_PRIVATE_KEY (+ optional public); needs REVVAULT_ALLOW_PRIVATE=1
 revealui/env/npm
 revealui/env/services
 revealui/env/stripe
@@ -293,16 +294,26 @@ revdev/tauri-signing-public-key           # updater public key (also embedded in
 The canonical license-signing keypair (`revdev/license-signing-{private,public}-key`) is a
 production-runtime secret - it appears in the machine-checked Production runtime table above,
 carrying its declared migration target `revealui/prod/license/{private,public}-key` (the
-value-move is P3-4, owner-gated). The `revealui/env/license` bundle below is the local-dev
-`with-secrets` mirror of that keypair, consumed by `~/revfleet/revealui/.envrc` via
-`revvault export-env`.
+value-move is P3-4, owner-gated). Local-dev bundles (GAP-260 P2-2):
 
 ```
-revealui/env/license   # Multi-key bundle for local dev: REVEALUI_LICENSE_PRIVATE_KEY + REVEALUI_LICENSE_PUBLIC_KEY
+revealui/env/license          # PUBLIC only: REVEALUI_LICENSE_PUBLIC_KEY (+ optional MODE)
+                              # with-secrets license → revvault export-env --public-only
+revealui/env/license-signing  # PRIVATE: REVEALUI_LICENSE_PRIVATE_KEY
+                              # with-secrets license-signing requires REVVAULT_ALLOW_PRIVATE=1
 # Reserved: revealui/prod/license/{private,public}-key - the DECLARED Ed25519 migration target (P3-4).
 # It previously held a pre-cutover RSA/RS256 pair. The target is UNVERIFIED: a stale RSA-era value
 # may still occupy this path (RSA is incompatible with the Ed25519 runtime verifier), so the P3-4
 # value-move is gated on a computeKeyId readback. Adversarial verification of the target is in flight.
+```
+
+Operator migration (one-time, owner machine):
+
+```bash
+# Split the old combined bundle into public + signing paths (values never printed).
+# 1) Ensure revealui/env/license contains only PUBLIC KEY= lines
+# 2) Put PRIVATE KEY lines under revealui/env/license-signing
+# 3) Mint/local sign: REVVAULT_ALLOW_PRIVATE=1 with-secrets license-signing -- <cmd>
 ```
 
 **Deployment mode (GAP-260 P4-1):** set `REVEALUI_DEPLOYMENT_MODE=hosted` or `forge` on each

--- a/scripts/sync/__tests__/license-public-only-mint-boundary.test.ts
+++ b/scripts/sync/__tests__/license-public-only-mint-boundary.test.ts
@@ -1,0 +1,72 @@
+/**
+ * GAP-260 P2-2: public-only license consumers must not mint.
+ *
+ * `with-secrets:license` loads revealui/env/license (public SPKI only).
+ * Mint/sign call sites must use with-secrets:license-signing (private) or
+ * production env that intentionally holds REVEALUI_LICENSE_PRIVATE_KEY.
+ *
+ * Mechanical: any file that documents `with-secrets license` (not
+ * license-signing) must not also call generateLicenseKey.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist' || name === '.git' || name === 'coverage') {
+      continue;
+    }
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (
+      name.endsWith('.ts') ||
+      name.endsWith('.tsx') ||
+      name.endsWith('.md') ||
+      name.endsWith('.sh')
+    ) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+describe('GAP-260 P2-2 public-only mint boundary', () => {
+  it('no file both invokes with-secrets license (public) and generateLicenseKey', () => {
+    const files = walk(REPO_ROOT);
+    const offenders: string[] = [];
+    for (const file of files) {
+      // Skip this test file and the with-secrets definition itself.
+      const rel = relative(REPO_ROOT, file);
+      if (rel.includes('license-public-only-mint-boundary')) continue;
+      if (rel.includes('45-with-secrets')) continue;
+      const text = readFileSync(file, 'utf8');
+      // Match public license namespace only — not "license-signing".
+      const usesPublicLicenseNs =
+        text.includes('with-secrets license ') ||
+        text.includes('with-secrets license\n') ||
+        text.includes('with-secrets license --') ||
+        text.includes("with-secrets:license'") ||
+        text.includes('with-secrets:license"') ||
+        text.includes("consumers: ['with-secrets:license']") ||
+        text.includes('consumers: ["with-secrets:license"]');
+      // Narrow: "with-secrets license" as a command word (not license-signing)
+      const cmdPublic =
+        text.includes('with-secrets license --') ||
+        text.includes('with-secrets license\n') ||
+        (text.includes('with-secrets license') && !text.includes('license-signing'));
+      if (!(usesPublicLicenseNs || cmdPublic)) continue;
+      if (text.includes('generateLicenseKey')) {
+        // Allow SECRET_PATHS / SECRETS docs that mention both as narrative.
+        if (rel.startsWith('docs/') || rel.includes('secret-paths.ts')) continue;
+        offenders.push(rel);
+      }
+    }
+    expect(offenders, `public-only + mint offenders: ${offenders.join(', ')}`).toEqual([]);
+  });
+});

--- a/scripts/sync/__tests__/secret-paths-lockstep.test.ts
+++ b/scripts/sync/__tests__/secret-paths-lockstep.test.ts
@@ -147,14 +147,25 @@ describe('SECRETS.md ↔ spec lockstep (rendered derived view)', () => {
 });
 
 describe('env/* mirror invariant (R8)', () => {
-  it('revealui/env/license is declared, intentionally unsynced, and absent from every manifest', () => {
+  it('revealui/env/license is public-only, intentionally unsynced, and absent from every manifest (GAP-260 P2-2)', () => {
     expect(DECLARED_PATHS.has('revealui/env/license')).toBe(true);
     expect(SYNCED_PATHS.has('revealui/env/license')).toBe(false);
     expect(allManifestPaths).not.toContain('revealui/env/license');
     const def = SECRET_PATHS.find((d) => d.path === 'revealui/env/license');
-    // It bundles the private key → must be sensitive.
+    expect(def?.kind).toBe('signing-public');
+    expect(def?.sensitive).toBe(false);
+    expect(isSensitiveKind(def?.kind ?? 'public-config')).toBe(false);
+    expect(def?.consumers).toEqual(['with-secrets:license']);
+  });
+
+  it('revealui/env/license-signing is private, intentionally unsynced (GAP-260 P2-2)', () => {
+    expect(DECLARED_PATHS.has('revealui/env/license-signing')).toBe(true);
+    expect(SYNCED_PATHS.has('revealui/env/license-signing')).toBe(false);
+    expect(allManifestPaths).not.toContain('revealui/env/license-signing');
+    const def = SECRET_PATHS.find((d) => d.path === 'revealui/env/license-signing');
+    expect(def?.kind).toBe('signing-private');
     expect(def?.sensitive).toBe(true);
-    expect(isSensitiveKind(def?.kind ?? 'public-config')).toBe(true);
+    expect(def?.consumers).toEqual(['with-secrets:license-signing']);
   });
 });
 

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -13,7 +13,8 @@
  * SCOPE (Phase 0, P0-1): this declares the PRODUCTION-SYNCED runtime path set -
  * the union of scripts/sync/revvault-vercel.toml + revvault-fly.toml (the
  * drift-critical surface) - plus the license signing keypair and the one
- * security-relevant `with-secrets` env bundle it mirrors (revealui/env/license,
+ * security-relevant `with-secrets` env bundles it mirrors (revealui/env/license +
+ * revealui/env/license-signing after GAP-260 P2-2,
  * R8). The dev/*, api-keys/*, credentials/*, revdev/tauri-*, forge/*, and
  * agents/* tiers are NOT modeled here yet; they remain hand-written prose in
  * docs/SECRETS.md OUTSIDE the generated markers. The SecretTier union carries
@@ -819,20 +820,27 @@ export const SECRET_PATHS: SecretPathDef[] = [
     note: 'the api own origin (MCP loopback + OpenAPI); also VITE_API_URL on marketing (anti-cross-wire, GAP-343)',
   },
 
-  // ── Env bundle (derived, verify-only - NOT synced to any platform) ────────
-  // Tracked here to enforce the R8 invariant: with-secrets loads the license
-  // keypair from a SEPARATE bundle path. intentionallyUnsynced excludes it from
-  // the manifest-missing check AND the doc generated-block bijection; it is
-  // documented in hand-prose. The private-vs-public split (env/license-public
-  // vs env/license-signing) is Phase 2 (P2-2).
+  // ── Env bundles (derived, verify-only - NOT synced to any platform) ───────
+  // R8: with-secrets loads license material from SEPARATE paths (GAP-260 P2-2).
+  //   license          → public SPKI only (verify / mode fallbacks)
+  //   license-signing  → private PKCS#8 (mint only; REVVAULT_ALLOW_PRIVATE=1)
   {
     path: 'revealui/env/license',
-    kind: 'signing-private',
-    sensitive: true,
+    kind: 'signing-public',
+    sensitive: false,
     tier: 'env',
     consumers: ['with-secrets:license'],
     intentionallyUnsynced: true,
-    note: 'export-env bundle for local dev - REVEALUI_LICENSE_PRIVATE_KEY + PUBLIC_KEY; mirrors the canonical license leaves (R8; split in P2-2)',
+    note: 'export-env public-only bundle: REVEALUI_LICENSE_PUBLIC_KEY (and MODE). Must NOT hold private key; with-secrets license uses revvault export-env --public-only',
+  },
+  {
+    path: 'revealui/env/license-signing',
+    kind: 'signing-private',
+    sensitive: true,
+    tier: 'env',
+    consumers: ['with-secrets:license-signing'],
+    intentionallyUnsynced: true,
+    note: 'export-env signing bundle: REVEALUI_LICENSE_PRIVATE_KEY (+ public if needed for self-check). with-secrets license-signing requires REVVAULT_ALLOW_PRIVATE=1',
   },
 ];
 


### PR DESCRIPTION
## Summary

GAP-260 **P2-2** (revealui half): path SSOT for public vs signing local-dev bundles.

| Path | Kind | with-secrets |
|------|------|--------------|
| `revealui/env/license` | signing-public | `license` (public-only export) |
| `revealui/env/license-signing` | signing-private | `license-signing` + `REVVAULT_ALLOW_PRIVATE=1` |

### Also
- SECRETS.md operator migration notes
- Lockstep tests + mint-boundary test (no public-only + generateLicenseKey)

### Companion
- revvault: `--public-only`
- revkit: with-secrets gates

### Owner vault ops (one-time, never print values)
1. Move private KEY= lines from combined `revealui/env/license` → `revealui/env/license-signing`
2. Leave only public KEY= lines in `revealui/env/license`
3. Mint: `REVVAULT_ALLOW_PRIVATE=1 with-secrets license-signing -- <cmd>`

### Owner merge
```bash
gh pr merge <N> -R RevealUIStudio/revealui --merge
```