### PR TITLE
fix(apify-actor): close :: and NAT64 SSRF residuals (GAP-431)

### DIFF
--- a/packages/apify-actor-governed-run/src/__tests__/tools.test.ts
+++ b/packages/apify-actor-governed-run/src/__tests__/tools.test.ts
@@ -75,12 +75,43 @@ describe('webFetchTool', () => {
       ['short-form IPv4 (normalizes to loopback)', 'http://127.1/'],
       ['canonical loopback', 'http://127.0.0.1/'],
       ['canonical cloud metadata endpoint', 'http://169.254.169.254/'],
+      // Guardrail-2 APPROVE-with-residuals on revealui#2202
+      // (https://github.com/RevealUIStudio/revealui/pull/2202#issuecomment-5085198453):
+      // two more IPv6 bypasses the 13-target probe above did not cover.
+      ['IPv6 unspecified address (:: routes to localhost on Linux)', 'http://[::]/'],
+      [
+        'NAT64 well-known prefix (64:ff9b::/96) embedding the cloud metadata IPv4 address',
+        'http://[64:ff9b::a9fe:a9fe]/',
+      ],
     ];
 
     it.each(mustBeBlocked)('blocks: %s (%s)', async (_label, url) => {
       const result = await webFetchTool.execute({ url });
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/not allowed/);
+    });
+  });
+
+  describe('SSRF guard -- confirmed-reachable addresses must not be over-blocked', () => {
+    const mustStayReachable: Array<[label: string, ip: string]> = [
+      ['just past the 172.16.0.0/12 private range', '172.32.0.1'],
+      ['just past the 100.64.0.0/10 CGNAT range', '100.128.0.1'],
+    ];
+
+    it.each(mustStayReachable)('does not block: %s (%s)', async (_label, ip) => {
+      // Stub fetch so the guard is exercised without a real network call --
+      // what's under test is that isBlockedHost lets the request through to
+      // fetch() at all, not the network behavior beyond that point.
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('ok', { status: 200 }));
+      try {
+        const result = await webFetchTool.execute({ url: `http://${ip}/` });
+        expect(fetchSpy).toHaveBeenCalled();
+        expect(result.success).toBe(true);
+      } finally {
+        fetchSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/apify-actor-governed-run/src/agent/tools.ts
+++ b/packages/apify-actor-governed-run/src/agent/tools.ts
@@ -80,16 +80,30 @@ function isBlockedIPv4(ip: string): boolean {
   return false;
 }
 
-/** Blocked IPv6 ranges: loopback (::1), unique local addresses (fc00::/7,
- * covers fd00::/8), link-local (fe80::/10), and IPv4-mapped addresses
- * (::ffff:a.b.c.d), whose embedded IPv4 address is recursively checked
- * against `isBlockedIPv4` -- this is what closes the
- * `[::ffff:127.0.0.1]` / `[::ffff:a9fe:a9fe]` bypasses. */
+/** Render the last two 16-bit groups of an expanded IPv6 address as the dotted
+ * IPv4 address they embed -- shared by the IPv4-mapped (`::ffff:a.b.c.d`) and
+ * NAT64 (`64:ff9b::a.b.c.d`) embed forms below. */
+function embeddedIPv4(groups: number[]): string {
+  const g6 = groups[6] ?? 0;
+  const g7 = groups[7] ?? 0;
+  return [(g6 >> 8) & 0xff, g6 & 0xff, (g7 >> 8) & 0xff, g7 & 0xff].join('.');
+}
+
+/** Blocked IPv6 ranges: unspecified (::, which routes to localhost on
+ * Linux), loopback (::1), unique local addresses (fc00::/7, covers
+ * fd00::/8), link-local (fe80::/10), IPv4-mapped addresses (::ffff:a.b.c.d),
+ * and the NAT64 well-known prefix (64:ff9b::/96) -- both of the latter two
+ * embed an IPv4 address in the low 32 bits, recursively checked against
+ * `isBlockedIPv4`. This is what closes the `[::ffff:127.0.0.1]` /
+ * `[::ffff:a9fe:a9fe]` bypasses plus the residual `[::]` and
+ * `[64:ff9b::a9fe:a9fe]` bypasses (guardrail-2 APPROVE-with-residuals on
+ * revealui#2202). */
 function isBlockedIPv6(address: string): boolean {
   const groups = expandIPv6Groups(address);
   if (!groups) return true; // unparseable -- fail closed
 
   const isZero = (n: number): boolean => n === 0;
+  if (groups.every(isZero)) return true; // :: unspecified address
   if (groups.slice(0, 7).every(isZero) && groups[7] === 1) return true; // ::1
 
   const first = groups[0] ?? 0;
@@ -97,12 +111,10 @@ function isBlockedIPv6(address: string): boolean {
   if (first >= 0xfe80 && first <= 0xfebf) return true; // fe80::/10 (link-local)
 
   const isIPv4Mapped = groups.slice(0, 5).every(isZero) && groups[5] === 0xffff;
-  if (isIPv4Mapped) {
-    const g6 = groups[6] ?? 0;
-    const g7 = groups[7] ?? 0;
-    const embeddedIPv4 = [(g6 >> 8) & 0xff, g6 & 0xff, (g7 >> 8) & 0xff, g7 & 0xff].join('.');
-    return isBlockedIPv4(embeddedIPv4);
-  }
+  if (isIPv4Mapped) return isBlockedIPv4(embeddedIPv4(groups));
+
+  const isNAT64 = groups[0] === 0x64 && groups[1] === 0xff9b && groups.slice(2, 6).every(isZero);
+  if (isNAT64) return isBlockedIPv4(embeddedIPv4(groups));
 
   return false;
 }


### PR DESCRIPTION
## Summary

Guardrail-2 reviewer left an APPROVE-with-residuals verdict on #2202
(https://github.com/RevealUIStudio/revealui/pull/2202#issuecomment-5085198453)
flagging two non-blocking SSRF bypasses in the `web_fetch` tool's
`isBlockedHost` guard (`packages/apify-actor-governed-run/src/agent/tools.ts`),
to close before Apify Store submission. This PR closes both.

| Residual | Why it slipped through | Fix |
|---|---|---|
| `http://[::]/` | The IPv6 unspecified address `::` routes to localhost on Linux. Its IPv4 twin `0.0.0.0/8` was already blocked by `isBlockedIPv4`, but `isBlockedIPv6` had no all-zero-groups check. | `isBlockedIPv6` now blocks `::` outright (all 8 groups zero) before the `::1` check. |
| `http://[64:ff9b::a9fe:a9fe]/` | The NAT64 well-known prefix `64:ff9b::/96` embeds an IPv4 address in its low 32 bits (here, the cloud metadata address `169.254.169.254`) — the same embed trick already closed for `::ffff:`-mapped addresses. | Extracted a shared `embeddedIPv4()` helper from the existing `::ffff:` handling and reused it for the `64:ff9b::/96` prefix, recursively checking the embedded address through `isBlockedIPv4` (same pattern, not a new special case). |

## Red → green evidence

Both cases were added to the existing reviewer's probe-target test table
(`src/__tests__/tools.test.ts`) FIRST as failing tests, confirmed red against
the pre-fix guard:

```
❯ src/__tests__/tools.test.ts (25 tests | 2 failed)
  × blocks: IPv6 unspecified address (:: routes to localhost on Linux) (http://[::]/)
  × blocks: NAT64 well-known prefix (64:ff9b::/96) embedding the cloud metadata IPv4 address (http://[64:ff9b::a9fe:a9fe]/)

AssertionError: expected 'fetch failed' to match /not allowed/
```

(the `fetch failed` error confirms the guard let the request through to the
real `fetch()` call rather than blocking it — the bypass was real, not a test
artifact).

After the fix, same suite:

```
Test Files  1 passed (1)
     Tests  25 passed (25)
```

## No over-blocking

Added a companion "confirmed-reachable addresses" test group covering the
two addresses the reviewer confirmed must stay reachable — `172.32.0.1` (just
past the 172.16.0.0/12 private range) and `100.128.0.1` (just past the
100.64.0.0/10 CGNAT range) — stubbing `fetch` so the guard is exercised
without a real network call. Both pass unblocked, both before and after this
change.

## Verification run

- `pnpm vitest run` in `packages/apify-actor-governed-run`: 9 test files, 61
  tests, all green.
- `pnpm typecheck` / `pnpm lint` (biome): clean.
- `pnpm gate --changed`: all phases pass **except** "Contracts OpenAPI mirror
  drift" — confirmed pre-existing and unrelated (reproduces identically on a
  pristine `origin/test` checkout with zero diff to `packages/openapi/`;
  tracked separately as GAP-436 in the internal tracker). This PR touches neither
  `packages/openapi` nor `packages/mcp`.
- Pre-push quality gate (phase 1, changed-scoped) ran automatically and
  passed.

## Review status

**REVIEW-PENDING under guardrail 2 — do not merge until a non-author APPROVE
verdict is recorded.** This touches `packages/apify-actor-governed-run/`,
which is on the fleet's widened security-sensitive path list (SSRF-adjacent
code). The fleet security-path self-check (`--diff origin/test`) confirms:
security-sensitive, gate held pending a recorded verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
