### PR TITLE
fix(admin): multipart create for upload collections (GAP-452)

### DIFF
--- a/apps/admin/src/__tests__/api/proxy-routes.test.ts
+++ b/apps/admin/src/__tests__/api/proxy-routes.test.ts
@@ -238,6 +238,42 @@ describe('POST /api/collections/[collection]', () => {
     });
     expect(res.status).toBe(503);
   });
+
+  it('GAP-452: streams multipart create through to content media without JSON re-encode', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeUpstreamOk({ success: true, data: { id: 'm1', url: 'https://cdn.example/a.png' } }, 201),
+    );
+    const form = new FormData();
+    form.append('file', new File([new Uint8Array([1, 2, 3])], 'a.png', { type: 'image/png' }));
+    form.append('alt', 'hero');
+    const req = new NextRequest('http://localhost/api/collections/media', {
+      method: 'POST',
+      body: form,
+    });
+    const res = await collectionsPost(req, { params: Promise.resolve({ collection: 'media' }) });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.doc).toEqual({ id: 'm1', url: 'https://cdn.example/a.png' });
+    const call = mockFetch.mock.calls[0];
+    expect(String(call?.[0])).toContain('/api/content/media');
+    const init = call?.[1] as RequestInit;
+    const ct = (init.headers as Record<string, string>)['Content-Type'] ?? '';
+    expect(ct.startsWith('multipart/form-data')).toBe(true);
+    expect(typeof init.body === 'string').toBe(false);
+  });
+
+  it('GAP-452: still rejects unauthenticated multipart create', async () => {
+    mockGetSession.mockResolvedValueOnce(null as never);
+    const form = new FormData();
+    form.append('file', new File([new Uint8Array([1])], 'a.png', { type: 'image/png' }));
+    const req = new NextRequest('http://localhost/api/collections/media', {
+      method: 'POST',
+      body: form,
+    });
+    const res = await collectionsPost(req, { params: Promise.resolve({ collection: 'media' }) });
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/admin/src/app/api/collections/[collection]/route.ts
+++ b/apps/admin/src/app/api/collections/[collection]/route.ts
@@ -75,6 +75,18 @@ async function proxyResponse(response: Response): Promise<NextResponse> {
     );
   }
 
+  // Upload create (media) returns { success, data: T }; normalize for APIClient.
+  if (
+    data &&
+    typeof data === 'object' &&
+    data.data &&
+    !Array.isArray(data.data) &&
+    !data.docs &&
+    !data.doc
+  ) {
+    return NextResponse.json({ doc: data.data }, { status: response.status });
+  }
+
   return NextResponse.json(data, { status: response.status });
 }
 
@@ -110,6 +122,27 @@ export async function POST(
   }
 
   const { collection } = await params;
+  const contentType = request.headers.get('content-type') ?? '';
+
+  // GAP-452: upload collections (media) create via multipart. Stream the body
+  // through like /api/media so the api server's single-sourced validator stays
+  // the only upload gate. JSON create for non-upload collections is unchanged.
+  if (contentType.startsWith('multipart/form-data')) {
+    try {
+      const target = await resolveCreateTarget(collection, undefined);
+      const init: RequestInit & { duplex: 'half' } = {
+        method: 'POST',
+        headers: await apiForwardHeaders(request, { 'Content-Type': contentType }),
+        body: request.body,
+        duplex: 'half',
+      };
+      const apiResponse = await fetch(target, init);
+      return proxyResponse(apiResponse);
+    } catch (err) {
+      return apiUnavailable(collection, err);
+    }
+  }
+
   const body = await request.json();
 
   try {

--- a/packages/core/src/client/admin/components/DocumentForm.tsx
+++ b/packages/core/src/client/admin/components/DocumentForm.tsx
@@ -107,6 +107,26 @@ export function DocumentForm({
         </h3>
 
         <form onSubmit={handleSubmit} className="space-y-6">
+          {collection.upload && !document ? (
+            <div>
+              <label htmlFor="__file" className="block text-sm font-medium text-foreground">
+                File
+                <span className="text-red-500 ml-1">*</span>
+              </label>
+              <div className="mt-1">
+                <input
+                  type="file"
+                  id="__file"
+                  required
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) handleFieldChange('file', file);
+                  }}
+                  className="block w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary/10 file:text-primary hover:file:bg-primary/20"
+                />
+              </div>
+            </div>
+          ) : null}
           {visibleFields.map((field: RevealUIField) => (
             <div key={field.name || 'layout'}>
               <label htmlFor={field.name} className="block text-sm font-medium text-foreground">

--- a/packages/core/src/client/admin/utils/apiClient.ts
+++ b/packages/core/src/client/admin/utils/apiClient.ts
@@ -136,8 +136,10 @@ export class APIClient {
     const method = (options.method ?? 'GET').toUpperCase();
     const csrfToken = Unsafe.has(method) ? readCsrfToken() : undefined;
 
+    // FormData must set its own multipart boundary; never force JSON Content-Type.
+    const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData;
     const headers: HeadersInit = {
-      'Content-Type': 'application/json',
+      ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
       ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
       ...options.headers,
     };
@@ -266,6 +268,30 @@ export class APIClient {
   async create(options: CreateOptions): Promise<RevealDocument> {
     const { collection, data } = options;
     const endpoint = `/api/collections/${collection}`;
+
+    // GAP-452: upload collections send File + fields as multipart so the api
+    // media endpoint (multipart-only) accepts the create.
+    const fileEntry = Object.entries(data).find(
+      ([, v]) => typeof File !== 'undefined' && v instanceof File,
+    );
+    if (fileEntry) {
+      const formData = new FormData();
+      const [fileKey, fileValue] = fileEntry;
+      // Api media upload expects the binary field name `file`.
+      formData.append('file', fileValue as File);
+      for (const [key, value] of Object.entries(data)) {
+        if (key === fileKey) continue;
+        if (value === null || value === undefined) continue;
+        // Skip nested objects (richtext caption) on create; follow-up PATCH owns them.
+        if (typeof value === 'object') continue;
+        formData.append(key, String(value));
+      }
+      const response = await this.request<{ doc: RevealDocument }>(endpoint, {
+        method: 'POST',
+        body: formData,
+      });
+      return response.doc;
+    }
 
     const response = await this.request<{ doc: RevealDocument }>(endpoint, {
       method: 'POST',


### PR DESCRIPTION
## Summary

Collection-editor create for **upload collections** (media) posted JSON to a multipart-only API and always 400ed. This wires the editor create path to multipart end-to-end while keeping the api media validator single-sourced.

## Design (PR note)

Prefer **(b)** from GAP-452: forwarder streams multipart verbatim (same pattern as `/api/media`), editor/`apiClient` send FormData when a `File` is present. Upload validation stays only on `apps/server` media routes.

## Changes

1. **`DocumentForm`** — required file input on create when `collection.upload` is set
2. **`apiClient.create`** — builds `FormData` (`file` + scalar fields; nested caption deferred to PATCH)
3. **`POST /api/collections/[collection]`** — multipart stream-through; JSON path unchanged
4. **Response normalize** — `{ success, data }` upload envelope → `{ doc }` for the client
5. **Tests** — multipart media create success + 401 without session

Dashboard still deep-links media to `/media` library (UX override); this PR makes the generic editor path work if used.

## Verify

```bash
# CI: apps/admin proxy-routes tests
# Manual: open generic editor for media if navigated directly → file + alt → 201 + R2 URL
```

Not security-sensitive.