### PR TITLE
fix(server): traverse classified anchor holes (burned seqs + foreign scopes) (GAP-447)

### DIFF
--- a/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
+++ b/apps/server/src/jobs/__tests__/audit-anchor-sweep.test.ts
@@ -12,13 +12,20 @@ import {
 import { type AuditEntry, type AuditRowSignerFn, DrizzleAuditStore } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
 import { auditAnchors, usageMeters } from '@revealui/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createTestDb,
   type TestDb,
 } from '../../../../../packages/test/src/utils/drizzle-test-db.js';
-import { planContiguousBatch, type SignedAuditRow } from '../audit-anchor-batch.js';
+import {
+  assertTraversalIntegrity,
+  isConsecutiveFromStart,
+  planContiguousBatch,
+  planTraversableBatch,
+  type ScopeRangeRow,
+  type SignedAuditRow,
+} from '../audit-anchor-batch.js';
 import { runAuditAnchorSweep, SYSTEM_ANCHOR_SCOPE } from '../audit-anchor-sweep.js';
 
 const KID = 'kid-s4-3';
@@ -88,6 +95,183 @@ describe('planContiguousBatch (GAP-355 S4-3)', () => {
   });
 });
 
+describe('planTraversableBatch (GAP-447 existence-classified hole traversal)', () => {
+  it('returns null for empty candidates', () => {
+    expect(planTraversableBatch(0, [], new Map())).toBeNull();
+  });
+
+  it('lastAnchoredSeq=0: permissive start — walk begins at the first candidate, not seq 1', () => {
+    const rows: SignedAuditRow[] = [{ seq: 5, signature: 's5' }];
+    const result = planTraversableBatch(0, rows, new Map());
+    expect(result).toEqual({
+      rows,
+      seqFrom: 5,
+      seqTo: 5,
+      holes: { burned: [], foreign: 0 },
+    });
+  });
+
+  it('lastAnchoredSeq=0 with internally non-contiguous candidates: gaps between them are still traversed', () => {
+    const rows: SignedAuditRow[] = [
+      { seq: 1, signature: 'a' },
+      { seq: 3, signature: 'c' },
+    ];
+    const rangeMap = new Map<number, ScopeRangeRow>([[2, { sameScope: false, signed: true }]]);
+    const result = planTraversableBatch(0, rows, rangeMap);
+    expect(result).toEqual({
+      rows,
+      seqFrom: 1,
+      seqTo: 3,
+      holes: { burned: [], foreign: 1 },
+    });
+  });
+
+  it('burned seq (absent from rangeMap) is traversable', () => {
+    const rows: SignedAuditRow[] = [
+      { seq: 1, signature: 'a' },
+      { seq: 3, signature: 'c' },
+    ];
+    const result = planTraversableBatch(0, rows, new Map()); // seq 2 absent entirely
+    expect(result).toEqual({
+      rows,
+      seqFrom: 1,
+      seqTo: 3,
+      holes: { burned: [2], foreign: 0 },
+    });
+  });
+
+  it('foreign-scope present row is traversable (count only, not enumerated)', () => {
+    const rows: SignedAuditRow[] = [
+      { seq: 1, signature: 'a' },
+      { seq: 3, signature: 'c' },
+    ];
+    const rangeMap = new Map<number, ScopeRangeRow>([[2, { sameScope: false, signed: true }]]);
+    const result = planTraversableBatch(0, rows, rangeMap);
+    expect(result?.holes).toEqual({ burned: [], foreign: 1 });
+  });
+
+  it('present + same-scope + unsigned row FAILS CLOSED and stalls before it', () => {
+    const rows: SignedAuditRow[] = [
+      { seq: 1, signature: 'a' },
+      { seq: 3, signature: 'c' },
+    ];
+    const rangeMap = new Map<number, ScopeRangeRow>([[2, { sameScope: true, signed: false }]]);
+    const result = planTraversableBatch(0, rows, rangeMap);
+    expect(result).toEqual({
+      rows: [{ seq: 1, signature: 'a' }],
+      seqFrom: 1,
+      seqTo: 1,
+      holes: { burned: [], foreign: 0 },
+      stalledAtSeq: 2,
+    });
+  });
+
+  it('stall right at the very start (no progress) still returns a result, not null', () => {
+    // lastAnchoredSeq=10 (an established anchor/floor): the walk must start
+    // exactly at seq 11, so the same-scope-unsigned row there stalls with
+    // zero rows collected, distinct from "no candidates at all" (null).
+    const rows: SignedAuditRow[] = [{ seq: 13, signature: 'c' }];
+    const rangeMap = new Map<number, ScopeRangeRow>([
+      [11, { sameScope: true, signed: false }],
+      [12, { sameScope: false, signed: true }],
+    ]);
+    const result = planTraversableBatch(10, rows, rangeMap);
+    expect(result).toEqual({
+      rows: [],
+      seqFrom: 11,
+      seqTo: 10,
+      holes: { burned: [], foreign: 0 },
+      stalledAtSeq: 11,
+    });
+  });
+
+  it('lastAnchoredSeq>0: an established anchor requires the full range attested, not just the first candidate', () => {
+    const rows: SignedAuditRow[] = [{ seq: 13, signature: 's13' }];
+    const rangeMap = new Map<number, ScopeRangeRow>([[12, { sameScope: false, signed: true }]]);
+    // seq 11 absent (burned), seq 12 foreign, seq 13 the candidate.
+    const result = planTraversableBatch(10, rows, rangeMap);
+    expect(result).toEqual({
+      rows,
+      seqFrom: 11,
+      seqTo: 13,
+      holes: { burned: [11], foreign: 1 },
+    });
+  });
+
+  it('no holes at all when candidates are already contiguous', () => {
+    const rows: SignedAuditRow[] = [
+      { seq: 11, signature: 'a' },
+      { seq: 12, signature: 'b' },
+      { seq: 13, signature: 'c' },
+    ];
+    const result = planTraversableBatch(10, rows, new Map());
+    expect(result).toEqual({ rows, seqFrom: 11, seqTo: 13, holes: { burned: [], foreign: 0 } });
+  });
+});
+
+describe('isConsecutiveFromStart', () => {
+  it('true for empty candidates', () => {
+    expect(isConsecutiveFromStart(0, [])).toBe(true);
+  });
+
+  it('true when contiguous with lastAnchoredSeq', () => {
+    expect(
+      isConsecutiveFromStart(10, [
+        { seq: 11, signature: 'a' },
+        { seq: 12, signature: 'b' },
+      ]),
+    ).toBe(true);
+  });
+
+  it('false when the first candidate does not follow lastAnchoredSeq', () => {
+    expect(isConsecutiveFromStart(10, [{ seq: 13, signature: 'a' }])).toBe(false);
+  });
+
+  it('false when candidates have an internal gap, even with lastAnchoredSeq=0', () => {
+    expect(
+      isConsecutiveFromStart(0, [
+        { seq: 1, signature: 'a' },
+        { seq: 3, signature: 'b' },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe('assertTraversalIntegrity', () => {
+  it('passes for a consistent result (span == leaves + holes)', () => {
+    expect(() =>
+      assertTraversalIntegrity({
+        rows: [{ seq: 11, signature: 'a' }],
+        seqFrom: 10,
+        seqTo: 12,
+        holes: { burned: [10], foreign: 1 },
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws when the recorded holes do not account for the full span', () => {
+    expect(() =>
+      assertTraversalIntegrity({
+        rows: [{ seq: 11, signature: 'a' }],
+        seqFrom: 10,
+        seqTo: 12,
+        holes: { burned: [], foreign: 0 }, // missing 2 holes
+      }),
+    ).toThrow(/span/);
+  });
+
+  it('throws on an empty batch', () => {
+    expect(() =>
+      assertTraversalIntegrity({
+        rows: [],
+        seqFrom: 1,
+        seqTo: 1,
+        holes: { burned: [], foreign: 0 },
+      }),
+    ).toThrow(/empty batch/);
+  });
+});
+
 describe('runAuditAnchorSweep (PGlite)', () => {
   let testDb: TestDb;
   let db: Database;
@@ -119,6 +303,15 @@ describe('runAuditAnchorSweep (PGlite)', () => {
         }),
       );
     }
+  }
+
+  /**
+   * GAP-447: burn a seq value the same way production does — `nextval()` the
+   * bigserial sequence with no corresponding INSERT. The append-only trigger
+   * makes the row undeletable, so this is the only way a real seq gap forms.
+   */
+  async function burnSeq(): Promise<void> {
+    await db.execute(sql`SELECT nextval(pg_get_serial_sequence('audit_log', 'seq'))`);
   }
 
   it('inserts a verifiable anchor when batch size is reached', async () => {
@@ -493,5 +686,153 @@ describe('runAuditAnchorSweep (PGlite)', () => {
     });
     expect(result.anchorsInserted).toBe(0);
     expect(await db.select().from(auditAnchors)).toHaveLength(0);
+  });
+
+  // ── GAP-447: existence-classified hole traversal ──────────────────────────
+
+  it('GAP-447: anchors across a burned seq and records it in holes.burned', async () => {
+    const ts = new Date('2026-07-27T09:00:00.000Z');
+    await appendSigned(1, 'acct_max', ts); // seq 1
+    await burnSeq(); // seq 2, no row
+    await appendSigned(1, 'acct_max', new Date(ts.getTime() + 1000)); // seq 3
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 2,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-27T09:00:10.000Z'),
+    });
+
+    expect(result.anchorsInserted).toBe(1);
+    expect(result.errors).toEqual([]);
+
+    const anchors = await db.select().from(auditAnchors).where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(anchors).toHaveLength(1);
+    const a = anchors[0];
+    if (!a) throw new Error('missing anchor');
+    expect(a.seqFrom).toBe(1);
+    expect(a.seqTo).toBe(3);
+    expect(a.leafCount).toBe(2);
+    expect(a.holes).toEqual({ burned: [2], foreign: 0 });
+
+    const verify = verifyAuditAnchorRoot(
+      {
+        tenant: a.tenant,
+        seqFrom: a.seqFrom,
+        seqTo: a.seqTo,
+        leafCount: a.leafCount,
+        root: a.root,
+        holes: a.holes ?? undefined,
+      },
+      a.rootSignature,
+      (kid) => (kid === KID ? pub : null),
+    );
+    expect(verify.valid).toBe(true);
+  });
+
+  it('GAP-447: cross-scope interleave — system anchors across a tenant row (holes.foreign), tenant anchors its own row', async () => {
+    const store = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    await store.append(
+      makeEntry({ id: 'sys-1', tenant: null, timestamp: new Date('2026-07-27T09:00:00.000Z') }),
+    ); // seq 1
+    await store.append(
+      makeEntry({ id: 't-1', tenant: 'acct_max', timestamp: new Date('2026-07-27T09:00:01.000Z') }),
+    ); // seq 2
+    await store.append(
+      makeEntry({ id: 'sys-2', tenant: null, timestamp: new Date('2026-07-27T09:00:02.000Z') }),
+    ); // seq 3
+
+    const result = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 2, // system scope must fetch BOTH seq1 and seq3 as candidates in one query
+      maxLagMs: 1, // tenant's lone leaf (below batchSize) anchors via max-lag instead
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-27T09:00:10.000Z'),
+    });
+
+    expect(result.systemOutcome).toBe('inserted');
+    expect(result.anchorsInserted).toBe(2);
+
+    const systemAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, SYSTEM_ANCHOR_SCOPE));
+    expect(systemAnchors).toHaveLength(1);
+    expect(systemAnchors[0]?.seqFrom).toBe(1);
+    expect(systemAnchors[0]?.seqTo).toBe(3);
+    expect(systemAnchors[0]?.leafCount).toBe(2);
+    expect(systemAnchors[0]?.holes).toEqual({ burned: [], foreign: 1 });
+
+    const tenantAnchors = await db
+      .select()
+      .from(auditAnchors)
+      .where(eq(auditAnchors.tenant, 'acct_max'));
+    expect(tenantAnchors).toHaveLength(1);
+    expect(tenantAnchors[0]?.seqFrom).toBe(2);
+    expect(tenantAnchors[0]?.seqTo).toBe(2);
+    expect(tenantAnchors[0]?.holes).toBeNull();
+  });
+
+  it('GAP-447: a same-scope UNSIGNED row inside the hole fails closed — stalls, warns, anchors nothing past it', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    const unsignedStore = new DrizzleAuditStore(db);
+
+    // Establish a real prior anchor first, so `last=anchored` (not the
+    // GAP-427 legacy floor, which would otherwise silently jump past an
+    // unsigned row on a scope's very first pass — that path is pre-existing
+    // and out of scope here; GAP-447 fail-closed is about a scope that
+    // ALREADY anchors normally hitting a genuinely anomalous unsigned row).
+    await signedStore.append(makeEntry({ id: 's1', tenant: 'acct_max' })); // seq 1
+    const first = await runAuditAnchorSweep({
+      db,
+      signer: cryptoSigner,
+      batchSize: 1,
+      canAnchorTenant: async () => true,
+      recordMeter: false,
+      now: () => new Date('2026-07-27T09:00:10.000Z'),
+    });
+    expect(first.anchorsInserted).toBe(1);
+
+    await unsignedStore.append(makeEntry({ id: 'u2', tenant: 'acct_max' })); // seq 2 — genuine anomaly
+    await signedStore.append(makeEntry({ id: 's3', tenant: 'acct_max' })); // seq 3
+
+    const { logger } = await import('@revealui/core/observability/logger');
+    const warnSpy = vi.spyOn(logger, 'warn');
+    try {
+      const second = await runAuditAnchorSweep({
+        db,
+        signer: cryptoSigner,
+        batchSize: 1,
+        canAnchorTenant: async () => true,
+        recordMeter: false,
+        now: () => new Date('2026-07-27T09:00:20.000Z'),
+      });
+
+      // The stall happens right at the start of this pass's range (seq 2,
+      // immediately after last=1) — zero forward progress, so this pass
+      // inserts nothing further.
+      expect(second.anchorsInserted).toBe(0);
+      expect(second.errors).toEqual([]);
+
+      const anchors = await db
+        .select()
+        .from(auditAnchors)
+        .where(eq(auditAnchors.tenant, 'acct_max'));
+      expect(anchors).toHaveLength(1); // still just the first pass's anchor
+      expect(anchors[0]?.seqFrom).toBe(1);
+      expect(anchors[0]?.seqTo).toBe(1); // nothing anchored past the unsigned row
+      expect(anchors[0]?.holes).toBeNull();
+
+      const stallWarns = warnSpy.mock.calls.filter(
+        (call) => String(call[0]).includes('blocks traversal') && String(call[0]).includes('seq=2'),
+      );
+      expect(stallWarns.length).toBeGreaterThan(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/apps/server/src/jobs/audit-anchor-batch.ts
+++ b/apps/server/src/jobs/audit-anchor-batch.ts
@@ -1,10 +1,49 @@
 /**
  * Pure batch planning for GAP-355 Stage 4 S4-3 (no I/O, no package side-effects).
+ * GAP-447 adds existence-classified hole traversal (`planTraversableBatch`)
+ * alongside the original strict-contiguity planner, kept unchanged below for
+ * compatibility.
  */
 
 export interface SignedAuditRow {
   seq: number;
   signature: string;
+}
+
+/**
+ * GAP-447: classification of one seq in (lastAnchoredSeq, maxCandidateSeq]
+ * that is NOT itself a same-scope signed candidate — derived from a single
+ * `SELECT seq, tenant, (signature IS NULL)` query over the range.
+ */
+export interface ScopeRangeRow {
+  /** True when the row's tenant matches this anchor's scope (system or the given tenant). */
+  sameScope: boolean;
+  /** True when the row is signed (signature IS NOT NULL). */
+  signed: boolean;
+}
+
+export interface HoleInfo {
+  /** Seqs with no audit_log row at all — burned (nextval consumed, INSERT never landed). */
+  burned: number[];
+  /** Count of present rows scoped to a different tenant (their seqs are not individually recorded). */
+  foreign: number;
+}
+
+export interface TraversableBatchResult {
+  /** The signed rows to Merkle-root, in seq order. May be empty (only when `stalledAtSeq` is set). */
+  rows: SignedAuditRow[];
+  /** First seq attested by this batch's range (== lastAnchoredSeq + 1 once an anchor/floor exists). */
+  seqFrom: number;
+  /** Last seq attested by this batch's range (last processed seq, whether leaf, burned, or foreign). */
+  seqTo: number;
+  holes: HoleInfo;
+  /**
+   * Present when traversal stopped early at a present, same-scope, UNSIGNED
+   * row (fail-closed — post-GAP-417 rails this should be impossible, so it is
+   * the one remaining anomaly signal). `rows` covers everything strictly
+   * before this seq; nothing at or after it is included this pass.
+   */
+  stalledAtSeq?: number;
 }
 
 function isContiguous(seqs: readonly number[]): boolean {
@@ -43,4 +82,134 @@ export function planContiguousBatch(
     prefix.push(cur);
   }
   return prefix.length >= 1 ? prefix : null;
+}
+
+/**
+ * GAP-447: existence-classified hole traversal. Given the same-scope signed
+ * candidates (ordered by seq) and a classification map covering every OTHER
+ * seq in (lastAnchoredSeq, maxCandidateSeq], walk the full range seq-by-seq:
+ *
+ *   - seq matches the next candidate      → include it as a leaf.
+ *   - seq absent from `rangeMap`          → burned (permanently absent — the
+ *     append-only trigger makes deletion impossible); traversable.
+ *   - seq present, other scope            → foreign; traversable (count only).
+ *   - seq present, same scope, unsigned   → FAIL CLOSED: stop here. Post-
+ *     GAP-417 rails this should be impossible; it is the one remaining
+ *     anomaly signal, so it stalls the batch rather than being traversed.
+ *
+ * `lastAnchoredSeq === 0` (no prior anchor and no legacy floor for this
+ * scope) is permissive at the START only, matching `planContiguousBatch`:
+ * the walk begins at the first candidate's own seq rather than forcing
+ * `seqFrom` back to 1 — the audit_log seq is a single sequence shared across
+ * every tenant, so seqs before a scope's first-ever row are almost certainly
+ * other tenants' rows, not holes worth enumerating. Once any anchor or floor
+ * exists for the scope, `seqFrom` is exactly `lastAnchoredSeq + 1` so every
+ * seq in between is attested (leaf, burned, or foreign) with no unattested
+ * gap between consecutive anchors.
+ *
+ * Returns null only when there are no candidates at all (nothing to do this
+ * pass). A stall with zero rows traversed still returns a result (rows: [])
+ * so the caller can distinguish "genuine stall right at the start" (warn +
+ * metric) from "no candidates" (silent skip).
+ */
+export function planTraversableBatch(
+  lastAnchoredSeq: number,
+  scopeCandidates: readonly SignedAuditRow[],
+  rangeMap: ReadonlyMap<number, ScopeRangeRow>,
+): TraversableBatchResult | null {
+  if (scopeCandidates.length === 0) return null;
+  const firstCandidate = scopeCandidates[0];
+  const maxSeq = scopeCandidates[scopeCandidates.length - 1]?.seq;
+  if (!firstCandidate || maxSeq === undefined) return null;
+
+  const startSeq = lastAnchoredSeq > 0 ? lastAnchoredSeq + 1 : firstCandidate.seq;
+
+  const rows: SignedAuditRow[] = [];
+  const burned: number[] = [];
+  let foreign = 0;
+  let candidateIdx = 0;
+
+  for (let seq = startSeq; seq <= maxSeq; seq++) {
+    const nextCandidate = scopeCandidates[candidateIdx];
+    if (nextCandidate && nextCandidate.seq === seq) {
+      rows.push(nextCandidate);
+      candidateIdx++;
+      continue;
+    }
+    const info = rangeMap.get(seq);
+    if (!info) {
+      burned.push(seq);
+      continue;
+    }
+    if (!info.sameScope) {
+      foreign++;
+      continue;
+    }
+    if (!info.signed) {
+      return {
+        rows,
+        seqFrom: startSeq,
+        seqTo: seq - 1,
+        holes: { burned, foreign },
+        stalledAtSeq: seq,
+      };
+    }
+    // Present, same scope, signed, but not the expected next candidate:
+    // candidates are fetched exhaustively over this same range, so this
+    // should be unreachable. Defensive no-op rather than a thrown assertion,
+    // matching the fail-closed posture of the branch above (never silently
+    // skip ahead — but also never crash the sweep on a query mismatch).
+  }
+
+  if (rows.length === 0) return null;
+  return { rows, seqFrom: startSeq, seqTo: maxSeq, holes: { burned, foreign } };
+}
+
+/**
+ * True when `scopeCandidates` are contiguous with `lastAnchoredSeq` (or with
+ * each other, when `lastAnchoredSeq === 0`) — the common case with zero
+ * holes, where the classification-map query can be skipped entirely.
+ */
+export function isConsecutiveFromStart(
+  lastAnchoredSeq: number,
+  scopeCandidates: readonly SignedAuditRow[],
+): boolean {
+  if (scopeCandidates.length === 0) return true;
+  const first = scopeCandidates[0];
+  if (!first) return true;
+  if (lastAnchoredSeq > 0 && first.seq !== lastAnchoredSeq + 1) return false;
+  return isContiguous(scopeCandidates.map((r) => r.seq));
+}
+
+/**
+ * Self-consistency check before signing (replaces `assertContiguousSeq` for
+ * the traversable planner): every seq strictly between consecutive rows must
+ * be accounted for by a recorded hole (burned, individually, or foreign, by
+ * count), and the leaf span from `seqFrom`/`seqTo` must match `rows.length`
+ * plus the total holes traversed.
+ */
+export function assertTraversalIntegrity(result: TraversableBatchResult): void {
+  const { rows, seqFrom, seqTo, holes } = result;
+  if (rows.length === 0) {
+    throw new Error('assertTraversalIntegrity: empty batch');
+  }
+  for (let i = 1; i < rows.length; i++) {
+    const prev = rows[i - 1];
+    const cur = rows[i];
+    if (!(prev && cur) || cur.seq <= prev.seq) {
+      throw new Error(`assertTraversalIntegrity: seq not strictly increasing at index ${i}`);
+    }
+  }
+  const first = rows[0];
+  const last = rows[rows.length - 1];
+  if (!(first && last) || first.seq < seqFrom || last.seq > seqTo) {
+    throw new Error('assertTraversalIntegrity: leaf seqs fall outside seqFrom..seqTo');
+  }
+  const span = seqTo - seqFrom + 1;
+  const holesCount = holes.burned.length + holes.foreign;
+  if (span !== rows.length + holesCount) {
+    throw new Error(
+      `assertTraversalIntegrity: span ${span} != leaves ${rows.length} + holes ${holesCount}`,
+    );
+  }
 }

--- a/apps/server/src/jobs/audit-anchor-sweep.ts
+++ b/apps/server/src/jobs/audit-anchor-sweep.ts
@@ -3,18 +3,33 @@
  *
  * For each non-null tenant with Max+ `auditLog` and new signed audit_log
  * rows after the last anchor, when the batch is **ready** (size ≥ N or
- * age ≥ max lag), build a contiguous batch, Merkle-root the signature
- * leaves, sign the root (Stage 3 Ed25519), insert audit_anchors, and
- * meter `audit_anchor`. Failures never delete audit rows (append-only).
+ * age ≥ max lag), build a batch, Merkle-root the signature leaves, sign the
+ * root (Stage 3 Ed25519), insert audit_anchors, and meter `audit_anchor`.
+ * Failures never delete audit rows (append-only).
+ *
+ * GAP-447: batches are built by existence-classified hole traversal
+ * (`planTraversableBatch`, `apps/server/src/jobs/audit-anchor-batch.ts`)
+ * rather than strict +1 contiguity. A non-consecutive candidate set no
+ * longer stalls the batch forever at a burned bigserial value — the
+ * append-only trigger (migrations 0002 + 0026) makes row deletion
+ * impossible, so an absent seq PROVES the value was consumed by `nextval()`
+ * without an INSERT ever landing (an aborted transaction), and a present row
+ * scoped to a different tenant proves non-deletion too. Both are traversable;
+ * only a present, SAME-scope, UNSIGNED row still stalls the batch (post-
+ * GAP-417 rails this should be impossible, so it remains the one real
+ * anomaly signal). Traversed holes are recorded on the anchor (`holes` jsonb
+ * column) and covered by the root signature (`@revealui/security`'s
+ * `signAuditAnchorRoot`/`verifyAuditAnchorRoot`).
  *
  * Null-tenant (system) rows anchor too, via one additional pass per sweep
  * (GAP-427 ruling 2026-07-27): they land in `audit_anchors` under the
- * reserved `SYSTEM_ANCHOR_SCOPE` ('__system__') sentinel tenant value.
- * `audit_log.tenant` itself stays null on those rows (no schema migration);
- * only the anchor row's `tenant` column carries the sentinel. The system
- * pass is not entitlement-gated (`canAnchorTenant` is per-account; system
- * events are the operator's own audit trail) and never writes a usage
- * meter (no account FK backs a null tenant).
+ * reserved `SYSTEM_ANCHOR_SCOPE` ('__system__') sentinel tenant value
+ * (canonical definition: `@revealui/db/schema`, re-exported here for
+ * compatibility). `audit_log.tenant` itself stays null on those rows (no
+ * schema migration); only the anchor row's `tenant` column carries the
+ * sentinel. The system pass is not entitlement-gated (`canAnchorTenant` is
+ * per-account; system events are the operator's own audit trail) and never
+ * writes a usage meter (no account FK backs a null tenant).
  *
  * Gated by AUDIT_ANCHOR_SWEEP_ENABLED=true on the worker process.
  */
@@ -24,7 +39,6 @@ import { isFeatureEnabled } from '@revealui/core/features';
 import { logger } from '@revealui/core/observability/logger';
 import { metrics } from '@revealui/core/observability/metrics';
 import {
-  assertContiguousSeq,
   buildMerkleRootFromSignatures,
   createAuditRowSignerFromEnv,
   type Ed25519AuditRowSigner,
@@ -32,20 +46,21 @@ import {
 } from '@revealui/core/security';
 import { getClient } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
-import { auditAnchors, auditLog } from '@revealui/db/schema';
-import { and, asc, count, eq, gt, isNotNull, isNull, max } from 'drizzle-orm';
+import { auditAnchors, auditLog, SYSTEM_ANCHOR_SCOPE } from '@revealui/db/schema';
+import { and, asc, count, eq, gt, isNotNull, isNull, lte, max } from 'drizzle-orm';
 import { accountHasAuditLogFeature } from '../lib/account-entitlement.js';
 import { recordUsageMeter } from '../lib/metering.js';
-import { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
+import {
+  assertTraversalIntegrity,
+  isConsecutiveFromStart,
+  planTraversableBatch,
+  type ScopeRangeRow,
+  type SignedAuditRow,
+  type TraversableBatchResult,
+} from './audit-anchor-batch.js';
 
+export { SYSTEM_ANCHOR_SCOPE } from '@revealui/db/schema';
 export { planContiguousBatch, type SignedAuditRow } from './audit-anchor-batch.js';
-
-/**
- * GAP-427: the audit_anchors.tenant value for anchors over null-tenant
- * (system) audit_log rows. audit_anchors.tenant is NOT NULL, so a sentinel
- * avoids a schema migration; the underlying audit_log rows stay null.
- */
-export const SYSTEM_ANCHOR_SCOPE = '__system__';
 
 /** Countersigned default batch size (§9). Override: AUDIT_ANCHOR_BATCH_SIZE. */
 export const DEFAULT_ANCHOR_BATCH_SIZE = 256;
@@ -93,6 +108,10 @@ const mWaiting = metrics.counter(
 const mFloorEngaged = metrics.counter(
   'revealui_audit_anchor_floor_engaged_total',
   'Tenant sweep passes that started from a derived legacy floor (GAP-427/429)',
+);
+const mHolesTraversed = metrics.counter(
+  'revealui_audit_anchor_holes_traversed_total',
+  'Burned + foreign-scope seqs traversed while building an anchor (GAP-447)',
 );
 
 export interface AnchorSweepResult {
@@ -276,6 +295,34 @@ function auditLogTenantMatch(tenant: string, isSystem: boolean) {
   return isSystem ? isNull(auditLog.tenant) : eq(auditLog.tenant, tenant);
 }
 
+/**
+ * GAP-447: one existence-classification query over (fromSeqExclusive,
+ * toSeqInclusive] — every audit_log row in range, any scope, with just enough
+ * to classify: is it this scope's, and is it signed. Absence from the map
+ * means the seq is burned (no row at all). Fetched ONLY when the candidate
+ * set isn't already contiguous (`isConsecutiveFromStart`); the common,
+ * gapless case never pays this extra round trip.
+ */
+async function fetchScopeRangeMap(
+  db: Database,
+  tenant: string,
+  isSystem: boolean,
+  fromSeqExclusive: number,
+  toSeqInclusive: number,
+): Promise<Map<number, ScopeRangeRow>> {
+  const rows = await db
+    .select({ seq: auditLog.seq, rowTenant: auditLog.tenant, signature: auditLog.signature })
+    .from(auditLog)
+    .where(and(gt(auditLog.seq, fromSeqExclusive), lte(auditLog.seq, toSeqInclusive)));
+
+  const map = new Map<number, ScopeRangeRow>();
+  for (const row of rows) {
+    const sameScope = isSystem ? row.rowTenant === null : row.rowTenant === tenant;
+    map.set(row.seq, { sameScope, signed: row.signature !== null });
+  }
+  return map;
+}
+
 async function lastAnchoredSeq(db: Database, tenant: string): Promise<number> {
   const rows = await db
     .select({ m: max(auditAnchors.seqTo) })
@@ -377,16 +424,46 @@ async function anchorTenantBatch(
 
   if (signed.length === 0) return done('skipped');
 
-  const batch = planContiguousBatch(last, signed);
-  if (!batch || batch.length === 0) {
-    if (signed[0] && (last === 0 || signed[0].seq !== last + 1)) {
-      mGaps.inc();
-      logger.warn(
-        `audit-anchor-sweep: gap for tenant=${tenant} lastAnchored=${last} nextSeq=${signed[0].seq} — skip`,
-      );
-    }
-    return done('skipped');
+  // GAP-447: skip the classification query entirely when the fetched
+  // candidates are already contiguous (the common case) — only a gap
+  // (relative to `last` or internally) triggers the extra range fetch.
+  let plan: TraversableBatchResult | null;
+  if (isConsecutiveFromStart(last, signed)) {
+    const first = signed[0];
+    const lastRow = signed[signed.length - 1];
+    plan =
+      first && lastRow
+        ? {
+            rows: signed,
+            seqFrom: first.seq,
+            seqTo: lastRow.seq,
+            holes: { burned: [], foreign: 0 },
+          }
+        : null;
+  } else {
+    const maxSeq = signed[signed.length - 1]?.seq;
+    const rangeMap =
+      maxSeq !== undefined
+        ? await fetchScopeRangeMap(db, tenant, isSystem, last, maxSeq)
+        : new Map<number, ScopeRangeRow>();
+    plan = planTraversableBatch(last, signed, rangeMap);
   }
+
+  if (!plan) return done('skipped');
+
+  if (plan.stalledAtSeq !== undefined) {
+    // Present, same-scope, UNSIGNED row — post-GAP-417 rails this should be
+    // impossible, the one remaining anomaly signal. Stall (never traverse it).
+    mGaps.inc();
+    logger.warn(
+      `audit-anchor-sweep: same-scope unsigned row blocks traversal tenant=${tenant} seq=${plan.stalledAtSeq}` +
+        (plan.rows.length > 0 ? ` — partial batch up to seq=${plan.seqTo}` : ' — stall'),
+    );
+  }
+
+  if (plan.rows.length === 0) return done('skipped');
+
+  const batch = plan.rows;
 
   // Size primary; time is max lag for a partial batch (§9).
   const readyBySize = batch.length >= batchSize;
@@ -396,13 +473,13 @@ async function anchorTenantBatch(
     return done('waiting');
   }
 
-  const seqs = batch.map((r) => r.seq);
-  assertContiguousSeq(seqs);
+  assertTraversalIntegrity(plan);
   const signatures = batch.map((r) => r.signature);
   const { root, leafCount } = buildMerkleRootFromSignatures(signatures);
-  const seqFrom = batch[0]?.seq;
-  const seqTo = batch[batch.length - 1]?.seq;
-  if (seqFrom === undefined || seqTo === undefined) return done('skipped');
+  const { seqFrom, seqTo, holes } = plan;
+  const holesTraversed = holes.burned.length + holes.foreign;
+  const holesForSigning =
+    holesTraversed > 0 ? { burned: holes.burned, foreign: holes.foreign } : undefined;
 
   const { value: rootSignature } = signAuditAnchorRoot(signer, {
     tenant,
@@ -410,6 +487,7 @@ async function anchorTenantBatch(
     seqTo,
     leafCount,
     root,
+    ...(holesForSigning ? { holes: holesForSigning } : {}),
   });
 
   await db.insert(auditAnchors).values({
@@ -419,12 +497,21 @@ async function anchorTenantBatch(
     root,
     rootSignature,
     leafCount,
+    holes: holesForSigning ?? null,
   });
 
   mAnchorsCreated.inc();
-  logger.info(
-    `audit-anchor-sweep: anchored tenant=${tenant} seq=${seqFrom}..${seqTo} leaves=${leafCount}`,
-  );
+  if (holesTraversed > 0) {
+    mHolesTraversed.inc(holesTraversed);
+    logger.info(
+      `audit-anchor-sweep: anchored tenant=${tenant} seq=${seqFrom}..${seqTo} leaves=${leafCount} ` +
+        `holes(burned=[${holes.burned.join(',')}] foreign=${holes.foreign})`,
+    );
+  } else {
+    logger.info(
+      `audit-anchor-sweep: anchored tenant=${tenant} seq=${seqFrom}..${seqTo} leaves=${leafCount}`,
+    );
+  }
 
   if (doMeter) {
     try {

--- a/apps/server/src/lib/__tests__/audit-anchor-proof.test.ts
+++ b/apps/server/src/lib/__tests__/audit-anchor-proof.test.ts
@@ -52,6 +52,60 @@ describe('buildAnchorInclusionProof (GAP-355 S4-4)', () => {
     if (!r.ok) expect(r.code).toBe('ROOT_MISMATCH');
   });
 
+  describe('GAP-447: holes-carrying anchors (non-contiguous rows)', () => {
+    it('proves a seq when the row set has real gaps (burned/foreign seqs traversed)', () => {
+      // Anchor range 10..14, but only seq 10, 12, 14 are real leaves — 11 and
+      // 13 were traversed holes (burned or foreign-scope), not part of `rows`.
+      const sigs = ['sig-10', 'sig-12', 'sig-14'];
+      const { root, leafCount } = buildMerkleRootFromSignatures(sigs);
+      const rows = [
+        { seq: 10, signature: 'sig-10' },
+        { seq: 12, signature: 'sig-12' },
+        { seq: 14, signature: 'sig-14' },
+      ];
+      const anchor = { seqFrom: 10, seqTo: 14, root, leafCount };
+
+      const result = buildAnchorInclusionProof(anchor, rows, 12);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // Position-based (index 1), NOT seq - seqFrom (which would be 2).
+        expect(result.leafIndex).toBe(1);
+        expect(result.recomputedRoot).toBe(root);
+      }
+    });
+
+    it('rejects a seq inside the range but not among the actual leaves (a hole itself)', () => {
+      const sigs = ['sig-10', 'sig-12'];
+      const { root, leafCount } = buildMerkleRootFromSignatures(sigs);
+      const rows = [
+        { seq: 10, signature: 'sig-10' },
+        { seq: 12, signature: 'sig-12' },
+      ];
+      const anchor = { seqFrom: 10, seqTo: 12, root, leafCount };
+
+      // seq 11 is in [seqFrom, seqTo] but was a traversed hole, not a leaf.
+      const result = buildAnchorInclusionProof(anchor, rows, 11);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.code).toBe('MISSING_LEAF');
+    });
+
+    it('rejects out-of-order rows even within a valid range', () => {
+      const sigs = ['sig-10', 'sig-12'];
+      const { root, leafCount } = buildMerkleRootFromSignatures(sigs);
+      const rows = [
+        { seq: 12, signature: 'sig-12' },
+        { seq: 10, signature: 'sig-10' },
+      ];
+      const result = buildAnchorInclusionProof(
+        { seqFrom: 10, seqTo: 12, root, leafCount },
+        rows,
+        10,
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.code).toBe('MISSING_LEAF');
+    });
+  });
+
   it('smoke: root signature envelope still binds range (S4-2)', () => {
     const { privateKey } = generateKeyPairSync('ed25519');
     const pem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();

--- a/apps/server/src/lib/audit-anchor-proof.ts
+++ b/apps/server/src/lib/audit-anchor-proof.ts
@@ -1,5 +1,9 @@
 /**
  * Pure helpers for GAP-355 Stage 4 S4-4 inclusion proofs over an anchor range.
+ * GAP-447: an anchor's [seqFrom, seqTo] range may contain holes (burned seqs
+ * + foreign-scope rows) traversed around the actual leaves, so `rows` is no
+ * longer required to be contiguous — only strictly increasing, within range,
+ * and exactly `leafCount` long.
  */
 
 import {
@@ -34,12 +38,16 @@ export interface ProofBuildErr {
 }
 
 /**
- * Build an inclusion proof for `seq` given ordered signed rows covering the
- * anchor range (must be contiguous seqFrom..seqTo with one signature each).
+ * Build an inclusion proof for `seq` given the anchor's actual signed rows
+ * (ordered by seq ascending). GAP-447: rows need not be contiguous with each
+ * other or with `seqFrom`/`seqTo` — an anchor with traversed holes has real
+ * gaps in the range by design. `seq` itself must be one of `rows` (a burned
+ * or foreign-scope seq traversed within the range is not a valid proof
+ * target — it has no leaf to prove).
  */
 export function buildAnchorInclusionProof(
   anchor: AnchorRange,
-  /** Rows ordered by seq ascending, covering the full range. */
+  /** Rows ordered by seq ascending — the anchor's actual leaves, one per signature. */
   rows: ReadonlyArray<{ seq: number; signature: string }>,
   seq: number,
 ): ProofBuildOk | ProofBuildErr {
@@ -50,8 +58,7 @@ export function buildAnchorInclusionProof(
     return { ok: false, error: 'no signed rows for range', code: 'EMPTY' };
   }
 
-  const expectedCount = anchor.seqTo - anchor.seqFrom + 1;
-  if (rows.length !== expectedCount || rows.length !== anchor.leafCount) {
+  if (rows.length !== anchor.leafCount) {
     return {
       ok: false,
       error: `row count ${rows.length} != leafCount ${anchor.leafCount}`,
@@ -59,13 +66,22 @@ export function buildAnchorInclusionProof(
     };
   }
 
-  // Enforce order + coverage
+  // Enforce order + range coverage. Strictly increasing, not necessarily
+  // contiguous — holes (burned seqs, foreign-scope rows) are legitimate gaps.
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
-    if (!row || row.seq !== anchor.seqFrom + i) {
+    const prev = i > 0 ? rows[i - 1] : undefined;
+    if (!row || row.seq < anchor.seqFrom || row.seq > anchor.seqTo) {
       return {
         ok: false,
-        error: `expected seq ${anchor.seqFrom + i} at index ${i}`,
+        error: `row at index ${i} has seq outside anchor range`,
+        code: 'MISSING_LEAF',
+      };
+    }
+    if (prev && row.seq <= prev.seq) {
+      return {
+        ok: false,
+        error: `rows out of order at index ${i}`,
         code: 'MISSING_LEAF',
       };
     }
@@ -81,10 +97,13 @@ export function buildAnchorInclusionProof(
     };
   }
 
-  const leafIndex = seq - anchor.seqFrom;
+  // GAP-447: leaf index is the row's POSITION among the anchor's actual
+  // leaves, not `seq - seqFrom` — that arithmetic assumed a contiguous range,
+  // which no longer holds once holes are traversed within [seqFrom, seqTo].
+  const leafIndex = rows.findIndex((r) => r.seq === seq);
   const signature = rows[leafIndex]?.signature;
-  const leafHash = leafHashes[leafIndex];
-  if (!(signature && leafHash)) {
+  const leafHash = leafIndex >= 0 ? leafHashes[leafIndex] : undefined;
+  if (leafIndex < 0 || !(signature && leafHash)) {
     return { ok: false, error: 'leaf missing', code: 'MISSING_LEAF' };
   }
 

--- a/apps/server/src/routes/__tests__/audit-anchors.test.ts
+++ b/apps/server/src/routes/__tests__/audit-anchors.test.ts
@@ -18,7 +18,7 @@ import {
 import { type AuditEntry, type AuditRowSignerFn, DrizzleAuditStore } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
 import { accountMemberships, accounts, auditAnchors, auditLog, users } from '@revealui/db/schema';
-import { asc, eq } from 'drizzle-orm';
+import { asc, eq, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -177,6 +177,59 @@ describe('GET /anchors + /anchors/:id/proof (GAP-355 S4-4, PGlite)', () => {
     if (!row) throw new Error('insert failed');
     return row.id;
   }
+
+  it('GAP-447: surfaces holes in the list response and proves a leaf by position, not seq offset', async () => {
+    const signedStore = new DrizzleAuditStore(db, canonicalSignerFn(priv));
+    await signedStore.append(makeEntry({ id: 'h1', tenant: 'acct_max' })); // seq 1
+    await db.execute(sql`SELECT nextval(pg_get_serial_sequence('audit_log', 'seq'))`); // burn seq 2
+    await signedStore.append(makeEntry({ id: 'h3', tenant: 'acct_max' })); // seq 3
+
+    const rows = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.tenant, 'acct_max'))
+      .orderBy(asc(auditLog.seq));
+    const signatures = rows.map((r) => {
+      if (!r.signature) throw new Error('missing sig');
+      return r.signature;
+    });
+    const { root, leafCount } = buildMerkleRootFromSignatures(signatures);
+    const holes = { burned: [2], foreign: 0 };
+    const { value: rootSignature } = signAuditAnchorRoot(cryptoSigner, {
+      tenant: 'acct_max',
+      seqFrom: 1,
+      seqTo: 3,
+      leafCount,
+      root,
+      holes,
+    });
+    const [inserted] = await db
+      .insert(auditAnchors)
+      .values({ tenant: 'acct_max', seqFrom: 1, seqTo: 3, root, rootSignature, leafCount, holes })
+      .returning({ id: auditAnchors.id });
+    if (!inserted) throw new Error('insert failed');
+
+    const app = createAuthedApp(user, db);
+
+    const listRes = await app.request('/anchors');
+    expect(listRes.status).toBe(200);
+    const listBody = (await listRes.json()) as {
+      anchors: Array<{ id: string; holes: { burned: number[]; foreign: number } | null }>;
+    };
+    expect(listBody.anchors[0]?.holes).toEqual(holes);
+
+    // seq 3 is the SECOND real leaf (position 1), not index (3 - seqFrom = 2).
+    const proofRes = await app.request(`/anchors/${inserted.id}/proof?seq=3`);
+    expect(proofRes.status).toBe(200);
+    const proofBody = (await proofRes.json()) as {
+      anchor: { holes: { burned: number[]; foreign: number } | null };
+      proof: { leafIndex: number };
+      row: { seq: number; leafHash: string };
+    };
+    expect(proofBody.anchor.holes).toEqual(holes);
+    expect(proofBody.proof.leafIndex).toBe(1);
+    expect(proofBody.row.seq).toBe(3);
+  });
 
   it('returns 401 when unauthenticated', async () => {
     const app = createAuthedApp(undefined, db);

--- a/apps/server/src/routes/audit.ts
+++ b/apps/server/src/routes/audit.ts
@@ -97,6 +97,12 @@ function serializeAnchor(row: typeof auditAnchors.$inferSelect) {
     root: row.root,
     rootSignature: row.rootSignature,
     leafCount: row.leafCount,
+    // GAP-447: burned seqs + foreign-scope-row count traversed within this
+    // anchor's range, covered by rootSignature. Required for offline
+    // verification to reproduce the exact signed bytes — omitting it here
+    // would make any holes-carrying anchor unverifiable by a downloading
+    // client. null when no holes were traversed (the common case).
+    holes: row.holes ?? null,
     createdAt: row.createdAt.toISOString(),
     deliveredAt: row.deliveredAt ? row.deliveredAt.toISOString() : null,
     deliveryChannel: row.deliveryChannel ?? null,
@@ -258,6 +264,11 @@ app.get('/anchors/:id/proof', async (c) => {
     signedRows,
     seq,
   );
+  // GAP-447: `signedRows` is already fetched scoped to (tenant, signed,
+  // [seqFrom, seqTo]) — it naturally excludes burned/foreign-scope seqs, so
+  // `buildAnchorInclusionProof` sees only real leaves and no `holes` param is
+  // needed there. `anchor.holes` is descriptive metadata surfaced to the
+  // client via `serializeAnchor` below, not an input to proof building.
   if (!built.ok) {
     if (built.code === 'SEQ_OUT_OF_RANGE') {
       throw new HTTPException(400, {

--- a/packages/db/migrations/0031_gap447_audit_anchors_holes.sql
+++ b/packages/db/migrations/0031_gap447_audit_anchors_holes.sql
@@ -1,0 +1,10 @@
+-- GAP-447: existence-classified hole traversal for the audit anchor sweep.
+-- Records the burned (permanently absent) seqs + foreign-scope-row count an
+-- anchor traversed within its [seq_from, seq_to] range, so a customer/ops
+-- verifier can re-check that recorded-burned seqs are still absent. NULL
+-- means no holes were traversed (the pre-GAP-447 shape and still the common
+-- case) — hand-written for the ADD COLUMN IF NOT EXISTS idempotent form,
+-- following the 0011/0015/0030 precedent. Companion Drizzle schema change at
+-- packages/db/src/schema/audit-anchors.ts adds the `holes` jsonb column.
+
+ALTER TABLE "audit_anchors" ADD COLUMN IF NOT EXISTS "holes" jsonb;

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -92,6 +92,12 @@
       "rationale": "GAP-429 item 4: partial index (tenant, seq) WHERE signature IS NULL supporting legacyUnsignedFloor() on the anchors request path and the no-anchor sweep pass. Hand-written for the CREATE INDEX IF NOT EXISTS idempotent form with a partial-index predicate, following the 0008_jobs_visibility_timeout precedent. Companion Drizzle schema change at packages/db/src/schema/audit-log.ts adds the same index via .where() for type-level modeling.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. A generate attempt from this branch re-emitted the 0028/0029 drift on top of the stale 0027 snapshot, confirming the debt is shared, not new."
+    },
+    {
+      "tag": "0031_gap447_audit_anchors_holes",
+      "rationale": "GAP-447 existence-classified hole traversal: adds nullable `holes` jsonb column to audit_anchors recording burned seqs + foreign-scope-row count traversed within an anchor's range. Hand-written for the single ADD COLUMN IF NOT EXISTS idempotent statement, following the 0011/0015/0030 column-addition precedent. Companion Drizzle schema change at packages/db/src/schema/audit-anchors.ts adds the holes column (jsonb, typed via $type<AuditAnchorHoles>()) for type-safety; the security package's signAuditAnchorRoot/verifyAuditAnchorRoot cover the field in the signed payload only when present, so pre-existing anchors (NULL holes) verify unchanged.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. The Drizzle schema at audit-anchors.ts already reflects the holes column at the type level; the sweep + verify paths query via Drizzle ORM / the security package's pure functions."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1785084298662,
       "tag": "0030_gap429_audit_log_unsigned_floor_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1785175772410,
+      "tag": "0031_gap447_audit_anchors_holes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/audit-store.test.ts
+++ b/packages/db/src/__tests__/audit-store.test.ts
@@ -132,6 +132,30 @@ describe('DrizzleAuditStore  -  append-only enforcement', () => {
     expect(batchValues[1]?.id).toBe('e2');
   });
 
+  // ── GAP-447: reject the SYSTEM_ANCHOR_SCOPE sentinel as a tenant value ─────
+
+  it('append() rejects entry.tenant === SYSTEM_ANCHOR_SCOPE (unsigned path)', async () => {
+    await expect(store.append(makeEntry({ tenant: '__system__' }))).rejects.toThrow(
+      /reserved system-anchor sentinel/,
+    );
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('append() rejects entry.tenant === SYSTEM_ANCHOR_SCOPE (signed path)', async () => {
+    const signedStore = new DrizzleAuditStore(db as never, () => 'v1.ed25519.kid.sig');
+    await expect(signedStore.append(makeEntry({ tenant: '__system__' }))).rejects.toThrow(
+      /reserved system-anchor sentinel/,
+    );
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('appendBatch() rejects a batch containing entry.tenant === SYSTEM_ANCHOR_SCOPE', async () => {
+    await expect(
+      store.appendBatch([makeEntry({ id: 'e1' }), makeEntry({ id: 'e2', tenant: '__system__' })]),
+    ).rejects.toThrow(/reserved system-anchor sentinel/);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
   // ── DB-level trigger (migration verification) ─────────────────────────────
 
   it('migration SQL contains append-only trigger for audit_log', async () => {

--- a/packages/db/src/audit-store.ts
+++ b/packages/db/src/audit-store.ts
@@ -11,6 +11,7 @@
 
 import { and, count, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
 import type { Database } from './client/index.js';
+import { SYSTEM_ANCHOR_SCOPE } from './schema/audit-anchors.js';
 import { auditLog } from './schema/audit-log.js';
 
 // ─── Local Type Mirrors ─────────────────────────────────────────────────────
@@ -124,8 +125,25 @@ export class DrizzleAuditStore {
     }
   }
 
+  /**
+   * GAP-447 ONE DOOR: `SYSTEM_ANCHOR_SCOPE` ('__system__') is reserved for
+   * the audit_anchors.tenant sentinel over null-tenant (system) rows
+   * (GAP-427). audit_log.tenant must never actually be set to that value —
+   * a row scoped to the sentinel would collide with the system anchor pass's
+   * own bookkeeping and be misclassified as a genuine tenant. Enforced here,
+   * the single write door, for both the signed and unsigned append paths.
+   */
+  private assertNotSentinelTenant(entry: AuditEntry): void {
+    if (entry.tenant === SYSTEM_ANCHOR_SCOPE) {
+      throw new Error(
+        `DrizzleAuditStore: entry.tenant cannot be the reserved system-anchor sentinel "${SYSTEM_ANCHOR_SCOPE}" (GAP-447) — use tenant: null for system-scope events.`,
+      );
+    }
+  }
+
   /** Append a single entry to the audit log */
   async append(entry: AuditEntry): Promise<void> {
+    this.assertNotSentinelTenant(entry);
     if (!this.signer) {
       this.refuseUnsignedInProduction();
       // Unsigned mode (dev/test only): DB assigns `seq` (column default),
@@ -153,6 +171,9 @@ export class DrizzleAuditStore {
   /** Append multiple entries atomically in a single INSERT */
   async appendBatch(entries: AuditEntry[]): Promise<void> {
     if (entries.length === 0) return;
+    for (const entry of entries) {
+      this.assertNotSentinelTenant(entry);
+    }
 
     if (!this.signer) {
       this.refuseUnsignedInProduction();

--- a/packages/db/src/schema/audit-anchors.ts
+++ b/packages/db/src/schema/audit-anchors.ts
@@ -15,12 +15,30 @@ import {
   check,
   index,
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
+
+/**
+ * GAP-427 (ruling 2026-07-27), relocated here GAP-447: the audit_anchors.tenant
+ * value for anchors over null-tenant (system) audit_log rows. audit_anchors.tenant
+ * is NOT NULL, so a sentinel avoids a schema migration; the underlying
+ * audit_log rows stay null. Canonical home is `@revealui/db` (schema-adjacent,
+ * not crypto/DB-access) so `DrizzleAuditStore` can reject it as a tenant value
+ * at the single write door without importing from `apps/server`.
+ * `apps/server/src/jobs/audit-anchor-sweep.ts` re-exports this for compatibility.
+ */
+export const SYSTEM_ANCHOR_SCOPE = '__system__' as const;
+
+/** Burned (permanently absent) seqs + a foreign-scope-row count an anchor traversed (GAP-447). */
+export interface AuditAnchorHoles {
+  burned: number[];
+  foreign: number;
+}
 
 export const auditAnchors = pgTable(
   'audit_anchors',
@@ -50,6 +68,17 @@ export const auditAnchors = pgTable(
     rootSignature: text('root_signature').notNull(),
 
     leafCount: integer('leaf_count').notNull(),
+
+    /**
+     * GAP-447: burned seqs + foreign-scope-row count traversed within
+     * [seqFrom, seqTo] while building this anchor. NULL means no holes were
+     * traversed (the pre-GAP-447 shape, and still the common case) — every
+     * anchor written before this column existed reads back as NULL here,
+     * which round-trips to the same signed payload (see
+     * `auditAnchorSignableBytes` in `@revealui/security`: an `undefined`
+     * `holes` field is omitted from the canonical bytes entirely).
+     */
+    holes: jsonb('holes').$type<AuditAnchorHoles>(),
 
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 

--- a/packages/security/src/__tests__/audit-anchor-verify.test.ts
+++ b/packages/security/src/__tests__/audit-anchor-verify.test.ts
@@ -20,7 +20,7 @@ function makeKeypair(): { privateKeyPem: string; publicKeyPem: string } {
 }
 
 describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
-  it('accepts a valid root-only verification', () => {
+  it('accepts a valid root-only verification', async () => {
     const { privateKeyPem, publicKeyPem } = makeKeypair();
     const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
     const sigs = ['a', 'b', 'c'];
@@ -34,7 +34,7 @@ describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
     };
     const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
 
-    const result = verifyAuditAnchorOffline({
+    const result = await verifyAuditAnchorOffline({
       publicKeyPem,
       anchor: { ...anchorBase, rootSignature },
     });
@@ -42,7 +42,7 @@ describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
     expect(result.checks.some((c) => c.includes('VALID'))).toBe(true);
   });
 
-  it('rejects a tampered root', () => {
+  it('rejects a tampered root', async () => {
     const { privateKeyPem, publicKeyPem } = makeKeypair();
     const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
     const { root, leafCount } = buildMerkleRootFromSignatures(['x', 'y']);
@@ -55,7 +55,7 @@ describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
     };
     const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
 
-    const result = verifyAuditAnchorOffline({
+    const result = await verifyAuditAnchorOffline({
       publicKeyPem,
       anchor: {
         ...anchorBase,
@@ -66,7 +66,7 @@ describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
     expect(result.ok).toBe(false);
   });
 
-  it('accepts root + inclusion proof for one leaf', () => {
+  it('accepts root + inclusion proof for one leaf', async () => {
     const { privateKeyPem, publicKeyPem } = makeKeypair();
     const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
     const sigs = ['s0', 's1', 's2', 's3'];
@@ -82,7 +82,7 @@ describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
     const leafIndex = 2;
     const proof = buildInclusionProof(leafHashes, leafIndex);
 
-    const result = verifyAuditAnchorOffline({
+    const result = await verifyAuditAnchorOffline({
       publicKeyPem,
       anchor: { ...anchorBase, rootSignature },
       inclusion: {
@@ -96,7 +96,7 @@ describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
     expect(result.checks.some((c) => c.includes('inclusion proof VALID'))).toBe(true);
   });
 
-  it('rejects inclusion proof for wrong leaf signature', () => {
+  it('rejects inclusion proof for wrong leaf signature', async () => {
     const { privateKeyPem, publicKeyPem } = makeKeypair();
     const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
     const sigs = ['s0', 's1'];
@@ -111,7 +111,7 @@ describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
     const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
     const proof = buildInclusionProof(leafHashes, 0);
 
-    const result = verifyAuditAnchorOffline({
+    const result = await verifyAuditAnchorOffline({
       publicKeyPem,
       anchor: { ...anchorBase, rootSignature },
       inclusion: {
@@ -121,5 +121,133 @@ describe('verifyAuditAnchorOffline (GAP-355 S4-5)', () => {
       },
     });
     expect(result.ok).toBe(false);
+  });
+});
+
+describe('verifyAuditAnchorOffline holes (GAP-447)', () => {
+  it('back-compat: a pre-change anchor (no holes field at all) still verifies', async () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const { root, leafCount } = buildMerkleRootFromSignatures(['a', 'b']);
+    // Simulates an anchor signed BEFORE GAP-447 (signAuditAnchorRoot invoked
+    // with no `holes` key at all — not even `holes: undefined`).
+    const anchorBase = { tenant: 'acct_t', seqFrom: 1, seqTo: 2, leafCount, root };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
+
+    const result = await verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: { ...anchorBase, rootSignature },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts an anchor with burned + foreign holes covered by the signature', async () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const { root, leafCount } = buildMerkleRootFromSignatures(['a', 'b']);
+    const anchorBase = {
+      tenant: 'acct_t',
+      seqFrom: 10,
+      seqTo: 13,
+      leafCount,
+      root,
+      holes: { burned: [11], foreign: 1 },
+    };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
+
+    const result = await verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: { ...anchorBase, rootSignature },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects when the holes shipped with the anchor were not part of the signed payload', async () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const { root, leafCount } = buildMerkleRootFromSignatures(['a', 'b']);
+    // span (10..11) == leafCount (2) so this signs cleanly WITHOUT holes.
+    const anchorBase = { tenant: 'acct_t', seqFrom: 10, seqTo: 11, leafCount, root };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase); // signed WITHOUT holes
+
+    const result = await verifyAuditAnchorOffline({
+      publicKeyPem,
+      // Anchor now claims an (empty) holes object that was never part of the
+      // signed payload — the omitted-key vs explicit-empty-object distinction
+      // must change the signed bytes, so this must NOT verify.
+      anchor: { ...anchorBase, holes: { burned: [], foreign: 0 }, rootSignature },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('skips the live burned-seq recheck when no checker is injected (true offline mode)', async () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const { root, leafCount } = buildMerkleRootFromSignatures(['a']);
+    const anchorBase = {
+      tenant: 'acct_t',
+      seqFrom: 5,
+      seqTo: 6,
+      leafCount,
+      root,
+      holes: { burned: [6], foreign: 0 },
+    };
+    // seqFrom..seqTo spans 5..6 with leafCount 1: seq 5 is the one leaf, seq 6
+    // is the recorded-burned hole traversed above it.
+    const anchorWithSingleLeafRange = { ...anchorBase, seqFrom: 5, seqTo: 6, leafCount: 1 };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorWithSingleLeafRange);
+
+    const result = await verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: { ...anchorWithSingleLeafRange, rootSignature },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.checks.some((c) => c.includes('recheck skipped'))).toBe(true);
+  });
+
+  it('passes the live burned-seq recheck when the injected checker confirms absence', async () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const { root, leafCount } = buildMerkleRootFromSignatures(['a']);
+    const anchorBase = {
+      tenant: 'acct_t',
+      seqFrom: 5,
+      seqTo: 6,
+      leafCount,
+      root,
+      holes: { burned: [6], foreign: 0 },
+    };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
+
+    const result = await verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: { ...anchorBase, rootSignature },
+      checkBurnedSeqAbsent: async () => false,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.checks.some((c) => c.includes('confirmed still absent'))).toBe(true);
+  });
+
+  it('fails with a distinct error when a row now exists at a recorded-burned seq', async () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = new Ed25519AuditRowSigner(privateKeyPem, 'kid-v');
+    const { root, leafCount } = buildMerkleRootFromSignatures(['a']);
+    const anchorBase = {
+      tenant: 'acct_t',
+      seqFrom: 5,
+      seqTo: 6,
+      leafCount,
+      root,
+      holes: { burned: [6], foreign: 0 },
+    };
+    const { value: rootSignature } = signAuditAnchorRoot(signer, anchorBase);
+
+    const result = await verifyAuditAnchorOffline({
+      publicKeyPem,
+      anchor: { ...anchorBase, rootSignature },
+      checkBurnedSeqAbsent: async (seq) => seq === 6, // tamper: a row now exists at the burned seq
+    });
+    expect(result.ok).toBe(false);
+    expect(result.checks.some((c) => c.includes('now exists') && c.includes('tamper'))).toBe(true);
   });
 });

--- a/packages/security/src/__tests__/audit-merkle.test.ts
+++ b/packages/security/src/__tests__/audit-merkle.test.ts
@@ -143,4 +143,84 @@ describe('audit Merkle (GAP-355 Stage 4 S4-2)', () => {
       }),
     ).toThrow(/leafCount/);
   });
+
+  describe('holes (GAP-447)', () => {
+    it('an undefined holes field serializes IDENTICALLY to no holes field at all', () => {
+      const base = { tenant: 't', seqFrom: 1, seqTo: 2, leafCount: 2, root: 'c'.repeat(64) };
+      const withoutKey = auditAnchorSignableBytes(base);
+      const withUndefined = auditAnchorSignableBytes({ ...base, holes: undefined });
+      expect(new TextDecoder().decode(withoutKey)).toBe(new TextDecoder().decode(withUndefined));
+    });
+
+    it('an explicit (even empty) holes object changes the signed bytes', () => {
+      const base = { tenant: 't', seqFrom: 1, seqTo: 2, leafCount: 2, root: 'c'.repeat(64) };
+      const withoutHoles = auditAnchorSignableBytes(base);
+      const withEmptyHoles = auditAnchorSignableBytes({
+        ...base,
+        holes: { burned: [], foreign: 0 },
+      });
+      expect(new TextDecoder().decode(withoutHoles)).not.toBe(
+        new TextDecoder().decode(withEmptyHoles),
+      );
+    });
+
+    it('leafCount must equal the seq span MINUS the traversed holes', () => {
+      // span 1..4 = 4 seqs; 1 burned + 1 foreign traversed ⇒ 2 real leaves.
+      expect(() =>
+        auditAnchorSignableBytes({
+          tenant: 't',
+          seqFrom: 1,
+          seqTo: 4,
+          leafCount: 2,
+          root: 'd'.repeat(64),
+          holes: { burned: [2], foreign: 1 },
+        }),
+      ).not.toThrow();
+      expect(() =>
+        auditAnchorSignableBytes({
+          tenant: 't',
+          seqFrom: 1,
+          seqTo: 4,
+          leafCount: 4, // wrong: ignores the holes
+          root: 'd'.repeat(64),
+          holes: { burned: [2], foreign: 1 },
+        }),
+      ).toThrow(/leafCount/);
+    });
+
+    it('rejects a burned seq outside the seqFrom..seqTo range', () => {
+      expect(() =>
+        auditAnchorSignableBytes({
+          tenant: 't',
+          seqFrom: 1,
+          seqTo: 2,
+          leafCount: 1,
+          root: 'e'.repeat(64),
+          holes: { burned: [99], foreign: 0 },
+        }),
+      ).toThrow(/outside anchor range/);
+    });
+
+    it('signs and verifies an anchor carrying holes', () => {
+      const sigs = ['h0', 'h1'];
+      const { root, leafCount } = buildMerkleRootFromSignatures(sigs);
+      const anchor = {
+        tenant: 'acct_holes',
+        seqFrom: 10,
+        seqTo: 13,
+        leafCount,
+        root,
+        holes: { burned: [12], foreign: 1 },
+      };
+      const { value } = signAuditAnchorRoot(signer, anchor);
+      expect(
+        verifyAuditAnchorRoot(anchor, value, (kid) => (kid === 'kid-merkle' ? pub : null)).valid,
+      ).toBe(true);
+      // Tampering the holes after signing must invalidate the signature.
+      const tampered = { ...anchor, holes: { burned: [13], foreign: 1 } };
+      expect(
+        verifyAuditAnchorRoot(tampered, value, (kid) => (kid === 'kid-merkle' ? pub : null)).valid,
+      ).toBe(false);
+    });
+  });
 });

--- a/packages/security/src/audit-anchor-verify.ts
+++ b/packages/security/src/audit-anchor-verify.ts
@@ -1,16 +1,33 @@
 /**
- * Offline audit-anchor verification (GAP-355 Stage 4 S4-5).
+ * Offline audit-anchor verification (GAP-355 Stage 4 S4-5; extended GAP-447).
  *
- * Pure library: no network, no database. Customers (and `verify-audit-anchor`
- * CLI) pass a published SPKI public key, a root record (from API download or
- * export), and optionally an inclusion proof for one row signature.
+ * Core verification (root signature + inclusion proof) is a pure library: no
+ * network, no database. Customers (and `verify-audit-anchor` CLI) pass a
+ * published SPKI public key, a root record (from API download or export), and
+ * optionally an inclusion proof for one row signature.
+ *
+ * GAP-447 adds one OPTIONAL live recheck on top of that pure core: an anchor
+ * may carry `holes.burned` seqs (traversed because no row existed there at
+ * anchor-build time). Since `audit_log.seq` is written explicitly by the
+ * store (not purely DB-generated per row — see `nextSeqValues` in
+ * `@revealui/db`'s `DrizzleAuditStore`), a "burned" seq could later be filled
+ * by a forged row, which would be a real integrity violation the signed
+ * payload alone cannot detect (it only proves what was true when signed). A
+ * caller with DB access may inject `checkBurnedSeqAbsent` to re-verify each
+ * recorded-burned seq is STILL absent right now. When omitted (the true
+ * "no network, no database" mode — e.g. the CLI verifying a customer-held
+ * export), that recheck is skipped and only the root + inclusion proof are
+ * verified.
  *
  * Exit contract for CLI consumers:
- *   - root signature must verify over JCS { tenant, seqFrom, seqTo, leafCount, root }
+ *   - root signature must verify over JCS { tenant, seqFrom, seqTo, leafCount, root[, holes] }
  *   - if proof present: leaf = SHA-256(signature), inclusion path must recompute root
+ *   - if checkBurnedSeqAbsent provided and holes.burned non-empty: every burned seq
+ *     must still be absent, or verification fails with a distinct reason
  */
 
 import {
+  type AuditAnchorHoles,
   type AuditAnchorSignable,
   hashAuditSignatureLeaf,
   type InclusionProof,
@@ -18,6 +35,9 @@ import {
   verifyInclusionProof,
 } from './audit-merkle.js';
 import type { PublicKeyResolver } from './audit-signing.js';
+
+/** Injected DB-aware check: does a row currently exist at this seq (for the anchor's scope)? */
+export type SeqExistsChecker = (seq: number) => Promise<boolean>;
 
 export interface OfflineAnchorRecord extends AuditAnchorSignable {
   /** Stage-3 style envelope: v1.ed25519.<kid>.<sig> */
@@ -40,6 +60,12 @@ export interface OfflineVerifyInput {
   publicKeyPem: string;
   anchor: OfflineAnchorRecord;
   inclusion?: OfflineInclusionProofInput;
+  /**
+   * GAP-447: optional live recheck that every seq in `anchor.holes.burned` is
+   * STILL absent. Omit for a true offline verify (no DB access available);
+   * provide when the caller has a live audit_log to re-check against.
+   */
+  checkBurnedSeqAbsent?: SeqExistsChecker;
 }
 
 export interface OfflineVerifyResult {
@@ -54,12 +80,48 @@ function singleKeyResolver(publicKeyPem: string): PublicKeyResolver {
 }
 
 /**
- * Verify an anchor root signature and optional inclusion proof offline.
- * Never throws for expected invalid crypto; returns ok:false + reasons.
+ * Recheck (GAP-447) that every recorded-burned seq is STILL absent. Skipped
+ * (ok:true, informational check only) when either there are no burned seqs to
+ * check or no `checkBurnedSeqAbsent` was injected — the pure offline mode.
  */
-export function verifyAuditAnchorOffline(input: OfflineVerifyInput): OfflineVerifyResult {
+async function verifyBurnedSeqsStillAbsent(
+  holes: AuditAnchorHoles | undefined,
+  checkBurnedSeqAbsent: SeqExistsChecker | undefined,
+): Promise<{ ok: boolean; checks: string[] }> {
+  const burned = holes?.burned ?? [];
+  if (burned.length === 0) return { ok: true, checks: [] };
+  if (!checkBurnedSeqAbsent) {
+    return {
+      ok: true,
+      checks: [
+        `${burned.length} burned seq(s) recorded; liveness recheck skipped (no checkBurnedSeqAbsent provided)`,
+      ],
+    };
+  }
+  for (const seq of burned) {
+    const exists = await checkBurnedSeqAbsent(seq);
+    if (exists) {
+      return {
+        ok: false,
+        checks: [
+          `burned seq ${seq} recorded as permanently absent, but a row now exists at that seq — anchor integrity violated (possible tamper)`,
+        ],
+      };
+    }
+  }
+  return { ok: true, checks: [`${burned.length} burned seq(s) confirmed still absent`] };
+}
+
+/**
+ * Verify an anchor root signature and optional inclusion proof offline, plus
+ * (GAP-447, optional) a live recheck that recorded-burned seqs are still
+ * absent. Never throws for expected invalid crypto; returns ok:false + reasons.
+ */
+export async function verifyAuditAnchorOffline(
+  input: OfflineVerifyInput,
+): Promise<OfflineVerifyResult> {
   const checks: string[] = [];
-  const { publicKeyPem, anchor, inclusion } = input;
+  const { publicKeyPem, anchor, inclusion, checkBurnedSeqAbsent } = input;
 
   if (!(publicKeyPem.includes('BEGIN PUBLIC KEY') || publicKeyPem.includes('BEGIN'))) {
     // Allow raw PEM without forcing exact header wording; empty is hard fail.
@@ -76,6 +138,7 @@ export function verifyAuditAnchorOffline(input: OfflineVerifyInput): OfflineVeri
       seqTo: anchor.seqTo,
       leafCount: anchor.leafCount,
       root: anchor.root,
+      ...(anchor.holes !== undefined ? { holes: anchor.holes } : {}),
     };
     // Validate shape via auditAnchorSignableBytes rules by calling verify path
   } catch (err) {
@@ -109,7 +172,9 @@ export function verifyAuditAnchorOffline(input: OfflineVerifyInput): OfflineVeri
 
   if (!inclusion) {
     checks.push('no inclusion proof provided (root-only verify)');
-    return { ok: true, checks, kid: rootResult.kid };
+    const holesResult = await verifyBurnedSeqsStillAbsent(anchor.holes, checkBurnedSeqAbsent);
+    checks.push(...holesResult.checks);
+    return { ok: holesResult.ok, checks, kid: rootResult.kid };
   }
 
   // Inclusion proof path
@@ -152,5 +217,8 @@ export function verifyAuditAnchorOffline(input: OfflineVerifyInput): OfflineVeri
   }
 
   checks.push(`inclusion proof VALID for seq=${inclusion.seq} leafIndex=${expectedLeafIndex}`);
-  return { ok: true, checks, kid: rootResult.kid };
+
+  const holesResult = await verifyBurnedSeqsStillAbsent(anchor.holes, checkBurnedSeqAbsent);
+  checks.push(...holesResult.checks);
+  return { ok: holesResult.ok, checks, kid: rootResult.kid };
 }

--- a/packages/security/src/audit-merkle.ts
+++ b/packages/security/src/audit-merkle.ts
@@ -180,12 +180,58 @@ export function verifyInclusionProof(
 
 // ── Root signing (binds range + root) ─────────────────────────────────
 
+/**
+ * GAP-447: seqs traversed within an anchor's [seqFrom, seqTo] range that are
+ * NOT among the anchor's own leaves — classified at sweep time from a single
+ * existence query over the range, never guessed:
+ *   - `burned`  — seqs with no audit_log row at all. The append-only trigger
+ *     (migrations 0002 + 0026) makes deletion impossible, so an absent seq
+ *     proves the value was consumed by `nextval()` without an INSERT landing
+ *     (an aborted transaction), not a deletion. Enumerated individually so a
+ *     verifier can re-check each is still absent (see `holes` on
+ *     `AuditAnchorSignable`).
+ *   - `foreign` — count of rows present at a traversed seq but scoped to a
+ *     different tenant (or, for the system scope, any non-null tenant).
+ *     Their existence already proves non-deletion, so only the count is
+ *     signed — the individual seqs carry no anomaly signal worth re-checking.
+ */
+export interface AuditAnchorHoles {
+  burned: readonly number[];
+  foreign: number;
+}
+
 export interface AuditAnchorSignable {
   tenant: string;
   seqFrom: number;
   seqTo: number;
   leafCount: number;
   root: string;
+  /**
+   * GAP-447: holes traversed while building this anchor. Optional and
+   * covered by the root signature when present — `undefined` serializes to
+   * EXACTLY the pre-GAP-447 payload (the key is omitted, not signed as
+   * `null`/`undefined`), so every anchor signed before this change still
+   * verifies unchanged.
+   */
+  holes?: AuditAnchorHoles;
+}
+
+function assertValidHoles(anchor: AuditAnchorSignable): void {
+  const holes = anchor.holes;
+  if (holes === undefined) return;
+  if (!Array.isArray(holes.burned)) {
+    throw new Error('auditAnchorSignableBytes: holes.burned must be an array');
+  }
+  for (const seq of holes.burned) {
+    if (!Number.isInteger(seq) || seq < anchor.seqFrom || seq > anchor.seqTo) {
+      throw new Error(
+        `auditAnchorSignableBytes: holes.burned seq ${seq} outside anchor range ${anchor.seqFrom}..${anchor.seqTo}`,
+      );
+    }
+  }
+  if (!Number.isInteger(holes.foreign) || holes.foreign < 0) {
+    throw new Error('auditAnchorSignableBytes: holes.foreign must be a non-negative integer');
+  }
 }
 
 /** Canonical bytes signed for an anchor root (shared by sign + verify). */
@@ -205,19 +251,32 @@ export function auditAnchorSignableBytes(anchor: AuditAnchorSignable): Uint8Arra
   if (!/^[0-9a-f]{64}$/.test(anchor.root)) {
     throw new Error('auditAnchorSignableBytes: root must be 64-char lowercase hex');
   }
-  const expectedLeaves = anchor.seqTo - anchor.seqFrom + 1;
+  assertValidHoles(anchor);
+  // GAP-447: with holes traversed, the leaf count is the seq span MINUS the
+  // burned + foreign seqs traversed within it (they occupy seq slots in the
+  // range without contributing a leaf). No holes ⇒ identical to the original
+  // "leafCount must equal the seq span" check.
+  const holesCount = anchor.holes ? anchor.holes.burned.length + anchor.holes.foreign : 0;
+  const expectedLeaves = anchor.seqTo - anchor.seqFrom + 1 - holesCount;
   if (anchor.leafCount !== expectedLeaves) {
     throw new Error(
-      `auditAnchorSignableBytes: leafCount ${anchor.leafCount} != seq span ${expectedLeaves}`,
+      `auditAnchorSignableBytes: leafCount ${anchor.leafCount} != seq span ${expectedLeaves} (span=${anchor.seqTo - anchor.seqFrom + 1}, holes=${holesCount})`,
     );
   }
-  const canonical = canonicalizeJcs({
+  const payload: Record<string, unknown> = {
     tenant: anchor.tenant,
     seqFrom: anchor.seqFrom,
     seqTo: anchor.seqTo,
     leafCount: anchor.leafCount,
     root: anchor.root,
-  });
+  };
+  if (anchor.holes !== undefined) {
+    payload.holes = {
+      burned: [...anchor.holes.burned].sort((a, b) => a - b),
+      foreign: anchor.holes.foreign,
+    };
+  }
+  const canonical = canonicalizeJcs(payload);
   return new TextEncoder().encode(canonical);
 }
 

--- a/packages/security/src/server.ts
+++ b/packages/security/src/server.ts
@@ -33,16 +33,18 @@ export {
   createAuditMiddleware,
   InMemoryAuditStorage,
 } from './audit.js';
-// Offline anchor verify (GAP-355 Stage 4 S4-5)
+// Offline anchor verify (GAP-355 Stage 4 S4-5; GAP-447 live burned-seq recheck)
 export type {
   OfflineAnchorRecord,
   OfflineInclusionProofInput,
   OfflineVerifyInput,
   OfflineVerifyResult,
+  SeqExistsChecker,
 } from './audit-anchor-verify.js';
 export { verifyAuditAnchorOffline } from './audit-anchor-verify.js';
-// Merkle roots over row signatures (GAP-355 Stage 4 S4-2)
+// Merkle roots over row signatures (GAP-355 Stage 4 S4-2; GAP-447 holes)
 export type {
+  AuditAnchorHoles,
   AuditAnchorSignable,
   InclusionProof,
   MerkleBuildResult,

--- a/scripts/security/verify-audit-anchor.ts
+++ b/scripts/security/verify-audit-anchor.ts
@@ -137,7 +137,21 @@ function asAnchor(raw: unknown): OfflineAnchorRecord {
   if (!(tenant && root && rootSignature)) {
     throw new Error('anchor requires tenant, root, rootSignature, seqFrom, seqTo, leafCount');
   }
-  return { tenant, seqFrom, seqTo, leafCount, root, rootSignature };
+  // GAP-447: pass through optional holes (burned seqs + foreign count) — they
+  // are covered by the root signature, so an anchor exported without them
+  // still verifies; one carrying them verifies only if the signature covers
+  // the exact holes present in the JSON.
+  const rawHoles = o.holes;
+  const holes =
+    rawHoles && typeof rawHoles === 'object'
+      ? {
+          burned: Array.isArray((rawHoles as Record<string, unknown>).burned)
+            ? ((rawHoles as Record<string, unknown>).burned as unknown[]).map((n) => Number(n))
+            : [],
+          foreign: Number((rawHoles as Record<string, unknown>).foreign ?? 0),
+        }
+      : undefined;
+  return { tenant, seqFrom, seqTo, leafCount, root, rootSignature, ...(holes ? { holes } : {}) };
 }
 
 function asProof(raw: unknown): OfflineInclusionProofInput {
@@ -160,7 +174,7 @@ function asProof(raw: unknown): OfflineInclusionProofInput {
   };
 }
 
-function main(): number {
+async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
     printHelp();
@@ -191,7 +205,7 @@ function main(): number {
     return 1;
   }
 
-  const result = verifyAuditAnchorOffline({
+  const result = await verifyAuditAnchorOffline({
     publicKeyPem,
     anchor,
     inclusion,
@@ -207,4 +221,4 @@ function main(): number {
   return result.ok ? 0 : 1;
 }
 
-process.exit(main());
+main().then((code) => process.exit(code));


### PR DESCRIPTION
## Summary

Countersigned design (owner, 2026-07-27). The audit anchor sweep's strict
+1 contiguity stalled in prod at a burned bigserial (seq 2618 absent,
owner-verified). `audit_log` is append-only (migrations 0002 + 0026:
`BEFORE UPDATE OR DELETE` raises), and `previous_signature` was abandoned
(never written — [audit-store.ts:179](packages/db/src/audit-store.ts),
spec D7.5). So absence of a row PROVES a burned seq (`nextval()` consumed,
INSERT never landed), never a deletion, and a present row scoped to a
different tenant proves non-deletion too. Both are now traversable. Only a
present, **same-scope, UNSIGNED** row still fails closed — post-GAP-417
rails this should be impossible, so it remains the one real anomaly signal.

### What changed

- **[audit-anchor-batch.ts](apps/server/src/jobs/audit-anchor-batch.ts)** —
  new pure `planTraversableBatch` (existence-classified hole traversal over
  a single classification query), `isConsecutiveFromStart` (skips that
  query in the common gapless case), `assertTraversalIntegrity` (span ==
  leaves + holes self-check, replaces `assertContiguousSeq` for this path).
  `planContiguousBatch` stays exported unchanged for compatibility.
- **[audit-anchor-sweep.ts](apps/server/src/jobs/audit-anchor-sweep.ts)** —
  switches to the new planner; fetches `SELECT seq, tenant, (signature IS
  NULL)` over `(lastAnchored, maxCandidateSeq]` only when candidates aren't
  already contiguous; records traversed holes on the anchor; logs + a new
  `revealui_audit_anchor_holes_traversed_total` counter. `SYSTEM_ANCHOR_SCOPE`
  moved to `@revealui/db/schema` (re-exported here for compatibility).
- **[schema/audit-anchors.ts](packages/db/src/schema/audit-anchors.ts)** —
  nullable `holes` jsonb column (`{ burned: number[], foreign: number }`).
  NULL means no holes traversed — every anchor written before this column
  existed reads back NULL and verifies unchanged.
- **[0031_gap447_audit_anchors_holes.sql](packages/db/migrations/0031_gap447_audit_anchors_holes.sql)** —
  hand-written `ADD COLUMN IF NOT EXISTS`, following the 0011/0015/0030
  precedent (`_custom.json` entry added, migration-journal validator green).
- **[audit-store.ts](packages/db/src/audit-store.ts)** — `DrizzleAuditStore`
  rejects any write whose `entry.tenant` is the `SYSTEM_ANCHOR_SCOPE`
  sentinel, both signed and unsigned append paths — the one door GAP-427's
  system-scope bookkeeping depends on never colliding with a real tenant.
- **[audit-merkle.ts](packages/security/src/audit-merkle.ts)** —
  `AuditAnchorSignable` gains an OPTIONAL `holes` field, covered by the root
  signature only when present. `undefined` serializes to **identical bytes**
  as before (proven by test: `auditAnchorSignableBytes({...no holes})` ===
  `auditAnchorSignableBytes({...holes: undefined})`), so every pre-existing
  anchor still verifies unchanged. `leafCount` validation now accounts for
  holes (`span - holesCount`).
- **[audit-anchor-verify.ts](packages/security/src/audit-anchor-verify.ts)** —
  `verifyAuditAnchorOffline` is now async and accepts an optional injected
  `checkBurnedSeqAbsent` callback to re-verify at verify time that recorded-
  burned seqs are **still** absent. Since `audit_log.seq` is written
  explicitly (not purely DB-generated per row — see `nextSeqValues`), a
  forged row could later fill a recorded-burned seq; that fails verification
  with a distinct "possible tamper" reason. Omitted (the true no-network/
  no-database CLI mode) skips the recheck — the pure root+inclusion-proof
  verify still runs.
- **[lib/audit-anchor-proof.ts](apps/server/src/lib/audit-anchor-proof.ts)
  + [routes/audit.ts](apps/server/src/routes/audit.ts)** — found while
  auditing every consumer of the anchor row shape (not itself in the
  original design bullets, but a real bug the change would otherwise ship
  broken): `buildAnchorInclusionProof` assumed a contiguous range
  (`leafIndex = seq - seqFrom`); a holes-carrying anchor would have
  spuriously thrown `MISSING_LEAF` or returned the wrong leaf for every
  proof request. Fixed to validate strictly-increasing, `leafCount`-length
  rows (holes are legitimate gaps, not a contiguity violation) and compute
  `leafIndex` by the row's position among the actual leaves. `serializeAnchor`
  now includes `holes` in the API response so a downloading client can
  reproduce the exact signed payload.

### Trust-statement change

Anchors now cover **every committed signed row of the scope in the
attested range**, not just a contiguous prefix. Deletion-resistance is the
append-only trigger (migrations 0002 + 0026); a burned seq is provably
non-deletion, and the traversed holes are themselves covered by the root
signature — tampering with the recorded holes invalidates the signature.

### Prove-red

```
git restore --source=origin/test -- apps/server/src/jobs/audit-anchor-sweep.ts apps/server/src/jobs/audit-anchor-batch.ts
```
→ **19 tests failed** in `audit-anchor-sweep.test.ts` (new `planTraversableBatch`
/ `isConsecutiveFromStart` / `assertTraversalIntegrity` unit tests +
GAP-447 PGlite integration tests), confirming the new tests actually
exercise new behavior, not something the base code already did.

```
git restore --source=HEAD --staged --worktree -- <same files>
```
→ full affected set green:

| Suite | Tests |
|---|---|
| `audit-anchor-sweep.test.ts` | 36 |
| `audit-anchor-proof.test.ts` | 7 |
| `audit-anchors.test.ts` | 10 |
| `audit-store.test.ts` | 11 |
| `audit-store.integration.test.ts` | 8 |
| `packages/security` (full suite) | 767 |

### Test plan

- [x] Burned seq: sign a row, `SELECT nextval(pg_get_serial_sequence('audit_log','seq'))` with no INSERT (the exact production mechanism), sign another row → sweep anchors across it, `holes.burned=[thatSeq]`, root verifies.
- [x] Cross-scope interleave: system rows with a tenant row in the middle → system scope anchors across it (`holes.foreign=1`), tenant scope still anchors its own row.
- [x] Fail closed: a same-scope UNSIGNED row inside the hole stalls the batch at that point (nothing anchored past it), warn logged naming the seq, `mGaps` incremented.
- [x] Sentinel rejection at `audit-store` (signed + unsigned writes, single + batch).
- [x] Back-compat: an anchor created WITHOUT holes (pre-change shape, and even a byte-identical `holes: undefined` vs. omitted-key comparison) still verifies; a row appearing later at a recorded-burned seq fails verification with a distinct error via the injected live-recheck callback.
- [x] Migration journal validator green (32 SQL files, 32 journal entries).
- [x] Biome clean on all changed files; `tsc --noEmit` clean on `apps/server`, `packages/db`, `packages/security`.
- [x] Pre-push gate green, including the "audit_log ONE DOOR" hard-fail check.

### Spec deviations

None from the countersigned design. One addition beyond the explicit
bullets: `audit-anchor-proof.ts` + `routes/audit.ts` needed fixing (found
via a dedicated consumer audit) so the anchors download/proof API doesn't
silently break for any anchor that actually traversed a hole — without it,
GAP-447 would ship a sweep that anchors correctly but a proof API that
can't serve inclusion proofs for those same anchors.

---

## Settlement amendment (guardrail-2 REQUEST-CHANGES, addressed in `80987d631`)

Non-author review ([comment 5095491027](https://github.com/RevealUIStudio/revealui/pull/2232#issuecomment-5095491027)) found a real defect in the original premise: **absence of a row at a seq proves non-DELETION (the append-only trigger). It does not prove non-PENDENCY.**

`DrizzleAuditStore.append`/`appendBatch` allocate `seq` via `nextval()` in a separate round trip *before* the INSERT ([audit-store.ts:159](packages/db/src/audit-store.ts), [audit-store.ts:249-266](packages/db/src/audit-store.ts)). Two concurrent writers can therefore commit out of seq order — writer A takes seq N, writer B takes seq N+1 and commits first. An unfixed sweep sees N as absent and signs it away as permanently burned the moment it queries, even though writer A's row is only in flight, not gone. Once that happens the row is orphaned forever: no future anchor ever revisits a covered range, and `buildAnchorInclusionProof`'s `row count != leafCount` check makes every proof in that anchor 409 — including for untouched leaves. The exposure is worst on the caught-up, low-volume max-lag path, which is exactly the `__system__` scope's steady state.

**Fix — settlement, not mere absence, before classifying a hole as burned** (the reviewer's option (a), the cheapest durable form, no new process state):

- New pure `settledMaxSeq` ([audit-anchor-batch.ts](apps/server/src/jobs/audit-anchor-batch.ts)): given seq-ordered rows with timestamps, returns the highest seq old enough (`>= AUDIT_ANCHOR_SETTLE_MS`, default 120s) to trust, stopping at the first row that isn't.
- `audit_log.seq` is one global sequence, so `nextval()` calls happen in strictly increasing return-value order: if seq(A) < seq(B), A's `nextval()` necessarily happened before B's. So once the highest-seq candidate in a prefix has been committed for at least the settle window, every lower seq in that prefix started its own `nextval()`→INSERT race at least that long ago too — if it still hasn't landed, it never will (burned) or it already has (and would be present, not absent).
- The sweep ([audit-anchor-sweep.ts](apps/server/src/jobs/audit-anchor-sweep.ts)) caps the working candidate set to this settled prefix *before* attempting any hole traversal. Candidates newer than the window — and any hole at or beyond them — defer to the next tick. This degrades exactly to the pre-GAP-447 self-healing stall for the narrow window where an in-flight write could still land, and has zero effect on the already-contiguous fast path (no absence is ever interpreted there, so there's nothing to misclassify).
- New env var `AUDIT_ANCHOR_SETTLE_MS` (default 120000ms), documented in the sweep header and a new `docs/ENVIRONMENT-VARIABLES-GUIDE.md` § "Audit Anchor Sweep" (which also closes a pre-existing gap: the other four `AUDIT_ANCHOR_*` vars were never documented there either).

**Regression test** reproduces the reviewer's exact hostile fixture in `audit-anchor-sweep.test.ts`: seq 1 commits, seq 2 is reserved via `nextval()` with its INSERT still in flight, seq 3 commits, a sweep pass runs in that window, and *then* seq 2 finally lands. Proved RED against the pre-fix code first (6 failures — 5 pure `settledMaxSeq` unit tests plus the PGlite fixture, which reproduced the defect log line verbatim: `anchored tenant=acct_max seq=1..3 leaves=2 holes(burned=[2] foreign=0)`), then GREEN with the fix (42/42 in the sweep test file — the sweep truncates the first pass at the settled prefix (`seq 1..1`, no holes recorded), and a later pass, once the window has passed, picks up seq 2 and seq 3 as real leaves with zero burn misattribution).

Corrected premise for the design record: the append-only trigger proves non-deletion; it does not prove non-pendency. The settlement window is what closes that gap. (Owner: amending the `.jv` spec's finding 2 wording separately to match.)

---

**Security-classed (audit anchoring surface): needs a non-author guardrail-2 verdict before merge — review-pending.**

