### PR TITLE
fix(harnesses): resolve manager through dist, not a src reach-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_INSTALL_FLAGS }}
 
+      - name: Build @revealui/harnesses (gates + manager modules, GAP-408/GAP-421)
+        # Built once, early, for two dist-only consumers that must not reach
+        # into src/ (GAP-421 §6.2): doc-currency.ts resolves its
+        # SHARED_FLEET_RULES detection tuples from dist/gates, and
+        # structure.ts resolves checkManager from dist/manager (manager-resolver.cjs,
+        # mirroring gates-resolver.cjs). Building just this one package is
+        # cheap relative to the whole monorepo (Quality is install-only
+        # otherwise). Absence degrades gracefully for doc-currency (warn +
+        # shared-rules-skipped run) but fails closed for the manager check
+        # (GAP-406 hard-fail posture), so this step must run before Structure
+        # validation and the path-gated manager-only check below.
+        run: pnpm --filter @revealui/harnesses build
+        env:
+          SKIP_ENV_VALIDATION: "true"
+
       - name: Biome lint (hard fail)
         run: pnpm lint
 
@@ -158,18 +173,6 @@ jobs:
         # same keys are required (stale dist → 422 on session.patch). Does not
         # build @revealui/contracts (needs @revealui/db; Quality has install only).
         run: pnpm validate:marketing-voice-prose-slots
-
-      - name: Build @revealui/harnesses (doc-currency's gates module, GAP-408)
-        # doc-currency.ts resolves its shared SHARED_FLEET_RULES detection
-        # tuples from packages/harnesses/dist/gates — build just that one
-        # package rather than the whole monorepo (Quality is install-only
-        # otherwise). Absence degrades to a warn + shared-rules-skipped run
-        # (see doc-currency.ts's ABSENCE BEHAVIOR comment), not a crash, so
-        # this step is a belt-and-braces guarantee of full coverage, not a
-        # hard dependency of the job passing.
-        run: pnpm --filter @revealui/harnesses build
-        env:
-          SKIP_ENV_VALIDATION: "true"
 
       - name: Doc-currency validation (hard fail)
         # Stale-fact drift guard: docs/**/*.md + apps/marketing/**/*.md prose,

--- a/scripts/validate/manager-resolver.cjs
+++ b/scripts/validate/manager-resolver.cjs
@@ -1,0 +1,45 @@
+'use strict';
+// manager-resolver.cjs — locate the @revealui/harnesses manager module
+// (GAP-421 §6.2). Mirrors gates-resolver.cjs's resolution pattern: load the
+// built dist through a same-repo relative path, never the bare
+// `@revealui/harnesses` specifier (which would require a package.json
+// dependency edge that scripts/validate/boundary.ts Check 4 forbids for an
+// optional Fair Source package).
+//
+// Unlike gates-resolver.cjs, this resolver has no REVEALUI_HARNESSES_DIR
+// fallback: `manager` has exactly one consumer (structure.ts, in this same
+// checkout), so the local dist path is the only resolution route that
+// matters today.
+//
+// Returns null (never throws) when the dist has not been built — the caller
+// decides how to degrade. structure.ts treats a null resolution as fail
+// closed, matching the GAP-406 hard-fail posture for a missing/invalid
+// manager.json (a silently-skipped manager check is the same class of miss
+// as a silently-skipped guardrail-2 hold).
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LOCAL_DIST_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'packages',
+  'harnesses',
+  'dist',
+  'manager',
+  'index.js',
+);
+
+/**
+ * @returns {unknown | null}
+ */
+function resolveManagerModule() {
+  if (fs.existsSync(LOCAL_DIST_PATH)) {
+    return require(LOCAL_DIST_PATH);
+  }
+
+  return null;
+}
+
+module.exports = { resolveManagerModule, LOCAL_DIST_PATH };

--- a/scripts/validate/structure.ts
+++ b/scripts/validate/structure.ts
@@ -12,8 +12,31 @@
  */
 
 import { existsSync, readdirSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import { checkManager } from '../../packages/harnesses/src/manager/index.js';
+
+// The manager module is resolved through the built dist (manager-resolver.cjs,
+// the same pattern gates-resolver.cjs uses for the `./gates` subpath) rather
+// than a `src/` reach-in. GAP-421 §6.2: the previous relative import bypassed
+// both the export map and dist/, so the `./manager` subpath export had never
+// actually been exercised by its only consumer. Resolving through dist closes
+// that gap; CI builds @revealui/harnesses before running structure validation
+// (see .github/workflows/ci.yml) so this always resolves there.
+interface ManagerModuleShape {
+  checkManager: (projectRoot: string) => {
+    ok: boolean;
+    errors: string[];
+    warnings: string[];
+  };
+}
+
+function loadManagerModule(): ManagerModuleShape | null {
+  const require = createRequire(import.meta.url);
+  const { resolveManagerModule } = require('./manager-resolver.cjs') as {
+    resolveManagerModule: () => ManagerModuleShape | null;
+  };
+  return resolveManagerModule();
+}
 
 interface ValidationRule {
   path: string;
@@ -462,18 +485,27 @@ class StructureValidator {
     // `revealui-harnesses manager check` (no parallel validator).
     if (existsSync('packages/harnesses') || existsSync('.revealui/manager.json')) {
       console.log('\n🔍 Checking project manager (.revealui)...');
-      const managerResult = checkManager(process.cwd());
-      for (const warning of managerResult.warnings) {
-        console.log(`⚠️  ${warning}`);
-      }
-      if (!managerResult.ok) {
-        for (const error of managerResult.errors) {
-          console.log(`❌ ${error}`);
-        }
-        console.log('   Run: pnpm exec revealui-harnesses manager materialize');
+      const managerModule = loadManagerModule();
+      if (!managerModule) {
+        console.log(
+          '❌ @revealui/harnesses manager module not built (packages/harnesses/dist/manager missing)',
+        );
+        console.log('   Run: pnpm --filter @revealui/harnesses build');
         allValid = false;
       } else {
-        console.log('✅ Project manager (.revealui/manager.json) present and valid');
+        const managerResult = managerModule.checkManager(process.cwd());
+        for (const warning of managerResult.warnings) {
+          console.log(`⚠️  ${warning}`);
+        }
+        if (!managerResult.ok) {
+          for (const error of managerResult.errors) {
+            console.log(`❌ ${error}`);
+          }
+          console.log('   Run: pnpm exec revealui-harnesses manager materialize');
+          allValid = false;
+        } else {
+          console.log('✅ Project manager (.revealui/manager.json) present and valid');
+        }
       }
     }
 
@@ -543,7 +575,15 @@ export function validateProjectManager(root: string = process.cwd()): boolean {
     console.log('skip: no packages/harnesses or .revealui/manager.json');
     return true;
   }
-  const managerResult = checkManager(root);
+  const managerModule = loadManagerModule();
+  if (!managerModule) {
+    console.error(
+      'ERROR: @revealui/harnesses manager module not built (packages/harnesses/dist/manager missing)',
+    );
+    console.error('Run: pnpm --filter @revealui/harnesses build');
+    return false;
+  }
+  const managerResult = managerModule.checkManager(root);
   for (const warning of managerResult.warnings) {
     console.warn(`WARN: ${warning}`);
   }


### PR DESCRIPTION
## Summary

- `scripts/validate/structure.ts` imported `checkManager` directly from `packages/harnesses/src/manager/index.js` -- a `src/` reach-in that bypasses both the package's export map and its built `dist/`. GAP-421's routing audit (§6.2) flagged this: the `./manager` subpath export existed in `package.json` and was built by `tsup.config.ts`, but had never actually been exercised by its only consumer.
- Adds `scripts/validate/manager-resolver.cjs`, mirroring the existing `gates-resolver.cjs` pattern used for the `./gates` subpath: resolve `packages/harnesses/dist/manager` via a same-repo relative path, never the bare `@revealui/harnesses` specifier (a `package.json` dependency edge that `boundary.ts` Check 4 forbids for an optional Fair Source package). Unlike `gates`, `manager` has no cross-repo consumer today, so there's no `REVEALUI_HARNESSES_DIR` fallback.
- `structure.ts` now fails closed (with an actionable "build the package first" message) instead of silently reaching into `src/` when the dist hasn't been built -- matching the existing GAP-406 hard-fail posture for a missing/invalid `manager.json`.
- `.github/workflows/ci.yml`'s "Build @revealui/harnesses" step moves earlier (right after install, before Structure validation), so both dist-only consumers -- doc-currency's gates module and this new manager resolution -- always resolve in CI. Verified locally: `pnpm validate:structure -- --manager-only` fails closed with dist absent and passes cleanly once `pnpm --filter @revealui/harnesses build` has run, matching the new CI order.

Routing ratified by owner directive 2026-07-25 (GAP-421). Steps 6 and 8 of the same audit (daemon-ownership ADR + the DELETE train that depends on it) are explicitly out of scope for this PR.

## Test plan

- [x] `pnpm --filter @revealui/harnesses build && pnpm --filter @revealui/harnesses test` -- 41 files / 542 tests pass
- [x] `pnpm --filter @revealui/harnesses typecheck` -- clean
- [x] `pnpm validate:structure` / `-- --manager-only` -- pass with dist built
- [x] `rm -rf packages/harnesses/dist && pnpm validate:structure -- --manager-only` -- fails closed with the expected build-first message (proves the new fail-closed path)
- [x] `pnpm typecheck:all` -- 58/58 packages clean
- [x] `pnpm gate:quick` -- PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)