### PR TITLE
ci(e2e): provision admin audit env — GAP-338/417 rails are fail-closed by design

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,6 +693,20 @@ jobs:
         env:
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
 
+      # The admin server runs `next start` (NODE_ENV=production, not
+      # overridable) and the GAP-338/417 audit rails are fail-closed with no
+      # escape hatch: a production admin refuses to serve without a DB
+      # connection env AND an Ed25519 signing key. E2E provisions the real
+      # thing — an ephemeral per-run key — instead of bypassing the rail.
+      - name: Generate ephemeral audit signing key (E2E only)
+        run: |
+          openssl genpkey -algorithm ed25519 -out /tmp/e2e-audit-key.pem
+          {
+            echo "REVEALUI_AUDIT_SIGNING_KEY<<E2E_KEY_EOF"
+            cat /tmp/e2e-audit-key.pem
+            echo "E2E_KEY_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Start API server
         run: pnpm --filter server start &
         env:
@@ -704,6 +718,7 @@ jobs:
         run: pnpm --filter admin start &
         env:
           SKIP_ENV_VALIDATION: "true"
+          POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
 
       - name: Start marketing server
         run: pnpm --filter marketing start &
@@ -753,6 +768,24 @@ jobs:
     needs: [quality, build]
     if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
 
+    # The admin server's GAP-338/417 audit rails are fail-closed in production
+    # (`next start`): a DB connection env + signing key are boot requirements.
+    # Same pgvector service + migrations as the E2E Smoke job.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: smoke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -778,10 +811,27 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "true"
 
+      - name: Apply migrations to the smoke database
+        run: pnpm --filter @revealui/db db:migrate
+        env:
+          POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+
+      # See the E2E Smoke job: production admin refuses to boot without the
+      # audit env (GAP-338/417, no escape hatch by design). Provision it.
+      - name: Generate ephemeral audit signing key (E2E only)
+        run: |
+          openssl genpkey -algorithm ed25519 -out /tmp/e2e-audit-key.pem
+          {
+            echo "REVEALUI_AUDIT_SIGNING_KEY<<E2E_KEY_EOF"
+            cat /tmp/e2e-audit-key.pem
+            echo "E2E_KEY_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Start Admin server
         run: pnpm --filter admin start &
         env:
           SKIP_ENV_VALIDATION: "true"
+          POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
 
       - name: Start marketing server
         run: pnpm --filter marketing start &
@@ -825,6 +875,23 @@ jobs:
     needs: [quality, build]
     if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
 
+    # See e2e-accessibility: production admin's fail-closed audit rails
+    # (GAP-338/417) require a DB env + signing key at boot.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: smoke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -850,10 +917,27 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "true"
 
+      - name: Apply migrations to the smoke database
+        run: pnpm --filter @revealui/db db:migrate
+        env:
+          POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+
+      # See the E2E Smoke job: production admin refuses to boot without the
+      # audit env (GAP-338/417, no escape hatch by design). Provision it.
+      - name: Generate ephemeral audit signing key (E2E only)
+        run: |
+          openssl genpkey -algorithm ed25519 -out /tmp/e2e-audit-key.pem
+          {
+            echo "REVEALUI_AUDIT_SIGNING_KEY<<E2E_KEY_EOF"
+            cat /tmp/e2e-audit-key.pem
+            echo "E2E_KEY_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Start Admin server
         run: pnpm --filter admin start &
         env:
           SKIP_ENV_VALIDATION: "true"
+          POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
 
       - name: Wait for Admin
         run: |


### PR DESCRIPTION
Fixes the three promote-only E2E failures on #2175. The admin server ('next start' = production, not overridable) now refuses to boot without a DB connection env + Ed25519 signing key — the train's fail-closed rails working exactly as designed, meeting E2E jobs that never provisioned audit env.

Provisions the real thing rather than bypassing the rail: ephemeral per-run Ed25519 key in every E2E job, pgvector service + migrations added to Accessibility and Visual Regression (Smoke already had them), POSTGRES_URL on every admin start step. E2E now proves the boot rail end to end.

Once this merges to test, #2175 picks it up automatically (its head is test) and the E2E suite re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)