### PR TITLE
fix(build): turbo test task depends on own build (clean-checkout test runs)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -109,7 +109,7 @@
     },
     "test": {
       "cache": false,
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "inputs": [
         "src/**/*.ts",
         "src/**/*.tsx",


### PR DESCRIPTION
One-line `turbo.json` fix: the `test` task's `dependsOn` moves from `["^build"]` to `["build"]` (own build transitively implies `^build`).

**Why:** per-package test runs (`pnpm turbo run test --filter=@revealui/core`) fail on clean checkouts because tests import the package's own `dist/`-resolving entry paths. Hit independently by two build agents today and confirmed in the #2233 review; CI only passes because `ci.yml` happens to run a full packages build first.

**Verification:** fresh worktree (no dist) — `pnpm turbo run test --filter=@revealui/tokens` now runs `build → test`, 3/3 tasks successful, zero manual steps; dry-run graph shows the own-build edge with no cycles. CI wall-time unaffected (build already runs first there; the edge is cache-hit).

Non-security surface (build config only). Merge-ready on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)