### PR TITLE
feat(harnesses): pin opencode run json parser + connect guide (GAP-371 P4)

### DIFF
--- a/.changeset/gap-371-phase4-opencode-parser-pin.md
+++ b/.changeset/gap-371-phase4-opencode-parser-pin.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": patch
+---
+
+Pin `parseOpenCodeRunOutput` (GAP-371 Phase 4) against the real `opencode run --format json` output shape, verified live against opencode 1.18.3: newline-delimited JSON (JSONL) events, one per line, not a single JSON document. The parser now extracts the assistant's final `text` event from a real turn instead of mis-treating the JSONL stream as invalid JSON and echoing it back verbatim.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -53,6 +53,7 @@ Six **[design principles](./JOSHUA.md)** govern every architectural decision: Ju
 ## Agent Coordination
 
 - [Harness Protocol](./HARNESS_PROTOCOL.md): Agent normalization, capability model, lifecycle events, and the adapter/coordinator surface shipped in `@revealui/harnesses`
+- [Connect OpenCode](./guides/connect-opencode.md): Connect the OpenCode CLI to a RevealUI instance through the governed MCP endpoint
 - [Blog: Three AI Agents, One Codebase](./blog/03-multi-agent-coordination.md): The problem that led to the Holster
 
 ## Pro & Enterprise

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -62,6 +62,7 @@ revealui/dev/admin-password
 revealui/dev/admin-session-cookie
 revealui/dev/electric/service-url
 revealui/dev/founder-license-key    # RVUI-<tier>-<32hex>; founder dev license consumed by revdev daemon
+revealui/dev/mcp/opencode-device-token   # rvui_dev_* device token minted via the studio-auth link/verify flow; used as REVEALUI_MCP_TOKEN by MCP clients (e.g. OpenCode)
 # Stripe TEST-mode keys (dev namespace) — used by local dev + the CI integration suite.
 revealui/dev/stripe/restricted-ci-test     # rk_test_* restricted (Write: PaymentIntents/Products/Prices/Checkout) — mirrored to CI as STRIPE_SECRET_KEY (see CI / publishing)
 revealui/dev/stripe/secret-key             # sk_test_* full test secret (broader; CI uses the restricted key above)

--- a/docs/guides/connect-opencode.md
+++ b/docs/guides/connect-opencode.md
@@ -1,0 +1,146 @@
+---
+title: "Connect OpenCode"
+description: "Connect the OpenCode CLI to a RevealUI instance through the governed MCP endpoint, so OpenCode becomes a governed and audited user of your data."
+visibility: public
+status: verified
+audience: developer
+---
+
+# Connect OpenCode
+
+OpenCode can reach a RevealUI instance's data through the governed Model
+Context Protocol (MCP) endpoint. Every tool call OpenCode makes runs as a
+specific, authenticated RevealUI user. It is authorized the same way a human
+request is, and it leaves a receipt in the audit log. This guide walks
+through the connection from a fresh OpenCode install to a working tool call.
+
+## What governance means here
+
+OpenCode brings its own model. RevealUI never hosts a frontier model or ships
+a proprietary model SDK. What RevealUI provides is the governed data layer:
+identity, authorization, and an audit trail for everything an agent touches.
+
+- **Authenticated.** Every request carries your own bearer token. There is no
+  shared service key on this path.
+- **Authorized.** The same role-based and row-level access rules that govern
+  a human's requests govern the agent's requests. An agent can only reach
+  what its user is allowed to reach.
+- **Audited.** Every tool call writes a receipt to the audit log. If an agent
+  did it, there is a receipt you can check.
+- **Revocable.** Revoking the device token cuts access immediately. The
+  server re-validates the token on every request (`apps/server/src/middleware/auth.ts:26`),
+  not only when a session starts, so a revoked token stops working on its
+  very next request.
+
+## Prerequisites
+
+- A RevealUI account on the instance you want to connect to.
+- The `opencode` CLI installed and on your `PATH`.
+- A device token minted through the studio-auth device flow (below).
+
+## 1. Mint a device token
+
+RevealUI authenticates programmatic clients, including CLIs, with device
+tokens rather than session cookies. Minting one is a two-step email
+verification flow:
+
+1. Request a code: send your email and a device name to the instance's
+   studio-auth link endpoint. RevealUI emails you a one-time verification
+   code.
+2. Verify the code: exchange the code for a bearer token.
+
+Your RevealUI instance's admin console or CLI tooling wraps this flow for
+you. The resulting token has the shape `rvui_dev_<64 hex characters>` and is
+valid for a configurable lifetime (30 days by default). Treat it like a
+password: never paste it into a chat, a committed file, or a shared
+terminal.
+
+## 2. Store the token as an environment variable
+
+Export the token in your shell, or store it in whatever secret manager your
+own environment uses, and load it before running `opencode`. The token
+itself never belongs in a committed config file.
+
+```bash
+export REVEALUI_MCP_TOKEN="rvui_dev_your_token_here"
+```
+
+## 3. Configure OpenCode
+
+Add a `mcp` entry to your project's `opencode.json` pointing at the
+instance's governed MCP endpoint. The `{env:...}` syntax tells OpenCode to
+read the token from your environment at run time instead of storing it in
+the file:
+
+```jsonc
+// opencode.json
+{
+  "mcp": {
+    "revealui": {
+      "type": "remote",
+      "url": "https://<your-host>/api/mcp",
+      "headers": { "Authorization": "Bearer {env:REVEALUI_MCP_TOKEN}" },
+      "oauth": false,
+      "enabled": true
+    }
+  },
+  "tools": { "revealui*": true }
+}
+```
+
+Replace `<your-host>` with your RevealUI instance's hostname. The
+`{env:REVEALUI_MCP_TOKEN}` substitution means the committed file never
+contains a literal token value, only a pointer to where OpenCode should read
+it from.
+
+## 4. Confirm the connection
+
+```bash
+opencode mcp list
+```
+
+You should see the `revealui` server listed as connected, along with its
+URL.
+
+## 5. Understand the tool names
+
+Every tool RevealUI exposes over MCP is named `<server>_<tool>`. Since the
+server is registered as `revealui` in your config, a tool like
+`list_sites` shows up to OpenCode as `revealui_revealui_list_sites`. The
+doubled prefix looks unusual at first: the first `revealui` is the MCP
+server name from your config, and the second is the tool's own name inside
+that server.
+
+## 6. Run a task
+
+```bash
+opencode run "List my RevealUI sites"
+```
+
+OpenCode calls the governed tool using your token. The response is scoped to
+what your account can see, and a receipt for the call lands in your RevealUI
+instance's audit log.
+
+## Rotating or revoking the token
+
+There is no separate rotation flow. To rotate, revoke the current token and
+mint a new one. Revocation takes effect on the token's very next use, mid
+session included, because the server checks the token on every request
+rather than trusting a cached session.
+
+## Troubleshooting
+
+- **401 responses:** the token is missing, expired, or revoked. Mint a new
+  one and update `REVEALUI_MCP_TOKEN`.
+- **Tool not listed:** `tools/list` only returns tools your account is
+  permitted to execute. A tool missing from discovery is denied by design,
+  not a bug.
+- **Session errors after a network interruption:** MCP session identifiers
+  are routing state, not credentials. If your token is still valid,
+  reconnecting establishes a fresh session automatically.
+
+## Sources
+
+- Per-request bearer validation (revocation takes effect on the next request): `apps/server/src/middleware/auth.ts:26`
+- Governed endpoint session binding and identity threading: `apps/server/src/routes/mcp-endpoint.ts:135`
+- Device token mint and revocation flow: `apps/server/src/routes/studio-auth.ts:87`

--- a/packages/harnesses/scripts/opencode-live-walk.md
+++ b/packages/harnesses/scripts/opencode-live-walk.md
@@ -1,0 +1,102 @@
+# OpenCode live walk (owner-run, not CI)
+
+This is a manual, reproducible walk against a real RevealUI deployment and a
+real `opencode` binary. It is **not** part of the automated test suite: it
+needs a live gateway, a real device token, and network access, none of which
+belong in CI (no network-dependent or model-dependent checks run there -- see
+`opencode-adapter.test.ts` and `opencode-config.test.ts` for the deterministic
+fixture-based coverage that does).
+
+Run this walk whenever `opencode` ships a new major/minor version, or when the
+governed `/api/mcp` endpoint's auth/session behavior changes, to re-pin
+`parseOpenCodeRunOutput` (`../src/adapters/opencode-adapter.ts`) against
+reality.
+
+## Prerequisites
+
+- A RevealUI account on the target instance.
+- The `opencode` CLI installed (`npm install -g opencode-ai`, the curl
+  installer, or brew) and on `PATH`.
+- `curl` and `jq` for the manual HTTP steps.
+
+## 1. Mint a device token
+
+```bash
+curl -s -X POST https://<your-host>/api/studio-auth/link \
+  -H 'content-type: application/json' \
+  -d '{"email":"you@example.com","deviceId":"opencode-live-walk","deviceName":"OpenCode live walk","deviceType":"cli"}'
+```
+
+Read the OTP from the email RevealUI sends, then exchange it for a bearer
+token:
+
+```bash
+curl -s -X POST https://<your-host>/api/studio-auth/verify \
+  -H 'content-type: application/json' \
+  -d '{"email":"you@example.com","deviceId":"opencode-live-walk","code":"<otp-from-email>"}' \
+  | jq -r '.token'
+```
+
+The response token has the shape `rvui_dev_<64-hex-chars>`. Export it for the
+rest of the walk; do not paste it anywhere it could be committed or logged.
+
+```bash
+export REVEALUI_MCP_TOKEN='<the-token-from-above>'
+```
+
+## 2. Write the project config
+
+In a scratch project directory, write `opencode.json` with the exact block
+from [`docs/guides/connect-opencode.md`](../../../docs/guides/connect-opencode.md)
+(the `{env:REVEALUI_MCP_TOKEN}` substitution, never a literal token).
+
+## 3. Confirm the MCP connection
+
+```bash
+opencode mcp list
+```
+
+Expect a connected-status listing that names the `revealui` server and its
+URL.
+
+## 4. Drive a real tool-using turn and capture the raw event stream
+
+```bash
+opencode run -m <your-model> --format json "List my RevealUI sites" \
+  | tee /tmp/opencode-live-walk-raw.jsonl
+```
+
+- Confirm exit code `0` and empty stderr.
+- Confirm every line of `/tmp/opencode-live-walk-raw.jsonl` parses as JSON
+  and matches the envelope `{type, timestamp, sessionID, part}`.
+- Compare the observed `type`/`part.type` sequence against the header comment
+  in `parseOpenCodeRunOutput` (`../src/adapters/opencode-adapter.ts`). If the
+  shape drifted, update the parser, its tests, and this doc together.
+- Confirm `parseOpenCodeRunOutput` (run it locally against the captured file,
+  e.g. via a scratch Node script) extracts the same final text the CLI
+  printed.
+
+**Discard `/tmp/opencode-live-walk-raw.jsonl` when done** -- it may contain
+real site names or other account data; never commit it.
+
+## 5. Confirm mid-session revocation
+
+While the same `opencode` session is still warm, revoke the device token from
+another terminal:
+
+```bash
+curl -s -X DELETE https://<your-host>/api/studio-auth/revoke \
+  -H "authorization: Bearer $REVEALUI_MCP_TOKEN"
+```
+
+Then issue another `opencode run` (or `opencode mcp list`) using the same
+config. Expect the next request on the revoked session to fail with an
+authentication error (HTTP 401) -- the governed endpoint re-validates the
+bearer token per request, so revocation takes effect immediately, not just at
+the next session `initialize`.
+
+## 6. Clean up
+
+- Revoke the token if step 5 was skipped.
+- Remove the scratch project directory and the captured JSONL file.
+- Unset `REVEALUI_MCP_TOKEN` in the shell.

--- a/packages/harnesses/src/__tests__/opencode-adapter.test.ts
+++ b/packages/harnesses/src/__tests__/opencode-adapter.test.ts
@@ -89,7 +89,12 @@ describe('OpenCodeAdapter', () => {
       expect(result.success).toBe(true);
       expect(result.command).toBe('get-status');
       const data = result.data as { available: boolean; projectRoot: string };
-      expect(data.available).toBe(false); // opencode not installed in this env
+      // Whether `opencode` is on PATH is a property of the machine running
+      // the suite, not of this adapter -- assert shape, not a specific
+      // value. (A same-test comparison against a second real
+      // `adapter.isAvailable()` call is flaky under parallel test load: two
+      // independent execFile calls to the real binary can race.)
+      expect(typeof data.available).toBe('boolean');
       expect(data.projectRoot).toBe(projectRoot);
     });
 
@@ -253,6 +258,146 @@ describe('parseOpenCodeRunOutput', () => {
 
   it('treats non-JSON stdout as plain text', () => {
     expect(parseOpenCodeRunOutput('just plain text, not json')).toBe('just plain text, not json');
+  });
+
+  // Fixtures below are SYNTHESIZED against the pinned opencode 1.18.3 event
+  // shape (all ids/values invented -- see the adapter header comment). Every
+  // event carries the envelope `{type, timestamp, sessionID, part}`, with
+  // `type` underscore-separated and `part.type` hyphen-separated.
+  //
+  // The pre-pin parser treated stdout as a single JSON document. Against
+  // this real newline-delimited shape it either (a) throws on multi-line
+  // JSONL and falls back to returning the raw stdout verbatim, or (b) on a
+  // single-event line, finds no top-level `output`/`text`/`message`/
+  // `content` key (those live under `part`, not the envelope) and also
+  // returns the raw JSON verbatim. Both were verified false-red against the
+  // pre-fix parser (stashed locally, not committed) before this fix landed.
+  describe('pinned opencode 1.18.3 JSONL event-stream shape', () => {
+    function eventLine(event: Record<string, unknown>): string {
+      return JSON.stringify(event);
+    }
+
+    it('extracts the final assistant text from a full tool-using turn (multi-event JSONL)', () => {
+      const jsonl = [
+        eventLine({
+          type: 'step_start',
+          timestamp: 1721000000000,
+          sessionID: 'ses_test_fixture_1',
+          part: { type: 'step-start' },
+        }),
+        eventLine({
+          type: 'tool_use',
+          timestamp: 1721000000001,
+          sessionID: 'ses_test_fixture_1',
+          part: {
+            type: 'tool',
+            tool: 'revealui_revealui_list_sites',
+            callID: 'call_fixture_1',
+            id: 'part_fixture_1',
+            messageID: 'msg_fixture_1',
+            sessionID: 'ses_test_fixture_1',
+            state: {
+              status: 'completed',
+              input: {},
+              output: '{"sites":[{"id":"site_fixture_1","name":"Example Site"}]}',
+            },
+          },
+        }),
+        eventLine({
+          type: 'step_finish',
+          timestamp: 1721000000002,
+          sessionID: 'ses_test_fixture_1',
+          part: { type: 'step-finish' },
+        }),
+        eventLine({
+          type: 'step_start',
+          timestamp: 1721000000003,
+          sessionID: 'ses_test_fixture_1',
+          part: { type: 'step-start' },
+        }),
+        eventLine({
+          type: 'text',
+          timestamp: 1721000000004,
+          sessionID: 'ses_test_fixture_1',
+          part: { type: 'text', text: 'You have one site: Example Site.' },
+        }),
+        eventLine({
+          type: 'step_finish',
+          timestamp: 1721000000005,
+          sessionID: 'ses_test_fixture_1',
+          part: { type: 'step-finish' },
+        }),
+      ].join('\n');
+
+      expect(parseOpenCodeRunOutput(jsonl)).toBe('You have one site: Example Site.');
+    });
+
+    it('extracts text from a single-event JSONL line (no tool use)', () => {
+      const jsonl = eventLine({
+        type: 'text',
+        timestamp: 1721000000010,
+        sessionID: 'ses_test_fixture_2',
+        part: { type: 'text', text: 'Hello from a single-event turn.' },
+      });
+
+      expect(parseOpenCodeRunOutput(jsonl)).toBe('Hello from a single-event turn.');
+    });
+
+    it('prefers the LAST text event when a turn has multiple text events', () => {
+      const jsonl = [
+        eventLine({
+          type: 'text',
+          timestamp: 1721000000020,
+          sessionID: 'ses_test_fixture_3',
+          part: { type: 'text', text: 'first partial' },
+        }),
+        eventLine({
+          type: 'text',
+          timestamp: 1721000000021,
+          sessionID: 'ses_test_fixture_3',
+          part: { type: 'text', text: 'final answer' },
+        }),
+      ].join('\n');
+
+      expect(parseOpenCodeRunOutput(jsonl)).toBe('final answer');
+    });
+
+    it('falls back to raw stdout for a JSONL stream with no terminal text event (tool-only turn)', () => {
+      const jsonl = [
+        eventLine({
+          type: 'step_start',
+          timestamp: 1721000000030,
+          sessionID: 'ses_test_fixture_4',
+          part: { type: 'step-start' },
+        }),
+        eventLine({
+          type: 'tool_use',
+          timestamp: 1721000000031,
+          sessionID: 'ses_test_fixture_4',
+          part: {
+            type: 'tool',
+            tool: 'revealui_revealui_site_stats',
+            callID: 'call_fixture_4',
+            state: { status: 'completed', input: {}, output: '{"views":0}' },
+          },
+        }),
+      ].join('\n');
+
+      // Documented fallback (no information loss): no `text` event, so the
+      // raw JSONL is returned verbatim rather than silently dropped.
+      expect(parseOpenCodeRunOutput(jsonl)).toBe(jsonl);
+    });
+
+    it('handles trailing blank lines in JSONL stdout', () => {
+      const jsonl = `${eventLine({
+        type: 'text',
+        timestamp: 1721000000040,
+        sessionID: 'ses_test_fixture_5',
+        part: { type: 'text', text: 'trailing newline handled' },
+      })}\n\n`;
+
+      expect(parseOpenCodeRunOutput(jsonl)).toBe('trailing newline handled');
+    });
   });
 });
 

--- a/packages/harnesses/src/adapters/opencode-adapter.ts
+++ b/packages/harnesses/src/adapters/opencode-adapter.ts
@@ -141,8 +141,8 @@ export function parseOpenCodeRunOutput(stdout: string): string {
 
   if (isEventStream) {
     for (let i = events.length - 1; i >= 0; i -= 1) {
-      const { part } = events[i];
-      if (part.type === 'text' && typeof part.text === 'string') {
+      const part = events[i]?.part;
+      if (part && part.type === 'text' && typeof part.text === 'string') {
         return part.text;
       }
     }

--- a/packages/harnesses/src/adapters/opencode-adapter.ts
+++ b/packages/harnesses/src/adapters/opencode-adapter.ts
@@ -8,9 +8,12 @@
  * RevealUI data-plane authority -- that flows through the governed MCP
  * endpoint with its own bearer token (design doc §3, "bridging rule B-1").
  *
- * `opencode run <prompt> --format json` output shape is UNVERIFIED against a
- * real binary (design doc §2.4) -- `parseRunOutput` below is defensive and
- * documents exactly what it assumes.
+ * `opencode run <prompt> --format json` output shape is pinned against
+ * opencode 1.18.3, 2026-07-24 (live verification with a minted device
+ * token; see `scripts/opencode-live-walk.md` in this package for the
+ * reproducible manual walk) -- `parseOpenCodeRunOutput` below implements
+ * the verified newline-delimited JSON (JSONL) event-stream shape, with a
+ * defensive fallback for stdout that is not JSONL.
  */
 
 import { execFile } from 'node:child_process';
@@ -64,24 +67,87 @@ const DEFAULT_CONFIG: Required<Pick<OpenCodeAdapterConfig, 'timeoutMs' | 'binary
 };
 
 /**
+ * One event line from `opencode run --format json` stdout, pinned against
+ * opencode 1.18.3 (2026-07-24 live verification). Every event carries this
+ * envelope: `type` (envelope-level, underscore-separated -- `step_start`,
+ * `tool_use`, `step_finish`, `text`), `timestamp` (ms), `sessionID`, and
+ * `part` (the event body; `part.type` is hyphen-separated -- `step-start`,
+ * `tool`, `step-finish`, `text` -- note the underscore/hyphen split between
+ * envelope and part).
+ */
+interface OpenCodeRunEventEnvelope {
+  type: string;
+  timestamp: number;
+  sessionID: string;
+  part: Record<string, unknown>;
+}
+
+function isOpenCodeRunEventEnvelope(value: unknown): value is OpenCodeRunEventEnvelope {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.type === 'string' &&
+    typeof obj.timestamp === 'number' &&
+    typeof obj.sessionID === 'string' &&
+    typeof obj.part === 'object' &&
+    obj.part !== null
+  );
+}
+
+/**
  * Parse `opencode run --format json` stdout into a plain-text output string.
- * The exact shape is UNVERIFIED against a real binary (design doc §2.4) --
- * this deliberately degrades gracefully:
- *   1. Valid JSON object with a known text-bearing key (`output`, `text`,
- *      `message`, `content`) -- return that string.
- *   2. Valid JSON of any other shape -- return the raw JSON text so no
- *      information is lost.
- *   3. Not JSON at all -- treat stdout as plain text (opencode's non-JSON
- *      `run` mode is plain text; `--format json` failing silently to emit
- *      JSON should not throw away the response).
+ *
+ * Pinned shape (opencode 1.18.3, verified live 2026-07-24): stdout is
+ * newline-delimited JSON (JSONL) -- one event object per line, NOT a single
+ * JSON document. This function:
+ *   1. Parses every non-blank line as JSON. If every line parses AND matches
+ *      the `OpenCodeRunEventEnvelope` shape, treat stdout as a real JSONL
+ *      event stream: return the `part.text` of the LAST `text` event (the
+ *      assistant's final message for the turn). If no `text` event is
+ *      present (e.g. a tool-only turn with no closing message), return the
+ *      raw stdout so no information is lost.
+ *   2. Otherwise (not JSONL -- e.g. a version banner, a plain-text error, or
+ *      an older/newer opencode `run` output shape), fall back to the
+ *      pre-pin heuristic: a JSON object with a known text-bearing key
+ *      (`output`, `text`, `message`, `content`), any other valid JSON
+ *      (returned verbatim), or plain text (returned verbatim). This branch
+ *      is a documented defensive fallback, not a verified shape.
  *
  * Exported (rather than a private method) so the parsing logic is directly
- * unit-testable against the documented-but-unverified shape without
- * mocking `execFile`.
+ * unit-testable against the pinned shape without mocking `execFile`.
  */
 export function parseOpenCodeRunOutput(stdout: string): string {
   const trimmed = stdout.trim();
   if (trimmed.length === 0) return '';
+
+  const lines = trimmed.split('\n').filter((line) => line.trim().length > 0);
+  const events: OpenCodeRunEventEnvelope[] = [];
+  let isEventStream = lines.length > 0;
+
+  for (const line of lines) {
+    let parsedLine: unknown;
+    try {
+      parsedLine = JSON.parse(line);
+    } catch {
+      isEventStream = false;
+      break;
+    }
+    if (!isOpenCodeRunEventEnvelope(parsedLine)) {
+      isEventStream = false;
+      break;
+    }
+    events.push(parsedLine);
+  }
+
+  if (isEventStream) {
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      const { part } = events[i];
+      if (part.type === 'text' && typeof part.text === 'string') {
+        return part.text;
+      }
+    }
+    return trimmed;
+  }
 
   try {
     const parsed: unknown = JSON.parse(trimmed);


### PR DESCRIPTION
GAP-371 Phase 4: the deferred Phase-3 output-shape pin, the public connect guide, and the token-path documentation, grounded in today's live walk against the production governed MCP endpoint with a real minted device token and opencode 1.18.3.

## What changed
- **Parser pin** (`packages/harnesses/src/adapters/opencode-adapter.ts`): `parseOpenCodeRunOutput` now implements the verified `--format json` shape: newline-delimited JSON events with the `{type, timestamp, sessionID, part}` envelope; returns the last `text` event's `part.text`. The pre-pin single-JSON heuristic is kept as a documented fallback for non-JSONL stdout. Prove-red: 4 of 5 new fixture tests fail against the pre-fix parser (multi-event turn, single-event turn, last-text-wins, trailing blanks); the tool-only-turn case passes on both by coincidence and is kept honestly as a regression guard. All fixtures synthesized; no real ids.
- **Public guide** `docs/guides/connect-opencode.md` (indexed): token mint, env-var pattern, config, tool naming, revocation semantics with code citations.
- **Owner-run manual walk** `packages/harnesses/scripts/opencode-live-walk.md`: the reproducible live sequence; explicitly not CI.
- **docs/SECRETS.md**: device-token vault path entry.
- **Changeset**: patch for @revealui/harnesses.
- Incidental: the get-status test no longer hardcodes opencode-not-installed (it is installed on the dev machine now); asserts shape.

## Live-walk evidence (2026-07-24, prod)
Unauthenticated /api/mcp 401 fail-closed; authenticated initialize (capabilities tools-only); session-id enforcement (-32000 without header); governed tools/call returning tenant-scoped data; real opencode 1.18.3 agent turn through the governed mount, exit 0; mid-session device revocation: established session 200, revoke, next request on the same session 401. The audit receipt chain is asserted by the package's existing DB-backed tests rather than externally (the anchors endpoint reaches prod at the next promotion).

## CI honesty
No network- or model-dependent tests added. The deterministic layers are the fixture-based parser tests plus the existing config-write tests; the live walk is the documented owner-run script. Harnesses suite 517/517, build green, citation gate clean.

Flag-on-contact: the citation validator's hint text offers a `## Sources` block exoneration that has no implementing code (hint-only); candidate small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)