### PR TITLE
feat(license-signer): GAP-260 P4-2 isolated mint service with HMAC auth

### DIFF
--- a/apps/license-signer/README.md
+++ b/apps/license-signer/README.md
@@ -1,0 +1,43 @@
+# `@revealui/license-signer`
+
+Isolated license JWT mint service (GAP-260 **P4-2**).
+
+Holds the Ed25519 **signing private key** and exposes a single HMAC-authed mint
+endpoint. Callers (api webhooks after P4-3, operator tooling) never load the
+private key; they call this process with a dedicated invoke secret.
+
+## Endpoints
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/health/live` | none | liveness |
+| `POST` | `/internal/mint` | HMAC | mint license JWT via `generateLicenseKey` |
+
+## HMAC (per-call)
+
+Headers:
+
+- `X-RevealUI-Signer-Timestamp` — unix seconds
+- `X-RevealUI-Signer-Signature` — `hex(hmac-sha256(secret, \`${ts}.${METHOD}.${path}.${body}\`))`
+
+Skew window: 300s. **No fallback** to `REVEALUI_SECRET`.
+
+## Env
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `REVEALUI_LICENSE_PRIVATE_KEY` | yes | PKCS#8 Ed25519 PEM |
+| `REVEALUI_LICENSE_PUBLIC_KEY` | no | when set, JWT header gets `kid` |
+| `REVEALUI_SIGNER_INVOKE_SECRET` | yes | vault: `revealui/prod/license/signer-invoke-secret` |
+| `PORT` | no | default `8791` |
+
+## Local run
+
+```bash
+# From monorepo root (signing bundle is private):
+REVVAULT_ALLOW_PRIVATE=1 with-secrets license-signing -- \
+  env REVEALUI_SIGNER_INVOKE_SECRET="$(revvault get --full revealui/prod/license/signer-invoke-secret)" \
+  pnpm --filter @revealui/license-signer dev
+```
+
+Mint cutover (api → this service) is **P4-3** (`REVEALUI_LICENSE_SIGN_VIA_SIGNER`).

--- a/apps/license-signer/package.json
+++ b/apps/license-signer/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@revealui/license-signer",
+  "version": "0.1.0",
+  "description": "Isolated license JWT mint service (GAP-260 P4-2). Holds the signing private key; HMAC-authed internal mint API.",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@hono/node-server": "^2.0.11",
+    "@revealui/core": "workspace:*",
+    "hono": "4.12.27",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@revealui/dev": "workspace:*",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24.13.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage --coverage.reporter=json-summary --coverage.reporter=html --coverage.reporter=text",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check ."
+  }
+}

--- a/apps/license-signer/src/app.test.ts
+++ b/apps/license-signer/src/app.test.ts
@@ -1,0 +1,139 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { validateLicenseKey } from '@revealui/core/license';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createLicenseSignerApp } from './app.js';
+import { signMintRequest } from './auth.js';
+
+const INVOKE_SECRET = 'unit-test-signer-invoke-secret';
+const PATH = '/internal/mint';
+
+let privateKeyPem: string;
+let publicKeyPem: string;
+
+beforeAll(() => {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  publicKeyPem = publicKey;
+  privateKeyPem = privateKey;
+});
+
+function env(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    REVEALUI_SIGNER_INVOKE_SECRET: INVOKE_SECRET,
+    REVEALUI_LICENSE_PRIVATE_KEY: privateKeyPem,
+    REVEALUI_LICENSE_PUBLIC_KEY: publicKeyPem,
+    ...overrides,
+  };
+}
+
+async function signedMint(
+  app: ReturnType<typeof createLicenseSignerApp>,
+  body: string,
+  opts?: { secret?: string; ts?: number; skipSig?: boolean },
+): Promise<Response> {
+  const ts = opts?.ts ?? Math.floor(Date.now() / 1000);
+  const secret = opts?.secret ?? INVOKE_SECRET;
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (!opts?.skipSig) {
+    headers['x-revealui-signer-timestamp'] = String(ts);
+    headers['x-revealui-signer-signature'] = signMintRequest(secret, 'POST', PATH, body, ts);
+  }
+  return app.request(PATH, { method: 'POST', headers, body });
+}
+
+describe('createLicenseSignerApp', () => {
+  it('GET /health/live is unauthenticated', async () => {
+    const app = createLicenseSignerApp(env());
+    const res = await app.request('/health/live');
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, service: 'license-signer' });
+  });
+
+  it('POST /internal/mint returns 401 without HMAC headers', async () => {
+    const app = createLicenseSignerApp(env());
+    const res = await signedMint(app, '{"tier":"pro","customerId":"cus_a"}', { skipSig: true });
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: string; reason: string };
+    expect(json.error).toBe('unauthorized');
+    expect(json.reason).toBe('missing_headers');
+  });
+
+  it('POST /internal/mint returns 401 for bad signature', async () => {
+    const app = createLicenseSignerApp(env());
+    const res = await signedMint(app, '{"tier":"pro","customerId":"cus_a"}', {
+      secret: 'wrong-secret',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /internal/mint returns 503 when invoke secret missing', async () => {
+    const app = createLicenseSignerApp({
+      REVEALUI_LICENSE_PRIVATE_KEY: privateKeyPem,
+    });
+    const res = await app.request(PATH, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ error: 'signer_misconfigured' });
+  });
+
+  it('POST /internal/mint returns 503 when private key missing', async () => {
+    const app = createLicenseSignerApp({
+      REVEALUI_SIGNER_INVOKE_SECRET: INVOKE_SECRET,
+    });
+    const res = await signedMint(app, '{"tier":"pro","customerId":"cus_a"}');
+    expect(res.status).toBe(503);
+  });
+
+  it('POST /internal/mint returns 400 for invalid body', async () => {
+    const app = createLicenseSignerApp(env());
+    const res = await signedMint(app, '{"tier":"free","customerId":"cus_a"}');
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe('invalid_body');
+  });
+
+  it('POST /internal/mint mints a JWT via generateLicenseKey', async () => {
+    const app = createLicenseSignerApp(env());
+    const body = JSON.stringify({ tier: 'pro', customerId: 'cus_mint_1' });
+    const res = await signedMint(app, body);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { licenseKey: string };
+    expect(typeof json.licenseKey).toBe('string');
+    expect(json.licenseKey.split('.')).toHaveLength(3);
+
+    const payload = await validateLicenseKey(json.licenseKey, publicKeyPem);
+    expect(payload).not.toBeNull();
+    expect(payload?.tier).toBe('pro');
+    expect(payload?.customerId).toBe('cus_mint_1');
+    expect(typeof payload?.jti).toBe('string');
+  });
+
+  it('does not fall back to REVEALUI_SECRET for invoke auth', async () => {
+    const app = createLicenseSignerApp({
+      REVEALUI_SECRET: 'session-only',
+      REVEALUI_LICENSE_PRIVATE_KEY: privateKeyPem,
+      // no REVEALUI_SIGNER_INVOKE_SECRET
+    });
+    const body = JSON.stringify({ tier: 'pro', customerId: 'cus_x' });
+    // Sign with REVEALUI_SECRET as if someone tried the wrong secret
+    const ts = Math.floor(Date.now() / 1000);
+    const res = await app.request(PATH, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-revealui-signer-timestamp': String(ts),
+        'x-revealui-signer-signature': signMintRequest('session-only', 'POST', PATH, body, ts),
+      },
+      body,
+    });
+    // Misconfigured: missing dedicated invoke secret → 503, not 401 from REVEALUI_SECRET
+    expect(res.status).toBe(503);
+  });
+});

--- a/apps/license-signer/src/app.ts
+++ b/apps/license-signer/src/app.ts
@@ -1,0 +1,76 @@
+/**
+ * Hono app for the license-signer service (GAP-260 P4-2).
+ */
+
+import { Hono } from 'hono';
+import {
+  getInvokeSecret,
+  SIGNER_SIGNATURE_HEADER,
+  SIGNER_TIMESTAMP_HEADER,
+  verifyMintRequest,
+} from './auth.js';
+import {
+  getSigningPrivateKey,
+  getSigningPublicKey,
+  mintLicenseKey,
+  mintRequestSchema,
+} from './mint.js';
+
+export function createLicenseSignerApp(env: NodeJS.ProcessEnv = process.env): Hono {
+  const app = new Hono();
+
+  app.get('/health/live', (c) => c.json({ ok: true, service: 'license-signer' }));
+
+  app.post('/internal/mint', async (c) => {
+    let secret: string;
+    try {
+      secret = getInvokeSecret(env);
+    } catch {
+      return c.json({ error: 'signer_misconfigured' }, 503);
+    }
+
+    let privateKey: string;
+    try {
+      privateKey = getSigningPrivateKey(env);
+    } catch {
+      return c.json({ error: 'signer_misconfigured' }, 503);
+    }
+
+    const bodyText = await c.req.text();
+    const path = new URL(c.req.url).pathname;
+    const auth = verifyMintRequest({
+      secret,
+      method: c.req.method,
+      path,
+      body: bodyText,
+      timestampHeader: c.req.header(SIGNER_TIMESTAMP_HEADER),
+      signatureHeader: c.req.header(SIGNER_SIGNATURE_HEADER),
+    });
+    if (!auth.ok) {
+      return c.json({ error: 'unauthorized', reason: auth.reason }, 401);
+    }
+
+    let json: unknown;
+    try {
+      json = bodyText ? JSON.parse(bodyText) : {};
+    } catch {
+      return c.json({ error: 'invalid_json' }, 400);
+    }
+
+    const parsed = mintRequestSchema.safeParse(json);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_body', details: parsed.error.flatten() }, 400);
+    }
+
+    try {
+      const publicKey = getSigningPublicKey(env);
+      const licenseKey = await mintLicenseKey(parsed.data, privateKey, publicKey);
+      return c.json({ licenseKey });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: 'mint_failed', message }, 500);
+    }
+  });
+
+  return app;
+}

--- a/apps/license-signer/src/auth.test.ts
+++ b/apps/license-signer/src/auth.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { getInvokeSecret, MAX_SKEW_SECONDS, signMintRequest, verifyMintRequest } from './auth.js';
+
+const SECRET = 'test-signer-invoke-secret-do-not-use-in-prod';
+const METHOD = 'POST';
+const PATH = '/internal/mint';
+const BODY = '{"tier":"pro","customerId":"cus_1"}';
+
+describe('getInvokeSecret', () => {
+  it('returns REVEALUI_SIGNER_INVOKE_SECRET', () => {
+    expect(getInvokeSecret({ REVEALUI_SIGNER_INVOKE_SECRET: `  ${SECRET}  ` })).toBe(SECRET);
+  });
+
+  it('throws when missing (no REVEALUI_SECRET fallback)', () => {
+    expect(() => getInvokeSecret({})).toThrow(/REVEALUI_SIGNER_INVOKE_SECRET/);
+    expect(() => getInvokeSecret({ REVEALUI_SECRET: 'session-secret' })).toThrow(
+      /no REVEALUI_SECRET fallback/,
+    );
+  });
+});
+
+describe('signMintRequest + verifyMintRequest', () => {
+  it('accepts a correctly signed request within skew', () => {
+    const now = 1_700_000_000;
+    const sig = signMintRequest(SECRET, METHOD, PATH, BODY, now);
+    const result = verifyMintRequest({
+      secret: SECRET,
+      method: METHOD,
+      path: PATH,
+      body: BODY,
+      timestampHeader: String(now),
+      signatureHeader: sig,
+      nowSeconds: now,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects missing headers', () => {
+    expect(
+      verifyMintRequest({
+        secret: SECRET,
+        method: METHOD,
+        path: PATH,
+        body: BODY,
+        timestampHeader: undefined,
+        signatureHeader: undefined,
+      }),
+    ).toEqual({ ok: false, reason: 'missing_headers' });
+  });
+
+  it('rejects non-numeric timestamp', () => {
+    expect(
+      verifyMintRequest({
+        secret: SECRET,
+        method: METHOD,
+        path: PATH,
+        body: BODY,
+        timestampHeader: 'not-a-number',
+        signatureHeader: 'ab',
+      }),
+    ).toEqual({ ok: false, reason: 'bad_timestamp' });
+  });
+
+  it('rejects skew beyond MAX_SKEW_SECONDS', () => {
+    const now = 1_700_000_000;
+    const ts = now - (MAX_SKEW_SECONDS + 1);
+    const sig = signMintRequest(SECRET, METHOD, PATH, BODY, ts);
+    expect(
+      verifyMintRequest({
+        secret: SECRET,
+        method: METHOD,
+        path: PATH,
+        body: BODY,
+        timestampHeader: String(ts),
+        signatureHeader: sig,
+        nowSeconds: now,
+      }),
+    ).toEqual({ ok: false, reason: 'skew' });
+  });
+
+  it('rejects wrong signature', () => {
+    const now = 1_700_000_000;
+    const sig = signMintRequest(SECRET, METHOD, PATH, BODY, now);
+    // Flip last nibble
+    const bad = `${sig.slice(0, -1)}${sig.endsWith('0') ? '1' : '0'}`;
+    expect(
+      verifyMintRequest({
+        secret: SECRET,
+        method: METHOD,
+        path: PATH,
+        body: BODY,
+        timestampHeader: String(now),
+        signatureHeader: bad,
+        nowSeconds: now,
+      }),
+    ).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('rejects when body is tampered', () => {
+    const now = 1_700_000_000;
+    const sig = signMintRequest(SECRET, METHOD, PATH, BODY, now);
+    expect(
+      verifyMintRequest({
+        secret: SECRET,
+        method: METHOD,
+        path: PATH,
+        body: '{"tier":"enterprise","customerId":"cus_1"}',
+        timestampHeader: String(now),
+        signatureHeader: sig,
+        nowSeconds: now,
+      }),
+    ).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('normalizes method case when signing/verifying', () => {
+    const now = 1_700_000_000;
+    const sig = signMintRequest(SECRET, 'post', PATH, BODY, now);
+    expect(
+      verifyMintRequest({
+        secret: SECRET,
+        method: 'POST',
+        path: PATH,
+        body: BODY,
+        timestampHeader: String(now),
+        signatureHeader: sig,
+        nowSeconds: now,
+      }),
+    ).toEqual({ ok: true });
+  });
+});

--- a/apps/license-signer/src/auth.ts
+++ b/apps/license-signer/src/auth.ts
@@ -1,0 +1,86 @@
+/**
+ * Per-call HMAC auth for the license-signer mint API (GAP-260 P4-2).
+ *
+ * Headers:
+ *   X-RevealUI-Signer-Timestamp — unix seconds
+ *   X-RevealUI-Signer-Signature — hex(hmac-sha256(secret, `${ts}.${METHOD}.${path}.${body}`))
+ *
+ * No fallback to REVEALUI_SECRET. Fail closed when secret missing or skew too large.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const SIGNER_TIMESTAMP_HEADER = 'x-revealui-signer-timestamp';
+export const SIGNER_SIGNATURE_HEADER = 'x-revealui-signer-signature';
+
+/** Max |now - timestamp| allowed (seconds). */
+export const MAX_SKEW_SECONDS = 300;
+
+export function getInvokeSecret(env: NodeJS.ProcessEnv = process.env): string {
+  const secret = env.REVEALUI_SIGNER_INVOKE_SECRET?.trim() ?? '';
+  if (!secret) {
+    throw new Error(
+      'REVEALUI_SIGNER_INVOKE_SECRET is required (no REVEALUI_SECRET fallback). ' +
+        'Set via revvault path revealui/prod/license/signer-invoke-secret.',
+    );
+  }
+  return secret;
+}
+
+export function signMintRequest(
+  secret: string,
+  method: string,
+  path: string,
+  body: string,
+  timestampSeconds: number,
+): string {
+  const payload = `${timestampSeconds}.${method.toUpperCase()}.${path}.${body}`;
+  return createHmac('sha256', secret).update(payload, 'utf8').digest('hex');
+}
+
+export type AuthFailure =
+  | 'missing_headers'
+  | 'bad_timestamp'
+  | 'skew'
+  | 'bad_signature'
+  | 'missing_secret';
+
+export function verifyMintRequest(input: {
+  secret: string;
+  method: string;
+  path: string;
+  body: string;
+  timestampHeader: string | undefined;
+  signatureHeader: string | undefined;
+  nowSeconds?: number;
+  maxSkewSeconds?: number;
+}): { ok: true } | { ok: false; reason: AuthFailure } {
+  const tsRaw = input.timestampHeader?.trim() ?? '';
+  const sigRaw = input.signatureHeader?.trim() ?? '';
+  if (!(tsRaw && sigRaw)) {
+    return { ok: false, reason: 'missing_headers' };
+  }
+  const ts = Number(tsRaw);
+  if (!Number.isFinite(ts) || ts <= 0) {
+    return { ok: false, reason: 'bad_timestamp' };
+  }
+  const now = input.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const maxSkew = input.maxSkewSeconds ?? MAX_SKEW_SECONDS;
+  if (Math.abs(now - ts) > maxSkew) {
+    return { ok: false, reason: 'skew' };
+  }
+  const expected = signMintRequest(input.secret, input.method, input.path, input.body, ts);
+  try {
+    const a = Buffer.from(sigRaw, 'hex');
+    const b = Buffer.from(expected, 'hex');
+    if (a.length !== b.length || a.length === 0) {
+      return { ok: false, reason: 'bad_signature' };
+    }
+    if (!timingSafeEqual(a, b)) {
+      return { ok: false, reason: 'bad_signature' };
+    }
+  } catch {
+    return { ok: false, reason: 'bad_signature' };
+  }
+  return { ok: true };
+}

--- a/apps/license-signer/src/index.ts
+++ b/apps/license-signer/src/index.ts
@@ -1,0 +1,32 @@
+/**
+ * license-signer process entry (GAP-260 P4-2).
+ *
+ * Env:
+ *   REVEALUI_LICENSE_PRIVATE_KEY   — required PKCS#8 Ed25519 PEM
+ *   REVEALUI_LICENSE_PUBLIC_KEY    — optional; enables kid on JWT header
+ *   REVEALUI_SIGNER_INVOKE_SECRET  — required HMAC secret (no REVEALUI_SECRET fallback)
+ *   PORT                           — default 8791
+ */
+
+import { serve } from '@hono/node-server';
+import { createLicenseSignerApp } from './app.js';
+import { getInvokeSecret } from './auth.js';
+import { getSigningPrivateKey } from './mint.js';
+
+function boot(): void {
+  // Fail loud at process start so a misconfigured deploy never binds a port.
+  getInvokeSecret(process.env);
+  getSigningPrivateKey(process.env);
+
+  const port = Number(process.env.PORT ?? '8791');
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error(`Invalid PORT: ${process.env.PORT}`);
+  }
+
+  const app = createLicenseSignerApp(process.env);
+  serve({ fetch: app.fetch, port }, (info) => {
+    process.stdout.write(`license-signer listening on :${info.port}\n`);
+  });
+}
+
+boot();

--- a/apps/license-signer/src/mint.ts
+++ b/apps/license-signer/src/mint.ts
@@ -1,0 +1,65 @@
+/**
+ * Mint handler body validation + generateLicenseKey (unchanged core API).
+ */
+
+import { generateLicenseKey } from '@revealui/core/license';
+import { z } from 'zod';
+
+export const mintRequestSchema = z.object({
+  tier: z.enum(['pro', 'max', 'enterprise']),
+  customerId: z.string().min(1),
+  domains: z.array(z.string()).optional(),
+  maxSites: z.number().int().positive().optional(),
+  maxUsers: z.number().int().positive().optional(),
+  perpetual: z.boolean().optional(),
+  /** When omitted, generateLicenseKey uses the subscription default TTL. */
+  expiresInSeconds: z.number().int().positive().nullable().optional(),
+  jti: z.string().min(1).optional(),
+});
+
+export type MintRequest = z.infer<typeof mintRequestSchema>;
+
+export async function mintLicenseKey(
+  req: MintRequest,
+  privateKeyPem: string,
+  publicKeyPem?: string,
+): Promise<string> {
+  const expiresIn =
+    req.expiresInSeconds === undefined
+      ? undefined
+      : req.expiresInSeconds === null
+        ? null
+        : req.expiresInSeconds;
+
+  return generateLicenseKey(
+    {
+      tier: req.tier,
+      customerId: req.customerId,
+      domains: req.domains,
+      maxSites: req.maxSites,
+      maxUsers: req.maxUsers,
+      perpetual: req.perpetual,
+      jti: req.jti,
+    },
+    privateKeyPem,
+    expiresIn,
+    publicKeyPem,
+  );
+}
+
+export function getSigningPrivateKey(env: NodeJS.ProcessEnv = process.env): string {
+  const raw = env.REVEALUI_LICENSE_PRIVATE_KEY?.trim() ?? '';
+  if (!raw) {
+    throw new Error(
+      'REVEALUI_LICENSE_PRIVATE_KEY is required in license-signer (PKCS#8 Ed25519 PEM).',
+    );
+  }
+  // Restore PEM newlines when stored as single-line with \n escapes.
+  return raw.split('\\n').join('\n');
+}
+
+export function getSigningPublicKey(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const raw = env.REVEALUI_LICENSE_PUBLIC_KEY?.trim() ?? '';
+  if (!raw) return undefined;
+  return raw.split('\\n').join('\n');
+}

--- a/apps/license-signer/tsconfig.json
+++ b/apps/license-signer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0",
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolvePackageJsonExports": true,
+    "resolveJsonModule": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/apps/license-signer/tsup.config.ts
+++ b/apps/license-signer/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  platform: 'node',
+  target: 'node24',
+  bundle: true,
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  outDir: 'dist',
+  // Bundle workspace packages so extensionless ESM imports resolve at build time.
+  noExternal: [/^@revealui\//],
+  external: [],
+});

--- a/apps/license-signer/vitest.config.ts
+++ b/apps/license-signer/vitest.config.ts
@@ -1,0 +1,6 @@
+import { createVitestConfig } from '@revealui/dev/vitest';
+
+export default createVitestConfig({
+  testTimeout: 15_000,
+  include: ['src/**/*.test.ts'],
+});

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -23,9 +23,9 @@ export const METRICS = {
   /** Packages in `packages/` directories. Source: claim-drift countPackages. */
   packages: 29,
   /** Apps in `apps/`. Source: claim-drift countApps. */
-  apps: 4,
+  apps: 5,
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
-  workspaces: 33,
+  workspaces: 34,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
   testFiles: 1061,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -21,7 +21,7 @@ All gates must pass on the `main` branch before deploy.
 
 - [ ] `pnpm gate` passes all three phases (quality, typecheck, test + build) **(blocking)**
 - [ ] `pnpm lint` reports zero errors (Biome 2) **(blocking)**
-- [ ] `pnpm typecheck:all` clean across all 33 workspaces **(blocking)**
+- [ ] `pnpm typecheck:all` clean across all 34 workspaces **(blocking)**
 - [ ] `pnpm test` passes the full test suite **(blocking)**
 - [ ] `pnpm build` succeeds for all apps and packages **(blocking)**
 - [ ] `pnpm validate:structure` confirms workspace structure integrity **(blocking)**

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -26,8 +26,8 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-22 (
 | Metric | Canonical value | Source of truth (script ref) | Notes |
 |---|---|---|---|
 | Packages in `packages/` | **29** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
-| Apps in `apps/` | **4** | `countApps()` | admin / server / docs / marketing. Was 5 (one app removed per PR #936 + #946 + #947). |
-| Workspaces (monorepo total) | **33** | `countWorkspaces()` (= 29 packages + 4 apps) | |
+| Apps in `apps/` | **5** | `countApps()` | admin / server / docs / marketing / license-signer (GAP-260 P4-2). |
+| Workspaces (monorepo total) | **34** | `countWorkspaces()` (= 29 packages + 5 apps) | |
 | Test files | **1122** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). claim-drift allows site.ts METRICS.testFiles within tolerance 100. |
 | UI components in `packages/presentation/` | **65** | `countUIComponents()` | Marketing copy says "65 native React components" or similar. |
 | **MCP servers** | **13** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); Supabase launcher removed (13 count). |

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -305,6 +305,9 @@ revealui/env/license-signing  # PRIVATE: REVEALUI_LICENSE_PRIVATE_KEY
 # It previously held a pre-cutover RSA/RS256 pair. The target is UNVERIFIED: a stale RSA-era value
 # may still occupy this path (RSA is incompatible with the Ed25519 runtime verifier), so the P3-4
 # value-move is gated on a computeKeyId readback. Adversarial verification of the target is in flight.
+# GAP-260 P4-2 (apps/license-signer), not platform-synced until signer deploy:
+revealui/prod/license/signer-invoke-secret  # REVEALUI_SIGNER_INVOKE_SECRET
+                                            # HMAC for POST /internal/mint; NEVER reuse REVEALUI_SECRET
 ```
 
 Operator migration (one-time, owner machine):
@@ -314,12 +317,18 @@ Operator migration (one-time, owner machine):
 # 1) Ensure revealui/env/license contains only PUBLIC KEY= lines
 # 2) Put PRIVATE KEY lines under revealui/env/license-signing
 # 3) Mint/local sign: REVVAULT_ALLOW_PRIVATE=1 with-secrets license-signing -- <cmd>
+# 4) P4-2: mint a high-entropy invoke secret once:
+#    revvault set revealui/prod/license/signer-invoke-secret
 ```
 
 **Deployment mode (GAP-260 P4-1):** set `REVEALUI_DEPLOYMENT_MODE=hosted` or `forge` on each
 runtime (api + admin). Prefer explicit MODE over private-key sniffing so hosted admin can boot
 without the signing private key (signer isolation). When MODE is unset, runtimes still fall
 back to "private key present → hosted". `MODE=forge` with a private key present fails boot.
+
+**License-signer (GAP-260 P4-2):** `apps/license-signer` is the isolated mint process. It
+requires `REVEALUI_LICENSE_PRIVATE_KEY` + `REVEALUI_SIGNER_INVOKE_SECRET` at boot (fail-loud).
+Mint cutover from api/webhooks is P4-3; private-key drop from admin/Fly is P4-4.
 
 ### LLM / AI providers
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -130,7 +130,7 @@ cd revealui
 pnpm install
 pnpm gate                # Run the full CI gate locally
 pnpm test                # Run the full test suite
-pnpm typecheck:all       # Typecheck all 33 workspaces
+pnpm typecheck:all       # Typecheck all 34 workspaces
 pnpm validate:claims     # Run the marketing/docs claim-drift gate
 ```
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -229,7 +229,7 @@ This is the part that's genuinely hard to replicate by stitching services togeth
 
 Some numbers on what's actually shipped:
 
-- **33 workspaces** across the monorepo (4 apps, 29 packages with 23 MIT, 5 Fair Source, 1 internal)
+- **34 workspaces** across the monorepo (5 apps, 29 packages with 23 MIT, 5 Fair Source, 1 internal)
 - **97 database tables** via Drizzle ORM on NeonDB (Postgres)
 - **65 UI components** in `@revealui/presentation`, with one third-party runtime dependency (`tailwind-merge`), built directly on Tailwind v4 and React, with `cva` and `cn` vendored in-package
 - **13 first-party MCP servers** in `@revealui/mcp`

--- a/docs/security/INFORMATION_SECURITY_POLICY.md
+++ b/docs/security/INFORMATION_SECURITY_POLICY.md
@@ -132,7 +132,7 @@ RevealUI does not store credit card numbers or payment method details. All payme
 All changes pass through the CI gate before reaching `test` or `main`:
 
 1. **Quality** (parallel): Biome lint (hard fail), security audits (warn), structure checks (warn)
-2. **Type checking** (serial): TypeScript strict mode across all 33 workspaces
+2. **Type checking** (serial): TypeScript strict mode across all 34 workspaces
 3. **Test + Build** (parallel): Vitest (full suite, hard fail), Turborepo build verification
 
 ### Branch Pipeline

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "deps:fix": "syncpack fix && syncpack format",
     "dev": "turbo run dev --parallel",
     "dev:api": "pnpm --filter server dev",
+    "dev:license-signer": "pnpm --filter @revealui/license-signer dev",
     "smoke:server-tsx": "node scripts/ci/server-tsx-boot-smoke.mjs",
     "dev:app": "pnpm run build:auth && concurrently --kill-others-on-fail -n admin,server -c cyan,yellow \"pnpm --filter admin dev\" \"pnpm --filter server dev\"",
     "dev:admin": "pnpm run build:auth && pnpm --filter admin dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,7 +367,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -539,6 +539,43 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  apps/license-signer:
+    dependencies:
+      '@hono/node-server':
+        specifier: '>=2.0.5'
+        version: 2.0.11(hono@4.12.27)
+      '@revealui/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      hono:
+        specifier: 4.12.27
+        version: 4.12.27
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../../packages/dev
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.5
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(@microsoft/api-extractor@7.58.11(@types/node@25.9.5))(jiti@2.7.0)(postcss@8.5.20)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   apps/marketing:
     dependencies:
       '@fontsource-variable/inter':
@@ -570,7 +607,7 @@ importers:
         version: 10.67.0(react@19.2.7)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react:
         specifier: '>=19.2.4'
         version: 19.2.7
@@ -11859,7 +11896,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -55,6 +55,7 @@ export interface SecretPathDef {
    * Where this path is consumed. Tokens:
    *   vercel:api | vercel:admin | vercel:marketing | vercel:docs | fly:worker
    *   with-secrets:license | with-secrets:license-signing
+   *   app:license-signer (GAP-260 P4-2 isolated mint process; not a Vercel app)
    */
   consumers: string[];
   /** Feeds P0-5 (⊇ REQUIRED_IN_PRODUCTION_HOSTED). Set only where confirmed required-at-boot. */
@@ -841,6 +842,18 @@ export const SECRET_PATHS: SecretPathDef[] = [
     consumers: ['with-secrets:license-signing'],
     intentionallyUnsynced: true,
     note: 'export-env signing bundle: REVEALUI_LICENSE_PRIVATE_KEY (+ public if needed for self-check). with-secrets license-signing requires REVVAULT_ALLOW_PRIVATE=1',
+  },
+  // GAP-260 P4-2: dedicated HMAC for apps/license-signer mint API.
+  // NOT REVEALUI_SECRET. Not platform-synced until the signer deploy lands (P4-3/P4-4).
+  {
+    path: 'revealui/prod/license/signer-invoke-secret',
+    kind: 'credential',
+    sensitive: true,
+    tier: 'prod',
+    consumers: ['app:license-signer'],
+    intentionallyUnsynced: true,
+    envVars: ['REVEALUI_SIGNER_INVOKE_SECRET'],
+    note: 'HMAC-SHA256 per-call auth for POST /internal/mint on apps/license-signer. No REVEALUI_SECRET fallback. Owner mints vault value before first signer deploy.',
   },
 ];
 


### PR DESCRIPTION
## Summary

GAP-260 **P4-2**: stand up `apps/license-signer` as the isolated license JWT mint process.

- **Hono** service: `GET /health/live`, `POST /internal/mint`
- Mints via unchanged `generateLicenseKey` from `@revealui/core/license`
- Per-call **HMAC** auth: `REVEALUI_SIGNER_INVOKE_SECRET` only (no `REVEALUI_SECRET` fallback), 300s skew
- Fail-loud boot if invoke secret or private key missing
- Declares vault path `revealui/prod/license/signer-invoke-secret` in `SECRET_PATHS` (intentionally unsynced until signer deploy)
- Claim-drift: METRICS apps 5 / workspaces 34

## Not in this PR (later phases)

- **P4-3** mint client cutover (`REVEALUI_LICENSE_SIGN_VIA_SIGNER`)
- **P4-4** drop private key from admin/Fly
- Deploy wiring / platform sync of invoke secret

## Acceptance (P4-2)

- [x] Signer holds signing private key and calls `generateLicenseKey` unchanged
- [x] HMAC-authed per-call with dedicated invoke secret
- [x] Unit tests (auth + mint route) green
- [x] `validate:secret-paths` green

## Test plan

- [x] `pnpm --filter @revealui/license-signer test` (17 tests)
- [x] `pnpm --filter @revealui/license-signer typecheck` / `build` / `lint`
- [x] `pnpm validate:claims` / `validate:secret-paths`
- [ ] CI green on PR

## Owner follow-ups (ops, not this PR)

```bash
revvault set revealui/prod/license/signer-invoke-secret
```