### PR TITLE
feat(harnesses): gates control layer for guardrail2 + doc-currency (GAP-408)

### DIFF
--- a/.changeset/gap-408-control-layer-gates.md
+++ b/.changeset/gap-408-control-layer-gates.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+Add a `gates` subpath export (GAP-408 control-layer redesign): `evaluateGuardrail2` / `verdictForBody` / `collectVerdicts` (the guardrail-2 verdict-marker parser) and `SHARED_DETECTION_RULES` / `COMMON_EXON` / `STRIPE_LIVE_EXON` (the doc-currency stale-fact detection data). These are now the single editable source for logic that `scripts/validate/guardrail2-verdict.cjs` and `scripts/validate/doc-currency.ts` load at runtime, and that the private revealui-jv checkout's equivalent scripts resolve via an adapter — no vendored copies on either side of the public/private boundary.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,18 @@ jobs:
         # build @revealui/contracts (needs @revealui/db; Quality has install only).
         run: pnpm validate:marketing-voice-prose-slots
 
+      - name: Build @revealui/harnesses (doc-currency's gates module, GAP-408)
+        # doc-currency.ts resolves its shared SHARED_FLEET_RULES detection
+        # tuples from packages/harnesses/dist/gates — build just that one
+        # package rather than the whole monorepo (Quality is install-only
+        # otherwise). Absence degrades to a warn + shared-rules-skipped run
+        # (see doc-currency.ts's ABSENCE BEHAVIOR comment), not a crash, so
+        # this step is a belt-and-braces guarantee of full coverage, not a
+        # hard dependency of the job passing.
+        run: pnpm --filter @revealui/harnesses build
+        env:
+          SKIP_ENV_VALIDATION: "true"
+
       - name: Doc-currency validation (hard fail)
         # Stale-fact drift guard: docs/**/*.md + apps/marketing/**/*.md prose,
         # plus apps/marketing/app/content/**/*.ts marketing-copy string

--- a/.github/workflows/sec-audit-label-guard.yml
+++ b/.github/workflows/sec-audit-label-guard.yml
@@ -58,10 +58,43 @@ jobs:
           # expression is empty and checkout falls back to the default-branch
           # ref those events already run from.
           ref: ${{ github.event.pull_request.base.sha }}
+          # GAP-408: guardrail2-verdict.cjs is a thin adapter over the
+          # @revealui/harnesses gates module. Builds it from THIS checkout's
+          # own source (packages/harnesses/ + packages/dev/ for the shared
+          # tsconfig, plus every package.json so pnpm can resolve the
+          # workspace filter) rather than installing a published npm artifact
+          # — see security-review-gate.yml's matching comment for why (a
+          # publish-pinned dependency would leave the gate fail-closed on an
+          # unbounded window until the next manual stable release). The
+          # resolver's npm-install fallback (REVEALUI_HARNESSES_DIR) stays in
+          # gates-resolver.cjs for the .jv side, unused here.
           sparse-checkout: |
             scripts/validate/sec-audit-label-decision.cjs
             scripts/validate/guardrail2-verdict.cjs
+            scripts/validate/gates-resolver.cjs
+            package.json
+            pnpm-workspace.yaml
+            pnpm-lock.yaml
+            .npmrc
+            packages/*/package.json
+            apps/*/package.json
+            packages/harnesses/
+            packages/dev/
           sparse-checkout-cone-mode: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: '10.28.2'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Build @revealui/harnesses (guardrail2-verdict gates module, GAP-408)
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile --filter @revealui/harnesses
+          pnpm --filter @revealui/harnesses build
 
       - name: Guard the clearance label
         env:

--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -60,11 +60,46 @@ jobs:
           # GAP-404: gate loads SECURITY_PATHS from security-paths.shared.json
           # at module load. Sparse list must include that JSON or the job
           # crashes ENOENT before it can classify the PR (revealui#2074).
+          # GAP-408: guardrail2-verdict.cjs is a thin adapter over the
+          # @revealui/harnesses gates module. Builds it from THIS checkout's
+          # own source (packages/harnesses/ + packages/dev/ for the shared
+          # tsconfig, plus every package.json so pnpm can resolve the
+          # workspace filter) rather than installing a published npm artifact
+          # — a pinned-to-a-release dependency would leave every PR (including
+          # the test->main promotion) fail-closed until a manual stable
+          # release publishes a version that doesn't exist yet at merge time.
+          # gates-resolver.cjs's local-dist path picks up the build below with
+          # no further wiring; the resolver's npm-install fallback
+          # (REVEALUI_HARNESSES_DIR) stays in the module for the .jv side,
+          # unused here.
           sparse-checkout: |
             scripts/validate/security-review-gate.cjs
             scripts/validate/guardrail2-verdict.cjs
+            scripts/validate/gates-resolver.cjs
             scripts/validate/security-paths.shared.json
+            package.json
+            pnpm-workspace.yaml
+            pnpm-lock.yaml
+            .npmrc
+            packages/*/package.json
+            apps/*/package.json
+            packages/harnesses/
+            packages/dev/
           sparse-checkout-cone-mode: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: '10.28.2'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Build @revealui/harnesses (guardrail2-verdict gates module, GAP-408)
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile --filter @revealui/harnesses
+          pnpm --filter @revealui/harnesses build
 
       - name: Evaluate review gate
         env:

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -76,6 +76,11 @@
       "types": "./dist/hotfix/index.d.ts",
       "import": "./dist/hotfix/index.js",
       "default": "./dist/hotfix/index.js"
+    },
+    "./gates": {
+      "types": "./dist/gates/index.d.ts",
+      "import": "./dist/gates/index.js",
+      "default": "./dist/gates/index.js"
     }
   },
   "files": [

--- a/packages/harnesses/src/gates/__tests__/doc-currency-shared-rules.test.ts
+++ b/packages/harnesses/src/gates/__tests__/doc-currency-shared-rules.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COMMON_EXON,
+  SHARED_DETECTION_RULES,
+  STRIPE_LIVE_EXON,
+} from '../doc-currency-shared-rules.js';
+
+describe('SHARED_DETECTION_RULES', () => {
+  it('carries the 8 fleet-fact rule ids in canonical order', () => {
+    expect(SHARED_DETECTION_RULES.map((r) => r.id)).toEqual([
+      'revealcoin-as-current',
+      'railway-as-current',
+      'vercel-blob-as-current',
+      'supabase-as-current',
+      'stripe-not-live-claim',
+      'forge-tier-name',
+      'max-price-stale',
+      'retired-suite-path',
+    ]);
+  });
+
+  it('every rule has at least one anyOf term and a non-empty unlessLineHas list', () => {
+    for (const rule of SHARED_DETECTION_RULES) {
+      expect(rule.anyOf.length).toBeGreaterThan(0);
+      expect(rule.unlessLineHas.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('retired-suite-path carries only the username-free ~/suite/ form (public-issue-redaction carve-out)', () => {
+    const rule = SHARED_DETECTION_RULES.find((r) => r.id === 'retired-suite-path');
+    expect(rule?.anyOf).toEqual(['~/suite/']);
+  });
+
+  it('a term present as current is a candidate hit and absent-exoneration line is not exonerated', () => {
+    const rule = SHARED_DETECTION_RULES.find((r) => r.id === 'railway-as-current');
+    expect(rule).toBeDefined();
+    const line = 'deploy the service to railway';
+    const isHit = rule!.anyOf.some((t) => line.includes(t));
+    const isExonerated = rule!.unlessLineHas.some((t) => line.includes(t));
+    expect(isHit).toBe(true);
+    expect(isExonerated).toBe(false);
+  });
+});
+
+describe('COMMON_EXON / STRIPE_LIVE_EXON', () => {
+  it('are non-empty exoneration marker sets', () => {
+    expect(COMMON_EXON.length).toBeGreaterThan(0);
+    expect(STRIPE_LIVE_EXON.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/harnesses/src/gates/__tests__/guardrail2-verdict.test.ts
+++ b/packages/harnesses/src/gates/__tests__/guardrail2-verdict.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CommentLike,
+  collectVerdicts,
+  evaluateGuardrail2,
+  type ReviewLike,
+  verdictForBody,
+} from '../guardrail2-verdict.js';
+
+const RC_MARKER = '<!-- guardrail2-verdict: REQUEST-CHANGES -->';
+const AP_MARKER = '<!-- guardrail2-verdict: APPROVE -->';
+
+// A realistic verdict comment: human-readable heading + the machine marker on its
+// own trailing line, exactly as the marker contract prescribes.
+const rcBody = `## Guardrail-2 security verdict: REQUEST-CHANGES\n\nTwo blockers found.\n\n${RC_MARKER}`;
+const apBody = `## Guardrail-2 security verdict: APPROVE\n\nLooks good.\n\n${AP_MARKER}`;
+
+const review = (login: string, ts: string, body: string): ReviewLike => ({
+  author: { login },
+  submittedAt: ts,
+  body,
+});
+const comment = (login: string, ts: string, body: string): CommentLike => ({
+  author: { login },
+  createdAt: ts,
+  body,
+});
+
+describe('verdictForBody', () => {
+  it('reads a well-formed REQUEST-CHANGES marker on its own line', () => {
+    expect(verdictForBody(rcBody)).toBe('REQUEST-CHANGES');
+  });
+  it('reads a well-formed APPROVE marker', () => {
+    expect(verdictForBody(apBody)).toBe('APPROVE');
+  });
+  it('returns null when there is no marker', () => {
+    expect(verdictForBody('## verdict: APPROVE (heading only, no marker)')).toBeNull();
+  });
+  it('ignores a marker with an unknown token (malformed)', () => {
+    expect(verdictForBody('<!-- guardrail2-verdict: MAYBE -->')).toBeNull();
+  });
+  it('ignores prose that merely mentions the marker mid-sentence', () => {
+    // Not a bare marker line: there is text after the closing --> so endsWith fails.
+    expect(
+      verdictForBody('The contract is `<!-- guardrail2-verdict: APPROVE -->` on its own line.'),
+    ).toBeNull();
+  });
+  it('takes the LAST well-formed marker when a body carries duplicates', () => {
+    // A reviewer who corrects themselves within one comment: last line wins.
+    expect(verdictForBody(`${AP_MARKER}\nOn reflection:\n${RC_MARKER}`)).toBe('REQUEST-CHANGES');
+  });
+  it('handles a non-string / empty body without throwing', () => {
+    expect(verdictForBody(undefined)).toBeNull();
+    expect(verdictForBody('')).toBeNull();
+  });
+});
+
+describe('collectVerdicts', () => {
+  it('tags author vs non-author and normalizes both timestamp fields', () => {
+    const recs = collectVerdicts({
+      reviews: [review('reviewer', '2026-07-16T02:00:00Z', apBody)],
+      comments: [comment('builder', '2026-07-16T01:00:00Z', rcBody)],
+      authorLogin: 'builder',
+    });
+    expect(recs).toEqual([
+      {
+        verdict: 'APPROVE',
+        timestamp: '2026-07-16T02:00:00Z',
+        author: 'reviewer',
+        isAuthor: false,
+      },
+      {
+        verdict: 'REQUEST-CHANGES',
+        timestamp: '2026-07-16T01:00:00Z',
+        author: 'builder',
+        isAuthor: true,
+      },
+    ]);
+  });
+  it('drops bodies without a marker', () => {
+    const recs = collectVerdicts({
+      comments: [comment('x', '2026-07-16T01:00:00Z', 'no marker here')],
+    });
+    expect(recs).toEqual([]);
+  });
+});
+
+describe('evaluateGuardrail2 — no markers', () => {
+  it('returns no-marker so the caller falls back to legacy label logic', () => {
+    expect(
+      evaluateGuardrail2({ comments: [comment('x', '2026-07-16T01:00:00Z', 'hi')] }).status,
+    ).toBe('no-marker');
+    expect(evaluateGuardrail2({}).status).toBe('no-marker');
+  });
+});
+
+describe('evaluateGuardrail2 — distinct-reviewer topology (spec primary logic)', () => {
+  it('HOLDS on a lone non-author REQUEST-CHANGES', () => {
+    const r = evaluateGuardrail2({
+      comments: [comment('reviewer', '2026-07-16T01:00:00Z', rcBody)],
+      authorLogin: 'builder',
+    });
+    expect(r.status).toBe('hold');
+    expect(r.status === 'hold' && r.reviewer).toBe('reviewer');
+  });
+  it('CLEARS when a later non-author APPROVE resolves the REQUEST-CHANGES', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('reviewer', '2026-07-16T01:00:00Z', rcBody),
+        comment('reviewer', '2026-07-16T03:00:00Z', apBody),
+      ],
+      authorLogin: 'builder',
+    });
+    expect(r.status).toBe('clear');
+  });
+  it("IGNORES the author's own REQUEST-CHANGES when a non-author APPROVE exists", () => {
+    // The builder cannot re-block a reviewer-approved PR: with a non-author verdict
+    // present, author markers are excluded entirely — even a LATER author RC.
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('reviewer', '2026-07-16T01:00:00Z', apBody),
+        comment('builder', '2026-07-16T05:00:00Z', rcBody),
+      ],
+      authorLogin: 'builder',
+    });
+    expect(r.status).toBe('clear');
+  });
+  it('the builder cannot self-clear a reviewer REQUEST-CHANGES with a later author APPROVE', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('reviewer', '2026-07-16T01:00:00Z', rcBody),
+        comment('builder', '2026-07-16T05:00:00Z', apBody),
+      ],
+      authorLogin: 'builder',
+    });
+    expect(r.status).toBe('hold');
+    expect(r.status === 'hold' && r.reviewer).toBe('reviewer');
+  });
+});
+
+describe('evaluateGuardrail2 — single-login fail-safe (current fleet topology)', () => {
+  // Verified 2026-07-16: every fleet comment/review is authored by the same
+  // account, the PR author too. Login cannot separate reviewer from builder,
+  // so author markers must NOT be dropped — dropping them would ignore the
+  // reviewer's own REQUEST-CHANGES, which IS the #1910 miss. Latest verdict
+  // governs; RC holds.
+  it('HOLDS on a latest author-login REQUEST-CHANGES (the #1910 reviewer verdict)', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('RevealUIStudio', '2026-07-17T00:04:57Z', apBody),
+        comment('RevealUIStudio', '2026-07-17T00:13:55Z', rcBody),
+      ],
+      authorLogin: 'RevealUIStudio',
+    });
+    expect(r.status).toBe('hold');
+  });
+  it('CLEARS when the latest same-login verdict is APPROVE', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('RevealUIStudio', '2026-07-17T00:13:55Z', rcBody),
+        comment('RevealUIStudio', '2026-07-17T00:20:00Z', apBody),
+      ],
+      authorLogin: 'RevealUIStudio',
+    });
+    expect(r.status).toBe('clear');
+  });
+  it('breaks a same-timestamp tie toward REQUEST-CHANGES (fail-safe)', () => {
+    const r = evaluateGuardrail2({
+      comments: [
+        comment('RevealUIStudio', '2026-07-17T00:13:55Z', apBody),
+        comment('RevealUIStudio', '2026-07-17T00:13:55Z', rcBody),
+      ],
+      authorLogin: 'RevealUIStudio',
+    });
+    expect(r.status).toBe('hold');
+  });
+});
+
+// The regression the whole change exists to prevent. Reproduces revealui#1910:
+// a security-sensitive PR carrying sec-review:approved with a live REQUEST-CHANGES
+// verdict. BEFORE this change the gate cleared it on the label; AFTER, it holds.
+describe('evaluateGuardrail2 — revealui#1910 prove-red (before/after)', () => {
+  const pr1910 = {
+    author: { login: 'RevealUIStudio' },
+    labels: [{ name: 'sec-review:approved' }],
+    reviewDecision: '',
+    reviews: [] as ReviewLike[],
+    comments: [
+      comment('RevealUIStudio', '2026-07-17T00:04:57Z', apBody),
+      comment('RevealUIStudio', '2026-07-17T00:13:55Z', rcBody),
+    ],
+  };
+
+  // The OLD gate logic, verbatim: label present OR approving review → clear.
+  function legacyDecision(pr: typeof pr1910): 'clear' | 'hold' {
+    const labels = new Set(pr.labels.map((l) => l.name));
+    const hasReviewLabel = [...labels].some((l) =>
+      ['sec-review:approved', 'security-reviewed', 'coordinator-approved'].includes(l),
+    );
+    const approved = pr.reviewDecision === 'APPROVED';
+    return approved || hasReviewLabel ? 'clear' : 'hold';
+  }
+
+  it('BEFORE: the legacy label-only logic cleared #1910 (the bug)', () => {
+    expect(legacyDecision(pr1910)).toBe('clear');
+  });
+
+  it('AFTER: the marker-aware evaluation HOLDS #1910 despite the label', () => {
+    const r = evaluateGuardrail2({
+      reviews: pr1910.reviews,
+      comments: pr1910.comments,
+      authorLogin: pr1910.author.login,
+    });
+    expect(r.status).toBe('hold');
+    expect(r.status === 'hold' && r.timestamp).toBe('2026-07-17T00:13:55Z');
+  });
+});
+
+// Prove-red: mutate the marker grammar (require a different sentinel) and show
+// the parser stops recognizing the canonical marker. Demonstrates the tests
+// are actually exercising the grammar, not vacuously passing.
+describe('prove-red — marker grammar mutation', () => {
+  it('a mutated MARKER_OPEN sentinel would not match the canonical marker', () => {
+    const MUTATED_OPEN = '<!-- guardrail2-verdict-v2:';
+    const canonicalLine = '<!-- guardrail2-verdict: APPROVE -->';
+    expect(canonicalLine.trim().startsWith(MUTATED_OPEN)).toBe(false);
+    // ...and the real parser, unmutated, still recognizes it (the "restore" half).
+    expect(verdictForBody(canonicalLine)).toBe('APPROVE');
+  });
+});

--- a/packages/harnesses/src/gates/doc-currency-shared-rules.ts
+++ b/packages/harnesses/src/gates/doc-currency-shared-rules.ts
@@ -1,0 +1,216 @@
+/**
+ * doc-currency-shared-rules — the fleet-fact DETECTION tuples shared by the
+ * doc-currency stale-fact scanners.
+ *
+ * Control layer (GAP-408): this module is the single editable source for the
+ * SHARED_FLEET_RULES detection data (id + anyOf + unlessLineHas). The public
+ * revealui `scripts/validate/doc-currency.ts` and the private
+ * `.jv/scripts/doc-currency-check.ts` both load this module at runtime and
+ * attach their own repo-appropriate MESSAGES keyed by rule id — messages are
+ * not shared, only detection is.
+ *
+ * Privacy carve-out (per .jv `.claude/rules/doc-currency.md` cross-scanner
+ * lockstep section): the `retired-suite-path` rule below carries only the
+ * username-free `~/suite/` form. The absolute (`/home/<user>/suite/`) and
+ * WSL-UNC forms embed a developer username, which the public repo's
+ * `gate:security` local-path-leak check forbids — those two terms stay a
+ * PRIVATE .jv-only overlay merged onto this rule at load time, never here.
+ * Likewise `boi-mandatory` (internal legal/business posture, no public
+ * surface) is not in this module at all — it stays wholly .jv-only.
+ */
+
+export interface DetectionRule {
+  id: string;
+  /** A occurrence is a candidate hit if it contains (case-insensitive) ANY of these. */
+  anyOf: readonly string[];
+  /** …UNLESS the same occurrence also contains ANY of these exoneration markers. */
+  unlessLineHas: readonly string[];
+}
+
+/**
+ * Shared past-tense / correction markers — if any appears alongside a banned
+ * term, the term is being discussed as past/known, not asserted as current.
+ */
+export const COMMON_EXON: readonly string[] = [
+  'cancel',
+  'dropped',
+  'drop ',
+  'remov',
+  'retir',
+  'superseded',
+  'supersede',
+  'deprecat',
+  'former',
+  'historical',
+  'history',
+  'archive',
+  'legacy',
+  'no longer',
+  'not required',
+  'not used',
+  'instead',
+  'migrat',
+  'replaced',
+  'sunset',
+  'void',
+  'was ',
+  'were ',
+  'used to',
+  'transitional',
+  'exempt',
+  '→',
+  '->',
+  '~~',
+  'do not',
+  "don't",
+  'never',
+  'pending',
+  'not yet',
+  'will be',
+  'once ',
+  'before ',
+  'n/a',
+  'obsolete',
+  'phased out',
+  'wind down',
+  'winding down',
+  'decommiss',
+];
+
+/**
+ * Bespoke exoneration list for `stripe-not-live-claim` — NOT `COMMON_EXON`,
+ * whose "not yet" / "pending" / "before" / "will be" markers would exonerate
+ * the exact phrasing a stale not-flipped claim uses. This list exonerates
+ * flip-done / rollback / past-tense markers instead.
+ */
+export const STRIPE_LIVE_EXON: readonly string[] = [
+  'flipped 2026-06-26',
+  'flipped on 2026-06-26',
+  'executed 2026-06-26',
+  'was flipped',
+  'has been flipped',
+  'now flipped',
+  'now live',
+  'went live',
+  'rollback',
+  'roll back',
+  '~~',
+  'previously',
+  'used to',
+  'formerly',
+  'no longer',
+  'historical',
+  'archive',
+  'superseded',
+  'retired',
+  'was ',
+  'were ',
+];
+
+/**
+ * SHARED FLEET FACTS — detection tuples only (no messages; those stay
+ * per-repo). Order is the canonical order both scanners render rules in.
+ */
+export const SHARED_DETECTION_RULES: readonly DetectionRule[] = [
+  {
+    id: 'revealcoin-as-current',
+    anyOf: ['revealcoin', 'rvc ', '$rvc', '$rvui', 'rvui-payment', 'rvui payment'],
+    unlessLineHas: [...COMMON_EXON, 'cancelled 2026-05-29', 'shelved'],
+  },
+  {
+    id: 'railway-as-current',
+    anyOf: ['railway'],
+    unlessLineHas: [...COMMON_EXON, 'fly.io', 'fly machine', 'not railway'],
+  },
+  {
+    id: 'vercel-blob-as-current',
+    anyOf: ['blob_read_write_token', 'vercel blob', '@vercel/blob', 'vercel/postgres'],
+    unlessLineHas: [...COMMON_EXON, 'r2', 'cloudflare'],
+  },
+  {
+    id: 'supabase-as-current',
+    anyOf: ['supabase'],
+    unlessLineHas: [
+      ...COMMON_EXON,
+      'neon',
+      'electric',
+      'removal',
+      'boundary',
+      'rag',
+      'dual-db',
+      'dual db',
+    ],
+  },
+  {
+    // Inverse of a retired `stripe-live-claim`: Stripe live mode was flipped
+    // ON 2026-06-26, so a doc still asserting Stripe is NOT flipped /
+    // test-mode AS CURRENT is the drift. Uses STRIPE_LIVE_EXON, not
+    // COMMON_EXON — see that constant's doc comment for why.
+    id: 'stripe-not-live-claim',
+    anyOf: [
+      'stripe live mode is not flipped',
+      'stripe live-mode is not flipped',
+      'stripe live-flip is not',
+      'stripe live-flip has not',
+      'stripe live-flip is owner-gated and has not',
+      'stripe is not flipped',
+      'stripe not flipped',
+      'stripe live keys are not flipped',
+      'stripe live mode is still false',
+      'stripe live-mode is still false',
+      'stripe_live_mode is still false',
+      'payments are not live',
+      'billing is not live',
+      'stripe live mode has not executed',
+      'stripe live-flip has not executed',
+      'flip stripe live mode',
+      'flip stripe live-mode',
+    ],
+    unlessLineHas: STRIPE_LIVE_EXON,
+  },
+  {
+    id: 'forge-tier-name',
+    anyOf: [
+      'forge tier',
+      'forge perpetual',
+      'forge (enterprise)',
+      'enterprise (forge)',
+      '"forge" tier',
+    ],
+    unlessLineHas: [...COMMON_EXON, 'renamed', 'now enterprise'],
+  },
+  {
+    // Pricing-truth guard. RevealUI Max is $299/mo; the retired $149/mo Max
+    // figure presented as current is stale drift. Enumerated tier+price
+    // phrasings (like stripe-not-live-claim) rather than a bare '$149',
+    // because $149 is a legitimate current figure elsewhere (the Pro
+    // Perpetual support renewal is $149/yr) — anchoring the Max name beside
+    // the price avoids flagging those.
+    id: 'max-price-stale',
+    anyOf: [
+      'max $149',
+      'max: $149',
+      'max - $149',
+      'max — $149',
+      'max plan $149',
+      'max tier $149',
+      'max is $149',
+      'max at $149',
+      'max ($149',
+      'revealui max $149',
+      '| max | $149',
+      '$149/mo max',
+      '$149/month max',
+      '$149 for max',
+      '$149/mo for max',
+      '$149/month for max',
+    ],
+    unlessLineHas: [...COMMON_EXON, '$299', '299/mo', 'perpetual', 'renewal'],
+  },
+  {
+    // Username-free form only — see the file header's privacy carve-out.
+    id: 'retired-suite-path',
+    anyOf: ['~/suite/'],
+    unlessLineHas: [...COMMON_EXON, 'now ~/revfleet', 'renamed'],
+  },
+];

--- a/packages/harnesses/src/gates/guardrail2-verdict.ts
+++ b/packages/harnesses/src/gates/guardrail2-verdict.ts
@@ -1,0 +1,190 @@
+/**
+ * guardrail2-verdict — canonical parser for guardrail-2 verdict markers off PR
+ * comments and reviews, and the hold/clear decision they drive.
+ *
+ * Control layer (GAP-408): this module is the single editable source. The
+ * public revealui `scripts/validate/guardrail2-verdict.cjs` and the private
+ * `.jv/scripts/guardrail2-verdict.js` are thin adapters that load THIS module
+ * at runtime — neither carries a vendored copy of the logic below.
+ *
+ * Why this exists: the review-before-merge gate (security-review-gate.cjs /
+ * security-pr-review-check.js) and the server-side label guard
+ * (sec-audit-label-decision.cjs) used to clear a PR on the
+ * `sec-review:approved` label alone. Neither looked for a live
+ * REQUEST-CHANGES. revealui#1910 merged with the label applied AGAINST a
+ * REQUEST-CHANGES verdict that was sitting right there as a comment. This
+ * module is the shared parse+decide logic every gate consults so a
+ * REQUEST-CHANGES cannot be papered over by the label.
+ *
+ * THE MARKER CONTRACT: every guardrail-2 verdict a session posts (comment OR
+ * review body) carries a machine-parseable trailer on its own line:
+ *     <!-- guardrail2-verdict: REQUEST-CHANGES -->
+ *     <!-- guardrail2-verdict: APPROVE -->
+ * An HTML comment: invisible in rendered markdown, unambiguous, greppable.
+ * The human-readable `## Guardrail-2 ... verdict: <VERDICT>` heading stays
+ * too, for people.
+ *
+ * TOPOLOGY NOTE (verified 2026-07-16, load-bearing). Every fleet PR — and
+ * every comment and review on it — is authored by a single GitHub account.
+ * So login CANNOT tell the builder's comment apart from the reviewer's
+ * comment today. Two consequences:
+ *   - The `evaluateGuardrail2` DISTINCT-REVIEWER branch (login-filtered
+ *     non-author verdicts, the spec's primary logic) is correct and
+ *     unit-tested, but only ENGAGES once reviewer verdicts carry a distinct
+ *     identity (post org-migration, or a reviewing session that
+ *     authenticates as a different account).
+ *   - Until then the SINGLE-LOGIN fail-safe branch runs: author markers are
+ *     NOT dropped (dropping them would ignore the reviewer's own
+ *     REQUEST-CHANGES — the exact #1910 miss), the latest verdict governs,
+ *     and a REQUEST-CHANGES holds.
+ * This module only supplies the hold/clear signal. The `sec-review:approved`
+ * label stays owner-applied; clearing a PR still needs both a non-holding
+ * verdict AND the label the way it always did.
+ *
+ * Zero authored regex (fleet no-regex HARDLINE): startsWith/endsWith/slice/
+ * trim + a lexicographic timestamp compare (ISO-8601 Z strings sort
+ * chronologically).
+ */
+
+export const MARKER_OPEN = '<!-- guardrail2-verdict:';
+export const MARKER_CLOSE = '-->';
+export const REQUEST_CHANGES = 'REQUEST-CHANGES';
+export const APPROVE = 'APPROVE';
+
+export type Verdict = typeof REQUEST_CHANGES | typeof APPROVE;
+
+export interface ReviewLike {
+  author?: { login?: string | null } | null;
+  body?: string | null;
+  submittedAt?: string | null;
+}
+
+export interface CommentLike {
+  author?: { login?: string | null } | null;
+  body?: string | null;
+  createdAt?: string | null;
+}
+
+export interface VerdictRecord {
+  verdict: Verdict;
+  timestamp: string;
+  author: string;
+  isAuthor: boolean;
+}
+
+export interface EvaluateInput {
+  reviews?: readonly ReviewLike[];
+  comments?: readonly CommentLike[];
+  authorLogin?: string;
+}
+
+export interface NoMarkerResult {
+  status: 'no-marker';
+}
+
+export interface HoldResult {
+  status: 'hold';
+  reviewer: string;
+  timestamp: string;
+  verdict: typeof REQUEST_CHANGES;
+}
+
+export interface ClearResult {
+  status: 'clear';
+  reviewer: string;
+  timestamp: string;
+  verdict: Verdict;
+}
+
+export type EvaluateResult = NoMarkerResult | HoldResult | ClearResult;
+
+/**
+ * The verdict for ONE body: its LAST well-formed marker line, or null. A
+ * line counts only when, trimmed, it starts with MARKER_OPEN, ends with
+ * MARKER_CLOSE, and the text between them trims to exactly one of the two
+ * tokens. Prose that merely mentions the marker mid-sentence, or an unknown
+ * token, is not a verdict. Last-wins lets a reviewer correct themselves
+ * within a single comment.
+ */
+export function verdictForBody(body: string | null | undefined): Verdict | null {
+  if (typeof body !== 'string' || body.length === 0) return null;
+  let found: Verdict | null = null;
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    if (!(line.startsWith(MARKER_OPEN) && line.endsWith(MARKER_CLOSE))) continue;
+    const inner = line.slice(MARKER_OPEN.length, line.length - MARKER_CLOSE.length).trim();
+    if (inner === REQUEST_CHANGES || inner === APPROVE) found = inner;
+    // malformed / unknown token → ignored (fail-safe: an ambiguous marker is not a verdict)
+  }
+  return found;
+}
+
+/**
+ * Normalize reviews + comments into verdict records — one per body that
+ * carries a verdict. Author-inclusive; each record is tagged `isAuthor`.
+ * Reviews stamp their time in `submittedAt`, comments in `createdAt`.
+ */
+export function collectVerdicts(input: EvaluateInput = {}): VerdictRecord[] {
+  const { reviews = [], comments = [], authorLogin = '' } = input;
+  const out: VerdictRecord[] = [];
+  const consume = (item: ReviewLike | CommentLike, timestamp: string): void => {
+    const login = item.author?.login ?? '';
+    const verdict = verdictForBody(item.body);
+    if (verdict) {
+      out.push({
+        verdict,
+        timestamp,
+        author: login,
+        isAuthor: login !== '' && login === authorLogin,
+      });
+    }
+  };
+  for (const r of reviews) consume(r, r.submittedAt ?? '');
+  for (const c of comments) consume(c, c.createdAt ?? '');
+  return out;
+}
+
+/**
+ * Max-timestamp record; on a timestamp tie, REQUEST-CHANGES wins (fail-safe
+ * — a same-instant APPROVE never masks a REQUEST-CHANGES). ISO-8601 Z
+ * strings compare lexicographically === chronologically.
+ */
+function latest(records: readonly VerdictRecord[]): VerdictRecord | null {
+  let best: VerdictRecord | null = null;
+  for (const rec of records) {
+    if (best === null || rec.timestamp > best.timestamp) {
+      best = rec;
+    } else if (rec.timestamp === best.timestamp && rec.verdict === REQUEST_CHANGES) {
+      best = rec;
+    }
+  }
+  return best;
+}
+
+/**
+ * The gate decision.
+ *   { status: 'no-marker' }                             → caller falls back to legacy label/review logic
+ *   { status: 'hold',  reviewer, timestamp, verdict }    → an outstanding REQUEST-CHANGES; do NOT clear
+ *   { status: 'clear', reviewer, timestamp, verdict }    → latest verdict is APPROVE
+ */
+export function evaluateGuardrail2(input: EvaluateInput = {}): EvaluateResult {
+  const all = collectVerdicts(input);
+  if (all.length === 0) return { status: 'no-marker' };
+
+  // DISTINCT-REVIEWER branch (spec's primary logic; engages when reviewer
+  // verdicts carry a login other than the PR author). The builder can never
+  // self-clear: only NON-AUTHOR verdicts are considered, so a later author
+  // APPROVE cannot lift a reviewer's REQUEST-CHANGES.
+  const nonAuthor = all.filter((r) => !r.isAuthor);
+  // SINGLE-LOGIN fail-safe: when no verdict is attributable to a non-author
+  // (today's topology), fall back to the whole set rather than dropping the
+  // reviewer's verdict.
+  const pool = nonAuthor.length > 0 ? nonAuthor : all;
+
+  const gov = latest(pool);
+  if (gov === null) return { status: 'no-marker' };
+  if (gov.verdict === REQUEST_CHANGES) {
+    return { status: 'hold', reviewer: gov.author, timestamp: gov.timestamp, verdict: gov.verdict };
+  }
+  return { status: 'clear', reviewer: gov.author, timestamp: gov.timestamp, verdict: gov.verdict };
+}

--- a/packages/harnesses/src/gates/index.ts
+++ b/packages/harnesses/src/gates/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Gates — canonical parsers/data shared by the fleet's security + doc-currency
+ * gate machinery (GAP-408 control-layer redesign). See the module-level docs
+ * on each export for what consumes it and why it lives here instead of a
+ * vendored per-repo copy.
+ */
+
+export type { DetectionRule } from './doc-currency-shared-rules.js';
+export {
+  COMMON_EXON,
+  SHARED_DETECTION_RULES,
+  STRIPE_LIVE_EXON,
+} from './doc-currency-shared-rules.js';
+export type {
+  ClearResult,
+  CommentLike,
+  EvaluateInput,
+  EvaluateResult,
+  HoldResult,
+  NoMarkerResult,
+  ReviewLike,
+  Verdict,
+  VerdictRecord,
+} from './guardrail2-verdict.js';
+export {
+  APPROVE,
+  collectVerdicts,
+  evaluateGuardrail2,
+  MARKER_CLOSE,
+  MARKER_OPEN,
+  REQUEST_CHANGES,
+  verdictForBody,
+} from './guardrail2-verdict.js';

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'src/goals/index.ts',
     'src/hooks/index.ts',
     'src/hotfix/index.ts',
+    'src/gates/index.ts',
   ],
   format: ['esm'],
   dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,7 +367,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -607,7 +607,7 @@ importers:
         version: 10.67.0(react@19.2.7)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react:
         specifier: '>=19.2.4'
         version: 19.2.7
@@ -11896,7 +11896,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7

--- a/scripts/validate/doc-currency.ts
+++ b/scripts/validate/doc-currency.ts
@@ -50,18 +50,70 @@
 
 import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import ts from 'typescript';
 
 const ROOT = path.resolve(import.meta.dirname, '../..');
 const BASELINE_PATH = path.join(ROOT, 'scripts/validate/doc-currency-baseline.json');
 
+// Detection data for the SHARED_FLEET_RULES below lives in @revealui/harnesses
+// (packages/harnesses/src/gates/doc-currency-shared-rules.ts) — single
+// editable source, GAP-408 control-layer redesign. Resolved via the same
+// gates-resolver.cjs guardrail2-verdict.cjs uses (local dist, or a
+// REVEALUI_HARNESSES_DIR npm install), through `createRequire` — a static
+// `import ... from '@revealui/harnesses'` would need a package.json
+// dependency edge, which scripts/validate/boundary.ts Check 4 forbids for an
+// optional Fair Source package.
+//
+// ABSENCE BEHAVIOR (decision, see doc-currency.md cross-scanner lockstep
+// section): WARN and continue with the shared rule set empty, rather than
+// hard-fail the whole scanner. doc-currency is a best-effort stale-fact
+// scanner, not a merge-authorization gate (contrast guardrail2-verdict, which
+// fails closed because a silently-skipped hold is a security miss) — and the
+// scanner's own design philosophy is "a noisy/broken gate gets disabled"
+// (see the file's top-level doc comment). This mirrors the existing
+// unreadable-baseline handling below (warn, degrade gracefully, never crash).
+interface GatesModuleShape {
+  COMMON_EXON: readonly string[];
+  STRIPE_LIVE_EXON: readonly string[];
+  SHARED_DETECTION_RULES: readonly {
+    id: string;
+    anyOf: readonly string[];
+    unlessLineHas: readonly string[];
+  }[];
+}
+
+function loadGatesModule(): GatesModuleShape | null {
+  const require = createRequire(import.meta.url);
+  const { resolveGatesModule } = require('./gates-resolver.cjs') as {
+    resolveGatesModule: () => GatesModuleShape | null;
+  };
+  const mod = resolveGatesModule();
+  if (!mod) {
+    process.stderr.write(
+      '[doc-currency] WARNING: could not resolve the @revealui/harnesses gates module ' +
+        '(packages/harnesses not built, and REVEALUI_HARNESSES_DIR is unset/unresolvable). ' +
+        'Scanning with the SHARED fleet-fact rules SKIPPED — this run only enforces no ' +
+        'repo-specific rules the public scanner has (none today). ' +
+        'Fix: pnpm --filter @revealui/harnesses build.\n',
+    );
+    return null;
+  }
+  return mod;
+}
+
+const gates = loadGatesModule();
+const SHARED_COMMON_EXON = gates?.COMMON_EXON ?? [];
+const SHARED_STRIPE_LIVE_EXON = gates?.STRIPE_LIVE_EXON ?? [];
+const SHARED_DETECTION_RULES = gates?.SHARED_DETECTION_RULES ?? [];
+
 export interface Rule {
   id: string;
   /** A occurrence is a candidate hit if it contains (case-insensitive) ANY of these. */
-  anyOf: string[];
+  anyOf: readonly string[];
   /** …UNLESS the same occurrence also contains ANY of these exoneration markers. */
-  unlessLineHas: string[];
+  unlessLineHas: readonly string[];
   message: string;
 }
 
@@ -119,216 +171,50 @@ export function parseArgs(argv: readonly string[]): {
 // doc-currency rule §lockstep.
 // ---------------------------------------------------------------------------
 
-/** Shared past-tense / correction markers — if any appears alongside the
- *  banned term, the term is being discussed as past/known, not asserted as
- *  current. */
-export const COMMON_EXON: readonly string[] = [
-  'cancel',
-  'dropped',
-  'drop ',
-  'remov',
-  'retir',
-  'superseded',
-  'supersede',
-  'deprecat',
-  'former',
-  'historical',
-  'history',
-  'archive',
-  'legacy',
-  'no longer',
-  'not required',
-  'not used',
-  'instead',
-  'migrat',
-  'replaced',
-  'sunset',
-  'void',
-  'was ',
-  'were ',
-  'used to',
-  'transitional',
-  'exempt',
-  '→',
-  '->',
-  '~~',
-  'do not',
-  "don't",
-  'never',
-  'pending',
-  'not yet',
-  'will be',
-  'once ',
-  'before ',
-  'n/a',
-  'obsolete',
-  'phased out',
-  'wind down',
-  'winding down',
-  'decommiss',
-];
+/** Re-exported for any external consumer that imported these from this
+ *  module before the GAP-408 control-layer move. The editable source is now
+ *  `@revealui/harnesses/gates` — see `packages/harnesses/src/gates/
+ *  doc-currency-shared-rules.ts`. */
+export const COMMON_EXON: readonly string[] = SHARED_COMMON_EXON;
+export const STRIPE_LIVE_EXON: readonly string[] = SHARED_STRIPE_LIVE_EXON;
 
-/**
- * Bespoke exoneration list for `stripe-not-live-claim` — NOT `COMMON_EXON`,
- * whose "not yet" / "pending" / "before" / "will be" markers would exonerate
- * the exact phrasing a stale not-flipped claim uses. This list exonerates
- * flip-done / rollback / past-tense markers instead.
- */
-export const STRIPE_LIVE_EXON: readonly string[] = [
-  'flipped 2026-06-26',
-  'flipped on 2026-06-26',
-  'executed 2026-06-26',
-  'was flipped',
-  'has been flipped',
-  'now flipped',
-  'now live',
-  'went live',
-  'rollback',
-  'roll back',
-  '~~',
-  'previously',
-  'used to',
-  'formerly',
-  'no longer',
-  'historical',
-  'archive',
-  'superseded',
-  'retired',
-  'was ',
-  'were ',
-];
+// Repo-appropriate messages, keyed by the shared rule id. Detection
+// (anyOf / unlessLineHas) is NOT edited here — that lives in
+// @revealui/harnesses/gates (packages/harnesses/src/gates/
+// doc-currency-shared-rules.ts). Only the wording is repo-specific.
+const SHARED_RULE_MESSAGES: Readonly<Record<string, string>> = {
+  'revealcoin-as-current':
+    'RevealCoin/RVC/$RVUI was cancelled. Present it as past only, not a current or planned payment rail.',
+  'railway-as-current':
+    'Railway was dropped as an infrastructure target (stack is Vercel + Neon + Fly). Do not present Railway as a live deployment target.',
+  'vercel-blob-as-current':
+    'Vercel Blob is being retired in favor of Cloudflare R2 as canonical object storage. Do not instruct provisioning a new Blob token.',
+  'supabase-as-current':
+    'Supabase is being removed in favor of the RevealUI-native stack (Neon + ElectricSQL). Present Supabase as transitional or legacy only.',
+  'stripe-not-live-claim':
+    'Stripe live mode is on. Do not present Stripe billing as not yet flipped, or test-mode as the current state.',
+  'forge-tier-name':
+    'The billing tier "Forge" was renamed to "Enterprise". Use "Enterprise" going forward.',
+  'max-price-stale':
+    'RevealUI Max is $299/mo (cents-of-record: scripts/setup/stripe-catalog.ts). Do not present $149 as the current Max price.',
+  'retired-suite-path':
+    'The ~/suite/ path was retired 2026-05-08 (now ~/revfleet/). Update the path.',
+};
 
-const SHARED_FLEET_RULES: readonly Rule[] = [
-  {
-    id: 'revealcoin-as-current',
-    anyOf: ['revealcoin', 'rvc ', '$rvc', '$rvui', 'rvui-payment', 'rvui payment'],
-    unlessLineHas: [...COMMON_EXON, 'cancelled 2026-05-29', 'shelved'],
-    message:
-      'RevealCoin/RVC/$RVUI was cancelled. Present it as past only, not a current or planned payment rail.',
-  },
-  {
-    id: 'railway-as-current',
-    anyOf: ['railway'],
-    unlessLineHas: [...COMMON_EXON, 'fly.io', 'fly machine', 'not railway'],
-    message:
-      'Railway was dropped as an infrastructure target (stack is Vercel + Neon + Fly). Do not present Railway as a live deployment target.',
-  },
-  {
-    id: 'vercel-blob-as-current',
-    anyOf: ['blob_read_write_token', 'vercel blob', '@vercel/blob', 'vercel/postgres'],
-    unlessLineHas: [...COMMON_EXON, 'r2', 'cloudflare'],
-    message:
-      'Vercel Blob is being retired in favor of Cloudflare R2 as canonical object storage. Do not instruct provisioning a new Blob token.',
-  },
-  {
-    id: 'supabase-as-current',
-    anyOf: ['supabase'],
-    unlessLineHas: [
-      ...COMMON_EXON,
-      'neon',
-      'electric',
-      'removal',
-      'boundary',
-      'rag',
-      'dual-db',
-      'dual db',
-    ],
-    message:
-      'Supabase is being removed in favor of the RevealUI-native stack (Neon + ElectricSQL). Present Supabase as transitional or legacy only.',
-  },
-  {
-    // Inverse of a retired `stripe-live-claim`: Stripe live mode was flipped
-    // ON, so a doc still asserting Stripe is NOT flipped / test-mode AS
-    // CURRENT is the drift. Uses the bespoke STRIPE_LIVE_EXON list, not
-    // COMMON_EXON — see the constant's doc comment for why.
-    id: 'stripe-not-live-claim',
-    anyOf: [
-      'stripe live mode is not flipped',
-      'stripe live-mode is not flipped',
-      'stripe live-flip is not',
-      'stripe live-flip has not',
-      'stripe live-flip is owner-gated and has not',
-      'stripe is not flipped',
-      'stripe not flipped',
-      'stripe live keys are not flipped',
-      'stripe live mode is still false',
-      'stripe live-mode is still false',
-      'stripe_live_mode is still false',
-      'payments are not live',
-      'billing is not live',
-      'stripe live mode has not executed',
-      'stripe live-flip has not executed',
-      'flip stripe live mode',
-      'flip stripe live-mode',
-    ],
-    unlessLineHas: STRIPE_LIVE_EXON,
-    message:
-      'Stripe live mode is on. Do not present Stripe billing as not yet flipped, or test-mode as the current state.',
-  },
-  {
-    id: 'forge-tier-name',
-    anyOf: [
-      'forge tier',
-      'forge perpetual',
-      'forge (enterprise)',
-      'enterprise (forge)',
-      '"forge" tier',
-    ],
-    unlessLineHas: [...COMMON_EXON, 'renamed', 'now enterprise'],
-    message:
-      'The billing tier "Forge" was renamed to "Enterprise". Use "Enterprise" going forward.',
-  },
-  {
-    // Pricing-truth guard. The Max subscription is $299/mo; the cents-of-record
-    // is scripts/setup/stripe-catalog.ts (revealui_max_monthly.unitAmount =
-    // 29900). The retired $149/mo Max figure presented as current is stale
-    // drift. Enumerated tier+price phrasings (like stripe-not-live-claim) rather
-    // than a bare '$149' term, because $149 is a legitimate current figure
-    // elsewhere (the Pro Perpetual support renewal is $149/yr) — anchoring the
-    // Max name beside the price avoids flagging those.
-    id: 'max-price-stale',
-    anyOf: [
-      'max $149',
-      'max: $149',
-      'max - $149',
-      'max — $149',
-      'max plan $149',
-      'max tier $149',
-      'max is $149',
-      'max at $149',
-      'max ($149',
-      'revealui max $149',
-      '| max | $149',
-      '$149/mo max',
-      '$149/month max',
-      '$149 for max',
-      '$149/mo for max',
-      '$149/month for max',
-    ],
-    unlessLineHas: [...COMMON_EXON, '$299', '299/mo', 'perpetual', 'renewal'],
-    message:
-      'RevealUI Max is $299/mo (cents-of-record: scripts/setup/stripe-catalog.ts). Do not present $149 as the current Max price.',
-  },
-  {
-    // Retired developer path. `~/suite/` was renamed to `~/revfleet/` on
-    // 2026-05-08; a doc presenting `~/suite/` as a live path is stale. Fleet
-    // fact — kept in lockstep with the .jv scanner's retired-suite-path, EXCEPT
-    // this public scanner carries only the username-free `~/suite/` form. The
-    // absolute (`/home/<user>/suite/`) and WSL-UNC forms embed a developer
-    // username, which gate:security's local-path-leak check forbids in public
-    // code, so those two anyOf terms stay .jv-only. `~/suite/` is the form that
-    // actually appears in public docs anyway.
-    id: 'retired-suite-path',
-    anyOf: ['~/suite/'],
-    unlessLineHas: [...COMMON_EXON, 'now ~/revfleet', 'renamed'],
-    message: 'The ~/suite/ path was retired 2026-05-08 (now ~/revfleet/). Update the path.',
-  },
-];
+const SHARED_FLEET_RULES: readonly Rule[] = SHARED_DETECTION_RULES.map((rule) => ({
+  id: rule.id,
+  anyOf: rule.anyOf,
+  unlessLineHas: rule.unlessLineHas,
+  message: SHARED_RULE_MESSAGES[rule.id] ?? `stale-fact drift: ${rule.id}`,
+}));
 
 /** The public revealui scanner enforces the SHARED fleet-fact set only; it has
  *  no repo-specific rules (the private .jv scanner adds `boi-mandatory`, which
- *  has no public surface). Kept in lockstep with
- *  .jv/scripts/doc-currency-check.ts §SHARED_FLEET_RULES. */
+ *  has no public surface). Detection tuples come from
+ *  `@revealui/harnesses/gates` (single editable source, GAP-408); the private
+ *  `.jv/scripts/doc-currency-check.ts` loads the same package via its resolver
+ *  adapter and layers a private overlay (retired-suite-path's username-bearing
+ *  terms + the wholly-private boi-mandatory rule) on top. */
 export const RULES: readonly Rule[] = SHARED_FLEET_RULES;
 
 // ---------------------------------------------------------------------------

--- a/scripts/validate/gates-resolver.cjs
+++ b/scripts/validate/gates-resolver.cjs
@@ -1,0 +1,61 @@
+'use strict';
+// gates-resolver.cjs — locate the @revealui/harnesses gates module (GAP-408
+// control-layer redesign). Shared by guardrail2-verdict.cjs and
+// doc-currency.ts so the resolution logic lives in exactly one place.
+//
+// Resolution order:
+//   1. Local monorepo dist (packages/harnesses/dist/gates/index.js) — the
+//      normal path whenever the package has been built in this checkout
+//      (pnpm gate, or any CI job that runs `pnpm --filter @revealui/harnesses
+//      build` first).
+//   2. REVEALUI_HARNESSES_DIR — a directory containing an npm install of
+//      @revealui/harnesses (`npm install --prefix <dir> @revealui/harnesses@<pin>`).
+//      This is the path for CI jobs that only sparse-checkout a handful of
+//      gate scripts and never clone packages/harnesses at all (e.g. the
+//      pull_request_target security-review-gate.yml job).
+//
+// Loaded by a same-repo/filesystem RELATIVE path or an explicit installed
+// package directory — never the bare `@revealui/harnesses` specifier resolved
+// from THIS repo's own node_modules, which would require a package.json
+// dependency edge that scripts/validate/boundary.ts Check 4 forbids
+// (@revealui/harnesses is an optional Fair Source package).
+//
+// Returns null (never throws) when nothing resolves — callers decide the
+// fail-open/fail-closed posture for their own gate.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LOCAL_DIST_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'packages',
+  'harnesses',
+  'dist',
+  'gates',
+  'index.js',
+);
+
+/**
+ * @returns {unknown | null}
+ */
+function resolveGatesModule() {
+  if (fs.existsSync(LOCAL_DIST_PATH)) {
+    return require(LOCAL_DIST_PATH);
+  }
+
+  const installDir = process.env.REVEALUI_HARNESSES_DIR;
+  if (installDir) {
+    try {
+      const resolved = require.resolve('@revealui/harnesses/gates', { paths: [installDir] });
+      return require(resolved);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+module.exports = { resolveGatesModule, LOCAL_DIST_PATH };

--- a/scripts/validate/guardrail2-verdict.cjs
+++ b/scripts/validate/guardrail2-verdict.cjs
@@ -1,131 +1,41 @@
 'use strict';
-// guardrail2-verdict.cjs — parse guardrail-2 verdict markers off PR comments and
-// reviews, and decide whether an outstanding REQUEST-CHANGES holds the merge.
+// guardrail2-verdict.cjs — thin adapter (GAP-408 control-layer redesign).
 //
-// Why this exists: the review-before-merge gate (security-review-gate.cjs) and the
-// server-side label guard (sec-audit-label-decision.cjs) both used to clear a PR on
-// the `sec-review:approved` label alone. Neither looked for a live REQUEST-CHANGES.
-// revealui#1910 merged with the label applied AGAINST a REQUEST-CHANGES verdict that
-// was sitting right there as a comment. This module is the shared parse+decide logic
-// both gates now consult so a REQUEST-CHANGES cannot be papered over by the label.
+// The real parser lives in @revealui/harnesses (packages/harnesses/src/gates/
+// guardrail2-verdict.ts). This file only resolves and loads it, then
+// re-exports the same public API so security-review-gate.cjs,
+// sec-audit-label-decision.cjs, and the vitest suite that migrated to
+// packages/harnesses/src/gates/__tests__/ keep working unchanged. There is no
+// vendored copy of the parsing logic here — a guarded mirror is still a
+// mirror. Resolution goes through gates-resolver.cjs (local dist, or a
+// REVEALUI_HARNESSES_DIR npm install for sparse-checkout CI jobs).
 //
-// THE MARKER CONTRACT: every guardrail-2 verdict a session posts (comment OR review
-// body) carries a machine-parseable trailer on its own line:
-//     <!-- guardrail2-verdict: REQUEST-CHANGES -->
-//     <!-- guardrail2-verdict: APPROVE -->
-// An HTML comment: invisible in rendered markdown, unambiguous, greppable. The
-// human-readable `## Guardrail-2 ... verdict: <VERDICT>` heading stays too, for people.
-//
-// TOPOLOGY NOTE (verified 2026-07-16, load-bearing). Every fleet PR — and every
-// comment and review on it — is authored by the single GitHub account
-// `RevealUIStudio` (the only account `gh` can post as). So login CANNOT tell the
-// builder's comment apart from the reviewer's comment today. Two consequences:
-//   - The `evaluateGuardrail2` DISTINCT-REVIEWER branch (login-filtered non-author
-//     verdicts, the spec's primary logic) is correct and unit-tested, but only
-//     ENGAGES once reviewer verdicts carry a distinct identity (post org-migration,
-//     or a reviewing session that authenticates `gh` as a different account).
-//   - Until then the SINGLE-LOGIN fail-safe branch runs: author markers are NOT
-//     dropped (dropping them would ignore the reviewer's own REQUEST-CHANGES — the
-//     exact #1910 miss), the latest verdict governs, and a REQUEST-CHANGES holds.
-// This module only supplies the hold/clear signal. The `sec-review:approved` label
-// stays owner-applied; clearing a PR still needs both a non-holding verdict AND the
-// label the way it always did.
-//
-// Zero authored regex (fleet no-regex HARDLINE): startsWith/endsWith/slice/trim + a
-// lexicographic timestamp compare (ISO-8601 Z strings sort chronologically).
-//
-// Mirrored — keep in lockstep with the fleet checker's copy at
-// .jv/scripts/guardrail2-verdict.js. The two live in different repos and cannot
-// require each other; this is the same deliberate two-lists-drift discipline the
-// SECURITY_PATHS lists carry.
+// FAILS CLOSED: this parser gates merges. Silently falling back to "no
+// verdict" when the module cannot be resolved is exactly the failure mode
+// this module exists to prevent, so an unresolved module throws instead of
+// returning a stub.
 
-const MARKER_OPEN = '<!-- guardrail2-verdict:';
-const MARKER_CLOSE = '-->';
-const REQUEST_CHANGES = 'REQUEST-CHANGES';
-const APPROVE = 'APPROVE';
+const { resolveGatesModule } = require('./gates-resolver.cjs');
 
-// The verdict for ONE body: its LAST well-formed marker line, or null. A line counts
-// only when, trimmed, it starts with MARKER_OPEN, ends with MARKER_CLOSE, and the text
-// between them trims to exactly one of the two tokens. Prose that merely mentions the
-// marker mid-sentence, or an unknown token, is not a verdict. Last-wins lets a reviewer
-// correct themselves within a single comment.
-function verdictForBody(body) {
-  if (typeof body !== 'string' || body.length === 0) return null;
-  let found = null;
-  for (const rawLine of body.split('\n')) {
-    const line = rawLine.trim();
-    if (!line.startsWith(MARKER_OPEN) || !line.endsWith(MARKER_CLOSE)) continue;
-    const inner = line.slice(MARKER_OPEN.length, line.length - MARKER_CLOSE.length).trim();
-    if (inner === REQUEST_CHANGES || inner === APPROVE) found = inner;
-    // malformed / unknown token → ignored (fail-safe: an ambiguous marker is not a verdict)
-  }
-  return found;
-}
+const mod = resolveGatesModule();
 
-// Normalize reviews + comments into verdict records — one per body that carries a
-// verdict. Author-inclusive; each record is tagged `isAuthor`. Reviews stamp their
-// time in `submittedAt`, comments in `createdAt`.
-function collectVerdicts({ reviews = [], comments = [], authorLogin = '' } = {}) {
-  const out = [];
-  const consume = (item) => {
-    const login = (item && item.author && item.author.login) || '';
-    const body = (item && item.body) || '';
-    const timestamp = (item && (item.submittedAt || item.createdAt)) || '';
-    const verdict = verdictForBody(body);
-    if (verdict) {
-      out.push({ verdict, timestamp, author: login, isAuthor: login !== '' && login === authorLogin });
-    }
-  };
-  for (const r of reviews) consume(r);
-  for (const c of comments) consume(c);
-  return out;
-}
-
-// Max-timestamp record; on a timestamp tie, REQUEST-CHANGES wins (fail-safe — a
-// same-instant APPROVE never masks a REQUEST-CHANGES). ISO-8601 Z strings compare
-// lexicographically === chronologically.
-function latest(records) {
-  let best = null;
-  for (const rec of records) {
-    if (best === null || rec.timestamp > best.timestamp) {
-      best = rec;
-    } else if (rec.timestamp === best.timestamp && rec.verdict === REQUEST_CHANGES) {
-      best = rec;
-    }
-  }
-  return best;
-}
-
-// The gate decision.
-//   { status: 'no-marker' }                                  → caller falls back to legacy label/review logic
-//   { status: 'hold',  reviewer, timestamp, verdict }        → an outstanding REQUEST-CHANGES; do NOT clear
-//   { status: 'clear', reviewer, timestamp, verdict }        → latest verdict is APPROVE
-function evaluateGuardrail2({ reviews = [], comments = [], authorLogin = '' } = {}) {
-  const all = collectVerdicts({ reviews, comments, authorLogin });
-  if (all.length === 0) return { status: 'no-marker' };
-
-  // DISTINCT-REVIEWER branch (spec's primary logic; engages when reviewer verdicts
-  // carry a login other than the PR author). The builder can never self-clear: only
-  // NON-AUTHOR verdicts are considered, so a later author APPROVE cannot lift a
-  // reviewer's REQUEST-CHANGES.
-  const nonAuthor = all.filter((r) => !r.isAuthor);
-  const pool = nonAuthor.length > 0 ? nonAuthor : all;
-  // SINGLE-LOGIN fail-safe: when no verdict is attributable to a non-author (today's
-  // topology), fall back to the whole set rather than dropping the reviewer's verdict.
-
-  const gov = latest(pool);
-  if (gov.verdict === REQUEST_CHANGES) {
-    return { status: 'hold', reviewer: gov.author, timestamp: gov.timestamp, verdict: gov.verdict };
-  }
-  return { status: 'clear', reviewer: gov.author, timestamp: gov.timestamp, verdict: gov.verdict };
+if (!mod) {
+  throw new Error(
+    'guardrail2-verdict: could not resolve the @revealui/harnesses gates module.\n' +
+      '  This parser gates merges — failing closed rather than silently treating\n' +
+      '  every PR as having no recorded verdict.\n' +
+      '  Fix: build it locally (pnpm --filter @revealui/harnesses build), or set\n' +
+      '  REVEALUI_HARNESSES_DIR to a directory where\n' +
+      '  `npm install --prefix <dir> @revealui/harnesses@<pin>` was run.\n',
+  );
 }
 
 module.exports = {
-  MARKER_OPEN,
-  MARKER_CLOSE,
-  REQUEST_CHANGES,
-  APPROVE,
-  verdictForBody,
-  collectVerdicts,
-  evaluateGuardrail2,
+  MARKER_OPEN: mod.MARKER_OPEN,
+  MARKER_CLOSE: mod.MARKER_CLOSE,
+  REQUEST_CHANGES: mod.REQUEST_CHANGES,
+  APPROVE: mod.APPROVE,
+  verdictForBody: mod.verdictForBody,
+  collectVerdicts: mod.collectVerdicts,
+  evaluateGuardrail2: mod.evaluateGuardrail2,
 };


### PR DESCRIPTION
GAP-408 revealui side (control-layer shape per the gap's 2026-07-24 redesign: no vendored mirrors, no drift guards; the .jv-side thin adapters are a peer session's claimed complementary slice).

## What changed
- **packages/harnesses/src/gates/**: the new single editable source. `guardrail2-verdict.ts` (verdict-marker parser, ported verbatim: distinct-reviewer branch, author-inclusive fail-safe, latest-governs) + `doc-currency-shared-rules.ts` (the 8 shared detection tuples; only the username-free retired-suite-path term, per the standing redaction carve-out) + typed exports on subpath `@revealui/harnesses/gates`.
- **scripts/validate/gates-resolver.cjs** (new): local monorepo dist first, then REVEALUI_HARNESSES_DIR (an npm install) — deliberately NOT a bare import, which boundary.ts Check 4 forbids for optional Fair Source packages.
- **Thin adapters**: `guardrail2-verdict.cjs` re-exports the package parser and FAILS CLOSED unresolved (it gates merges); `doc-currency.ts` loads shared tuples, attaches repo messages, and warns-and-degrades unresolved (scanner, mirroring its existing unreadable-baseline posture).
- **CI**: ci.yml builds harnesses before doc-currency; security-review-gate.yml + sec-audit-label-guard.yml build the package FROM THE BASE-REF CHECKOUT via widened sparse checkout + filtered install (~15s added). An earlier npm-pin design was rejected in review: it created an unbounded fail-closed window until a manual stable release published a not-yet-existing version.
- Changeset: minor.

## Evidence
- Drift audit first: both hand-lockstep pairs had ZERO semantic drift (the 2026-07-17 reconciliation held) — this change is pure structure, no behavior delta.
- Prove-red: marker-grammar mutation fails 13/20 gates tests; reverted, 20/20. Adapter byte-compat proven by the pre-existing 38 adapter/label-decision tests passing unchanged through the thin adapter.
- doc-currency --mode=ci identical pre/post (47 baselined, 0 NEW). Package 542+ tests, typecheck (noUncheckedIndexedAccess), build, and gate phase 1 all green; sparse-checkout install/build sequence verified empirically in a fresh clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)