### PR TITLE
feat(harnesses): hook grok normalizer + PreToolUse receipts

### DIFF
--- a/.changeset/hook-grok-normalizer.md
+++ b/.changeset/hook-grok-normalizer.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": patch
+---
+
+Add `hook grok` normalizer + PreToolUse receipt spool; extend Grok hook templates with pre-tool.json.

--- a/.revealui/adapters/grok.md
+++ b/.revealui/adapters/grok.md
@@ -36,6 +36,7 @@ What they run (warn-only, never blocks the session):
 | SessionStart / SessionEnd | `tmpscript-check.js` (lifecycle until GAP-295 control-layer cutover) |
 | SessionStart | `revealui-harnesses session register --backend grok` (soft if daemon down) |
 | SessionEnd | `revealui-harnesses session end` (signed when identity cached; soft if daemon down) |
+| PreToolUse | `revealui-harnesses hook grok` (policy + receipt spool) |
 
 Do not copy hardlines into `~/.grok/rules/`. Do not invent a second hotfix registry.
-Rebuild `@revealui/harnesses` so `dist/cli.js session` is available before expecting daemon register.
+Rebuild `@revealui/harnesses` so `dist/cli.js session` / `hook grok` are available.

--- a/.revealui/adapters/grok/hooks/pre-tool.json
+++ b/.revealui/adapters/grok/hooks/pre-tool.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$HOME/revfleet/revealui/packages/harnesses/dist/cli.js\" hook grok 2>/dev/null || revealui-harnesses hook grok 2>/dev/null || true",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/harnesses/src/__tests__/hook-normalizers.test.ts
+++ b/packages/harnesses/src/__tests__/hook-normalizers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { normalizeClaudeCodeHookEvent } from '../hooks/normalizers/claude-code.js';
 import { normalizeCursorHookEvent } from '../hooks/normalizers/cursor.js';
+import { normalizeGrokHookEvent } from '../hooks/normalizers/grok.js';
 import { isImplementedHookSource, normalizeHookEvent } from '../hooks/normalizers/index.js';
 import { normalizeVSCodeHookEvent } from '../hooks/normalizers/vscode.js';
 
@@ -364,10 +365,11 @@ describe('normalizeVSCodeHookEvent', () => {
 });
 
 describe('normalizeHookEvent dispatch', () => {
-  it('isImplementedHookSource is true for cursor, claude-code, and vscode; false otherwise', () => {
+  it('isImplementedHookSource is true for cursor, claude-code, vscode, grok; false otherwise', () => {
     expect(isImplementedHookSource('cursor')).toBe(true);
     expect(isImplementedHookSource('claude-code')).toBe(true);
     expect(isImplementedHookSource('vscode')).toBe(true);
+    expect(isImplementedHookSource('grok')).toBe(true);
     expect(isImplementedHookSource('opencode')).toBe(false);
     expect(isImplementedHookSource('something-else')).toBe(false);
   });
@@ -388,5 +390,56 @@ describe('normalizeHookEvent dispatch', () => {
     const event = normalizeHookEvent('vscode', { hook_event_name: 'Stop' }, 'advisory');
     expect(event.source).toBe('vscode');
     expect(event.kind).toBe('stop');
+  });
+});
+
+describe('normalizeGrokHookEvent', () => {
+  it('maps documented pre_tool_use snake payload to pre-shell for run_terminal_command', () => {
+    const event = normalizeGrokHookEvent(
+      {
+        hookEventName: 'pre_tool_use',
+        sessionId: 's1',
+        toolName: 'run_terminal_command',
+        toolInput: { command: 'ls' },
+      },
+      'advisory',
+    );
+    expect(event.source).toBe('grok');
+    expect(event.kind).toBe('pre-shell');
+    expect(event.command).toBe('ls');
+    expect(event.identity.conversationId).toBe('s1');
+  });
+
+  it('maps PreToolUse Pascal + Claude tool aliases', () => {
+    const event = normalizeGrokHookEvent(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo hi' },
+      },
+      'advisory',
+    );
+    expect(event.kind).toBe('pre-shell');
+    expect(event.command).toBe('echo hi');
+  });
+
+  it('maps SessionStart and SessionEnd', () => {
+    expect(normalizeGrokHookEvent({ hookEventName: 'SessionStart' }, 'advisory').kind).toBe(
+      'session-start',
+    );
+    expect(normalizeGrokHookEvent({ hookEventName: 'session_end' }, 'advisory').kind).toBe(
+      'session-end',
+    );
+  });
+
+  it('is registered as an implemented hook source', () => {
+    expect(isImplementedHookSource('grok')).toBe(true);
+    const event = normalizeHookEvent(
+      'grok',
+      { hookEventName: 'PreToolUse', toolName: 'read_file' },
+      'advisory',
+    );
+    expect(event.source).toBe('grok');
+    expect(event.kind).toBe('pre-tool');
   });
 });

--- a/packages/harnesses/src/__tests__/hook-run.test.ts
+++ b/packages/harnesses/src/__tests__/hook-run.test.ts
@@ -75,6 +75,41 @@ describe('runHookCommand', () => {
     });
   });
 
+  it('builds the grok-native response shape on deny/allow', async () => {
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        keyId: 'k1',
+        signature: 'sig',
+        issuedAt: new Date().toISOString(),
+        rules: [{ kind: 'pre-shell', permission: 'deny', reason: 'no shells' }],
+      }),
+      'utf8',
+    );
+
+    const denied = await runHookCommand(
+      'grok',
+      {
+        hookEventName: 'pre_tool_use',
+        toolName: 'run_terminal_command',
+        toolInput: { command: 'rm -rf /' },
+      },
+      { spoolPath, snapshotPath },
+    );
+    expect(denied.responseJson).toEqual({ decision: 'deny', reason: 'no shells' });
+    expect(denied.exitCode).toBe(2);
+    expect(denied.spooled).toBe(true);
+
+    const allowed = await runHookCommand(
+      'grok',
+      { hookEventName: 'PreToolUse', toolName: 'read_file' },
+      { spoolPath, snapshotPath },
+    );
+    expect(allowed.responseJson).toEqual({ decision: 'allow' });
+    expect(allowed.exitCode).toBe(0);
+  });
+
   it('builds the claude-code-native response shape on deny/ask/allow', async () => {
     await writeFile(
       snapshotPath,

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -77,6 +77,12 @@ describe('project manager (.revealui)', () => {
     expect(endCmds.some((c) => c.includes('hotfix-check.js'))).toBe(true);
     expect(endCmds.some((c) => c.includes('tmpscript-check.js'))).toBe(true);
     expect(endCmds.some((c) => c.includes('session end'))).toBe(true);
+
+    const pre = JSON.parse(
+      readFileSync(join(root, '.revealui/adapters/grok/hooks/pre-tool.json'), 'utf-8'),
+    ) as { hooks: { PreToolUse: Array<{ hooks: Array<{ command: string }> }> } };
+    const preCmds = pre.hooks.PreToolUse.flatMap((g) => g.hooks.map((h) => h.command));
+    expect(preCmds.some((c) => c.includes('hook grok'))).toBe(true);
   });
 
   it('writeManagerAdapterContent emits manager content + cursor hooks + opencode surfaces', () => {

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -12,7 +12,7 @@
  *   list                             List harnesses in TSV format
  *   sync <harnessId> <push|pull>     Sync harness config to/from SSD
  *   coordinate [--project <path>]    Print current workboard state
- *   hook <cursor|claude-code|vscode> Normalize a hook payload from stdin, evaluate policy, spool the receipt
+ *   hook <cursor|claude-code|vscode|grok> Normalize a hook payload from stdin, evaluate policy, spool the receipt
  *   session register|end             Soft-optional RevDev daemon session boundary (Grok/equal adapters)
  *
  * License: FSL-1.1-MIT
@@ -486,7 +486,7 @@ async function readStdin(): Promise<string> {
 async function handleHookCommand(source: string | undefined): Promise<void> {
   if (!(source && isImplementedHookSource(source))) {
     process.stderr.write(
-      `Unsupported hook source: ${source ?? '(none)'}. Supported: cursor, claude-code, vscode\n`,
+      `Unsupported hook source: ${source ?? '(none)'}. Supported: cursor, claude-code, vscode, grok\n`,
     );
     process.exitCode = 1;
     return;
@@ -716,7 +716,7 @@ Commands:
   sync <id> <push|pull>             Sync harness config to/from SSD (requires daemon)
   health                            Run health check (requires daemon)
   coordinate [--project <path>]     Print workboard state
-  hook <cursor|claude-code|vscode>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
+  hook <cursor|claude-code|vscode|grok>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
   session register|end              Soft-optional RevDev daemon session boundary (equal adapters)
   content <subcommand>              Manage canonical content definitions
   manager materialize [--project p] Write manager.json + .revealui/content + Cursor/OpenCode surfaces + equal stubs

--- a/packages/harnesses/src/hooks/normalizers/grok.ts
+++ b/packages/harnesses/src/hooks/normalizers/grok.ts
@@ -1,0 +1,151 @@
+/**
+ * Grok Build Hook Normalizer
+ *
+ * Maps Grok's native hook payload onto `HarnessHookEvent`. Grok accepts both
+ * its own event names and Cursor/Claude camelCase aliases (see Grok user guide
+ * hooks.md). Native payload (documented 2026-07) uses camelCase fields on
+ * stdin: hookEventName, sessionId, toolName, toolInput, cwd, workspaceRoot.
+ * Claude-compat payloads may use hook_event_name / tool_name / tool_input.
+ *
+ * PreToolUse response contract (Grok): { decision: 'allow' | 'deny', reason? }.
+ * Exit code 2 is also treated as deny by some editors; we emit both shapes
+ * consistently via buildGrokResponse in run-hook.ts.
+ */
+
+import type {
+  HarnessEnforcementTier,
+  HarnessHookEvent,
+  HarnessHookEventKind,
+} from '../../types/hook-event.js';
+import { asRecord, readString, readStringArray } from './raw-object.js';
+
+/** Grok / Claude / Cursor event name aliases -> canonical kind. */
+const GROK_EVENT_KIND_MAP: ReadonlyMap<string, HarnessHookEventKind> = new Map([
+  // Grok snake (documented example pre_tool_use)
+  ['session_start', 'session-start'],
+  ['session_end', 'session-end'],
+  ['user_prompt_submit', 'prompt-submit'],
+  ['pre_tool_use', 'pre-tool'],
+  ['post_tool_use', 'post-tool'],
+  ['stop', 'stop'],
+  // Grok Pascal / Claude
+  ['SessionStart', 'session-start'],
+  ['SessionEnd', 'session-end'],
+  ['UserPromptSubmit', 'prompt-submit'],
+  ['PreToolUse', 'pre-tool'],
+  ['PostToolUse', 'post-tool'],
+  ['Stop', 'stop'],
+  // Cursor camel aliases Grok accepts
+  ['sessionStart', 'session-start'],
+  ['sessionEnd', 'session-end'],
+  ['preToolUse', 'pre-tool'],
+  ['postToolUse', 'post-tool'],
+  ['beforeShellExecution', 'pre-shell'],
+  ['afterShellExecution', 'post-shell'],
+  ['beforeMCPExecution', 'pre-mcp'],
+  ['afterMCPExecution', 'post-mcp'],
+  ['beforeSubmitPrompt', 'prompt-submit'],
+  ['afterFileEdit', 'file-edit'],
+  ['subagentStart', 'session-start'],
+  ['subagentStop', 'session-end'],
+]);
+
+/** Shell tools (Grok native + Claude aliases). */
+const SHELL_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'run_terminal_command',
+  'Bash',
+  'BashOutput',
+]);
+
+/** File edit tools (Grok native + Claude aliases). */
+const FILE_EDIT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'search_replace',
+  'write',
+  'Edit',
+  'Write',
+  'MultiEdit',
+  'NotebookEdit',
+]);
+
+function readEventName(rec: Record<string, unknown>): string {
+  return (
+    readString(rec, 'hookEventName') ??
+    readString(rec, 'hook_event_name') ??
+    readString(rec, 'event') ??
+    'unknown'
+  );
+}
+
+function readToolName(rec: Record<string, unknown>): string | undefined {
+  return readString(rec, 'toolName') ?? readString(rec, 'tool_name');
+}
+
+function readToolInput(rec: Record<string, unknown>): Record<string, unknown> {
+  const primary = asRecord(rec.toolInput);
+  if (Object.keys(primary).length > 0) return primary;
+  return asRecord(rec.tool_input);
+}
+
+function readConversationId(rec: Record<string, unknown>): string | undefined {
+  return (
+    readString(rec, 'sessionId') ??
+    readString(rec, 'session_id') ??
+    readString(rec, 'conversation_id')
+  );
+}
+
+/**
+ * Normalize one Grok hook stdin payload into a `HarnessHookEvent`.
+ * Total — never throws. Unrecognized events fall back to `pre-tool`.
+ */
+export function normalizeGrokHookEvent(
+  raw: unknown,
+  enforcementTier: HarnessEnforcementTier,
+): HarnessHookEvent {
+  const rec = asRecord(raw);
+  const eventName = readEventName(rec);
+  const toolName = readToolName(rec);
+  const toolInput = readToolInput(rec);
+
+  let kind = GROK_EVENT_KIND_MAP.get(eventName) ?? 'pre-tool';
+  if (toolName && SHELL_TOOL_NAMES.has(toolName)) {
+    kind =
+      eventName === 'PostToolUse' || eventName === 'post_tool_use' || eventName === 'postToolUse'
+        ? 'post-shell'
+        : 'pre-shell';
+  } else if (
+    toolName &&
+    FILE_EDIT_TOOL_NAMES.has(toolName) &&
+    (eventName === 'PostToolUse' ||
+      eventName === 'post_tool_use' ||
+      eventName === 'postToolUse' ||
+      eventName === 'afterFileEdit')
+  ) {
+    kind = 'file-edit';
+  }
+
+  const command = readString(toolInput, 'command') ?? readString(rec, 'command') ?? undefined;
+  const filePath =
+    readString(toolInput, 'file_path') ??
+    readString(toolInput, 'target_file') ??
+    readString(toolInput, 'path') ??
+    readString(rec, 'file_path');
+
+  return {
+    kind,
+    source: 'grok',
+    timestamp: new Date().toISOString(),
+    identity: {
+      conversationId: readConversationId(rec),
+      generationId: readString(rec, 'generationId') ?? readString(rec, 'generation_id'),
+      modelId: readString(rec, 'model') ?? readString(rec, 'modelId'),
+    },
+    toolName: toolName ?? (GROK_EVENT_KIND_MAP.has(eventName) ? undefined : eventName),
+    command,
+    filePaths: filePath
+      ? [filePath]
+      : (readStringArray(toolInput, 'file_paths') ?? readStringArray(rec, 'file_paths')),
+    enforcementTier,
+    raw,
+  };
+}

--- a/packages/harnesses/src/hooks/normalizers/index.ts
+++ b/packages/harnesses/src/hooks/normalizers/index.ts
@@ -5,19 +5,25 @@ import type {
 } from '../../types/hook-event.js';
 import { normalizeClaudeCodeHookEvent } from './claude-code.js';
 import { normalizeCursorHookEvent } from './cursor.js';
+import { normalizeGrokHookEvent } from './grok.js';
 import { normalizeVSCodeHookEvent } from './vscode.js';
 
 export { normalizeClaudeCodeHookEvent } from './claude-code.js';
 export { normalizeCursorHookEvent } from './cursor.js';
+export { normalizeGrokHookEvent } from './grok.js';
 export { normalizeVSCodeHookEvent } from './vscode.js';
 
 /** Sources with a normalizer implemented in this package today. */
-export type ImplementedHookSource = Extract<HarnessHookSource, 'cursor' | 'claude-code' | 'vscode'>;
+export type ImplementedHookSource = Extract<
+  HarnessHookSource,
+  'cursor' | 'claude-code' | 'vscode' | 'grok'
+>;
 
 const IMPLEMENTED_SOURCES: ReadonlySet<string> = new Set<ImplementedHookSource>([
   'cursor',
   'claude-code',
   'vscode',
+  'grok',
 ]);
 
 /** True if `normalizeHookEvent` has a normalizer for this source. */
@@ -45,5 +51,7 @@ export function normalizeHookEvent(
       return normalizeClaudeCodeHookEvent(raw, enforcementTier);
     case 'vscode':
       return normalizeVSCodeHookEvent(raw, enforcementTier);
+    case 'grok':
+      return normalizeGrokHookEvent(raw, enforcementTier);
   }
 }

--- a/packages/harnesses/src/hooks/policy.ts
+++ b/packages/harnesses/src/hooks/policy.ts
@@ -57,7 +57,7 @@ export interface PolicySnapshot {
 }
 
 const PolicySnapshotRuleSchema = z.object({
-  source: z.enum(['cursor', 'claude-code', 'vscode', 'opencode']).optional(),
+  source: z.enum(['cursor', 'claude-code', 'vscode', 'opencode', 'grok']).optional(),
   kind: z
     .enum([
       'session-start',

--- a/packages/harnesses/src/hooks/run-hook.ts
+++ b/packages/harnesses/src/hooks/run-hook.ts
@@ -87,6 +87,27 @@ function buildClaudeCodeResponse(decision: PolicyDecision): Record<string, unkno
   return { decision: 'approve' };
 }
 
+/**
+ * Build the Grok-native PreToolUse permission response
+ * (Grok hooks guide: allow | deny + optional reason).
+ */
+function buildGrokResponse(decision: PolicyDecision): Record<string, unknown> {
+  if (decision.permission === 'deny') {
+    return {
+      decision: 'deny',
+      reason: decision.reason ?? 'Denied by RevealUI policy',
+    };
+  }
+  if (decision.permission === 'ask') {
+    // Grok has no documented ask; surface as deny with reason so policy floors hold.
+    return {
+      decision: 'deny',
+      reason: decision.reason ?? 'Requires confirmation per RevealUI policy',
+    };
+  }
+  return { decision: 'allow' };
+}
+
 /** Event kinds that correspond to VS Code's `PreToolUse` hook. */
 const VSCODE_PRE_TOOL_KINDS: ReadonlySet<HarnessHookEventKind> = new Set([
   'pre-tool',
@@ -130,6 +151,7 @@ function buildEditorResponse(
 ): Record<string, unknown> {
   if (source === 'cursor') return buildCursorResponse(decision);
   if (source === 'vscode') return buildVSCodeResponse(kind, decision);
+  if (source === 'grok') return buildGrokResponse(decision);
   return buildClaudeCodeResponse(decision);
 }
 

--- a/packages/harnesses/src/manager/grok-session-hooks.ts
+++ b/packages/harnesses/src/manager/grok-session-hooks.ts
@@ -48,6 +48,10 @@ const SESSION_REGISTER_CMD =
 const SESSION_END_CMD =
   'node "$HOME/revfleet/revealui/packages/harnesses/dist/cli.js" session end 2>/dev/null || revealui-harnesses session end 2>/dev/null || true';
 
+/** Policy + receipt spool for tool events (stdin JSON from Grok → control layer). */
+const HOOK_GROK_CMD =
+  'node "$HOME/revfleet/revealui/packages/harnesses/dist/cli.js" hook grok 2>/dev/null || revealui-harnesses hook grok 2>/dev/null || true';
+
 export const GROK_SESSION_START_HOOKS_JSON = hookFile('SessionStart', [
   {
     hooks: [
@@ -81,8 +85,16 @@ export const GROK_SESSION_END_HOOKS_JSON = hookFile('SessionEnd', [
   },
 ]);
 
+/** PreToolUse: normalize + policy + spool receipt (same plane as Cursor/Claude). */
+export const GROK_PRE_TOOL_HOOKS_JSON = hookFile('PreToolUse', [
+  {
+    hooks: [{ type: 'command', command: HOOK_GROK_CMD, timeout: 15 }],
+  },
+]);
+
 /** Install filenames under `~/.grok/hooks/` (and under GROK_HOOK_TEMPLATE_DIR). */
 export const GROK_HOOK_FILES = {
   'session-start.json': GROK_SESSION_START_HOOKS_JSON,
   'session-end.json': GROK_SESSION_END_HOOKS_JSON,
+  'pre-tool.json': GROK_PRE_TOOL_HOOKS_JSON,
 } as const;

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -198,9 +198,10 @@ What they run (warn-only, never blocks the session):
 | SessionStart / SessionEnd | \`tmpscript-check.js\` (lifecycle until GAP-295 control-layer cutover) |
 | SessionStart | \`revealui-harnesses session register --backend grok\` (soft if daemon down) |
 | SessionEnd | \`revealui-harnesses session end\` (signed when identity cached; soft if daemon down) |
+| PreToolUse | \`revealui-harnesses hook grok\` (policy + receipt spool) |
 
 Do not copy hardlines into \`~/.grok/rules/\`. Do not invent a second hotfix registry.
-Rebuild \`@revealui/harnesses\` so \`dist/cli.js session\` is available before expecting daemon register.
+Rebuild \`@revealui/harnesses\` so \`dist/cli.js session\` / \`hook grok\` are available.
 `,
     'utf-8',
   );

--- a/packages/harnesses/src/types/hook-event.ts
+++ b/packages/harnesses/src/types/hook-event.ts
@@ -56,7 +56,7 @@ export const HARNESS_HOOK_EVENT_KINDS: readonly HarnessHookEventKind[] = [
 ] as const;
 
 /** Editors this package can normalize a hook payload from. */
-export type HarnessHookSource = 'cursor' | 'claude-code' | 'vscode' | 'opencode';
+export type HarnessHookSource = 'cursor' | 'claude-code' | 'vscode' | 'opencode' | 'grok';
 
 /** All valid sources as a readonly array (iteration / membership checks). */
 export const HARNESS_HOOK_SOURCES: readonly HarnessHookSource[] = [
@@ -64,6 +64,7 @@ export const HARNESS_HOOK_SOURCES: readonly HarnessHookSource[] = [
   'claude-code',
   'vscode',
   'opencode',
+  'grok',
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Equal-adapter **tool-event** plane for Grok:

- `revealui-harnesses hook grok` normalizer (snake/Pascal/Cursor aliases)
- Grok allow/deny response shape + receipt spool
- Materialize `pre-tool.json` → install under `~/.grok/hooks/`
- Extends SessionStart/End templates already on test (#2292/#2296)

Live smoke (this machine): daemon up; `session register` ok; `hook grok` returns `{"decision":"allow"}`.

## Test plan

- [x] 506 package tests (incl. grok normalizer + hook-run)
- [x] pre-push gate PASS
- [ ] CI green
- [ ] Owner merge

## Owner

```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```