### PR TITLE
fix(apify-actor): resolve guardrail-2 blockers on GAP-431 receipt actor

### DIFF
--- a/packages/apify-actor-governed-run/README.md
+++ b/packages/apify-actor-governed-run/README.md
@@ -3,26 +3,41 @@
 If an agent did it, there's a receipt.
 
 This actor runs an AI agent task for you and hands back both the result and a
-cryptographically signed, offline-verifiable receipt of every action the
-agent took: every model call and every tool call, in order, with a signature
-you can check without ever talking to us again.
+cryptographically signed receipt of every action the agent took: every model
+call and every tool call, in order, with a signature you can check without
+ever talking to us again.
 
 ## What you get
 
 - **A completed task.** Give the actor a task and your own LLM API key
   (Anthropic or OpenAI), and it runs an agent loop until the task is done or
   it hits a step limit.
-- **A signed receipt.** Every model call and tool call is recorded into an
-  action log, and the whole log is signed with a fresh Ed25519 key generated
-  for that run. The public key travels with the receipt, so anyone can verify
-  it offline with nothing but the receipt itself.
+- **A signed, tamper-evident receipt.** Every model call and tool call is
+  recorded into an action log, and the whole log, together with the
+  identifiers of the Apify run that produced it, is signed with a fresh
+  Ed25519 key generated for that run. Anyone can check the signature offline
+  with nothing but the receipt itself, and confirm that nothing in it changed
+  after signing.
+- **A platform-attributable run record.** The actor also publishes the
+  receipt to that run's own dataset and key-value store on Apify, the same
+  places the rest of the run's output lives. Nobody but the actual running
+  actor process can write there for that run, so a verifier who wants proof
+  the run really happened, not just that the receipt is internally
+  consistent, can fetch that record from the Apify API for the `actorRunId`
+  embedded in the receipt and confirm it matches.
 - **A free way to check any receipt.** Run this actor again in
   "verify-receipt" mode with a receipt you already have, and it tells you
   whether the signature is valid. This mode is free.
 
-What the receipt is: a cryptographically signed and offline-verifiable record
-of the actions an agent took. What it is not: a compliance certification of
-any kind. This actor makes no SOC 2, ISO, or other compliance claim.
+**What a receipt proves, and what it doesn't.** Standalone verification
+(`verifyReceipt`, or "verify-receipt" mode) proves the action log was not
+altered after signing. It does not, by itself, prove the run happened on
+Apify at all. Anyone can generate their own Ed25519 keypair and sign a
+fabricated action log claiming any `actorRunId` they like, and that receipt
+will still verify. Proving provenance, that a specific receipt corresponds to
+a run RevealUI's actor actually executed, needs the extra step above: checking
+`receipt.actorRunId` against that run's own dataset or key-value record on
+Apify. This actor makes no SOC 2, ISO, or other compliance claim either way.
 
 ## Input
 
@@ -90,13 +105,22 @@ price-only adjustment. Example `PUT` body shape (see
 
 1. Every model call and tool call the agent makes is appended to an action
    log, in order, along with a final entry recording the run's output.
-2. The action log is canonicalized with RFC 8785 JSON Canonicalization (the
-   same canonicalizer RevealUI's own internal audit log uses, so the byte
-   representation is deterministic regardless of key order) and signed with a
-   fresh Ed25519 keypair generated for that run.
-3. The receipt embeds the action log, the signature, the public key, the
-   algorithm, and a timestamp. Nothing about verifying it depends on
-   RevealUI's infrastructure or on this actor still existing.
+2. The action log, together with the run's `actorId`, `actorRunId`, and
+   `actorBuildId` (read from `Actor.getEnv()`; all three are `null` for a run
+   outside the Apify platform, such as local `pnpm dev`), is canonicalized
+   with RFC 8785 JSON Canonicalization (the same canonicalizer RevealUI's own
+   internal audit log uses, so the byte representation is deterministic
+   regardless of key order) and signed with a fresh Ed25519 keypair generated
+   for that run.
+3. The receipt embeds the action log, the run identifiers, the signature, the
+   public key, the algorithm, and a timestamp. Checking the signature depends
+   on none of RevealUI's infrastructure and none of this actor still existing.
+   Checking provenance instead of just integrity does depend on the run's own
+   record still being retrievable from Apify.
+4. The actor publishes that same receipt to the run's dataset
+   (`Actor.pushData`) and key-value store (`Actor.setValue('OUTPUT', ...)`),
+   both of which only the actual running actor process can write to for that
+   run.
 
 ```ts
 import { verifyReceipt } from '@revealui/apify-actor-governed-run';
@@ -107,15 +131,20 @@ const result = verifyReceipt(receipt); // { valid: boolean, reason?: string }
 ## Known limitations (v0.1)
 
 - The built-in tool catalog has exactly one tool (`web_fetch`, a bounded
-  HTTP(S) fetch). It refuses obvious private/loopback/cloud-metadata hosts
-  and does not follow redirects, but it is not a complete SSRF defense (no
-  DNS-rebinding protection). Expanding the tool catalog is future work.
+  HTTP(S) fetch). It resolves DNS and blocks the private, loopback,
+  link-local, and carrier-grade-NAT ranges across both IPv4 and IPv6
+  (including IPv4-mapped IPv6 addresses), and it does not follow redirects.
+  It does not pin the connection to the address it validated, so a true
+  DNS-rebinding attack, where the DNS answer changes between that check and
+  the fetch a moment later, is still out of scope. A public hostname with a
+  static record pointed at a blocked address is fully blocked. Expanding the
+  tool catalog is future work.
 - The Dockerfile has not been smoke-tested against a live `apify run` or the
   Apify build system. Run `apify run` locally and `apify push` to a test
   actor before Store submission.
-- This PR is review-pending under the fleet's guardrail-2 security review
-  gate (the receipt-signing code touches a security-sensitive surface). See
-  the PR body.
+- This package is review-pending under the fleet's guardrail-2 security
+  review gate (the receipt-signing and SSRF-guard code touch a
+  security-sensitive surface). See the PR body for the current verdict.
 
 ## Development
 

--- a/packages/apify-actor-governed-run/src/__tests__/load-llm-client.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/load-llm-client.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Guardrail-2 hygiene finding (revealui#2198): `@revealui/ai` was declared in
+// `optionalDependencies` but hard-imported at `main.ts:1` with no guard, so
+// the actor could not even start without it -- the declaration didn't match
+// runtime behavior. The fix makes the load genuinely lazy and the failure
+// mode a clear, actionable error.
+
+describe('loadLLMClient', () => {
+  it('returns LLMClient when @revealui/ai resolves', async () => {
+    vi.resetModules();
+    const { loadLLMClient } = await import('../agent/load-llm-client.js');
+    const LLMClient = await loadLLMClient();
+    expect(typeof LLMClient).toBe('function');
+  });
+
+  it('throws a clear, actionable error when @revealui/ai cannot be loaded', async () => {
+    vi.resetModules();
+    vi.doMock('@revealui/ai', () => {
+      throw new Error("Cannot find package '@revealui/ai'");
+    });
+
+    try {
+      const { loadLLMClient } = await import('../agent/load-llm-client.js');
+      await expect(loadLLMClient()).rejects.toThrow(/run-task mode requires @revealui\/ai/);
+    } finally {
+      vi.doUnmock('@revealui/ai');
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/apify-actor-governed-run/src/__tests__/receipt-provenance.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/receipt-provenance.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { signActionLog } from '../receipt/sign.js';
+import { verifyReceipt } from '../receipt/verify.js';
+import type { ActionLogEntry, Receipt, RunContext } from '../types.js';
+
+// Guardrail-2 blocker 1 (revealui#2198 REQUEST-CHANGES): a receipt proved
+// nothing about provenance -- anyone could mint a valid one with a fresh
+// keypair and a fabricated action log. The fix binds the receipt to the
+// actual Apify run (actorId / actorRunId / actorBuildId) inside the signed
+// payload, so a verifier can cross-check a receipt's claimed run against
+// that run's own platform-attributable record (its dataset/KV store).
+// Standalone `verifyReceipt` still only proves the bytes were not tampered
+// with after signing -- that is documented honestly in the README now.
+
+const actionLog: ActionLogEntry[] = [
+  {
+    index: 0,
+    type: 'final_output',
+    timestamp: '2026-07-26T00:00:00.000Z',
+    detail: { output: 'done' },
+  },
+];
+
+const platformRunContext: RunContext = {
+  actorId: 'actor-abc123',
+  actorRunId: 'run-xyz789',
+  actorBuildId: 'build-def456',
+};
+
+const localRunContext: RunContext = { actorId: null, actorRunId: null, actorBuildId: null };
+
+describe('receipt provenance binding (prove red)', () => {
+  it('embeds the actor/run/build identifiers the caller supplies into the receipt', () => {
+    const receipt = signActionLog(actionLog, platformRunContext);
+    expect(receipt.actorId).toBe(platformRunContext.actorId);
+    expect(receipt.actorRunId).toBe(platformRunContext.actorRunId);
+    expect(receipt.actorBuildId).toBe(platformRunContext.actorBuildId);
+  });
+
+  it('falls back to null run-context fields for a local (non-platform) run and still verifies', () => {
+    const receipt = signActionLog(actionLog, localRunContext);
+    expect(receipt.actorId).toBeNull();
+    expect(receipt.actorRunId).toBeNull();
+    expect(receipt.actorBuildId).toBeNull();
+    expect(verifyReceipt(receipt)).toEqual({ valid: true });
+  });
+
+  it('signs the run-context fields: changing actorRunId after signing invalidates the receipt', () => {
+    const receipt = signActionLog(actionLog, platformRunContext);
+    const forged: Receipt = { ...receipt, actorRunId: 'a-different-run-id' };
+    expect(verifyReceipt(forged).valid).toBe(false);
+  });
+
+  it('signs actorId and actorBuildId too -- neither can be swapped after signing', () => {
+    const receipt = signActionLog(actionLog, platformRunContext);
+    expect(verifyReceipt({ ...receipt, actorId: 'someone-elses-actor' }).valid).toBe(false);
+    expect(verifyReceipt({ ...receipt, actorBuildId: 'a-different-build' }).valid).toBe(false);
+  });
+});

--- a/packages/apify-actor-governed-run/src/__tests__/receipt-roundtrip.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/receipt-roundtrip.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { signActionLog } from '../receipt/sign.js';
 import { verifyReceipt } from '../receipt/verify.js';
-import type { ActionLogEntry } from '../types.js';
+import type { ActionLogEntry, RunContext } from '../types.js';
+
+const runContext: RunContext = {
+  actorId: 'actor-abc123',
+  actorRunId: 'run-xyz789',
+  actorBuildId: 'build-def456',
+};
 
 const sampleActionLog: ActionLogEntry[] = [
   {
@@ -26,20 +32,23 @@ const sampleActionLog: ActionLogEntry[] = [
 
 describe('signActionLog / verifyReceipt roundtrip', () => {
   it('signs an action log and verifies it as valid', () => {
-    const receipt = signActionLog(sampleActionLog);
+    const receipt = signActionLog(sampleActionLog, runContext);
 
     expect(receipt.algorithm).toBe('ed25519');
     expect(receipt.actionLog).toEqual(sampleActionLog);
     expect(receipt.signature).toMatch(/^v1\.ed25519\.[0-9a-f-]+\.[A-Za-z0-9_-]+$/);
     expect(receipt.publicKey).toContain('BEGIN PUBLIC KEY');
+    expect(receipt.actorId).toBe(runContext.actorId);
+    expect(receipt.actorRunId).toBe(runContext.actorRunId);
+    expect(receipt.actorBuildId).toBe(runContext.actorBuildId);
 
     const result = verifyReceipt(receipt);
     expect(result).toEqual({ valid: true });
   });
 
   it('produces a different keypair (and signature) per run', () => {
-    const first = signActionLog(sampleActionLog);
-    const second = signActionLog(sampleActionLog);
+    const first = signActionLog(sampleActionLog, runContext);
+    const second = signActionLog(sampleActionLog, runContext);
 
     expect(first.publicKey).not.toBe(second.publicKey);
     expect(first.signature).not.toBe(second.signature);
@@ -48,7 +57,7 @@ describe('signActionLog / verifyReceipt roundtrip', () => {
   });
 
   it('verifies an empty action log', () => {
-    const receipt = signActionLog([]);
+    const receipt = signActionLog([], runContext);
     expect(verifyReceipt(receipt)).toEqual({ valid: true });
   });
 });

--- a/packages/apify-actor-governed-run/src/__tests__/receipt-tamper.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/receipt-tamper.test.ts
@@ -2,7 +2,7 @@ import { generateKeyPairSync } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { signActionLog } from '../receipt/sign.js';
 import { verifyReceipt } from '../receipt/verify.js';
-import type { ActionLogEntry, Receipt } from '../types.js';
+import type { ActionLogEntry, Receipt, RunContext } from '../types.js';
 
 const baseActionLog: ActionLogEntry[] = [
   {
@@ -13,9 +13,11 @@ const baseActionLog: ActionLogEntry[] = [
   },
 ];
 
+const runContext: RunContext = { actorId: 'a', actorRunId: 'r', actorBuildId: 'b' };
+
 describe('verifyReceipt rejects tampered receipts (prove red)', () => {
   it('rejects a receipt whose action log was modified after signing', () => {
-    const receipt = signActionLog(baseActionLog);
+    const receipt = signActionLog(baseActionLog, runContext);
 
     const tampered: Receipt = {
       ...receipt,
@@ -28,22 +30,22 @@ describe('verifyReceipt rejects tampered receipts (prove red)', () => {
   });
 
   it('rejects a receipt whose timestamp was modified after signing', () => {
-    const receipt = signActionLog(baseActionLog);
+    const receipt = signActionLog(baseActionLog, runContext);
     const tampered: Receipt = { ...receipt, timestamp: '2099-01-01T00:00:00.000Z' };
 
     expect(verifyReceipt(tampered).valid).toBe(false);
   });
 
   it('rejects a receipt with a substituted signature from a different keypair', () => {
-    const receiptA = signActionLog(baseActionLog);
-    const receiptB = signActionLog(baseActionLog);
+    const receiptA = signActionLog(baseActionLog, runContext);
+    const receiptB = signActionLog(baseActionLog, runContext);
 
     const forged: Receipt = { ...receiptA, signature: receiptB.signature };
     expect(verifyReceipt(forged).valid).toBe(false);
   });
 
   it('rejects a receipt whose public key does not match the signature kid', () => {
-    const receipt = signActionLog(baseActionLog);
+    const receipt = signActionLog(baseActionLog, runContext);
     const { publicKey: unrelatedPublicKey } = generateKeyPairSync('ed25519', {
       privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
       publicKeyEncoding: { type: 'spki', format: 'pem' },
@@ -62,7 +64,7 @@ describe('verifyReceipt rejects tampered receipts (prove red)', () => {
   });
 
   it('rejects an unrecognized signature format', () => {
-    const receipt = signActionLog(baseActionLog);
+    const receipt = signActionLog(baseActionLog, runContext);
     const forged: Receipt = { ...receipt, signature: 'not-a-real-signature' };
     expect(verifyReceipt(forged).valid).toBe(false);
   });

--- a/packages/apify-actor-governed-run/src/__tests__/receipt-unknown-key-injection.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/receipt-unknown-key-injection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { signActionLog } from '../receipt/sign.js';
+import { verifyReceipt } from '../receipt/verify.js';
+import type { RunContext } from '../types.js';
+
+// Guardrail-2 blocker 2 (revealui#2198 REQUEST-CHANGES): ActionLogEntrySchema
+// and ReceiptSchema were non-strict `z.object`s, so Zod silently stripped
+// unknown keys during `safeParse`. verify.ts canonicalized the parsed
+// (post-strip) data, but every consumer reads the caller's original,
+// pre-strip `receipt`/`actionLog` object -- so an injected field survived
+// into what a consumer renders while the signature never covered it, and
+// `verifyReceipt` still reported `{ valid: true }`. Making both schemas
+// `.strict()` makes verification reject any receipt carrying a field the
+// signature does not cover, instead of silently ignoring it.
+
+const runContext: RunContext = { actorId: 'a', actorRunId: 'r', actorBuildId: 'b' };
+
+describe('verifyReceipt rejects unknown-key injection (prove red)', () => {
+  it('rejects a receipt with a field injected onto a signed action log entry', () => {
+    const receipt = signActionLog(
+      [
+        {
+          index: 0,
+          type: 'model_call',
+          timestamp: '2026-07-26T00:00:00.000Z',
+          detail: { content: 'the real answer' },
+        },
+      ],
+      runContext,
+    );
+
+    const withInjectedField = {
+      ...receipt,
+      actionLog: [
+        {
+          ...receipt.actionLog[0],
+          attackerField: 'a field the signature never covered',
+        },
+      ],
+    };
+
+    expect(verifyReceipt(withInjectedField).valid).toBe(false);
+  });
+
+  it('rejects a receipt with an unknown top-level field injected', () => {
+    const receipt = signActionLog(
+      [{ index: 0, type: 'final_output', timestamp: '2026-07-26T00:00:00.000Z', detail: {} }],
+      runContext,
+    );
+
+    const withInjectedField = { ...receipt, unexpectedField: 'also never signed' };
+    expect(verifyReceipt(withInjectedField).valid).toBe(false);
+  });
+});

--- a/packages/apify-actor-governed-run/src/__tests__/tools.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/tools.test.ts
@@ -1,5 +1,28 @@
-import { describe, expect, it } from 'vitest';
-import { BUILT_IN_TOOLS, selectTools, webFetchTool } from '../agent/tools.js';
+import { describe, expect, it, vi } from 'vitest';
+
+// Guardrail-2 blocker 3 (revealui#2198 REQUEST-CHANGES): `isBlockedHost` did
+// string equality/prefix matching on `url.hostname` with no DNS resolution,
+// and never stripped the brackets WHATWG URL wraps around a literal IPv6
+// host. The reviewer probed the guard directly and found 8 of 13 targets
+// slipped through (IPv6 entirely unfiltered, a loopback/link-local/CGN
+// address one hop past the single hardcoded value, and a public DNS name
+// with a static A record pointed at the cloud metadata IP). The 13-target
+// table below is the reviewer's reproduction, verbatim; every one of them
+// must resolve to "blocked" after the fix (or the tool must be disabled).
+//
+// `169.254.169.254.nip.io` needs a real DNS query to resolve for real (nip.io
+// wildcard-DNS's any `<ip>.nip.io` name to `<ip>`) -- mocked here so the test
+// is deterministic and does not depend on network access in CI/sandboxes.
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (hostname: string, _options: unknown) => {
+    if (hostname === '169.254.169.254.nip.io') {
+      return [{ address: '169.254.169.254', family: 4 }];
+    }
+    throw new Error(`unexpected dns lookup in test for host: ${hostname}`);
+  }),
+}));
+
+const { BUILT_IN_TOOLS, selectTools, webFetchTool } = await import('../agent/tools.js');
 
 describe('selectTools', () => {
   it('returns all built-in tools when no allowlist is given', () => {
@@ -28,16 +51,37 @@ describe('webFetchTool', () => {
     expect(result.error).toMatch(/http\/https/);
   });
 
-  it('rejects loopback hosts', async () => {
-    const result = await webFetchTool.execute({ url: 'http://127.0.0.1/secret' });
+  it('rejects malformed params', async () => {
+    const result = await webFetchTool.execute({ notUrl: 'nope' });
     expect(result.success).toBe(false);
-    expect(result.error).toMatch(/not allowed/);
+    expect(result.error).toMatch(/invalid params/);
   });
 
-  it('rejects the cloud metadata endpoint', async () => {
-    const result = await webFetchTool.execute({ url: 'http://169.254.169.254/latest/meta-data/' });
-    expect(result.success).toBe(false);
-    expect(result.error).toMatch(/not allowed/);
+  describe("SSRF guard -- the reviewer's 13-target probe table (prove red)", () => {
+    const mustBeBlocked: Array<[label: string, url: string]> = [
+      ['IPv6 loopback (bracket-stripping bug: WHATWG URL yields "[::1]")', 'http://[::1]/'],
+      ['IPv4-mapped IPv6 loopback', 'http://[::ffff:127.0.0.1]/'],
+      ['IPv4-mapped IPv6 cloud metadata address', 'http://[::ffff:a9fe:a9fe]/'],
+      ['IPv6 unique local address (ULA, fc00::/7)', 'http://[fd00::1]/'],
+      ['loopback range beyond the single hardcoded 127.0.0.1', 'http://127.0.0.2/'],
+      ['link-local range beyond the single hardcoded metadata IP', 'http://169.254.169.253/'],
+      ['carrier-grade NAT / cloud metadata range (100.64.0.0/10)', 'http://100.100.100.200/'],
+      [
+        'public DNS name with a static A record at the metadata IP',
+        'http://169.254.169.254.nip.io/',
+      ],
+      ['decimal-encoded IPv4 (normalizes to the metadata IP)', 'http://2852039166/'],
+      ['hex-encoded IPv4 (normalizes to loopback)', 'http://0x7f000001/'],
+      ['short-form IPv4 (normalizes to loopback)', 'http://127.1/'],
+      ['canonical loopback', 'http://127.0.0.1/'],
+      ['canonical cloud metadata endpoint', 'http://169.254.169.254/'],
+    ];
+
+    it.each(mustBeBlocked)('blocks: %s (%s)', async (_label, url) => {
+      const result = await webFetchTool.execute({ url });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not allowed/);
+    });
   });
 
   it('rejects private RFC1918 ranges', async () => {
@@ -48,9 +92,11 @@ describe('webFetchTool', () => {
     }
   });
 
-  it('rejects malformed params', async () => {
-    const result = await webFetchTool.execute({ notUrl: 'nope' });
-    expect(result.success).toBe(false);
-    expect(result.error).toMatch(/invalid params/);
+  it('rejects .internal and .local suffixed hostnames', async () => {
+    for (const url of ['http://foo.internal/', 'http://bar.local/']) {
+      const result = await webFetchTool.execute({ url });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not allowed/);
+    }
   });
 });

--- a/packages/apify-actor-governed-run/src/agent/load-llm-client.ts
+++ b/packages/apify-actor-governed-run/src/agent/load-llm-client.ts
@@ -1,0 +1,26 @@
+/**
+ * Lazily load `@revealui/ai`'s `LLMClient`.
+ *
+ * `@revealui/ai` is declared under `optionalDependencies` (package.json)
+ * because `verify-receipt` mode never needs it -- only `run-task` mode does.
+ * A top-level static import (the original shape, `main.ts:1`) defeated that:
+ * it made the whole actor process fail to even start without `@revealui/ai`
+ * present, textually satisfying the optional-dependency declaration while
+ * breaking its actual contract (GAP-431 guardrail-2 hygiene finding). This
+ * makes the optionality real -- `run-task` mode fails with a clear,
+ * actionable error instead of a bare module-resolution crash, and
+ * `verify-receipt` mode is entirely unaffected either way.
+ */
+export async function loadLLMClient(): Promise<typeof import('@revealui/ai').LLMClient> {
+  try {
+    const mod = await import('@revealui/ai');
+    return mod.LLMClient;
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `run-task mode requires @revealui/ai, which could not be loaded (${cause}). ` +
+        '@revealui/ai is an optionalDependency of this package because verify-receipt ' +
+        'mode does not need it -- install it to use run-task mode.',
+    );
+  }
+}

--- a/packages/apify-actor-governed-run/src/agent/tools.ts
+++ b/packages/apify-actor-governed-run/src/agent/tools.ts
@@ -1,3 +1,5 @@
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIPv4, isIPv6 } from 'node:net';
 import type { Tool, ToolResult } from '@revealui/ai';
 import { z } from 'zod/v4';
 
@@ -8,26 +10,142 @@ const WEB_FETCH_PARAMS = z.object({
 const MAX_RESPONSE_CHARS = 100_000;
 const FETCH_TIMEOUT_MS = 15_000;
 
-/**
- * Hostnames/ranges this tool refuses to fetch. This is a minimal, static
- * SSRF guard (no DNS resolution, no redirect-chain re-checking) appropriate
- * for a v0.1 scaffold running on Apify's own infrastructure -- it blocks the
- * obvious cloud-metadata and loopback/private targets an LLM-directed fetch
- * could otherwise be steered at. It is NOT a complete SSRF defense (e.g. DNS
- * rebinding is out of scope here); see the PR body's open design questions.
- */
-function isBlockedHost(hostname: string): boolean {
-  const host = hostname.toLowerCase();
-  if (host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0' || host === '::1')
-    return true;
-  if (host === '169.254.169.254') return true; // cloud metadata endpoint
-  if (host.endsWith('.internal') || host.endsWith('.local')) return true;
-  if (host.startsWith('10.') || host.startsWith('192.168.')) return true;
-  if (host.startsWith('172.')) {
-    const secondOctet = Number(host.split('.')[1]);
-    if (secondOctet >= 16 && secondOctet <= 31) return true;
+const HEX_DIGITS = '0123456789abcdefABCDEF';
+
+function isValidHexGroup(group: string): boolean {
+  if (group.length === 0 || group.length > 4) return false;
+  for (const char of group) {
+    if (!HEX_DIGITS.includes(char)) return false;
   }
+  return true;
+}
+
+/** Strip the brackets WHATWG URL wraps a literal IPv6 host in (`[::1]` ->
+ * `::1`). Fixed bug (guardrail-2 blocker 3): the old guard compared against
+ * the bracketed form, so its own `'::1'` check could never match. */
+function stripIPv6Brackets(hostname: string): string {
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
+/** Expand a (possibly `::`-compressed) IPv6 address into its 8 16-bit groups.
+ * Returns `null` for anything that doesn't parse as exactly 8 groups -- the
+ * caller treats an unparsed address as blocked (fail closed). No regex (fleet
+ * no-regex rule): hex-digit validation is a plain character-set membership
+ * check via `HEX_DIGITS.includes`. */
+function expandIPv6Groups(address: string): number[] | null {
+  const halves = address.split('::');
+  if (halves.length > 2) return null;
+
+  const parseSide = (side: string): number[] | null => {
+    if (side === '') return [];
+    const groups: number[] = [];
+    for (const part of side.split(':')) {
+      if (!isValidHexGroup(part)) return null;
+      groups.push(Number.parseInt(part, 16));
+    }
+    return groups;
+  };
+
+  if (halves.length === 1) {
+    const groups = parseSide(halves[0] ?? '');
+    return groups && groups.length === 8 ? groups : null;
+  }
+
+  const left = parseSide(halves[0] ?? '');
+  const right = parseSide(halves[1] ?? '');
+  if (!(left && right)) return null;
+  const missing = 8 - left.length - right.length;
+  if (missing < 0) return null;
+  return [...left, ...new Array(missing).fill(0), ...right];
+}
+
+/** Blocked IPv4 ranges: loopback, RFC1918 private, link-local (covers the
+ * cloud metadata endpoint and its whole /16, not just the single address),
+ * carrier-grade NAT (covers 100.100.100.200, the Alibaba Cloud metadata
+ * address), and 0.0.0.0/8. */
+function isBlockedIPv4(ip: string): boolean {
+  const octets = ip.split('.').map(Number);
+  const [a, b] = octets;
+  if (a === undefined || b === undefined) return true;
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 0) return true; // 0.0.0.0/8
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local + cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
   return false;
+}
+
+/** Blocked IPv6 ranges: loopback (::1), unique local addresses (fc00::/7,
+ * covers fd00::/8), link-local (fe80::/10), and IPv4-mapped addresses
+ * (::ffff:a.b.c.d), whose embedded IPv4 address is recursively checked
+ * against `isBlockedIPv4` -- this is what closes the
+ * `[::ffff:127.0.0.1]` / `[::ffff:a9fe:a9fe]` bypasses. */
+function isBlockedIPv6(address: string): boolean {
+  const groups = expandIPv6Groups(address);
+  if (!groups) return true; // unparseable -- fail closed
+
+  const isZero = (n: number): boolean => n === 0;
+  if (groups.slice(0, 7).every(isZero) && groups[7] === 1) return true; // ::1
+
+  const first = groups[0] ?? 0;
+  if (first >= 0xfc00 && first <= 0xfdff) return true; // fc00::/7 (ULA)
+  if (first >= 0xfe80 && first <= 0xfebf) return true; // fe80::/10 (link-local)
+
+  const isIPv4Mapped = groups.slice(0, 5).every(isZero) && groups[5] === 0xffff;
+  if (isIPv4Mapped) {
+    const g6 = groups[6] ?? 0;
+    const g7 = groups[7] ?? 0;
+    const embeddedIPv4 = [(g6 >> 8) & 0xff, g6 & 0xff, (g7 >> 8) & 0xff, g7 & 0xff].join('.');
+    return isBlockedIPv4(embeddedIPv4);
+  }
+
+  return false;
+}
+
+/** Non-IP hostname heuristics that don't need DNS: obvious internal-only
+ * suffixes/names. */
+function isBlockedHostnameSuffix(host: string): boolean {
+  return host === 'localhost' || host.endsWith('.internal') || host.endsWith('.local');
+}
+
+/**
+ * SSRF guard for the `web_fetch` tool. Blocks the cloud-metadata, loopback,
+ * link-local, private, and carrier-grade-NAT ranges across both IPv4 and
+ * IPv6 (including IPv4-mapped IPv6 addresses), plus obvious internal
+ * hostname suffixes. For a hostname that isn't a literal IP, it resolves DNS
+ * and checks every resolved address, which is what stops a public name with
+ * a static A/AAAA record pointed at a blocked address (e.g. a
+ * `*.nip.io`-style wildcard DNS name resolving to the metadata IP).
+ *
+ * This does NOT re-check the resolved address at connection time, so a true
+ * DNS-rebinding attack (the DNS answer changing between this check and the
+ * `fetch()` call a few lines below) is still out of scope -- that requires
+ * pinning the TCP connection to the specific address validated here, which
+ * is more than this v0.1 scaffold carries. A *static* record pointed at a
+ * blocked address, which is the reviewed bypass class, is fully closed.
+ */
+async function isBlockedHost(hostname: string): Promise<boolean> {
+  const host = stripIPv6Brackets(hostname).toLowerCase();
+
+  if (isBlockedHostnameSuffix(host)) return true;
+  if (isIPv4(host)) return isBlockedIPv4(host);
+  if (isIPv6(host)) return isBlockedIPv6(host);
+
+  // Not a literal IP -- resolve it and check every address it points at.
+  let addresses: Array<{ address: string; family: number }>;
+  try {
+    addresses = await dnsLookup(host, { all: true });
+  } catch {
+    return true; // cannot resolve -- fail closed rather than let fetch() try
+  }
+  return addresses.some((entry) =>
+    entry.family === 6 ? isBlockedIPv6(entry.address) : isBlockedIPv4(entry.address),
+  );
 }
 
 export const webFetchTool: Tool = {
@@ -51,7 +169,7 @@ export const webFetchTool: Tool = {
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       return { success: false, error: 'only http/https URLs are allowed' };
     }
-    if (isBlockedHost(url.hostname)) {
+    if (await isBlockedHost(url.hostname)) {
       return {
         success: false,
         error: 'this host is not allowed (private, loopback, or internal address)',

--- a/packages/apify-actor-governed-run/src/index.ts
+++ b/packages/apify-actor-governed-run/src/index.ts
@@ -21,6 +21,7 @@ export {
   parseActorInput,
   type Receipt,
   ReceiptSchema,
+  type RunContext,
   type RunTaskInput,
   type VerifyReceiptInput,
 } from './types.js';

--- a/packages/apify-actor-governed-run/src/main.ts
+++ b/packages/apify-actor-governed-run/src/main.ts
@@ -1,10 +1,11 @@
-import { LLMClient } from '@revealui/ai';
 import { Actor } from 'apify';
+import { loadLLMClient } from './agent/load-llm-client.js';
 import { runGovernedTask } from './agent/run-governed-task.js';
 import { selectTools } from './agent/tools.js';
 import { CHARGEABLE_EVENTS } from './pricing.config.js';
 import { signActionLog } from './receipt/sign.js';
 import { verifyReceipt } from './receipt/verify.js';
+import type { RunContext } from './types.js';
 import { parseActorInput } from './types.js';
 
 await Actor.init();
@@ -15,6 +16,17 @@ try {
   const rawInput = await Actor.getInput();
   const input = parseActorInput(rawInput);
 
+  // GAP-431 guardrail-2 blocker 1: bind every receipt to the actual Apify
+  // run. `Actor.getEnv()` returns `null` for each field when not running on
+  // the platform (e.g. local `pnpm dev`) -- the receipt still signs and
+  // verifies, it just carries no platform-attributable run to cross-check.
+  const env = Actor.getEnv();
+  const runContext: RunContext = {
+    actorId: env.actorId,
+    actorRunId: env.actorRunId,
+    actorBuildId: env.actorBuildId,
+  };
+
   if (input.mode === 'verify-receipt') {
     await Actor.charge({ eventName: CHARGEABLE_EVENTS.receiptVerification.name });
     const result = verifyReceipt(input.receipt);
@@ -22,6 +34,7 @@ try {
     await Actor.setValue('OUTPUT', result);
   } else {
     const tools = selectTools(input.toolAllowlist);
+    const LLMClient = await loadLLMClient();
     // Explicit BYOK key from actor input -- never a tenant-stored/DB-resolved
     // key, so constructing this client never touches a database.
     const llmClient = new LLMClient({
@@ -43,9 +56,14 @@ try {
       },
     });
 
-    const receipt = signActionLog(actionLog);
+    const receipt = signActionLog(actionLog, runContext);
     await Actor.charge({ eventName: CHARGEABLE_EVENTS.runCompleted.name });
 
+    // Publish the receipt to this run's own platform-controlled dataset/KV
+    // store (GAP-431 guardrail-2 blocker 1). A verifier who trusts
+    // `receipt.actorRunId` can fetch that run's dataset from the Apify API
+    // and confirm the SAME receipt is on record there -- something a
+    // standalone forger, who never actually ran on Apify, cannot produce.
     const result = { result: output, stopReason, receipt };
     await Actor.pushData(result);
     await Actor.setValue('OUTPUT', result);

--- a/packages/apify-actor-governed-run/src/receipt/sign.ts
+++ b/packages/apify-actor-governed-run/src/receipt/sign.ts
@@ -1,6 +1,6 @@
 import { createPublicKey, generateKeyPairSync } from 'node:crypto';
 import { deriveAuditKid, Ed25519AuditRowSigner } from '@revealui/security/server';
-import type { ActionLogEntry, Receipt } from '../types.js';
+import type { ActionLogEntry, Receipt, RunContext } from '../types.js';
 import { receiptSignableBytes } from './signable.js';
 
 /**
@@ -18,8 +18,15 @@ import { receiptSignableBytes } from './signable.js';
  * in the receipt, so a receipt can be verified by anyone with no dependency on
  * RevealUI's servers or secrets -- the actor's entire trust story is "the
  * receipt carries its own key."
+ *
+ * `runContext` (GAP-431 guardrail-2 blocker 1) binds the receipt to the
+ * actual Apify run -- the caller (main.ts) derives it from `Actor.getEnv()`.
+ * It is signed, not just attached, so it cannot be swapped after the fact.
+ * This is what makes a receipt platform-attributable: a verifier can take
+ * `receipt.actorRunId` and check that run's own dataset/KV record on Apify
+ * for a matching receipt, something a standalone forger cannot produce.
  */
-export function signActionLog(actionLog: ActionLogEntry[]): Receipt {
+export function signActionLog(actionLog: ActionLogEntry[], runContext: RunContext): Receipt {
   const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
     privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
     publicKeyEncoding: { type: 'spki', format: 'pem' },
@@ -30,8 +37,8 @@ export function signActionLog(actionLog: ActionLogEntry[]): Receipt {
   const timestamp = new Date().toISOString();
   const algorithm = 'ed25519' as const;
 
-  const bytes = receiptSignableBytes({ actionLog, algorithm, timestamp });
+  const bytes = receiptSignableBytes({ actionLog, algorithm, timestamp, ...runContext });
   const { value: signature } = signer.sign(bytes);
 
-  return { actionLog, signature, publicKey, algorithm, timestamp };
+  return { actionLog, signature, publicKey, algorithm, timestamp, ...runContext };
 }

--- a/packages/apify-actor-governed-run/src/receipt/signable.ts
+++ b/packages/apify-actor-governed-run/src/receipt/signable.ts
@@ -1,10 +1,15 @@
 import { canonicalizeJcs } from '@revealui/security';
-import type { ActionLogEntry } from '../types.js';
+import type { ActionLogEntry, RunContext } from '../types.js';
 
 /** The exact fields a receipt's signature covers. `publicKey` travels with the
  * receipt for verification but is deliberately NOT part of the signed payload
- * -- it identifies the key, it isn't integrity-bearing data. */
-export interface ReceiptSignablePayload {
+ * -- it identifies the key, it isn't integrity-bearing data.
+ *
+ * `actorId` / `actorRunId` / `actorBuildId` (the run-context fields) ARE part
+ * of the signed payload -- that is the whole point (GAP-431 guardrail-2
+ * blocker 1): a receipt's provenance claim must be tamper-evident, not just
+ * carried alongside the signature as unsigned metadata. */
+export interface ReceiptSignablePayload extends RunContext {
   actionLog: ActionLogEntry[];
   algorithm: 'ed25519';
   timestamp: string;
@@ -24,6 +29,9 @@ export function receiptSignableBytes(payload: ReceiptSignablePayload): Uint8Arra
     actionLog: payload.actionLog,
     algorithm: payload.algorithm,
     timestamp: payload.timestamp,
+    actorId: payload.actorId,
+    actorRunId: payload.actorRunId,
+    actorBuildId: payload.actorBuildId,
   });
   return new TextEncoder().encode(canonical);
 }

--- a/packages/apify-actor-governed-run/src/receipt/verify.ts
+++ b/packages/apify-actor-governed-run/src/receipt/verify.ts
@@ -25,7 +25,16 @@ export function verifyReceipt(receipt: unknown): VerifyReceiptResult {
   if (!parsed.success) {
     return { valid: false, reason: `malformed receipt: ${parsed.error.message}` };
   }
-  const { actionLog, signature, publicKey, algorithm, timestamp } = parsed.data;
+  const {
+    actionLog,
+    signature,
+    publicKey,
+    algorithm,
+    timestamp,
+    actorId,
+    actorRunId,
+    actorBuildId,
+  } = parsed.data;
 
   let keyObject: ReturnType<typeof createPublicKey>;
   try {
@@ -50,7 +59,14 @@ export function verifyReceipt(receipt: unknown): VerifyReceiptResult {
     return { valid: false, reason: 'signature key id does not match the embedded public key' };
   }
 
-  const bytes = receiptSignableBytes({ actionLog, algorithm, timestamp });
+  const bytes = receiptSignableBytes({
+    actionLog,
+    algorithm,
+    timestamp,
+    actorId,
+    actorRunId,
+    actorBuildId,
+  });
   const result = verifyEd25519AuditSignature(bytes, signature, () => keyObject);
   if (!result.valid) {
     return { valid: false, reason: result.reason ?? 'signature verification failed' };

--- a/packages/apify-actor-governed-run/src/types.ts
+++ b/packages/apify-actor-governed-run/src/types.ts
@@ -6,22 +6,53 @@ import { z } from 'zod/v4';
  * a final entry recording the run's output. This array is the payload the
  * receipt signs -- it is the thing a customer is paying to have proven.
  */
-export const ActionLogEntrySchema = z.object({
-  index: z.number().int().nonnegative(),
-  type: z.enum(['model_call', 'tool_call', 'final_output']),
-  timestamp: z.string(),
-  detail: z.record(z.string(), z.unknown()),
-});
+export const ActionLogEntrySchema = z
+  .object({
+    index: z.number().int().nonnegative(),
+    type: z.enum(['model_call', 'tool_call', 'final_output']),
+    timestamp: z.string(),
+    detail: z.record(z.string(), z.unknown()),
+  })
+  .strict();
 export type ActionLogEntry = z.infer<typeof ActionLogEntrySchema>;
 
-/** The signed, offline-verifiable receipt returned alongside a run's result. */
-export const ReceiptSchema = z.object({
-  actionLog: z.array(ActionLogEntrySchema),
-  signature: z.string().min(1),
-  publicKey: z.string().min(1),
-  algorithm: z.literal('ed25519'),
-  timestamp: z.string(),
-});
+/**
+ * The Apify run this receipt is bound to. Embedded inside the signed payload
+ * (see `receipt/signable.ts`) so a receipt cannot be re-attributed to a
+ * different actor/run/build after signing. All three are `null` when running
+ * outside the Apify platform (e.g. local `pnpm dev` / `tsx src/main.ts`),
+ * since `Actor.getEnv()` returns `null` for each field in that case -- a
+ * locally-signed receipt still verifies (signature integrity holds), it just
+ * carries no platform-attributable run to cross-check against.
+ */
+export interface RunContext {
+  actorId: string | null;
+  actorRunId: string | null;
+  actorBuildId: string | null;
+}
+
+/**
+ * The signed, offline-verifiable receipt returned alongside a run's result.
+ *
+ * `verifyReceipt` proves only that these bytes were not altered after
+ * signing -- it does NOT prove the run actually happened on Apify. Provenance
+ * (was this a genuine RevealUI Governed Agent Run, not a self-minted forgery)
+ * requires cross-checking `actorRunId` against that run's own dataset/KV
+ * record on the Apify platform, which the actor publishes at the end of every
+ * run (see main.ts) and which nobody but the real running actor can write to.
+ */
+export const ReceiptSchema = z
+  .object({
+    actionLog: z.array(ActionLogEntrySchema),
+    signature: z.string().min(1),
+    publicKey: z.string().min(1),
+    algorithm: z.literal('ed25519'),
+    timestamp: z.string(),
+    actorId: z.string().nullable(),
+    actorRunId: z.string().nullable(),
+    actorBuildId: z.string().nullable(),
+  })
+  .strict();
 export type Receipt = z.infer<typeof ReceiptSchema>;
 
 /** Actor input, `run-task` mode: execute an agent task and return a receipt. */

--- a/scripts/validate/security-paths.shared.json
+++ b/scripts/validate/security-paths.shared.json
@@ -52,6 +52,7 @@
     "packages/editor/",
     "packages/db/src/schema/audit-log",
     "packages/db/src/audit-store",
-    "packages/db/migrations/"
+    "packages/db/migrations/",
+    "packages/apify-actor-governed-run/"
   ]
 }


### PR DESCRIPTION
## Summary

Fix-forward on the REQUEST-CHANGES verdict recorded on #2198 after it merged ahead of review: https://github.com/RevealUIStudio/revealui/pull/2198#issuecomment-5085062163

Each blocker below has a failing test added first (reproducing the reviewer's finding), then the fix, then green.

### Blocker 1 — receipt provenance (`src/receipt/sign.ts`, `src/receipt/verify.ts`, `src/receipt/signable.ts`, `src/types.ts`, `src/main.ts`)

**Finding:** the signed payload was `{actionLog, algorithm, timestamp}` with no binding to the actor/run/build, so anyone could mint a self-consistent, "valid" receipt for a run that never happened.

**Fix:** `RunContext` (`actorId`/`actorRunId`/`actorBuildId`, sourced from `Actor.getEnv()`, `null` for local runs) is now inside the JCS-canonicalized signed payload and the `Receipt` schema, so it cannot be swapped after signing. `main.ts` publishes the receipt to the run's own `Actor.pushData`/`Actor.setValue` dataset/KV, a location only the real running actor can write to. README rewritten to state plainly: standalone verification proves integrity (tamper-evidence), not provenance; provenance requires cross-checking `receipt.actorRunId` against that run's own platform record.

**Test:** `src/__tests__/receipt-provenance.test.ts` (red before: fields didn't exist; green after: fields are embedded, signed, and tamper-checked).

### Blocker 2 — verify-what-you-read (`src/types.ts`)

**Finding:** `ActionLogEntrySchema`/`ReceiptSchema` were non-strict, so Zod silently stripped an injected unknown key during `safeParse`. The signature check covered the stripped data; every consumer reads the caller's original, unstripped object, so an injected field survived into what gets rendered while `verifyReceipt` still said `valid: true`.

**Fix:** both schemas are now `.strict()`.

**Test:** `src/__tests__/receipt-unknown-key-injection.test.ts`, reproducing the exact injected-field attack (red before: `valid: true`; green after: `valid: false`).

### Blocker 3 — SSRF guard (`src/agent/tools.ts`)

**Finding:** `isBlockedHost` compared against `url.hostname` with no bracket-stripping (so its own `'::1'` check could never match WHATWG's `[::1]`), no IPv6 handling at all, and single-address checks instead of full ranges. 8 of the reviewer's 13 probe targets slipped through.

**Fix:** rewrote the guard — strips IPv6 brackets, parses and range-checks both IPv4 and IPv6 (including IPv4-mapped addresses like `::ffff:127.0.0.1`), covers full CIDR ranges (127.0.0.0/8, 169.254.0.0/16, 100.64.0.0/10, fc00::/7, fe80::/10, etc.) instead of single hardcoded addresses, and resolves DNS for non-literal hostnames so a public name with a static record pointed at a blocked address (the `*.nip.io` case) is also blocked. True DNS-rebinding (the answer changing between check and fetch) remains out of scope and is now stated honestly in the README rather than blocked.

**Test:** `src/__tests__/tools.test.ts` — all 13 of the reviewer's probe targets as a parameterized table (red before: 8 pass through; green after: all 13 blocked).

### Hygiene — `@revealui/ai` optional dependency (`src/main.ts`, new `src/agent/load-llm-client.ts`)

**Finding:** declared in `optionalDependencies` but hard-imported at `main.ts:1`, so the actor couldn't start without it even in `verify-receipt` mode, which never needs it.

**Fix:** extracted to `loadLLMClient()`, a lazy dynamic `import()` with a clear, actionable error if it can't resolve. `verify-receipt` mode is now genuinely unaffected by whether `@revealui/ai` is installed.

**Test:** `src/__tests__/load-llm-client.test.ts` (happy path + mocked load failure).

### Guardrail-2 list widening

Added `packages/apify-actor-governed-run/` to `scripts/validate/security-paths.shared.json` (GAP-404 canonical source — audited; it is NOT under `packages/harnesses/`, that was the reviewer's placeholder guess) so this whole package is caught by guardrail-2 mechanically on future changes. Confirmed working: `security-pr-review-check.js --diff origin/test` now classifies this branch as security-sensitive.

## REVIEW-PENDING under guardrail 2

**The standing REQUEST-CHANGES on #2198 resolves only when a fresh APPROVE verdict is recorded on THIS PR.** Do not merge on green CI alone — CI passing is not a recorded verdict (that is the exact #1711 lesson this fix inherits). This PR should be reviewed by a non-author session before merge.

## What I could not fully address from the verdict

- **Suggestion (not a blocker): unbounded tool-calls-per-step / unbounded `verify-receipt` payload size / raw `err.message` echoed to OUTPUT** — the reviewer's "Suggestions" section items were left as-is; they were not blockers and are reasonable follow-up gaps, not addressed in this fix-forward PR to keep the diff focused on the three numbered blockers + the hygiene item the task specified.
- **True DNS-rebinding (TCP connection pinning)** — explicitly out of scope per the reviewer's own tiered guidance ("if that is more than a v0.1 scaffold should carry..."); the static-record bypass class (the actual reviewed bug) is fully closed, and the residual gap is now stated honestly in the README rather than silently left as a broader disclaimer than necessary.
- **Pre-existing, unrelated gate failure**: `pnpm gate --changed` on this branch fails one check, "Contracts OpenAPI mirror drift" (`packages/openapi/contracts.openapi.json`). Verified this exists identically on a clean, untouched checkout of `origin/test` before any of my changes (already tracked as GAP-436). Not touched by this PR.

## Test plan

- [x] `receipt-provenance.test.ts` — red before fix, green after
- [x] `receipt-unknown-key-injection.test.ts` — red before fix, green after
- [x] `tools.test.ts` 13-target SSRF probe table — red before fix (8/13 slip through), green after (13/13 blocked)
- [x] `load-llm-client.test.ts` — new coverage for the lazy-import hygiene fix
- [x] Full package suite: 57/57 green (`pnpm --filter @revealui/apify-actor-governed-run test`)
- [x] `pnpm --filter @revealui/apify-actor-governed-run typecheck` clean
- [x] `pnpm --filter @revealui/apify-actor-governed-run lint` clean
- [x] `pnpm gate --changed` green except the pre-existing, unrelated GAP-436 drift noted above
- [x] `security-pr-review-check.js --diff origin/test` now correctly flags this PR as security-sensitive (confirms the list widening works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)