### PR TITLE
fix(apify): ship §4.2-clean listing as extracted Store README (GAP-431 live-leak fix)

### DIFF
--- a/scripts/deploy/build-apify-actor-standalone.mjs
+++ b/scripts/deploy/build-apify-actor-standalone.mjs
@@ -126,7 +126,15 @@ mkdirSync(path.join(outDir, '.actor'), { recursive: true });
 
 console.log('[build-apify-actor] 3/6 copying compiled output + static files...');
 cpSync(path.join(pkgDir, 'dist'), path.join(outDir, 'dist'), { recursive: true });
-cpSync(path.join(pkgDir, 'README.md'), path.join(outDir, 'README.md'));
+// Apify extracts the Store listing from the pushed root README.md, so the
+// PUBLIC, §4.2-clean listing (packages/.../.actor/README.md) must land at the
+// artifact root — NOT the package root README.md, which is internal developer
+// notes (internal repo refs, guardrail-2 status, "unpublished"). Shipping the
+// dev README as the listing leaked internal detail to the public Store page.
+// Copy the clean listing to both the artifact root and .actor/ so whichever
+// path Apify resolves, it is the clean one.
+cpSync(path.join(pkgDir, '.actor', 'README.md'), path.join(outDir, 'README.md'));
+cpSync(path.join(pkgDir, '.actor', 'README.md'), path.join(outDir, '.actor', 'README.md'));
 cpSync(
   path.join(pkgDir, '.actor', 'input_schema.json'),
   path.join(outDir, '.actor', 'input_schema.json'),


### PR DESCRIPTION
The published actor's Store page was showing the INTERNAL dev README. Apify extracts the listing from the pushed root README.md, but the build script copied the package-root README.md (developer notes: internal repo refs, guardrail-2 status, 'Internal, unpublished', broken npm import) there instead of the §4.2-clean .actor/README.md. Now copies the clean listing to both artifact root and .actor/. Verified: rebuilt artifact root README is the clean public listing, leak scan clean. Build-script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)