### PR TITLE
fix(db,auth,admin): audit env assert matches the real client contract (GAP-417 item 5)

### DIFF
--- a/.changeset/gap-417-assert-getclient-contract.md
+++ b/.changeset/gap-417-assert-getclient-contract.md
@@ -1,0 +1,6 @@
+---
+'@revealui/db': minor
+'@revealui/auth': minor
+---
+
+Close the audit env-parity fail-open (GAP-417 item 5): `@revealui/db` now exports `hasDatabaseConnectionEnv()`, a boot-time predicate that matches `getClient()`'s connection resolution exactly (config url, then POSTGRES_URL / DATABASE_URL), and `assertAuditStorageEnv` consumes it instead of a local triple that also accepted `DATABASE_HOST` — an env shape `getClient()` never consults, which let the assert pass, the install throw, and production silently keep the in-memory audit sink.

--- a/apps/admin/src/__tests__/instrumentation-audit-storage.test.ts
+++ b/apps/admin/src/__tests__/instrumentation-audit-storage.test.ts
@@ -109,6 +109,20 @@ describe('installAdminAuditStorage (GAP-338)', () => {
     expect(written).not.toContain('non-production');
   });
 
+  it('production + install-construct failure: refuses to serve — assert/client drift must not fail open (GAP-417 item 5)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    installAuditStorage.mockImplementation(() => {
+      throw new Error('Database connection string not provided');
+    });
+
+    const { installAdminAuditStorage } = await import('../instrumentation-node');
+    await installAdminAuditStorage();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const written = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(written).toContain('AUDIT STORAGE INSTALL FAILED');
+  });
+
   it('Forge kit (RUNTIME_INIT): self-test BLOCKS and a failure refuses to serve (#2161 review)', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('RUNTIME_INIT', 'true');

--- a/apps/admin/src/app/api/health/__tests__/health-routes.test.ts
+++ b/apps/admin/src/app/api/health/__tests__/health-routes.test.ts
@@ -97,6 +97,49 @@ describe('GET /api/health', () => {
     expect(body.service).toBe('RevealUI Admin');
   });
 
+  it('non-production in-memory audit storage is informational: degraded check entry, still 200 (GAP-338/417)', async () => {
+    mockGetSession.mockResolvedValue({ user: { role: 'admin' } });
+    const mockFind = vi.fn().mockResolvedValue({ docs: [] });
+    mockGetRevealUIInstance.mockResolvedValue({ find: mockFind });
+
+    const { GET } = await loadRoute();
+    const res = await GET({ headers: { get: () => null } } as never);
+
+    // The test process runs on the real in-memory audit singleton — a
+    // by-design non-production state must not 503 the admin.
+    expect((res as { status: number }).status).toBe(200);
+    const body = (
+      res as unknown as {
+        body: { status: string; checks: Array<{ name: string; status: string }> };
+      }
+    ).body;
+    expect(body.status).toBe('healthy');
+    expect(body.checks.find((c) => c.name === 'audit-storage')?.status).toBe('degraded');
+  });
+
+  it('PRODUCTION in-memory audit storage is an outage: unhealthy check, 503 (GAP-338/417)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    try {
+      mockGetSession.mockResolvedValue({ user: { role: 'admin' } });
+      const mockFind = vi.fn().mockResolvedValue({ docs: [] });
+      mockGetRevealUIInstance.mockResolvedValue({ find: mockFind });
+
+      const { GET } = await loadRoute();
+      const res = await GET({ headers: { get: () => null } } as never);
+
+      expect((res as { status: number }).status).toBe(503);
+      const body = (
+        res as unknown as {
+          body: { status: string; checks: Array<{ name: string; status: string }> };
+        }
+      ).body;
+      expect(body.status).toBe('unhealthy');
+      expect(body.checks.find((c) => c.name === 'audit-storage')?.status).toBe('unhealthy');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('returns 503 when database is unhealthy', async () => {
     mockGetSession.mockResolvedValue({ user: { role: 'admin' } });
     mockGetRevealUIInstance.mockRejectedValue(new Error('Connection refused'));

--- a/apps/admin/src/app/api/health/route.ts
+++ b/apps/admin/src/app/api/health/route.ts
@@ -116,7 +116,10 @@ export async function GET(request: Request) {
           'Audit storage is IN-MEMORY in production — admin audit emits evaporate on restart',
       });
     } else {
-      overallStatus = overallStatus === 'healthy' ? 'degraded' : overallStatus;
+      // By-design state (dev shell / test env without a DB): informational
+      // check entry only. It must NOT downgrade overallStatus — this route
+      // maps every non-healthy overall to 503, and a deliberate dev default
+      // is not an outage (the 503 belongs to production in-memory only).
       checks.push({
         name: 'audit-storage',
         status: 'degraded',
@@ -124,7 +127,9 @@ export async function GET(request: Request) {
       });
     }
   } catch (error) {
-    overallStatus = overallStatus === 'healthy' ? 'degraded' : overallStatus;
+    // Probe failure is informational too — the audit path itself is guarded
+    // at boot (instrumentation) and at write time; the health probe must not
+    // 503 the whole admin because the check could not run.
     checks.push({
       name: 'audit-storage',
       status: 'degraded',

--- a/apps/admin/src/instrumentation-node.ts
+++ b/apps/admin/src/instrumentation-node.ts
@@ -80,7 +80,23 @@ export async function installAdminAuditStorage(): Promise<void> {
       return;
     }
 
-    installAuditStorage();
+    try {
+      installAuditStorage();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (process.env.NODE_ENV === 'production') {
+        // GAP-417 item-5 backstop: a construct-time failure here means the
+        // parity assert and the real client contract have drifted (the exact
+        // DATABASE_HOST fail-open the #2161 re-review proved). Refuse to
+        // serve rather than silently keep the in-memory sink.
+        process.stderr.write(`AUDIT STORAGE INSTALL FAILED (admin):\n  - ${message}\n`);
+        process.exit(1);
+      }
+      process.stderr.write(
+        `[GAP-338] admin audit storage install failed (non-fatal, non-production): ${message}\n`,
+      );
+      return;
+    }
 
     if (process.env.RUNTIME_INIT) {
       // Forge kit: a long-running container with an async boot chain, the

--- a/apps/server/src/lib/__tests__/audit-storage.pglite.test.ts
+++ b/apps/server/src/lib/__tests__/audit-storage.pglite.test.ts
@@ -167,10 +167,20 @@ describe('assertAuditStorageEnv — synchronous env-parity guard (GAP-355 Stage 
     );
   });
 
-  it('passes when any of DATABASE_URL / POSTGRES_URL / DATABASE_HOST is present', () => {
+  it('passes when DATABASE_URL or POSTGRES_URL is present', () => {
     expect(() => assertAuditStorageEnv({ DATABASE_URL: 'postgres://x' })).not.toThrow();
     expect(() => assertAuditStorageEnv({ POSTGRES_URL: 'postgres://x' })).not.toThrow();
-    expect(() => assertAuditStorageEnv({ DATABASE_HOST: 'db.internal' })).not.toThrow();
+  });
+
+  it('DATABASE_HOST alone THROWS — getClient() cannot build a connection from it (GAP-417 item 5)', () => {
+    // The #2161 re-review proved this empirically on the old predicate: the
+    // assert passed on DATABASE_HOST alone, getClient() then threw inside
+    // installAuditStorage, the caller swallowed it, and production silently
+    // kept the in-memory sink. The assert must accept exactly what
+    // getClient() accepts.
+    expect(() => assertAuditStorageEnv({ DATABASE_HOST: 'db.internal' })).toThrow(
+      'AUDIT STORAGE ENV PARITY FAILED',
+    );
   });
 
   it('on a production deployment, throws when the signing key is absent (GAP-355 Stage 3)', () => {

--- a/docker-compose.forge.yml
+++ b/docker-compose.forge.yml
@@ -20,6 +20,10 @@
 #   JWT_SECRET                — 32+ char random secret (openssl rand -hex 32)
 #   REVEALUI_PUBLIC_KEY       — RSA public key for license verification
 #   REVEALUI_PRIVATE_KEY      — RSA private key for license issuance
+#   REVEALUI_AUDIT_SIGNING_KEY — Ed25519 PKCS#8 PEM; signs every audit row
+#                               (required in production: api validate-startup
+#                               and admin instrumentation both refuse to boot
+#                               without it — ADR §2b, self-hosted signs too)
 #   RESEND_API_KEY            — transactional email (optional — disables email features if absent)
 # =============================================================================
 
@@ -72,6 +76,12 @@ services:
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       REVEALUI_PUBLIC_KEY: ${REVEALUI_PUBLIC_KEY:?REVEALUI_PUBLIC_KEY is required}
       REVEALUI_PRIVATE_KEY: ${REVEALUI_PRIVATE_KEY:?REVEALUI_PRIVATE_KEY is required}
+
+      # Audit-row signing (GAP-355 Stage 3 / GAP-417). validate-startup refuses
+      # to boot the api without a parseable Ed25519 key — the compose previously
+      # never passed it through, so an un-keyed kit restart-looped with a
+      # generic missing-env error instead of this named one.
+      REVEALUI_AUDIT_SIGNING_KEY: ${REVEALUI_AUDIT_SIGNING_KEY:?REVEALUI_AUDIT_SIGNING_KEY is required (Ed25519 PKCS#8 PEM - signs every audit row)}
 
       # CMS origin for CORS
       ADMIN_URL: ${ADMIN_URL:-http://admin:4000}
@@ -136,6 +146,11 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       REVEALUI_PUBLIC_KEY: ${REVEALUI_PUBLIC_KEY}
       REVEALUI_PRIVATE_KEY: ${REVEALUI_PRIVATE_KEY}
+
+      # Audit-row signing (GAP-338/GAP-417): the admin process installs
+      # persistent signed audit storage at boot and refuses to serve in
+      # production without the key. Same key as the api service.
+      REVEALUI_AUDIT_SIGNING_KEY: ${REVEALUI_AUDIT_SIGNING_KEY}
 
       # API URL (internal container network)
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://api:3004}

--- a/packages/auth/src/server/audit-storage.ts
+++ b/packages/auth/src/server/audit-storage.ts
@@ -34,7 +34,7 @@
 import { randomUUID } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
 import type { AuditRowSignerFn, DrizzleAuditStore as DrizzleAuditStoreType } from '@revealui/db';
-import { DrizzleAuditStore, getClient } from '@revealui/db';
+import { DrizzleAuditStore, getClient, hasDatabaseConnectionEnv } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
 import type {
   AuditEvent,
@@ -247,13 +247,18 @@ function reconstructEvent(entry: {
  * target DB); that needs the write-read round trip of `auditStorageSelfTest`.
  */
 export function assertAuditStorageEnv(env: NodeJS.ProcessEnv = process.env): void {
-  const hasDbConnection = Boolean(env.DATABASE_URL || env.POSTGRES_URL || env.DATABASE_HOST);
-  if (!hasDbConnection) {
+  // GAP-417 item 5: the predicate is OWNED by @revealui/db and matches
+  // getClient()'s resolution exactly (config url, then POSTGRES_URL /
+  // DATABASE_URL). The previous local triple also accepted DATABASE_HOST,
+  // which getClient() never consults — so the assert passed, the install then
+  // threw, and production silently kept the in-memory sink (proven in the
+  // #2161 re-review). Never re-inline this check.
+  if (!hasDatabaseConnectionEnv(env)) {
     throw new Error(
-      'AUDIT STORAGE ENV PARITY FAILED: no database connection env is set (one of ' +
-        'DATABASE_URL, POSTGRES_URL, DATABASE_HOST is required), so the audit write path ' +
-        'cannot persist rows. Refusing to serve — an agent action that cannot be recorded ' +
-        'must not execute (fail-closed integrity, ' +
+      'AUDIT STORAGE ENV PARITY FAILED: no usable database connection is configured ' +
+        '(set POSTGRES_URL or DATABASE_URL, or provide @revealui/config database.url), ' +
+        'so the audit write path cannot persist rows. Refusing to serve — an agent ' +
+        'action that cannot be recorded must not execute (fail-closed integrity, ' +
         'docs/decisions/2026-07-12-audit-receipt-architecture.md §2a).',
     );
   }

--- a/packages/db/src/client/index.ts
+++ b/packages/db/src/client/index.ts
@@ -269,22 +269,42 @@ export function getClient(typeOrConnectionString?: DatabaseType | string): Datab
 /**
  * Internal function to get (or lazily create) the single 'rest' client.
  */
+/**
+ * Resolve the database connection string EXACTLY the way `getClient()` will:
+ * `@revealui/config` (lazy, process-global) first, then the `POSTGRES_URL` /
+ * `DATABASE_URL` fallback (`||` also catches empty strings). The `env`
+ * parameter covers only the env-var fallback — the config module always reads
+ * the real process env, matching runtime behavior.
+ */
+function resolveDatabaseUrl(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  let url: string | undefined;
+  try {
+    const configUrl = configModule.database?.url;
+    if (typeof configUrl === 'string') {
+      url = configUrl;
+    }
+  } catch {
+    // Config validation failed or module unavailable - will use env fallback
+    url = undefined;
+  }
+  return url || env.POSTGRES_URL || env.DATABASE_URL || undefined;
+}
+
+/**
+ * Whether `getClient()` would be able to construct a client from the current
+ * environment. THE boot-time predicate for callers that must fail closed
+ * before installing a DB-backed subsystem (GAP-417: the audit env assert
+ * previously accepted `DATABASE_HOST`, which this resolution never consults,
+ * so the assert passed and the install then threw — a silent fail-open).
+ * Keep this and `getClientByType` on the same resolution, always.
+ */
+export function hasDatabaseConnectionEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(resolveDatabaseUrl(env));
+}
+
 function getClientByType(): Database {
   if (!restClient) {
-    // Try to get from config module (ESM - lazy validation via Proxy)
-    let url: string | undefined;
-    try {
-      const configUrl = configModule.database?.url;
-      if (typeof configUrl === 'string') {
-        url = configUrl;
-      }
-    } catch {
-      // Config validation failed or module unavailable - will use process.env fallback
-      url = undefined;
-    }
-
-    // Fallback to process.env (use || to also catch empty strings)
-    url = url || process.env.POSTGRES_URL || process.env.DATABASE_URL;
+    const url = resolveDatabaseUrl();
 
     if (!url || typeof url !== 'string') {
       throw new Error(

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -37,6 +37,7 @@ export {
   getPoolMetrics,
   getRestClient,
   getRestPool,
+  hasDatabaseConnectionEnv,
   requiresTransactions,
   resetClient,
   schema,


### PR DESCRIPTION
Closes the fail-open the #2161 re-review proved empirically: `assertAuditStorageEnv` accepted `DATABASE_HOST`, which `getClient()` never consults — so the assert passed, `installAuditStorage()` threw into a swallow-and-continue catch, and production silently kept the in-memory audit sink.

**One predicate, one owner.** `@revealui/db` now exports `hasDatabaseConnectionEnv()`, extracted from `getClientByType()`'s own resolution (config url → `POSTGRES_URL` → `DATABASE_URL`) so the two can never drift; the assert consumes it. Red-first proven: the flipped `DATABASE_HOST`-must-throw test fails against the pre-fix dist (exactly 1 of 15), green after.

**Backstop for the class, not just the instance.** An install-construct failure on a production admin now refuses to serve (exit 1) instead of being swallowed — even if the predicate and client drift again someday, the failure is loud, never a silent in-memory sink.

**Forge kit plumbing (from the same review's residuals):**
- `docker-compose.forge.yml` never forwarded `REVEALUI_AUDIT_SIGNING_KEY` to either container, so an un-keyed kit restart-looped on a generic missing-env error. Now passed to api (`:?` require-fenced with a named message) and admin.
- Migrate-before-boot verified and recorded: the stamped kit runs a one-shot `migrate` service gated `service_completed_successfully` before api + admin (`apps/server/Dockerfile.forge` migrate stage) — the restart-loop concern is handled by design there.

Tests: server audit suites 17/17, admin instrumentation 11/11 (new production install-failure case), typechecks clean for db/auth/admin/server.

⚠️ Security-sensitive (`packages/auth/`): needs a recorded non-author guardrail-2 verdict + `sec-review:approved` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)