### PR TITLE
fix(compose): remove marketing service missing Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,14 @@
 #   3. docker compose up -d
 #
 # Apps:
-#   - api:       Hono REST API (port 3004)
-#   - admin:     Next.js Admin Dashboard (port 4000)
-#   - marketing: Next.js Marketing Site (port 3000)
+#   - api:   Hono REST API (port 3004)
+#   - admin: Next.js Admin Dashboard (port 4000)
+#
+# Marketing (apps/marketing) is a Vite SPA deployed on Vercel, not part of
+# self-host compose. It has no Dockerfile and is intentionally omitted.
 #
 # Infrastructure:
-#   - postgres:  Local PostgreSQL (alternative to NeonDB for self-hosting)
-#   - nginx:     Reverse proxy with HTTPS termination
+#   - postgres: Local PostgreSQL (alternative to NeonDB for self-hosting)
 #
 # Databases (NeonDB, Supabase) default to external managed services.
 # For fully self-hosted setups, use the included PostgreSQL container.
@@ -100,25 +101,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    networks:
-      - revealui
-    restart: unless-stopped
-
-  # ---------------------------------------------------------------------------
-  # Marketing — Next.js Marketing + Waitlist (standalone output)
-  # ---------------------------------------------------------------------------
-  marketing:
-    build:
-      context: .
-      dockerfile: apps/marketing/Dockerfile
-    container_name: revealui-marketing
-    env_file: .env
-    environment:
-      NODE_ENV: production
-      PORT: "3000"
-      HOSTNAME: 0.0.0.0
-    ports:
-      - "${MARKETING_PORT:-3000}:3000"
     networks:
       - revealui
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Root `docker-compose.yml` declared a `marketing` service that built from `apps/marketing/Dockerfile`, which does not exist.
- Marketing is a Vite SPA deployed on Vercel, not part of the self-host compose stack.
- Removes the service and updates the compose header so `docker compose config` / bare `docker compose up` no longer fail on a missing Dockerfile (GAP-445).

## Test plan
- [x] Confirmed `apps/marketing/Dockerfile` is absent; `apps/server` and `apps/admin` Dockerfiles remain
- [x] `docker compose config --services` → `postgres`, `api`, `admin` only (no `marketing`)
- [x] Grep of `docker-compose.yml` shows no remaining service/build reference to marketing Dockerfile
- [ ] Optional: `docker compose up -d` with a local `.env` (pre-existing `env_file: .env` requirement for api/admin)