### PR TITLE
fix(docker): drop pnpm cache-mount so Railway builds the template Dockerfiles (GAP-430)

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -43,9 +43,14 @@ COPY packages/tokens/package.json ./packages/tokens/
 COPY packages/utils/package.json ./packages/utils/
 COPY apps/admin/package.json ./apps/admin/
 
-# Install dependencies with frozen lockfile
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --filter admin...
+# Install dependencies with frozen lockfile.
+# No BuildKit cache mount here on purpose: this Dockerfile is also the build
+# source for the public Railway marketplace template, and Railway's builder
+# rejects the `--mount=type=cache,id=...` syntax local Docker accepts
+# ("missing the cacheKey prefix from its id"). A plain install is portable
+# across Railway, local Docker, and CI. The fleet's own images build from the
+# .forge Dockerfiles.
+RUN pnpm install --frozen-lockfile --filter admin...
 
 # Builder stage
 FROM base AS builder

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -33,9 +33,14 @@ COPY packages/setup/package.json ./packages/setup/
 COPY packages/utils/package.json ./packages/utils/
 COPY apps/server/package.json ./apps/server/
 
-# Install dependencies with frozen lockfile
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --filter server...
+# Install dependencies with frozen lockfile.
+# No BuildKit cache mount here on purpose: this Dockerfile is also the build
+# source for the public Railway marketplace template, and Railway's builder
+# rejects the `--mount=type=cache,id=...` syntax local Docker accepts
+# ("missing the cacheKey prefix from its id"). A plain install is portable
+# across Railway, local Docker, and CI. The fleet's own images build from the
+# .forge Dockerfiles.
+RUN pnpm install --frozen-lockfile --filter server...
 
 # Builder stage
 FROM base AS builder


### PR DESCRIPTION
Railway's Metal builder rejects `--mount=type=cache,id=pnpm,target=/pnpm/store` ("missing the cacheKey prefix from its id") when building the marketplace template's api + admin from apps/server/Dockerfile and apps/admin/Dockerfile. Local Docker and CI accept it, but the public template must build on Railway. Removed the cache mount from both plain Dockerfiles; portable everywhere. Fleet's own images build from the .forge variants, unaffected. Build-script/Docker only, not security-sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)