### PR TITLE
fix(admin): MFA page no longer bounces to login on license 401

### DIFF
--- a/apps/admin/src/lib/auth/__tests__/redirect-to-login.test.ts
+++ b/apps/admin/src/lib/auth/__tests__/redirect-to-login.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isPreAuthPublicPath, redirectToLogin } from '../redirect-to-login';
+
+describe('isPreAuthPublicPath', () => {
+  it('recognizes MFA and login surfaces', () => {
+    expect(isPreAuthPublicPath('/mfa')).toBe(true);
+    expect(isPreAuthPublicPath('/mfa?upgrade=pro')).toBe(false); // pathname only
+    expect(isPreAuthPublicPath('/login')).toBe(true);
+    expect(isPreAuthPublicPath('/signup')).toBe(true);
+    expect(isPreAuthPublicPath('/rotate-password')).toBe(true);
+    expect(isPreAuthPublicPath('/reset-password')).toBe(true);
+    expect(isPreAuthPublicPath('/setup')).toBe(true);
+    expect(isPreAuthPublicPath('/')).toBe(false);
+    expect(isPreAuthPublicPath('/settings/api-keys')).toBe(false);
+  });
+});
+
+describe('redirectToLogin', () => {
+  const assign = vi.fn();
+
+  beforeEach(() => {
+    assign.mockReset();
+    vi.stubGlobal('window', {
+      location: {
+        pathname: '/',
+        search: '',
+        hash: '',
+        assign,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not bounce when already on /mfa (MFA challenge has no full session)', () => {
+    window.location.pathname = '/mfa';
+    redirectToLogin();
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('does not bounce when already on /login', () => {
+    window.location.pathname = '/login';
+    redirectToLogin();
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('sends protected paths to login with returnUrl', () => {
+    window.location.pathname = '/settings/api-keys';
+    window.location.search = '';
+    redirectToLogin();
+    expect(assign).toHaveBeenCalledWith('/login?returnUrl=%2Fsettings%2Fapi-keys');
+  });
+});

--- a/apps/admin/src/lib/auth/redirect-to-login.ts
+++ b/apps/admin/src/lib/auth/redirect-to-login.ts
@@ -2,12 +2,39 @@
  * Client-side re-auth redirect for dead or rejected sessions (GAP-454).
  * Keeps the return path so the operator lands back after sign-in.
  */
+
+/**
+ * Public pre-auth surfaces (mirror apps/admin/src/proxy.ts PUBLIC_PATHS).
+ * LicenseProvider and other 401 handlers must NOT bounce off these — e.g.
+ * MFA challenge has no full session yet, so /api/billing/subscription 401
+ * is expected and must not send the user back to /login (GAP-360 walk).
+ */
+export function isPreAuthPublicPath(pathname: string): boolean {
+  return (
+    pathname === '/login' ||
+    pathname.startsWith('/login/') ||
+    pathname === '/signup' ||
+    pathname.startsWith('/signup/') ||
+    pathname === '/mfa' ||
+    pathname.startsWith('/mfa/') ||
+    pathname === '/rotate-password' ||
+    pathname.startsWith('/rotate-password/') ||
+    pathname === '/reset-password' ||
+    pathname.startsWith('/reset-password/') ||
+    pathname === '/setup' ||
+    pathname.startsWith('/setup/')
+  );
+}
+
 export function redirectToLogin(returnPath?: string): void {
   if (typeof window === 'undefined') return;
   const path =
     returnPath ?? `${window.location.pathname}${window.location.search}${window.location.hash}`;
   // Avoid a redirect loop if we are already on the login surface.
   if (path === '/login' || path.startsWith('/login?')) return;
+  // Mid MFA / signup / password recovery: no full session yet; 401s from
+  // license probes must not abort the challenge.
+  if (isPreAuthPublicPath(window.location.pathname)) return;
   const returnUrl = encodeURIComponent(path || '/');
   window.location.assign(`/login?returnUrl=${returnUrl}`);
 }

--- a/apps/admin/src/lib/providers/LicenseProvider.tsx
+++ b/apps/admin/src/lib/providers/LicenseProvider.tsx
@@ -4,7 +4,7 @@ import type { LicenseTierId } from '@revealui/contracts/pricing';
 import type { FeatureFlags } from '@revealui/core/features';
 import { createPaywall } from '@revealui/paywall';
 import { PaywallProvider, usePaywall } from '@revealui/paywall/client';
-import { redirectToLogin } from '@/lib/auth/redirect-to-login';
+import { isPreAuthPublicPath, redirectToLogin } from '@/lib/auth/redirect-to-login';
 
 /** Shared paywall instance for the admin. */
 const paywall = createPaywall();
@@ -43,6 +43,12 @@ export class LicenseResolveFailure extends Error {
 }
 
 async function resolveSaasTier(): Promise<string> {
+  // Login / MFA / signup have no full session yet. Do not probe subscription
+  // (401 would bounce /mfa → /login — owner GAP-360 walk).
+  if (typeof window !== 'undefined' && isPreAuthPublicPath(window.location.pathname)) {
+    throw new LicenseResolveFailure('auth-required', 'pre-auth public path; skip license probe');
+  }
+
   const apiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
   if (!apiUrl) {
     // No SaaS API configured  -  genuine free/local posture.
@@ -60,6 +66,7 @@ async function resolveSaasTier(): Promise<string> {
 
   if (res.status === 401) {
     // Dead session: send the operator to re-auth. Do not claim free.
+    // redirectToLogin itself no-ops on /mfa etc. as a second belt.
     redirectToLogin();
     throw new LicenseResolveFailure('auth-required', 'subscription returned 401');
   }


### PR DESCRIPTION
## Summary
**Bug (GAP-360 Pro walk):** password sign-in → MFA page flashes → back to login form.

**Cause:** root `LicenseProvider` always fetches `GET {API}/api/billing/subscription`. On `/mfa` there is no full session yet (only `mfa-pending`), so the API returns **401** and `redirectToLogin()` navigates away from the challenge.

**Fix:**
- `isPreAuthPublicPath()` for `/mfa`, `/login`, signup, rotate, reset, setup
- `redirectToLogin` no-ops on those paths
- `LicenseProvider` skips the subscription probe on those paths

## Test plan
- [x] Phase-1 gate green locally
- [ ] Owner: password → MFA form stays → enter TOTP → land in admin
- [ ] CI green