### PR TITLE
fix(admin): route free-tier CTA to license page on self-host

### DIFF
--- a/apps/admin/src/app/(backend)/layout.tsx
+++ b/apps/admin/src/app/(backend)/layout.tsx
@@ -1,4 +1,5 @@
 import { RootLayout } from '@revealui/core/admin';
+import { isHostedDeployment } from '@revealui/core/deployment-mode';
 import { cookies, headers } from 'next/headers';
 import Script from 'next/script';
 /* RevealUI Admin Layout - Local implementation */
@@ -28,6 +29,9 @@ export const dynamic = 'force-dynamic';
 // `||` not `??`: Compose `${VAR:-}` delivers unset vars as empty strings.
 const siteName = process.env.REVEALUI_BRAND_NAME || process.env.REVEALUI_TENANT_NAME || 'RevealUI';
 const isFleetMode = process.env.REVEALUI_FLEET_MODE === 'true';
+// GAP-260 P4-1: which product posture is this process. FreeTierBanner uses
+// this to stop pointing self-host at a Stripe checkout it has no keys for.
+const isHosted = isHostedDeployment(process.env);
 const ADMIN_ROLES = new Set(['owner', 'admin', 'super-admin']);
 
 export default async function Layout({ children }: Args) {
@@ -47,7 +51,12 @@ export default async function Layout({ children }: Args) {
       ) : null}
       <LicenseProvider isFleetMode={isFleetMode}>
         <ErrorBoundary>
-          <AdminSidebarLayout siteName={siteName} isFleetMode={isFleetMode} isAdmin={isAdmin}>
+          <AdminSidebarLayout
+            siteName={siteName}
+            isFleetMode={isFleetMode}
+            isHosted={isHosted}
+            isAdmin={isAdmin}
+          >
             {children}
           </AdminSidebarLayout>
         </ErrorBoundary>

--- a/apps/admin/src/components/FreeTierBanner.tsx
+++ b/apps/admin/src/components/FreeTierBanner.tsx
@@ -7,7 +7,18 @@ import { useLicense } from '@/lib/providers/LicenseProvider';
 
 const DISMISS_KEY = 'rvui-free-tier-dismissed';
 
-export function FreeTierBanner() {
+interface FreeTierBannerProps {
+  /**
+   * True on the hosted SaaS deployment, false on self-host (the unlicensed
+   * Forge/template shape). Resolved server-side via `isHostedDeployment()`
+   * and prop-drilled down, the same pattern used for `isFleetMode` — a
+   * `NEXT_PUBLIC_*` env would get inlined at framework build time and miss
+   * the value stamped into a self-host deploy at runtime.
+   */
+  isHosted: boolean;
+}
+
+export function FreeTierBanner({ isHosted }: FreeTierBannerProps) {
   const { tier, isLoading } = useLicense();
   // Start dismissed=true to avoid a hydration flash on the server render.
   // useEffect corrects it client-side after sessionStorage is available.
@@ -27,14 +38,25 @@ export function FreeTierBanner() {
   return (
     <div className="mb-4 flex items-center justify-between gap-x-6 rounded-lg bg-primary px-5 py-2.5 text-sm text-primary-foreground">
       <p>
-        You&apos;re on the <span className="font-semibold">Free plan</span> &mdash; 3 users and
-        1,000 agent tasks/month.{' '}
-        <Link
-          href="/account/billing?upgrade=pro"
-          className="font-semibold underline underline-offset-2 hover:opacity-80"
-        >
-          Start your 7-day Pro trial &rarr;
-        </Link>
+        You&apos;re on the <span className="font-semibold">Free plan</span>. 3 users and 1,000 agent
+        tasks/month.{' '}
+        {isHosted ? (
+          <Link
+            href="/account/billing?upgrade=pro"
+            className="font-semibold underline underline-offset-2 hover:opacity-80"
+          >
+            Start your 7-day Pro trial &rarr;
+          </Link>
+        ) : (
+          <a
+            href="https://revealui.com/pricing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold underline underline-offset-2 hover:opacity-80"
+          >
+            Unlock Pro with a license &rarr;
+          </a>
+        )}
       </p>
       <Button
         type="button"

--- a/apps/admin/src/components/__tests__/FreeTierBanner.test.tsx
+++ b/apps/admin/src/components/__tests__/FreeTierBanner.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseLicense = vi.fn();
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+vi.mock('@revealui/presentation/server', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    appearance?: string;
+    variant?: string;
+    size?: string;
+  }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  IconClose: () => <span data-testid="icon-close" />,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { FreeTierBanner } from '../FreeTierBanner';
+
+afterEach(() => {
+  cleanup();
+  sessionStorage.clear();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseLicense.mockReturnValue({ tier: 'free', isLoading: false });
+});
+
+describe('FreeTierBanner', () => {
+  it('renders nothing while loading', () => {
+    mockUseLicense.mockReturnValue({ tier: 'free', isLoading: true });
+    render(<FreeTierBanner isHosted={false} />);
+    expect(screen.queryByText(/Free plan/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing above the free tier', () => {
+    mockUseLicense.mockReturnValue({ tier: 'pro', isLoading: false });
+    render(<FreeTierBanner isHosted={false} />);
+    expect(screen.queryByText(/Free plan/)).not.toBeInTheDocument();
+  });
+
+  it('hosted deploy: links the Stripe trial CTA at /account/billing', () => {
+    render(<FreeTierBanner isHosted={true} />);
+    const link = screen.getByText(/Start your 7-day Pro trial/);
+    expect(link).toHaveAttribute('href', '/account/billing?upgrade=pro');
+    expect(screen.queryByText(/Unlock Pro with a license/)).not.toBeInTheDocument();
+  });
+
+  it('self-host deploy: links the license CTA at the vendor pricing page, opened safely', () => {
+    render(<FreeTierBanner isHosted={false} />);
+    const link = screen.getByText(/Unlock Pro with a license/);
+    expect(link).toHaveAttribute('href', 'https://revealui.com/pricing');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.queryByText(/Start your 7-day Pro trial/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/7-day trial/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -203,11 +203,13 @@ export function AdminSidebarLayout({
   children,
   siteName = 'RevealUI',
   isFleetMode = false,
+  isHosted = false,
   isAdmin = true,
 }: {
   children: React.ReactNode;
   siteName?: string;
   isFleetMode?: boolean;
+  isHosted?: boolean;
   isAdmin?: boolean;
 }) {
   return (
@@ -215,7 +217,7 @@ export function AdminSidebarLayout({
       navbar={<span />}
       sidebar={<AdminSidebarContent siteName={siteName} isAdmin={isAdmin} />}
     >
-      {isFleetMode ? null : <FreeTierBanner />}
+      {isFleetMode ? null : <FreeTierBanner isHosted={isHosted} />}
       {children}
       {isFleetMode ? null : <UpgradeDialog />}
     </SidebarLayout>

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -1087,18 +1087,8 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_LINKS[0].description',
-    text: 'Max adds AI memory, advanced inference, and compliance tooling.',
-    evidence: [
-      MEMORY,
-      { kind: 'code', ref: 'packages/ai/src/inference', note: 'inference layer' },
-      RBAC_ABAC,
-    ],
-  },
-  {
-    file: 'pricing-teaser.ts',
-    exportPath: 'PRICING_TEASER_LINKS[1].description',
-    text: 'Enterprise adds scale and compliance controls.',
-    evidence: [TIER_LIMITS, RBAC_ABAC],
+    text: 'Max adds AI memory and advanced inference.',
+    evidence: [MEMORY, { kind: 'code', ref: 'packages/ai/src/inference', note: 'inference layer' }],
   },
   {
     file: 'pricing-teaser.ts',

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -67,13 +67,13 @@ export const PRICING_TEASER_LINKS: readonly TeaserLink[] = [
   {
     id: 'max',
     name: 'Max',
-    description: 'Max adds AI memory, advanced inference, and compliance tooling.',
+    description: 'Max adds AI memory and advanced inference.',
     href: '/pricing',
   },
   {
     id: 'enterprise',
     name: 'Enterprise',
-    description: 'Enterprise adds scale and compliance controls.',
+    description: 'Enterprise adds scale.',
     href: '/pricing',
   },
 ] as const;


### PR DESCRIPTION
## Problem

`FreeTierBanner` always linked its upgrade CTA to `/account/billing?upgrade=pro`, which triggers a Stripe checkout. On a self-host deployment with no Stripe keys configured, that checkout dead-ends. It is also conceptually wrong: self-host unlocks Pro via a license key, not a Stripe subscription.

## Fix

- Hosted vs self-host branch: `isHostedDeployment()` from `@revealui/core/deployment-mode`, resolved **server-side** in `apps/admin/src/app/(backend)/layout.tsx` and prop-drilled through `AdminSidebarLayout` down to `FreeTierBanner` (`isHosted` prop). This mirrors the existing `isFleetMode` prop-drill pattern already used in that same layout, and the same pattern already used for the hosted flag on the Agents and API Keys server shells (`apps/admin/src/app/(backend)/agents/page.tsx`, `.../settings/api-keys/page.tsx`) — a `NEXT_PUBLIC_*` env would get inlined into the client bundle at framework build time and miss a self-host kit's runtime-stamped value.
- **Hosted** (`isHostedDeployment()` true): unchanged — "Start your 7-day Pro trial" → `/account/billing?upgrade=pro` (Stripe).
- **Self-host** (`isHostedDeployment()` false, including a misconfigured deploy — the prop defaults to `false`): the CTA now links to `https://revealui.com/pricing` (verified this route exists in `apps/marketing/app/App.tsx`) with copy "Unlock Pro with a license →", opened safely (`target="_blank" rel="noopener noreferrer"`, matching the existing external-link convention elsewhere in admin). No "7-day trial" wording, since that's Stripe-specific.
- Dropped an em dash from the banner's lead sentence while touching this copy (repo NO-EM-DASHES convention).

## Also in this PR (owner-approved copy correction, pure removal)

`apps/marketing/app/content/pricing-teaser.ts` claimed "Max adds AI memory, advanced inference, **and compliance tooling**" and "Enterprise adds scale **and compliance controls**." The signed-receipt audit log is a baseline feature across tiers, not a Max/Enterprise add-on, so the compliance clauses were removed (no new capability claim substituted). Updated the mirrored `claims-evidence.ts` entries in lockstep (the claims-evidence gate pins exact copy text per entry); the Enterprise line dropped below the gate's prose-length threshold after the edit, so its now-orphaned evidence entry was removed rather than left stale.

## Tests

- `apps/admin/src/components/__tests__/FreeTierBanner.test.tsx` (new): loading state renders nothing, above-free-tier renders nothing, hosted renders the Stripe trial link at `/account/billing?upgrade=pro`, self-host renders the license link at `https://revealui.com/pricing` with `target="_blank" rel="noopener noreferrer"` and no "7-day trial" wording anywhere.
- Pre-existing `AdminSidebarLayout` / `UpgradeDialog` suites re-run clean (no regression from the new `isHosted` prop).

## Verification run locally

- `tsc --noEmit` on the admin app: clean.
- `vitest run` on the new + adjacent admin suites: 21/21 passed.
- `tsx scripts/validate/claims-evidence.ts`: 614 indexed claims, all matched.
- `tsx scripts/validate/claim-drift.ts`: 0 mismatches.
- `biome check` on all touched files: clean.
- Full pre-push gate (Phase 1 security + CI gate, ~60 checks including project-manager, claim-drift, claims-evidence, pricing-lockstep, marketing-voice): PASS.
- Coordination guardrail-2 check (`security-pr-review-check.js --diff origin/test`): no security-sensitive files touched — no coordinator gate required.

## Not merging

Opening for review only — not self-merging, no labels applied.