### PR TITLE
feat(agents): GAP-411 tenant spawn isolation, skill catalogs, durable obs

### DIFF
--- a/apps/server/src/lib/__tests__/ai-observability-wire.test.ts
+++ b/apps/server/src/lib/__tests__/ai-observability-wire.test.ts
@@ -4,16 +4,26 @@ vi.mock('@revealui/core/observability/logger', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
+const load = vi.fn().mockResolvedValue(undefined);
 const AgentEventLogger = vi.fn(function AgentEventLogger(
-  this: { maxEvents?: number },
-  opts?: { maxEvents?: number },
+  this: { maxEvents?: number; load: typeof load },
+  opts?: { maxEvents?: number; storage?: unknown; autoFlush?: boolean },
 ) {
   this.maxEvents = opts?.maxEvents;
+  this.load = load;
+  return this;
+});
+const FileSystemEventStorage = vi.fn(function FileSystemEventStorage(
+  this: { path: string },
+  path: string,
+) {
+  this.path = path;
   return this;
 });
 
 vi.mock('@revealui/ai/observability', () => ({
   AgentEventLogger,
+  FileSystemEventStorage,
 }));
 
 describe('ai-observability-wire', () => {
@@ -31,10 +41,34 @@ describe('ai-observability-wire', () => {
     expect(AgentEventLogger).not.toHaveBeenCalled();
   });
 
-  it('creates logger when REVEALUI_AI_OBSERVABILITY=1', async () => {
+  it('creates in-memory logger when REVEALUI_AI_OBSERVABILITY=1 without path', async () => {
     const { createAgentEventLoggerIfEnabled } = await import('../ai-observability-wire.js');
     const eventLogger = await createAgentEventLoggerIfEnabled({ REVEALUI_AI_OBSERVABILITY: '1' });
     expect(eventLogger).not.toBeNull();
     expect(AgentEventLogger).toHaveBeenCalledWith({ maxEvents: 1000 });
+    expect(FileSystemEventStorage).not.toHaveBeenCalled();
+  });
+
+  it('uses FileSystemEventStorage when REVEALUI_AI_OBSERVABILITY_PATH is set', async () => {
+    const { createAgentEventLoggerIfEnabled, parseObservabilityFlushMs } = await import(
+      '../ai-observability-wire.js'
+    );
+    expect(parseObservabilityFlushMs({})).toBe(5000);
+    expect(parseObservabilityFlushMs({ REVEALUI_AI_OBSERVABILITY_FLUSH_MS: '2500' })).toBe(2500);
+
+    const eventLogger = await createAgentEventLoggerIfEnabled({
+      REVEALUI_AI_OBSERVABILITY: '1',
+      REVEALUI_AI_OBSERVABILITY_PATH: '/tmp/agent-events.json',
+      REVEALUI_AI_OBSERVABILITY_FLUSH_MS: '3000',
+    });
+    expect(eventLogger).not.toBeNull();
+    expect(FileSystemEventStorage).toHaveBeenCalledWith('/tmp/agent-events.json');
+    expect(AgentEventLogger).toHaveBeenCalledWith({
+      maxEvents: 1000,
+      storage: expect.any(Object),
+      autoFlush: true,
+      flushIntervalMs: 3000,
+    });
+    expect(load).toHaveBeenCalledOnce();
   });
 });

--- a/apps/server/src/lib/__tests__/ai-skills-wire.test.ts
+++ b/apps/server/src/lib/__tests__/ai-skills-wire.test.ts
@@ -4,6 +4,17 @@ vi.mock('@revealui/core/observability/logger', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
+const loadAllSkills = vi.fn().mockResolvedValue(undefined);
+const getAll = vi.fn().mockReturnValue([{ metadata: { name: 'demo' } }]);
+const SkillRegistry = vi.fn(function SkillRegistry(this: {
+  loadAllSkills: typeof loadAllSkills;
+  getAll: typeof getAll;
+}) {
+  this.loadAllSkills = loadAllSkills;
+  this.getAll = getAll;
+  return this;
+});
+const loadAllFromDirectory = vi.fn().mockResolvedValue([{ metadata: { name: 'extra' } }]);
 const createAgentSkillProvider = vi.fn(() => ({ injectSkillInstructions: vi.fn() }));
 const SkillActivator = vi.fn(function SkillActivator(this: unknown) {
   return this;
@@ -13,6 +24,8 @@ vi.mock('@revealui/ai/skills', () => ({
   createAgentSkillProvider,
   globalSkillRegistry: { name: 'global' },
   SkillActivator,
+  SkillRegistry,
+  loadAllFromDirectory,
 }));
 
 describe('ai-skills-wire', () => {
@@ -30,11 +43,33 @@ describe('ai-skills-wire', () => {
     expect(createAgentSkillProvider).not.toHaveBeenCalled();
   });
 
-  it('builds provider when REVEALUI_AI_SKILLS=1', async () => {
+  it('builds provider and loads registry catalog when REVEALUI_AI_SKILLS=1', async () => {
     const { createSkillProviderIfEnabled } = await import('../ai-skills-wire.js');
     const provider = await createSkillProviderIfEnabled({ REVEALUI_AI_SKILLS: '1' });
     expect(provider).not.toBeNull();
+    expect(SkillRegistry).toHaveBeenCalledOnce();
+    expect(loadAllSkills).toHaveBeenCalledWith(false);
     expect(SkillActivator).toHaveBeenCalledOnce();
     expect(createAgentSkillProvider).toHaveBeenCalledOnce();
+  });
+
+  it('loads extra catalog dirs from REVEALUI_AI_SKILLS_DIRS', async () => {
+    const { createSkillProviderIfEnabled, parseSkillCatalogDirs } = await import(
+      '../ai-skills-wire.js'
+    );
+    expect(parseSkillCatalogDirs({ REVEALUI_AI_SKILLS_DIRS: '/a/skills,/b/skills' })).toEqual([
+      '/a/skills',
+      '/b/skills',
+    ]);
+    expect(parseSkillCatalogDirs({ REVEALUI_AI_SKILLS_DIRS: '/a:/b' })).toEqual(['/a', '/b']);
+
+    await createSkillProviderIfEnabled({
+      REVEALUI_AI_SKILLS: '1',
+      REVEALUI_AI_SKILLS_DIRS: '/extra/skills',
+    });
+    expect(loadAllFromDirectory).toHaveBeenCalledWith(
+      '/extra/skills',
+      expect.objectContaining({ scope: 'local' }),
+    );
   });
 });

--- a/apps/server/src/lib/ai-observability-wire.ts
+++ b/apps/server/src/lib/ai-observability-wire.ts
@@ -1,14 +1,20 @@
 /**
- * GAP-406 WIRE phase 4 — opt-in `@revealui/ai/observability` mount for apps/server.
+ * GAP-406 WIRE phase 4 + GAP-411 residual — opt-in `@revealui/ai/observability`.
  *
- * `REVEALUI_AI_OBSERVABILITY=1` (or true/yes/on): creates an in-process
- * AgentEventLogger for agent-stream instrumentation.
+ * `REVEALUI_AI_OBSERVABILITY=1` (or true/yes/on): creates an AgentEventLogger
+ * for agent-stream instrumentation.
  * Default (unset): null.
+ *
+ * Durable storage (GAP-411 residual 3):
+ * - `REVEALUI_AI_OBSERVABILITY_PATH` — filesystem path for JSON event store.
+ *   When set, uses `FileSystemEventStorage` with auto-flush.
+ * - `REVEALUI_AI_OBSERVABILITY_FLUSH_MS` — flush interval (default 5000).
+ * - Without PATH: in-memory only (original phase-4 behavior).
  *
  * Pro package is loaded via dynamic import (boundary: optional Fair Source).
  *
  * @see docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
- * @see GAP-406
+ * @see GAP-411
  */
 
 import { logger } from '@revealui/core/observability/logger';
@@ -30,6 +36,14 @@ export interface AgentEventLoggerLike {
   }): void;
 }
 
+export function parseObservabilityFlushMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.REVEALUI_AI_OBSERVABILITY_FLUSH_MS?.trim();
+  if (!raw) return 5000;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 100) return 5000;
+  return Math.floor(n);
+}
+
 /**
  * Create an agent event logger when enabled. Returns null when off or package missing.
  */
@@ -42,8 +56,30 @@ export async function createAgentEventLoggerIfEnabled(
 
   try {
     const obs = await import('@revealui/ai/observability');
+    const storagePath = env.REVEALUI_AI_OBSERVABILITY_PATH?.trim();
+
+    if (storagePath) {
+      const storage = new obs.FileSystemEventStorage(storagePath);
+      const flushIntervalMs = parseObservabilityFlushMs(env);
+      const eventLogger = new obs.AgentEventLogger({
+        maxEvents: 1000,
+        storage,
+        autoFlush: true,
+        flushIntervalMs,
+      });
+      // Load any prior durable events into the circular buffer.
+      await eventLogger.load();
+      logger.info('[ai-observability-wire] GAP-411: AgentEventLogger ready (file storage)', {
+        path: storagePath,
+        flushIntervalMs,
+      });
+      return eventLogger;
+    }
+
     const eventLogger = new obs.AgentEventLogger({ maxEvents: 1000 });
-    logger.info('[ai-observability-wire] GAP-406 phase 4: AgentEventLogger ready (in-memory)');
+    logger.info(
+      '[ai-observability-wire] GAP-406 phase 4: AgentEventLogger ready (in-memory; set REVEALUI_AI_OBSERVABILITY_PATH for durable storage)',
+    );
     return eventLogger;
   } catch (error) {
     logger.warn('[ai-observability-wire] failed to load @revealui/ai/observability', {

--- a/apps/server/src/lib/ai-skills-wire.ts
+++ b/apps/server/src/lib/ai-skills-wire.ts
@@ -1,14 +1,20 @@
 /**
- * GAP-406 WIRE phase 4 — opt-in `@revealui/ai/skills` mount for apps/server.
+ * GAP-406 WIRE phase 4 + GAP-411 residual — opt-in `@revealui/ai/skills` mount.
  *
- * `REVEALUI_AI_SKILLS=1` (or true/yes/on): builds an AgentSkillProvider over the
- * process globalSkillRegistry for agent runtime injection.
+ * `REVEALUI_AI_SKILLS=1` (or true/yes/on): builds an AgentSkillProvider over a
+ * SkillRegistry loaded from disk catalog paths.
  * Default (unset): null — no skills load when disabled.
+ *
+ * Catalog paths (GAP-411 residual 2):
+ * - `REVEALUI_AI_SKILLS_GLOBAL_DIR` — global skills dir (default `~/.revealui/skills`)
+ * - `REVEALUI_AI_SKILLS_LOCAL_DIR` — project-relative dir (default `.revealui/skills`)
+ * - `REVEALUI_AI_SKILLS_PROJECT_ROOT` — project root for local dir resolution
+ * - `REVEALUI_AI_SKILLS_DIRS` — extra absolute/relative dirs (comma or colon separated)
  *
  * Pro package is loaded via dynamic import (boundary: optional Fair Source).
  *
  * @see docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
- * @see GAP-406
+ * @see GAP-411
  */
 
 import { logger } from '@revealui/core/observability/logger';
@@ -21,7 +27,21 @@ export function isAiSkillsWireEnabled(env: NodeJS.ProcessEnv = process.env): boo
 }
 
 /**
- * Build a skill provider when enabled. Returns null when off or package missing.
+ * Parse extra skill catalog directories from `REVEALUI_AI_SKILLS_DIRS`.
+ * Comma-separated preferred. When no commas are present, also split on `:`
+ * (POSIX path lists). Prefer commas for paths that contain colons.
+ */
+export function parseSkillCatalogDirs(env: NodeJS.ProcessEnv = process.env): string[] {
+  const raw = env.REVEALUI_AI_SKILLS_DIRS?.trim();
+  if (!raw) return [];
+  const parts = raw.includes(',') ? raw.split(',') : raw.split(':');
+  return parts.map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Build a skill provider when enabled. Loads skills from configured catalog
+ * dirs into a registry (not an empty process global). Returns null when off
+ * or package missing.
  */
 export async function createSkillProviderIfEnabled(
   env: NodeJS.ProcessEnv = process.env,
@@ -32,9 +52,47 @@ export async function createSkillProviderIfEnabled(
 
   try {
     const skills = await import('@revealui/ai/skills');
-    const activator = new skills.SkillActivator({ registry: skills.globalSkillRegistry });
+
+    const globalDir = env.REVEALUI_AI_SKILLS_GLOBAL_DIR?.trim();
+    const localDir = env.REVEALUI_AI_SKILLS_LOCAL_DIR?.trim();
+    const projectRoot = env.REVEALUI_AI_SKILLS_PROJECT_ROOT?.trim();
+
+    const registry = new skills.SkillRegistry({
+      ...(globalDir ? { globalDir } : {}),
+      ...(localDir ? { localDir } : {}),
+      ...(projectRoot ? { projectRoot } : {}),
+    });
+
+    // Primary catalog: global + project-local install dirs.
+    await registry.loadAllSkills(false);
+
+    // Extra catalog dirs (operator-installed packs, monorepo skill libraries).
+    const extraDirs = parseSkillCatalogDirs(env);
+    for (const dir of extraDirs) {
+      try {
+        const loaded = await skills.loadAllFromDirectory(dir, {
+          registry,
+          scope: 'local',
+        });
+        logger.info('[ai-skills-wire] loaded skills from extra catalog dir', {
+          dir,
+          count: loaded.length,
+        });
+      } catch (error) {
+        logger.warn('[ai-skills-wire] failed to load extra catalog dir', {
+          dir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const skillCount = registry.getAll().length;
+    const activator = new skills.SkillActivator({ registry });
     const provider = skills.createAgentSkillProvider(activator);
-    logger.info('[ai-skills-wire] GAP-406 phase 4: AgentSkillProvider ready (global registry)');
+    logger.info('[ai-skills-wire] GAP-411: AgentSkillProvider ready', {
+      skillCount,
+      extraDirs: extraDirs.length,
+    });
     return provider;
   } catch (error) {
     logger.warn('[ai-skills-wire] failed to load @revealui/ai/skills', {

--- a/apps/server/src/lib/mcp-hypervisor-wire.ts
+++ b/apps/server/src/lib/mcp-hypervisor-wire.ts
@@ -9,13 +9,18 @@
  *   Register + start process-local first-party MCP servers via `revealui-mcp`.
  *   Default server list is public introspection only (`contracts,docs`) unless
  *   `REVEALUI_MCP_HYPERVISOR_SERVERS` overrides (comma-separated allowlist).
- *   Process-local children inherit `process.env` for host credentials.
+ *   Process-local children inherit `process.env` for host credentials
+ *   (host-owned, not tenant isolation).
  *
  * Phase 3 (with phase 1):
  *   Credential resolver reads `mcp/<tenantId>/<serverName>/env` (JSON object of
  *   env vars) from a Vault (default revvault). Missing path → null (no tenant
- *   env). Tenant spawn still merges process.env in the hypervisor today;
- *   isolation tightening is a follow-up.
+ *   env).
+ *
+ * GAP-411 residual 1 (tenant spawn isolation):
+ *   `MCPHypervisor.startServerForTenant` no longer spreads host `process.env`.
+ *   Tenant children get allowlisted host baseline (PATH/TMP/HOME/locale) +
+ *   server config.env + vault-resolved tenant credentials only.
  *
  * Default (env unset): no-op. Safe for local/dev/serverless without hypervisor traffic.
  *

--- a/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
+++ b/docs/architecture/ADR-007-c11-unwired-subsystem-incubate.md
@@ -61,10 +61,20 @@ Marketing and package copy still describe the MCP hypervisor as the live agent t
 
 `validate:incubate-posture` allowlists wire modules under `apps/server/src/lib/*-wire.ts` (and agent-stream consumer for skills/observability).
 
+## Progress — GAP-411 residual depth (2026-07-31)
+
+| Residual | Status | Notes |
+|----------|--------|-------|
+| Tenant spawn env isolation | Shipped | `buildTenantSpawnEnv` + `startServerForTenant` no longer spreads host `process.env` |
+| Skill catalog install paths | Shipped | `REVEALUI_AI_SKILLS_*` dirs + `loadAllSkills` / `loadAllFromDirectory` on wire |
+| Durable observability storage | Shipped | `REVEALUI_AI_OBSERVABILITY_PATH` → `FileSystemEventStorage` + auto-flush |
+
+Host-owned process-local `startServer` still inherits full `process.env` (not a tenant boundary).
+
 ## Verification
 
-- Production mounts of incubating surfaces go only through allowlisted GAP-406 wire modules (env-gated).
+- Production mounts of incubating surfaces go only through allowlisted GAP-406/411 wire modules (env-gated).
 - Package headers still note library surfaces; app default remains off without env flags.
-- **Phase 6 gate:** `pnpm validate:incubate-posture` fails on non-allowlisted app imports. Standing ticket: GAP-406 (close when residual product follow-ups done or abandoned).
+- **Phase 6 gate:** `pnpm validate:incubate-posture` fails on non-allowlisted app imports.
 - **Clone advisory:** `pnpm audit:clones` reports exact multi-file clones under `packages/` (optional prevention; advisory exit 0).
-- **Follow-up (not this train):** tenant spawn env isolation (avoid host `process.env` merge); deeper skill catalog install; durable event storage for observability.
+- GAP-411 residual product depth: tenant isolation + skill catalogs + file event storage (see table above).

--- a/packages/mcp/src/__tests__/hypervisor.test.ts
+++ b/packages/mcp/src/__tests__/hypervisor.test.ts
@@ -1020,11 +1020,16 @@ describe('MCPHypervisor', () => {
       const spawnEnv = spawnCall?.[2]?.env as NodeJS.ProcessEnv;
       expect(spawnEnv.MCP_SERVER_MODE).toBe('tenant');
       expect(spawnEnv.TENANT_TOKEN).toBe('vault-token');
-      for (const secretKey of ['STRIPE_SECRET_KEY', 'DATABASE_URL', 'REVEALUI_SECRET']) {
-        if (process.env[secretKey] !== undefined) {
-          expect(spawnEnv[secretKey]).toBeUndefined();
-        }
-      }
+      // Always assert denylisted host secrets cannot appear on tenant spawn env
+      // (pure buildTenantSpawnEnv test injects them; this covers the live spawn call).
+      expect(spawnEnv.STRIPE_SECRET_KEY).toBeUndefined();
+      expect(spawnEnv.DATABASE_URL).toBeUndefined();
+      expect(spawnEnv.REVEALUI_SECRET).toBeUndefined();
+      expect(spawnEnv.NODE_OPTIONS).toBeUndefined();
+      // Spawn env must be composed only of allowlist + config + tenant keys
+      // we deliberately set (plus whatever allowlisted keys exist on the host).
+      expect(spawnEnv.MCP_SERVER_MODE).toBe('tenant');
+      expect(spawnEnv.TENANT_TOKEN).toBe('vault-token');
     });
   });
 });

--- a/packages/mcp/src/__tests__/hypervisor.test.ts
+++ b/packages/mcp/src/__tests__/hypervisor.test.ts
@@ -991,6 +991,7 @@ describe('MCPHypervisor', () => {
     });
 
     it('startServerForTenant spawns without spreading host process.env', async () => {
+      vi.useFakeTimers();
       const hv = MCPHypervisor.getInstance();
       hv.registerServer({
         ...testConfig,
@@ -1002,23 +1003,25 @@ describe('MCPHypervisor', () => {
         },
       });
 
-      await hv.startServerForTenant('test-server', {
+      mockProcess.stdout.on.mockImplementation(() => mockProcess);
+      mockProcess.stderr.on.mockImplementation(() => mockProcess);
+      mockProcess.on.mockImplementation(() => mockProcess);
+
+      const startPromise = hv.startServerForTenant('test-server', {
         tenantId: 'tenant-a',
         tier: 'pro',
       });
+      // Advance past 500ms startup + 5s tools/list discovery timeout
+      await vi.advanceTimersByTimeAsync(5_501);
+      await startPromise;
 
       expect(spawn).toHaveBeenCalled();
       const spawnCall = vi.mocked(spawn).mock.calls.at(-1);
       const spawnEnv = spawnCall?.[2]?.env as NodeJS.ProcessEnv;
       expect(spawnEnv.MCP_SERVER_MODE).toBe('tenant');
       expect(spawnEnv.TENANT_TOKEN).toBe('vault-token');
-      // Host secrets must not ride along even when present on process.env
-      // (we only assert isolation shape: no full process.env merge means
-      // keys present only on process.env and not allowlisted are absent).
       for (const secretKey of ['STRIPE_SECRET_KEY', 'DATABASE_URL', 'REVEALUI_SECRET']) {
         if (process.env[secretKey] !== undefined) {
-          // If the host happens to set these, isolation must still drop them
-          // unless they were allowlisted (they are not).
           expect(spawnEnv[secretKey]).toBeUndefined();
         }
       }

--- a/packages/mcp/src/__tests__/hypervisor.test.ts
+++ b/packages/mcp/src/__tests__/hypervisor.test.ts
@@ -1,5 +1,11 @@
+import { spawn } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MCPHypervisor, type MCPServerConfig } from '../hypervisor.js';
+import {
+  buildTenantSpawnEnv,
+  MCPHypervisor,
+  type MCPServerConfig,
+  TENANT_SPAWN_HOST_ENV_ALLOWLIST,
+} from '../hypervisor.js';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -56,6 +62,7 @@ describe('MCPHypervisor', () => {
   afterEach(() => {
     MCPHypervisor._resetForTests();
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   describe('getInstance()', () => {
@@ -941,6 +948,80 @@ describe('MCPHypervisor', () => {
       );
 
       await expect(toolPromise).resolves.toBeDefined();
+    });
+  });
+
+  describe('buildTenantSpawnEnv + startServerForTenant isolation (GAP-411)', () => {
+    it('buildTenantSpawnEnv never copies arbitrary host secrets', () => {
+      const env = buildTenantSpawnEnv(
+        { SERVER_FLAG: '1' },
+        { TENANT_KEY: 'secret-tenant' },
+        {
+          PATH: '/usr/bin',
+          HOME: '/home/user',
+          STRIPE_SECRET_KEY: 'sk_live_should_not_leak',
+          DATABASE_URL: 'postgres://should-not-leak',
+          NODE_OPTIONS: '--require ./evil.js',
+          LANG: 'en_US.UTF-8',
+        },
+      );
+
+      expect(env.PATH).toBe('/usr/bin');
+      expect(env.HOME).toBe('/home/user');
+      expect(env.LANG).toBe('en_US.UTF-8');
+      expect(env.SERVER_FLAG).toBe('1');
+      expect(env.TENANT_KEY).toBe('secret-tenant');
+      expect(env.STRIPE_SECRET_KEY).toBeUndefined();
+      expect(env.DATABASE_URL).toBeUndefined();
+      expect(env.NODE_OPTIONS).toBeUndefined();
+      expect(TENANT_SPAWN_HOST_ENV_ALLOWLIST).toContain('PATH');
+      expect(TENANT_SPAWN_HOST_ENV_ALLOWLIST).not.toContain('NODE_OPTIONS');
+    });
+
+    it('tenant credentials override config.env and allowlisted host keys', () => {
+      const env = buildTenantSpawnEnv(
+        { SHARED: 'from-config', PATH: '/config/bin' },
+        { SHARED: 'from-tenant', EXTRA: 't' },
+        { PATH: '/host/bin', HOME: '/home/h' },
+      );
+      expect(env.PATH).toBe('/config/bin'); // config beats host
+      expect(env.SHARED).toBe('from-tenant'); // tenant beats config
+      expect(env.EXTRA).toBe('t');
+      expect(env.HOME).toBe('/home/h');
+    });
+
+    it('startServerForTenant spawns without spreading host process.env', async () => {
+      const hv = MCPHypervisor.getInstance();
+      hv.registerServer({
+        ...testConfig,
+        env: { MCP_SERVER_MODE: 'tenant' },
+      });
+      hv.setCredentialResolver({
+        async resolve() {
+          return { TENANT_TOKEN: 'vault-token' };
+        },
+      });
+
+      await hv.startServerForTenant('test-server', {
+        tenantId: 'tenant-a',
+        tier: 'pro',
+      });
+
+      expect(spawn).toHaveBeenCalled();
+      const spawnCall = vi.mocked(spawn).mock.calls.at(-1);
+      const spawnEnv = spawnCall?.[2]?.env as NodeJS.ProcessEnv;
+      expect(spawnEnv.MCP_SERVER_MODE).toBe('tenant');
+      expect(spawnEnv.TENANT_TOKEN).toBe('vault-token');
+      // Host secrets must not ride along even when present on process.env
+      // (we only assert isolation shape: no full process.env merge means
+      // keys present only on process.env and not allowlisted are absent).
+      for (const secretKey of ['STRIPE_SECRET_KEY', 'DATABASE_URL', 'REVEALUI_SECRET']) {
+        if (process.env[secretKey] !== undefined) {
+          // If the host happens to set these, isolation must still drop them
+          // unless they were allowlisted (they are not).
+          expect(spawnEnv[secretKey]).toBeUndefined();
+        }
+      }
     });
   });
 });

--- a/packages/mcp/src/hypervisor.ts
+++ b/packages/mcp/src/hypervisor.ts
@@ -43,6 +43,61 @@ export interface MCPServerConfig {
 }
 
 /**
+ * Host env keys allowed into tenant MCP children (GAP-411).
+ * Intentionally excludes secrets, tokens, API keys, and NODE_OPTIONS
+ * (code injection). Tenant credentials come only from the credential
+ * resolver + explicit server config.env.
+ */
+export const TENANT_SPAWN_HOST_ENV_ALLOWLIST = [
+  'PATH',
+  'PATHEXT',
+  'SYSTEMROOT',
+  'WINDIR',
+  'COMSPEC',
+  'TMP',
+  'TEMP',
+  'TMPDIR',
+  'HOME',
+  'USERPROFILE',
+  'HOMEDRIVE',
+  'HOMEPATH',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TZ',
+] as const;
+
+/**
+ * Build process env for a tenant-scoped MCP spawn.
+ *
+ * Does **not** spread `process.env` (GAP-411 residual). Only:
+ * 1. allowlisted host baseline (PATH/TMP/HOME/locale),
+ * 2. server `config.env`,
+ * 3. tenant credentials from the credential resolver.
+ *
+ * Host-owned process-local servers (`startServer`) still inherit full
+ * `process.env` — they are not tenant isolation boundaries.
+ */
+export function buildTenantSpawnEnv(
+  configEnv: Record<string, string> | undefined,
+  tenantEnv: Record<string, string>,
+  hostEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const baseline: Record<string, string> = {};
+  for (const key of TENANT_SPAWN_HOST_ENV_ALLOWLIST) {
+    const value = hostEnv[key];
+    if (typeof value === 'string' && value.length > 0) {
+      baseline[key] = value;
+    }
+  }
+  return {
+    ...baseline,
+    ...(configEnv ?? {}),
+    ...tenantEnv,
+  };
+}
+
+/**
  * Resolves credentials for a specific tenant/workspace at server spawn time.
  * Implementations should fetch from the database (tenantProviderConfigs, userApiKeys)
  * and return env vars to inject into the MCP server process.
@@ -655,7 +710,8 @@ export class MCPHypervisor {
       if (resolved) tenantEnv = resolved;
     }
 
-    // Create an isolated config with tenant credentials merged
+    // Create an isolated config with tenant credentials merged into config.env
+    // for bookkeeping; the actual spawn env never spreads process.env (GAP-411).
     const config: MCPServerConfig = {
       ...baseEntry.config,
       env: { ...baseEntry.config.env, ...tenantEnv },
@@ -669,10 +725,10 @@ export class MCPHypervisor {
       lastPingAt: null,
     };
 
-    // Spawn process
+    // Tenant spawn: allowlisted host baseline + config.env + tenant credentials only.
     const child = spawn(config.command, config.args, {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, ...config.env },
+      env: buildTenantSpawnEnv(baseEntry.config.env, tenantEnv),
     });
 
     entry.process = child;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -101,12 +101,14 @@ export {
 } from './contracts.js';
 // Hypervisor: process management + dynamic tool discovery
 export {
+  buildTenantSpawnEnv,
   type MCPCredentialResolver,
   MCPHypervisor,
   type MCPServerConfig,
   type MCPTenantContext,
   type MCPTool,
   type NamespacedTool,
+  TENANT_SPAWN_HOST_ENV_ALLOWLIST,
 } from './hypervisor.js';
 export type { McpMeterEvent, McpMeterSink } from './metering.js';
 // OAuth 2.1 client provider (Stage 2 PR-2.1 — revvault-backed credential storage)


### PR DESCRIPTION
## Summary

Closes the three **GAP-411** residual product-depth items on C11 incubators (after opt-in WIRE p1–p4):

1. **Tenant spawn env isolation** — `MCPHypervisor.startServerForTenant` uses `buildTenantSpawnEnv` (allowlisted host baseline PATH/TMP/HOME/locale + server `config.env` + vault tenant credentials). No longer spreads host `process.env` (secrets/tokens/`NODE_OPTIONS` cannot leak into tenant children). Host process-local `startServer` still inherits full env by design.
2. **Skill catalog install** — `ai-skills-wire` builds a `SkillRegistry`, runs `loadAllSkills`, and loads `REVEALUI_AI_SKILLS_DIRS` via `loadAllFromDirectory` (plus optional `REVEALUI_AI_SKILLS_{GLOBAL,LOCAL,PROJECT}_*`).
3. **Durable observability** — `REVEALUI_AI_OBSERVABILITY_PATH` enables `FileSystemEventStorage` with auto-flush (`REVEALUI_AI_OBSERVABILITY_FLUSH_MS`, default 5000). Without path, in-memory remains.

ADR-007 progress table updated.

## Env knobs (all opt-in)

| Flag | Role |
|------|------|
| `REVEALUI_MCP_HYPERVISOR` (+ spawn) | existing wire |
| `REVEALUI_AI_SKILLS` | enable skill provider |
| `REVEALUI_AI_SKILLS_DIRS` | extra catalog dirs |
| `REVEALUI_AI_SKILLS_GLOBAL_DIR` / `_LOCAL_DIR` / `_PROJECT_ROOT` | registry roots |
| `REVEALUI_AI_OBSERVABILITY` | enable event logger |
| `REVEALUI_AI_OBSERVABILITY_PATH` | durable JSON file store |
| `REVEALUI_AI_OBSERVABILITY_FLUSH_MS` | flush interval |

## Test plan

- [x] `pnpm --filter @revealui/mcp exec vitest run src/__tests__/hypervisor.test.ts` (incl. GAP-411 isolation)
- [x] server `ai-skills-wire` + `ai-observability-wire` unit tests
- [x] local phase-1 pre-push gate
- [ ] CI on this PR

## Related

- GAP-411 (close after merge)
- ADR-007
- Sibling remediation: #2320 (cron dual + load-test staleness)