### PR TITLE
docs(plan): drop dead ADR-005 link and the superseded two-repo claim

### DIFF
--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -14,10 +14,9 @@ owner: RevealUI Studio
 
 **This public snapshot is retired (2026-07-16).**
 
-Detailed planning for RevealUI lives in the internal coordination hub, per the
-two-repo model in
-[ADR-005](./architecture/ADR-005-two-repo-model.md): release timelines and
-phase tracking are business-sensitive and are not mirrored into this repo. The
+Detailed planning for RevealUI lives in a private internal coordination hub:
+release timelines and phase tracking are business-sensitive and are not
+mirrored into this repo. The
 former quarterly public-snapshot cadence is retired with this stub; the
 snapshot repeatedly aged into stale guidance between refreshes (see the
 drift-sweep findings in PR #1893).


### PR DESCRIPTION
One dead link, plus a stale claim that came with it.

## The link

`ADR-005-two-repo-model.md` was promoted to the central fleet archive earlier today, so the relative link in `docs/MASTER_PLAN.md` no longer resolves.

## The claim

The same sentence asserted the **two-repo model**. ADR-005 itself records that as superseded by the four-repo model on 2026-05-18 — so the citation pointed at a document contradicting the sentence it was supporting. Dropping the link and the stale framing fixes both.

## No archive URL substituted

The archive is private and this repo is public. A citation that 404s for every outside reader is worse than no citation.

## How it was found

The archive gate's new relative-link resolution. The previous scan matched only repo-rooted paths, so every relative markdown link in the fleet was invisible to it — and this one had been green while dead. Turning that on found 26 previously-unreported dead links fleet-wide; this is the only one in the public repo.

Docs only. Full local gate passed, including `Archive links (hard fail)` — which itself only started working after a stale `@revealui/harnesses` dist was rebuilt (`scanInboundLinks` existed in source but not in `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)