### PR TITLE
fix(worker-liveness): report a safe fingerprint of the failing error's shape

### DIFF
--- a/apps/server/src/routes/cron/worker-liveness.test.ts
+++ b/apps/server/src/routes/cron/worker-liveness.test.ts
@@ -43,7 +43,7 @@ vi.mock('@revealui/security/server', async () => {
   };
 });
 
-import app, { classifyProbeError, safeErrorCode } from './worker-liveness.js';
+import app, { classifyProbeError, safeErrorCode, safeErrorNames } from './worker-liveness.js';
 
 const CRON_SECRET = 'test-cron-secret-long-enough-32chars!';
 
@@ -248,6 +248,34 @@ describe('classifyProbeError', () => {
     const top = new TypeError('fetch failed', { cause: aggregate });
 
     expect(classifyProbeError(top)).toBe('dns-unresolved');
+  });
+
+  // GAP-455 round 3. Two deployed classifiers both answered 'network-error'
+  // with no code, so the SHAPE of the throw is the remaining signal.
+  it('fingerprints the error tree with allowlisted class names', () => {
+    const aggregate = new AggregateError([new RangeError('x')], 'all failed');
+    const top = new TypeError('fetch failed', { cause: aggregate });
+    expect(safeErrorNames(top)).toEqual(['TypeError', 'AggregateError', 'RangeError']);
+  });
+
+  it('reports an unrecognized error class as "other" rather than echoing it', () => {
+    class SneakyError extends Error {
+      override name = 'Sneaky https://worker.example.internal';
+    }
+    const names = safeErrorNames(new SneakyError('boom'));
+    expect(names).toEqual(['other']);
+    expect(names.join(',')).not.toContain('worker.example.internal');
+  });
+
+  it('names a non-Error throw, which the walk cannot otherwise see', () => {
+    expect(safeErrorNames('just a string')).toEqual(['non-error-throw']);
+    expect(safeErrorNames(undefined)).toEqual(['undefined-throw']);
+  });
+
+  it('caps the fingerprint so a deep tree cannot produce unbounded output', () => {
+    let err = new Error('leaf');
+    for (let i = 0; i < 30; i++) err = new Error(`level-${i}`, { cause: err });
+    expect(safeErrorNames(err).length).toBeLessThanOrEqual(8);
   });
 
   it('terminates on an AggregateError that contains itself', () => {

--- a/apps/server/src/routes/cron/worker-liveness.ts
+++ b/apps/server/src/routes/cron/worker-liveness.ts
@@ -49,7 +49,7 @@ const HEALTH_CHECK_TIMEOUT_MS = 10_000;
  * change to the diagnostic contract; then one run always says which build
  * answered. Cheap, and it never leaks anything about the target.
  */
-const PROBE_VERSION = 2;
+const PROBE_VERSION = 3;
 
 const safeFetch = createSafeFetch();
 
@@ -193,6 +193,65 @@ export function safeErrorCode(err: unknown): string | undefined {
   return code;
 }
 
+/**
+ * Error class names we are willing to echo, because each is a fixed identifier
+ * from Node/undici/the platform and carries nothing about the target.
+ *
+ * An allowlist rather than "just report err.name": a custom error class could
+ * in principle carry data in its name, and this response is read from a PUBLIC
+ * repo's CI logs. Anything unrecognized is reported as 'other', which is still
+ * the diagnostic signal we need (it says "not one of the known shapes") while
+ * making a leak structurally impossible.
+ */
+const REPORTABLE_ERROR_NAMES: ReadonlySet<string> = new Set([
+  'AbortError',
+  'AggregateError',
+  'DOMException',
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SocketError',
+  'SyntaxError',
+  'TimeoutError',
+  'TypeError',
+  'URIError',
+  'UndiciError',
+]);
+
+/** Cap on reported names, so a pathological tree cannot produce unbounded output. */
+const MAX_REPORTED_NAMES = 8;
+
+/**
+ * A safe structural fingerprint of the failure: the class names along the
+ * error tree, in visit order.
+ *
+ * GAP-455, round 3. Two deployed classifiers have now both answered
+ * 'network-error' with no code — meaning the throw carries no SSRF message and
+ * no `code` anywhere, including inside AggregateError.errors. That narrows the
+ * cause but does not name it, and each further guess costs a full deploy
+ * cycle.
+ *
+ * Reporting the SHAPE ends the guessing: `['TypeError','AggregateError']` says
+ * something very different from `['Error']` or `['other']`, and none of it can
+ * leak the worker's hostname the way a message would.
+ */
+export function safeErrorNames(err: unknown): string[] {
+  const names: string[] = [];
+
+  walkErrorTree(err, (current) => {
+    if (names.length >= MAX_REPORTED_NAMES) return;
+    names.push(REPORTABLE_ERROR_NAMES.has(current.name) ? current.name : 'other');
+  });
+
+  // A throw that is not an Error at all never enters the walk, and that is
+  // itself a live hypothesis for the observed body — so say so explicitly
+  // rather than reporting an empty array that reads like "nothing happened".
+  if (names.length === 0) names.push(err === undefined ? 'undefined-throw' : 'non-error-throw');
+
+  return names;
+}
+
 app.get('/worker-liveness', async (c) => {
   const cronSecret = process.env.REVEALUI_CRON_SECRET;
   const provided = c.req.header('X-Cron-Secret') || c.req.header('x-cron-secret');
@@ -256,13 +315,16 @@ app.get('/worker-liveness', async (c) => {
     // from classifyProbeError and (when present) the constant error code.
     const reason = classifyProbeError(err);
     const code = safeErrorCode(err);
+    // Round 3: two deployed classifiers both answered 'network-error' with no
+    // code, so the SHAPE of the throw is now the only thing left to report.
+    const names = safeErrorNames(err);
 
     // GAP-455: these buckets used to be one. Every non-timeout throw reported
     // 'network-error', so a probe that never opened a socket (guard rejection,
     // DNS failure, bad env value) was indistinguishable from a genuinely dark
     // worker  -  and the first live runs were exactly that false alarm. The
     // split is what makes a red run diagnosable from its body alone.
-    logger.error(`[worker-liveness] probe failed (${reason})`, undefined, { reason, code });
+    logger.error(`[worker-liveness] probe failed (${reason})`, undefined, { reason, code, names });
     void sendCronFailureAlert({
       jobName: 'worker-liveness',
       error: new Error(
@@ -271,9 +333,12 @@ app.get('/worker-liveness', async (c) => {
           : `Worker liveness check failed: ${reason}${code ? ` (${code})` : ''}`,
       ),
       severity: 'error',
-      metadata: { reason, code },
+      metadata: { reason, code, names },
     });
-    return c.json({ healthy: false, error: reason, code, checkedAt, probe: PROBE_VERSION }, 503);
+    return c.json(
+      { healthy: false, error: reason, code, names, checkedAt, probe: PROBE_VERSION },
+      503,
+    );
   }
 });
 


### PR DESCRIPTION
## The probe:2 run came back, and it killed the leading hypothesis

```json
{"healthy":false,"error":"network-error","checkedAt":"...","probe":2}
```

`probe: 2` confirms the AggregateError traversal from #2249 is live — the version marker did its job on its first outing. And the answer is still `network-error` with **no code**, now including inside `AggregateError.errors`.

That rules out the c-ares/DNS theory this gap was filed on: a resolver failure would surface as `dns-unresolved`, and any guard rejection as `blocked-by-guard`. Whatever throws carries no SSRF message and no error code anywhere in its tree.

## Why a fingerprint instead of a third guess

The remaining signal is the *shape* of the throw, and each further guess costs a full deploy cycle. `safeErrorNames` walks the same tree and reports class names in visit order — `['TypeError','AggregateError']` says something very different from `['Error']` or `['non-error-throw']`.

It also names the **non-Error-throw** case explicitly. `walkErrorTree` requires `instanceof Error`, so a thrown string or `undefined` produces exactly the observed body. An empty fingerprint would read as "nothing happened" when it is in fact a live hypothesis.

## Leak-safe by construction

Names come from an **allowlist** of platform error classes rather than echoing `err.name`, because a custom class could carry data in its name and this body is read from a PUBLIC repo's CI logs. Anything unrecognized reports as `other` — still the signal we need, while making a leak structurally impossible.

A test constructs an error whose `name` embeds a hostname and asserts it does not survive. Output is capped at 8 entries so a pathological tree cannot produce unbounded output.

## Verification

25 tests pass. Pre-PR fleet security check run **before** opening this time: no security-sensitive files, no coordinator gate. (I skipped that step on #2253 and had to correct myself after the gate caught it.)

## Still open

Schedule stays **disabled**, GAP-455 stays **open**, worker liveness stays unmonitored. This is diagnosis, not the cause fix — but it should be the last diagnostic round, since a fingerprint plus the absent code narrows the shape to something identifiable.