### PR TITLE
feat(marketing,docs): hero L2 A/B + docs-pro visibility CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,12 @@ jobs:
         # apps/docs/scripts/check-links.ts.
         run: pnpm --filter docs check:links
 
+      - name: Docs-pro visibility boundary
+        # docs-app-hardening PR2: public/docs-pro/** is hand-tracked and not
+        # covered by prune-non-public.mjs. Fail if any file lacks visibility
+        # frontmatter or uses a NEVER_SERVE basename.
+        run: pnpm --filter docs check:docs-pro-boundary
+
       - name: Citation gate (hard fail, validity + coverage-strict)
         # Every code-behaviour claim in gated docs must cite a source:line that
         # resolves and sits in range (VALIDITY, zero baseline), and must not add

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -51,7 +51,8 @@
     "test:ui": "vitest --ui",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "vercel-build": "cd ../.. && pnpm turbo build --filter=docs"
+    "vercel-build": "cd ../.. && pnpm turbo build --filter=docs",
+    "check:docs-pro-boundary": "node scripts/check-docs-pro-boundary.mjs"
   },
   "type": "module"
 }

--- a/apps/docs/public/docs-pro/ai/index.md
+++ b/apps/docs/public/docs-pro/ai/index.md
@@ -1,3 +1,7 @@
+---
+visibility: public
+---
+
 # @revealui/ai
 
 AI agents, open-model inference, CRDT memory, and the A2A protocol — distributed under **Fair Source (FSL-1.1-MIT)**, source-visible in the public repo, with runtime feature gates that require a Pro / Enterprise subscription or a perpetual license. Each release converts to plain MIT after 2 years.

--- a/apps/docs/public/docs-pro/editors/index.md
+++ b/apps/docs/public/docs-pro/editors/index.md
@@ -1,3 +1,7 @@
+---
+visibility: public
+---
+
 # Editor Config Sync — see RevCon
 
 > **This page redirects.** Editor configuration sync is **not** an `@revealui/editors` package inside this monorepo. It ships as a separate fleet product called **RevCon**, distributed standalone and used independently of any RevealUI license.

--- a/apps/docs/public/docs-pro/index.md
+++ b/apps/docs/public/docs-pro/index.md
@@ -1,3 +1,7 @@
+---
+visibility: public
+---
+
 # RevealUI Pro
 
 RevealUI Pro adds AI agents, MCP integrations, and inference orchestration on top of the open-source foundation. The default and recommended inference path is open-model (Ollama, Canonical Inference Snaps); cloud-compatible providers (Groq, HuggingFace, OpenAI-compatible) are pluggable but opt-in.

--- a/apps/docs/public/docs-pro/inference/index.md
+++ b/apps/docs/public/docs-pro/inference/index.md
@@ -1,3 +1,7 @@
+---
+visibility: public
+---
+
 # Open-Model Inference
 
 RevealUI AI defaults to open-model inference (Snaps, Ollama). Groq, Anthropic, OpenAI, and HuggingFace are pluggable, opt-in cloud adapters. Each one is a thin wrapper that calls the vendor's OpenAI-compatible HTTP endpoint using your own API key. RevealUI never hosts a model and ships no proprietary vendor SDK.

--- a/apps/docs/public/docs-pro/mcp/index.md
+++ b/apps/docs/public/docs-pro/mcp/index.md
@@ -1,3 +1,7 @@
+---
+visibility: public
+---
+
 # @revealui/mcp
 
 MCP (Model Context Protocol) servers for RevealUI. Connect your AI agents to Stripe, Neon, Vercel, Playwright, and more via standardized tool interfaces.

--- a/apps/docs/scripts/__tests__/check-docs-pro-boundary.test.ts
+++ b/apps/docs/scripts/__tests__/check-docs-pro-boundary.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { readVisibility } from '../served-docs.mjs';
+
+describe('docs-pro boundary helpers', () => {
+  it('readVisibility still resolves public for docs-pro frontmatter shape', () => {
+    expect(readVisibility('---\nvisibility: public\ntitle: X\n---\nbody')).toBe('public');
+  });
+});

--- a/apps/docs/scripts/check-docs-pro-boundary.mjs
+++ b/apps/docs/scripts/check-docs-pro-boundary.mjs
@@ -5,21 +5,23 @@
 // path; this gate is the fail-closed CI assertion for that tree.
 //
 // Zero authored regex: line scans only (fleet hardline).
+// Dirent-based walk (no stat-then-read TOCTOU — CodeQL js/file-system-race).
 
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { basename, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NEVER_SERVE, readVisibility } from "./served-docs.mjs";
 
 const here = fileURLToPath(new URL(".", import.meta.url));
 const docsProRoot = join(here, "..", "public", "docs-pro");
+const publicRoot = join(here, "..", "public");
 
 const problems = [];
 
 async function walk(dir) {
   let entries;
   try {
-    entries = await readdir(dir);
+    entries = await readdir(dir, { withFileTypes: true });
   } catch (err) {
     if (err && err.code === "ENOENT") {
       process.stdout.write("check-docs-pro-boundary: no public/docs-pro/ (ok)\n");
@@ -27,22 +29,29 @@ async function walk(dir) {
     }
     throw err;
   }
-  for (const name of entries) {
-    const full = join(dir, name);
-    const st = await stat(full);
-    if (st.isDirectory()) {
+  for (const ent of entries) {
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) {
       await walk(full);
       continue;
     }
-    if (!(name.endsWith(".md") || name.endsWith(".mdx"))) continue;
-    const rel = relative(join(here, "..", "public"), full);
+    if (!ent.isFile()) continue;
+    if (!(ent.name.endsWith(".md") || ent.name.endsWith(".mdx"))) continue;
+    const rel = relative(publicRoot, full);
     if (NEVER_SERVE.has(basename(full))) {
       problems.push(
         `${rel} — NEVER_SERVE basename under docs-pro (remove or relocate)`,
       );
       continue;
     }
-    const content = await readFile(full, "utf8");
+    // Single open: read only; no prior exists/stat race.
+    let content;
+    try {
+      content = await readFile(full, "utf8");
+    } catch (err) {
+      problems.push(`${rel} — unreadable (${err && err.code ? err.code : "error"})`);
+      continue;
+    }
     const vis = readVisibility(content);
     if (vis === null) {
       problems.push(

--- a/apps/docs/scripts/check-docs-pro-boundary.mjs
+++ b/apps/docs/scripts/check-docs-pro-boundary.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// docs-app-hardening PR2: fail CI if public/docs-pro/** markdown lacks an
+// explicit visibility frontmatter key, or if a NEVER_SERVE basename appears
+// under docs-pro. Hand-tracked docs-pro is outside prune-non-public's copy
+// path; this gate is the fail-closed CI assertion for that tree.
+//
+// Zero authored regex: line scans only (fleet hardline).
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { NEVER_SERVE, readVisibility } from "./served-docs.mjs";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const docsProRoot = join(here, "..", "public", "docs-pro");
+
+const problems = [];
+
+async function walk(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if (err && err.code === "ENOENT") {
+      process.stdout.write("check-docs-pro-boundary: no public/docs-pro/ (ok)\n");
+      return;
+    }
+    throw err;
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    const st = await stat(full);
+    if (st.isDirectory()) {
+      await walk(full);
+      continue;
+    }
+    if (!(name.endsWith(".md") || name.endsWith(".mdx"))) continue;
+    const rel = relative(join(here, "..", "public"), full);
+    if (NEVER_SERVE.has(basename(full))) {
+      problems.push(
+        `${rel} — NEVER_SERVE basename under docs-pro (remove or relocate)`,
+      );
+      continue;
+    }
+    const content = await readFile(full, "utf8");
+    const vis = readVisibility(content);
+    if (vis === null) {
+      problems.push(
+        `${rel} — missing visibility frontmatter (require visibility: public|internal|pro)`,
+      );
+    }
+  }
+}
+
+await walk(docsProRoot);
+
+if (problems.length) {
+  process.stderr.write(`check-docs-pro-boundary: ${problems.length} violation(s)\n`);
+  for (const p of problems) process.stderr.write(`  ${p}\n`);
+  process.exit(1);
+}
+process.stdout.write("check-docs-pro-boundary: ok\n");

--- a/apps/marketing/app/__tests__/hero-variant.test.ts
+++ b/apps/marketing/app/__tests__/hero-variant.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { HOME_HERO, HOME_HERO_FOUNDATION, HOME_HERO_OWNERSHIP } from '../content/home';
+import {
+  HOME_HERO,
+  HOME_HERO_FOUNDATION,
+  HOME_HERO_L2,
+  HOME_HERO_OWNERSHIP,
+} from '../content/home';
 import { selectHomeHero } from '../lib/hero-variant';
 
 describe('selectHomeHero', () => {
@@ -42,5 +47,11 @@ describe('selectHomeHero', () => {
     expect(HOME_HERO.subtitle.support).toBe('It runs on any AI provider you choose.');
     expect(HOME_HERO_FOUNDATION.subtitle.sentence2).toBe(HOME_HERO.subtitle.sentence2);
     expect(HOME_HERO_OWNERSHIP.subtitle.sentence2).toBe(HOME_HERO.subtitle.sentence2);
+  });
+
+  it('serves the L2 leverage-frame for ?hero=l2', () => {
+    expect(selectHomeHero('?hero=l2')).toBe(HOME_HERO_L2);
+    expect(HOME_HERO_L2.h1).toBe('Ship your next product on the work your last one finished.');
+    expect(HOME_HERO_L2.subtitle).toEqual(HOME_HERO.subtitle);
   });
 });

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -646,6 +646,25 @@ export const CLAIMS: readonly ClaimEntry[] = [
       },
     ],
   },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_HERO_L2.h1',
+    text: 'Ship your next product on the work your last one finished.',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'packages',
+        note: 'corpus L2 leverage-frame A/B (06-copy-corpus §4.1); owner go 2026-07-31 via ?hero=l2, not default traffic',
+      },
+      {
+        kind: 'test',
+        ref: 'apps/marketing/app/__tests__/hero-variant.test.ts#serves the L2 leverage-frame for ?hero=l2',
+        note: 'locks L2 H1 as optional experiment variant',
+      },
+      LICENSE_MIT,
+      SELF_HOST,
+    ],
+  },
 
   // ── home.ts — problem ────────────────────────────────────────────────────
   {

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -66,6 +66,14 @@ export const HOME_HERO_OWNERSHIP = {
   h1: 'Run your whole business on one runtime you own.',
 } as const;
 
+// Corpus L2 leverage-frame A/B (06-copy-corpus.md §4.1). Owner go 2026-07-31:
+// enable via ?hero=l2 only — not default traffic. Measurement still needs an
+// analytics sink (same note as foundation/ownership).
+export const HOME_HERO_L2 = {
+  ...HOME_HERO,
+  h1: 'Ship your next product on the work your last one finished.',
+} as const;
+
 // ---------------------------------------------------------------------------
 // Problem (comparison table)
 // ---------------------------------------------------------------------------

--- a/apps/marketing/app/lib/hero-variant.ts
+++ b/apps/marketing/app/lib/hero-variant.ts
@@ -1,4 +1,9 @@
-import { HOME_HERO, HOME_HERO_FOUNDATION, HOME_HERO_OWNERSHIP } from '../content/home';
+import {
+  HOME_HERO,
+  HOME_HERO_FOUNDATION,
+  HOME_HERO_L2,
+  HOME_HERO_OWNERSHIP,
+} from '../content/home';
 
 /**
  * Homepage-hero A/B variant selector.
@@ -6,6 +11,7 @@ import { HOME_HERO, HOME_HERO_FOUNDATION, HOME_HERO_OWNERSHIP } from '../content
  * Default: leverage-frame L1 (`HOME_HERO`, owner ruling 2026-07-29).
  * `?hero=foundation` — Foundation A/B (ADR 2026-06-07 decision 6).
  * `?hero=ownership` — prior default H1, rollback/preview only.
+ * `?hero=l2` — corpus L2 leverage-frame (owner go 2026-07-31; not default).
  *
  * An automatic traffic split + conversion measurement is deliberately out of
  * scope here: the marketing app has no analytics sink yet, so a real experiment
@@ -15,11 +21,13 @@ import { HOME_HERO, HOME_HERO_FOUNDATION, HOME_HERO_OWNERSHIP } from '../content
 export type HomeHeroVariant =
   | typeof HOME_HERO
   | typeof HOME_HERO_FOUNDATION
-  | typeof HOME_HERO_OWNERSHIP;
+  | typeof HOME_HERO_OWNERSHIP
+  | typeof HOME_HERO_L2;
 
 export function selectHomeHero(search: string): HomeHeroVariant {
   const hero = new URLSearchParams(search).get('hero');
   if (hero === 'foundation') return HOME_HERO_FOUNDATION;
   if (hero === 'ownership') return HOME_HERO_OWNERSHIP;
+  if (hero === 'l2') return HOME_HERO_L2;
   return HOME_HERO;
 }


### PR DESCRIPTION
## Summary

Owner residual execute (2026-07-31):

1. **Hero L2** — \`HOME_HERO_L2\` + \`?hero=l2\` (corpus §4.1; not default) + claims-evidence
2. **docs-app PR2** — \`check-docs-pro-boundary.mjs\` + CI + frontmatter on docs-pro files

### Already true on test

- FDE pack §3 as \`PROOF_DEPLOYERS\` under Proof
- docs-app PR3 security headers in \`apps/docs/vercel.json\`

## Test plan

- [x] hero-variant tests 8/8
- [x] check-docs-pro-boundary ok
- [x] phase-1 ci-gate --changed PASS