### PR TITLE
fix(marketing): replace dead five-primitive vocab on public surfaces (GAP-456)

### DIFF
--- a/apps/docs/app/routes/DocsIndexPage.tsx
+++ b/apps/docs/app/routes/DocsIndexPage.tsx
@@ -10,7 +10,7 @@ export function DocsIndexPage() {
 
   const content = `# RevealUI Documentation
 
-Agentic business runtime. Users, content, products, payments, and AI come pre-wired, open source, and ready to deploy.
+Agentic business runtime. People, Content, Offers, Payments, and Agents come pre-wired, open source, and ready to deploy.
 
 ## Quick Start
 

--- a/apps/docs/app/showcase/accordion.showcase.tsx
+++ b/apps/docs/app/showcase/accordion.showcase.tsx
@@ -45,8 +45,8 @@ const story: ShowcaseStory = {
         <Accordion>
           <AccordionItem title="What is RevealUI?">
             <p>
-              RevealUI is an agentic business runtime that provides users, content, products,
-              payments, and AI out of the box.
+              RevealUI is an agentic business runtime that provides People, Content, Offers,
+              Payments, and Agents out of the box.
             </p>
           </AccordionItem>
           <AccordionItem title="Is it open source?">

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -433,7 +433,7 @@ const LICENSE_ED25519: EvidenceRef = {
 const ENGINES: EvidenceRef = {
   kind: 'code',
   ref: 'packages/engines/src',
-  note: 'the five business primitives: users, content, products, payments, agents',
+  note: 'the five business primitives: People, Content, Offers, Payments, Agents',
 };
 const AGENT_CHAT: EvidenceRef = {
   kind: 'code',

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -154,7 +154,7 @@ export function BlogPostPage() {
             Ready to build?
           </h2>
           <p className="mt-4 text-base leading-7 text-muted-foreground">
-            Users, content, products, payments, and intelligence, pre-wired. Start locally in
+            People, Content, Offers, Payments, and Agents, pre-wired. Start locally in
             minutes.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -154,8 +154,7 @@ export function BlogPostPage() {
             Ready to build?
           </h2>
           <p className="mt-4 text-base leading-7 text-muted-foreground">
-            People, Content, Offers, Payments, and Agents, pre-wired. Start locally in
-            minutes.
+            People, Content, Offers, Payments, and Agents, pre-wired. Start locally in minutes.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
             <Button asChild size="lg" variant="brand">

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -1,6 +1,6 @@
 # RevealUI
 
-> The agentic business runtime. Five primitives — users, content, products, payments, AI — pre-wired for humans and AI agents to build businesses together. Open source (MIT) + Fair Source (FSL-1.1-MIT) Pro packages. Self-hostable. No vendor lock-in.
+> The agentic business runtime. Five primitives: People, Content, Offers, Payments, and Agents, pre-wired for humans and AI agents to build businesses together. Open source (MIT) + Fair Source (FSL-1.1-MIT) Pro packages. Self-hostable. No vendor lock-in.
 
 ## Documentation
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -11,7 +11,7 @@ I've started three software companies. Each time, I spent the first three to six
 
 That's not a skills problem. That's an infrastructure problem. And after the third time, I decided to solve it.
 
-RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence (the five primitives every product needs) are pre-wired, open source, and ready to deploy. One codebase. One deployment. Zero months wasted on plumbing.
+RevealUI is the open runtime for businesses that run their own AI. People, Content, Offers, Payments, and Agents (the five primitives every product needs) are pre-wired, open source, and ready to deploy. One codebase. One deployment. Zero months wasted on plumbing.
 
 ## The problem nobody talks about
 
@@ -225,7 +225,7 @@ RevealUI is not an admin with plugins bolted on. It's not a boilerplate you clon
 
 When a user signs up, the auth system creates their session, assigns their default role, and checks their license tier. When they access content, the collection's `access.read` function can reference their tier, their role, or any custom claim. When they upgrade via Stripe, the webhook handler updates their license, which updates their feature flags, which unlocks gated content and capabilities, all in the same request cycle.
 
-This is the part that's genuinely hard to replicate by stitching services together. The integration isn't in the glue code between separate tools. The integration is in the data model. Users, content, products, payments, and features share a schema. They share a database. They share a session. The relationships are first-class, not afterthoughts.
+This is the part that's genuinely hard to replicate by stitching services together. The integration isn't in the glue code between separate tools. The integration is in the data model. People, content, offers, payments, and agents share a schema. They share a database. They share a session. The relationships are first-class, not afterthoughts.
 
 Some numbers on what's actually shipped:
 
@@ -257,7 +257,7 @@ RevDev Studio (Tauri + React) is the native AI experience for agent coordination
 
 The near-term roadmap includes MCP server registry listings, A2A agent discovery for RevealUI-to-RevealUI communication, a broader template library, and a template marketplace where developers can publish project starters. The community lives on [GitHub Discussions](https://github.com/RevealUIStudio/revealui/discussions), so join early and help shape what gets built next.
 
-But the core thesis won't change: **every software company needs users, content, products, payments, and intelligence. You shouldn't have to build them from scratch.**
+But the core thesis won't change: **every software company needs People, Content, Offers, Payments, and Agents. You shouldn't have to build them from scratch.**
 
 Build your business, not your boilerplate.
 

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -107,7 +107,7 @@ sudo snap install nemotron-3-nano    # Or: ollama pull gemma4:e2b
 └── @revealui/mcp                    # MCP tool integrations
 ```
 
-The entire AI-powered business stack  -  users, content, products, payments, intelligence  -  running without a cloud API call in sight.
+The entire AI-powered business stack  -  People, Content, Offers, Payments, and Agents, running without a cloud API call in sight.
 
 ## Who this is for
 

--- a/docs/blog/06-open-source-and-pro.md
+++ b/docs/blog/06-open-source-and-pro.md
@@ -25,7 +25,7 @@ This wasn't a naive decision. I'm aware of the arguments for more restrictive li
 
 I understand that risk. I accept it. Here's why.
 
-RevealUI is an open runtime for businesses that run their own AI. The four business primitives that make it useful -- Users, Content, Products, Payments -- are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
+RevealUI is an open runtime for businesses that run their own AI. The open-core business primitives, People, Content, Offers, and Payments, are MIT licensed and will stay MIT forever. These are table stakes. Every business needs auth, a content system, a product catalog, and payment processing. Making these proprietary would limit adoption without meaningfully protecting revenue. The value isn't in the code; it's in the integration, the maintenance, and the roadmap.
 
 The MCP framework is the one piece worth naming carefully: `@revealui/mcp` (the hypervisor, the 13 first-party servers, and the adapter base class) is one of the five Pro packages, Fair Source under FSL-1.1-MIT, not MIT. It's source-visible and converts to MIT two years after each release, but MCP integration is a paid capability today. I'd rather state that plainly than imply the AI tooling is free when it isn't.
 
@@ -90,7 +90,7 @@ A few things worth noting about this table.
 
 **The free tier is genuinely useful.** Unlimited admin collections, session-based auth, basic real-time sync, local AI inference (Inference Snaps / Ollama), and full source code access. You can build and run a real product on the free tier. I don't want "free" to mean "demo."
 
-**All four business primitives work on free.** Users, Content, Products, Payments -- the MIT core -- are fully functional at every tier. Free doesn't cripple the business stack to pressure upgrades. The tier boundaries are about scale (more sites, more users, higher rate limits) and AI capabilities.
+**Open-core business primitives work on free.** People, Content, Offers, and Payments, the MIT core, are fully functional at every tier. Free doesn't cripple the business stack to pressure upgrades. The tier boundaries are about scale (more sites, more users, higher rate limits) and AI capabilities.
 
 **Pro and Max include a 7-day trial.** You try it, you decide, you pay if it's worth it. If the product can't convince you in seven days, a payment wall on day one wasn't going to help.
 
@@ -176,7 +176,7 @@ I don't know if this model will work. MIT open source with a commercial AI tier 
 
 What I do know is that the alternative -- restrictive licensing, crippled free tiers, dark patterns in the upgrade flow -- might generate more short-term revenue but would make me build a product I don't want to use.
 
-RevealUI is the business stack I wanted when I started building software companies. Users, content, products, payments, and intelligence -- pre-wired, open source, and ready to deploy. If it's useful to you at $0, that's a win. If it's useful enough to pay for, even better.
+RevealUI is the business stack I wanted when I started building software companies. People, Content, Offers, Payments, and Agents, pre-wired, open source, and ready to deploy. If it's useful to you at $0, that's a win. If it's useful enough to pay for, even better.
 
 The code is on [GitHub](https://github.com/RevealUIStudio/revealui). The license is MIT. The Pro features include a 7-day free trial. Everything I've described in this post is verifiable.
 

--- a/docs/blog/07-agent-first-future.md
+++ b/docs/blog/07-agent-first-future.md
@@ -16,7 +16,7 @@ author: Joshua Vaughn
 
 ---
 
-I have been building RevealUI for the past year as the open runtime for businesses that run their own AI -- the kind of thing where you get users, content, products, payments, and intelligence pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
+I have been building RevealUI for the past year as the open runtime for businesses that run their own AI -- the kind of thing where you get People, Content, Offers, Payments, and Agents pre-wired, open source, and ready to deploy. The whole point is that you should not have to re-implement billing or auth or an admin every time you start a new software business.
 
 But somewhere around the third month of building, I realized something that changed the architecture fundamentally: **the next wave of customers for software platforms are not human.**
 
@@ -307,6 +307,6 @@ The user interface for the future has yet to reveal itself. But we know one thin
 
 ---
 
-*RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence -- pre-wired and ready to deploy. Learn more at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. People, Content, Offers, Payments, and Agents, pre-wired and ready to deploy. Learn more at [revealui.com](https://revealui.com).*
 
 *Follow the project on [GitHub](https://github.com/RevealUIStudio/revealui).*

--- a/docs/blog/08-getting-started.md
+++ b/docs/blog/08-getting-started.md
@@ -9,7 +9,7 @@ author: Joshua Vaughn
 
 **Build a complete business application with auth, content, and payments  -  faster than you can order lunch.**
 
-RevealUI is the open runtime for businesses that run their own AI. Instead of gluing together a dozen SaaS tools and spending weeks on boilerplate, you get users, content, products, payments, and intelligence pre-wired and ready to deploy.
+RevealUI is the open runtime for businesses that run their own AI. Instead of gluing together a dozen SaaS tools and spending weeks on boilerplate, you get People, Content, Offers, Payments, and Agents pre-wired and ready to deploy.
 
 This tutorial walks you through creating a real business application from scratch. By the end, you will have a working admin with typed collections, session-based authentication, a REST API with Swagger documentation, Stripe billing, license enforcement, and an admin dashboard  -  deployed to production on Vercel.
 
@@ -599,7 +599,7 @@ Stop the clock. With accounts pre-provisioned (NeonDB, Stripe, Vercel) and copy-
 - **An admin dashboard**  -  manage content, users, licenses, and settings from a single interface
 - **Deployed to production on Vercel**  -  global edge network, automatic SSL, zero-config scaling
 
-This is what "build your business, not your boilerplate" means. Every piece of infrastructure that software companies need  -  users, content, products, payments, and intelligence  -  is pre-wired and ready.
+This is what "build your business, not your boilerplate" means. Every piece of infrastructure that software companies need  -  People, Content, Offers, Payments, and Agents are pre-wired and ready.
 
 ---
 
@@ -631,4 +631,4 @@ The pattern scales. Add products, orders, tickets, knowledge bases  -  each coll
 
 ---
 
-*RevealUI is the open runtime for businesses that run their own AI. Users, content, products, payments, and intelligence  -  pre-wired, open source, and ready to deploy. Get started at [revealui.com](https://revealui.com).*
+*RevealUI is the open runtime for businesses that run their own AI. People, Content, Offers, Payments, and Agents, pre-wired, open source, and ready to deploy. Get started at [revealui.com](https://revealui.com).*

--- a/docs/blog/11-revfleet-product-family.md
+++ b/docs/blog/11-revfleet-product-family.md
@@ -9,7 +9,7 @@ author: Joshua Vaughn
 
 Most tools sell you a library. You install it, wire it into one corner of your app, and move on. RevealUI is built the other way around. It is a runtime that an entire family of products sits on top of, each one solving a problem you hit the moment you start running software for real.
 
-We call the family RevFleet. RevealUI is the flagship: the agentic business runtime that gives you users, content, products, payments, and intelligence pre-wired into one deployable system. The other seven products are the tools we built to operate it, and we ship every one of them.
+We call the family RevFleet. RevealUI is the flagship: the agentic business runtime that gives you People, Content, Offers, Payments, and Agents pre-wired into one deployable system. The other seven products are the tools we built to operate it, and we ship every one of them.
 
 This post is the map. It is also honest about where each product is, because "shipping" means different things at different stages, and you deserve to know which is which before you build on it.
 
@@ -26,7 +26,7 @@ No product on this page hides behind a vaguer word than that.
 
 ## The flagship: RevealUI
 
-**RevealUI** (Beta) is the foundation everything else builds on. The five primitives, users, content, products, payments, and intelligence, are pre-wired into a single runtime that your team and your AI agents share through one open protocol. Standard Postgres for data, S3-compatible object storage, real-time sync, a typed REST API with an OpenAPI spec, session auth, and feature gating, all in the box.
+**RevealUI** (Beta) is the foundation everything else builds on. The five primitives, People, Content, Offers, Payments, and Agents, are pre-wired into a single runtime that your team and your AI agents share through one open protocol. Standard Postgres for data, S3-compatible object storage, real-time sync, a typed REST API with an OpenAPI spec, session auth, and feature gating, all in the box.
 
 You can run a real business on the open-source core today. Start here. Add the rest of the fleet as you grow into it.
 


### PR DESCRIPTION
## Summary

Closes the residual from copy-corpus punch-list row 10 / **GAP-456**: public surfaces still shipped the dead five-primitive list (Users / products / intelligence) while homepage content modules already use **People, Content, Offers, Payments, Agents**.

## Files

- Blog post CTA (`BlogPostPage.tsx`)
- Docs landing (`DocsIndexPage.tsx`)
- Blog posts 01/04/06/07/08/11 under `docs/blog/`
- Showcase accordion sample, claims-evidence note, `llms.txt`

## Verify

```bash
git grep "products, payments, and intelligence" -- apps docs || echo clean
```

## Notes

- MIT license framing on open-source post preserved: open-core = People, Content, Offers, Payments (not claiming Agents as MIT).
- Em dashes on touched blog footer lines replaced with commas (no-em-dashes).
- Owner screenshot sign-off still required per GAP-456 acceptance (GAP-299 precedent).

Not security-sensitive.
