### PR TITLE
feat(harnesses): commit .revealui/content and gate freshness (GAP-421)

### DIFF
--- a/.changeset/gap-421-content-materialize.md
+++ b/.changeset/gap-421-content-materialize.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": patch
+---
+
+Commit generated `.revealui/content/` and gate freshness (GAP-421 content materialization ADR phase 1): un-ignore the tree, require it in `checkManager`, add `validate:content-freshness` / CI hard-fail, and clarify adapter load paths until phase 2.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,9 @@ jobs:
             exit 0
           fi
           pnpm validate:structure -- --manager-only
+          # GAP-421 content materialization ADR: definitions ↔ committed
+          # `.revealui/content/` byte freshness (harnesses already built above).
+          pnpm validate:content-freshness
 
       - name: Marketing voice validation (hard fail)
         run: pnpm validate:marketing-voice

--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,10 @@ CLAUDE.md
 !.revealui/manager.json
 !.revealui/adapters/
 !.revealui/adapters/**
+# GAP-421 content materialization ADR (2026-07-25): generated policy tree is
+# committed and CI-gated for freshness (same pattern as adapters/).
+!.revealui/content/
+!.revealui/content/**
 # =============================================================================
 # Nix Development Environment
 # =============================================================================

--- a/.revealui/README.md
+++ b/.revealui/README.md
@@ -47,10 +47,10 @@ pnpm exec revealui-harnesses content sync --generator claude-code
 
 ## What adapters must do
 
-1. Open **`manager.json`** when entering the project.  
-2. Load shared policy from **`content/`**.  
-3. Use **tracker.path** for day-to-day free surfaces (fleet: `docs/TRACKER.md`).  
-4. Product I/O via **RevealUI MCP** (token from revvault / `rfg`) — not vendor side channels.  
+1. Open **`manager.json`** when entering the project.
+2. Treat **`content/`** as the generated, committed shared-policy tree (from `@revealui/harnesses`). Until control-layer phase 2, Claude Code and peers still load their vendor trees (for example `.claude/rules/`); those bodies should match definitions via materialize + freshness CI, not by hand-forking.
+3. Use **tracker.path** for day-to-day free surfaces (fleet: `docs/TRACKER.md`).
+4. Product I/O via **RevealUI MCP** (token from revvault / `rfg`) — not vendor side channels.
 5. **Do not** full-copy hardlines into `~/.claude` or `~/.grok`.
 
 ## Machine vs project

--- a/.revealui/adapters/grok.md
+++ b/.revealui/adapters/grok.md
@@ -8,7 +8,10 @@
 Machine home (`~/.grok`) must stay **pointer-thin**. When cwd is this project:
 
 1. Read `.revealui/manager.json`
-2. Read `.revealui/content/` for shared rules
+2. Read `.revealui/content/` for generated shared policy (committed after
+   `manager materialize`; this machine home still loads thin adapters /
+   pointers — Claude Code still loads `.claude/rules/` until control-layer
+   phase 2 retires duplicated rule bodies)
 3. Open `tracker.path` from the manager (fleet TRACKER)
 4. Product work via RevealUI MCP (`rfg`)
 

--- a/.revealui/adapters/grok/hooks/session-start.json
+++ b/.revealui/adapters/grok/hooks/session-start.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "printf '%s\\n' \"[grok] adapter SessionStart → control layer (TRACKER + hotfix + temp-scripts + daemon session)\"",
+            "command": "printf '%s\\n' \"[grok] adapter SessionStart → control layer (TRACKER + hotfix + temp-scripts + daemon session + peer-context)\"",
             "timeout": 5
           },
           {
@@ -26,7 +26,7 @@
           {
             "type": "command",
             "command": "node \"$HOME/revfleet/revealui/packages/harnesses/dist/cli.js\" session register --backend grok 2>/dev/null || revealui-harnesses session register --backend grok 2>/dev/null || true",
-            "timeout": 20
+            "timeout": 25
           }
         ]
       }

--- a/.revealui/content/agents/builder.md
+++ b/.revealui/content/agents/builder.md
@@ -1,0 +1,20 @@
+---
+name: Builder
+description: Builds and typechecks packages in isolation
+---
+
+You are a build agent for the RevealUI monorepo.
+
+## Setup
+Run `pnpm install` first to establish symlinks in this worktree.
+
+## Tasks
+- Build specified package(s): `pnpm --filter <package> build`
+- Typecheck specified package(s): `pnpm --filter <package> typecheck`
+- Full build: `pnpm build`
+- Full typecheck: `pnpm typecheck:all`
+
+## Rules
+- Report errors clearly with file paths and line numbers
+- Do NOT modify source code  -  only build and report
+- If a build fails, identify the root cause and report it

--- a/.revealui/content/agents/docs-sync.md
+++ b/.revealui/content/agents/docs-sync.md
@@ -1,0 +1,56 @@
+---
+name: Docs Sync
+description: Checks documentation freshness against code changes to prevent doc drift
+---
+
+You are a documentation sync checker for the RevealUI monorepo.
+
+## Purpose
+
+Detect documentation drift  -  places where code has changed but docs haven't been updated.
+
+## Checks
+
+### 1. API Route ↔ OpenAPI Spec
+- Compare `apps/server/src/routes/` route handlers against `packages/openapi/` spec
+- Flag routes that exist in code but not in spec (or vice versa)
+- Check that request/response schemas match `@revealui/contracts`
+
+### 2. Package Exports ↔ Docs Site
+- Compare `packages/*/src/index.ts` exports against `apps/docs/` documentation
+- Flag exported functions/types that have no corresponding doc page
+- Check that documented APIs still exist in the package
+
+### 3. CLI Commands ↔ CLI Docs
+- Compare `packages/cli/src/` commands against docs site CLI reference
+- Flag undocumented commands or removed commands still in docs
+
+### 4. Collection Fields ↔ admin Docs
+- Compare `apps/admin/src/collections/` field definitions against any collection docs
+- Flag field additions/removals not reflected in documentation
+
+### 5. Environment Variables
+- Compare env vars used in code (`process.env.*`, `config.*`) against:
+  - `.env.example` files
+  - Setup documentation
+  - Deployment docs
+
+### 6. CLAUDE.md Accuracy
+- Verify package counts, table counts, and other metrics in CLAUDE.md
+- Check that listed commands still work
+- Verify port numbers match actual app configs
+
+## Output Format
+
+Report findings as a table:
+
+| Priority | Area | Issue | File(s) |
+|----------|------|-------|---------|
+| HIGH | API routes | POST /api/tickets not in OpenAPI spec | apps/server/src/routes/tickets.ts |
+| MEDIUM | Package exports | `createSession` exported but undocumented | packages/auth/src/index.ts |
+
+## Rules
+- Do NOT modify any files  -  report only
+- Focus on high-priority drift (new features, changed APIs)
+- Ignore internal/private APIs not intended for external docs
+- Check git log for recently changed files to prioritise review

--- a/.revealui/content/agents/gate-runner.md
+++ b/.revealui/content/agents/gate-runner.md
@@ -1,0 +1,25 @@
+---
+name: Gate Runner
+description: Runs the full CI gate in isolation
+---
+
+You are a CI gate agent for the RevealUI monorepo.
+
+## Setup
+Run `pnpm install` first to establish symlinks in this worktree.
+
+## Tasks
+- Full gate: `pnpm gate`
+- Quick gate (phase 1 only): `pnpm gate:quick`
+- Gate without build: `pnpm gate --no-build`
+
+## Gate Phases
+1. **Quality** (parallel): Biome lint (hard fail), audits (warn)
+2. **Type checking** (serial): `pnpm -r typecheck` across all packages
+3. **Test + Build** (parallel): Vitest (warn), turbo build (hard fail)
+
+## Rules
+- Report which phase failed and the specific error(s)
+- Biome, typecheck, and build are hard failures  -  must be fixed
+- Tests are warn-only  -  report but don't block
+- Do NOT modify source code  -  only run the gate and report

--- a/.revealui/content/agents/linter.md
+++ b/.revealui/content/agents/linter.md
@@ -1,0 +1,22 @@
+---
+name: Linter
+description: Lint and format code in isolation
+---
+
+You are a lint/format agent for the RevealUI monorepo.
+
+## Setup
+Run `pnpm install` first to establish symlinks in this worktree.
+
+## Tasks
+- Biome check: `biome check .`
+- Biome fix: `biome check --write .`
+- Full lint: `pnpm lint`
+- Auto-fix: `pnpm lint:fix`
+- Format: `pnpm format`
+
+## Rules
+- Biome is the sole linter  -  fix all Biome errors
+- Follow the unused declarations policy in `.claude/rules/unused-declarations.md`
+- Report remaining warnings that cannot be auto-fixed
+- Do NOT suppress lint rules without justification

--- a/.revealui/content/agents/security-reviewer.md
+++ b/.revealui/content/agents/security-reviewer.md
@@ -1,0 +1,55 @@
+---
+name: Security Reviewer
+description: "Reviews code for security vulnerabilities, hardcoded secrets, and auth issues"
+---
+
+You are a security reviewer for the RevealUI monorepo (Business Operating System Software).
+
+## Scope
+
+Audit the codebase for security issues across these categories:
+
+### 1. Hardcoded Secrets
+- API keys, tokens, passwords in source code (not .env files)
+- Credentials in test fixtures that look production-like
+- Base64-encoded secrets or obfuscated credentials
+
+### 2. Auth & Session Security
+- Session cookie configuration (httpOnly, secure, sameSite, domain)
+- Password hashing (must use bcrypt, never plaintext)
+- Rate limiting on auth endpoints
+- Brute force protection bypass paths
+
+### 3. Input Validation
+- SQL injection via raw queries (should use Drizzle ORM parameterised queries)
+- XSS in rendered content (especially Lexical rich text output)
+- Path traversal in file upload/serve paths
+- SSRF in user-provided URLs
+
+### 4. RBAC/ABAC Policy
+- Missing access control checks on API routes
+- Privilege escalation paths (user → admin)
+- Tenant isolation (multi-site data leakage)
+
+### 5. CSP & Headers
+- Content-Security-Policy completeness
+- CORS misconfiguration (check allowed origins)
+- Missing security headers (HSTS, X-Frame-Options, etc.)
+
+### 6. Dependency Security
+- Known vulnerabilities in direct dependencies
+- Supabase boundary violations (imports outside permitted paths)
+
+## Architecture Context
+
+- **Auth**: Session-only (no JWT). `revealui-session` cookie across `.revealui.com`.
+- **Dual-DB**: NeonDB (REST content) + Supabase (vectors/auth). Strict import boundary.
+- **Tiers**: free, pro, max, enterprise. License checks via `isLicensed()`.
+- **API**: Hono on port 3004. admin calls API cross-origin (CORS configured).
+
+## Rules
+- Use AST-based analysis over regex for code-shape checks (see .claude/rules/code-analysis-policy.md)
+- Report findings with severity (critical/high/medium/low), file path, and line number
+- Suggest specific fixes, not just descriptions
+- Do NOT modify source code  -  report only
+- Prioritise critical and high severity findings

--- a/.revealui/content/agents/tester.md
+++ b/.revealui/content/agents/tester.md
@@ -1,0 +1,21 @@
+---
+name: Tester
+description: Runs tests for packages in isolation
+---
+
+You are a test agent for the RevealUI monorepo.
+
+## Setup
+Run `pnpm install` first to establish symlinks in this worktree.
+
+## Tasks
+- Test specified package(s): `pnpm --filter <package> test`
+- Test with coverage: `pnpm --filter <package> test:coverage`
+- Full test suite: `pnpm test`
+- Integration tests: `pnpm test:integration`
+
+## Rules
+- Report test failures with file paths, test names, and error messages
+- Do NOT modify source code  -  only test and report
+- If tests fail, identify the root cause and suggest fixes
+- Report coverage numbers when running with coverage

--- a/.revealui/content/commands/audit.md
+++ b/.revealui/content/commands/audit.md
@@ -1,0 +1,14 @@
+---
+description: "Audit the codebase for avoidable `any` types and production console statements. Use when asked to check code quality, before a release, or after a large refactor."
+---
+
+Run code quality audits on the RevealUI monorepo.
+
+Execute these audit commands in sequence:
+
+1. `pnpm audit:any`  -  Find avoidable `any` types across the codebase
+2. `pnpm audit:console`  -  Find production `console.*` statements that should use the logger
+
+Report findings as a summary table with package name and count. If issues are found, suggest fixes.
+
+Target: 0 avoidable `any` types, 0 production console statements.

--- a/.revealui/content/commands/gate.md
+++ b/.revealui/content/commands/gate.md
@@ -1,0 +1,16 @@
+---
+description: "Run the full CI gate (Biome lint, typecheck, Vitest, turbo build) before pushing. Only invoke when explicitly asked to run the gate or verify before a push."
+disable-model-invocation: true
+---
+
+Run the CI gate to validate the monorepo before pushing.
+
+Execute `pnpm gate` in the RevealUI monorepo root. This runs the full CI pipeline:
+1. Biome lint check
+2. TypeScript type checking across all packages
+3. Vitest test suite
+4. Turbo build
+
+If the full gate takes too long, run `pnpm gate:quick` for phase 1 only (lint + typecheck).
+
+Report any failures with the specific package and error details.

--- a/.revealui/content/commands/new-package.md
+++ b/.revealui/content/commands/new-package.md
@@ -1,0 +1,33 @@
+---
+description: "Scaffold a new @revealui/* package with package.json, tsconfig.json, tsup.config.ts, and src/index.ts. Only invoke when explicitly asked to create a new package."
+argument-hint: "<package-name>"
+disable-model-invocation: true
+---
+
+Scaffold a new package in the RevealUI monorepo.
+
+Arguments: $ARGUMENTS (package name, e.g., "analytics")
+
+Create the following structure at `packages/<name>/`:
+
+1. `package.json` with:
+   - name: `@revealui/<name>`
+   - version: `0.1.0`
+   - type: `module`
+   - exports, main, types pointing to `dist/`
+   - scripts: build, dev, lint, test, typecheck
+   - publishConfig.access: `public` (or `"private": true` for Pro packages)
+   - engines.node: `>=24.13.0`
+
+2. `tsconfig.json` extending `@revealui/dev/tsconfig`
+
+3. `tsup.config.ts` with entry `src/index.ts`, dts, format esm
+
+4. `src/index.ts` with a placeholder export
+
+5. `README.md` with package name and description
+
+After scaffolding, remind the user to:
+- Run `pnpm install` to link the new package
+- Add `workspace:*` references from consuming packages
+- Create a changeset with `pnpm changeset`

--- a/.revealui/content/commands/stripe-best-practices.md
+++ b/.revealui/content/commands/stripe-best-practices.md
@@ -1,0 +1,39 @@
+---
+description: "Apply when working on Stripe billing, payments, webhooks, subscriptions, or checkout flows (apps/server/src/routes/billing.ts, packages/services)."
+---
+
+Apply Stripe best practices when implementing or reviewing payment code in this project:
+
+## Webhook Handling
+- Always verify webhook signatures using `stripe.webhooks.constructEvent()` with the raw request body (never parsed JSON)
+- Use idempotency keys for all mutating API calls (charges, subscriptions, refunds)
+- Return 200 immediately after signature verification; process asynchronously if needed
+- Handle all relevant events: `checkout.session.completed`, `customer.subscription.deleted`, `customer.subscription.updated`, `invoice.payment_failed`
+
+## Subscription Management
+- Store `customer.id`, `subscription.id`, and `subscription.status` in your DB  -  not just price/product IDs
+- Use `subscription.status` to gate access: only `active` and `trialing` grant access
+- Handle `past_due` gracefully  -  show dunning UI, don't immediately revoke access
+- Use `cancel_at_period_end: true` for user-initiated cancellations (preserves access until period end)
+
+## Checkout & Billing Portal
+- Use `metadata` on checkout sessions to pass internal IDs (userId, planId) through to webhooks
+- Always set `client_reference_id` to your internal user ID
+- Use Stripe Billing Portal for plan changes and cancellations  -  don't build your own
+
+## Security
+- Never log full Stripe objects  -  they may contain PII
+- Never expose secret keys client-side; all Stripe API calls must be server-side
+- Use restricted API keys scoped to minimum permissions for each service
+- Validate that webhook events reference resources owned by your users before acting
+
+## Error Handling
+- Retry on `rate_limit_error` and network errors with exponential backoff
+- On `card_error` and `invalid_request_error`, surface Stripe's `message` to the user (it's user-safe)
+- Log `stripe_error` codes for debugging; never expose raw error objects to clients
+
+## RevealUI-Specific
+- Webhook endpoint: `apps/admin` at `/api/webhooks/stripe` (NOT the API endpoint)
+- Stripe service: `packages/services/src/stripe/`
+- Billing routes: `apps/server/src/routes/billing.ts`
+- Price IDs are managed via `pnpm stripe:seed`  -  see `scripts/setup/seed-stripe.ts`

--- a/.revealui/content/rules/adapter-only.md
+++ b/.revealui/content/rules/adapter-only.md
@@ -1,0 +1,36 @@
+# Adapter Only (no dual-home mirrors)
+
+Claude Code, Grok, Cursor, OpenCode, VS Code, and product agents are **adapters**.
+Shared policy, product tools, coordination, and day-to-day backlog live in the
+RevealUI native layer. Adapters communicate with that layer; they do not re-author
+shared hardlines.
+
+## Authority order
+
+1. **Project manager** — `./.revealui/manager.json` (+ `.revealui/content/`)
+2. **Package definitions** — `@revealui/harnesses` content definitions (this rule set)
+3. **Fleet TRACKER** — free-surface board (`docs/TRACKER.md` / private planning tree)
+4. **Adapter homes** — thin pointers, vendor tool names, TUI ops only
+
+## Rules
+
+1. **No new full hardline body** under vendor homes (`~/.claude/rules` forks of
+   shared policy, `~/.grok/rules` full copies). Pointers only for shared policy.
+2. **Equal-rank vendors.** No adapter outranks another under the manager.
+3. **Product I/O** goes through RevealUI MCP (governed user + receipts), not
+   per-harness side channels for product actions.
+4. **Session orientation** uses the shared tracker/manager check (one script),
+   not dual banners re-authored per adapter.
+5. **Quality over speed** still applies; thinning mirrors is not an excuse to
+   skip proof.
+
+## Illegal mirror (stop / thin)
+
+A vendor rule file that restates a full Plane A hardline body instead of citing
+the package definition or machine-global owner is an illegal mirror. Fix by
+thinning to a pointer, not by copying more prose.
+
+## References
+
+- ADR harness policy / runtime / launch planes
+- GAP-406, GAP-318, tracker-first, quality-over-speed

--- a/.revealui/content/rules/agent-dispatch.md
+++ b/.revealui/content/rules/agent-dispatch.md
@@ -1,0 +1,26 @@
+# Agent Profile Dispatch
+
+Profiles live in `.claude/agents/`. Spawn them via the Agent tool when a task is
+too large or specialized for the current session.
+
+## Profiles
+
+| Profile | When to spawn |
+|---------|--------------|
+| `gate-runner` | Running the full CI gate (`pnpm gate`), verifying the repo is clean before a push or release |
+| `security-reviewer` | Auditing auth flows, reviewing security-sensitive PRs, checking new API routes for vulnerabilities |
+| `builder` | Large feature implementation spanning multiple packages that would pollute the current session context |
+| `tester` | Writing test suites, achieving coverage targets, fixing batches of failing tests |
+| `docs-sync` | Updating public docs, syncing API reference, writing changelogs, keeping MASTER_PLAN in sync |
+| `linter` | Bulk lint fixes, unused declaration sweeps, `any` type removal, Biome cleanup across the monorepo |
+
+## Rules
+
+1. Don't spawn a profile for work that takes under 15 minutes in the current session.
+2. Check the workboard before spawning  -  another agent may already own that area.
+3. Always give spawned agents:
+   - Current phase from the internal planning hub's MASTER_PLAN.md
+   - Relevant workboard state
+   - The specific task and acceptance criteria
+4. Spawned agents report findings back to the parent. Only the parent updates MASTER_PLAN.md.
+5. Spawned agents must not create plan files outside MASTER_PLAN.md (see `planning.md`).

--- a/.revealui/content/rules/biome.md
+++ b/.revealui/content/rules/biome.md
@@ -1,0 +1,42 @@
+# Biome Conventions
+
+## Overview
+
+Biome 2 is the sole linter and formatter for this monorepo.
+
+## Commands
+
+- `pnpm lint`  -  check all files with Biome (`biome check .`)
+- `pnpm format`  -  format all files with Biome (`biome format --write .`)
+- `pnpm lint:fix`  -  auto-fix with Biome (`biome check --write .`)
+- `biome check .`  -  lint + format check (per-package)
+- `biome check --write .`  -  auto-fix (used by lint-staged)
+
+## Lint-Staged
+
+Pre-commit hook runs `biome check --write` on staged `*.{ts,tsx,js,jsx}` files via Husky + lint-staged.
+
+## Key Rules
+
+- No unused variables or imports (auto-removed on format)
+- No `console.*` in production code (use `@revealui/utils` logger instead)
+- No `any` types (use `unknown` + type guards)
+- Consistent import ordering (auto-sorted)
+- Single quotes for strings
+- Trailing commas
+- Semicolons always
+- 2-space indentation (tabs in Biome config, spaces in output)
+
+## Suppressing Rules
+
+- Use `// biome-ignore <rule>: <reason>` for specific lines
+- Avoid blanket suppressions  -  prefer fixing the code
+- Document why a suppression is needed in the comment
+
+## Unused Variables  -  Special Protocol
+
+**Before suppressing any unused variable or import warning, read `.claude/rules/unused-declarations.md`.**
+
+The mandatory decision tree there must be followed. Unused declarations frequently indicate incomplete implementations that need to be finished, not suppressed. Silencing the warning without completing the code creates permanent dead stubs.
+
+TL;DR: implement first, suppress only as a last resort.

--- a/.revealui/content/rules/code-analysis-policy.md
+++ b/.revealui/content/rules/code-analysis-policy.md
@@ -1,0 +1,35 @@
+# Code Analysis Policy
+
+Use AST-based or structural analysis for code-policy and security checks whenever the rule depends on syntax, identifiers, or code shape.
+
+## Prefer AST-Based Analysis For
+
+- security gate checks over application code
+- architecture and boundary rules
+- auth/password handling checks
+- response/body serialization checks
+- import-policy enforcement beyond simple path inventory
+
+## Regex Is Acceptable Only For
+
+- broad inventory scans over raw text
+- committed secret patterns
+- literal token/URL/key detection
+- quick warning-level heuristics that are explicitly marked approximate
+
+## Do Not Use Regex As Source Of Truth For
+
+- whether a value is stored in plaintext
+- whether a secret is hardcoded in executable code
+- whether a boundary rule is violated by code structure
+- whether a security-sensitive value reaches a sink
+
+## Working Rule
+
+If a check can be expressed against the TypeScript/JavaScript AST with reasonable effort, use AST analysis first.
+
+If regex is still used:
+
+- document it as heuristic-only
+- keep it warning-level unless independently verified
+- add a follow-up to migrate it to AST/structural analysis

--- a/.revealui/content/rules/code-over-docs.md
+++ b/.revealui/content/rules/code-over-docs.md
@@ -1,0 +1,33 @@
+# Code Over Docs
+
+The source code is the single source of truth. Documentation (READMEs, specs,
+plans, handoffs, ADRs, comments, gap files, memory) *describes* the system; the
+code *defines* it. When any doc and the code disagree, the code is correct and
+the doc is stale.
+
+## Apply every session
+
+1. **Verify against code before acting.** Never implement, review, plan, or
+   report from a doc claim alone. Load-bearing claims need `file:line` in
+   actual source (or a test that exercises the path).
+2. **On disagreement: trust code, then fix the doc.** A doc↔code conflict is a
+   doc bug. Do not "fix" working code to match stale prose without an explicit
+   decision that the doc's behavior is the intended one.
+3. **Doc-tier authority is subordinate.** Handoff / plan tiers resolve
+   doc-vs-doc conflicts only. Code outranks all tiers on factual system
+   behavior.
+4. **Prioritize code work over doc work.** Correct code outranks nicer prose
+   about code. Doc sweeps ride behind the code fixes they describe.
+5. **Comments are docs too.** Stale headers or comments are drift; the code
+   path below them is what you trust.
+
+## Explicitly rejected
+
+- Treating gap files, handoffs, or ADRs as proof of runtime behavior
+- Marking exhaustive / md-truth claims verified without reading the file body
+- Shipping doc-only "fixes" that leave wrong code unchanged
+
+## References
+
+- Sibling: quality-over-speed, durable-solutions, tracker-first
+- Exhaustive / md-truth programs prove claims against code, not against docs

--- a/.revealui/content/rules/database.md
+++ b/.revealui/content/rules/database.md
@@ -1,0 +1,35 @@
+# Database Conventions
+
+## Primary Store: NeonDB (PostgreSQL)
+
+RevealUI uses **NeonDB as the primary store** via Drizzle ORM. The schema lives in `packages/db/src/schema/` (86 tables) and migrates via standard `drizzle-kit migrate`.
+
+Legacy `@supabase/supabase-js` code has been phased out from runtime — there are zero `from '@supabase/supabase-js'` imports left in `packages/` or `apps/`. **New features must not introduce a Supabase dependency.**
+
+## Schema Organization
+
+Schemas live under `packages/db/src/schema/` — one file per logical domain (accounts, users, sites, posts, agents, RAG, billing, etc.). Use Drizzle ORM for all queries.
+
+```ts
+import { db } from '@revealui/db'
+import { posts } from '@revealui/db/schema'
+
+const results = await db.select().from(posts).where(eq(posts.status, 'published'))
+```
+
+## Vector / Embedding Storage
+
+Vector embeddings (RAG, AI memory) live in NeonDB on the `pgvector` extension. HNSW indexes are created in `0002_triggers_search_vectors.sql`. Tables: `rag_documents`, `rag_chunks`, `agent_memories.embedding`.
+
+## Database MCP
+
+Agent database tooling uses Neon MCP. The legacy customer Supabase MCP adapter was removed; do not reintroduce `supabase-mcp` or `@supabase/supabase-js` into the app code.
+
+## Migration Discipline
+
+See `packages/db/docs/migrations-discipline.md`. The `pnpm validate:migrations` static check enforces:
+- Every `.sql` file has a journal entry, and vice versa
+- Journal `when` values are strictly increasing
+- Every journal entry has a `meta/<NNNN>_snapshot.json` (or an explicit allowlist entry in `meta/_custom.json`)
+- `ALTER TABLE ... ADD CONSTRAINT` is wrapped in `DO $$ BEGIN ... EXCEPTION ... END $$` blocks for idempotency
+- `DROP CONSTRAINT` uses `IF EXISTS`

--- a/.revealui/content/rules/disposition-actions.md
+++ b/.revealui/content/rules/disposition-actions.md
@@ -1,0 +1,42 @@
+# Disposition Actions — Propose, Don't Dispose
+
+Agent work is **proposal-shaped by default**. A proposal produces an artifact
+someone else can act on; a disposition consummates an outcome. Proposals never
+need special authorization; dispositions always do.
+
+## Always safe (proposal-shaped)
+
+- Reading, grepping, auditing; empirical tests in session scratch
+- Posting review or verdict comments on PRs
+- Creating worktrees, committing to fresh branches, pushing feature branches
+- Opening PRs, filing gaps, authoring specs and lane docs
+
+## Disposition-shaped (requires named in-session owner authorization)
+
+- Merging any PR the agent authored this session
+- Merging any PR whose subject matter is security (design docs included)
+- Applying gate-clearing labels (`sec-review:approved` and siblings)
+- Deleting remote branches
+- Mutating repo settings, rulesets, required checks, Actions secrets, webhooks
+- Force pushes, history rewrites, removing another session's worktree
+
+A blanket preference in memory ("merge green PRs") does **not** cover
+security-classed items. Only named in-session words or a standing settings
+allow rule do.
+
+## Never bundle a disposition with anything else
+
+One disposition action per shell command, alone. Mid-bundle blocks leave half-
+executed state.
+
+## When a PR is ready and no authorization exists
+
+Stop at the open PR. List the exact one-line owner command under owner actions.
+Do not re-send a blocked command or accomplish the disposition through another
+tool.
+
+## References
+
+- Sibling: tracker-first, quality-over-speed, durable-solutions
+- Adapter glue may deny merge/force at the permission layer; this rule is the
+  policy body adapters must not re-author in full.

--- a/.revealui/content/rules/durable-solutions.md
+++ b/.revealui/content/rules/durable-solutions.md
@@ -1,0 +1,52 @@
+# Durable Solutions
+
+Prefer long-term durable solutions. Fix root causes in the owning layer (shared
+lib, env bootstrap, policy, product primitive) so the failure class cannot
+recur. Session-local patches, one-off shell recipes, and "works on my machine"
+overrides are not done unless the owner accepts a **registered hotfix**.
+
+## Rules
+
+1. **Durable first.** Extend the real primitive; do not invent a parallel path.
+2. **Hotfixes are debt.** Allowed only when production or a peer must be
+   unblocked *now*. Register the same turn with symptom, temporary shape,
+   durable target, paths, and optional gap id.
+3. **Every hotfix has a destination.** Pending entries surface at session
+   boundaries until converted.
+4. **Unregistered hotfixes are policy violations** (same class as orphan temp
+   scripts).
+
+## Non-durable shapes (register or refuse)
+
+| Shape | Examples |
+|-------|----------|
+| Env / machine only | Editing gitignored `.env.local` without fixing loaders |
+| Session-only | Scratch scripts left for the owner; undocumented escapes |
+| Symptom patch | Catch-and-ignore without root fix |
+| Parallel path | Second seed script or resolver "just for X" |
+| Silent demotion | "We'll harden later" with no registry entry |
+
+## Durable shapes
+
+- Shared module / rule / hook / CI gate that fails closed for the class
+- Documented escape hatches with explicit env flags
+- Gaps/ADRs when the durable fix needs multi-session design
+- Tests that lock the durable behavior (prove red, then green)
+
+## CLI (control layer)
+
+```bash
+revealui-harnesses hotfix check
+revealui-harnesses hotfix list
+revealui-harnesses hotfix audit [path]
+# Only if a temporary patch is unavoidable (admits debt):
+revealui-harnesses hotfix register --title … --symptom … --temporary … --durable …
+revealui-harnesses hotfix resolve <id> --pr <url>
+```
+
+Store: `~/.local/share/revealui/hotfixes/manifest.json` (not vendor homes).
+
+## References
+
+- Sibling: extend-before-create, quality-over-speed, code-over-docs, adapter-only
+- GAP-405 — registry + adapter cutover; no dual Claude/Grok mirrors

--- a/.revealui/content/rules/monorepo.md
+++ b/.revealui/content/rules/monorepo.md
@@ -1,0 +1,54 @@
+# Monorepo Conventions
+
+## Structure
+- Apps live in `apps/`  -  deployable services (Next.js, Hono, Vite)
+- Packages live in `packages/`  -  shared libraries consumed by apps
+- Scripts live in `scripts/`  -  CLI tools, automation, CI gates
+
+## Package Manager
+- pnpm 10 with workspace protocol
+- Internal deps use `workspace:*` (never hardcoded versions)
+- Run `pnpm install:clean` (suppresses Node deprecation warnings)
+- `preinstall` script enforces pnpm-only (`npx only-allow pnpm`)
+
+## Turborepo
+- `turbo run build --parallel` for parallel builds
+- `turbo run test --concurrency=15` for parallel tests
+- Package-level `turbo.json` for task overrides (rare)
+- Cache stored in `.turbo/` (gitignored)
+
+## Package Conventions
+- Every package has: `build`, `dev`, `lint`, `test`, `typecheck` scripts
+- Build output goes to `dist/` via tsup
+- Source in `src/`, tests in `src/__tests__/` or `__tests__/`
+- Entry point: `src/index.ts` → `dist/index.js`
+- Use `exports` field in package.json for subpath exports
+- Include `files: ["dist", "README.md"]` for publishing
+
+## Dependency Rules
+- Use `syncpack` for version alignment (`pnpm deps:check`, `pnpm deps:fix`)
+- Use `catalog:` for shared devDependencies (e.g., `"zod": "catalog:"`)
+- pnpm overrides in root package.json for security patches
+- `onlyBuiltDependencies` whitelist for native modules
+
+## CI Gate
+- `pnpm gate` runs the full CI pipeline locally: lint → typecheck → test → build
+- `pnpm gate:quick` runs phase 1 only (fast feedback)
+- Must pass before pushing (enforced by Husky pre-push hook)
+
+## Adding a New Package
+1. Create `packages/<name>/` with package.json, tsconfig.json, tsup.config.ts
+2. Name: `@revealui/<name>`
+3. Add `workspace:*` references from consuming packages
+4. Register in turbo pipeline (automatic via conventions)
+5. Add to CI if needed
+
+## Publishing
+- OSS packages: `publishConfig.access: "public"`, MIT license
+- Pro packages: `publishConfig.access: "public"`, commercial license (source-available on npm)
+- Use changesets for versioning: `pnpm changeset` → `pnpm changeset:version` → `pnpm changeset:publish`
+
+## Import Conventions
+- Use package names (`@revealui/core`) not relative paths between packages
+- Use `~/` alias within apps (maps to `src/*`)
+- Use ES Modules (`import`/`export`) everywhere

--- a/.revealui/content/rules/parameterization.md
+++ b/.revealui/content/rules/parameterization.md
@@ -1,0 +1,52 @@
+# Parameterization Conventions
+
+## Core Rule
+
+**Never hardcode configuration values inline.** All tunable constants (TTLs, limits, lengths, thresholds, intervals) must be:
+
+1. **Extracted** into a named config object or constant at module scope
+2. **Typed** with an explicit interface
+3. **Defaulted** with sensible production values
+4. **Overridable** via an exported `configure*()` function or constructor parameter
+
+## Pattern
+
+```ts
+export interface ModuleConfig {
+  /** TTL in milliseconds (default: 5 minutes) */
+  ttlMs: number
+  /** Max entries before forced cleanup (default: 10_000) */
+  maxEntries: number
+}
+
+const DEFAULT_CONFIG: ModuleConfig = {
+  ttlMs: 5 * 60 * 1000,
+  maxEntries: 10_000,
+}
+
+let config: ModuleConfig = { ...DEFAULT_CONFIG }
+
+export function configureModule(overrides: Partial<ModuleConfig>): void {
+  config = { ...DEFAULT_CONFIG, ...overrides }
+}
+```
+
+## Why
+
+- Tests need fast TTLs and small limits
+- Deployments may need different thresholds than development
+- `Math.random()` is not cryptographically secure  -  use `crypto.randomInt()` for security-sensitive values (OTPs, tokens, nonces)
+
+## Applies To
+
+- Rate limit windows and thresholds
+- Cache TTLs and max sizes
+- OTP/token lengths and expiry times
+- Retry counts and backoff intervals
+- Batch sizes and concurrency limits
+
+## Does NOT Apply To
+
+- Structural constants (HTTP status codes, header names, URL paths)
+- Type discriminants and enum values
+- Schema definitions (use contracts)

--- a/.revealui/content/rules/quality-over-speed.md
+++ b/.revealui/content/rules/quality-over-speed.md
@@ -1,0 +1,32 @@
+# Quality Over Speed (standing order)
+
+**Quality is always the primary metric** for code, config, and documentation.
+Speed is a lagging benefit of good systems and better hardware/pricing — not a
+reason to ship weak work, thin proofs, or dual-home shortcuts.
+
+## Apply every session (including concurrent multi-agent work)
+
+1. **Correctness first.** Prove red→green where tests apply. Prefer root-cause
+   durable fixes over hotfixes (register any unavoidable hotfix the same turn).
+2. **Proof over pace.** Claims about system behavior need `code:line` or test
+   evidence (code-over-docs). Doc edits without proof are incomplete.
+3. **One solid change beats three rushed ones.** Do not expand scope to "finish
+   the wave" if quality drops. Stop at a clean PR boundary.
+4. **Concurrency does not lower the bar.** Parallel sessions still use exclusive
+   shards/worktrees, full gates for risk level, and no self-merge of security or
+   unreviewed work. Faster calendar time is worthless if two agents thrash the
+   same surface or invent parallel queues.
+5. **Manager + adapters.** Shared policy lives under `.revealui` / package
+   definitions. Do not mirror hardlines into vendor homes "to go faster."
+
+## Explicitly rejected
+
+- Skipping tests, audits, or claim proof to close a session sooner
+- Partial file reads marked verified in exhaustive / md-truth ledgers
+- Dual-writing the same rule into Claude and Grok homes
+- Merging or force-pushing to "unblock" without owner disposition when required
+
+## When pressed for speed
+
+Reduce **scope**, not **quality**. Ship a smaller correct slice; leave the rest
+as TRACKER gaps/lanes with acceptance criteria intact.

--- a/.revealui/content/rules/skills-usage.md
+++ b/.revealui/content/rules/skills-usage.md
@@ -1,0 +1,32 @@
+# Skill Auto-Use Guidelines
+
+When the Skill tool is available, proactively invoke the following skills in these situations:
+
+## Always invoke automatically (no user prompt needed)
+
+- `/vercel-react-best-practices`  -  before completing any PR that touches React components or hooks
+- `/stripe-best-practices`  -  any time you write or modify billing, payment, webhook, or Stripe code
+- `/next-best-practices`  -  when implementing features in apps/admin or apps/marketing
+- `/next-cache-components`  -  when adding 'use cache', cache profiles, or PPR to a Next.js route
+- `/vercel-composition-patterns`  -  when adding new components to @revealui/presentation
+- `/web-design-guidelines`  -  when asked to review a UI, page, or component for quality
+- `/review`  -  when the user asks for a code review, asks to "check" or "look at" code
+- `/add-tests`  -  when the user asks to write tests or add coverage for a specific file
+- `/audit`  -  before any release or after a large refactor touching multiple packages
+- `/turborepo`  -  when modifying turbo.json, pipeline configuration, or monorepo task dependencies
+
+## Only invoke on explicit user request (disable-model-invocation: true)
+
+- `/gate`  -  user must explicitly ask to run the gate
+- `/sync-lts`  -  user must explicitly ask to sync or backup
+- `/new-package`  -  user must explicitly ask to scaffold a package
+- `/new-professional-project`  -  user must explicitly ask to create a project
+- `/vercel-deploy`  -  user must explicitly ask to deploy
+- `/deploy-check`  -  user must explicitly ask for pre-deploy check
+- `/db-migrate`  -  user must explicitly ask to create or apply database migrations
+- `/preflight`  -  user must explicitly ask to run the preflight checklist
+
+## When in doubt
+
+If a skill's description matches the current task, prefer invoking it over not invoking it.
+The overhead of loading a skill is low; missing relevant guidance has higher cost.

--- a/.revealui/content/rules/tailwind.md
+++ b/.revealui/content/rules/tailwind.md
@@ -1,0 +1,142 @@
+# Tailwind CSS v4 Conventions
+
+## Version
+
+RevealUI uses **Tailwind CSS v4** (`^4.1.18`). All new code must use v4 patterns.
+
+## Current State
+
+The shared config in `packages/dev/src/tailwind/` uses a **v3 compatibility pattern** (JS config file + JS plugins). This works because Tailwind v4 auto-detects `tailwind.config.ts` and falls back to v3 behavior. Migration to native v4 CSS config is deferred to Phase 2.
+
+## v4 Gotchas (Must Know)
+
+### Import Syntax
+```css
+/* CORRECT (v4) */
+@import "tailwindcss";
+
+/* WRONG (v3  -  deprecated) */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+### Custom Utilities
+```css
+/* CORRECT (v4) */
+@utility my-util {
+  /* styles */
+}
+
+/* WRONG (v3) */
+@layer utilities {
+  .my-util { /* styles */ }
+}
+@layer components {
+  .my-component { /* styles */ }
+}
+```
+
+### CSS Variable Syntax
+```html
+<!-- CORRECT (v4)  -  parentheses -->
+<div class="bg-(--brand-color)">
+
+<!-- WRONG (v3)  -  square brackets -->
+<div class="bg-[--brand-color]">
+```
+
+### Important Modifier
+```html
+<!-- CORRECT (v4)  -  at the end -->
+<div class="bg-red-500!">
+
+<!-- WRONG (v3)  -  at the start -->
+<div class="bg-!red-500">
+```
+
+### Default Behavior Changes
+- **Border/ring color**: now `currentColor` (was `gray-200` in v3)
+- **Ring width**: default is `1px` (was `3px` in v3)
+- **`hover:`**: only applies on devices that support hover (no-touch)
+- **Stacked variants**: apply left-to-right (reversed from v3)
+- **`space-*` / `divide-*`**: selectors changed  -  prefer `gap` with flex/grid
+
+### Transform Utilities
+```html
+<!-- CORRECT (v4) -->
+<div class="scale-none rotate-none translate-none">
+
+<!-- WRONG (v3) -->
+<div class="transform-none">
+```
+
+### Prefix Syntax
+```css
+/* v4 prefix */
+@import "tailwindcss" prefix(tw);
+/* Classes use tw:bg-red-500 */
+```
+
+### CSS Modules / Component Styles
+Use `@reference` to access theme variables in CSS modules or component `<style>` blocks.
+
+### PostCSS Plugin
+```js
+// v4  -  new package name
+{ plugins: { '@tailwindcss/postcss': {} } }
+
+// v3  -  old (still works but deprecated)
+{ plugins: { tailwindcss: {} } }
+```
+
+### Vite Plugin (preferred over PostCSS for Vite apps)
+```js
+import tailwindcss from '@tailwindcss/vite'
+export default { plugins: [tailwindcss()] }
+```
+
+## Theme Configuration (v4 native)
+
+In v4, theme tokens go in CSS, not JS:
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-brand: #ea580c;
+  --font-sans: "Inter", sans-serif;
+  --breakpoint-xs: 475px;
+  --breakpoint-3xl: 1920px;
+}
+```
+
+## RevealUI Shared Config
+
+| File | Purpose |
+|------|---------|
+| `packages/dev/src/tailwind/tailwind.config.ts` | Shared v3-compat config (fonts, plugins, screens) |
+| `packages/dev/src/tailwind/create-config.ts` | Helper to merge shared + app configs |
+| `packages/dev/src/tailwind/postcss.config.ts` | PostCSS config with `@tailwindcss/postcss` |
+| `packages/dev/src/tailwind/styles.css` | Base CSS (`@import "tailwindcss"`) |
+
+### Consumer Pattern (current  -  v3 compat)
+```ts
+// apps/admin/tailwind.config.ts
+import { createTailwindConfig } from '@revealui/dev/tailwind/create-config'
+export default createTailwindConfig({
+  content: ['./src/**/*.{ts,tsx}'],
+  // app-specific overrides
+})
+```
+
+## Rules for New Code
+
+1. **Never use `@tailwind` directives**  -  use `@import "tailwindcss"` instead
+2. **Never use `@layer utilities` or `@layer components`** for custom utilities  -  use `@utility`
+3. **Use `bg-(--var)` syntax** for CSS variables, not `bg-[--var]`
+4. **Important goes at the end**: `bg-red-500!` not `!bg-red-500`
+5. **Prefer `gap`** over `space-*` / `divide-*` for spacing in flex/grid
+6. **No `transform-none`**  -  use `scale-none`, `rotate-none`, `translate-none`
+7. **Don't add new v3 JS plugins**  -  if a v4 CSS equivalent exists, use that
+8. **Content paths are auto-detected** in v4  -  only add manual paths for edge cases

--- a/.revealui/content/rules/tracker-first.md
+++ b/.revealui/content/rules/tracker-first.md
@@ -1,0 +1,23 @@
+# Tracker First (all models / providers)
+
+Open the fleet **TRACKER** before inventing work:
+
+`docs/TRACKER.md` (generated from `docs/initiatives/*.yml` via `node scripts/initiatives-render.js`)
+
+## Rules
+
+1. **Day-to-day free surfaces live only on TRACKER.** Gaps and lanes are the execution units; initiatives group them.
+2. **Do not invent parallel queues** in harness homes (`~/.claude`, `~/.grok`), root `TODO.md`, or chat-only lists.
+3. **CURRENT-HANDOFF** is session deltas only. **MASTER_PLAN** is strategy only.
+4. **Product I/O** goes through RevealUI MCP (governed user + receipts), not per-harness side channels.
+5. Shared policy is authored once (Plane A / `@revealui/harnesses` content definitions). Adapters **consume**; they do not full-copy hardlines.
+
+## Claim work
+
+Register a workboard note for an existing gap or lane id from TRACKER. Status lives on the gap YAML or lane plan — never hand-copied into TRACKER tables.
+
+## References
+
+- ADR `2026-07-22-single-fleet-tracker`
+- ADR `2026-07-21-harness-policy-runtime-launch-planes`
+- GAP-318, GAP-406

--- a/.revealui/content/rules/unused-declarations.md
+++ b/.revealui/content/rules/unused-declarations.md
@@ -1,0 +1,130 @@
+# Unused Declarations Policy
+
+## Core Rule
+
+**NEVER suppress an unused variable/import warning without first determining if the code is incomplete.**
+
+Unused declarations in this codebase frequently signal incomplete implementations  -  stubs, scaffolded functions, planned integrations  -  not dead code. Suppressing the warning without completing the code leads to permanent placeholders that silently rot.
+
+---
+
+## Mandatory Decision Tree
+
+When you encounter an `no-unused-vars`, `noUnusedVariables`, or `noUnusedFunctionParameters` warning, you MUST follow this decision tree **before taking any action**:
+
+```
+1. Is the declaration a stub or placeholder?
+   └─ Signs: empty function body, `// TODO`, `throw new Error('not implemented')`,
+             adjacent commented-out code, file has <10 lines of real logic,
+             variable name matches a feature that exists elsewhere in the codebase
+   └─ Action: IMPLEMENT the missing functionality. Do not suppress.
+
+2. Is the declaration an intentionally-created side-effect resource?
+   └─ Signs: infrastructure-as-code (Pulumi/CDK), event listener registration,
+             DB migration runner, resource that must exist but isn't referenced
+   └─ Action: Rename with `_` prefix to signal intentional non-use.
+              Add a comment explaining WHY it exists.
+
+3. Is the import used only as a type (TypeScript)?
+   └─ Signs: import is from a types package, used only in `type X = ...` expressions
+   └─ Action: Change to `import type { ... }`  -  Biome will no longer flag it.
+
+4. Is the parameter required by a callback signature you don't control?
+   └─ Signs: Express/Hono middleware `(req, res, next)`, event handler `(event, context)`,
+             interface implementation where all params are mandated
+   └─ Action: Prefix with `_` (e.g. `_req`, `_event`). Add a comment if non-obvious.
+
+5. Is it genuinely dead code with no planned use?
+   └─ Signs: feature was removed, import was replaced, duplicate of another symbol
+   └─ Action: DELETE the declaration entirely. Per the Legacy Code Removal Policy,
+              no grace periods  -  remove it and all call sites in the same change.
+```
+
+---
+
+## What "Implement" Means
+
+When you determine a declaration is incomplete (case 1), the required steps are:
+
+1. **Search the codebase** for related implementations, types, interfaces, and tests that reveal intent.
+2. **Check the plan file** at `~/.claude/plans/` for any documented phase covering this feature.
+3. **Check for contracts** in `packages/contracts/src/`  -  the schema often describes the expected behavior.
+4. **Implement the function/class/module** based on what the surrounding code expects.
+5. **Run `pnpm gate:quick`** after implementing to verify no new errors were introduced.
+
+Do NOT:
+- Add `// biome-ignore lint/correctness/noUnusedVariables: TODO implement`
+- Rename to `_variable` just to silence the warning when the variable should be used
+- Delete a stub that represents planned functionality without implementing it first
+
+---
+
+## Examples
+
+### Wrong  -  suppressing an incomplete stub
+```ts
+// biome-ignore lint/correctness/noUnusedVariables: TODO
+const semanticMemory = new SemanticMemory()
+```
+
+### Right  -  implement it
+```ts
+const semanticMemory = new SemanticMemory()
+await semanticMemory.store('key', content, embedding)
+```
+
+---
+
+### Wrong  -  deleting a planned integration
+```ts
+// Was: import { ProceduralMemory } from './procedural-memory.js'
+// Deleted because "unused"
+```
+
+### Right  -  implement the module it was waiting for
+```ts
+// packages/ai/src/memory/memory/procedural-memory.ts
+export class ProceduralMemory { ... }
+// Then use it where the original import was
+```
+
+---
+
+### Wrong  -  renaming away the signal
+```ts
+// Original: const routeTableAssoc = new aws.ec2.RouteTableAssociation(...)
+// "Fixed": const _routeTableAssoc = new aws.ec2.RouteTableAssociation(...)
+// No comment explaining why
+```
+
+### Right  -  rename AND document
+```ts
+// Route table association must exist for subnet routing to function.
+// The variable is not referenced after creation; AWS manages the association.
+const _routeTableAssoc = new aws.ec2.RouteTableAssociation(...)
+```
+
+---
+
+## Verification Step After Any Lint Fix
+
+After resolving any unused declaration warning, run:
+
+```bash
+# Confirm the fix compiles
+pnpm --filter <package> typecheck
+
+# Confirm Biome is clean on the changed file
+node_modules/.bin/biome check <file>
+
+# If the declaration was a stub that you implemented, run the tests
+pnpm --filter <package> test
+```
+
+Never move to the next task without completing this verification.
+
+---
+
+## Relationship to Gate Verification Rule
+
+This policy works in conjunction with the gate verification rule: complete the implementation → verify with lint/type/test → then move on. The gate catches regressions; this policy prevents incomplete code from silently accumulating.

--- a/.revealui/content/skills/db-migrate/SKILL.md
+++ b/.revealui/content/skills/db-migrate/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: Database Migration
+description: Create and apply Drizzle ORM migrations with dual-DB boundary checks (NeonDB vs Supabase)
+disable-model-invocation: true
+---
+
+# Database Migration Workflow
+
+Guide for creating and applying Drizzle ORM migrations in the RevealUI dual-database architecture.
+
+## Pre-Flight Checks
+
+Before creating a migration:
+
+1. **Identify the target database**:
+   - **NeonDB** (REST content): users, sessions, collections, products, orders, licenses, pages, sites, tickets, agents, api-keys, GDPR
+   - **Supabase** (vectors/auth): embeddings, AI memory storage, real-time auth
+   - If unsure, check `packages/db/src/schema/rest.ts` (NeonDB) vs `packages/db/src/schema/vector.ts` (Supabase)
+
+2. **Check existing schema** for conflicts:
+   ```bash
+   # View current schema files
+   ls packages/db/src/schema/
+
+   # Check for table name conflicts
+   grep -r "export const.*pgTable" packages/db/src/schema/
+   ```
+
+3. **Verify contracts alignment**  -  new tables/columns should have corresponding Zod schemas:
+   ```bash
+   ls packages/contracts/src/
+   ```
+
+## Migration Steps
+
+### Step 1: Modify Schema
+
+Edit the appropriate schema file in `packages/db/src/schema/`:
+
+- Follow existing patterns (see adjacent schema files)
+- Use Drizzle's `pgTable`, column types, and relations
+- Add indexes for frequently queried columns
+- Add `createdAt`/`updatedAt` timestamps with defaults
+
+### Step 2: Generate Migration
+
+```bash
+cd packages/db
+pnpm drizzle-kit generate
+```
+
+Review the generated SQL in `packages/db/drizzle/`  -  check for:
+- Destructive changes (DROP TABLE, DROP COLUMN)
+- Data loss risks (column type changes without USING clause)
+- Missing indexes on foreign keys
+
+### Step 3: Apply Migration (Development Only)
+
+```bash
+# Development database ONLY  -  never production
+pnpm db:migrate
+```
+
+**NEVER run `drizzle-kit push`**  -  always use `drizzle-kit migrate` (the PreToolUse hook blocks `push`).
+
+### Step 4: Verify
+
+```bash
+# Typecheck the db package
+pnpm --filter @revealui/db typecheck
+
+# Run db tests
+pnpm --filter @revealui/db test
+
+# If schema changes affect contracts, update and test those too
+pnpm --filter @revealui/contracts typecheck
+pnpm --filter @revealui/contracts test
+```
+
+### Step 5: Update Contracts (if needed)
+
+If you added new tables or columns that are exposed via the API:
+
+1. Add/update Zod schema in `packages/contracts/src/`
+2. Export from `packages/contracts/src/index.ts`
+3. Update any API routes that use the new schema
+
+## Dual-DB Boundary Rules
+
+| If your change touches... | Put it in... | Client |
+|---------------------------|-------------|--------|
+| Content, users, sessions, products, orders | `packages/db/src/schema/` (NeonDB barrel) | Drizzle ORM |
+| Vector embeddings, AI memory | `packages/db/src/schema/vector.ts` | Supabase client |
+| Real-time auth helpers | `packages/db/src/auth/` | Supabase client |
+
+**Never mix** NeonDB and Supabase operations in the same module.
+
+## Rollback
+
+If a migration needs to be reverted:
+
+1. Create a new migration that undoes the changes (Drizzle doesn't have built-in rollback)
+2. Never manually edit the migration journal (`_journal.json`)
+3. Document the rollback reason in the migration file comment

--- a/.revealui/content/skills/preflight/SKILL.md
+++ b/.revealui/content/skills/preflight/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: Preflight Check
+description: Run the 15-check pre-launch preflight and interpret results with context-aware fix suggestions
+disable-model-invocation: true
+---
+
+# Preflight Check
+
+Run the full pre-launch preflight checklist and interpret results.
+
+## Run
+
+```bash
+pnpm preflight
+```
+
+This runs 15 checks covering lint, types, tests, build, security, and structure.
+
+## Interpreting Results
+
+### Hard Failures (must fix before launch)
+
+| Check | What It Means | Common Fix |
+|-------|--------------|------------|
+| **Biome lint** | Code style or correctness violation | `pnpm lint:fix` then review remaining |
+| **TypeScript** | Type errors across workspaces | `pnpm typecheck:all` to see full list |
+| **Build** | Compilation failure in one or more packages | Check `dist/` output, tsup config |
+| **Tests** | Unit/integration test failures | `pnpm test` to see which tests fail |
+
+### Warn-Only (should fix, won't block)
+
+| Check | What It Means | Common Fix |
+|-------|--------------|------------|
+| **`any` audit** | Avoidable `any` types found | `pnpm audit:any`  -  use `unknown` + type guards |
+| **Console audit** | `console.*` in production code | `pnpm audit:console`  -  use `@revealui/utils` logger |
+| **Structure** | Supabase boundary violations or package issues | `pnpm validate:structure` |
+| **Security** | CSP, CORS, or header issues | Check `packages/security/` |
+| **Dependencies** | Version mismatches across workspaces | `pnpm deps:check` then `pnpm deps:fix` |
+
+## After Preflight
+
+If all hard checks pass:
+
+1. Run `pnpm gate` for the full CI gate (superset of preflight)
+2. Check for uncommitted changes: `git status`
+3. Review the deployment checklist: `/deploy-check`
+
+If checks fail, fix in priority order:
+1. Build failures (blocks everything)
+2. Type errors (blocks CI)
+3. Test failures (blocks confidence)
+4. Lint issues (blocks merge)
+5. Warn-only items (fix before release)

--- a/.revealui/content/skills/revealui-conventions/SKILL.md
+++ b/.revealui/content/skills/revealui-conventions/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: RevealUI Conventions
+description: "RevealUI coding conventions for any code task  -  writing, editing, reviewing, creating,\nfixing, refactoring, changing, adding, or updating TypeScript, React, CSS, or config files.\nCovers TypeScript strict mode, ES Modules, Biome formatting, Tailwind v4 syntax,\nconventional commits, monorepo workspace protocol, feature gating, parameterization,\nand unused declaration policy."
+---
+
+# RevealUI Conventions
+
+Follow these conventions for ALL code in the RevealUI monorepo.
+
+## TypeScript
+
+- Always use strict mode (`strict: true` in tsconfig)
+- Use ES Modules (`import`/`export`), never CommonJS (`require`)
+- Prefer `interface` over `type` for object shapes (unless union/intersection needed)
+- Use explicit return types on exported functions
+- Avoid `any`  -  use `unknown` and narrow with type guards
+- Use `as const` for literal objects and arrays when appropriate
+- Prefer `satisfies` over `as` for type assertions when possible
+- Use optional chaining (`?.`) and nullish coalescing (`??`) over manual checks
+- Async/await over `.then()` chains
+
+## Git
+
+### Commit Messages
+- Use conventional commits: `type(scope): description`
+- Types: feat, fix, refactor, docs, test, chore, ci, perf
+- Scope is optional, use package name for monorepos (e.g., `feat(core): add parser`)
+- Description in imperative mood, lowercase, no period
+- Keep subject line under 72 characters
+
+### Branch Naming
+- Feature: `feat/<short-description>`
+- Bugfix: `fix/<short-description>`
+- Chore: `chore/<short-description>`
+
+### Identity
+- RevealUI Studio <founder@revealui.com>
+
+## Monorepo
+
+### Structure
+- Apps live in `apps/`  -  deployable services (Next.js, Hono, Vite)
+- Packages live in `packages/`  -  shared libraries consumed by apps
+- Scripts live in `scripts/`  -  CLI tools, automation, CI gates
+
+### Package Manager
+- pnpm 10 with workspace protocol
+- Internal deps use `workspace:*` (never hardcoded versions)
+- Run `pnpm install:clean` (suppresses Node deprecation warnings)
+- `preinstall` script enforces pnpm-only (`npx only-allow pnpm`)
+
+### Turborepo
+- `turbo run build --parallel` for parallel builds
+- `turbo run test --concurrency=15` for parallel tests
+- Package-level `turbo.json` for task overrides (rare)
+- Cache stored in `.turbo/` (gitignored)
+
+### Package Conventions
+- Every package has: `build`, `dev`, `lint`, `test`, `typecheck` scripts
+- Build output goes to `dist/` via tsup
+- Source in `src/`, tests in `src/__tests__/` or `__tests__/`
+- Entry point: `src/index.ts` → `dist/index.js`
+- Use `exports` field in package.json for subpath exports
+- Include `files: ["dist", "README.md"]` for publishing
+
+### Dependency Rules
+- Use `syncpack` for version alignment (`pnpm deps:check`, `pnpm deps:fix`)
+- Use `catalog:` for shared devDependencies (e.g., `"zod": "catalog:"`)
+- pnpm overrides in root package.json for security patches
+
+### CI Gate
+- `pnpm gate` runs the full CI pipeline locally: lint → typecheck → test → build
+- `pnpm gate:quick` runs phase 1 only (fast feedback)
+- Must pass before pushing (enforced by Husky pre-push hook)
+
+### Adding a New Package
+1. Create `packages/<name>/` with package.json, tsconfig.json, tsup.config.ts
+2. Name: `@revealui/<name>`
+3. Add `workspace:*` references from consuming packages
+4. Register in turbo pipeline (automatic via conventions)
+
+### Publishing
+- OSS packages: `publishConfig.access: "public"`, MIT license
+- Pro packages: `"private": true` (not published to npm)
+- Use changesets for versioning: `pnpm changeset` → `pnpm changeset:version` → `pnpm changeset:publish`
+
+### Import Conventions
+- Use package names (`@revealui/core`) not relative paths between packages
+- Use `~/` alias within apps (maps to `src/*`)
+- Use ES Modules (`import`/`export`) everywhere
+
+## Biome
+
+Biome 2 is the sole linter and formatter for this monorepo.
+
+### Commands
+- `pnpm lint`  -  check all files (`biome check .`)
+- `pnpm format`  -  format all files (`biome format --write .`)
+- `pnpm lint:fix`  -  auto-fix (`biome check --write .`)
+
+### Key Rules
+- No unused variables or imports (auto-removed on format)
+- No `console.*` in production code (use `@revealui/utils` logger)
+- No `any` types (use `unknown` + type guards)
+- Consistent import ordering (auto-sorted)
+- Single quotes for strings
+- Trailing commas
+- Semicolons always
+- 2-space indentation
+
+### Suppressing Rules
+- Use `// biome-ignore <rule>: <reason>` for specific lines
+- Avoid blanket suppressions  -  prefer fixing the code
+- Document why a suppression is needed
+
+## Tailwind v4
+
+RevealUI uses **Tailwind CSS v4** (`^4.1.18`). Key syntax changes from v3:
+
+### Must-Know Gotchas
+
+```css
+/* CORRECT (v4) */
+@import "tailwindcss";
+
+/* WRONG (v3) */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+```css
+/* CORRECT (v4) */
+@utility my-util { /* styles */ }
+
+/* WRONG (v3) */
+@layer utilities { .my-util { /* styles */ } }
+```
+
+```html
+<!-- CORRECT (v4)  -  parentheses for CSS vars -->
+<div class="bg-(--brand-color)">
+
+<!-- WRONG (v3)  -  square brackets -->
+<div class="bg-[--brand-color]">
+```
+
+```html
+<!-- CORRECT (v4)  -  important at the end -->
+<div class="bg-red-500!">
+
+<!-- WRONG (v3)  -  important at the start -->
+<div class="bg-!red-500">
+```
+
+### Rules for New Code
+1. Never use `@tailwind` directives  -  use `@import "tailwindcss"`
+2. Never use `@layer utilities` or `@layer components`  -  use `@utility`
+3. Use `bg-(--var)` syntax for CSS variables, not `bg-[--var]`
+4. Important goes at the end: `bg-red-500!` not `!bg-red-500`
+5. Prefer `gap` over `space-*` / `divide-*` for spacing in flex/grid
+6. No `transform-none`  -  use `scale-none`, `rotate-none`, `translate-none`
+
+## Parameterization
+
+**Never hardcode configuration values inline.** All tunable constants (TTLs, limits, lengths, thresholds, intervals) must be:
+
+1. **Extracted** into a named config object or constant at module scope
+2. **Typed** with an explicit interface
+3. **Defaulted** with sensible production values
+4. **Overridable** via an exported `configure*()` function or constructor parameter
+
+### Pattern
+
+```ts
+export interface ModuleConfig {
+  /** TTL in milliseconds (default: 5 minutes) */
+  ttlMs: number
+  /** Max entries before forced cleanup (default: 10_000) */
+  maxEntries: number
+}
+
+const DEFAULT_CONFIG: ModuleConfig = {
+  ttlMs: 5 * 60 * 1000,
+  maxEntries: 10_000,
+}
+
+let config: ModuleConfig = { ...DEFAULT_CONFIG }
+
+export function configureModule(overrides: Partial<ModuleConfig>): void {
+  config = { ...DEFAULT_CONFIG, ...overrides }
+}
+```
+
+### Applies To
+- Rate limit windows and thresholds
+- Cache TTLs and max sizes
+- OTP/token lengths and expiry times
+- Retry counts and backoff intervals
+- Batch sizes and concurrency limits
+
+### Does NOT Apply To
+- Structural constants (HTTP status codes, header names, URL paths)
+- Type discriminants and enum values
+- Schema definitions (use contracts)
+
+## Unused Declarations
+
+**NEVER suppress an unused variable/import warning without first determining if the code is incomplete.**
+
+### Mandatory Decision Tree
+
+```
+1. Stub or placeholder?
+   → IMPLEMENT the missing functionality. Do not suppress.
+
+2. Intentional side-effect resource?
+   → Rename with `_` prefix. Add a comment explaining WHY.
+
+3. Type-only import?
+   → Change to `import type { ... }`.
+
+4. Required callback parameter?
+   → Prefix with `_` (e.g. `_req`). Comment if non-obvious.
+
+5. Genuinely dead code?
+   → DELETE entirely. No grace periods.
+```
+
+### Verification After Any Lint Fix
+
+```bash
+pnpm --filter <package> typecheck
+node_modules/.bin/biome check <file>
+pnpm --filter <package> test   # if you implemented a stub
+```
+
+## Feature Gating
+
+### Tier Model
+
+| Tier | Code String | Distribution |
+|------|-------------|-------------|
+| Free | `'free'` | MIT, open source |
+| Pro | `'pro'` | Source-available, commercially licensed |
+| Max | `'max'` | Extended Pro features |
+| Enterprise (Forge) | `'enterprise'` | White-label (planned), multi-tenant, self-hosted |
+
+### Runtime Checks
+
+```ts
+import { isLicensed, isFeatureEnabled } from '@revealui/core'
+
+if (isLicensed('pro')) { /* Pro+ feature */ }
+if (isFeatureEnabled('ai')) { /* AI feature (requires Pro) */ }
+```
+
+### Package Boundaries
+- **OSS**: `@revealui/core`, `contracts`, `db`, `auth`, `presentation`, `router`, `config`, `utils`, `cli`, `setup`, `sync`, `dev`, `test`
+- **Pro**: `@revealui/ai`, `mcp`, `editors`, `services`, `harnesses`
+
+### Rules
+1. OSS packages must never import from Pro packages
+2. Pro packages may import from OSS packages
+3. Public tests must not hard-require Pro package source paths
+4. Feature gates use `isLicensed()` / `isFeatureEnabled()`, not environment variables

--- a/.revealui/content/skills/revealui-db/SKILL.md
+++ b/.revealui/content/skills/revealui-db/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: RevealUI Database
+description: "RevealUI database conventions for any task involving database, schema, query, migration,\nDrizzle ORM, NeonDB, PostgreSQL, vectors, embeddings, or data modeling. NeonDB is the\nprimary store; legacy Supabase code has been phased out and must not be reintroduced."
+---
+
+# Database Conventions
+
+## Primary Store: NeonDB (PostgreSQL)
+
+RevealUI uses **NeonDB as the primary store** via Drizzle ORM. The schema lives in `packages/db/src/schema/` (86 tables across accounts, users, sites, posts, agents, RAG, billing, jobs, webhooks, audit, etc.). Migrations apply via standard `drizzle-kit migrate`.
+
+Legacy `@supabase/supabase-js` code has been phased out from runtime — zero real `from '@supabase/supabase-js'` imports remain in `packages/` or `apps/`. **New features must not introduce a Supabase dependency.**
+
+## Query Patterns (Drizzle ORM on Neon)
+
+```ts
+import { db } from '@revealui/db'
+import { posts } from '@revealui/db/schema'
+
+const results = await db.select().from(posts).where(eq(posts.status, 'published'))
+```
+
+## Vector / Embedding Storage
+
+Vector embeddings (RAG, AI memory) live in NeonDB on the `pgvector` extension. HNSW indexes are created in `0002_triggers_search_vectors.sql`. Schemas: `rag_documents`, `rag_chunks`, `agent_memories.embedding`.
+
+## Database MCP
+
+Agent database tooling uses the Neon MCP launcher (`launchNeonMcp`). The legacy customer Supabase MCP adapter was removed; do not reintroduce `supabase-mcp` or `@supabase/supabase-js` as runtime dependencies.
+
+## Migration Discipline
+
+See `packages/db/docs/migrations-discipline.md`. `pnpm validate:migrations` enforces journal/snapshot/idempotency invariants.
+
+## Schema Change Workflow
+
+1. Add or modify schema in `packages/db/src/schema/`
+2. Run `pnpm --filter @revealui/db db:generate` (drizzle-kit will produce the SQL + snapshot)
+3. Review the generated SQL — wrap any `ADD CONSTRAINT` in `DO $$ BEGIN ... END $$` for idempotency
+4. Apply locally via `pnpm --filter @revealui/db db:migrate` (requires `POSTGRES_URL`)
+5. Run `pnpm --filter @revealui/db test` to confirm nothing regressed
+6. Commit migration + snapshot together

--- a/.revealui/content/skills/revealui-debugging/SKILL.md
+++ b/.revealui/content/skills/revealui-debugging/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: RevealUI Debugging
+description: "Systematic debugging workflow for RevealUI. Use when encountering any bug, test failure,\nunexpected behavior, error, or broken functionality. Prevents shotgun debugging."
+---
+
+# RevealUI Debugging Workflow
+
+When something breaks, follow this process. Do not skip steps.
+
+## The Process
+
+### 1. Reproduce
+
+- Get the exact error message, stack trace, or unexpected output
+- Find the minimal reproduction case
+- Confirm it reproduces consistently (not flaky)
+- If it only fails under `turbo run test`, see `$revealui-testing` for concurrency triage
+
+### 2. Hypothesize
+
+- Form ONE specific hypothesis about the root cause
+- Write it down before changing any code
+- Base it on evidence (error message, stack trace, git blame), not intuition
+
+### 3. Validate
+
+- Design a test or check that confirms/refutes your hypothesis
+- Run it
+- If refuted, form a new hypothesis  -  do not stack unrelated fixes
+
+### 4. Fix Narrowly
+
+- Change the minimum code to fix the root cause
+- Do not refactor surrounding code
+- Do not fix adjacent issues you noticed along the way (file them separately)
+
+### 5. Verify
+
+- Run the original failing test/scenario
+- Run `pnpm --filter <package> test` to check for regressions
+- Run `npx biome check --write <file>` on changed files
+
+### 6. Commit
+
+- One commit for the fix
+- Format: `fix(scope): description of what was broken`
+
+## Anti-Patterns
+
+- Changing multiple things at once ("shotgun debugging")
+- Fixing symptoms instead of root causes
+- Adding try/catch blocks to silence errors
+- Increasing timeouts to hide race conditions
+- Reverting to "known good" without understanding what broke
+- Asking "does this fix it?" without a hypothesis
+
+## Common RevealUI Debugging Paths
+
+| Symptom | First Check |
+|---------|------------|
+| Import error | Package built? `pnpm --filter <pkg> build` |
+| Type error across packages | `pnpm typecheck:all`  -  check `workspace:*` versions |
+| Test passes alone, fails in gate | Concurrency pressure  -  see `$revealui-testing` |
+| Supabase error in unexpected path | Import boundary violation  -  see `$revealui-db` |
+| Biome error after edit | Run `npx biome check --write <file>` |

--- a/.revealui/content/skills/revealui-review/SKILL.md
+++ b/.revealui/content/skills/revealui-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: RevealUI Code Review
+description: "Code review checklist for RevealUI. Use when reviewing code, completing a feature,\nchecking quality, or before committing. Invoke explicitly with $revealui-review."
+disable-model-invocation: true
+---
+
+# RevealUI Code Review
+
+Run this checklist before committing or claiming work is complete.
+
+## Automated Checks
+
+Run each command and confirm clean output:
+
+```bash
+# 1. Biome lint + format
+pnpm lint
+
+# 2. TypeScript  -  all packages
+pnpm typecheck:all
+
+# 3. Tests  -  affected packages
+pnpm --filter <package> test
+
+# 4. Quick gate (lint + typecheck + structure)
+pnpm gate:quick
+```
+
+## Manual Checks
+
+### Type Safety
+- [ ] No `any` types (use `unknown` + type guards)
+- [ ] No `as` casts where `satisfies` works
+- [ ] Exported functions have explicit return types
+- [ ] `import type` used for type-only imports
+
+### Code Quality
+- [ ] No `console.*` in production code (use `@revealui/utils` logger)
+- [ ] No hardcoded config values (use parameterization pattern)
+- [ ] No unused variables/imports (follow decision tree if flagged)
+- [ ] Single responsibility  -  each file does one thing
+
+### Architecture
+- [ ] No Supabase imports outside permitted paths
+- [ ] No cross-package relative imports (use `@revealui/<name>`)
+- [ ] Internal deps use `workspace:*`
+- [ ] OSS packages don't import from Pro packages
+
+### Tailwind v4
+- [ ] `bg-(--var)` not `bg-[--var]` for CSS variables
+- [ ] `bg-red-500!` not `!bg-red-500` for important
+- [ ] `@import "tailwindcss"` not `@tailwind`
+- [ ] `@utility` not `@layer utilities`
+- [ ] `gap` preferred over `space-*`
+
+### Git
+- [ ] Conventional commit: `type(scope): description`
+- [ ] Subject under 72 characters, imperative mood
+- [ ] Identity: RevealUI Studio <founder@revealui.com>
+- [ ] No secrets in committed files

--- a/.revealui/content/skills/revealui-safety/SKILL.md
+++ b/.revealui/content/skills/revealui-safety/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: RevealUI Safety
+description: "RevealUI safety guardrails for any code task  -  editing, writing, creating, fixing,\nrefactoring, changing, adding, updating, or removing files. Protects credentials,\nenforces import boundaries, ensures code quality, and verifies work before completion."
+---
+
+# RevealUI Safety
+
+Follow these rules for ALL code changes in the RevealUI monorepo.
+
+## Protected Files  -  Ask Before Editing
+
+- `.env*` files (`.env`, `.env.local`, `.env.production`, etc.)
+- Lock files: `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`
+- Database schema files in `packages/db/src/schema/`  -  changes require migration planning
+
+## Protected Paths  -  Never Edit
+
+- Windows host mounts (typically `/mnt/c/`) and the LTS backup mount (`$LTS_ROOT`, typically `/mnt/e/`)  -  read-only
+- System/credential directories: `/etc/`, `~/.ssh/`, `~/.gnupg/`, `~/.aws/`
+
+## Database Imports
+
+`@supabase/supabase-js` has been phased out from internal runtime — do not reintroduce it as a runtime dependency. NeonDB (via `@revealui/db` + Drizzle) is the primary store. The legacy customer Supabase MCP adapter was also removed; do not re-add `supabase-mcp` launchers.
+
+## Code Quality
+
+- Never use `any`  -  use `unknown` + type guards
+- Never add `console.*` in production code  -  use `@revealui/utils` logger
+- Never hardcode API keys, tokens, passwords, or secrets
+- Use `crypto.randomInt()` for security-sensitive values, not `Math.random()`
+
+## Static Analysis
+
+- For security and architecture validation scripts, prefer AST-based analysis over regex when the rule depends on syntax or code shape
+- Use regex only for heuristic inventory scans (for example obvious secret patterns), not as the source of truth for code-security conclusions
+
+## After Every Edit
+
+Run `npx biome check --write <file>` on each file you edit before moving on.
+
+## Before Claiming Done
+
+1. Run `pnpm gate:quick` and confirm no new errors
+2. Review `git diff` for unintended changes
+3. Ensure conventional commit format: `type(scope): description`
+4. Git identity: RevealUI Studio <founder@revealui.com>
+
+## Known Limitation
+
+These rules are advisory. Unlike Claude Code (which enforces via lifecycle hooks), Codex has no hook system. If working on sensitive files, explicitly invoke `$revealui-safety` to load these rules.

--- a/.revealui/content/skills/revealui-tdd/SKILL.md
+++ b/.revealui/content/skills/revealui-tdd/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: RevealUI TDD
+description: "Test-driven development workflow for RevealUI. Use when implementing any feature,\nfixing bugs, adding functionality, or writing new code. Enforces write-test-first,\nred-green-refactor cycle. Works with Vitest and React Testing Library."
+---
+
+# RevealUI TDD Workflow
+
+Follow this cycle for every code change. No exceptions.
+
+## The Cycle
+
+1. **Write a failing test**  -  describe the expected behavior
+2. **Run it**  -  confirm it fails for the right reason
+3. **Write minimal implementation**  -  just enough to pass
+4. **Run it**  -  confirm it passes
+5. **Refactor**  -  clean up, then run tests again
+6. **Commit**  -  one commit per cycle
+
+## Commands
+
+```bash
+# Run tests for a specific package
+pnpm --filter @revealui/<package> test
+
+# Run a specific test file
+pnpm --filter @revealui/<package> test -- <file>
+
+# Run with coverage
+pnpm --filter @revealui/<package> test -- --coverage
+```
+
+## Test File Conventions
+
+- Unit/integration: `*.test.ts` in `src/__tests__/` or adjacent to source
+- E2E: `*.e2e.ts` in `packages/test/`
+- Use `@revealui/test` for shared fixtures, mocks, and utilities
+
+## What to Test
+
+- Public API surface of each module
+- Error paths and edge cases
+- Integration points between packages
+
+## What NOT to Test
+
+- Private implementation details
+- Third-party library internals
+- Type-only code (interfaces, type aliases)
+
+## Repo-Specific Patterns
+
+For concurrency tuning, flaky test triage, and Pro/OSS test boundaries, see the `$revealui-testing` skill.
+
+## Anti-Patterns
+
+- Writing implementation before the test
+- Writing tests that pass immediately (test must fail first)
+- Testing implementation details instead of behavior
+- Skipping the refactor step
+- Large commits with multiple features

--- a/.revealui/content/skills/revealui-testing/SKILL.md
+++ b/.revealui/content/skills/revealui-testing/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: RevealUI Testing
+description: "RevealUI monorepo testing rules and failure-triage guidance. Use when changing tests,\nfixing flaky suites, adjusting Vitest config, debugging Turbo test failures, handling\nReact Testing Library warnings, or deciding between scoped timeouts, worker limits,\nand test refactors in this repo."
+---
+
+# RevealUI Testing
+
+Use this skill after the generic `vitest` and `react-testing-library` skills when the work is specific to this monorepo.
+
+## Use This For
+
+- `pnpm test` or `pnpm gate --phase=3 --no-build` failures
+- Turbo fan-out flakiness that does not reproduce in isolated package runs
+- Vitest worker/concurrency tuning in `packages/*` or `apps/*`
+- React Testing Library `act(...)` warnings in this repo
+- optional Pro package boundaries in tests
+- deciding whether a failure is a real regression, test debt, or runner pressure
+
+## Repo Rules
+
+### 1. Prefer Narrow Fixes
+
+Default order:
+
+1. fix the test or component contract if behavior is actually wrong
+2. fix stale selectors, bad async assertions, or missing `await`
+3. add a scoped timeout to the single slow test or suite
+4. cap workers for the package if the failure only happens under Turbo fan-out
+5. only then consider broader runner changes
+
+Do not raise global Vitest timeouts just to get green runs.
+
+### 2. Treat “Passes Alone, Fails Under Turbo” as Concurrency Pressure First
+
+If a package passes in isolation but flakes during `turbo run test`, assume resource pressure before assuming product logic broke.
+
+Preferred fix order:
+
+- specific test timeout for known cold imports or expensive setup
+- package-level `fileParallelism: false` and `maxWorkers: 1` for packages with heavy imports, database mocks, or expensive startup
+- lower Turbo concurrency in the gate if the machine is getting killed or saturated
+
+This repo already needed that pattern in packages like `packages/test` and `packages/db`.
+
+### 3. Package-Level Vitest Caps Are Acceptable Here
+
+If a package repeatedly flakes only under monorepo fan-out, it is acceptable to cap that package’s internal Vitest concurrency.
+
+Typical pattern:
+
+```ts
+test: {
+  fileParallelism: false,
+  maxWorkers: 1,
+}
+```
+
+Use this for:
+
+- import-smoke suites
+- packages with heavy module initialization
+- DB/client/process orchestration tests
+
+Do not apply it repo-wide by default.
+
+### 4. Fix `act(...)` Warnings, Don’t Ignore Them
+
+Common fixes in this repo:
+
+- use `await user.click(...)` instead of `fireEvent.click(...)` when the interaction is user-level
+- use `findBy*` or `waitFor` when the click triggers async state
+- assert on the post-update UI state, not just the callback
+- wrap hook state updates in `act(...)` only when there is no better user-facing path
+
+If a warning remains, explain why the pattern is intentional before adding an ignore.
+
+### 5. Prefer `userEvent`, Use `fireEvent` Sparingly
+
+Default to `@testing-library/user-event` for:
+
+- clicks
+- typing
+- keyboard navigation
+- focus/blur behavior
+
+Keep `fireEvent` for narrow low-level cases like synthetic events or very small DOM-only transitions.
+
+### 6. Optional Pro Packages Must Stay Optional in Public Tests
+
+Public repo tests must not hard-require private sibling source trees or Pro package source paths.
+
+Allowed patterns:
+
+- dynamic import with graceful skip/fallback
+- separate Pro-only test config/suite
+- package docs that clearly mark Pro-only flows
+
+Disallowed patterns:
+
+- static imports to missing Pro source
+- default OSS test runs that silently depend on adjacent private repos
+
+### 7. Keep OSS and Pro Test Surfaces Honest
+
+If a test is Pro-only:
+
+- move it into a Pro-specific directory or config
+- exclude it from default OSS test runs
+- do not leave it mixed into the default suite with hidden assumptions
+
+### 8. Distinguish Noise from Failure
+
+Not all stderr is actionable failure in this repo.
+
+Usually acceptable:
+
+- intentional error-path logs in tests exercising failure branches
+- expected jsdom limitations
+- known parser warnings from fixture-driven negative tests
+
+Actionable:
+
+- `act(...)` warnings
+- `MaxListenersExceededWarning`
+- timeouts that only vanish with broad global increases
+- tests that only pass because of local private package availability
+
+## Working Pattern
+
+When triaging a red test lane:
+
+1. rerun the failing package or file directly
+2. decide whether it is reproducible in isolation
+3. if yes, fix the test/component/implementation
+4. if no, treat it as concurrency pressure and tune narrowly
+5. rerun the package
+6. rerun the gate phase that exposed it
+
+Do not keep stacking unrelated fixes without re-verifying the exact failing lane.
+
+## Gate-Specific Guidance
+
+- `pnpm gate --phase=3 --no-build` is the fastest useful repro for test/build instability
+- if a gate hang appears, inspect shared process helpers before changing many tests
+- Turbo warnings about missing outputs are configuration debt, not test correctness
+- a warning-level test check in the gate still deserves cleanup if it hides real regressions
+
+## What Not To Do
+
+- don’t inflate all test timeouts
+- don’t disable assertions just to remove flakes
+- don’t mix Pro-only tests back into OSS-default suites
+- don’t silence `act(...)` or listener warnings when the underlying fix is small
+- don’t assume a package is stable because it passed alone once

--- a/.revealui/content/skills/tailwind-4-docs/SKILL.md
+++ b/.revealui/content/skills/tailwind-4-docs/SKILL.md
@@ -1,0 +1,47 @@
+# Tailwind CSS v4 Documentation Skill
+
+## Purpose
+
+Agent-optimized access to Tailwind CSS v4 documentation for answering questions, selecting utilities/variants, configuring Tailwind v4, and avoiding v3→v4 migration pitfalls.
+
+## Quick Start
+
+1. Check if docs snapshot exists: `references/docs/` should contain ~194 MDX files
+2. If missing or stale, initialize: `python3 scripts/sync_tailwind_docs.py --accept-docs-license`
+3. Identify the topic category from `references/docs-index.tsx`
+4. Load the relevant MDX file from `references/docs/`
+5. Always cross-check against `references/gotchas.md` for breaking changes
+
+## References
+
+| Path | Description |
+|------|-------------|
+| `references/docs/` | Generated MDX docs snapshot (gitignored) |
+| `references/docs-index.tsx` | Category and slug mapping (gitignored) |
+| `references/docs-source.txt` | Upstream repo, commit, and date (gitignored) |
+| `references/gotchas.md` | v4 migration pitfalls and breaking changes (committed) |
+
+## MDX Handling
+
+- Treat `export const` statements as metadata
+- Treat JSX callouts (`<TipInfo>`, `<TipBad>`, `<TipGood>`) as guidance
+- Code blocks contain working examples
+
+## Common Entry Points
+
+| Topic | File |
+|-------|------|
+| Migration from v3 | `upgrade-guide.mdx` |
+| Configuration | `adding-custom-styles.mdx` |
+| Theme | `theme.mdx` |
+| Dark mode | `dark-mode.mdx` |
+| Responsive | `responsive-design.mdx` |
+| Hover/focus/state | `hover-focus-and-other-states.mdx` |
+
+## Sync Command
+
+```bash
+python3 .claude/skills/tailwind-4-docs/scripts/sync_tailwind_docs.py --accept-docs-license
+```
+
+Based on [Lombiq/Tailwind-Agent-Skills](https://github.com/Lombiq/Tailwind-Agent-Skills) (BSD-3-Clause).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ audience: agent
 ---
 
 > **Project manager (all vendors equal):** open [`.revealui/manager.json`](.revealui/manager.json) first.
-> Shared rules/skills: [`.revealui/content/`](.revealui/content/) (generated from `@revealui/harnesses`).
+> Shared policy is generated from `@revealui/harnesses` into [`.revealui/content/`](.revealui/content/) (committed; refresh with `revealui-harnesses manager materialize`).
+> Vendor adapter trees (`.claude/`, `.cursor/`, …) remain the files each harness loads until control-layer phase 2.
 > This file is an adapter orientation doc, not a second policy home. See [`.revealui/README.md`](.revealui/README.md).
 
 # RevealUI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ audience: agent
 ---
 
 > **Project manager (all vendors equal):** open [`.revealui/manager.json`](.revealui/manager.json) first.
-> Shared rules/skills: [`.revealui/content/`](.revealui/content/) (generated from `@revealui/harnesses`).
+> Shared policy is generated from `@revealui/harnesses` into [`.revealui/content/`](.revealui/content/) (committed; refresh with `revealui-harnesses manager materialize`).
+> This Claude adapter still loads [`.claude/rules/`](.claude/rules/) until control-layer phase 2 retires duplicated rule bodies.
 > This file is an adapter orientation doc, not a second policy home. See [`.revealui/README.md`](.revealui/README.md).
 
 # RevealUI Monorepo

--- a/apps/admin/src/app/(frontend)/next/exit-preview/GET.ts
+++ b/apps/admin/src/app/(frontend)/next/exit-preview/GET.ts
@@ -1,7 +1,0 @@
-import { draftMode } from 'next/headers';
-
-export async function GET(): Promise<Response> {
-  const draft = await draftMode();
-  draft.disable();
-  return new Response('Draft mode is disabled');
-}

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "validate:incubate-posture": "tsx scripts/validate/incubate-posture.ts",
     "validate:engines-posture": "tsx scripts/validate/engines-posture.ts",
     "validate:structure": "tsx scripts/validate/structure.ts",
+    "validate:content-freshness": "pnpm --filter @revealui/harnesses build && node packages/harnesses/dist/cli.js content diff --generator claude-code --check --project .",
     "validate:catalog": "tsx scripts/validate/catalog-changeset.ts --warn",
     "validate:claims": "tsx scripts/validate/claim-drift.ts",
     "validate:claims-evidence": "tsx scripts/validate/claims-evidence.ts",

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -99,6 +99,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "content:snapshot:check": "vitest run src/__tests__/content-snapshot.test.ts",
+    "content:freshness": "node dist/cli.js content diff --generator claude-code --check --project ../..",
     "content:snapshot:write": "tsx scripts/write-content-snapshots.mts"
   },
   "type": "module",

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -151,12 +151,30 @@ describe('project manager (.revealui)', () => {
     expect(cfg.tracker.note).toContain('private .jv');
   });
 
-  it('check fails without manager and passes after write', () => {
+  it('check fails without manager and passes after materialize + content', () => {
     const root = tempProject();
     expect(checkManager(root).ok).toBe(false);
     writeManager(root);
+    // Manager alone is no longer enough (GAP-421 content ADR phase 1): content
+    // tree must exist. writeManager without materialize content → not ok.
+    const managerOnly = checkManager(root);
+    expect(managerOnly.ok).toBe(false);
+    expect(managerOnly.errors.some((e) => e.includes('content'))).toBe(true);
+
+    materializeManager(root);
+    writeManagerAdapterContent(root);
     const after = checkManager(root);
     expect(after.ok).toBe(true);
+  });
+
+  it('check fails when content tree is missing after manager.json exists', () => {
+    const root = tempProject();
+    writeManager(root);
+    const result = checkManager(root);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('missing or empty') && e.includes('content'))).toBe(
+      true,
+    );
   });
 
   it('writeManager is a no-op when content is already identical', () => {

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -86,7 +86,10 @@ async function rpcCall(method: string, params: unknown = {}): Promise<unknown> {
 
 async function handleContentCommand(subcommand: string | undefined, args: string[]): Promise<void> {
   const manifest = buildManifest();
-  const projectRoot = process.cwd();
+  // Same --project resolution as `manager` (GAP-421 content freshness runs from
+  // monorepo root via packages/harnesses/dist/cli.js).
+  const projectIdx = args.indexOf('--project');
+  const projectRoot = projectIdx >= 0 ? (args[projectIdx + 1] ?? DEFAULT_PROJECT) : DEFAULT_PROJECT;
   const ctx = { projectRoot };
 
   switch (subcommand) {
@@ -728,7 +731,8 @@ Commands:
 Content Subcommands:
   content list                      List all canonical content with metadata
   content validate                  Validate all definitions against schemas
-  content diff [--generator <id>] [--check]  Disk vs definitions (exit 1 with --check on drift)
+  content diff [--generator <id>] [--check] [--project p]
+                                Disk vs definitions (exit 1 with --check on drift)
   content snapshot [--check|--write] [--generator <id>]  Definition ↔ committed snapshot (GAP-406)
   content sync [--generator <id>] [--dry-run]  Generate into .revealui/content (default generator)
   content export --output <path>    Export canonical + generated files to directory

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { GROK_HOOK_FILES, GROK_HOOK_TEMPLATE_DIR } from './grok-session-hooks.js';
 import {
@@ -170,7 +170,10 @@ export function materializeGrokPointer(projectRoot: string): string {
 Machine home (\`~/.grok\`) must stay **pointer-thin**. When cwd is this project:
 
 1. Read \`.revealui/manager.json\`
-2. Read \`.revealui/content/\` for shared rules
+2. Read \`.revealui/content/\` for generated shared policy (committed after
+   \`manager materialize\`; this machine home still loads thin adapters /
+   pointers — Claude Code still loads \`.claude/rules/\` until control-layer
+   phase 2 retires duplicated rule bodies)
 3. Open \`tracker.path\` from the manager (fleet TRACKER)
 4. Product work via RevealUI MCP (\`rfg\`)
 
@@ -248,23 +251,56 @@ export interface ManagerCheckResult {
   warnings: string[];
 }
 
+/**
+ * True when the content tree has at least one non-empty nested path (rules,
+ * commands, agents, or skills). Used by checkManager (GAP-421 content ADR).
+ */
+function contentTreeHasFiles(contentRoot: string): boolean {
+  try {
+    const top = readdirSync(contentRoot, { withFileTypes: true });
+    for (const entry of top) {
+      if (entry.isFile() && entry.name !== '.gitkeep') return true;
+      if (entry.isDirectory()) {
+        const nested = readdirSync(join(contentRoot, entry.name), { withFileTypes: true });
+        if (nested.some((e) => e.isFile() || e.isDirectory())) return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 /** Fail if manager missing; warn if equal-rank adapter stubs/surfaces lag materialize. */
 export function checkManager(projectRoot: string): ManagerCheckResult {
   const errors: string[] = [];
   const warnings: string[] = [];
   const mPath = managerPath(projectRoot);
   const managerText = readFileOrNull(mPath);
+  let parsedConfig: ManagerConfig | undefined;
   if (managerText === null) {
     errors.push(
       `missing ${MANAGER_DIR}/${MANAGER_FILE} — run: revealui-harnesses manager materialize`,
     );
   } else {
     try {
-      ManagerSchema.parse(JSON.parse(managerText) as unknown);
+      parsedConfig = ManagerSchema.parse(JSON.parse(managerText) as unknown);
     } catch (err) {
       errors.push(`invalid manager.json: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
+
+  // GAP-421 content materialization ADR phase 1: absent/empty content tree is
+  // a hard error once manager.json exists (materialize writes both).
+  if (parsedConfig !== undefined) {
+    const contentRoot = contentRootPath(projectRoot, parsedConfig);
+    if (!contentTreeHasFiles(contentRoot)) {
+      errors.push(
+        `missing or empty ${MANAGER_DIR}/${parsedConfig.contentRoot}/ — run: revealui-harnesses manager materialize`,
+      );
+    }
+  }
+
   const claudeStub = join(projectRoot, '.claude', 'rules', '00-revealui-manager.md');
   if (readFileOrNull(claudeStub) === null) {
     warnings.push('missing .claude/rules/00-revealui-manager.md stub (materialize claude-code)');

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -275,9 +275,19 @@ async function gate(): Promise<void> {
         // GAP-406 residual: definition ↔ committed generator snapshot lock.
         // Fails when package definitions change without refreshing
         // packages/harnesses/content-snapshots/*.json (unit tests also cover this).
+        // Locks generator determinism only — not on-disk `.revealui/content` freshness.
         name: 'Harnesses content snapshot (hard fail)',
         command: 'pnpm',
         args: ['--filter', '@revealui/harnesses', 'content:snapshot:check'],
+      },
+      {
+        // GAP-421 content materialization ADR phase 1: definitions must match
+        // the committed `.revealui/content/` tree (byte compare via diffContent).
+        // Run after harnesses build (manager-only path builds the package first
+        // in CI; local gate assumes dist exists or builds via filter below).
+        name: 'Harnesses content tree freshness (hard fail)',
+        command: 'pnpm',
+        args: ['validate:content-freshness'],
       },
       {
         name: 'Boundary validation',


### PR DESCRIPTION
## Summary

Executes **GAP-421 content materialization ADR phase 1** (ratified 2026-07-25): the generated policy tree under `.revealui/content/` is now real, committed, and CI-gated.

Also closes a small accidental exact-dup (`exit-preview/GET.ts` twin of `route.ts`).

## What changed

- Un-ignore `.revealui/content/**` in `.gitignore` (same pattern as `adapters/`)
- Materialize + commit 35 content files (rules, commands, agents, skills)
- `checkManager` hard-fails when content tree is missing/empty
- `pnpm validate:content-freshness` (definitions ↔ disk via `content diff --check`)
- Path-gated CI Quality step after manager check; local `ci-gate` phase 1 hard-fail
- Adapter prose honesty: content is generated+committed; vendor trees still load until phase 2
- Grok pointer source reworded; re-materialized adapters

## Already on `test` (this PR does not re-do)

GAP-421 §9 steps 1–3, 5, 7, 8 already shipped earlier:
- #2165 protocol export, #2166 manager resolver, #2167 hygiene
- #2168 incubate-posture harnesses, #2169 DELETE train + daemon-ownership ADR

## Residual (not this PR)

- **HttpGateway port into RevDev daemon** (daemon-ownership ADR step 6 / GAP-353)
- **Phase 2:** retire duplicated `.claude/rules/` bodies in favor of definitions only

## Test plan

- [x] `pnpm --filter @revealui/harnesses test` (516 passed in worktree)
- [x] `node packages/harnesses/dist/cli.js content diff --generator claude-code --check --project .`
- [x] `node packages/harnesses/dist/cli.js manager check --project .`
- [ ] CI green on this PR