### PR TITLE
feat(auth,db,security,admin): GAP-417 both rails — no escape hatch into unsigned production audit rows

### DIFF
--- a/.changeset/gap-417-both-rails.md
+++ b/.changeset/gap-417-both-rails.md
@@ -1,0 +1,7 @@
+---
+'@revealui/auth': minor
+'@revealui/db': minor
+'@revealui/security': minor
+---
+
+GAP-417 both rails (owner-countersigned): the audit path has no escape hatch into unsigned production rows. `assertAuditStorageEnv` refuses a production boot without the signing key regardless of `SKIP_ENV_VALIDATION`; `DrizzleAuditStore.append`/`appendBatch` refuse to land an unsigned row when `NODE_ENV=production`; and the signer composition normalizes single-line `\n`-escaped PEMs so `env_file` transports (RevForge kits) can carry the key.

--- a/apps/admin/src/app/api/health/__tests__/health-routes.test.ts
+++ b/apps/admin/src/app/api/health/__tests__/health-routes.test.ts
@@ -73,6 +73,53 @@ describe('GET /api/health', () => {
     );
   });
 
+  it('unauthenticated + PRODUCTION in-memory audit storage: bare 503, no detail, no I/O (GAP-417)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    try {
+      mockGetSession.mockResolvedValue(null);
+      const { GET } = await loadRoute();
+      const res = await GET({ headers: { get: () => null } } as never);
+
+      // The test process runs on the real in-memory audit singleton, so the
+      // production zero-I/O probe fires. Monitors see the outage; the body
+      // stays a bare status (public-issue-redaction posture) and the engine
+      // is never touched for an anonymous caller.
+      expect((res as { status: number }).status).toBe(503);
+      const body = (res as unknown as { body: Record<string, unknown> }).body;
+      expect(body).toEqual({ status: 'unhealthy' });
+      expect(mockGetRevealUIInstance).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('authenticated admin + PRODUCTION probe failure: unhealthy 503 (#2162 review refinement)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { audit } = await import('@revealui/security/server');
+    const probeSpy = vi.spyOn(audit, 'isInMemoryStorage').mockImplementation(() => {
+      throw new Error('probe boom');
+    });
+    try {
+      mockGetSession.mockResolvedValue({ user: { role: 'admin' } });
+      const mockFind = vi.fn().mockResolvedValue({ docs: [] });
+      mockGetRevealUIInstance.mockResolvedValue({ find: mockFind });
+
+      const { GET } = await loadRoute();
+      const res = await GET({ headers: { get: () => null } } as never);
+
+      expect((res as { status: number }).status).toBe(503);
+      const body = (
+        res as unknown as {
+          body: { status: string; checks: Array<{ name: string; status: string }> };
+        }
+      ).body;
+      expect(body.checks.find((c) => c.name === 'audit-storage')?.status).toBe('unhealthy');
+    } finally {
+      probeSpy.mockRestore();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('returns minimal status for non-admin authenticated users', async () => {
     mockGetSession.mockResolvedValue({ user: { role: 'user' } });
     const { GET } = await loadRoute();

--- a/apps/admin/src/app/api/health/route.ts
+++ b/apps/admin/src/app/api/health/route.ts
@@ -25,6 +25,21 @@ export async function GET(request: Request) {
   const isAuthenticated = session?.user?.role === 'admin';
 
   if (!isAuthenticated) {
+    // GAP-417 (owner-ruled 2026-07-25): the unauthenticated arm reflects the
+    // real overall status CODE so uptime monitors and the kit healthcheck
+    // finally see a production audit outage, while leaking zero check detail
+    // (public-issue-redaction posture: a bare {status} body either way).
+    // Only zero-I/O probes run for anonymous callers — no DB query, no
+    // Stripe call, no new anonymous load surface.
+    try {
+      const { audit } = await import('@revealui/security/server');
+      if (process.env.NODE_ENV === 'production' && audit.isInMemoryStorage()) {
+        return NextResponse.json({ status: 'unhealthy' }, { status: 503 });
+      }
+    } catch {
+      // Probe unavailable: stay minimal-healthy — the boot rails and the
+      // authenticated arm carry the detailed signal.
+    }
     return NextResponse.json({ status: 'healthy' });
   }
 
@@ -127,14 +142,26 @@ export async function GET(request: Request) {
       });
     }
   } catch (error) {
-    // Probe failure is informational too — the audit path itself is guarded
-    // at boot (instrumentation) and at write time; the health probe must not
-    // 503 the whole admin because the check could not run.
-    checks.push({
-      name: 'audit-storage',
-      status: 'degraded',
-      message: error instanceof Error ? error.message : 'Audit storage check failed',
-    });
+    if (process.env.NODE_ENV === 'production') {
+      // #2162 review refinement: a probe that cannot even run in PRODUCTION
+      // is an anomalous state that must keep its status-code signal — it is
+      // the one arm that would otherwise report 200 while the audit surface
+      // is unobservable.
+      overallStatus = 'unhealthy';
+      checks.push({
+        name: 'audit-storage',
+        status: 'unhealthy',
+        message: error instanceof Error ? error.message : 'Audit storage check failed',
+      });
+    } else {
+      // Non-production probe failure stays informational — the audit path is
+      // guarded at boot and at write time; a dev shell must not 503 on it.
+      checks.push({
+        name: 'audit-storage',
+        status: 'degraded',
+        message: error instanceof Error ? error.message : 'Audit storage check failed',
+      });
+    }
   }
 
   // System metrics

--- a/apps/server/src/lib/__tests__/audit-storage.pglite.test.ts
+++ b/apps/server/src/lib/__tests__/audit-storage.pglite.test.ts
@@ -21,7 +21,7 @@ import type { AuditEvent, AuditStorage } from '@revealui/core/security';
 import { AuditSystem } from '@revealui/core/security';
 import type { Database } from '@revealui/db/client';
 import { eq } from 'drizzle-orm';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createTestDb,
   type TestDb,
@@ -201,12 +201,71 @@ describe('assertAuditStorageEnv — synchronous env-parity guard (GAP-355 Stage 
 
   it('does not require the signing key outside production (dev/test run unsigned)', () => {
     expect(() => assertAuditStorageEnv({ DATABASE_URL: 'postgres://x' })).not.toThrow();
+  });
+
+  it('SKIP_ENV_VALIDATION no longer exempts the signing key in production (GAP-417 items 1-2, owner-countersigned)', () => {
+    // The audit path has no escape hatch: a production boot without the key
+    // refuses even under SKIP — unsigned rows stall anchor contiguity forever.
     expect(() =>
       assertAuditStorageEnv({
         NODE_ENV: 'production',
         DATABASE_URL: 'postgres://x',
         SKIP_ENV_VALIDATION: 'true',
       }),
-    ).not.toThrow();
+    ).toThrow('REVEALUI_AUDIT_SIGNING_KEY');
+  });
+});
+
+describe('GAP-417 store-level rail — a production process never lands an unsigned row', () => {
+  let testDb: TestDb;
+
+  beforeEach(async () => {
+    testDb = await createTestDb();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await testDb.close();
+  });
+
+  it('production + no injected signer: append AND appendBatch refuse, nothing lands', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { DrizzleAuditStore } = await import('@revealui/db');
+    const { auditLog } = await import('@revealui/db/schema');
+    const store = new DrizzleAuditStore(testDb.drizzle as unknown as Database);
+
+    const entry = {
+      id: randomUUID(),
+      timestamp: new Date(),
+      eventType: 'data.read',
+      severity: 'info',
+      agentId: 'agent-1',
+      payload: {},
+      policyViolations: [],
+    };
+
+    await expect(store.append(entry)).rejects.toThrow('UNSIGNED');
+    await expect(store.appendBatch([entry])).rejects.toThrow('UNSIGNED');
+    const rows = await testDb.drizzle.select().from(auditLog);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('non-production unsigned append still lands (dev/test run unsigned by design)', async () => {
+    const { DrizzleAuditStore } = await import('@revealui/db');
+    const { auditLog } = await import('@revealui/db/schema');
+    const store = new DrizzleAuditStore(testDb.drizzle as unknown as Database);
+
+    await store.append({
+      id: randomUUID(),
+      timestamp: new Date(),
+      eventType: 'data.read',
+      severity: 'info',
+      agentId: 'agent-1',
+      payload: {},
+      policyViolations: [],
+    });
+    const rows = await testDb.drizzle.select().from(auditLog);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.signature).toBeNull();
   });
 });

--- a/apps/server/src/lib/__tests__/validate-startup.test.ts
+++ b/apps/server/src/lib/__tests__/validate-startup.test.ts
@@ -157,6 +157,17 @@ describe('validateStartup — audit signing key (GAP-355 Stage 3, both modes)', 
     expect(() => validateStartup(env)).toThrow('REVEALUI_AUDIT_SIGNING_KEY');
   });
 
+  it('accepts a single-line \\n-escaped Ed25519 key (env_file transport, #2164 review)', () => {
+    // The kit's docker/.env carries the PEM one-line with literal \n escapes;
+    // the format check must read the SAME normalized value the signer does,
+    // or a valid kit key fails boot blaming the key instead of the transport.
+    const env = validLiveProdEnv();
+    const escaped = (env.REVEALUI_AUDIT_SIGNING_KEY as string).split('\n').join('\\n');
+    expect(() =>
+      validateStartup(validLiveProdEnv({ REVEALUI_AUDIT_SIGNING_KEY: escaped })),
+    ).not.toThrow();
+  });
+
   it('rejects a REVEALUI_AUDIT_SIGNING_KEY that is not a valid Ed25519 key', () => {
     expect(() =>
       validateStartup(validLiveProdEnv({ REVEALUI_AUDIT_SIGNING_KEY: 'not-a-pem' })),

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -16,6 +16,7 @@ import {
   hostMatchesLicensedDomains,
   validateLicenseKey,
 } from '@revealui/core/license';
+import { normalizeEnvPem } from '@revealui/core/security';
 import { getClient } from '@revealui/db/client';
 import { billingCatalog } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
@@ -310,7 +311,11 @@ export function validateStartup(
   // / REVEALUI_SECRET fallback died with the HMAC path (a signing key with a
   // fallback is not a signing key). Self-hosted operators generate their own key
   // at `pnpm setup` (GAP-355 PR-3); until then a missing/invalid key fails boot.
-  const auditSigningKey = env.REVEALUI_AUDIT_SIGNING_KEY ?? '';
+  // normalizeEnvPem: env_file transports (RevForge kits) deliver the PEM
+  // single-line with \n escapes — the format check must read the SAME
+  // normalized value the signer composes from, or a valid kit key fails boot
+  // with a misleading parse error (#2164 review, proven across call sites).
+  const auditSigningKey = normalizeEnvPem(env.REVEALUI_AUDIT_SIGNING_KEY ?? '');
   if (!skipFormat(auditSigningKey)) {
     const signingKeyProblem = classifyEd25519PrivateKey(auditSigningKey);
     if (signingKeyProblem) {

--- a/packages/auth/src/server/audit-storage.ts
+++ b/packages/auth/src/server/audit-storage.ts
@@ -270,13 +270,21 @@ export function assertAuditStorageEnv(env: NodeJS.ProcessEnv = process.env): voi
   // done by validate-startup; this is the audit-owned presence parity check, so
   // the contract cannot silently drift on one serving process. Dev/test
   // (NODE_ENV !== 'production') runs unsigned by design and is exempt.
-  if (env.NODE_ENV === 'production' && env.SKIP_ENV_VALIDATION !== 'true') {
+  //
+  // GAP-417 items 1-2 (owner-countersigned 2026-07-25): SKIP_ENV_VALIDATION no
+  // longer exempts this check. The audit path has NO escape hatch — a
+  // production process that cannot sign must not boot, because unsigned rows
+  // are indistinguishable from tampering AND permanently stall anchor
+  // contiguity once the sweep filters them. SKIP still covers non-audit env
+  // validation elsewhere; it never buys an unsigned production audit log.
+  if (env.NODE_ENV === 'production') {
     if (!env.REVEALUI_AUDIT_SIGNING_KEY) {
       throw new Error(
         'AUDIT STORAGE ENV PARITY FAILED: REVEALUI_AUDIT_SIGNING_KEY is not set on a ' +
           'production deployment, so the audit write path cannot sign rows. Refusing to ' +
           'serve — an unsigned row in the post-Stage-3 era is indistinguishable from ' +
-          'tampering (docs/decisions/2026-07-12-audit-receipt-architecture.md §2a).',
+          'tampering (docs/decisions/2026-07-12-audit-receipt-architecture.md §2a). ' +
+          'SKIP_ENV_VALIDATION does not exempt the audit path (GAP-417).',
       );
     }
   }

--- a/packages/db/src/audit-store.ts
+++ b/packages/db/src/audit-store.ts
@@ -105,10 +105,31 @@ export class DrizzleAuditStore {
     private readonly signer?: AuditRowSignerFn,
   ) {}
 
+  /**
+   * GAP-417 items 1-2 (owner-countersigned 2026-07-25), store-level rail: a
+   * production process must never land an unsigned audit row, regardless of
+   * how it booted. Unsigned rows are indistinguishable from tampering and
+   * permanently stall anchor contiguity once the sweep filters them. The
+   * boot-time assert is the first rail; this is the backstop for any path
+   * that constructs a signer-less store while NODE_ENV=production.
+   */
+  private refuseUnsignedInProduction(): void {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'DrizzleAuditStore: refusing to write an UNSIGNED audit row in production — ' +
+          'no row signer is injected. An unsigned row is indistinguishable from ' +
+          'tampering and stalls anchor contiguity (GAP-417). Provision ' +
+          'REVEALUI_AUDIT_SIGNING_KEY and construct the store through createAuditStore.',
+      );
+    }
+  }
+
   /** Append a single entry to the audit log */
   async append(entry: AuditEntry): Promise<void> {
     if (!this.signer) {
-      // Unsigned mode: DB assigns `seq` (column default), `signature` stays NULL.
+      this.refuseUnsignedInProduction();
+      // Unsigned mode (dev/test only): DB assigns `seq` (column default),
+      // `signature` stays NULL.
       await this.db.insert(auditLog).values(this.unsignedValues(entry));
       return;
     }
@@ -134,6 +155,7 @@ export class DrizzleAuditStore {
     if (entries.length === 0) return;
 
     if (!this.signer) {
+      this.refuseUnsignedInProduction();
       await this.db.insert(auditLog).values(entries.map((entry) => this.unsignedValues(entry)));
       return;
     }

--- a/packages/security/src/__tests__/audit-signer-env.test.ts
+++ b/packages/security/src/__tests__/audit-signer-env.test.ts
@@ -96,3 +96,37 @@ describe('createAuditRowSignerFromEnv', () => {
     expect(res.kid?.startsWith('ed25519-')).toBe(true);
   });
 });
+
+describe('env_file PEM normalization (GAP-417 — RevForge kit transport)', () => {
+  function makePem(): string {
+    const { privateKey } = generateKeyPairSync('ed25519', {
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    });
+    return privateKey;
+  }
+
+  it('a single-line \\n-escaped private key composes the SAME signer as the multi-line PEM', () => {
+    const pem = makePem();
+    const escaped = pem.split('\n').join('\\n');
+
+    const fromMultiline = createAuditRowSignerFromEnv({ REVEALUI_AUDIT_SIGNING_KEY: pem });
+    const fromEscaped = createAuditRowSignerFromEnv({ REVEALUI_AUDIT_SIGNING_KEY: escaped });
+
+    expect(fromEscaped.mode).toBe('signed');
+    expect(fromEscaped.kid).toBe(fromMultiline.kid);
+  });
+
+  it('an escaped public key resolves and cross-checks against the escaped private key', () => {
+    const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    });
+    const resolved = resolveAuditPublicKey({
+      REVEALUI_AUDIT_SIGNING_KEY: privateKey.split('\n').join('\\n'),
+      REVEALUI_AUDIT_PUBLIC_KEY: publicKey.split('\n').join('\\n'),
+    });
+    expect(resolved).not.toBeNull();
+    expect(resolved?.publicKeyPem).toBe(publicKey);
+  });
+});

--- a/packages/security/src/audit-signer-env.ts
+++ b/packages/security/src/audit-signer-env.ts
@@ -44,6 +44,17 @@ export interface AuditSignerResolution {
 }
 
 /**
+ * Restore real newlines in a single-line PEM. `env_file` transports (RevForge
+ * kits write `docker/.env`, and Docker's env_file format is one line per key)
+ * deliver PEMs with literal `\n` escapes; real multi-line PEMs pass through
+ * untouched. Mirrors the license path's normalizePem (GAP-259 P0-4 precedent:
+ * split/join, no authored regex).
+ */
+function normalizeEnvPem(raw: string): string {
+  return raw.includes('\\n') ? raw.split('\\n').join('\n') : raw;
+}
+
+/**
  * Derive a stable, key-bound kid: `ed25519-<first 16 hex of sha256(SPKI DER)>`.
  * Computed over the PUBLIC half, so it is identical whether derived from the
  * private key (a signer) or the public key (the endpoint). Deterministic for a
@@ -72,10 +83,11 @@ function resolveKid(env: AuditSignerEnv, publicKey: KeyObject): string {
  * with a fallback is not a signing key.
  */
 export function createAuditRowSignerFromEnv(env: AuditSignerEnv): AuditSignerResolution {
-  const privateKeyPem = env.REVEALUI_AUDIT_SIGNING_KEY?.trim();
-  if (!privateKeyPem) {
+  const rawKey = env.REVEALUI_AUDIT_SIGNING_KEY?.trim();
+  if (!rawKey) {
     return { signer: undefined, cryptoSigner: undefined, mode: 'unsigned' };
   }
+  const privateKeyPem = normalizeEnvPem(rawKey);
   const publicKey = createPublicKey(createPrivateKey(privateKeyPem));
   const kid = resolveKid(env, publicKey);
   const cryptoSigner = new Ed25519AuditRowSigner(privateKeyPem, kid);
@@ -111,8 +123,10 @@ export interface ResolvedAuditPublicKey {
  * key. A misconfiguration must be loud.
  */
 export function resolveAuditPublicKey(env: AuditSignerEnv): ResolvedAuditPublicKey | null {
-  const explicit = env.REVEALUI_AUDIT_PUBLIC_KEY?.trim();
-  const privateKeyPem = env.REVEALUI_AUDIT_SIGNING_KEY?.trim();
+  const rawExplicit = env.REVEALUI_AUDIT_PUBLIC_KEY?.trim();
+  const explicit = rawExplicit ? normalizeEnvPem(rawExplicit) : rawExplicit;
+  const rawPrivate = env.REVEALUI_AUDIT_SIGNING_KEY?.trim();
+  const privateKeyPem = rawPrivate ? normalizeEnvPem(rawPrivate) : rawPrivate;
   let publicKey: KeyObject;
   if (explicit) {
     publicKey = createPublicKey(explicit);

--- a/packages/security/src/audit-signer-env.ts
+++ b/packages/security/src/audit-signer-env.ts
@@ -49,8 +49,14 @@ export interface AuditSignerResolution {
  * deliver PEMs with literal `\n` escapes; real multi-line PEMs pass through
  * untouched. Mirrors the license path's normalizePem (GAP-259 P0-4 precedent:
  * split/join, no authored regex).
+ *
+ * EXPORTED so every reader of the audit key env normalizes identically — the
+ * #2164 review proved the one-reader-of-four drift class empirically: the
+ * signer composed fine while validate-startup's format check and both offline
+ * verifiers threw on the same single-line key. Never read
+ * `REVEALUI_AUDIT_SIGNING_KEY` / `REVEALUI_AUDIT_PUBLIC_KEY` without this.
  */
-function normalizeEnvPem(raw: string): string {
+export function normalizeEnvPem(raw: string): string {
   return raw.includes('\\n') ? raw.split('\\n').join('\n') : raw;
 }
 

--- a/packages/security/src/server.ts
+++ b/packages/security/src/server.ts
@@ -68,6 +68,7 @@ export type {
 export {
   createAuditRowSignerFromEnv,
   deriveAuditKid,
+  normalizeEnvPem,
   resolveAuditPublicKey,
 } from './audit-signer-env.js';
 // Per-row Ed25519 audit signing (GAP-355 Stage 3 — node:crypto)

--- a/scripts/security/verify-audit-anchor.ts
+++ b/scripts/security/verify-audit-anchor.ts
@@ -41,6 +41,7 @@
 import { createPrivateKey, createPublicKey } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import {
+  normalizeEnvPem,
   type OfflineAnchorRecord,
   type OfflineInclusionProofInput,
   verifyAuditAnchorOffline,
@@ -105,11 +106,13 @@ No network. No database.
 function resolvePublicKeyPem(args: Args): string | null {
   if (args.publicKeyPem) return args.publicKeyPem;
   if (args.publicKeyPath) return readFileSync(args.publicKeyPath, 'utf8');
+  // normalizeEnvPem: env-carried PEMs may be single-line \n-escaped (env_file
+  // transport) — every reader of these vars normalizes (#2164 review).
   const fromEnv = process.env.REVEALUI_AUDIT_PUBLIC_KEY;
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return normalizeEnvPem(fromEnv);
   const privatePem = process.env.REVEALUI_AUDIT_SIGNING_KEY;
   if (privatePem) {
-    return createPublicKey(createPrivateKey(privatePem))
+    return createPublicKey(createPrivateKey(normalizeEnvPem(privatePem)))
       .export({ type: 'spki', format: 'pem' })
       .toString();
   }

--- a/scripts/security/verify-audit-signatures.ts
+++ b/scripts/security/verify-audit-signatures.ts
@@ -33,6 +33,7 @@ import { auditLog } from '@revealui/db/schema';
 import {
   type AuditSignable,
   classifyAuditSignature,
+  normalizeEnvPem,
   verifyAuditRow,
 } from '@revealui/security/server';
 import { desc, eq } from 'drizzle-orm';
@@ -68,11 +69,13 @@ function parseArgs(argv: string[]): Args {
 /** SPKI PEM to verify with, or null if none is available in this environment. */
 function resolvePublicKeyPem(args: Args): string | null {
   if (args.publicKeyPem) return args.publicKeyPem;
+  // normalizeEnvPem: env-carried PEMs may be single-line \n-escaped (env_file
+  // transport) — every reader of these vars normalizes (#2164 review).
   const fromEnv = process.env.REVEALUI_AUDIT_PUBLIC_KEY;
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return normalizeEnvPem(fromEnv);
   const privatePem = process.env.REVEALUI_AUDIT_SIGNING_KEY;
   if (privatePem) {
-    return createPublicKey(createPrivateKey(privatePem))
+    return createPublicKey(createPrivateKey(normalizeEnvPem(privatePem)))
       .export({ type: 'spki', format: 'pem' })
       .toString();
   }


### PR DESCRIPTION
Implements the GAP-417 items 1-2 doctrine as **owner-countersigned in-session 2026-07-25 ("both rails")**, plus the owner-ruled health signal:

**Rail 1 (boot).** `SKIP_ENV_VALIDATION` no longer exempts the audit signing key in production: `assertAuditStorageEnv` refuses regardless. The audit path has no escape hatch — a production process that cannot sign must not boot, because unsigned rows are indistinguishable from tampering and permanently stall anchor contiguity once the sweep filters them. SKIP keeps covering non-audit env validation.

**Rail 2 (store).** `DrizzleAuditStore.append`/`appendBatch` refuse to land an UNSIGNED row when `NODE_ENV=production` — the backstop for any path that constructs a signer-less store however it booted. Dev/test unsigned behavior is unchanged.

**env_file PEM transport.** `createAuditRowSignerFromEnv` and `resolveAuditPublicKey` normalize single-line `\n`-escaped PEMs (Docker env_file is one line per key; mirrors the license normalizePem precedent, split/join, no authored regex). Prerequisite for the RevForge kit provisioning the audit key at all (follow-up PR in the revforge repo).

**Health signal (owner-ruled: reflect status code).** The unauthenticated `/api/health` arm now reflects the real overall status CODE via a zero-I/O audit probe — bare `{status}` body either way (public-issue-redaction posture), no DB or Stripe work for anonymous callers — so uptime monitors and the kit healthcheck finally see a production audit outage. Plus the #2162 review refinement: a production probe FAILURE in the authenticated arm is unhealthy/503, not informational; non-production stays informational (the #2161-era dev-shell 503 does not come back).

**Red-first, run against base dists:** exactly the two new rails failed (SKIP-exemption flip: "expected [Function] to throw"; store rail: "promise resolved instead of rejecting") with everything else green — then green after the fix (server audit suites 26/26, security 10/10, admin health + instrumentation 24/24, auth 531, typechecks clean across db/security/auth/admin/server).

⚠️ Security-sensitive (`packages/auth/`, `packages/security/`): needs a recorded non-author guardrail-2 verdict + `sec-review:approved` before merge. Owner countersign for the doctrine itself is on record in-session (2026-07-25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)