### PR TITLE
fix(auth): scope required SESSION_COOKIE_DOMAIN to hosted deployments

### DIFF
--- a/apps/admin/src/__tests__/utils/session-cookies.test.ts
+++ b/apps/admin/src/__tests__/utils/session-cookies.test.ts
@@ -81,11 +81,14 @@ describe('requireSessionCookieDomain', () => {
     expect(requireSessionCookieDomain()).toBe('.revealui.com');
   });
 
-  it('throws in production when the variable is missing', () => {
+  it('throws in production on a hosted deployment when the variable is missing', () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    // Hosted SaaS signal: REVEALUI_LICENSE_PRIVATE_KEY present (see
+    // @revealui/core/deployment-mode isHostedDeployment).
+    vi.stubEnv('REVEALUI_LICENSE_PRIVATE_KEY', 'a-private-key');
     expect(() => requireSessionCookieDomain()).toThrow(
-      'SESSION_COOKIE_DOMAIN env var is required in production for cross-subdomain auth',
+      'SESSION_COOKIE_DOMAIN env var is required in production for cross-subdomain auth on a RevealUI Studio hosted deployment',
     );
   });
 
@@ -93,6 +96,17 @@ describe('requireSessionCookieDomain', () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
     vi.stubEnv('REVEALUI_FLEET_MODE', 'true');
+    expect(requireSessionCookieDomain()).toBeUndefined();
+  });
+
+  // GAP-446: a fresh, unlicensed self-host (e.g. the Railway marketplace
+  // template) has no REVEALUI_LICENSE_PRIVATE_KEY, no REVEALUI_DEPLOYMENT_MODE,
+  // and no REVEALUI_FLEET_MODE — exactly the env shape env-validation.ts's
+  // `isSaasHosted` already treats as "SESSION_COOKIE_DOMAIN not required" at
+  // boot. This must agree at request time too, or a correct login 500s.
+  it('falls back to host-only on a plain unlicensed self-host instead of throwing', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
     expect(requireSessionCookieDomain()).toBeUndefined();
   });
 });

--- a/apps/admin/src/lib/utils/session-cookies.ts
+++ b/apps/admin/src/lib/utils/session-cookies.ts
@@ -11,6 +11,7 @@
  * host-only delete is a browser-level no-op and the user stays signed in.
  */
 
+import { isHostedDeployment } from '@revealui/core/deployment-mode';
 import { logger } from '@revealui/utils/logger';
 import type { NextResponse } from 'next/server';
 
@@ -53,16 +54,29 @@ export function sessionCookieDomain(options?: SessionCookieDomainOptions): strin
 
 /**
  * Strict domain derivation for the sign-in session cookie: in production a
- * missing `SESSION_COOKIE_DOMAIN` throws  -  unless `REVEALUI_FLEET_MODE` is
- * set (fleet kits run host-only cookies by design).
+ * missing `SESSION_COOKIE_DOMAIN` throws, but ONLY on a RevealUI Studio
+ * hosted-SaaS deployment (`isHostedDeployment()` — admin.revealui.com +
+ * api.revealui.com sharing one auth cookie across subdomains). Every other
+ * posture — a RevForge Fleet-branded kit or a plain OSS/unlicensed self-host
+ * (GAP-430/GAP-440, no `REVEALUI_LICENSE_PRIVATE_KEY`) — runs single-host and
+ * falls back to a host-only cookie, matching `sessionCookieDomain()`.
+ *
+ * This MUST use the same `isHostedDeployment()` signal as
+ * `env-validation.ts`'s `isSaasHosted` check (which already exempts every
+ * self-host posture from requiring `SESSION_COOKIE_DOMAIN` at boot). Before
+ * GAP-446 this function used a narrower, unrelated `REVEALUI_FLEET_MODE`-only
+ * exemption that never recognized a plain self-host — so a stranger's fresh
+ * Railway deploy (no license key, no Fleet flag) passed boot-time validation
+ * but threw on every successful sign-in at request time, turning a correct
+ * login into a 500.
  */
 export function requireSessionCookieDomain(): string | undefined {
   if (process.env.NODE_ENV !== 'production') {
     return undefined;
   }
-  if (!(process.env.SESSION_COOKIE_DOMAIN || process.env.REVEALUI_FLEET_MODE)) {
+  if (isHostedDeployment(process.env) && !process.env.SESSION_COOKIE_DOMAIN) {
     throw new Error(
-      'SESSION_COOKIE_DOMAIN env var is required in production for cross-subdomain auth',
+      'SESSION_COOKIE_DOMAIN env var is required in production for cross-subdomain auth on a RevealUI Studio hosted deployment',
     );
   }
   return process.env.SESSION_COOKIE_DOMAIN || undefined;


### PR DESCRIPTION
## Root cause (the real bug, real Postgres only)

Every prior GAP-446 reproduction (#2223 DB-guard, #2225 createdAt coercion +
emailVerified persistence) ran against PGlite and passed. On a **real
Postgres** self-host (Railway, `pgvector/pgvector:pg16`), a fresh admin
still 500s on login with the **correct** credentials, even with those fixes
on `origin/test` (HEAD `ecc8cb751`):

- Wrong email → clean `401 INVALID_CREDENTIALS` (fails before the buggy code runs)
- Correct email → `500`, admin logs both `"Error signing in"` (the route's own
  catch) and `"Unexpected error"` (the generic `handleApiError` branch)

`signIn()` in `packages/auth/src/server/auth.ts` is **not** the throw site —
every DB-touching step in it is already guarded (rate limit, brute force,
user lookup, bcrypt, session rotation, and the audit-write chain all catch
internally, verified by driving them against real Postgres with a real
Ed25519 `REVEALUI_AUDIT_SIGNING_KEY` installed exactly like
`instrumentation-node.ts` does at boot).

The actual throw is in `apps/admin/src/app/api/auth/sign-in/route.ts:142`,
**after** `signIn()` already returned `success: true`:

```ts
response.cookies.set('revealui-session', result.sessionToken, {
  ...
  domain: requireSessionCookieDomain(),   // <-- throws here
});
```

[`requireSessionCookieDomain()`](apps/admin/src/lib/utils/session-cookies.ts:59)
threw whenever `SESSION_COOKIE_DOMAIN` was unset **unless** `REVEALUI_FLEET_MODE`
was also set. A plain, unlicensed self-host (no license key, no Fleet flag —
exactly the Railway marketplace-template shape) has neither, so it throws on
**every successful login**, which the outer `catch` turns into the reported
500. This only fires on success (wrong email never reaches the cookie-set
code), which is exactly the asymmetry reported.

This was drift, not a new mistake: `apps/admin/src/lib/utils/env-validation.ts`
already has an `isSaasHosted` check (via `isHostedDeployment()`) that
correctly exempts this exact deployment shape from requiring
`SESSION_COOKIE_DOMAIN` **at boot** (GAP-430/GAP-440, see the comment at
env-validation.ts:158-162 and its test file). `requireSessionCookieDomain()`
was never updated to use the same signal — it still checked only for
`REVEALUI_FLEET_MODE`, so boot-time validation passed but the request-time
check disagreed and threw anyway.

## The "missing id" clue (red herring, resolved)

`Database row missing required id field - skipping`
([safe-parse.ts](packages/core/src/database/safe-parse.ts)) fires "at startup
and during each login" because
[`universal-postgres.ts`](packages/core/src/database/universal-postgres.ts)'s
`connect()` runs a raw `SELECT 1` health check and pipes its result through
`safeParseRevealDocuments()`, which — correctly — drops the id-less
`{ "?column?": 1 }` row and logs a warning. The return value of that query is
discarded, so this is harmless noise, not the crash. Confirmed by isolating
the call: the warning fires with or without the bug present. Not fixed here
(no behavior change from it) — filing a follow-up gap for the raw-query
signature would be reasonable but out of scope for this login-breaking fix.

## Fix

`requireSessionCookieDomain()` now gates the throw on `isHostedDeployment()`
(`@revealui/core/deployment-mode`) — the **same** signal
`env-validation.ts`'s `isSaasHosted` already uses — instead of the narrower,
unrelated `REVEALUI_FLEET_MODE`-only exemption. A RevForge Fleet kit and a
plain OSS/unlicensed self-host both classify as non-hosted (`isHostedDeployment()`
is false whenever `REVEALUI_LICENSE_PRIVATE_KEY` is absent) and now correctly
fall back to a host-only cookie, matching `sessionCookieDomain()`'s existing
behavior. Only a real RevealUI Studio hosted-SaaS deployment (which carries
the private license-signing key) still requires `SESSION_COOKIE_DOMAIN`.

## Red -> green evidence (real Postgres, `pgvector/pgvector:pg16`, not PGlite)

Stood up a real `pgvector/pgvector:pg16` container, ran `drizzle-kit migrate`
against it, seeded a bootstrap admin via the **actual** onInit path (the
dynamic-SQL `create()` collections-engine operation + the typed TOS/emailVerified
Drizzle writes), installed real Postgres-backed signed audit storage exactly
like `instrumentation-node.ts` does at boot, then drove the real
`apps/admin/src/app/api/auth/sign-in/route.ts` `POST` handler end to end
(NODE_ENV=production, no `SESSION_COOKIE_DOMAIN`, no `REVEALUI_FLEET_MODE`,
no `REVEALUI_LICENSE_PRIVATE_KEY` — the exact env shape of a fresh Railway
self-host):

**Before fix (origin/test HEAD `ecc8cb751`):**
```
{"level":"error","message":"Error signing in", ...
  "stack":"Error: SESSION_COOKIE_DOMAIN env var is required in production for
  cross-subdomain auth\n    at requireSessionCookieDomain
  (.../session-cookies.ts:64:11)\n    at signInHandler (.../route.ts:142:15)..."}
{"level":"error","message":"Unexpected error", ...}
status: 500
body: {"error":"INTERNAL_ERROR","message":"An unexpected error occurred",...}
```
Wrong email in the same run: `status: 401` (`INVALID_CREDENTIALS`) — clean,
matching the report.

**After fix (this branch):**
```
status: 200
body: {"user":{"id":"rvl_...","email":"founder@revealui.com","name":"Admin User",...}}
```
Wrong email: unchanged, `status: 401`.

Also ran the full `apps/admin` auth-route + `session-cookies` Vitest suites
(174 tests, 12 test files) green, and `pnpm build` for the whole workspace
(admin app builds clean, including the touched route).

## Files

- [apps/admin/src/lib/utils/session-cookies.ts](apps/admin/src/lib/utils/session-cookies.ts) — the fix
- [apps/admin/src/__tests__/utils/session-cookies.test.ts](apps/admin/src/__tests__/utils/session-cookies.test.ts) — updated + new regression test for the plain-self-host shape

## Security note

**REVIEW-PENDING under guardrail 2 — do not merge until a non-author APPROVE
verdict is recorded.** This touches the sign-in cookie-domain gate on the
crown-jewel auth path. The fleet security-review pre-PR self-check
(`--diff origin/test`) currently reports no match against the fleet
sensitive-path list for this specific file, but the change is auth-adjacent
(session cookie scoping on the login response) and should get the same
non-author review discipline as the rest of the GAP-446 arc (#2223, #2225).

## Test plan

- [x] Reproduced red on real Postgres (`pgvector/pgvector:pg16`), not PGlite
- [x] Root-caused to `requireSessionCookieDomain()` throwing post-success
- [x] Fixed by reusing `isHostedDeployment()` (same signal as `env-validation.ts`)
- [x] Verified green on the same real-Postgres harness (200 on correct creds, 401 unchanged on wrong email)
- [x] `apps/admin` auth + session-cookies Vitest suites green (174 tests)
- [x] `pnpm build` green for the full workspace
- [ ] Owner/non-author guardrail-2 review before merge
