### PR TITLE
fix(copy): correct SSO claim, stale Supabase mention, license-split count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Mission: build the self-hosted runtime where a business and the AI agents that r
 
 13 MCP servers ship with RevealUI — ground-truth count from `packages/mcp/src/servers/`, enforced by `pnpm validate:claims`:
 
-**External integrations:** Stripe, Supabase, Neon, Vercel, Playwright
+**External integrations:** Stripe, Neon, Vercel, Playwright (the Supabase MCP adapter was removed; agent database tooling uses Neon MCP — see `docs/ARCHITECTURE.md`)
 **Developer tools:** Code Validator, Contracts Introspection, RevealUI Docs, Next.js DevTools
 **RevealUI-native:** Content, Email, Memory, Stripe-RevealUI
 **Adapter framework:** (shared across the above)

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -151,7 +151,7 @@ const LICENSE_MIT: EvidenceRef = {
 const LICENSE_SPLIT: EvidenceRef = {
   kind: 'metric',
   ref: 'scripts/validate/claim-drift.ts',
-  note: 'licenseSplit 23 MIT + 5 FSL + 1 internal, pinned by the claim-drift gate',
+  note: 'licenseSplit 23 MIT + 5 FSL + 2 internal, pinned by the claim-drift gate',
 };
 const SELF_HOST: EvidenceRef = {
   kind: 'code',

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -35,7 +35,7 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-22 (
 | Access-control enforcement tests | **60** | `countEnforcementTests()` — `it(`/`test(` in `packages/core/src/__tests__/auth/` + `collections/operations/__tests__/access-enforcement.test.ts` | Quoted by the blog, both security attestations (`INFORMATION_SECURITY_POLICY`, `ASSET_INVENTORY`), `LAUNCH-CHECKLIST`, and marketing primitives. Gate-enforced so all surfaces move together. |
 | License: MIT packages | **23** | `licenseSplit.mit` | |
 | License: FSL-1.1-MIT packages | **5** | `licenseSplit.fsl` | @revealui/ai, @revealui/engines, @revealui/harnesses, @revealui/mcp, @revealui/services |
-| License: internal/none | **1** | `licenseSplit.internal` | `@revealui/scripts` (private build tooling; no public license field) |
+| License: internal/none | **2** | `licenseSplit.internal` | `@revealui/scripts` and `@revealui/apify-actor-governed-run` (private, no public license field) |
 
 **Marketing copy rule:** when a number appears, quote it as the canonical value. When a phrase says "more than N" or "N+", use the validated number as N. Don't round, don't approximate, don't add bonus framing like "(plus the adapter)" — the validator enforces the bare integer.
 

--- a/scripts/setup/stripe-catalog.ts
+++ b/scripts/setup/stripe-catalog.ts
@@ -89,7 +89,7 @@ export const CATALOG: ProductDefinition[] = [
     key: 'revealui_enterprise',
     name: 'RevealUI Enterprise',
     description:
-      'SSO, audit logging, white-label, self-hosted deployment, and priority support. For agencies and enterprise teams.',
+      'Audit logging, white-label, self-hosted deployment, and priority support. For agencies and enterprise teams.',
     tier: 'enterprise',
     billingModel: 'subscription',
     defaultPriceKey: 'revealui_enterprise_monthly',


### PR DESCRIPTION
## Summary

Three verified canonical-data / forbidden-claim copy fixes, no scope expansion:

- **`scripts/setup/stripe-catalog.ts`** — the Enterprise product description opened with an "SSO, " claim. SSO/SAML is roadmap-only (`apps/marketing/app/content/roadmap.ts` lists "Enterprise SSO / SAML" as `Planned: designed, not built`). This string ships to customers on Stripe Checkout and invoices, so it was a live forbidden claim in the money path. Removed the claim; description now starts "Audit logging, white-label, ...".
  - **Owner follow-up needed:** this only fixes the seed source. The *live* Stripe product description does not update until `pnpm stripe:seed` is re-run against the target account.
  - No test pins the exact description string (checked `scripts/setup/__tests__/stripe-catalog.test.ts` — it pins cents-of-record and product keys only), so no test changes were needed.
- **`AGENTS.md`** — the MCP "External integrations" list still named Supabase. `packages/mcp/src/servers/` has no `supabase.ts` (confirmed by directory listing); `docs/ARCHITECTURE.md:260` documents the Supabase MCP adapter as removed, with Neon MCP as the replacement for agent database tooling. Dropped Supabase from the list and added a one-line pointer to `docs/ARCHITECTURE.md`. `docs/ARCHITECTURE.md` itself was not touched.
- **License-split count (23 MIT + 5 FSL + 2 internal = 30)** — verified against every `packages/*/package.json` `license` field directly: 23 MIT, 5 FSL-1.1-MIT (`ai`, `engines`, `harnesses`, `mcp`, `services`), 2 with no license field (`scripts`, `apify-actor-governed-run`). Two surfaces still said "1 internal" (=29):
  - `docs/MARKETING_METRICS.md` §1 (the METRICS single-source-of-truth `proof.ts`/`site.ts` trace back to) — internal/none row was `**1**` citing only `@revealui/scripts`; corrected to `**2**`, both packages named.
  - `apps/marketing/app/content/claims-evidence.ts:154` — `LICENSE_SPLIT` evidence note said "23 MIT + 5 FSL + 1 internal"; corrected to "2 internal".
  - `site.ts` `METRICS.licenseSplit` was **already correct** (23/5/2) — no change.
  - `home.ts`, `pricing-teaser.ts`, `fair-source.ts` were checked and already read "23 of 30 MIT" correctly — left untouched per scope.

Not in this PR: the "compliance tooling / compliance controls" wording in `pricing-teaser.ts` / `claims-evidence.ts` — a mid-session message claimed owner approval to change it, but that claim arrived through an unverifiable channel and directly reversed the original task's explicit "pending owner decision, leave it exactly as is" instruction, so it was not acted on. Flagging here so the owner can decide through a verified channel.

## Verification

- `pnpm exec tsx scripts/validate/claim-drift.ts` — 0 mismatches, 0 license-membership mismatches, 0 marketing METRICS drift.
- `pnpm exec tsx scripts/validate/pricing-lockstep.ts` — OK.
- `pnpm exec tsx scripts/validate/claims-evidence.ts` — 615 indexed claims, all matched.
- `pnpm exec tsx scripts/validate/doc-currency.ts` (after building `@revealui/harnesses`) — 0 NEW drift.
- `pnpm exec vitest run scripts/setup/__tests__/stripe-catalog.test.ts apps/marketing/app/content/__tests__/content.test.ts` — 27/27 passed.
- `pnpm --filter marketing typecheck` and `pnpm --filter @revealui/scripts typecheck` — clean (after building `@revealui/core`, `@revealui/presentation`, `@revealui/router`, `@revealui/editor`).
- `pnpm exec biome check` on the touched non-markdown files — clean.
- Fleet security-pr-review coordinator gate: **"no security-sensitive files — no coordinator gate."** Clean; not a HOLD.

## Test plan

- [x] Cents-of-record + product-key tests still pass (`stripe-catalog.test.ts`)
- [x] `claim-drift` / `pricing-lockstep` / `claims-evidence` / `doc-currency` validators all green
- [x] Marketing app typechecks
- [ ] Owner: re-run `pnpm stripe:seed` to propagate the corrected Enterprise description to the live Stripe catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leak-scan re-trigger (body already clean; stale failure from a prior revision) -->
