### PR TITLE
feat(harnesses): GAP-421 phase 2 — Claude rules from definitions

### DIFF
--- a/.claude/rules/adapter-only.md
+++ b/.claude/rules/adapter-only.md
@@ -1,0 +1,36 @@
+# Adapter Only (no dual-home mirrors)
+
+Claude Code, Grok, Cursor, OpenCode, VS Code, and product agents are **adapters**.
+Shared policy, product tools, coordination, and day-to-day backlog live in the
+RevealUI native layer. Adapters communicate with that layer; they do not re-author
+shared hardlines.
+
+## Authority order
+
+1. **Project manager** — `./.revealui/manager.json` (+ `.revealui/content/`)
+2. **Package definitions** — `@revealui/harnesses` content definitions (this rule set)
+3. **Fleet TRACKER** — free-surface board (`docs/TRACKER.md` / private planning tree)
+4. **Adapter homes** — thin pointers, vendor tool names, TUI ops only
+
+## Rules
+
+1. **No new full hardline body** under vendor homes (`~/.claude/rules` forks of
+   shared policy, `~/.grok/rules` full copies). Pointers only for shared policy.
+2. **Equal-rank vendors.** No adapter outranks another under the manager.
+3. **Product I/O** goes through RevealUI MCP (governed user + receipts), not
+   per-harness side channels for product actions.
+4. **Session orientation** uses the shared tracker/manager check (one script),
+   not dual banners re-authored per adapter.
+5. **Quality over speed** still applies; thinning mirrors is not an excuse to
+   skip proof.
+
+## Illegal mirror (stop / thin)
+
+A vendor rule file that restates a full Plane A hardline body instead of citing
+the package definition or machine-global owner is an illegal mirror. Fix by
+thinning to a pointer, not by copying more prose.
+
+## References
+
+- ADR harness policy / runtime / launch planes
+- GAP-406, GAP-318, tracker-first, quality-over-speed

--- a/.claude/rules/agent-dispatch.md
+++ b/.claude/rules/agent-dispatch.md
@@ -11,16 +11,16 @@ too large or specialized for the current session.
 | `security-reviewer` | Auditing auth flows, reviewing security-sensitive PRs, checking new API routes for vulnerabilities |
 | `builder` | Large feature implementation spanning multiple packages that would pollute the current session context |
 | `tester` | Writing test suites, achieving coverage targets, fixing batches of failing tests |
-| `docs-sync` | Updating public docs, syncing API reference, writing changelogs, keeping the hub master plan in sync |
+| `docs-sync` | Updating public docs, syncing API reference, writing changelogs, keeping MASTER_PLAN in sync |
 | `linter` | Bulk lint fixes, unused declaration sweeps, `any` type removal, Biome cleanup across the monorepo |
 
 ## Rules
 
 1. Don't spawn a profile for work that takes under 15 minutes in the current session.
-2. Check the workboard before spawning — another agent may already own that area.
+2. Check the workboard before spawning  -  another agent may already own that area.
 3. Always give spawned agents:
-   - Current phase from the hub master plan (see `docs/INDEX.md` "Fleet coordination")
+   - Current phase from the internal planning hub's MASTER_PLAN.md
    - Relevant workboard state
    - The specific task and acceptance criteria
-4. Spawned agents report findings back to the parent. Only the parent updates the hub master plan.
-5. Spawned agents must not create plan files outside the hub master plan (see `planning.md`).
+4. Spawned agents report findings back to the parent. Only the parent updates MASTER_PLAN.md.
+5. Spawned agents must not create plan files outside MASTER_PLAN.md (see `planning.md`).

--- a/.claude/rules/biome.md
+++ b/.claude/rules/biome.md
@@ -6,11 +6,11 @@ Biome 2 is the sole linter and formatter for this monorepo.
 
 ## Commands
 
-- `pnpm lint` — check all files with Biome (`biome check .`)
-- `pnpm format` — format all files with Biome (`biome format --write .`)
-- `pnpm lint:fix` — auto-fix with Biome (`biome check --write .`)
-- `biome check .` — lint + format check (per-package)
-- `biome check --write .` — auto-fix (used by lint-staged)
+- `pnpm lint`  -  check all files with Biome (`biome check .`)
+- `pnpm format`  -  format all files with Biome (`biome format --write .`)
+- `pnpm lint:fix`  -  auto-fix with Biome (`biome check --write .`)
+- `biome check .`  -  lint + format check (per-package)
+- `biome check --write .`  -  auto-fix (used by lint-staged)
 
 ## Lint-Staged
 
@@ -24,16 +24,16 @@ Pre-commit hook runs `biome check --write` on staged `*.{ts,tsx,js,jsx}` files v
 - Consistent import ordering (auto-sorted)
 - Single quotes for strings
 - Trailing commas
-- Semicolons enforced "always"
+- Semicolons always
 - 2-space indentation (tabs in Biome config, spaces in output)
 
 ## Suppressing Rules
 
 - Use `// biome-ignore <rule>: <reason>` for specific lines
-- Avoid blanket suppressions — prefer fixing the code
+- Avoid blanket suppressions  -  prefer fixing the code
 - Document why a suppression is needed in the comment
 
-## Unused Variables — Special Protocol
+## Unused Variables  -  Special Protocol
 
 **Before suppressing any unused variable or import warning, read `.claude/rules/unused-declarations.md`.**
 

--- a/.claude/rules/code-analysis-policy.md
+++ b/.claude/rules/code-analysis-policy.md
@@ -1,0 +1,35 @@
+# Code Analysis Policy
+
+Use AST-based or structural analysis for code-policy and security checks whenever the rule depends on syntax, identifiers, or code shape.
+
+## Prefer AST-Based Analysis For
+
+- security gate checks over application code
+- architecture and boundary rules
+- auth/password handling checks
+- response/body serialization checks
+- import-policy enforcement beyond simple path inventory
+
+## Regex Is Acceptable Only For
+
+- broad inventory scans over raw text
+- committed secret patterns
+- literal token/URL/key detection
+- quick warning-level heuristics that are explicitly marked approximate
+
+## Do Not Use Regex As Source Of Truth For
+
+- whether a value is stored in plaintext
+- whether a secret is hardcoded in executable code
+- whether a boundary rule is violated by code structure
+- whether a security-sensitive value reaches a sink
+
+## Working Rule
+
+If a check can be expressed against the TypeScript/JavaScript AST with reasonable effort, use AST analysis first.
+
+If regex is still used:
+
+- document it as heuristic-only
+- keep it warning-level unless independently verified
+- add a follow-up to migrate it to AST/structural analysis

--- a/.claude/rules/code-over-docs.md
+++ b/.claude/rules/code-over-docs.md
@@ -1,0 +1,33 @@
+# Code Over Docs
+
+The source code is the single source of truth. Documentation (READMEs, specs,
+plans, handoffs, ADRs, comments, gap files, memory) *describes* the system; the
+code *defines* it. When any doc and the code disagree, the code is correct and
+the doc is stale.
+
+## Apply every session
+
+1. **Verify against code before acting.** Never implement, review, plan, or
+   report from a doc claim alone. Load-bearing claims need `file:line` in
+   actual source (or a test that exercises the path).
+2. **On disagreement: trust code, then fix the doc.** A doc↔code conflict is a
+   doc bug. Do not "fix" working code to match stale prose without an explicit
+   decision that the doc's behavior is the intended one.
+3. **Doc-tier authority is subordinate.** Handoff / plan tiers resolve
+   doc-vs-doc conflicts only. Code outranks all tiers on factual system
+   behavior.
+4. **Prioritize code work over doc work.** Correct code outranks nicer prose
+   about code. Doc sweeps ride behind the code fixes they describe.
+5. **Comments are docs too.** Stale headers or comments are drift; the code
+   path below them is what you trust.
+
+## Explicitly rejected
+
+- Treating gap files, handoffs, or ADRs as proof of runtime behavior
+- Marking exhaustive / md-truth claims verified without reading the file body
+- Shipping doc-only "fixes" that leave wrong code unchanged
+
+## References
+
+- Sibling: quality-over-speed, durable-solutions, tracker-first
+- Exhaustive / md-truth programs prove claims against code, not against docs

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,0 +1,35 @@
+# Database Conventions
+
+## Primary Store: NeonDB (PostgreSQL)
+
+RevealUI uses **NeonDB as the primary store** via Drizzle ORM. The schema lives in `packages/db/src/schema/` (86 tables) and migrates via standard `drizzle-kit migrate`.
+
+Legacy `@supabase/supabase-js` code has been phased out from runtime — there are zero `from '@supabase/supabase-js'` imports left in `packages/` or `apps/`. **New features must not introduce a Supabase dependency.**
+
+## Schema Organization
+
+Schemas live under `packages/db/src/schema/` — one file per logical domain (accounts, users, sites, posts, agents, RAG, billing, etc.). Use Drizzle ORM for all queries.
+
+```ts
+import { db } from '@revealui/db'
+import { posts } from '@revealui/db/schema'
+
+const results = await db.select().from(posts).where(eq(posts.status, 'published'))
+```
+
+## Vector / Embedding Storage
+
+Vector embeddings (RAG, AI memory) live in NeonDB on the `pgvector` extension. HNSW indexes are created in `0002_triggers_search_vectors.sql`. Tables: `rag_documents`, `rag_chunks`, `agent_memories.embedding`.
+
+## Database MCP
+
+Agent database tooling uses Neon MCP. The legacy customer Supabase MCP adapter was removed; do not reintroduce `supabase-mcp` or `@supabase/supabase-js` into the app code.
+
+## Migration Discipline
+
+See `packages/db/docs/migrations-discipline.md`. The `pnpm validate:migrations` static check enforces:
+- Every `.sql` file has a journal entry, and vice versa
+- Journal `when` values are strictly increasing
+- Every journal entry has a `meta/<NNNN>_snapshot.json` (or an explicit allowlist entry in `meta/_custom.json`)
+- `ALTER TABLE ... ADD CONSTRAINT` is wrapped in `DO $$ BEGIN ... EXCEPTION ... END $$` blocks for idempotency
+- `DROP CONSTRAINT` uses `IF EXISTS`

--- a/.claude/rules/disposition-actions.md
+++ b/.claude/rules/disposition-actions.md
@@ -1,0 +1,42 @@
+# Disposition Actions — Propose, Don't Dispose
+
+Agent work is **proposal-shaped by default**. A proposal produces an artifact
+someone else can act on; a disposition consummates an outcome. Proposals never
+need special authorization; dispositions always do.
+
+## Always safe (proposal-shaped)
+
+- Reading, grepping, auditing; empirical tests in session scratch
+- Posting review or verdict comments on PRs
+- Creating worktrees, committing to fresh branches, pushing feature branches
+- Opening PRs, filing gaps, authoring specs and lane docs
+
+## Disposition-shaped (requires named in-session owner authorization)
+
+- Merging any PR the agent authored this session
+- Merging any PR whose subject matter is security (design docs included)
+- Applying gate-clearing labels (`sec-review:approved` and siblings)
+- Deleting remote branches
+- Mutating repo settings, rulesets, required checks, Actions secrets, webhooks
+- Force pushes, history rewrites, removing another session's worktree
+
+A blanket preference in memory ("merge green PRs") does **not** cover
+security-classed items. Only named in-session words or a standing settings
+allow rule do.
+
+## Never bundle a disposition with anything else
+
+One disposition action per shell command, alone. Mid-bundle blocks leave half-
+executed state.
+
+## When a PR is ready and no authorization exists
+
+Stop at the open PR. List the exact one-line owner command under owner actions.
+Do not re-send a blocked command or accomplish the disposition through another
+tool.
+
+## References
+
+- Sibling: tracker-first, quality-over-speed, durable-solutions
+- Adapter glue may deny merge/force at the permission layer; this rule is the
+  policy body adapters must not re-author in full.

--- a/.claude/rules/durable-solutions.md
+++ b/.claude/rules/durable-solutions.md
@@ -1,0 +1,52 @@
+# Durable Solutions
+
+Prefer long-term durable solutions. Fix root causes in the owning layer (shared
+lib, env bootstrap, policy, product primitive) so the failure class cannot
+recur. Session-local patches, one-off shell recipes, and "works on my machine"
+overrides are not done unless the owner accepts a **registered hotfix**.
+
+## Rules
+
+1. **Durable first.** Extend the real primitive; do not invent a parallel path.
+2. **Hotfixes are debt.** Allowed only when production or a peer must be
+   unblocked *now*. Register the same turn with symptom, temporary shape,
+   durable target, paths, and optional gap id.
+3. **Every hotfix has a destination.** Pending entries surface at session
+   boundaries until converted.
+4. **Unregistered hotfixes are policy violations** (same class as orphan temp
+   scripts).
+
+## Non-durable shapes (register or refuse)
+
+| Shape | Examples |
+|-------|----------|
+| Env / machine only | Editing gitignored `.env.local` without fixing loaders |
+| Session-only | Scratch scripts left for the owner; undocumented escapes |
+| Symptom patch | Catch-and-ignore without root fix |
+| Parallel path | Second seed script or resolver "just for X" |
+| Silent demotion | "We'll harden later" with no registry entry |
+
+## Durable shapes
+
+- Shared module / rule / hook / CI gate that fails closed for the class
+- Documented escape hatches with explicit env flags
+- Gaps/ADRs when the durable fix needs multi-session design
+- Tests that lock the durable behavior (prove red, then green)
+
+## CLI (control layer)
+
+```bash
+revealui-harnesses hotfix check
+revealui-harnesses hotfix list
+revealui-harnesses hotfix audit [path]
+# Only if a temporary patch is unavoidable (admits debt):
+revealui-harnesses hotfix register --title … --symptom … --temporary … --durable …
+revealui-harnesses hotfix resolve <id> --pr <url>
+```
+
+Store: `~/.local/share/revealui/hotfixes/manifest.json` (not vendor homes).
+
+## References
+
+- Sibling: extend-before-create, quality-over-speed, code-over-docs, adapter-only
+- GAP-405 — registry + adapter cutover; no dual Claude/Grok mirrors

--- a/.claude/rules/monorepo.md
+++ b/.claude/rules/monorepo.md
@@ -1,0 +1,54 @@
+# Monorepo Conventions
+
+## Structure
+- Apps live in `apps/`  -  deployable services (Next.js, Hono, Vite)
+- Packages live in `packages/`  -  shared libraries consumed by apps
+- Scripts live in `scripts/`  -  CLI tools, automation, CI gates
+
+## Package Manager
+- pnpm 10 with workspace protocol
+- Internal deps use `workspace:*` (never hardcoded versions)
+- Run `pnpm install:clean` (suppresses Node deprecation warnings)
+- `preinstall` script enforces pnpm-only (`npx only-allow pnpm`)
+
+## Turborepo
+- `turbo run build --parallel` for parallel builds
+- `turbo run test --concurrency=15` for parallel tests
+- Package-level `turbo.json` for task overrides (rare)
+- Cache stored in `.turbo/` (gitignored)
+
+## Package Conventions
+- Every package has: `build`, `dev`, `lint`, `test`, `typecheck` scripts
+- Build output goes to `dist/` via tsup
+- Source in `src/`, tests in `src/__tests__/` or `__tests__/`
+- Entry point: `src/index.ts` → `dist/index.js`
+- Use `exports` field in package.json for subpath exports
+- Include `files: ["dist", "README.md"]` for publishing
+
+## Dependency Rules
+- Use `syncpack` for version alignment (`pnpm deps:check`, `pnpm deps:fix`)
+- Use `catalog:` for shared devDependencies (e.g., `"zod": "catalog:"`)
+- pnpm overrides in root package.json for security patches
+- `onlyBuiltDependencies` whitelist for native modules
+
+## CI Gate
+- `pnpm gate` runs the full CI pipeline locally: lint → typecheck → test → build
+- `pnpm gate:quick` runs phase 1 only (fast feedback)
+- Must pass before pushing (enforced by Husky pre-push hook)
+
+## Adding a New Package
+1. Create `packages/<name>/` with package.json, tsconfig.json, tsup.config.ts
+2. Name: `@revealui/<name>`
+3. Add `workspace:*` references from consuming packages
+4. Register in turbo pipeline (automatic via conventions)
+5. Add to CI if needed
+
+## Publishing
+- OSS packages: `publishConfig.access: "public"`, MIT license
+- Pro packages: `publishConfig.access: "public"`, commercial license (source-available on npm)
+- Use changesets for versioning: `pnpm changeset` → `pnpm changeset:version` → `pnpm changeset:publish`
+
+## Import Conventions
+- Use package names (`@revealui/core`) not relative paths between packages
+- Use `~/` alias within apps (maps to `src/*`)
+- Use ES Modules (`import`/`export`) everywhere

--- a/.claude/rules/parameterization.md
+++ b/.claude/rules/parameterization.md
@@ -1,0 +1,52 @@
+# Parameterization Conventions
+
+## Core Rule
+
+**Never hardcode configuration values inline.** All tunable constants (TTLs, limits, lengths, thresholds, intervals) must be:
+
+1. **Extracted** into a named config object or constant at module scope
+2. **Typed** with an explicit interface
+3. **Defaulted** with sensible production values
+4. **Overridable** via an exported `configure*()` function or constructor parameter
+
+## Pattern
+
+```ts
+export interface ModuleConfig {
+  /** TTL in milliseconds (default: 5 minutes) */
+  ttlMs: number
+  /** Max entries before forced cleanup (default: 10_000) */
+  maxEntries: number
+}
+
+const DEFAULT_CONFIG: ModuleConfig = {
+  ttlMs: 5 * 60 * 1000,
+  maxEntries: 10_000,
+}
+
+let config: ModuleConfig = { ...DEFAULT_CONFIG }
+
+export function configureModule(overrides: Partial<ModuleConfig>): void {
+  config = { ...DEFAULT_CONFIG, ...overrides }
+}
+```
+
+## Why
+
+- Tests need fast TTLs and small limits
+- Deployments may need different thresholds than development
+- `Math.random()` is not cryptographically secure  -  use `crypto.randomInt()` for security-sensitive values (OTPs, tokens, nonces)
+
+## Applies To
+
+- Rate limit windows and thresholds
+- Cache TTLs and max sizes
+- OTP/token lengths and expiry times
+- Retry counts and backoff intervals
+- Batch sizes and concurrency limits
+
+## Does NOT Apply To
+
+- Structural constants (HTTP status codes, header names, URL paths)
+- Type discriminants and enum values
+- Schema definitions (use contracts)

--- a/.claude/rules/quality-over-speed.md
+++ b/.claude/rules/quality-over-speed.md
@@ -1,0 +1,34 @@
+# Quality Over Speed (standing order)
+
+**Quality is always the primary metric** for code, config, and documentation.
+Speed is a lagging benefit of good systems and better hardware/pricing — not a
+reason to ship weak work, thin proofs, or dual-home shortcuts.
+
+## Apply every session (including concurrent multi-agent work)
+
+1. **Correctness first.** Prove red→green where tests apply. Prefer root-cause
+   durable fixes over hotfixes (register any unavoidable hotfix the same turn).
+2. **Proof over pace.** Claims about system behavior need `code:line` or test
+   evidence (code-over-docs). Doc edits without proof are incomplete.
+3. **One solid change beats three rushed ones.** Do not expand scope to "finish
+   the wave" if quality drops. Stop at a clean PR boundary.
+4. **Concurrency does not lower the bar.** Parallel sessions still use exclusive
+   shards/worktrees, full gates for risk level, and no self-merge of security or
+   unreviewed work. Faster calendar time is worthless if two agents thrash the
+   same surface or invent parallel queues.
+5. **Manager + adapters.** Shared policy lives under `.revealui` / package
+   definitions. Do not mirror hardlines into vendor homes "to go faster."
+
+## Explicitly rejected
+
+- Skipping tests, audits, or claim proof to close a session sooner
+- Partial file reads marked verified in exhaustive / md-truth ledgers
+- Dual-writing the same rule into Claude and Grok homes
+- Merging or force-pushing to "unblock" without owner disposition when required
+- Silencing unused params/locals with a leading underscore (`_line`) instead of
+  implementing, redesigning the signature, or deleting (see unused-declarations)
+
+## When pressed for speed
+
+Reduce **scope**, not **quality**. Ship a smaller correct slice; leave the rest
+as TRACKER gaps/lanes with acceptance criteria intact.

--- a/.claude/rules/skills-usage.md
+++ b/.claude/rules/skills-usage.md
@@ -4,27 +4,27 @@ When the Skill tool is available, proactively invoke the following skills in the
 
 ## Always invoke automatically (no user prompt needed)
 
-- `/vercel-react-best-practices` — before completing any PR that touches React components or hooks
-- `/stripe-best-practices` — any time you write or modify billing, payment, webhook, or Stripe code
-- `/next-best-practices` — when implementing features in apps/admin or apps/marketing
-- `/next-cache-components` — when adding 'use cache', cache profiles, or PPR to a Next.js route
-- `/vercel-composition-patterns` — when adding new components to @revealui/presentation
-- `/web-design-guidelines` — when asked to review a UI, page, or component for quality
-- `/review` — when the user asks for a code review, asks to "check" or "look at" code
-- `/add-tests` — when the user asks to write tests or add coverage for a specific file
-- `/audit` — before any release or after a large refactor touching multiple packages
-- `/turborepo` — when modifying turbo.json, pipeline configuration, or monorepo task dependencies
+- `/vercel-react-best-practices`  -  before completing any PR that touches React components or hooks
+- `/stripe-best-practices`  -  any time you write or modify billing, payment, webhook, or Stripe code
+- `/next-best-practices`  -  when implementing features in apps/admin or apps/marketing
+- `/next-cache-components`  -  when adding 'use cache', cache profiles, or PPR to a Next.js route
+- `/vercel-composition-patterns`  -  when adding new components to @revealui/presentation
+- `/web-design-guidelines`  -  when asked to review a UI, page, or component for quality
+- `/review`  -  when the user asks for a code review, asks to "check" or "look at" code
+- `/add-tests`  -  when the user asks to write tests or add coverage for a specific file
+- `/audit`  -  before any release or after a large refactor touching multiple packages
+- `/turborepo`  -  when modifying turbo.json, pipeline configuration, or monorepo task dependencies
 
 ## Only invoke on explicit user request (disable-model-invocation: true)
 
-- `/gate` — user must explicitly ask to run the gate
-- `/sync-lts` — user must explicitly ask to sync or backup
-- `/new-package` — user must explicitly ask to scaffold a package
-- `/new-professional-project` — user must explicitly ask to create a project
-- `/vercel-deploy` — user must explicitly ask to deploy
-- `/deploy-check` — user must explicitly ask for pre-deploy check
-- `/db-migrate` — user must explicitly ask to create or apply database migrations
-- `/preflight` — user must explicitly ask to run the preflight checklist
+- `/gate`  -  user must explicitly ask to run the gate
+- `/sync-lts`  -  user must explicitly ask to sync or backup
+- `/new-package`  -  user must explicitly ask to scaffold a package
+- `/new-professional-project`  -  user must explicitly ask to create a project
+- `/vercel-deploy`  -  user must explicitly ask to deploy
+- `/deploy-check`  -  user must explicitly ask for pre-deploy check
+- `/db-migrate`  -  user must explicitly ask to create or apply database migrations
+- `/preflight`  -  user must explicitly ask to run the preflight checklist
 
 ## When in doubt
 

--- a/.claude/rules/tailwind.md
+++ b/.claude/rules/tailwind.md
@@ -1,0 +1,142 @@
+# Tailwind CSS v4 Conventions
+
+## Version
+
+RevealUI uses **Tailwind CSS v4** (`^4.1.18`). All new code must use v4 patterns.
+
+## Current State
+
+The shared config in `packages/dev/src/tailwind/` uses a **v3 compatibility pattern** (JS config file + JS plugins). This works because Tailwind v4 auto-detects `tailwind.config.ts` and falls back to v3 behavior. Migration to native v4 CSS config is deferred to Phase 2.
+
+## v4 Gotchas (Must Know)
+
+### Import Syntax
+```css
+/* CORRECT (v4) */
+@import "tailwindcss";
+
+/* WRONG (v3  -  deprecated) */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+### Custom Utilities
+```css
+/* CORRECT (v4) */
+@utility my-util {
+  /* styles */
+}
+
+/* WRONG (v3) */
+@layer utilities {
+  .my-util { /* styles */ }
+}
+@layer components {
+  .my-component { /* styles */ }
+}
+```
+
+### CSS Variable Syntax
+```html
+<!-- CORRECT (v4)  -  parentheses -->
+<div class="bg-(--brand-color)">
+
+<!-- WRONG (v3)  -  square brackets -->
+<div class="bg-[--brand-color]">
+```
+
+### Important Modifier
+```html
+<!-- CORRECT (v4)  -  at the end -->
+<div class="bg-red-500!">
+
+<!-- WRONG (v3)  -  at the start -->
+<div class="bg-!red-500">
+```
+
+### Default Behavior Changes
+- **Border/ring color**: now `currentColor` (was `gray-200` in v3)
+- **Ring width**: default is `1px` (was `3px` in v3)
+- **`hover:`**: only applies on devices that support hover (no-touch)
+- **Stacked variants**: apply left-to-right (reversed from v3)
+- **`space-*` / `divide-*`**: selectors changed  -  prefer `gap` with flex/grid
+
+### Transform Utilities
+```html
+<!-- CORRECT (v4) -->
+<div class="scale-none rotate-none translate-none">
+
+<!-- WRONG (v3) -->
+<div class="transform-none">
+```
+
+### Prefix Syntax
+```css
+/* v4 prefix */
+@import "tailwindcss" prefix(tw);
+/* Classes use tw:bg-red-500 */
+```
+
+### CSS Modules / Component Styles
+Use `@reference` to access theme variables in CSS modules or component `<style>` blocks.
+
+### PostCSS Plugin
+```js
+// v4  -  new package name
+{ plugins: { '@tailwindcss/postcss': {} } }
+
+// v3  -  old (still works but deprecated)
+{ plugins: { tailwindcss: {} } }
+```
+
+### Vite Plugin (preferred over PostCSS for Vite apps)
+```js
+import tailwindcss from '@tailwindcss/vite'
+export default { plugins: [tailwindcss()] }
+```
+
+## Theme Configuration (v4 native)
+
+In v4, theme tokens go in CSS, not JS:
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-brand: #ea580c;
+  --font-sans: "Inter", sans-serif;
+  --breakpoint-xs: 475px;
+  --breakpoint-3xl: 1920px;
+}
+```
+
+## RevealUI Shared Config
+
+| File | Purpose |
+|------|---------|
+| `packages/dev/src/tailwind/tailwind.config.ts` | Shared v3-compat config (fonts, plugins, screens) |
+| `packages/dev/src/tailwind/create-config.ts` | Helper to merge shared + app configs |
+| `packages/dev/src/tailwind/postcss.config.ts` | PostCSS config with `@tailwindcss/postcss` |
+| `packages/dev/src/tailwind/styles.css` | Base CSS (`@import "tailwindcss"`) |
+
+### Consumer Pattern (current  -  v3 compat)
+```ts
+// apps/admin/tailwind.config.ts
+import { createTailwindConfig } from '@revealui/dev/tailwind/create-config'
+export default createTailwindConfig({
+  content: ['./src/**/*.{ts,tsx}'],
+  // app-specific overrides
+})
+```
+
+## Rules for New Code
+
+1. **Never use `@tailwind` directives**  -  use `@import "tailwindcss"` instead
+2. **Never use `@layer utilities` or `@layer components`** for custom utilities  -  use `@utility`
+3. **Use `bg-(--var)` syntax** for CSS variables, not `bg-[--var]`
+4. **Important goes at the end**: `bg-red-500!` not `!bg-red-500`
+5. **Prefer `gap`** over `space-*` / `divide-*` for spacing in flex/grid
+6. **No `transform-none`**  -  use `scale-none`, `rotate-none`, `translate-none`
+7. **Don't add new v3 JS plugins**  -  if a v4 CSS equivalent exists, use that
+8. **Content paths are auto-detected** in v4  -  only add manual paths for edge cases

--- a/.claude/rules/tracker-first.md
+++ b/.claude/rules/tracker-first.md
@@ -1,0 +1,23 @@
+# Tracker First (all models / providers)
+
+Open the fleet **TRACKER** before inventing work:
+
+`docs/TRACKER.md` (generated from `docs/initiatives/*.yml` via `node scripts/initiatives-render.js`)
+
+## Rules
+
+1. **Day-to-day free surfaces live only on TRACKER.** Gaps and lanes are the execution units; initiatives group them.
+2. **Do not invent parallel queues** in harness homes (`~/.claude`, `~/.grok`), root `TODO.md`, or chat-only lists.
+3. **CURRENT-HANDOFF** is session deltas only. **MASTER_PLAN** is strategy only.
+4. **Product I/O** goes through RevealUI MCP (governed user + receipts), not per-harness side channels.
+5. Shared policy is authored once (Plane A / `@revealui/harnesses` content definitions). Adapters **consume**; they do not full-copy hardlines.
+
+## Claim work
+
+Register a workboard note for an existing gap or lane id from TRACKER. Status lives on the gap YAML or lane plan — never hand-copied into TRACKER tables.
+
+## References
+
+- ADR `2026-07-22-single-fleet-tracker`
+- ADR `2026-07-21-harness-policy-runtime-launch-planes`
+- GAP-318, GAP-406

--- a/.claude/rules/unused-declarations.md
+++ b/.claude/rules/unused-declarations.md
@@ -1,0 +1,134 @@
+# Unused Declarations Policy (HARDLINE)
+
+**Status:** HARDLINE for every session (Claude, Grok, Cursor, any adapter). Owner
+directive 2026-07-29. Thoroughness is non-negotiable. Laziness is rejected.
+
+## Core rule
+
+**NEVER silence an unused variable, parameter, or import by renaming it with a
+leading underscore (`_line`, `_unused`, `_event`) when the honest fix is to
+implement the value, redesign the API, or delete dead code.**
+
+Biome and many linters *allow* underscore-prefixed names as unused. That
+exception is **not** permission to skip work. This codebase treats
+underscore-silence as a policy violation equal to biome-ignore on a TODO stub.
+
+Unused declarations usually mean **incomplete implementation**, not "noise to
+mute." Thorough agents implement. Lazy agents rename to `_x` and move on.
+
+Companion: quality-over-speed (reduce scope, never quality).
+
+---
+
+## Mandatory decision tree
+
+When you see `noUnusedVariables`, `noUnusedParameters`, TS6133, or any
+"declared but never read" diagnostic, **before any edit**:
+
+```
+1. Should this value drive logic that is missing?
+   └─ Signs: parameter is in the public API, named for a real concern (line,
+             path, token, id), body only uses a sibling arg, or adjacent tests
+             expect behavior from this input
+   └─ Action: IMPLEMENT using the parameter. Empty short-circuit, validation,
+              error paths, and detectors all count as real use. Do not prefix `_`.
+
+2. Do you control the function signature?
+   └─ Yes, and the param is unnecessary → REMOVE it from the signature and
+      update every call site in the same change. Prefer a smaller honest API.
+   └─ Yes, and the param is needed later in the same PR → implement now.
+
+3. Is the import type-only?
+   └─ Action: `import type { ... }` (not underscore rename).
+
+4. Is it genuinely dead with no planned use?
+   └─ Action: DELETE the declaration and call sites. No grace period.
+
+5. Is the parameter forced by a host callback signature you cannot change?
+   └─ Signs only: framework-mandated arity (e.g. Express `(err, req, res, next)`
+      when you only need `next`), or an interface you implement but do not own
+   └─ Action: prefix `_` **only then**, and add a one-line comment naming the
+      host signature. This is the sole underscore carve-out for parameters.
+
+6. Is it an intentional side-effect binding (IaC / must construct)?
+   └─ Action: `_` prefix **only with** a comment explaining the side effect.
+      Never use this for application logic params.
+```
+
+If none of 5–6 apply, **underscore is forbidden**.
+
+---
+
+## Explicitly rejected (every session)
+
+- `_line`, `_req`, `_unused`, `_args` to quiet TS6133 / Biome when you own the API
+- `// biome-ignore ... noUnusedVariables: TODO`
+- "I'll wire it later" after renaming to `_`
+- Deleting a stub that represents required behavior without implementing it
+- Partial fixes that leave the thorough path for "someone else"
+
+---
+
+## What implement means
+
+1. Search related types, tests, and call sites for intent.
+2. Use the parameter in real control flow (validate, short-circuit, detect, log
+   structured fields, pass through). Empty `line.trim()` guards are valid when
+   they match the audit contract.
+3. Typecheck + Biome + tests for the package before moving on.
+4. Prefer one correct change over a silent underscore.
+
+---
+
+## Examples
+
+### Wrong — silence the audit string
+```ts
+export function findHits(_line: string, tokens: Token[]): Hit[] {
+  return detect(wordTexts(tokens));
+}
+```
+
+### Right — use the line (empty short-circuit is real use)
+```ts
+export function findHits(line: string, tokens: Token[]): Hit[] {
+  if (line.trim().length === 0) return [];
+  return detect(wordTexts(tokens));
+}
+```
+
+### Wrong — mute a stub
+```ts
+// biome-ignore lint/correctness/noUnusedVariables: TODO
+const semanticMemory = new SemanticMemory()
+```
+
+### Right — implement
+```ts
+const semanticMemory = new SemanticMemory()
+await semanticMemory.store('key', content, embedding)
+```
+
+### Allowed underscore (host-mandated only)
+```ts
+// Hono error handler arity is fixed by the framework; body only needs err.
+app.onError((_req, err) => respond(err))
+```
+
+---
+
+## Verification (mandatory before next task)
+
+```bash
+pnpm --filter <package> typecheck
+pnpm exec biome check <file>
+pnpm --filter <package> test   # if behavior changed
+```
+
+---
+
+## Relationship
+
+- **quality-over-speed** — thoroughness outranks session throughput
+- **code-over-docs** — unused params that should affect behavior are incomplete product
+- **durable-solutions** — underscore silence is a temporary shape; refuse it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ audience: agent
 
 > **Project manager (all vendors equal):** open [`.revealui/manager.json`](.revealui/manager.json) first.
 > Shared policy is generated from `@revealui/harnesses` into [`.revealui/content/`](.revealui/content/) (committed; refresh with `revealui-harnesses manager materialize`).
-> This Claude adapter still loads [`.claude/rules/`](.claude/rules/) until control-layer phase 2 retires duplicated rule bodies.
+> Claude loads [`.claude/rules/`](.claude/rules/): definition-backed rules are **mirrored** from content (GAP-421 phase 2); monorepo-only rules stay hand-authored. Do not dual-edit definition rule bodies.
 > This file is an adapter orientation doc, not a second policy home. See [`.revealui/README.md`](.revealui/README.md).
 
 # RevealUI Monorepo

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -93,11 +93,13 @@ describe('project manager (.revealui)', () => {
     expect(written.byGenerator['claude-code']).toBeGreaterThan(0);
     expect(written.byGenerator.cursor).toBe(1);
     expect(written.byGenerator.opencode).toBeGreaterThan(0);
-    expect(written.total).toBe(
+    const generatorTotal =
       written.byGenerator['claude-code'] +
-        written.byGenerator.cursor +
-        written.byGenerator.opencode,
-    );
+      written.byGenerator.cursor +
+      written.byGenerator.opencode;
+    // GAP-421 phase 2: definition rules also mirrored under .claude/rules/
+    expect(written.claudeRuleMirrors.length).toBeGreaterThan(0);
+    expect(written.total).toBe(generatorTotal + written.claudeRuleMirrors.length);
 
     const hooks = JSON.parse(readFileSync(join(root, '.cursor/hooks.json'), 'utf-8')) as {
       version: number;
@@ -113,6 +115,10 @@ describe('project manager (.revealui)', () => {
     );
     expect(contentRule.length).toBeGreaterThan(20);
 
+    // Phase 2: Claude load path matches content for definition rules
+    const claudeRule = readFileSync(join(root, '.claude/rules/code-over-docs.md'), 'utf-8');
+    expect(claudeRule).toBe(contentRule);
+
     // OpenCode gets at least one agent or command under .opencode
     const opencodePaths = written.paths.filter((p) => p.startsWith('.opencode/'));
     expect(opencodePaths.length).toBeGreaterThan(0);
@@ -122,6 +128,19 @@ describe('project manager (.revealui)', () => {
     expect(check.warnings.filter((w) => w.includes('cursor') || w.includes('opencode'))).toEqual(
       [],
     );
+  });
+
+  it('checkManager fails when .claude/rules dual drifts from content (GAP-421 phase 2)', () => {
+    const root = tempProject();
+    materializeManager(root);
+    writeManagerAdapterContent(root);
+    expect(checkManager(root).ok).toBe(true);
+
+    const dual = join(root, '.claude/rules/code-over-docs.md');
+    writeFileSync(dual, `${readFileSync(dual, 'utf-8')}\n// dual drift\n`, 'utf-8');
+    const drifted = checkManager(root);
+    expect(drifted.ok).toBe(false);
+    expect(drifted.errors.some((e) => e.includes('dual drift'))).toBe(true);
   });
 
   it('materialize preserves existing monorepo manager fields', () => {

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -88,6 +88,7 @@ export {
 } from './snapshot.js';
 export type { WriteManagerAdapterContentResult } from './write-manager-adapters.js';
 export {
+  claudeRulePathForDefinitionId,
   MANAGER_MATERIALIZE_GENERATORS,
   writeManagerAdapterContent,
 } from './write-manager-adapters.js';

--- a/packages/harnesses/src/content/write-manager-adapters.ts
+++ b/packages/harnesses/src/content/write-manager-adapters.ts
@@ -4,18 +4,23 @@
  * - `claude-code` (default) → `.revealui/content/` (policy SSOT on disk)
  * - `cursor` → `.cursor/hooks.json` (vendor-native hooks only)
  * - `opencode` → `.opencode/{agents,commands}/`
+ * - GAP-421 phase 2: definition rules also mirrored to `.claude/rules/<id>.md`
+ *   so Claude Code loads the same body as content (no hand duals).
  *
  * Vendor trees remain thin adapters; hardlines stay in package definitions +
  * manager content. Hooks/agents/commands that must live under vendor paths
  * still emit via this one materialize path so Cursor/OpenCode are not
  * "hooks-tree only" orphans outside the manager.
+ *
+ * Monorepo-only rules under `.claude/rules/` that are NOT definition ids
+ * (e.g. git.md, coordination.md) are left alone.
  */
 
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { buildManifest } from './definitions/index.js';
 import { getGenerator } from './generators/index.js';
-import { DEFAULT_CONTENT_GENERATOR_ID } from './generators/types.js';
+import { DEFAULT_CONTENT_GENERATOR_ID, MANAGER_CONTENT_OUTPUT } from './generators/types.js';
 import type { Manifest } from './schemas/manifest.js';
 
 /**
@@ -28,14 +33,29 @@ export const MANAGER_MATERIALIZE_GENERATORS: readonly string[] = [
   'opencode',
 ];
 
+/** Content rules path prefix under the project (relative). */
+const CONTENT_RULES_PREFIX = `${MANAGER_CONTENT_OUTPUT}/rules/`;
+
+/**
+ * Relative path for the Claude Code load surface for a definition rule id.
+ * Not used for `00-revealui-manager.md` (adapter stub from materializeManager).
+ */
+export function claudeRulePathForDefinitionId(ruleId: string): string {
+  return join('.claude', 'rules', `${ruleId}.md`);
+}
+
 export interface WriteManagerAdapterContentResult {
   byGenerator: Record<string, number>;
   total: number;
   paths: string[];
+  /** Definition rules mirrored into `.claude/rules/` (GAP-421 phase 2). */
+  claudeRuleMirrors: string[];
 }
 
 /**
  * Generate + write files for each manager-materialize generator under projectRoot.
+ * Also mirrors definition-backed rule bodies into `.claude/rules/` so Claude Code
+ * cannot drift from definitions (ADR 2026-07-25 phase 2).
  */
 export function writeManagerAdapterContent(
   projectRoot: string,
@@ -45,6 +65,7 @@ export function writeManagerAdapterContent(
   const manifest = options?.manifest ?? buildManifest();
   const byGenerator: Record<string, number> = {};
   const paths: string[] = [];
+  const claudeRuleMirrors: string[] = [];
   let total = 0;
 
   for (const id of generatorIds) {
@@ -60,10 +81,29 @@ export function writeManagerAdapterContent(
       mkdirSync(dirname(absolutePath), { recursive: true });
       writeFileSync(absolutePath, file.content, 'utf-8');
       paths.push(file.relativePath);
+
+      // GAP-421 phase 2: same rule body under Claude's load path.
+      if (
+        id === DEFAULT_CONTENT_GENERATOR_ID &&
+        file.relativePath.startsWith(CONTENT_RULES_PREFIX)
+      ) {
+        const ruleFile = basename(file.relativePath);
+        if (!ruleFile.endsWith('.md') || ruleFile.startsWith('00-')) {
+          continue;
+        }
+        const ruleId = ruleFile.slice(0, -'.md'.length);
+        const claudeRel = claudeRulePathForDefinitionId(ruleId);
+        const claudeAbs = join(projectRoot, claudeRel);
+        mkdirSync(dirname(claudeAbs), { recursive: true });
+        writeFileSync(claudeAbs, file.content, 'utf-8');
+        claudeRuleMirrors.push(claudeRel);
+        paths.push(claudeRel);
+        total += 1;
+      }
     }
     byGenerator[id] = files.length;
     total += files.length;
   }
 
-  return { byGenerator, total, paths };
+  return { byGenerator, total, paths, claudeRuleMirrors };
 }

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -1,5 +1,7 @@
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { buildManifest } from '../content/definitions/index.js';
+import { claudeRulePathForDefinitionId } from '../content/write-manager-adapters.js';
 import { GROK_HOOK_FILES, GROK_HOOK_TEMPLATE_DIR } from './grok-session-hooks.js';
 import {
   MANAGER_CONTENT_DIR,
@@ -88,10 +90,11 @@ export function materializeClaudeStub(projectRoot: string): string {
 # RevealUI manager (Claude adapter)
 
 1. Open **\`.revealui/manager.json\`** for project authority.
-2. Shared rules/skills: **\`.revealui/content/\`** (generated from \`@revealui/harnesses\`).
-3. Day-to-day free surfaces: path in \`manager.json\` → \`tracker.path\` (fleet: \`docs/TRACKER.md\`).
-4. Product I/O: RevealUI MCP only (device token via \`rfg\` / revvault) — not vendor side channels.
-5. Equal vendors: Claude is not more authoritative than Grok, Cursor, or OpenCode.
+2. Shared policy SSOT: package definitions → **\`.revealui/content/\`** (materialize).
+3. Claude loads \`.claude/rules/\`: definition-backed rule bodies are **mirrored** from content (GAP-421 phase 2); monorepo-only rules stay hand-authored here; this stub is adapter-only.
+4. Day-to-day free surfaces: path in \`manager.json\` → \`tracker.path\` (fleet: \`docs/TRACKER.md\`).
+5. Product I/O: RevealUI MCP only (device token via \`rfg\` / revvault) — not vendor side channels.
+6. Equal vendors: Claude is not more authoritative than Grok, Cursor, or OpenCode.
 
 See \`.revealui/README.md\`.
 `;
@@ -298,6 +301,33 @@ export function checkManager(projectRoot: string): ManagerCheckResult {
       errors.push(
         `missing or empty ${MANAGER_DIR}/${parsedConfig.contentRoot}/ — run: revealui-harnesses manager materialize`,
       );
+    } else {
+      // Phase 2: definition rule bodies under .claude/rules must match content
+      // (Claude load path). Monorepo-only rules (git.md, …) are not checked.
+      const manifest = buildManifest();
+      for (const rule of manifest.rules) {
+        const contentRel = join(MANAGER_DIR, parsedConfig.contentRoot, 'rules', `${rule.id}.md`);
+        const contentAbs = join(projectRoot, contentRel);
+        const claudeRel = claudeRulePathForDefinitionId(rule.id);
+        const claudeAbs = join(projectRoot, claudeRel);
+        const contentBody = readFileOrNull(contentAbs);
+        const claudeBody = readFileOrNull(claudeAbs);
+        if (contentBody === null) {
+          errors.push(`missing ${contentRel} — run: revealui-harnesses manager materialize`);
+          continue;
+        }
+        if (claudeBody === null) {
+          errors.push(
+            `missing ${claudeRel} (GAP-421 phase 2: definition rules must load under .claude/rules) — run: revealui-harnesses manager materialize`,
+          );
+          continue;
+        }
+        if (claudeBody !== contentBody) {
+          errors.push(
+            `dual drift: ${claudeRel} !== ${contentRel} — run: revealui-harnesses manager materialize`,
+          );
+        }
+      }
     }
   }
 

--- a/scripts/validate/__tests__/rules-lockstep.test.ts
+++ b/scripts/validate/__tests__/rules-lockstep.test.ts
@@ -107,4 +107,41 @@ describe('verifyLockstep', () => {
     expect(problems).toHaveLength(1);
     expect(problems[0]).toContain('malformed');
   });
+
+  it('definition-owned Claude rules must match content (not revcon hash)', () => {
+    const body = '# Biome\nfrom definitions\n';
+    writeRule('rules/biome.md', body);
+    mkdirSync(path.join(root, '.revealui', 'content', 'rules'), { recursive: true });
+    writeFileSync(path.join(root, '.revealui', 'content', 'rules', 'biome.md'), body);
+    // Manifest still has a stale revcon hash for biome.
+    const manifest: Manifest = {
+      mode: 'copy',
+      editor: 'claude',
+      profiles: ['revealui'],
+      files: {
+        'rules/biome.md': {
+          source: 'profiles/revealui/claude/rules/biome.md',
+          sha256: 'deadbeef',
+        },
+      },
+    };
+    const defIds = new Set(['biome']);
+    expect(verifyLockstep(root, manifest, ['.claude/rules/biome.md'], defIds)).toEqual([]);
+
+    writeRule('rules/biome.md', `${body}\ndrift\n`);
+    const drifted = verifyLockstep(root, manifest, ['.claude/rules/biome.md'], defIds);
+    expect(drifted.some((p) => p.includes('dual drift'))).toBe(true);
+  });
+
+  it('definition mirrors not in the revcon manifest are not strays when they match content', () => {
+    const body = '# Code over docs\n';
+    writeRule('rules/code-over-docs.md', body);
+    mkdirSync(path.join(root, '.revealui', 'content', 'rules'), { recursive: true });
+    writeFileSync(path.join(root, '.revealui', 'content', 'rules', 'code-over-docs.md'), body);
+    writeRule('rules/git.md', '# Git\n');
+    const manifest = manifestFor({ 'rules/git.md': '' });
+    const defIds = new Set(['code-over-docs']);
+    const tracked = ['.claude/rules/git.md', '.claude/rules/code-over-docs.md'];
+    expect(verifyLockstep(root, manifest, tracked, defIds)).toEqual([]);
+  });
 });

--- a/scripts/validate/rules-lockstep.ts
+++ b/scripts/validate/rules-lockstep.ts
@@ -1,29 +1,30 @@
 /**
  * Rules Lockstep Gate
  *
- * The `.claude/` config surface (rules/, agents/, skills/) is MATERIALIZED
- * into this repo by revcon (`link.sh --mode copy`) from its profile sources,
- * with a manifest at `.claude/.revcon-manifest.json` recording each file's
- * profile source and sha256. The copies are git-tracked so fresh clones,
- * worktrees, and CI all see the same rules; this gate keeps them in lockstep:
+ * The `.claude/` config surface has two owners (GAP-421 phase 2):
  *
- *   1. Every manifest entry must exist on disk with a matching sha256
- *      (a mismatch means a local hand-edit: edit the revcon profile
- *      instead, then re-run link.sh --mode copy).
- *   2. Every git-tracked file under the materialized dirs must appear in
- *      the manifest (a stray means a hand-added file bypassing revcon).
+ *   A) **revcon-owned** files (agents, skills, monorepo-only rules) are
+ *      MATERIALIZED by revcon (`link.sh --mode copy`) with a manifest at
+ *      `.claude/.revcon-manifest.json` recording each file's profile source
+ *      and sha256.
+ *   B) **definition-owned** rules under `.claude/rules/<id>.md` that also
+ *      exist as `.revealui/content/rules/<id>.md` are mirrored by
+ *      `revealui-harnesses manager materialize` from package definitions.
+ *      Those must match content byte-for-byte (not the revcon profile copy).
  *
- * Sibling of the SECRETS.md lockstep test (scripts/sync/__tests__/
- * secret-paths-lockstep.test.ts): same derived-view pattern, different
- * surface. Staleness relative to the CURRENT revcon profiles is checked on
- * the revcon side (`status.sh`) and at session start, not here: CI for this
- * repo verifies only self-consistency, so it needs no sibling checkout.
+ * Gate rules:
+ *   1. Every revcon-manifest entry that is NOT a definition-owned rule must
+ *      exist with a matching sha256 (edit the revcon profile + re-link).
+ *   2. Every definition-owned `.claude/rules/<id>.md` must match content
+ *      (run manager materialize). Manifest hash for those ids is ignored.
+ *   3. Every other git-tracked file under the materialized dirs must appear
+ *      in the revcon manifest (stray hand-add).
  *
  * Usage:
  *   pnpm validate:rules-lockstep
  *
  * Exit codes:
- *   0 = manifest present, all hashes match, no strays
+ *   0 = consistent
  *   1 = drift detected (list printed) or manifest missing
  */
 
@@ -36,6 +37,8 @@ import { pathToFileURL } from 'node:url';
 const ROOT = path.resolve(import.meta.dirname, '../..');
 export const MANIFEST_REL = path.posix.join('.claude', '.revcon-manifest.json');
 export const MATERIALIZED_DIRS = ['.claude/rules', '.claude/agents', '.claude/skills'];
+const CONTENT_RULES_REL = path.posix.join('.revealui', 'content', 'rules');
+const MATERIALIZE_CMD = 'pnpm exec revealui-harnesses manager materialize';
 const REAPPLY_CMD =
   'bash ~/revfleet/revcon/link.sh --target ~/revfleet/revealui --profile revfleet --profile revealui --editor claude --mode copy';
 
@@ -65,6 +68,30 @@ export function loadManifest(root: string): Manifest | null {
   return parsed as Manifest;
 }
 
+/**
+ * Basenames (without .md) of definition-backed rules present under content.
+ * Empty when the content tree is absent (caller still fails manager check).
+ */
+export function definitionRuleIdsFromContent(root: string): Set<string> {
+  const dir = path.join(root, CONTENT_RULES_REL);
+  const ids = new Set<string>();
+  if (!fs.existsSync(dir)) return ids;
+  for (const name of fs.readdirSync(dir)) {
+    if (!name.endsWith('.md') || name.startsWith('00-')) continue;
+    ids.add(name.slice(0, -'.md'.length));
+  }
+  return ids;
+}
+
+/** True when `rel` is `.claude/rules/<definition-id>.md`. */
+export function isDefinitionClaudeRule(rel: string, definitionIds: Set<string>): boolean {
+  const prefix = '.claude/rules/';
+  if (!rel.startsWith(prefix) || !rel.endsWith('.md')) return false;
+  const base = rel.slice(prefix.length, -'.md'.length);
+  if (base.includes('/') || base.startsWith('00-')) return false;
+  return definitionIds.has(base);
+}
+
 function gitTrackedMaterializedFiles(root: string): string[] {
   const out = execFileSync('git', ['ls-files', '--', ...MATERIALIZED_DIRS], {
     cwd: root,
@@ -77,9 +104,16 @@ function gitTrackedMaterializedFiles(root: string): string[] {
  * Pure verification core: returns one human-readable problem line per
  * violation. `trackedFiles` is the repo-relative list of git-tracked files
  * under MATERIALIZED_DIRS (injected so tests need no git repo).
+ * `definitionIds` is injected for tests; defaults from content tree when omitted.
  */
-export function verifyLockstep(root: string, manifest: Manifest, trackedFiles: string[]): string[] {
+export function verifyLockstep(
+  root: string,
+  manifest: Manifest,
+  trackedFiles: string[],
+  definitionIds?: Set<string>,
+): string[] {
   const problems: string[] = [];
+  const defIds = definitionIds ?? definitionRuleIdsFromContent(root);
 
   if (manifest.mode !== 'copy' || typeof manifest.files !== 'object' || manifest.files === null) {
     return [`${MANIFEST_REL} is malformed (expected mode "copy" with a files map)`];
@@ -99,6 +133,26 @@ export function verifyLockstep(root: string, manifest: Manifest, trackedFiles: s
       problems.push(`${fileRel} - still a symlink; re-materialize with link.sh --mode copy`);
       continue;
     }
+
+    // Definition-owned rules: lock to content, not the revcon profile hash.
+    if (isDefinitionClaudeRule(fileRel, defIds)) {
+      const id = path.posix.basename(fileRel, '.md');
+      const contentAbs = path.join(root, CONTENT_RULES_REL, `${id}.md`);
+      if (!fs.existsSync(contentAbs)) {
+        problems.push(
+          `${fileRel} - definition rule missing content twin ${CONTENT_RULES_REL}/${id}.md — run: ${MATERIALIZE_CMD}`,
+        );
+        continue;
+      }
+      if (sha256OfFile(abs) !== sha256OfFile(contentAbs)) {
+        problems.push(
+          `${fileRel} - dual drift vs ${CONTENT_RULES_REL}/${id}.md (GAP-421 phase 2). ` +
+            `Run: ${MATERIALIZE_CMD}`,
+        );
+      }
+      continue;
+    }
+
     const have = sha256OfFile(abs);
     if (have !== entry.sha256) {
       problems.push(
@@ -108,13 +162,31 @@ export function verifyLockstep(root: string, manifest: Manifest, trackedFiles: s
     }
   }
 
+  // Definition mirrors not in the revcon manifest still must match content.
   for (const tracked of trackedFiles) {
-    if (!manifestRels.has(tracked)) {
+    if (!isDefinitionClaudeRule(tracked, defIds)) continue;
+    const id = path.posix.basename(tracked, '.md');
+    const abs = path.join(root, tracked);
+    const contentAbs = path.join(root, CONTENT_RULES_REL, `${id}.md`);
+    if (!fs.existsSync(abs)) continue;
+    if (!fs.existsSync(contentAbs)) {
+      problems.push(`${tracked} - definition rule missing content twin — run: ${MATERIALIZE_CMD}`);
+      continue;
+    }
+    if (sha256OfFile(abs) !== sha256OfFile(contentAbs)) {
       problems.push(
-        `${tracked} - tracked but not in the manifest (hand-added?). ` +
-          'Add it to the revcon profile and re-run link.sh --mode copy, or untrack it.',
+        `${tracked} - dual drift vs ${CONTENT_RULES_REL}/${id}.md — run: ${MATERIALIZE_CMD}`,
       );
     }
+  }
+
+  for (const tracked of trackedFiles) {
+    if (manifestRels.has(tracked)) continue;
+    if (isDefinitionClaudeRule(tracked, defIds)) continue; // owned by materialize
+    problems.push(
+      `${tracked} - tracked but not in the manifest (hand-added?). ` +
+        'Add it to the revcon profile and re-run link.sh --mode copy, or untrack it.',
+    );
   }
 
   return problems;
@@ -129,7 +201,9 @@ export function main(): number {
     return 1;
   }
 
-  const problems = verifyLockstep(ROOT, manifest, gitTrackedMaterializedFiles(ROOT));
+  const tracked = gitTrackedMaterializedFiles(ROOT);
+  const defIds = definitionRuleIdsFromContent(ROOT);
+  const problems = verifyLockstep(ROOT, manifest, tracked, defIds);
 
   if (problems.length > 0) {
     console.error(`✗ ${problems.length} rules-lockstep violation(s):`);
@@ -137,13 +211,15 @@ export function main(): number {
       console.error(`  ${p}`);
     }
     console.error('');
-    console.error(`  Re-apply from profiles: ${REAPPLY_CMD}`);
+    console.error(`  Revcon-owned: ${REAPPLY_CMD}`);
+    console.error(`  Definition-owned: ${MATERIALIZE_CMD}`);
     return 1;
   }
 
   const count = Object.keys(manifest.files).length;
   console.log(
-    `✓ rules lockstep: ${count} materialized file(s) match the manifest (profiles: ${manifest.profiles.join(', ')}); no strays`,
+    `✓ rules lockstep: ${count} revcon-manifest file(s) (profiles: ${manifest.profiles.join(', ')}); ` +
+      `${defIds.size} definition rule(s) match content; no strays`,
   );
   return 0;
 }


### PR DESCRIPTION
## Summary
GAP-421 **phase 2** (ADR 2026-07-25 content materialization): definition-backed rule bodies under Claude's load path come from the same generator as `.revealui/content`.

### Product
- `writeManagerAdapterContent` mirrors each content rule into `.claude/rules/<id>.md`
- `checkManager` fails on missing/drifted definition duals
- Materialized monorepo rules (definition set) committed; monorepo-only revcon rules (git, coordination, …) unchanged

### Gate
- `validate:rules-lockstep` treats definition-owned `.claude/rules/*` as content-locked (not revcon-hash-locked)

## Peer order
- Peer jv#957 (GAP-355 close) left alone
- GAP-360 owner walk left alone
- After GAP-419 doc close, this was the next free product residual

## Test plan
- [x] manager + config-normalizer vitest
- [x] rules-lockstep unit tests
- [x] local phase-1 gate PASS on push
- [ ] CI green