### PR TITLE
fix(worker-liveness): a guard that cannot build itself is not a blocked target

### DIFF
--- a/apps/server/src/routes/cron/worker-liveness.test.ts
+++ b/apps/server/src/routes/cron/worker-liveness.test.ts
@@ -310,6 +310,29 @@ describe('classifyProbeError against the real SSRF guard', () => {
     );
   });
 
+  // Locks the fragment against the guard's ACTUAL message. If ssrf.ts rewords
+  // "connection guard unavailable", this fails — rather than silently
+  // degrading to 'blocked-by-guard', which is a valid enum value and would
+  // therefore break nothing while pointing an operator at the wrong system.
+  it('classifies a guard that cannot build itself as guard-unavailable', async () => {
+    const { createSafeFetch: realSafeFetch } = await vi.importActual<
+      typeof import('@revealui/security/server')
+    >('@revealui/security/server');
+
+    const broken = realSafeFetch({
+      dispatcherFactory: async () => {
+        throw new TypeError('Agent is not a constructor');
+      },
+    });
+
+    const err = await broken('https://1.1.1.1/health').catch((e: unknown) => e);
+    expect(classifyProbeError(err)).toBe('guard-unavailable');
+
+    // The distinction that matters operationally: this must NOT read as the
+    // target having been blocked.
+    expect(classifyProbeError(err)).not.toBe('blocked-by-guard');
+  });
+
   it('classifies an unresolvable host as dns-unresolved', async () => {
     const { createSafeFetch: realSafeFetch } = await vi.importActual<
       typeof import('@revealui/security/server')

--- a/apps/server/src/routes/cron/worker-liveness.ts
+++ b/apps/server/src/routes/cron/worker-liveness.ts
@@ -49,7 +49,7 @@ const HEALTH_CHECK_TIMEOUT_MS = 10_000;
  * change to the diagnostic contract; then one run always says which build
  * answered. Cheap, and it never leaks anything about the target.
  */
-const PROBE_VERSION = 3;
+const PROBE_VERSION = 4;
 
 const safeFetch = createSafeFetch();
 
@@ -69,6 +69,7 @@ export type ProbeFailureReason =
   | 'blocked-private-ip'
   | 'blocked-redirect'
   | 'invalid-target'
+  | 'guard-unavailable'
   | 'blocked-by-guard'
   | 'network-error';
 
@@ -85,6 +86,15 @@ export type ProbeFailureReason =
  * (which is the exact bug GAP-455 is about).
  */
 const GUARD_MESSAGE_TOKENS: ReadonlyArray<readonly [string, ProbeFailureReason]> = [
+  // The guard could not BUILD itself, so nothing was ever dialled and the
+  // target's health is unknown rather than bad. Without this entry the message
+  // falls through to the generic `SSRF:` branch and reports
+  // 'blocked-by-guard', which an operator correctly reads as "the target was
+  // blocked" and takes to the worker URL or the allowlist — the wrong place
+  // entirely. That is the same misdirection GAP-455 spent four rounds and
+  // three deploys on, one level up, and nothing fails when it happens because
+  // 'blocked-by-guard' is a valid value. Caught in review of #2263.
+  ['connection guard unavailable', 'guard-unavailable'],
   ['did not resolve to any public IP', 'dns-unresolved'],
   ['resolved to private IP', 'blocked-private-ip'],
   ['is a private/reserved IP', 'blocked-private-ip'],


### PR DESCRIPTION
Follow-up to the guardrail-2 review of #2263, which caught that PR undoing its own stated goal one level up. Implements the reviewer's suggested fix verbatim.

## The finding

#2263 made the guard say `connection guard unavailable`. That message matched no entry in `GUARD_MESSAGE_TOKENS`, so it fell through to the generic `SSRF:` branch and classified as **`blocked-by-guard`**.

An operator reading `blocked-by-guard` correctly understands *"the target was blocked"* and goes to the worker URL or the allowlist. The real condition is that **the guard could not construct itself and nothing was ever dialled** — the target's health is unknown, not bad.

That is the same misdirection GAP-455 spent four rounds and three deploys on, moved up a level. And nothing failed when it happened, because `blocked-by-guard` is a valid enum value: it degraded **silently**, which is exactly what that file's own header warns about.

## Change

- `guard-unavailable` added to `ProbeFailureReason` and `GUARD_MESSAGE_TOKENS`
- `PROBE_VERSION` 3 → 4, since the diagnostic contract changed

## The test drives the real guard

Not a synthetic message. It calls the actual `createSafeFetch` with a `dispatcherFactory` that throws, so the fragment is locked against `ssrf.ts`'s real text — if that message is reworded, this fails rather than silently degrading again.

**Proven red against the pre-fix classifier**, failing with exactly:

```
expected 'blocked-by-guard' to be 'guard-unavailable'
```

26 tests pass. Not security-sensitive (checked before opening).

## Credit

The reviewer caught this, not me. I wrote both the guard fix and the classifier and did not notice the consumer collapsing the distinction the guard had just gained — which is a reasonable argument for why non-author review is worth its latency.