### PR TITLE
fix(sync): map marketing VITE_API_URL from public/api-url

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -124,9 +124,9 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/passkey/rp-id` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/passkey/rp-name` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/preview-token-secret` | credential | yes | vercel:api | HMAC-SHA256 key for edit-session preview tokens - short-lived read-only credential |
-| `revealui/prod/public/api-url` | public-config | no | vercel:api, vercel:admin, vercel:marketing, vercel:docs | required@boot; api self-origin: REVEALUI_API_URL (+ NEXT_PUBLIC_API_URL twin). Governed MCP tools fail without it. |
-| `revealui/prod/public/is-live` | public-config | no | vercel:admin, vercel:marketing | NEXT_PUBLIC_IS_LIVE - Stripe live-mode feature flag |
-| `revealui/prod/public/server-url` | public-config | no | vercel:api, vercel:admin, vercel:marketing, fly:worker |  |
+| `revealui/prod/public/api-url` | public-config | no | vercel:api, vercel:admin, vercel:marketing, vercel:docs | required@boot; api self-origin: REVEALUI_API_URL (+ NEXT_PUBLIC_API_URL twin on Next apps; VITE_API_URL on marketing). Governed MCP tools fail without it. |
+| `revealui/prod/public/is-live` | public-config | no | vercel:admin | NEXT_PUBLIC_IS_LIVE - Stripe live-mode feature flag |
+| `revealui/prod/public/server-url` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/r2/access-key-id` | credential | yes | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/r2/account-id` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/r2/bucket` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
@@ -174,8 +174,8 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/staging/passkey/origin` | public-config | no | vercel:api-staging, vercel:admin-staging | the admin app origin, https://admin.staging.revealui.com |
 | `revealui/staging/passkey/rp-id` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
 | `revealui/staging/passkey/rp-name` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
-| `revealui/staging/public/api-url` | public-config | no | vercel:api-staging, vercel:admin-staging, vercel:marketing-staging | the api own origin (MCP loopback + OpenAPI); also VITE_API_URL on marketing (anti-cross-wire, GAP-343) |
-| `revealui/staging/public/server-url` | public-config | no | vercel:api-staging, vercel:admin-staging, vercel:marketing-staging | the admin app own origin (parity with the prod server-url leaf) |
+| `revealui/staging/public/api-url` | public-config | no | vercel:api-staging, vercel:admin-staging, vercel:marketing-staging | the api own origin (MCP loopback + OpenAPI); VITE_API_URL on marketing (anti-cross-wire, GAP-343/350) |
+| `revealui/staging/public/server-url` | public-config | no | vercel:api-staging, vercel:admin-staging | the admin app own origin (parity with the prod server-url leaf) |
 | `revealui/staging/r2/access-key-id` | credential | yes | vercel:api-staging, vercel:admin-staging |  |
 | `revealui/staging/r2/account-id` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
 | `revealui/staging/r2/bucket` | public-config | no | vercel:api-staging, vercel:admin-staging |  |

--- a/scripts/sync/__tests__/secret-paths-lockstep.test.ts
+++ b/scripts/sync/__tests__/secret-paths-lockstep.test.ts
@@ -114,6 +114,22 @@ describe('manifest ↔ spec lockstep', () => {
     expect(pub?.path).toBe('revealui/staging/license/public-key');
   });
 
+  // GAP-350: marketing is Vite — only VITE_API_URL is baked; NEXT_PUBLIC_* twins
+  // have zero readers in apps/marketing and must not re-enter the marketing blocks.
+  it('prod marketing syncs VITE_API_URL from public/api-url and no Next twins (GAP-350)', () => {
+    const marketing = vercelVars.filter((v) => v.source === 'vercel:revealui-marketing');
+    const names = marketing.map((v) => v.name).sort();
+    expect(names).toEqual(['VITE_API_URL']);
+    expect(marketing[0]?.path).toBe('revealui/prod/public/api-url');
+  });
+
+  it('staging marketing syncs VITE_API_URL only (GAP-350 parity with prod)', () => {
+    const marketing = stagingVars.filter((v) => v.source === 'vercel:revealui-marketing-staging');
+    const names = marketing.map((v) => v.name).sort();
+    expect(names).toEqual(['VITE_API_URL']);
+    expect(marketing[0]?.path).toBe('revealui/staging/public/api-url');
+  });
+
   // GAP-343: the staging manifest reuses exactly five prod paths on purpose
   // (Gmail SA transport + one Stripe meter-event name - see the manifest
   // header + the consumers additions on those prod SECRET_PATHS entries).

--- a/scripts/sync/revvault-vercel-staging.toml
+++ b/scripts/sync/revvault-vercel-staging.toml
@@ -226,7 +226,7 @@ GOOGLE_SERVICE_ACCOUNT_EMAIL = "revealui/prod/google/service-account-email"
 # Auth + session (parity with api)
 SESSION_COOKIE_DOMAIN = "revealui/staging/session-cookie-domain"
 
-# Public URLs (parity twins across api/admin/marketing)
+# Public URLs (parity twins across api/admin; marketing uses VITE_API_URL)
 NEXT_PUBLIC_API_URL        = "revealui/staging/public/api-url"
 REVEALUI_API_URL           = "revealui/staging/public/api-url"
 NEXT_PUBLIC_SERVER_URL     = "revealui/staging/public/server-url"
@@ -255,15 +255,11 @@ skip = [
 ]
 
 [projects.revealui-marketing-staging.vars]
-# THE anti-cross-wire var this whole manifest exists to set explicitly: prod
-# marketing has NO VITE_API_URL today and hard-falls-back to the LIVE
-# api.revealui.com in every PROD build (apps/marketing/app/lib/api.ts:8-10).
-# Without this line, staging marketing would silently call the live api.
-VITE_API_URL               = "revealui/staging/public/api-url"
-NEXT_PUBLIC_API_URL        = "revealui/staging/public/api-url"
-REVEALUI_API_URL           = "revealui/staging/public/api-url"
-NEXT_PUBLIC_SERVER_URL     = "revealui/staging/public/server-url"
-REVEALUI_PUBLIC_SERVER_URL = "revealui/staging/public/server-url"
-# NEXT_PUBLIC_IS_LIVE intentionally excluded — genuine orphan, no code reader
-# (GAP-345), and dropping it for staging removes one class of confusion this
-# environment exists to avoid.
+# THE anti-cross-wire var: Vite bakes VITE_API_URL at build time
+# (apps/marketing/app/lib/api.ts). Without this line staging marketing would
+# hard-fall-back to the LIVE api.revealui.com in every PROD build. Prod
+# marketing maps the same env to revealui/prod/public/api-url (GAP-350).
+VITE_API_URL = "revealui/staging/public/api-url"
+# Dropped 2026-07-28 (GAP-350 parity with prod marketing): NEXT_PUBLIC_* /
+# REVEALUI_* twins have zero readers in apps/marketing (Vite, not Next).
+# NEXT_PUBLIC_IS_LIVE was already excluded (GAP-345 orphan).

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -153,7 +153,7 @@ REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
 # Self origin for governed MCP tool loopback (credentialsProvider → REST).
 # Missing on api caused live tool calls to fail while /api/mcp auth still
 # returned 400 Session ID required (auth green, tools dead). Same vault leaf
-# as admin/marketing NEXT_PUBLIC_API_URL / REVEALUI_API_URL.
+# as admin NEXT_PUBLIC_API_URL / REVEALUI_API_URL and marketing VITE_API_URL.
 REVEALUI_API_URL           = "revealui/prod/public/api-url"
 NEXT_PUBLIC_API_URL        = "revealui/prod/public/api-url"
 
@@ -245,7 +245,7 @@ ELECTRIC_SERVICE_URL = "revealui/prod/electric/service-url"
 # Mode flags (canonical pair — kept post-Q7)
 NEXT_PUBLIC_IS_LIVE = "revealui/prod/public/is-live"
 
-# Public URLs (parity twins across api/admin/marketing)
+# Public URLs (parity twins across api/admin; marketing uses VITE_API_URL)
 NEXT_PUBLIC_API_URL        = "revealui/prod/public/api-url"
 REVEALUI_API_URL           = "revealui/prod/public/api-url"
 NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
@@ -277,14 +277,16 @@ skip = [
 ]
 
 [projects.revealui-marketing.vars]
-# Mode flags + public URLs (canonical paths shared with admin/api)
-NEXT_PUBLIC_IS_LIVE        = "revealui/prod/public/is-live"
-NEXT_PUBLIC_API_URL        = "revealui/prod/public/api-url"
-REVEALUI_API_URL           = "revealui/prod/public/api-url"
-NEXT_PUBLIC_SERVER_URL     = "revealui/prod/public/server-url"
-REVEALUI_PUBLIC_SERVER_URL = "revealui/prod/public/server-url"
-# NEXT_PUBLIC_ADMIN_URL dropped 2026-05-09: not used in apps/marketing yet.
-# Re-add when CMS_URL → ADMIN_URL rename ships.
+# Vite bakes VITE_* at build time (apps/marketing/app/lib/api.ts). Without this
+# line every PROD build hard-falls-back to https://api.revealui.com, so the
+# vault leaf is the durable source of truth (GAP-350; staging already set it
+# in revvault-vercel-staging.toml via GAP-343).
+VITE_API_URL = "revealui/prod/public/api-url"
+# Dropped 2026-07-28 (GAP-350): NEXT_PUBLIC_* / REVEALUI_* twins had zero
+# readers in apps/marketing (Vite, not Next). NEXT_PUBLIC_IS_LIVE,
+# NEXT_PUBLIC_API_URL, REVEALUI_API_URL, NEXT_PUBLIC_SERVER_URL, and
+# REVEALUI_PUBLIC_SERVER_URL remain on api/admin where code reads them.
+# NEXT_PUBLIC_ADMIN_URL was already dropped 2026-05-09 (no marketing reader).
 
 
 # ── revealui-docs ───────────────────────────────────────────────────────────

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -512,7 +512,8 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'public-config',
     sensitive: false,
     tier: 'prod',
-    consumers: ['vercel:api', 'vercel:admin', 'vercel:marketing', 'fly:worker'],
+    // marketing dropped (GAP-350): Vite app does not read SERVER_URL twins.
+    consumers: ['vercel:api', 'vercel:admin', 'fly:worker'],
   },
   {
     path: 'revealui/prod/public/api-url',
@@ -520,17 +521,20 @@ export const SECRET_PATHS: SecretPathDef[] = [
     sensitive: false,
     tier: 'prod',
     // vercel:api is required for governed MCP tool loopback (self REST calls).
+    // vercel:marketing reads it as VITE_API_URL (GAP-350); admin/api still use
+    // REVEALUI_API_URL + NEXT_PUBLIC_API_URL.
     consumers: ['vercel:api', 'vercel:admin', 'vercel:marketing', 'vercel:docs'],
     requiredInProdHosted: true,
-    envVars: ['REVEALUI_API_URL'],
-    note: 'api self-origin: REVEALUI_API_URL (+ NEXT_PUBLIC_API_URL twin). Governed MCP tools fail without it.',
+    envVars: ['REVEALUI_API_URL', 'VITE_API_URL'],
+    note: 'api self-origin: REVEALUI_API_URL (+ NEXT_PUBLIC_API_URL twin on Next apps; VITE_API_URL on marketing). Governed MCP tools fail without it.',
   },
   {
     path: 'revealui/prod/public/is-live',
     kind: 'public-config',
     sensitive: false,
     tier: 'prod',
-    consumers: ['vercel:admin', 'vercel:marketing'],
+    // marketing dropped (GAP-350): zero readers in apps/marketing.
+    consumers: ['vercel:admin'],
     note: 'NEXT_PUBLIC_IS_LIVE - Stripe live-mode feature flag',
   },
   // ── STAGING (GAP-343 Phase 3) ──────────────────────────────────────────────
@@ -809,7 +813,8 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'public-config',
     sensitive: false,
     tier: 'staging',
-    consumers: ['vercel:api-staging', 'vercel:admin-staging', 'vercel:marketing-staging'],
+    // marketing-staging dropped (GAP-350): Vite app does not read SERVER_URL twins.
+    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
     note: 'the admin app own origin (parity with the prod server-url leaf)',
   },
   {
@@ -818,7 +823,7 @@ export const SECRET_PATHS: SecretPathDef[] = [
     sensitive: false,
     tier: 'staging',
     consumers: ['vercel:api-staging', 'vercel:admin-staging', 'vercel:marketing-staging'],
-    note: 'the api own origin (MCP loopback + OpenAPI); also VITE_API_URL on marketing (anti-cross-wire, GAP-343)',
+    note: 'the api own origin (MCP loopback + OpenAPI); VITE_API_URL on marketing (anti-cross-wire, GAP-343/350)',
   },
 
   // ── Env bundles (derived, verify-only - NOT synced to any platform) ───────


### PR DESCRIPTION
## Summary

GAP-350: `apps/marketing` is Vite and resolves the API origin from `import.meta.env.VITE_API_URL` ([api.ts](apps/marketing/app/lib/api.ts)). The prod revvault→Vercel manifest synced only inert `NEXT_PUBLIC_*` / `REVEALUI_*` twins that marketing never reads, so every production build fell back to the hard-coded `https://api.revealui.com`.

### Changes

- **Add** `VITE_API_URL = "revealui/prod/public/api-url"` on `revealui-marketing` (same vault leaf as admin/api `NEXT_PUBLIC_API_URL` / `REVEALUI_API_URL`).
- **Drop** inert marketing vars (zero readers in `apps/marketing`): `NEXT_PUBLIC_IS_LIVE`, `NEXT_PUBLIC_API_URL`, `REVEALUI_API_URL`, `NEXT_PUBLIC_SERVER_URL`, `REVEALUI_PUBLIC_SERVER_URL`.
- **Staging marketing** parity: keep only `VITE_API_URL` (drop the same inert twins); fix stale "prod has NO VITE_API_URL" comment.
- **secret-paths + SECRETS.md** consumer/notes update; lockstep tests assert marketing blocks are `VITE_API_URL` only.

### Grep evidence (dropped vars)

```
# apps/marketing readers of API/server env names
VITE_API_URL          → api.ts, og.ts, edit-mode.ts, PricingPage, PricingTeaser
VITE_ADMIN_URL        → PricingPage only (hard fallback; not synced here)
NEXT_PUBLIC_IS_LIVE   → no matches
NEXT_PUBLIC_API_URL   → no matches
REVEALUI_API_URL      → no matches
NEXT_PUBLIC_SERVER_URL → no matches
REVEALUI_PUBLIC_SERVER_URL → no matches
```

Admin/api blocks still carry the Next twins unchanged.

### Test plan

- [x] `pnpm exec vitest run scripts/sync/__tests__/secret-paths-lockstep.test.ts` (23 passed)
- [ ] Owner: after merge, `revvault sync vercel --manifest scripts/sync/revvault-vercel.toml` then redeploy marketing so the build bakes `VITE_API_URL`