### PR TITLE
fix(admin): serve R2 media in CSP + next/image, allow blob: previews, drop Cloudinary/Blob remnants (GAP-208)

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -119,18 +119,13 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        // Vercel Blob CDN — originals stored here, next/image resizes on demand
-        hostname: '*.blob.vercel-storage.com',
-      },
-      {
-        protocol: 'https',
-        hostname: 'res.cloudinary.com',
-      },
-      {
-        protocol: 'https',
         hostname: 'www.gravatar.com',
       },
-      ...[process.env.NEXT_PUBLIC_SERVER_URL?.trim()]
+      // Cloudflare R2 public bucket — the canonical (and sole) object-storage
+      // backend for media originals (GAP-208); next/image resizes on demand.
+      // The retired Vercel Blob + never-canonical Cloudinary entries were
+      // removed with the R2 cutover.
+      ...[process.env.R2_PUBLIC_BASE_URL?.trim(), process.env.NEXT_PUBLIC_SERVER_URL?.trim()]
         .filter(Boolean)
         .map((item) => {
           try {

--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -57,6 +57,27 @@ describe('admin proxy — CSP nonce (GAP-219)', () => {
     expect(directive(csp, 'img-src')).toContain('https://*.stripe.com');
   });
 
+  it('allows blob: in img-src so media upload previews can render (GAP-208)', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const imgSrc = directive(res.headers.get('content-security-policy') ?? '', 'img-src');
+    expect(imgSrc).toContain('blob:');
+  });
+
+  it('adds the R2 public origin to img-src when R2_PUBLIC_BASE_URL is set (GAP-208)', async () => {
+    vi.stubEnv('R2_PUBLIC_BASE_URL', 'https://pub-abc123.r2.dev/media');
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const imgSrc = directive(res.headers.get('content-security-policy') ?? '', 'img-src');
+    expect(imgSrc).toContain('https://pub-abc123.r2.dev');
+    vi.unstubAllEnvs();
+  });
+
+  it('carries no Cloudinary sources and locks object-src to none (R2 is the sole backend)', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const csp = res.headers.get('content-security-policy') ?? '';
+    expect(csp).not.toContain('cloudinary.com');
+    expect(directive(csp, 'object-src')).toContain("'none'");
+  });
+
   it('allows the marketing origin in frame-src so the edit-session canvas can frame the preview', async () => {
     const res = await proxy(new NextRequest('https://admin.example.com/login'));
     const frameSrc = directive(res.headers.get('content-security-policy') ?? '', 'frame-src');
@@ -151,6 +172,8 @@ describe('admin proxy — CSP fleet mode (GAP-290)', () => {
     const imgSrc = directive(res.headers.get('content-security-policy') ?? '', 'img-src');
     expect(imgSrc).not.toContain('stripe.com');
     expect(imgSrc).not.toContain('cloudinary.com');
+    // blob: previews are origin-local; fleet kits keep them (GAP-208).
+    expect(imgSrc).toContain('blob:');
   });
 
   it('strips Stripe from frame-src and connect-src in fleet mode', async () => {

--- a/apps/admin/src/lib/security/csp.ts
+++ b/apps/admin/src/lib/security/csp.ts
@@ -15,7 +15,7 @@
  *     `Content-Security-Policy` header and applies it to its framework, bundle,
  *     and inline bootstrap scripts (plus `<Script>` components).
  *   - We deliberately KEEP the external-script host allowlist (Stripe, Maps,
- *     Cloudinary, Vercel insights) in non-fleet mode and do NOT use
+ *     Vercel insights) in non-fleet mode and do NOT use
  *     `'strict-dynamic'`, which would make those host-sources be ignored. In
  *     fleet mode (`REVEALUI_FLEET_MODE=true`) the hosted third-party SDK domains
  *     are omitted — fleet kits are self-hosted and must not phone home to
@@ -56,10 +56,27 @@ export interface AdminCspOptions {
   /**
    * `REVEALUI_FLEET_MODE === 'true'` — running as a fleet kit.
    * When true, hosted third-party SDK domains (Stripe.js, Vercel Analytics,
-   * Google Maps, Cloudinary) are omitted from every CSP directive. Fleet kits
-   * are self-hosted and must not include SaaS-specific external origins.
+   * Google Maps) are omitted from every CSP directive. Fleet kits are
+   * self-hosted and must not include SaaS-specific external origins.
    */
   isFleetMode?: boolean;
+  /**
+   * `R2_PUBLIC_BASE_URL` — public base URL of the Cloudflare R2 media bucket
+   * (the canonical and sole object-storage backend; GAP-208). Its origin is
+   * added to `img-src` so R2-served media renders. `''` when unset (the
+   * next/image same-origin path still works via `'self'`).
+   */
+  r2PublicBaseUrl?: string;
+}
+
+/** Origin of a base URL, or `''` when unset/malformed (no-regex: URL parser). */
+function originOf(baseUrl: string): string {
+  if (!baseUrl) return '';
+  try {
+    return new URL(baseUrl).origin;
+  } catch {
+    return '';
+  }
 }
 
 /**
@@ -91,6 +108,7 @@ export function buildAdminCsp(options: AdminCspOptions): string {
     serverUrl,
     marketingUrl,
     isFleetMode = false,
+    r2PublicBaseUrl = '',
   } = options;
   const vercelPreview = isVercel && !isVercelProd;
 
@@ -104,7 +122,6 @@ export function buildAdminCsp(options: AdminCspOptions): string {
           'https://checkout.stripe.com',
           'https://js.stripe.com',
           'https://maps.googleapis.com',
-          'https://res.cloudinary.com',
           'https://cdn.vercel-insights.com',
         ]),
     ...(vercelPreview ? ['https://vercel.live', 'https://*.vercel.live'] : []),
@@ -135,16 +152,31 @@ export function buildAdminCsp(options: AdminCspOptions): string {
     ...(isVercel ? [] : ['http://localhost:3000', 'http://localhost:4000']),
   ];
 
+  const r2Origin = originOf(r2PublicBaseUrl);
+  const imgSrc = [
+    "'self'",
+    // Local upload-preview thumbnails (URL.createObjectURL) — origin-local,
+    // kept in fleet mode too (GAP-208).
+    'blob:',
+    'data:',
+    ...(isFleetMode ? [] : ['https://*.stripe.com']),
+    ...(r2Origin ? [r2Origin] : []),
+    'https://www.gravatar.com',
+  ];
+
   const directives = [
     "default-src 'self'",
     `script-src ${scriptSrc.join(' ')}`,
     "child-src 'self'",
     "style-src 'self' 'unsafe-inline'",
-    `img-src 'self' ${isFleetMode ? '' : 'https://res.cloudinary.com https://*.stripe.com '}data: https://www.gravatar.com`,
+    `img-src ${imgSrc.join(' ')}`,
     "font-src 'self' data:",
     `frame-src ${frameSrc.join(' ')}`,
     `connect-src ${connectSrc.join(' ')}`,
-    ...(isFleetMode ? [] : ['object-src https://res.cloudinary.com']),
+    // No <object>/<embed> anywhere in admin; the old hosted-mode Cloudinary
+    // object-src was dead config (Cloudinary is not a storage backend — R2 is
+    // canonical and sole, GAP-208).
+    "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
     'upgrade-insecure-requests',

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -100,6 +100,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
       (process.env.REVEALUI_FLEET_MODE === 'true' ? '' : 'https://revealui.com')
     ).trim(),
     isFleetMode: process.env.REVEALUI_FLEET_MODE === 'true',
+    r2PublicBaseUrl: (process.env.R2_PUBLIC_BASE_URL || '').trim(),
   });
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);


### PR DESCRIPTION
## Summary

The GAP-208 R2 smoke test (live admin, media upload) surfaced three serving-side defects; this fixes all three in the admin CSP + next/image allowlist:

- **`img-src` gains `blob:`** — the upload UI's local preview thumbnails are `URL.createObjectURL` blob URLs, which the browser was blocking (seen in the live console during the smoke test).
- **`img-src` + `images.remotePatterns` gain the canonical R2 public origin** (derived from `R2_PUBLIC_BASE_URL` via the URL parser, no regex; both hosted and fleet modes) — previously R2-served originals were absent from both allowlists while the **retired Vercel Blob CDN** ("originals stored here" — false since #1644) and the **never-canonical Cloudinary host** were still allowlisted. Those remnants are removed.
- **`object-src` becomes an explicit `'none'`** — the old hosted-mode `object-src https://res.cloudinary.com` was dead config; admin renders no `<object>`/`<embed>`. Cloudinary is also dropped from `script-src` (no usage anywhere in `apps/admin/src`).

## Test plan

- [x] Prove-red: with the source files reverted to `origin/test`, the three new proxy-csp assertions (blob:, R2 origin via stubbed env, no-Cloudinary + object-src 'none') and the updated fleet-mode assertion all FAIL (4 failed / 19 passed); with the fix they pass 23/23.
- [x] `biome check` on the changed files — clean.
- [x] `pnpm --filter admin typecheck` — clean (after building the workspace dependency closure in the worktree).

## Notes

- Security-classed (CSP surface): needs a non-author guardrail-2 verdict before merge — review-pending.
- The remaining GAP-208 smoke-test question (whether the form-save 400 was just the required `alt` field) is being verified live and is independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
