### PR TITLE
fix(core): make DecoratorBlockNode block-level, cover alt-field regression

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@revealui/dev": "workspace:*",
+    "@testing-library/react": "catalog:",
     "@types/json-schema": "^7.0.15",
     "@types/pg": "^8.20.0",
     "@types/react": "catalog:",

--- a/packages/core/src/client/richtext/components/__tests__/ImageUploadButton.test.tsx
+++ b/packages/core/src/client/richtext/components/__tests__/ImageUploadButton.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+/**
+ * ImageUploadButton mutation-sensitive regression test
+ *
+ * upload.test.ts's "required alt field" suite (see formDataFor() in that
+ * file) rebuilds its own FormData rather than exercising
+ * ImageUploadButton.tsx's actual handleFileSelect handler, so deleting the
+ * `formData.append('alt', altText)` line there leaves the whole suite green
+ * (reviewer finding on PR #2230). This test mounts the real component,
+ * drives a real file-input change event, and inspects the FormData the
+ * component itself builds and hands to postMediaUpload - so removing that
+ * line fails it.
+ */
+
+import { LexicalComposer } from '@lexical/react/LexicalComposer';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImageUploadButton } from '../ImageUploadButton.js';
+import { deriveAltTextFromFilename, postMediaUpload } from '../upload.js';
+
+vi.mock('../upload.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../upload.js')>();
+  return {
+    ...actual,
+    postMediaUpload: vi.fn(),
+  };
+});
+
+/** jsdom has no image decoder - fire `onload` as soon as `src` is set. */
+class StubImage {
+  width = 400;
+  height = 300;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  #src = '';
+
+  get src(): string {
+    return this.#src;
+  }
+
+  set src(value: string) {
+    this.#src = value;
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+function renderUploadButton(): void {
+  render(
+    <LexicalComposer
+      initialConfig={{
+        namespace: 'test',
+        onError: (error) => {
+          throw error;
+        },
+      }}
+    >
+      <ImageUploadButton />
+    </LexicalComposer>,
+  );
+}
+
+describe('ImageUploadButton - alt field mutation guard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('Image', StubImage);
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn().mockReturnValue('blob:test'),
+      revokeObjectURL: vi.fn(),
+    });
+    (postMediaUpload as Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://example.com/uploads/company-logo.png' }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sends the derived alt text in the FormData posted to postMediaUpload', async () => {
+    renderUploadButton();
+
+    const input = screen.getByLabelText('Upload image') as HTMLInputElement;
+    const file = new File(['binary-image-data'], 'company-logo.png', { type: 'image/png' });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(postMediaUpload).toHaveBeenCalledTimes(1));
+
+    const formData = (postMediaUpload as Mock).mock.calls[0]?.[1] as FormData;
+    expect(formData.get('alt')).toBe(deriveAltTextFromFilename('company-logo.png'));
+  });
+});

--- a/packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts
+++ b/packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts
@@ -53,6 +53,14 @@ export abstract class DecoratorBlockNode<
     return false;
   }
 
+  isInline(): false {
+    return false;
+  }
+
+  canIndent(): false {
+    return false;
+  }
+
   exportJSON(): SerializedDecoratorBlockNode<T> {
     return {
       ...super.exportJSON(),

--- a/packages/core/src/client/richtext/nodes/__tests__/DecoratorBlockNode.test.ts
+++ b/packages/core/src/client/richtext/nodes/__tests__/DecoratorBlockNode.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+/**
+ * DecoratorBlockNode isInline/canIndent tests
+ *
+ * DecoratorBlockNode extends Lexical's DecoratorNode without overriding
+ * isInline(), so it inherits the DecoratorNode default of `true`.
+ * $insertNodeToNearestRoot branches on isInline(): an inline node gets
+ * wrapped in a paragraph before insertion. That means every
+ * editor-inserted image persists as root > paragraph > image and renders
+ * as <p><figure><img/></figure></p>, which is invalid HTML (a <figure> is
+ * not permitted inside a <p>) and causes a hydration mismatch. Matching
+ * @lexical/react's LexicalDecoratorBlockNode (isInline(): false), the
+ * image node must land directly under the root.
+ */
+
+import { $insertNodeToNearestRoot } from '@lexical/utils';
+import type { LexicalEditor } from 'lexical';
+import { $getRoot, createEditor } from 'lexical';
+import { describe, expect, it } from 'vitest';
+import { $createImageNode, ImageNode } from '../ImageNode.js';
+
+function createTestEditor(): LexicalEditor {
+  return createEditor({
+    nodes: [ImageNode],
+    onError: (error) => {
+      throw error;
+    },
+  });
+}
+
+describe('DecoratorBlockNode isInline/canIndent', () => {
+  it('inserts an ImageNode as a direct child of the root, not wrapped in a paragraph', () => {
+    const editor = createTestEditor();
+
+    editor.update(
+      () => {
+        $getRoot().selectEnd();
+        const imageNode = $createImageNode({ src: 'x' });
+        $insertNodeToNearestRoot(imageNode);
+      },
+      { discrete: true },
+    );
+
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      const imageNode = root
+        .getChildren()
+        .find((child): child is ImageNode => child instanceof ImageNode);
+
+      expect(imageNode).toBeDefined();
+      expect(imageNode?.getParent()).toBe(root);
+    });
+  });
+
+  it('reports isInline() as false and canIndent() as false', () => {
+    const editor = createTestEditor();
+    let imageNode: ImageNode | undefined;
+
+    editor.update(
+      () => {
+        imageNode = $createImageNode({ src: 'x' });
+      },
+      { discrete: true },
+    );
+
+    expect((imageNode as ImageNode).isInline()).toBe(false);
+    expect((imageNode as ImageNode).canIndent()).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1145,6 +1145,9 @@ importers:
       '@revealui/dev':
         specifier: workspace:*
         version: link:../dev
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15


### PR DESCRIPTION
## Summary

Follow-up to #2230, which merged with a **REQUEST-CHANGES verdict standing** (full evidence: https://github.com/RevealUIStudio/revealui/pull/2230#issuecomment-5095332430). This PR completes the two blockers that shipped to `test` unresolved.

### Defect 1 — `DecoratorBlockNode` reports `isInline() === true`

[`DecoratorBlockNode.ts`](packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts) extends Lexical's `DecoratorNode` without overriding `isInline()`, so it inherits the default `true`. `$insertNodeToNearestRoot` branches on `isInline()` and wraps inline nodes in a paragraph before insertion, so every editor-inserted image persisted as `root > paragraph > image` and rendered as `<p><figure><img/></figure></p>`, invalid HTML (a `<figure>` cannot sit inside a `<p>`) that also caused a hydration mismatch.

Fix: added `isInline(): false` and `canIndent(): false`, matching `@lexical/react@0.46.0`'s `LexicalDecoratorBlockNode` (confirmed against `node_modules/@lexical/react/src/LexicalDecoratorBlockNode.ts` — those are the two methods our class was missing relative to the reference implementation).

### Defect 2 — the alt-upload fix had no mutation-sensitive test

The #2230 alt-upload fix (`formData.append('alt', altText)` in [`ImageUploadButton.tsx`](packages/core/src/client/richtext/components/ImageUploadButton.tsx)) shipped with no test that would catch its own regression. `upload.test.ts`'s `formDataFor()` helper (lines 134-141) rebuilds its own `FormData` rather than exercising the component, so the reviewer proved deleting the `append` line leaves the whole suite green.

Fix: added [`ImageUploadButton.test.tsx`](packages/core/src/client/richtext/components/__tests__/ImageUploadButton.test.tsx), which mounts the real component under `@testing-library/react` (added as a devDependency of `@revealui/core`, already in the workspace catalog), drives a real `fireEvent.change` on the hidden file input, and asserts on the `FormData` the component itself builds before it reaches the (mocked) `postMediaUpload`. `Image` and `URL.createObjectURL` are stubbed for jsdom's missing image-decode step.

## Evidence

### Defect 1 — red before fix, green after

Red (before adding `isInline()`/`canIndent()`):
```
FAIL  DecoratorBlockNode isInline/canIndent > inserts an ImageNode as a direct child of the root, not wrapped in a paragraph
AssertionError: expected undefined to be defined
FAIL  DecoratorBlockNode isInline/canIndent > reports isInline() as false and canIndent() as false
AssertionError: expected true to be false
```

Green (after the fix):
```
Test Files  2 passed (2)
     Tests  4 passed (4)
```
(includes the existing `ImageNode.test.ts` createDOM/updateDOM suite, unaffected.)

### Defect 2 — mutation check

With `formData.append('alt', altText)` temporarily deleted:
```
FAIL  ImageUploadButton - alt field mutation guard > sends the derived alt text in the FormData posted to postMediaUpload
AssertionError: expected null to be 'company-logo'
```

Restored, green:
```
Test Files  1 passed (1)
     Tests  1 passed (1)
```

### Full package suite / typecheck / lint

- `pnpm turbo run test --filter=@revealui/core` — 117 test files, 2781 tests, all green
- `pnpm --filter @revealui/core typecheck` — clean
- `biome check` on all changed/new files — clean

## Security review

**SECURITY-CLASSED (richtext sensitive path) — review-pending, do NOT merge until a non-author guardrail-2 verdict is recorded.**

Fleet security-path checker (internal tooling) output:
```
🔒 Current branch is SECURITY-SENSITIVE (vs origin/test). Touched: packages/core/src/client/richtext/components/__tests__/ImageUploadButton.test.tsx, packages/core/src/client/richtext/nodes/DecoratorBlockNode.ts, packages/core/src/client/richtext/nodes/__tests__/DecoratorBlockNode.test.ts
   When you open the PR, it needs a recorded coordinator verdict before merge.
```

## Known follow-up (not migrated here)

Any image nodes saved to content between #2230's merge and this fix may already be persisted paragraph-wrapped (`root > paragraph > image`). This PR fixes new insertions only; migrating already-saved documents is a separate, deliberate follow-up decision, not bundled into this fix.

## Deviations from the task spec

- Pushing the branch required building `@revealui/harnesses` (`pnpm turbo run build --filter=@revealui/harnesses`) in addition to `@revealui/core`, because the repo's pre-push gate's "Project manager check" hard-fails when `packages/harnesses/dist/manager` is missing in a fresh worktree. Unrelated to the richtext fix; done to get a clean gate run.

