### PR TITLE
feat(marketing): ship L1 leverage hero as homepage default

### DIFF
--- a/apps/marketing/app/__tests__/hero-variant.test.ts
+++ b/apps/marketing/app/__tests__/hero-variant.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { HOME_HERO, HOME_HERO_FOUNDATION } from '../content/home';
+import { HOME_HERO, HOME_HERO_FOUNDATION, HOME_HERO_OWNERSHIP } from '../content/home';
 import { selectHomeHero } from '../lib/hero-variant';
 
 describe('selectHomeHero', () => {
@@ -7,32 +7,40 @@ describe('selectHomeHero', () => {
     expect(selectHomeHero('?hero=foundation')).toBe(HOME_HERO_FOUNDATION);
   });
 
-  it('serves the canonical hero by default (no query)', () => {
-    expect(selectHomeHero('')).toBe(HOME_HERO);
+  it('serves the ownership rollback for ?hero=ownership', () => {
+    expect(selectHomeHero('?hero=ownership')).toBe(HOME_HERO_OWNERSHIP);
   });
 
-  it('serves the canonical hero for any non-foundation value', () => {
+  it('serves the L1 default hero by default (no query)', () => {
+    expect(selectHomeHero('')).toBe(HOME_HERO);
+    expect(HOME_HERO.h1).toBe('Build it once. Every product after starts ahead.');
+  });
+
+  it('serves the L1 default for unknown hero values', () => {
     expect(selectHomeHero('?hero=runtime')).toBe(HOME_HERO);
     expect(selectHomeHero('?other=1')).toBe(HOME_HERO);
   });
 
-  it('isolates the noun in the H1 only (corpus §4.1 lock: Sub unchanged)', () => {
+  it('isolates the H1 only across variants (subtitle unchanged)', () => {
     expect(HOME_HERO_FOUNDATION.h1).not.toBe(HOME_HERO.h1);
+    expect(HOME_HERO_OWNERSHIP.h1).not.toBe(HOME_HERO.h1);
     expect(HOME_HERO_FOUNDATION.subtitle).toEqual(HOME_HERO.subtitle);
+    expect(HOME_HERO_OWNERSHIP.subtitle).toEqual(HOME_HERO.subtitle);
     expect(HOME_HERO_FOUNDATION.eyebrow).toBe(HOME_HERO.eyebrow);
     expect(HOME_HERO_FOUNDATION.cta).toEqual(HOME_HERO.cta);
   });
 
-  it('matches the corpus §4.1 H1 lock verbatim', () => {
+  it('matches the Foundation A/B H1 lock verbatim', () => {
     expect(HOME_HERO_FOUNDATION.h1).toBe('The foundation your business runs on.');
   });
 
-  it('keeps the full locked positioning form on both hero variants', () => {
+  it('keeps the full locked positioning form on all hero variants', () => {
     expect(HOME_HERO.subtitle.sentence1).toContain('under one roof');
     expect(HOME_HERO.subtitle.sentence2).toBe(
       'Every agent is a governed and audited user that lives on your infrastructure.',
     );
     expect(HOME_HERO.subtitle.support).toBe('It runs on any AI provider you choose.');
     expect(HOME_HERO_FOUNDATION.subtitle.sentence2).toBe(HOME_HERO.subtitle.sentence2);
+    expect(HOME_HERO_OWNERSHIP.subtitle.sentence2).toBe(HOME_HERO.subtitle.sentence2);
   });
 });

--- a/apps/marketing/app/__tests__/use-audience-head.test.ts
+++ b/apps/marketing/app/__tests__/use-audience-head.test.ts
@@ -79,7 +79,7 @@ describe('useAudienceHead — non-technical audience', () => {
 describe('useAudienceHead — technical audience', () => {
   it('sets document.title to the technical headline', () => {
     renderHook(() => useAudienceHead('technical'));
-    expect(document.title).toBe('RevealUI | Run your whole business on one runtime you own.');
+    expect(document.title).toBe('RevealUI | Build it once. Every product after starts ahead.');
   });
 
   it('does not mutate link[rel=canonical]', () => {
@@ -129,7 +129,7 @@ describe('useAudienceHead — audience switch', () => {
       rerender({ audience: 'technical' });
     });
 
-    expect(document.title).toBe('RevealUI | Run your whole business on one runtime you own.');
+    expect(document.title).toBe('RevealUI | Build it once. Every product after starts ahead.');
     expect(document.documentElement.dataset.audience).toBe('technical');
   });
 

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -563,12 +563,36 @@ export const CLAIMS: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO.h1',
+    text: 'Build it once. Every product after starts ahead.',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'packages',
+        note: 'five primitives implemented once and reused across products on one monorepo runtime',
+      },
+      {
+        kind: 'test',
+        ref: 'apps/marketing/app/__tests__/hero-variant.test.ts#serves the L1 default hero by default',
+        note: 'locks the L1 H1 string as the homepage default after owner ruling 2026-07-29',
+      },
+      LICENSE_MIT,
+      SELF_HOST,
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_HERO_OWNERSHIP.h1',
     text: 'Run your whole business on one runtime you own.',
     evidence: [
       {
         kind: 'code',
         ref: 'packages',
-        note: 'auth, content, billing, agents in one monorepo runtime',
+        note: 'prior default H1 retained as ?hero=ownership rollback preview',
+      },
+      {
+        kind: 'test',
+        ref: 'apps/marketing/app/__tests__/hero-variant.test.ts#serves the ownership rollback for ?hero=ownership',
+        note: 'locks ownership H1 as optional rollback variant',
       },
       LICENSE_MIT,
       SELF_HOST,

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -28,10 +28,12 @@ import type { Cta, FaqItem } from './types';
 
 export const HOME_HERO = {
   eyebrow: 'Open source. Self-hostable.',
-  h1: 'Run your whole business on one runtime you own.',
-  // Locked public form (copy-voice.md + ADR 2026-07-09 / 2026-07-21): two
-  // positioning sentences + support. Receipt foil is NOT in the subtitle; it
-  // is the ReceiptCard caption under this hero.
+  // Owner ruling 2026-07-29: ship corpus L1 leverage-frame as default H1
+  // (06-copy-corpus.md §4.1 punch-list row 9). Subtitle stays the locked
+  // positioning form (copy-voice.md + ADR 2026-07-09 / 2026-07-21): two
+  // sentences + support. Receipt foil is NOT in the subtitle; it is the
+  // ReceiptCard caption under this hero.
+  h1: 'Build it once. Every product after starts ahead.',
   subtitle: {
     sentence1:
       'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof.',
@@ -46,19 +48,22 @@ export const HOME_HERO = {
 
 // ---------------------------------------------------------------------------
 // Hero: "Foundation" A/B variant (canonical lock).
-// Per docs/marketing/06-copy-corpus.md §4.1 (sanctioned A/B variant under ADR
+// Per docs/marketing/06-copy-corpus.md §4.1 (sanctioned A/B under ADR
 // 2026-06-07 decision 6, hero only): H1 reframes around "foundation"; subtitle
-// inherits the default unchanged. The noun-test is the H1 only; the subtitle
-// keeps the canonical "runtime" noun. Served via selectHomeHero()
-// (app/lib/hero-variant.ts): the homepage hero renders this variant when the
-// URL carries ?hero=foundation, else HOME_HERO. An automatic traffic split +
-// conversion measurement is separate (the marketing app has no analytics sink
-// yet).
+// inherits the default unchanged. Served via selectHomeHero() when the URL
+// carries ?hero=foundation, else HOME_HERO.
 // ---------------------------------------------------------------------------
 
 export const HOME_HERO_FOUNDATION = {
   ...HOME_HERO,
   h1: 'The foundation your business runs on.',
+} as const;
+
+// Prior default H1, retained for rollback preview via ?hero=ownership
+// (not automatic traffic). Same subtitle as HOME_HERO.
+export const HOME_HERO_OWNERSHIP = {
+  ...HOME_HERO,
+  h1: 'Run your whole business on one runtime you own.',
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/lib/hero-variant.ts
+++ b/apps/marketing/app/lib/hero-variant.ts
@@ -1,20 +1,25 @@
-import { HOME_HERO, HOME_HERO_FOUNDATION } from '../content/home';
+import { HOME_HERO, HOME_HERO_FOUNDATION, HOME_HERO_OWNERSHIP } from '../content/home';
 
 /**
  * Homepage-hero A/B variant selector.
  *
- * Serves the "Foundation" hero variant when the URL carries `?hero=foundation`,
- * else the canonical `HOME_HERO`. This is the manual / preview serving seam for
- * the hero-noun A/B: visit `/?hero=foundation` to see the variant. "runtime"
- * stays the canonical noun on every other surface.
+ * Default: leverage-frame L1 (`HOME_HERO`, owner ruling 2026-07-29).
+ * `?hero=foundation` — Foundation A/B (ADR 2026-06-07 decision 6).
+ * `?hero=ownership` — prior default H1, rollback/preview only.
  *
  * An automatic traffic split + conversion measurement is deliberately out of
  * scope here: the marketing app has no analytics sink yet, so a real experiment
  * (cohort assignment + event logging + a winner readout) is its own piece of
  * work. This selector is the seam that work plugs into.
  */
-export function selectHomeHero(search: string): typeof HOME_HERO | typeof HOME_HERO_FOUNDATION {
-  return new URLSearchParams(search).get('hero') === 'foundation'
-    ? HOME_HERO_FOUNDATION
-    : HOME_HERO;
+export type HomeHeroVariant =
+  | typeof HOME_HERO
+  | typeof HOME_HERO_FOUNDATION
+  | typeof HOME_HERO_OWNERSHIP;
+
+export function selectHomeHero(search: string): HomeHeroVariant {
+  const hero = new URLSearchParams(search).get('hero');
+  if (hero === 'foundation') return HOME_HERO_FOUNDATION;
+  if (hero === 'ownership') return HOME_HERO_OWNERSHIP;
+  return HOME_HERO;
 }

--- a/apps/marketing/app/lib/use-audience-head.ts
+++ b/apps/marketing/app/lib/use-audience-head.ts
@@ -29,20 +29,21 @@ const SEO: Record<Audience, AudienceSeo> = {
       'https://api.revealui.com/api/og?title=RevealUI&description=Your%20business%2C%20delivered%20and%20yours%20to%20own.',
   },
   technical: {
-    title: 'RevealUI | Run your whole business on one runtime you own.',
-    // Mirrors HOME_HERO subtitle (canonical 2026-07-09 form, no em dashes).
+    title: 'RevealUI | Build it once. Every product after starts ahead.',
+    // Title mirrors HOME_HERO.h1 (L1 default, 2026-07-29). Description mirrors
+    // HOME_HERO subtitle (canonical 2026-07-09 form, no em dashes).
     description:
       'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof. Every agent is a governed and audited user that lives on your infrastructure. It runs on any AI provider you choose.',
-    ogTitle: 'RevealUI | Run your whole business on one runtime you own.',
+    ogTitle: 'RevealUI | Build it once. Every product after starts ahead.',
     ogDescription:
       'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof. Every agent is a governed and audited user that lives on your infrastructure.',
     ogImage:
-      'https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own.',
-    twitterTitle: 'RevealUI | Run your whole business on one runtime you own.',
+      'https://api.revealui.com/api/og?title=RevealUI&description=Build%20it%20once.%20Every%20product%20after%20starts%20ahead.',
+    twitterTitle: 'RevealUI | Build it once. Every product after starts ahead.',
     twitterDescription:
       'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof. Every agent is a governed and audited user that lives on your infrastructure.',
     twitterImage:
-      'https://api.revealui.com/api/og?title=RevealUI&description=Run%20your%20whole%20business%20on%20one%20runtime%20you%20own.',
+      'https://api.revealui.com/api/og?title=RevealUI&description=Build%20it%20once.%20Every%20product%20after%20starts%20ahead.',
   },
 };
 


### PR DESCRIPTION
## Summary
Owner ruling 2026-07-29 (copy corpus punch-list row 9): ship leverage-frame **L1** as the live homepage default H1.

- Default H1: **Build it once. Every product after starts ahead.**
- Locked positioning subtitle unchanged (sentence1 / sentence2 / support).
- `?hero=foundation` and `?hero=ownership` (prior default) remain as previews.
- Claims evidence + SEO titles updated; capability proof points at the hero-variant tests.

## Test plan
- [x] `vitest` hero-variant (7) + use-audience-head (12)
- [x] `pnpm validate:claims` green
- [x] local pre-push phase-1 gate PASS
- [ ] CI green on PR

## Coord
Peer note: `workboard.d/notes/2026-07-29T18-grok-copy-corpus-closeout.md`. Companion .jv corpus punch-list update follows.