### PR TITLE
fix(dev): coverageInclude:false factory option; restore loaded-only coverage for @revealui/test

### DIFF
--- a/packages/dev/src/__tests__/create-vitest-config.test.ts
+++ b/packages/dev/src/__tests__/create-vitest-config.test.ts
@@ -41,6 +41,20 @@ describe('createVitestConfig', () => {
     expect(config.test?.coverage).toBeUndefined();
   });
 
+  it('omits the coverage include key when coverageInclude is false (loaded-files-only measurement)', () => {
+    const config = createVitestConfig({ coverageInclude: false });
+    const coverage = config.test?.coverage as { include?: string[]; exclude?: string[] };
+    expect(coverage).toBeDefined();
+    expect('include' in coverage).toBe(false);
+    expect(coverage?.exclude).toBeDefined();
+  });
+
+  it('writes the coverage include key by default', () => {
+    const config = createVitestConfig();
+    const coverage = config.test?.coverage as { include?: string[] };
+    expect(coverage?.include).toEqual(['src/**/*.ts']);
+  });
+
   it('merges overrides for env and aliases', () => {
     const config = createVitestConfig({
       overrides: {

--- a/packages/dev/src/vitest/create-config.ts
+++ b/packages/dev/src/vitest/create-config.ts
@@ -39,8 +39,16 @@ export interface CreateVitestConfigOptions {
   exclude?: string[];
   /** When false, omit coverage block. Default: true. */
   coverage?: boolean;
-  /** Coverage include globs. Default: src TypeScript files. */
-  coverageInclude?: string[];
+  /**
+   * Coverage include globs. Default: src TypeScript files. Pass `false` to
+   * omit the `include` key entirely — the v8 provider then measures ONLY
+   * files the test run actually loads, instead of reporting every
+   * include-matched file (unloaded files count 0% and enter the
+   * denominator). Use for test-utilities packages whose helper trees are
+   * exercised by OTHER packages' suites or by integration/e2e runs excluded
+   * from the unit-coverage job.
+   */
+  coverageInclude?: string[] | false;
   /** Coverage exclude globs. Default: tests and __tests__ trees. */
   coverageExclude?: string[];
   /**
@@ -111,7 +119,7 @@ export function createVitestConfig(options: CreateVitestConfigOptions = {}): Vit
             coverage: {
               provider: 'v8' as const,
               reporter: coverageReporters,
-              include: coverageInclude,
+              ...(coverageInclude !== false ? { include: coverageInclude } : {}),
               exclude: coverageExclude,
               ...(thresholds ? { thresholds } : {}),
             },

--- a/packages/test/vitest.config.ts
+++ b/packages/test/vitest.config.ts
@@ -5,6 +5,15 @@ export default createVitestConfig({
   maxWorkers: 1,
   hookTimeout: 30_000,
   exclude: ['src/integration/**', 'src/integration-pro/**', '**/e2e/**', '**/node_modules/**'],
+  // Loaded-files-only coverage (no `include` key). This package is test
+  // infrastructure: its fixtures/mocks/patterns/integration helpers are
+  // exercised by OTHER packages' suites and by the integration/e2e runs this
+  // unit job excludes, so an include-all denominator counts them at 0% and
+  // sank the package from green to 15% lines at the 2026-07-25 promotion
+  // (#2110 factory migration regression — the pre-factory config had no
+  // include key and the thresholds below were calibrated to loaded-only
+  // measurement).
+  coverageInclude: false,
   coverageExclude: [
     'node_modules/**',
     '**/*.test.ts',


### PR DESCRIPTION
Unblocks the promotion PR #2148, whose Coverage check is the sole red: the createVitestConfig migration (#2110) always writes `coverage.include`, which makes the v8 provider report every include-matched file. @revealui/test's helper trees (fixtures, mocks, patterns, integration setup — exercised by other packages' suites and by the integration/e2e runs the unit-coverage job excludes) entered the denominator at 0% and sank the package to 15.28% lines against its 35% threshold. Feature CI never sees this because only the promotion path runs the full Coverage job; it passed on the previous promotion (#2069, July 22) and failed on #2148.

**Fix:** a `coverageInclude: false` factory option that omits the include key, restoring the pre-factory loaded-files-only measurement the thresholds were calibrated against; @revealui/test opts in with a rationale comment. Factory default is unchanged and now test-pinned.

**Proof:** reproduced red locally via `pnpm turbo run test:coverage --filter @revealui/test` (15.28/11.24/16.2/29.1 — same numbers as the #2148 Coverage job); green after the change (48.96 lines / 36.25 funcs / 50.19 stmts / 57.89 branches, 20/20 test files). Factory suite 55/55 including two new cases (include omitted when false; include written by default). Biome clean.

Once merged to test, #2148 absorbs it automatically (its head is test) and Coverage re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)