### PR TITLE
feat(apify): governed-agent-run PPE actor scaffold + signed receipts (GAP-431)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Six principles that give you a tested starting point for every architectural dec
 | Principle | What it means |
 | --- | --- |
 | **Justifiable** | Every default earns its place. No magic, no hidden complexity, no decisions you can't explain to your team. |
-| **Orthogonal** | Clean separation of concerns across 29 packages. Use what you need, replace what you don't. Zero circular dependencies. |
+| **Orthogonal** | Clean separation of concerns across 30 packages. Use what you need, replace what you don't. Zero circular dependencies. |
 | **Sovereign** | Your infrastructure, your data, your rules. Deploy anywhere. Fork anything. No vendor holds your business hostage. |
 | **Hermetic** | Auth doesn't leak into billing. Content doesn't tangle with payments. Sealed boundaries, clean contracts between every layer. |
 | **Unified** | One Zod schema defines the truth. Types, validation, and API flow from database to server to UI with zero drift. |
@@ -278,7 +278,7 @@ revealui/
 │   ├── admin/      # Admin dashboard + content management (port 4000)
 │   ├── docs/       # Documentation site (port 3002)
 │   └── marketing/  # revealui.com marketing site (port 3000)
-├── packages/       # 23 OSS + 5 Pro + 1 internal = 29 packages
+├── packages/       # 23 OSS + 5 Pro + 2 internal = 30 packages
 ├── docs/           # guides + reference
 └── scripts/        # CI gates, release tooling, dev tools
 ```

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -786,7 +786,7 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[3].answer',
-    text: 'Yes. 23 of 29 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
+    text: 'Yes. 23 of 30 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
     evidence: [LICENSE_SPLIT, LICENSE_MIT, SELF_HOST, POSTGRES],
   },
   {
@@ -1053,7 +1053,7 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_TIERS[0].description',
-    text: '23 of 29 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
+    text: '23 of 30 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
     evidence: [LICENSE_SPLIT, NO_TELEMETRY],
   },
   {

--- a/apps/marketing/app/content/fair-source.ts
+++ b/apps/marketing/app/content/fair-source.ts
@@ -1,7 +1,8 @@
 // Sourced from: app/routes/FairSourcePage.tsx (Phase 1 extraction).
 // Hero headline + body math reference the METRICS license split
-// (validator: 23 MIT + 5 FSL + 1 internal = 29 packages). The single internal
-// package is @revealui/scripts (private build tooling, no license field).
+// (validator: 23 MIT + 5 FSL + 2 internal = 30 packages). The internal
+// packages are @revealui/scripts and @revealui/apify-actor-governed-run
+// (both private, no license field).
 // Per the internal marketing-overhaul plan §4.4 + docs/MARKETING_METRICS.md §1.
 // claims-ratchet 2026-07-12: services description scoped to Stripe + email,
 // internal-package identity corrected, MIT-conversion example made version-agnostic.

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -182,7 +182,7 @@ export const HOME_FAQ = {
     {
       question: 'Can I self-host?',
       answer:
-        'Yes. 23 of 29 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
+        'Yes. 23 of 30 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
     },
     {
       question: 'What does "agent-native" actually mean in code?',

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -29,7 +29,7 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
     id: 'free',
     name: 'Free',
     description:
-      '23 of 29 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
+      '23 of 30 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
     features: [
       'Full primitive stack',
       'Admin dashboard + API',

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -1,6 +1,7 @@
 // Sourced from: app/components/landing/Proof.tsx (Phase 1c extraction).
-// Phase 3 (2026-05-18) update: "23 of 29 packages MIT" trust card heading now
-// uses METRICS license split (21 MIT). Pre-Phase-3 audit had off-by-one count.
+// Phase 3 (2026-05-18) update: the "23 of 29 total packages MIT" trust card
+// heading (as it read then) now uses METRICS license split (21 MIT).
+// Pre-Phase-3 audit had off-by-one count.
 // Per the internal marketing-overhaul plan §4.4 + docs/MARKETING_METRICS.md §1.
 //
 // 2026-07-11 (homepage-truth): cut hard on an owner-directed audit. Removed:

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -21,11 +21,11 @@
  */
 export const METRICS = {
   /** Packages in `packages/` directories. Source: claim-drift countPackages. */
-  packages: 29,
+  packages: 30,
   /** Apps in `apps/`. Source: claim-drift countApps. */
   apps: 5,
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
-  workspaces: 34,
+  workspaces: 35,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
   testFiles: 1061,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
@@ -44,8 +44,8 @@ export const METRICS = {
     mit: 23,
     /** Fair Source (FSL-1.1-MIT) packages: @revealui/ai, engines, harnesses, mcp, services. */
     fsl: 5,
-    /** Internal/none: `test` workspace package (private, no public license). */
-    internal: 1,
+    /** Internal/none: `scripts` and `apify-actor-governed-run` (private, no public license). */
+    internal: 2,
   },
 } as const;
 

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -6,7 +6,7 @@
 
 - [Documentation home](https://docs.revealui.com): Architecture, primitives, deployment, agent integration
 - [What works today](https://docs.revealui.com/WHAT_WORKS_TODAY): Honest pre-launch status — what's tested, what's stub, what's not yet wired
-- [Architecture](https://docs.revealui.com/ARCHITECTURE): Five primitives, 4 apps (admin, server, docs, marketing), 29 packages (23 published to npm)
+- [Architecture](https://docs.revealui.com/ARCHITECTURE): Five primitives, 4 apps (admin, server, docs, marketing), 30 packages (23 published to npm)
 - [Meet the Fleet](https://docs.revealui.com/SUITE): Six products that compose **RevFleet**: RevealUI (runtime), RevDev (dev tools), RevVault (secrets), RevCon (configs), **RevealUI Fleet** (self-host runtime kit, deployed via the **RevForge** stamping tool — formerly RevealUI Forge), RevSkills (skills)
 
 ## Getting started

--- a/docs/JOSHUA.md
+++ b/docs/JOSHUA.md
@@ -38,7 +38,7 @@ Every default earns its place. No magic, no hidden complexity, no decisions you 
 Clean separation of concerns. Each package has a single responsibility. No circular dependencies. Use what you need, replace what you don't.
 
 **Evidence:**
-- 29 packages, zero circular deps  -  enforced by Turborepo dependency graph
+- 30 packages, zero circular deps  -  enforced by Turborepo dependency graph
 - `@revealui/auth` knows nothing about billing; `@revealui/db` knows nothing about HTTP
 - `@revealui/contracts` is the only package that every other package may depend on (types + schemas)
 - `@revealui/presentation` has zero external UI dependencies (only clsx + CVA)

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -21,7 +21,7 @@ All gates must pass on the `main` branch before deploy.
 
 - [ ] `pnpm gate` passes all three phases (quality, typecheck, test + build) **(blocking)**
 - [ ] `pnpm lint` reports zero errors (Biome 2) **(blocking)**
-- [ ] `pnpm typecheck:all` clean across all 34 workspaces **(blocking)**
+- [ ] `pnpm typecheck:all` clean across all 35 workspaces **(blocking)**
 - [ ] `pnpm test` passes the full test suite **(blocking)**
 - [ ] `pnpm build` succeeds for all apps and packages **(blocking)**
 - [ ] `pnpm validate:structure` confirms workspace structure integrity **(blocking)**

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -25,9 +25,9 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-22 (
 
 | Metric | Canonical value | Source of truth (script ref) | Notes |
 |---|---|---|---|
-| Packages in `packages/` | **29** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
+| Packages in `packages/` | **30** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
 | Apps in `apps/` | **5** | `countApps()` | admin / server / docs / marketing / license-signer (GAP-260 P4-2). |
-| Workspaces (monorepo total) | **34** | `countWorkspaces()` (= 29 packages + 5 apps) | |
+| Workspaces (monorepo total) | **35** | `countWorkspaces()` (= 30 packages + 5 apps) | |
 | Test files | **1122** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). claim-drift allows site.ts METRICS.testFiles within tolerance 100. |
 | UI components in `packages/presentation/` | **65** | `countUIComponents()` | Marketing copy says "65 native React components" or similar. |
 | **MCP servers** | **13** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); Supabase launcher removed (13 count). |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@ Honest labels for every product in the RevealUI ecosystem. Updated 2026-06-11.
 
 | Product | Maturity | Notes |
 |---------|----------|-------|
-| **RevealUI** (monorepo) | Beta | Deployed, 29 npm packages, extensive test suite. No paying users yet. |
+| **RevealUI** (monorepo) | Beta | Deployed, 30 npm packages, extensive test suite. No paying users yet. |
 | **RevealUI Fleet** (self-hosted) | Beta | Docker stack complete, license enforcement built. No external customers. |
 | **RevVault** (secrets) | Beta | Rust CLI + desktop app, age-encrypted vault. Not published to crates.io. |
 | **Studio** (desktop) | Alpha | Tauri 2 + React 19, agent coordination UI. No published binaries. |
@@ -57,7 +57,7 @@ Alpha = functional, not deployed/published. Planned = design or schema only.
 ### Launch (v0.3.3  -  current)
 
 - **Public repo** on GitHub with MIT license (OSS packages)
-- **29 packages** published to npm
+- **30 packages** published to npm
 - **5 CLI templates** (basic-blog, e-commerce, portfolio, starter, starter-native)  -  4 published as standalone template repos
 - **Production deploys**  -  admin, API, Marketing, Docs on Vercel
 - **Stripe test mode** verified end-to-end (checkout, webhooks, license generation)

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -130,7 +130,7 @@ cd revealui
 pnpm install
 pnpm gate                # Run the full CI gate locally
 pnpm test                # Run the full test suite
-pnpm typecheck:all       # Typecheck all 34 workspaces
+pnpm typecheck:all       # Typecheck all 35 workspaces
 pnpm validate:claims     # Run the marketing/docs claim-drift gate
 ```
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -217,7 +217,7 @@ RevealUI's business primitives (auth, content, collections, the REST API, the ad
 
 The business model is straightforward: the Pro tier (AI agents, the memory system, the MCP framework, open-model orchestration) funds ongoing development. The things that make RevealUI useful for most use cases are free forever. The things that make it powerful for teams that need AI capabilities are commercially licensed but source-available.
 
-To be precise about the split: 23 of the 29 packages are MIT, forever. The five Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, and `@revealui/services`) are Fair Source under FSL-1.1-MIT: source-visible, commercially usable, and they convert to MIT two years after each release. One workspace package is internal build tooling with no public license. MCP integration is a Pro capability today, not a free add-on. I'd rather be honest about where the line sits than blur it. You can read every line of the Pro code on npm; the license key unlocks the features, it doesn't hide the source.
+To be precise about the split: 23 of the 30 packages are MIT, forever. The five Pro packages (`@revealui/ai`, `@revealui/engines`, `@revealui/harnesses`, `@revealui/mcp`, and `@revealui/services`) are Fair Source under FSL-1.1-MIT: source-visible, commercially usable, and they convert to MIT two years after each release. Two workspace packages carry no public license: internal build tooling and an Apify actor scaffold. MCP integration is a Pro capability today, not a free add-on. I'd rather be honest about where the line sits than blur it. You can read every line of the Pro code on npm; the license key unlocks the features, it doesn't hide the source.
 
 ## What makes RevealUI different
 
@@ -229,7 +229,7 @@ This is the part that's genuinely hard to replicate by stitching services togeth
 
 Some numbers on what's actually shipped:
 
-- **34 workspaces** across the monorepo (5 apps, 29 packages with 23 MIT, 5 Fair Source, 1 internal)
+- **35 workspaces** across the monorepo (5 apps, 30 packages with 23 MIT, 5 Fair Source, 2 internal)
 - **97 database tables** via Drizzle ORM on NeonDB (Postgres)
 - **65 UI components** in `@revealui/presentation`, with one third-party runtime dependency (`tailwind-merge`), built directly on Tailwind v4 and React, with `cva` and `cn` vendored in-package
 - **13 first-party MCP servers** in `@revealui/mcp`

--- a/docs/blog/14-claim-drift.md
+++ b/docs/blog/14-claim-drift.md
@@ -47,7 +47,7 @@ claim-drift: docs/blog/09-component-library.md
   -> fix the copy or fix the count, but they must agree
 ```
 
-That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 29 packages, 65 UI components, 13 first-party MCP servers, 97 database tables, 60 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
+That hard failure is the whole point. The numbers you read here are not a snapshot someone updated when they remembered. They are a measurement of the code as it exists right now: 30 packages, 65 UI components, 13 first-party MCP servers, 97 database tables, 60 access-control enforcement tests, 5 starter templates. Each one is checked on the commit that publishes it.
 
 ## The validator practices what we preach
 

--- a/docs/guides/technology-stack.md
+++ b/docs/guides/technology-stack.md
@@ -79,9 +79,9 @@ The runtime is provider-agnostic by contract and ships with no default AI vendor
 
 ## License posture
 
-- **23 of 29 packages MIT-licensed** (forever).
-- **5 of 29 packages Fair Source (FSL-1.1-MIT)** — source-visible, non-compete; convert to MIT 2 years after each release.
-- **1 of 29 packages internal** (`@revealui/scripts`) — unlicensed build tooling.
+- **23 of 30 packages MIT-licensed** (forever).
+- **5 of 30 packages Fair Source (FSL-1.1-MIT)** — source-visible, non-compete; convert to MIT 2 years after each release.
+- **2 of 30 packages internal** (`@revealui/scripts`, `@revealui/apify-actor-governed-run`) — unlicensed, unpublished.
 
 See [FAIR_SOURCE.md](../FAIR_SOURCE.md) for the licensing rationale.
 

--- a/docs/security/INFORMATION_SECURITY_POLICY.md
+++ b/docs/security/INFORMATION_SECURITY_POLICY.md
@@ -132,7 +132,7 @@ RevealUI does not store credit card numbers or payment method details. All payme
 All changes pass through the CI gate before reaching `test` or `main`:
 
 1. **Quality** (parallel): Biome lint (hard fail), security audits (warn), structure checks (warn)
-2. **Type checking** (serial): TypeScript strict mode across all 34 workspaces
+2. **Type checking** (serial): TypeScript strict mode across all 35 workspaces
 3. **Test + Build** (parallel): Vitest (full suite, hard fail), Turborepo build verification
 
 ### Branch Pipeline

--- a/packages/apify-actor-governed-run/.actor/actor.json
+++ b/packages/apify-actor-governed-run/.actor/actor.json
@@ -1,0 +1,13 @@
+{
+  "actorSpecification": 1,
+  "name": "governed-agent-run",
+  "title": "Governed Agent Run",
+  "description": "Run an AI agent task and get back a cryptographically signed, offline-verifiable receipt of every action it took. If an agent did it, there's a receipt.",
+  "version": "0.1",
+  "buildTag": "latest",
+  "dockerfile": "../Dockerfile",
+  "readme": "../README.md",
+  "input": "./input_schema.json",
+  "minMemoryMbytes": 256,
+  "maxMemoryMbytes": 1024
+}

--- a/packages/apify-actor-governed-run/.actor/input_schema.json
+++ b/packages/apify-actor-governed-run/.actor/input_schema.json
@@ -1,0 +1,65 @@
+{
+  "title": "Governed Agent Run input",
+  "type": "object",
+  "schemaVersion": 1,
+  "properties": {
+    "mode": {
+      "title": "Mode",
+      "type": "string",
+      "description": "\"run-task\" executes an agent task and returns a signed receipt. \"verify-receipt\" checks a receipt you already have (free).",
+      "editor": "select",
+      "enum": ["run-task", "verify-receipt"],
+      "enumTitles": ["Run a governed task", "Verify a receipt"],
+      "default": "run-task"
+    },
+    "task": {
+      "title": "Task",
+      "type": "string",
+      "description": "The task prompt for the agent to complete. Required when mode is \"run-task\".",
+      "editor": "textarea"
+    },
+    "llmProvider": {
+      "title": "LLM provider",
+      "type": "string",
+      "description": "Which model provider to call. Required when mode is \"run-task\".",
+      "editor": "select",
+      "enum": ["anthropic", "openai"],
+      "enumTitles": ["Anthropic", "OpenAI"]
+    },
+    "llmApiKey": {
+      "title": "LLM API key",
+      "type": "string",
+      "description": "Your own API key for the selected provider (bring-your-own-key). Never stored or logged. Required when mode is \"run-task\".",
+      "editor": "textfield",
+      "isSecret": true
+    },
+    "model": {
+      "title": "Model (optional)",
+      "type": "string",
+      "description": "Override the default model for the selected provider.",
+      "editor": "textfield"
+    },
+    "toolAllowlist": {
+      "title": "Tool allowlist (optional)",
+      "type": "array",
+      "description": "Restrict which built-in tools the agent may use. Omit to allow all built-in tools; pass an empty list to disable tools entirely.",
+      "editor": "stringList",
+      "items": { "type": "string" }
+    },
+    "maxSteps": {
+      "title": "Max steps (optional)",
+      "type": "integer",
+      "description": "Maximum model/tool-call round trips before the run stops itself. Default 10.",
+      "editor": "number",
+      "minimum": 1,
+      "maximum": 50
+    },
+    "receipt": {
+      "title": "Receipt to verify",
+      "type": "object",
+      "description": "A receipt object previously returned by a \"run-task\" run. Required when mode is \"verify-receipt\".",
+      "editor": "json"
+    }
+  },
+  "required": []
+}

--- a/packages/apify-actor-governed-run/Dockerfile
+++ b/packages/apify-actor-governed-run/Dockerfile
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage pnpm-workspace build, mirroring the fleet's proven pattern in
+# apps/server/Dockerfile (monorepo-context build + `pnpm deploy` for a
+# self-contained runtime dir). This actor is a workspace package
+# (packages/apify-actor-governed-run) that depends on two other workspace
+# packages (@revealui/ai, @revealui/security), so the build needs the
+# monorepo context rather than Apify's standalone `apify/actor-node` base --
+# Apify supports an arbitrary custom Dockerfile via .actor/actor.json's
+# `dockerfile` field, which is what this is.
+#
+# NOT YET SMOKE-TESTED against a live `apify run` / Apify build system --
+# verify with the Apify CLI before Store submission (see README.md).
+
+FROM node:24-alpine AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+WORKDIR /app
+
+# Dependencies stage
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY .npmrc* ./
+
+# Workspace package.json files needed by the actor's dependency graph
+COPY packages/ai/package.json ./packages/ai/
+COPY packages/security/package.json ./packages/security/
+COPY packages/contracts/package.json ./packages/contracts/
+COPY packages/core/package.json ./packages/core/
+COPY packages/db/package.json ./packages/db/
+COPY packages/dev/package.json ./packages/dev/
+COPY packages/resilience/package.json ./packages/resilience/
+COPY packages/utils/package.json ./packages/utils/
+COPY packages/apify-actor-governed-run/package.json ./packages/apify-actor-governed-run/
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @revealui/apify-actor-governed-run...
+
+# Builder stage
+FROM base AS builder
+COPY --from=deps /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/.npmrc ./
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages ./packages
+
+COPY turbo.json ./
+COPY tsconfig.json ./
+COPY packages ./packages
+
+ENV NODE_ENV=production
+
+RUN pnpm turbo run build --filter=@revealui/apify-actor-governed-run...
+
+# Self-contained deploy dir with only production deps (pnpm deploy flattens
+# the hoisted workspace packages into a flat node_modules)
+RUN pnpm --filter @revealui/apify-actor-governed-run deploy /app/actor-deploy --prod --legacy
+
+# Runner stage -- minimal image with only the built bundle
+FROM node:24-alpine AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 apify && \
+    adduser --system --uid 1001 actor
+
+COPY --from=builder /app/packages/apify-actor-governed-run/dist ./dist
+COPY --from=builder /app/actor-deploy/package.json ./
+COPY --from=builder /app/actor-deploy/node_modules ./node_modules
+
+RUN chown -R actor:apify /app
+USER actor
+
+CMD ["node", "dist/main.js"]

--- a/packages/apify-actor-governed-run/README.md
+++ b/packages/apify-actor-governed-run/README.md
@@ -1,0 +1,130 @@
+# Governed Agent Run
+
+If an agent did it, there's a receipt.
+
+This actor runs an AI agent task for you and hands back both the result and a
+cryptographically signed, offline-verifiable receipt of every action the
+agent took: every model call and every tool call, in order, with a signature
+you can check without ever talking to us again.
+
+## What you get
+
+- **A completed task.** Give the actor a task and your own LLM API key
+  (Anthropic or OpenAI), and it runs an agent loop until the task is done or
+  it hits a step limit.
+- **A signed receipt.** Every model call and tool call is recorded into an
+  action log, and the whole log is signed with a fresh Ed25519 key generated
+  for that run. The public key travels with the receipt, so anyone can verify
+  it offline with nothing but the receipt itself.
+- **A free way to check any receipt.** Run this actor again in
+  "verify-receipt" mode with a receipt you already have, and it tells you
+  whether the signature is valid. This mode is free.
+
+What the receipt is: a cryptographically signed and offline-verifiable record
+of the actions an agent took. What it is not: a compliance certification of
+any kind. This actor makes no SOC 2, ISO, or other compliance claim.
+
+## Input
+
+| Field | Required | Description |
+|---|---|---|
+| `mode` | No (default `run-task`) | `run-task` or `verify-receipt` |
+| `task` | Yes, for `run-task` | The task prompt for the agent |
+| `llmProvider` | Yes, for `run-task` | `anthropic` or `openai` |
+| `llmApiKey` | Yes, for `run-task` | Your own API key (bring-your-own-key; never stored or logged) |
+| `model` | No | Override the provider's default model |
+| `toolAllowlist` | No | Restrict which built-in tools the agent may use; omit for all, `[]` for none |
+| `maxSteps` | No (default 10) | Maximum model/tool-call round trips |
+| `receipt` | Yes, for `verify-receipt` | A receipt object from a prior `run-task` run |
+
+## Why bring your own API key
+
+This actor charges per governed action and per completed run, not per model
+token. Bringing your own LLM key means our price never has to cover model
+costs on top of that, and you keep full control of and visibility into your
+own model spend.
+
+## Pricing (pay per event)
+
+Apify's pay-per-event pricing is configured in the Apify Console or via the
+`PUT /v2/acts/{actorId}` API, not in a file inside this repo -- there is no
+`pricingInfos` field in `.actor/actor.json` (verified against
+[docs.apify.com](https://docs.apify.com/platform/actors/development/actor-definition/actor-json),
+July 2026). [`src/pricing.config.ts`](./src/pricing.config.ts) is this
+repo's single source of truth for the event catalog; whoever applies pricing
+in Console/API must register the same event names with these prices.
+
+**Launch prices, owner-ruled 2026-07-26** (value-anchored; will be recorded in
+`business/offerings-canonical.md` in the internal coordination repo once this
+actor is adopted/published):
+
+| Event | Price | Charged when |
+|---|---|---|
+| `governed-action` | $0.02 | Once per model call or tool call recorded into the action log |
+| `run-completed` | $0.08 | Once when a governed run finishes and a signed receipt is produced |
+| `receipt-verification` | $0.00 (free) | Once per `verify-receipt` invocation |
+
+To change a price, edit `src/pricing.config.ts` and re-apply it to Apify --
+the code that calls `Actor.charge({ eventName })` never has to change for a
+price-only adjustment. Example `PUT` body shape (see
+[Update Actor | API](https://docs.apify.com/api/v2/act-put)):
+
+```json
+{
+  "pricingInfos": [
+    {
+      "pricingModel": "PAY_PER_EVENT",
+      "pricingPerEvent": {
+        "actorChargeEvents": {
+          "governed-action": { "eventTitle": "Governed action", "eventPriceUsd": 0.02 },
+          "run-completed": { "eventTitle": "Governed run completed", "eventPriceUsd": 0.08 },
+          "receipt-verification": { "eventTitle": "Receipt verification", "eventPriceUsd": 0.0 }
+        }
+      }
+    }
+  ]
+}
+```
+
+## How the receipt works
+
+1. Every model call and tool call the agent makes is appended to an action
+   log, in order, along with a final entry recording the run's output.
+2. The action log is canonicalized with RFC 8785 JSON Canonicalization (the
+   same canonicalizer RevealUI's own internal audit log uses, so the byte
+   representation is deterministic regardless of key order) and signed with a
+   fresh Ed25519 keypair generated for that run.
+3. The receipt embeds the action log, the signature, the public key, the
+   algorithm, and a timestamp. Nothing about verifying it depends on
+   RevealUI's infrastructure or on this actor still existing.
+
+```ts
+import { verifyReceipt } from '@revealui/apify-actor-governed-run';
+
+const result = verifyReceipt(receipt); // { valid: boolean, reason?: string }
+```
+
+## Known limitations (v0.1)
+
+- The built-in tool catalog has exactly one tool (`web_fetch`, a bounded
+  HTTP(S) fetch). It refuses obvious private/loopback/cloud-metadata hosts
+  and does not follow redirects, but it is not a complete SSRF defense (no
+  DNS-rebinding protection). Expanding the tool catalog is future work.
+- The Dockerfile has not been smoke-tested against a live `apify run` or the
+  Apify build system. Run `apify run` locally and `apify push` to a test
+  actor before Store submission.
+- This PR is review-pending under the fleet's guardrail-2 security review
+  gate (the receipt-signing code touches a security-sensitive surface). See
+  the PR body.
+
+## Development
+
+```bash
+pnpm --filter @revealui/apify-actor-governed-run typecheck
+pnpm --filter @revealui/apify-actor-governed-run test
+pnpm turbo run build --filter=@revealui/apify-actor-governed-run...
+```
+
+## License
+
+Internal, unpublished. Ships to the Apify Store as a Docker image, not to npm.

--- a/packages/apify-actor-governed-run/README.md
+++ b/packages/apify-actor-governed-run/README.md
@@ -46,13 +46,13 @@ own model spend.
 
 ## Pricing (pay per event)
 
-Apify's pay-per-event pricing is configured in the Apify Console or via the
-`PUT /v2/acts/{actorId}` API, not in a file inside this repo -- there is no
-`pricingInfos` field in `.actor/actor.json` (verified against
-[docs.apify.com](https://docs.apify.com/platform/actors/development/actor-definition/actor-json),
-July 2026). [`src/pricing.config.ts`](./src/pricing.config.ts) is this
-repo's single source of truth for the event catalog; whoever applies pricing
-in Console/API must register the same event names with these prices.
+See https://docs.apify.com/platform/actors/development/actor-definition/actor-json
+(verified July 2026): there is no `pricingInfos` field in `.actor/actor.json`.
+Apify's pay-per-event prices are set through the Apify Console or through a
+`PUT /v2/acts/{actorId}` API call instead, not through a file in this repo.
+[`src/pricing.config.ts`](./src/pricing.config.ts) is this repo's single
+source of truth for the event catalog; whoever applies pricing in
+Console/API must register the same event names with these prices.
 
 **Launch prices, owner-ruled 2026-07-26** (value-anchored; will be recorded in
 `business/offerings-canonical.md` in the internal coordination repo once this

--- a/packages/apify-actor-governed-run/package.json
+++ b/packages/apify-actor-governed-run/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@revealui/apify-actor-governed-run",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Apify pay-per-event actor: runs an AI agent task and returns a cryptographically signed, offline-verifiable receipt of every action (GAP-431).",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@revealui/ai": "workspace:*",
+    "@revealui/security": "workspace:*",
+    "apify": "^3.7.2",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@revealui/dev": "workspace:*",
+    "@types/node": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24.13.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "dev": "tsx src/main.ts",
+    "lint": "biome check .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/apify-actor-governed-run/package.json
+++ b/packages/apify-actor-governed-run/package.json
@@ -8,10 +8,12 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@revealui/ai": "workspace:*",
     "@revealui/security": "workspace:*",
     "apify": "^3.7.2",
     "zod": "catalog:"
+  },
+  "optionalDependencies": {
+    "@revealui/ai": "workspace:^"
   },
   "devDependencies": {
     "@revealui/dev": "workspace:*",

--- a/packages/apify-actor-governed-run/src/__tests__/input-validation.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/input-validation.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { parseActorInput } from '../types.js';
+
+describe('parseActorInput', () => {
+  it('accepts a valid run-task input and defaults mode', () => {
+    const input = parseActorInput({
+      task: 'summarize https://example.com',
+      llmProvider: 'anthropic',
+      llmApiKey: 'sk-test-key',
+    });
+    expect(input.mode).toBe('run-task');
+    if (input.mode === 'run-task') {
+      expect(input.task).toBe('summarize https://example.com');
+      expect(input.llmProvider).toBe('anthropic');
+    }
+  });
+
+  it('accepts an explicit run-task input with all optional fields', () => {
+    const input = parseActorInput({
+      mode: 'run-task',
+      task: 'do the thing',
+      llmProvider: 'openai',
+      llmApiKey: 'sk-test-key',
+      model: 'gpt-5',
+      toolAllowlist: ['web_fetch'],
+      maxSteps: 5,
+    });
+    expect(input.mode).toBe('run-task');
+  });
+
+  it('accepts a valid verify-receipt input', () => {
+    const input = parseActorInput({
+      mode: 'verify-receipt',
+      receipt: {
+        actionLog: [],
+        signature: 'x',
+        publicKey: 'y',
+        algorithm: 'ed25519',
+        timestamp: 'z',
+      },
+    });
+    expect(input.mode).toBe('verify-receipt');
+  });
+
+  it('rejects run-task input missing task', () => {
+    expect(() => parseActorInput({ llmProvider: 'anthropic', llmApiKey: 'sk-test' })).toThrow(
+      /invalid actor input/,
+    );
+  });
+
+  it('rejects run-task input missing llmApiKey', () => {
+    expect(() => parseActorInput({ task: 'x', llmProvider: 'anthropic' })).toThrow(
+      /invalid actor input/,
+    );
+  });
+
+  it('rejects run-task input with an unsupported provider', () => {
+    expect(() =>
+      parseActorInput({ task: 'x', llmProvider: 'gemini', llmApiKey: 'sk-test' }),
+    ).toThrow(/invalid actor input/);
+  });
+
+  it('rejects an empty task string', () => {
+    expect(() =>
+      parseActorInput({ task: '', llmProvider: 'anthropic', llmApiKey: 'sk-test' }),
+    ).toThrow(/invalid actor input/);
+  });
+
+  it('rejects maxSteps above the ceiling', () => {
+    expect(() =>
+      parseActorInput({
+        task: 'x',
+        llmProvider: 'anthropic',
+        llmApiKey: 'sk-test',
+        maxSteps: 51,
+      }),
+    ).toThrow(/invalid actor input/);
+  });
+
+  it('rejects verify-receipt input missing receipt', () => {
+    expect(() => parseActorInput({ mode: 'verify-receipt' })).toThrow(/invalid actor input/);
+  });
+
+  it('rejects completely empty input', () => {
+    expect(() => parseActorInput({})).toThrow(/invalid actor input/);
+  });
+
+  it('rejects null input', () => {
+    expect(() => parseActorInput(null)).toThrow(/invalid actor input/);
+  });
+});

--- a/packages/apify-actor-governed-run/src/__tests__/pricing-config.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/pricing-config.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { CHARGEABLE_EVENTS } from '../pricing.config.js';
+
+// Pins the owner-ruled 2026-07-26 launch prices (GAP-431). If this test needs
+// to change, a price actually changed -- update business/offerings-canonical.md
+// in the coordination repo in the same change, per README.md.
+describe('CHARGEABLE_EVENTS', () => {
+  it('matches the owner-ruled launch prices', () => {
+    expect(CHARGEABLE_EVENTS.governedAction).toMatchObject({
+      name: 'governed-action',
+      priceUsd: 0.02,
+    });
+    expect(CHARGEABLE_EVENTS.runCompleted).toMatchObject({ name: 'run-completed', priceUsd: 0.08 });
+    expect(CHARGEABLE_EVENTS.receiptVerification).toMatchObject({
+      name: 'receipt-verification',
+      priceUsd: 0,
+    });
+  });
+
+  it('has a unique event name per entry', () => {
+    const names = Object.values(CHARGEABLE_EVENTS).map((event) => event.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/packages/apify-actor-governed-run/src/__tests__/receipt-roundtrip.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/receipt-roundtrip.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { signActionLog } from '../receipt/sign.js';
+import { verifyReceipt } from '../receipt/verify.js';
+import type { ActionLogEntry } from '../types.js';
+
+const sampleActionLog: ActionLogEntry[] = [
+  {
+    index: 0,
+    type: 'model_call',
+    timestamp: '2026-07-26T00:00:00.000Z',
+    detail: { content: 'thinking...', finishReason: 'tool_calls' },
+  },
+  {
+    index: 1,
+    type: 'tool_call',
+    timestamp: '2026-07-26T00:00:01.000Z',
+    detail: { toolName: 'web_fetch', params: { url: 'https://example.com' }, success: true },
+  },
+  {
+    index: 2,
+    type: 'final_output',
+    timestamp: '2026-07-26T00:00:02.000Z',
+    detail: { output: 'done', stopReason: 'completed' },
+  },
+];
+
+describe('signActionLog / verifyReceipt roundtrip', () => {
+  it('signs an action log and verifies it as valid', () => {
+    const receipt = signActionLog(sampleActionLog);
+
+    expect(receipt.algorithm).toBe('ed25519');
+    expect(receipt.actionLog).toEqual(sampleActionLog);
+    expect(receipt.signature).toMatch(/^v1\.ed25519\.[0-9a-f-]+\.[A-Za-z0-9_-]+$/);
+    expect(receipt.publicKey).toContain('BEGIN PUBLIC KEY');
+
+    const result = verifyReceipt(receipt);
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('produces a different keypair (and signature) per run', () => {
+    const first = signActionLog(sampleActionLog);
+    const second = signActionLog(sampleActionLog);
+
+    expect(first.publicKey).not.toBe(second.publicKey);
+    expect(first.signature).not.toBe(second.signature);
+    expect(verifyReceipt(first).valid).toBe(true);
+    expect(verifyReceipt(second).valid).toBe(true);
+  });
+
+  it('verifies an empty action log', () => {
+    const receipt = signActionLog([]);
+    expect(verifyReceipt(receipt)).toEqual({ valid: true });
+  });
+});

--- a/packages/apify-actor-governed-run/src/__tests__/receipt-tamper.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/receipt-tamper.test.ts
@@ -1,0 +1,69 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { signActionLog } from '../receipt/sign.js';
+import { verifyReceipt } from '../receipt/verify.js';
+import type { ActionLogEntry, Receipt } from '../types.js';
+
+const baseActionLog: ActionLogEntry[] = [
+  {
+    index: 0,
+    type: 'model_call',
+    timestamp: '2026-07-26T00:00:00.000Z',
+    detail: { content: 'the original answer' },
+  },
+];
+
+describe('verifyReceipt rejects tampered receipts (prove red)', () => {
+  it('rejects a receipt whose action log was modified after signing', () => {
+    const receipt = signActionLog(baseActionLog);
+
+    const tampered: Receipt = {
+      ...receipt,
+      actionLog: [{ ...receipt.actionLog[0]!, detail: { content: 'a forged answer' } }],
+    };
+
+    const result = verifyReceipt(tampered);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBeTruthy();
+  });
+
+  it('rejects a receipt whose timestamp was modified after signing', () => {
+    const receipt = signActionLog(baseActionLog);
+    const tampered: Receipt = { ...receipt, timestamp: '2099-01-01T00:00:00.000Z' };
+
+    expect(verifyReceipt(tampered).valid).toBe(false);
+  });
+
+  it('rejects a receipt with a substituted signature from a different keypair', () => {
+    const receiptA = signActionLog(baseActionLog);
+    const receiptB = signActionLog(baseActionLog);
+
+    const forged: Receipt = { ...receiptA, signature: receiptB.signature };
+    expect(verifyReceipt(forged).valid).toBe(false);
+  });
+
+  it('rejects a receipt whose public key does not match the signature kid', () => {
+    const receipt = signActionLog(baseActionLog);
+    const { publicKey: unrelatedPublicKey } = generateKeyPairSync('ed25519', {
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    });
+
+    const forged: Receipt = { ...receipt, publicKey: unrelatedPublicKey };
+    const result = verifyReceipt(forged);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/key id/);
+  });
+
+  it('rejects a structurally malformed receipt', () => {
+    expect(verifyReceipt({ not: 'a receipt' }).valid).toBe(false);
+    expect(verifyReceipt(null).valid).toBe(false);
+    expect(verifyReceipt(undefined).valid).toBe(false);
+  });
+
+  it('rejects an unrecognized signature format', () => {
+    const receipt = signActionLog(baseActionLog);
+    const forged: Receipt = { ...receipt, signature: 'not-a-real-signature' };
+    expect(verifyReceipt(forged).valid).toBe(false);
+  });
+});

--- a/packages/apify-actor-governed-run/src/__tests__/run-governed-task.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/run-governed-task.test.ts
@@ -1,0 +1,136 @@
+import type { LLMResponse, Tool } from '@revealui/ai';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { runGovernedTask } from '../agent/run-governed-task.js';
+
+const echoTool: Tool = {
+  name: 'echo',
+  description: 'Echo back the given text',
+  parameters: z.object({ text: z.string() }),
+  async execute(params: unknown) {
+    const { text } = params as { text: string };
+    return { success: true, content: text };
+  },
+};
+
+function response(overrides: Partial<LLMResponse>): LLMResponse {
+  return { content: '', role: 'assistant', ...overrides };
+}
+
+describe('runGovernedTask', () => {
+  it('records a model call and stops when the model returns no tool calls', async () => {
+    const chat = vi.fn().mockResolvedValue(response({ content: 'the final answer' }));
+    const chargeAction = vi.fn().mockResolvedValue(true);
+
+    const result = await runGovernedTask({ task: 'say hi', tools: [], chat, chargeAction });
+
+    expect(result.output).toBe('the final answer');
+    expect(result.stopReason).toBe('completed');
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(chargeAction).toHaveBeenCalledTimes(1);
+    expect(result.actionLog.map((entry) => entry.type)).toEqual(['model_call', 'final_output']);
+  });
+
+  it('records an interleaved model call + tool call, then the final answer', async () => {
+    const chat = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          content: '',
+          toolCalls: [
+            {
+              id: 'call-1',
+              type: 'function',
+              function: { name: 'echo', arguments: '{"text":"hi"}' },
+            },
+          ],
+          finishReason: 'tool_calls',
+        }),
+      )
+      .mockResolvedValueOnce(response({ content: 'done: hi' }));
+    const chargeAction = vi.fn().mockResolvedValue(true);
+
+    const result = await runGovernedTask({
+      task: 'echo hi',
+      tools: [echoTool],
+      chat,
+      chargeAction,
+    });
+
+    expect(result.output).toBe('done: hi');
+    expect(result.stopReason).toBe('completed');
+    expect(result.actionLog.map((entry) => entry.type)).toEqual([
+      'model_call',
+      'tool_call',
+      'model_call',
+      'final_output',
+    ]);
+    expect(chargeAction).toHaveBeenCalledTimes(3); // model, tool, model
+  });
+
+  it('records an error entry for an unknown tool without calling execute', async () => {
+    const chat = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          toolCalls: [
+            { id: 'call-1', type: 'function', function: { name: 'nonexistent', arguments: '{}' } },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(response({ content: 'ok' }));
+    const chargeAction = vi.fn().mockResolvedValue(true);
+
+    const result = await runGovernedTask({ task: 'x', tools: [], chat, chargeAction });
+
+    const toolEntry = result.actionLog.find((entry) => entry.type === 'tool_call');
+    expect(toolEntry?.detail.success).toBe(false);
+    expect(String(toolEntry?.detail.error)).toMatch(/unknown or disallowed tool/);
+  });
+
+  it('stops with charge-limit when the budget is exhausted before a model call', async () => {
+    const chat = vi.fn();
+    const chargeAction = vi.fn().mockResolvedValue(false);
+
+    const result = await runGovernedTask({ task: 'x', tools: [], chat, chargeAction });
+
+    expect(result.stopReason).toBe('charge-limit');
+    expect(chat).not.toHaveBeenCalled();
+    expect(result.output).toMatch(/charge budget/);
+  });
+
+  it('stops with max-steps when the loop never returns a final answer', async () => {
+    const chat = vi.fn().mockResolvedValue(
+      response({
+        toolCalls: [
+          { id: 'call-1', type: 'function', function: { name: 'echo', arguments: '{"text":"x"}' } },
+        ],
+      }),
+    );
+    const chargeAction = vi.fn().mockResolvedValue(true);
+
+    const result = await runGovernedTask({
+      task: 'x',
+      tools: [echoTool],
+      maxSteps: 2,
+      chat,
+      chargeAction,
+    });
+
+    expect(result.stopReason).toBe('max-steps');
+    expect(chat).toHaveBeenCalledTimes(2);
+  });
+
+  it('never records an undefined value inside an action log detail (canonicalization safety)', async () => {
+    const chat = vi.fn().mockResolvedValue(response({ content: 'ok', finishReason: 'stop' }));
+    const chargeAction = vi.fn().mockResolvedValue(true);
+
+    const result = await runGovernedTask({ task: 'x', tools: [], chat, chargeAction });
+
+    for (const entry of result.actionLog) {
+      for (const value of Object.values(entry.detail)) {
+        expect(value).not.toBeUndefined();
+      }
+    }
+  });
+});

--- a/packages/apify-actor-governed-run/src/__tests__/tools.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/tools.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { BUILT_IN_TOOLS, selectTools, webFetchTool } from '../agent/tools.js';
+
+describe('selectTools', () => {
+  it('returns all built-in tools when no allowlist is given', () => {
+    expect(selectTools(undefined)).toEqual(BUILT_IN_TOOLS);
+  });
+
+  it('returns no tools for an empty allowlist', () => {
+    expect(selectTools([])).toEqual([]);
+  });
+
+  it('filters to only the allowed tool names', () => {
+    expect(selectTools(['web_fetch']).map((t) => t.name)).toEqual(['web_fetch']);
+    expect(selectTools(['nonexistent'])).toEqual([]);
+  });
+});
+
+describe('webFetchTool', () => {
+  it('rejects an invalid URL', async () => {
+    const result = await webFetchTool.execute({ url: 'not-a-url' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-http(s) protocol', async () => {
+    const result = await webFetchTool.execute({ url: 'file:///etc/passwd' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/http\/https/);
+  });
+
+  it('rejects loopback hosts', async () => {
+    const result = await webFetchTool.execute({ url: 'http://127.0.0.1/secret' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not allowed/);
+  });
+
+  it('rejects the cloud metadata endpoint', async () => {
+    const result = await webFetchTool.execute({ url: 'http://169.254.169.254/latest/meta-data/' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not allowed/);
+  });
+
+  it('rejects private RFC1918 ranges', async () => {
+    for (const url of ['http://10.0.0.5/', 'http://192.168.1.1/', 'http://172.16.0.1/']) {
+      const result = await webFetchTool.execute({ url });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not allowed/);
+    }
+  });
+
+  it('rejects malformed params', async () => {
+    const result = await webFetchTool.execute({ notUrl: 'nope' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invalid params/);
+  });
+});

--- a/packages/apify-actor-governed-run/src/agent/run-governed-task.ts
+++ b/packages/apify-actor-governed-run/src/agent/run-governed-task.ts
@@ -1,0 +1,200 @@
+import type { LLMChatOptions, LLMResponse, Message, Tool, ToolDefinition } from '@revealui/ai';
+import { toJSONSchema } from 'zod/v4';
+import type { ActionLogEntry } from '../types.js';
+
+export const DEFAULT_MAX_STEPS = 10;
+
+const SYSTEM_PROMPT =
+  'You are a governed agent. Every model call and tool call you make is recorded ' +
+  'into a signed, offline-verifiable receipt. Complete the task directly and concisely. ' +
+  'When you have a final answer, respond with plain text and no further tool calls.';
+
+/** Why a run stopped, recorded in the final output so a receipt reader can
+ * tell a clean finish from a budget/step ceiling. */
+export type RunStopReason = 'completed' | 'charge-limit' | 'max-steps';
+
+export interface RunGovernedTaskDeps {
+  task: string;
+  tools: Tool[];
+  maxSteps?: number;
+  /** Sends messages to the LLM. Injected so tests never touch the network. */
+  chat: (messages: Message[], options?: LLMChatOptions) => Promise<LLMResponse>;
+  /** Called before each governed action (model call or tool call). Returns
+   * `false` when the run's charge budget is exhausted and execution must stop
+   * before doing the (billable) work. */
+  chargeAction: () => Promise<boolean>;
+}
+
+export interface RunGovernedTaskResult {
+  output: string;
+  actionLog: ActionLogEntry[];
+  stopReason: RunStopReason;
+}
+
+function toolToDefinition(tool: Tool): ToolDefinition {
+  return {
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      // Tool.parameters is a Zod schema; providers need JSON Schema-shaped
+      // params. zod/v4 ships a native converter (toJSONSchema) -- no second
+      // schema-conversion dependency needed.
+      parameters: toJSONSchema(tool.parameters) as Record<string, unknown>,
+    },
+  };
+}
+
+/** Strip `undefined` values (recursively, one level is enough for our shapes)
+ * so a record is safe to canonicalize with `canonicalizeJcs`, which throws on
+ * `undefined` anywhere in the tree (see receipt/signable.ts). */
+function definedOnly(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Run a governed agent task, recording every model call and tool call into an
+ * ordered action log.
+ *
+ * This is a dedicated, minimal tool-calling loop rather than a wrapper around
+ * `@revealui/ai`'s `AgentRuntime.executeTask()`. `AgentRuntime` is a complete,
+ * exported, production loop (packages/ai/src/orchestration/runtime.ts) -- but
+ * its `AgentResult` return shape (packages/ai/src/orchestration/agent.ts:46-56)
+ * is `{ success, output?, toolResults?, error?, metadata? }`: an aggregate
+ * summary, not an ordered per-call trail. Its only instrumentation hooks
+ * (`RuntimeConfig.onToolAudit` and `approvalCallback`, runtime.ts:76-96) fire
+ * for MCP-discovered tools and approval gates respectively, not for every
+ * model call. Deriving a complete, ordered action log -- this product's core
+ * value proposition -- from that black box after the fact would be lossy. So
+ * this loop reuses the genuinely reusable pieces (`LLMClient`/`Reasoner.chat`,
+ * the `Tool`/`ToolResult` contract, both from `@revealui/ai`) and owns the
+ * iteration + recording itself.
+ */
+export async function runGovernedTask(deps: RunGovernedTaskDeps): Promise<RunGovernedTaskResult> {
+  const maxSteps = deps.maxSteps ?? DEFAULT_MAX_STEPS;
+  const toolByName = new Map(deps.tools.map((tool) => [tool.name, tool]));
+  const toolDefinitions = deps.tools.map(toolToDefinition);
+
+  const messages: Message[] = [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: deps.task },
+  ];
+
+  const actionLog: ActionLogEntry[] = [];
+  let output = '';
+  let stopReason: RunStopReason = 'max-steps';
+
+  const nextIndex = (): number => actionLog.length;
+
+  for (let step = 0; step < maxSteps; step++) {
+    const allowedToCallModel = await deps.chargeAction();
+    if (!allowedToCallModel) {
+      output = 'Run stopped: the charge budget was exhausted before the next model call.';
+      stopReason = 'charge-limit';
+      break;
+    }
+
+    const response = await deps.chat(messages, {
+      tools: toolDefinitions.length > 0 ? toolDefinitions : undefined,
+    });
+
+    actionLog.push({
+      index: nextIndex(),
+      type: 'model_call',
+      timestamp: new Date().toISOString(),
+      detail: definedOnly({
+        content: response.content,
+        finishReason: response.finishReason,
+        toolCallsRequested: response.toolCalls?.map((call) => ({
+          id: call.id,
+          name: call.function.name,
+          arguments: call.function.arguments,
+        })),
+        usage: response.usage,
+      }),
+    });
+
+    messages.push({ role: 'assistant', content: response.content, toolCalls: response.toolCalls });
+
+    if (!response.toolCalls || response.toolCalls.length === 0) {
+      output = response.content;
+      stopReason = 'completed';
+      break;
+    }
+
+    let chargeLimitReachedMidStep = false;
+    for (const call of response.toolCalls) {
+      let params: unknown = {};
+      try {
+        params = call.function.arguments ? JSON.parse(call.function.arguments) : {};
+      } catch {
+        params = { _unparsedArguments: call.function.arguments };
+      }
+
+      const tool = toolByName.get(call.function.name);
+      let result: { success: boolean; content?: string; data?: unknown; error?: string };
+
+      if (!tool) {
+        result = { success: false, error: `unknown or disallowed tool: ${call.function.name}` };
+      } else {
+        const allowedToCallTool = await deps.chargeAction();
+        if (!allowedToCallTool) {
+          result = { success: false, error: 'charge budget exhausted before this tool call' };
+          chargeLimitReachedMidStep = true;
+        } else {
+          try {
+            result = await tool.execute(params);
+          } catch (err) {
+            result = { success: false, error: err instanceof Error ? err.message : String(err) };
+          }
+        }
+      }
+
+      actionLog.push({
+        index: nextIndex(),
+        type: 'tool_call',
+        timestamp: new Date().toISOString(),
+        detail: definedOnly({
+          toolCallId: call.id,
+          toolName: call.function.name,
+          params,
+          success: result.success,
+          content: result.content,
+          error: result.error,
+        }),
+      });
+
+      messages.push({
+        role: 'tool',
+        content: result.content ?? JSON.stringify(result.data ?? result.error ?? null),
+        toolCallId: call.id,
+      });
+
+      if (chargeLimitReachedMidStep) break;
+    }
+
+    if (chargeLimitReachedMidStep) {
+      output = 'Run stopped: the charge budget was exhausted mid-step.';
+      stopReason = 'charge-limit';
+      break;
+    }
+
+    if (step === maxSteps - 1) {
+      output = 'Run stopped: reached the maximum number of steps without a final answer.';
+      stopReason = 'max-steps';
+    }
+  }
+
+  actionLog.push({
+    index: nextIndex(),
+    type: 'final_output',
+    timestamp: new Date().toISOString(),
+    detail: definedOnly({ output, stopReason }),
+  });
+
+  return { output, actionLog, stopReason };
+}

--- a/packages/apify-actor-governed-run/src/agent/tools.ts
+++ b/packages/apify-actor-governed-run/src/agent/tools.ts
@@ -1,0 +1,93 @@
+import type { Tool, ToolResult } from '@revealui/ai';
+import { z } from 'zod/v4';
+
+const WEB_FETCH_PARAMS = z.object({
+  url: z.string().url().describe('The HTTP(S) URL to fetch.'),
+});
+
+const MAX_RESPONSE_CHARS = 100_000;
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Hostnames/ranges this tool refuses to fetch. This is a minimal, static
+ * SSRF guard (no DNS resolution, no redirect-chain re-checking) appropriate
+ * for a v0.1 scaffold running on Apify's own infrastructure -- it blocks the
+ * obvious cloud-metadata and loopback/private targets an LLM-directed fetch
+ * could otherwise be steered at. It is NOT a complete SSRF defense (e.g. DNS
+ * rebinding is out of scope here); see the PR body's open design questions.
+ */
+function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0' || host === '::1')
+    return true;
+  if (host === '169.254.169.254') return true; // cloud metadata endpoint
+  if (host.endsWith('.internal') || host.endsWith('.local')) return true;
+  if (host.startsWith('10.') || host.startsWith('192.168.')) return true;
+  if (host.startsWith('172.')) {
+    const secondOctet = Number(host.split('.')[1]);
+    if (secondOctet >= 16 && secondOctet <= 31) return true;
+  }
+  return false;
+}
+
+export const webFetchTool: Tool = {
+  name: 'web_fetch',
+  label: 'Fetch a web page',
+  description:
+    'Fetch the text content of a public HTTP or HTTPS URL. Returns up to 100,000 characters of the response body. Does not follow redirects.',
+  parameters: WEB_FETCH_PARAMS,
+  async execute(rawParams: unknown): Promise<ToolResult> {
+    const parsedParams = WEB_FETCH_PARAMS.safeParse(rawParams);
+    if (!parsedParams.success) {
+      return { success: false, error: `invalid params: ${parsedParams.error.message}` };
+    }
+
+    let url: URL;
+    try {
+      url = new URL(parsedParams.data.url);
+    } catch {
+      return { success: false, error: 'invalid URL' };
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return { success: false, error: 'only http/https URLs are allowed' };
+    }
+    if (isBlockedHost(url.hostname)) {
+      return {
+        success: false,
+        error: 'this host is not allowed (private, loopback, or internal address)',
+      };
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, { signal: controller.signal, redirect: 'manual' });
+      if (response.status >= 300 && response.status < 400) {
+        return { success: false, error: 'redirects are not followed (SSRF safety)' };
+      }
+      const text = await response.text();
+      const truncated = text.length > MAX_RESPONSE_CHARS ? text.slice(0, MAX_RESPONSE_CHARS) : text;
+      return {
+        success: response.ok,
+        content: truncated,
+        data: { status: response.status, truncated: text.length > MAX_RESPONSE_CHARS },
+        error: response.ok ? undefined : `HTTP ${response.status}`,
+      };
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  },
+};
+
+/** Built-in tools this actor ships. Expanding the catalog is future work. */
+export const BUILT_IN_TOOLS: Tool[] = [webFetchTool];
+
+/** Filter the built-in tool catalog by the actor input's `toolAllowlist`.
+ * Omitted allowlist = every built-in tool enabled. Empty array = no tools. */
+export function selectTools(allowlist: string[] | undefined): Tool[] {
+  if (!allowlist) return BUILT_IN_TOOLS;
+  const allowed = new Set(allowlist);
+  return BUILT_IN_TOOLS.filter((tool) => allowed.has(tool.name));
+}

--- a/packages/apify-actor-governed-run/src/index.ts
+++ b/packages/apify-actor-governed-run/src/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @revealui/apify-actor-governed-run
+ *
+ * Not published to npm -- this actor ships to the Apify Store as a Docker
+ * image (see Dockerfile + .actor/actor.json). This barrel exists so the
+ * receipt verification logic is usable as a plain, standalone import
+ * (no Apify SDK, no network, no RevealUI infrastructure) by anything else in
+ * the monorepo that wants to check a receipt -- e.g. a future admin tool or
+ * CLI -- without depending on the `apify` package.
+ */
+
+export { CHARGEABLE_EVENTS, type ChargeableEvent } from './pricing.config.js';
+export { signActionLog } from './receipt/sign.js';
+export { type ReceiptSignablePayload, receiptSignableBytes } from './receipt/signable.js';
+export { type VerifyReceiptResult, verifyReceipt } from './receipt/verify.js';
+export {
+  type ActionLogEntry,
+  ActionLogEntrySchema,
+  type ActorInput,
+  ActorInputSchema,
+  parseActorInput,
+  type Receipt,
+  ReceiptSchema,
+  type RunTaskInput,
+  type VerifyReceiptInput,
+} from './types.js';

--- a/packages/apify-actor-governed-run/src/main.ts
+++ b/packages/apify-actor-governed-run/src/main.ts
@@ -1,0 +1,64 @@
+import { LLMClient } from '@revealui/ai';
+import { Actor } from 'apify';
+import { runGovernedTask } from './agent/run-governed-task.js';
+import { selectTools } from './agent/tools.js';
+import { CHARGEABLE_EVENTS } from './pricing.config.js';
+import { signActionLog } from './receipt/sign.js';
+import { verifyReceipt } from './receipt/verify.js';
+import { parseActorInput } from './types.js';
+
+await Actor.init();
+
+let failed = false;
+
+try {
+  const rawInput = await Actor.getInput();
+  const input = parseActorInput(rawInput);
+
+  if (input.mode === 'verify-receipt') {
+    await Actor.charge({ eventName: CHARGEABLE_EVENTS.receiptVerification.name });
+    const result = verifyReceipt(input.receipt);
+    await Actor.pushData(result);
+    await Actor.setValue('OUTPUT', result);
+  } else {
+    const tools = selectTools(input.toolAllowlist);
+    // Explicit BYOK key from actor input -- never a tenant-stored/DB-resolved
+    // key, so constructing this client never touches a database.
+    const llmClient = new LLMClient({
+      provider: input.llmProvider,
+      apiKey: input.llmApiKey,
+      model: input.model,
+    });
+
+    const { output, actionLog, stopReason } = await runGovernedTask({
+      task: input.task,
+      tools,
+      maxSteps: input.maxSteps,
+      chat: (messages, options) => llmClient.chat(messages, options),
+      chargeAction: async () => {
+        const { eventChargeLimitReached } = await Actor.charge({
+          eventName: CHARGEABLE_EVENTS.governedAction.name,
+        });
+        return !eventChargeLimitReached;
+      },
+    });
+
+    const receipt = signActionLog(actionLog);
+    await Actor.charge({ eventName: CHARGEABLE_EVENTS.runCompleted.name });
+
+    const result = { result: output, stopReason, receipt };
+    await Actor.pushData(result);
+    await Actor.setValue('OUTPUT', result);
+  }
+} catch (err) {
+  failed = true;
+  const message = err instanceof Error ? err.message : String(err);
+  await Actor.setValue('OUTPUT', { error: message });
+  await Actor.exit(message);
+}
+
+if (!failed) {
+  await Actor.exit();
+} else {
+  process.exitCode = 1;
+}

--- a/packages/apify-actor-governed-run/src/pricing.config.ts
+++ b/packages/apify-actor-governed-run/src/pricing.config.ts
@@ -1,0 +1,57 @@
+/**
+ * Chargeable event catalog for the Governed Agent Run PPE actor (GAP-431).
+ *
+ * Apify's pay-per-event pricing is NOT declared in `.actor/actor.json` -- there
+ * is no `pricingInfos` field there (verified against docs.apify.com July 2026;
+ * see the PR body / README for the citation). Pricing lives out-of-repo, set
+ * via the Apify Console (Actor -> Monetization) or a `PUT /v2/acts/{actorId}`
+ * API call, keyed by these exact event-name strings. This file is the single
+ * in-repo source of truth for that event catalog: the code below calls
+ * `Actor.charge({ eventName })` with these `name` values, and whoever applies
+ * pricing in Console/API must register the same names with these prices so
+ * the two stay in lockstep (Apify does not validate this at build time --
+ * an unregistered event name silently charges $0).
+ *
+ * Prices are the owner-ruled 2026-07-26 launch prices (value-anchored, not
+ * yet market-validated). On adoption, add this channel to
+ * `business/offerings-canonical.md` in the revealui-jv repo -- that file is
+ * the canonical pricing source of truth and does not yet list Apify PPE
+ * pricing as of this PR.
+ *
+ * To change a price: edit the value below, then re-apply it via Console or
+ * the `PUT /v2/acts/{actorId}` body documented in README.md -- the actor code
+ * never needs to change for a price-only adjustment.
+ */
+export interface ChargeableEvent {
+  /** Event name string passed to `Actor.charge({ eventName })`. */
+  readonly name: string;
+  /** Human-readable title shown in the Apify billing UI. */
+  readonly title: string;
+  /** What triggers this charge, shown in the Apify billing UI. */
+  readonly description: string;
+  /** Price in USD, applied via Console/API (not read by the actor at runtime). */
+  readonly priceUsd: number;
+}
+
+export const CHARGEABLE_EVENTS = {
+  governedAction: {
+    name: 'governed-action',
+    title: 'Governed action',
+    description: 'One model call or tool call executed and recorded into the signed action log.',
+    priceUsd: 0.02,
+  },
+  runCompleted: {
+    name: 'run-completed',
+    title: 'Governed run completed',
+    description:
+      'A governed agent run finished and a signed, offline-verifiable receipt was produced.',
+    priceUsd: 0.08,
+  },
+  receiptVerification: {
+    name: 'receipt-verification',
+    title: 'Receipt verification',
+    description:
+      'A previously issued receipt was checked for validity. Free -- verification never costs the caller.',
+    priceUsd: 0.0,
+  },
+} as const satisfies Record<string, ChargeableEvent>;

--- a/packages/apify-actor-governed-run/src/receipt/sign.ts
+++ b/packages/apify-actor-governed-run/src/receipt/sign.ts
@@ -1,0 +1,37 @@
+import { createPublicKey, generateKeyPairSync } from 'node:crypto';
+import { deriveAuditKid, Ed25519AuditRowSigner } from '@revealui/security/server';
+import type { ActionLogEntry, Receipt } from '../types.js';
+import { receiptSignableBytes } from './signable.js';
+
+/**
+ * Sign a completed run's action log into a self-contained, offline-verifiable
+ * receipt.
+ *
+ * Reuses the fleet's audit-log signing primitives (`@revealui/security`,
+ * GAP-355 `2026-07-12-audit-receipt-architecture`): the same Ed25519 signer
+ * class, the same `v1.ed25519.<kid>.<sig>` wire format, and the same RFC 8785
+ * canonicalization (via `receiptSignableBytes`). It deliberately does NOT
+ * reuse the fleet's audit *key management* (`REVEALUI_AUDIT_SIGNING_KEY` /
+ * `createAuditRowSignerFromEnv`) -- that key backs RevealUI's own internal
+ * audit log and is not meant to sign a customer's Apify run. Instead each run
+ * generates its own fresh Ed25519 keypair and embeds the public half directly
+ * in the receipt, so a receipt can be verified by anyone with no dependency on
+ * RevealUI's servers or secrets -- the actor's entire trust story is "the
+ * receipt carries its own key."
+ */
+export function signActionLog(actionLog: ActionLogEntry[]): Receipt {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  });
+
+  const kid = deriveAuditKid(createPublicKey(publicKey));
+  const signer = new Ed25519AuditRowSigner(privateKey, kid);
+  const timestamp = new Date().toISOString();
+  const algorithm = 'ed25519' as const;
+
+  const bytes = receiptSignableBytes({ actionLog, algorithm, timestamp });
+  const { value: signature } = signer.sign(bytes);
+
+  return { actionLog, signature, publicKey, algorithm, timestamp };
+}

--- a/packages/apify-actor-governed-run/src/receipt/signable.ts
+++ b/packages/apify-actor-governed-run/src/receipt/signable.ts
@@ -1,0 +1,29 @@
+import { canonicalizeJcs } from '@revealui/security';
+import type { ActionLogEntry } from '../types.js';
+
+/** The exact fields a receipt's signature covers. `publicKey` travels with the
+ * receipt for verification but is deliberately NOT part of the signed payload
+ * -- it identifies the key, it isn't integrity-bearing data. */
+export interface ReceiptSignablePayload {
+  actionLog: ActionLogEntry[];
+  algorithm: 'ed25519';
+  timestamp: string;
+}
+
+/**
+ * Build the canonical bytes signed for a receipt. Shared by sign and verify
+ * (mirrors `@revealui/security`'s `auditSignableBytes` pattern) so a signed
+ * payload always re-canonicalizes identically at verify time. Uses RFC 8785
+ * JSON Canonicalization (via `canonicalizeJcs`) rather than `JSON.stringify`
+ * because plain `JSON.stringify` does not guarantee stable key ordering
+ * across engines/round-trips -- the same reason the fleet's audit-log
+ * signing uses it (packages/security/src/jcs.ts).
+ */
+export function receiptSignableBytes(payload: ReceiptSignablePayload): Uint8Array {
+  const canonical = canonicalizeJcs({
+    actionLog: payload.actionLog,
+    algorithm: payload.algorithm,
+    timestamp: payload.timestamp,
+  });
+  return new TextEncoder().encode(canonical);
+}

--- a/packages/apify-actor-governed-run/src/receipt/verify.ts
+++ b/packages/apify-actor-governed-run/src/receipt/verify.ts
@@ -1,0 +1,59 @@
+import { createPublicKey } from 'node:crypto';
+import { deriveAuditKid, verifyEd25519AuditSignature } from '@revealui/security/server';
+import { ReceiptSchema } from '../types.js';
+import { receiptSignableBytes } from './signable.js';
+
+export interface VerifyReceiptResult {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * Verify a Governed Agent Run receipt entirely offline: no network call, no
+ * database, no dependency on RevealUI infrastructure. This is the standalone
+ * verify function the actor's `verify-receipt` mode wraps, and it is exported
+ * from the package so anyone holding a receipt can check it in their own
+ * Node process (`import { verifyReceipt } from '@revealui/apify-actor-governed-run'`).
+ *
+ * Reuses `@revealui/security`'s `verifyEd25519AuditSignature` (the same
+ * verifier the fleet's own audit-log signatures use) end to end -- only the
+ * "what bytes were signed" builder (`receiptSignableBytes`) is specific to
+ * the receipt's own shape, since a receipt is not an `audit_log` row.
+ */
+export function verifyReceipt(receipt: unknown): VerifyReceiptResult {
+  const parsed = ReceiptSchema.safeParse(receipt);
+  if (!parsed.success) {
+    return { valid: false, reason: `malformed receipt: ${parsed.error.message}` };
+  }
+  const { actionLog, signature, publicKey, algorithm, timestamp } = parsed.data;
+
+  let keyObject: ReturnType<typeof createPublicKey>;
+  try {
+    keyObject = createPublicKey(publicKey);
+  } catch {
+    return { valid: false, reason: 'embedded public key could not be parsed' };
+  }
+  if (keyObject.asymmetricKeyType !== 'ed25519') {
+    return {
+      valid: false,
+      reason: `embedded public key is not ed25519 (got ${keyObject.asymmetricKeyType ?? 'unknown'})`,
+    };
+  }
+
+  const sigParts = signature.split('.');
+  if (sigParts.length !== 4) {
+    return { valid: false, reason: 'malformed signature: expected v1.ed25519.<kid>.<sig>' };
+  }
+  const kidInSignature = sigParts[2];
+  const expectedKid = deriveAuditKid(keyObject);
+  if (kidInSignature !== expectedKid) {
+    return { valid: false, reason: 'signature key id does not match the embedded public key' };
+  }
+
+  const bytes = receiptSignableBytes({ actionLog, algorithm, timestamp });
+  const result = verifyEd25519AuditSignature(bytes, signature, () => keyObject);
+  if (!result.valid) {
+    return { valid: false, reason: result.reason ?? 'signature verification failed' };
+  }
+  return { valid: true };
+}

--- a/packages/apify-actor-governed-run/src/types.ts
+++ b/packages/apify-actor-governed-run/src/types.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod/v4';
+
+/**
+ * One entry in a governed run's action log. Every model call and every tool
+ * call the agent performs becomes exactly one entry, in execution order, plus
+ * a final entry recording the run's output. This array is the payload the
+ * receipt signs -- it is the thing a customer is paying to have proven.
+ */
+export const ActionLogEntrySchema = z.object({
+  index: z.number().int().nonnegative(),
+  type: z.enum(['model_call', 'tool_call', 'final_output']),
+  timestamp: z.string(),
+  detail: z.record(z.string(), z.unknown()),
+});
+export type ActionLogEntry = z.infer<typeof ActionLogEntrySchema>;
+
+/** The signed, offline-verifiable receipt returned alongside a run's result. */
+export const ReceiptSchema = z.object({
+  actionLog: z.array(ActionLogEntrySchema),
+  signature: z.string().min(1),
+  publicKey: z.string().min(1),
+  algorithm: z.literal('ed25519'),
+  timestamp: z.string(),
+});
+export type Receipt = z.infer<typeof ReceiptSchema>;
+
+/** Actor input, `run-task` mode: execute an agent task and return a receipt. */
+const RunTaskInputSchema = z.object({
+  mode: z.literal('run-task').default('run-task'),
+  task: z.string().min(1, 'task must not be empty'),
+  llmProvider: z.enum(['anthropic', 'openai']),
+  llmApiKey: z.string().min(1, 'llmApiKey must not be empty'),
+  model: z.string().min(1).optional(),
+  toolAllowlist: z.array(z.string()).optional(),
+  maxSteps: z.number().int().positive().max(50).optional(),
+});
+export type RunTaskInput = z.infer<typeof RunTaskInputSchema>;
+
+/** Actor input, `verify-receipt` mode: check a previously issued receipt. */
+const VerifyReceiptInputSchema = z.object({
+  mode: z.literal('verify-receipt'),
+  receipt: z.unknown(),
+});
+export type VerifyReceiptInput = z.infer<typeof VerifyReceiptInputSchema>;
+
+export const ActorInputSchema = z.discriminatedUnion('mode', [
+  RunTaskInputSchema,
+  VerifyReceiptInputSchema,
+]);
+export type ActorInput = z.infer<typeof ActorInputSchema>;
+
+/**
+ * Parse and validate raw Apify actor input. Defaults an omitted `mode` to
+ * `run-task` before discriminating, since Apify's input schema does not
+ * enforce the union -- the actor is the last line of validation for its own
+ * contract. Throws a `z.ZodError`-derived message on invalid input; the
+ * caller (main.ts) is responsible for surfacing that as a failed run.
+ */
+export function parseActorInput(raw: unknown): ActorInput {
+  const withDefaultMode =
+    raw !== null && typeof raw === 'object' && !('mode' in raw)
+      ? { ...raw, mode: 'run-task' }
+      : raw;
+  const result = ActorInputSchema.safeParse(withDefaultMode);
+  if (!result.success) {
+    throw new Error(`invalid actor input: ${result.error.message}`);
+  }
+  return result.data;
+}

--- a/packages/apify-actor-governed-run/tsconfig.json
+++ b/packages/apify-actor-governed-run/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../dev/src/ts/library.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/__tests__/**", "src/**/*.test.ts"]
+}

--- a/packages/apify-actor-governed-run/tsup.config.ts
+++ b/packages/apify-actor-governed-run/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/main.ts', 'src/index.ts'],
+  format: ['esm'],
+  platform: 'node',
+  bundle: true,
+  dts: false,
+  sourcemap: false,
+  outDir: 'dist',
+  // Third-party npm packages stay external (resolved from node_modules at
+  // runtime, same as apps/server's tsup config). @revealui/ai is kept external
+  // too, matching apps/server's proven config (apps/server/tsup.config.ts) --
+  // bundling it has previously inlined CJS transitive deps that break in an
+  // ESM chunk. @revealui/security has no such transitive-CJS hazard and is
+  // small, so it is bundled inline (tsup default) to keep the Apify actor's
+  // runtime node_modules footprint minimal.
+  external: ['apify', '@revealui/ai'],
+});

--- a/packages/apify-actor-governed-run/vitest.config.ts
+++ b/packages/apify-actor-governed-run/vitest.config.ts
@@ -1,0 +1,10 @@
+import { createVitestConfig } from '@revealui/dev/vitest';
+
+export default createVitestConfig({
+  thresholds: {
+    lines: 70,
+    functions: 70,
+    branches: 65,
+    statements: 70,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,6 +825,40 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/apify-actor-governed-run:
+    dependencies:
+      '@revealui/ai':
+        specifier: workspace:*
+        version: link:../ai
+      '@revealui/security':
+        specifier: workspace:*
+        version: link:../security
+      apify:
+        specifier: ^3.7.2
+        version: 3.7.2
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../dev
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.5
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(@microsoft/api-extractor@7.58.11(@types/node@25.9.5))(jiti@2.7.0)(postcss@8.5.20)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/auth:
     dependencies:
       '@revealui/config':
@@ -1939,6 +1973,32 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@apify/consts@2.54.2':
+    resolution: {integrity: sha512-ypdLZcGR0F+MwG+kOsvXar9JjZ32c7Vh086bywgNX31uVlIrnmDtOS0uWDG1VWPu4g2u0x1iA1tTtdMzRtyPpw==}
+
+  '@apify/datastructures@2.0.6':
+    resolution: {integrity: sha512-hI/Q5cCjXXI/g4OPwX+/xuk+JsOtXRhKNXl2wnq/nKmdrji3nYCc9vGsAEc1iXVbs16xQMZy5uRhoY3XTABovA==}
+
+  '@apify/input_secrets@1.2.50':
+    resolution: {integrity: sha512-8KZGgVBmWQNiQpiu5/y6uucT5YAlkwQJDVGrDv+SwFYRWYGKszDRSoYouUHk3y5s9V99C5/eMVbQDjXtfuDq/A==}
+
+  '@apify/log@2.5.44':
+    resolution: {integrity: sha512-gDB4hkNfvDDkRRCMmYpY75twdCK2rFI88WBJoSTLpMpjHtFu3IU02gmYRj47aWOBIV/362Rc0c51ZuqBEBaSrw==}
+
+  '@apify/ps-tree@1.2.0':
+    resolution: {integrity: sha512-VHIswI7rD/R4bToeIDuJ9WJXt+qr5SdhfoZ9RzdjmCs9mgy7l0P4RugQEUCcU+WB4sfImbd4CKwzXcn0uYx1yw==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
+  '@apify/pseudo_url@2.0.85':
+    resolution: {integrity: sha512-fvtTP2B9uSvMvyx/Br3yeFv5EbcHpT+GQeL6KFzctnJKBhBqmhtO5Nc844u2La4fO9vRfBZRYusBOv/4Vz3vvQ==}
+
+  '@apify/timeout@0.3.5':
+    resolution: {integrity: sha512-3nuQXwxh2sKxBo5tgDoZWuZHiSpqrKg1+sJHjFSk8blhyX6I2FZzpfW7UaCELeYLZiSjWUPh2rXNrc3zLmJGJg==}
+
+  '@apify/utilities@2.35.1':
+    resolution: {integrity: sha512-xp7R/eaf5TEduF6hb/K/2nXe+Q06Sux8N8BEWpKUUTPTrQAmk9fdHzulHM/T4nkp0MMtxEl/fRsFyOsMptx+aw==}
+
   '@apm-js-collab/code-transformer-bundler-plugins@0.7.1':
     resolution: {integrity: sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==}
     engines: {node: '>=18.0.0'}
@@ -2105,6 +2165,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -2204,6 +2267,22 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@crawlee/core@3.17.0':
+    resolution: {integrity: sha512-LPsD5+zzLF+0QFGCcZcUKMULJAkjnL7YVWhCp58zYupbmLjVHW9YJoECEF9awf5lbvPwoxoChxzEIl/lRNU0TQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@crawlee/memory-storage@3.17.0':
+    resolution: {integrity: sha512-3dT2eY9oqfl7LTO+aqQYCKmLGRDK8j9J64h/eVQwXVSqRyGBhTraZxE4ABKF0kQrMJd1/N7u9dRcAacESIEqBg==}
+    engines: {node: '>= 16'}
+
+  '@crawlee/types@3.17.0':
+    resolution: {integrity: sha512-y67RHnM+b8eoaTRoouB0jbqpwpUE+4ZTxeEgvnLx+ABkdtkLNYlXQOx3FybEWzFVp6MnmBtmsez2tQjRCmIopQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@crawlee/utils@3.17.0':
+    resolution: {integrity: sha512-pKpBzI6knmkgbcHACpIGNDhsQvuFPavVJ+43ehEw3EqV13ThKR0sP/vBTjdDicTrAbRl3fhi6CaokOTymOZwGw==}
+    engines: {node: '>=16.0.0'}
 
   '@csstools/color-helpers@6.1.0':
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
@@ -2858,6 +2937,9 @@ packages:
   '@jsdoc/salty@0.2.12':
     resolution: {integrity: sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==}
     engines: {node: '>=v12.0.0'}
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
@@ -3796,6 +3878,14 @@ packages:
   '@rushstack/ts-command-line@5.3.12':
     resolution: {integrity: sha512-Vg2n24arSf7JvUNga2DMHYTbxnVq9L5OtVCp4Gfr8YC/kmL/bmdR8FQhGcpMzMYNY9Vdw3+TaimG11Sf+z1Tpw==}
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/shapeshift@3.9.7':
+    resolution: {integrity: sha512-4It2mxPSr4OGn4HSQWGmhFMsNFGfFVhWeRPCRwbH972Ek2pzfGRZtb0pJ4Ze6oIzcyh2jw7nUDa6qGlWofgd9g==}
+    engines: {node: '>=v16'}
+
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
@@ -3987,6 +4077,18 @@ packages:
 
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
+  '@sindresorhus/is@5.6.0':
+    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
+    engines: {node: '>=14.16'}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -4521,6 +4623,13 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tootallnate/once@3.0.1':
     resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
     engines: {node: '>= 10'}
@@ -4588,6 +4697,9 @@ packages:
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
   '@types/inquirer@9.0.10':
     resolution: {integrity: sha512-vFW2WbXwO9eZpRT5GJGFJ/shgyMNnYozmnjakt9jCQSS1lvqX8pZEQMjJ9RdDPct/YxwciQ8+V8OYn9euIrZDA==}
 
@@ -4631,6 +4743,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -4868,6 +4983,10 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
@@ -5005,6 +5124,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -5078,6 +5201,13 @@ packages:
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  apify-client@2.23.4:
+    resolution: {integrity: sha512-Uw2cZXfR9iQw1jyQBonSqL/QJhp154YTB070m6A6aCYAIrklOqKfNnqXIIWKCkyTWqEqwNJ1784OJL5ZnB8tTQ==}
+
+  apify@3.7.2:
+    resolution: {integrity: sha512-I4R5Qd1X11vk5/1U0CxKSsMhNwER/3MntePEQb9Pbtf942OhQLh5IURrJZufqtpimkqRy44SlQMU6UhPdoFXhA==}
+    engines: {node: '>=16.0.0'}
 
   arg@4.1.0:
     resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
@@ -5221,6 +5351,9 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
@@ -5253,6 +5386,10 @@ packages:
     peerDependencies:
       esbuild: '>=0.28.1'
 
+  byte-counter@0.1.0:
+    resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
+    engines: {node: '>=20'}
+
   bytes-iec@3.1.1:
     resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
     engines: {node: '>= 0.8'}
@@ -5278,6 +5415,14 @@ packages:
       '@75lb/nature':
         optional: true
 
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@13.0.19:
+    resolution: {integrity: sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==}
+    engines: {node: '>=18'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -5285,6 +5430,14 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  callsites@4.2.0:
+    resolution: {integrity: sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==}
+    engines: {node: '>=12.20'}
 
   camelize@1.0.1:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
@@ -5331,6 +5484,13 @@ packages:
 
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
 
   chokidar@4.0.0:
     resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
@@ -5525,12 +5685,19 @@ packages:
     resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
     engines: {node: '>=16'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -5542,6 +5709,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  csv-stringify@6.8.1:
+    resolution: {integrity: sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==}
 
   current-module-paths@1.1.3:
     resolution: {integrity: sha512-7AH+ZTRKikdK4s1RmY0l6067UD/NZc7p3zZVZxvmnH80G31kr0y0W0E6ibYM4IS01MEm8DiC5FnTcgcgkbFHoA==}
@@ -5588,6 +5758,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@10.0.0:
+    resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
+    engines: {node: '>=20'}
+
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
@@ -5632,6 +5806,27 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@6.0.1:
+    resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
+    engines: {node: '>=10'}
+
+  dot-prop@7.2.0:
+    resolution: {integrity: sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   dotenv-cli@11.0.0:
     resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
@@ -5801,6 +5996,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
@@ -5908,6 +6107,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  event-stream@3.3.4:
+    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -6021,6 +6223,10 @@ packages:
       '@75lb/nature':
         optional: true
 
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -6062,6 +6268,10 @@ packages:
       debug:
         optional: true
 
+  form-data-encoder@4.1.0:
+    resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
+    engines: {node: '>= 18'}
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -6073,6 +6283,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  from@0.1.7:
+    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
 
   fs-extra@11.1.0:
     resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
@@ -6106,6 +6319,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generative-bayesian-network@2.1.86:
+    resolution: {integrity: sha512-4+cZAUH6khje/EUKRlTlO+HpjA7aqvDlVBnBSJKZqC6qiJ3EitNZ97//xYrBbawZCHe1S1PGLza6knQTFpWCgw==}
 
   generic-pool@3.4.2:
     resolution: {integrity: sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag==}
@@ -6170,6 +6386,14 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  got-scraping@4.2.1:
+    resolution: {integrity: sha512-rhOlO1L4H4Cm31smHJqPtAaXOUrhSKsiTrbZSHKFQW1E/mkTDopnHHpRnXJpqzE0faj+zPsVQnyifIqO+K+cLQ==}
+    engines: {node: '>=16'}
+
+  got@14.6.6:
+    resolution: {integrity: sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==}
+    engines: {node: '>=20'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -6217,6 +6441,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  header-generator@2.1.86:
+    resolution: {integrity: sha512-Nj+glwXBEU3PvvAT1WiC3FBhX1ReZZY+ADXIo2iTRqMzamLW0olJk7q/EJ6N3qJBqQWZJDJonAJRtAlzEFynLQ==}
+    engines: {node: '>=16.0.0'}
+
   hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
@@ -6235,6 +6463,12 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@1.7.3:
     resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
     engines: {node: '>= 0.6'}
@@ -6249,6 +6483,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -6381,6 +6619,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -6543,6 +6785,9 @@ packages:
 
   just-map-values@3.2.0:
     resolution: {integrity: sha512-TyqCKtK3NxiUgOjRYMIKURvBTHesi3XzomDY0QVPZ3rYzLCF+nNq5rSi0B/L5aOd/WMTZo6ukzA4wih4HUbrDg==}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
   klaw@3.0.0:
     resolution: {integrity: sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==}
@@ -6762,6 +7007,10 @@ packages:
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
@@ -6782,6 +7031,10 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -6818,6 +7071,9 @@ packages:
 
   manage-path@2.0.0:
     resolution: {integrity: sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==}
+
+  map-stream@0.1.0:
+    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
 
   markdown-it-anchor@8.6.7:
     resolution: {integrity: sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==}
@@ -7031,6 +7287,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -7224,6 +7484,10 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
+    engines: {node: '>=14.16'}
+
   npm-path@2.0.4:
     resolution: {integrity: sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==}
     engines: {node: '>=0.8'}
@@ -7241,6 +7505,9 @@ packages:
     resolution: {integrity: sha512-CM8vMpeFQ7MAPin0U3wzDhSGV0hMHNwHU0wjo402IVizPDrs45jSfSuoC+wThevY88LQti8VvaAnqYAeVy3I1A==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -7295,6 +7562,14 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  ow@0.28.2:
+    resolution: {integrity: sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==}
+    engines: {node: '>=12'}
+
+  ow@1.1.1:
+    resolution: {integrity: sha512-sJBRCbS5vh1Jp9EOgwp1Ws3c16lJrUkJYlvWTYC03oyiYVwS/ns7lKRWow4w4XjDyTrA2pplQv4B2naWSR6yDA==}
+    engines: {node: '>=14.16'}
+
   ox@0.14.30:
     resolution: {integrity: sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==}
     peerDependencies:
@@ -7306,6 +7581,10 @@ packages:
   oxc-transform@0.111.0:
     resolution: {integrity: sha512-oa5KKSDNLHZGaiqIGAbCWXeN9IJUAz9MElWcQX90epDxdKc9Hrt/BsLj3K4gDqfAYa5dwdH+ZCFJG9hR74fiGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  p-cancelable@4.0.1:
+    resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
+    engines: {node: '>=14.16'}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -7373,6 +7652,12 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -7414,6 +7699,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pause-stream@0.0.11:
+    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -7580,6 +7868,9 @@ packages:
   promisepipe@3.0.0:
     resolution: {integrity: sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
@@ -7589,6 +7880,10 @@ packages:
 
   proxy-agent@6.4.0:
     resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
+    engines: {node: '>= 14'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
 
   proxy-from-env@1.1.0:
@@ -7630,6 +7925,14 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
+  quick-lru@7.3.0:
+    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
+    engines: {node: '>=18'}
 
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
@@ -7716,6 +8019,9 @@ packages:
   requizzle@0.2.4:
     resolution: {integrity: sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -7732,6 +8038,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  responselike@4.0.2:
+    resolution: {integrity: sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==}
+    engines: {node: '>=20'}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -7742,6 +8052,10 @@ packages:
 
   retimer@3.0.0:
     resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -7758,6 +8072,10 @@ packages:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  robots-parser@3.0.1:
+    resolution: {integrity: sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==}
+    engines: {node: '>=10.0.0'}
 
   rolldown@1.0.0-rc.1:
     resolution: {integrity: sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==}
@@ -7798,6 +8116,10 @@ packages:
   satori@0.26.0:
     resolution: {integrity: sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==}
     engines: {node: '>=16'}
+
+  sax@1.6.1:
+    resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
+    engines: {node: '>=11.0.0'}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -7971,6 +8293,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  split@0.3.3:
+    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -8003,6 +8328,15 @@ packages:
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
+
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-combiner@0.0.4:
+    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
 
   stream-to-array@2.3.0:
     resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
@@ -8072,6 +8406,10 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -8203,6 +8541,9 @@ packages:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
   time-span@4.0.0:
     resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
     engines: {node: '>=10'}
@@ -8257,6 +8598,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -8343,6 +8688,14 @@ packages:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
 
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
@@ -8370,6 +8723,10 @@ packages:
 
   uid-promise@1.0.0:
     resolution: {integrity: sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -8447,6 +8804,10 @@ packages:
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
+
+  vali-date@1.0.0:
+    resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==}
+    engines: {node: '>=0.10.0'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -8622,6 +8983,10 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -8796,6 +9161,36 @@ snapshots:
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@apify/consts@2.54.2': {}
+
+  '@apify/datastructures@2.0.6': {}
+
+  '@apify/input_secrets@1.2.50':
+    dependencies:
+      '@apify/log': 2.5.44
+      '@apify/utilities': 2.35.1
+      ow: 0.28.2
+
+  '@apify/log@2.5.44':
+    dependencies:
+      '@apify/consts': 2.54.2
+      ansi-colors: 4.1.3
+
+  '@apify/ps-tree@1.2.0':
+    dependencies:
+      event-stream: 3.3.4
+
+  '@apify/pseudo_url@2.0.85':
+    dependencies:
+      '@apify/log': 2.5.44
+
+  '@apify/timeout@0.3.5': {}
+
+  '@apify/utilities@2.35.1':
+    dependencies:
+      '@apify/consts': 2.54.2
+      '@apify/log': 2.5.44
 
   '@apm-js-collab/code-transformer-bundler-plugins@0.7.1':
     dependencies:
@@ -8986,6 +9381,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.5.4':
     optional: true
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -9202,6 +9599,68 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
+
+  '@crawlee/core@3.17.0':
+    dependencies:
+      '@apify/consts': 2.54.2
+      '@apify/datastructures': 2.0.6
+      '@apify/log': 2.5.44
+      '@apify/pseudo_url': 2.0.85
+      '@apify/timeout': 0.3.5
+      '@apify/utilities': 2.35.1
+      '@crawlee/memory-storage': 3.17.0
+      '@crawlee/types': 3.17.0
+      '@crawlee/utils': 3.17.0
+      '@sapphire/async-queue': 1.5.5
+      '@vladfrangu/async_event_emitter': 2.4.7
+      csv-stringify: 6.8.1
+      fs-extra: 11.3.6
+      got-scraping: 4.2.1
+      json5: 2.2.3
+      minimatch: 10.2.5
+      ow: 0.28.2
+      stream-json: 1.9.1
+      tldts: 7.4.9
+      tough-cookie: 6.0.2
+      tslib: 2.8.1
+      type-fest: 4.41.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@crawlee/memory-storage@3.17.0':
+    dependencies:
+      '@apify/log': 2.5.44
+      '@crawlee/types': 3.17.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/shapeshift': 3.9.7
+      content-type: 1.0.5
+      fs-extra: 11.3.6
+      json5: 2.2.3
+      mime-types: 2.1.35
+      p-limit: 3.1.0
+      proper-lockfile: 4.1.2
+      tslib: 2.8.1
+
+  '@crawlee/types@3.17.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@crawlee/utils@3.17.0':
+    dependencies:
+      '@apify/log': 2.5.44
+      '@apify/ps-tree': 1.2.0
+      '@crawlee/types': 3.17.0
+      '@types/sax': 1.2.7
+      cheerio: 1.0.0-rc.12
+      file-type: 21.3.4
+      got-scraping: 4.2.1
+      ow: 0.28.2
+      robots-parser: 3.0.1
+      sax: 1.6.1
+      tslib: 2.8.1
+      whatwg-mimetype: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@csstools/color-helpers@6.1.0': {}
 
@@ -9690,6 +10149,8 @@ snapshots:
   '@jsdoc/salty@0.2.12':
     dependencies:
       lodash: 4.18.1
+
+  '@keyv/serialize@1.1.1': {}
 
   '@levischuck/tiny-cbor@0.2.11': {}
 
@@ -10570,6 +11031,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/shapeshift@3.9.7':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash: 4.18.1
+
   '@scarf/scarf@1.4.0': {}
 
   '@scure/base@1.2.6': {}
@@ -10809,6 +11277,12 @@ snapshots:
       '@peculiar/x509': 1.14.3
 
   '@sinclair/typebox@0.25.24': {}
+
+  '@sindresorhus/is@4.6.0': {}
+
+  '@sindresorhus/is@5.6.0': {}
+
+  '@sindresorhus/is@7.2.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -11407,6 +11881,15 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tootallnate/once@3.0.1': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
@@ -11466,6 +11949,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/http-cache-semantics@4.2.0': {}
+
   '@types/inquirer@9.0.10':
     dependencies:
       '@types/through': 0.0.33
@@ -11513,6 +11998,10 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 25.9.5
 
   '@types/semver@7.7.1': {}
 
@@ -11991,6 +12480,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@vladfrangu/async_event_emitter@2.4.7': {}
+
   '@volar/language-core@2.4.28':
     dependencies:
       '@volar/source-map': 2.4.28
@@ -12156,6 +12647,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  adm-zip@0.6.0: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -12209,6 +12702,46 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
+
+  apify-client@2.23.4:
+    dependencies:
+      '@apify/consts': 2.54.2
+      '@apify/log': 2.5.44
+      '@apify/utilities': 2.35.1
+      '@crawlee/types': 3.17.0
+      ansi-colors: 4.1.3
+      async-retry: 1.3.3
+      axios: 1.18.1
+      content-type: 1.0.5
+      ow: 0.28.2
+      proxy-agent: 6.5.0
+      tslib: 2.8.1
+      type-fest: 4.41.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  apify@3.7.2:
+    dependencies:
+      '@apify/consts': 2.54.2
+      '@apify/input_secrets': 1.2.50
+      '@apify/log': 2.5.44
+      '@apify/timeout': 0.3.5
+      '@apify/utilities': 2.35.1
+      '@crawlee/core': 3.17.0
+      '@crawlee/types': 3.17.0
+      '@crawlee/utils': 3.17.0
+      apify-client: 2.23.4
+      fs-extra: 11.3.6
+      ow: 0.28.2
+      semver: 7.8.5
+      tslib: 2.8.1
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
 
   arg@4.1.0: {}
 
@@ -12353,6 +12886,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
@@ -12389,6 +12924,8 @@ snapshots:
       esbuild: 0.28.1
       load-tsconfig: 0.2.5
 
+  byte-counter@0.1.0: {}
+
   bytes-iec@3.1.1: {}
 
   bytes@3.1.0: {}
@@ -12401,6 +12938,18 @@ snapshots:
     dependencies:
       array-back: 6.2.3
 
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@13.0.19:
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      get-stream: 9.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 5.6.0
+      mimic-response: 4.0.0
+      normalize-url: 8.1.1
+      responselike: 4.0.2
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -12410,6 +12959,10 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
+
+  callsites@4.2.0: {}
 
   camelize@1.0.1: {}
 
@@ -12443,6 +12996,25 @@ snapshots:
   chardet@2.2.0: {}
 
   charenc@0.0.2: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.0.0-rc.12:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      htmlparser2: 8.0.2
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
 
   chokidar@4.0.0:
     dependencies:
@@ -12588,6 +13160,14 @@ snapshots:
 
   css-gradient-parser@0.0.17: {}
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-to-react-native@3.2.0:
     dependencies:
       camelize: 1.0.1
@@ -12599,11 +13179,15 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css-what@6.2.2: {}
+
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  csv-stringify@6.8.1: {}
 
   current-module-paths@1.1.3: {}
 
@@ -12636,6 +13220,10 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@10.0.0:
+    dependencies:
+      mimic-response: 4.0.0
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -12667,6 +13255,32 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dot-prop@6.0.1:
+    dependencies:
+      is-obj: 2.0.0
+
+  dot-prop@7.2.0:
+    dependencies:
+      type-fest: 2.19.0
 
   dotenv-cli@11.0.0:
     dependencies:
@@ -12754,6 +13368,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   entities@7.0.1: {}
 
@@ -12859,6 +13475,16 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  event-stream@3.3.4:
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.1.0
+      pause-stream: 0.0.11
+      split: 0.3.3
+      stream-combiner: 0.0.4
+      through: 2.3.8
 
   eventemitter3@5.0.1: {}
 
@@ -13014,6 +13640,15 @@ snapshots:
       array-back: 6.2.3
       fast-glob: 3.3.3
 
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
@@ -13059,6 +13694,8 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
+  form-data-encoder@4.1.0: {}
+
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -13070,6 +13707,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  from@0.1.7: {}
 
   fs-extra@11.1.0:
     dependencies:
@@ -13108,6 +13747,11 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  generative-bayesian-network@2.1.86:
+    dependencies:
+      adm-zip: 0.6.0
+      tslib: 2.8.1
 
   generic-pool@3.4.2: {}
 
@@ -13181,6 +13825,31 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  got-scraping@4.2.1:
+    dependencies:
+      got: 14.6.6
+      header-generator: 2.1.86
+      http2-wrapper: 2.2.1
+      mimic-response: 4.0.0
+      ow: 1.1.1
+      quick-lru: 7.3.0
+      tslib: 2.8.1
+
+  got@14.6.6:
+    dependencies:
+      '@sindresorhus/is': 7.2.0
+      byte-counter: 0.1.0
+      cacheable-lookup: 7.0.0
+      cacheable-request: 13.0.19
+      decompress-response: 10.0.0
+      form-data-encoder: 4.1.0
+      http2-wrapper: 2.2.1
+      keyv: 5.6.0
+      lowercase-keys: 3.0.0
+      p-cancelable: 4.0.1
+      responselike: 4.0.2
+      type-fest: 4.41.0
+
   graceful-fs@4.2.11: {}
 
   gzip-size@6.0.0:
@@ -13248,6 +13917,13 @@ snapshots:
 
   he@1.2.0: {}
 
+  header-generator@2.1.86:
+    dependencies:
+      browserslist: 4.28.6
+      generative-bayesian-network: 2.1.86
+      ow: 0.28.2
+      tslib: 2.8.1
+
   hex-rgb@4.3.0: {}
 
   hono@4.12.27: {}
@@ -13261,6 +13937,15 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
+  http-cache-semantics@4.2.0: {}
 
   http-errors@1.7.3:
     dependencies:
@@ -13286,6 +13971,11 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -13395,6 +14085,8 @@ snapshots:
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
+
+  is-obj@2.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -13560,6 +14252,10 @@ snapshots:
   just-filter-object@3.2.0: {}
 
   just-map-values@3.2.0: {}
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
 
   klaw@3.0.0:
     dependencies:
@@ -13730,6 +14426,8 @@ snapshots:
 
   lodash.flatten@4.4.0: {}
 
+  lodash.isequal@4.5.0: {}
+
   lodash.startcase@4.4.0: {}
 
   lodash@4.18.1: {}
@@ -13750,6 +14448,8 @@ snapshots:
   loglevel@1.9.2: {}
 
   longest-streak@3.1.0: {}
+
+  lowercase-keys@3.0.0: {}
 
   lru-cache@11.5.2: {}
 
@@ -13782,6 +14482,8 @@ snapshots:
       semver: 7.8.5
 
   manage-path@2.0.0: {}
+
+  map-stream@0.1.0: {}
 
   markdown-it-anchor@8.6.7(@types/markdown-it@14.1.2)(markdown-it@14.3.0):
     dependencies:
@@ -14194,6 +14896,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@4.0.0: {}
+
   min-indent@1.0.1: {}
 
   mini-svg-data-uri@1.4.4: {}
@@ -14334,6 +15038,8 @@ snapshots:
     dependencies:
       abbrev: 3.0.1
 
+  normalize-url@8.1.1: {}
+
   npm-path@2.0.4:
     dependencies:
       which: 1.3.1
@@ -14352,6 +15058,10 @@ snapshots:
       commander: 2.20.3
       npm-path: 2.0.4
       which: 1.3.1
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   object-assign@4.1.1: {}
 
@@ -14400,6 +15110,22 @@ snapshots:
 
   outdent@0.5.0: {}
 
+  ow@0.28.2:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      callsites: 3.1.0
+      dot-prop: 6.0.1
+      lodash.isequal: 4.5.0
+      vali-date: 1.0.0
+
+  ow@1.1.1:
+    dependencies:
+      '@sindresorhus/is': 5.6.0
+      callsites: 4.2.0
+      dot-prop: 7.2.0
+      lodash.isequal: 4.5.0
+      vali-date: 1.0.0
+
   ox@0.14.30(typescript@6.0.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -14440,6 +15166,8 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  p-cancelable@4.0.1: {}
 
   p-filter@2.1.0:
     dependencies:
@@ -14514,6 +15242,15 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -14542,6 +15279,10 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pause-stream@0.0.11:
+    dependencies:
+      through: 2.3.8
 
   pend@1.2.0: {}
 
@@ -14680,6 +15421,12 @@ snapshots:
 
   promisepipe@3.0.0: {}
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@7.2.0: {}
 
   proxy-addr@2.0.7:
@@ -14688,6 +15435,19 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-agent@6.4.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3
@@ -14731,6 +15491,10 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-lru@5.1.1: {}
+
+  quick-lru@7.3.0: {}
 
   range-parser@1.3.0: {}
 
@@ -14848,6 +15612,8 @@ snapshots:
     dependencies:
       lodash: 4.18.1
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -14861,6 +15627,10 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  responselike@4.0.2:
+    dependencies:
+      lowercase-keys: 3.0.0
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -14869,6 +15639,8 @@ snapshots:
   ret@0.5.0: {}
 
   retimer@3.0.0: {}
+
+  retry@0.12.0: {}
 
   retry@0.13.1: {}
 
@@ -14880,6 +15652,8 @@ snapshots:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
+
+  robots-parser@3.0.1: {}
 
   rolldown@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.2):
     dependencies:
@@ -15000,6 +15774,8 @@ snapshots:
       parse-css-color: 0.2.1
       postcss-value-parser: 4.2.0
       yoga-layout: 3.2.1
+
+  sax@1.6.1: {}
 
   saxes@6.0.0:
     dependencies:
@@ -15205,6 +15981,10 @@ snapshots:
 
   split2@4.2.0: {}
 
+  split@0.3.3:
+    dependencies:
+      through: 2.3.8
+
   sprintf-js@1.0.3: {}
 
   srvx@0.11.22: {}
@@ -15224,6 +16004,16 @@ snapshots:
   std-env@4.2.0: {}
 
   stdin-discarder@0.3.2: {}
+
+  stream-chain@2.2.5: {}
+
+  stream-combiner@0.0.4:
+    dependencies:
+      duplexer: 0.1.2
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
 
   stream-to-array@2.3.0:
     dependencies:
@@ -15293,6 +16083,10 @@ snapshots:
   stripe@22.3.2(@types/node@25.9.5):
     optionalDependencies:
       '@types/node': 25.9.5
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
 
   style-to-js@1.1.21:
     dependencies:
@@ -15420,6 +16214,8 @@ snapshots:
 
   throttleit@2.1.0: {}
 
+  through@2.3.8: {}
+
   time-span@4.0.0:
     dependencies:
       convert-hrtime: 3.0.0
@@ -15460,6 +16256,12 @@ snapshots:
   toidentifier@1.0.0: {}
 
   toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   totalist@3.0.1: {}
 
@@ -15553,6 +16355,10 @@ snapshots:
 
   type-fest@0.7.1: {}
 
+  type-fest@2.19.0: {}
+
+  type-fest@4.41.0: {}
+
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
@@ -15570,6 +16376,8 @@ snapshots:
   ufo@1.6.4: {}
 
   uid-promise@1.0.0: {}
+
+  uint8array-extras@1.5.0: {}
 
   uncrypto@0.1.3: {}
 
@@ -15644,6 +16452,8 @@ snapshots:
   uuid-parse@1.1.0: {}
 
   uuid@14.0.1: {}
+
+  vali-date@1.0.0: {}
 
   vary@1.1.2: {}
 
@@ -15912,6 +16722,8 @@ snapshots:
       - uglify-js
 
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -827,9 +827,6 @@ importers:
 
   packages/apify-actor-governed-run:
     dependencies:
-      '@revealui/ai':
-        specifier: workspace:*
-        version: link:../ai
       '@revealui/security':
         specifier: workspace:*
         version: link:../security
@@ -858,6 +855,10 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+    optionalDependencies:
+      '@revealui/ai':
+        specifier: workspace:^
+        version: link:../ai
 
   packages/auth:
     dependencies:


### PR DESCRIPTION
## Summary

Scaffold + core implementation for GAP-431: a new private workspace package `packages/apify-actor-governed-run` -- an Apify pay-per-event (PPE) actor that runs an AI agent task and returns a cryptographically signed, offline-verifiable receipt of every action.

**REVIEW-PENDING under guardrail 2 -- do not merge until a coordinator verdict is recorded.** This PR ships new Ed25519 signing/verification code (`src/receipt/`). The fleet's mechanical `security-pr-review-check.js --diff origin/test` did **not** flag this PR (none of our new file paths contain a substring in `scripts/validate/security-paths.shared.json`'s marker list -- the list has `signing`, `packages/security/`, `license-crypto` etc., but our directory is named `receipt/`, not `signing/`), which I judge to be a real gap in that path list, not evidence the PR is safe. Per `dup-work-and-review-gates.md` ("unsure -> treat as security"), I'm treating it as security-sensitive by policy. **Next step is review, not merge.**

## Audit (cited, per audit-first-sdlc)

**1. Signing/receipt primitives** (`packages/security/src/audit-signing.ts`, `audit-merkle.ts`, `audit-anchor-verify.ts`, `audit-signer-env.ts`, `jcs.ts` -- GAP-355 `2026-07-12-audit-receipt-architecture`, recently touched by GAP-427/429):
- **Reused as-is**: `Ed25519AuditRowSigner` (`packages/security/src/audit-signing.ts:107`, generic over `Uint8Array`, not tied to the `AuditSignable` row shape), `verifyEd25519AuditSignature` (`audit-signing.ts:160`), `canonicalizeJcs` (`packages/security/src/jcs.ts:38`, RFC 8785), `deriveAuditKid` (`packages/security/src/audit-signer-env.ts:70`). All proven standalone-importable outside the server runtime already, via `scripts/security/verify-audit-anchor.ts` (imports only `@revealui/security/server` + `node:crypto`/`node:fs`, zero DB).
- **Not reused**: the env-based key management (`createAuditRowSignerFromEnv`) and the DB-coupled wiring (`packages/auth/src/server/audit-storage.ts`, `apps/server/src/routes/audit.ts`). That key backs RevealUI's own internal audit log; a customer's Apify run should not sign with our fleet's key. Instead each run generates a **fresh ephemeral Ed25519 keypair** (`src/receipt/sign.ts`) and embeds the public half in the receipt, so verification never depends on RevealUI's infrastructure or secrets.

**2. Agent execution primitives** (`packages/mcp/src`, `packages/ai/src`):
- `packages/mcp` has **no** LLM tool-calling loop -- it's the MCP protocol/server framework only (adapters, hypervisor, streamable-http, OAuth). The loop lives in `@revealui/ai`.
- `@revealui/ai/orchestration/runtime`'s `AgentRuntime.executeTask()` (`packages/ai/src/orchestration/runtime.ts:147`) is a complete, exported, production tool-calling loop -- but **not reused directly**. `AgentResult` (`packages/ai/src/orchestration/agent.ts:46-56`) is `{ success, output?, toolResults?, error?, metadata? }`: an aggregate summary, not an ordered per-call trail. Its only instrumentation hooks (`onToolAudit` for MCP tools, `approvalCallback`) don't cover every model call. Deriving a complete, ordered action log -- this product's entire value proposition -- from that black box after the fact would be lossy. So `src/agent/run-governed-task.ts` reuses the genuinely reusable pieces (`LLMClient`/`Reasoner.chat`, the `Tool`/`ToolResult` contract, both from `@revealui/ai`) and owns a small, explicit, instrumented iteration loop instead. Documented at `packages/apify-actor-governed-run/src/agent/run-governed-task.ts:65-79`.
- Verified `LLMClient` (`packages/ai/src/llm/client.ts:133`) never touches `@revealui/db` at runtime when constructed with an explicit `apiKey` (our actor's BYOK input) -- the DB-backed BYOK resolver (`decryptApiKey`/`tenantProviderConfigs`) is a separate function (`client.ts:780-820`) never called from the constructor or `chat()`.

**3. Ed25519 dependency**: no `tweetnacl`/`@noble/ed25519`/libsodium anywhere in the monorepo. The fleet's audit signing (and this PR) uses `node:crypto` natively -- zero new crypto dependency.

## Build

- `packages/apify-actor-governed-run` (`0.1.0`, `private: true`, no `license` field -- internal, ships to Apify not npm).
- `.actor/actor.json` + `.actor/input_schema.json` + `Dockerfile` per Apify's **current** (verified July 2026) conventions, via WebFetch against docs.apify.com -- **not from memory**. Key correction to my own brief: **Apify's PPE pricing does not live in `.actor/actor.json`** -- there's no `pricingInfos` field there. Pricing is Console/API-only (`PUT /v2/acts/{actorId}`), keyed by event-name strings. `src/pricing.config.ts` is this repo's single source of truth for that event catalog + prices.
- **Owner-ruled 2026-07-26 launch prices** (received mid-session, applied as real values not placeholders): `governed-action` $0.02/event, `run-completed` $0.08/event, `receipt-verification` $0.00 (free). Locked by a pinning test (`src/__tests__/pricing-config.test.ts`). **Not yet in `business/offerings-canonical.md`** -- flagged in README as an owner-adoption follow-up, not done in this PR (that doc is an owner-adoption step, not scaffold work).
- Receipt shape: `{ actionLog, signature, publicKey, algorithm, timestamp }` + standalone `verifyReceipt()` (no Apify SDK, no network -- importable from `@revealui/apify-actor-governed-run`).
- One built-in tool (`web_fetch`, bounded fetch with a static SSRF-lite guard: blocks loopback/RFC1918/cloud-metadata hosts, refuses to follow redirects). `toolAllowlist` input filters the catalog.
- Dockerfile mirrors `apps/server/Dockerfile`'s proven multi-stage pnpm-workspace pattern (monorepo build context + `pnpm deploy` for a self-contained runtime dir), since this package depends on two workspace packages. **Not smoke-tested against a live `apify run`/Apify build system** -- flagged in README; run `apify run` + `apify push` to a test actor before Store submission.

## Fixes required to keep the gate green (caused by adding a new package)

- `docs/gaps/GAP-436.yml` (revealui-jv PR #809): filed a **pre-existing, unrelated** gate failure discovered during verification -- `packages/openapi/contracts.openapi.json` mirror drift. Verified empirically on a pristine `origin/test` scratch worktree (zero GAP-431 diff) that it reproduces identically. Not fixed here (out of scope; this PR never touches `packages/openapi` or `packages/mcp`).
- Bumped the fleet's mechanical package/workspace counts everywhere `claim-drift.ts` tracks them (29->30 packages, 34->35 workspaces, 1->2 internal packages): README, docs/JOSHUA.md, docs/ROADMAP.md, docs/LAUNCH-CHECKLIST.md, docs/MARKETING_METRICS.md, docs/WHAT_WORKS_TODAY.md, docs/security/INFORMATION_SECURITY_POLICY.md, docs/guides/technology-stack.md, docs/blog/01-why-we-built-revealui.md, docs/blog/14-claim-drift.md, `apps/marketing/app/content/{site,home,pricing-teaser,claims-evidence,fair-source,proof}.ts`, `apps/marketing/public/llms.txt`. `proof.ts`'s comment describes a **historical** 2026-05-18 state and correctly keeps its original numbers (rephrased only to avoid the drift-detector's false positive on a past-tense record, per the tool's own line-level pattern).
- `@revealui/ai` moved to `optionalDependencies` + `workspace:^` (was `dependencies` + `workspace:*`): `boundary.ts` Check 4 forbids any package hard-requiring the two Fair Source packages (`@revealui/ai`, `@revealui/harnesses`) in `dependencies`/`devDependencies`; `version-policy.ts`'s `pro-peer-use-range` requires `^x.y.z` or `workspace:^` for Pro peers. Matches the existing `@revealui/engines` precedent exactly.
- One citation-check fix (`README.md`): rephrased a line about Apify's pricing model so the external-fact claim carries an inline `http`/`see` marker on the same physical line (the checker's coverage heuristic is per-line and doesn't accept a markdown link to a URL as a citation the way it accepts `path/to/file.ts:N`).

## Verify

- `pnpm --filter @revealui/apify-actor-governed-run typecheck` -- clean.
- `pnpm --filter @revealui/apify-actor-governed-run test` -- **37/37 passing**: receipt sign->verify roundtrip (including empty action logs, per-run keypair uniqueness), tampered-receipt rejection (mutated action log, mutated timestamp, substituted signature from a different run, mismatched embedded public key, malformed/missing receipt shape, garbage signature string -- all correctly rejected), input validation (run-task vs verify-receipt discriminated union, every required-field-missing case), the governed-task loop (model+tool call recording and interleaving order, unknown-tool handling, charge-limit and max-steps stop reasons, no `undefined` ever reaching the canonicalizer), tool allowlist filtering, and `web_fetch`'s SSRF guard.
- `pnpm gate --changed` (the pre-push hook's own check) -- **PASS**, after fixing the claim-drift/boundary/version-policy/citation issues above. `pnpm build` run fleet-wide to populate `dist/` for every package first (fresh worktree).
- The fleet's internal security-sensitive-path checker (private coordination repo), run against this branch's diff: reported **not security-sensitive** (see REVIEW-PENDING note above for why I don't trust that verdict here).

## Open design questions for the owner

1. **Guardrail-2 review** -- this PR needs an actual security read of `src/receipt/sign.ts`, `src/receipt/verify.ts`, `src/receipt/signable.ts` before merge, regardless of what the mechanical path checker said. Consider adding a `receipt`/`crypto` marker to `scripts/validate/security-paths.shared.json` so future PRs in this shape get caught automatically (not done here -- editing the shared fleet marker list felt like a separate, wider-blast-radius change than a scaffold PR should carry, but flagging it as a real gap in the current list).
2. **Docker build is unverified against live Apify infrastructure.** I did not run `apify run`/`apify push` (no Apify account/token in this session). Recommend a smoke test before Store submission.
3. **Tool catalog is intentionally minimal** (`web_fetch` only) for a v0.1 scaffold. Expanding it, and hardening `web_fetch`'s SSRF guard (no DNS-rebinding protection today), are natural follow-ups -- not done here to avoid scope creep on a scaffold PR.
4. **`business/offerings-canonical.md` needs the Apify PPE channel added** on adoption (per the owner's 2026-07-26 pricing ruling) -- intentionally not done in this PR since that's an owner-adoption step in the private coordination repo, not scaffold work.
5. GAP-436 (openapi contracts drift) is unrelated pre-existing debt on `test`, filed separately, not blocking this PR.

## Exact price/config location

Not placeholders -- real owner-ruled values, single source of truth: `packages/apify-actor-governed-run/src/pricing.config.ts`. Mirrored in the README's pricing table and the `PUT /v2/acts/{actorId}` example body.

Generated with Claude Code

