### PR TITLE
feat(harnesses): session peer-context panel (GAP-459 S2)

### DIFF
--- a/.changeset/gap459-s2-peer-panel.md
+++ b/.changeset/gap459-s2-peer-panel.md
@@ -2,4 +2,4 @@
 "@revealui/harnesses": minor
 ---
 
-GAP-459 S2: session peer-context panel (`session peers` / register prints WARN when coordination unavailable)
+GAP-459: session peer panel + archive-on-exit into revfleet cold sessions/daemon (live set stays unpolluted)

--- a/.changeset/gap459-s2-peer-panel.md
+++ b/.changeset/gap459-s2-peer-panel.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+GAP-459 S2: session peer-context panel (`session peers` / register prints WARN when coordination unavailable)

--- a/packages/harnesses/src/__tests__/peer-context.test.ts
+++ b/packages/harnesses/src/__tests__/peer-context.test.ts
@@ -46,6 +46,19 @@ describe('formatPeerPanel', () => {
     expect(text).toContain('peers: none other active');
     expect(text).not.toMatch(/WARN/);
   });
+
+  it('notes abandoned sessions excluded from the live peer list', () => {
+    const text = formatPeerPanel({
+      status: 'available',
+      peers: [{ agentId: 'live', task: 'working', active: true }],
+      abandonedExcluded: 40,
+      reservations: [],
+      findings: [],
+      source: 'context.snapshot',
+    });
+    expect(text).toContain('40 abandoned/idle');
+    expect(text).toContain('archive workflow');
+  });
 });
 
 describe('fetchPeerContext', () => {
@@ -144,8 +157,9 @@ describe('fetchPeerContext', () => {
               id: req.id,
               result: {
                 sessions: [
-                  { id: 'me', task: 'self' },
-                  { id: 'other', task: 'peer work', active: true },
+                  { id: 'me', task: 'self', active: true, staleSeconds: 1 },
+                  { id: 'other', task: 'peer work', active: true, staleSeconds: 2 },
+                  { id: 'zombie', task: 'abandoned', active: false, staleSeconds: 99999 },
                 ],
               },
             })}\n`,
@@ -163,6 +177,8 @@ describe('fetchPeerContext', () => {
     expect(snap.status).toBe('degraded');
     expect(snap.source).toBe('session.list');
     expect(snap.peers.map((p) => p.agentId)).toEqual(['other']);
+    expect(snap.abandonedExcluded).toBe(1);
     expect(formatPeerPanel(snap)).toContain('WARN');
+    expect(formatPeerPanel(snap)).toContain('abandoned/idle');
   });
 });

--- a/packages/harnesses/src/__tests__/peer-context.test.ts
+++ b/packages/harnesses/src/__tests__/peer-context.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { fetchPeerContext, formatPeerPanel } from '../session/peer-context.js';
+
+describe('formatPeerPanel', () => {
+  it('WARNs when unavailable (never silent empty)', () => {
+    const text = formatPeerPanel({
+      status: 'unavailable',
+      reason: 'daemon socket absent',
+      peers: [],
+      reservations: [],
+      findings: [],
+      source: 'none',
+    });
+    expect(text).toContain('[peer-context] WARN');
+    expect(text).toContain('daemon socket absent');
+    expect(text).toContain('Proceeding without peer awareness');
+  });
+
+  it('lists peers and claims when available', () => {
+    const text = formatPeerPanel({
+      status: 'available',
+      peers: [{ agentId: 'alice', task: 'GAP-459 S2', active: true }],
+      reservations: [{ agentId: 'bob', path: '/tmp/x.ts' }],
+      findings: [{ agentId: 'bob', eventType: 'peer.finding', summary: 'done' }],
+      source: 'context.snapshot',
+    });
+    expect(text).toContain('[peer-context] ok');
+    expect(text).toContain('alice');
+    expect(text).toContain('GAP-459 S2');
+    expect(text).toContain('/tmp/x.ts');
+    expect(text).toContain('peer.finding');
+  });
+
+  it('shows none other when available with empty peers', () => {
+    const text = formatPeerPanel({
+      status: 'available',
+      peers: [],
+      reservations: [],
+      findings: [],
+      source: 'context.snapshot',
+    });
+    expect(text).toContain('peers: none other active');
+    expect(text).not.toMatch(/WARN/);
+  });
+});
+
+describe('fetchPeerContext', () => {
+  const dirs: string[] = [];
+  const servers: Array<ReturnType<typeof createServer>> = [];
+
+  afterEach(async () => {
+    for (const s of servers) {
+      await new Promise<void>((resolve) => s.close(() => resolve()));
+    }
+    servers.length = 0;
+    for (const d of dirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it('returns unavailable when socket missing', async () => {
+    const snap = await fetchPeerContext({
+      socketPath: join(tmpdir(), `no-sock-${Date.now()}`),
+    });
+    expect(snap.status).toBe('unavailable');
+    expect(snap.source).toBe('none');
+    expect(formatPeerPanel(snap)).toContain('WARN');
+  });
+
+  it('uses context.snapshot when the daemon implements it', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'peer-ctx-'));
+    dirs.push(dir);
+    const sock = join(dir, 'harness.sock');
+    const server = createServer((socket) => {
+      let buf = '';
+      socket.on('data', (chunk) => {
+        buf += chunk.toString();
+        if (!buf.includes('\n')) return;
+        const req = JSON.parse(buf.split('\n')[0]!) as { id: number; method: string };
+        if (req.method === 'context.snapshot') {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              result: {
+                available: true,
+                peers: [{ agentId: 'peer-1', task: 'hello', active: true, isSelf: false }],
+                reservations: [],
+                findings: [],
+              },
+            })}\n`,
+          );
+        } else {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              error: { message: `unknown ${req.method}` },
+            })}\n`,
+          );
+        }
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.listen(sock, () => resolve());
+      server.on('error', reject);
+    });
+
+    const snap = await fetchPeerContext({ socketPath: sock, actorAgentId: 'me' });
+    expect(snap.status).toBe('available');
+    expect(snap.source).toBe('context.snapshot');
+    expect(snap.peers).toHaveLength(1);
+    expect(snap.peers[0]?.agentId).toBe('peer-1');
+  });
+
+  it('falls back to session.list when context.snapshot is missing', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'peer-fallback-'));
+    dirs.push(dir);
+    const sock = join(dir, 'harness.sock');
+    const server = createServer((socket) => {
+      let buf = '';
+      socket.on('data', (chunk) => {
+        buf += chunk.toString();
+        if (!buf.includes('\n')) return;
+        const req = JSON.parse(buf.split('\n')[0]!) as { id: number; method: string };
+        if (req.method === 'context.snapshot') {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              error: { code: -32601, message: 'Method not found: context.snapshot' },
+            })}\n`,
+          );
+        } else if (req.method === 'session.list') {
+          socket.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              result: {
+                sessions: [
+                  { id: 'me', task: 'self' },
+                  { id: 'other', task: 'peer work', active: true },
+                ],
+              },
+            })}\n`,
+          );
+        }
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.listen(sock, () => resolve());
+      server.on('error', reject);
+    });
+
+    const snap = await fetchPeerContext({ socketPath: sock, actorAgentId: 'me' });
+    expect(snap.status).toBe('degraded');
+    expect(snap.source).toBe('session.list');
+    expect(snap.peers.map((p) => p.agentId)).toEqual(['other']);
+    expect(formatPeerPanel(snap)).toContain('WARN');
+  });
+});

--- a/packages/harnesses/src/__tests__/session-boundary.test.ts
+++ b/packages/harnesses/src/__tests__/session-boundary.test.ts
@@ -31,6 +31,31 @@ describe('session boundary (soft-optional daemon)', () => {
     expect(result.reason).toMatch(/absent/i);
   });
 
+  it('archives on end even when socket absent (skipArchive false)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sess-arch-'));
+    dirs.push(dir);
+    process.env.REVFLEET_ARCHIVE = join(dir, 'archive');
+    process.env.REVDEV_DAEMON_SESSION_DIR = join(dir, 'sessions');
+    process.env.REVDEV_HOOK_IDENTITY_DIR = join(dir, 'ids');
+    const { writeDaemonSessionCache } = await import('../session/identity-cache.js');
+    writeDaemonSessionCache('archived-agent-1', 'ppid-arch');
+    const ended = await sessionEnd({
+      socketPath: join(dir, 'no.sock'),
+      ppid: 'ppid-arch',
+      exitSummary: 'test-archive',
+      backend: 'test',
+    });
+    expect(ended.skipped).toBe(true);
+    const { existsSync, readdirSync } = await import('node:fs');
+    const cold = join(dir, 'archive', 'cold', 'sessions', 'daemon');
+    expect(existsSync(cold)).toBe(true);
+    const files = readdirSync(cold).filter((f) => f.endsWith('.json'));
+    expect(files.length).toBeGreaterThanOrEqual(1);
+    delete process.env.REVFLEET_ARCHIVE;
+    delete process.env.REVDEV_DAEMON_SESSION_DIR;
+    delete process.env.REVDEV_HOOK_IDENTITY_DIR;
+  });
+
   it('registers and ends against a mock daemon with signing', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'sess-bound-'));
     dirs.push(dir);
@@ -113,6 +138,7 @@ describe('session boundary (soft-optional daemon)', () => {
     const ended = await sessionEnd({
       socketPath: sock,
       ppid: 'testppid',
+      skipArchive: true,
     });
     expect(ended.ok).toBe(true);
     expect(ended.agentId).toBe(agentId);

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -13,7 +13,7 @@
  *   sync <harnessId> <push|pull>     Sync harness config to/from SSD
  *   coordinate [--project <path>]    Print current workboard state
  *   hook <cursor|claude-code|vscode|grok> Normalize a hook payload from stdin, evaluate policy, spool the receipt
- *   session register|end             Soft-optional RevDev daemon session boundary (Grok/equal adapters)
+ *   session register|end|peers       Soft-optional RevDev daemon session boundary + peer panel (GAP-459)
  *
  * License: FSL-1.1-MIT
  */
@@ -717,7 +717,7 @@ Commands:
   health                            Run health check (requires daemon)
   coordinate [--project <path>]     Print workboard state
   hook <cursor|claude-code|vscode|grok>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
-  session register|end              Soft-optional RevDev daemon session boundary (equal adapters)
+  session register|end|peers        Soft-optional RevDev session boundary + peer panel (GAP-459)
   content <subcommand>              Manage canonical content definitions
   manager materialize [--project p] Write manager.json + .revealui/content + Cursor/OpenCode surfaces + equal stubs
   manager check [--project p]       Verify project manager present and valid

--- a/packages/harnesses/src/manager/grok-session-hooks.ts
+++ b/packages/harnesses/src/manager/grok-session-hooks.ts
@@ -9,8 +9,9 @@
  * Design:
  * - SessionStart / SessionEnd: TRACKER + hotfix + temp-scripts + RevDev
  *   session.register / session.end (soft-optional when daemon socket down).
+ * - SessionStart register also prints GAP-459 peer-context (WARN if down).
  * - Hotfix/temp adapters under `~/.claude` call the same control registries.
- * - Daemon boundary via `revealui-harnesses session register|end` (this package).
+ * - Daemon boundary via `revealui-harnesses session register|end|peers`.
  * - No full hardline prose; no OpenClaw; subscription OAuth never appears here.
  *
  * Credential topology: ADR 2026-07-29-provider-credential-topology-green-yellow-red
@@ -58,13 +59,14 @@ export const GROK_SESSION_START_HOOKS_JSON = hookFile('SessionStart', [
       {
         type: 'command',
         command:
-          'printf \'%s\\n\' "[grok] adapter SessionStart → control layer (TRACKER + hotfix + temp-scripts + daemon session)"',
+          'printf \'%s\\n\' "[grok] adapter SessionStart → control layer (TRACKER + hotfix + temp-scripts + daemon session + peer-context)"',
         timeout: 5,
       },
       { type: 'command', command: TRACKER_CMD, timeout: 12 },
       { type: 'command', command: HOTFIX_CMD, timeout: 15 },
       { type: 'command', command: TMPSCRIPT_CMD, timeout: 12 },
-      { type: 'command', command: SESSION_REGISTER_CMD, timeout: 20 },
+      // register prints GAP-459 peer panel (or WARN if daemon down)
+      { type: 'command', command: SESSION_REGISTER_CMD, timeout: 25 },
     ],
   },
 ]);

--- a/packages/harnesses/src/session/archive-exit.ts
+++ b/packages/harnesses/src/session/archive-exit.ts
@@ -1,0 +1,93 @@
+/**
+ * Archive a session exit into the RevFleet cold archive.
+ *
+ * Destination (operator convention, not product git):
+ *   $REVFLEET_ARCHIVE/cold/sessions/daemon/   when REVFLEET_ARCHIVE is the parent
+ *   $REVFLEET_ARCHIVE/sessions/daemon/        when REVFLEET_ARCHIVE is already cold/
+ *   default: ~/revfleet/archive/cold/sessions/daemon/
+ *
+ * Purpose: keep a durable, centralized record of ended sessions so live peer
+ * lists and workboard state stay clean. Soft-optional: never throws.
+ */
+
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface SessionExitRecord {
+  readonly agentId: string;
+  readonly endedAt: string;
+  readonly exitSummary: string;
+  readonly backend?: string;
+  readonly workDir?: string;
+  readonly task?: string;
+  readonly ppid?: string | number;
+  readonly source: string;
+  readonly daemonEnded: boolean;
+  readonly notes?: string;
+}
+
+export interface ArchiveExitResult {
+  readonly ok: boolean;
+  readonly path?: string;
+  readonly ledgerPath?: string;
+  readonly reason?: string;
+}
+
+/** Resolve cold sessions/daemon directory under the fleet archive. */
+export function coldDaemonSessionsDir(): string {
+  const env = process.env.REVFLEET_ARCHIVE?.trim();
+  if (env) {
+    // Parent layout: ~/revfleet/archive → cold/sessions/daemon
+    // Cold layout:   ~/revfleet/archive/cold → sessions/daemon
+    if (env.endsWith('/cold') || env.endsWith('\\cold') || /[/\\]cold$/.test(env)) {
+      return join(env, 'sessions', 'daemon');
+    }
+    return join(env, 'cold', 'sessions', 'daemon');
+  }
+  return join(homedir(), 'revfleet', 'archive', 'cold', 'sessions', 'daemon');
+}
+
+function safeSlug(id: string): string {
+  return id.replace(/[^a-zA-Z0-9._-]+/g, '_').slice(0, 120) || 'session';
+}
+
+function stamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+/**
+ * Write one exit record + append a ledger line.
+ * Soft: returns ok:false on I/O errors; never throws.
+ */
+export function archiveSessionExit(record: SessionExitRecord): ArchiveExitResult {
+  try {
+    const dir = coldDaemonSessionsDir();
+    mkdirSync(dir, { recursive: true });
+    const fileName = `${stamp()}-${safeSlug(record.agentId)}.json`;
+    const filePath = join(dir, fileName);
+    const body = `${JSON.stringify(record, null, 2)}\n`;
+    writeFileSync(filePath, body, { encoding: 'utf8', mode: 0o600 });
+
+    const ledgerPath = join(dir, 'ledger.jsonl');
+    const line = `${JSON.stringify({
+      endedAt: record.endedAt,
+      agentId: record.agentId,
+      exitSummary: record.exitSummary,
+      backend: record.backend,
+      workDir: record.workDir,
+      task: record.task,
+      daemonEnded: record.daemonEnded,
+      source: record.source,
+      file: fileName,
+    })}\n`;
+    appendFileSync(ledgerPath, line, { encoding: 'utf8', mode: 0o600 });
+
+    return { ok: true, path: filePath, ledgerPath };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/harnesses/src/session/boundary.ts
+++ b/packages/harnesses/src/session/boundary.ts
@@ -9,6 +9,7 @@
  */
 
 import { hostname } from 'node:os';
+import { archiveSessionExit } from './archive-exit.js';
 import {
   clearDaemonSessionCache,
   clearHookIdentity,
@@ -44,6 +45,13 @@ export interface EndOptions {
   readonly exitSummary?: string;
   /** When set, end this agent even if cache missing (must have identity). */
   readonly agentId?: string;
+  /** Optional backend label for cold archive (e.g. grok, claude-code). */
+  readonly backend?: string;
+  /** Optional work dir / task captured at exit for the archive record. */
+  readonly workDir?: string;
+  readonly task?: string;
+  /** Skip cold-archive write (tests). Default false. */
+  readonly skipArchive?: boolean;
 }
 
 function defaultAgentId(backend: string): string {
@@ -123,23 +131,57 @@ export async function sessionRegister(options: RegisterOptions): Promise<Session
 }
 
 /**
- * End the cached daemon session (signature-required). Soft if no cache or daemon down.
+ * End the cached daemon session (signature-required), then archive the exit
+ * into the RevFleet cold session store so live peer lists stay unpolluted.
+ * Soft if no cache or daemon down — archive still runs when agentId is known.
  */
 export async function sessionEnd(options: EndOptions = {}): Promise<SessionBoundaryResult> {
   const socketPath = options.socketPath;
+  const exitSummary = options.exitSummary ?? 'hook-session-end';
+  const ppid = options.ppid ?? process.ppid;
+
   if (!isDaemonSocketPresent(socketPath)) {
-    clearDaemonSessionCache(options.ppid ?? process.ppid);
-    return { ok: false, skipped: true, reason: 'daemon socket absent' };
+    const agentId = options.agentId ?? readDaemonSessionCache(ppid);
+    if (agentId && !options.skipArchive) {
+      archiveSessionExit({
+        agentId,
+        endedAt: new Date().toISOString(),
+        exitSummary,
+        backend: options.backend,
+        workDir: options.workDir ?? process.cwd(),
+        task: options.task,
+        ppid,
+        source: 'session.end',
+        daemonEnded: false,
+        notes: 'daemon socket absent; archived without session.end RPC',
+      });
+    }
+    clearDaemonSessionCache(ppid);
+    return { ok: false, skipped: true, reason: 'daemon socket absent', agentId };
   }
 
-  const agentId = options.agentId ?? readDaemonSessionCache(options.ppid ?? process.ppid);
+  const agentId = options.agentId ?? readDaemonSessionCache(ppid);
   if (!agentId) {
     return { ok: false, skipped: true, reason: 'no cached daemon session id' };
   }
 
   const identity = resolveAfterRegister({ agentId });
   if (!identity) {
-    clearDaemonSessionCache(options.ppid ?? process.ppid);
+    if (!options.skipArchive) {
+      archiveSessionExit({
+        agentId,
+        endedAt: new Date().toISOString(),
+        exitSummary,
+        backend: options.backend,
+        workDir: options.workDir ?? process.cwd(),
+        task: options.task,
+        ppid,
+        source: 'session.end',
+        daemonEnded: false,
+        notes: 'no signing identity; cache cleared; prune may reap daemon row',
+      });
+    }
+    clearDaemonSessionCache(ppid);
     return {
       ok: false,
       skipped: true,
@@ -150,9 +192,11 @@ export async function sessionEnd(options: EndOptions = {}): Promise<SessionBound
 
   const params: Record<string, unknown> = {
     actorAgentId: agentId,
-    exitSummary: options.exitSummary ?? 'hook-session-end',
+    exitSummary,
   };
 
+  let daemonEnded = false;
+  let endError: string | undefined;
   try {
     const signature = signRpc(identity as HookIdentity, 'session.end', params);
     await rpcCall('session.end', params, {
@@ -160,17 +204,46 @@ export async function sessionEnd(options: EndOptions = {}): Promise<SessionBound
       timeoutMs: options.timeoutMs ?? 4000,
       signature,
     });
-    clearDaemonSessionCache(options.ppid ?? process.ppid);
-    clearHookIdentity(agentId);
-    return { ok: true, skipped: false, agentId };
+    daemonEnded = true;
   } catch (err) {
-    // Still clear cache so we do not leave stale ids; prune reaps daemon rows.
-    clearDaemonSessionCache(options.ppid ?? process.ppid);
-    return {
-      ok: false,
-      skipped: false,
-      agentId,
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    endError = err instanceof Error ? err.message : String(err);
   }
+
+  // Always clear local cache after an exit attempt so peers do not keep a
+  // stale "live" claim for this process.
+  clearDaemonSessionCache(ppid);
+  clearHookIdentity(agentId);
+
+  if (!options.skipArchive) {
+    const archived = archiveSessionExit({
+      agentId,
+      endedAt: new Date().toISOString(),
+      exitSummary,
+      backend: options.backend,
+      workDir: options.workDir ?? process.cwd(),
+      task: options.task,
+      ppid,
+      source: 'session.end',
+      daemonEnded,
+      notes: endError ? `session.end RPC failed: ${endError}` : undefined,
+    });
+    if (archived.ok && archived.path) {
+      // Visible one-liner so SessionEnd logs show the archive path.
+      process.stderr.write(`[session-archive] wrote ${archived.path}\n`);
+    } else if (!archived.ok) {
+      process.stderr.write(
+        `[session-archive] WARN: cold archive failed (${archived.reason ?? 'unknown'})\n`,
+      );
+    }
+  }
+
+  if (daemonEnded) {
+    return { ok: true, skipped: false, agentId };
+  }
+  return {
+    ok: false,
+    skipped: false,
+    agentId,
+    reason: endError ?? 'session.end failed',
+  };
 }

--- a/packages/harnesses/src/session/boundary.ts
+++ b/packages/harnesses/src/session/boundary.ts
@@ -157,7 +157,12 @@ export async function sessionEnd(options: EndOptions = {}): Promise<SessionBound
       });
     }
     clearDaemonSessionCache(ppid);
-    return { ok: false, skipped: true, reason: 'daemon socket absent', agentId };
+    return {
+      ok: false,
+      skipped: true,
+      reason: 'daemon socket absent',
+      ...(agentId ? { agentId } : {}),
+    };
   }
 
   const agentId = options.agentId ?? readDaemonSessionCache(ppid);

--- a/packages/harnesses/src/session/cli.ts
+++ b/packages/harnesses/src/session/cli.ts
@@ -1,9 +1,13 @@
 /**
- * CLI: `revealui-harnesses session register|end`
+ * CLI: `revealui-harnesses session register|end|peers`
  * Always exits 0 for hook use (soft-optional daemon). Print status on stderr/stdout.
+ *
+ * GAP-459 S2: register and peers print a peer-context panel. When the daemon
+ * is down the panel is a visible WARN (never silent empty peers).
  */
 
 import { sessionEnd, sessionRegister } from './boundary.js';
+import { renderPeerPanel } from './peer-context.js';
 
 function printResult(
   label: string,
@@ -20,11 +24,18 @@ function nextArg(rest: string[], i: number): string | undefined {
   return rest[i + 1];
 }
 
+async function printPeerPanel(actorAgentId?: string): Promise<void> {
+  const panel = await renderPeerPanel({ actorAgentId });
+  // SessionStart surfaces: stderr is reliable across Claude + Grok hooks.
+  process.stderr.write(panel);
+}
+
 export async function runSessionCli(args: string[]): Promise<void> {
   const [subcommand, ...rest] = args;
   if (subcommand === 'register') {
     let backend = 'grok';
     let workDir = process.cwd();
+    let skipPeers = false;
     for (let i = 0; i < rest.length; i++) {
       const nxt = nextArg(rest, i);
       if (rest[i] === '--backend' && nxt) {
@@ -33,10 +44,28 @@ export async function runSessionCli(args: string[]): Promise<void> {
       } else if (rest[i] === '--work-dir' && nxt) {
         workDir = nxt;
         i++;
+      } else if (rest[i] === '--no-peers') {
+        skipPeers = true;
       }
     }
     const result = await sessionRegister({ backend, workDir });
     printResult('register', result);
+    if (!skipPeers) {
+      await printPeerPanel(result.agentId);
+    }
+    return;
+  }
+
+  if (subcommand === 'peers') {
+    let actorAgentId: string | undefined;
+    for (let i = 0; i < rest.length; i++) {
+      const nxt = nextArg(rest, i);
+      if (rest[i] === '--actor' && nxt) {
+        actorAgentId = nxt;
+        i++;
+      }
+    }
+    await printPeerPanel(actorAgentId);
     return;
   }
 
@@ -55,10 +84,12 @@ export async function runSessionCli(args: string[]): Promise<void> {
   }
 
   process.stderr.write(`Usage:
-  revealui-harnesses session register [--backend grok|claude-code|…] [--work-dir PATH]
+  revealui-harnesses session register [--backend grok|claude-code|…] [--work-dir PATH] [--no-peers]
+  revealui-harnesses session peers [--actor AGENT_ID]
   revealui-harnesses session end [--summary TEXT]
 
 Soft-optional RevDev daemon session boundary (GAP control-layer peer adapters).
 Always exits 0 so SessionStart/SessionEnd hooks never block.
+GAP-459: register/peers print peer-context (WARN when coordination unavailable).
 `);
 }

--- a/packages/harnesses/src/session/index.ts
+++ b/packages/harnesses/src/session/index.ts
@@ -1,4 +1,10 @@
 export {
+  type ArchiveExitResult,
+  archiveSessionExit,
+  coldDaemonSessionsDir,
+  type SessionExitRecord,
+} from './archive-exit.js';
+export {
   type EndOptions,
   type RegisterOptions,
   type SessionBoundaryResult,

--- a/packages/harnesses/src/session/index.ts
+++ b/packages/harnesses/src/session/index.ts
@@ -21,13 +21,13 @@ export {
 } from './identity-cache.js';
 export {
   type FetchPeerContextOptions,
+  fetchPeerContext,
+  formatPeerPanel,
   type PeerContextSnapshot,
   type PeerContextStatus,
   type PeerFindingLine,
   type PeerReservationLine,
   type PeerSessionLine,
-  fetchPeerContext,
-  formatPeerPanel,
   renderPeerPanel,
 } from './peer-context.js';
 export { defaultSocketPath, isDaemonSocketPresent, rpcCall } from './rpc.js';

--- a/packages/harnesses/src/session/index.ts
+++ b/packages/harnesses/src/session/index.ts
@@ -19,5 +19,16 @@ export {
   saveHookIdentity,
   writeDaemonSessionCache,
 } from './identity-cache.js';
+export {
+  type FetchPeerContextOptions,
+  type PeerContextSnapshot,
+  type PeerContextStatus,
+  type PeerFindingLine,
+  type PeerReservationLine,
+  type PeerSessionLine,
+  fetchPeerContext,
+  formatPeerPanel,
+  renderPeerPanel,
+} from './peer-context.js';
 export { defaultSocketPath, isDaemonSocketPresent, rpcCall } from './rpc.js';
 export { hashParams, signRpc } from './sign.js';

--- a/packages/harnesses/src/session/peer-context.ts
+++ b/packages/harnesses/src/session/peer-context.ts
@@ -33,11 +33,17 @@ export interface PeerContextSnapshot {
   /** Short reason when unavailable/degraded (shown in WARN line). */
   readonly reason?: string;
   readonly selfAgentId?: string | null;
+  /** Live peers only (active window). Abandoned rows are omitted from pollution. */
   readonly peers: readonly PeerSessionLine[];
+  /** Count of non-ended sessions excluded as abandoned/idle (not listed). */
+  readonly abandonedExcluded?: number;
   readonly reservations: readonly PeerReservationLine[];
   readonly findings: readonly PeerFindingLine[];
   readonly source: 'context.snapshot' | 'session.list' | 'none';
 }
+
+/** Max staleSeconds still treated as "live" for the peer panel (seconds). */
+export const PEER_LIVE_STALE_SECONDS = 300;
 
 export interface FetchPeerContextOptions {
   readonly socketPath?: string;
@@ -56,6 +62,15 @@ function str(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value : fallback;
 }
 
+function numField(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
 function asPeerFromSnapshotRow(row: unknown): PeerSessionLine | null {
   const r = asRecord(row);
   if (!r) return null;
@@ -67,6 +82,17 @@ function asPeerFromSnapshotRow(row: unknown): PeerSessionLine | null {
     active: r.active === true || r.active === 't',
     isSelf: r.isSelf === true,
   };
+}
+
+/** Keep only peers still inside the live window (active flag or low staleSeconds). */
+function isLivePeer(row: unknown): boolean {
+  const r = asRecord(row);
+  if (!r) return false;
+  if (r.active === true || r.active === 't') return true;
+  const stale = numField(r.staleSeconds) ?? numField(r.stale_seconds);
+  if (stale !== undefined) return stale <= PEER_LIVE_STALE_SECONDS;
+  // session.list without staleSeconds: only trust explicit active=true above.
+  return false;
 }
 
 function asFinding(row: unknown): PeerFindingLine | null {
@@ -132,7 +158,9 @@ export async function fetchPeerContext(
     }
 
     const peersRaw = Array.isArray(o.peers) ? o.peers : [];
-    const peers = peersRaw
+    const liveRows = peersRaw.filter(isLivePeer);
+    const abandonedExcluded = Math.max(0, peersRaw.length - liveRows.length);
+    const peers = liveRows
       .map(asPeerFromSnapshotRow)
       .filter((p): p is PeerSessionLine => p != null);
 
@@ -148,6 +176,7 @@ export async function fetchPeerContext(
       status: 'available',
       selfAgentId: actorAgentId ?? (typeof o.selfAgentId === 'string' ? o.selfAgentId : null),
       peers,
+      abandonedExcluded,
       reservations,
       findings,
       source: 'context.snapshot',
@@ -203,16 +232,21 @@ async function fetchPeersViaSessionList(options: {
     const o = asRecord(raw);
     const sessions = Array.isArray(o?.sessions) ? o.sessions : [];
     const peers: PeerSessionLine[] = [];
+    let abandonedExcluded = 0;
     for (const row of sessions) {
       const r = asRecord(row);
       if (!r) continue;
       const id = str(r.id) || str(r.agentId) || str(r.agent_id);
       if (!id) continue;
       if (options.actorAgentId && id === options.actorAgentId) continue;
+      if (!isLivePeer(row)) {
+        abandonedExcluded += 1;
+        continue;
+      }
       peers.push({
         agentId: id,
         task: str(r.task, '(no task)'),
-        active: r.active === true || r.active === 't',
+        active: true,
       });
     }
     return {
@@ -220,6 +254,7 @@ async function fetchPeersViaSessionList(options: {
       reason: options.reason,
       selfAgentId: options.actorAgentId ?? null,
       peers,
+      abandonedExcluded,
       reservations: [],
       findings: [],
       source: 'session.list',
@@ -271,6 +306,12 @@ export function formatPeerPanel(snapshot: PeerContextSnapshot): string {
     if (snapshot.peers.length > 12) {
       lines.push(`  … +${snapshot.peers.length - 12} more`);
     }
+  }
+
+  if ((snapshot.abandonedExcluded ?? 0) > 0) {
+    lines.push(
+      `[peer-context] note: ${snapshot.abandonedExcluded} abandoned/idle session row(s) hidden — end sessions via archive workflow so they leave the live set`,
+    );
   }
 
   if (snapshot.reservations.length > 0) {

--- a/packages/harnesses/src/session/peer-context.ts
+++ b/packages/harnesses/src/session/peer-context.ts
@@ -74,7 +74,7 @@ function asFinding(row: unknown): PeerFindingLine | null {
   if (!r) return null;
   const agentId = str(r.agentId) || str(r.agent_id);
   const eventType = str(r.eventType) || str(r.event_type);
-  if (!agentId || !eventType) return null;
+  if (!(agentId && eventType)) return null;
   const payload = asRecord(r.payload) ?? {};
   const summary = str(payload.summary) || str(payload.message) || eventType;
   return { agentId, eventType, summary };
@@ -85,7 +85,7 @@ function asReservation(row: unknown): PeerReservationLine | null {
   if (!r) return null;
   const agentId = str(r.agentId) || str(r.agent_id);
   const path = str(r.path) || str(r.file_path);
-  if (!agentId || !path) return null;
+  if (!(agentId && path)) return null;
   return { agentId, path };
 }
 

--- a/packages/harnesses/src/session/peer-context.ts
+++ b/packages/harnesses/src/session/peer-context.ts
@@ -1,0 +1,297 @@
+/**
+ * GAP-459 S2 — peer-context panel for session start.
+ *
+ * Fetches `context.snapshot` (S1) when available; falls back to `session.list`
+ * if the daemon is older than S1. When the daemon is down, returns a visible
+ * unavailable result — never a silent empty peer set (ADR 2026-07-28).
+ */
+
+import { isDaemonSocketPresent, rpcCall } from './rpc.js';
+
+export type PeerContextStatus = 'available' | 'unavailable' | 'degraded';
+
+export interface PeerSessionLine {
+  readonly agentId: string;
+  readonly task: string;
+  readonly active?: boolean;
+  readonly isSelf?: boolean;
+}
+
+export interface PeerReservationLine {
+  readonly agentId: string;
+  readonly path: string;
+}
+
+export interface PeerFindingLine {
+  readonly agentId: string;
+  readonly eventType: string;
+  readonly summary: string;
+}
+
+export interface PeerContextSnapshot {
+  readonly status: PeerContextStatus;
+  /** Short reason when unavailable/degraded (shown in WARN line). */
+  readonly reason?: string;
+  readonly selfAgentId?: string | null;
+  readonly peers: readonly PeerSessionLine[];
+  readonly reservations: readonly PeerReservationLine[];
+  readonly findings: readonly PeerFindingLine[];
+  readonly source: 'context.snapshot' | 'session.list' | 'none';
+}
+
+export interface FetchPeerContextOptions {
+  readonly socketPath?: string;
+  readonly actorAgentId?: string;
+  readonly timeoutMs?: number;
+  readonly includeSelf?: boolean;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function str(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asPeerFromSnapshotRow(row: unknown): PeerSessionLine | null {
+  const r = asRecord(row);
+  if (!r) return null;
+  const agentId = str(r.agentId) || str(r.id);
+  if (!agentId) return null;
+  return {
+    agentId,
+    task: str(r.task, '(no task)'),
+    active: r.active === true || r.active === 't',
+    isSelf: r.isSelf === true,
+  };
+}
+
+function asFinding(row: unknown): PeerFindingLine | null {
+  const r = asRecord(row);
+  if (!r) return null;
+  const agentId = str(r.agentId) || str(r.agent_id);
+  const eventType = str(r.eventType) || str(r.event_type);
+  if (!agentId || !eventType) return null;
+  const payload = asRecord(r.payload) ?? {};
+  const summary = str(payload.summary) || str(payload.message) || eventType;
+  return { agentId, eventType, summary };
+}
+
+function asReservation(row: unknown): PeerReservationLine | null {
+  const r = asRecord(row);
+  if (!r) return null;
+  const agentId = str(r.agentId) || str(r.agent_id);
+  const path = str(r.path) || str(r.file_path);
+  if (!agentId || !path) return null;
+  return { agentId, path };
+}
+
+/**
+ * Load peer context. Soft-optional: never throws.
+ */
+export async function fetchPeerContext(
+  options: FetchPeerContextOptions = {},
+): Promise<PeerContextSnapshot> {
+  const socketPath = options.socketPath;
+  if (!isDaemonSocketPresent(socketPath)) {
+    return {
+      status: 'unavailable',
+      reason: 'daemon socket absent',
+      peers: [],
+      reservations: [],
+      findings: [],
+      source: 'none',
+    };
+  }
+
+  const actorAgentId = options.actorAgentId;
+  const timeoutMs = options.timeoutMs ?? 4000;
+
+  try {
+    const raw = await rpcCall(
+      'context.snapshot',
+      {
+        actorAgentId,
+        includeSelf: options.includeSelf === true,
+      },
+      { socketPath, timeoutMs },
+    );
+    const o = asRecord(raw);
+    if (!o) {
+      return {
+        status: 'degraded',
+        reason: 'context.snapshot returned empty body',
+        peers: [],
+        reservations: [],
+        findings: [],
+        source: 'context.snapshot',
+      };
+    }
+
+    const peersRaw = Array.isArray(o.peers) ? o.peers : [];
+    const peers = peersRaw
+      .map(asPeerFromSnapshotRow)
+      .filter((p): p is PeerSessionLine => p != null);
+
+    const reservations = (Array.isArray(o.reservations) ? o.reservations : [])
+      .map(asReservation)
+      .filter((r): r is PeerReservationLine => r != null);
+
+    const findings = (Array.isArray(o.findings) ? o.findings : [])
+      .map(asFinding)
+      .filter((f): f is PeerFindingLine => f != null);
+
+    return {
+      status: 'available',
+      selfAgentId: actorAgentId ?? (typeof o.selfAgentId === 'string' ? o.selfAgentId : null),
+      peers,
+      reservations,
+      findings,
+      source: 'context.snapshot',
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // S1 not on this daemon yet → fall back to session.list presence only.
+    if (/Method not found|context\.snapshot|not found/i.test(message)) {
+      return fetchPeersViaSessionList({
+        socketPath,
+        actorAgentId,
+        timeoutMs,
+        reason: 'context.snapshot unavailable; using session.list',
+      });
+    }
+    // License / Pro gate or other soft failures: still visible.
+    if (/-32001|license|Pro/i.test(message)) {
+      return {
+        status: 'degraded',
+        reason: `peer snapshot needs Pro coordination license (${message})`,
+        peers: [],
+        reservations: [],
+        findings: [],
+        source: 'none',
+      };
+    }
+    return {
+      status: 'unavailable',
+      reason: message,
+      peers: [],
+      reservations: [],
+      findings: [],
+      source: 'none',
+    };
+  }
+}
+
+async function fetchPeersViaSessionList(options: {
+  socketPath?: string;
+  actorAgentId?: string;
+  timeoutMs: number;
+  reason: string;
+}): Promise<PeerContextSnapshot> {
+  try {
+    const raw = await rpcCall(
+      'session.list',
+      {},
+      {
+        socketPath: options.socketPath,
+        timeoutMs: options.timeoutMs,
+      },
+    );
+    const o = asRecord(raw);
+    const sessions = Array.isArray(o?.sessions) ? o.sessions : [];
+    const peers: PeerSessionLine[] = [];
+    for (const row of sessions) {
+      const r = asRecord(row);
+      if (!r) continue;
+      const id = str(r.id) || str(r.agentId) || str(r.agent_id);
+      if (!id) continue;
+      if (options.actorAgentId && id === options.actorAgentId) continue;
+      peers.push({
+        agentId: id,
+        task: str(r.task, '(no task)'),
+        active: r.active === true || r.active === 't',
+      });
+    }
+    return {
+      status: 'degraded',
+      reason: options.reason,
+      selfAgentId: options.actorAgentId ?? null,
+      peers,
+      reservations: [],
+      findings: [],
+      source: 'session.list',
+    };
+  } catch (err) {
+    return {
+      status: 'unavailable',
+      reason: err instanceof Error ? err.message : String(err),
+      peers: [],
+      reservations: [],
+      findings: [],
+      source: 'none',
+    };
+  }
+}
+
+/**
+ * Format a multi-line peer panel for SessionStart stdout/stderr.
+ * Always produces at least one line so absence of peers is not silent when
+ * the layer is unavailable.
+ */
+export function formatPeerPanel(snapshot: PeerContextSnapshot): string {
+  const lines: string[] = [];
+
+  if (snapshot.status === 'unavailable') {
+    lines.push(
+      `[peer-context] WARN: coordination layer unavailable (${snapshot.reason ?? 'unknown'}). Proceeding without peer awareness.`,
+    );
+    return `${lines.join('\n')}\n`;
+  }
+
+  if (snapshot.status === 'degraded') {
+    lines.push(
+      `[peer-context] WARN: degraded peer view (${snapshot.reason ?? 'partial'}). Autonomy continues.`,
+    );
+  } else {
+    lines.push(`[peer-context] ok (source=${snapshot.source})`);
+  }
+
+  if (snapshot.peers.length === 0) {
+    lines.push('[peer-context] peers: none other active on this machine');
+  } else {
+    lines.push(`[peer-context] peers (${snapshot.peers.length}):`);
+    for (const p of snapshot.peers.slice(0, 12)) {
+      const flag = p.active === false ? ' idle' : '';
+      const task = p.task.replace(/\s+/g, ' ').slice(0, 80);
+      lines.push(`  - ${p.agentId}${flag}: ${task}`);
+    }
+    if (snapshot.peers.length > 12) {
+      lines.push(`  … +${snapshot.peers.length - 12} more`);
+    }
+  }
+
+  if (snapshot.reservations.length > 0) {
+    lines.push(`[peer-context] file claims (${snapshot.reservations.length}):`);
+    for (const r of snapshot.reservations.slice(0, 8)) {
+      lines.push(`  - ${r.agentId}: ${r.path}`);
+    }
+  }
+
+  if (snapshot.findings.length > 0) {
+    lines.push(`[peer-context] recent findings (${snapshot.findings.length}):`);
+    for (const f of snapshot.findings.slice(0, 5)) {
+      lines.push(`  - ${f.agentId} ${f.eventType}: ${f.summary.slice(0, 100)}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+/** Fetch + format in one call for CLI/hooks. */
+export async function renderPeerPanel(options: FetchPeerContextOptions = {}): Promise<string> {
+  const snap = await fetchPeerContext(options);
+  return formatPeerPanel(snap);
+}


### PR DESCRIPTION
## Summary
- **Peer panel (S2):** `session peers` / `session register` print live peers or a **WARN** when coordination is down.
- **Archive-on-exit:** `session end` writes a durable record under `~/revfleet/archive/cold/sessions/daemon/` (`*.json` + `ledger.jsonl`) so ended sessions stay tracked offline and leave the live peer set.
- Prefer `context.snapshot` (S1 / revdev#341); fall back to `session.list`.
- **Pollution filter:** abandoned/idle daemon rows are hidden from the peer panel with a count note (exit via archive workflow to clear them from the live set).
- Grok SessionStart/End already call control-layer `session register|end`.
- Claude: thin Stop hook prefers control-layer `session end` (archive); fallback RPC + thin archive write.

## Design
GAP-459 phase-1 design; cold archive convention (`archive/cold/README.md` sessions/daemon).

## Test plan
- [x] peer-context + session-boundary tests (incl. archive-on-absent)
- [x] `pnpm gate --phase=1 --changed` PASS
- [ ] CI green
- [ ] After merge: rebuild harnesses; exit a session and confirm file under `archive/cold/sessions/daemon/`
- [ ] Optional: `harness.prune` or reaper for pre-existing abandoned rows (not ended historically)