### PR TITLE
fix(marketing): replace blog placeholder copy with honest content (GAP-423)

### DIFF
--- a/apps/marketing/app/lib/blog-posts.ts
+++ b/apps/marketing/app/lib/blog-posts.ts
@@ -169,7 +169,7 @@ const POST_METADATA: PostMeta[] = [
     slug: 'http-402-payments',
     title: 'Paying for AI API Calls with HTTP 402 and USDC',
     excerpt:
-      'Coming soon: how the x402 protocol will enable agent-native micropayments without accounts or subscriptions. This post is the design.',
+      'The design for agent-native micropayments: HTTP 402 plus USDC lets agents pay per API call without accounts or subscriptions. Code-complete and dormant behind a feature flag until the billing-readiness gate clears.',
     publishedAt: '2026-03-21T12:00:00.000Z',
     author: 'RevealUI Team',
     file: '02-http-402-payments.md',

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -140,7 +140,9 @@ export function BlogPostPage() {
             ) : typeof post.content === 'string' ? (
               <Markdown>{post.content}</Markdown>
             ) : (
-              <p className="text-muted-foreground italic">Content rendering coming soon.</p>
+              // Content shape unrecognized (neither Lexical nor markdown string):
+              // render the real excerpt instead of placeholder copy (GAP-423).
+              <p className="text-muted-foreground">{post.excerpt}</p>
             )}
           </div>
         </div>


### PR DESCRIPTION
Two customer-visible blog placeholders found by the copy-corpus sweep:

- **BlogPostPage fallback**: the unrecognized-content branch rendered a literal "Content rendering coming soon." as visible body copy. It now renders the post's real excerpt.
- **x402 listing excerpt**: still said "Coming soon:" over a fully-written design article. Rewritten to describe the published content honestly (code-complete, dormant behind the feature flag), matching the post's own banner.

Remaining "coming soon" strings in apps/marketing are the intentional, claims-evidence-registered honesty copy. Verified: claims-evidence 615/615 matched, biome clean, marketing suite 133/133 green locally. Copy-voice rules applied (full clauses, no em dashes). Internal tracking: fleet gap tracker GAP-423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)