### PR TITLE
perf(db): partial index for the audit legacy-floor derivation + floor-log throttle (GAP-429 item 4)

### DIFF
--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -13,7 +13,7 @@ import { type AuditEntry, type AuditRowSignerFn, DrizzleAuditStore } from '@reve
 import type { Database } from '@revealui/db/client';
 import { auditAnchors } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createTestDb,
   type TestDb,
@@ -338,6 +338,41 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     expect(result.tenantsSkipped).toBe(1);
     expect(result.errors).toEqual([]);
     expect(await db.select().from(auditAnchors)).toHaveLength(0);
+  });
+
+  it('GAP-429: floor-engaged log fires once per tenant per process (metric every pass)', async () => {
+    // Unique tenant: the throttle Set is module-level, so tenants used by
+    // earlier tests in this file may already be marked as logged.
+    const tenant = 'acct_throttle_only';
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db);
+    await signedStore.append(makeEntry({ id: 'th-s1', tenant }));
+    await unsignedStore.append(makeEntry({ id: 'th-u2', tenant }));
+
+    const { logger } = await import('@revealui/core/observability/logger');
+    const infoSpy = vi.spyOn(logger, 'info');
+    try {
+      const sweepOptions = {
+        db,
+        signer: cryptoSigner,
+        batchSize: 1,
+        canAnchorTenant: async () => true,
+        recordMeter: false,
+        now: () => new Date('2026-07-23T12:00:10.000Z'),
+      };
+      const first = await runAuditAnchorSweep(sweepOptions);
+      const second = await runAuditAnchorSweep(sweepOptions);
+      // Engagement stays observable in the result on EVERY pass...
+      expect(first.tenantsFloorEngaged).toBe(1);
+      expect(second.tenantsFloorEngaged).toBe(1);
+      // ...but the log line fires only once for the tenant.
+      const floorLogs = infoSpy.mock.calls.filter((call) =>
+        String(call[0]).includes(`legacy floor engaged tenant=${tenant}`),
+      );
+      expect(floorLogs).toHaveLength(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 
   it('no-ops without a signer (unsigned mode)', async () => {

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -258,6 +258,11 @@ export async function legacyUnsignedFloor(db: Database, tenant: string): Promise
 
 type TenantOutcome = 'inserted' | 'waiting' | 'skipped';
 
+// GAP-429: a tenant stuck in the no-anchors state (e.g. floor above the entire
+// signed era) re-engages the floor on every poll tick — log once per tenant
+// per process; the counter still increments every pass.
+const floorLoggedTenants = new Set<string>();
+
 async function anchorTenantBatch(
   db: Database,
   signer: Ed25519AuditRowSigner,
@@ -274,9 +279,12 @@ async function anchorTenantBatch(
   const floorEngaged = floor > 0;
   if (floorEngaged) {
     mFloorEngaged.inc();
-    logger.info(
-      `audit-anchor-sweep: legacy floor engaged tenant=${tenant} floor=${floor} — anchors attest seq ${floor + 1} onward`,
-    );
+    if (!floorLoggedTenants.has(tenant)) {
+      floorLoggedTenants.add(tenant);
+      logger.info(
+        `audit-anchor-sweep: legacy floor engaged tenant=${tenant} floor=${floor} — anchors attest seq ${floor + 1} onward`,
+      );
+    }
   }
   const done = (outcome: TenantOutcome) => ({ outcome, floorEngaged });
   const last = anchored > 0 ? anchored : floor;

--- a/packages/db/migrations/0030_gap429_audit_log_unsigned_floor_idx.sql
+++ b/packages/db/migrations/0030_gap429_audit_log_unsigned_floor_idx.sql
@@ -1,0 +1,12 @@
+-- GAP-429 item 4: partial index for the legacy-floor derivation.
+-- legacyUnsignedFloor() (apps/server/src/jobs/audit-anchor-sweep.ts) computes
+-- max(seq) WHERE tenant = $1 AND signature IS NULL on the anchors request path
+-- and on every no-anchor sweep pass. audit_log only indexes tenant alone, so
+-- the healthy no-legacy case scans the tenant's whole row set to return 0.
+-- Unsigned rows are a closed, non-growing era post-enforcement (rails from the
+-- 2026-07-26 promotion), so this index stays tiny. Hand-written for the
+-- IF NOT EXISTS idempotent form (see migrations-discipline.md; same class as
+-- 0008's partial index).
+
+CREATE INDEX IF NOT EXISTS "audit_log_tenant_unsigned_idx"
+  ON "audit_log" ("tenant", "seq") WHERE "signature" IS NULL;

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -86,6 +86,12 @@
       "rationale": "GAP-302 residual (b): DROP COLUMN licenses.npm_username. Column was never written at runtime (perpetual package access is GitHub-team based via github_username + provisionGitHubAccess). Hand-written single-statement DROP COLUMN IF EXISTS for idempotency. Companion Drizzle schema change at packages/db/src/schema/licenses.ts removes the field so types match the DB.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. Schema at licenses.ts already omits npmUsername at the type level."
+    },
+    {
+      "tag": "0030_gap429_audit_log_unsigned_floor_idx",
+      "rationale": "GAP-429 item 4: partial index (tenant, seq) WHERE signature IS NULL supporting legacyUnsignedFloor() on the anchors request path and the no-anchor sweep pass. Hand-written for the CREATE INDEX IF NOT EXISTS idempotent form with a partial-index predicate, following the 0008_jobs_visibility_timeout precedent. Companion Drizzle schema change at packages/db/src/schema/audit-log.ts adds the same index via .where() for type-level modeling.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. A generate attempt from this branch re-emitted the 0028/0029 drift on top of the stale 0027 snapshot, confirming the debt is shared, not new."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1784700000000,
       "tag": "0029_drop_licenses_npm_username",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1785084298662,
+      "tag": "0030_gap429_audit_log_unsigned_floor_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/audit-log.ts
+++ b/packages/db/src/schema/audit-log.ts
@@ -76,6 +76,14 @@ export const auditLog = pgTable(
     index('audit_log_severity_idx').on(table.severity),
     index('audit_log_seq_idx').on(table.seq),
     index('audit_log_tenant_idx').on(table.tenant),
+    // GAP-429: the legacy-floor derivation (max seq WHERE tenant AND signature
+    // IS NULL) runs on the anchors request path and every no-anchor sweep pass.
+    // Without this partial index the healthy no-legacy case scans the tenant's
+    // whole row set to return 0. Unsigned rows are a closed, non-growing era
+    // post-enforcement, so the index stays tiny.
+    index('audit_log_tenant_unsigned_idx')
+      .on(table.tenant, table.seq)
+      .where(sql`${table.signature} IS NULL`),
     check('audit_log_severity_check', sql`severity IN ('info', 'warn', 'critical')`),
   ],
 );


### PR DESCRIPTION
## Summary

Closes out the review residual from #2185: the floor derivation ran unindexed on the anchors request path, and the floor-engaged log repeated every poll tick.

## What changed

- `audit_log` gains `audit_log_tenant_unsigned_idx` ON `(tenant, seq)` WHERE `signature IS NULL`. The healthy no-legacy case previously scanned the tenant's whole row set to return 0 on a no-store endpoint. The unsigned era is closed post-enforcement, so the index stays tiny. The Drizzle schema models the same index via `.where()`.
- Migration `0030` is hand-written idempotent SQL (`CREATE INDEX IF NOT EXISTS` with a partial predicate, following the 0008 precedent) with a `_custom.json` entry. A generate attempt re-emitted the pre-existing 0028/0029 snapshot drift on top of the stale 0027 snapshot, confirming the snapshot debt is shared, not new — noted in the entry.
- The floor-engaged log is throttled to once per tenant per process; the `revealui_audit_anchor_floor_engaged_total` counter and the `tenantsFloorEngaged` result field still report every pass.

## Tests (prove-red)

14/14 sweep tests green. Reverting only the sweep file to `origin/test` fails exactly the new throttle test with `expected [ ...(2) ] to have a length of 1 but got 2` (base logs on both passes). The partial index is exercised by every PGlite schema load in the suite and applied for real by the Drizzle Migrations CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
