### PR TITLE
feat(knowledge-graph): claims extractor + revkg claims-check (GAP-462 Phase 3)

### DIFF
--- a/packages/knowledge-graph/README.md
+++ b/packages/knowledge-graph/README.md
@@ -21,16 +21,32 @@ on two sites is one row: the canonical graph is convergent by construction
   (`ON CONFLICT DO NOTHING` for G-Set rows, `LEAST`/`GREATEST` for monotonic
   columns).
 - **Tier-1 extractors** (`./extractors`): workspace, ts-project (TS compiler
-  API), db-schema, git, docs-frontmatter, routes — no regex over source.
+  API), db-schema, git, docs-frontmatter, routes, **claims** (claims-evidence →
+  `documents` edges, GAP-462) — no regex over source.
 - **Search** (`./search`): pgvector cosine + `websearch_to_tsquery`/`ts_rank` +
   recursive-CTE BFS, RRF-fused (k=60), reranked by node-distance and
-  episode-mentions, with point-in-time predicates.
-- **`revkg` CLI**: `scan`, `search`, `node`, `neighbors`, `at`.
+  episode-mentions, with point-in-time predicates. `kgDrift` walks current
+  `documents` edges for doc-currency candidates.
+- **`revkg` CLI**: `scan`, `search`, `node`, `neighbors`, `at`, `drift`,
+  `claims-check [--publish]`.
 
 Embeddings are injected (`Embedder`) and best-effort — wired to `@revealui/ai`
 `generateEmbedding` (nomic-embed-text, 768) by the CLI, degrading to NULL
 embeddings + deferred backfill when Ollama is down. The core library imports no
 LLM SDK.
+
+## Claims honesty (GAP-462)
+
+```bash
+# Parse claims-evidence, verify path evidence exists (no DB)
+pnpm exec revkg claims-check --root . --repo revealui
+
+# Ingest claim concepts + documents edges into Neon (needs POSTGRES_URL)
+pnpm exec revkg claims-check --root . --repo revealui --publish
+
+# After a claims publish (or full scan), report doc/code staleness
+pnpm exec revkg drift --repo revealui
+```
 
 ## Development
 

--- a/packages/knowledge-graph/src/cli/revkg.ts
+++ b/packages/knowledge-graph/src/cli/revkg.ts
@@ -8,6 +8,9 @@
  *   revkg neighbors <naturalKey> [--depth <n>] [--at <iso>]
  *   revkg at <naturalKey> <iso>
  *   revkg drift [--repo <name>] [--json]                   doc-currency drift report (spec §8.5)
+ *   revkg claims-check [--root] [--repo] [--fleet] [--publish] [--json]
+ *       Parse claims-evidence, verify path evidence exists; with --publish ingest
+ *       claim-scan documents edges into the graph (GAP-462 Phase 3).
  *
  * Connects to Neon via its own pool (`@revealui/db`'s `createPool`, DATABASE_URL
  * / POSTGRES_URL resolved by `getConnectionIdentity`) rather than the shared
@@ -28,7 +31,14 @@
 import { hostname } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { makePoolExecutor } from '../db/executor.js';
-import { additiveExtractors, tier1Extractors } from '../extractors/index.js';
+import {
+  additiveExtractors,
+  CLAIMS_EVIDENCE_REL,
+  claimsExtractor,
+  missingEvidencePaths,
+  parseClaimsEvidenceSource,
+  tier1Extractors,
+} from '../extractors/index.js';
 import { isDir, readJsonFile, readTextFile } from '../extractors/shared.js';
 import { applyScan, ingestEpisode } from '../ingest/index.js';
 import { resolveNaturalKey } from '../ingest/resolve.js';
@@ -74,7 +84,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   const positionals: string[] = [];
   const flags = new Map<string, string>();
   const bools = new Set<string>();
-  const boolFlags = new Set(['fleet', 'json']);
+  const boolFlags = new Set(['fleet', 'json', 'publish']);
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === undefined) continue;
@@ -311,6 +321,129 @@ async function cmdDrift(args: ParsedArgs): Promise<void> {
   }
 }
 
+interface ClaimsCheckSummary {
+  repo: string;
+  root: string;
+  claims: number;
+  documentsEdges: number;
+  missingEvidence: number;
+  published: boolean;
+  issues: ReturnType<typeof missingEvidencePaths>;
+}
+
+async function claimsCheckOne(
+  root: string,
+  repo: string,
+  publish: boolean,
+  embedder: Embedder | undefined,
+  exec: KgExecutor | undefined,
+): Promise<ClaimsCheckSummary> {
+  const text = readTextFile(join(root, CLAIMS_EVIDENCE_REL));
+  if (text === null) {
+    return {
+      repo,
+      root,
+      claims: 0,
+      documentsEdges: 0,
+      missingEvidence: 0,
+      published: false,
+      issues: [],
+    };
+  }
+
+  const claims = parseClaimsEvidenceSource(text, CLAIMS_EVIDENCE_REL);
+  const issues = missingEvidencePaths(root, claims, repo);
+
+  const products = await claimsExtractor.extract({
+    repoRoot: root,
+    repo,
+    siteId: hostname(),
+    now: new Date(),
+  });
+  const documentsEdges = products.reduce(
+    (n, p) => n + p.edges.filter((e) => e.relation === 'documents').length,
+    0,
+  );
+
+  let published = false;
+  if (publish) {
+    if (!exec) fail('claims-check --publish requires a database connection');
+    for (const product of products) {
+      await applyScan(exec, product, { embedder, recordOutbox: true });
+    }
+    published = products.length > 0;
+  }
+
+  return {
+    repo,
+    root,
+    claims: claims.length,
+    documentsEdges,
+    missingEvidence: issues.length,
+    published,
+    issues,
+  };
+}
+
+async function cmdClaimsCheck(args: ParsedArgs): Promise<void> {
+  const root = args.flags.get('root') ?? process.cwd();
+  const publish = args.bools.has('publish');
+  const summaries: ClaimsCheckSummary[] = [];
+
+  let exec: KgExecutor | undefined;
+  let close: (() => Promise<void>) | undefined;
+  let embedder: Embedder | undefined;
+  if (publish) {
+    const pool = await getExecutor();
+    exec = pool.exec;
+    close = pool.close;
+    embedder = await loadEmbedder();
+    if (!embedder) out('  (no embedder available — embeddings deferred)');
+  }
+
+  try {
+    if (args.bools.has('fleet')) {
+      const parent = dirname(root);
+      const { readdirSync } = await import('node:fs');
+      const entries = readdirSync(parent).filter((e) => !e.startsWith('.'));
+      for (const entry of entries) {
+        const path = join(parent, entry);
+        if (!(isDir(path) && isRepoRoot(path))) continue;
+        const evidence = join(path, CLAIMS_EVIDENCE_REL);
+        if (readTextFile(evidence) === null) continue;
+        summaries.push(await claimsCheckOne(path, entry, publish, embedder, exec));
+      }
+    } else {
+      const repo = args.flags.get('repo') ?? basename(root);
+      if (!isRepoRoot(root)) fail(`${root} does not look like a repo root`);
+      summaries.push(await claimsCheckOne(root, repo, publish, embedder, exec));
+    }
+  } finally {
+    if (close) await close();
+  }
+
+  if (args.bools.has('json')) {
+    out(JSON.stringify(summaries, null, 2));
+  } else {
+    for (const s of summaries) {
+      out(
+        `${s.repo}: ${s.claims} claims, ${s.documentsEdges} documents edges, ${s.missingEvidence} missing evidence${s.published ? ' (published)' : ''}`,
+      );
+      for (const issue of s.issues.slice(0, 20)) {
+        out(`  missing  ${issue.exportPath}  ${issue.evidenceRef}`);
+      }
+      if (s.issues.length > 20) out(`  … ${s.issues.length - 20} more`);
+    }
+  }
+
+  const totalMissing = summaries.reduce((n, s) => n + s.missingEvidence, 0);
+  if (totalMissing > 0) process.exit(1);
+  if (summaries.length === 0) {
+    out('claims-check: no claims-evidence.ts found');
+    process.exit(1);
+  }
+}
+
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
   const args = parseArgs(rest);
@@ -333,8 +466,11 @@ async function main(): Promise<void> {
     case 'drift':
       await cmdDrift(args);
       break;
+    case 'claims-check':
+      await cmdClaimsCheck(args);
+      break;
     default:
-      out('usage: revkg <scan|search|node|neighbors|at|drift> [...]');
+      out('usage: revkg <scan|search|node|neighbors|at|drift|claims-check> [...]');
       process.exit(command ? 1 : 0);
   }
 }

--- a/packages/knowledge-graph/src/extractors/__tests__/claims.test.ts
+++ b/packages/knowledge-graph/src/extractors/__tests__/claims.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Claims-evidence extractor (GAP-462 Phase 3): AST parse of CLAIMS + documents edges.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  CLAIMS_EVIDENCE_REL,
+  claimsExtractor,
+  evidencePathFromRef,
+  isPathEvidence,
+  missingEvidencePaths,
+  parseClaimsEvidenceSource,
+} from '../claims.ts';
+import { claimKey, fileKey } from '../shared.ts';
+
+const tempDirs: string[] = [];
+
+async function makeTempRepo(files: Record<string, string>): Promise<string> {
+  const root = mkdtempSync(join(tmpdir(), 'revkg-claims-'));
+  tempDirs.push(root);
+  for (const [relPath, content] of Object.entries(files)) {
+    const full = join(root, relPath);
+    await mkdir(dirname(full), { recursive: true });
+    writeFileSync(full, content, 'utf-8');
+  }
+  return root;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const FIXTURE_SOURCE = `
+export type EvidenceKind = 'code' | 'command' | 'url' | 'metric' | 'test';
+export interface EvidenceRef {
+  readonly kind: EvidenceKind;
+  readonly ref: string;
+  readonly note?: string;
+}
+
+const AUTH: EvidenceRef = {
+  kind: 'code',
+  ref: 'packages/auth/src/server/auth.ts',
+  note: 'sessions',
+};
+
+const CMD: EvidenceRef = {
+  kind: 'command',
+  ref: 'pnpm validate:claims',
+};
+
+export const CLAIMS: readonly ClaimEntry[] = [
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_HERO.h1',
+    text: 'Run your whole business on one runtime you own.',
+    evidence: [
+      AUTH,
+      {
+        kind: 'test',
+        ref: 'packages/auth/src/__tests__/sign-in.test.ts#signs in',
+        note: 'proof obligation',
+      },
+      CMD,
+    ],
+  },
+  {
+    file: 'site.ts',
+    exportPath: 'SITE.brandTagline',
+    text: 'The open runtime.',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'LICENSE',
+      },
+    ],
+  },
+];
+
+interface ClaimEntry {
+  file: string;
+  exportPath: string;
+  text: string;
+  evidence: readonly EvidenceRef[];
+}
+`;
+
+describe('parseClaimsEvidenceSource', () => {
+  it('resolves const evidence refs and inline objects', () => {
+    const claims = parseClaimsEvidenceSource(FIXTURE_SOURCE);
+    expect(claims).toHaveLength(2);
+    expect(claims[0]?.exportPath).toBe('HOME_HERO.h1');
+    expect(claims[0]?.evidence).toEqual([
+      { kind: 'code', ref: 'packages/auth/src/server/auth.ts', note: 'sessions' },
+      {
+        kind: 'test',
+        ref: 'packages/auth/src/__tests__/sign-in.test.ts#signs in',
+        note: 'proof obligation',
+      },
+      { kind: 'command', ref: 'pnpm validate:claims' },
+    ]);
+    expect(claims[1]?.file).toBe('site.ts');
+    expect(claims[1]?.evidence[0]?.ref).toBe('LICENSE');
+  });
+
+  it('returns empty when CLAIMS is absent', () => {
+    expect(parseClaimsEvidenceSource('export const x = 1;\n')).toEqual([]);
+  });
+});
+
+describe('evidencePathFromRef / isPathEvidence', () => {
+  it('strips test title fragments', () => {
+    expect(evidencePathFromRef('packages/a/b.test.ts#title here')).toBe('packages/a/b.test.ts');
+  });
+
+  it('accepts code/test/metric paths and rejects urls and commands', () => {
+    expect(isPathEvidence('code', 'packages/auth/src/x.ts')).toBe(true);
+    expect(isPathEvidence('test', 'a.test.ts#t')).toBe(true);
+    expect(isPathEvidence('command', 'pnpm test')).toBe(false);
+    expect(isPathEvidence('url', 'https://example.com')).toBe(false);
+    expect(isPathEvidence('code', 'https://example.com/x')).toBe(false);
+  });
+});
+
+describe('claimsExtractor', () => {
+  it('emits claim concepts and documents edges (claim → code)', async () => {
+    const root = await makeTempRepo({
+      [CLAIMS_EVIDENCE_REL]: FIXTURE_SOURCE,
+      'packages/auth/src/server/auth.ts': 'export {};\n',
+      'packages/auth/src/__tests__/sign-in.test.ts': "it('signs in', () => {});\n",
+      LICENSE: 'MIT\n',
+      'apps/marketing/app/content/home.ts': 'export {};\n',
+      'apps/marketing/app/content/site.ts': 'export {};\n',
+    });
+
+    const products = await claimsExtractor.extract({
+      repoRoot: root,
+      repo: 'revealui',
+      siteId: 'test',
+      now: new Date('2026-07-29T00:00:00Z'),
+    });
+    expect(products).toHaveLength(1);
+    const product = products[0];
+    if (!product) throw new Error('expected product');
+
+    expect(product.scope).toEqual({ repo: 'revealui', extractor: 'claims' });
+    expect(product.episode.source).toBe('revealui:claims');
+
+    const claimNk = claimKey('revealui', 'home.ts', 'HOME_HERO.h1');
+    const claimNode = product.nodes.find((n) => n.naturalKey === claimNk);
+    expect(claimNode?.kind).toBe('concept');
+    expect(claimNode?.attributes?.proposedKind).toBe('claim');
+
+    const docs = product.edges.filter((e) => e.relation === 'documents');
+    // AUTH + test path + LICENSE = 3 documents edges (command skipped)
+    expect(docs).toHaveLength(3);
+    for (const e of docs) {
+      expect(e.source.kind).toBe('concept');
+      expect(e.target.kind).toBe('file');
+    }
+
+    const authEdge = docs.find(
+      (e) => e.target.naturalKey === fileKey('revealui', 'packages/auth/src/server/auth.ts'),
+    );
+    expect(authEdge?.source.naturalKey).toBe(claimNk);
+  });
+
+  it('is deterministic across two runs', async () => {
+    const root = await makeTempRepo({
+      [CLAIMS_EVIDENCE_REL]: FIXTURE_SOURCE,
+      LICENSE: 'MIT\n',
+    });
+    const ctx = {
+      repoRoot: root,
+      repo: 'revealui',
+      siteId: 'test',
+      now: new Date('2026-07-29T00:00:00Z'),
+    };
+    const a = await claimsExtractor.extract(ctx);
+    const b = await claimsExtractor.extract(ctx);
+    const edgeKeys = (p: typeof a) =>
+      p
+        .flatMap((x) => x.edges)
+        .map(
+          (e) =>
+            `${e.source.kind}:${e.source.naturalKey}|${e.target.kind}:${e.target.naturalKey}|${e.relation}`,
+        )
+        .sort();
+    const nodeKeys = (p: typeof a) =>
+      p
+        .flatMap((x) => x.nodes)
+        .map((n) => `${n.kind}:${n.naturalKey}`)
+        .sort();
+    expect(edgeKeys(a)).toEqual(edgeKeys(b));
+    expect(nodeKeys(a)).toEqual(nodeKeys(b));
+  });
+
+  it('returns empty when the index is absent', async () => {
+    const root = await makeTempRepo({ 'README.md': '# hi\n' });
+    const products = await claimsExtractor.extract({
+      repoRoot: root,
+      repo: 'agency',
+      siteId: 'test',
+      now: new Date(),
+    });
+    expect(products).toEqual([]);
+  });
+});
+
+describe('missingEvidencePaths', () => {
+  it('reports path-shaped evidence that is not on disk', async () => {
+    const root = await makeTempRepo({
+      [CLAIMS_EVIDENCE_REL]: FIXTURE_SOURCE,
+      // LICENSE present so only auth + test are missing
+      LICENSE: 'MIT\n',
+    });
+    const claims = parseClaimsEvidenceSource(FIXTURE_SOURCE);
+    const issues = missingEvidencePaths(root, claims, 'revealui');
+    expect(issues.some((i) => i.evidenceRef.includes('auth.ts'))).toBe(true);
+    expect(issues.some((i) => i.evidenceRef === 'LICENSE')).toBe(false);
+  });
+});

--- a/packages/knowledge-graph/src/extractors/__tests__/determinism.test.ts
+++ b/packages/knowledge-graph/src/extractors/__tests__/determinism.test.ts
@@ -40,6 +40,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  claimsExtractor,
   dbSchemaExtractor,
   docsFrontmatterExtractor,
   gitExtractor,
@@ -100,6 +101,7 @@ const TIER1: readonly Extractor[] = [
   dbSchemaExtractor,
   docsFrontmatterExtractor,
   routesExtractor,
+  claimsExtractor,
 ];
 
 describe('extractor determinism — two runs over an unchanged tree', () => {
@@ -123,6 +125,9 @@ describe('extractor determinism — two runs over an unchanged tree', () => {
       'apps/mmm-app/app/api/widgets/route.ts':
         "export async function GET() { return new Response('ok'); }\n",
       'docs/gaps/GAP-999.md': '---\nstatus: open\npriority: high\n---\n# GAP-999\n',
+      'apps/marketing/app/content/claims-evidence.ts':
+        "export const CLAIMS = [{ file: 'home.ts', exportPath: 'H.x', text: 'hi', evidence: [{ kind: 'code', ref: 'LICENSE' }] }];\n",
+      LICENSE: 'MIT\n',
     });
     const ctx: ExtractorContext = {
       repoRoot,

--- a/packages/knowledge-graph/src/extractors/claims.ts
+++ b/packages/knowledge-graph/src/extractors/claims.ts
@@ -1,0 +1,379 @@
+/**
+ * Claims-evidence extractor (Tier-1, GAP-462 Phase 3).
+ *
+ * Parses `apps/marketing/app/content/claims-evidence.ts` with the TypeScript
+ * compiler API (no regex, no hard import of marketing modules) and emits:
+ *
+ * - `concept` nodes with `proposedKind: 'claim'` per CLAIMS entry
+ * - `file` nodes for the marketing content module and for path-shaped evidence
+ * - `documents` edges (claim → evidence file) so `kgDrift` / `revkg drift` can
+ *   report when code last-confirmed is newer than the claim scan
+ *
+ * Evidence kinds `code`, `test`, and `metric` that look like repo-relative paths
+ * produce `documents` edges. `command` / `url` are recorded only on the claim
+ * node attributes (no graph edge). Test refs may use `path#title`; the path
+ * fragment before `#` is the code target.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+import type { EdgeInput, NodeInput } from '../types.js';
+import { claimKey, fileKey, readTextFile, scanEpisode, toPosix } from './shared.js';
+import type { Extractor, ExtractorContext, ScanProduct } from './types.js';
+
+/** Default location of the claims-evidence index in the revealui monorepo. */
+export const CLAIMS_EVIDENCE_REL = 'apps/marketing/app/content/claims-evidence.ts';
+
+const CONTENT_DIR = 'apps/marketing/app/content';
+
+/** Path-shaped evidence kinds that feed `documents` edges. */
+const PATH_EVIDENCE_KINDS = new Set(['code', 'test', 'metric']);
+
+export interface ParsedEvidence {
+  kind: string;
+  ref: string;
+  note?: string;
+}
+
+export interface ParsedClaim {
+  file: string;
+  exportPath: string;
+  text: string;
+  evidence: ParsedEvidence[];
+}
+
+export interface ClaimsCheckIssue {
+  claimKey: string;
+  exportPath: string;
+  evidenceRef: string;
+  reason: string;
+}
+
+function mapKey(kind: string, naturalKey: string): string {
+  return `${kind}:${naturalKey}`;
+}
+
+function propertyName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isPrivateIdentifier(name)) return name.text;
+  if (ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)) return name.text;
+  return null;
+}
+
+function stringFromExpression(expr: ts.Expression): string | undefined {
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) {
+    return expr.text;
+  }
+  return undefined;
+}
+
+function objectStringProp(obj: ts.ObjectLiteralExpression, key: string): string | undefined {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    const name = propertyName(prop.name);
+    if (name !== key) continue;
+    return stringFromExpression(prop.initializer);
+  }
+  return undefined;
+}
+
+function parseEvidenceObject(obj: ts.ObjectLiteralExpression): ParsedEvidence | null {
+  const kind = objectStringProp(obj, 'kind');
+  const ref = objectStringProp(obj, 'ref');
+  if (!(kind && ref)) return null;
+  const note = objectStringProp(obj, 'note');
+  return note !== undefined ? { kind, ref, note } : { kind, ref };
+}
+
+/**
+ * Collect const bindings that look like EvidenceRef object literals
+ * (`kind` + `ref` string properties). Used to resolve identifier references
+ * inside CLAIMS[].evidence arrays.
+ */
+function collectEvidenceConsts(source: ts.SourceFile): Map<string, ParsedEvidence> {
+  const out = new Map<string, ParsedEvidence>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      let init: ts.Expression = node.initializer;
+      while (
+        ts.isAsExpression(init) ||
+        ts.isSatisfiesExpression(init) ||
+        ts.isTypeAssertionExpression(init)
+      ) {
+        init = init.expression;
+      }
+      if (ts.isObjectLiteralExpression(init)) {
+        const parsed = parseEvidenceObject(init);
+        if (parsed) out.set(node.name.text, parsed);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return out;
+}
+
+function findClaimsArray(source: ts.SourceFile): ts.ArrayLiteralExpression | null {
+  let found: ts.ArrayLiteralExpression | null = null;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'CLAIMS'
+    ) {
+      let init = node.initializer;
+      if (!init) return;
+      while (
+        ts.isAsExpression(init) ||
+        ts.isSatisfiesExpression(init) ||
+        ts.isTypeAssertionExpression(init)
+      ) {
+        init = init.expression;
+      }
+      if (ts.isArrayLiteralExpression(init)) {
+        found = init;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return found;
+}
+
+function parseEvidenceElement(
+  el: ts.Expression,
+  consts: Map<string, ParsedEvidence>,
+): ParsedEvidence | null {
+  if (ts.isIdentifier(el)) {
+    return consts.get(el.text) ?? null;
+  }
+  if (ts.isObjectLiteralExpression(el)) {
+    return parseEvidenceObject(el);
+  }
+  if (ts.isAsExpression(el) || ts.isSatisfiesExpression(el)) {
+    return parseEvidenceElement(el.expression, consts);
+  }
+  return null;
+}
+
+function parseClaimObject(
+  obj: ts.ObjectLiteralExpression,
+  consts: Map<string, ParsedEvidence>,
+): ParsedClaim | null {
+  const file = objectStringProp(obj, 'file');
+  const exportPath = objectStringProp(obj, 'exportPath');
+  const text = objectStringProp(obj, 'text');
+  if (!(file && exportPath && text !== undefined)) return null;
+
+  const evidence: ParsedEvidence[] = [];
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    if (propertyName(prop.name) !== 'evidence') continue;
+    let init = prop.initializer;
+    while (ts.isAsExpression(init) || ts.isSatisfiesExpression(init)) {
+      init = init.expression;
+    }
+    if (!ts.isArrayLiteralExpression(init)) continue;
+    for (const el of init.elements) {
+      const parsed = parseEvidenceElement(el, consts);
+      if (parsed) evidence.push(parsed);
+    }
+  }
+
+  return { file, exportPath, text, evidence };
+}
+
+/**
+ * Parse claims-evidence TypeScript source into claim entries.
+ * Exported for unit tests and for `revkg claims-check` without full extract.
+ */
+export function parseClaimsEvidenceSource(
+  sourceText: string,
+  fileName = CLAIMS_EVIDENCE_REL,
+): ParsedClaim[] {
+  const source = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+  const consts = collectEvidenceConsts(source);
+  const arr = findClaimsArray(source);
+  if (!arr) return [];
+
+  const claims: ParsedClaim[] = [];
+  for (const el of arr.elements) {
+    let expr: ts.Expression = el;
+    while (ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr)) {
+      expr = expr.expression;
+    }
+    if (!ts.isObjectLiteralExpression(expr)) continue;
+    const claim = parseClaimObject(expr, consts);
+    if (claim) claims.push(claim);
+  }
+  return claims;
+}
+
+/**
+ * Strip optional `#test title` suffix used by capability-claim test refs.
+ * Returns the repo-relative path portion only.
+ */
+export function evidencePathFromRef(ref: string): string {
+  const hash = ref.indexOf('#');
+  if (hash === -1) return toPosix(ref);
+  return toPosix(ref.slice(0, hash));
+}
+
+/** True when the kind+ref pair is a path we can attach a `documents` edge to. */
+export function isPathEvidence(kind: string, ref: string): boolean {
+  if (!PATH_EVIDENCE_KINDS.has(kind)) return false;
+  if (ref.length === 0) return false;
+  // URLs and absolute paths are not monorepo evidence.
+  if (ref.includes('://') || ref.startsWith('/')) return false;
+  return true;
+}
+
+/**
+ * Filesystem check: every path-shaped evidence ref should exist under repoRoot
+ * (file or directory). Used by `revkg claims-check` without a database.
+ */
+export function missingEvidencePaths(
+  repoRoot: string,
+  claims: readonly ParsedClaim[],
+  repo: string,
+): ClaimsCheckIssue[] {
+  const issues: ClaimsCheckIssue[] = [];
+  for (const claim of claims) {
+    const ck = claimKey(repo, claim.file, claim.exportPath);
+    for (const ev of claim.evidence) {
+      if (!isPathEvidence(ev.kind, ev.ref)) continue;
+      const rel = evidencePathFromRef(ev.ref);
+      if (!existsSync(join(repoRoot, rel))) {
+        issues.push({
+          claimKey: ck,
+          exportPath: claim.exportPath,
+          evidenceRef: ev.ref,
+          reason: `missing path: ${rel}`,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+export const claimsExtractor: Extractor = {
+  name: 'claims',
+  async extract(ctx: ExtractorContext): Promise<ScanProduct[]> {
+    const fullPath = join(ctx.repoRoot, CLAIMS_EVIDENCE_REL);
+    const text = readTextFile(fullPath);
+    if (text === null) return [];
+
+    let claims: ParsedClaim[];
+    try {
+      claims = parseClaimsEvidenceSource(text, CLAIMS_EVIDENCE_REL);
+    } catch {
+      return [];
+    }
+    if (claims.length === 0) return [];
+
+    const nodes = new Map<string, NodeInput>();
+    const edges: EdgeInput[] = [];
+
+    const indexNode: NodeInput = {
+      kind: 'file',
+      name: 'claims-evidence.ts',
+      naturalKey: fileKey(ctx.repo, CLAIMS_EVIDENCE_REL),
+      repo: ctx.repo,
+      attributes: { path: CLAIMS_EVIDENCE_REL, language: 'typescript' },
+      summary: 'Marketing claims-evidence index (sentence → proof)',
+    };
+    nodes.set(mapKey(indexNode.kind, indexNode.naturalKey), indexNode);
+
+    for (const claim of claims) {
+      const contentRel = toPosix(join(CONTENT_DIR, claim.file));
+      const contentKey = fileKey(ctx.repo, contentRel);
+      if (!nodes.has(mapKey('file', contentKey))) {
+        const contentNode: NodeInput = {
+          kind: 'file',
+          name: claim.file,
+          naturalKey: contentKey,
+          repo: ctx.repo,
+          attributes: { path: contentRel, language: 'typescript' },
+        };
+        nodes.set(mapKey('file', contentKey), contentNode);
+      }
+
+      const cKey = claimKey(ctx.repo, claim.file, claim.exportPath);
+      const claimNode: NodeInput = {
+        kind: 'concept',
+        name: claim.exportPath,
+        naturalKey: cKey,
+        repo: ctx.repo,
+        summary: claim.text.length > 240 ? `${claim.text.slice(0, 237)}...` : claim.text,
+        attributes: {
+          proposedKind: 'claim',
+          contentFile: claim.file,
+          exportPath: claim.exportPath,
+          text: claim.text,
+          path: contentRel,
+        },
+      };
+      nodes.set(mapKey(claimNode.kind, claimNode.naturalKey), claimNode);
+
+      edges.push({
+        source: { kind: 'file', naturalKey: contentKey },
+        target: { kind: 'concept', naturalKey: cKey },
+        relation: 'contains',
+        fact: `${claim.file} contains claim ${claim.exportPath}`,
+        repo: ctx.repo,
+      });
+
+      edges.push({
+        source: { kind: 'file', naturalKey: indexNode.naturalKey },
+        target: { kind: 'concept', naturalKey: cKey },
+        relation: 'mentions',
+        fact: `claims-evidence indexes ${claim.exportPath}`,
+        repo: ctx.repo,
+      });
+
+      for (const ev of claim.evidence) {
+        if (!isPathEvidence(ev.kind, ev.ref)) continue;
+        const rel = evidencePathFromRef(ev.ref);
+        const codeKey = fileKey(ctx.repo, rel);
+        if (!nodes.has(mapKey('file', codeKey))) {
+          const codeNode: NodeInput = {
+            kind: 'file',
+            name: rel.split('/').pop() ?? rel,
+            naturalKey: codeKey,
+            repo: ctx.repo,
+            attributes: {
+              path: rel,
+              evidenceKind: ev.kind,
+              ...(ev.note ? { note: ev.note } : {}),
+            },
+          };
+          nodes.set(mapKey('file', codeKey), codeNode);
+        }
+
+        // documents: DOC (claim) → CODE (evidence) per kgDrift direction convention
+        edges.push({
+          source: { kind: 'concept', naturalKey: cKey },
+          target: { kind: 'file', naturalKey: codeKey },
+          relation: 'documents',
+          fact: `${claim.exportPath} documents ${rel}`,
+          repo: ctx.repo,
+          attributes: {
+            evidenceKind: ev.kind,
+            ...(ev.note ? { note: ev.note } : {}),
+          },
+        });
+      }
+    }
+
+    return [
+      {
+        episode: scanEpisode(ctx, 'claims', { claims: claims.length }),
+        nodes: [...nodes.values()],
+        edges,
+        scope: { repo: ctx.repo, extractor: 'claims' },
+      },
+    ];
+  },
+};

--- a/packages/knowledge-graph/src/extractors/index.ts
+++ b/packages/knowledge-graph/src/extractors/index.ts
@@ -1,3 +1,14 @@
+export {
+  CLAIMS_EVIDENCE_REL,
+  type ClaimsCheckIssue,
+  claimsExtractor,
+  evidencePathFromRef,
+  isPathEvidence,
+  missingEvidencePaths,
+  type ParsedClaim,
+  type ParsedEvidence,
+  parseClaimsEvidenceSource,
+} from './claims.js';
 export { dbSchemaExtractor } from './db-schema.js';
 export { docsFrontmatterExtractor } from './docs-frontmatter.js';
 export { gitExtractor } from './git.js';
@@ -7,6 +18,7 @@ export { tsProjectExtractor } from './ts-project.js';
 export type { Extractor, ExtractorContext, ScanProduct } from './types.js';
 export { workspaceExtractor } from './workspace.js';
 
+import { claimsExtractor } from './claims.js';
 import { dbSchemaExtractor } from './db-schema.js';
 import { docsFrontmatterExtractor } from './docs-frontmatter.js';
 import { gitExtractor } from './git.js';
@@ -22,6 +34,7 @@ export const tier1Extractors: readonly Extractor[] = [
   dbSchemaExtractor,
   docsFrontmatterExtractor,
   routesExtractor,
+  claimsExtractor,
 ];
 
 export const additiveExtractors: readonly Extractor[] = [gitExtractor];

--- a/packages/knowledge-graph/src/extractors/shared.ts
+++ b/packages/knowledge-graph/src/extractors/shared.ts
@@ -53,6 +53,14 @@ export function gapKey(gapId: string): string {
   return gapId;
 }
 
+/**
+ * A marketing claim entry from claims-evidence (repo-scoped).
+ * `contentFile` is relative to `apps/marketing/app/content/` (e.g. `home.ts`).
+ */
+export function claimKey(repo: string, contentFile: string, exportPath: string): string {
+  return `${repo}:claim:${toPosix(contentFile)}#${exportPath}`;
+}
+
 export function toPosix(p: string): string {
   return p.split('\\').join('/');
 }

--- a/packages/knowledge-graph/src/search/drift.ts
+++ b/packages/knowledge-graph/src/search/drift.ts
@@ -7,13 +7,12 @@
  * walks every CURRENT `documents` edge and reports the ones where that holds,
  * sorted by staleness delta (largest first) so the worst drift surfaces first.
  *
- * Direction convention (no extractor emits `documents` edges yet as of P4 —
- * this is Tier-2/manual-episode territory per spec §6 Tier 2 and the P3 rider
- * list — so this is a documented assumption, not an empirically-observed
- * convention): `source` is the DOC node, `target` is the CODE node, matching
- * the spec's literal wording ("any doc node whose `documents` edge TARGETS a
- * code node"). `kgAddEpisode` / `kg_add_episode` callers that emit `documents`
- * edges must follow this direction for `revkg drift` to report them correctly.
+ * Direction convention: `source` is the DOC node, `target` is the CODE node,
+ * matching the spec's literal wording ("any doc node whose `documents` edge
+ * TARGETS a code node"). The Tier-1 `claims` extractor (GAP-462 Phase 3) emits
+ * claim concept → evidence file edges in this direction; manual
+ * `kgAddEpisode` / `kg_add_episode` callers must do the same for `revkg drift`
+ * to report them correctly.
  *
  * Read-only: no writes, no invalidation. Feeds the `doc-code-reconciliation`
  * lane and the doc-currency stale-fact scanner with grounded, per-claim


### PR DESCRIPTION
## Summary

GAP-462 Phase 3: feed the fleet knowledge graph from marketing claims-evidence so `revkg drift` is not empty by construction and agents can query claim ↔ proof edges.

### What shipped

- **`claims` Tier-1 extractor** — parses `apps/marketing/app/content/claims-evidence.ts` via the TypeScript compiler API (no regex, no hard import of marketing modules)
  - `concept` nodes with `proposedKind: 'claim'` per CLAIMS entry
  - `file` nodes for content modules + path-shaped evidence
  - **`documents` edges** claim → evidence file (matches `kgDrift` direction convention)
  - `contains` / `mentions` edges from content + index files
- **`revkg claims-check`** — filesystem verify (no DB); `--publish` applies claim-scan via `applyScan`; `--fleet` / `--json` supported
- Wired into `tier1Extractors` so `revkg scan` also ingests claims
- Tests (8 new + determinism list updated); package suite green (64)

### Dogfood (local, no DB)

```
revkg claims-check --root . --repo revealui
# revealui: 614 claims, 635 documents edges, 0 missing evidence
```

### Follow-ups

- Owner: `revkg claims-check --publish` (or full `revkg scan`) against Neon, then `revkg drift --repo revealui`
- Phase 4: remaining fleet repos under claim-gates; optional claim kind promotion
- Still open: Phase 2 profiles [revealui#2293](https://github.com/RevealUIStudio/revealui/pull/2293), agency CI [agency#109](https://github.com/RevealUIStudio/agency/pull/109)

## Test plan

- [x] `pnpm --filter @revealui/knowledge-graph test` (64)
- [x] `pnpm --filter @revealui/knowledge-graph build`
- [x] `revkg claims-check --root . --repo revealui` → 614 / 635 / 0 missing
- [ ] CI green
- [ ] Optional: `--publish` against dogfood Neon