### PR TITLE
chore(release): version packages (harnesses 0.10.0 gates export +cascades)

### DIFF
--- a/.changeset/editor-canvas-default-preview-page.md
+++ b/.changeset/editor-canvas-default-preview-page.md
@@ -1,5 +1,0 @@
----
-'@revealui/editor': patch
----
-
-Land canvas defaults for a fresh edit session: resolve a published page (`home` then `products` then first) when no dirty docs exist, so the preview iframe is not stuck on bare `/`. Export `pickDefaultPreviewPageId` for the preference order.

--- a/.changeset/gap-199-native-master-spec.md
+++ b/.changeset/gap-199-native-master-spec.md
@@ -1,9 +1,0 @@
----
-"@revealui/harnesses": minor
----
-
-feat(harnesses): GAP-199 native master-spec coupling advisory on file-edit hooks
-
-Provider-agnostic twin of the Claude PostToolUse master-spec-pr-coupling hook.
-Warns (never blocks) when contracts/db schema/apps sources edit without the
-product canon doc dirty; wired through runHookCommand for all editor sources.

--- a/.changeset/gap-371-phase4-opencode-parser-pin.md
+++ b/.changeset/gap-371-phase4-opencode-parser-pin.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Pin `parseOpenCodeRunOutput` (GAP-371 Phase 4) against the real `opencode run --format json` output shape, verified live against opencode 1.18.3: newline-delimited JSON (JSONL) events, one per line, not a single JSON document. The parser now extracts the assistant's final `text` event from a real turn instead of mis-treating the JSONL stream as invalid JSON and echoing it back verbatim.

--- a/.changeset/gap-408-control-layer-gates.md
+++ b/.changeset/gap-408-control-layer-gates.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": minor
----
-
-Add a `gates` subpath export (GAP-408 control-layer redesign): `evaluateGuardrail2` / `verdictForBody` / `collectVerdicts` (the guardrail-2 verdict-marker parser) and `SHARED_DETECTION_RULES` / `COMMON_EXON` / `STRIPE_LIVE_EXON` (the doc-currency stale-fact detection data). These are now the single editable source for logic that `scripts/validate/guardrail2-verdict.cjs` and `scripts/validate/doc-currency.ts` load at runtime, and that the private revealui-jv checkout's equivalent scripts resolve via an adapter — no vendored copies on either side of the public/private boundary.

--- a/.changeset/manager-finish-gap-406.md
+++ b/.changeset/manager-finish-gap-406.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": minor
----
-
-Finish the `.revealui` project manager (GAP-406): default `content sync` lands under the manager tree, materialize preserves existing manager.json, structure/CI gate hard-fail on invalid manager when `.revealui` or harnesses change, equal-rank adapter stubs stay gitignored outside the manager tree.

--- a/.changeset/presentation-fix-block-annotation-path.md
+++ b/.changeset/presentation-fix-block-annotation-path.md
@@ -1,5 +1,0 @@
----
-'@revealui/presentation': patch
----
-
-Fix `RenderBlocks` emitting `data-rvui-field` paths one segment short of the real draft structure (e.g. `blocks.0.title` instead of `blocks.0.data.title`). Every block component reads its fields from `block.data.*`, so a path stopping at the block index landed an edit-session patch as a sibling of `data` instead of inside it — silently corrupting the block's data on write, both in the session draft and (on publish) the live page. Attributes only appear in edit mode (`editable` + `docId`), so this does not affect any non-edit-mode rendering or visual output.

--- a/.changeset/ves-p2-voice-block-ops.md
+++ b/.changeset/ves-p2-voice-block-ops.md
@@ -1,6 +1,0 @@
----
-'@revealui/contracts': patch
-'@revealui/editor': patch
----
-
-VES P2 slice: gate fleet-marketing session patches with marketing-voice Tier-1 validation, extend prose slots for contracts block shapes, and add blocks.insert/remove/move ops on the session API plus canvas block chrome.

--- a/apps/license-signer/CHANGELOG.md
+++ b/apps/license-signer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @revealui/license-signer
+
+## 0.1.1
+
+### Patch Changes
+
+- @revealui/core@0.12.1

--- a/apps/license-signer/package.json
+++ b/apps/license-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/license-signer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Isolated license JWT mint service (GAP-260 P4-2). Holds the signing private key; HMAC-authed internal mint API.",
   "private": true,
   "type": "module",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/ai
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+  - @revealui/core@0.12.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/ai",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AI runtime for agent-driven products — agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
   "keywords": [
     "agent",

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @revealui/auth
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+  - @revealui/core@0.12.1
+  - @revealui/security@0.5.1
+
 ## 0.4.9
 
 ### Patch Changes

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/auth",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Database-backed session auth for Hono and Next.js — bcrypt, OAuth, brute-force protection, rate limiting, password reset. Ships with RevealUI.",
   "keywords": [
     "auth",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/cli
 
+## 0.9.3
+
+### Patch Changes
+
+- @revealui/setup@0.7.1
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Create RevealUI projects with a single command",
   "keywords": [
     "cli",

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/contracts
 
+## 0.8.1
+
+### Patch Changes
+
+- 86780ad: VES P2 slice: gate fleet-marketing session patches with marketing-voice Tier-1 validation, extend prose slots for contracts block shapes, and add blocks.insert/remove/move ops on the session API plus canvas block chrome.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/contracts",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Single source of truth for Zod schemas and TypeScript types shared across packages and apps. Ships with RevealUI.",
   "keywords": [
     "contracts",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/core
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+  - @revealui/security@0.5.1
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/core",
-  "version": "0.12.0",
-  "description": "RevealUI's runtime engine \u2014 admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
+  "version": "0.12.1",
+  "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {
     "@electric-sql/pglite": "catalog:",

--- a/packages/create-revealui/CHANGELOG.md
+++ b/packages/create-revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-revealui
 
+## 0.5.16
+
+### Patch Changes
+
+- @revealui/cli@0.9.3
+
 ## 0.5.15
 
 ### Patch Changes

--- a/packages/create-revealui/package.json
+++ b/packages/create-revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-revealui",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "Create a new RevealUI project",
   "keywords": [
     "cli",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @revealui/editor
 
+## 0.2.1
+
+### Patch Changes
+
+- 86780ad: Land canvas defaults for a fresh edit session: resolve a published page (`home` then `products` then first) when no dirty docs exist, so the preview iframe is not stuck on bare `/`. Export `pickDefaultPreviewPageId` for the preference order.
+- 86780ad: VES P2 slice: gate fleet-marketing session patches with marketing-voice Tier-1 validation, extend prose slots for contracts block shapes, and add blocks.insert/remove/move ops on the session API plus canvas block chrome.
+- Updated dependencies [86780ad]
+- Updated dependencies [86780ad]
+  - @revealui/presentation@0.12.1
+  - @revealui/contracts@0.8.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/editor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Visual edit-session runtime and dashboard canvas for RevealUI content",
   "license": "MIT",
   "repository": {

--- a/packages/engines/CHANGELOG.md
+++ b/packages/engines/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @revealui/engines
 
+## 0.4.9
+
+### Patch Changes
+
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+  - @revealui/auth@0.4.10
+  - @revealui/core@0.12.1
+  - @revealui/services@0.7.8
+
 ## 0.4.8
 
 ### Patch Changes

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/engines",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": true,
   "description": "Unified entry point for the five RevealUI business primitives — users, content, products, payments, agents.",
   "license": "FSL-1.1-MIT",

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @revealui/harnesses
 
+## 0.10.0
+
+### Minor Changes
+
+- 03560dd: feat(harnesses): GAP-199 native master-spec coupling advisory on file-edit hooks
+
+  Provider-agnostic twin of the Claude PostToolUse master-spec-pr-coupling hook.
+  Warns (never blocks) when contracts/db schema/apps sources edit without the
+  product canon doc dirty; wired through runHookCommand for all editor sources.
+
+- d11130e: Add a `gates` subpath export (GAP-408 control-layer redesign): `evaluateGuardrail2` / `verdictForBody` / `collectVerdicts` (the guardrail-2 verdict-marker parser) and `SHARED_DETECTION_RULES` / `COMMON_EXON` / `STRIPE_LIVE_EXON` (the doc-currency stale-fact detection data). These are now the single editable source for logic that `scripts/validate/guardrail2-verdict.cjs` and `scripts/validate/doc-currency.ts` load at runtime, and that the private revealui-jv checkout's equivalent scripts resolve via an adapter — no vendored copies on either side of the public/private boundary.
+- b5c7c57: Finish the `.revealui` project manager (GAP-406): default `content sync` lands under the manager tree, materialize preserves existing manager.json, structure/CI gate hard-fail on invalid manager when `.revealui` or harnesses change, equal-rank adapter stubs stay gitignored outside the manager tree.
+
+### Patch Changes
+
+- 4ff3280: Pin `parseOpenCodeRunOutput` (GAP-371 Phase 4) against the real `opencode run --format json` output shape, verified live against opencode 1.18.3: newline-delimited JSON (JSONL) events, one per line, not a single JSON document. The parser now extracts the assistant's final `text` event from a real turn instead of mis-treating the JSONL stream as invalid JSON and echoing it back verbatim.
+  - @revealui/core@0.12.1
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AI harness integration — adapters, daemon, workboard coordination, JSON-RPC server.",
   "repository": {
     "type": "git",

--- a/packages/knowledge-graph/CHANGELOG.md
+++ b/packages/knowledge-graph/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @revealui/knowledge-graph
 
+## 0.1.4
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/knowledge-graph/package.json
+++ b/packages/knowledge-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/knowledge-graph",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Fleet knowledge graph — bi-temporal, content-addressed graph (ontology, deterministic IDs, deterministic ingestion, hybrid search) over Neon + pgvector. GAP-340.",
   "keywords": [
     "knowledge-graph",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @revealui/mcp
 
+## 0.8.2
+
+### Patch Changes
+
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+  - @revealui/core@0.12.1
+  - @revealui/security@0.5.1
+  - @revealui/knowledge-graph@0.1.4
+  - @revealui/setup@0.7.1
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Model Context Protocol framework — first-party server launchers, adapter pattern, tool discovery, and an incubating multi-server hypervisor (not app-mounted by default; ADR-007).",
   "repository": {
     "type": "git",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/RevealUIStudio/revealui",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@revealui/mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/presentation/CHANGELOG.md
+++ b/packages/presentation/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/presentation
 
+## 0.12.1
+
+### Patch Changes
+
+- 86780ad: Fix `RenderBlocks` emitting `data-rvui-field` paths one segment short of the real draft structure (e.g. `blocks.0.title` instead of `blocks.0.data.title`). Every block component reads its fields from `block.data.*`, so a path stopping at the block index landed an edit-session patch as a sibling of `data` instead of inside it — silently corrupting the block's data on write, both in the session draft and (on publish) the live page. Attributes only appear in edit mode (`editable` + `docId`), so this does not affect any non-edit-mode rendering or visual output.
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/presentation",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Native React UI components built on Tailwind v4. Buttons, forms, dialogs, navigation, and more.",
   "keywords": [
     "components",

--- a/packages/revealui/CHANGELOG.md
+++ b/packages/revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # revealui
 
+## 0.1.11
+
+### Patch Changes
+
+- create-revealui@0.5.16
+
 ## 0.1.10
 
 ### Patch Changes

--- a/packages/revealui/package.json
+++ b/packages/revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revealui",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "RevealUI — open-source agentic business runtime. Meta-installer that proxies to create-revealui. NOT published: npm rejects bare 'revealui' as too similar to 'reveal-ui'; use 'create-revealui' (npm create revealui) or '@revealui/core' instead.",
   "keywords": [

--- a/packages/security/CHANGELOG.md
+++ b/packages/security/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/security
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/security",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Security primitives — CSP/CORS/HSTS headers, RBAC + ABAC policy engine, encryption helpers, audit logging, GDPR compliance. Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/services
 
+## 0.7.8
+
+### Patch Changes
+
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+  - @revealui/core@0.12.1
+
 ## 0.7.7
 
 ### Patch Changes

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/services",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "External service integrations, Stripe (payment processing + circuit breaker) and email (Gmail API delivery). Ships with RevealUI.",
   "repository": {
     "type": "git",

--- a/packages/setup/CHANGELOG.md
+++ b/packages/setup/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/setup
 
+## 0.7.1
+
+### Patch Changes
+
+- @revealui/security@0.5.1
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/setup",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Setup utilities for new projects — environment config, database init, secrets validation. Used by @revealui/cli.",
   "keywords": [
     "cli",

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/sync
 
+## 0.3.18
+
+### Patch Changes
+
+- Updated dependencies [86780ad]
+  - @revealui/contracts@0.8.1
+
 ## 0.3.17
 
 ### Patch Changes

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/sync",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Real-time sync layer wrapping ElectricSQL and Yjs CRDT — offline queue, shape cache, conflict resolution, collaborative documents. Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Consumes the 7 pending changesets via `pnpm changeset:version` — headline: @revealui/harnesses 0.10.0 with the ./gates subpath export (GAP-408 control layer), plus the editor-canvas, opencode-parser-pin, manager, presentation, and VES voice-ops bumps with their cascading patch bumps (42 files: package.json versions + CHANGELOGs).

Why now: the two release.yml dispatches at main both no-op'd — `changeset publish` only publishes versions already committed, and no version commit existed (registry still at harnesses 0.9.0). This is the missing step, following the established pattern (#1924, #2006): version PR → test → next promotion → `gh workflow run release.yml --ref main`.

Nothing functional changes; versions + changelogs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)