### PR TITLE
fix(server): anchor null-tenant audit rows under the __system__ scope (GAP-427)

### DIFF
--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@revealui/core/security';
 import { type AuditEntry, type AuditRowSignerFn, DrizzleAuditStore } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
-import { auditAnchors } from '@revealui/db/schema';
+import { auditAnchors, usageMeters } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -19,7 +19,7 @@ import {
   type TestDb,
 } from '../../../../../packages/test/src/utils/drizzle-test-db.js';
 import { planContiguousBatch, type SignedAuditRow } from '../audit-anchor-batch.js';
-import { runAuditAnchorSweep } from '../audit-anchor-sweep.js';
+import { runAuditAnchorSweep, SYSTEM_ANCHOR_SCOPE } from '../audit-anchor-sweep.js';
 
 const KID = 'kid-s4-3';
 
@@ -214,7 +214,7 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     expect(await db.select().from(auditAnchors)).toHaveLength(0);
   });
 
-  it('counts null-tenant signed rows and never anchors them', async () => {
+  it('GAP-427: counts null-tenant signed rows and anchors them under the system scope, not per-tenant', async () => {
     const store = new DrizzleAuditStore(db, canonicalSignerFn(priv));
     await store.append(makeEntry({ tenant: null, id: 'null-tenant-1' }));
     await store.append(makeEntry({ tenant: 'acct_max', id: 't1' }));
@@ -231,10 +231,117 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     });
 
     expect(result.nullTenantSignedRows).toBe(1);
-    const anchors = await db.select().from(auditAnchors);
-    expect(anchors.every((a) => a.tenant !== null && a.tenant.length > 0)).toBe(true);
-    // null-tenant row is not in any anchor range as a tenant key
-    expect(anchors.some((a) => a.tenant === '')).toBe(false);
+    // The per-tenant loop never treats the null-tenant row as a "tenant" key.
+    const tenantAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(tenantAnchors).toHaveLength(1);
+    // It anchors separately, via the system-scope pass.
+    expect(result.systemOutcome).toBe('inserted');
+    const systemAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(systemAnchors).toHaveLength(1);
+    expect(systemAnchors[0]?.leafCount).toBe(1);
+  });
+
+  it('GAP-427: system scope anchors signed null-tenant rows above the null-tenant unsigned floor', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db); // pre-enforcement legacy rows, no signer
+
+    // Legacy era (closed): unsigned null-tenant seq 1. Signed era: seq 2..3.
+    await unsignedStore.append(makeEntry({ id: 'sys-u1', tenant: null }));
+    await signedStore.append(makeEntry({ id: 'sys-s2', tenant: null }));
+    await signedStore.append(makeEntry({ id: 'sys-s3', tenant: null }));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 2,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.systemOutcome).toBe('inserted');
+    expect(result.tenantsFloorEngaged).toBe(1);
+    expect(result.anchorsInserted).toBe(1);
+
+    const anchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.seqFrom).toBe(2);
+    expect(anchors[0]?.seqTo).toBe(3);
+
+    // No account FK backs a null tenant — the system pass must never meter.
+    const meters = await db.select().from(usageMeters);
+    expect(meters).toHaveLength(0);
+  });
+
+  it('GAP-427: systemOutcome is skipped when there are no null-tenant rows', async () => {
+    await appendSigned(3, 'acct_max', new Date('2026-07-23T12:00:00.000Z'));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 3,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.systemOutcome).toBe('skipped');
+    expect(result.nullTenantSignedRows).toBe(0);
+    const systemAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(systemAnchors).toHaveLength(0);
+  });
+
+  it('GAP-427: a tenant anchor and the system anchor both land in one sweep', async () => {
+    // Non-interleaved seq runs (tenant rows first, then null-tenant rows) —
+    // the global-seq interleave limitation is pre-existing and out of scope.
+    await appendSigned(2, 'acct_max', new Date('2026-07-23T12:00:00.000Z'));
+    const store = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    await store.append(
+      makeEntry({ id: 'sys-1', tenant: null, timestamp: new Date('2026-07-23T12:00:01.000Z') }),
+    );
+    await store.append(
+      makeEntry({ id: 'sys-2', tenant: null, timestamp: new Date('2026-07-23T12:00:02.000Z') }),
+    );
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 2,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.anchorsInserted).toBe(2);
+    expect(result.systemOutcome).toBe('inserted');
+
+    const tenantAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(tenantAnchors).toHaveLength(1);
+    expect(tenantAnchors[0]?.seqFrom).toBe(1);
+    expect(tenantAnchors[0]?.seqTo).toBe(2);
+
+    const systemAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(systemAnchors).toHaveLength(1);
+    expect(systemAnchors[0]?.seqFrom).toBe(3);
+    expect(systemAnchors[0]?.seqTo).toBe(4);
   });
 
   it('skips when an unsigned hole appears above an existing anchor (strict contiguity)', async () => {

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -6,7 +6,15 @@
  * age ≥ max lag), build a contiguous batch, Merkle-root the signature
  * leaves, sign the root (Stage 3 Ed25519), insert audit_anchors, and
  * meter `audit_anchor`. Failures never delete audit rows (append-only).
- * Null-tenant rows are never anchored (§9); volume is gauged each tick.
+ *
+ * Null-tenant (system) rows anchor too, via one additional pass per sweep
+ * (GAP-427 ruling 2026-07-27): they land in `audit_anchors` under the
+ * reserved `SYSTEM_ANCHOR_SCOPE` ('__system__') sentinel tenant value.
+ * `audit_log.tenant` itself stays null on those rows (no schema migration);
+ * only the anchor row's `tenant` column carries the sentinel. The system
+ * pass is not entitlement-gated (`canAnchorTenant` is per-account; system
+ * events are the operator's own audit trail) and never writes a usage
+ * meter (no account FK backs a null tenant).
  *
  * Gated by AUDIT_ANCHOR_SWEEP_ENABLED=true on the worker process.
  */
@@ -31,6 +39,13 @@ import { recordUsageMeter } from '../lib/metering.js';
 import { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
 
 export { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
+
+/**
+ * GAP-427: the audit_anchors.tenant value for anchors over null-tenant
+ * (system) audit_log rows. audit_anchors.tenant is NOT NULL, so a sentinel
+ * avoids a schema migration; the underlying audit_log rows stay null.
+ */
+export const SYSTEM_ANCHOR_SCOPE = '__system__';
 
 /** Countersigned default batch size (§9). Override: AUDIT_ANCHOR_BATCH_SIZE. */
 export const DEFAULT_ANCHOR_BATCH_SIZE = 256;
@@ -69,7 +84,7 @@ const mErrors = metrics.counter(
 );
 const mNullTenant = metrics.gauge(
   'revealui_audit_null_tenant_signed_rows',
-  'Signed audit_log rows with null tenant (never anchored in Stage 4)',
+  'Signed audit_log rows with null tenant, anchored under the __system__ scope (GAP-427 ruling 2026-07-27)',
 );
 const mWaiting = metrics.counter(
   'revealui_audit_anchor_waiting_total',
@@ -85,9 +100,11 @@ export interface AnchorSweepResult {
   anchorsInserted: number;
   tenantsSkipped: number;
   tenantsWaiting: number;
-  /** Tenants whose pass started from a derived legacy floor (no anchors yet). */
+  /** Tenant (and system-scope) passes that started from a derived legacy floor. */
   tenantsFloorEngaged: number;
   nullTenantSignedRows: number;
+  /** GAP-427: outcome of the one null-tenant system-scope pass this sweep. */
+  systemOutcome: 'inserted' | 'waiting' | 'skipped';
   errors: string[];
 }
 
@@ -160,6 +177,7 @@ export async function runAuditAnchorSweep(
     tenantsWaiting: 0,
     tenantsFloorEngaged: 0,
     nullTenantSignedRows: 0,
+    systemOutcome: 'skipped',
     errors: [],
   };
 
@@ -168,18 +186,14 @@ export async function runAuditAnchorSweep(
     return result;
   }
 
-  // §9: null-tenant volume metric (never anchored in Stage 4).
+  // GAP-427: null-tenant (system) volume gauge. Anchored below via the
+  // dedicated system-scope pass, not the per-tenant loop.
   const [nullRow] = await db
     .select({ c: count() })
     .from(auditLog)
     .where(and(isNull(auditLog.tenant), isNotNull(auditLog.signature)));
   result.nullTenantSignedRows = Number(nullRow?.c ?? 0);
   mNullTenant.set(result.nullTenantSignedRows);
-  if (result.nullTenantSignedRows > 0) {
-    logger.warn(
-      `audit-anchor-sweep: ${result.nullTenantSignedRows} signed audit_log row(s) have null tenant (skipped)`,
-    );
-  }
 
   const tenantRows = await db
     .selectDistinct({ tenant: auditLog.tenant })
@@ -188,6 +202,9 @@ export async function runAuditAnchorSweep(
 
   for (const { tenant } of tenantRows) {
     if (!tenant) continue;
+    // Defensive: a hostile or buggy writer must never collide with the
+    // system scope's anchor bookkeeping (GAP-427).
+    if (tenant === SYSTEM_ANCHOR_SCOPE) continue;
     result.tenantsConsidered++;
     try {
       if (!(await canAnchor(tenant))) {
@@ -222,7 +239,41 @@ export async function runAuditAnchorSweep(
     }
   }
 
+  // GAP-427: one system-scope pass for null-tenant rows. Not entitlement
+  // gated and never metered (recordMeter forced false — no account FK).
+  try {
+    const { outcome, floorEngaged } = await anchorTenantBatch(
+      db,
+      signer,
+      SYSTEM_ANCHOR_SCOPE,
+      batchSize,
+      maxLagMs,
+      now,
+      /* doMeter */ false,
+      /* isSystem */ true,
+    );
+    result.systemOutcome = outcome;
+    if (floorEngaged) result.tenantsFloorEngaged++;
+    if (outcome === 'inserted') result.anchorsInserted++;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    result.errors.push(`${SYSTEM_ANCHOR_SCOPE}: ${msg}`);
+    logger.error(
+      'audit-anchor-sweep: system scope failed',
+      err instanceof Error ? err : new Error(msg),
+    );
+  }
+
   return result;
+}
+
+/**
+ * audit_log.tenant predicate for a scope: a real tenant (`eq`) or the
+ * GAP-427 system scope, which matches null-tenant rows directly since
+ * audit_log.tenant is never set to SYSTEM_ANCHOR_SCOPE itself.
+ */
+function auditLogTenantMatch(tenant: string, isSystem: boolean) {
+  return isSystem ? isNull(auditLog.tenant) : eq(auditLog.tenant, tenant);
 }
 
 async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
@@ -244,14 +295,22 @@ async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
  * Legacy rows are never retro-signed — a backfilled signature would be
  * indistinguishable from tampering (ADR 2026-07-12 §2a).
  *
+ * `isSystem` (GAP-427 ruling 2026-07-27) selects the null-tenant floor
+ * instead of a real tenant's; `tenant` is still the audit_anchors.tenant key
+ * (SYSTEM_ANCHOR_SCOPE) the caller is deriving the floor for.
+ *
  * Exported for the anchors API lag surface (GAP-429), which reports the same
  * floor so sub-floor legacy rows are visible rather than silently excluded.
  */
-export async function legacyUnsignedFloor(db: Database, tenant: string): Promise<number> {
+export async function legacyUnsignedFloor(
+  db: Database,
+  tenant: string,
+  isSystem = false,
+): Promise<number> {
   const rows = await db
     .select({ m: max(auditLog.seq) })
     .from(auditLog)
-    .where(and(eq(auditLog.tenant, tenant), isNull(auditLog.signature)));
+    .where(and(auditLogTenantMatch(tenant, isSystem), isNull(auditLog.signature)));
   const m = rows[0]?.m;
   return typeof m === 'number' && Number.isFinite(m) ? m : 0;
 }
@@ -271,11 +330,13 @@ async function anchorTenantBatch(
   maxLagMs: number,
   now: () => Date,
   doMeter: boolean,
+  isSystem = false,
 ): Promise<{ outcome: TenantOutcome; floorEngaged: boolean }> {
   const anchored = await lastAnchoredSeq(db, tenant);
-  // GAP-427: first anchor for a tenant starts above the closed unsigned era,
-  // not at seq 1. Once anchors exist, strict last+1 contiguity governs.
-  const floor = anchored > 0 ? 0 : await legacyUnsignedFloor(db, tenant);
+  // GAP-427: first anchor for a tenant (or the system scope) starts above the
+  // closed unsigned era, not at seq 1. Once anchors exist, strict last+1
+  // contiguity governs.
+  const floor = anchored > 0 ? 0 : await legacyUnsignedFloor(db, tenant, isSystem);
   const floorEngaged = floor > 0;
   if (floorEngaged) {
     mFloorEngaged.inc();
@@ -296,7 +357,13 @@ async function anchorTenantBatch(
       timestamp: auditLog.timestamp,
     })
     .from(auditLog)
-    .where(and(eq(auditLog.tenant, tenant), isNotNull(auditLog.signature), gt(auditLog.seq, last)))
+    .where(
+      and(
+        auditLogTenantMatch(tenant, isSystem),
+        isNotNull(auditLog.signature),
+        gt(auditLog.seq, last),
+      ),
+    )
     .orderBy(asc(auditLog.seq))
     .limit(batchSize);
 
@@ -408,7 +475,7 @@ export function startAuditAnchorSweep(env: Record<string, string | undefined> = 
       logger.info(
         `audit-anchor-sweep: tick tenants=${r.tenantsConsidered} inserted=${r.anchorsInserted} ` +
           `waiting=${r.tenantsWaiting} skipped=${r.tenantsSkipped} nullTenant=${r.nullTenantSignedRows} ` +
-          `errors=${r.errors.length}`,
+          `system=${r.systemOutcome} errors=${r.errors.length}`,
       );
     });
   };

--- a/apps/server/src/routes/__tests__/audit-anchors.test.ts
+++ b/apps/server/src/routes/__tests__/audit-anchors.test.ts
@@ -25,6 +25,7 @@ import {
   createTestDb,
   type TestDb,
 } from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+import { SYSTEM_ANCHOR_SCOPE } from '../../jobs/audit-anchor-sweep.js';
 import auditRoute from '../audit.js';
 
 const KID = 'kid-s4-4';
@@ -320,6 +321,38 @@ describe('GET /anchors + /anchors/:id/proof (GAP-355 S4-4, PGlite)', () => {
 
     const app = createAuthedApp(user, db);
     const res = await app.request(`/anchors/${foreign?.id}/proof?seq=${seqFrom}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('GAP-427: returns 404 for a system-scope anchor (tenant is never client-supplied)', async () => {
+    // GET /anchors derives `tenant` from the caller's own account membership
+    // (getUserAccountId) — there is no request param a client can set to
+    // '__system__'. This locks the existing tenant-isolation check (anchor
+    // .tenant !== caller tenant → 404) also covers the reserved sentinel, the
+    // same way it already covers any other tenant's anchors.
+    const { signatures, seqFrom, seqTo } = await seedSignedRows(2);
+    const { root, leafCount } = buildMerkleRootFromSignatures(signatures);
+    const { value: rootSignature } = signAuditAnchorRoot(cryptoSigner, {
+      tenant: SYSTEM_ANCHOR_SCOPE,
+      seqFrom,
+      seqTo,
+      leafCount,
+      root,
+    });
+    const [systemAnchor] = await db
+      .insert(auditAnchors)
+      .values({
+        tenant: SYSTEM_ANCHOR_SCOPE,
+        seqFrom,
+        seqTo,
+        root,
+        rootSignature,
+        leafCount,
+      })
+      .returning({ id: auditAnchors.id });
+
+    const app = createAuthedApp(user, db);
+    const res = await app.request(`/anchors/${systemAnchor?.id}/proof?seq=${seqFrom}`);
     expect(res.status).toBe(404);
   });
 

--- a/docs/security/AUDIT_RECEIPTS.md
+++ b/docs/security/AUDIT_RECEIPTS.md
@@ -62,6 +62,27 @@ Below the floor:
 
 The floor never spans live history. A `seq` hole that appears above an existing anchor still stalls the sweep and raises the gap metric.
 
+## System scope (GAP-427 ruling 2026-07-27)
+
+Not every audit row has a tenant. System and operator-level events (agent
+spawns outside an account context, platform-level actions) write `audit_log`
+rows with `tenant = null`. Those rows anchor too: each sweep runs one
+additional pass, after the per-tenant loop, that anchors them under the
+reserved `__system__` scope. `audit_anchors.tenant` carries the
+`SYSTEM_ANCHOR_SCOPE` ('__system__') sentinel value for these anchors (the
+column is `NOT NULL`); `audit_log.tenant` itself is untouched and stays null
+on the underlying rows.
+
+The system pass is not entitlement-gated (`auditLog`/Max+ is a per-account
+check; system events are the operator's own audit trail, not a customer's)
+and never writes a usage meter (no account FK backs a null tenant).
+
+The same legacy-floor semantics apply: while the system scope has zero
+anchors, the sweep derives a floor from the highest **unsigned** null-tenant
+row and anchors from `floor + 1` forward. Rows at or below that floor are
+pre-enforcement legacy rows and are never retro-signed, for the same reason
+as the per-tenant floor above.
+
 ## Offline verify
 
 ```bash

--- a/packages/db/src/schema/audit-anchors.ts
+++ b/packages/db/src/schema/audit-anchors.ts
@@ -27,7 +27,13 @@ export const auditAnchors = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
 
-    /** Matches audit_log.tenant; null-tenant rows are never anchored (Stage 4 §9). */
+    /**
+     * Matches audit_log.tenant for real tenants. Null-tenant (system) rows
+     * anchor under the reserved '__system__' sentinel instead, since this
+     * column is NOT NULL and audit_log.tenant itself stays null on those
+     * rows (GAP-427 ruling 2026-07-27; see SYSTEM_ANCHOR_SCOPE in
+     * apps/server/src/jobs/audit-anchor-sweep.ts).
+     */
     tenant: text('tenant').notNull(),
 
     /** Inclusive seq range of signed audit_log rows covered by this root. */


### PR DESCRIPTION
## Summary

Owner ruling 2026-07-27: null-tenant (system) audit rows MUST be anchored,
under a dedicated system scope. Before this change the anchor sweep skipped
null-tenant rows entirely, so prod (1725 signed null-tenant rows, zero tenant
rows) could never anchor a single root.

Adds `SYSTEM_ANCHOR_SCOPE = '__system__'` as the `audit_anchors.tenant` value
for anchors over null-tenant `audit_log` rows. `audit_anchors.tenant` is
`NOT NULL`, so the sentinel avoids a schema migration; the underlying
`audit_log.tenant` column stays null on the rows themselves — only the anchor
row's `tenant` column carries the sentinel.

- `runAuditAnchorSweep` runs one additional system-scope pass after the
  per-tenant loop. It reuses the same `anchorTenantBatch` code path (floor
  derivation, contiguity, batch readiness, Merkle root, signing, insert),
  generalized to filter `audit_log` by `isNull(tenant)` instead of
  `eq(tenant, tenant)` when in system mode.
- The system pass is **not** entitlement-gated (`canAnchorTenant` is
  per-account; system events are the operator's own audit trail) and
  **never** writes a usage meter (no account FK backs a null tenant) —
  `doMeter` is forced `false` at the call site.
- The tenant enumeration loop defensively skips any row whose `tenant`
  literally equals `'__system__'`, so a hostile or buggy writer can't
  collide with the system scope's anchor bookkeeping.
- Legacy-floor semantics are identical to the per-tenant case: while the
  system scope has zero anchors, the floor is the highest **unsigned**
  null-tenant `seq`; rows at or below it are pre-enforcement legacy and are
  never retro-signed.
- `AnchorSweepResult` gains `systemOutcome: 'inserted' | 'waiting' |
  'skipped'`; a system insert also counts into `anchorsInserted`. The tick
  log line gains ` system=<outcome>`.
- Removed the old `logger.warn(... "(skipped)")` for null-tenant rows (the
  doctrine changed — they're no longer skipped). `nullTenantSignedRows` and
  the `revealui_audit_null_tenant_signed_rows` gauge are kept, with the gauge
  help text updated to describe the system scope.
- `packages/db/src/schema/audit-anchors.ts`: comment-only change on the
  `tenant` column describing the sentinel. No migration — the column type
  and constraints are unchanged.
- `docs/security/AUDIT_RECEIPTS.md`: new "System scope (GAP-427 ruling
  2026-07-27)" subsection under the legacy-floor documentation.

### Deviations from spec / design notes

- `result.tenantsFloorEngaged` also counts the system pass when it floor-
  engages (per spec point 6, "the floorEngaged metric/log applies" to the
  system scope identically to tenants). The field name still says "tenants"
  since no new field was requested for this.
- The `mWaiting` / `mGaps` / `mErrors` Prometheus counters (help text still
  says "Tenants"/"tenant") are **not** incremented for the system pass, to
  avoid silently redefining what those metrics count. The system pass's
  outcome is fully observable via `result.systemOutcome` and the extended
  tick log line instead. `mAnchorsCreated` and `mFloorEngaged` **are** shared
  (generic wording / explicitly requested).
- `GET /api/audit/anchors` (`apps/server/src/routes/audit.ts`) was **not**
  changed. Its `tenant` is derived entirely server-side via
  `getUserAccountId` (an `accountMemberships` lookup) — there is no request
  parameter a client can set to `'__system__'`. The existing tenant-isolation
  check on `GET /anchors/:id/proof` (`anchor.tenant !== tenant → 404`)
  already covers a system-scope anchor the same way it covers any other
  tenant's anchor. Added one test (`audit-anchors.test.ts`) locking this in
  by inserting a `'__system__'`-tenant anchor and asserting the proof
  endpoint 404s for a normal tenant caller.

## Prove-red

After committing, restored the pre-fix `audit-anchor-sweep.ts` from `HEAD`
(the branch's own prior state, i.e. `origin/test`) and re-ran the sweep test
file:

- **Red** (pre-fix `audit-anchor-sweep.ts`): 4 failed / 13 passed — the 4
  new/rewritten GAP-427 system-scope tests failed (`systemOutcome` was
  `undefined`, `anchorsInserted` missing the system anchor); the 13
  pre-existing tests were unaffected.
- **Green** (fix restored from `HEAD`): 17/17 passed (sweep) + 9/9 passed
  (routes) = 26/26.

## Test plan

- [x] `pnpm --filter server exec vitest run src/jobs/__tests__/audit-anchor-sweep.test.ts` — 17/17 passed
- [x] `pnpm --filter server exec vitest run src/routes/__tests__/audit-anchors.test.ts` — 9/9 passed
- [x] Prove-red: 4/17 failed on base code, 17/17 green with the fix
- [x] `biome check` clean on all 5 changed files
- [x] `pnpm --filter server typecheck` — zero errors in any of the 5 changed
      files (remaining repo-wide errors are pre-existing, from workspace
      packages whose dists weren't built in this worktree — unrelated to
      this change)
- [x] Pre-push gate (security + CI phases) passed

**Security-classed (audit anchoring surface): needs a non-author guardrail-2 verdict before merge — review-pending.**
