### PR TITLE
chore(release): promote test to main — GAP-427 system anchor scope + GAP-208 R2/CSP serving + auth sign-in fixes

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -119,18 +119,13 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        // Vercel Blob CDN — originals stored here, next/image resizes on demand
-        hostname: '*.blob.vercel-storage.com',
-      },
-      {
-        protocol: 'https',
-        hostname: 'res.cloudinary.com',
-      },
-      {
-        protocol: 'https',
         hostname: 'www.gravatar.com',
       },
-      ...[process.env.NEXT_PUBLIC_SERVER_URL?.trim()]
+      // Cloudflare R2 public bucket — the canonical (and sole) object-storage
+      // backend for media originals (GAP-208); next/image resizes on demand.
+      // The retired Vercel Blob + never-canonical Cloudinary entries were
+      // removed with the R2 cutover.
+      ...[process.env.R2_PUBLIC_BASE_URL?.trim(), process.env.NEXT_PUBLIC_SERVER_URL?.trim()]
         .filter(Boolean)
         .map((item) => {
           try {

--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -353,31 +353,36 @@ export default buildConfig({
             // — 'super-admin' here violates users_role_check and the create fails.
             role: 'owner',
             roles: ['super-admin'],
-            // The operator sets this account via REVEALUI_ADMIN_EMAIL/PASSWORD;
-            // it is trusted by definition and there is no mailbox to verify on a
-            // self-host. Mark it verified so sign-in does not gate the operator
-            // out after the 24h email-verification grace window.
-            emailVerified: true,
           },
         });
 
         revealui.logger.info(`First admin user created: ${adminEmail}`);
 
-        // Stamp TOS acceptance on the typed tos_accepted_at / tos_version
-        // columns: revealui.create() above can't persist them (the engine's
-        // dynamic-SQL adapter rejects camelCase column identifiers), so an
-        // onInit-created owner would otherwise have a NULL tos_accepted_at.
-        // Record them via a typed Drizzle write, mirroring the web setup route
-        // (api/setup) and the CLI (scripts/admin/bootstrap). Non-fatal — a
+        // Stamp TOS acceptance AND email verification on their typed columns.
+        // revealui.create() above cannot persist these (the engine's dynamic-SQL
+        // adapter rejects camelCase column identifiers), so an onInit-created
+        // owner would otherwise have NULL tos_accepted_at and email_verified
+        // stuck at its `false` default. The operator sets this account via
+        // REVEALUI_ADMIN_EMAIL/PASSWORD, so it is trusted by definition and there
+        // is no mailbox to verify on a self-host; marking it verified keeps
+        // sign-in from gating the operator out after the 24h grace window.
+        // Both are typed Drizzle writes (which DO map camelCase correctly),
+        // mirroring the web setup route (api/setup) and the CLI. Non-fatal — a
         // failure here is a backfillable gap, not a reason to abort startup.
         // Imports are lazy because pulling @revealui/db/client into the
         // top-level module graph causes Turbopack async-module-init issues
         // (see the poolFactory note near the top of this file).
         try {
           const { getClient } = await import('@revealui/db/client');
+          const { eq } = await import('@revealui/db/orm');
+          const { users } = await import('@revealui/db/schema');
           const { stampTosAcceptanceByEmail } = await import('@/lib/auth/tos');
           const db = getClient('rest');
           await stampTosAcceptanceByEmail(db, adminEmail);
+          await db
+            .update(users)
+            .set({ emailVerified: true, emailVerifiedAt: new Date() })
+            .where(eq(users.email, adminEmail));
         } catch (tosError) {
           const message = tosError instanceof Error ? tosError.message : String(tosError);
           revealui.logger.error(

--- a/apps/admin/revealui.config.ts
+++ b/apps/admin/revealui.config.ts
@@ -353,6 +353,11 @@ export default buildConfig({
             // — 'super-admin' here violates users_role_check and the create fails.
             role: 'owner',
             roles: ['super-admin'],
+            // The operator sets this account via REVEALUI_ADMIN_EMAIL/PASSWORD;
+            // it is trusted by definition and there is no mailbox to verify on a
+            // self-host. Mark it verified so sign-in does not gate the operator
+            // out after the 24h email-verification grace window.
+            emailVerified: true,
           },
         });
 

--- a/apps/admin/src/__tests__/proxy-csp.test.ts
+++ b/apps/admin/src/__tests__/proxy-csp.test.ts
@@ -57,6 +57,27 @@ describe('admin proxy — CSP nonce (GAP-219)', () => {
     expect(directive(csp, 'img-src')).toContain('https://*.stripe.com');
   });
 
+  it('allows blob: in img-src so media upload previews can render (GAP-208)', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const imgSrc = directive(res.headers.get('content-security-policy') ?? '', 'img-src');
+    expect(imgSrc).toContain('blob:');
+  });
+
+  it('adds the R2 public origin to img-src when R2_PUBLIC_BASE_URL is set (GAP-208)', async () => {
+    vi.stubEnv('R2_PUBLIC_BASE_URL', 'https://pub-abc123.r2.dev/media');
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const imgSrc = directive(res.headers.get('content-security-policy') ?? '', 'img-src');
+    expect(imgSrc).toContain('https://pub-abc123.r2.dev');
+    vi.unstubAllEnvs();
+  });
+
+  it('carries no Cloudinary sources and locks object-src to none (R2 is the sole backend)', async () => {
+    const res = await proxy(new NextRequest('https://admin.example.com/login'));
+    const csp = res.headers.get('content-security-policy') ?? '';
+    expect(csp).not.toContain('cloudinary.com');
+    expect(directive(csp, 'object-src')).toContain("'none'");
+  });
+
   it('allows the marketing origin in frame-src so the edit-session canvas can frame the preview', async () => {
     const res = await proxy(new NextRequest('https://admin.example.com/login'));
     const frameSrc = directive(res.headers.get('content-security-policy') ?? '', 'frame-src');
@@ -151,6 +172,8 @@ describe('admin proxy — CSP fleet mode (GAP-290)', () => {
     const imgSrc = directive(res.headers.get('content-security-policy') ?? '', 'img-src');
     expect(imgSrc).not.toContain('stripe.com');
     expect(imgSrc).not.toContain('cloudinary.com');
+    // blob: previews are origin-local; fleet kits keep them (GAP-208).
+    expect(imgSrc).toContain('blob:');
   });
 
   it('strips Stripe from frame-src and connect-src in fleet mode', async () => {

--- a/apps/admin/src/app/api/auth/sign-in/route.ts
+++ b/apps/admin/src/app/api/auth/sign-in/route.ts
@@ -144,7 +144,10 @@ async function signInHandler(request: NextRequest): Promise<NextResponse> {
 
     return response;
   } catch (error) {
-    logger.error('Error signing in', { error });
+    logger.error('Error signing in', error instanceof Error ? error : undefined, {
+      message: error instanceof Error ? error.message : String(error),
+      name: error instanceof Error ? error.name : 'unknown',
+    });
     return createErrorResponse(error, {
       endpoint: '/api/auth/sign-in',
       operation: 'sign_in',

--- a/apps/admin/src/lib/security/csp.ts
+++ b/apps/admin/src/lib/security/csp.ts
@@ -15,7 +15,7 @@
  *     `Content-Security-Policy` header and applies it to its framework, bundle,
  *     and inline bootstrap scripts (plus `<Script>` components).
  *   - We deliberately KEEP the external-script host allowlist (Stripe, Maps,
- *     Cloudinary, Vercel insights) in non-fleet mode and do NOT use
+ *     Vercel insights) in non-fleet mode and do NOT use
  *     `'strict-dynamic'`, which would make those host-sources be ignored. In
  *     fleet mode (`REVEALUI_FLEET_MODE=true`) the hosted third-party SDK domains
  *     are omitted — fleet kits are self-hosted and must not phone home to
@@ -56,10 +56,27 @@ export interface AdminCspOptions {
   /**
    * `REVEALUI_FLEET_MODE === 'true'` — running as a fleet kit.
    * When true, hosted third-party SDK domains (Stripe.js, Vercel Analytics,
-   * Google Maps, Cloudinary) are omitted from every CSP directive. Fleet kits
-   * are self-hosted and must not include SaaS-specific external origins.
+   * Google Maps) are omitted from every CSP directive. Fleet kits are
+   * self-hosted and must not include SaaS-specific external origins.
    */
   isFleetMode?: boolean;
+  /**
+   * `R2_PUBLIC_BASE_URL` — public base URL of the Cloudflare R2 media bucket
+   * (the canonical and sole object-storage backend; GAP-208). Its origin is
+   * added to `img-src` so R2-served media renders. `''` when unset (the
+   * next/image same-origin path still works via `'self'`).
+   */
+  r2PublicBaseUrl?: string;
+}
+
+/** Origin of a base URL, or `''` when unset/malformed (no-regex: URL parser). */
+function originOf(baseUrl: string): string {
+  if (!baseUrl) return '';
+  try {
+    return new URL(baseUrl).origin;
+  } catch {
+    return '';
+  }
 }
 
 /**
@@ -91,6 +108,7 @@ export function buildAdminCsp(options: AdminCspOptions): string {
     serverUrl,
     marketingUrl,
     isFleetMode = false,
+    r2PublicBaseUrl = '',
   } = options;
   const vercelPreview = isVercel && !isVercelProd;
 
@@ -104,7 +122,6 @@ export function buildAdminCsp(options: AdminCspOptions): string {
           'https://checkout.stripe.com',
           'https://js.stripe.com',
           'https://maps.googleapis.com',
-          'https://res.cloudinary.com',
           'https://cdn.vercel-insights.com',
         ]),
     ...(vercelPreview ? ['https://vercel.live', 'https://*.vercel.live'] : []),
@@ -135,16 +152,31 @@ export function buildAdminCsp(options: AdminCspOptions): string {
     ...(isVercel ? [] : ['http://localhost:3000', 'http://localhost:4000']),
   ];
 
+  const r2Origin = originOf(r2PublicBaseUrl);
+  const imgSrc = [
+    "'self'",
+    // Local upload-preview thumbnails (URL.createObjectURL) — origin-local,
+    // kept in fleet mode too (GAP-208).
+    'blob:',
+    'data:',
+    ...(isFleetMode ? [] : ['https://*.stripe.com']),
+    ...(r2Origin ? [r2Origin] : []),
+    'https://www.gravatar.com',
+  ];
+
   const directives = [
     "default-src 'self'",
     `script-src ${scriptSrc.join(' ')}`,
     "child-src 'self'",
     "style-src 'self' 'unsafe-inline'",
-    `img-src 'self' ${isFleetMode ? '' : 'https://res.cloudinary.com https://*.stripe.com '}data: https://www.gravatar.com`,
+    `img-src ${imgSrc.join(' ')}`,
     "font-src 'self' data:",
     `frame-src ${frameSrc.join(' ')}`,
     `connect-src ${connectSrc.join(' ')}`,
-    ...(isFleetMode ? [] : ['object-src https://res.cloudinary.com']),
+    // No <object>/<embed> anywhere in admin; the old hosted-mode Cloudinary
+    // object-src was dead config (Cloudinary is not a storage backend — R2 is
+    // canonical and sole, GAP-208).
+    "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
     'upgrade-insecure-requests',

--- a/apps/admin/src/lib/utils/__tests__/env-validation.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/env-validation.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { validateRequiredEnvVars } from '../env-validation.js';
+
+/**
+ * GAP-430/GAP-440: a fresh, unlicensed self-host deploy (e.g. the Railway
+ * marketplace template) never uses Stripe checkout, cross-subdomain session
+ * cookies, or the Workspace-backed signup verification email — those are
+ * hosted-SaaS-only concerns. Requiring their env vars in production blocked
+ * a stranger's deploy from booting at all without SKIP_ENV_VALIDATION=true.
+ */
+
+const ENV_KEYS = [
+  'REVEALUI_SECRET',
+  'REVEALUI_PUBLIC_SERVER_URL',
+  'POSTGRES_URL',
+  'DATABASE_URL',
+  'REVEALUI_KEK',
+  'REVEALUI_FLEET_MODE',
+  'REVEALUI_LICENSE_PRIVATE_KEY',
+  'REVEALUI_DEPLOYMENT_MODE',
+  'SESSION_COOKIE_DOMAIN',
+  'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
+  'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
+  'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
+  'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+  'GOOGLE_PRIVATE_KEY',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+const VALID_KEK = 'a'.repeat(64);
+
+function setCriticalRequiredVars(): void {
+  process.env.REVEALUI_SECRET = 'a'.repeat(32);
+  process.env.REVEALUI_PUBLIC_SERVER_URL = 'https://admin.example.com';
+  process.env.POSTGRES_URL = 'postgresql://user:pass@host:5432/db';
+  process.env.REVEALUI_KEK = VALID_KEK;
+}
+
+describe('validateRequiredEnvVars', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  describe('unlicensed self-host / marketplace-template deploy (no license private key)', () => {
+    it('does not require SESSION_COOKIE_DOMAIN, Stripe price IDs, or Google email vars', () => {
+      setCriticalRequiredVars();
+      // No REVEALUI_LICENSE_PRIVATE_KEY, no REVEALUI_DEPLOYMENT_MODE, no
+      // REVEALUI_FLEET_MODE — exactly the env shape of a stranger's fresh
+      // Railway deploy (REVEALUI_ALLOW_UNLICENSED_SELF_HOST is a separate,
+      // license-enforcement-only flag checked in instrumentation.ts, not here).
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+
+    it('still requires the critical base vars (e.g. REVEALUI_KEK)', () => {
+      // Deliberately omit REVEALUI_KEK.
+      process.env.REVEALUI_SECRET = 'a'.repeat(32);
+      process.env.REVEALUI_PUBLIC_SERVER_URL = 'https://admin.example.com';
+      process.env.POSTGRES_URL = 'postgresql://user:pass@host:5432/db';
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(false);
+      expect(result.missing).toContain('REVEALUI_KEK');
+    });
+  });
+
+  describe('RevForge Fleet-branded kit (REVEALUI_FLEET_MODE=true)', () => {
+    it('does not require SESSION_COOKIE_DOMAIN, Stripe price IDs, or Google email vars', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_FLEET_MODE = 'true';
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+  });
+
+  describe('RevealUI Studio hosted SaaS (REVEALUI_LICENSE_PRIVATE_KEY present)', () => {
+    it('still requires SESSION_COOKIE_DOMAIN, Stripe price IDs, and Google email vars', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'a-private-key';
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(false);
+      expect(result.missing).toEqual(
+        expect.arrayContaining([
+          'SESSION_COOKIE_DOMAIN',
+          'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
+          'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
+          'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
+          'GOOGLE_SERVICE_ACCOUNT_EMAIL',
+          'GOOGLE_PRIVATE_KEY',
+        ]),
+      );
+    });
+
+    it('passes when all hosted-only vars are set', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'a-private-key';
+      process.env.SESSION_COOKIE_DOMAIN = '.example.com';
+      process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID = 'price_pro';
+      process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID = 'price_max';
+      process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID = 'price_ent';
+      process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL = 'svc@example.iam.gserviceaccount.com';
+      process.env.GOOGLE_PRIVATE_KEY = 'a-private-key';
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+  });
+
+  describe('non-production environments', () => {
+    it('never requires the hosted-only vars regardless of deployment mode', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'a-private-key';
+
+      const result = validateRequiredEnvVars({ environment: 'development' });
+
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+  });
+});

--- a/apps/admin/src/lib/utils/env-validation.ts
+++ b/apps/admin/src/lib/utils/env-validation.ts
@@ -5,6 +5,8 @@
  * Validates critical environment variables at startup.
  */
 
+import { isHostedDeployment } from '@revealui/core/deployment-mode';
+
 /**
  * Literal hex-set check (no regex). Returns true when value is exactly 64
  * characters and every character is in [0-9a-fA-F]. Mirrors the format
@@ -47,6 +49,18 @@ export function validateRequiredEnvVars(
   const { failOnMissing = false, environment } = options;
 
   const isFleetMode = Boolean(process.env.REVEALUI_FLEET_MODE);
+
+  // A RevealUI Studio hosted-SaaS deployment is the ONLY posture that uses
+  // self-billing (Stripe checkout), cross-subdomain session cookies, and the
+  // Workspace-backed signup verification email. Every other posture — a
+  // RevForge-stamped Fleet kit (isFleetMode) AND a plain OSS/unlicensed
+  // self-host or marketplace-template deploy (GAP-430/GAP-440) — never uses
+  // any of those, so requiring their env vars in "production" mode blocks a
+  // stranger's fresh deploy for no reason. isHostedDeployment() defaults to
+  // false whenever REVEALUI_LICENSE_PRIVATE_KEY is absent (the normal case
+  // for a self-host template with no license key at all), so this needs no
+  // new env var from the deploying operator.
+  const isSaasHosted = isHostedDeployment(process.env);
 
   // Base required variables — apply in all environments (hosted + Fleet).
   //
@@ -138,38 +152,48 @@ export function validateRequiredEnvVars(
       warnings.push(error);
     }
 
-    // SESSION_COOKIE_DOMAIN is required in production for cross-subdomain auth.
-    // Without it, sign-in throws at request time instead of at startup.
-    if (!process.env.SESSION_COOKIE_DOMAIN) {
-      missing.push('SESSION_COOKIE_DOMAIN');
-    }
-
-    // Stripe price IDs are required in production  -  without them, billing buttons
-    // silently send priceId:'' which the API rejects with a 400, showing
-    // "Failed to start checkout" to paying customers with no actionable error.
-    const stripePriceVars = [
-      'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
-      'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
-      'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
-    ];
-    for (const key of stripePriceVars) {
-      if (!process.env[key]) {
-        missing.push(key);
+    // SESSION_COOKIE_DOMAIN, Stripe checkout, and Workspace signup-verification
+    // email are all hosted-SaaS-only concerns (self-billing + cross-subdomain
+    // cookies + Workspace-backed mail). A self-host deploy — Fleet-branded
+    // (isFleetMode, checked above) or a plain OSS/unlicensed self-host or
+    // marketplace-template deploy (GAP-430/GAP-440, isSaasHosted false because
+    // it has no REVEALUI_LICENSE_PRIVATE_KEY) — never uses any of these, so
+    // requiring them here previously blocked a stranger's fresh deploy from
+    // booting without SKIP_ENV_VALIDATION.
+    if (isSaasHosted) {
+      // SESSION_COOKIE_DOMAIN is required in production for cross-subdomain auth.
+      // Without it, sign-in throws at request time instead of at startup.
+      if (!process.env.SESSION_COOKIE_DOMAIN) {
+        missing.push('SESSION_COOKIE_DOMAIN');
       }
-    }
 
-    // Transactional email transport (Gmail API — packages/services/src/email).
-    // The signup VERIFICATION email is sent from THIS admin app; without both
-    // vars getEmailProvider() falls back to a no-op that drops every send, so a
-    // non-first signup is created with no session and no email and (after the
-    // 24h grace) is locked out with no working recovery. Required in hosted
-    // production so a misconfigured deploy fails fast at boot (instrumentation.ts)
-    // instead of silently locking out every new user. Fleet kits are exempt
-    // (no Workspace email) via the !isFleetMode guard above.
-    const emailTransportVars = ['GOOGLE_SERVICE_ACCOUNT_EMAIL', 'GOOGLE_PRIVATE_KEY'];
-    for (const key of emailTransportVars) {
-      if (!process.env[key]) {
-        missing.push(key);
+      // Stripe price IDs are required in production  -  without them, billing buttons
+      // silently send priceId:'' which the API rejects with a 400, showing
+      // "Failed to start checkout" to paying customers with no actionable error.
+      const stripePriceVars = [
+        'NEXT_PUBLIC_STRIPE_PRO_PRICE_ID',
+        'NEXT_PUBLIC_STRIPE_MAX_PRICE_ID',
+        'NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID',
+      ];
+      for (const key of stripePriceVars) {
+        if (!process.env[key]) {
+          missing.push(key);
+        }
+      }
+
+      // Transactional email transport (Gmail API — packages/services/src/email).
+      // The signup VERIFICATION email is sent from THIS admin app; without both
+      // vars getEmailProvider() falls back to a no-op that drops every send, so a
+      // non-first signup is created with no session and no email and (after the
+      // 24h grace) is locked out with no working recovery. Required in hosted
+      // production so a misconfigured deploy fails fast at boot (instrumentation.ts)
+      // instead of silently locking out every new user. Fleet kits and other
+      // self-host deploys are exempt (no Workspace email) via isSaasHosted above.
+      const emailTransportVars = ['GOOGLE_SERVICE_ACCOUNT_EMAIL', 'GOOGLE_PRIVATE_KEY'];
+      for (const key of emailTransportVars) {
+        if (!process.env[key]) {
+          missing.push(key);
+        }
       }
     }
   }

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -100,6 +100,7 @@ export default async function proxy(request: NextRequest): Promise<NextResponse 
       (process.env.REVEALUI_FLEET_MODE === 'true' ? '' : 'https://revealui.com')
     ).trim(),
     isFleetMode: process.env.REVEALUI_FLEET_MODE === 'true',
+    r2PublicBaseUrl: (process.env.R2_PUBLIC_BASE_URL || '').trim(),
   });
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);

--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@revealui/core/security';
 import { type AuditEntry, type AuditRowSignerFn, DrizzleAuditStore } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
-import { auditAnchors } from '@revealui/db/schema';
+import { auditAnchors, usageMeters } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -19,7 +19,7 @@ import {
   type TestDb,
 } from '../../../../../packages/test/src/utils/drizzle-test-db.js';
 import { planContiguousBatch, type SignedAuditRow } from '../audit-anchor-batch.js';
-import { runAuditAnchorSweep } from '../audit-anchor-sweep.js';
+import { runAuditAnchorSweep, SYSTEM_ANCHOR_SCOPE } from '../audit-anchor-sweep.js';
 
 const KID = 'kid-s4-3';
 
@@ -214,7 +214,7 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     expect(await db.select().from(auditAnchors)).toHaveLength(0);
   });
 
-  it('counts null-tenant signed rows and never anchors them', async () => {
+  it('GAP-427: counts null-tenant signed rows and anchors them under the system scope, not per-tenant', async () => {
     const store = new DrizzleAuditStore(db, canonicalSignerFn(priv));
     await store.append(makeEntry({ tenant: null, id: 'null-tenant-1' }));
     await store.append(makeEntry({ tenant: 'acct_max', id: 't1' }));
@@ -231,10 +231,117 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     });
 
     expect(result.nullTenantSignedRows).toBe(1);
-    const anchors = await db.select().from(auditAnchors);
-    expect(anchors.every((a) => a.tenant !== null && a.tenant.length > 0)).toBe(true);
-    // null-tenant row is not in any anchor range as a tenant key
-    expect(anchors.some((a) => a.tenant === '')).toBe(false);
+    // The per-tenant loop never treats the null-tenant row as a "tenant" key.
+    const tenantAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(tenantAnchors).toHaveLength(1);
+    // It anchors separately, via the system-scope pass.
+    expect(result.systemOutcome).toBe('inserted');
+    const systemAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(systemAnchors).toHaveLength(1);
+    expect(systemAnchors[0]?.leafCount).toBe(1);
+  });
+
+  it('GAP-427: system scope anchors signed null-tenant rows above the null-tenant unsigned floor', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db); // pre-enforcement legacy rows, no signer
+
+    // Legacy era (closed): unsigned null-tenant seq 1. Signed era: seq 2..3.
+    await unsignedStore.append(makeEntry({ id: 'sys-u1', tenant: null }));
+    await signedStore.append(makeEntry({ id: 'sys-s2', tenant: null }));
+    await signedStore.append(makeEntry({ id: 'sys-s3', tenant: null }));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 2,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.systemOutcome).toBe('inserted');
+    expect(result.tenantsFloorEngaged).toBe(1);
+    expect(result.anchorsInserted).toBe(1);
+
+    const anchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]?.seqFrom).toBe(2);
+    expect(anchors[0]?.seqTo).toBe(3);
+
+    // No account FK backs a null tenant — the system pass must never meter.
+    const meters = await db.select().from(usageMeters);
+    expect(meters).toHaveLength(0);
+  });
+
+  it('GAP-427: systemOutcome is skipped when there are no null-tenant rows', async () => {
+    await appendSigned(3, 'acct_max', new Date('2026-07-23T12:00:00.000Z'));
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 3,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.systemOutcome).toBe('skipped');
+    expect(result.nullTenantSignedRows).toBe(0);
+    const systemAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(systemAnchors).toHaveLength(0);
+  });
+
+  it('GAP-427: a tenant anchor and the system anchor both land in one sweep', async () => {
+    // Non-interleaved seq runs (tenant rows first, then null-tenant rows) —
+    // the global-seq interleave limitation is pre-existing and out of scope.
+    await appendSigned(2, 'acct_max', new Date('2026-07-23T12:00:00.000Z'));
+    const store = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    await store.append(
+      makeEntry({ id: 'sys-1', tenant: null, timestamp: new Date('2026-07-23T12:00:01.000Z') }),
+    );
+    await store.append(
+      makeEntry({ id: 'sys-2', tenant: null, timestamp: new Date('2026-07-23T12:00:02.000Z') }),
+    );
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 2,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-23T12:00:10.000Z'),
+    });
+
+    expect(result.anchorsInserted).toBe(2);
+    expect(result.systemOutcome).toBe('inserted');
+
+    const tenantAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(tenantAnchors).toHaveLength(1);
+    expect(tenantAnchors[0]?.seqFrom).toBe(1);
+    expect(tenantAnchors[0]?.seqTo).toBe(2);
+
+    const systemAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(systemAnchors).toHaveLength(1);
+    expect(systemAnchors[0]?.seqFrom).toBe(3);
+    expect(systemAnchors[0]?.seqTo).toBe(4);
   });
 
   it('skips when an unsigned hole appears above an existing anchor (strict contiguity)', async () => {

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -6,7 +6,15 @@
  * age ≥ max lag), build a contiguous batch, Merkle-root the signature
  * leaves, sign the root (Stage 3 Ed25519), insert audit_anchors, and
  * meter `audit_anchor`. Failures never delete audit rows (append-only).
- * Null-tenant rows are never anchored (§9); volume is gauged each tick.
+ *
+ * Null-tenant (system) rows anchor too, via one additional pass per sweep
+ * (GAP-427 ruling 2026-07-27): they land in `audit_anchors` under the
+ * reserved `SYSTEM_ANCHOR_SCOPE` ('__system__') sentinel tenant value.
+ * `audit_log.tenant` itself stays null on those rows (no schema migration);
+ * only the anchor row's `tenant` column carries the sentinel. The system
+ * pass is not entitlement-gated (`canAnchorTenant` is per-account; system
+ * events are the operator's own audit trail) and never writes a usage
+ * meter (no account FK backs a null tenant).
  *
  * Gated by AUDIT_ANCHOR_SWEEP_ENABLED=true on the worker process.
  */
@@ -31,6 +39,13 @@ import { recordUsageMeter } from '../lib/metering.js';
 import { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
 
 export { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
+
+/**
+ * GAP-427: the audit_anchors.tenant value for anchors over null-tenant
+ * (system) audit_log rows. audit_anchors.tenant is NOT NULL, so a sentinel
+ * avoids a schema migration; the underlying audit_log rows stay null.
+ */
+export const SYSTEM_ANCHOR_SCOPE = '__system__';
 
 /** Countersigned default batch size (§9). Override: AUDIT_ANCHOR_BATCH_SIZE. */
 export const DEFAULT_ANCHOR_BATCH_SIZE = 256;
@@ -69,7 +84,7 @@ const mErrors = metrics.counter(
 );
 const mNullTenant = metrics.gauge(
   'revealui_audit_null_tenant_signed_rows',
-  'Signed audit_log rows with null tenant (never anchored in Stage 4)',
+  'Signed audit_log rows with null tenant, anchored under the __system__ scope (GAP-427 ruling 2026-07-27)',
 );
 const mWaiting = metrics.counter(
   'revealui_audit_anchor_waiting_total',
@@ -85,9 +100,11 @@ export interface AnchorSweepResult {
   anchorsInserted: number;
   tenantsSkipped: number;
   tenantsWaiting: number;
-  /** Tenants whose pass started from a derived legacy floor (no anchors yet). */
+  /** Tenant (and system-scope) passes that started from a derived legacy floor. */
   tenantsFloorEngaged: number;
   nullTenantSignedRows: number;
+  /** GAP-427: outcome of the one null-tenant system-scope pass this sweep. */
+  systemOutcome: 'inserted' | 'waiting' | 'skipped';
   errors: string[];
 }
 
@@ -160,6 +177,7 @@ export async function runAuditAnchorSweep(
     tenantsWaiting: 0,
     tenantsFloorEngaged: 0,
     nullTenantSignedRows: 0,
+    systemOutcome: 'skipped',
     errors: [],
   };
 
@@ -168,18 +186,14 @@ export async function runAuditAnchorSweep(
     return result;
   }
 
-  // §9: null-tenant volume metric (never anchored in Stage 4).
+  // GAP-427: null-tenant (system) volume gauge. Anchored below via the
+  // dedicated system-scope pass, not the per-tenant loop.
   const [nullRow] = await db
     .select({ c: count() })
     .from(auditLog)
     .where(and(isNull(auditLog.tenant), isNotNull(auditLog.signature)));
   result.nullTenantSignedRows = Number(nullRow?.c ?? 0);
   mNullTenant.set(result.nullTenantSignedRows);
-  if (result.nullTenantSignedRows > 0) {
-    logger.warn(
-      `audit-anchor-sweep: ${result.nullTenantSignedRows} signed audit_log row(s) have null tenant (skipped)`,
-    );
-  }
 
   const tenantRows = await db
     .selectDistinct({ tenant: auditLog.tenant })
@@ -188,6 +202,9 @@ export async function runAuditAnchorSweep(
 
   for (const { tenant } of tenantRows) {
     if (!tenant) continue;
+    // Defensive: a hostile or buggy writer must never collide with the
+    // system scope's anchor bookkeeping (GAP-427).
+    if (tenant === SYSTEM_ANCHOR_SCOPE) continue;
     result.tenantsConsidered++;
     try {
       if (!(await canAnchor(tenant))) {
@@ -222,7 +239,41 @@ export async function runAuditAnchorSweep(
     }
   }
 
+  // GAP-427: one system-scope pass for null-tenant rows. Not entitlement
+  // gated and never metered (recordMeter forced false — no account FK).
+  try {
+    const { outcome, floorEngaged } = await anchorTenantBatch(
+      db,
+      signer,
+      SYSTEM_ANCHOR_SCOPE,
+      batchSize,
+      maxLagMs,
+      now,
+      /* doMeter */ false,
+      /* isSystem */ true,
+    );
+    result.systemOutcome = outcome;
+    if (floorEngaged) result.tenantsFloorEngaged++;
+    if (outcome === 'inserted') result.anchorsInserted++;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    result.errors.push(`${SYSTEM_ANCHOR_SCOPE}: ${msg}`);
+    logger.error(
+      'audit-anchor-sweep: system scope failed',
+      err instanceof Error ? err : new Error(msg),
+    );
+  }
+
   return result;
+}
+
+/**
+ * audit_log.tenant predicate for a scope: a real tenant (`eq`) or the
+ * GAP-427 system scope, which matches null-tenant rows directly since
+ * audit_log.tenant is never set to SYSTEM_ANCHOR_SCOPE itself.
+ */
+function auditLogTenantMatch(tenant: string, isSystem: boolean) {
+  return isSystem ? isNull(auditLog.tenant) : eq(auditLog.tenant, tenant);
 }
 
 async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
@@ -244,14 +295,22 @@ async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
  * Legacy rows are never retro-signed — a backfilled signature would be
  * indistinguishable from tampering (ADR 2026-07-12 §2a).
  *
+ * `isSystem` (GAP-427 ruling 2026-07-27) selects the null-tenant floor
+ * instead of a real tenant's; `tenant` is still the audit_anchors.tenant key
+ * (SYSTEM_ANCHOR_SCOPE) the caller is deriving the floor for.
+ *
  * Exported for the anchors API lag surface (GAP-429), which reports the same
  * floor so sub-floor legacy rows are visible rather than silently excluded.
  */
-export async function legacyUnsignedFloor(db: Database, tenant: string): Promise<number> {
+export async function legacyUnsignedFloor(
+  db: Database,
+  tenant: string,
+  isSystem = false,
+): Promise<number> {
   const rows = await db
     .select({ m: max(auditLog.seq) })
     .from(auditLog)
-    .where(and(eq(auditLog.tenant, tenant), isNull(auditLog.signature)));
+    .where(and(auditLogTenantMatch(tenant, isSystem), isNull(auditLog.signature)));
   const m = rows[0]?.m;
   return typeof m === 'number' && Number.isFinite(m) ? m : 0;
 }
@@ -271,11 +330,13 @@ async function anchorTenantBatch(
   maxLagMs: number,
   now: () => Date,
   doMeter: boolean,
+  isSystem = false,
 ): Promise<{ outcome: TenantOutcome; floorEngaged: boolean }> {
   const anchored = await lastAnchoredSeq(db, tenant);
-  // GAP-427: first anchor for a tenant starts above the closed unsigned era,
-  // not at seq 1. Once anchors exist, strict last+1 contiguity governs.
-  const floor = anchored > 0 ? 0 : await legacyUnsignedFloor(db, tenant);
+  // GAP-427: first anchor for a tenant (or the system scope) starts above the
+  // closed unsigned era, not at seq 1. Once anchors exist, strict last+1
+  // contiguity governs.
+  const floor = anchored > 0 ? 0 : await legacyUnsignedFloor(db, tenant, isSystem);
   const floorEngaged = floor > 0;
   if (floorEngaged) {
     mFloorEngaged.inc();
@@ -296,7 +357,13 @@ async function anchorTenantBatch(
       timestamp: auditLog.timestamp,
     })
     .from(auditLog)
-    .where(and(eq(auditLog.tenant, tenant), isNotNull(auditLog.signature), gt(auditLog.seq, last)))
+    .where(
+      and(
+        auditLogTenantMatch(tenant, isSystem),
+        isNotNull(auditLog.signature),
+        gt(auditLog.seq, last),
+      ),
+    )
     .orderBy(asc(auditLog.seq))
     .limit(batchSize);
 
@@ -408,7 +475,7 @@ export function startAuditAnchorSweep(env: Record<string, string | undefined> = 
       logger.info(
         `audit-anchor-sweep: tick tenants=${r.tenantsConsidered} inserted=${r.anchorsInserted} ` +
           `waiting=${r.tenantsWaiting} skipped=${r.tenantsSkipped} nullTenant=${r.nullTenantSignedRows} ` +
-          `errors=${r.errors.length}`,
+          `system=${r.systemOutcome} errors=${r.errors.length}`,
       );
     });
   };

--- a/apps/server/src/routes/__tests__/audit-anchors.test.ts
+++ b/apps/server/src/routes/__tests__/audit-anchors.test.ts
@@ -25,6 +25,7 @@ import {
   createTestDb,
   type TestDb,
 } from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+import { SYSTEM_ANCHOR_SCOPE } from '../../jobs/audit-anchor-sweep.js';
 import auditRoute from '../audit.js';
 
 const KID = 'kid-s4-4';
@@ -320,6 +321,38 @@ describe('GET /anchors + /anchors/:id/proof (GAP-355 S4-4, PGlite)', () => {
 
     const app = createAuthedApp(user, db);
     const res = await app.request(`/anchors/${foreign?.id}/proof?seq=${seqFrom}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('GAP-427: returns 404 for a system-scope anchor (tenant is never client-supplied)', async () => {
+    // GET /anchors derives `tenant` from the caller's own account membership
+    // (getUserAccountId) — there is no request param a client can set to
+    // '__system__'. This locks the existing tenant-isolation check (anchor
+    // .tenant !== caller tenant → 404) also covers the reserved sentinel, the
+    // same way it already covers any other tenant's anchors.
+    const { signatures, seqFrom, seqTo } = await seedSignedRows(2);
+    const { root, leafCount } = buildMerkleRootFromSignatures(signatures);
+    const { value: rootSignature } = signAuditAnchorRoot(cryptoSigner, {
+      tenant: SYSTEM_ANCHOR_SCOPE,
+      seqFrom,
+      seqTo,
+      leafCount,
+      root,
+    });
+    const [systemAnchor] = await db
+      .insert(auditAnchors)
+      .values({
+        tenant: SYSTEM_ANCHOR_SCOPE,
+        seqFrom,
+        seqTo,
+        root,
+        rootSignature,
+        leafCount,
+      })
+      .returning({ id: auditAnchors.id });
+
+    const app = createAuthedApp(user, db);
+    const res = await app.request(`/anchors/${systemAnchor?.id}/proof?seq=${seqFrom}`);
     expect(res.status).toBe(404);
   });
 

--- a/docs/security/AUDIT_RECEIPTS.md
+++ b/docs/security/AUDIT_RECEIPTS.md
@@ -62,6 +62,27 @@ Below the floor:
 
 The floor never spans live history. A `seq` hole that appears above an existing anchor still stalls the sweep and raises the gap metric.
 
+## System scope (GAP-427 ruling 2026-07-27)
+
+Not every audit row has a tenant. System and operator-level events (agent
+spawns outside an account context, platform-level actions) write `audit_log`
+rows with `tenant = null`. Those rows anchor too: each sweep runs one
+additional pass, after the per-tenant loop, that anchors them under the
+reserved `__system__` scope. `audit_anchors.tenant` carries the
+`SYSTEM_ANCHOR_SCOPE` ('__system__') sentinel value for these anchors (the
+column is `NOT NULL`); `audit_log.tenant` itself is untouched and stays null
+on the underlying rows.
+
+The system pass is not entitlement-gated (`auditLog`/Max+ is a per-account
+check; system events are the operator's own audit trail, not a customer's)
+and never writes a usage meter (no account FK backs a null tenant).
+
+The same legacy-floor semantics apply: while the system scope has zero
+anchors, the sweep derives a floor from the highest **unsigned** null-tenant
+row and anchors from `floor + 1` forward. Rows at or below that floor are
+pre-enforcement legacy rows and are never retro-signed, for the same reason
+as the per-tenant floor above.
+
 ## Offline verify
 
 ```bash

--- a/packages/auth/src/server/__tests__/auth.test.ts
+++ b/packages/auth/src/server/__tests__/auth.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // ---------------------------------------------------------------------------
 // Mock dependencies (vi.mock is hoisted above imports by Vitest)
 // ---------------------------------------------------------------------------
+const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }));
 vi.mock('@revealui/core/observability/logger', () => ({
-  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  logger: { error: mockLoggerError, info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
 // Mock bcryptjs
@@ -315,14 +316,72 @@ describe('auth', () => {
       }
     });
 
-    it('returns unexpected_error on uncaught exception', async () => {
-      mockCheckRateLimit.mockRejectedValueOnce(new Error('unexpected'));
+    it('returns database_error (not unexpected_error) when the rate-limit check throws', async () => {
+      // GAP-430 regression: checkRateLimit's storage backend (DatabaseStorage
+      // in production) can throw for reasons unrelated to the credential
+      // check. Before this guard, any such throw fell through to the outer
+      // catch and reported the generic, undiagnosable 'unexpected_error'.
+      mockCheckRateLimit.mockRejectedValueOnce(new Error('rate limit storage down'));
+
+      const result = await signIn('test@example.com', 'Password123');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.reason).toBe('database_error');
+      }
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Error checking rate limit',
+        expect.any(Error),
+        expect.objectContaining({ message: 'rate limit storage down' }),
+      );
+    });
+
+    it('returns database_error (not unexpected_error) when the account-lock check throws', async () => {
+      mockIsAccountLocked.mockRejectedValueOnce(new Error('lock storage down'));
+
+      const result = await signIn('test@example.com', 'Password123');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.reason).toBe('database_error');
+      }
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Error checking account lock status',
+        expect.any(Error),
+        expect.objectContaining({ message: 'lock storage down' }),
+      );
+    });
+
+    it('still succeeds when clearFailedAttempts throws (best-effort bookkeeping, not a gate)', async () => {
+      mockLimit.mockResolvedValueOnce([makeUser()]);
+      mockBcryptCompare.mockResolvedValueOnce(true);
+      mockClearFailedAttempts.mockRejectedValueOnce(new Error('clear storage down'));
+
+      const result = await signIn('test@example.com', 'Password123');
+      expect(result.success).toBe(true);
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Error clearing failed attempts after successful login',
+        expect.any(Error),
+        expect.objectContaining({ message: 'clear storage down' }),
+      );
+    });
+
+    it('logs the real error on a genuinely uncaught exception (outer catch)', async () => {
+      // auditLoginSuccess is documented as best-effort/never-throwing, but the
+      // outer catch must still surface the real error object (not swallow it
+      // silently) if that guarantee is ever violated.
+      mockLimit.mockResolvedValueOnce([makeUser()]);
+      mockBcryptCompare.mockResolvedValueOnce(true);
+      mockAuditLoginSuccess.mockRejectedValueOnce(new Error('audit boom'));
 
       const result = await signIn('test@example.com', 'Password123');
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.reason).toBe('unexpected_error');
       }
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Unexpected error in signIn',
+        expect.any(Error),
+        expect.objectContaining({ message: 'audit boom' }),
+      );
     });
 
     it('returns email_not_verified for unverified account past grace period', async () => {

--- a/packages/auth/src/server/__tests__/auth.test.ts
+++ b/packages/auth/src/server/__tests__/auth.test.ts
@@ -168,6 +168,27 @@ describe('auth', () => {
       expect(result.sessionToken).toBe('session-token-abc');
     });
 
+    it('signs in when createdAt is a string, not a Date (Postgres storage path)', async () => {
+      // Regression (GAP-446): the Postgres storage path returns createdAt as an
+      // ISO string, not a Date object. With emailVerified:false the sign-in reads
+      // createdAt to compute account age; calling .getTime() on a string threw a
+      // TypeError that fell through to the outer catch and turned a valid login
+      // into "unexpected_error" on real deploys. The account is within the 24h
+      // grace window, so login must succeed.
+      const oneHourAgoIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const user = makeUser({
+        emailVerified: false,
+        createdAt: oneHourAgoIso as unknown as Date,
+      });
+      mockLimit.mockResolvedValueOnce([user]);
+      mockBcryptCompare.mockResolvedValueOnce(true);
+
+      const result = await signIn('test@example.com', 'Password123');
+      expect(result.reason).not.toBe('unexpected_error');
+      expect(result.success).toBe(true);
+      expect(result.sessionToken).toBe('session-token-abc');
+    });
+
     it('returns error for nonexistent user', async () => {
       mockLimit.mockResolvedValueOnce([]); // no user found
 

--- a/packages/auth/src/server/__tests__/oninit-bootstrap-signin.test.ts
+++ b/packages/auth/src/server/__tests__/oninit-bootstrap-signin.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Fresh Unlicensed Self-Host Bootstrap → Sign-In (PGlite)
+ *
+ * Reproduces GAP-430's Railway marketplace-template failure: a first admin
+ * seeded exactly the way `apps/admin/revealui.config.ts` onInit() seeds it
+ * (via the collections engine's dynamic-SQL create path — the users
+ * collection has no typed `create` handler in
+ * `apps/admin/src/lib/db/typedCollectionStorage.ts`, so onInit's
+ * `revealui.create({ collection: 'users', ... })` falls through to the raw
+ * INSERT built by `insertDocumentQuery` in
+ * `packages/core/src/collections/operations/sqlAdapter.ts`) then fails to
+ * sign in with "Unexpected error".
+ *
+ * The raw INSERT only supplies the columns onInit actually passes
+ * (name, email, password, role, plus `roles` folded into `_json` because
+ * it's a hasMany `select` field) and leaves every other column — including
+ * `created_at` — to its SQL-level DEFAULT, exactly like the real bootstrap.
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  createTestDb,
+  type TestDb,
+} from '../../../../../packages/test/src/utils/drizzle-test-db.js';
+
+let testDb: TestDb;
+
+vi.mock('@revealui/db/client', () => ({
+  getClient: () => testDb.drizzle,
+  // DatabaseStorage's constructor calls createClient() to open its own real
+  // `pg` Pool. The pool is never queried in these tests — its `.db` is
+  // swapped for the PGlite-backed client immediately after construction —
+  // but the constructor call itself must not throw.
+  createClient: () => testDb.drizzle,
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import type { Database } from '@revealui/db/client';
+import { users } from '@revealui/db/schema';
+import bcrypt from 'bcryptjs';
+import { signIn } from '../auth.js';
+import { DatabaseStorage, resetStorage, setStorage } from '../storage/index.js';
+
+beforeAll(async () => {
+  process.env.REVEALUI_SECRET = 'test-secret-for-oninit-bootstrap-tests';
+  testDb = await createTestDb();
+}, 30_000);
+
+afterAll(async () => {
+  await testDb.close();
+});
+
+afterEach(async () => {
+  const { sql } = await import('drizzle-orm');
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "sessions"'));
+  await testDb.drizzle.execute(sql.raw('DELETE FROM "users"'));
+});
+
+/**
+ * Seed a first-admin row exactly the way the dynamic-SQL collections engine
+ * would for `onInit`'s `revealui.create({ collection: 'users', data: {
+ * name, email, password, role: 'owner', roles: ['super-admin'] } })` call —
+ * bcrypt-hash the password (create.ts does this before the INSERT), fold
+ * `roles` into `_json` (it's a hasMany `select` field, so it never becomes a
+ * real column per `isJsonFieldType`), and generate the `rvl_`-prefixed id
+ * exactly like `create.ts`'s `id = String(... : \`rvl_${crypto.randomUUID()}\`)`.
+ * Every other column (notably `created_at`) is left unset so Postgres
+ * applies its column DEFAULT — there is no Drizzle `.insert()` in this path.
+ */
+async function seedOnInitAdmin(email: string, password: string): Promise<string> {
+  const id = `rvl_${crypto.randomUUID()}`;
+  const hashedPassword = await bcrypt.hash(password, 12);
+  const jsonBlob = JSON.stringify({ roles: ['super-admin'] });
+
+  await testDb.pglite.query(
+    `INSERT INTO "users" (id, "name", "email", "password", "role", "_json") VALUES ($1, $2, $3, $4, $5, $6)`,
+    [id, 'Admin User', email, hashedPassword, 'owner', jsonBlob],
+  );
+
+  return id;
+}
+
+describe('onInit bootstrap admin → signIn (PGlite, fresh unlicensed self-host)', () => {
+  it('signs in successfully for a first admin created via the dynamic-SQL bootstrap path', async () => {
+    const email = 'founder@example.com';
+    const password = 'CorrectHorseBatteryStaple123!';
+    await seedOnInitAdmin(email, password);
+
+    // Sanity: confirm the row the collections engine would have produced —
+    // in particular that created_at came from the SQL DEFAULT, not an app value.
+    const [row] = await testDb.drizzle.select().from(users).where(eq(users.email, email));
+    expect(row).toBeDefined();
+    expect(row.createdAt).toBeInstanceOf(Date);
+    expect(row.emailVerified).toBe(false);
+
+    const result = await signIn(email, password, {
+      userAgent: 'test-agent',
+      ipAddress: '127.0.0.1',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    if (result.success) {
+      expect(result.sessionToken).toBeDefined();
+      expect(result.user.email).toBe(email);
+    }
+  });
+
+  it('signs in successfully when getStorage() resolves DatabaseStorage (production-shaped rate-limit/brute-force backend, not the test-only in-memory fallback)', async () => {
+    // A Free-tier Railway deploy runs with NODE_ENV=production and a real
+    // POSTGRES_URL, so getStorage() (packages/auth/src/server/storage/index.ts)
+    // resolves DatabaseStorage, never InMemoryStorage. The previous test never
+    // exercised that path (POSTGRES_URL/DATABASE_URL are forced empty by this
+    // package's vitest.config.ts, so getStorage() fell back to in-memory).
+    // DatabaseStorage's constructor opens its own real `pg` Pool via a
+    // connection string, which PGlite (no TCP listener) can't satisfy — so
+    // build one against a throwaway address (never queried) and swap its
+    // internal Drizzle client for the PGlite-backed one, exercising the exact
+    // same rate_limits SQL (get/set/atomicUpdate) DatabaseStorage runs in prod.
+    const dbBackedStorage = new DatabaseStorage('postgresql://unused:unused@localhost:5432/unused');
+    (dbBackedStorage as unknown as { db: Database }).db = testDb.drizzle as unknown as Database;
+    setStorage(dbBackedStorage);
+
+    try {
+      const email = 'founder-dbstorage@example.com';
+      const password = 'CorrectHorseBatteryStaple123!';
+      await seedOnInitAdmin(email, password);
+
+      const result = await signIn(email, password, {
+        userAgent: 'test-agent',
+        ipAddress: '127.0.0.1',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+      if (result.success) {
+        expect(result.sessionToken).toBeDefined();
+        expect(result.user.email).toBe(email);
+      }
+    } finally {
+      resetStorage();
+    }
+  });
+});

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -205,9 +205,13 @@ export async function signIn(
       );
     }
 
-    // Check email verification (with grace period for new accounts)
+    // Check email verification (with grace period for new accounts).
+    // Coerce createdAt: the Postgres storage path returns timestamps as strings
+    // (not Date objects), so calling .getTime() directly threw a TypeError that
+    // fell through to the outer catch and turned a valid login into a generic
+    // "unexpected error" on real deploys. new Date() accepts a Date or a string.
     if (!user.emailVerified) {
-      const accountAge = Date.now() - user.createdAt.getTime();
+      const accountAge = Date.now() - new Date(user.createdAt).getTime();
       if (accountAge > EMAIL_VERIFICATION_GRACE_PERIOD_MS) {
         return {
           success: false,

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -37,9 +37,31 @@ export async function signIn(
   },
 ): Promise<SignInResult> {
   try {
-    // Rate limiting by IP address
+    // Rate limiting by IP address. The storage backend (DatabaseStorage in
+    // production) can throw for reasons unrelated to the credential check
+    // itself (pool exhaustion, a transaction-pooling quirk, a storage
+    // misconfiguration) — guard it like every other DB-touching step below so
+    // a throw here fails closed with a diagnosable reason instead of falling
+    // through to the generic outer catch.
     const ipKey = options?.ipAddress || 'unknown';
-    const rateLimit = await checkRateLimit(`signin:${ipKey}`);
+    let rateLimit: { allowed: boolean };
+    try {
+      rateLimit = await checkRateLimit(`signin:${ipKey}`);
+    } catch (rateLimitError) {
+      logger.error(
+        'Error checking rate limit',
+        rateLimitError instanceof Error ? rateLimitError : undefined,
+        {
+          message:
+            rateLimitError instanceof Error ? rateLimitError.message : String(rateLimitError),
+        },
+      );
+      return {
+        success: false,
+        reason: 'database_error',
+        error: 'Database error',
+      };
+    }
     if (!rateLimit.allowed) {
       return {
         success: false,
@@ -48,8 +70,27 @@ export async function signIn(
       };
     }
 
-    // Brute force protection by email
-    const bruteForceCheck = await isAccountLocked(email);
+    // Brute force protection by email. Same rationale as the rate-limit
+    // guard above — the storage backend can throw independently of whether
+    // the account is actually locked.
+    let bruteForceCheck: { locked: boolean; lockUntil?: number };
+    try {
+      bruteForceCheck = await isAccountLocked(email);
+    } catch (lockCheckError) {
+      logger.error(
+        'Error checking account lock status',
+        lockCheckError instanceof Error ? lockCheckError : undefined,
+        {
+          message:
+            lockCheckError instanceof Error ? lockCheckError.message : String(lockCheckError),
+        },
+      );
+      return {
+        success: false,
+        reason: 'database_error',
+        error: 'Database error',
+      };
+    }
     if (bruteForceCheck.locked) {
       const lockMinutes = bruteForceCheck.lockUntil
         ? Math.ceil((bruteForceCheck.lockUntil - Date.now()) / (60 * 1000))
@@ -145,8 +186,24 @@ export async function signIn(
       return failInvalidCredentials();
     }
 
-    // Successful login - clear failed attempts
-    await clearFailedAttempts(email);
+    // Successful login - clear failed attempts. Best-effort: this is
+    // bookkeeping on an already-successful credential check, not a gate, so a
+    // storage hiccup here must not fail an otherwise-valid login (it can only
+    // make a future lockout trigger slightly sooner, never bypass one).
+    try {
+      await clearFailedAttempts(email);
+    } catch (clearAttemptsError) {
+      logger.error(
+        'Error clearing failed attempts after successful login',
+        clearAttemptsError instanceof Error ? clearAttemptsError : undefined,
+        {
+          message:
+            clearAttemptsError instanceof Error
+              ? clearAttemptsError.message
+              : String(clearAttemptsError),
+        },
+      );
+    }
 
     // Check email verification (with grace period for new accounts)
     if (!user.emailVerified) {
@@ -212,8 +269,12 @@ export async function signIn(
       user,
       sessionToken: token,
     };
-  } catch {
-    logger.error('Unexpected error in signIn');
+  } catch (err) {
+    logger.error('Unexpected error in signIn', err instanceof Error ? err : undefined, {
+      message: err instanceof Error ? err.message : String(err),
+      name: err instanceof Error ? err.name : 'unknown',
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     return {
       success: false,
       reason: 'unexpected_error',

--- a/packages/db/src/schema/audit-anchors.ts
+++ b/packages/db/src/schema/audit-anchors.ts
@@ -27,7 +27,13 @@ export const auditAnchors = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
 
-    /** Matches audit_log.tenant; null-tenant rows are never anchored (Stage 4 §9). */
+    /**
+     * Matches audit_log.tenant for real tenants. Null-tenant (system) rows
+     * anchor under the reserved '__system__' sentinel instead, since this
+     * column is NOT NULL and audit_log.tenant itself stays null on those
+     * rows (GAP-427 ruling 2026-07-27; see SYSTEM_ANCHOR_SCOPE in
+     * apps/server/src/jobs/audit-anchor-sweep.ts).
+     */
     tenant: text('tenant').notNull(),
 
     /** Inclusive seq range of signed audit_log rows covered by this root. */


### PR DESCRIPTION
Promotes the accumulated test head to main. Everything aboard carries a recorded guardrail-2 verdict (APPROVE) and `sec-review:approved`:

- **#2226 (GAP-427):** anchor null-tenant audit rows under the `__system__` scope per the 2026-07-27 owner ruling — unblocks prod anchoring (acceptance: first `audit_anchors` row after the worker redeploy).
- **#2224 (GAP-208):** admin CSP + next/image serve R2 media, `blob:` upload previews allowed, Cloudinary/Vercel-Blob remnants removed, `object-src 'none'`.
- Peer auth fixes already verdict-cleared on test: #2223 (fresh unlicensed self-host sign-in + relaxed OSS env validation, GAP-440) and #2225 (bootstrap admin emailVerified persisted via typed write, GAP-446).

Security-classed (audit anchoring + CSP + auth surfaces): needs `sec-review:approved` before merge. Merge with a merge commit per the promote policy.

Post-merge: `deploy.yml` auto-deploys admin + api (CSP fix live); the Fly worker needs a manual redeploy from main to pick up the system-scope sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
