### PR TITLE
chore(harnesses): de-regex yaml escaping, document normalizer posture

### DIFF
--- a/packages/harnesses/src/content/generators/claude-code.ts
+++ b/packages/harnesses/src/content/generators/claude-code.ts
@@ -18,8 +18,40 @@ import { MANAGER_CONTENT_OUTPUT } from './types.js';
 
 const CONTENT = MANAGER_CONTENT_OUTPUT;
 
+// Characters that force a YAML scalar to be quoted (fleet no-regex hardline:
+// Set membership over a character class, per .claude/rules/no-regex.md).
+const YAML_QUOTING_CHARS = new Set([
+  ':',
+  '#',
+  '\n',
+  '"',
+  "'",
+  '{',
+  '}',
+  '[',
+  ']',
+  ',',
+  '&',
+  '*',
+  '?',
+  '|',
+  '>',
+  '!',
+  '%',
+  '@',
+  '`',
+]);
+
+function needsYamlQuoting(value: string): boolean {
+  if (value.trim() !== value) return true;
+  for (const char of value) {
+    if (YAML_QUOTING_CHARS.has(char)) return true;
+  }
+  return false;
+}
+
 function yamlEscape(value: string): string {
-  if (/[:#\n"'{}[\],&*?|>!%@`]/.test(value) || value.trim() !== value) {
+  if (needsYamlQuoting(value)) {
     return JSON.stringify(value);
   }
   return value;

--- a/packages/harnesses/src/hooks/normalizers/cursor.ts
+++ b/packages/harnesses/src/hooks/normalizers/cursor.ts
@@ -15,6 +15,14 @@
  *
  * `user_email` is read ONLY to prove the trust boundary: it is never copied
  * onto `HarnessHookIdentity` (design invariant I-1). It stays in `raw`.
+ *
+ * INTENTIONALLY UNREACHED TODAY (GAP-293 harness parity, GAP-421 §4.2): no
+ * Cursor harness home invokes `revealui-harnesses hook` yet, so this
+ * normalizer has zero live callers. It exists so `runHookCommand` /
+ * `normalizeHookEvent` (`../run-hook.ts`) already dispatch on
+ * `HarnessHookSource` for every editor the harness protocol targets, ahead of
+ * Cursor actually wiring the hook. Not dead code — do not delete without
+ * re-checking GAP-293's wiring status first.
  */
 
 import type {

--- a/packages/harnesses/src/hooks/normalizers/vscode.ts
+++ b/packages/harnesses/src/hooks/normalizers/vscode.ts
@@ -33,6 +33,14 @@
  *    built-in Copilot agent-mode tool set (code.visualstudio.com/docs/copilot/agents/agent-tools),
  *    not from the hooks reference itself -- best-effort, same posture as
  *    Cursor's `beforeReadFile` -> synthetic `Read` toolName fallback.
+ *
+ * INTENTIONALLY UNREACHED TODAY (GAP-293 harness parity, GAP-421 §4.2): no
+ * VS Code harness home invokes `revealui-harnesses hook` yet, so this
+ * normalizer has zero live callers. It exists so `runHookCommand` /
+ * `normalizeHookEvent` (`../run-hook.ts`) already dispatch on
+ * `HarnessHookSource` for every editor the harness protocol targets, ahead of
+ * VS Code actually wiring the hook. Not dead code -- do not delete without
+ * re-checking GAP-293's wiring status first.
  */
 
 import type {


### PR DESCRIPTION
## Summary

Two KEEP-hygiene items from the GAP-421 harnesses routing audit (step 3, no owner gate):

- `packages/harnesses/src/content/generators/claude-code.ts:22` carried the package's only unmarked regex (a YAML-special-char class), inside the very module that authors the fleet's no-regex rule content. Replaced with a `Set`-based character check (the `no-regex.md` "character class checks -> explicit checks" alternative). Output is unchanged -- the committed content snapshot check still passes.
- `packages/harnesses/src/hooks/normalizers/cursor.ts` and `vscode.ts` have zero live callers today: no Cursor or VS Code harness home invokes `revealui-harnesses hook` yet. This is intentional under GAP-293 harness parity, but the audit found it was only inferable from context, not stated in-file -- added an explicit note to each docblock so a later dead-code sweep doesn't misread them.

No behavior change; no changeset (internal-only, no consumer-visible surface changed).

Routing ratified by owner directive 2026-07-25 (GAP-421). Steps 6 and 8 of the same audit (daemon-ownership ADR + the DELETE train that depends on it) are explicitly out of scope for this PR.

## Test plan

- [x] `pnpm --filter @revealui/harnesses build` -- clean
- [x] `pnpm --filter @revealui/harnesses test` -- 41 files / 542 tests pass (content snapshot test included)
- [x] `pnpm --filter @revealui/harnesses typecheck` -- clean
- [x] `pnpm gate:quick` -- PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)