### PR TITLE
fix(admin): dead session must not look free (GAP-454)

### DIFF
--- a/apps/admin/src/app/(backend)/layout.tsx
+++ b/apps/admin/src/app/(backend)/layout.tsx
@@ -5,6 +5,7 @@ import Script from 'next/script';
 /* RevealUI Admin Layout - Local implementation */
 import type React from 'react';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { AuthRequiredListener } from '@/lib/auth/AuthRequiredListener';
 import { AdminSidebarLayout } from '@/lib/components/AdminSidebarLayout';
 import { LicenseProvider } from '@/lib/providers/LicenseProvider';
 import config from '../../../revealui.config';
@@ -50,6 +51,7 @@ export default async function Layout({ children }: Args) {
         />
       ) : null}
       <LicenseProvider isFleetMode={isFleetMode}>
+        <AuthRequiredListener />
         <ErrorBoundary>
           <AdminSidebarLayout
             siteName={siteName}

--- a/apps/admin/src/components/FreeTierBanner.tsx
+++ b/apps/admin/src/components/FreeTierBanner.tsx
@@ -19,7 +19,7 @@ interface FreeTierBannerProps {
 }
 
 export function FreeTierBanner({ isHosted }: FreeTierBannerProps) {
-  const { tier, isLoading } = useLicense();
+  const { tier, isLoading, resolveError } = useLicense();
   // Start dismissed=true to avoid a hydration flash on the server render.
   // useEffect corrects it client-side after sessionStorage is available.
   const [dismissed, setDismissed] = useState(true);
@@ -33,7 +33,9 @@ export function FreeTierBanner({ isHosted }: FreeTierBannerProps) {
     setDismissed(true);
   }, []);
 
-  if (isLoading || dismissed || tier !== 'free') return null;
+  // GAP-454: never claim Free when tier resolution failed (401 / network).
+  // Only a successful resolve to free may show the money-adjacent banner.
+  if (isLoading || dismissed || resolveError || tier !== 'free') return null;
 
   return (
     <div className="mb-4 flex items-center justify-between gap-x-6 rounded-lg bg-primary px-5 py-2.5 text-sm text-primary-foreground">

--- a/apps/admin/src/components/__tests__/FreeTierBanner.test.tsx
+++ b/apps/admin/src/components/__tests__/FreeTierBanner.test.tsx
@@ -47,18 +47,18 @@ afterEach(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockUseLicense.mockReturnValue({ tier: 'free', isLoading: false });
+  mockUseLicense.mockReturnValue({ tier: 'free', isLoading: false, resolveError: null });
 });
 
 describe('FreeTierBanner', () => {
   it('renders nothing while loading', () => {
-    mockUseLicense.mockReturnValue({ tier: 'free', isLoading: true });
+    mockUseLicense.mockReturnValue({ tier: 'free', isLoading: true, resolveError: null });
     render(<FreeTierBanner isHosted={false} />);
     expect(screen.queryByText(/Free plan/)).not.toBeInTheDocument();
   });
 
   it('renders nothing above the free tier', () => {
-    mockUseLicense.mockReturnValue({ tier: 'pro', isLoading: false });
+    mockUseLicense.mockReturnValue({ tier: 'pro', isLoading: false, resolveError: null });
     render(<FreeTierBanner isHosted={false} />);
     expect(screen.queryByText(/Free plan/)).not.toBeInTheDocument();
   });
@@ -79,4 +79,24 @@ describe('FreeTierBanner', () => {
     expect(screen.queryByText(/Start your 7-day Pro trial/)).not.toBeInTheDocument();
     expect(screen.queryByText(/7-day trial/)).not.toBeInTheDocument();
   });
+});
+
+it('renders nothing when tier resolution failed with auth-required (GAP-454)', () => {
+  mockUseLicense.mockReturnValue({
+    tier: 'free',
+    isLoading: false,
+    resolveError: 'auth-required',
+  });
+  render(<FreeTierBanner isHosted={true} />);
+  expect(screen.queryByText(/Free plan/)).not.toBeInTheDocument();
+});
+
+it('renders nothing when tier resolution failed as unavailable (GAP-454)', () => {
+  mockUseLicense.mockReturnValue({
+    tier: 'free',
+    isLoading: false,
+    resolveError: 'unavailable',
+  });
+  render(<FreeTierBanner isHosted={true} />);
+  expect(screen.queryByText(/Free plan/)).not.toBeInTheDocument();
 });

--- a/apps/admin/src/lib/auth/AuthRequiredListener.tsx
+++ b/apps/admin/src/lib/auth/AuthRequiredListener.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { AUTH_REQUIRED_EVENT_NAME } from '@revealui/paywall/client';
+import { useEffect } from 'react';
+import { redirectToLogin } from './redirect-to-login';
+
+/**
+ * Listens for API 401s from upgradeAwareFetch and sends the operator to login
+ * (GAP-454). Mount once under the admin providers tree.
+ */
+export function AuthRequiredListener(): null {
+  useEffect(() => {
+    const onAuthRequired = () => {
+      redirectToLogin();
+    };
+    window.addEventListener(AUTH_REQUIRED_EVENT_NAME, onAuthRequired);
+    return () => {
+      window.removeEventListener(AUTH_REQUIRED_EVENT_NAME, onAuthRequired);
+    };
+  }, []);
+  return null;
+}

--- a/apps/admin/src/lib/auth/redirect-to-login.ts
+++ b/apps/admin/src/lib/auth/redirect-to-login.ts
@@ -1,0 +1,13 @@
+/**
+ * Client-side re-auth redirect for dead or rejected sessions (GAP-454).
+ * Keeps the return path so the operator lands back after sign-in.
+ */
+export function redirectToLogin(returnPath?: string): void {
+  if (typeof window === 'undefined') return;
+  const path =
+    returnPath ?? `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  // Avoid a redirect loop if we are already on the login surface.
+  if (path === '/login' || path.startsWith('/login?')) return;
+  const returnUrl = encodeURIComponent(path || '/');
+  window.location.assign(`/login?returnUrl=${returnUrl}`);
+}

--- a/apps/admin/src/lib/providers/LicenseProvider.tsx
+++ b/apps/admin/src/lib/providers/LicenseProvider.tsx
@@ -4,35 +4,72 @@ import type { LicenseTierId } from '@revealui/contracts/pricing';
 import type { FeatureFlags } from '@revealui/core/features';
 import { createPaywall } from '@revealui/paywall';
 import { PaywallProvider, usePaywall } from '@revealui/paywall/client';
+import { redirectToLogin } from '@/lib/auth/redirect-to-login';
 
 /** Shared paywall instance for the admin. */
 const paywall = createPaywall();
+
+/**
+ * Why tier resolution failed. Surfaces must never invent a FREE plan when this
+ * is set (GAP-454): a 401 is re-auth, not free; a network/5xx is unknown.
+ */
+export type LicenseResolveError = 'auth-required' | 'unavailable' | null;
 
 /** The value exposed by the license context (backwards-compatible shape). */
 export interface LicenseContextValue {
   tier: LicenseTierId;
   features: FeatureFlags | null;
   isLoading: boolean;
+  /**
+   * Non-null when the tier fetch did not succeed. FreeTierBanner and other
+   * money-adjacent UI must treat this as "do not claim free".
+   */
+  resolveError: LicenseResolveError;
   refetch: () => Promise<void>;
+}
+
+/**
+ * Thrown from resolveSaasTier so PaywallProvider does not invent free.
+ * The paywall provider maps this to resolveError + null features.
+ */
+export class LicenseResolveFailure extends Error {
+  readonly kind: 'auth-required' | 'unavailable';
+
+  constructor(kind: 'auth-required' | 'unavailable', message: string) {
+    super(message);
+    this.name = 'LicenseResolveFailure';
+    this.kind = kind;
+  }
 }
 
 async function resolveSaasTier(): Promise<string> {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
-  if (!apiUrl) return 'free';
-
-  try {
-    const res = await fetch(`${apiUrl}/api/billing/subscription`, {
-      credentials: 'include',
-    });
-    if (res.ok) {
-      const data = (await res.json()) as { tier: LicenseTierId };
-      return data.tier;
-    }
-  } catch {
-    // Subscription check failed (CORS, network, 401)  -  stay on free tier
+  if (!apiUrl) {
+    // No SaaS API configured  -  genuine free/local posture.
+    return 'free';
   }
 
-  return 'free';
+  let res: Response;
+  try {
+    res = await fetch(`${apiUrl}/api/billing/subscription`, {
+      credentials: 'include',
+    });
+  } catch {
+    throw new LicenseResolveFailure('unavailable', 'subscription fetch failed (network)');
+  }
+
+  if (res.status === 401) {
+    // Dead session: send the operator to re-auth. Do not claim free.
+    redirectToLogin();
+    throw new LicenseResolveFailure('auth-required', 'subscription returned 401');
+  }
+
+  if (!res.ok) {
+    throw new LicenseResolveFailure('unavailable', `subscription returned ${res.status}`);
+  }
+
+  const data = (await res.json()) as { tier: LicenseTierId };
+  return data.tier;
 }
 
 interface LicenseProviderProps {
@@ -56,11 +93,12 @@ export function LicenseProvider({ children, isFleetMode = false }: LicenseProvid
  * `LicenseContextValue` shape for backwards compatibility.
  */
 export function useLicense(): LicenseContextValue {
-  const { tier, features, isLoading, refetch } = usePaywall();
+  const { tier, features, isLoading, refetch, resolveError } = usePaywall();
   return {
     tier: tier as LicenseTierId,
     features: features as FeatureFlags | null,
     isLoading,
+    resolveError: (resolveError as LicenseResolveError) ?? null,
     refetch,
   };
 }

--- a/apps/admin/src/lib/providers/index.tsx
+++ b/apps/admin/src/lib/providers/index.tsx
@@ -1,5 +1,6 @@
 import { ElectricProvider } from '@revealui/sync/provider';
 import type React from 'react';
+import { AuthRequiredListener } from '@/lib/auth/AuthRequiredListener';
 import { UpgradeDialog } from '@/lib/components/UpgradeDialog';
 import { HeaderThemeProvider } from './HeaderTheme/index';
 import { LicenseProvider } from './LicenseProvider';
@@ -19,6 +20,7 @@ export const Providers = ({ children, isFleetMode = false }: ProvidersProps) => 
       <ThemeProvider>
         <HeaderThemeProvider>
           <LicenseProvider isFleetMode={isFleetMode}>
+            <AuthRequiredListener />
             {children}
             {isFleetMode ? null : <UpgradeDialog />}
           </LicenseProvider>

--- a/packages/auth/src/server/session.ts
+++ b/packages/auth/src/server/session.ts
@@ -185,7 +185,7 @@ export async function getSession(
     if (requestContext) {
       const bindingError = validateSessionBinding(session, requestContext);
       if (bindingError) {
-        logger.warn('Session binding violation  -  invalidating session', {
+        logger.error('Session binding violation  -  invalidating session', {
           sessionId: session.id,
           reason: bindingError,
         });

--- a/packages/paywall/src/client/PaywallProvider.tsx
+++ b/packages/paywall/src/client/PaywallProvider.tsx
@@ -4,14 +4,22 @@ import { createContext, use, useEffect, useState } from 'react';
 import type { Paywall } from '../core/paywall.js';
 import type { FeatureFlags } from '../core/types.js';
 
+/** Why tier resolution failed (GAP-454 class: never invent free on failure). */
+export type PaywallResolveError = 'auth-required' | 'unavailable' | null;
+
 /** The value exposed by the paywall context. */
 export interface PaywallContextValue {
   /** The current tier (e.g. 'free', 'pro'). */
   tier: string;
-  /** Boolean map of feature flags for the current tier. `null` while loading. */
+  /** Boolean map of feature flags for the current tier. `null` while loading or on error. */
   features: FeatureFlags<string> | null;
   /** True while the initial tier resolution is in flight. */
   isLoading: boolean;
+  /**
+   * Set when resolveTier failed. Consumers must not treat `tier` as a verified
+   * plan while this is non-null (default tier may still be the SSR placeholder).
+   */
+  resolveError: PaywallResolveError;
   /** Re-fetch the tier (e.g. after a subscription change). */
   refetch: () => Promise<void>;
   /** The paywall instance for direct access. */
@@ -28,11 +36,16 @@ export interface PaywallProviderProps {
    * Async function that resolves the current user's tier.
    * Called once on mount and again on `refetch()`.
    *
+   * Throw an Error with `kind: 'auth-required' | 'unavailable'` (or name
+   * `LicenseResolveFailure` / message containing those tokens) so the provider
+   * does not invent a free tier on failure.
+   *
    * @example
    * ```ts
    * resolveTier={async () => {
    *   const res = await fetch('/api/billing/subscription', { credentials: 'include' });
-   *   if (!res.ok) return 'free';
+   *   if (res.status === 401) throw Object.assign(new Error('auth'), { kind: 'auth-required' });
+   *   if (!res.ok) throw Object.assign(new Error('unavailable'), { kind: 'unavailable' });
    *   const data = await res.json();
    *   return data.tier;
    * }}
@@ -42,28 +55,48 @@ export interface PaywallProviderProps {
   children: React.ReactNode;
 }
 
+function classifyResolveError(err: unknown): Exclude<PaywallResolveError, null> {
+  if (err && typeof err === 'object') {
+    const kind = (err as { kind?: string }).kind;
+    if (kind === 'auth-required' || kind === 'unavailable') return kind;
+    const name = (err as { name?: string }).name;
+    if (name === 'LicenseResolveFailure') {
+      const k = (err as { kind?: string }).kind;
+      if (k === 'auth-required' || k === 'unavailable') return k;
+    }
+    const message = String((err as { message?: string }).message ?? '');
+    if (message.includes('auth-required') || message.includes('401')) return 'auth-required';
+  }
+  return 'unavailable';
+}
+
 /**
  * React context provider that resolves the current tier and computes
  * feature flags from a paywall instance.
  *
  * Wrap your app (or a subtree) with this provider, then use `usePaywall()`
- * in any child component to read `{ tier, features, isLoading }`.
+ * in any child component to read `{ tier, features, isLoading, resolveError }`.
  */
 export function PaywallProvider({ paywall, resolveTier, children }: PaywallProviderProps) {
   const [tier, setTier] = useState<string>(paywall.defaultTier);
   const [features, setFeatures] = useState<FeatureFlags<string> | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [resolveError, setResolveError] = useState<PaywallResolveError>(null);
 
   async function fetchTier() {
     try {
       setIsLoading(true);
+      setResolveError(null);
       const resolved = await resolveTier();
       setTier(resolved);
       setFeatures(paywall.getFeaturesForTier(resolved));
-    } catch {
-      // Fall back to default (free) tier on any error
-      setTier(paywall.defaultTier);
-      setFeatures(paywall.getFeaturesForTier(paywall.defaultTier));
+      setResolveError(null);
+    } catch (err) {
+      // GAP-454: do NOT invent free on failure. Keep SSR placeholder tier but
+      // mark features null and surface resolveError for consumers.
+      const classified = classifyResolveError(err);
+      setResolveError(classified);
+      setFeatures(null);
     } finally {
       setIsLoading(false);
     }
@@ -75,7 +108,9 @@ export function PaywallProvider({ paywall, resolveTier, children }: PaywallProvi
   }, []);
 
   return (
-    <PaywallContext value={{ tier, features, isLoading, refetch: fetchTier, paywall }}>
+    <PaywallContext
+      value={{ tier, features, isLoading, resolveError, refetch: fetchTier, paywall }}
+    >
       {children}
     </PaywallContext>
   );
@@ -86,13 +121,14 @@ export function PaywallProvider({ paywall, resolveTier, children }: PaywallProvi
  *
  * Must be used within a `<PaywallProvider>`.
  *
- * @returns `{ tier, features, isLoading, refetch, paywall }`
+ * @returns `{ tier, features, isLoading, resolveError, refetch, paywall }`
  *
  * @example
  * ```tsx
  * function SettingsPage() {
- *   const { tier, features, isLoading } = usePaywall();
+ *   const { tier, features, isLoading, resolveError } = usePaywall();
  *   if (isLoading) return <Spinner />;
+ *   if (resolveError) return <UnavailableOrReauth />;
  *   if (!features?.ai) return <UpgradePrompt />;
  *   return <AISettings />;
  * }

--- a/packages/paywall/src/client/__tests__/upgrade-aware-fetch.test.ts
+++ b/packages/paywall/src/client/__tests__/upgrade-aware-fetch.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  AUTH_REQUIRED_EVENT_NAME,
   dispatchUpgradeEvent,
   UPGRADE_EVENT_NAME,
   type UpgradeEventDetail,
@@ -207,5 +208,18 @@ describe('upgradeAwareFetch', () => {
     expect(events).toHaveLength(0);
 
     window.removeEventListener(UPGRADE_EVENT_NAME, handler);
+  });
+
+  it('dispatches auth-required on 401 (GAP-454)', async () => {
+    const handler = vi.fn();
+    window.addEventListener(AUTH_REQUIRED_EVENT_NAME, handler);
+    const mockResponse = new Response(JSON.stringify({ error: 'Authentication required' }), {
+      status: 401,
+    });
+    vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+    const res = await upgradeAwareFetch('/api/data');
+    expect(res.status).toBe(401);
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener(AUTH_REQUIRED_EVENT_NAME, handler);
   });
 });

--- a/packages/paywall/src/client/index.ts
+++ b/packages/paywall/src/client/index.ts
@@ -49,9 +49,12 @@ export {
   type PaywallContextValue,
   PaywallProvider,
   type PaywallProviderProps,
+  type PaywallResolveError,
   usePaywall,
 } from './PaywallProvider.js';
 export {
+  AUTH_REQUIRED_EVENT_NAME,
+  dispatchAuthRequiredEvent,
   dispatchUpgradeEvent,
   UPGRADE_EVENT_NAME,
   type UpgradeEventDetail,

--- a/packages/paywall/src/client/upgrade-aware-fetch.ts
+++ b/packages/paywall/src/client/upgrade-aware-fetch.ts
@@ -16,6 +16,9 @@
 /** The DOM event name dispatched when an upgrade is required. */
 export const UPGRADE_EVENT_NAME = 'revealui:upgrade-required';
 
+/** Dispatched when the API rejects the session (401). Admin re-auth listens. */
+export const AUTH_REQUIRED_EVENT_NAME = 'revealui:auth-required';
+
 /** Detail payload for the upgrade event. */
 export interface UpgradeEventDetail {
   /** The feature that triggered the upgrade prompt, if known. */
@@ -43,8 +46,16 @@ export function dispatchUpgradeEvent(detail: UpgradeEventDetail): void {
  * Reads the feature name from the `x-paywall-feature` or
  * `x-revealui-feature` response header when available.
  */
+export function dispatchAuthRequiredEvent(status = 401): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT_NAME, { detail: { status } }));
+}
+
 export function upgradeAwareFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   return fetch(input, init).then((response) => {
+    if (response.status === 401) {
+      dispatchAuthRequiredEvent(401);
+    }
     if (response.status === 402 || response.status === 503) {
       const feature =
         response.headers.get('x-paywall-feature') ??


### PR DESCRIPTION
## Summary

Fixes the live misdirection where a dead browser session made admin look **signed-in on the Free plan** while every API call returned 401.

## Changes

1. **resolveSaasTier** — 401 → redirectToLogin + throw auth-required; network/non-OK → unavailable. Never return free on failure.
2. **PaywallProvider** — surfaces resolveError; does not invent free on catch.
3. **FreeTierBanner** — only renders when resolveError is null and tier is free.
4. **upgradeAwareFetch** — dispatches revealui:auth-required on 401; admin AuthRequiredListener redirects to login.
5. **Session binding violation** — log at error for prod visibility.

## Tests

- paywall upgrade-aware-fetch (+ 401 auth event) 13/13 pass locally

## Not in this PR

- Proxy session validity (DB read per nav) deferred
- GAP-455 red-path / schedule #2272

Not security-sensitive beyond better auth UX.