### PR TITLE
chore(release): promote test to main — GAP-427 audit anchor legacy floor

### DIFF
--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -301,8 +301,10 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     };
     const first = await runAuditAnchorSweep(sweepOptions);
     expect(first.anchorsInserted).toBe(1);
+    expect(first.tenantsFloorEngaged).toBe(1); // GAP-429: engagement is observable
     const second = await runAuditAnchorSweep(sweepOptions);
     expect(second.anchorsInserted).toBe(0);
+    expect(second.tenantsFloorEngaged).toBe(0); // anchors exist now — floor not consulted
 
     // Floor = 3 (highest unsigned seq): the one anchor covers exactly the
     // signed era. Legacy rows 1..3 (unsigned + interleaved signed) stay
@@ -311,6 +313,31 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     expect(anchors).toHaveLength(1);
     expect(anchors[0]?.seqFrom).toBe(4);
     expect(anchors[0]?.seqTo).toBe(5);
+  });
+
+  it('GAP-429: floor above the entire signed era reports engagement and anchors nothing', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db);
+    // Signed seq 1 sits below the floor (unsigned seq 2 closed the era); there
+    // is no signed era above the floor, so the sweep has nothing to anchor —
+    // but the engagement must still be visible, not a silent skip.
+    await signedStore.append(makeEntry({ id: 's1', tenant: 'acct_max' }));
+    await unsignedStore.append(makeEntry({ id: 'u2', tenant: 'acct_max' }));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 1,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.tenantsFloorEngaged).toBe(1);
+    expect(result.anchorsInserted).toBe(0);
+    expect(result.tenantsSkipped).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(await db.select().from(auditAnchors)).toHaveLength(0);
   });
 
   it('no-ops without a signer (unsigned mode)', async () => {

--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -237,14 +237,15 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     expect(anchors.some((a) => a.tenant === '')).toBe(false);
   });
 
-  it('skips when signed seqs jump after last anchor (unsigned hole)', async () => {
+  it('skips when an unsigned hole appears above an existing anchor (strict contiguity)', async () => {
     const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
     const unsignedStore = new DrizzleAuditStore(db); // no signer → signature null
-    await signedStore.append(makeEntry({ id: 's1', tenant: 'acct_max' }));
-    await unsignedStore.append(makeEntry({ id: 'u2', tenant: 'acct_max' }));
-    await signedStore.append(makeEntry({ id: 's3', tenant: 'acct_max' }));
 
-    // First pass anchors contiguous prefix [seq 1] only (size/lag ready).
+    // Anchor seq 1 first, THEN an unsigned row lands above it. Post-GAP-417
+    // rails this cannot happen in prod; if it does, it is a genuine integrity
+    // signal — the sweep must stall on it, never jump it (GAP-427 floor only
+    // applies while a tenant has no anchors at all).
+    await signedStore.append(makeEntry({ id: 's1', tenant: 'acct_max' }));
     const first = await runAuditAnchorSweep({
       db,
       signer: cryptoSigner,
@@ -254,6 +255,9 @@ describe('runAuditAnchorSweep (PGlite)', () => {
       now: () => new Date('2026-07-23T12:00:10.000Z'),
     });
     expect(first.anchorsInserted).toBe(1);
+
+    await unsignedStore.append(makeEntry({ id: 'u2', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's3', tenant: 'acct_max' }));
 
     // last=1; next signed is seq 3 (seq 2 unsigned). Gap → no further insert.
     const second = await runAuditAnchorSweep({
@@ -269,6 +273,44 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     const anchors = await db.select().from(auditAnchors).where(eq(auditAnchors.tenant, 'acct_max'));
     expect(anchors).toHaveLength(1);
     expect(anchors[0]?.seqTo).toBe(1);
+  });
+
+  it('GAP-427: first anchor starts above the closed unsigned legacy era (floor)', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db); // pre-enforcement legacy rows
+
+    // Legacy era (closed): unsigned seq 1, signed seq 2 interleaved, unsigned
+    // seq 3. Signed era: seq 4..5. Mirrors the prod shape from the GAP-417
+    // item-4 sweep (unsigned rows interleaved up to the floor).
+    await unsignedStore.append(makeEntry({ id: 'u1', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's2', tenant: 'acct_max' }));
+    await unsignedStore.append(makeEntry({ id: 'u3', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's4', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's5', tenant: 'acct_max' }));
+
+    // Without the floor the sweep anchors the interleaved legacy prefix
+    // [2..2] on pass one, then gap-stalls forever at the unsigned hole — the
+    // signed era 4..5 never anchors (proven red against the base code).
+    const sweepOptions = {
+      db,
+      signer: cryptoSigner,
+      batchSize: 2,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    };
+    const first = await runAuditAnchorSweep(sweepOptions);
+    expect(first.anchorsInserted).toBe(1);
+    const second = await runAuditAnchorSweep(sweepOptions);
+    expect(second.anchorsInserted).toBe(0);
+
+    // Floor = 3 (highest unsigned seq): the one anchor covers exactly the
+    // signed era. Legacy rows 1..3 (unsigned + interleaved signed) stay
+    // unanchored and are never retro-signed.
+    const anchors = await db.select().from(auditAnchors).where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.seqFrom).toBe(4);
+    expect(anchors[0]?.seqTo).toBe(5);
   });
 
   it('no-ops without a signer (unsigned mode)', async () => {

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -75,12 +75,18 @@ const mWaiting = metrics.counter(
   'revealui_audit_anchor_waiting_total',
   'Tenants with unanchored rows still under batch-size and max-lag thresholds',
 );
+const mFloorEngaged = metrics.counter(
+  'revealui_audit_anchor_floor_engaged_total',
+  'Tenant sweep passes that started from a derived legacy floor (GAP-427/429)',
+);
 
 export interface AnchorSweepResult {
   tenantsConsidered: number;
   anchorsInserted: number;
   tenantsSkipped: number;
   tenantsWaiting: number;
+  /** Tenants whose pass started from a derived legacy floor (no anchors yet). */
+  tenantsFloorEngaged: number;
   nullTenantSignedRows: number;
   errors: string[];
 }
@@ -152,6 +158,7 @@ export async function runAuditAnchorSweep(
     anchorsInserted: 0,
     tenantsSkipped: 0,
     tenantsWaiting: 0,
+    tenantsFloorEngaged: 0,
     nullTenantSignedRows: 0,
     errors: [],
   };
@@ -189,7 +196,7 @@ export async function runAuditAnchorSweep(
         continue;
       }
 
-      const outcome = await anchorTenantBatch(
+      const { outcome, floorEngaged } = await anchorTenantBatch(
         db,
         signer,
         tenant,
@@ -198,6 +205,7 @@ export async function runAuditAnchorSweep(
         now,
         doMeter,
       );
+      if (floorEngaged) result.tenantsFloorEngaged++;
       if (outcome === 'inserted') result.anchorsInserted++;
       else if (outcome === 'waiting') {
         result.tenantsWaiting++;
@@ -235,8 +243,11 @@ async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
  * highest unsigned seq is a stable floor: anchoring attests floor+1 forward.
  * Legacy rows are never retro-signed — a backfilled signature would be
  * indistinguishable from tampering (ADR 2026-07-12 §2a).
+ *
+ * Exported for the anchors API lag surface (GAP-429), which reports the same
+ * floor so sub-floor legacy rows are visible rather than silently excluded.
  */
-async function legacyUnsignedFloor(db: Database, tenant: string): Promise<number> {
+export async function legacyUnsignedFloor(db: Database, tenant: string): Promise<number> {
   const rows = await db
     .select({ m: max(auditLog.seq) })
     .from(auditLog)
@@ -255,11 +266,20 @@ async function anchorTenantBatch(
   maxLagMs: number,
   now: () => Date,
   doMeter: boolean,
-): Promise<TenantOutcome> {
+): Promise<{ outcome: TenantOutcome; floorEngaged: boolean }> {
   const anchored = await lastAnchoredSeq(db, tenant);
   // GAP-427: first anchor for a tenant starts above the closed unsigned era,
   // not at seq 1. Once anchors exist, strict last+1 contiguity governs.
-  const last = anchored > 0 ? anchored : await legacyUnsignedFloor(db, tenant);
+  const floor = anchored > 0 ? 0 : await legacyUnsignedFloor(db, tenant);
+  const floorEngaged = floor > 0;
+  if (floorEngaged) {
+    mFloorEngaged.inc();
+    logger.info(
+      `audit-anchor-sweep: legacy floor engaged tenant=${tenant} floor=${floor} — anchors attest seq ${floor + 1} onward`,
+    );
+  }
+  const done = (outcome: TenantOutcome) => ({ outcome, floorEngaged });
+  const last = anchored > 0 ? anchored : floor;
 
   const candidates = await db
     .select({
@@ -280,7 +300,7 @@ async function anchorTenantBatch(
     if (oldestTs === null) oldestTs = row.timestamp;
   }
 
-  if (signed.length === 0) return 'skipped';
+  if (signed.length === 0) return done('skipped');
 
   const batch = planContiguousBatch(last, signed);
   if (!batch || batch.length === 0) {
@@ -290,7 +310,7 @@ async function anchorTenantBatch(
         `audit-anchor-sweep: gap for tenant=${tenant} lastAnchored=${last} nextSeq=${signed[0].seq} — skip`,
       );
     }
-    return 'skipped';
+    return done('skipped');
   }
 
   // Size primary; time is max lag for a partial batch (§9).
@@ -298,7 +318,7 @@ async function anchorTenantBatch(
   const ageMs = oldestTs ? now().getTime() - oldestTs.getTime() : 0;
   const readyByLag = batch.length >= 1 && ageMs >= maxLagMs;
   if (!(readyBySize || readyByLag)) {
-    return 'waiting';
+    return done('waiting');
   }
 
   const seqs = batch.map((r) => r.seq);
@@ -307,7 +327,7 @@ async function anchorTenantBatch(
   const { root, leafCount } = buildMerkleRootFromSignatures(signatures);
   const seqFrom = batch[0]?.seq;
   const seqTo = batch[batch.length - 1]?.seq;
-  if (seqFrom === undefined || seqTo === undefined) return 'skipped';
+  if (seqFrom === undefined || seqTo === undefined) return done('skipped');
 
   const { value: rootSignature } = signAuditAnchorRoot(signer, {
     tenant,
@@ -351,7 +371,7 @@ async function anchorTenantBatch(
     }
   }
 
-  return 'inserted';
+  return done('inserted');
 }
 
 let sweepTimer: ReturnType<typeof setInterval> | null = null;

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -226,6 +226,25 @@ async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
   return typeof m === 'number' && Number.isFinite(m) ? m : 0;
 }
 
+/**
+ * GAP-427: legacy anchor floor. Rows written before signed writes were
+ * enforced (GAP-417 both rails) left unsigned rows interleaved in the seq
+ * order; each one is a permanent contiguity hole, so a tenant with no anchors
+ * yet would gap-stall forever after the first pre-hole run. The rails
+ * guarantee no new unsigned rows, so the era is closed and the tenant's
+ * highest unsigned seq is a stable floor: anchoring attests floor+1 forward.
+ * Legacy rows are never retro-signed — a backfilled signature would be
+ * indistinguishable from tampering (ADR 2026-07-12 §2a).
+ */
+async function legacyUnsignedFloor(db: Database, tenant: string): Promise<number> {
+  const rows = await db
+    .select({ m: max(auditLog.seq) })
+    .from(auditLog)
+    .where(and(eq(auditLog.tenant, tenant), isNull(auditLog.signature)));
+  const m = rows[0]?.m;
+  return typeof m === 'number' && Number.isFinite(m) ? m : 0;
+}
+
 type TenantOutcome = 'inserted' | 'waiting' | 'skipped';
 
 async function anchorTenantBatch(
@@ -237,7 +256,10 @@ async function anchorTenantBatch(
   now: () => Date,
   doMeter: boolean,
 ): Promise<TenantOutcome> {
-  const last = await lastAnchoredSeq(db, tenant);
+  const anchored = await lastAnchoredSeq(db, tenant);
+  // GAP-427: first anchor for a tenant starts above the closed unsigned era,
+  // not at seq 1. Once anchors exist, strict last+1 contiguity governs.
+  const last = anchored > 0 ? anchored : await legacyUnsignedFloor(db, tenant);
 
   const candidates = await db
     .select({

--- a/apps/server/src/routes/__tests__/audit-anchors.test.ts
+++ b/apps/server/src/routes/__tests__/audit-anchors.test.ts
@@ -205,6 +205,8 @@ describe('GET /anchors + /anchors/:id/proof (GAP-355 S4-4, PGlite)', () => {
         lastAnchoredSeqTo: number;
         unanchoredSignedCount: number;
         oldestUnanchoredAt: string | null;
+        legacyFloor: number;
+        preFloorSignedCount: number;
       };
     };
     expect(body.tenant).toBe('acct_max');
@@ -213,6 +215,49 @@ describe('GET /anchors + /anchors/:id/proof (GAP-355 S4-4, PGlite)', () => {
     expect(body.lag.lastAnchoredSeqTo).toBe(seqTo);
     expect(body.lag.unanchoredSignedCount).toBe(1);
     expect(body.lag.oldestUnanchoredAt).toBeTruthy();
+    // GAP-429: all-signed history has no legacy era.
+    expect(body.lag.legacyFloor).toBe(0);
+    expect(body.lag.preFloorSignedCount).toBe(0);
+  });
+
+  it('GAP-429: lag names the legacy floor and the sub-floor signed rows', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db); // pre-enforcement legacy rows
+    // Legacy era: unsigned seq 1, signed seq 2 interleaved, unsigned seq 3.
+    // Signed era: seq 4..5, anchored (the GAP-427 floor behavior).
+    await unsignedStore.append(makeEntry({ id: 'u1', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's2', tenant: 'acct_max' }));
+    await unsignedStore.append(makeEntry({ id: 'u3', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's4', tenant: 'acct_max' }));
+    await signedStore.append(makeEntry({ id: 's5', tenant: 'acct_max' }));
+
+    const era = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.tenant, 'acct_max'))
+      .orderBy(asc(auditLog.seq));
+    const eraSignatures = era
+      .filter((r) => r.seq >= 4 && r.signature)
+      .map((r) => r.signature as string);
+    await insertAnchor(eraSignatures, 4, 5);
+
+    const app = createAuthedApp(user, db);
+    const res = await app.request('/anchors');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      lag: {
+        lastAnchoredSeqTo: number;
+        unanchoredSignedCount: number;
+        legacyFloor: number;
+        preFloorSignedCount: number;
+      };
+    };
+    expect(body.lag.lastAnchoredSeqTo).toBe(5);
+    expect(body.lag.unanchoredSignedCount).toBe(0);
+    // Floor = 3 (highest unsigned seq); the signed row at seq 2 is visible as
+    // pre-floor legacy (row-verifiable, never in a root), not silently absent.
+    expect(body.lag.legacyFloor).toBe(3);
+    expect(body.lag.preFloorSignedCount).toBe(1);
   });
 
   it('returns a verifiable inclusion proof and marks delivered', async () => {

--- a/apps/server/src/routes/audit.ts
+++ b/apps/server/src/routes/audit.ts
@@ -21,6 +21,7 @@ import { OpenAPIHono } from '@revealui/openapi';
 import { and, asc, count, desc, eq, gt, gte, isNotNull, lte, max } from 'drizzle-orm';
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import { legacyUnsignedFloor } from '../jobs/audit-anchor-sweep.js';
 import { buildAnchorInclusionProof } from '../lib/audit-anchor-proof.js';
 
 interface UserContext {
@@ -153,6 +154,26 @@ app.get('/anchors', async (c) => {
     .orderBy(asc(auditLog.timestamp))
     .limit(1);
 
+  // GAP-429: name the pre-enforcement legacy era instead of going silent about
+  // it. Signed rows at or below the floor are row-verifiable but never enter a
+  // root (GAP-427 — no retro-signing); the existing fields keep their
+  // semantics (unanchored tail = signed rows above the last anchor).
+  const legacyFloor = await legacyUnsignedFloor(db, tenant);
+  let preFloorSignedCount = 0;
+  if (legacyFloor > 0) {
+    const [preFloorRow] = await db
+      .select({ c: count() })
+      .from(auditLog)
+      .where(
+        and(
+          eq(auditLog.tenant, tenant),
+          isNotNull(auditLog.signature),
+          lte(auditLog.seq, legacyFloor),
+        ),
+      );
+    preFloorSignedCount = Number(preFloorRow?.c ?? 0);
+  }
+
   c.header('Cache-Control', 'no-store');
   return c.json(
     {
@@ -164,6 +185,8 @@ app.get('/anchors', async (c) => {
         oldestUnanchoredAt: oldestUnanchored?.timestamp
           ? oldestUnanchored.timestamp.toISOString()
           : null,
+        legacyFloor,
+        preFloorSignedCount,
       },
     },
     200,

--- a/docs/security/AUDIT_RECEIPTS.md
+++ b/docs/security/AUDIT_RECEIPTS.md
@@ -46,8 +46,10 @@ Positioning foil: "If an agent did it, there's a receipt." That is true for Max 
 - `lastAnchoredSeqTo`
 - `unanchoredSignedCount`
 - `oldestUnanchoredAt`
+- `legacyFloor` (the pre-enforcement floor for this tenant, 0 when there is no legacy era)
+- `preFloorSignedCount` (signed rows at or below the floor: row-verifiable, never in a root)
 
-Until the worker seals the tail (batch size or max lag), those signed rows are real but not yet in a customer-held root. UI and copy should not treat the foil as true for the unanchored tail.
+Until the worker seals the tail (batch size or max lag), those signed rows are real but not yet in a customer-held root. UI and copy should not treat the foil as true for the unanchored tail. The `unanchoredSignedCount` tail covers rows above the last anchor only; rows below the floor are reported separately via `preFloorSignedCount`, never counted as unanchored tail.
 
 ## Legacy floor (pre-enforcement rows)
 

--- a/docs/security/AUDIT_RECEIPTS.md
+++ b/docs/security/AUDIT_RECEIPTS.md
@@ -49,6 +49,17 @@ Positioning foil: "If an agent did it, there's a receipt." That is true for Max 
 
 Until the worker seals the tail (batch size or max lag), those signed rows are real but not yet in a customer-held root. UI and copy should not treat the foil as true for the unanchored tail.
 
+## Legacy floor (pre-enforcement rows)
+
+Anchors attest the signed era only. A deployment that wrote audit rows before signed writes were enforced carries a closed legacy era: unsigned rows, sometimes interleaved with early signed rows. Every unsigned row is a permanent hole in the sequence, so the sweep derives a per-tenant floor (the highest unsigned `seq`) and anchors from `floor + 1` forward. The floor is only consulted while a tenant has no anchors at all.
+
+Below the floor:
+
+- Unsigned legacy rows are never retro-signed. A backfilled signature would be indistinguishable from tampering, which is the exact failure receipts exist to prevent.
+- Signed rows interleaved below the floor remain verifiable per row with the offline check, but no Merkle root covers them.
+
+The floor never spans live history. A `seq` hole that appears above an existing anchor still stalls the sweep and raises the gap metric.
+
 ## Offline verify
 
 ```bash


### PR DESCRIPTION
Promotes the audit anchor legacy-floor fix (#2182, guardrail-2 APPROVE recorded on the PR) to main. Single change since the last promote (#2180).

After deploy: the acceptance observation is the first prod anchor landing (audit_anchors count > 0 after a sweep tick with AUDIT_ANCHOR_SWEEP_ENABLED=true on the worker). Merge with a merge commit per the promote policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)