### PR TITLE
fix(auth): coerce createdAt on sign-in + seed bootstrap admin emailVerified (GAP-446)

### DIFF
--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -353,31 +353,36 @@ export default buildConfig({
             // — 'super-admin' here violates users_role_check and the create fails.
             role: 'owner',
             roles: ['super-admin'],
-            // The operator sets this account via REVEALUI_ADMIN_EMAIL/PASSWORD;
-            // it is trusted by definition and there is no mailbox to verify on a
-            // self-host. Mark it verified so sign-in does not gate the operator
-            // out after the 24h email-verification grace window.
-            emailVerified: true,
           },
         });
 
         revealui.logger.info(`First admin user created: ${adminEmail}`);
 
-        // Stamp TOS acceptance on the typed tos_accepted_at / tos_version
-        // columns: revealui.create() above can't persist them (the engine's
-        // dynamic-SQL adapter rejects camelCase column identifiers), so an
-        // onInit-created owner would otherwise have a NULL tos_accepted_at.
-        // Record them via a typed Drizzle write, mirroring the web setup route
-        // (api/setup) and the CLI (scripts/admin/bootstrap). Non-fatal — a
+        // Stamp TOS acceptance AND email verification on their typed columns.
+        // revealui.create() above cannot persist these (the engine's dynamic-SQL
+        // adapter rejects camelCase column identifiers), so an onInit-created
+        // owner would otherwise have NULL tos_accepted_at and email_verified
+        // stuck at its `false` default. The operator sets this account via
+        // REVEALUI_ADMIN_EMAIL/PASSWORD, so it is trusted by definition and there
+        // is no mailbox to verify on a self-host; marking it verified keeps
+        // sign-in from gating the operator out after the 24h grace window.
+        // Both are typed Drizzle writes (which DO map camelCase correctly),
+        // mirroring the web setup route (api/setup) and the CLI. Non-fatal — a
         // failure here is a backfillable gap, not a reason to abort startup.
         // Imports are lazy because pulling @revealui/db/client into the
         // top-level module graph causes Turbopack async-module-init issues
         // (see the poolFactory note near the top of this file).
         try {
           const { getClient } = await import('@revealui/db/client');
+          const { eq } = await import('@revealui/db/orm');
+          const { users } = await import('@revealui/db/schema');
           const { stampTosAcceptanceByEmail } = await import('@/lib/auth/tos');
           const db = getClient('rest');
           await stampTosAcceptanceByEmail(db, adminEmail);
+          await db
+            .update(users)
+            .set({ emailVerified: true, emailVerifiedAt: new Date() })
+            .where(eq(users.email, adminEmail));
         } catch (tosError) {
           const message = tosError instanceof Error ? tosError.message : String(tosError);
           revealui.logger.error(

--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -353,6 +353,11 @@ export default buildConfig({
             // — 'super-admin' here violates users_role_check and the create fails.
             role: 'owner',
             roles: ['super-admin'],
+            // The operator sets this account via REVEALUI_ADMIN_EMAIL/PASSWORD;
+            // it is trusted by definition and there is no mailbox to verify on a
+            // self-host. Mark it verified so sign-in does not gate the operator
+            // out after the 24h email-verification grace window.
+            emailVerified: true,
           },
         });
 

--- a/packages/auth/src/server/__tests__/auth.test.ts
+++ b/packages/auth/src/server/__tests__/auth.test.ts
@@ -168,6 +168,27 @@ describe('auth', () => {
       expect(result.sessionToken).toBe('session-token-abc');
     });
 
+    it('signs in when createdAt is a string, not a Date (Postgres storage path)', async () => {
+      // Regression (GAP-446): the Postgres storage path returns createdAt as an
+      // ISO string, not a Date object. With emailVerified:false the sign-in reads
+      // createdAt to compute account age; calling .getTime() on a string threw a
+      // TypeError that fell through to the outer catch and turned a valid login
+      // into "unexpected_error" on real deploys. The account is within the 24h
+      // grace window, so login must succeed.
+      const oneHourAgoIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const user = makeUser({
+        emailVerified: false,
+        createdAt: oneHourAgoIso as unknown as Date,
+      });
+      mockLimit.mockResolvedValueOnce([user]);
+      mockBcryptCompare.mockResolvedValueOnce(true);
+
+      const result = await signIn('test@example.com', 'Password123');
+      expect(result.reason).not.toBe('unexpected_error');
+      expect(result.success).toBe(true);
+      expect(result.sessionToken).toBe('session-token-abc');
+    });
+
     it('returns error for nonexistent user', async () => {
       mockLimit.mockResolvedValueOnce([]); // no user found
 

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -205,9 +205,13 @@ export async function signIn(
       );
     }
 
-    // Check email verification (with grace period for new accounts)
+    // Check email verification (with grace period for new accounts).
+    // Coerce createdAt: the Postgres storage path returns timestamps as strings
+    // (not Date objects), so calling .getTime() directly threw a TypeError that
+    // fell through to the outer catch and turned a valid login into a generic
+    // "unexpected error" on real deploys. new Date() accepts a Date or a string.
     if (!user.emailVerified) {
-      const accountAge = Date.now() - user.createdAt.getTime();
+      const accountAge = Date.now() - new Date(user.createdAt).getTime();
       if (accountAge > EMAIL_VERIFICATION_GRACE_PERIOD_MS) {
         return {
           success: false,


### PR DESCRIPTION
## Problem (the SECOND fresh-deploy login bug, production-Postgres only)
After #2223 fixed the swallowed-error path, a fresh unlicensed self-host still 500'd on the correct-credentials login. Root cause: an unverified account within the 24h email-verification grace window computes `accountAge` from `user.createdAt`, but the Postgres storage path returns `createdAt` as a **string**, so `createdAt.getTime()` threw a TypeError → outer catch → "unexpected error". The bootstrap admin is seeded with `emailVerified` defaulting to false, so this hit the very first login every time. The prior regression test used an in-memory DB that returned a Date, so it never reproduced this.

## Fix
- `packages/auth/src/server/auth.ts`: `new Date(user.createdAt).getTime()` — tolerates a string or a Date.
- `apps/admin/revealui.config.ts`: seed the operator's env-driven bootstrap admin with `emailVerified: true` (trusted account, no mailbox to verify on a self-host), so sign-in never gates the operator out after the 24h grace window.
- Regression test: `signIn` with `createdAt` as an ISO string succeeds — proven red before the coerce, green after.

## Notes
- Pre-existing on `test` (not this PR): 3 `signUp` unit-test failures (signUp source untouched here) — worth a separate look.
- **Crown-jewel auth surface. REVIEW-PENDING under guardrail 2 — do not merge until a non-author APPROVE verdict is recorded.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)