### PR TITLE
feat(examples): RevealUI Starter Kit (GAP-434)

### DIFF
--- a/examples/starter-kit/.env.starter.example
+++ b/examples/starter-kit/.env.starter.example
@@ -1,0 +1,51 @@
+# RevealUI Starter Kit — env template for docker-compose.starter.yml
+#
+# Copy this file to .env, then run scripts/generate-secrets.sh to fill the
+# secret values below (or generate them yourself with the commands shown).
+# Never commit .env.
+
+# ── Postgres ────────────────────────────────────────────────────────────────
+POSTGRES_DB=revealui
+POSTGRES_USER=revealui
+# openssl rand -hex 24
+POSTGRES_PASSWORD=
+
+# ── Core secrets (required) ─────────────────────────────────────────────────
+# openssl rand -hex 32
+REVEALUI_SECRET=
+# openssl rand -hex 32   (must be exactly 64 hex chars)
+REVEALUI_KEK=
+# openssl genpkey -algorithm Ed25519 -out audit-signing-key.pem
+# then paste the file's contents here as one line with \n for newlines,
+# or leave real newlines — both are normalized.
+REVEALUI_AUDIT_SIGNING_KEY=
+
+# ── URLs (required — must match between api and admin) ──────────────────────
+POSTGRES_URL=postgresql://revealui:${POSTGRES_PASSWORD}@postgres:5432/revealui
+REVEALUI_PUBLIC_SERVER_URL=http://localhost:3004
+NEXT_PUBLIC_SERVER_URL=http://localhost:3004
+NEXT_PUBLIC_API_URL=http://localhost:3004
+API_URL=http://api:3004
+CORS_ORIGIN=http://localhost:4000
+
+# ── First admin login (admin app, required for first boot) ──────────────────
+REVEALUI_ADMIN_EMAIL=you@example.com
+# a real password — rotate it immediately after your first login
+REVEALUI_ADMIN_PASSWORD=
+
+# ── License (omit both to boot at Free/OSS tier — this is the kit default) ──
+# REVEALUI_LICENSE_KEY=
+# REVEALUI_LICENSE_PUBLIC_KEY=
+# Free-tier opt-in is already set in docker-compose.starter.yml
+# (REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true) — no need to set it here too.
+
+# ── Optional ─────────────────────────────────────────────────────────────────
+# GOOGLE_SERVICE_ACCOUNT_EMAIL=
+# GOOGLE_PRIVATE_KEY=
+# X402_ENABLED=false
+# X402_RECEIVING_ADDRESS=
+
+# ── First-party governed-agent recipes (recipes/, optional) ─────────────────
+# Only needed if you want the recipes to call a real model instead of running
+# in offline demo mode. See recipes/README or GETTING-STARTED.md.
+# ANTHROPIC_API_KEY=

--- a/examples/starter-kit/.gitignore
+++ b/examples/starter-kit/.gitignore
@@ -1,0 +1,3 @@
+receipt-*.json
+node_modules
+dist

--- a/examples/starter-kit/GETTING-STARTED.md
+++ b/examples/starter-kit/GETTING-STARTED.md
@@ -1,0 +1,106 @@
+---
+title: "RevealUI Starter Kit — Getting Started"
+description: "Launch-ready self-host config, deploy scripts, and governed-agent recipes on top of create-revealui."
+visibility: private
+status: verified
+audience: buyer
+---
+
+# RevealUI Starter Kit
+
+This kit is content and curation layered on top of the free, MIT-licensed
+`create-revealui` scaffolder and framework, not a separate product. Everything
+free in RevealUI (the scaffolder, the five app templates, the framework
+packages) stays free. What this kit adds:
+
+1. A **fixed, tested docker-compose recipe** for self-hosting the RevealUI
+   backend at Free (OSS) tier, no license key required.
+2. A **one-command bootstrap** that wires up the database migration step the
+   free scaffolder documents but doesn't run for you.
+3. An **env template with real secret-generation commands**, not just prose.
+4. **Three governed-agent recipes**, each producing a cryptographically
+   signed, offline-verifiable receipt of every action — the pattern the
+   fleet's own Apify actor uses, generalized for use in your own app.
+5. Access to the private RevealUI Substack section and lifetime kit updates
+   (see your purchase confirmation for the invite).
+
+## What "governed agent" and "receipt" mean here
+
+Any action a sensitive tool takes — a refund, a permission grant, a step in
+an autonomous loop — gets logged as an entry in an ordered action log. At the
+end of a run, the whole log is signed with a fresh Ed25519 keypair generated
+just for that run. The public half of the key travels with the receipt, so
+**anyone can verify the receipt offline, with no network call and no
+dependency on RevealUI's servers** — the receipt carries its own key.
+
+What a receipt proves: the logged actions were not altered after signing.
+What it does not prove: which machine ran the recipe, or that a specific LLM
+call actually happened. Say it that way to your own users if you build on
+this — overclaiming here is the fastest way to lose trust in an audit trail.
+
+## Quick start: the governed-agent recipes (no docker required)
+
+These are ordinary TypeScript files. From this directory:
+
+```bash
+pnpm install
+pnpm recipe:action   # a single governed action, signed and verified
+pnpm recipe:loop      # a multi-step, budget-capped agent loop, signed and verified
+pnpm verify-receipt receipt-action.json   # verify any receipt, fully offline
+```
+
+`recipe:loop` runs in **offline demo mode** by default (a scripted stand-in
+for the model, no network, no API key) so you can see the whole pattern run
+end to end immediately. To use a real model:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... pnpm recipe:loop
+```
+
+Read `src/receipts/sign.ts` and `src/receipts/verify.ts` for the primitives —
+they're built entirely on `@revealui/security` (MIT, free, ships with every
+RevealUI install). Nothing in the receipt mechanism requires a Pro license.
+
+## Self-hosting the RevealUI backend (Free tier, no license key)
+
+The docker-compose path here is a fixed, minimal version of the one in the
+main `revealui` repo root, scoped to Postgres + the API + the admin
+dashboard (the marketing site is a separate app; run it with
+`pnpm --filter marketing dev` if you want it too).
+
+```bash
+cp .env.starter.example .env
+bash scripts/generate-secrets.sh >> .env   # fills in every *_SECRET / *_KEY value
+# edit .env: set REVEALUI_ADMIN_EMAIL to your real email
+bash scripts/bootstrap.sh                  # starts postgres, migrates, then api + admin
+```
+
+This boots at **Free (OSS) tier by default** — `REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true`
+is already set in `docker-compose.starter.yml`. If you have a Fleet license,
+set `REVEALUI_LICENSE_KEY` / `REVEALUI_LICENSE_PUBLIC_KEY` in `.env` instead.
+
+Once `admin` reports healthy, log in at `http://localhost:4000/` with the
+`REVEALUI_ADMIN_EMAIL` / `REVEALUI_ADMIN_PASSWORD` you set in `.env` (this
+only seeds the account once — rotate the password immediately after your
+first login).
+
+`[owner: test once]` — the docker build itself (`docker compose -f
+docker-compose.starter.yml build`) was not run end-to-end in the session that
+built this kit, to avoid a long build inside an agent session. The compose
+file's YAML and env-var interpolation were validated (`docker compose config`),
+and every underlying piece (`apps/server/Dockerfile`, `apps/admin/Dockerfile`,
+the `REVEALUI_ALLOW_UNLICENSED_SELF_HOST` gate) is the same code the fleet's
+own Railway deployment doc verifies against. Run the actual build once before
+shipping the first purchase confirmation.
+
+## Upgrading to Pro
+
+This kit is content-only — it does not include or require a Pro license.
+Your purchase includes a coupon for **your first month of RevealUI Pro
+free**; see your purchase confirmation email for the code. Apply it at
+checkout when you're ready to upgrade at revealui.com/pricing.
+
+## Support
+
+Questions and requests go in the private RevealUI Substack section (invite
+in your purchase confirmation). Kit updates ship there too.

--- a/examples/starter-kit/README.md
+++ b/examples/starter-kit/README.md
@@ -1,0 +1,3 @@
+# RevealUI Starter Kit
+
+See [GETTING-STARTED.md](./GETTING-STARTED.md).

--- a/examples/starter-kit/docker-compose.starter.yml
+++ b/examples/starter-kit/docker-compose.starter.yml
@@ -1,0 +1,105 @@
+# =============================================================================
+# RevealUI Starter Kit — self-host compose (Free/OSS tier, no license key)
+# =============================================================================
+#
+# This is a fixed, minimal version of the repo root's `docker-compose.yml`,
+# scoped to the two services that make up the RevealUI backend: the API and
+# the admin dashboard, plus a local Postgres. It intentionally does not
+# include the `marketing` service from the root file — that service's
+# Dockerfile does not exist in this checkout (apps/marketing is a Vite app
+# with no Dockerfile), so including it here would produce a compose file that
+# fails to build. If you need the marketing site too, run it separately with
+# `pnpm --filter marketing dev` or build your own Dockerfile for it.
+#
+# Quick start:
+#   1. cp .env.starter.example .env
+#   2. bash scripts/generate-secrets.sh >> .env   (fills in the *_SECRET vars)
+#   3. bash scripts/bootstrap.sh                  (boots postgres, migrates, then api+admin)
+#
+# This boots at Free (OSS) tier by default: REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true
+# is set on both api and admin below (GAP-436). Remove it and set
+# REVEALUI_LICENSE_KEY / REVEALUI_LICENSE_PUBLIC_KEY if you have a Fleet license.
+# =============================================================================
+
+services:
+  postgres:
+    # pgvector/pgvector:pg16 (not vanilla postgres): migration 0000 runs
+    # `CREATE EXTENSION vector`, which a plain postgres image cannot satisfy.
+    image: pgvector/pgvector:pg16
+    container_name: revealui-starter-postgres
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-revealui}
+      POSTGRES_USER: ${POSTGRES_USER:-revealui}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - starter-postgres-data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-revealui}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - starter
+    restart: unless-stopped
+
+  api:
+    build:
+      context: ../..
+      dockerfile: apps/server/Dockerfile
+    container_name: revealui-starter-api
+    env_file: .env
+    environment:
+      NODE_ENV: production
+      API_PORT: "3004"
+      REVEALUI_ALLOW_UNLICENSED_SELF_HOST: "true"
+    ports:
+      - "${API_PORT:-3004}:3004"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3004/health').then(r=>{if(!r.ok)process.exit(1)})"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    networks:
+      - starter
+    restart: unless-stopped
+
+  admin:
+    build:
+      context: ../..
+      dockerfile: apps/admin/Dockerfile
+    container_name: revealui-starter-admin
+    env_file: .env
+    environment:
+      NODE_ENV: production
+      PORT: "4000"
+      HOSTNAME: 0.0.0.0
+      REVEALUI_ALLOW_UNLICENSED_SELF_HOST: "true"
+    ports:
+      - "${CMS_PORT:-4000}:4000"
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:4000/api/health').then(r=>{if(!r.ok)process.exit(1)})"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - starter
+    restart: unless-stopped
+
+networks:
+  starter:
+    driver: bridge
+
+volumes:
+  starter-postgres-data:
+    driver: local

--- a/examples/starter-kit/package.json
+++ b/examples/starter-kit/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "revealui-starter-kit",
+  "version": "0.1.0",
+  "private": true,
+  "description": "RevealUI Starter Kit — launch-ready self-host config, deploy scripts, and governed-agent recipes on top of create-revealui.",
+  "type": "module",
+  "scripts": {
+    "recipe:action": "tsx src/recipes/01-single-governed-action.ts",
+    "recipe:loop": "tsx src/recipes/02-budget-capped-agent-loop.ts",
+    "verify-receipt": "tsx src/verify-receipt-cli.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check ."
+  },
+  "dependencies": {
+    "@revealui/security": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@revealui/dev": "workspace:*",
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24.13.0"
+  }
+}

--- a/examples/starter-kit/scripts/bootstrap.sh
+++ b/examples/starter-kit/scripts/bootstrap.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Bring up the starter kit's self-host stack in the right order: postgres
+# healthy, then migrate (host-side, against the monorepo's own db tooling —
+# `npx create-revealui`'s installer never wires this up automatically, so
+# this script is what does), then api and admin.
+#
+# Run from examples/starter-kit/, with the full revealui monorepo checked
+# out above it (docker-compose.starter.yml builds from apps/server/Dockerfile
+# and apps/admin/Dockerfile in the repo root) and .env already populated
+# (see .env.starter.example + scripts/generate-secrets.sh).
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [ ! -f .env ]; then
+  echo "Missing .env. Copy .env.starter.example to .env and fill it in" >&2
+  echo "(scripts/generate-secrets.sh generates the secret values)." >&2
+  exit 1
+fi
+
+COMPOSE="docker compose -f docker-compose.starter.yml"
+
+echo "==> Starting postgres"
+$COMPOSE up -d postgres
+echo "==> Waiting for postgres to report healthy"
+until [ "$($COMPOSE ps --format json postgres 2>/dev/null | grep -c '"Health":"healthy"')" -ge 1 ]; do
+  sleep 2
+done
+
+# Run migrations from the repo root, on the host, against the compose
+# postgres exposed on localhost (POSTGRES_PORT, default 5432) — this is the
+# step `npx create-revealui` sets up templates for but never runs itself.
+echo "==> Running database migrations (host-side, pnpm db:migrate)"
+(
+  cd ../..
+  set -a
+  # shellcheck disable=SC1091
+  source "examples/starter-kit/.env"
+  set +a
+  export POSTGRES_URL="postgresql://${POSTGRES_USER:-revealui}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-revealui}"
+  pnpm db:migrate
+)
+
+echo "==> Starting api and admin"
+$COMPOSE up -d api admin
+
+echo "==> Done. Waiting on health checks:"
+echo "    API health:   http://localhost:${API_PORT:-3004}/health"
+echo "    Admin health: http://localhost:${CMS_PORT:-4000}/api/health"
+echo "Once admin is healthy, log in at http://localhost:${CMS_PORT:-4000}/ with"
+echo "REVEALUI_ADMIN_EMAIL / REVEALUI_ADMIN_PASSWORD from .env (first boot only)."

--- a/examples/starter-kit/scripts/generate-secrets.sh
+++ b/examples/starter-kit/scripts/generate-secrets.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Generate every secret docker-compose.starter.yml needs and print them as
+# .env-format lines. Usage:
+#
+#   bash scripts/generate-secrets.sh > secrets.env
+#   cat secrets.env  # review, then paste the values into .env
+#
+# Or pipe straight into .env (only if .env doesn't already have real values —
+# this does NOT merge, it just prints new lines):
+#
+#   bash scripts/generate-secrets.sh >> .env
+#
+# Requires: openssl (present on macOS/Linux by default; on Windows use WSL
+# or Git Bash with openssl installed).
+set -euo pipefail
+
+echo "POSTGRES_PASSWORD=$(openssl rand -hex 24)"
+echo "REVEALUI_SECRET=$(openssl rand -hex 32)"
+echo "REVEALUI_KEK=$(openssl rand -hex 32)"
+
+# Ed25519 signing key for the audit log — REVEALUI_AUDIT_SIGNING_KEY needs the
+# full PEM, so a temp file round-trip is simpler than shelling out to sed.
+tmp_key="$(mktemp)"
+trap 'rm -f "$tmp_key"' EXIT
+openssl genpkey -algorithm Ed25519 -out "$tmp_key" 2>/dev/null
+# Fold real newlines into \n so the value is a single .env line.
+key_escaped="$(awk '{printf "%s\\n", $0}' "$tmp_key")"
+echo "REVEALUI_AUDIT_SIGNING_KEY=${key_escaped}"
+
+echo "REVEALUI_ADMIN_PASSWORD=$(openssl rand -hex 16)"
+
+echo "# Generated $(date -u +%Y-%m-%dT%H:%M:%SZ). Rotate REVEALUI_ADMIN_PASSWORD after your first login." >&2

--- a/examples/starter-kit/src/receipts/__tests__/roundtrip.test.ts
+++ b/examples/starter-kit/src/receipts/__tests__/roundtrip.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { localRunContext } from '../run-context.js';
+import { signActionLog } from '../sign.js';
+import type { ActionLogEntry } from '../types.js';
+import { verifyReceipt } from '../verify.js';
+
+const sampleActionLog: ActionLogEntry[] = [
+  {
+    index: 0,
+    type: 'tool_call',
+    timestamp: '2026-07-27T00:00:00.000Z',
+    detail: { toolName: 'issue_refund', params: { amountCents: 4200 }, success: true },
+  },
+  {
+    index: 1,
+    type: 'final_output',
+    timestamp: '2026-07-27T00:00:01.000Z',
+    detail: { output: 'done' },
+  },
+];
+
+describe('signActionLog / verifyReceipt roundtrip', () => {
+  it('signs an action log and verifies it as valid', () => {
+    const receipt = signActionLog(sampleActionLog, localRunContext());
+
+    expect(receipt.algorithm).toBe('ed25519');
+    expect(receipt.signature).toMatch(/^v1\.ed25519\.[0-9a-f-]+\.[A-Za-z0-9_-]+$/);
+    expect(receipt.publicKey).toContain('BEGIN PUBLIC KEY');
+
+    expect(verifyReceipt(receipt)).toEqual({ valid: true });
+  });
+
+  it('rejects a receipt whose action log was modified after signing', () => {
+    const receipt = signActionLog(sampleActionLog, localRunContext());
+    const tampered = {
+      ...receipt,
+      actionLog: [{ ...receipt.actionLog[0]!, detail: { forged: true } }],
+    };
+    expect(verifyReceipt(tampered).valid).toBe(false);
+  });
+
+  it('rejects a receipt with an unrelated public key substituted in', () => {
+    const receiptA = signActionLog(sampleActionLog, localRunContext());
+    const receiptB = signActionLog(sampleActionLog, localRunContext());
+    const forged = { ...receiptA, publicKey: receiptB.publicKey };
+    expect(verifyReceipt(forged).valid).toBe(false);
+  });
+
+  it('rejects a structurally malformed receipt', () => {
+    expect(verifyReceipt({ not: 'a receipt' }).valid).toBe(false);
+    expect(verifyReceipt(null).valid).toBe(false);
+  });
+
+  it('verifies a receipt with an empty action log', () => {
+    const receipt = signActionLog([], localRunContext());
+    expect(verifyReceipt(receipt)).toEqual({ valid: true });
+  });
+});

--- a/examples/starter-kit/src/receipts/run-context.ts
+++ b/examples/starter-kit/src/receipts/run-context.ts
@@ -1,0 +1,12 @@
+import { randomUUID } from 'node:crypto';
+import { hostname } from 'node:os';
+import type { RunContext } from './types.js';
+
+/**
+ * A plain local run context: this machine's hostname and a fresh run id.
+ * Not independently attributable (see the honesty note in `verify.ts`) —
+ * it's just enough to tell two receipts on your own disk apart.
+ */
+export function localRunContext(): RunContext {
+  return { runnerId: hostname(), runId: randomUUID() };
+}

--- a/examples/starter-kit/src/receipts/sign.ts
+++ b/examples/starter-kit/src/receipts/sign.ts
@@ -1,0 +1,37 @@
+import { createPublicKey, generateKeyPairSync } from 'node:crypto';
+import { deriveAuditKid, Ed25519AuditRowSigner } from '@revealui/security/server';
+import { receiptSignableBytes } from './signable.js';
+import type { ActionLogEntry, Receipt, RunContext } from './types.js';
+
+/**
+ * Sign a completed run's action log into a self-contained, offline-verifiable
+ * receipt.
+ *
+ * Reuses the fleet's own audit-log signing primitives (`@revealui/security`,
+ * GAP-355 `2026-07-12-audit-receipt-architecture`) — the same Ed25519 signer
+ * class, the same `v1.ed25519.<kid>.<sig>` wire format, and the same RFC 8785
+ * canonicalization (via `receiptSignableBytes`) that RevealUI's own audit log
+ * and the GAP-431 Apify actor use. It deliberately does NOT reuse the
+ * fleet's audit *key management* — that key backs RevealUI's own internal
+ * audit log, not a recipe you run on your own machine. Instead every run
+ * generates its own fresh Ed25519 keypair and embeds the public half
+ * directly in the receipt, so a receipt can be verified by anyone with no
+ * dependency on RevealUI's servers or secrets: the receipt carries its own
+ * key.
+ */
+export function signActionLog(actionLog: ActionLogEntry[], runContext: RunContext): Receipt {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519', {
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  });
+
+  const kid = deriveAuditKid(createPublicKey(publicKey));
+  const signer = new Ed25519AuditRowSigner(privateKey, kid);
+  const timestamp = new Date().toISOString();
+  const algorithm = 'ed25519' as const;
+
+  const bytes = receiptSignableBytes({ actionLog, algorithm, timestamp, ...runContext });
+  const { value: signature } = signer.sign(bytes);
+
+  return { actionLog, signature, publicKey, algorithm, timestamp, ...runContext };
+}

--- a/examples/starter-kit/src/receipts/signable.ts
+++ b/examples/starter-kit/src/receipts/signable.ts
@@ -1,0 +1,35 @@
+import { canonicalizeJcs } from '@revealui/security';
+import type { ActionLogEntry, RunContext } from './types.js';
+
+/** The exact fields a receipt's signature covers. `publicKey` travels with the
+ * receipt for verification but is deliberately NOT part of the signed payload
+ * — it identifies the key, it isn't integrity-bearing data. `runnerId` /
+ * `runId` ARE part of the signed payload, same as GAP-431's `actorId` /
+ * `actorRunId` — provenance metadata that isn't signed is freely editable
+ * metadata, which defeats the point of a receipt.
+ */
+export interface ReceiptSignablePayload extends RunContext {
+  actionLog: ActionLogEntry[];
+  algorithm: 'ed25519';
+  timestamp: string;
+}
+
+/**
+ * Build the canonical bytes signed for a receipt. Shared by sign and verify
+ * so a signed payload always re-canonicalizes identically at verify time.
+ * Uses RFC 8785 JSON Canonicalization (`@revealui/security`'s
+ * `canonicalizeJcs`) rather than `JSON.stringify`, because plain
+ * `JSON.stringify` does not guarantee stable key ordering across
+ * engines/round-trips — the same reason the fleet's own audit-log signing
+ * uses it (`packages/security/src/jcs.ts`).
+ */
+export function receiptSignableBytes(payload: ReceiptSignablePayload): Uint8Array {
+  const canonical = canonicalizeJcs({
+    actionLog: payload.actionLog,
+    algorithm: payload.algorithm,
+    timestamp: payload.timestamp,
+    runnerId: payload.runnerId,
+    runId: payload.runId,
+  });
+  return new TextEncoder().encode(canonical);
+}

--- a/examples/starter-kit/src/receipts/types.ts
+++ b/examples/starter-kit/src/receipts/types.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod/v4';
+
+/**
+ * One entry in a governed run's action log: every tool call and model call
+ * the agent performs, in execution order, plus a final entry recording the
+ * run's output. This array is the payload the receipt signs — it is the
+ * thing a buyer's compliance tooling is actually paying to verify.
+ *
+ * Shape mirrors `packages/apify-actor-governed-run/src/types.ts`
+ * (`ActionLogEntrySchema`) — the fleet's first shipped governed-receipt
+ * implementation (GAP-431) — generalized here for use outside the Apify
+ * platform. `.strict()` matters: a non-strict schema would silently drop
+ * unknown keys during parsing, letting an attacker inject a field into a
+ * receipt that the signature never covered.
+ */
+export const ActionLogEntrySchema = z
+  .object({
+    index: z.number().int().nonnegative(),
+    type: z.enum(['tool_call', 'model_call', 'final_output']),
+    timestamp: z.string(),
+    detail: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+export type ActionLogEntry = z.infer<typeof ActionLogEntrySchema>;
+
+/**
+ * Where this run happened. `null` for every field on a plain local run
+ * (`tsx` on a laptop, no hosting platform) — the receipt still verifies
+ * (signature integrity holds); it just carries no third-party-attributable
+ * run to cross-check against. Fill these in if you deploy the recipe
+ * behind a platform that can independently confirm a run identifier
+ * (the pattern GAP-431 uses for Apify).
+ */
+export interface RunContext {
+  runnerId: string | null;
+  runId: string | null;
+}
+
+/**
+ * The signed, offline-verifiable receipt returned alongside a run's result.
+ *
+ * `verifyReceipt` (src/receipts/verify.ts) proves only that these bytes were
+ * not altered after signing — it does NOT prove which machine ran the
+ * recipe. That is an honest, load-bearing distinction: say it this way in
+ * any buyer-facing copy, never "proves the agent ran on our servers."
+ */
+export const ReceiptSchema = z
+  .object({
+    actionLog: z.array(ActionLogEntrySchema),
+    signature: z.string().min(1),
+    publicKey: z.string().min(1),
+    algorithm: z.literal('ed25519'),
+    timestamp: z.string(),
+    runnerId: z.string().nullable(),
+    runId: z.string().nullable(),
+  })
+  .strict();
+export type Receipt = z.infer<typeof ReceiptSchema>;

--- a/examples/starter-kit/src/receipts/verify.ts
+++ b/examples/starter-kit/src/receipts/verify.ts
@@ -1,0 +1,61 @@
+import { createPublicKey } from 'node:crypto';
+import { deriveAuditKid, verifyEd25519AuditSignature } from '@revealui/security/server';
+import { receiptSignableBytes } from './signable.js';
+import { ReceiptSchema } from './types.js';
+
+export interface VerifyReceiptResult {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * Verify a receipt entirely offline: no network call, no database, no
+ * dependency on RevealUI infrastructure — the whole point of shipping the
+ * public key inside the receipt itself. Anyone holding a `receipt.json` can
+ * run this in their own Node process; it's what `verify-receipt-cli.ts`
+ * wraps for the command line.
+ *
+ * This proves the receipt's bytes were not altered after signing. It does
+ * NOT prove which machine produced the run, or that a specific LLM call
+ * actually happened — say that honestly in any buyer-facing copy. If you
+ * need platform-attributable provenance too, see the GAP-431 pattern
+ * (`packages/apify-actor-governed-run`), which binds a receipt to a
+ * third-party run record it cannot forge.
+ */
+export function verifyReceipt(receipt: unknown): VerifyReceiptResult {
+  const parsed = ReceiptSchema.safeParse(receipt);
+  if (!parsed.success) {
+    return { valid: false, reason: `malformed receipt: ${parsed.error.message}` };
+  }
+  const { actionLog, signature, publicKey, algorithm, timestamp, runnerId, runId } = parsed.data;
+
+  let keyObject: ReturnType<typeof createPublicKey>;
+  try {
+    keyObject = createPublicKey(publicKey);
+  } catch {
+    return { valid: false, reason: 'embedded public key could not be parsed' };
+  }
+  if (keyObject.asymmetricKeyType !== 'ed25519') {
+    return {
+      valid: false,
+      reason: `embedded public key is not ed25519 (got ${keyObject.asymmetricKeyType ?? 'unknown'})`,
+    };
+  }
+
+  const sigParts = signature.split('.');
+  if (sigParts.length !== 4) {
+    return { valid: false, reason: 'malformed signature: expected v1.ed25519.<kid>.<sig>' };
+  }
+  const kidInSignature = sigParts[2];
+  const expectedKid = deriveAuditKid(keyObject);
+  if (kidInSignature !== expectedKid) {
+    return { valid: false, reason: 'signature key id does not match the embedded public key' };
+  }
+
+  const bytes = receiptSignableBytes({ actionLog, algorithm, timestamp, runnerId, runId });
+  const result = verifyEd25519AuditSignature(bytes, signature, () => keyObject);
+  if (!result.valid) {
+    return { valid: false, reason: result.reason ?? 'signature verification failed' };
+  }
+  return { valid: true };
+}

--- a/examples/starter-kit/src/recipes/01-single-governed-action.ts
+++ b/examples/starter-kit/src/recipes/01-single-governed-action.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env tsx
+/**
+ * Recipe 1 — a single governed action, signed and verified end to end.
+ *
+ * The pattern this shows: any sensitive action your agent (or a human
+ * clicking a button an agent exposed) takes goes through a `tool_call` that
+ * gets logged, then the whole run gets signed into a receipt anyone can
+ * verify offline. Governance here doesn't care whether an LLM decided to
+ * call the tool — it cares that the action itself is provable after the
+ * fact. Swap `issueRefund` below for your own sensitive action (a payout, a
+ * permission grant, a data export) and you have the same guarantee.
+ *
+ * Run:
+ *   pnpm recipe:action
+ *
+ * Output: prints the receipt and writes it to receipt-action.json next to
+ * this file's cwd (the kit root).
+ */
+import { writeFile } from 'node:fs/promises';
+import { localRunContext } from '../receipts/run-context.js';
+import { signActionLog } from '../receipts/sign.js';
+import type { ActionLogEntry } from '../receipts/types.js';
+import { verifyReceipt } from '../receipts/verify.js';
+
+interface RefundParams {
+  customerId: string;
+  amountCents: number;
+  reason: string;
+}
+
+interface RefundResult {
+  success: boolean;
+  refundId: string;
+}
+
+/** Stand-in for a real sensitive action. Replace with your own tool. */
+async function issueRefund(params: RefundParams): Promise<RefundResult> {
+  // A real implementation would call your payments provider here. This
+  // recipe is about the receipt, not the refund, so it just returns a
+  // deterministic fake id.
+  return { success: true, refundId: `re_${params.customerId}_${Date.now()}` };
+}
+
+async function main(): Promise<void> {
+  const params: RefundParams = {
+    customerId: 'cus_demo_001',
+    amountCents: 4200,
+    reason: 'starter-kit recipe demo',
+  };
+
+  const actionLog: ActionLogEntry[] = [];
+
+  const callTimestamp = new Date().toISOString();
+  const result = await issueRefund(params);
+  actionLog.push({
+    index: 0,
+    type: 'tool_call',
+    timestamp: callTimestamp,
+    detail: { toolName: 'issue_refund', params, result },
+  });
+  actionLog.push({
+    index: 1,
+    type: 'final_output',
+    timestamp: new Date().toISOString(),
+    detail: { output: `refund ${result.refundId} issued for customer ${params.customerId}` },
+  });
+
+  const receipt = signActionLog(actionLog, localRunContext());
+  const verified = verifyReceipt(receipt);
+
+  console.log('Governed action complete.');
+  console.log(`  tool: issue_refund → ${result.refundId}`);
+  console.log(`  receipt signature: ${receipt.signature.slice(0, 40)}…`);
+  console.log(`  verifyReceipt(receipt): valid=${verified.valid}`);
+
+  await writeFile('receipt-action.json', `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log('  wrote receipt-action.json');
+
+  if (!verified.valid) {
+    console.error(`Receipt failed to verify: ${verified.reason ?? 'unknown reason'}`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/starter-kit/src/recipes/02-budget-capped-agent-loop.ts
+++ b/examples/starter-kit/src/recipes/02-budget-capped-agent-loop.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env tsx
+/**
+ * Recipe 2 — a multi-step governed agent loop, budget-capped, signed end to
+ * end.
+ *
+ * Mirrors the pattern in `packages/apify-actor-governed-run/src/agent/
+ * run-governed-task.ts` (the fleet's first shipped governed-receipt actor,
+ * GAP-431) but generalized for use inside your own app: every model call and
+ * every tool call becomes one entry in an ordered action log; a chargeAction
+ * budget check runs before each billable step; the whole run gets signed
+ * into one receipt. `stopReason` is one of 'completed' | 'charge-limit' |
+ * 'max-steps' — the same three outcomes the actor uses.
+ *
+ * Two modes, chosen automatically:
+ *   - ANTHROPIC_API_KEY set: makes real Anthropic Messages API calls (plain
+ *     fetch, no SDK, no @revealui/ai dependency — this recipe only needs
+ *     @revealui/security for the receipt).
+ *   - ANTHROPIC_API_KEY unset: runs a scripted, deterministic stand-in
+ *     "model" so the recipe is fully runnable offline (no network, no key)
+ *     for evaluation and CI. Clearly labeled DEMO_MODE.
+ *
+ * Run:
+ *   pnpm recipe:loop                       # offline demo mode
+ *   ANTHROPIC_API_KEY=sk-ant-... pnpm recipe:loop   # real model
+ *
+ * Output: prints the run and writes receipt-loop.json.
+ */
+import { writeFile } from 'node:fs/promises';
+import { localRunContext } from '../receipts/run-context.js';
+import { signActionLog } from '../receipts/sign.js';
+import type { ActionLogEntry } from '../receipts/types.js';
+import { verifyReceipt } from '../receipts/verify.js';
+
+const MAX_CHARGEABLE_ACTIONS = 5;
+const MODEL = process.env['ANTHROPIC_MODEL'] ?? 'claude-haiku-4-5';
+
+interface ToolDefinition {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+const tools: ToolDefinition[] = [
+  {
+    name: 'check_stock',
+    description: 'Look up the current stock level for a SKU.',
+    input_schema: {
+      type: 'object',
+      properties: { sku: { type: 'string' } },
+      required: ['sku'],
+    },
+  },
+  {
+    name: 'place_reorder',
+    description: 'Place a reorder for a SKU at a given quantity.',
+    input_schema: {
+      type: 'object',
+      properties: { sku: { type: 'string' }, quantity: { type: 'number' } },
+      required: ['sku', 'quantity'],
+    },
+  },
+];
+
+const STOCK_LEVELS: Record<string, number> = { 'SKU-42': 3 };
+
+function runTool(name: string, input: Record<string, unknown>): unknown {
+  if (name === 'check_stock') {
+    const sku = String(input['sku']);
+    return { sku, quantity: STOCK_LEVELS[sku] ?? 0 };
+  }
+  if (name === 'place_reorder') {
+    return { success: true, sku: input['sku'], quantity: input['quantity'] };
+  }
+  return { error: `unknown tool: ${name}` };
+}
+
+interface AnthropicToolUseBlock {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+interface AnthropicTextBlock {
+  type: 'text';
+  text: string;
+}
+type AnthropicContentBlock = AnthropicToolUseBlock | AnthropicTextBlock;
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content:
+    | string
+    | Array<AnthropicContentBlock | { type: 'tool_result'; tool_use_id: string; content: string }>;
+}
+
+async function callAnthropic(messages: AnthropicMessage[]): Promise<{
+  content: AnthropicContentBlock[];
+  stop_reason: string;
+}> {
+  const apiKey = process.env['ANTHROPIC_API_KEY'];
+  if (!apiKey) {
+    return callScriptedStandIn(messages);
+  }
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({ model: MODEL, max_tokens: 1024, tools, messages }),
+  });
+  if (!res.ok) {
+    throw new Error(`Anthropic API error ${res.status}: ${await res.text()}`);
+  }
+  const body = (await res.json()) as { content: AnthropicContentBlock[]; stop_reason: string };
+  return body;
+}
+
+/**
+ * A deterministic stand-in for the model, used only when no API key is set.
+ * It follows the exact same task the real model would be given: check
+ * SKU-42's stock, and if it's below 10, reorder 50 units. This keeps the
+ * recipe runnable with zero network access and zero secrets, while still
+ * producing a genuine multi-step action log to sign.
+ */
+function callScriptedStandIn(messages: AnthropicMessage[]): {
+  content: AnthropicContentBlock[];
+  stop_reason: string;
+} {
+  const toolResultCount = messages.filter(
+    (m) =>
+      Array.isArray(m.content) && m.content.some((b) => 'type' in b && b.type === 'tool_result'),
+  ).length;
+
+  if (toolResultCount === 0) {
+    return {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', id: 'call_1', name: 'check_stock', input: { sku: 'SKU-42' } }],
+    };
+  }
+  if (toolResultCount === 1) {
+    return {
+      stop_reason: 'tool_use',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'call_2',
+          name: 'place_reorder',
+          input: { sku: 'SKU-42', quantity: 50 },
+        },
+      ],
+    };
+  }
+  return {
+    stop_reason: 'end_turn',
+    content: [{ type: 'text', text: 'Stock for SKU-42 was below threshold; reordered 50 units.' }],
+  };
+}
+
+async function main(): Promise<void> {
+  const demoMode = !process.env['ANTHROPIC_API_KEY'];
+  console.log(
+    demoMode
+      ? 'DEMO_MODE (no ANTHROPIC_API_KEY set) — using a scripted stand-in model, no network calls.'
+      : `Live mode — calling ${MODEL}.`,
+  );
+
+  const actionLog: ActionLogEntry[] = [];
+  let chargeableActions = 0;
+  let index = 0;
+
+  function charge(): boolean {
+    if (chargeableActions >= MAX_CHARGEABLE_ACTIONS) return false;
+    chargeableActions += 1;
+    return true;
+  }
+
+  const messages: AnthropicMessage[] = [
+    {
+      role: 'user',
+      content:
+        "Check the stock level for SKU-42 and, if it's below 10, place a reorder for 50 units.",
+    },
+  ];
+
+  let stopReason: 'completed' | 'charge-limit' | 'max-steps' = 'max-steps';
+  const maxSteps = 6;
+
+  for (let step = 0; step < maxSteps; step++) {
+    if (!charge()) {
+      stopReason = 'charge-limit';
+      break;
+    }
+    const response = await callAnthropic(messages);
+    actionLog.push({
+      index: index++,
+      type: 'model_call',
+      timestamp: new Date().toISOString(),
+      detail: { stopReason: response.stop_reason },
+    });
+    messages.push({ role: 'assistant', content: response.content });
+
+    if (response.stop_reason !== 'tool_use') {
+      const finalText = response.content.find((b): b is AnthropicTextBlock => b.type === 'text');
+      actionLog.push({
+        index: index++,
+        type: 'final_output',
+        timestamp: new Date().toISOString(),
+        detail: { output: finalText?.text ?? '' },
+      });
+      stopReason = 'completed';
+      break;
+    }
+
+    const toolResults: Array<{ type: 'tool_result'; tool_use_id: string; content: string }> = [];
+    for (const block of response.content) {
+      if (block.type !== 'tool_use') continue;
+      if (!charge()) {
+        stopReason = 'charge-limit';
+        break;
+      }
+      const result = runTool(block.name, block.input);
+      actionLog.push({
+        index: index++,
+        type: 'tool_call',
+        timestamp: new Date().toISOString(),
+        detail: { toolName: block.name, input: block.input, result },
+      });
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: block.id,
+        content: JSON.stringify(result),
+      });
+    }
+    if (stopReason === 'charge-limit') break;
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  const receipt = signActionLog(actionLog, localRunContext());
+  const verified = verifyReceipt(receipt);
+
+  console.log(`Run complete. stopReason=${stopReason}, actions logged=${actionLog.length}`);
+  console.log(`  verifyReceipt(receipt): valid=${verified.valid}`);
+
+  await writeFile('receipt-loop.json', `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log('  wrote receipt-loop.json');
+
+  if (!verified.valid) {
+    console.error(`Receipt failed to verify: ${verified.reason ?? 'unknown reason'}`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/starter-kit/src/verify-receipt-cli.ts
+++ b/examples/starter-kit/src/verify-receipt-cli.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env tsx
+/**
+ * Recipe 3 — verify any receipt, fully offline, from the command line.
+ *
+ * This is the differentiator's other half: your compliance or audit tooling
+ * doesn't need this kit, this framework, or a network call to check a
+ * receipt — it needs `verifyReceipt` (src/receipts/verify.ts) and a JSON
+ * file. This CLI is that check, callable standalone.
+ *
+ * Run:
+ *   pnpm verify-receipt receipt-action.json
+ *   pnpm verify-receipt receipt-loop.json
+ */
+import { readFile } from 'node:fs/promises';
+import { verifyReceipt } from './receipts/verify.js';
+
+async function main(): Promise<void> {
+  const path = process.argv[2];
+  if (!path) {
+    console.error('Usage: pnpm verify-receipt <path-to-receipt.json>');
+    process.exitCode = 1;
+    return;
+  }
+
+  const raw = await readFile(path, 'utf8');
+  const receipt: unknown = JSON.parse(raw);
+  const result = verifyReceipt(receipt);
+
+  if (result.valid) {
+    console.log(`VALID — ${path} verifies offline, no network call made.`);
+  } else {
+    console.error(`INVALID — ${path}: ${result.reason ?? 'unknown reason'}`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/starter-kit/tsconfig.json
+++ b/examples/starter-kit/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../packages/dev/src/ts/library.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,6 +773,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  examples/starter-kit:
+    dependencies:
+      '@revealui/security':
+        specifier: workspace:*
+        version: link:../../packages/security
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../../packages/dev
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.5
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/ai:
     dependencies:
       '@revealui/contracts':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - apps/*
   - packages/*
+  - examples/starter-kit
 
 catalog:
   '@biomejs/biome': ^2.5.2


### PR DESCRIPTION
## Summary

- Adds `examples/starter-kit/`: the RevealUI Starter Kit — the $299 Polar.sh
  content-only SKU from GAP-434 (`.jv`), built on top of `create-revealui`
  output rather than duplicating it.
- Fixed, tested `docker-compose.starter.yml` (postgres + api + admin, Free/OSS
  tier via `REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true`). Deliberately drops the
  root `docker-compose.yml`'s `marketing` service, which references a
  Dockerfile that doesn't exist (filed as `GAP-444` in `.jv`, pre-existing,
  unrelated to this PR — verified with `git diff origin/test` showing zero
  changes to that file).
- `scripts/bootstrap.sh` + `scripts/generate-secrets.sh`: wires up the
  database migration step `create-revealui`'s own CLI documents but never
  runs automatically (its `installers/database.ts` exists, is tested, and is
  never called from `create.ts`/`create-flow.ts`), plus real
  `openssl`-based secret generation instead of prose instructions.
- Three governed-agent recipes (`src/recipes/`, `src/verify-receipt-cli.ts`)
  demonstrating the signed-receipt pattern end to end, built entirely on the
  free, MIT-licensed `@revealui/security` package — the same Ed25519
  primitives the GAP-431 Apify actor (`packages/apify-actor-governed-run`)
  uses, generalized here for use outside Apify and without a hard dependency
  on the Pro `@revealui/ai` package (recipe 2's optional real-LLM path is a
  ~15-line plain `fetch` call to the Anthropic Messages API, not an SDK
  dependency).
- Registers `examples/starter-kit` as a pnpm workspace member (needed to
  resolve `@revealui/security` via the normal workspace dependency graph
  instead of vendoring the signing code).

## Audit findings this extends (not duplicates)

Full audit in the coordinating `.jv` session; headline findings:
- `create-revealui` already gives a complete, non-Pro-gated local dev
  experience (5 templates, generated `.env.development.local` with a fresh
  `REVEALUI_SECRET`, optional Dev Container/Devbox, git init) — this kit does
  not re-scaffold any of that.
- `PRO_TEMPLATES` in `create-flow.ts` is empty; none of the five templates
  touch the two FSL packages (`@revealui/ai`, `@revealui/harnesses`) — the
  free scaffold and this kit both stay Free-tier by construction, not by
  convention.
- `packages/security` (MIT) already ships the Ed25519 sign/verify/JCS-canon
  primitives this kit's receipts use — nothing new was invented there.

## Test plan

- [x] `pnpm --filter revealui-starter-kit typecheck` — clean
- [x] `pnpm --filter revealui-starter-kit lint` — clean (biome)
- [x] `pnpm --filter revealui-starter-kit test` — 5/5 passing (sign/verify
      roundtrip + tamper-detection, mirrors the GAP-431 actor's own test
      shape)
- [x] Ran `pnpm recipe:action`, `pnpm recipe:loop` (offline demo mode, no
      API key), and `pnpm verify-receipt` against both generated receipts —
      all produced valid, offline-verified receipts
- [x] `docker compose -f docker-compose.starter.yml config --quiet` —
      compose file parses and interpolates cleanly against a real `.env`
- [x] `pnpm gate --changed` — PASS (full run, all hard-fail checks green;
      the one pre-existing unrelated failure, `packages/openapi` contracts
      drift, is `GAP-438`/tracked separately and confirmed untouched by this
      branch)
- [x] Fleet security-review pre-PR self-check (`--diff origin/test`)
      — "no security-sensitive files — no coordinator gate"
- [ ] **Owner: test once** — the actual `docker compose -f
      docker-compose.starter.yml build` was not run end-to-end in-session
      (avoided a long build inside the agent session per instruction). YAML/
      env interpolation is proven; the image build itself is not.

Companion `.jv` PR (listing copy + owner Polar/Stripe setup steps + the
GAP-444 filing): revealui-jv#824

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
