### PR TITLE
fix(admin): capture page-wide media drops + restyle media library to design canon

### DIFF
--- a/apps/admin/src/app/(backend)/media/__tests__/use-window-file-drop.test.ts
+++ b/apps/admin/src/app/(backend)/media/__tests__/use-window-file-drop.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression coverage for the page-wide drag capture fix (owner report:
+ * dropping an image outside the media page's DropZone navigated the whole
+ * tab to the raw file and the in-progress edit was lost).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useWindowFileDrop } from '../use-window-file-drop.js';
+
+function makeFileList(count: number): FileList {
+  const files = Array.from(
+    { length: count },
+    (_, i) => new File([`data-${i}`], `file-${i}.png`, { type: 'image/png' }),
+  );
+  const indexed: Record<number, File> = {};
+  for (const [index, file] of files.entries()) {
+    indexed[index] = file;
+  }
+  return {
+    ...indexed,
+    length: files.length,
+    item: (index: number) => files[index] ?? null,
+    [Symbol.iterator]: function* iterate() {
+      yield* files;
+    },
+  } as unknown as FileList;
+}
+
+function dispatchDrag(type: string, opts: { hasFiles?: boolean; fileCount?: number } = {}): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'dataTransfer', {
+    configurable: true,
+    value: {
+      types: opts.hasFiles === false ? [] : ['Files'],
+      files: makeFileList(opts.fileCount ?? 1),
+    },
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe('useWindowFileDrop', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preventDefaults dragover unconditionally, so a stray drop can never navigate the tab', () => {
+    const onFiles = vi.fn();
+    renderHook(() => useWindowFileDrop({ uploading: false, onFiles }));
+
+    const event = dispatchDrag('dragover');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('preventDefaults drop and routes the dropped files to onFiles', () => {
+    const onFiles = vi.fn();
+    renderHook(() => useWindowFileDrop({ uploading: false, onFiles }));
+
+    const event = dispatchDrag('drop', { fileCount: 2 });
+    expect(event.defaultPrevented).toBe(true);
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(onFiles.mock.calls[0]?.[0]).toHaveLength(2);
+  });
+
+  it('still preventDefaults drop while uploading, but ignores the drop (no double-upload)', () => {
+    const onFiles = vi.fn();
+    renderHook(() => useWindowFileDrop({ uploading: true, onFiles }));
+
+    const event = dispatchDrag('drop', { fileCount: 1 });
+    expect(event.defaultPrevented).toBe(true);
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the drag-active overlay flag once a file drag enters the window, and clears it on drop', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() => useWindowFileDrop({ uploading: false, onFiles }));
+
+    expect(result.current.isDraggingFiles).toBe(false);
+
+    act(() => {
+      dispatchDrag('dragenter');
+    });
+    expect(result.current.isDraggingFiles).toBe(true);
+
+    act(() => {
+      dispatchDrag('drop', { fileCount: 1 });
+    });
+    expect(result.current.isDraggingFiles).toBe(false);
+  });
+
+  it('clears the overlay flag on dragleave', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() => useWindowFileDrop({ uploading: false, onFiles }));
+
+    act(() => {
+      dispatchDrag('dragenter');
+    });
+    expect(result.current.isDraggingFiles).toBe(true);
+
+    act(() => {
+      dispatchDrag('dragleave');
+    });
+    expect(result.current.isDraggingFiles).toBe(false);
+  });
+
+  it('never raises the overlay while an upload is already in flight', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() => useWindowFileDrop({ uploading: true, onFiles }));
+
+    act(() => {
+      dispatchDrag('dragenter');
+    });
+    expect(result.current.isDraggingFiles).toBe(false);
+  });
+
+  it('ignores drag events whose dataTransfer carries no files', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() => useWindowFileDrop({ uploading: false, onFiles }));
+
+    act(() => {
+      dispatchDrag('dragenter', { hasFiles: false });
+    });
+    expect(result.current.isDraggingFiles).toBe(false);
+  });
+
+  it('removes all window listeners on unmount', () => {
+    const onFiles = vi.fn();
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useWindowFileDrop({ uploading: false, onFiles }));
+    const addedTypes = addSpy.mock.calls.map((call) => call[0]);
+
+    unmount();
+    const removedTypes = removeSpy.mock.calls.map((call) => call[0]);
+
+    for (const type of ['dragenter', 'dragover', 'dragleave', 'drop']) {
+      expect(addedTypes).toContain(type);
+      expect(removedTypes).toContain(type);
+    }
+  });
+});

--- a/apps/admin/src/app/(backend)/media/__tests__/use-window-file-drop.test.ts
+++ b/apps/admin/src/app/(backend)/media/__tests__/use-window-file-drop.test.ts
@@ -8,7 +8,7 @@
 
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { useWindowFileDrop } from '../use-window-file-drop.js';
+import { useWindowFileDrop } from '../use-window-file-drop';
 
 function makeFileList(count: number): FileList {
   const files = Array.from(

--- a/apps/admin/src/app/(backend)/media/page.tsx
+++ b/apps/admin/src/app/(backend)/media/page.tsx
@@ -7,6 +7,7 @@ import {
   IconTrash,
   IconUpload,
   InputCVA,
+  Skeleton,
 } from '@revealui/presentation';
 import {
   SelectCVA as Select,
@@ -17,6 +18,7 @@ import {
 } from '@revealui/presentation/client';
 import { type ChangeEvent, useCallback, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
+import { useWindowFileDrop } from './use-window-file-drop.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -133,12 +135,16 @@ function DropZone({
       }}
       onDragLeave={() => setDragOver(false)}
       onDrop={(e) => {
+        // The page-level capture (use-window-file-drop.ts) also listens on
+        // window for stray drops; stop here so an in-zone drop doesn't fire
+        // onFiles twice.
         e.preventDefault();
+        e.stopPropagation();
         setDragOver(false);
         if (e.dataTransfer.files.length > 0) onFiles(e.dataTransfer.files);
       }}
-      className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 transition-colors ${
-        dragOver ? 'border-primary bg-primary/10' : 'border-border hover:border-ring'
+      className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-10 text-center transition-colors sm:p-12 ${
+        dragOver ? 'border-primary bg-primary/10' : 'border-border hover:border-ring hover:bg-card'
       } ${uploading ? 'pointer-events-none opacity-50' : ''}`}
       onClick={() => inputRef.current?.click()}
       onKeyDown={(e) => {
@@ -146,11 +152,20 @@ function DropZone({
       }}
       tabIndex={0}
     >
-      <IconUpload className="mb-2 size-8 text-muted-foreground" aria-hidden="true" />
-      <p className="text-sm text-muted-foreground">
-        {uploading ? 'Uploading...' : 'Drop files here or click to upload'}
+      <span
+        className={`flex size-14 items-center justify-center rounded-full transition-colors ${
+          dragOver ? 'bg-primary/20 text-primary' : 'bg-primary/10 text-primary'
+        }`}
+      >
+        <IconUpload className="size-6" aria-hidden="true" />
+      </span>
+      <p className="mt-4 text-sm font-medium text-foreground">
+        {uploading ? 'Uploading...' : 'Drop images to upload'}
       </p>
-      <p className="mt-1 text-xs text-muted-foreground">JPEG, PNG, WebP, GIF</p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {uploading ? 'Hang tight, this only takes a moment.' : 'or click to browse your files'}
+      </p>
+      <p className="mt-3 font-mono text-xs text-muted-foreground">JPEG · PNG · WebP · GIF</p>
       <InputCVA
         ref={inputRef}
         type="file"
@@ -168,6 +183,23 @@ function DropZone({
   );
 }
 
+function DragOverlay() {
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+      aria-hidden="true"
+    >
+      <div className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-primary bg-card px-14 py-12 shadow-lg">
+        <span className="flex size-14 items-center justify-center rounded-full bg-primary/15 text-primary">
+          <IconUpload className="size-7" aria-hidden="true" />
+        </span>
+        <p className="text-lg font-semibold text-foreground">Drop to upload</p>
+        <p className="text-sm text-muted-foreground">Release anywhere on this page</p>
+      </div>
+    </div>
+  );
+}
+
 function MediaCard({
   item,
   onDelete,
@@ -180,7 +212,7 @@ function MediaCard({
   const [deleting, setDeleting] = useState(false);
 
   return (
-    <div className="group relative overflow-hidden rounded-lg border border-border bg-card transition-colors hover:border-ring">
+    <div className="group relative overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-all hover:border-ring hover:shadow-md">
       <Button
         type="button"
         appearance="ghost"
@@ -204,11 +236,16 @@ function MediaCard({
           )}
         </div>
       </Button>
-      <div className="p-3">
+      <div className="space-y-1 p-3">
         <p className="truncate text-sm font-medium text-foreground" title={item.filename}>
           {item.filename}
         </p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
+        {item.alt && (
+          <p className="truncate text-xs text-muted-foreground" title={item.alt}>
+            Alt: {item.alt}
+          </p>
+        )}
+        <p className="font-mono text-xs text-muted-foreground">
           {item.mimeType.split('/')[1]?.toUpperCase()} · {formatBytes(item.filesize)}
         </p>
       </div>
@@ -226,7 +263,7 @@ function MediaCard({
           }
         }}
         disabled={deleting}
-        className="absolute top-2 right-2 size-8 rounded-full bg-card/80 p-1.5 text-muted-foreground opacity-0 backdrop-blur transition-opacity hover:text-error group-hover:opacity-100"
+        className="absolute top-2 right-2 size-8 rounded-full border border-border bg-card/90 p-1.5 text-muted-foreground opacity-0 backdrop-blur transition-all hover:border-error/40 hover:bg-error/10 hover:text-error focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
         aria-label={`Delete ${item.filename}`}
       >
         <IconTrash className="size-4" aria-hidden="true" />
@@ -248,7 +285,7 @@ function PreviewModal({ item, onClose }: { item: MediaItem; onClose: () => void 
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: click stops propagation to backdrop */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: modal content panel needs click stop-propagation */}
       <div
-        className="relative max-h-[90vh] max-w-[90vw] overflow-auto rounded-lg bg-popover p-4 shadow-2xl"
+        className="relative max-h-[90vh] max-w-[90vw] overflow-auto rounded-xl border border-border bg-popover p-5 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <Button
@@ -257,7 +294,7 @@ function PreviewModal({ item, onClose }: { item: MediaItem; onClose: () => void 
           variant="neutral"
           size="icon"
           onClick={onClose}
-          className="absolute top-3 right-3 size-8 rounded-full bg-muted p-1.5 text-muted-foreground hover:text-foreground"
+          className="absolute top-3 right-3 size-8 rounded-full border border-border bg-card p-1.5 text-muted-foreground hover:text-foreground"
           aria-label="Close preview"
         >
           <IconClose className="size-5" aria-hidden="true" />
@@ -267,21 +304,21 @@ function PreviewModal({ item, onClose }: { item: MediaItem; onClose: () => void 
           <img
             src={item.url}
             alt={item.alt ?? item.filename}
-            className="max-h-[80vh] max-w-full rounded object-contain"
+            className="max-h-[80vh] max-w-full rounded-lg object-contain"
           />
         ) : (
           <div className="flex h-64 w-96 items-center justify-center text-muted-foreground">
             File preview not available
           </div>
         )}
-        <div className="mt-4 space-y-1 text-sm">
+        <div className="mt-4 space-y-1.5 border-t border-border pt-4 text-sm">
           <p className="font-medium text-foreground">{item.filename}</p>
-          <p className="text-muted-foreground">
+          <p className="font-mono text-xs text-muted-foreground">
             {item.mimeType} · {formatBytes(item.filesize)}
             {item.width != null && item.height != null && ` · ${item.width}x${item.height}`}
           </p>
           {item.alt && <p className="text-muted-foreground">Alt: {item.alt}</p>}
-          <p className="text-muted-foreground">
+          <p className="text-xs text-muted-foreground">
             Uploaded {new Date(item.createdAt).toLocaleDateString()}
           </p>
         </div>
@@ -338,20 +375,29 @@ export default function MediaLibraryPage() {
     loadMedia(0);
   }
 
-  const handleUpload = async (files: FileList) => {
-    setUploading(true);
-    setError(null);
-    try {
-      for (const file of Array.from(files)) {
-        await uploadMedia(serverUrl, file);
+  const handleUpload = useCallback(
+    async (files: FileList) => {
+      setUploading(true);
+      setError(null);
+      try {
+        for (const file of Array.from(files)) {
+          await uploadMedia(serverUrl, file);
+        }
+        await loadMedia(page, filter);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Upload failed');
+      } finally {
+        setUploading(false);
       }
-      await loadMedia(page, filter);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Upload failed');
-    } finally {
-      setUploading(false);
-    }
-  };
+    },
+    [serverUrl, loadMedia, page, filter],
+  );
+
+  // Page-wide drag capture (owner report: a stray drop outside the DropZone
+  // navigated the whole tab to the raw image file and the in-progress edit
+  // was lost). Always preventDefaults window dragover/drop; routes dropped
+  // files to the same upload handler the DropZone uses.
+  const { isDraggingFiles } = useWindowFileDrop({ uploading, onFiles: handleUpload });
 
   const handleDelete = async (id: string) => {
     try {
@@ -376,9 +422,11 @@ export default function MediaLibraryPage() {
 
   return (
     <div className="space-y-6">
+      {isDraggingFiles && <DragOverlay />}
+
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">Media Library</h1>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">Media Library</h1>
           <p className="mt-1 text-sm text-muted-foreground">
             {totalDocs} {totalDocs === 1 ? 'file' : 'files'}
           </p>
@@ -416,10 +464,10 @@ export default function MediaLibraryPage() {
       {loading && items.length === 0 ? (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
           {Array.from({ length: 12 }).map((_, i) => (
-            <div
+            <Skeleton
               // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no stable ID
               key={`skeleton-${i}`}
-              className="h-52 animate-pulse rounded-lg border border-border bg-card"
+              className="h-52 rounded-xl border border-border"
             />
           ))}
         </div>

--- a/apps/admin/src/app/(backend)/media/page.tsx
+++ b/apps/admin/src/app/(backend)/media/page.tsx
@@ -18,7 +18,7 @@ import {
 } from '@revealui/presentation/client';
 import { type ChangeEvent, useCallback, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
-import { useWindowFileDrop } from './use-window-file-drop.js';
+import { useWindowFileDrop } from './use-window-file-drop';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/apps/admin/src/app/(backend)/media/use-window-file-drop.ts
+++ b/apps/admin/src/app/(backend)/media/use-window-file-drop.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface UseWindowFileDropOptions {
+  /** While true, drops are captured (preventDefault still fires) but never routed to `onFiles`. */
+  uploading: boolean;
+  onFiles: (files: FileList) => void;
+}
+
+interface UseWindowFileDropResult {
+  /** True while a file drag is over the window and should show the full-page overlay. */
+  isDraggingFiles: boolean;
+}
+
+function dragCarriesFiles(event: DragEvent): boolean {
+  const types = event.dataTransfer?.types;
+  if (!types) return false;
+  for (const type of types) {
+    if (type === 'Files') return true;
+  }
+  return false;
+}
+
+/**
+ * Captures drag-and-drop at the window level so a file dropped anywhere on
+ * the media page  -  not just the in-page DropZone  -  never falls through to
+ * the browser default of navigating the tab to the raw file. `dragover` and
+ * `drop` always call preventDefault, unconditionally, so navigation can never
+ * happen regardless of upload state. File routing (and the drag-active
+ * overlay) are suppressed while an upload is already in flight.
+ */
+export function useWindowFileDrop({
+  uploading,
+  onFiles,
+}: UseWindowFileDropOptions): UseWindowFileDropResult {
+  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+
+  useEffect(() => {
+    let dragDepth = 0;
+
+    function handleDragEnter(event: DragEvent) {
+      if (!dragCarriesFiles(event)) return;
+      event.preventDefault();
+      dragDepth += 1;
+      if (!uploading) setIsDraggingFiles(true);
+    }
+
+    function handleDragOver(event: DragEvent) {
+      event.preventDefault();
+    }
+
+    function handleDragLeave(event: DragEvent) {
+      event.preventDefault();
+      dragDepth = Math.max(0, dragDepth - 1);
+      if (dragDepth === 0) setIsDraggingFiles(false);
+    }
+
+    function handleDrop(event: DragEvent) {
+      event.preventDefault();
+      dragDepth = 0;
+      setIsDraggingFiles(false);
+      if (uploading) return;
+      const files = event.dataTransfer?.files;
+      if (files && files.length > 0) onFiles(files);
+    }
+
+    window.addEventListener('dragenter', handleDragEnter);
+    window.addEventListener('dragover', handleDragOver);
+    window.addEventListener('dragleave', handleDragLeave);
+    window.addEventListener('drop', handleDrop);
+
+    return () => {
+      window.removeEventListener('dragenter', handleDragEnter);
+      window.removeEventListener('dragover', handleDragOver);
+      window.removeEventListener('dragleave', handleDragLeave);
+      window.removeEventListener('drop', handleDrop);
+    };
+  }, [uploading, onFiles]);
+
+  return { isDraggingFiles };
+}

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -27,7 +27,7 @@ export const METRICS = {
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
   workspaces: 35,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
-  testFiles: 1061,
+  testFiles: 1162,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */
   uiComponents: 65,
   /**

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -5,7 +5,7 @@ title: "Marketing Metrics — Pinned Truth"
 description: "Single source of truth for every metric, count, and status claim used in the marketing app and public-facing copy. Updated when the code changes; validated by claim-drift CI gate."
 category: internal
 audience: maintainer
-last-verified: 2026-07-22
+last-verified: 2026-07-27
 verified-via: pnpm tsx scripts/validate/claim-drift.ts
 ---
 
@@ -21,14 +21,14 @@ If a number appears in marketing copy, it MUST match the value below. If a value
 
 ## 1. Codebase metrics (validated by claim-drift CI gate)
 
-Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-22 (GAP-407 Session B re-verify).
+Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-27 (re-verified while fixing the admin media library page; testFiles bump to 1162 kept the count inside the claim-drift tolerance).
 
 | Metric | Canonical value | Source of truth (script ref) | Notes |
 |---|---|---|---|
 | Packages in `packages/` | **30** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
 | Apps in `apps/` | **5** | `countApps()` | admin / server / docs / marketing / license-signer (GAP-260 P4-2). |
 | Workspaces (monorepo total) | **35** | `countWorkspaces()` (= 30 packages + 5 apps) | |
-| Test files | **1122** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). claim-drift allows site.ts METRICS.testFiles within tolerance 100. |
+| Test files | **1162** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). claim-drift allows site.ts METRICS.testFiles within tolerance 100. |
 | UI components in `packages/presentation/` | **65** | `countUIComponents()` | Marketing copy says "65 native React components" or similar. |
 | **MCP servers** | **13** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); Supabase launcher removed (13 count). |
 | DB tables (Drizzle pgTable) | **97** | `countDbTables()` — `pgTable(` declarations across `packages/db/src/schema/*.ts` | Was 86 (2026-06-22); 93 after GAP-300; 96 on 2026-07-22; **97** after GAP-355 S4-1 `audit_anchors` (2026-07-23). `site.ts` METRICS.dbTables is gate-enforced by claim-drift. |


### PR DESCRIPTION
## Defect 1 — stray drops navigated the tab, losing work

**Owner report:** dragging an image onto the media page (but missing the DropZone) turned the whole tab into the raw image; the in-progress edit was lost.

**Root cause:** [`DropZone`](apps/admin/src/app/(backend)/media/page.tsx) only called `preventDefault()` inside its own `div`'s drag handlers. Any drop elsewhere on the page fell through to the browser default: navigate the tab to the dropped file.

**Fix — page-wide drag capture:**
- New hook [`use-window-file-drop.ts`](apps/admin/src/app/(backend)/media/use-window-file-drop.ts) attaches `window`-level `dragenter` / `dragover` / `dragleave` / `drop` listeners for the lifetime of the page.
- `dragover` and `drop` call `preventDefault()` **unconditionally**, so a stray drop can never navigate away, regardless of upload state.
- When a drag carrying files (`dataTransfer.types` includes `Files`) enters the window, `isDraggingFiles` flips true and the page renders a full-page "Drop to upload" overlay. Dropping anywhere routes the files to the same `handleUpload` the DropZone already used.
- Drops while `uploading` is true are still `preventDefault`-ed (still can't navigate) but are *not* routed to the upload handler, so a drop mid-upload can't kick off a second batch.
- The overlay clears on `dragleave` (depth-tracked, so it survives crossing child element boundaries) and on `drop`.
- Listeners are added/removed via a `useEffect` cleanup, keyed to `[uploading, onFiles]`.
- `DropZone`'s own `onDrop` now calls `stopPropagation()` so an in-zone drop is handled exactly once (not double-routed through both the local handler and the window listener).
- Click-to-upload and the Enter/Space keyboard path on the DropZone are untouched.

**Tests:** [`__tests__/use-window-file-drop.test.ts`](apps/admin/src/app/(backend)/media/__tests__/use-window-file-drop.test.ts) — 8 focused cases: preventDefault on dragover, preventDefault + file routing on drop, drop-while-uploading is preventDefault-ed but not routed, overlay flag lifecycle (dragenter → drop, dragenter → dragleave), overlay suppressed while uploading, drags with no files ignored, and listener cleanup on unmount. Proved red first (the file didn't exist on `origin/test`; removing the implementation locally reproduced the same "Failed to resolve import" failure) and green after implementing the hook.

## Defect 2 — "the styles on this form are awful"

Invoked the `revealui-design` skill (Cobalt brand canon, dark-first OKLCH `--rvui-*` tokens) before touching any class name, and stuck to the token vocabulary already bridged into Tailwind utilities for the `(backend)` route group (`apps/admin/src/app/(backend)/custom.css`): `bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`, `bg-primary`/`text-primary`, `bg-error`/`text-error`, `hover:border-ring`. No new dependencies, no new CSS files, no custom tokens invented.

**Before → after, by surface:**
- **DropZone** — was a flat `rounded-lg` box with a plain upload icon. Now: `rounded-xl`, bigger padding, the upload icon sits in a brand-tinted circular chip (`bg-primary/10 text-primary`) that intensifies on drag-over, clearer two-line copy ("Drop images to upload" / "or click to browse your files"), and a mono-set format caption (`JPEG · PNG · WebP · GIF`).
- **Full-page drop overlay** (new, ties to Defect 1) — `bg-background/80 backdrop-blur-sm` scrim with a centered dashed-border brand card, matching the DropZone's icon-chip treatment.
- **Media grid cards** — `rounded-lg` → `rounded-xl`, added `shadow-sm` → `hover:shadow-md` elevation on top of the existing hover border change (design-canon rule: card hover darkens the ring/border and adds elevation, never a scale/translate transform). Meta line (mimetype + filesize) now renders in `font-mono` for the "studio data" register already used elsewhere in the admin app (jobs, webhooks, coordination, logs pages). Alt text now displays on the card (previously alt was captured by the API but only ever shown in the preview modal). Delete button restyled with a defined ring instead of a floating icon, and now also reveals on keyboard focus (`group-focus-within`) in addition to hover — it was hover-only before, unreachable by sighted keyboard users.
- **Loading skeletons** — swapped the raw `animate-pulse` divs for `@revealui/presentation`'s `Skeleton` component (existing design-system primitive, previously unused on this page).
- **Preview modal** — `rounded-lg` → `rounded-xl` with a border, technical metadata (mime type / size / dimensions) moved to `font-mono`, close button gained a defined ring to match the delete button treatment.
- **Header** — added `tracking-tight` to the `h1` per the brand's tight-headline type rule.

**Deviation noted per the task's own carve-out:** the raw `<img>` elements (media grid + preview modal) were left as-is. Switching to `next/image` is not trivial here: `item.url` points at R2-hosted URLs, and wiring `next/image` correctly would require confirming/extending `images.remotePatterns` for the R2 host plus verifying render behavior for non-image file types — out of scope for a bug-fix PR and flagged in the task instructions as "leave and note it" if non-trivial.

**Not touched:** no new "alt text" *input* was added to the upload flow. The task listed "the upload/alt input flow" as a restyle target, but no such input exists in the current page (the API supports an `alt` field, but nothing in the UI ever collects it) — adding that would be a new feature, not a restyle, so it's out of scope per the bug-fix framing. The existing alt *display* (preview modal) was restyled, and alt now also surfaces on the grid card.

## Test plan
- [x] `pnpm --filter admin exec vitest run "src/app/(backend)/media"` — 8/8 passing
- [x] Proved the new hook test red (file absent on `origin/test`; same failure reproduced by deleting the implementation locally) before implementing
- [x] `biome check` on all three touched/added files — clean
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm gate --phase=1 --changed` (the exact check the `feature/*` pre-push hook runs) — full PASS, including the two GAP-406/GAP-354 hard-fail claim-drift and citation gates
- [x] Invoked `revealui-design` skill before any styling change; invoked `vercel:react-best-practices` before finalizing (reviewed against the re-render, event-listener, and conditional-render rule sets — no violations; top-level components stay outside `MediaLibraryPage`, `handleUpload` is now `useCallback`-wrapped so the window-listener effect isn't rebuilding every render)
- [ ] Manual drag-and-drop smoke test against a live admin instance (not run — no local admin dev server / DB in this session; the fix is unit-tested at the hook boundary per the task's own test-plan carve-out)

## Incidental fix required to get a green gate
Adding one new test file (`use-window-file-drop.test.ts`) pushed the repo's tracked test-file count from 1161 to 1162. `apps/marketing/app/content/site.ts`'s `METRICS.testFiles` claim (1061) was already sitting exactly at the claim-drift validator's tolerance boundary (100) against `origin/test`'s real count (1161) — any single new test file anywhere in the repo would have tipped it over. Bumped `METRICS.testFiles` to 1162 and refreshed `docs/MARKETING_METRICS.md` §1 to match, per the validator's own remediation instructions. Verified this was pre-existing (not introduced by this PR) by running the validator against a clean `origin/test` checkout before making the change.
