### PR TITLE
chore(release): promote test to main — audit-singleton prod fix + release-tag CI fix

### DIFF
--- a/.changeset/audit-singleton-globalthis.md
+++ b/.changeset/audit-singleton-globalthis.md
@@ -1,0 +1,5 @@
+---
+'@revealui/security': patch
+---
+
+Anchor the process-wide `audit` singleton on `globalThis` (keyed via `Symbol.for`) so bundlers that duplicate the package's module graph across chunks (observed with Turbopack in the admin production build) still resolve one shared `AuditSystem` instance. Fixes the boot-time persistent-storage swap landing on a different module copy than the one routes resolve, which left production admin audit emits in-memory and `/api/health` reporting `audit-storage: unhealthy`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,20 +117,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
-      # `changeset publish` creates tags only for the packages it actually
-      # publishes — on a re-run after a successful publish there are no tags at
-      # HEAD, so this step and the release step after it intentionally no-op.
-      # Say so explicitly instead of silently pushing nothing.
-      - name: Push tags
+      # `changeset publish` is SUPPOSED to create tags for what it publishes,
+      # but runs 30184318015 + the 0.10 morning train (2026-07-25) proved the
+      # in-runner tag creation can silently produce nothing even while logging
+      # "New tag:" — and `git push --follow-tags` only pushes ANNOTATED tags,
+      # while changesets creates LIGHTWEIGHT ones, so even created tags never
+      # left the runner. Last tags to actually reach the remote were 07-19.
+      # Belt and braces: `changeset tag` is idempotent (creates only missing
+      # tags for current package.json versions), and `--tags` pushes
+      # lightweight tags. A re-run after a successful publish becomes a no-op
+      # at the push (tags already on the remote), not a silent skip.
+      - name: Create + push tags
         if: ${{ !inputs.dry-run }}
         run: |
+          pnpm changeset tag
           tag_count="$(git tag --points-at HEAD | wc -l)"
           if [ "$tag_count" -eq 0 ]; then
-            echo "::notice title=No tags at HEAD::changeset publish created no tags (nothing newly published — likely a re-run), so no tags are pushed and no GitHub releases will be created."
-          else
-            echo "Pushing $tag_count tag(s) created by changeset publish."
+            echo "::error title=No tags at HEAD::changeset tag created nothing — package.json versions at HEAD have no tags to create, which after a publish means something is wrong. Failing loudly instead of skipping."
+            exit 1
           fi
-          git push --follow-tags
+          echo "Pushing $tag_count tag(s) at HEAD."
+          git push origin --tags
 
       # Release bodies come from each package's own CHANGELOG.md section for the
       # tagged version (changesets convention). generate_release_notes is

--- a/packages/security/src/__tests__/audit-singleton-global.test.ts
+++ b/packages/security/src/__tests__/audit-singleton-global.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * GAP-338 follow-up: the `audit` singleton must be PROCESS-wide, not
+ * module-copy-wide.
+ *
+ * The admin production build bundles a separate copy of this package's module
+ * graph into the instrumentation chunk and each route chunk (Turbopack;
+ * `serverExternalPackages` does not take effect for the workspace package), so
+ * a plain module-level singleton splits: the boot-time persistent-storage swap
+ * lands on one copy while routes emit into their own in-memory copies —
+ * observed live as `/api/health` `audit-storage: unhealthy` on hosted prod
+ * (2026-07-25).
+ *
+ * `vi.resetModules()` + dynamic import simulates exactly that: two independent
+ * module registries each evaluating `audit.ts` from scratch. Without the
+ * `globalThis` anchor the two evaluations construct two different
+ * `AuditSystem` instances and this test FAILS (proven red before the fix);
+ * with the anchor both copies resolve the same instance, so a storage swap
+ * installed through either copy is visible to the other.
+ */
+describe('audit singleton across duplicated module copies', () => {
+  it('two independent module registries resolve the same AuditSystem instance', async () => {
+    vi.resetModules();
+    const firstCopy = await import('../audit');
+    vi.resetModules();
+    const secondCopy = await import('../audit');
+
+    expect(firstCopy.audit).toBe(secondCopy.audit);
+  });
+
+  it('a storage swap through one copy is visible to the other copy', async () => {
+    vi.resetModules();
+    const firstCopy = await import('../audit');
+    vi.resetModules();
+    const secondCopy = await import('../audit');
+
+    // A minimal non-in-memory storage stub: after swapping it in through the
+    // FIRST copy, the SECOND copy must stop reporting in-memory storage — the
+    // exact cross-bundle contract the admin /api/health `audit-storage` check
+    // verifies in production (instrumentation swaps, route observes).
+    const stub = {
+      write: async () => undefined,
+      query: async () => [],
+      count: async () => 0,
+    };
+    firstCopy.audit.setStorage(stub);
+    try {
+      expect(firstCopy.audit.isInMemoryStorage()).toBe(false);
+      expect(secondCopy.audit.isInMemoryStorage()).toBe(false);
+    } finally {
+      // Restore the default so the shared process-wide singleton does not leak
+      // the stub into other suites in this worker.
+      firstCopy.audit.setStorage(new firstCopy.InMemoryAuditStorage());
+    }
+  });
+});

--- a/packages/security/src/audit.ts
+++ b/packages/security/src/audit.ts
@@ -712,6 +712,38 @@ export class AuditReportGenerator {
 // (RFC 8785 canonicalization over the full row) — see `audit-signing.ts`.
 
 /**
- * Global audit system
+ * Global audit system — process-wide, anchored on `globalThis`.
+ *
+ * A plain module-level singleton is NOT process-wide under a bundler that
+ * duplicates this package's module graph across chunks. The admin production
+ * build does exactly that (Turbopack bundles a separate copy of
+ * `@revealui/security` into the instrumentation chunk and route chunks;
+ * `serverExternalPackages` does not take effect for this workspace package),
+ * so the GAP-338 boot-time persistent-storage swap landed on the
+ * instrumentation copy while every route emitted into its own pristine
+ * in-memory copy — observed live as `/api/health` `audit-storage: unhealthy`
+ * on hosted prod (2026-07-25), the exact cross-bundle failure the #2156
+ * health check exists to catch. Module identity cannot be trusted across
+ * bundles; `globalThis` + `Symbol.for` is the process-wide anchor, so every
+ * copy of this module resolves the same instance and a storage swap installed
+ * by any copy is seen by all of them.
  */
-export const audit = new AuditSystem(new InMemoryAuditStorage());
+const AUDIT_SYSTEM_GLOBAL_KEY = Symbol.for('revealui.security.audit-system');
+
+interface AuditSystemGlobal {
+  [AUDIT_SYSTEM_GLOBAL_KEY]?: AuditSystem;
+}
+
+const auditSystemGlobal = globalThis as AuditSystemGlobal;
+
+function resolveProcessWideAuditSystem(): AuditSystem {
+  const existing = auditSystemGlobal[AUDIT_SYSTEM_GLOBAL_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created = new AuditSystem(new InMemoryAuditStorage());
+  auditSystemGlobal[AUDIT_SYSTEM_GLOBAL_KEY] = created;
+  return created;
+}
+
+export const audit: AuditSystem = resolveProcessWideAuditSystem();


### PR DESCRIPTION
Promotes 4 commits:
- #2179 fix(security): audit singleton anchored on globalThis (fixes hosted admin /api/health 503 audit-storage; guardrail-2 APPROVE recorded, sec-review:approved)
- #2178 ci(release): explicit tag creation
- #2177 backflow merge

After deploy: curl -s https://admin.revealui.com/api/health should return {\"status\":\"healthy\"} with NO env changes. Then the GAP-338 close-condition walk (login row across redeploy) and GAP-360 F6 walk unblock.

Merge with Create a merge commit (fleet promote rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)