### PR TITLE
fix(sync): resolve shape-hook Invalid URL (Sentry REVEALUI-ADMIN-8) — origin default + ClientOnly SSR gate

### DIFF
--- a/apps/admin/src/app/(backend)/chat/page.tsx
+++ b/apps/admin/src/app/(backend)/chat/page.tsx
@@ -9,12 +9,22 @@ import {
   IconGlobe,
   Skeleton,
 } from '@revealui/presentation';
-import { useConversations } from '@revealui/sync';
+import { ClientOnly, useConversations } from '@revealui/sync';
 import { useState } from 'react';
 import AgentChat from '@/lib/components/Agent';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
+// Shape hooks need a browser origin (Electric requires an absolute URL), so
+// the hook-bearing body only renders client-side.
 export default function ChatPage() {
+  return (
+    <ClientOnly>
+      <ChatPageInner />
+    </ClientOnly>
+  );
+}
+
+function ChatPageInner() {
   const {
     conversations,
     isLoading: sidebarLoading,

--- a/apps/admin/src/app/(backend)/coordination/page.tsx
+++ b/apps/admin/src/app/(backend)/coordination/page.tsx
@@ -10,7 +10,7 @@ import {
   Skeleton,
 } from '@revealui/presentation';
 import type { CoordinationSessionRecord } from '@revealui/sync';
-import { useCoordinationSessions } from '@revealui/sync';
+import { ClientOnly, useCoordinationSessions } from '@revealui/sync';
 import { useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
@@ -59,7 +59,10 @@ function truncate(s: string, n: number): string {
 export default function CoordinationPage() {
   return (
     <LicenseGate feature="dashboard">
-      <CoordinationDashboard />
+      {/* Shape hooks need a browser origin (Electric requires an absolute URL). */}
+      <ClientOnly>
+        <CoordinationDashboard />
+      </ClientOnly>
     </LicenseGate>
   );
 }

--- a/apps/admin/src/app/(backend)/knowledge-graph/page.tsx
+++ b/apps/admin/src/app/(backend)/knowledge-graph/page.tsx
@@ -13,7 +13,7 @@ import {
   Textarea,
 } from '@revealui/presentation';
 import type { KgEdgeRecord, KgNodeRecord } from '@revealui/sync';
-import { useKgViewDocument, useKnowledgeGraph } from '@revealui/sync';
+import { ClientOnly, useKgViewDocument, useKnowledgeGraph } from '@revealui/sync';
 import { useEffect, useMemo, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 
@@ -56,7 +56,10 @@ function formatTimestamp(iso: string | null): string {
 export default function KnowledgeGraphPage() {
   return (
     <LicenseGate feature="ai">
-      <KnowledgeGraphExplorer />
+      {/* Shape hooks need a browser origin (Electric requires an absolute URL). */}
+      <ClientOnly>
+        <KnowledgeGraphExplorer />
+      </ClientOnly>
     </LicenseGate>
   );
 }

--- a/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
@@ -2,7 +2,7 @@
 
 import { Badge, Button, Card, EmptyState, LinkButton, Skeleton } from '@revealui/presentation';
 import type { TaskSubmissionRecord } from '@revealui/sync';
-import { useTaskSubmissions } from '@revealui/sync';
+import { ClientOnly, useTaskSubmissions } from '@revealui/sync';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
@@ -34,7 +34,17 @@ const STATUS_BADGE_COLORS: Record<string, 'warning' | 'brand' | 'success' | 'dan
 // Task Dashboard
 // =============================================================================
 
+// Shape hooks need a browser origin (Electric requires an absolute URL), so
+// the hook-bearing body only renders client-side.
 export default function TaskDashboardPage() {
+  return (
+    <ClientOnly>
+      <TaskDashboardInner />
+    </ClientOnly>
+  );
+}
+
+function TaskDashboardInner() {
   const { submissions, isLoading, error } = useTaskSubmissions();
   const [filter, setFilter] = useState<StatusFilter>('all');
   const [selectedTask, setSelectedTask] = useState<string | null>(null);

--- a/apps/admin/src/lib/components/agents/__tests__/agent-contexts.test.tsx
+++ b/apps/admin/src/lib/components/agents/__tests__/agent-contexts.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@revealui/sync', () => ({
+  ClientOnly: ({ children }: { children: React.ReactNode }) => children,
   useAgentContexts: vi.fn(),
 }));
 

--- a/apps/admin/src/lib/components/agents/__tests__/chat-conversations.test.tsx
+++ b/apps/admin/src/lib/components/agents/__tests__/chat-conversations.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@revealui/sync', () => ({
+  ClientOnly: ({ children }: { children: React.ReactNode }) => children,
   useConversations: vi.fn(),
 }));
 

--- a/apps/admin/src/lib/components/agents/agent-contexts.tsx
+++ b/apps/admin/src/lib/components/agents/agent-contexts.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge } from '@revealui/presentation';
-import { useAgentContexts } from '@revealui/sync';
+import { ClientOnly, useAgentContexts } from '@revealui/sync';
 
 interface AgentContextsProps {
   agentId: string;
@@ -19,7 +19,17 @@ function formatRelativeTime(isoDate: string): string {
   return `${days}d ago`;
 }
 
-export function AgentContexts({ agentId }: AgentContextsProps) {
+// Shape hooks need a browser origin (Electric requires an absolute URL), so
+// the hook-bearing body only renders client-side.
+export function AgentContexts(props: AgentContextsProps) {
+  return (
+    <ClientOnly>
+      <AgentContextsInner {...props} />
+    </ClientOnly>
+  );
+}
+
+function AgentContextsInner({ agentId }: AgentContextsProps) {
   const { contexts, isLoading, error } = useAgentContexts();
 
   const agentContexts = contexts.filter((c) => c.agent_id === agentId);

--- a/apps/admin/src/lib/components/agents/agent-memory.tsx
+++ b/apps/admin/src/lib/components/agents/agent-memory.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, IconTrash } from '@revealui/presentation';
-import { useAgentMemory } from '@revealui/sync';
+import { ClientOnly, useAgentMemory } from '@revealui/sync';
 import { useState } from 'react';
 
 interface AgentMemoryProps {
@@ -55,7 +55,17 @@ function formatRelativeTime(isoDate: string): string {
  * Displays episodic, semantic, and working memories with live updates
  * via ElectricSQL shape subscriptions.
  */
-export function AgentMemory({ agentId }: AgentMemoryProps) {
+// Shape hooks need a browser origin (Electric requires an absolute URL), so
+// the hook-bearing body only renders client-side.
+export function AgentMemory(props: AgentMemoryProps) {
+  return (
+    <ClientOnly>
+      <AgentMemoryInner {...props} />
+    </ClientOnly>
+  );
+}
+
+function AgentMemoryInner({ agentId }: AgentMemoryProps) {
   const { memories, isLoading, error, remove } = useAgentMemory(agentId);
   const [filter, setFilter] = useState<string | null>(null);
   const [removingId, setRemovingId] = useState<string | null>(null);

--- a/packages/sync/src/__tests__/client-only.test.tsx
+++ b/packages/sync/src/__tests__/client-only.test.tsx
@@ -1,0 +1,66 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ClientOnly } from '../client-only.js';
+import { ElectricProvider, useElectricConfig } from '../provider/index.js';
+
+describe('ClientOnly', () => {
+  it('renders children after client mount', () => {
+    render(
+      <ClientOnly>
+        <div data-testid="gated">gated content</div>
+      </ClientOnly>,
+    );
+
+    expect(screen.getByTestId('gated')).toBeInTheDocument();
+  });
+
+  it('renders nothing during server prerender', () => {
+    expect(
+      renderToString(
+        <ClientOnly>
+          <div>gated content</div>
+        </ClientOnly>,
+      ),
+    ).toBe('');
+  });
+
+  it('shields the server prerender from children that require a browser, like shape hooks', () => {
+    // Regression stand-in for Sentry REVEALUI-ADMIN-8: shape hooks throw
+    // TypeError: Invalid URL when constructed without a browser origin.
+    function BrowserOnlyChild(): ReactNode {
+      throw new TypeError('Invalid URL');
+    }
+
+    expect(() =>
+      renderToString(
+        <ClientOnly>
+          <BrowserOnlyChild />
+        </ClientOnly>,
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe('ElectricProvider proxyBaseUrl default', () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ElectricProvider>{children}</ElectricProvider>
+  );
+
+  it('defaults to window.location.origin in the browser', () => {
+    const { result } = renderHook(() => useElectricConfig(), { wrapper });
+
+    expect(result.current.proxyBaseUrl).toBe(window.location.origin);
+    expect(result.current.proxyBaseUrl).not.toBe('');
+  });
+
+  it('honors an explicit proxyBaseUrl prop over the origin default', () => {
+    const explicit = ({ children }: { children: ReactNode }) => (
+      <ElectricProvider proxyBaseUrl="https://admin.example.com">{children}</ElectricProvider>
+    );
+    const { result } = renderHook(() => useElectricConfig(), { wrapper: explicit });
+
+    expect(result.current.proxyBaseUrl).toBe('https://admin.example.com');
+  });
+});

--- a/packages/sync/src/client-only.tsx
+++ b/packages/sync/src/client-only.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { type ReactNode, useSyncExternalStore } from 'react';
+
+const noop = (): void => {
+  // The mounted store never changes after subscription; nothing to clean up.
+};
+const emptySubscribe = (): (() => void) => noop;
+const getClientSnapshot = (): boolean => true;
+const getServerSnapshot = (): boolean => false;
+
+/**
+ * Renders children only after client mount. Server prerender (and the
+ * hydration pass) renders nothing.
+ *
+ * Sync hooks construct an Electric `ShapeStream` during render, and the
+ * Electric client requires an absolute URL (`new URL(url)` with no base).
+ * During server prerender there is no `window.location` to resolve against,
+ * so any component calling a shape hook throws `TypeError: Invalid URL`
+ * when server-rendered (Sentry REVEALUI-ADMIN-8). Realtime shape surfaces
+ * have no prerender value; gate them behind this boundary:
+ *
+ * ```tsx
+ * export default function Page() {
+ *   return (
+ *     <ClientOnly>
+ *       <PageInner />
+ *     </ClientOnly>
+ *   );
+ * }
+ * ```
+ *
+ * Implemented with `useSyncExternalStore` (server snapshot `false`, client
+ * snapshot `true`) so the mount flip is hydration-safe without an effect.
+ */
+export function ClientOnly({ children }: { children: ReactNode }): ReactNode {
+  const mounted = useSyncExternalStore(emptySubscribe, getClientSnapshot, getServerSnapshot);
+  return mounted ? children : null;
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -10,6 +10,7 @@
  * subscribers automatically through ElectricSQL replication.
  */
 
+export { ClientOnly } from './client-only.js';
 export type {
   CollabDocumentState,
   KgViewAnnotation,

--- a/packages/sync/src/provider/index.tsx
+++ b/packages/sync/src/provider/index.tsx
@@ -11,7 +11,11 @@ interface ElectricContextValue {
   serviceUrl: string | null;
   /**
    * Base URL prefix for authenticated admin shape proxy routes.
-   * Default '' keeps all hook URLs relative (works for same-origin apps).
+   * The Electric client requires an absolute shape URL (`new URL(url)` with
+   * no base), so this must never be relative at fetch time. When unset, the
+   * provider defaults to `window.location.origin` in the browser; during
+   * server prerender it stays '' — shape-hook components must therefore be
+   * gated behind `ClientOnly` (see `client-only.tsx`).
    * Set to 'https://admin.revealui.com' when consuming from a different origin.
    */
   proxyBaseUrl: string;
@@ -39,7 +43,8 @@ export function ElectricProvider(props: {
   const value = useMemo(
     () => ({
       serviceUrl: props.serviceUrl ?? null,
-      proxyBaseUrl: props.proxyBaseUrl ?? '',
+      proxyBaseUrl:
+        props.proxyBaseUrl ?? (typeof window !== 'undefined' ? window.location.origin : ''),
       debug: props.debug ?? false,
     }),
     [props.serviceUrl, props.proxyBaseUrl, props.debug],


### PR DESCRIPTION
## Problem

Sentry REVEALUI-ADMIN-8: `TypeError: Invalid URL` on `GET /chat` in prod admin.

Electric's `ShapeStream` requires an absolute URL (`new URL(url)` with no base, `constructUrl_fn` in `@electric-sql/client`). The admin app mounts `ElectricProvider` without `proxyBaseUrl` (`apps/admin/src/lib/providers/index.tsx`), so every shape hook built a relative `/api/shapes/*` URL:

- **Browser**: `new URL('/api/shapes/conversations')` throws — the conversations sidebar surfaces "Invalid URL" instead of data.
- **Server prerender**: same throw, unhandled → the Sentry issue on every `/chat` visit. `Shape` subscribes eagerly on construction, so the pipeline starts during SSR.

The provider's own doc comment claimed "Default '' keeps all hook URLs relative (works for same-origin apps)" — that assumption was never true against the Electric client.

## Fix (owning layer: @revealui/sync)

1. `ElectricProvider` defaults `proxyBaseUrl` to `window.location.origin` in the browser; explicit prop still wins. Stale comment corrected.
2. New `ClientOnly` boundary exported from `@revealui/sync` (`useSyncExternalStore` mounted flip — hydration-safe, no effect) so realtime shape surfaces skip server prerender entirely.
3. Gated all five admin shape surfaces: `/chat`, `/knowledge-graph`, `/coordination`, `/marketplace/tasks`, and `AgentContexts` / `AgentMemory` (used on `/agents/[agentId]`).

## Verification

- New tests: `ClientOnly` renders children client-side, renders nothing via `renderToString`, and shields SSR from a throwing (browser-only) child; provider origin default + explicit-prop precedence.
- `@revealui/sync` suite: 20 files / 258 tests green. Admin agents suites: 10/10 green (mocks updated with a `ClientOnly` passthrough). Admin `tsc --noEmit` clean. Pre-push gate: PASS.
- Fleet security checker `--diff origin/test`: no security-sensitive files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)