### PR TITLE
docs: R2 retirement sweep — Vercel Blob is retired, not retiring

### DIFF
--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -67,7 +67,6 @@ The wizard continues through database, storage, payment, and dev environment set
 @revealui/cli  [4/8] Configure storage
 ? Which storage provider would you like to use?
   > Cloudflare R2 - S3-compatible object storage (recommended)
-    Vercel Blob - legacy, being retired in favor of R2
     Skip - Configure later
 
 @revealui/cli  [5/8] Configure payments

--- a/docs/blog/10-own-your-data.md
+++ b/docs/blog/10-own-your-data.md
@@ -25,7 +25,7 @@ New features are built to stay portable on purpose: the project is mid-migration
 
 ## Object storage you can move
 
-Files, images, and uploads go to Cloudflare R2, which is S3-compatible. That hyphenated word is the whole point. R2 is the canonical backend (the older Vercel Blob integration is legacy and being retired), but the code talks to it through the S3 API, the same API that AWS S3, MinIO, and a dozen other stores speak.
+Files, images, and uploads go to Cloudflare R2, which is S3-compatible. That hyphenated word is the whole point. R2 is the canonical backend (the old Vercel Blob integration was retired), but the code talks to it through the S3 API, the same API that AWS S3, MinIO, and a dozen other stores speak.
 
 So the storage layer passes the same test the database does. Point the S3 credentials at a different provider and your application does not notice. Your media is not trapped behind a vendor SDK with no standard under it. It is objects in a bucket, addressable the way object storage has been addressable for fifteen years.
 

--- a/docs/guides/technology-stack.md
+++ b/docs/guides/technology-stack.md
@@ -24,7 +24,7 @@ RevealUI is a framework, not a stack. The five primitives (people, content, offe
 |---|---|---|
 | **NeonDB** (Postgres) | Primary database — 97 tables across the five primitives | Serverless Postgres; pgvector supported; any standard Postgres works as a substitute (the agnosticism principle is a contract, not a coupling). |
 | **Drizzle ORM** | Schema definition + type-safe queries | Schema-first, accurate types, no runtime overhead, no proprietary query DSL. |
-| **Cloudflare R2** | Canonical object-storage backend | S3-compatible, no egress fees; `@aws-sdk/client-s3` is the client. The legacy Vercel Blob backend is being retired per GAP-208. |
+| **Cloudflare R2** | Canonical object-storage backend | S3-compatible, no egress fees. The legacy Vercel Blob backend was retired. |
 | **ElectricSQL** (optional) | Real-time browser sync layer | Off by default. When enabled, syncs Postgres tables to a local PGlite store in the browser for offline-capable UIs. |
 
 ## Frontend

--- a/docs/security/ASSET_INVENTORY.md
+++ b/docs/security/ASSET_INVENTORY.md
@@ -21,7 +21,7 @@ This inventory covers the RevealUI open-core monorepo (MIT core packages + Fair 
 > **Infrastructure-in-transition note (added 2026-05-29).** Several entries below are mid-migration and their status is **transitional**, not steady-state:
 > - **Supabase (DS-002, TP-006)** is **decommissioned as an internal datastore** per ADR [`2026-05-01-supabase-removal`](https://github.com/RevealUIStudio/revealui/blob/main/docs/decisions/2026-05-01-supabase-removal.md). RAG and vector embeddings now live on NeonDB `pgvector`. Credential offboarding is complete: no `SUPABASE_*` variable is read by the runtime or required by any env validator. Rows below are retained as historical records for the audit trail. The customer Supabase MCP adapter was also removed.
 > - The **ElectricSQL sync host (DS-003, TP-007)** is re-platforming **Railway → Fly.io** (infrastructure ADR dated 2026-05-18). Railway no longer runs an active RevealUI service — the sync capability is out of production service pending the Fly.io re-platform — so "Railway" rows below are historical.
-> - **Storage** is Cloudflare R2 (S3-compatible); the legacy Vercel Blob backend is being retired (GAP-208).
+> - **Storage** is Cloudflare R2 (S3-compatible); the legacy Vercel Blob backend was retired.
 > - **RevealCoin (SVC-007)** was cancelled 2026-05-29 (repo private+archived, keys destroyed).
 >
 > Rows are retained (not deleted) until each migration completes, so the inventory stays a faithful map of what is *currently* deployed. Each migration's completion will flip the corresponding rows.


### PR DESCRIPTION
Docs-only. The storage cutover is complete in code (zero Blob imports, zero deps, no provider file, CLI offers R2 as the sole backend, native SigV4 client since 2026-06-09), but four docs still presented it as in progress: blog 08's CLI transcript listed a Blob option the prompt no longer prints, blog 10 and the tech-stack guide said 'being retired', the asset inventory likewise, and the tech-stack table still named the dropped AWS SDK as the client. All corrected to past tense matching the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)