### PR TITLE
feat(gates): enforce the archive convention in the public repo too

### DIFF
--- a/.changeset/archive-check-shared-gate.md
+++ b/.changeset/archive-check-shared-gate.md
@@ -1,0 +1,14 @@
+---
+'@revealui/harnesses': minor
+---
+
+Add the shared archive-check gate (`./gates` export): `scanInboundLinks`,
+`isHistoricalPath`, `countOccurrences`, `ARCHIVE_URL_PREFIX`, and the per-repo
+historical-path marker sets.
+
+Docs moved to the central fleet archive must leave no live inbound links
+behind. That rule was previously enforced only in the private coordination
+repo, so links could rot in the public repo — the one place a dead link is
+externally visible. The matching logic now has one home here and is consumed by
+both repos' thin adapters, so the two cannot drift (same reasoning as the
+existing doc-currency and guardrail2-verdict gate exports).

--- a/.github/workflows/archive-check.yml
+++ b/.github/workflows/archive-check.yml
@@ -1,0 +1,67 @@
+name: Archive Check
+
+# GAP-451. Docs archived out of this repo into the central fleet archive must
+# leave no live inbound links behind. Until now only the private coordination
+# repo enforced this, so links could rot here — the one repo where a dead link
+# is externally visible.
+#
+# Runs with NO secret and NO access to the archive repo: the scan needs only
+# the list of paths archived out of THIS repo (scripts/validate/
+# archived-paths.json), which are this repo's own former paths. That is what
+# makes the gate work on fork PRs, where secrets are unavailable and a
+# token-based check would silently no-op.
+#
+# The matching logic is shared with the coordination repo's checker via
+# @revealui/harnesses (packages/harnesses/src/gates/archive-check.ts), so the
+# two cannot drift.
+
+on:
+  push:
+    branches: [main, test]
+  pull_request:
+    branches: [main, test]
+  schedule:
+    # Daily. The manifest can fall behind the real archive, and the
+    # coordination repo's authoritative checker catches that separately.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "24"
+  PNPM_VERSION: "10.28.2"
+
+concurrency:
+  group: archive-check-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  archive-check:
+    name: Archive Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # The gate fails closed if it cannot resolve the shared module, so the
+      # build is a hard prerequisite rather than an optimization.
+      - name: Build the shared gates module
+        run: pnpm --filter @revealui/harnesses build
+
+      - name: Check for dead inbound links to archived docs
+        run: node scripts/validate/archive-check.cjs --ci

--- a/packages/harnesses/src/gates/__tests__/archive-check.test.ts
+++ b/packages/harnesses/src/gates/__tests__/archive-check.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ARCHIVE_URL_PREFIX,
+  countOccurrences,
+  isHistoricalPath,
+  JV_HISTORICAL_MARKERS,
+  REVEALUI_HISTORICAL_MARKERS,
+  scanInboundLinks,
+} from '../archive-check.js';
+
+const ORIGIN = 'docs/decisions/2026-01-01-some-ruling.md';
+
+function scan(files: { path: string; content: string }[], repo = 'revealui') {
+  return scanInboundLinks({
+    repoFolderName: repo,
+    originPaths: [ORIGIN],
+    files,
+    historicalMarkers: repo === 'revealui' ? REVEALUI_HISTORICAL_MARKERS : JV_HISTORICAL_MARKERS,
+  });
+}
+
+describe('countOccurrences', () => {
+  it('counts non-overlapping matches', () => {
+    expect(countOccurrences('a-b-a-b-a', 'a')).toBe(3);
+    expect(countOccurrences('aaaa', 'aa')).toBe(2);
+  });
+
+  it('returns 0 for an empty needle rather than looping forever', () => {
+    expect(countOccurrences('anything', '')).toBe(0);
+  });
+});
+
+describe('isHistoricalPath', () => {
+  it('recognizes each repo’s own historical locations', () => {
+    expect(isHistoricalPath('docs/archive/old.md', REVEALUI_HISTORICAL_MARKERS)).toBe(true);
+    expect(isHistoricalPath('docs/guides/live.md', REVEALUI_HISTORICAL_MARKERS)).toBe(false);
+
+    expect(isHistoricalPath('docs/lanes/_closed/x/plan.md', JV_HISTORICAL_MARKERS)).toBe(true);
+    expect(isHistoricalPath('docs/audits/2026-05-29-audit.md', JV_HISTORICAL_MARKERS)).toBe(true);
+    expect(isHistoricalPath('docs/gaps/GAP-451.yml', JV_HISTORICAL_MARKERS)).toBe(false);
+  });
+
+  it('keeps the two repos’ marker sets distinct', () => {
+    // docs/audits/ is historical in the coordination repo but not a declared
+    // historical location in the public one. Merging the sets would silently
+    // widen behavior in whichever repo did not ask for it.
+    expect(isHistoricalPath('docs/audits/x.md', REVEALUI_HISTORICAL_MARKERS)).toBe(false);
+  });
+});
+
+describe('scanInboundLinks', () => {
+  it('flags a live doc that still links an archived path', () => {
+    const found = scan([{ path: 'docs/guides/setup.md', content: `see [ruling](${ORIGIN})` }]);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.origin).toBe(ORIGIN);
+    expect(found[0]?.file).toBe('docs/guides/setup.md');
+    expect(found[0]?.detail).toContain(ARCHIVE_URL_PREFIX);
+  });
+
+  // The subtlety that makes a naive substring match wrong: the correct pointer
+  // CONTAINS the origin path, so matching the origin alone would flag a
+  // properly-repointed doc and make repointing impossible.
+  it('does NOT flag a correctly repointed link', () => {
+    const repointed = `https://github.com/RevealUIStudio/${ARCHIVE_URL_PREFIX}revealui/${ORIGIN}`;
+    expect(scan([{ path: 'docs/guides/setup.md', content: `see [ruling](${repointed})` }])).toEqual(
+      [],
+    );
+  });
+
+  it('flags only the excess when a file has both a repointed and a stale link', () => {
+    const repointed = `https://github.com/RevealUIStudio/${ARCHIVE_URL_PREFIX}revealui/${ORIGIN}`;
+    const found = scan([
+      { path: 'docs/guides/setup.md', content: `fixed: ${repointed}\nstale: ${ORIGIN}\n` },
+    ]);
+    expect(found).toHaveLength(1);
+  });
+
+  it('skips historical records, which correctly describe the past', () => {
+    expect(scan([{ path: 'docs/archive/2026-03-28-old.md', content: `links ${ORIGIN}` }])).toEqual(
+      [],
+    );
+  });
+
+  it('returns nothing when no paths have been archived', () => {
+    expect(
+      scanInboundLinks({
+        repoFolderName: 'revealui',
+        originPaths: [],
+        files: [{ path: 'docs/a.md', content: 'anything at all' }],
+        historicalMarkers: REVEALUI_HISTORICAL_MARKERS,
+      }),
+    ).toEqual([]);
+  });
+
+  it('ignores an empty origin entry instead of matching every file', () => {
+    const found = scanInboundLinks({
+      repoFolderName: 'revealui',
+      originPaths: [''],
+      files: [{ path: 'docs/a.md', content: 'unrelated' }],
+      historicalMarkers: REVEALUI_HISTORICAL_MARKERS,
+    });
+    expect(found).toEqual([]);
+  });
+
+  it('scopes the repointed form to the right repo folder', () => {
+    // A pointer at the WRONG repo folder is still a dead link for this repo.
+    const wrongRepo = `${ARCHIVE_URL_PREFIX}revealui-jv/${ORIGIN}`;
+    expect(scan([{ path: 'docs/a.md', content: wrongRepo }], 'revealui')).toHaveLength(1);
+  });
+});

--- a/packages/harnesses/src/gates/archive-check.ts
+++ b/packages/harnesses/src/gates/archive-check.ts
@@ -1,0 +1,143 @@
+/**
+ * Archive-check — shared inbound-link scanning for the central fleet archive.
+ *
+ * GAP-451. When a stale document is moved to the central archive
+ * (`RevealUIStudio/revfleet-archive`), every LIVE inbound link to its old path
+ * must be repointed at the archive URL. A link left behind is a dead link that
+ * looks alive — the failure class this gate exists to catch.
+ *
+ * ## Why this lives in the control layer
+ *
+ * The checker began life as a single script in the private coordination repo,
+ * which meant the PUBLIC repo had no enforcement at all: docs could be archived
+ * out of `revealui` and their inbound links rot unnoticed, in the one repo
+ * where a broken link is externally visible. Copying the script across would
+ * have created the dual-home mirror `parallel-native-implementation.md`
+ * forbids, and mirrors drift (the same lesson as GAP-408's doc-currency and
+ * guardrail2-verdict extractions, which is why those already live here).
+ *
+ * So the matching logic has ONE home — this module — and each repo keeps only
+ * a thin adapter that supplies the filesystem side.
+ *
+ * ## Why the public repo does not need archive access
+ *
+ * The archive repo is PRIVATE and `revealui` is PUBLIC. A public repo cannot
+ * safely hold a token to a private one: fork PRs receive no secrets, so the
+ * gate would silently no-op on exactly the outside contributions most worth
+ * checking, and private archive content could surface in public CI logs.
+ *
+ * The scan does not actually need the archive. It needs only the LIST OF
+ * ARCHIVED ORIGIN PATHS for the repo being scanned — and for `revealui` those
+ * are paths in `revealui` itself, carrying no private information. The public
+ * adapter therefore reads a committed paths-only manifest, and the private
+ * adapter derives the same list from the real archive (where it also validates
+ * headers and INDEX rows, which the manifest cannot).
+ */
+
+/** Prefix of a correctly-repointed archive link. */
+export const ARCHIVE_URL_PREFIX = 'revfleet-archive/blob/main/';
+
+/**
+ * Relative-path substrings marking a file as itself a historical record.
+ *
+ * A doc under one of these correctly DESCRIBES the past, so it referencing an
+ * archived path is not drift — rewriting it would make the record lie about
+ * its own moment. Mirrors the skip-list philosophy in `master-handoff.md` and
+ * `jv-doc-locations.md`.
+ *
+ * These are per-repo because the two repos organize history differently, and
+ * they are deliberately NOT merged into one broad `/archive/` pattern: that
+ * would silently widen the private repo's existing behavior during what is
+ * meant to be a behavior-preserving extraction.
+ */
+export const JV_HISTORICAL_MARKERS: readonly string[] = [
+  'docs/handoffs/archive/',
+  '.claude/archive/',
+  'docs/audits/',
+  'docs/lanes/_closed/',
+];
+
+/** Historical-record paths in the public framework repo. */
+export const REVEALUI_HISTORICAL_MARKERS: readonly string[] = ['docs/archive/'];
+
+/** True when `relPath` is itself a historical record and must not be rewritten. */
+export function isHistoricalPath(relPath: string, markers: readonly string[]): boolean {
+  return markers.some((marker) => relPath.includes(marker));
+}
+
+/** Count non-overlapping occurrences of `needle`. Substring only, no regex. */
+export function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count++;
+    idx = haystack.indexOf(needle, idx + needle.length);
+  }
+  return count;
+}
+
+/** One live file to scan. Adapters supply these; this module never touches fs. */
+export interface ScannedFile {
+  /** Repo-relative path, forward-slashed. */
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface DeadInboundLink {
+  readonly kind: 'dead-inbound-link';
+  readonly repo: string;
+  /** Repo-relative path of the file still carrying the stale link. */
+  readonly file: string;
+  /** The archived origin path it still points at. */
+  readonly origin: string;
+  readonly detail: string;
+}
+
+export interface ScanInboundLinksInput {
+  /** Archive folder name for the repo, e.g. 'revealui' or 'revealui-jv'. */
+  readonly repoFolderName: string;
+  /** Origin paths that have been archived out of this repo. */
+  readonly originPaths: readonly string[];
+  readonly files: readonly ScannedFile[];
+  readonly historicalMarkers: readonly string[];
+}
+
+/**
+ * Find live files still linking an archived path.
+ *
+ * The subtlety that makes a naive substring match wrong: a CORRECTLY repointed
+ * link necessarily contains the origin path, because the archive mirrors each
+ * repo's relative paths — the right pointer
+ * `revfleet-archive/blob/main/<repo>/<origin>` embeds `<origin>` verbatim. So
+ * matching on the origin alone flags a fixed doc exactly like a broken one,
+ * and repointing would be impossible without gaming the string. Both forms are
+ * counted and only the EXCESS is reported.
+ */
+export function scanInboundLinks(input: ScanInboundLinksInput): DeadInboundLink[] {
+  const { repoFolderName, originPaths, files, historicalMarkers } = input;
+  const violations: DeadInboundLink[] = [];
+
+  const liveFiles = files.filter((f) => !isHistoricalPath(f.path, historicalMarkers));
+
+  for (const origin of originPaths) {
+    if (!origin) continue;
+    const repointed = `${ARCHIVE_URL_PREFIX}${repoFolderName}/${origin}`;
+
+    for (const file of liveFiles) {
+      const total = countOccurrences(file.content, origin);
+      if (total === 0) continue;
+      if (total > countOccurrences(file.content, repointed)) {
+        violations.push({
+          kind: 'dead-inbound-link',
+          repo: repoFolderName,
+          file: file.path,
+          origin,
+          detail: `${file.path} still links archived path "${origin}" (repo: ${repoFolderName}) — repoint it at ${repointed}`,
+        });
+      }
+    }
+  }
+
+  return violations;
+}

--- a/packages/harnesses/src/gates/index.ts
+++ b/packages/harnesses/src/gates/index.ts
@@ -5,6 +5,19 @@
  * vendored per-repo copy.
  */
 
+export type {
+  DeadInboundLink,
+  ScanInboundLinksInput,
+  ScannedFile,
+} from './archive-check.js';
+export {
+  ARCHIVE_URL_PREFIX,
+  countOccurrences,
+  isHistoricalPath,
+  JV_HISTORICAL_MARKERS,
+  REVEALUI_HISTORICAL_MARKERS,
+  scanInboundLinks,
+} from './archive-check.js';
 export type { DetectionRule } from './doc-currency-shared-rules.js';
 export {
   COMMON_EXON,

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -391,6 +391,13 @@ async function gate(): Promise<void> {
         args: ['validate:doc-currency', '--mode=ci'],
       },
       {
+        // GAP-451: docs archived out of this repo must leave no live inbound
+        // links behind. Local parity with .github/workflows/archive-check.yml.
+        name: 'Archive links (hard fail)',
+        command: 'node',
+        args: ['scripts/validate/archive-check.cjs', '--ci'],
+      },
+      {
         name: 'Design-context drift (hard fail)',
         command: 'pnpm',
         args: ['validate:design-context'],

--- a/scripts/validate/archive-check.cjs
+++ b/scripts/validate/archive-check.cjs
@@ -1,0 +1,149 @@
+'use strict';
+// archive-check.cjs — public-repo half of the fleet archive gate (GAP-451).
+//
+// When a stale doc is moved out of this repo into the central fleet archive
+// (RevealUIStudio/revfleet-archive), every LIVE inbound link to its old path
+// must be repointed at the archive URL. A link left behind is a dead link that
+// still looks alive — in the one repo where that is externally visible.
+//
+// The matching logic is NOT vendored here. It lives once in
+// @revealui/harnesses (packages/harnesses/src/gates/archive-check.ts) and is
+// shared with the coordination repo's checker, so the two cannot drift — a
+// guarded mirror is still a mirror (GAP-408 precedent).
+//
+// WHY NO ARCHIVE ACCESS: the archive repo is private and this repo is public.
+// A public repo cannot safely hold a token to a private one (fork PRs get no
+// secrets, so the gate would silently no-op on outside contributions, and
+// private content could reach public logs). The scan does not need the
+// archive — only the list of paths archived out of THIS repo, which are this
+// repo's own paths. That list is the committed manifest below.
+//
+// The manifest is a convenience, not the authority: the coordination repo's
+// checker reads the real archive and will flag a manifest that has drifted
+// out of sync with it.
+//
+// FAIL-CLOSED on an unresolvable gates module (same posture as
+// guardrail2-verdict.cjs) — silently passing is the failure mode this exists
+// to prevent. Fails OPEN on a missing manifest, which just means nothing has
+// been archived out of this repo yet.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { resolveGatesModule } = require('./gates-resolver.cjs');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const MANIFEST_PATH = path.join(__dirname, 'archived-paths.json');
+const REPO_FOLDER_NAME = 'revealui';
+
+const SKIP_DIR_NAMES = new Set([
+  '.git',
+  'node_modules',
+  '.next',
+  'dist',
+  'build',
+  'coverage',
+  '.turbo',
+  'opensrc',
+  'playwright-report',
+  'test-results',
+]);
+
+function listMarkdownFiles(root) {
+  const out = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (SKIP_DIR_NAMES.has(entry.name)) continue;
+        stack.push(abs);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+      out.push(abs);
+    }
+  }
+  return out;
+}
+
+function readManifest() {
+  let raw;
+  try {
+    raw = fs.readFileSync(MANIFEST_PATH, 'utf8');
+  } catch {
+    return null;
+  }
+  const parsed = JSON.parse(raw);
+  const paths = parsed && parsed.archivedPaths;
+  if (!Array.isArray(paths)) {
+    throw new Error(
+      `archive-check: ${path.relative(REPO_ROOT, MANIFEST_PATH)} must contain an "archivedPaths" array.`,
+    );
+  }
+  return paths.filter((p) => typeof p === 'string' && p.length > 0);
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const ciMode = argv.includes('--ci');
+
+  const gates = resolveGatesModule();
+  if (!gates) {
+    throw new Error(
+      'archive-check: could not resolve the @revealui/harnesses gates module.\n' +
+        '  This gate protects published documentation links — failing closed rather\n' +
+        '  than silently reporting zero violations.\n' +
+        "  Fix: pnpm --filter @revealui/harnesses build (or set REVEALUI_HARNESSES_DIR).",
+    );
+  }
+
+  const originPaths = readManifest();
+  if (originPaths === null) {
+    // Nothing archived out of this repo yet.
+    if (ciMode) process.stdout.write('[archive-check] no manifest — nothing archived yet.\n');
+    process.exit(0);
+  }
+  if (originPaths.length === 0) {
+    if (ciMode) process.stdout.write('[archive-check] manifest empty — nothing to check.\n');
+    process.exit(0);
+  }
+
+  const files = listMarkdownFiles(REPO_ROOT).map((abs) => ({
+    path: path.relative(REPO_ROOT, abs).split(path.sep).join('/'),
+    content: fs.readFileSync(abs, 'utf8'),
+  }));
+
+  const violations = gates.scanInboundLinks({
+    repoFolderName: REPO_FOLDER_NAME,
+    originPaths,
+    files,
+    historicalMarkers: gates.REVEALUI_HISTORICAL_MARKERS,
+  });
+
+  if (violations.length === 0) {
+    process.stdout.write(
+      `[archive-check] OK — ${originPaths.length} archived path(s), no dead inbound links.\n`,
+    );
+    process.exit(0);
+  }
+
+  const lines = [`[archive-check] ${violations.length} dead inbound link(s):`];
+  for (const v of violations) lines.push(`  - ${v.detail}`);
+  lines.push(
+    ciMode
+      ? '[archive-check] --ci mode: failing.'
+      : '[archive-check] warn-only. Run with --ci to see enforcement behavior.',
+  );
+  process.stderr.write(`${lines.join('\n')}\n`);
+
+  process.exit(ciMode ? 1 : 0);
+}
+
+main();

--- a/scripts/validate/archived-paths.json
+++ b/scripts/validate/archived-paths.json
@@ -1,0 +1,18 @@
+{
+  "$comment": [
+    "Paths archived OUT of this repo into RevealUIStudio/revfleet-archive (GAP-451).",
+    "Paths only, by design: the archive repo is private and this repo is public, so no",
+    "archive content crosses the boundary. These are this repo's own former paths.",
+    "Consumed by scripts/validate/archive-check.cjs to flag live docs that still link them.",
+    "Regenerate when archiving a doc; the coordination repo's checker reads the real",
+    "archive and will flag this manifest if it drifts out of sync."
+  ],
+  "repoFolderName": "revealui",
+  "archivedPaths": [
+    "docs/architecture/ADR-002-dual-database.md",
+    "docs/architecture/ADR-005-two-repo-model.md",
+    "docs/archive/2026-03-28-DOCUMENTATION_ASSESSMENT.md",
+    "docs/archive/README.md",
+    "docs/decisions/licensing-platform-evaluation.md"
+  ]
+}


### PR DESCRIPTION
Closes the enforcement disparity between the private coordination repo and this
one. Owner-directed, and coordinated with the live GAP-451 session (see the
workboard note).

## The gap

`.jv` has enforced the archive convention since Phase 1. This repo had
**nothing**: no validator, no workflow, no session warning. #2252 just archived
five docs out of here, so live docs could start linking dead paths with no
signal — in the one repo where a broken link is externally visible.

This is not theoretical. The same failure class made `.jv`'s `test` branch red
for 45 minutes today (13 dead inbound links after the Phase 4 migration).

## What landed

| | before | after |
|---|---|---|
| validator | `.jv` only | shared module + adapter in both |
| CI gate | `.jv` only | + `archive-check.yml` here |
| local gate | `.jv` only | + hard-fail step in `pnpm gate` |

The matching logic is **not copied**. It lives once in
`packages/harnesses/src/gates/archive-check.ts`, consumed by thin adapters —
the GAP-408 precedent already used for `doc-currency-shared-rules` and
`guardrail2-verdict`. A guarded mirror is still a mirror.

## Why this gate needs no secret

The archive repo is private; this repo is public. A public repo cannot safely
hold a token to a private one — fork PRs receive no secrets, so the gate would
silently no-op on exactly the outside contributions most worth checking, and
private archive content could reach public CI logs.

The scan does not need the archive. It needs only the list of paths archived
out of **this** repo, which are this repo's own former paths and carry nothing
private. That is `scripts/validate/archived-paths.json`, generated from the real
archive and committed here.

The manifest is a convenience, not the authority: `.jv`'s checker reads the
actual archive and will flag this manifest if it drifts.

## Behavior-preserving extraction

Historical-path marker sets stay **per-repo** and are deliberately not merged
into one broad `/archive/` pattern — that would silently widen `.jv`'s existing
skip behavior during what should be a pure extraction. This repo declares its
own (`docs/archive/`).

The repointed-vs-stale distinction (a correct pointer *contains* the origin
path, so a naive match would flag fixed docs and make repointing impossible) is
ported as-is from the peer's recent fix, with a test pinning it.

## Verification

- 36 gate tests pass, 11 new.
- **The gate was proven to fire**, not just to pass: a probe file linking an
  archived path is caught, exits 1 under `--ci`, exits 0 in warn mode, and
  exits 0 once removed.
- Against the real tree: 5 archived paths, no dead links.
- Fails closed when the shared module cannot be resolved — silently reporting
  zero violations is the precise failure this exists to prevent.

## Follow-up (not in this PR)

`.jv`'s `scripts/archive-check.js` still carries its own copy of the scan. Its
cutover to this shared module is the remaining half; left to the live GAP-451
session rather than edited concurrently.

Refs GAP-451.
