### PR TITLE
chore(server): enable the audit anchor sweep on the fly worker (GAP-427 acceptance)

### DIFF
--- a/apps/server/fly.toml
+++ b/apps/server/fly.toml
@@ -24,6 +24,13 @@ primary_region = 'iad'
 [env]
   NODE_ENV = 'production'
   WORKER_PORT = '8080'
+  # GAP-355 Stage 4 / GAP-427: per-tenant Merkle anchor sweep. The worker
+  # boot calls startAuditAnchorSweep(), which no-ops without this flag.
+  # Inserting anchors also requires REVEALUI_AUDIT_SIGNING_KEY (synced from
+  # revvault via scripts/sync/revvault-fly.toml). The legacy floor (merged
+  # 2026-07-26) makes the first prod sweep start above the pre-enforcement
+  # unsigned era instead of gap-stalling.
+  AUDIT_ANCHOR_SWEEP_ENABLED = 'true'
   # REVMARKET_EXECUTOR_ENABLED defaults to OFF. Flip to 'true' when
   # the marketplace UI is ready to accept real customer task
   # submissions. Set via `flyctl secrets set REVMARKET_EXECUTOR_ENABLED=true`


### PR DESCRIPTION
One-line durable config: sets AUDIT_ANCHOR_SWEEP_ENABLED='true' in apps/server/fly.toml [env]. The worker boot already calls startAuditAnchorSweep() and no-ops without the flag; the signing key is already mapped in scripts/sync/revvault-fly.toml. Takes effect only on the next owner-run flyctl deploy, so merging this does not itself activate anything.

With the legacy floor merged, the first prod sweep starts above the pre-enforcement unsigned era; the first inserted anchor (audit_anchors > 0) is the GAP-427 acceptance observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)