### PR TITLE
fix(admin): auto-login after web setup (GAP-247 F8)

### DIFF
--- a/apps/admin/src/__tests__/api/setup-routes.test.ts
+++ b/apps/admin/src/__tests__/api/setup-routes.test.ts
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockFind = vi.fn();
 const mockCreate = vi.fn();
+const mockCreateSession = vi.fn();
 
 vi.mock('@/lib/utils/revealui-singleton', () => ({
   getRevealUIInstance: () =>
@@ -35,6 +36,11 @@ vi.mock('@revealui/db/client', () => ({
   getClient: () => ({ update: mockUpdate, insert: mockInsert }),
 }));
 
+// Session mint uses the same createSession primitive as sign-in (GAP-247 F8).
+vi.mock('@revealui/auth/server', () => ({
+  createSession: (...args: unknown[]) => mockCreateSession(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // Route imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -49,8 +55,23 @@ function makePostRequest(body: Record<string, unknown>): Request {
   return new Request('http://localhost/api/setup', {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'user-agent': 'setup-route-test',
+      'x-forwarded-for': '203.0.113.10',
+    },
   });
+}
+
+function getSetCookie(res: Response): string[] {
+  // undici/NextResponse expose getSetCookie when available; fall back to
+  // repeated get() for older Headers implementations.
+  const headers = res.headers as Headers & { getSetCookie?: () => string[] };
+  if (typeof headers.getSetCookie === 'function') {
+    return headers.getSetCookie();
+  }
+  const single = headers.get('set-cookie');
+  return single ? [single] : [];
 }
 
 // ---------------------------------------------------------------------------
@@ -63,6 +84,10 @@ describe('POST /api/setup', () => {
     // Default: no existing users
     mockFind.mockResolvedValue({ totalDocs: 0, docs: [] });
     mockCreate.mockResolvedValue({ id: '1', email: 'admin@test.com' });
+    mockCreateSession.mockResolvedValue({
+      token: 'test-session-token',
+      session: { id: 'sess-1' },
+    });
   });
 
   it('creates admin user and returns 201', async () => {
@@ -78,6 +103,54 @@ describe('POST /api/setup', () => {
     expect(body.status).toBe('created');
     expect(body.user?.email).toBe('admin@test.com');
     expect(body.seeded).toBe(true);
+  });
+
+  it('mints a session and sets auth cookies on success (GAP-247 F8)', async () => {
+    const res = await POST(
+      makePostRequest({
+        email: 'admin@test.com',
+        password: 'securepassword12',
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.sessionMinted).toBe(true);
+    expect(body.user?.id).toBe('1');
+
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      '1',
+      expect.objectContaining({
+        userAgent: 'setup-route-test',
+        ipAddress: '203.0.113.10',
+      }),
+    );
+
+    const cookies = getSetCookie(res);
+    const joined = cookies.join('\n');
+    expect(joined).toMatch(/revealui-session=test-session-token/);
+    expect(joined).toMatch(/revealui-role=owner/);
+    // Cookie flags must match sign-in (httpOnly + sameSite=lax; secure only in prod)
+    expect(joined).toMatch(/HttpOnly/i);
+    expect(joined).toMatch(/SameSite=Lax/i);
+  });
+
+  it('still returns 201 when session mint fails (non-fatal auto-login)', async () => {
+    mockCreateSession.mockRejectedValueOnce(new Error('session store unavailable'));
+
+    const res = await POST(
+      makePostRequest({
+        email: 'admin@test.com',
+        password: 'securepassword12',
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.status).toBe('created');
+    expect(body.sessionMinted).toBeUndefined();
+    const cookies = getSetCookie(res);
+    expect(cookies.join('\n')).not.toMatch(/revealui-session=/);
   });
 
   it('stamps TOS acceptance via a typed write after creating the admin', async () => {
@@ -133,6 +206,7 @@ describe('POST /api/setup', () => {
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.status).toBe('locked');
+    expect(mockCreateSession).not.toHaveBeenCalled();
   });
 
   it('rejects invalid email', async () => {

--- a/apps/admin/src/app/(frontend)/setup/SetupForm.tsx
+++ b/apps/admin/src/app/(frontend)/setup/SetupForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import type { ChangeEvent, FormEvent } from 'react';
 import { useState } from 'react';
 import { PasswordInput } from '@/lib/components/PasswordInput';
+import { navigateAfterAuthChange } from '@/lib/utils/auth-navigation';
 
 interface SetupFormProps {
   /** Site name resolved server-side to avoid build-time env inlining. */
@@ -20,6 +21,7 @@ export function SetupForm({ siteName }: SetupFormProps) {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [sessionMinted, setSessionMinted] = useState(false);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -36,8 +38,20 @@ export function SetupForm({ siteName }: SetupFormProps) {
       const data = await res.json();
 
       if (data.status === 'created') {
+        const minted = data.sessionMinted === true;
+        setSessionMinted(minted);
         setSuccess(true);
-        setTimeout(() => router.push('/login'), 2000);
+        // Full document navigation when a session was minted so the App Router
+        // cache (logged-out RSC payloads) is not replayed — same as LoginForm.
+        // Fall back to /login if mint failed so the admin can still sign in.
+        const dest = minted ? '/' : '/login';
+        setTimeout(() => {
+          if (minted) {
+            navigateAfterAuthChange(dest);
+          } else {
+            router.push(dest);
+          }
+        }, 2000);
         return;
       }
 
@@ -61,7 +75,9 @@ export function SetupForm({ siteName }: SetupFormProps) {
           Setup complete
         </Heading>
         <p className="text-sm text-muted-foreground">
-          Your admin account has been created. Redirecting to sign in…
+          {sessionMinted
+            ? 'Your admin account is ready. Taking you to the dashboard…'
+            : 'Your admin account has been created. Redirecting to sign in…'}
         </p>
         <div className="flex justify-center py-4">
           <div className="size-8 animate-spin rounded-full border-4 border-zinc-200 border-t-[var(--tenant-brand,#2563eb)] dark:border-zinc-700" />

--- a/apps/admin/src/app/(frontend)/setup/__tests__/SetupForm.test.tsx
+++ b/apps/admin/src/app/(frontend)/setup/__tests__/SetupForm.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * SetupForm post-bootstrap navigation (GAP-247 F8).
+ *
+ * When /api/setup mints a session, the form must full-navigate to '/' via
+ * navigateAfterAuthChange so the App Router cache does not replay a
+ * logged-out RSC payload. When mint fails, soft-push to /login.
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPush = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/lib/utils/auth-navigation', () => ({
+  navigateAfterAuthChange: (path: string) => mockNavigate(path),
+}));
+
+vi.mock('@revealui/presentation/server', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  FormLabel: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  Heading: ({ children }: any) => <h2>{children}</h2>,
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  InputCVA: (props: any) => <input {...props} />,
+}));
+
+vi.mock('@/lib/components/PasswordInput', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: lightweight test doubles
+  PasswordInput: ({ children }: any) => <div>{children}</div>,
+}));
+
+import { SetupForm } from '../SetupForm';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+async function fillAndSubmit(): Promise<void> {
+  fireEvent.change(screen.getByLabelText(/email/i), {
+    target: { value: 'admin@test.com' },
+  });
+  fireEvent.change(screen.getByLabelText(/^password$/i), {
+    target: { value: 'securepassword12' },
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /create admin account/i }));
+  });
+}
+
+describe('SetupForm', () => {
+  it('full-navigates to / when setup mints a session', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({
+        status: 'created',
+        sessionMinted: true,
+        user: { id: '1', email: 'admin@test.com', role: 'owner' },
+      }),
+    }) as unknown as typeof fetch;
+
+    render(<SetupForm siteName="RevealUI" />);
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByText(/taking you to the dashboard/i)).toBeTruthy();
+    });
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+      },
+      { timeout: 3000 },
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('soft-pushes to /login when session mint is absent', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({
+        status: 'created',
+        user: { id: '1', email: 'admin@test.com', role: 'owner' },
+      }),
+    }) as unknown as typeof fetch;
+
+    render(<SetupForm siteName="RevealUI" />);
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByText(/redirecting to sign in/i)).toBeTruthy();
+    });
+    await waitFor(
+      () => {
+        expect(mockPush).toHaveBeenCalledWith('/login');
+      },
+      { timeout: 3000 },
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /login when setup is locked', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ status: 'locked', message: 'Already set up' }),
+    }) as unknown as typeof fetch;
+
+    render(<SetupForm siteName="RevealUI" />);
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/login');
+    });
+  });
+});

--- a/apps/admin/src/app/api/setup/route.ts
+++ b/apps/admin/src/app/api/setup/route.ts
@@ -1,10 +1,17 @@
 import crypto from 'node:crypto';
+import { createSession } from '@revealui/auth/server';
 import { type BootstrapResult, bootstrap, type RevealUILike } from '@revealui/setup/bootstrap';
 import { logger } from '@revealui/utils/logger';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { stampTosAcceptanceByEmail } from '@/lib/auth/tos';
 import { getRevealUIInstance } from '@/lib/utils/revealui-singleton';
+import {
+  ROLE_COOKIE,
+  requireSessionCookieDomain,
+  SESSION_COOKIE,
+  sessionCookieDomain,
+} from '@/lib/utils/session-cookies';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -26,9 +33,35 @@ const isWebSetupDisabled =
   process.env.REVEALUI_ALLOW_WEB_SETUP !== 'true' && process.env.NODE_ENV === 'production';
 
 /**
+ * Attach the same auth cookies sign-in sets (GAP-247 F8 auto-login).
+ * Cookie flags mirror apps/admin/src/app/api/auth/sign-in/route.ts exactly —
+ * do not weaken httpOnly/secure/sameSite or diverge maxAge from DB session TTL.
+ */
+function attachSessionCookies(response: NextResponse, sessionToken: string, role: string): void {
+  response.cookies.set(ROLE_COOKIE, role, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 7,
+    domain: sessionCookieDomain(),
+  });
+
+  response.cookies.set(SESSION_COOKIE, sessionToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
+    domain: requireSessionCookieDomain(),
+  });
+}
+
+/**
  * POST /api/setup  -  Bootstrap a fresh RevealUI instance.
  *
  * Creates the first admin user and seeds minimal content.
+ * On success, mints a session (auto-login) so the new admin skips re-auth.
  * Self-disabling: returns 403 once any user exists.
  * No auth required (no users exist yet).
  * Disabled in production unless REVEALUI_ALLOW_WEB_SETUP=true.
@@ -165,6 +198,35 @@ export async function POST(request: Request): Promise<NextResponse<BootstrapResu
       logger.error('Post-create steps skipped: database client unavailable', {
         email: parsed.data.email,
         error: dbError instanceof Error ? dbError.message : String(dbError),
+      });
+    }
+
+    // Auto-login (GAP-247 F8): mint a session with the same createSession
+    // primitive sign-in uses. Non-fatal — admin creation already succeeded;
+    // a mint failure falls back to the old /login redirect on the client.
+    const userId = result.user?.id;
+    if (userId) {
+      try {
+        const userAgent = request.headers.get('user-agent') || undefined;
+        const ipAddress =
+          request.headers.get('x-real-ip') ||
+          request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+          undefined;
+        const { token } = await createSession(userId, { userAgent, ipAddress });
+        const body: BootstrapResult = { ...result, sessionMinted: true };
+        const response = NextResponse.json(body, { status: 201 });
+        attachSessionCookies(response, token, result.user?.role ?? 'owner');
+        return response;
+      } catch (sessionError) {
+        logger.error('Setup auto-login session mint failed', {
+          email: parsed.data.email,
+          userId,
+          error: sessionError instanceof Error ? sessionError.message : String(sessionError),
+        });
+      }
+    } else {
+      logger.warn('Setup auto-login skipped: bootstrap result missing user id', {
+        email: parsed.data.email,
       });
     }
   }

--- a/packages/cli/templates/basic-blog/.env.example
+++ b/packages/cli/templates/basic-blog/.env.example
@@ -30,9 +30,9 @@ STRIPE_WEBHOOK_SECRET=whsec_placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 
 # ─── Admin Bootstrap ─────────────────────────────────────────────────────────
-# Used on first run only to create the initial admin account
+# Set a strong password (min 12 chars) before first run.
 REVEALUI_ADMIN_EMAIL=admin@example.com
-REVEALUI_ADMIN_PASSWORD=changeme-min-12-chars
+REVEALUI_ADMIN_PASSWORD=
 
 # ─── Branding (Enterprise white-label) ───────────────────────────────────────
 # Customize the admin UI for your brand. Enterprise license required for full white-label.

--- a/packages/cli/templates/e-commerce/.env.example
+++ b/packages/cli/templates/e-commerce/.env.example
@@ -30,9 +30,9 @@ STRIPE_WEBHOOK_SECRET=whsec_placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 
 # ─── Admin Bootstrap ─────────────────────────────────────────────────────────
-# Used on first run only to create the initial admin account
+# Set a strong password (min 12 chars) before first run.
 REVEALUI_ADMIN_EMAIL=admin@example.com
-REVEALUI_ADMIN_PASSWORD=changeme-min-12-chars
+REVEALUI_ADMIN_PASSWORD=
 
 # ─── Branding (Enterprise white-label) ───────────────────────────────────────
 # Customize the admin UI for your brand. Enterprise license required for full white-label.

--- a/packages/cli/templates/portfolio/.env.example
+++ b/packages/cli/templates/portfolio/.env.example
@@ -30,9 +30,9 @@ STRIPE_WEBHOOK_SECRET=whsec_placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 
 # ─── Admin Bootstrap ─────────────────────────────────────────────────────────
-# Used on first run only to create the initial admin account
+# Set a strong password (min 12 chars) before first run.
 REVEALUI_ADMIN_EMAIL=admin@example.com
-REVEALUI_ADMIN_PASSWORD=changeme-min-12-chars
+REVEALUI_ADMIN_PASSWORD=
 
 # ─── Branding (Enterprise white-label) ───────────────────────────────────────
 # Customize the admin UI for your brand. Enterprise license required for full white-label.

--- a/packages/cli/templates/starter-native/.env.example
+++ b/packages/cli/templates/starter-native/.env.example
@@ -32,9 +32,9 @@ STRIPE_WEBHOOK_SECRET=whsec_placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 
 # ─── Admin Bootstrap ─────────────────────────────────────────────────────────
-# Used on first run only to create the initial admin account
+# Set a strong password (min 12 chars) before first run.
 REVEALUI_ADMIN_EMAIL=admin@example.com
-REVEALUI_ADMIN_PASSWORD=changeme-min-12-chars
+REVEALUI_ADMIN_PASSWORD=
 
 # ─── Branding (Enterprise white-label) ───────────────────────────────────────
 # Customize the admin UI for your brand. Enterprise license required for full white-label.

--- a/packages/cli/templates/starter/.env.example
+++ b/packages/cli/templates/starter/.env.example
@@ -30,9 +30,9 @@ STRIPE_WEBHOOK_SECRET=whsec_placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 
 # ─── Admin Bootstrap ─────────────────────────────────────────────────────────
-# Used on first run only to create the initial admin account
+# Set a strong password (min 12 chars) before first run.
 REVEALUI_ADMIN_EMAIL=admin@example.com
-REVEALUI_ADMIN_PASSWORD=changeme-min-12-chars
+REVEALUI_ADMIN_PASSWORD=
 
 # ─── Branding (Enterprise white-label) ───────────────────────────────────────
 # Customize the admin UI for your brand. Enterprise license required for full white-label.

--- a/packages/setup/src/__tests__/bootstrap.test.ts
+++ b/packages/setup/src/__tests__/bootstrap.test.ts
@@ -34,6 +34,7 @@ describe('bootstrap', () => {
     expect(result.status).toBe('created');
     expect(result.user?.email).toBe('admin@test.com');
     expect(result.user?.role).toBe('owner');
+    expect(result.user?.id).toBe('new-user');
     expect(result.seeded).toBe(true);
 
     // Verify user was created with both the DB role and Payload roles array.

--- a/packages/setup/src/bootstrap/index.ts
+++ b/packages/setup/src/bootstrap/index.ts
@@ -55,9 +55,19 @@ export interface BootstrapOptions {
 export interface BootstrapResult {
   status: 'created' | 'locked' | 'error';
   message: string;
-  user?: { email: string; role: string };
+  /**
+   * Created admin identity. `id` is the engine-returned primary key when the
+   * create() result includes one — callers (web /api/setup) use it to mint a
+   * session without re-checking the password.
+   */
+  user?: { id?: string; email: string; role: string };
   seeded?: boolean;
   error?: string;
+  /**
+   * Set by the web setup route after minting a session cookie (GAP-247 F8).
+   * Not produced by bootstrap() itself.
+   */
+  sessionMinted?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -197,8 +207,9 @@ export async function bootstrap(options: BootstrapOptions): Promise<BootstrapRes
   // apps/admin/src/lib/auth/tos.ts (stampTosAcceptanceByEmail), used by the web
   // setup route (apps/admin/src/app/api/setup/route.ts) and the CLI
   // (scripts/admin/bootstrap.ts).
+  let created: Record<string, unknown>;
   try {
-    await revealui.create({
+    created = await revealui.create({
       collection: 'users',
       data: {
         name: admin.name ?? 'Admin',
@@ -223,6 +234,8 @@ export async function bootstrap(options: BootstrapOptions): Promise<BootstrapRes
       error: err instanceof Error ? err.message : String(err),
     };
   }
+
+  const userId = created.id != null ? String(created.id) : undefined;
 
   // Seed minimal content
   let seeded = false;
@@ -251,8 +264,8 @@ export async function bootstrap(options: BootstrapOptions): Promise<BootstrapRes
 
   return {
     status: 'created',
-    message: `Admin user created${seeded ? ' and content seeded' : ''}. Sign in at /admin.`,
-    user: { email: admin.email, role: 'owner' },
+    message: `Admin user created${seeded ? ' and content seeded' : ''}.`,
+    user: { id: userId, email: admin.email, role: 'owner' },
     seeded,
   };
 }


### PR DESCRIPTION
## Summary

Closes the residual of **GAP-247** (F8 only; D1/D2 already shipped).

On `/setup` success the form redirected to `/login` with **no session**, forcing the just-created admin to re-authenticate. This PR mints a session on bootstrap success and lands the admin on the dashboard.

Also aligns CLI template `.env.example` files with D2 (empty `REVEALUI_ADMIN_PASSWORD=` so the placeholder fails the min-length gate), matching `packages/cli/src/generators/env-file.ts`.

## How session is minted

1. `bootstrap()` now returns the created user's **`id`** from the engine `create()` result.
2. After TOS + audit post-create steps, `POST /api/setup` calls **`createSession(userId, { userAgent, ipAddress })`** from `@revealui/auth/server` — the same primitive sign-in uses via `rotateSession` → `createSession`.
3. Cookie attachment mirrors [sign-in/route.ts](apps/admin/src/app/api/auth/sign-in/route.ts):
   - `revealui-session` — httpOnly, secure in production, `sameSite: 'lax'`, path `/`, maxAge 1 day, `requireSessionCookieDomain()`
   - `revealui-role` — same flags except maxAge 7 days, `sessionCookieDomain()`
4. Response body includes `sessionMinted: true` when mint succeeds.
5. Session mint is **non-fatal**: admin creation still returns 201 if mint fails; client falls back to `/login`.
6. `SetupForm` uses **`navigateAfterAuthChange('/')`** on mint success (full document navigation so App Router cache does not replay logged-out RSC payloads — same as LoginForm). Without mint, soft `router.push('/login')`.

## Test plan

- [x] `apps/admin` setup-routes tests (14) — includes cookie mint + non-fatal mint failure
- [x] `SetupForm` tests (3) — dashboard full-nav vs login fallback vs locked
- [x] `@revealui/setup` bootstrap tests (10) — user id on create
- [x] Pre-push CI gate phase 1 pass

## Residual risks

- **Mint failure after create:** rare DB/session-store errors leave the admin created but unauthenticated; form falls back to `/login` (logged loudly).
- **Missing `user.id` from engine create:** auto-login is skipped (warn log); same `/login` fallback.
- **No `auditLoginSuccess` on setup path:** setup uses `createSession` directly rather than `signIn` (no password re-check / rate-limit / MFA path). Bootstrap already writes `admin.bootstrap.completed` audit; login-success audit is not duplicated. Acceptable for first-admin bootstrap; if product wants a login-success receipt too, that can be a follow-up.
- **Cookie domain in production:** uses the same `requireSessionCookieDomain()` as sign-in; hosted SaaS without `SESSION_COOKIE_DOMAIN` throws at mint time (caught as non-fatal) — same class as sign-in failures on misconfigured deploy.

## Owner actions

Merge when green (do not self-merge without authorization):

```bash
gh pr merge <N> --squash
```