### PR TITLE
fix(infra): worker liveness check path + REVEALUI_API_URL manifest (GAP-443)

### DIFF
--- a/apps/server/fly.toml
+++ b/apps/server/fly.toml
@@ -59,15 +59,20 @@ primary_region = 'iad'
     hard_limit = 250
     soft_limit = 200
 
-  # Fly health check hits /api/health which is mounted by the Hono
-  # app at apps/server/src/routes/health.ts (worker.ts imports the
-  # full app so the route is available).
+  # Liveness check. The health route is mounted at /health (index.ts
+  # `app.route('/health', healthRoute)`), and its liveness handler ('/')
+  # returns 200 whenever the process is up. GAP-443: this was '/api/health',
+  # which 404s on the worker (the /api/* prefix only exists on the Vercel
+  # apps that rewrite to the Hono server; the worker serves it directly), so
+  # the machine flapped unhealthy on every probe. Use /health (liveness), NOT
+  # /health/ready — a readiness 503 on a degraded dependency would restart the
+  # worker in a loop; liveness only asks "is the process alive".
   [[http_service.checks]]
     interval = '30s'
     timeout = '5s'
     grace_period = '10s'
     method = 'GET'
-    path = '/api/health'
+    path = '/health'
 
 [[vm]]
   cpu_kind = 'shared'

--- a/scripts/sync/revvault-fly.toml
+++ b/scripts/sync/revvault-fly.toml
@@ -72,6 +72,11 @@ REVEALUI_ADMIN_API_KEY       = "revealui/prod/admin/api-key"
 # Public URLs (must be HTTPS + match each other per validate-startup.ts)
 REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
 NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
+# Governed-MCP loopback base (required-in-prod per required-env.ts). GAP-443:
+# was missing from this manifest, so the worker crash-looped on a missing
+# REVEALUI_API_URL until it was set Fly-direct by hand. Declaring it here means
+# a resync provisions it and a data-dir wipe can't silently reintroduce the gap.
+REVEALUI_API_URL           = "revealui/prod/public/api-url"
 
 # Required at prod boot (alerting + billing portal)
 REVEALUI_ALERT_EMAIL              = "revealui/prod/alert-email"


### PR DESCRIPTION
Two config defects surfaced when the durable Fly worker booted after a month stopped (see GAP-442 for the audit-write bug in the same boot).

## 1. Health check 404 → machine flapping unhealthy

The Fly `[http_service.checks]` probed `/api/health`, which **404s on the worker**: the health route is mounted at `/health` (`index.ts` `app.route('/health', healthRoute)`). The `/api/*` prefix only exists on the Vercel apps that rewrite to the Hono server — the worker serves it directly. Every 30s probe failed, so Fly kept marking the machine unhealthy. Fixed to `/health` (the liveness handler, always 200 when the process is up). Deliberately **not** `/health/ready` — a readiness 503 on a degraded dependency would restart-loop the worker; liveness only asks "is the process alive".

## 2. REVEALUI_API_URL missing from the sync manifest

`REVEALUI_API_URL` (required-in-prod per `required-env.ts`) was absent from `scripts/sync/revvault-fly.toml`, so a secrets resync never provisioned it and the worker crash-looped on the missing var until it was set Fly-direct by hand. Declared it (`revealui/prod/public/api-url`) so a resync sets it and a data-dir wipe can't reintroduce the gap.

Config-only, no code-path changes. Takes effect on the next worker deploy + resync.

Remaining GAP-443 items (worker license key so tier != free, canary key-type error, external liveness alert) stay on the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)