### PR TITLE
fix(auth): fresh unlicensed self-host sign-in + relax admin env validation for OSS self-host

### DIFF
--- a/apps/admin/src/app/api/auth/sign-in/route.ts
+++ b/apps/admin/src/app/api/auth/sign-in/route.ts
@@ -144,7 +144,10 @@ async function signInHandler(request: NextRequest): Promise<NextResponse> {
 
     return response;
   } catch (error) {
-    logger.error('Error signing in', { error });
+    logger.error('Error signing in', error instanceof Error ? error : undefined, {
+      message: error instanceof Error ? error.message : String(error),
+      name: error instanceof Error ? error.name : 'unknown',
+    });
     return createErrorResponse(error, {
       endpoint: '/api/auth/sign-in',
       operation: 'sign_in',

--- a/apps/admin/src/lib/utils/__tests__/env-validation.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/env-validation.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { validateRequiredEnvVars } from '../env-validation.js';
+
+/**
+ * GAP-430/GAP-440: a fresh, unlicensed self-host deploy (e.g. the Railway
+ * marketplace template) never uses Stripe checkout, cross-subdomain session
+ * cookies, or the Workspace-backed signup verification email — those are
+ * hosted-SaaS-only concerns. Requiring their env vars in production blocked
+ * a stranger's deploy from booting at all without SKIP_ENV_VALIDATION=true.
+ */
+
+const ENV_KEYS = [
+  'REVEALUI_SECRET',
+  'REVEALUI_PUBLIC_SERVER_URL',
+  'POSTGRES_URL',
+  'DATABASE_URL',
+  'REVEALUI_KEK',
+  'REVEALUI_FLEET_MODE',
+  'REVEALUI_LICENSE_PRIVATE_KEY',
+  'REVEALUI_DEPLOYMENT_MODE',
+  'SESSION_COOKIE_DOMAIN',
+  'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
+  'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
+  'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
+  'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+  'GOOGLE_PRIVATE_KEY',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+const VALID_KEK = 'a'.repeat(64);
+
+function setCriticalRequiredVars(): void {
+  process.env.REVEALUI_SECRET = 'a'.repeat(32);
+  process.env.REVEALUI_PUBLIC_SERVER_URL = 'https://admin.example.com';
+  process.env.POSTGRES_URL = 'postgresql://user:pass@host:5432/db';
+  process.env.REVEALUI_KEK = VALID_KEK;
+}
+
+describe('validateRequiredEnvVars', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  describe('unlicensed self-host / marketplace-template deploy (no license private key)', () => {
+    it('does not require SESSION_COOKIE_DOMAIN, Stripe price IDs, or Google email vars', () => {
+      setCriticalRequiredVars();
+      // No REVEALUI_LICENSE_PRIVATE_KEY, no REVEALUI_DEPLOYMENT_MODE, no
+      // REVEALUI_FLEET_MODE — exactly the env shape of a stranger's fresh
+      // Railway deploy (REVEALUI_ALLOW_UNLICENSED_SELF_HOST is a separate,
+      // license-enforcement-only flag checked in instrumentation.ts, not here).
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+
+    it('still requires the critical base vars (e.g. REVEALUI_KEK)', () => {
+      // Deliberately omit REVEALUI_KEK.
+      process.env.REVEALUI_SECRET = 'a'.repeat(32);
+      process.env.REVEALUI_PUBLIC_SERVER_URL = 'https://admin.example.com';
+      process.env.POSTGRES_URL = 'postgresql://user:pass@host:5432/db';
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(false);
+      expect(result.missing).toContain('REVEALUI_KEK');
+    });
+  });
+
+  describe('RevForge Fleet-branded kit (REVEALUI_FLEET_MODE=true)', () => {
+    it('does not require SESSION_COOKIE_DOMAIN, Stripe price IDs, or Google email vars', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_FLEET_MODE = 'true';
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+  });
+
+  describe('RevealUI Studio hosted SaaS (REVEALUI_LICENSE_PRIVATE_KEY present)', () => {
+    it('still requires SESSION_COOKIE_DOMAIN, Stripe price IDs, and Google email vars', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'a-private-key';
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(false);
+      expect(result.missing).toEqual(
+        expect.arrayContaining([
+          'SESSION_COOKIE_DOMAIN',
+          'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
+          'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
+          'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
+          'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+          'GOOGLE_PRIVATE_KEY',
+        ]),
+      );
+    });
+
+    it('passes when all hosted-only vars are set', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'a-private-key';
+      process.env.SESSION_COOKIE_DOMAIN = '.example.com';
+      process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID = 'price_pro';
+      process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID = 'price_max';
+      process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID = 'price_ent';
+      process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL = 'svc@example.iam.gserviceaccount.com';
+      process.env.GOOGLE_PRIVATE_KEY = 'a-private-key';
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+  });
+
+  describe('non-production environments', () => {
+    it('never requires the hosted-only vars regardless of deployment mode', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'a-private-key';
+
+      const result = validateRequiredEnvVars({ environment: 'development' });
+
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+  });
+});

--- a/apps/admin/src/lib/utils/env-validation.ts
+++ b/apps/admin/src/lib/utils/env-validation.ts
@@ -5,6 +5,8 @@
  * Validates critical environment variables at startup.
  */
 
+import { isHostedDeployment } from '@revealui/core/deployment-mode';
+
 /**
  * Literal hex-set check (no regex). Returns true when value is exactly 64
  * characters and every character is in [0-9a-fA-F]. Mirrors the format
@@ -47,6 +49,18 @@ export function validateRequiredEnvVars(
   const { failOnMissing = false, environment } = options;
 
   const isFleetMode = Boolean(process.env.REVEALUI_FLEET_MODE);
+
+  // A RevealUI Studio hosted-SaaS deployment is the ONLY posture that uses
+  // self-billing (Stripe checkout), cross-subdomain session cookies, and the
+  // Workspace-backed signup verification email. Every other posture — a
+  // RevForge-stamped Fleet kit (isFleetMode) AND a plain OSS/unlicensed
+  // self-host or marketplace-template deploy (GAP-430/GAP-440) — never uses
+  // any of those, so requiring their env vars in "production" mode blocks a
+  // stranger's fresh deploy for no reason. isHostedDeployment() defaults to
+  // false whenever REVEALUI_LICENSE_PRIVATE_KEY is absent (the normal case
+  // for a self-host template with no license key at all), so this needs no
+  // new env var from the deploying operator.
+  const isSaasHosted = isHostedDeployment(process.env);
 
   // Base required variables — apply in all environments (hosted + Fleet).
   //
@@ -138,38 +152,48 @@ export function validateRequiredEnvVars(
       warnings.push(error);
     }
 
-    // SESSION_COOKIE_DOMAIN is required in production for cross-subdomain auth.
-    // Without it, sign-in throws at request time instead of at startup.
-    if (!process.env.SESSION_COOKIE_DOMAIN) {
-      missing.push('SESSION_COOKIE_DOMAIN');
-    }
-
-    // Stripe price IDs are required in production  -  without them, billing buttons
-    // silently send priceId:'' which the API rejects with a 400, showing
-    // "Failed to start checkout" to paying customers with no actionable error.
-    const stripePriceVars = [
-      'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
-      'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
-      'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
-    ];
-    for (const key of stripePriceVars) {
-      if (!process.env[key]) {
-        missing.push(key);
+    // SESSION_COOKIE_DOMAIN, Stripe checkout, and Workspace signup-verification
+    // email are all hosted-SaaS-only concerns (self-billing + cross-subdomain
+    // cookies + Workspace-backed mail). A self-host deploy — Fleet-branded
+    // (isFleetMode, checked above) or a plain OSS/unlicensed self-host or
+    // marketplace-template deploy (GAP-430/GAP-440, isSaasHosted false because
+    // it has no REVEALUI_LICENSE_PRIVATE_KEY) — never uses any of these, so
+    // requiring them here previously blocked a stranger's fresh deploy from
+    // booting without SKIP_ENV_VALIDATION.
+    if (isSaasHosted) {
+      // SESSION_COOKIE_DOMAIN is required in production for cross-subdomain auth.
+      // Without it, sign-in throws at request time instead of at startup.
+      if (!process.env.SESSION_COOKIE_DOMAIN) {
+        missing.push('SESSION_COOKIE_DOMAIN');
       }
-    }
 
-    // Transactional email transport (Gmail API — packages/services/src/email).
-    // The signup VERIFICATION email is sent from THIS admin app; without both
-    // vars getEmailProvider() falls back to a no-op that drops every send, so a
-    // non-first signup is created with no session and no email and (after the
-    // 24h grace) is locked out with no working recovery. Required in hosted
-    // production so a misconfigured deploy fails fast at boot (instrumentation.ts)
-    // instead of silently locking out every new user. Fleet kits are exempt
-    // (no Workspace email) via the !isFleetMode guard above.
-    const emailTransportVars = ['GOOGLE_SERVICE_ACCOUNT_EMAIL', 'GOOGLE_PRIVATE_KEY'];
-    for (const key of emailTransportVars) {
-      if (!process.env[key]) {
-        missing.push(key);
+      // Stripe price IDs are required in production  -  without them, billing buttons
+      // silently send priceId:'' which the API rejects with a 400, showing
+      // "Failed to start checkout" to paying customers with no actionable error.
+      const stripePriceVars = [
+        'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
+        'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
+        'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
+      ];
+      for (const key of stripePriceVars) {
+        if (!process.env[key]) {
+          missing.push(key);
+        }
+      }
+
+      // Transactional email transport (Gmail API — packages/services/src/email).
+      // The signup VERIFICATION email is sent from THIS admin app; without both
+      // vars getEmailProvider() falls back to a no-op that drops every send, so a
+      // non-first signup is created with no session and no email and (after the
+      // 24h grace) is locked out with no working recovery. Required in hosted
+      // production so a misconfigured deploy fails fast at boot (instrumentation.ts)
+      // instead of silently locking out every new user. Fleet kits and other
+      // self-host deploys are exempt (no Workspace email) via isSaasHosted above.
+      const emailTransportVars = ['GOOGLE_SERVICE_ACCOUNT_EMAIL', 'GOOGLE_PRIVATE_KEY'];
+      for (const key of emailTransportVars) {
+        if (!process.env[key]) {
+          missing.push(key);
+        }
       }
     }
   }

--- a/packages/auth/src/server/__tests__/auth.test.ts
+++ b/packages/auth/src/server/__tests__/auth.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // ---------------------------------------------------------------------------
 // Mock dependencies (vi.mock is hoisted above imports by Vitest)
 // ---------------------------------------------------------------------------
+const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }));
 vi.mock('@revealui/core/observability/logger', () => ({
-  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  logger: { error: mockLoggerError, info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
 // Mock bcryptjs
@@ -315,14 +316,72 @@ describe('auth', () => {
       }
     });
 
-    it('returns unexpected_error on uncaught exception', async () => {
-      mockCheckRateLimit.mockRejectedValueOnce(new Error('unexpected'));
+    it('returns database_error (not unexpected_error) when the rate-limit check throws', async () => {
+      // GAP-430 regression: checkRateLimit's storage backend (DatabaseStorage
+      // in production) can throw for reasons unrelated to the credential
+      // check. Before this guard, any such throw fell through to the outer
+      // catch and reported the generic, undiagnosable 'unexpected_error'.
+      mockCheckRateLimit.mockRejectedValueOnce(new Error('rate limit storage down'));
+
+      const result = await signIn('test@example.com', 'Password123');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.reason).toBe('database_error');
+      }
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Error checking rate limit',
+        expect.any(Error),
+        expect.objectContaining({ message: 'rate limit storage down' }),
+      );
+    });
+
+    it('returns database_error (not unexpected_error) when the account-lock check throws', async () => {
+      mockIsAccountLocked.mockRejectedValueOnce(new Error('lock storage down'));
+
+      const result = await signIn('test@example.com', 'Password123');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.reason).toBe('database_error');
+      }
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Error checking account lock status',
+        expect.any(Error),
+        expect.objectContaining({ message: 'lock storage down' }),
+      );
+    });
+
+    it('still succeeds when clearFailedAttempts throws (best-effort bookkeeping, not a gate)', async () => {
+      mockLimit.mockResolvedValueOnce([makeUser()]);
+      mockBcryptCompare.mockResolvedValueOnce(true);
+      mockClearFailedAttempts.mockRejectedValueOnce(new Error('clear storage down'));
+
+      const result = await signIn('test@example.com', 'Password123');
+      expect(result.success).toBe(true);
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Error clearing failed attempts after successful login',
+        expect.any(Error),
+        expect.objectContaining({ message: 'clear storage down' }),
+      );
+    });
+
+    it('logs the real error on a genuinely uncaught exception (outer catch)', async () => {
+      // auditLoginSuccess is documented as best-effort/never-throwing, but the
+      // outer catch must still surface the real error object (not swallow it
+      // silently) if that guarantee is ever violated.
+      mockLimit.mockResolvedValueOnce([makeUser()]);
+      mockBcryptCompare.mockResolvedValueOnce(true);
+      mockAuditLoginSuccess.mockRejectedValueOnce(new Error('audit boom'));
 
       const result = await signIn('test@example.com', 'Password123');
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.reason).toBe('unexpected_error');
       }
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Unexpected error in signIn',
+        expect.any(Error),
+        expect.objectContaining({ message: 'audit boom' }),
+      );
     });
 
     it('returns email_not_verified for unverified account past grace period', async () => {

--- a/packages/auth/src/server/__tests__/oninit-bootstrap-signin.test.ts
+++ b/packages/auth/src/server/__tests__/oninit-bootstrap-signin.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Fresh Unlicensed Self-Host Bootstrap → Sign-In (PGlite)
+ *
+ * Reproduces GAP-430's Railway marketplace-template failure: a first admin
+ * seeded exactly the way `apps/admin/revealui.config.ts` onInit() seeds it
+ * (via the collections engine's dynamic-SQL create path — the users
+ * collection has no typed `create` handler in
+ * `apps/admin/src/lib/db/typedCollectionStorage.ts`, so onInit's
+ * `revealui.create({ collection: 'users', ... })` falls through to the raw
+ * INSERT built by `insertDocumentQuery` in
+ * `packages/core/src/collections/operations/sqlAdapter.ts`) then fails to
+ * sign in with "Unexpected error".
+ *
+ * The raw INSERT only supplies the columns onInit actually passes
+ * (name, email, password, role, plus `roles` folded into `_json` because
+ * it's a hasMany `select` field) and leaves every other column — including
+ * `created_at` — to its SQL-level DEFAULT, exactly like the real bootstrap.
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db/client', () => ({
+  getClient: () => testDb.drizzle,
+  // DatabaseStorage's constructor calls createClient() to open its own real
+  // `pg` Pool. The pool is never queried in these tests — its `.db` is
+  // swapped for the PGlite-backed client immediately after construction —
+  // but the constructor call itself must not throw.
+  createClient: () => testDb.drizzle,
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import type { Database } from '@revealui/db/client';
+import { users } from '@revealui/db/schema';
+import bcrypt from 'bcryptjs';
+import { signIn } from '../auth.js';
+import { DatabaseStorage, resetStorage, setStorage } from '../storage/index.js';
+
+beforeAll(async () => {
+  process.env.REVEALUI_SECRET = 'test-secret-for-oninit-bootstrap-tests';
+  testDb = await createTestDb();
+}, 30_000);
+
+afterAll(async () => {
+  await testDb.close();
+});
+
+afterEach(async () => {
+  const { sql } = await import('drizzle-orm');
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "sessions"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "users"'));
+});
+
+/**
+ * Seed a first-admin row exactly the way the dynamic-SQL collections engine
+ * would for `onInit`'s `revealui.create({ collection: 'users', data: {
+ * name, email, password, role: 'owner', roles: ['super-admin'] } })` call —
+ * bcrypt-hash the password (create.ts does this before the INSERT), fold
+ * `roles` into `_json` (it's a hasMany `select` field, so it never becomes a
+ * real column per `isJsonFieldType`), and generate the `rvl_`-prefixed id
+ * exactly like `create.ts`'s `id = String(... : \`rvl_${crypto.randomUUID()}\`)`.
+ * Every other column (notably `created_at`) is left unset so Postgres
+ * applies its column DEFAULT — there is no Drizzle `.insert()` in this path.
+ */
+async function seedOnInitAdmin(email: string, password: string): Promise<string> {
+  const id = `rvl_${crypto.randomUUID()}`;
+  const hashedPassword = await bcrypt.hash(password, 12);
+  const jsonBlob = JSON.stringify({ roles: ['super-admin'] });
+
+  await testDb.pglite.query(
+    `INSERT INTO "users" (id, "name", "email", "password", "role", "_json") VALUES ($1, $2, $3, $4, $5, $6)`,
+    [id, 'Admin User', email, hashedPassword, 'owner', jsonBlob],
+  );
+
+  return id;
+}
+
+describe('onInit bootstrap admin → signIn (PGlite, fresh unlicensed self-host)', () => {
+  it('signs in successfully for a first admin created via the dynamic-SQL bootstrap path', async () => {
+    const email = 'founder@example.com';
+    const password = 'CorrectHorseBatteryStaple123!';
+    await seedOnInitAdmin(email, password);
+
+    // Sanity: confirm the row the collections engine would have produced —
+    // in particular that created_at came from the SQL DEFAULT, not an app value.
+    const [row] = await testDb.drizzle.select().from(users).where(eq(users.email, email));
+    expect(row).toBeDefined();
+    expect(row.createdAt).toBeInstanceOf(Date);
+    expect(row.emailVerified).toBe(false);
+
+    const result = await signIn(email, password, {
+      userAgent: 'test-agent',
+      ipAddress: '127.0.0.1',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    if (result.success) {
+      expect(result.sessionToken).toBeDefined();
+      expect(result.user.email).toBe(email);
+    }
+  });
+
+  it('signs in successfully when getStorage() resolves DatabaseStorage (production-shaped rate-limit/brute-force backend, not the test-only in-memory fallback)', async () => {
+    // A Free-tier Railway deploy runs with NODE_ENV=production and a real
+    // POSTGRES_URL, so getStorage() (packages/auth/src/server/storage/index.ts)
+    // resolves DatabaseStorage, never InMemoryStorage. The previous test never
+    // exercised that path (POSTGRES_URL/DATABASE_URL are forced empty by this
+    // package's vitest.config.ts, so getStorage() fell back to in-memory).
+    // DatabaseStorage's constructor opens its own real `pg` Pool via a
+    // connection string, which PGlite (no TCP listener) can't satisfy — so
+    // build one against a throwaway address (never queried) and swap its
+    // internal Drizzle client for the PGlite-backed one, exercising the exact
+    // same rate_limits SQL (get/set/atomicUpdate) DatabaseStorage runs in prod.
+    const dbBackedStorage = new DatabaseStorage('postgresql://unused:unused@localhost:5432/unused');
+    (dbBackedStorage as unknown as { db: Database }).db = testDb.drizzle as unknown as Database;
+    setStorage(dbBackedStorage);
+
+    try {
+      const email = 'founder-dbstorage@example.com';
+      const password = 'CorrectHorseBatteryStaple123!';
+      await seedOnInitAdmin(email, password);
+
+      const result = await signIn(email, password, {
+        userAgent: 'test-agent',
+        ipAddress: '127.0.0.1',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+      if (result.success) {
+        expect(result.sessionToken).toBeDefined();
+        expect(result.user.email).toBe(email);
+      }
+    } finally {
+      resetStorage();
+    }
+  });
+});

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -37,9 +37,31 @@ export async function signIn(
   },
 ): Promise<SignInResult> {
   try {
-    // Rate limiting by IP address
+    // Rate limiting by IP address. The storage backend (DatabaseStorage in
+    // production) can throw for reasons unrelated to the credential check
+    // itself (pool exhaustion, a transaction-pooling quirk, a storage
+    // misconfiguration) — guard it like every other DB-touching step below so
+    // a throw here fails closed with a diagnosable reason instead of falling
+    // through to the generic outer catch.
     const ipKey = options?.ipAddress || 'unknown';
-    const rateLimit = await checkRateLimit(`signin:${ipKey}`);
+    let rateLimit: { allowed: boolean };
+    try {
+      rateLimit = await checkRateLimit(`signin:${ipKey}`);
+    } catch (rateLimitError) {
+      logger.error(
+        'Error checking rate limit',
+        rateLimitError instanceof Error ? rateLimitError : undefined,
+        {
+          message:
+            rateLimitError instanceof Error ? rateLimitError.message : String(rateLimitError),
+        },
+      );
+      return {
+        success: false,
+        reason: 'database_error',
+        error: 'Database error',
+      };
+    }
     if (!rateLimit.allowed) {
       return {
         success: false,
@@ -48,8 +70,27 @@ export async function signIn(
       };
     }
 
-    // Brute force protection by email
-    const bruteForceCheck = await isAccountLocked(email);
+    // Brute force protection by email. Same rationale as the rate-limit
+    // guard above — the storage backend can throw independently of whether
+    // the account is actually locked.
+    let bruteForceCheck: { locked: boolean; lockUntil?: number };
+    try {
+      bruteForceCheck = await isAccountLocked(email);
+    } catch (lockCheckError) {
+      logger.error(
+        'Error checking account lock status',
+        lockCheckError instanceof Error ? lockCheckError : undefined,
+        {
+          message:
+            lockCheckError instanceof Error ? lockCheckError.message : String(lockCheckError),
+        },
+      );
+      return {
+        success: false,
+        reason: 'database_error',
+        error: 'Database error',
+      };
+    }
     if (bruteForceCheck.locked) {
       const lockMinutes = bruteForceCheck.lockUntil
         ? Math.ceil((bruteForceCheck.lockUntil - Date.now()) / (60 * 1000))
@@ -145,8 +186,24 @@ export async function signIn(
       return failInvalidCredentials();
     }
 
-    // Successful login - clear failed attempts
-    await clearFailedAttempts(email);
+    // Successful login - clear failed attempts. Best-effort: this is
+    // bookkeeping on an already-successful credential check, not a gate, so a
+    // storage hiccup here must not fail an otherwise-valid login (it can only
+    // make a future lockout trigger slightly sooner, never bypass one).
+    try {
+      await clearFailedAttempts(email);
+    } catch (clearAttemptsError) {
+      logger.error(
+        'Error clearing failed attempts after successful login',
+        clearAttemptsError instanceof Error ? clearAttemptsError : undefined,
+        {
+          message:
+            clearAttemptsError instanceof Error
+              ? clearAttemptsError.message
+              : String(clearAttemptsError),
+        },
+      );
+    }
 
     // Check email verification (with grace period for new accounts)
     if (!user.emailVerified) {
@@ -212,8 +269,12 @@ export async function signIn(
       user,
       sessionToken: token,
     };
-  } catch {
-    logger.error('Unexpected error in signIn');
+  } catch (err) {
+    logger.error('Unexpected error in signIn', err instanceof Error ? err : undefined, {
+      message: err instanceof Error ? err.message : String(err),
+      name: err instanceof Error ? err.name : 'unknown',
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     return {
       success: false,
       reason: 'unexpected_error',


### PR DESCRIPTION
## Problem (found deploying the Railway template as a real stranger would)
A fresh, unlicensed Free-tier self-host seeds the first admin but then fails login with "Unexpected error in signIn" (packages/auth/src/server/auth.ts outer catch, which swallowed the error). Separately, the admin crash-loops on boot demanding SESSION_COOKIE_DOMAIN + Stripe price IDs + Google email vars an OSS self-host does not use.

## Root cause
The DB-storage calls in signIn (rate-limit, account-lock, clearFailedAttempts) were unguarded. `clearFailedAttempts` runs immediately after a SUCCESSFUL credential check; a storage hiccup on the fresh DB threw into the generic outer catch and turned a valid login into "Unexpected error", with the error swallowed and undiagnosable.

## Fix
- Guard each DB-touching sign-in step: genuine failures fail closed with a logged, diagnosable `database_error`; the post-success bookkeeping (`clearFailedAttempts`) is best-effort so it can never sink a valid login. Outer catch now logs the real error.
- Relax admin env validation: SESSION_COOKIE_DOMAIN, Stripe price IDs, and Google email are optional for a plain unlicensed OSS self-host; critical vars (REVEALUI_KEK etc.) stay hard-required. Admin now boots without SKIP_ENV_VALIDATION.

## Verification
Red→green regression `oninit-bootstrap-signin.test.ts` (freshly-seeded unlicensed admin signs in); auth suite 536 green; env-validation tests added.

**Design note / crown-jewel surface:** this changes the auth sign-in path. **REVIEW-PENDING under guardrail 2 — do not merge until a non-author APPROVE verdict is recorded.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)