### PR TITLE
test(ci): archive gate proves itself red and green on every run

### DIFF
--- a/.github/workflows/archive-check.yml
+++ b/.github/workflows/archive-check.yml
@@ -71,5 +71,27 @@ jobs:
       - name: Build the shared gates module
         run: pnpm --filter @revealui/harnesses build
 
+      # jv#871: a gate is not wired until CI has observed it green AND red.
+      # Seeding a violation into the repo cannot prove the red half, because
+      # this gate also runs in the local pre-push gate and correctly refuses
+      # the push first. So it proves itself against a fixture, every run.
+      - name: Self-test — the gate must FIRE on a seeded violation
+        run: |
+          fixture="$RUNNER_TEMP/archive-gate-fixture"
+          mkdir -p "$fixture/docs"
+          printf '[stale](docs/architecture/ADR-002-dual-database.md)\n' > "$fixture/docs/seed.md"
+          if node scripts/validate/archive-check.cjs --ci --root "$fixture"; then
+            echo "::error::archive-check did NOT fire on a seeded dead link — the gate is not actually checking anything"
+            exit 1
+          fi
+          echo "OK — gate fired on the seeded violation."
+
+      - name: Self-test — the gate must PASS on a clean fixture
+        run: |
+          clean="$RUNNER_TEMP/archive-gate-clean"
+          mkdir -p "$clean/docs"
+          printf 'no archived links here\n' > "$clean/docs/fine.md"
+          node scripts/validate/archive-check.cjs --ci --root "$clean"
+
       - name: Check for dead inbound links to archived docs
         run: node scripts/validate/archive-check.cjs --ci

--- a/scripts/validate/archive-check.cjs
+++ b/scripts/validate/archive-check.cjs
@@ -31,7 +31,22 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { resolveGatesModule } = require('./gates-resolver.cjs');
 
-const REPO_ROOT = path.resolve(__dirname, '..', '..');
+// `--root <dir>` scans a directory other than this repo. Its only purpose is
+// the CI self-test below: a gate wired into BOTH the local pre-push gate and CI
+// cannot be observed firing in CI by seeding a violation into the repo, because
+// the local gate correctly refuses the push first (and --no-verify is
+// forbidden). So the gate proves itself against a fixture instead, on every
+// run, which is stronger than a one-off observation anyway.
+function resolveRoot() {
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--root') return path.resolve(argv[i + 1] || '');
+    if (argv[i].startsWith('--root=')) return path.resolve(argv[i].slice('--root='.length));
+  }
+  return path.resolve(__dirname, '..', '..');
+}
+
+const REPO_ROOT = resolveRoot();
 const MANIFEST_PATH = path.join(__dirname, 'archived-paths.json');
 const REPO_FOLDER_NAME = 'revealui';
 


### PR DESCRIPTION
Closes my own exception to the rule I asked the peer to codify in jv#871: *a gate is not wired until CI has run it green AND red.*

The public archive gate had been observed **green in CI** and **red locally**. Not good enough by that bar.

## Why the obvious approach does not work, and why that matters

I tried seeding a dead link into the repo to force a red CI run. The push was refused — by **my own gate**, running in the local pre-push gate, before CI ever saw it. `--no-verify` is forbidden.

**Any gate with local/CI parity has this property.** The convention as written is unachievable for that entire class, which is worth knowing before someone else hits it and quietly skips the red half.

## The fixture approach is better than the one-off anyway

Two CI steps now run before the real scan:

```
Self-test — the gate must FIRE on a seeded violation   → asserts non-zero exit
Self-test — the gate must PASS on a clean fixture      → asserts zero exit
Check for dead inbound links to archived docs          → the real scan
```

This proves both directions **on every run**, not once at introduction. A gate that silently stops checking anything now fails its own self-test rather than reporting a comfortable green forever — which is precisely how both fleet archive gates failed earlier today.

Adds `--root` to the adapter, used only by those steps.

## Verification

```
seeded fixture exit=1   (gate fires)
clean  fixture exit=0   (gate passes)
real repo: OK — 5 archived path(s), no dead inbound links
```

Not security-sensitive (checked before opening).