### PR TITLE
fix(auth): MFA login after enroll — challenge parse + session step-up

### DIFF
--- a/apps/admin/src/app/api/auth/__tests__/sign-in-route.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/sign-in-route.test.ts
@@ -201,7 +201,9 @@ describe('POST /api/auth/sign-in', () => {
     const res = await POST(makeRequest({ email: 'mfa@example.com', password: 'ValidPass1' }));
 
     expect((res as { status: number }).status).toBe(200);
-    expect((res as unknown as { body: { requiresMfa: boolean } }).body.requiresMfa).toBe(true);
+    const body = (res as unknown as { body: { requiresMfa: boolean; mfaUserId?: string } }).body;
+    expect(body.requiresMfa).toBe(true);
+    expect(body.mfaUserId).toBe('mfa-user-1');
 
     const cookies = (res as unknown as { cookies: CookieStore }).cookies;
     expect(cookies.has('mfa-pending')).toBe(true);

--- a/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
@@ -271,7 +271,10 @@ describe('POST /api/auth/mfa/verify-setup', () => {
   it('should return success on valid TOTP code', async () => {
     mockGetSession.mockResolvedValue(mockSession);
     mockVerifyMFASetup.mockResolvedValue({ success: true });
-    mockRotateSession.mockResolvedValue({ token: 'session-after-mfa-setup' });
+    mockRotateSession.mockResolvedValue({
+      token: 'session-after-mfa-setup',
+      session: { id: 'session-after-mfa-setup' } as never,
+    });
 
     const request = createJsonRequest('http://localhost:3000/api/auth/mfa/verify-setup', {
       code: '123456',

--- a/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
@@ -271,6 +271,7 @@ describe('POST /api/auth/mfa/verify-setup', () => {
   it('should return success on valid TOTP code', async () => {
     mockGetSession.mockResolvedValue(mockSession);
     mockVerifyMFASetup.mockResolvedValue({ success: true });
+    mockRotateSession.mockResolvedValue({ token: 'session-after-mfa-setup' });
 
     const request = createJsonRequest('http://localhost:3000/api/auth/mfa/verify-setup', {
       code: '123456',
@@ -281,6 +282,14 @@ describe('POST /api/auth/mfa/verify-setup', () => {
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
     expect(mockVerifyMFASetup).toHaveBeenCalledWith(mockSession.user.id, '123456');
+    // C11 step-up: enrollment must mark the session mfaVerified so Save Key
+    // and other requireSessionWithMfa surfaces work without a forced re-login.
+    expect(mockRotateSession).toHaveBeenCalledWith(
+      mockSession.user.id,
+      expect.objectContaining({ metadata: { mfaVerified: true } }),
+    );
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).toMatch(/revealui-session=session-after-mfa-setup/);
   });
 
   it('should return 400 on invalid code', async () => {

--- a/apps/admin/src/app/api/auth/mfa/verify-setup/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify-setup/route.ts
@@ -7,7 +7,7 @@
  * Activates MFA on the account upon success.
  */
 
-import { getSession, verifyMFASetup } from '@revealui/auth/server';
+import { getSession, rotateSession, verifyMFASetup } from '@revealui/auth/server';
 import { MFAVerifyRequestContract } from '@revealui/contracts';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
@@ -18,6 +18,7 @@ import {
 } from '@/lib/utils/error-response';
 import { rejectRecoverySession } from '@/lib/utils/recovery-guard';
 import { extractRequestContext } from '@/lib/utils/request-context';
+import { sessionCookieDomain } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -70,7 +71,32 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    return NextResponse.json({ success: true });
+    // Enrollment just proved possession of the authenticator. Mark this
+    // session MFA-stepped so C11 gates (e.g. POST /api/user/api-keys) work
+    // without forcing a sign-out/sign-in loop. Without this, the account has
+    // mfaEnabled=true but session.metadata.mfaVerified is still false →
+    // "MFA required" / "MFA verification required" on the next sensitive action.
+    const userAgent = request.headers.get('user-agent') ?? undefined;
+    const ipAddress =
+      request.headers.get('x-real-ip') ||
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      undefined;
+    const { token: sessionToken } = await rotateSession(session.user.id, {
+      userAgent,
+      ipAddress,
+      metadata: { mfaVerified: true },
+    });
+
+    const response = NextResponse.json({ success: true });
+    response.cookies.set('revealui-session', sessionToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24,
+      domain: sessionCookieDomain({ logIfMissing: true }),
+    });
+    return response;
   } catch (error) {
     logger.error('Error verifying MFA setup', { error });
     return createErrorResponse(error, {

--- a/apps/admin/src/app/api/auth/sign-in/route.ts
+++ b/apps/admin/src/app/api/auth/sign-in/route.ts
@@ -85,7 +85,12 @@ async function signInHandler(request: NextRequest): Promise<NextResponse> {
         { userId: result.mfaUserId, expiresAt: Date.now() + 5 * 60 * 1000 },
         config.reveal.secret,
       );
-      const response = NextResponse.json({ requiresMfa: true }, { status: 200 });
+      // Body includes mfaUserId for client routing; the httpOnly mfa-pending
+      // cookie remains the authority for /api/auth/mfa/verify.
+      const response = NextResponse.json(
+        { requiresMfa: true, mfaUserId: result.mfaUserId },
+        { status: 200 },
+      );
       response.cookies.set('mfa-pending', signed, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',

--- a/packages/auth/src/react/__tests__/useSignIn.test.tsx
+++ b/packages/auth/src/react/__tests__/useSignIn.test.tsx
@@ -117,6 +117,29 @@ describe('useSignIn', () => {
     }
   });
 
+  it('returns MFA challenge when body is cookie-only shape ({ requiresMfa: true })', async () => {
+    // Live admin route historically returned only requiresMfa and put the
+    // user id in the httpOnly mfa-pending cookie. Must not fall through to
+    // the success schema (user expected object).
+    vi.stubGlobal('fetch', mockFetch({ requiresMfa: true }));
+
+    const { result } = renderHook(() => useSignIn());
+
+    let signInResult: Awaited<ReturnType<typeof result.current.signIn>>;
+    await waitFor(async () => {
+      signInResult = await result.current.signIn({
+        email: 'mfa@example.com',
+        password: 'password123',
+      });
+    });
+
+    expect(signInResult!.success).toBe(false);
+    if (!signInResult!.success && 'requiresMfa' in signInResult!) {
+      expect(signInResult!.requiresMfa).toBe(true);
+    }
+    expect(result.current.error).toBeNull();
+  });
+
   it('handles network error', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
 

--- a/packages/auth/src/react/useSignIn.ts
+++ b/packages/auth/src/react/useSignIn.ts
@@ -53,12 +53,12 @@ export interface SignInInput {
 }
 
 export interface UseSignInResult {
-  signIn: (
-    input: SignInInput,
-  ) => Promise<
+  signIn: (input: SignInInput) => Promise<
     | { success: true; user: User }
     | { success: false; error: string; code?: string }
-    | { success: false; requiresMfa: true; mfaUserId: string }
+    // mfaUserId is optional: the live sign-in route puts identity in the
+    // httpOnly mfa-pending cookie and may only return { requiresMfa: true }.
+    | { success: false; requiresMfa: true; mfaUserId?: string }
   >;
   isLoading: boolean;
   error: Error | null;
@@ -125,13 +125,17 @@ export function useSignIn(): UseSignInResult {
         };
       }
 
-      // Check for MFA challenge before parsing as full success
+      // MFA challenge is HTTP 200 with { requiresMfa: true } and no `user`.
+      // The server may omit mfaUserId from the body (identity lives in the
+      // httpOnly mfa-pending cookie). Requiring mfaUserId here forced the
+      // success schema parse, which threw "expected object, received undefined"
+      // on `user` and locked MFA-enabled accounts out of the login UI.
       const jsonObj = json as Record<string, unknown>;
-      if (jsonObj.requiresMfa === true && typeof jsonObj.mfaUserId === 'string') {
+      if (jsonObj.requiresMfa === true) {
         return {
           success: false as const,
           requiresMfa: true as const,
-          mfaUserId: jsonObj.mfaUserId,
+          ...(typeof jsonObj.mfaUserId === 'string' ? { mfaUserId: jsonObj.mfaUserId } : {}),
         };
       }
 


### PR DESCRIPTION
## Summary

Owner GAP-360 walk hit a **login lockout after MFA enroll**:

1. **Sign-in UI broke** once MFA was enabled. Server returns HTTP 200 `{ requiresMfa: true }` (identity in httpOnly `mfa-pending` cookie only). `useSignIn` required `mfaUserId` in the JSON body, fell through to the success schema, and threw Zod: `user` expected object, received undefined.

2. **Save API key still blocked after setup.** `verify-setup` flipped `mfaEnabled` on the user but never set `session.metadata.mfaVerified`, so C11 `requireSessionWithMfa` kept returning MFA errors until a full re-login step-up (which was broken by #1).

### Fix
- Treat `requiresMfa: true` as an MFA challenge even without body `mfaUserId`
- Include `mfaUserId` in the sign-in response body for client routing (cookie remains authority for verify)
- After successful MFA **setup** verify, `rotateSession` with `{ mfaVerified: true }` and refresh the session cookie

## Test plan
- [x] `packages/auth` `useSignIn` tests (7/7) including cookie-only MFA body shape
- [ ] CI unit tests on admin sign-in + MFA routes
- [ ] Owner: password sign-in → `/mfa` TOTP → Save API key works without the Zod error
- [ ] Owner: new enroll path leaves session stepped-up so Save Key works without re-login

## Security
Auth/MFA surfaces — needs non-author guardrail-2 verdict before merge.

## Workaround until deploy
After password submit (even if UI shows Zod error), open `https://admin.revealui.com/mfa` within 5 minutes and enter TOTP — the `mfa-pending` cookie may already be set.