### PR TITLE
fix: cod residuals GAP-244/327/410/414

### DIFF
--- a/.github/workflows/regen-visual-snapshots.yml
+++ b/.github/workflows/regen-visual-snapshots.yml
@@ -93,8 +93,10 @@ jobs:
 
       - name: Push regenerated snapshots to a new branch
         run: |
+          # Noreply identity required for Verified SSH-signed commits (GAP-327).
+          # founder@revealui.com has no user account to verify against after org conversion.
           git config user.name "RevealUI Studio"
-          git config user.email "founder@revealui.com"
+          git config user.email "43050008+joshua-v-dev@users.noreply.github.com"
           if [[ -z "$(git status --short e2e/__snapshots__/)" ]]; then
             echo "::notice::No snapshot changes detected — visual baseline already matches CI rendering"
             exit 0

--- a/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
+++ b/apps/admin/src/app/(frontend)/signup/SignupForm.tsx
@@ -313,7 +313,7 @@ function SignupContent({ apiUrl }: SignupFormProps) {
               autoComplete="new-password"
               className="pr-10"
               aria-label="Password"
-              minLength={8}
+              minLength={12}
               required
             />
           </PasswordInput>

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -193,24 +193,25 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // First user automatically becomes admin with verified email so they can
-    // access /admin immediately without waiting for email verification.
+    // First user becomes owner (DB) + super-admin (_json.roles) with verified
+    // email so they can access /admin immediately. GAP-244: same role as CLI
+    // bootstrap / setup (owner), not tenant 'admin'.
     let resolvedUser = result.user;
     if (isFirstUser && result.user?.id) {
       try {
         const db = getClient();
         const updatedUser = await updateUser(db, result.user.id, {
-          role: 'admin',
+          role: 'owner',
           emailVerified: true,
           emailVerifiedAt: new Date(),
         });
         // Grant the app-layer super-admin role in `_json.roles`. The DB `role`
         // column above is read by the proxy/cookie gate, but the engine's
         // access gates (isSuperAdmin / isAdmin via hasRole) read `_json.roles`
-        // — without this the first user is an admin the engine still denies.
+        // — without this the first user is an owner the engine still denies.
         // signUp() creates users via a typed insert that never populates
         // `_json`, so the grant must be a typed update afterward. Canonical
-        // owner shape per #1219: DB role + _json.roles=['super-admin'].
+        // owner shape per #1219 / GAP-244: DB role owner + _json.roles=['super-admin'].
         await grantSuperAdminRoleById(db, result.user.id);
         if (updatedUser) {
           resolvedUser = {
@@ -223,7 +224,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
         // and/or the `_json.roles` super-admin grant). Loud: a half-promoted
         // first user can't reach the engine-gated admin surface and needs a
         // manual backfill.
-        logger.error('Failed to promote first user to admin/super-admin', {
+        logger.error('Failed to promote first user to owner/super-admin', {
           userId: result.user.id,
           error: upgradeError instanceof Error ? upgradeError.message : String(upgradeError),
         });

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -257,7 +257,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
       },
     });
 
-    // Grant session if email is verified. First-user admin accounts are verified
+    // Grant session if email is verified. First-user owner accounts are verified
     // immediately above. Other new signups must verify their email first.
     const isVerified = resolvedUser?.emailVerified ?? false;
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "changeset": "changeset",
     "changeset:publish": "changeset publish",
     "changeset:status": "changeset status",
-    "changeset:version": "changeset version && pnpm install --no-frozen-lockfile && git add pnpm-lock.yaml",
+    "changeset:version": "changeset version && node scripts/sync-mcp-server-json.mjs && pnpm install --no-frozen-lockfile && git add pnpm-lock.yaml packages/mcp/server.json",
     "clean": "rm -rf node_modules packages/*/node_modules apps/*/node_modules packages/*/dist apps/*/dist packages/*/.next apps/*/.next packages/*/.turbo apps/*/.turbo packages/*/tsconfig.tsbuildinfo apps/*/tsconfig.tsbuildinfo .next .turbo",
     "clean:install": "pnpm clean && pnpm install:clean",
     "admin:bootstrap": "tsx scripts/admin/bootstrap.ts",

--- a/packages/contracts/src/api/__tests__/auth.test.ts
+++ b/packages/contracts/src/api/__tests__/auth.test.ts
@@ -85,16 +85,16 @@ describe('SignUpRequestContract', () => {
       }
     });
 
-    it('rejects password shorter than 8 characters', () => {
+    it('rejects password shorter than 12 characters (GAP-244)', () => {
       const result = SignUpRequestContract.validate({
         email: 'user@example.com',
-        password: 'Short1',
+        password: 'Short1pass', // 10 chars
         name: 'John Doe',
       });
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.errors.issues[0]?.message).toContain('at least 8 characters');
+        expect(result.errors.issues[0]?.message).toContain('at least 12 characters');
       }
     });
 

--- a/packages/contracts/src/api/auth.ts
+++ b/packages/contracts/src/api/auth.ts
@@ -12,7 +12,7 @@ import { createContract } from '../foundation/contract.js';
  *
  * Validates user registration data with:
  * - Email format validation and sanitization
- * - Password strength requirements (min 8 chars)
+ * - Password strength requirements (min 12 chars — GAP-244 lockstep with setup/bootstrap)
  * - Name validation and sanitization
  */
 export const SignUpRequestSchema = z.object({
@@ -21,7 +21,7 @@ export const SignUpRequestSchema = z.object({
     .min(1, 'Email is required')
     .email('Invalid email format')
     .transform((email) => email.toLowerCase().trim()),
-  password: z.string().min(8, 'Password must be at least 8 characters long'),
+  password: z.string().min(12, 'Password must be at least 12 characters long'),
   name: z
     .string()
     .min(1, 'Name is required')

--- a/packages/harnesses/src/hooks/run-hook.ts
+++ b/packages/harnesses/src/hooks/run-hook.ts
@@ -166,8 +166,8 @@ export async function runHookCommand(
 
   // GAP-199 native twin: warn-only when file-edit (or post-tool with paths)
   // touches contract/schema/app code without the product canon doc dirty.
-  // Never changes the permission decision — advisory only (Claude-side pair:
-  // ~/.claude/hooks/master-spec-pr-coupling.js).
+  // Never changes the permission decision — advisory only. Claude-side adapter
+  // invokes the same evaluatePolicy path via runHookCommand (no twin script).
   if (
     (event.kind === 'file-edit' || event.kind === 'post-tool') &&
     event.filePaths &&

--- a/scripts/sync-mcp-server-json.mjs
+++ b/scripts/sync-mcp-server-json.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * GAP-414 — keep packages/mcp/server.json version fields locked to package.json.
+ *
+ * `pnpm changeset:version` only rewrites package.json; the MCP registry metadata
+ * carries the same version in two fields. This post-step rewrites both from
+ * package.json so version PRs do not fail server-json.test.ts.
+ *
+ * Zero authored regex: JSON.parse / JSON.stringify only.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pkgPath = join(root, 'packages/mcp/package.json');
+const serverPath = join(root, 'packages/mcp/server.json');
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const server = JSON.parse(readFileSync(serverPath, 'utf8'));
+
+const version = pkg.version;
+if (typeof version !== 'string' || version.length === 0) {
+  console.error('sync-mcp-server-json: packages/mcp/package.json has no version');
+  process.exit(1);
+}
+
+server.version = version;
+if (!Array.isArray(server.packages) || !server.packages[0]) {
+  console.error('sync-mcp-server-json: server.json missing packages[0]');
+  process.exit(1);
+}
+server.packages[0].version = version;
+
+writeFileSync(serverPath, `${JSON.stringify(server, null, 2)}\n`, 'utf8');
+console.log(`sync-mcp-server-json: packages/mcp/server.json → ${version}`);

--- a/scripts/validate/citation-check.ts
+++ b/scripts/validate/citation-check.ts
@@ -712,8 +712,10 @@ function main(): void {
     for (const g of newGaps) {
       process.stderr.write(`  ⚠ ${g.file}:${g.line}  ${g.excerpt}\n`);
     }
+    // GAP-410: only inline citations on the claim's physical line exonerate.
+    // A ## Sources block is NOT implemented — do not promise it here.
     process.stderr.write(
-      '\n  Add a source citation (`path/to/file.ts:line`) on the line or in a `## Sources` block,\n' +
+      '\n  Add a source citation (`path/to/file.ts:line`) on the same line as the claim,\n' +
         '  or — if this is not a code-behaviour claim — rephrase / regenerate the baseline\n' +
         '  (`citation-check.ts --update-baseline`). Convention: .claude/rules/doc-citations.md\n',
     );


### PR DESCRIPTION
## Summary

Agent-doable code-over-docs residuals:

| Gap | Change |
|-----|--------|
| **GAP-244** | `SignUpRequestSchema` + SignupForm `minLength` 12; first-user DB role `owner` (matches bootstrap/setup) |
| **GAP-327** | Visual snapshot regen commits as noreply identity (Verified signatures) |
| **GAP-410** | citation-check hint no longer promises unimplemented `## Sources`; run-hook drops deleted twin path |
| **GAP-414** | `scripts/sync-mcp-server-json.mjs` + `changeset:version` post-step |

## Test plan

- [x] `node scripts/sync-mcp-server-json.mjs` (noop when already in sync)
- [ ] `pnpm --filter @revealui/contracts test` auth contract suite
- [ ] CI Unit Tests / Quality