### PR TITLE
fix(starter-kit): make the kit build from a clean clone via npm

### DIFF
--- a/.github/workflows/starter-kit-standalone.yml
+++ b/.github/workflows/starter-kit-standalone.yml
@@ -1,0 +1,116 @@
+name: Starter Kit Standalone
+
+# GAP-434. The starter kit ships to buyers as its own repo, so it must resolve
+# every dependency from the public npm registry with NO monorepo present.
+#
+# This is the check that was missing when the kit shipped broken: the kit used
+# to be a pnpm workspace member, so `workspace:*` and `catalog:` specs resolved
+# in-tree and the whole thing looked healthy while being unbuildable for a
+# buyer. A `docker compose config --quiet` parse passed too. Neither proved
+# anything.
+#
+# So this job copies the kit OUT of the repo, into a directory with no
+# workspace above it, and does a real install + typecheck + test + recipe run.
+
+on:
+  push:
+    branches: [main, test]
+    paths:
+      - examples/starter-kit/**
+      - pnpm-workspace.yaml
+      - .github/workflows/starter-kit-standalone.yml
+  pull_request:
+    branches: [main, test]
+    paths:
+      - examples/starter-kit/**
+      - pnpm-workspace.yaml
+      - .github/workflows/starter-kit-standalone.yml
+  schedule:
+    # Weekly: the kit floats on ^ ranges of published @revealui packages, so it
+    # can break without anyone touching this repo.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "24"
+  PNPM_VERSION: "10.28.2"
+
+concurrency:
+  group: starter-kit-standalone-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  standalone:
+    name: Clean-clone build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Assert the kit declares no workspace-only dependency specs
+        run: |
+          # `workspace:` and `catalog:` are pnpm-workspace protocols. They
+          # cannot resolve from a plain clone, so their presence here means the
+          # kit is unbuildable for a buyer no matter what the rest of CI says.
+          if grep -nF -e '"workspace:' -e '"catalog:' examples/starter-kit/package.json; then
+            echo "::error::examples/starter-kit/package.json uses workspace-only dep specs (workspace:/catalog:). A buyer's clean clone cannot resolve these. Use published npm ranges."
+            exit 1
+          fi
+          echo "OK — no workspace-only specs."
+
+      - name: Copy the kit out of the monorepo
+        run: |
+          mkdir -p "$RUNNER_TEMP/kit"
+          cp -r examples/starter-kit/. "$RUNNER_TEMP/kit/"
+          rm -rf "$RUNNER_TEMP/kit/node_modules"
+          echo "--- kit contents, with no workspace above it ---"
+          ls -a "$RUNNER_TEMP/kit"
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install from the public registry only
+        working-directory: ${{ runner.temp }}/kit
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Typecheck
+        working-directory: ${{ runner.temp }}/kit
+        run: pnpm typecheck
+
+      - name: Test
+        working-directory: ${{ runner.temp }}/kit
+        run: pnpm test
+
+      - name: Run the governed-agent recipes and verify their receipts
+        working-directory: ${{ runner.temp }}/kit
+        run: |
+          pnpm recipe:action
+          pnpm recipe:loop
+          pnpm verify-receipt receipt-action.json
+          pnpm verify-receipt receipt-loop.json
+
+      - name: Boot the kit's Postgres and confirm the vector extension
+        working-directory: ${{ runner.temp }}/kit
+        run: |
+          cp .env.starter.example .env
+          bash scripts/generate-secrets.sh >> .env
+          bash scripts/bootstrap.sh
+          set -a; . ./.env; set +a
+          docker compose -f docker-compose.starter.yml exec -T postgres \
+            psql -U "${POSTGRES_USER:-revealui}" -d "${POSTGRES_DB:-revealui}" \
+            -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+
+      - name: Tear down
+        if: always()
+        working-directory: ${{ runner.temp }}/kit
+        run: docker compose -f docker-compose.starter.yml down -v --remove-orphans || true

--- a/examples/starter-kit/.env.starter.example
+++ b/examples/starter-kit/.env.starter.example
@@ -20,24 +20,20 @@ REVEALUI_KEK=
 # or leave real newlines — both are normalized.
 REVEALUI_AUDIT_SIGNING_KEY=
 
-# ── URLs (required — must match between api and admin) ──────────────────────
-POSTGRES_URL=postgresql://revealui:${POSTGRES_PASSWORD}@postgres:5432/revealui
-REVEALUI_PUBLIC_SERVER_URL=http://localhost:3004
-NEXT_PUBLIC_SERVER_URL=http://localhost:3004
-NEXT_PUBLIC_API_URL=http://localhost:3004
-API_URL=http://api:3004
-CORS_ORIGIN=http://localhost:4000
+# ── Database URL ────────────────────────────────────────────────────────────
+# Your RevealUI app runs on the host (via `pnpm dev`), so it reaches the
+# compose Postgres at localhost, not at a container hostname.
+# scripts/bootstrap.sh prints this line filled in for you.
+POSTGRES_URL=postgresql://revealui:${POSTGRES_PASSWORD}@localhost:5432/revealui
 
-# ── First admin login (admin app, required for first boot) ──────────────────
+# ── First admin login (set these in your APP's .env, on first boot) ─────────
 REVEALUI_ADMIN_EMAIL=you@example.com
 # a real password — rotate it immediately after your first login
 REVEALUI_ADMIN_PASSWORD=
 
-# ── License (omit both to boot at Free/OSS tier — this is the kit default) ──
+# ── License (omit both to run at Free/OSS tier — this is the kit default) ───
 # REVEALUI_LICENSE_KEY=
 # REVEALUI_LICENSE_PUBLIC_KEY=
-# Free-tier opt-in is already set in docker-compose.starter.yml
-# (REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true) — no need to set it here too.
 
 # ── Optional ─────────────────────────────────────────────────────────────────
 # GOOGLE_SERVICE_ACCOUNT_EMAIL=

--- a/examples/starter-kit/GETTING-STARTED.md
+++ b/examples/starter-kit/GETTING-STARTED.md
@@ -13,10 +13,11 @@ This kit is content and curation layered on top of the free, MIT-licensed
 free in RevealUI (the scaffolder, the five app templates, the framework
 packages) stays free. What this kit adds:
 
-1. A **fixed, tested docker-compose recipe** for self-hosting the RevealUI
-   backend at Free (OSS) tier, no license key required.
-2. A **one-command bootstrap** that wires up the database migration step the
-   free scaffolder documents but doesn't run for you.
+1. A **ready-to-run Postgres** configured the way RevealUI actually needs it
+   (the `vector` extension its first migration requires), so self-hosting at
+   Free (OSS) tier works on the first try.
+2. A **one-command bootstrap** for that database, with the exact connection
+   string to paste into your app.
 3. An **env template with real secret-generation commands**, not just prose.
 4. **Three governed-agent recipes**, each producing a cryptographically
    signed, offline-verifiable receipt of every action — the pattern the
@@ -61,37 +62,53 @@ Read `src/receipts/sign.ts` and `src/receipts/verify.ts` for the primitives —
 they're built entirely on `@revealui/security` (MIT, free, ships with every
 RevealUI install). Nothing in the receipt mechanism requires a Pro license.
 
-## Self-hosting the RevealUI backend (Free tier, no license key)
+## Self-hosting RevealUI (Free tier, no license key)
 
-The docker-compose path here is a fixed, minimal version of the one in the
-main `revealui` repo root, scoped to Postgres + the API + the admin
-dashboard (the marketing site is a separate app; run it with
-`pnpm --filter marketing dev` if you want it too).
+RevealUI ships on the public npm registry, so your app is an ordinary npm
+install — there is no image to pull and nothing to build from source. Two
+pieces: a database (this kit gives you one), and the app itself (the free
+scaffolder gives you that).
+
+**1. Start the database.**
 
 ```bash
 cp .env.starter.example .env
 bash scripts/generate-secrets.sh >> .env   # fills in every *_SECRET / *_KEY value
-# edit .env: set REVEALUI_ADMIN_EMAIL to your real email
-bash scripts/bootstrap.sh                  # starts postgres, migrates, then api + admin
+bash scripts/bootstrap.sh                  # starts postgres, waits for health
 ```
 
-This boots at **Free (OSS) tier by default** — `REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true`
-is already set in `docker-compose.starter.yml`. If you have a Fleet license,
-set `REVEALUI_LICENSE_KEY` / `REVEALUI_LICENSE_PUBLIC_KEY` in `.env` instead.
+`bootstrap.sh` prints the exact `POSTGRES_URL` to use in the next step.
 
-Once `admin` reports healthy, log in at `http://localhost:4000/` with the
-`REVEALUI_ADMIN_EMAIL` / `REVEALUI_ADMIN_PASSWORD` you set in `.env` (this
-only seeds the account once — rotate the password immediately after your
-first login).
+**2. Create your app.**
 
-`[owner: test once]` — the docker build itself (`docker compose -f
-docker-compose.starter.yml build`) was not run end-to-end in the session that
-built this kit, to avoid a long build inside an agent session. The compose
-file's YAML and env-var interpolation were validated (`docker compose config`),
-and every underlying piece (`apps/server/Dockerfile`, `apps/admin/Dockerfile`,
-the `REVEALUI_ALLOW_UNLICENSED_SELF_HOST` gate) is the same code the fleet's
-own Railway deployment doc verifies against. Run the actual build once before
-shipping the first purchase confirmation.
+```bash
+npm create revealui@latest my-app
+cd my-app
+```
+
+Put the `POSTGRES_URL` from step 1 into `my-app/.env`, along with the
+`REVEALUI_SECRET`, `REVEALUI_KEK`, and `REVEALUI_AUDIT_SIGNING_KEY` values
+that `generate-secrets.sh` produced — they are the same secrets, and the app
+is what reads them.
+
+```bash
+pnpm install
+pnpm db:migrate
+pnpm dev
+```
+
+Your app is on `http://localhost:4000/`.
+
+This runs at **Free (OSS) tier** — no license key, nothing to activate. If you
+have a Fleet license, set `REVEALUI_LICENSE_KEY` / `REVEALUI_LICENSE_PUBLIC_KEY`
+in your app's `.env`.
+
+> **Why the app is not in the compose file.** Earlier versions of this kit
+> shipped a compose file that built the API and admin from the RevealUI
+> monorepo's own Dockerfiles. That only worked with the full monorepo checked
+> out two levels above the kit, which is not something you have. The framework
+> is on npm, so the app is an npm install and the compose file covers only the
+> database.
 
 ## Upgrading to Pro
 

--- a/examples/starter-kit/docker-compose.starter.yml
+++ b/examples/starter-kit/docker-compose.starter.yml
@@ -1,30 +1,30 @@
 # =============================================================================
-# RevealUI Starter Kit — self-host compose (Free/OSS tier, no license key)
+# RevealUI Starter Kit — Postgres for local self-hosting
 # =============================================================================
 #
-# This is a fixed, minimal version of the repo root's `docker-compose.yml`,
-# scoped to the two services that make up the RevealUI backend: the API and
-# the admin dashboard, plus a local Postgres. It intentionally does not
-# include the `marketing` service from the root file — that service's
-# Dockerfile does not exist in this checkout (apps/marketing is a Vite app
-# with no Dockerfile), so including it here would produce a compose file that
-# fails to build. If you need the marketing site too, run it separately with
-# `pnpm --filter marketing dev` or build your own Dockerfile for it.
+# This file provides ONE thing: a correctly-configured Postgres for a RevealUI
+# app to run against. The app itself is not built here — you create it with
+# `npm create revealui@latest`, which installs the framework from the public
+# npm registry (see GETTING-STARTED.md).
+#
+# Why there are no api/admin services here: an earlier version of this file
+# built them from the RevealUI monorepo's own Dockerfiles via `context: ../..`,
+# which meant the kit only worked if you had the entire monorepo checked out
+# two levels above it. That is not something a buyer has. The framework ships
+# on npm, so the app is an npm install, and this file covers only the one piece
+# npm cannot give you.
 #
 # Quick start:
 #   1. cp .env.starter.example .env
 #   2. bash scripts/generate-secrets.sh >> .env   (fills in the *_SECRET vars)
-#   3. bash scripts/bootstrap.sh                  (boots postgres, migrates, then api+admin)
-#
-# This boots at Free (OSS) tier by default: REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true
-# is set on both api and admin below (GAP-436). Remove it and set
-# REVEALUI_LICENSE_KEY / REVEALUI_LICENSE_PUBLIC_KEY if you have a Fleet license.
+#   3. bash scripts/bootstrap.sh                  (starts postgres, waits for health)
 # =============================================================================
 
 services:
   postgres:
-    # pgvector/pgvector:pg16 (not vanilla postgres): migration 0000 runs
-    # `CREATE EXTENSION vector`, which a plain postgres image cannot satisfy.
+    # pgvector/pgvector:pg16 (not vanilla postgres): RevealUI's migration 0000
+    # runs `CREATE EXTENSION vector`, which a plain postgres image cannot
+    # satisfy.
     image: pgvector/pgvector:pg16
     container_name: revealui-starter-postgres
     environment:
@@ -35,70 +35,15 @@ services:
     volumes:
       - starter-postgres-data:/var/lib/postgresql/data
     ports:
+      # Exposed on the host so your RevealUI app (running via `pnpm dev`)
+      # can reach it at localhost.
       - "${POSTGRES_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-revealui}"]
       interval: 10s
       timeout: 5s
       retries: 5
-    networks:
-      - starter
     restart: unless-stopped
-
-  api:
-    build:
-      context: ../..
-      dockerfile: apps/server/Dockerfile
-    container_name: revealui-starter-api
-    env_file: .env
-    environment:
-      NODE_ENV: production
-      API_PORT: "3004"
-      REVEALUI_ALLOW_UNLICENSED_SELF_HOST: "true"
-    ports:
-      - "${API_PORT:-3004}:3004"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3004/health').then(r=>{if(!r.ok)process.exit(1)})"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-    networks:
-      - starter
-    restart: unless-stopped
-
-  admin:
-    build:
-      context: ../..
-      dockerfile: apps/admin/Dockerfile
-    container_name: revealui-starter-admin
-    env_file: .env
-    environment:
-      NODE_ENV: production
-      PORT: "4000"
-      HOSTNAME: 0.0.0.0
-      REVEALUI_ALLOW_UNLICENSED_SELF_HOST: "true"
-    ports:
-      - "${CMS_PORT:-4000}:4000"
-    depends_on:
-      api:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:4000/api/health').then(r=>{if(!r.ok)process.exit(1)})"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-    networks:
-      - starter
-    restart: unless-stopped
-
-networks:
-  starter:
-    driver: bridge
 
 volumes:
   starter-postgres-data:

--- a/examples/starter-kit/package.json
+++ b/examples/starter-kit/package.json
@@ -9,19 +9,17 @@
     "recipe:loop": "tsx src/recipes/02-budget-capped-agent-loop.ts",
     "verify-receipt": "tsx src/verify-receipt-cli.ts",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
-    "lint": "biome check ."
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@revealui/security": "workspace:*",
-    "zod": "catalog:"
+    "@revealui/security": "^0.6.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@revealui/dev": "workspace:*",
-    "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:",
-    "vitest": "catalog:"
+    "@types/node": "^25.9.4",
+    "tsx": "^4.23.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "engines": {
     "node": ">=24.13.0"

--- a/examples/starter-kit/scripts/bootstrap.sh
+++ b/examples/starter-kit/scripts/bootstrap.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# Bring up the starter kit's self-host stack in the right order: postgres
-# healthy, then migrate (host-side, against the monorepo's own db tooling —
-# `npx create-revealui`'s installer never wires this up automatically, so
-# this script is what does), then api and admin.
+# Bring up the starter kit's Postgres and wait for it to report healthy.
 #
-# Run from examples/starter-kit/, with the full revealui monorepo checked
-# out above it (docker-compose.starter.yml builds from apps/server/Dockerfile
-# and apps/admin/Dockerfile in the repo root) and .env already populated
+# This script does NOT build or start the RevealUI app — the app comes from
+# `npm create revealui@latest`, which installs the framework from the public
+# npm registry. See GETTING-STARTED.md for the full flow. This script covers
+# the one piece npm cannot give you: a Postgres with the `vector` extension
+# available, which RevealUI's first migration requires.
+#
+# Run from examples/starter-kit/ with .env already populated
 # (see .env.starter.example + scripts/generate-secrets.sh).
 set -euo pipefail
 
@@ -22,30 +23,38 @@ COMPOSE="docker compose -f docker-compose.starter.yml"
 
 echo "==> Starting postgres"
 $COMPOSE up -d postgres
+
 echo "==> Waiting for postgres to report healthy"
-until [ "$($COMPOSE ps --format json postgres 2>/dev/null | grep -c '"Health":"healthy"')" -ge 1 ]; do
+for _ in $(seq 1 60); do
+  if [ "$($COMPOSE ps --format json postgres 2>/dev/null | grep -c '"Health":"healthy"')" -ge 1 ]; then
+    healthy=1
+    break
+  fi
   sleep 2
 done
 
-# Run migrations from the repo root, on the host, against the compose
-# postgres exposed on localhost (POSTGRES_PORT, default 5432) — this is the
-# step `npx create-revealui` sets up templates for but never runs itself.
-echo "==> Running database migrations (host-side, pnpm db:migrate)"
-(
-  cd ../..
-  set -a
-  # shellcheck disable=SC1091
-  source "examples/starter-kit/.env"
-  set +a
-  export POSTGRES_URL="postgresql://${POSTGRES_USER:-revealui}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-revealui}"
-  pnpm db:migrate
-)
+if [ "${healthy:-0}" -ne 1 ]; then
+  echo "postgres did not become healthy within ~2 minutes." >&2
+  echo "Check '$COMPOSE logs postgres' for the cause." >&2
+  exit 1
+fi
 
-echo "==> Starting api and admin"
-$COMPOSE up -d api admin
+# shellcheck disable=SC1091
+set -a
+source .env
+set +a
 
-echo "==> Done. Waiting on health checks:"
-echo "    API health:   http://localhost:${API_PORT:-3004}/health"
-echo "    Admin health: http://localhost:${CMS_PORT:-4000}/api/health"
-echo "Once admin is healthy, log in at http://localhost:${CMS_PORT:-4000}/ with"
-echo "REVEALUI_ADMIN_EMAIL / REVEALUI_ADMIN_PASSWORD from .env (first boot only)."
+echo
+echo "==> Postgres is up and healthy."
+echo
+echo "Point your RevealUI app at it with this POSTGRES_URL:"
+echo
+echo "    postgresql://${POSTGRES_USER:-revealui}:<POSTGRES_PASSWORD>@localhost:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-revealui}"
+echo
+echo "Next steps (from GETTING-STARTED.md):"
+echo "    npm create revealui@latest my-app"
+echo "    cd my-app"
+echo "    # copy POSTGRES_URL above into my-app/.env"
+echo "    pnpm install && pnpm db:migrate && pnpm dev"
+echo
+echo "Your app will be on http://localhost:4000/."

--- a/examples/starter-kit/scripts/generate-secrets.sh
+++ b/examples/starter-kit/scripts/generate-secrets.sh
@@ -14,9 +14,15 @@
 # or Git Bash with openssl installed).
 set -euo pipefail
 
-echo "POSTGRES_PASSWORD=$(openssl rand -hex 24)"
-echo "REVEALUI_SECRET=$(openssl rand -hex 32)"
-echo "REVEALUI_KEK=$(openssl rand -hex 32)"
+# Every value below is single-quoted. This is not cosmetic: the PEM value
+# contains spaces in its armor lines, and an unquoted .env line makes
+# `source .env` (which scripts/bootstrap.sh and most dev workflows do) try to
+# run part of the armor as a command and abort. Single quotes are safe here
+# because none of these values can contain a single quote (hex digits and
+# base64 PEM only).
+echo "POSTGRES_PASSWORD='$(openssl rand -hex 24)'"
+echo "REVEALUI_SECRET='$(openssl rand -hex 32)'"
+echo "REVEALUI_KEK='$(openssl rand -hex 32)'"
 
 # Ed25519 signing key for the audit log — REVEALUI_AUDIT_SIGNING_KEY needs the
 # full PEM, so a temp file round-trip is simpler than shelling out to sed.
@@ -25,8 +31,8 @@ trap 'rm -f "$tmp_key"' EXIT
 openssl genpkey -algorithm Ed25519 -out "$tmp_key" 2>/dev/null
 # Fold real newlines into \n so the value is a single .env line.
 key_escaped="$(awk '{printf "%s\\n", $0}' "$tmp_key")"
-echo "REVEALUI_AUDIT_SIGNING_KEY=${key_escaped}"
+echo "REVEALUI_AUDIT_SIGNING_KEY='${key_escaped}'"
 
-echo "REVEALUI_ADMIN_PASSWORD=$(openssl rand -hex 16)"
+echo "REVEALUI_ADMIN_PASSWORD='$(openssl rand -hex 16)'"
 
 echo "# Generated $(date -u +%Y-%m-%dT%H:%M:%SZ). Rotate REVEALUI_ADMIN_PASSWORD after your first login." >&2

--- a/examples/starter-kit/tsconfig.json
+++ b/examples/starter-kit/tsconfig.json
@@ -1,12 +1,31 @@
 {
-  "extends": "../../packages/dev/src/ts/library.json",
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "noEmit": true,
+    "target": "ES2022",
     "lib": ["ES2022"],
-    "rootDir": ".",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolvePackageJsonExports": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "types": ["node"],
+
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true,
+
+    "noEmit": true,
     "declaration": false,
     "declarationMap": false,
-    "sourceMap": false
+    "sourceMap": false,
+    "skipLibCheck": true,
+    "rootDir": "."
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,31 +773,6 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
-  examples/starter-kit:
-    dependencies:
-      '@revealui/security':
-        specifier: workspace:*
-        version: link:../../packages/security
-      zod:
-        specifier: 'catalog:'
-        version: 4.4.3
-    devDependencies:
-      '@revealui/dev':
-        specifier: workspace:*
-        version: link:../../packages/dev
-      '@types/node':
-        specifier: 'catalog:'
-        version: 25.9.5
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.1
-      typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
-      vitest:
-        specifier: 'catalog:'
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
-
   packages/ai:
     dependencies:
       '@revealui/contracts':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,13 @@
 packages:
   - apps/*
   - packages/*
-  - examples/starter-kit
+  # examples/starter-kit is deliberately NOT a workspace member (GAP-434).
+  # It ships to buyers as a standalone repo, so it must resolve every
+  # dependency from the public npm registry — `workspace:*` and `catalog:`
+  # specs only exist inside this workspace and fail on a clean clone.
+  # Membership here is what hid that: the kit installed fine in-tree and
+  # was unbuildable everywhere else. CI verifies it standalone instead,
+  # via .github/workflows/starter-kit-standalone.yml.
 
 catalog:
   '@biomejs/biome': ^2.5.2


### PR DESCRIPTION
## What

The starter kit ships to buyers as its own repo, but it could not be built from
one. This makes it build, and proves it.

## The bug

`examples/starter-kit/package.json` declared `@revealui/security: workspace:*`,
`@revealui/dev: workspace:*`, and five `catalog:` specs. Those are pnpm
workspace protocols. They only resolve inside this monorepo, so a buyer's
`pnpm install` failed on the first dependency. `docker-compose.starter.yml`
compounded it by building the api and admin images from `context: ../..` using
this repo's own Dockerfiles, which a buyer does not have.

The kit was a pnpm workspace member, and that is what hid it: it resolved,
typechecked, and tested fine in-tree while being unbuildable everywhere else.
A `docker compose config --quiet` parse passed too, and proved nothing.

## Why npm rather than prebuilt images

Everything the kit actually does already resolves from npm. Its eleven source
files import only `@revealui/security` (published, 0.6.0), `zod`, and node
builtins — nothing from this monorepo, nothing needing a container. And
`create-revealui` (published, 0.5.17) scaffolds a standalone app pulling
`@revealui/core|db|auth|contracts` from the registry, which is both the
framework's real install path and what the kit was always described as being
layered on top of.

So the app is an npm install, and the compose file covers only the piece npm
cannot give you: a Postgres with the `vector` extension that migration 0000
requires.

## Changes

- Real npm ranges in `package.json`. `@revealui/dev` dropped (it is unpublished
  — `npm view` returns 404) and its tsconfig inlined. The biome `lint` script
  goes with it rather than shipping a script that cannot run.
- Removed the kit from `pnpm-workspace.yaml`, so it is built and verified as
  the artifact a buyer receives rather than as an in-tree package. Lockfile
  regenerated (25 deletions, the stale importer).
- `docker-compose.starter.yml` is Postgres only, no build context.
- `bootstrap.sh` starts and health-checks that database and prints the exact
  `POSTGRES_URL`, instead of running monorepo migrations.
- `GETTING-STARTED.md` documents the npm flow and drops the `[owner: test once]`
  caveat, now discharged.

## A defect found by running it

`generate-secrets.sh` emitted the Ed25519 PEM unquoted. The armor line contains
spaces, so `source .env` — which `bootstrap.sh` and most dev workflows do —
tried to execute part of it and aborted. Every buyer following the documented
flow would have hit this. All generated values are now single-quoted.

This only surfaced because the flow was actually executed. Reading it looked fine.

## Verification

From a copy of the kit placed outside the monorepo, with no workspace above it:

- `pnpm install` resolves from the public registry only (`@revealui/security 0.6.0`)
- `pnpm typecheck` clean
- `pnpm test` 5/5 pass
- `pnpm recipe:action` and `pnpm recipe:loop` both run; receipts verify offline
- `bash scripts/bootstrap.sh` boots Postgres healthy; `CREATE EXTENSION vector`
  succeeds. Teardown via an EXIT trap, so nothing was left running.

The port override was exercised too (5432 was occupied on the dev box).

## Regression lock

`starter-kit-standalone.yml` copies the kit out of the repo and runs that same
sequence on every change to it, plus a weekly cron since the kit floats on `^`
ranges of published packages.

Its workspace-spec guard was proven both ways before commit: it exits 0 (fails
CI) against the old `package.json` and exits 1 (clean) against the new one.

## Not in scope

Polar listing, product setup, and the first test purchase remain owner steps on
GAP-434. This clears the build blocker that gated them.
