### PR TITLE
fix(security): the SSRF guard now says when it cannot build itself

### DIFF
--- a/packages/security/src/__tests__/ssrf.test.ts
+++ b/packages/security/src/__tests__/ssrf.test.ts
@@ -201,4 +201,59 @@ describe('createSafeFetch', () => {
     });
     await expect(safeFetch('https://1.1.1.1/')).rejects.toThrow('refusing to follow redirect');
   });
+
+  // GAP-455. A dispatcher that cannot be built used to surface as a bare
+  // TypeError with no `cause` and no `code` — indistinguishable from a network
+  // fault. A "worker unreachable" alarm was actually this, and it took four
+  // rounds and three production deploys to tell the two apart.
+  describe('when the connection guard cannot be built', () => {
+    it('reports a guard failure, not something that looks like a network fault', async () => {
+      const baseFetch = vi.fn();
+      const safeFetch = createSafeFetch({
+        baseFetch: baseFetch as unknown as typeof fetch,
+        dispatcherFactory: async () => {
+          throw new TypeError('Agent is not a constructor');
+        },
+      });
+
+      await expect(safeFetch('https://1.1.1.1/')).rejects.toThrow('SSRF:');
+      // Fails CLOSED: the request must not proceed unpinned.
+      expect(baseFetch).not.toHaveBeenCalled();
+    });
+
+    it('does not leak the target into the guard-failure message', async () => {
+      const safeFetch = createSafeFetch({
+        baseFetch: vi.fn() as unknown as typeof fetch,
+        dispatcherFactory: async () => {
+          throw new TypeError('boom');
+        },
+      });
+
+      const err = await safeFetch('https://1.1.1.1/secret-path').catch((e: Error) => e);
+      expect(err.message.startsWith('SSRF: connection guard unavailable')).toBe(true);
+      expect(err.message).not.toContain('1.1.1.1');
+      expect(err.message).not.toContain('secret-path');
+    });
+
+    it('retries construction instead of caching the rejection forever', async () => {
+      let attempts = 0;
+      const dispatcher = { sentinel: true };
+      const baseFetch = vi.fn(async () => new Response('ok', { status: 200 }));
+
+      const safeFetch = createSafeFetch({
+        baseFetch: baseFetch as unknown as typeof fetch,
+        dispatcherFactory: async () => {
+          attempts += 1;
+          if (attempts === 1) throw new TypeError('transient');
+          return dispatcher;
+        },
+      });
+
+      await expect(safeFetch('https://1.1.1.1/')).rejects.toThrow('SSRF:');
+      // Second call must rebuild. Memoizing the rejected promise previously
+      // poisoned every later call for the life of the process.
+      await expect(safeFetch('https://1.1.1.1/')).resolves.toBeDefined();
+      expect(attempts).toBe(2);
+    });
+  });
 });

--- a/packages/security/src/ssrf.ts
+++ b/packages/security/src/ssrf.ts
@@ -274,7 +274,27 @@ export function createSafeFetch(options: SafeFetchOptions = {}): typeof fetch {
 
   let dispatcherPromise: Promise<unknown> | undefined;
   const getDispatcher = (): Promise<unknown> => {
-    if (!dispatcherPromise) dispatcherPromise = dispatcherFactory();
+    if (!dispatcherPromise) {
+      dispatcherPromise = dispatcherFactory().catch((err: unknown) => {
+        // Do NOT cache a rejected promise. Previously one transient failure
+        // poisoned every later call for the life of the process, because the
+        // rejected promise was memoized and returned forever.
+        dispatcherPromise = undefined;
+
+        // Re-label as an SSRF-prefixed failure. A raw construction error is a
+        // bare TypeError with no `cause` and no `code`, which is
+        // indistinguishable from a network fault to any caller — GAP-455 spent
+        // four rounds and three deploys discovering that a "worker unreachable"
+        // alarm was actually this. The guard failing to build itself and the
+        // network failing are different diagnoses and must read differently.
+        //
+        // The message is a fixed constant: nothing from `err` is interpolated,
+        // so no target hostname can reach a log or an alert through here.
+        throw new Error('SSRF: connection guard unavailable — dispatcher initialization failed', {
+          cause: err,
+        });
+      });
+    }
     return dispatcherPromise;
   };
 
@@ -316,7 +336,21 @@ export function createSafeFetch(options: SafeFetchOptions = {}): typeof fetch {
  * internal address.
  */
 async function createValidatingDispatcher(): Promise<unknown> {
-  const { Agent } = await import('undici');
+  const mod = await import('undici');
+
+  // Resolve `Agent` from either module shape. A bundler can hand back a CJS
+  // namespace whose real exports sit under `default`, leaving `mod.Agent`
+  // undefined so `new Agent(...)` throws a bare TypeError with no `code` —
+  // which is exactly the signature observed in production (GAP-455). A missing
+  // module would instead carry ERR_MODULE_NOT_FOUND, so the import succeeding
+  // while `Agent` is absent is the interop case, not an absent dependency.
+  const candidate =
+    (mod as { Agent?: unknown }).Agent ?? (mod as { default?: { Agent?: unknown } }).default?.Agent;
+
+  if (typeof candidate !== 'function') {
+    throw new Error('SSRF: connection guard unavailable — undici Agent could not be resolved');
+  }
+  const Agent = candidate as typeof import('undici').Agent;
   const lookup = (
     hostname: string,
     _options: unknown,


### PR DESCRIPTION
⚠️ **SECURITY-SENSITIVE — review-pending, do not merge.** Touches `packages/security`. Needs a recorded guardrail-2 verdict from someone who did not author it. I wrote both this and the classifier that found it, so I must not clear it.

## What was actually wrong

A guard that fails to construct threw a **bare TypeError with no cause and no code** — indistinguishable from a network fault to every caller.

GAP-455 spent four rounds and three production deploys on this. The "worker unreachable" alarm was never about the worker. **The probe never contacted it**, which is exactly why the worker looked healthy throughout: it was.

## Located by shape, not by guessing

The deployed fingerprint returned `names:["TypeError"]` with no code. Local reproduction against the real guard showed only one site produces that signature:

| Simulated failure | Signature |
|---|---|
| **construction throws** | **`["TypeError"]`, no code** ← matches production |
| bogus dispatcher | `["TypeError","TypeError"]` |
| undefined dispatcher | no throw |
| any malformed URL | carries `ERR_INVALID_URL` |

## Changes

**1. Agent resolution handles both module shapes.** A bundler can return a CJS namespace whose exports sit under `default`, leaving `mod.Agent` undefined so `new Agent()` throws a bare TypeError. A genuinely missing module would carry `ERR_MODULE_NOT_FOUND`, so an import that *succeeds* while `Agent` is absent is the interop case, not an absent dependency.

**2. Construction failures are re-labelled** with a fixed `SSRF:`-prefixed message. Nothing from the caught error is interpolated, so no target hostname can reach a log or alert through this path. A test asserts the target does not appear in the message.

**3. Poisoned-promise fix**, found while reading: a rejected dispatcher promise was memoized and returned **forever**, so one transient construction failure broke every later call for the life of the process. It now clears and rebuilds.

## The security boundary is unchanged

It still **fails closed**. Requests do not proceed unpinned, they do not proceed at all. This makes an existing refusal *legible*; it does not relax it. The reviewer's question is whether the re-labelling can mask a real network fault — I believe not, since it wraps only the dispatcher factory, never the fetch call.

## Blast radius beyond the probe

`createSafeFetch` also backs `apps/server/src/routes/marketplace.ts` (the MCP proxy) and `packages/mcp/src/remote-client.ts`. If construction fails in that runtime, the marketplace returns 502 and marks transactions `failed` — **blaming the upstream operator for a fault on our side**. Still an inference; I have not driven those routes.

## Verification

63 tests pass, 3 new, **all proven red against the unfixed file** (reverting only `ssrf.ts` fails exactly those three).