### PR TITLE
fix(claim-gates): drop fleet-attribution from product-readme profile

### DIFF
--- a/packages/claim-gates/README.md
+++ b/packages/claim-gates/README.md
@@ -37,19 +37,19 @@ claim-gates --root /path/to/revealui
 # agency / marketing-site (hard-fail when clean)
 claim-gates --root /path/to/agency --profile marketing-site
 
-# sibling product (warn while baselining fleet leaks)
-claim-gates --root /path/to/revdev --profile product-readme --warn
+# sibling product README / docs (hard-fail; fleet-attribution off)
+claim-gates --root /path/to/revdev --profile product-readme
 
 pnpm validate:claims   # revealui monorepo thin wrapper + capability slice
 ```
 
-## Profiles (Phase 2)
+## Profiles (Phase 2+)
 
-| Profile | Use | Metrics / license | Missing scan dirs |
-|---------|-----|-------------------|-------------------|
-| `product-runtime` | Full revealui monorepo | On | Hard-fail if missing |
-| `marketing-site` | Agency (app/ + README) | Off; fleet-attribution off until allowlist | Soft skip |
-| `product-readme` | Sibling product docs | Off | Soft skip |
+| Profile | Use | Metrics / license | Fleet attribution | Missing scan dirs |
+|---------|-----|-------------------|-------------------|-------------------|
+| `product-runtime` | Full revealui monorepo | On | On (docs / marketing) | Hard-fail if missing |
+| `marketing-site` | Agency | Off | Off (intentional Studio/Rev* copy) | Soft skip |
+| `product-readme` | Sibling product docs | Off | Off (peer products name each other) | Soft skip |
 
 Auto-detect from root shape:
 

--- a/packages/claim-gates/src/__tests__/profiles.test.ts
+++ b/packages/claim-gates/src/__tests__/profiles.test.ts
@@ -58,6 +58,8 @@ describe('getProfile / existingRoots', () => {
     const readme = getProfile('product-readme');
     expect(readme.collectMonorepoMetrics).toBe(false);
     expect(readme.softScanDirs).toBe(true);
+    // Sibling product docs intentionally name fleet peers (see profiles.ts).
+    expect(readme.fleetAttributionFiles).toEqual([]);
   });
 
   it('filters candidates to paths that exist under root', () => {
@@ -76,7 +78,7 @@ describe('getProfile / existingRoots', () => {
 });
 
 describe('runClaimGates warn mode', () => {
-  it('exits 0 with --warn even when fleet leaks would fail hard', () => {
+  it('exits 0 with --warn even when unlinked future-tense would fail hard', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-gates-warn-'));
     try {
       fs.writeFileSync(
@@ -84,7 +86,8 @@ describe('runClaimGates warn mode', () => {
         [
           '# Fixture',
           '',
-          'RevDev is our engineering harness without any fleet attribution.',
+          // Unlinked future-tense marker (no issue/PR/milestone/workflow cite).
+          'The second surface (coming soon) will land later.',
           '',
         ].join('\n'),
       );

--- a/packages/claim-gates/src/profiles.ts
+++ b/packages/claim-gates/src/profiles.ts
@@ -108,7 +108,12 @@ const PRODUCT_README: ClaimProfile = {
   licenseScanRoots: ['README.md', 'CLAUDE.md', 'docs'],
   futureTenseFiles: ['README.md', 'CLAUDE.md'],
   aspirationalPaths: ['README.md', 'docs'],
-  fleetAttributionFiles: ['README.md', 'docs'],
+  // Fleet-product attribution is for revealui public docs that might present
+  // Studio/Rev* as if they were the runtime. Sibling product repos (revdev,
+  // revvault, …) intentionally name peer fleet products in README and docs;
+  // hard-fail attribution there is false-positive noise (126+ hits on revdev
+  // alone). Same v1 choice as marketing-site.
+  fleetAttributionFiles: [],
 };
 
 export const PROFILES: Readonly<Record<ClaimProfileName, ClaimProfile>> = {


### PR DESCRIPTION
## Summary

Sibling product repos (revdev, revvault, …) intentionally name peer fleet products. Scanning them with revealui-shaped fleet-attribution produced 100+ false positives and forced `--warn` CI.

**Change:** `product-readme.fleetAttributionFiles = []` (same v1 choice as marketing-site). Future-tense / numeric / aspirational gates remain hard-fail.

### Dogfood (local, after this change)

| Root | Exit |
|------|------|
| revdev / revvault / revcon / revskills / revkit | 0 |
| revforge | 1 (unrelated aspirational `RAG` in README — fixed in revforge follow-up) |

Merge before flipping sibling claim-gates workflows from `--warn` to hard-fail.

## Test plan

- [x] claim-gates unit tests (76)
- [x] hard-fail dogfood on five siblings
- [ ] CI green