### PR TITLE
fix(ci): disable the worker-liveness schedule until the probe stops false-alarming (GAP-455)

### DIFF
--- a/.github/workflows/worker-liveness.yml
+++ b/.github/workflows/worker-liveness.yml
@@ -16,12 +16,21 @@ name: Worker Liveness Probe (5-min)
 # and out of Actions logs.
 
 on:
-  schedule:
-    # Every 5 minutes (GitHub's minimum granularity). UTC. Scheduled runs can
-    # be delayed 5-15 min during high GHA load, so actual cadence is
-    # "approximately every 5 minutes," not exact  -  acceptable for a
-    # liveness backstop.
-    - cron: '*/5 * * * *'
+  # SCHEDULE DISABLED 2026-07-28 (GAP-455) — the probe false-alarmed on every
+  # scheduled run, returning {"healthy":false,"error":"network-error"} while
+  # the worker was verifiably healthy (direct /health 200, Fly checks passing,
+  # sweep ticks errors=0). A monitor that cries wolf is worse than no monitor,
+  # and this repo is PUBLIC, so each red run advertises an outage that is not
+  # happening. Re-enabling the cron below is part of GAP-455's acceptance,
+  # after the probe's error buckets are split (guard-blocked vs timeout vs
+  # network) and the real cause is confirmed and fixed. Manual runs still work.
+  #
+  # schedule:
+  #   # Every 5 minutes (GitHub's minimum granularity). UTC. Scheduled runs can
+  #   # be delayed 5-15 min during high GHA load, so actual cadence is
+  #   # "approximately every 5 minutes," not exact  -  acceptable for a
+  #   # liveness backstop.
+  #   - cron: '*/5 * * * *'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
Stops the false alarms shipped a few hours ago. Every scheduled run of the new liveness watcher failed with `{"healthy":false,"error":"network-error"}` while the worker was verifiably healthy at those exact moments (direct `/health` 200, Fly reporting checks passing, worker logs showing sweep ticks with `errors=0`).

Auth and config are ruled out by the run logs (secret present; the route returned a probe result, not 401 or `{skipped:true}`), and the worker host resolves to public addresses on both families, so the SSRF range check is not the trigger. The cause is not confirmable today because the route collapses every non-timeout throw into a single `network-error` bucket — precisely the guardrail-2 reviewer's non-blocking suggestion 2 on #2231. Splitting those buckets and fixing the real cause is GAP-455 (revealui-jv#853).

`workflow_dispatch` is retained so ops can probe on demand, and the commented cron block plus rationale sit inline so re-enabling is a deliberate step in GAP-455's acceptance, not a rediscovery.

Why disable rather than leave it red: a monitor that cries wolf trains everyone to ignore it, and this repo is public, so each red run advertises an outage that is not happening. Worker liveness is unmonitored until GAP-455 closes, and the gap says so explicitly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>