### PR TITLE
fix(core): richtext DecoratorBlockNode createDOM + required media alt field

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "expect-type": "^1.4.0",
+    "jsdom": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/core/src/client/richtext/components/ImageUploadButton.tsx
+++ b/packages/core/src/client/richtext/components/ImageUploadButton.tsx
@@ -11,7 +11,7 @@ import { logger } from '@revealui/core/utils/logger';
 import type React from 'react';
 import { useCallback, useRef, useState } from 'react';
 import { INSERT_IMAGE_COMMAND } from '../nodes/ImageNode.js';
-import { postMediaUpload } from './upload.js';
+import { deriveAltTextFromFilename, postMediaUpload } from './upload.js';
 
 /** Default maximum file size: 10 MB */
 const DEFAULT_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
@@ -92,9 +92,12 @@ export const ImageUploadButton: React.FC<ImageUploadButtonProps> = ({
           img.src = URL.createObjectURL(file);
         });
 
-        // Upload file
+        // Upload file. The admin Media collection requires `alt`, so it is
+        // derived from the filename and sent alongside the file.
+        const altText = deriveAltTextFromFilename(file.name);
         const formData = new FormData();
         formData.append('file', file);
+        formData.append('alt', altText);
 
         // Scale timeout with file size: 30s base + 10s per MB
         const timeoutMs = 30_000 + Math.ceil(file.size / (1024 * 1024)) * 10_000;
@@ -109,7 +112,16 @@ export const ImageUploadButton: React.FC<ImageUploadButtonProps> = ({
         }
 
         if (!response.ok) {
-          throw new Error(`Upload failed: ${response.statusText}`);
+          let message = `Upload failed: ${response.statusText}`;
+          try {
+            const body = (await response.json()) as { message?: unknown };
+            if (typeof body.message === 'string' && body.message.length > 0) {
+              message = body.message;
+            }
+          } catch {
+            // Body wasn't JSON - keep the generic message.
+          }
+          throw new Error(message);
         }
 
         const result = (await response.json()) as unknown;
@@ -123,7 +135,7 @@ export const ImageUploadButton: React.FC<ImageUploadButtonProps> = ({
         // Insert image into editor
         editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
           src: imageUrl,
-          alt: file.name.replace(/\.[^/.]+$/, ''), // Remove extension for alt text
+          alt: altText,
           width: imageDimensions.width,
           height: imageDimensions.height,
         });

--- a/packages/core/src/client/richtext/components/__tests__/upload.test.ts
+++ b/packages/core/src/client/richtext/components/__tests__/upload.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { postMediaUpload } from '../upload.js';
+import { deriveAltTextFromFilename, postMediaUpload } from '../upload.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -113,5 +113,45 @@ describe('postMediaUpload - CSRF token attach', () => {
       '/custom/upload',
       expect.objectContaining({ headers: { 'X-CSRF-Token': 'token-rotated' } }),
     );
+  });
+});
+
+describe('deriveAltTextFromFilename', () => {
+  it('strips the extension from a normal filename', () => {
+    expect(deriveAltTextFromFilename('photo.png')).toBe('photo');
+  });
+
+  it('keeps the whole name when there is no extension', () => {
+    expect(deriveAltTextFromFilename('photo')).toBe('photo');
+  });
+
+  it('keeps the whole name for a dotfile (leading dot is not an extension)', () => {
+    expect(deriveAltTextFromFilename('.env')).toBe('.env');
+  });
+});
+
+describe('image upload FormData - required alt field', () => {
+  function formDataFor(fileName: string): FormData {
+    const file = new Blob(['x'], { type: 'image/png' }) as unknown as File;
+    Object.defineProperty(file, 'name', { value: fileName });
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('alt', deriveAltTextFromFilename(fileName));
+    return formData;
+  }
+
+  it('includes an alt entry derived from a normal filename', () => {
+    const formData = formDataFor('photo.png');
+    expect(formData.get('alt')).toBe('photo');
+  });
+
+  it('includes an alt entry equal to the whole name when there is no extension', () => {
+    const formData = formDataFor('photo');
+    expect(formData.get('alt')).toBe('photo');
+  });
+
+  it('includes an alt entry equal to the whole name for a dotfile', () => {
+    const formData = formDataFor('.env');
+    expect(formData.get('alt')).toBe('.env');
   });
 });

--- a/packages/core/src/client/richtext/components/upload.ts
+++ b/packages/core/src/client/richtext/components/upload.ts
@@ -14,6 +14,17 @@
 import { readCsrfToken } from '../../admin/utils/csrf.js';
 
 /**
+ * Derive alt text from a filename by stripping its extension. Falls back to
+ * the whole name when there is no extension (`lastIndexOf` returns -1) or
+ * the only dot is a leading dotfile marker (e.g. `.env`), where `dot > 0` is
+ * false.
+ */
+export function deriveAltTextFromFilename(fileName: string): string {
+  const dot = fileName.lastIndexOf('.');
+  return dot > 0 ? fileName.slice(0, dot) : fileName;
+}
+
+/**
  * POST `body` to `uploadEndpoint`, echoing the CSRF cookie as `X-CSRF-Token`
  * when one is readable. `Content-Type` is never set here - `fetch` derives
  * the multipart boundary from the FormData body, and an explicit value would

--- a/packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts
+++ b/packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts
@@ -45,6 +45,14 @@ export abstract class DecoratorBlockNode<
     writable.__format = format;
   }
 
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
   exportJSON(): SerializedDecoratorBlockNode<T> {
     return {
       ...super.exportJSON(),

--- a/packages/core/src/client/richtext/nodes/__tests__/ImageNode.test.ts
+++ b/packages/core/src/client/richtext/nodes/__tests__/ImageNode.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+/**
+ * ImageNode createDOM/updateDOM tests
+ *
+ * DecoratorBlockNode (the shared base for ImageNode and the admin app's
+ * custom feature nodes) extends Lexical's DecoratorNode without overriding
+ * createDOM/updateDOM. Lexical's DecoratorNode inherits the throwing base
+ * implementations from LexicalNode, so any reconciliation of a
+ * DecoratorBlockNode subclass throws Lexical invariant #70
+ * ("createDOM: base method not extended") the first time it is rendered.
+ * This package's default vitest environment is node (see
+ * packages/dev/src/vitest/create-config.ts), so `document` is stubbed via
+ * jsdom for this file only.
+ */
+
+import type { EditorConfig, LexicalEditor } from 'lexical';
+import { createEditor } from 'lexical';
+import { describe, expect, it } from 'vitest';
+import { $createImageNode, ImageNode } from '../ImageNode.js';
+
+const editorConfig: EditorConfig = { namespace: 'test', theme: {} };
+
+function createTestEditor(): LexicalEditor {
+  return createEditor({
+    nodes: [ImageNode],
+    onError: (error) => {
+      throw error;
+    },
+  });
+}
+
+describe('ImageNode createDOM/updateDOM', () => {
+  it('createDOM returns an HTMLElement instead of throwing invariant #70', () => {
+    const editor = createTestEditor();
+    let node: ImageNode | undefined;
+    editor.update(
+      () => {
+        node = $createImageNode({ src: 'https://example.com/photo.png', alt: 'photo' });
+      },
+      { discrete: true },
+    );
+
+    expect(node).toBeDefined();
+    const dom = (node as ImageNode).createDOM(editorConfig, editor);
+    expect(dom).toBeInstanceOf(HTMLElement);
+  });
+
+  it('updateDOM returns false (never recreates the DOM element)', () => {
+    const editor = createTestEditor();
+    let node: ImageNode | undefined;
+    editor.update(
+      () => {
+        node = $createImageNode({ src: 'https://example.com/photo.png', alt: 'photo' });
+      },
+      { discrete: true },
+    );
+
+    const imageNode = node as ImageNode;
+    const dom = imageNode.createDOM(editorConfig, editor);
+    expect(imageNode.updateDOM(imageNode, dom, editorConfig)).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1163,6 +1163,9 @@ importers:
       expect-type:
         specifier: ^1.4.0
         version: 1.4.0
+      jsdom:
+        specifier: 29.0.1
+        version: 29.0.1(@noble/hashes@1.8.0)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(@microsoft/api-extractor@7.58.11(@types/node@25.9.5))(jiti@2.7.0)(postcss@8.5.20)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)


### PR DESCRIPTION
## Root causes

**Bug 1 — Lexical invariant #70 on richtext decorator nodes**
[`packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts:29-55`](packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts) — the abstract `DecoratorBlockNode` class extends Lexical's `DecoratorNode<JSX.Element>` but implemented neither `createDOM` nor `updateDOM`. Lexical's `DecoratorNode` itself does not override these either, so calls fell through to `LexicalNode`'s base implementations, which throw `createDOM: base method not extended` / `updateDOM: base method not extended` (Lexical invariant #70) the first time any subclass is reconciled to the DOM. Confirmed by reading `node_modules/.pnpm/lexical@0.46.0.../Lexical.dev.mjs` (the throwing base methods) and `@lexical/react`'s `LexicalDecoratorBlockNode.ts` (the upstream reference implementation this PR mirrors). Affects [`ImageNode`](packages/core/src/client/richtext/nodes/ImageNode.tsx) directly, and any admin custom feature node built on the same base.

**Bug 2 — POST /api/collections/media 400s on image upload**
[`packages/core/src/client/richtext/components/ImageUploadButton.tsx:96-97`](packages/core/src/client/richtext/components/ImageUploadButton.tsx) (pre-fix) built upload `FormData` with only a `file` entry. [`apps/admin/src/lib/collections/Media/index.ts:14-18`](apps/admin/src/lib/collections/Media/index.ts) declares `alt` as `required: true` on the Media collection, so every upload validation-failed with 400.

## What each fix does

- **DecoratorBlockNode**: adds `createDOM()` (returns a `div`) and `updateDOM()` (returns `false`, i.e. never recreate the element), matching `@lexical/react`'s `LexicalDecoratorBlockNode` minimal behavior exactly (no extra theme/format handling added).
- **ImageUploadButton**: derives `altText` from the filename without regex (`lastIndexOf('.')` + `slice`, extracted as the exported `deriveAltTextFromFilename` helper in `upload.ts` so it's unit-testable and shared), appends it as `formData.append('alt', altText)` before upload, and reuses the same `altText` for the `INSERT_IMAGE_COMMAND` payload — replacing the prior `file.name.replace(/\.[^/.]+$/, '')` regex (no-regex rule). Also improves the upload failure message: on `!response.ok`, tries to read a `message` field from the JSON response body and use it in the thrown `Error`, falling back to the original generic `Upload failed: ${response.statusText}` message if the body isn't JSON.

## Red → green proof

**Bug 1** — [`packages/core/src/client/richtext/nodes/__tests__/ImageNode.test.ts`](packages/core/src/client/richtext/nodes/__tests__/ImageNode.test.ts): constructs a real (headless) Lexical editor with `ImageNode` registered, creates a node via `$createImageNode`, and calls `createDOM`/`updateDOM` directly.

Before the fix, both assertions threw:
```
Error: createDOM: base method not extended
 ❯ ImageNode.createDOM .../lexical/dist/Lexical.dev.mjs:6286:7
```
After the fix: `2 passed (2)`.

**Bug 2** — extended [`packages/core/src/client/richtext/components/__tests__/upload.test.ts`](packages/core/src/client/richtext/components/__tests__/upload.test.ts) with `deriveAltTextFromFilename` unit tests and FormData-construction tests for three filename shapes (`photo.png` → `photo`, `photo` → `photo`, `.env` → `.env`).

Before the fix (function didn't exist yet):
```
TypeError: deriveAltTextFromFilename is not a function
```
6 of 12 tests in the file failed. After the fix: `12 passed (12)`.

Full suite after both fixes (via `pnpm turbo run test --filter=@revealui/core`, which builds workspace dependencies first): `115 test files passed, 2778 tests passed`.

`pnpm turbo run typecheck --filter=@revealui/core` — clean, no errors.
Biome (`biome check` on all changed files) — clean, no fixes needed.

## Security checker output

```
$ node .jv/scripts/security-pr-review-check.js --diff origin/test
🔒 Current branch is SECURITY-SENSITIVE (vs origin/test). Touched: packages/core/src/client/richtext/components/ImageUploadButton.tsx, packages/core/src/client/richtext/components/__tests__/upload.test.ts, packages/core/src/client/richtext/components/upload.ts, packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts, packages/core/src/client/richtext/nodes/__tests__/ImageNode.test.ts
   When you open the PR, it needs a recorded coordinator verdict before merge (see dup-work-and-review-gates.md).
(exit code 1)
```

**SECURITY-CLASSED (richtext sensitive path) — review-pending, do NOT merge until a non-author guardrail-2 verdict is recorded.**

## Known follow-ups (out of scope)

- The Content-Security-Policy `script-src` blocks `https://vercel.live` (the Vercel toolbar feedback script on deployments). That's a separate CSP-policy decision, not addressed here.
- Admin custom feature nodes (e.g. `EmbedNode`, `LabelNode`) are registered in their `feature.client.ts` files, but the core `RichTextEditor`'s `getNodesFromFeatures` never reads `feature.nodes`. This looks like a possible latent gap where custom feature nodes may not actually get registered on the editor — out of scope for this PR, flagging for follow-up investigation.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
