### PR TITLE
test(harnesses): lock injection-critical chars in the yaml quoting set

### DIFF
--- a/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
+++ b/packages/harnesses/src/__tests__/claude-code-content-generator.test.ts
@@ -101,6 +101,34 @@ describe('ClaudeCodeGenerator', () => {
     });
   });
 
+  describe('yaml quoting locks the injection-critical characters', () => {
+    // Exercises the REAL generator (not a mirrored predicate): if ':' , '\n'
+    // or '\r' is ever dropped from YAML_QUOTING_CHARS, the emitted frontmatter
+    // goes unquoted and these assertions fail by name. Origin: #2167
+    // guardrail-2 review finding 1 (the snapshot only locks ',' and '>').
+    const hostile: Array<[label: string, description: string, quoted: string]> = [
+      ['colon (key injection)', 'x: y', '"x: y"'],
+      ['newline (line injection)', 'a\nb', '"a\\nb"'],
+      ['carriage return (break injection)', 'a\rb', '"a\\rb"'],
+    ];
+
+    for (const [label, description, quoted] of hostile) {
+      it(`quotes a description containing ${label}`, () => {
+        const agent: Agent = {
+          id: 'hostile',
+          name: 'Hostile',
+          description,
+          tier: 'oss',
+          isolation: 'none',
+          tools: [],
+          content: 'body',
+        };
+        const [file] = new ClaudeCodeGenerator().generateAgent(agent, ctx);
+        expect(file?.content).toContain(`description: ${quoted}`);
+      });
+    }
+  });
+
   describe('generateAll', () => {
     it('emits all content under .revealui/content (manager tree)', () => {
       const manifest = buildManifest();

--- a/packages/harnesses/src/content/generators/claude-code.ts
+++ b/packages/harnesses/src/content/generators/claude-code.ts
@@ -24,6 +24,8 @@ const YAML_QUOTING_CHARS = new Set([
   ':',
   '#',
   '\n',
+  '\r', // bare CR is a YAML break character; unquoted it can split the scalar
+
   '"',
   "'",
   '{',


### PR DESCRIPTION
Closes finding 1 of the #2167 guardrail-2 review: the sha256 snapshot only trips on ',' and '>' (the characters current definition literals happen to use), so dropping ':' or '\n' from YAML_QUOTING_CHARS — the two key-injection-critical characters — would pass silently. These tests exercise the REAL generator with hostile descriptions (no mirrored predicate), so each injection-critical character fails a named test if it ever goes unquoted.

Also adds bare '\r' to the quoting set: it is a YAML break character and previously sailed through unquoted. No existing definition contains one, so generated output (and the snapshot) is unchanged.

Red-proof: removing ':' from the set failed exactly the colon test (1 failed / 544 passed); restored, 545/545 green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)