### PR TITLE
fix(ci): scope the archive-check install so the gate stops timing out

### DIFF
--- a/.github/workflows/archive-check.yml
+++ b/.github/workflows/archive-check.yml
@@ -41,7 +41,9 @@ jobs:
   archive-check:
     name: Archive Check
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Headroom over the scoped install + build. The first version of this
+    # workflow set 10 with an unscoped install and was cancelled at the limit.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -54,9 +56,15 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
 
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      # SCOPED install, not a full monorepo one. This gate needs exactly one
+      # package built; installing all 27 workspaces cold took over 10 minutes
+      # and hit the job timeout before the check ever ran, turning this gate
+      # into a red X on unrelated PRs. Same shape as security-review-gate.yml,
+      # which is the other lightweight gate job in this repo.
+      - name: Install (harnesses only)
+        run: pnpm install --frozen-lockfile --filter @revealui/harnesses
 
       # The gate fails closed if it cannot resolve the shared module, so the
       # build is a hard prerequisite rather than an optimization.


### PR DESCRIPTION
## What happened

The `Archive Check` job I added in #2253 was **cancelled at its 10-minute timeout** on PR #2255 — not failed. Every step after `Install` was skipped, so the check never actually ran. A gate meant to protect documentation links instead put a red X on an unrelated backflow PR.

```
5. Install                     — cancelled   ← hit timeout-minutes: 10
6. Build the shared gates module — skipped
7. Check for dead inbound links  — skipped
```

## Cause

My workflow ran a full monorepo `pnpm install --frozen-lockfile` with no pnpm cache. Installing all 27 workspaces cold does not fit in 10 minutes — and this gate needs exactly **one** package built.

`security-review-gate.yml`, the other lightweight gate job in this repo, already had this right:

```
pnpm install --frozen-lockfile --filter @revealui/harnesses
pnpm --filter @revealui/harnesses build
```

I wrote a new workflow instead of following the existing pattern for exactly this shape of job.

## Fix

Scoped install + `cache: pnpm`. Timeout raised to 20 for headroom, but that is not the fix — the install shape is.

Verified the gate still reports correctly with only that package built: 5 archived paths, no dead inbound links.

## Note

Until this merges, `Archive Check` will keep timing out on open PRs. It is a genuine red, not a flake — worth merging ahead of the others queued up.