### PR TITLE
feat(harnesses): session reap abandoned daemon rows (GAP-459)

### DIFF
--- a/.changeset/gap459-session-reap.md
+++ b/.changeset/gap459-session-reap.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+GAP-459: session reap CLI — cold-archive abandoned rows then signed harness.prune

--- a/.revealui/content/rules/quality-over-speed.md
+++ b/.revealui/content/rules/quality-over-speed.md
@@ -25,6 +25,8 @@ reason to ship weak work, thin proofs, or dual-home shortcuts.
 - Partial file reads marked verified in exhaustive / md-truth ledgers
 - Dual-writing the same rule into Claude and Grok homes
 - Merging or force-pushing to "unblock" without owner disposition when required
+- Silencing unused params/locals with a leading underscore (`_line`) instead of
+  implementing, redesigning the signature, or deleting (see unused-declarations)
 
 ## When pressed for speed
 

--- a/.revealui/content/rules/unused-declarations.md
+++ b/.revealui/content/rules/unused-declarations.md
@@ -1,130 +1,134 @@
-# Unused Declarations Policy
+# Unused Declarations Policy (HARDLINE)
 
-## Core Rule
+**Status:** HARDLINE for every session (Claude, Grok, Cursor, any adapter). Owner
+directive 2026-07-29. Thoroughness is non-negotiable. Laziness is rejected.
 
-**NEVER suppress an unused variable/import warning without first determining if the code is incomplete.**
+## Core rule
 
-Unused declarations in this codebase frequently signal incomplete implementations  -  stubs, scaffolded functions, planned integrations  -  not dead code. Suppressing the warning without completing the code leads to permanent placeholders that silently rot.
+**NEVER silence an unused variable, parameter, or import by renaming it with a
+leading underscore (`_line`, `_unused`, `_event`) when the honest fix is to
+implement the value, redesign the API, or delete dead code.**
 
----
+Biome and many linters *allow* underscore-prefixed names as unused. That
+exception is **not** permission to skip work. This codebase treats
+underscore-silence as a policy violation equal to biome-ignore on a TODO stub.
 
-## Mandatory Decision Tree
+Unused declarations usually mean **incomplete implementation**, not "noise to
+mute." Thorough agents implement. Lazy agents rename to `_x` and move on.
 
-When you encounter an `no-unused-vars`, `noUnusedVariables`, or `noUnusedFunctionParameters` warning, you MUST follow this decision tree **before taking any action**:
-
-```
-1. Is the declaration a stub or placeholder?
-   └─ Signs: empty function body, `// TODO`, `throw new Error('not implemented')`,
-             adjacent commented-out code, file has <10 lines of real logic,
-             variable name matches a feature that exists elsewhere in the codebase
-   └─ Action: IMPLEMENT the missing functionality. Do not suppress.
-
-2. Is the declaration an intentionally-created side-effect resource?
-   └─ Signs: infrastructure-as-code (Pulumi/CDK), event listener registration,
-             DB migration runner, resource that must exist but isn't referenced
-   └─ Action: Rename with `_` prefix to signal intentional non-use.
-              Add a comment explaining WHY it exists.
-
-3. Is the import used only as a type (TypeScript)?
-   └─ Signs: import is from a types package, used only in `type X = ...` expressions
-   └─ Action: Change to `import type { ... }`  -  Biome will no longer flag it.
-
-4. Is the parameter required by a callback signature you don't control?
-   └─ Signs: Express/Hono middleware `(req, res, next)`, event handler `(event, context)`,
-             interface implementation where all params are mandated
-   └─ Action: Prefix with `_` (e.g. `_req`, `_event`). Add a comment if non-obvious.
-
-5. Is it genuinely dead code with no planned use?
-   └─ Signs: feature was removed, import was replaced, duplicate of another symbol
-   └─ Action: DELETE the declaration entirely. Per the Legacy Code Removal Policy,
-              no grace periods  -  remove it and all call sites in the same change.
-```
+Companion: quality-over-speed (reduce scope, never quality).
 
 ---
 
-## What "Implement" Means
+## Mandatory decision tree
 
-When you determine a declaration is incomplete (case 1), the required steps are:
+When you see `noUnusedVariables`, `noUnusedParameters`, TS6133, or any
+"declared but never read" diagnostic, **before any edit**:
 
-1. **Search the codebase** for related implementations, types, interfaces, and tests that reveal intent.
-2. **Check the plan file** at `~/.claude/plans/` for any documented phase covering this feature.
-3. **Check for contracts** in `packages/contracts/src/`  -  the schema often describes the expected behavior.
-4. **Implement the function/class/module** based on what the surrounding code expects.
-5. **Run `pnpm gate:quick`** after implementing to verify no new errors were introduced.
+```
+1. Should this value drive logic that is missing?
+   └─ Signs: parameter is in the public API, named for a real concern (line,
+             path, token, id), body only uses a sibling arg, or adjacent tests
+             expect behavior from this input
+   └─ Action: IMPLEMENT using the parameter. Empty short-circuit, validation,
+              error paths, and detectors all count as real use. Do not prefix `_`.
 
-Do NOT:
-- Add `// biome-ignore lint/correctness/noUnusedVariables: TODO implement`
-- Rename to `_variable` just to silence the warning when the variable should be used
-- Delete a stub that represents planned functionality without implementing it first
+2. Do you control the function signature?
+   └─ Yes, and the param is unnecessary → REMOVE it from the signature and
+      update every call site in the same change. Prefer a smaller honest API.
+   └─ Yes, and the param is needed later in the same PR → implement now.
+
+3. Is the import type-only?
+   └─ Action: `import type { ... }` (not underscore rename).
+
+4. Is it genuinely dead with no planned use?
+   └─ Action: DELETE the declaration and call sites. No grace period.
+
+5. Is the parameter forced by a host callback signature you cannot change?
+   └─ Signs only: framework-mandated arity (e.g. Express `(err, req, res, next)`
+      when you only need `next`), or an interface you implement but do not own
+   └─ Action: prefix `_` **only then**, and add a one-line comment naming the
+      host signature. This is the sole underscore carve-out for parameters.
+
+6. Is it an intentional side-effect binding (IaC / must construct)?
+   └─ Action: `_` prefix **only with** a comment explaining the side effect.
+      Never use this for application logic params.
+```
+
+If none of 5–6 apply, **underscore is forbidden**.
+
+---
+
+## Explicitly rejected (every session)
+
+- `_line`, `_req`, `_unused`, `_args` to quiet TS6133 / Biome when you own the API
+- `// biome-ignore ... noUnusedVariables: TODO`
+- "I'll wire it later" after renaming to `_`
+- Deleting a stub that represents required behavior without implementing it
+- Partial fixes that leave the thorough path for "someone else"
+
+---
+
+## What implement means
+
+1. Search related types, tests, and call sites for intent.
+2. Use the parameter in real control flow (validate, short-circuit, detect, log
+   structured fields, pass through). Empty `line.trim()` guards are valid when
+   they match the audit contract.
+3. Typecheck + Biome + tests for the package before moving on.
+4. Prefer one correct change over a silent underscore.
 
 ---
 
 ## Examples
 
-### Wrong  -  suppressing an incomplete stub
+### Wrong — silence the audit string
+```ts
+export function findHits(_line: string, tokens: Token[]): Hit[] {
+  return detect(wordTexts(tokens));
+}
+```
+
+### Right — use the line (empty short-circuit is real use)
+```ts
+export function findHits(line: string, tokens: Token[]): Hit[] {
+  if (line.trim().length === 0) return [];
+  return detect(wordTexts(tokens));
+}
+```
+
+### Wrong — mute a stub
 ```ts
 // biome-ignore lint/correctness/noUnusedVariables: TODO
 const semanticMemory = new SemanticMemory()
 ```
 
-### Right  -  implement it
+### Right — implement
 ```ts
 const semanticMemory = new SemanticMemory()
 await semanticMemory.store('key', content, embedding)
 ```
 
----
-
-### Wrong  -  deleting a planned integration
+### Allowed underscore (host-mandated only)
 ```ts
-// Was: import { ProceduralMemory } from './procedural-memory.js'
-// Deleted because "unused"
-```
-
-### Right  -  implement the module it was waiting for
-```ts
-// packages/ai/src/memory/memory/procedural-memory.ts
-export class ProceduralMemory { ... }
-// Then use it where the original import was
+// Hono error handler arity is fixed by the framework; body only needs err.
+app.onError((_req, err) => respond(err))
 ```
 
 ---
 
-### Wrong  -  renaming away the signal
-```ts
-// Original: const routeTableAssoc = new aws.ec2.RouteTableAssociation(...)
-// "Fixed": const _routeTableAssoc = new aws.ec2.RouteTableAssociation(...)
-// No comment explaining why
-```
-
-### Right  -  rename AND document
-```ts
-// Route table association must exist for subnet routing to function.
-// The variable is not referenced after creation; AWS manages the association.
-const _routeTableAssoc = new aws.ec2.RouteTableAssociation(...)
-```
-
----
-
-## Verification Step After Any Lint Fix
-
-After resolving any unused declaration warning, run:
+## Verification (mandatory before next task)
 
 ```bash
-# Confirm the fix compiles
 pnpm --filter <package> typecheck
-
-# Confirm Biome is clean on the changed file
-node_modules/.bin/biome check <file>
-
-# If the declaration was a stub that you implemented, run the tests
-pnpm --filter <package> test
+pnpm exec biome check <file>
+pnpm --filter <package> test   # if behavior changed
 ```
-
-Never move to the next task without completing this verification.
 
 ---
 
-## Relationship to Gate Verification Rule
+## Relationship
 
-This policy works in conjunction with the gate verification rule: complete the implementation → verify with lint/type/test → then move on. The gate catches regressions; this policy prevents incomplete code from silently accumulating.
+- **quality-over-speed** — thoroughness outranks session throughput
+- **code-over-docs** — unused params that should affect behavior are incomplete product
+- **durable-solutions** — underscore silence is a temporary shape; refuse it

--- a/.revealui/content/skills/revealui-conventions/SKILL.md
+++ b/.revealui/content/skills/revealui-conventions/SKILL.md
@@ -204,28 +204,25 @@ export function configureModule(overrides: Partial<ModuleConfig>): void {
 - Type discriminants and enum values
 - Schema definitions (use contracts)
 
-## Unused Declarations
+## Unused Declarations (HARDLINE every session)
 
-**NEVER suppress an unused variable/import warning without first determining if the code is incomplete.**
+**NEVER silence unused with a leading underscore** (`_line`, `_unused`) when
+the honest fix is implement, redesign the signature, or delete. Biome's
+underscore exception is not a free pass. See rule `unused-declarations`
+(preamble tier 1).
 
 ### Mandatory Decision Tree
 
 ```
-1. Stub or placeholder?
-   → IMPLEMENT the missing functionality. Do not suppress.
-
-2. Intentional side-effect resource?
-   → Rename with `_` prefix. Add a comment explaining WHY.
-
-3. Type-only import?
-   → Change to `import type { ... }`.
-
-4. Required callback parameter?
-   → Prefix with `_` (e.g. `_req`). Comment if non-obvious.
-
-5. Genuinely dead code?
-   → DELETE entirely. No grace periods.
+1. Param should drive logic? → IMPLEMENT it (empty guards count as real use).
+2. You own the API and param is unnecessary? → REMOVE from signature + call sites.
+3. Type-only import? → `import type { ... }`.
+4. Genuinely dead? → DELETE. No grace periods.
+5. Host-mandated callback arity you cannot change? → `_` only with a comment naming the host.
+6. IaC side-effect construct? → `_` only with a WHY comment.
 ```
+
+Underscore silence for incomplete work is a hardline violation.
 
 ### Verification After Any Lint Fix
 

--- a/packages/harnesses/src/__tests__/session-reap.test.ts
+++ b/packages/harnesses/src/__tests__/session-reap.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { isAbandonedSessionRow } from '../session/reap.js';
+
+describe('isAbandonedSessionRow', () => {
+  it('keeps active peers', () => {
+    expect(isAbandonedSessionRow({ id: 'a', active: true, staleSeconds: 0 }, 3600, 'self')).toBe(
+      false,
+    );
+  });
+
+  it('skips self', () => {
+    expect(
+      isAbandonedSessionRow({ id: 'self', active: false, staleSeconds: 9999 }, 3600, 'self'),
+    ).toBe(false);
+  });
+
+  it('flags heartbeat-idle rows', () => {
+    expect(
+      isAbandonedSessionRow({ id: 'zombie', active: false, staleSeconds: 7200 }, 3600, 'self'),
+    ).toBe(true);
+  });
+
+  it('does not flag idle rows under the floor', () => {
+    expect(
+      isAbandonedSessionRow({ id: 'quiet', active: false, staleSeconds: 400 }, 3600, 'self'),
+    ).toBe(false);
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -13,7 +13,7 @@
  *   sync <harnessId> <push|pull>     Sync harness config to/from SSD
  *   coordinate [--project <path>]    Print current workboard state
  *   hook <cursor|claude-code|vscode|grok> Normalize a hook payload from stdin, evaluate policy, spool the receipt
- *   session register|end|peers       Soft-optional RevDev daemon session boundary + peer panel (GAP-459)
+ *   session register|end|peers|reap  Soft-optional RevDev session boundary + peer panel + reaper (GAP-459)
  *
  * License: FSL-1.1-MIT
  */
@@ -720,7 +720,7 @@ Commands:
   health                            Run health check (requires daemon)
   coordinate [--project <path>]     Print workboard state
   hook <cursor|claude-code|vscode|grok>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
-  session register|end|peers        Soft-optional RevDev session boundary + peer panel (GAP-459)
+  session register|end|peers|reap   Soft-optional RevDev session boundary + peer panel + reaper (GAP-459)
   content <subcommand>              Manage canonical content definitions
   manager materialize [--project p] Write manager.json + .revealui/content + Cursor/OpenCode surfaces + equal stubs
   manager check [--project p]       Verify project manager present and valid

--- a/packages/harnesses/src/session/cli.ts
+++ b/packages/harnesses/src/session/cli.ts
@@ -8,6 +8,7 @@
 
 import { sessionEnd, sessionRegister } from './boundary.js';
 import { renderPeerPanel } from './peer-context.js';
+import { DEFAULT_HEARTBEAT_STALE_SECONDS, sessionReap } from './reap.js';
 
 function printResult(
   label: string,
@@ -83,13 +84,59 @@ export async function runSessionCli(args: string[]): Promise<void> {
     return;
   }
 
+  if (subcommand === 'reap') {
+    let heartbeatStaleSeconds = DEFAULT_HEARTBEAT_STALE_SECONDS;
+    let staleDays = 7;
+    let hardDeleteDays = 30;
+    let dryRun = false;
+    let backend = 'grok';
+    for (let i = 0; i < rest.length; i++) {
+      const nxt = nextArg(rest, i);
+      if (rest[i] === '--heartbeat-seconds' && nxt) {
+        heartbeatStaleSeconds = Number(nxt);
+        i++;
+      } else if (rest[i] === '--stale-days' && nxt) {
+        staleDays = Number(nxt);
+        i++;
+      } else if (rest[i] === '--hard-delete-days' && nxt) {
+        hardDeleteDays = Number(nxt);
+        i++;
+      } else if (rest[i] === '--backend' && nxt) {
+        backend = nxt;
+        i++;
+      } else if (rest[i] === '--dry-run') {
+        dryRun = true;
+      }
+    }
+    const result = await sessionReap({
+      heartbeatStaleSeconds,
+      staleDays,
+      hardDeleteDays,
+      dryRun,
+      backend,
+    });
+    const status = result.ok ? 'ok' : result.skipped ? 'skip' : 'fail';
+    process.stderr.write(
+      `[session reap] ${status} candidates=${result.candidates} archived=${result.archived}` +
+        (result.aged !== undefined ? ` aged=${result.aged}` : '') +
+        (result.deleted !== undefined ? ` deleted=${result.deleted}` : '') +
+        (result.heartbeatStaleSeconds !== undefined
+          ? ` heartbeatSeconds=${result.heartbeatStaleSeconds}`
+          : '') +
+        (result.reason ? ` ${result.reason}` : '') +
+        '\n',
+    );
+    return;
+  }
+
   process.stderr.write(`Usage:
   revealui-harnesses session register [--backend grok|claude-code|…] [--work-dir PATH] [--no-peers]
   revealui-harnesses session peers [--actor AGENT_ID]
   revealui-harnesses session end [--summary TEXT]
+  revealui-harnesses session reap [--heartbeat-seconds N] [--stale-days N] [--hard-delete-days N] [--dry-run]
 
 Soft-optional RevDev daemon session boundary (GAP control-layer peer adapters).
 Always exits 0 so SessionStart/SessionEnd hooks never block.
-GAP-459: register/peers print peer-context (WARN when coordination unavailable).
+GAP-459: register/peers print peer-context; end archives; reap ends abandoned rows.
 `);
 }

--- a/packages/harnesses/src/session/index.ts
+++ b/packages/harnesses/src/session/index.ts
@@ -29,6 +29,7 @@ export {
   type FetchPeerContextOptions,
   fetchPeerContext,
   formatPeerPanel,
+  PEER_LIVE_STALE_SECONDS,
   type PeerContextSnapshot,
   type PeerContextStatus,
   type PeerFindingLine,
@@ -36,5 +37,12 @@ export {
   type PeerSessionLine,
   renderPeerPanel,
 } from './peer-context.js';
+export {
+  DEFAULT_HEARTBEAT_STALE_SECONDS,
+  type ReapOptions,
+  type ReapResult,
+  isAbandonedSessionRow,
+  sessionReap,
+} from './reap.js';
 export { defaultSocketPath, isDaemonSocketPresent, rpcCall } from './rpc.js';
 export { hashParams, signRpc } from './sign.js';

--- a/packages/harnesses/src/session/index.ts
+++ b/packages/harnesses/src/session/index.ts
@@ -39,9 +39,9 @@ export {
 } from './peer-context.js';
 export {
   DEFAULT_HEARTBEAT_STALE_SECONDS,
+  isAbandonedSessionRow,
   type ReapOptions,
   type ReapResult,
-  isAbandonedSessionRow,
   sessionReap,
 } from './reap.js';
 export { defaultSocketPath, isDaemonSocketPresent, rpcCall } from './rpc.js';

--- a/packages/harnesses/src/session/reap.ts
+++ b/packages/harnesses/src/session/reap.ts
@@ -1,0 +1,241 @@
+/**
+ * GAP-459 abandoned-session reaper (control layer).
+ *
+ * 1. List live daemon sessions
+ * 2. Cold-archive each heartbeat-idle candidate
+ * 3. Signed `harness.prune` with heartbeatStaleSeconds (daemon ends them)
+ *
+ * Soft-optional when the daemon is down. Never throws to callers that ignore
+ * the result; CLI prints status.
+ */
+
+import { archiveSessionExit } from './archive-exit.js';
+import { sessionRegister } from './boundary.js';
+import {
+  type HookIdentity,
+  loadHookIdentity,
+  readDaemonSessionCache,
+  resolveAfterRegister,
+} from './identity-cache.js';
+import { PEER_LIVE_STALE_SECONDS } from './peer-context.js';
+import { isDaemonSocketPresent, rpcCall } from './rpc.js';
+import { signRpc } from './sign.js';
+
+/** Default matches daemon MIN_HEARTBEAT_STALE_SECONDS (1 hour). */
+export const DEFAULT_HEARTBEAT_STALE_SECONDS = 3600;
+
+export interface ReapOptions {
+  readonly socketPath?: string;
+  readonly timeoutMs?: number;
+  readonly backend?: string;
+  readonly workDir?: string;
+  readonly ppid?: number | string;
+  /** Seconds of updated_at idle before reaping. Floored at 3600 by daemon. */
+  readonly heartbeatStaleSeconds?: number;
+  /** Start-age arm for classic prune (days). Default 7. */
+  readonly staleDays?: number;
+  readonly hardDeleteDays?: number;
+  /** Dry-run: archive candidates only, skip harness.prune. */
+  readonly dryRun?: boolean;
+}
+
+export interface ReapResult {
+  readonly ok: boolean;
+  readonly skipped: boolean;
+  readonly reason?: string;
+  readonly candidates: number;
+  readonly archived: number;
+  readonly aged?: number;
+  readonly deleted?: number;
+  readonly heartbeatStaleSeconds?: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function num(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+/**
+ * True when a session.list row looks abandoned (same class as peer-panel hide).
+ */
+export function isAbandonedSessionRow(
+  row: Record<string, unknown>,
+  heartbeatStaleSeconds: number,
+  selfAgentId?: string | null,
+): boolean {
+  const id = str(row.id) || str(row.agentId) || str(row.agent_id);
+  if (!id) return false;
+  if (selfAgentId && id === selfAgentId) return false;
+  if (row.active === true || row.active === 't') return false;
+  const stale = num(row.staleSeconds) ?? num(row.stale_seconds);
+  if (stale !== undefined) return stale >= heartbeatStaleSeconds;
+  // Without staleSeconds, treat non-active as abandoned only if we have no active flag true
+  return row.active === false || row.active === 'f';
+}
+
+export async function sessionReap(options: ReapOptions = {}): Promise<ReapResult> {
+  const socketPath = options.socketPath;
+  const heartbeatStaleSeconds = Math.max(
+    DEFAULT_HEARTBEAT_STALE_SECONDS,
+    Math.floor(options.heartbeatStaleSeconds ?? DEFAULT_HEARTBEAT_STALE_SECONDS),
+  );
+  const staleDays = Math.max(1, Math.floor(options.staleDays ?? 7));
+  const hardDeleteDays = Math.max(1, Math.floor(options.hardDeleteDays ?? 30));
+  const timeoutMs = options.timeoutMs ?? 8000;
+  const ppid = options.ppid ?? process.ppid;
+
+  if (!isDaemonSocketPresent(socketPath)) {
+    return {
+      ok: false,
+      skipped: true,
+      reason: 'daemon socket absent',
+      candidates: 0,
+      archived: 0,
+    };
+  }
+
+  // Ensure we have a signed identity for harness.prune.
+  let agentId = readDaemonSessionCache(ppid);
+  let identity: HookIdentity | null = agentId ? loadHookIdentity(agentId) : null;
+  if (!identity) {
+    const reg = await sessionRegister({
+      backend: options.backend ?? 'grok',
+      workDir: options.workDir ?? process.cwd(),
+      socketPath,
+      ppid,
+      timeoutMs,
+    });
+    if (!reg.ok || !reg.agentId) {
+      return {
+        ok: false,
+        skipped: true,
+        reason: reg.reason ?? 'could not register reaper identity',
+        candidates: 0,
+        archived: 0,
+      };
+    }
+    agentId = reg.agentId;
+    identity = resolveAfterRegister({ agentId }) ?? loadHookIdentity(agentId);
+  }
+  if (!identity || !agentId) {
+    return {
+      ok: false,
+      skipped: true,
+      reason: 'no signing identity for harness.prune',
+      candidates: 0,
+      archived: 0,
+    };
+  }
+
+  let listRaw: unknown;
+  try {
+    listRaw = await rpcCall('session.list', {}, { socketPath, timeoutMs });
+  } catch (err) {
+    return {
+      ok: false,
+      skipped: false,
+      reason: err instanceof Error ? err.message : String(err),
+      candidates: 0,
+      archived: 0,
+    };
+  }
+
+  const sessions = Array.isArray(asRecord(listRaw)?.sessions)
+    ? (asRecord(listRaw)!.sessions as unknown[])
+    : [];
+  const candidates: Array<{ id: string; task: string; staleSeconds?: number }> = [];
+  for (const row of sessions) {
+    const r = asRecord(row);
+    if (!r) continue;
+    if (!isAbandonedSessionRow(r, heartbeatStaleSeconds, agentId)) continue;
+    const id = str(r.id) || str(r.agentId);
+    candidates.push({
+      id,
+      task: str(r.task) || '(no task)',
+      staleSeconds: num(r.staleSeconds) ?? num(r.stale_seconds),
+    });
+  }
+
+  let archived = 0;
+  for (const c of candidates) {
+    const res = archiveSessionExit({
+      agentId: c.id,
+      endedAt: new Date().toISOString(),
+      exitSummary: 'reaped-abandoned',
+      backend: options.backend,
+      workDir: c.task,
+      task: c.task,
+      ppid,
+      source: 'session.reap',
+      daemonEnded: false,
+      notes: `candidate staleSeconds=${c.staleSeconds ?? '?'} heartbeatFloor=${heartbeatStaleSeconds}`,
+    });
+    if (res.ok) archived += 1;
+  }
+
+  if (options.dryRun) {
+    return {
+      ok: true,
+      skipped: false,
+      reason: 'dry-run: archived candidates only; prune skipped',
+      candidates: candidates.length,
+      archived,
+      heartbeatStaleSeconds,
+    };
+  }
+
+  const pruneParams: Record<string, unknown> = {
+    actorAgentId: agentId,
+    staleDays,
+    hardDeleteDays,
+    heartbeatStaleSeconds,
+  };
+
+  try {
+    const signature = signRpc(identity, 'harness.prune', pruneParams);
+    const result = (await rpcCall('harness.prune', pruneParams, {
+      socketPath,
+      timeoutMs: Math.max(timeoutMs, 15_000),
+      signature,
+    })) as { aged?: number; deleted?: number; heartbeatStaleSeconds?: number };
+
+    return {
+      ok: true,
+      skipped: false,
+      candidates: candidates.length,
+      archived,
+      aged: typeof result.aged === 'number' ? result.aged : undefined,
+      deleted: typeof result.deleted === 'number' ? result.deleted : undefined,
+      heartbeatStaleSeconds:
+        typeof result.heartbeatStaleSeconds === 'number'
+          ? result.heartbeatStaleSeconds
+          : heartbeatStaleSeconds,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      skipped: false,
+      reason: err instanceof Error ? err.message : String(err),
+      candidates: candidates.length,
+      archived,
+      heartbeatStaleSeconds,
+    };
+  }
+}
+
+// Re-export panel constant for callers that want display-aligned thresholds.
+export { PEER_LIVE_STALE_SECONDS };


### PR DESCRIPTION
## Summary
- `revealui-harnesses session reap` cold-archives heartbeat-idle candidates then calls signed `harness.prune` with `heartbeatStaleSeconds`
- Default floor 1 hour (daemon-enforced)
- `--dry-run` archives only

## Companion
revdev heartbeat prune arm PR.

## Security
harnesses session/* + prune coordination — needs non-author sec-review if gated.

## Test plan
- [x] unit tests isAbandonedSessionRow
- [x] phase-1 gate PASS
- [ ] CI green
- [ ] After both PRs merge: rebuild daemon+harnesses, `session reap`, confirm activeSessions drop