### PR TITLE
chore(ci): bump backflow-reusable pin to label-applying version

### DIFF
--- a/.github/workflows/backflow-main-into-test.yml
+++ b/.github/workflows/backflow-main-into-test.yml
@@ -26,7 +26,7 @@ jobs:
   backflow:
     # Pinned to a SHA — org-shared reusable was referenced by the mutable @main.
     # Bump this deliberately when the reusable changes.
-    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@010a9388aee91d6f6fef8fce5a18f897af42443b # main @ 2026-07-06 (backflow signed-merge — .github#7)
+    uses: RevealUIStudio/.github/.github/workflows/backflow-reusable.yml@e895ec57294c24089e3a0c7238d6c34ebb5fdf95 # main @ 2026-07-25 (backflow applies backflow:merge-commit label — .github#12)
     # Scope to ONLY the two secrets the reusable declares (its workflow_call.secrets
     # block documents this exact form) instead of `secrets: inherit`, which would
     # forward every caller secret (VERCEL_TOKEN, PROD_POSTGRES_URL, …) into it.


### PR DESCRIPTION
Picks up RevealUIStudio/.github#12 (e895ec5): the shared backflow reusable now applies `backflow:merge-commit` when it opens/updates its PR, so bot backflows stop arriving pre-deadlocked against this repo's backflow-merge-method-guard (#2153 and #2159 both needed manual labeling, one per promotion cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)