### PR TITLE
docs(ai): describe shipped llm/orchestration/tools in the package docblock

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -14,13 +14,18 @@
  * ```typescript
  * import { EpisodicMemory } from '@revealui/ai/memory/stores'
  * import { NodeIdService } from '@revealui/ai/memory/services'
+ * import { AgentOrchestrator, LLMClient, ToolRegistry } from '@revealui/ai'
  *
  * // Memory operations
  * const memory = new EpisodicMemory(userId, nodeId, db)
  * await memory.add(agentMemory)
- *
- * // LLM, orchestration, and tools coming soon
  * ```
+ *
+ * LLM, orchestration, and tools all ship from this root entry today:
+ * `LLMClient` and `createLLMClientFromEnv` come from `./llm/client.js`,
+ * `AgentOrchestrator` from `./orchestration/orchestrator.js`, and
+ * `ToolRegistry` plus `globalToolRegistry` from `./tools/registry.js`.
+ * See the re-export block below for the full surface.
  *
  * ## Architecture
  *


### PR DESCRIPTION
## What

Fixes a stale docblock in `packages/ai/src/index.ts`. The Quick Start block said:

```
// LLM, orchestration, and tools coming soon
```

All three ship, and they ship from the very same file. The re-export block directly below that comment already exports:

- `./llm/client.js`, `./llm/resolve.js`, `./llm/providers/*` ([packages/ai/src/index.ts:59-68](packages/ai/src/index.ts#L59-L68))
- `./orchestration/orchestrator.js`, `agent.js`, `runtime.js`, `streaming-runtime.js`, `ticket-agent.js` ([packages/ai/src/index.ts:72-78](packages/ai/src/index.ts#L72-L78))
- `./tools/registry.js`, `base.js`, `mcp-adapter.js`, and the rest of the tools surface ([packages/ai/src/index.ts:84-97](packages/ai/src/index.ts#L84-L97))

The comment has been contradicting the code beneath it for as long as those exports have existed.

## Change

Comment-only. The Quick Start example gains the real root-entry import, and the "coming soon" line is replaced with a short paragraph naming the actual entry points (`LLMClient` / `createLLMClientFromEnv`, `AgentOrchestrator`, `ToolRegistry` / `globalToolRegistry`) and where each lives.

## Scope

`1 file changed, 7 insertions(+), 2 deletions(-)`, entirely inside the leading block comment. No runtime code, no type surface, no export list touched.

## Verification

- `grep -c "coming soon" packages/ai/src/index.ts` returns `0`
- Symbol names were read from source before writing: `LLMClient` at `packages/ai/src/llm/client.ts:133`, `createLLMClientFromEnv` at `:655`, `AgentOrchestrator` at `packages/ai/src/orchestration/orchestrator.ts:18`, `ToolRegistry` at `packages/ai/src/tools/registry.ts:4`, `globalToolRegistry` at `:59`
- Pre-push gate passed on the feature branch

## Context

Found during the GAP-421 module-consumption audit of `@revealui/harnesses` and the packages around it. Broken out as its own PR because it is a public-package docs fix with no dependency on the audit's conclusions.

Refs GAP-421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
