### PR TITLE
feat(harnesses): Grok daemon session.register/end control boundary

### DIFF
--- a/.changeset/grok-daemon-session.md
+++ b/.changeset/grok-daemon-session.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": patch
+---
+
+Add soft-optional `session register|end` CLI for RevDev daemon boundary; wire Grok SessionStart/End hooks to register/end with shared identity cache.

--- a/.revealui/adapters/grok.md
+++ b/.revealui/adapters/grok.md
@@ -34,5 +34,8 @@ What they run (warn-only, never blocks the session):
 | SessionStart | `tracker-session-check.js` (manager + TRACKER) |
 | SessionStart / SessionEnd | `hotfix-check.js` → `revealui-harnesses hotfix` (GAP-405) |
 | SessionStart / SessionEnd | `tmpscript-check.js` (lifecycle until GAP-295 control-layer cutover) |
+| SessionStart | `revealui-harnesses session register --backend grok` (soft if daemon down) |
+| SessionEnd | `revealui-harnesses session end` (signed when identity cached; soft if daemon down) |
 
 Do not copy hardlines into `~/.grok/rules/`. Do not invent a second hotfix registry.
+Rebuild `@revealui/harnesses` so `dist/cli.js session` is available before expecting daemon register.

--- a/.revealui/adapters/grok/hooks/session-end.json
+++ b/.revealui/adapters/grok/hooks/session-end.json
@@ -5,8 +5,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "printf '%s\\n' \"[grok] adapter SessionEnd → control layer (hotfix + temp-scripts)\"",
+            "command": "printf '%s\\n' \"[grok] adapter SessionEnd → control layer (daemon session.end + hotfix + temp-scripts)\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"$HOME/revfleet/revealui/packages/harnesses/dist/cli.js\" session end 2>/dev/null || revealui-harnesses session end 2>/dev/null || true",
+            "timeout": 20
           },
           {
             "type": "command",

--- a/.revealui/adapters/grok/hooks/session-start.json
+++ b/.revealui/adapters/grok/hooks/session-start.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "printf '%s\\n' \"[grok] adapter SessionStart → control layer (TRACKER + hotfix + temp-scripts); no full hardline mirrors\"",
+            "command": "printf '%s\\n' \"[grok] adapter SessionStart → control layer (TRACKER + hotfix + temp-scripts + daemon session)\"",
             "timeout": 5
           },
           {
@@ -22,6 +22,11 @@
             "type": "command",
             "command": "node \"$HOME/.claude/hooks/tmpscript-check.js\" 2>/dev/null || true",
             "timeout": 12
+          },
+          {
+            "type": "command",
+            "command": "node \"$HOME/revfleet/revealui/packages/harnesses/dist/cli.js\" session register --backend grok 2>/dev/null || revealui-harnesses session register --backend grok 2>/dev/null || true",
+            "timeout": 20
           }
         ]
       }

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -68,6 +68,7 @@ describe('project manager (.revealui)', () => {
     expect(startCmds.some((c) => c.includes('tracker-session-check.js'))).toBe(true);
     expect(startCmds.some((c) => c.includes('hotfix-check.js'))).toBe(true);
     expect(startCmds.some((c) => c.includes('tmpscript-check.js'))).toBe(true);
+    expect(startCmds.some((c) => c.includes('session register'))).toBe(true);
 
     const end = JSON.parse(
       readFileSync(join(root, '.revealui/adapters/grok/hooks/session-end.json'), 'utf-8'),
@@ -75,6 +76,7 @@ describe('project manager (.revealui)', () => {
     const endCmds = end.hooks.SessionEnd.flatMap((g) => g.hooks.map((h) => h.command));
     expect(endCmds.some((c) => c.includes('hotfix-check.js'))).toBe(true);
     expect(endCmds.some((c) => c.includes('tmpscript-check.js'))).toBe(true);
+    expect(endCmds.some((c) => c.includes('session end'))).toBe(true);
   });
 
   it('writeManagerAdapterContent emits manager content + cursor hooks + opencode surfaces', () => {

--- a/packages/harnesses/src/__tests__/session-boundary.test.ts
+++ b/packages/harnesses/src/__tests__/session-boundary.test.ts
@@ -42,6 +42,7 @@ describe('session boundary (soft-optional daemon)', () => {
     const did = `did:revfleet:${agentId}:fpdeadbeef`;
 
     process.env.REVDEV_HOOK_IDENTITY_DIR = join(dir, 'ids');
+    process.env.REVDEV_DAEMON_SESSION_DIR = join(dir, 'sessions');
 
     const server = createServer((socket) => {
       let buf = '';
@@ -117,6 +118,7 @@ describe('session boundary (soft-optional daemon)', () => {
     expect(ended.agentId).toBe(agentId);
 
     delete process.env.REVDEV_HOOK_IDENTITY_DIR;
+    delete process.env.REVDEV_DAEMON_SESSION_DIR;
   });
 
   it('signRpc produces three base64url segments', () => {

--- a/packages/harnesses/src/__tests__/session-boundary.test.ts
+++ b/packages/harnesses/src/__tests__/session-boundary.test.ts
@@ -1,8 +1,8 @@
-import { createServer } from 'node:net';
+import { generateKeyPairSync } from 'node:crypto';
 import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { generateKeyPairSync } from 'node:crypto';
 import { afterEach, describe, expect, it } from 'vitest';
 import { hashParams, sessionEnd, sessionRegister, signRpc } from '../session/index.js';
 

--- a/packages/harnesses/src/__tests__/session-boundary.test.ts
+++ b/packages/harnesses/src/__tests__/session-boundary.test.ts
@@ -1,0 +1,137 @@
+import { createServer } from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { generateKeyPairSync } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { hashParams, sessionEnd, sessionRegister, signRpc } from '../session/index.js';
+
+describe('session boundary (soft-optional daemon)', () => {
+  const dirs: string[] = [];
+  const servers: Array<ReturnType<typeof createServer>> = [];
+
+  afterEach(async () => {
+    for (const s of servers) {
+      await new Promise<void>((resolve) => s.close(() => resolve()));
+    }
+    servers.length = 0;
+    for (const d of dirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it('skips register when socket absent', async () => {
+    const result = await sessionRegister({
+      backend: 'grok',
+      socketPath: join(tmpdir(), `no-such-sock-${Date.now()}`),
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/absent/i);
+  });
+
+  it('registers and ends against a mock daemon with signing', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sess-bound-'));
+    dirs.push(dir);
+    const sock = join(dir, 'harness.sock');
+    const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+    const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    const agentId = 'grok-test-agent-1';
+    const did = `did:revfleet:${agentId}:fpdeadbeef`;
+
+    process.env.REVDEV_HOOK_IDENTITY_DIR = join(dir, 'ids');
+
+    const server = createServer((socket) => {
+      let buf = '';
+      socket.on('data', (chunk) => {
+        buf += chunk.toString();
+        if (!buf.includes('\n')) return;
+        const line = buf.split('\n')[0]!;
+        const req = JSON.parse(line) as {
+          id: number;
+          method: string;
+          params?: Record<string, unknown>;
+          'x-revdev-signature'?: string;
+        };
+        if (req.method === 'session.register') {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              result: {
+                agentId,
+                sessionId: agentId,
+                did,
+                publicKeyPem,
+                privateKeyPem,
+              },
+            })}\n`,
+          );
+        } else if (req.method === 'session.end') {
+          if (!req['x-revdev-signature']) {
+            socket.write(
+              `${JSON.stringify({
+                jsonrpc: '2.0',
+                id: req.id,
+                error: { code: -32000, message: 'signature required' },
+              })}\n`,
+            );
+          } else {
+            socket.write(
+              `${JSON.stringify({ jsonrpc: '2.0', id: req.id, result: { ended: true } })}\n`,
+            );
+          }
+        } else {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              error: { message: `unknown ${req.method}` },
+            })}\n`,
+          );
+        }
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.listen(sock, () => resolve());
+      server.on('error', reject);
+    });
+
+    const reg = await sessionRegister({
+      backend: 'grok',
+      socketPath: sock,
+      agentId,
+      ppid: 'testppid',
+    });
+    expect(reg.ok).toBe(true);
+    expect(reg.agentId).toBe(agentId);
+
+    const ended = await sessionEnd({
+      socketPath: sock,
+      ppid: 'testppid',
+    });
+    expect(ended.ok).toBe(true);
+    expect(ended.agentId).toBe(agentId);
+
+    delete process.env.REVDEV_HOOK_IDENTITY_DIR;
+  });
+
+  it('signRpc produces three base64url segments', () => {
+    const { privateKey } = generateKeyPairSync('ed25519');
+    const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    const sig = signRpc(
+      {
+        did: 'did:revfleet:a:fp',
+        fingerprint: 'fp',
+        privateKeyPem,
+      },
+      'session.end',
+      { actorAgentId: 'a' },
+    );
+    expect(sig.split('.')).toHaveLength(3);
+    expect(hashParams('session.end', { actorAgentId: 'a' }).length).toBeGreaterThan(4);
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -13,6 +13,7 @@
  *   sync <harnessId> <push|pull>     Sync harness config to/from SSD
  *   coordinate [--project <path>]    Print current workboard state
  *   hook <cursor|claude-code|vscode> Normalize a hook payload from stdin, evaluate policy, spool the receipt
+ *   session register|end             Soft-optional RevDev daemon session boundary (Grok/equal adapters)
  *
  * License: FSL-1.1-MIT
  */
@@ -42,6 +43,7 @@ import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from '
 import { runHotfixCli } from './hotfix/cli.js';
 import { checkManager, materializeManager } from './manager/index.js';
 import { InferenceService } from './server/inference-service.js';
+import { runSessionCli } from './session/cli.js';
 import { WorkboardManager } from './workboard/workboard-manager.js';
 
 const DATA_DIR = join(homedir(), '.local', 'share', 'revealui');
@@ -700,6 +702,11 @@ async function main() {
       break;
     }
 
+    case 'session': {
+      await runSessionCli(args);
+      break;
+    }
+
     default:
       process.stdout.write(`revealui-harnesses — AI harness coordination for RevealUI
 
@@ -710,6 +717,7 @@ Commands:
   health                            Run health check (requires daemon)
   coordinate [--project <path>]     Print workboard state
   hook <cursor|claude-code|vscode>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
+  session register|end              Soft-optional RevDev daemon session boundary (equal adapters)
   content <subcommand>              Manage canonical content definitions
   manager materialize [--project p] Write manager.json + .revealui/content + Cursor/OpenCode surfaces + equal stubs
   manager check [--project p]       Verify project manager present and valid

--- a/packages/harnesses/src/manager/grok-session-hooks.ts
+++ b/packages/harnesses/src/manager/grok-session-hooks.ts
@@ -7,12 +7,10 @@
  * invent a second hardline body under `~/.grok`.
  *
  * Design:
- * - SessionStart / SessionEnd only for this slice (lifecycle parity with Claude
- *   session-start + stop surfaces for hotfix / temp-script / TRACKER).
- * - Commands call existing thin control-layer adapters under `~/.claude`
- *   (hotfix.js / tmpscript.js / hooks/*-check.js) — same registry, no twin.
- * - TRACKER orientation via fleet `tracker-session-check.js` (shared with
- *   Claude SessionStart; GAP-406).
+ * - SessionStart / SessionEnd: TRACKER + hotfix + temp-scripts + RevDev
+ *   session.register / session.end (soft-optional when daemon socket down).
+ * - Hotfix/temp adapters under `~/.claude` call the same control registries.
+ * - Daemon boundary via `revealui-harnesses session register|end` (this package).
  * - No full hardline prose; no OpenClaw; subscription OAuth never appears here.
  *
  * Credential topology: ADR 2026-07-29-provider-credential-topology-green-yellow-red
@@ -41,18 +39,28 @@ const TRACKER_CMD =
 const HOTFIX_CMD = 'node "$HOME/.claude/hooks/hotfix-check.js" 2>/dev/null || true';
 const TMPSCRIPT_CMD = 'node "$HOME/.claude/hooks/tmpscript-check.js" 2>/dev/null || true';
 
+/**
+ * Soft-optional daemon session boundary. Tries monorepo dist CLI first, then
+ * PATH binary. Always `|| true` so hooks never block when daemon is down.
+ */
+const SESSION_REGISTER_CMD =
+  'node "$HOME/revfleet/revealui/packages/harnesses/dist/cli.js" session register --backend grok 2>/dev/null || revealui-harnesses session register --backend grok 2>/dev/null || true';
+const SESSION_END_CMD =
+  'node "$HOME/revfleet/revealui/packages/harnesses/dist/cli.js" session end 2>/dev/null || revealui-harnesses session end 2>/dev/null || true';
+
 export const GROK_SESSION_START_HOOKS_JSON = hookFile('SessionStart', [
   {
     hooks: [
       {
         type: 'command',
         command:
-          'printf \'%s\\n\' "[grok] adapter SessionStart → control layer (TRACKER + hotfix + temp-scripts); no full hardline mirrors"',
+          'printf \'%s\\n\' "[grok] adapter SessionStart → control layer (TRACKER + hotfix + temp-scripts + daemon session)"',
         timeout: 5,
       },
       { type: 'command', command: TRACKER_CMD, timeout: 12 },
       { type: 'command', command: HOTFIX_CMD, timeout: 15 },
       { type: 'command', command: TMPSCRIPT_CMD, timeout: 12 },
+      { type: 'command', command: SESSION_REGISTER_CMD, timeout: 20 },
     ],
   },
 ]);
@@ -63,9 +71,10 @@ export const GROK_SESSION_END_HOOKS_JSON = hookFile('SessionEnd', [
       {
         type: 'command',
         command:
-          'printf \'%s\\n\' "[grok] adapter SessionEnd → control layer (hotfix + temp-scripts)"',
+          'printf \'%s\\n\' "[grok] adapter SessionEnd → control layer (daemon session.end + hotfix + temp-scripts)"',
         timeout: 5,
       },
+      { type: 'command', command: SESSION_END_CMD, timeout: 20 },
       { type: 'command', command: HOTFIX_CMD, timeout: 15 },
       { type: 'command', command: TMPSCRIPT_CMD, timeout: 12 },
     ],

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -196,8 +196,11 @@ What they run (warn-only, never blocks the session):
 | SessionStart | \`tracker-session-check.js\` (manager + TRACKER) |
 | SessionStart / SessionEnd | \`hotfix-check.js\` → \`revealui-harnesses hotfix\` (GAP-405) |
 | SessionStart / SessionEnd | \`tmpscript-check.js\` (lifecycle until GAP-295 control-layer cutover) |
+| SessionStart | \`revealui-harnesses session register --backend grok\` (soft if daemon down) |
+| SessionEnd | \`revealui-harnesses session end\` (signed when identity cached; soft if daemon down) |
 
 Do not copy hardlines into \`~/.grok/rules/\`. Do not invent a second hotfix registry.
+Rebuild \`@revealui/harnesses\` so \`dist/cli.js session\` is available before expecting daemon register.
 `,
     'utf-8',
   );

--- a/packages/harnesses/src/session/boundary.ts
+++ b/packages/harnesses/src/session/boundary.ts
@@ -1,0 +1,174 @@
+/**
+ * Control-layer session boundary: register / end against RevDev daemon.
+ *
+ * Soft-optional: when the socket is down or RPC fails, returns ok:false and
+ * never throws — session hooks must not block harness startup/shutdown.
+ *
+ * Used by Grok (and any equal adapter) SessionStart/SessionEnd. Claude still
+ * uses its Studio hook path which calls the same daemon + identity store.
+ */
+
+import { hostname } from 'node:os';
+import {
+  clearDaemonSessionCache,
+  clearHookIdentity,
+  type HookIdentity,
+  readDaemonSessionCache,
+  resolveAfterRegister,
+  writeDaemonSessionCache,
+} from './identity-cache.js';
+import { isDaemonSocketPresent, rpcCall } from './rpc.js';
+import { signRpc } from './sign.js';
+
+export interface SessionBoundaryResult {
+  readonly ok: boolean;
+  readonly skipped: boolean;
+  readonly agentId?: string;
+  readonly reason?: string;
+}
+
+export interface RegisterOptions {
+  readonly backend: string;
+  readonly workDir?: string;
+  readonly agentId?: string;
+  readonly agentName?: string;
+  readonly socketPath?: string;
+  readonly ppid?: number | string;
+  readonly timeoutMs?: number;
+}
+
+export interface EndOptions {
+  readonly socketPath?: string;
+  readonly ppid?: number | string;
+  readonly timeoutMs?: number;
+  readonly exitSummary?: string;
+  /** When set, end this agent even if cache missing (must have identity). */
+  readonly agentId?: string;
+}
+
+function defaultAgentId(backend: string): string {
+  const host =
+    hostname()
+      .replace(/[^a-zA-Z0-9_-]/g, '')
+      .slice(0, 24) || 'host';
+  return `${backend}-${host}-${process.pid}-${Date.now().toString(36)}`;
+}
+
+function asRegisterResult(raw: unknown): {
+  agentId: string;
+  did?: string;
+  publicKeyPem?: string;
+  privateKeyPem?: string;
+} | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const agentId =
+    (typeof o.agentId === 'string' && o.agentId) ||
+    (typeof o.sessionId === 'string' && o.sessionId) ||
+    (o.session &&
+      typeof o.session === 'object' &&
+      typeof (o.session as { id?: string }).id === 'string' &&
+      (o.session as { id: string }).id) ||
+    null;
+  if (!agentId) return null;
+  return {
+    agentId,
+    did: typeof o.did === 'string' ? o.did : undefined,
+    publicKeyPem: typeof o.publicKeyPem === 'string' ? o.publicKeyPem : undefined,
+    privateKeyPem: typeof o.privateKeyPem === 'string' ? o.privateKeyPem : undefined,
+  };
+}
+
+/**
+ * Register this process as a daemon session agent.
+ * Caches agent id under `/tmp/revealui-daemon-session-<ppid>.id` and
+ * signing material under hook-identities when the daemon returns a one-shot key.
+ */
+export async function sessionRegister(options: RegisterOptions): Promise<SessionBoundaryResult> {
+  const socketPath = options.socketPath;
+  if (!isDaemonSocketPresent(socketPath)) {
+    return { ok: false, skipped: true, reason: 'daemon socket absent' };
+  }
+
+  const agentId = options.agentId ?? defaultAgentId(options.backend);
+  const params = {
+    agentId,
+    agentName: options.agentName ?? agentId,
+    workDir: options.workDir ?? process.cwd(),
+    backend: options.backend,
+    pid: process.ppid,
+  };
+
+  try {
+    const raw = await rpcCall('session.register', params, {
+      socketPath,
+      timeoutMs: options.timeoutMs ?? 4000,
+    });
+    const reg = asRegisterResult(raw);
+    if (!reg) {
+      return { ok: false, skipped: false, reason: 'register returned no agentId' };
+    }
+    resolveAfterRegister(reg);
+    writeDaemonSessionCache(reg.agentId, options.ppid ?? process.ppid);
+    return { ok: true, skipped: false, agentId: reg.agentId };
+  } catch (err) {
+    return {
+      ok: false,
+      skipped: true,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * End the cached daemon session (signature-required). Soft if no cache or daemon down.
+ */
+export async function sessionEnd(options: EndOptions = {}): Promise<SessionBoundaryResult> {
+  const socketPath = options.socketPath;
+  if (!isDaemonSocketPresent(socketPath)) {
+    clearDaemonSessionCache(options.ppid ?? process.ppid);
+    return { ok: false, skipped: true, reason: 'daemon socket absent' };
+  }
+
+  const agentId = options.agentId ?? readDaemonSessionCache(options.ppid ?? process.ppid);
+  if (!agentId) {
+    return { ok: false, skipped: true, reason: 'no cached daemon session id' };
+  }
+
+  const identity = resolveAfterRegister({ agentId });
+  if (!identity) {
+    clearDaemonSessionCache(options.ppid ?? process.ppid);
+    return {
+      ok: false,
+      skipped: true,
+      agentId,
+      reason: 'no signing identity for session.end',
+    };
+  }
+
+  const params: Record<string, unknown> = {
+    actorAgentId: agentId,
+    exitSummary: options.exitSummary ?? 'hook-session-end',
+  };
+
+  try {
+    const signature = signRpc(identity as HookIdentity, 'session.end', params);
+    await rpcCall('session.end', params, {
+      socketPath,
+      timeoutMs: options.timeoutMs ?? 4000,
+      signature,
+    });
+    clearDaemonSessionCache(options.ppid ?? process.ppid);
+    clearHookIdentity(agentId);
+    return { ok: true, skipped: false, agentId };
+  } catch (err) {
+    // Still clear cache so we do not leave stale ids; prune reaps daemon rows.
+    clearDaemonSessionCache(options.ppid ?? process.ppid);
+    return {
+      ok: false,
+      skipped: false,
+      agentId,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/harnesses/src/session/boundary.ts
+++ b/packages/harnesses/src/session/boundary.ts
@@ -54,6 +54,10 @@ function defaultAgentId(backend: string): string {
   return `${backend}-${host}-${process.pid}-${Date.now().toString(36)}`;
 }
 
+function asStringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
 function asRegisterResult(raw: unknown): {
   agentId: string;
   did?: string;
@@ -62,27 +66,25 @@ function asRegisterResult(raw: unknown): {
 } | null {
   if (!raw || typeof raw !== 'object') return null;
   const o = raw as Record<string, unknown>;
-  const agentId =
-    (typeof o.agentId === 'string' && o.agentId) ||
-    (typeof o.sessionId === 'string' && o.sessionId) ||
-    (o.session &&
-      typeof o.session === 'object' &&
-      typeof (o.session as { id?: string }).id === 'string' &&
-      (o.session as { id: string }).id) ||
-    null;
+  let sessionId: string | undefined;
+  if (o.session && typeof o.session === 'object') {
+    sessionId = asStringField((o.session as { id?: unknown }).id);
+  }
+  const agentId = asStringField(o.agentId) ?? asStringField(o.sessionId) ?? sessionId;
   if (!agentId) return null;
   return {
     agentId,
-    did: typeof o.did === 'string' ? o.did : undefined,
-    publicKeyPem: typeof o.publicKeyPem === 'string' ? o.publicKeyPem : undefined,
-    privateKeyPem: typeof o.privateKeyPem === 'string' ? o.privateKeyPem : undefined,
+    did: asStringField(o.did),
+    publicKeyPem: asStringField(o.publicKeyPem),
+    privateKeyPem: asStringField(o.privateKeyPem),
   };
 }
 
 /**
  * Register this process as a daemon session agent.
- * Caches agent id under `/tmp/revealui-daemon-session-<ppid>.id` and
- * signing material under hook-identities when the daemon returns a one-shot key.
+ * Caches agent id under `~/.local/share/revealui/daemon-sessions/<ppid>.id`
+ * (mode 0600; not world-writable /tmp) and signing material under
+ * hook-identities when the daemon returns a one-shot key.
  */
 export async function sessionRegister(options: RegisterOptions): Promise<SessionBoundaryResult> {
   const socketPath = options.socketPath;

--- a/packages/harnesses/src/session/cli.ts
+++ b/packages/harnesses/src/session/cli.ts
@@ -1,0 +1,56 @@
+/**
+ * CLI: `revealui-harnesses session register|end`
+ * Always exits 0 for hook use (soft-optional daemon). Print status on stderr/stdout.
+ */
+
+import { sessionEnd, sessionRegister } from './boundary.js';
+
+function printResult(
+  label: string,
+  result: { ok: boolean; skipped: boolean; agentId?: string; reason?: string },
+): void {
+  const status = result.ok ? 'ok' : result.skipped ? 'skip' : 'fail';
+  const bits = [`[session ${label}] ${status}`];
+  if (result.agentId) bits.push(`agentId=${result.agentId}`);
+  if (result.reason) bits.push(result.reason);
+  process.stderr.write(`${bits.join(' ')}\n`);
+}
+
+export async function runSessionCli(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args;
+  if (subcommand === 'register') {
+    let backend = 'grok';
+    let workDir = process.cwd();
+    for (let i = 0; i < rest.length; i++) {
+      if (rest[i] === '--backend' && rest[i + 1]) {
+        backend = rest[++i]!;
+      } else if (rest[i] === '--work-dir' && rest[i + 1]) {
+        workDir = rest[++i]!;
+      }
+    }
+    const result = await sessionRegister({ backend, workDir });
+    printResult('register', result);
+    // Hooks: always exit 0
+    return;
+  }
+
+  if (subcommand === 'end') {
+    let exitSummary = 'hook-session-end';
+    for (let i = 0; i < rest.length; i++) {
+      if (rest[i] === '--summary' && rest[i + 1]) {
+        exitSummary = rest[++i]!;
+      }
+    }
+    const result = await sessionEnd({ exitSummary });
+    printResult('end', result);
+    return;
+  }
+
+  process.stderr.write(`Usage:
+  revealui-harnesses session register [--backend grok|claude-code|…] [--work-dir PATH]
+  revealui-harnesses session end [--summary TEXT]
+
+Soft-optional RevDev daemon session boundary (GAP control-layer peer adapters).
+Always exits 0 so SessionStart/SessionEnd hooks never block.
+`);
+}

--- a/packages/harnesses/src/session/cli.ts
+++ b/packages/harnesses/src/session/cli.ts
@@ -16,29 +16,37 @@ function printResult(
   process.stderr.write(`${bits.join(' ')}\n`);
 }
 
+function nextArg(rest: string[], i: number): string | undefined {
+  return rest[i + 1];
+}
+
 export async function runSessionCli(args: string[]): Promise<void> {
   const [subcommand, ...rest] = args;
   if (subcommand === 'register') {
     let backend = 'grok';
     let workDir = process.cwd();
     for (let i = 0; i < rest.length; i++) {
-      if (rest[i] === '--backend' && rest[i + 1]) {
-        backend = rest[++i]!;
-      } else if (rest[i] === '--work-dir' && rest[i + 1]) {
-        workDir = rest[++i]!;
+      const nxt = nextArg(rest, i);
+      if (rest[i] === '--backend' && nxt) {
+        backend = nxt;
+        i++;
+      } else if (rest[i] === '--work-dir' && nxt) {
+        workDir = nxt;
+        i++;
       }
     }
     const result = await sessionRegister({ backend, workDir });
     printResult('register', result);
-    // Hooks: always exit 0
     return;
   }
 
   if (subcommand === 'end') {
     let exitSummary = 'hook-session-end';
     for (let i = 0; i < rest.length; i++) {
-      if (rest[i] === '--summary' && rest[i + 1]) {
-        exitSummary = rest[++i]!;
+      const nxt = nextArg(rest, i);
+      if (rest[i] === '--summary' && nxt) {
+        exitSummary = nxt;
+        i++;
       }
     }
     const result = await sessionEnd({ exitSummary });

--- a/packages/harnesses/src/session/identity-cache.ts
+++ b/packages/harnesses/src/session/identity-cache.ts
@@ -1,0 +1,178 @@
+/**
+ * Hook identity cache — same layout as Claude Studio adapter
+ * (`~/.local/share/revealui/hook-identities/<agentId>.json`).
+ * Shared so Claude and Grok sessions use one control-layer store.
+ */
+
+import { chmodSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface HookIdentity {
+  readonly agentId: string;
+  readonly did: string;
+  readonly fingerprint: string;
+  readonly privateKeyPem: string;
+  readonly publicKeyPem?: string;
+}
+
+export function defaultIdentityDir(): string {
+  return (
+    process.env.REVDEV_HOOK_IDENTITY_DIR ??
+    join(homedir(), '.local', 'share', 'revealui', 'hook-identities')
+  );
+}
+
+export function parseFingerprint(did: string): string | null {
+  const parts = did.split(':');
+  if (parts.length < 4 || parts[0] !== 'did' || parts[1] !== 'revfleet') {
+    return null;
+  }
+  return parts[parts.length - 1] || null;
+}
+
+function ensureDir(dir: string): void {
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch {
+    /* race */
+  }
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    /* non-fatal */
+  }
+}
+
+function identityPath(dir: string, agentId: string): string {
+  if (
+    typeof agentId !== 'string' ||
+    agentId.length === 0 ||
+    agentId.includes('/') ||
+    agentId.includes('\\') ||
+    agentId.includes('..')
+  ) {
+    throw new Error(`session-identity: invalid agentId ${agentId}`);
+  }
+  return join(dir, `${agentId}.json`);
+}
+
+export function loadHookIdentity(
+  agentId: string,
+  dir: string = defaultIdentityDir(),
+): HookIdentity | null {
+  try {
+    const raw = readFileSync(identityPath(dir, agentId), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<HookIdentity>;
+    if (
+      !parsed ||
+      typeof parsed.did !== 'string' ||
+      typeof parsed.privateKeyPem !== 'string' ||
+      typeof parsed.fingerprint !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      agentId,
+      did: parsed.did,
+      fingerprint: parsed.fingerprint,
+      privateKeyPem: parsed.privateKeyPem,
+      publicKeyPem: typeof parsed.publicKeyPem === 'string' ? parsed.publicKeyPem : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveHookIdentity(identity: HookIdentity, dir: string = defaultIdentityDir()): void {
+  ensureDir(dir);
+  const target = identityPath(dir, identity.agentId);
+  const tmp = `${target}.${process.pid}.tmp`;
+  const body = `${JSON.stringify(
+    {
+      agentId: identity.agentId,
+      did: identity.did,
+      fingerprint: identity.fingerprint,
+      privateKeyPem: identity.privateKeyPem,
+      publicKeyPem: identity.publicKeyPem ?? null,
+      savedAt: new Date().toISOString(),
+    },
+    null,
+    2,
+  )}\n`;
+  writeFileSync(tmp, body, { encoding: 'utf-8', mode: 0o600 });
+  try {
+    chmodSync(tmp, 0o600);
+  } catch {
+    /* non-fatal */
+  }
+  renameSync(tmp, target);
+}
+
+export function resolveAfterRegister(
+  reg: {
+    agentId: string;
+    did?: string;
+    publicKeyPem?: string;
+    privateKeyPem?: string;
+  },
+  dir: string = defaultIdentityDir(),
+): HookIdentity | null {
+  if (!reg.agentId) return null;
+
+  if (reg.privateKeyPem && reg.did) {
+    const fingerprint = parseFingerprint(reg.did);
+    if (!fingerprint) return null;
+    const identity: HookIdentity = {
+      agentId: reg.agentId,
+      did: reg.did,
+      fingerprint,
+      privateKeyPem: reg.privateKeyPem,
+      publicKeyPem: reg.publicKeyPem,
+    };
+    try {
+      saveHookIdentity(identity, dir);
+    } catch {
+      /* still return in-memory */
+    }
+    return identity;
+  }
+
+  return loadHookIdentity(reg.agentId, dir);
+}
+
+export function clearHookIdentity(agentId: string, dir: string = defaultIdentityDir()): void {
+  try {
+    unlinkSync(identityPath(dir, agentId));
+  } catch {
+    /* missing ok */
+  }
+}
+
+/** Session id cache file (same pattern as Claude hooks). */
+export function daemonSessionCachePath(ppid: number | string = process.ppid): string {
+  return `/tmp/revealui-daemon-session-${ppid}.id`;
+}
+
+export function writeDaemonSessionCache(
+  agentId: string,
+  ppid: number | string = process.ppid,
+): void {
+  writeFileSync(daemonSessionCachePath(ppid), agentId, 'utf-8');
+}
+
+export function readDaemonSessionCache(ppid: number | string = process.ppid): string | null {
+  try {
+    return readFileSync(daemonSessionCachePath(ppid), 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDaemonSessionCache(ppid: number | string = process.ppid): void {
+  try {
+    unlinkSync(daemonSessionCachePath(ppid));
+  } catch {
+    /* ok */
+  }
+}

--- a/packages/harnesses/src/session/identity-cache.ts
+++ b/packages/harnesses/src/session/identity-cache.ts
@@ -149,16 +149,46 @@ export function clearHookIdentity(agentId: string, dir: string = defaultIdentity
   }
 }
 
-/** Session id cache file (same pattern as Claude hooks). */
+/**
+ * Per-process daemon session id cache.
+ * Lives under the private RevealUI data dir (0700), not world-writable /tmp
+ * (CodeQL insecure temporary file).
+ */
+export function daemonSessionCacheDir(): string {
+  return (
+    process.env.REVDEV_DAEMON_SESSION_DIR ??
+    join(homedir(), '.local', 'share', 'revealui', 'daemon-sessions')
+  );
+}
+
 export function daemonSessionCachePath(ppid: number | string = process.ppid): string {
-  return `/tmp/revealui-daemon-session-${ppid}.id`;
+  const safe = String(ppid).replace(/[^a-zA-Z0-9_-]/g, '');
+  if (!safe) {
+    throw new Error('daemon-session-cache: invalid ppid');
+  }
+  return join(daemonSessionCacheDir(), `${safe}.id`);
 }
 
 export function writeDaemonSessionCache(
   agentId: string,
   ppid: number | string = process.ppid,
 ): void {
-  writeFileSync(daemonSessionCachePath(ppid), agentId, 'utf-8');
+  const dir = daemonSessionCacheDir();
+  ensureDir(dir);
+  const target = daemonSessionCachePath(ppid);
+  const tmp = `${target}.${process.pid}.tmp`;
+  writeFileSync(tmp, agentId, { encoding: 'utf-8', mode: 0o600 });
+  try {
+    chmodSync(tmp, 0o600);
+  } catch {
+    /* non-fatal */
+  }
+  renameSync(tmp, target);
+  try {
+    chmodSync(target, 0o600);
+  } catch {
+    /* non-fatal */
+  }
 }
 
 export function readDaemonSessionCache(ppid: number | string = process.ppid): string | null {

--- a/packages/harnesses/src/session/index.ts
+++ b/packages/harnesses/src/session/index.ts
@@ -1,9 +1,9 @@
 export {
-  sessionEnd,
-  sessionRegister,
   type EndOptions,
   type RegisterOptions,
   type SessionBoundaryResult,
+  sessionEnd,
+  sessionRegister,
 } from './boundary.js';
 export { runSessionCli } from './cli.js';
 export {
@@ -11,13 +11,13 @@ export {
   clearHookIdentity,
   daemonSessionCachePath,
   defaultIdentityDir,
+  type HookIdentity,
   loadHookIdentity,
   parseFingerprint,
   readDaemonSessionCache,
   resolveAfterRegister,
   saveHookIdentity,
   writeDaemonSessionCache,
-  type HookIdentity,
 } from './identity-cache.js';
 export { defaultSocketPath, isDaemonSocketPresent, rpcCall } from './rpc.js';
 export { hashParams, signRpc } from './sign.js';

--- a/packages/harnesses/src/session/index.ts
+++ b/packages/harnesses/src/session/index.ts
@@ -1,0 +1,23 @@
+export {
+  sessionEnd,
+  sessionRegister,
+  type EndOptions,
+  type RegisterOptions,
+  type SessionBoundaryResult,
+} from './boundary.js';
+export { runSessionCli } from './cli.js';
+export {
+  clearDaemonSessionCache,
+  clearHookIdentity,
+  daemonSessionCachePath,
+  defaultIdentityDir,
+  loadHookIdentity,
+  parseFingerprint,
+  readDaemonSessionCache,
+  resolveAfterRegister,
+  saveHookIdentity,
+  writeDaemonSessionCache,
+  type HookIdentity,
+} from './identity-cache.js';
+export { defaultSocketPath, isDaemonSocketPresent, rpcCall } from './rpc.js';
+export { hashParams, signRpc } from './sign.js';

--- a/packages/harnesses/src/session/rpc.ts
+++ b/packages/harnesses/src/session/rpc.ts
@@ -3,8 +3,8 @@
  * Never throws for "daemon down" — callers treat null as skip.
  */
 
-import { createConnection } from 'node:net';
 import { existsSync, statSync } from 'node:fs';
+import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 

--- a/packages/harnesses/src/session/rpc.ts
+++ b/packages/harnesses/src/session/rpc.ts
@@ -1,0 +1,95 @@
+/**
+ * Soft-optional JSON-RPC over the RevDev harness Unix socket.
+ * Never throws for "daemon down" — callers treat null as skip.
+ */
+
+import { createConnection } from 'node:net';
+import { existsSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export function defaultSocketPath(): string {
+  return (
+    process.env.REVEALUI_SOCKET ?? join(homedir(), '.local', 'share', 'revealui', 'harness.sock')
+  );
+}
+
+/** Fast path: socket file exists (may still refuse connect if stale). */
+export function isDaemonSocketPresent(socketPath: string = defaultSocketPath()): boolean {
+  try {
+    if (!existsSync(socketPath)) return false;
+    const st = statSync(socketPath);
+    // Unix sockets report as FIFO/socket; existence is enough for soft probe.
+    return Boolean(st);
+  } catch {
+    return false;
+  }
+}
+
+export interface RpcCallOptions {
+  readonly socketPath?: string;
+  readonly timeoutMs?: number;
+  readonly signature?: string;
+}
+
+export async function rpcCall(
+  method: string,
+  params: Record<string, unknown> = {},
+  options: RpcCallOptions = {},
+): Promise<unknown> {
+  const socketPath = options.socketPath ?? defaultSocketPath();
+  const timeoutMs = options.timeoutMs ?? 5000;
+
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(socketPath);
+    let buffer = '';
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`RPC timeout after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    socket.on('connect', () => {
+      const frame: Record<string, unknown> = {
+        jsonrpc: '2.0',
+        id: 1,
+        method,
+        params,
+      };
+      if (options.signature) {
+        frame['x-revdev-signature'] = options.signature;
+      }
+      socket.write(`${JSON.stringify(frame)}\n`);
+    });
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const resp = JSON.parse(line) as {
+            result?: unknown;
+            error?: { message?: string; code?: number };
+          };
+          clearTimeout(timer);
+          socket.destroy();
+          if (resp.error) {
+            reject(new Error(resp.error.message ?? `RPC error ${resp.error.code ?? ''}`));
+          } else {
+            resolve(resp.result);
+          }
+        } catch (err) {
+          clearTimeout(timer);
+          socket.destroy();
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    });
+
+    socket.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}

--- a/packages/harnesses/src/session/sign.ts
+++ b/packages/harnesses/src/session/sign.ts
@@ -1,0 +1,78 @@
+/**
+ * Ed25519 RPC envelope signing for daemon mutations (session.end).
+ * Wire format matches RevDev hook/rpc-sign + daemon agent-identity-crypto.
+ */
+
+import { createHash, randomBytes, sign as cryptoSign } from 'node:crypto';
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+export function base58Encode(bytes: Uint8Array): string {
+  if (!bytes || bytes.length === 0) return '';
+  let leadingZeros = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] === 0) leadingZeros++;
+    else break;
+  }
+  let value = 0n;
+  for (let i = 0; i < bytes.length; i++) {
+    value = value * 256n + BigInt(bytes[i]!);
+  }
+  let result = '';
+  while (value > 0n) {
+    const remainder = value % 58n;
+    value = value / 58n;
+    result = BASE58_ALPHABET[Number(remainder)]! + result;
+  }
+  return '1'.repeat(leadingZeros) + result;
+}
+
+export function canonicalizeJSON(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalizeJSON(item)).join(',')}]`;
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const pairs = keys.map(
+    (k) => `${JSON.stringify(k)}:${canonicalizeJSON((value as Record<string, unknown>)[k])}`,
+  );
+  return `{${pairs.join(',')}}`;
+}
+
+export function hashParams(method: string, params: Record<string, unknown>): string {
+  const digest = createHash('sha256')
+    .update(`${method}:${canonicalizeJSON(params)}`)
+    .digest();
+  return base58Encode(new Uint8Array(digest));
+}
+
+export interface SignIdentity {
+  readonly did: string;
+  readonly fingerprint: string;
+  readonly privateKeyPem: string;
+}
+
+/** Build `x-revdev-signature` envelope string. */
+export function signRpc(
+  identity: SignIdentity,
+  method: string,
+  params: Record<string, unknown>,
+): string {
+  const header = { alg: 'EdDSA', typ: 'jws' };
+  const payload = {
+    did: identity.did,
+    kid: identity.fingerprint,
+    nonce: randomBytes(16).toString('hex'),
+    ts: Math.floor(Date.now() / 1000),
+    method,
+    paramsHash: hashParams(method, params),
+  };
+  const rawHeaderB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const rawPayloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const message = `${rawHeaderB64}.${rawPayloadB64}`;
+  const signatureBytes = cryptoSign(null, Buffer.from(message), identity.privateKeyPem);
+  const signature = Buffer.from(signatureBytes).toString('base64url');
+  return `${rawHeaderB64}.${rawPayloadB64}.${signature}`;
+}

--- a/packages/harnesses/src/session/sign.ts
+++ b/packages/harnesses/src/session/sign.ts
@@ -3,26 +3,30 @@
  * Wire format matches RevDev hook/rpc-sign + daemon agent-identity-crypto.
  */
 
-import { createHash, randomBytes, sign as cryptoSign } from 'node:crypto';
+import { createHash, sign as cryptoSign, randomBytes } from 'node:crypto';
 
 const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
 export function base58Encode(bytes: Uint8Array): string {
   if (!bytes || bytes.length === 0) return '';
   let leadingZeros = 0;
-  for (let i = 0; i < bytes.length; i++) {
-    if (bytes[i] === 0) leadingZeros++;
+  for (const b of bytes) {
+    if (b === 0) leadingZeros++;
     else break;
   }
   let value = 0n;
-  for (let i = 0; i < bytes.length; i++) {
-    value = value * 256n + BigInt(bytes[i]!);
+  for (const b of bytes) {
+    value = value * 256n + BigInt(b);
   }
   let result = '';
   while (value > 0n) {
-    const remainder = value % 58n;
+    const remainder = Number(value % 58n);
     value = value / 58n;
-    result = BASE58_ALPHABET[Number(remainder)]! + result;
+    const ch = BASE58_ALPHABET[remainder];
+    if (ch === undefined) {
+      throw new Error('base58 encode invariant failed');
+    }
+    result = ch + result;
   }
   return '1'.repeat(leadingZeros) + result;
 }


### PR DESCRIPTION
## Summary

Equal-adapter **RevDev daemon session boundary** for Grok (control layer):

| CLI | Behavior |
|-----|----------|
| `revealui-harnesses session register --backend grok` | `session.register` when socket up; soft skip when down |
| `revealui-harnesses session end` | Signed `session.end` using shared `hook-identities` cache |

- Grok `SessionStart` / `SessionEnd` hooks now also call register/end (templates under `.revealui/adapters/grok/hooks/`)
- Same identity store as Claude Studio hooks (`~/.local/share/revealui/hook-identities/`)
- Always exit 0 so hooks never block (daemon soft-optional)
- Unit tests: mock daemon + soft-absent socket (package suite 501 pass)

Machine: `~/.grok/hooks` updated from materialize on this operator.

## Peer

Builds on #2292. Does not claim GAP-355/360.

## Test plan

- [x] session-boundary + manager tests green
- [x] pre-push gate PASS
- [x] `session register` soft-skips with exit 0 when daemon ECONNREFUSED
- [ ] CI on PR green
- [ ] Owner merge

## Owner

```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```