### PR TITLE
fix(server): legacy anchor floor so the audit sweep clears the pre-enforcement era (GAP-427)

### DIFF
--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -237,14 +237,15 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     expect(anchors.some((a) => a.tenant === '')).toBe(false);
   });
 
-  it('skips when signed seqs jump after last anchor (unsigned hole)', async () => {
+  it('skips when an unsigned hole appears above an existing anchor (strict contiguity)', async () => {
     const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
     const unsignedStore = new DrizzleAuditStore(db); // no signer → signature null
-    await signedStore.append(makeEntry({ id: 's1', tenant: 'acct_max' }));
-    await unsignedStore.append(makeEntry({ id: 'u2', tenant: 'acct_max' }));
-    await signedStore.append(makeEntry({ id: 's3', tenant: 'acct_max' }));
 
-    // First pass anchors contiguous prefix [seq 1] only (size/lag ready).
+    // Anchor seq 1 first, THEN an unsigned row lands above it. Post-GAP-417
+    // rails this cannot happen in prod; if it does, it is a genuine integrity
+    // signal — the sweep must stall on it, never jump it (GAP-427 floor only
+    // applies while a tenant has no anchors at all).
+    await signedStore.append(makeEntry({ id: 's1', tenant: 'acct_max' }));
     const first = await runAuditAnchorSweep({
       db,
       signer: cryptoSigner,
@@ -254,6 +255,9 @@ describe('runAuditAnchorSweep (PGlite)', () => {
       now: () => new Date('2026-07-23T12:00:10.000Z'),
     });
     expect(first.anchorsInserted).toBe(1);
+
+    await unsignedStore.append(makeEntry({ id: 'u2', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's3', tenant: 'acct_max' }));
 
     // last=1; next signed is seq 3 (seq 2 unsigned). Gap → no further insert.
     const second = await runAuditAnchorSweep({
@@ -269,6 +273,44 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     const anchors = await db.select().from(auditAnchors).where(eq(auditAnchors.tenant, 'acct_max'));
     expect(anchors).toHaveLength(1);
     expect(anchors[0]?.seqTo).toBe(1);
+  });
+
+  it('GAP-427: first anchor starts above the closed unsigned legacy era (floor)', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db); // pre-enforcement legacy rows
+
+    // Legacy era (closed): unsigned seq 1, signed seq 2 interleaved, unsigned
+    // seq 3. Signed era: seq 4..5. Mirrors the prod shape from the GAP-417
+    // item-4 sweep (unsigned rows interleaved up to the floor).
+    await unsignedStore.append(makeEntry({ id: 'u1', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's2', tenant: 'acct_max' }));
+    await unsignedStore.append(makeEntry({ id: 'u3', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's4', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's5', tenant: 'acct_max' }));
+
+    // Without the floor the sweep anchors the interleaved legacy prefix
+    // [2..2] on pass one, then gap-stalls forever at the unsigned hole — the
+    // signed era 4..5 never anchors (proven red against the base code).
+    const sweepOptions = {
+      db,
+      signer: cryptoSigner,
+      batchSize: 2,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    };
+    const first = await runAuditAnchorSweep(sweepOptions);
+    expect(first.anchorsInserted).toBe(1);
+    const second = await runAuditAnchorSweep(sweepOptions);
+    expect(second.anchorsInserted).toBe(0);
+
+    // Floor = 3 (highest unsigned seq): the one anchor covers exactly the
+    // signed era. Legacy rows 1..3 (unsigned + interleaved signed) stay
+    // unanchored and are never retro-signed.
+    const anchors = await db.select().from(auditAnchors).where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.seqFrom).toBe(4);
+    expect(anchors[0]?.seqTo).toBe(5);
   });
 
   it('no-ops without a signer (unsigned mode)', async () => {

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -226,6 +226,25 @@ async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
   return typeof m === 'number' && Number.isFinite(m) ? m : 0;
 }
 
+/**
+ * GAP-427: legacy anchor floor. Rows written before signed writes were
+ * enforced (GAP-417 both rails) left unsigned rows interleaved in the seq
+ * order; each one is a permanent contiguity hole, so a tenant with no anchors
+ * yet would gap-stall forever after the first pre-hole run. The rails
+ * guarantee no new unsigned rows, so the era is closed and the tenant's
+ * highest unsigned seq is a stable floor: anchoring attests floor+1 forward.
+ * Legacy rows are never retro-signed — a backfilled signature would be
+ * indistinguishable from tampering (ADR 2026-07-12 §2a).
+ */
+async function legacyUnsignedFloor(db: Database, tenant: string): Promise<number> {
+  const rows = await db
+    .select({ m: max(auditLog.seq) })
+    .from(auditLog)
+    .where(and(eq(auditLog.tenant, tenant), isNull(auditLog.signature)));
+  const m = rows[0]?.m;
+  return typeof m === 'number' && Number.isFinite(m) ? m : 0;
+}
+
 type TenantOutcome = 'inserted' | 'waiting' | 'skipped';
 
 async function anchorTenantBatch(
@@ -237,7 +256,10 @@ async function anchorTenantBatch(
   now: () => Date,
   doMeter: boolean,
 ): Promise<TenantOutcome> {
-  const last = await lastAnchoredSeq(db, tenant);
+  const anchored = await lastAnchoredSeq(db, tenant);
+  // GAP-427: first anchor for a tenant starts above the closed unsigned era,
+  // not at seq 1. Once anchors exist, strict last+1 contiguity governs.
+  const last = anchored > 0 ? anchored : await legacyUnsignedFloor(db, tenant);
 
   const candidates = await db
     .select({

--- a/docs/security/AUDIT_RECEIPTS.md
+++ b/docs/security/AUDIT_RECEIPTS.md
@@ -49,6 +49,17 @@ Positioning foil: "If an agent did it, there's a receipt." That is true for Max 
 
 Until the worker seals the tail (batch size or max lag), those signed rows are real but not yet in a customer-held root. UI and copy should not treat the foil as true for the unanchored tail.
 
+## Legacy floor (pre-enforcement rows)
+
+Anchors attest the signed era only. A deployment that wrote audit rows before signed writes were enforced carries a closed legacy era: unsigned rows, sometimes interleaved with early signed rows. Every unsigned row is a permanent hole in the sequence, so the sweep derives a per-tenant floor (the highest unsigned `seq`) and anchors from `floor + 1` forward. The floor is only consulted while a tenant has no anchors at all.
+
+Below the floor:
+
+- Unsigned legacy rows are never retro-signed. A backfilled signature would be indistinguishable from tampering, which is the exact failure receipts exist to prevent.
+- Signed rows interleaved below the floor remain verifiable per row with the offline check, but no Merkle root covers them.
+
+The floor never spans live history. A `seq` hole that appears above an existing anchor still stalls the sweep and raises the gap metric.
+
 ## Offline verify
 
 ```bash


### PR DESCRIPTION
## Summary

Anchoring has never completed in prod (GAP-427): the pre-enforcement era left 170 unsigned `audit_log` rows (seq 1..1122, 123 of them interleaved above the first signed row), and every unsigned row is a permanent contiguity hole for the anchor sweep. Since the both-rails promotion guarantees no new unsigned rows, that era is closed, so the sweep now derives a per-tenant **legacy floor** (the highest unsigned `seq`) and starts contiguity at `floor + 1` when the tenant has no anchors yet.

## What changed

- `apps/server/src/jobs/audit-anchor-sweep.ts`: new `legacyUnsignedFloor()` (derived at sweep time, no new state). Consulted **only when a tenant has zero anchors**; once anchors exist, strict `last + 1` contiguity governs unchanged, so a hole appearing above an existing anchor still stalls the sweep and raises the gap metric.
- **No retro-signing.** Legacy rows (unsigned + the signed rows interleaved below the floor) stay outside every Merkle root. A backfilled signature would be indistinguishable from tampering, which is the property the receipts exist to prevent.
- `docs/security/AUDIT_RECEIPTS.md`: new "Legacy floor" section documenting the pre-floor era honestly (row-level verify still works below the floor; no root covers those rows).

## Behavior change note (reviewed intentionally)

The prior test `skips when signed seqs jump after last anchor (unsigned hole)` locked the stall-at-first-hole behavior for a tenant with **no anchors** — exactly the state GAP-427 rules is wrong (that fixture is a closed legacy era). It is reworked to lock the surviving semantics: an unsigned hole appearing **above an existing anchor** stalls, never jumps.

## Tests (prove-red)

New PGlite test `GAP-427: first anchor starts above the closed unsigned legacy era (floor)` with fixture unsigned(1), signed(2), unsigned(3), signed(4), signed(5):

- **Base code (red, run with the fix checked out to origin/test):** sweep anchors the interleaved legacy prefix `[2..2]`, then gap-stalls forever; assertion `seqFrom = 4` fails with `expected 2 to be 4`.
- **With the fix (green):** floor = 3, the single anchor covers exactly the signed era `[4..5]`; suite 12/12.

Note on the mechanism: with zero anchors, `planContiguousBatch` applies no gap check, so the actual prod stall shape is "anchor the first contiguous signed run, then stall at the first interleaved unsigned row" rather than "stall at seq 1". The fixture reproduces that real shape.

## After deploy

First real prod anchor landing (`audit_anchors` count > 0 after a sweep tick) is the observation that closes GAP-427 and unblocks Stage 4 anchoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
