### PR TITLE
fix(harnesses): remove broken ./protocol export

### DIFF
--- a/.changeset/gap-421-remove-broken-protocol-export.md
+++ b/.changeset/gap-421-remove-broken-protocol-export.md
@@ -1,0 +1,5 @@
+---
+'@revealui/harnesses': minor
+---
+
+Remove the `./protocol` subpath export. It was mapped in `package.json` but never listed in `tsup.config.ts`, so `dist/protocol/` never existed and the export 404'd (`ERR_MODULE_NOT_FOUND`) for anyone who tried it. GAP-421's routing audit found zero consumers of the subpath fleet-wide; protocol types, schemas, and factories remain available via the root `@revealui/harnesses` export, which already re-exports them.

--- a/packages/harnesses/README.md
+++ b/packages/harnesses/README.md
@@ -166,7 +166,8 @@ Tokens are durable (default 90-day TTL) and persisted as hashes, so a daemon res
 | `@revealui/harnesses/content` | Content definitions, manifest builders, generators (`DEFAULT_CONTENT_GENERATOR_ID` → manager tree) |
 | `@revealui/harnesses/manager` | Project manager schema, materialize, check (`.revealui`) |
 | `@revealui/harnesses/storage` | DaemonStore (PGlite-backed daemon state), schema |
-| `@revealui/harnesses/protocol` | Protocol adapter types, config generators, event normalizer |
+
+Protocol adapter types, config generators, and the event normalizer are re-exported from the root `@revealui/harnesses` entry only (see `packages/harnesses/src/index.ts:130-182`). The dedicated `@revealui/harnesses/protocol` subpath was removed (GAP-421): it was mapped in `package.json` but never listed in `packages/harnesses/tsup.config.ts:4-16`, so it 404'd for anyone who tried it, and nothing in the fleet consumed it. Re-add it once a real consumer needs the narrower import.
 
 ## Development
 

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -62,11 +62,6 @@
       "import": "./dist/goals/index.js",
       "default": "./dist/goals/index.js"
     },
-    "./protocol": {
-      "types": "./dist/protocol/index.d.ts",
-      "import": "./dist/protocol/index.js",
-      "default": "./dist/protocol/index.js"
-    },
     "./hooks": {
       "types": "./dist/hooks/index.d.ts",
       "import": "./dist/hooks/index.js",


### PR DESCRIPTION
## Summary

- Removes the `./protocol` subpath export from `packages/harnesses/package.json`. It was mapped in the export map but never listed in `tsup.config.ts`'s entry list, so `dist/protocol/` never existed and the export 404'd (`ERR_MODULE_NOT_FOUND`) for anyone who tried it.
- Follows the GAP-421 harnesses routing audit's own step 1 recommendation ("removing the export is the honest default given zero consumers") — zero fleet-wide consumers of the subpath were found; protocol types, schemas, and factories remain reachable via the root `@revealui/harnesses` export, which already re-exports them.
- Updates `packages/harnesses/README.md`'s export table to match, with a source citation.
- Adds a changeset (minor bump — this is a breaking change to the published export map, inside 0.x).

Routing ratified by owner directive 2026-07-25 (GAP-421). Steps 6 and 8 of the same audit (daemon-ownership ADR + the DELETE train that depends on it) are explicitly out of scope for this PR.

## Test plan

- [x] `pnpm --filter @revealui/harnesses build` — clean, no `dist/protocol/` (expected)
- [x] `pnpm --filter @revealui/harnesses test` — 41 files / 542 tests pass
- [x] `pnpm --filter @revealui/harnesses typecheck` — clean
- [x] `pnpm gate:quick` — PASS (phase 1 + full quality gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)