### PR TITLE
fix(ci): re-enable worker-liveness schedule after GAP-455 green proof

### DIFF
--- a/.github/workflows/worker-liveness.yml
+++ b/.github/workflows/worker-liveness.yml
@@ -16,21 +16,17 @@ name: Worker Liveness Probe (5-min)
 # and out of Actions logs.
 
 on:
-  # SCHEDULE DISABLED 2026-07-28 (GAP-455) — the probe false-alarmed on every
-  # scheduled run, returning {"healthy":false,"error":"network-error"} while
-  # the worker was verifiably healthy (direct /health 200, Fly checks passing,
-  # sweep ticks errors=0). A monitor that cries wolf is worse than no monitor,
-  # and this repo is PUBLIC, so each red run advertises an outage that is not
-  # happening. Re-enabling the cron below is part of GAP-455's acceptance,
-  # after the probe's error buckets are split (guard-blocked vs timeout vs
-  # network) and the real cause is confirmed and fixed. Manual runs still work.
-  #
-  # schedule:
-  #   # Every 5 minutes (GitHub's minimum granularity). UTC. Scheduled runs can
-  #   # be delayed 5-15 min during high GHA load, so actual cadence is
-  #   # "approximately every 5 minutes," not exact  -  acceptable for a
-  #   # liveness backstop.
-  #   - cron: '*/5 * * * *'
+  # Schedule re-enabled 2026-07-28 after GAP-455 green proof:
+  # run 30400804458 returned {"healthy":true,"status":200,"probe":4} with the
+  # #2267 classifier on production. Error buckets + guard-unavailable path
+  # ship on main; schedule was the remaining ops gate for the green case.
+  # Red-path proof (genuinely down worker) remains on GAP-455 before close.
+  schedule:
+    # Every 5 minutes (GitHub's minimum granularity). UTC. Scheduled runs can
+    # be delayed 5-15 min during high GHA load, so actual cadence is
+    # "approximately every 5 minutes," not exact  -  acceptable for a
+    # liveness backstop.
+    - cron: '*/5 * * * *'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
## Summary

Re-enables the 5-minute `schedule:` on `worker-liveness.yml` after production green proof:

- Run: https://github.com/RevealUIStudio/revealui/actions/runs/30400804458
- Body: `{"healthy":true,"status":200,"probe":4}`

## GAP-455 status

- Green while healthy: **proven**
- Schedule re-enable: **this PR**
- Red while genuinely down: still open (do not close the gap until recorded)

## Risk

Public repo: if false alarms return, schedule will advertise outages again. The #2267 path was designed to stop that class; first scheduled greens should be watched.

Not security-sensitive.