### PR TITLE
fix(docs): REST API nav link + GAP-395 frontmatter note

### DIFF
--- a/apps/docs/app/lib/nav.ts
+++ b/apps/docs/app/lib/nav.ts
@@ -70,6 +70,7 @@ export function buildDocNavSections(showcaseItems: NavItem[]): NavSection[] {
       title: 'Reference',
       items: [
         { label: 'Package Reference', path: '/reference' },
+        { label: 'REST API', path: '/api/rest-api' },
         { label: 'Component Catalog', path: '/component-catalog' },
         { label: 'AI', path: '/ai' },
         { label: 'Marketplace', path: '/marketplace' },

--- a/scripts/docs/generate-api.ts
+++ b/scripts/docs/generate-api.ts
@@ -63,8 +63,9 @@ function badge(method: string): string {
 function generateMarkdown(spec: OpenAPISpec): string {
   const lines: string[] = [];
 
-  // Header — YAML frontmatter required so copy-docs keeps this public
-  // when the public site should serve it (visibility: public).
+  // Header: YAML frontmatter required so copy-docs.sh keeps this public
+  // (visibility: public). Dropping it excludes /api/rest-api while nav still
+  // links it and Quality docs link-check fails (GAP-395).
   lines.push(
     `---`,
     `title: "REST API Reference"`,


### PR DESCRIPTION
## Summary
- Add **REST API** to docs Reference nav (`/api/rest-api`).
- Clarify `scripts/docs/generate-api.ts` frontmatter comment (GAP-395 residual salvaged from a merged dirty worktree).

## Context
Staged-but-uncommitted leftover in `.wt/gap-395-api-docs` after #2284. Nav still lacked REST API on `test` while the page path exists.

## Test plan
- [ ] Docs nav shows REST API under Reference
- [ ] `/api/rest-api` still has public frontmatter after `generate-api` regen
- [ ] CI green