### PR TITLE
fix(worker-liveness): split the probe's error buckets so a red run is diagnosable

### DIFF
--- a/apps/server/src/routes/cron/worker-liveness.test.ts
+++ b/apps/server/src/routes/cron/worker-liveness.test.ts
@@ -43,7 +43,7 @@ vi.mock('@revealui/security/server', async () => {
   };
 });
 
-import app from './worker-liveness.js';
+import app, { classifyProbeError } from './worker-liveness.js';
 
 const CRON_SECRET = 'test-cron-secret-long-enough-32chars!';
 
@@ -147,5 +147,112 @@ describe('Worker Liveness Cron', () => {
     expect(hoisted.sendCronFailureAlert).toHaveBeenCalledTimes(1);
     const call = hoisted.sendCronFailureAlert.mock.calls[0]?.[0];
     expect(call.error.message).not.toContain('worker.example.internal');
+  });
+
+  // GAP-455: a guard rejection must NOT report as 'network-error'. That
+  // collapse is what made the first live false alarm undiagnosable.
+  it('reports a guard rejection distinctly from a network fault', async () => {
+    process.env.REVEALUI_WORKER_HEALTH_URL = 'https://worker.example.internal/health';
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error('SSRF: worker.example.internal did not resolve to any public IP address'),
+      );
+
+    const res = await request({ 'X-Cron-Secret': CRON_SECRET });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe('dns-unresolved');
+    expect(body.error).not.toBe('network-error');
+
+    // The hostname is in the thrown message; it must not survive into the
+    // response body or the alert.
+    expect(JSON.stringify(body)).not.toContain('worker.example.internal');
+    const call = hoisted.sendCronFailureAlert.mock.calls[0]?.[0];
+    expect(call.error.message).not.toContain('worker.example.internal');
+    expect(call.metadata.reason).toBe('dns-unresolved');
+  });
+
+  it('surfaces a safe error code on a network fault', async () => {
+    process.env.REVEALUI_WORKER_HEALTH_URL = 'https://worker.example.internal/health';
+    const wrapped = new TypeError('fetch failed');
+    (wrapped as NodeJS.ErrnoException).cause = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED',
+    });
+    globalThis.fetch = vi.fn().mockRejectedValueOnce(wrapped);
+
+    const res = await request({ 'X-Cron-Secret': CRON_SECRET });
+    const body = await res.json();
+    expect(body.error).toBe('network-error');
+    expect(body.code).toBe('ECONNREFUSED');
+  });
+});
+
+describe('classifyProbeError', () => {
+  it('maps a timeout', () => {
+    expect(classifyProbeError(new DOMException('aborted', 'TimeoutError'))).toBe('timeout');
+    expect(classifyProbeError(new DOMException('aborted', 'AbortError'))).toBe('timeout');
+  });
+
+  it('finds the reason through a cause chain', () => {
+    // undici wraps a dispatcher-lookup rejection, so the guard's message sits
+    // one or more levels below the error fetch actually throws.
+    const root = new Error('SSRF: host.example resolved to private IP(s): 10.0.0.1');
+    const mid = new Error('other side closed', { cause: root });
+    const top = new TypeError('fetch failed', { cause: mid });
+    expect(classifyProbeError(top)).toBe('blocked-private-ip');
+  });
+
+  it('falls back to blocked-by-guard for an unrecognized guard message', () => {
+    expect(classifyProbeError(new Error('SSRF: some future rejection'))).toBe('blocked-by-guard');
+  });
+
+  it('reports a plain fault as network-error', () => {
+    expect(classifyProbeError(new TypeError('fetch failed'))).toBe('network-error');
+    expect(classifyProbeError('not an error')).toBe('network-error');
+  });
+
+  it('terminates on a self-referential cause chain', () => {
+    const err = new Error('boom') as Error & { cause?: unknown };
+    err.cause = err;
+    expect(classifyProbeError(err)).toBe('network-error');
+  });
+});
+
+// These drive the REAL SSRF guard rather than a stub. They are the reason the
+// message-fragment coupling in GUARD_MESSAGE_TOKENS is safe: if the guard
+// rewords a rejection, this block fails loudly instead of the classifier
+// quietly degrading every guard rejection back to 'network-error'.
+describe('classifyProbeError against the real SSRF guard', () => {
+  it('classifies a private-IP target as blocked-private-ip', async () => {
+    const { createSafeFetch: realSafeFetch } = await vi.importActual<
+      typeof import('@revealui/security/server')
+    >('@revealui/security/server');
+
+    await expect(realSafeFetch()('http://127.0.0.1/health')).rejects.toSatisfy(
+      (err: unknown) => classifyProbeError(err) === 'blocked-private-ip',
+    );
+  });
+
+  it('classifies a disallowed protocol as invalid-target', async () => {
+    const { createSafeFetch: realSafeFetch } = await vi.importActual<
+      typeof import('@revealui/security/server')
+    >('@revealui/security/server');
+
+    await expect(realSafeFetch()('ftp://example.com/health')).rejects.toSatisfy(
+      (err: unknown) => classifyProbeError(err) === 'invalid-target',
+    );
+  });
+
+  it('classifies an unresolvable host as dns-unresolved', async () => {
+    const { createSafeFetch: realSafeFetch } = await vi.importActual<
+      typeof import('@revealui/security/server')
+    >('@revealui/security/server');
+
+    // .invalid is reserved by RFC 2606 and is guaranteed never to resolve, so
+    // this does not depend on the runner's DNS answering for a made-up name.
+    await expect(realSafeFetch()('https://worker.invalid/health')).rejects.toSatisfy(
+      (err: unknown) => classifyProbeError(err) === 'dns-unresolved',
+    );
   });
 });

--- a/apps/server/src/routes/cron/worker-liveness.ts
+++ b/apps/server/src/routes/cron/worker-liveness.ts
@@ -41,6 +41,101 @@ const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 
 const safeFetch = createSafeFetch();
 
+/**
+ * Why the probe failed, as a CONSTANT token.
+ *
+ * Every value here is a fixed string chosen at build time. None of them is
+ * derived from the caught error's text, because the SSRF guard embeds the
+ * target hostname in its messages and that hostname must never reach a log,
+ * an alert email, or a response body (this is a public repo  -  see the file
+ * header). The token says which CLASS of failure happened; it never says
+ * where.
+ */
+export type ProbeFailureReason =
+  | 'timeout'
+  | 'dns-unresolved'
+  | 'blocked-private-ip'
+  | 'blocked-redirect'
+  | 'invalid-target'
+  | 'blocked-by-guard'
+  | 'network-error';
+
+/**
+ * Distinctive fragments of `@revealui/security`'s SSRF guard messages, mapped
+ * to our constant tokens. Matched with `includes` (not regex, per the fleet
+ * no-regex hardline) because the guard interpolates the hostname into the
+ * MIDDLE of most of these strings, so a prefix check would not fire.
+ *
+ * This couples us to another package's message text, which is why
+ * `worker-liveness.test.ts` drives the REAL guard and asserts these tokens
+ * come back  -  if the guard rewords a message, that test fails rather than
+ * this classifier silently degrading every guard rejection to 'network-error'
+ * (which is the exact bug GAP-455 is about).
+ */
+const GUARD_MESSAGE_TOKENS: ReadonlyArray<readonly [string, ProbeFailureReason]> = [
+  ['did not resolve to any public IP', 'dns-unresolved'],
+  ['resolved to private IP', 'blocked-private-ip'],
+  ['is a private/reserved IP', 'blocked-private-ip'],
+  ['refusing to follow redirect', 'blocked-redirect'],
+  ['invalid URL', 'invalid-target'],
+  ['disallowed protocol', 'invalid-target'],
+];
+
+/**
+ * Classify a probe failure into one constant token.
+ *
+ * Walks the `cause` chain: the guard's pre-flight `assertPublicUrl` throws
+ * directly, but a rejection from the undici dispatcher's validating `lookup`
+ * surfaces wrapped, with the real reason one or more `cause` levels down.
+ * Only the classification escapes this function  -  never the message.
+ */
+export function classifyProbeError(err: unknown): ProbeFailureReason {
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  let sawGuardRejection = false;
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+
+    if (current.name === 'TimeoutError' || current.name === 'AbortError') {
+      return 'timeout';
+    }
+
+    const message = current.message;
+    for (const [fragment, reason] of GUARD_MESSAGE_TOKENS) {
+      if (message.includes(fragment)) return reason;
+    }
+    if (message.startsWith('SSRF:')) sawGuardRejection = true;
+
+    current = current.cause;
+  }
+
+  // A guard rejection we have no specific token for still beats reporting a
+  // network fault: it means the request never left the process.
+  return sawGuardRejection ? 'blocked-by-guard' : 'network-error';
+}
+
+/**
+ * The error's `code`, when it is a safe constant to report.
+ *
+ * Node and undici codes are fixed identifiers (`ENOTFOUND`, `ECONNREFUSED`,
+ * `UND_ERR_CONNECT_TIMEOUT`, ...) that carry no hostname, so surfacing one
+ * turns an opaque 'network-error' into an actionable one. The VALUE is
+ * reported, never the message that may accompany it.
+ */
+export function safeErrorCode(err: unknown): string | undefined {
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    const code = (current as NodeJS.ErrnoException).code;
+    if (typeof code === 'string' && code.length > 0) return code;
+    current = current.cause;
+  }
+  return undefined;
+}
+
 app.get('/worker-liveness', async (c) => {
   const cronSecret = process.env.REVEALUI_CRON_SECRET;
   const provided = c.req.header('X-Cron-Secret') || c.req.header('x-cron-secret');
@@ -94,22 +189,28 @@ app.get('/worker-liveness', async (c) => {
   } catch (err) {
     // Never forward the caught error's message  -  the SSRF guard and
     // network-error paths can embed the target hostname in their text, and
-    // that must not reach logs or the alert email.
-    const isTimeout = err instanceof Error && err.name === 'TimeoutError';
-    const reason = isTimeout ? 'timeout' : 'network-error';
+    // that must not reach logs or the alert email. Only the constant token
+    // from classifyProbeError and (when present) the constant error code.
+    const reason = classifyProbeError(err);
+    const code = safeErrorCode(err);
 
-    logger.error(`[worker-liveness] worker unreachable (${reason})`, undefined, { reason });
+    // GAP-455: these buckets used to be one. Every non-timeout throw reported
+    // 'network-error', so a probe that never opened a socket (guard rejection,
+    // DNS failure, bad env value) was indistinguishable from a genuinely dark
+    // worker  -  and the first live runs were exactly that false alarm. The
+    // split is what makes a red run diagnosable from its body alone.
+    logger.error(`[worker-liveness] probe failed (${reason})`, undefined, { reason, code });
     void sendCronFailureAlert({
       jobName: 'worker-liveness',
       error: new Error(
-        isTimeout
+        reason === 'timeout'
           ? `Worker liveness check timed out after ${HEALTH_CHECK_TIMEOUT_MS}ms`
-          : 'Worker liveness check failed: network error',
+          : `Worker liveness check failed: ${reason}${code ? ` (${code})` : ''}`,
       ),
       severity: 'error',
-      metadata: { reason },
+      metadata: { reason, code },
     });
-    return c.json({ healthy: false, error: reason, checkedAt }, 503);
+    return c.json({ healthy: false, error: reason, code, checkedAt }, 503);
   }
 });
 


### PR DESCRIPTION
## What

Makes a red worker-liveness run diagnosable. **Does not close GAP-455, and does
not re-enable the schedule.**

## Why

The GAP-443 watcher went live and immediately false-alarmed. Every scheduled run
returned:

```json
{"healthy":false,"error":"network-error"}
```

while the worker was verifiably healthy — direct `/health` 200, Fly reporting
checks passing, its own logs showing sweep ticks with `errors=0`.

The cause could not be determined from the alerts, because every non-timeout
throw collapsed into that single bucket. A guard rejection that never opened a
socket was indistinguishable from a genuinely dark worker. This is the exact
failure mode the guardrail-2 reviewer raised as non-blocking suggestion 2 on
#2231; it turned out to be load-bearing.

## Change

`classifyProbeError` maps a failure to one constant token:

| token | meaning |
|---|---|
| `timeout` | probe exceeded 10s |
| `dns-unresolved` | guard resolved no public IP |
| `blocked-private-ip` | guard rejected a private/reserved address |
| `blocked-redirect` | guard refused a redirect |
| `invalid-target` | bad URL or disallowed protocol |
| `blocked-by-guard` | guard rejection with no more specific token |
| `network-error` | a real transport fault |

Plus the error's `code` when it is a safe constant (`ECONNREFUSED`, `ENOTFOUND`,
`UND_ERR_*`). The worker hostname still never reaches a log, an alert, or a
response body — only the classification does, and there is a test asserting the
hostname does not survive into either.

It walks the `cause` chain, because the guard's pre-flight `assertPublicUrl`
throws directly while a rejection from the undici dispatcher's validating
`lookup` arrives wrapped several levels down. Distinguishing those two is itself
diagnostic: pre-flight DNS failure and dial-time failure are different bugs.

## This contradicts the hypothesis on the gap

GAP-455 records "prefers AAAA, and the Vercel Node runtime has no IPv6 egress"
as the leading theory. Reading the guard, that does not survive:
`ssrf.ts:resolvePublicIps` concatenates `resolve4` results **before**
`resolve6`, so IPv4 is offered first.

A likelier candidate: `resolve4`/`resolve6` are c-ares queries and **both**
failures are swallowed by `.catch(() => [])`, so a resolver that does not answer
for c-ares in that runtime yields "did not resolve to any public IP" — which is
now its own token, `dns-unresolved`.

I have deliberately **not** acted on that. This PR ships the instrument so one
real run decides it, rather than shipping a fix for a guessed cause.

## Verification

- 18 tests pass.
- **Proved red without the fix**: reverting only the route file fails 10 tests,
  including `reports a guard rejection distinctly from a network fault`. The
  suite is not a regression guard written after the fact.
- Three tests drive the **real** SSRF guard (private IP, disallowed protocol,
  RFC 2606 `.invalid` host) and assert the tokens come back. That is what makes
  the message-fragment coupling safe: if the guard rewords a message, those fail
  loudly instead of the classifier quietly degrading every guard rejection back
  to `network-error` — the very bug this PR exists to prevent recurring.
- Cause-chain, self-referential-cause, and hostname-non-leak coverage included.
- Pre-push gate: PASS. Fleet security checker: no security-sensitive files.

## Next (needs this deployed)

Read one real run's `error` token, confirm or kill the DNS theory, fix the
cause, then re-enable the cron and prove both a green run while healthy and a
red run when genuinely down. Worker liveness stays UNMONITORED until then, which
the gap states plainly.
