### PR TITLE
fix(security): anchor the audit singleton on globalThis across bundled module copies

### DIFF
--- a/.changeset/audit-singleton-globalthis.md
+++ b/.changeset/audit-singleton-globalthis.md
@@ -1,0 +1,5 @@
+---
+'@revealui/security': patch
+---
+
+Anchor the process-wide `audit` singleton on `globalThis` (keyed via `Symbol.for`) so bundlers that duplicate the package's module graph across chunks (observed with Turbopack in the admin production build) still resolve one shared `AuditSystem` instance. Fixes the boot-time persistent-storage swap landing on a different module copy than the one routes resolve, which left production admin audit emits in-memory and `/api/health` reporting `audit-storage: unhealthy`.

--- a/packages/security/src/__tests__/audit-singleton-global.test.ts
+++ b/packages/security/src/__tests__/audit-singleton-global.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * GAP-338 follow-up: the `audit` singleton must be PROCESS-wide, not
+ * module-copy-wide.
+ *
+ * The admin production build bundles a separate copy of this package's module
+ * graph into the instrumentation chunk and each route chunk (Turbopack;
+ * `serverExternalPackages` does not take effect for the workspace package), so
+ * a plain module-level singleton splits: the boot-time persistent-storage swap
+ * lands on one copy while routes emit into their own in-memory copies —
+ * observed live as `/api/health` `audit-storage: unhealthy` on hosted prod
+ * (2026-07-25).
+ *
+ * `vi.resetModules()` + dynamic import simulates exactly that: two independent
+ * module registries each evaluating `audit.ts` from scratch. Without the
+ * `globalThis` anchor the two evaluations construct two different
+ * `AuditSystem` instances and this test FAILS (proven red before the fix);
+ * with the anchor both copies resolve the same instance, so a storage swap
+ * installed through either copy is visible to the other.
+ */
+describe('audit singleton across duplicated module copies', () => {
+  it('two independent module registries resolve the same AuditSystem instance', async () => {
+    vi.resetModules();
+    const firstCopy = await import('../audit');
+    vi.resetModules();
+    const secondCopy = await import('../audit');
+
+    expect(firstCopy.audit).toBe(secondCopy.audit);
+  });
+
+  it('a storage swap through one copy is visible to the other copy', async () => {
+    vi.resetModules();
+    const firstCopy = await import('../audit');
+    vi.resetModules();
+    const secondCopy = await import('../audit');
+
+    // A minimal non-in-memory storage stub: after swapping it in through the
+    // FIRST copy, the SECOND copy must stop reporting in-memory storage — the
+    // exact cross-bundle contract the admin /api/health `audit-storage` check
+    // verifies in production (instrumentation swaps, route observes).
+    const stub = {
+      write: async () => undefined,
+      query: async () => [],
+      count: async () => 0,
+    };
+    firstCopy.audit.setStorage(stub);
+    try {
+      expect(firstCopy.audit.isInMemoryStorage()).toBe(false);
+      expect(secondCopy.audit.isInMemoryStorage()).toBe(false);
+    } finally {
+      // Restore the default so the shared process-wide singleton does not leak
+      // the stub into other suites in this worker.
+      firstCopy.audit.setStorage(new firstCopy.InMemoryAuditStorage());
+    }
+  });
+});

--- a/packages/security/src/audit.ts
+++ b/packages/security/src/audit.ts
@@ -712,6 +712,38 @@ export class AuditReportGenerator {
 // (RFC 8785 canonicalization over the full row) — see `audit-signing.ts`.
 
 /**
- * Global audit system
+ * Global audit system — process-wide, anchored on `globalThis`.
+ *
+ * A plain module-level singleton is NOT process-wide under a bundler that
+ * duplicates this package's module graph across chunks. The admin production
+ * build does exactly that (Turbopack bundles a separate copy of
+ * `@revealui/security` into the instrumentation chunk and route chunks;
+ * `serverExternalPackages` does not take effect for this workspace package),
+ * so the GAP-338 boot-time persistent-storage swap landed on the
+ * instrumentation copy while every route emitted into its own pristine
+ * in-memory copy — observed live as `/api/health` `audit-storage: unhealthy`
+ * on hosted prod (2026-07-25), the exact cross-bundle failure the #2156
+ * health check exists to catch. Module identity cannot be trusted across
+ * bundles; `globalThis` + `Symbol.for` is the process-wide anchor, so every
+ * copy of this module resolves the same instance and a storage swap installed
+ * by any copy is seen by all of them.
  */
-export const audit = new AuditSystem(new InMemoryAuditStorage());
+const AUDIT_SYSTEM_GLOBAL_KEY = Symbol.for('revealui.security.audit-system');
+
+interface AuditSystemGlobal {
+  [AUDIT_SYSTEM_GLOBAL_KEY]?: AuditSystem;
+}
+
+const auditSystemGlobal = globalThis as AuditSystemGlobal;
+
+function resolveProcessWideAuditSystem(): AuditSystem {
+  const existing = auditSystemGlobal[AUDIT_SYSTEM_GLOBAL_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created = new AuditSystem(new InMemoryAuditStorage());
+  auditSystemGlobal[AUDIT_SYSTEM_GLOBAL_KEY] = created;
+  return created;
+}
+
+export const audit: AuditSystem = resolveProcessWideAuditSystem();


### PR DESCRIPTION
## What

Anchors the process-wide `audit` singleton (`packages/security/src/audit.ts`) on `globalThis` (keyed via `Symbol.for`) so every bundled copy of the module resolves the same `AuditSystem` instance.

## Why (live prod finding, GAP-338 follow-up)

`admin.revealui.com/api/health` returns **503 `{"status":"unhealthy"}`** on the current production deploy: the route bundle reports audit storage as in-memory in production, meaning admin route-level audit emits (login receipts included) evaporate on restart. This is exactly the cross-bundle failure the #2156 health check was built to catch — and it fired.

Root cause, reproduced locally on a clean production build (`next start`, DB env + Ed25519 signing key provisioned, same shape as the #2176 e2e env):

- The instrumentation chunk installs persistent storage successfully (`AUDIT SIGNING: ENABLED`, self-test reaches a real SQL query) — but into **its own copy** of the module graph.
- Turbopack bundles a separate copy of `@revealui/security` into the instrumentation chunk and route chunks (9 server chunks carried `InMemoryAuditStorage` after a clean build), so the swap never reaches the singleton the routes resolve.
- `serverExternalPackages: ['@revealui/security']` was tried first and does **not** take effect for this workspace package (chunks still bundled after a clean `--force` rebuild; `@revealui/config` externalizes fine, so this is specific to the package/subpath shape). Fighting the bundler is not durable; module identity cannot be trusted across bundles. `globalThis` is the process-wide anchor (the standard Next.js pattern for this duplication class).

## Proof

- **Red:** with base `audit.ts`, the new test (two independent module registries via `vi.resetModules()` + dynamic import) fails 2/2; local prod build serves `/api/health` → `503 {"status":"unhealthy"}`.
- **Green:** with this fix, the test passes 2/2; the same clean prod build + same env serves `/api/health` → `200 {"status":"healthy"}`.
- Full `@revealui/security` suite: 752 passed. `@revealui/auth` (owns the audit-storage boundary): 531 passed. Admin `instrumentation-audit-storage.test.ts`: 11 passed. Typecheck + Biome clean.

## Notes

- After merge + promote + deploy, the hosted prod `/api/health` should flip to 200 with no env changes (env parity was never the problem — the rails proved env present).
- Known residual (out of scope): module-level counters elsewhere in the package (e.g. audit write-failure ratios) are still per-copy under bundle duplication — monitoring granularity only, no correctness impact on the write path.
- Security-classed surface (`packages/security/`): **review-pending** — needs a recorded non-author guardrail-2 verdict before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
