### PR TITLE
fix(db): GAP-417 residual — targetEnv OR NODE_ENV unsigned refuse

### DIFF
--- a/packages/auth/src/server/audit-storage.ts
+++ b/packages/auth/src/server/audit-storage.ts
@@ -33,7 +33,11 @@
 
 import { randomUUID } from 'node:crypto';
 import { logger } from '@revealui/core/observability/logger';
-import type { AuditRowSignerFn, DrizzleAuditStore as DrizzleAuditStoreType } from '@revealui/db';
+import type {
+  AuditRowSignerFn,
+  DrizzleAuditStoreOptions,
+  DrizzleAuditStore as DrizzleAuditStoreType,
+} from '@revealui/db';
 import { DrizzleAuditStore, getClient, hasDatabaseConnectionEnv } from '@revealui/db';
 import type { Database } from '@revealui/db/client';
 import type {
@@ -82,9 +86,15 @@ export function getAuditRowSigner(): AuditRowSignerFn | undefined {
  * Construct a `DrizzleAuditStore` wired to the process-wide signer. Every audit
  * writer builds its store through this helper so a row written through the one
  * door on a signing deployment always carries a signature.
+ *
+ * @param options Optional store options (GAP-417 residual): pass `targetEnv`
+ *   from CLI writers that resolve a deployment target independent of NODE_ENV.
  */
-export function createAuditStore(db: Database): DrizzleAuditStoreType {
-  return new DrizzleAuditStore(db, getAuditRowSigner());
+export function createAuditStore(
+  db: Database,
+  options?: DrizzleAuditStoreOptions,
+): DrizzleAuditStoreType {
+  return new DrizzleAuditStore(db, getAuditRowSigner(), options);
 }
 
 /** Test-only reset of the cached signer (re-reads env on next `getAuditRowSigner`). */

--- a/packages/db/src/__tests__/audit-store.test.ts
+++ b/packages/db/src/__tests__/audit-store.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type AuditEntry, DrizzleAuditStore } from '../audit-store.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AuditEntry, DrizzleAuditStore, isProductionAuditTarget } from '../audit-store.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -154,6 +154,84 @@ describe('DrizzleAuditStore  -  append-only enforcement', () => {
       store.appendBatch([makeEntry({ id: 'e1' }), makeEntry({ id: 'e2', tenant: '__system__' })]),
     ).rejects.toThrow(/reserved system-anchor sentinel/);
     expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  // ── GAP-417 residual: targetEnv keying for unsigned refuse ─────────────────
+
+  describe('isProductionAuditTarget', () => {
+    it('treats production and prod as production surfaces', () => {
+      expect(isProductionAuditTarget('production', 'development')).toBe(true);
+      expect(isProductionAuditTarget('prod', 'development')).toBe(true);
+      expect(isProductionAuditTarget('PROD', 'development')).toBe(true);
+      expect(isProductionAuditTarget(undefined, 'production')).toBe(true);
+    });
+
+    it('treats non-prod targets as non-production only when NODE_ENV is also non-prod', () => {
+      expect(isProductionAuditTarget('dev', 'development')).toBe(false);
+      expect(isProductionAuditTarget('development', 'development')).toBe(false);
+      expect(isProductionAuditTarget('test', 'test')).toBe(false);
+      expect(isProductionAuditTarget('stage', 'development')).toBe(false);
+      expect(isProductionAuditTarget(undefined, 'development')).toBe(false);
+    });
+
+    it('OR-keying: either targetEnv or NODE_ENV production is enough', () => {
+      expect(isProductionAuditTarget('prod', 'development')).toBe(true);
+      expect(isProductionAuditTarget('dev', 'production')).toBe(true);
+    });
+  });
+
+  describe('unsigned refuse rail (GAP-417 residual targetEnv)', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    afterEach(() => {
+      if (originalNodeEnv === undefined) {
+        delete (process.env as { NODE_ENV?: string }).NODE_ENV;
+      } else {
+        (process.env as { NODE_ENV: string }).NODE_ENV = originalNodeEnv;
+      }
+    });
+
+    it('allows unsigned append when NODE_ENV is development and no targetEnv', async () => {
+      (process.env as { NODE_ENV: string }).NODE_ENV = 'development';
+      const local = new DrizzleAuditStore(db as never);
+      await expect(local.append(makeEntry())).resolves.toBeUndefined();
+      expect(db.insert).toHaveBeenCalledOnce();
+    });
+
+    it('refuses unsigned append when NODE_ENV is production', async () => {
+      (process.env as { NODE_ENV: string }).NODE_ENV = 'production';
+      const local = new DrizzleAuditStore(db as never);
+      await expect(local.append(makeEntry())).rejects.toThrow(/UNSIGNED audit row in production/);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('refuses unsigned append when targetEnv is prod even if NODE_ENV is development', async () => {
+      (process.env as { NODE_ENV: string }).NODE_ENV = 'development';
+      const local = new DrizzleAuditStore(db as never, undefined, { targetEnv: 'prod' });
+      await expect(local.append(makeEntry())).rejects.toThrow(/UNSIGNED audit row in production/);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('still refuses when NODE_ENV is production even if targetEnv is dev (fail-closed OR)', async () => {
+      (process.env as { NODE_ENV: string }).NODE_ENV = 'production';
+      const local = new DrizzleAuditStore(db as never, undefined, { targetEnv: 'dev' });
+      await expect(local.append(makeEntry())).rejects.toThrow(/UNSIGNED audit row in production/);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('does not throw the unsigned refuse when a signer is injected on a prod target', async () => {
+      (process.env as { NODE_ENV: string }).NODE_ENV = 'development';
+      // Refuse only runs when !signer — with a signer the UNSIGNED error must
+      // not appear (seq plumbing may still fail on the mock db).
+      const signed = new DrizzleAuditStore(db as never, () => 'v1.ed25519.kid.sig', {
+        targetEnv: 'prod',
+      });
+      try {
+        await signed.append(makeEntry());
+      } catch (err) {
+        expect(String(err)).not.toMatch(/UNSIGNED audit row in production/);
+      }
+    });
   });
 
   // ── DB-level trigger (migration verification) ─────────────────────────────

--- a/packages/db/src/audit-store.ts
+++ b/packages/db/src/audit-store.ts
@@ -87,35 +87,82 @@ export interface AuditFilter {
 // ─── Drizzle Audit Store ────────────────────────────────────────────────────
 
 /**
+ * Construction options for {@link DrizzleAuditStore}.
+ *
+ * GAP-417 residual (rail-2 keying): the store must refuse unsigned rows when
+ * the *target surface* is production, not only when `process.env.NODE_ENV` is
+ * `"production"`. CLI writers often run with `NODE_ENV=development` while
+ * pointed at a production database (`--env=prod` / `REVEALUI_ENV=prod`);
+ * they pass the resolved target here so the refuse rail still fires.
+ */
+export interface DrizzleAuditStoreOptions {
+  /**
+   * Resolved operator / deployment target (e.g. `prod`, `production`, `dev`).
+   * When set, production detection uses this instead of `NODE_ENV` alone.
+   * Accepts fleet short names (`prod`) and Node names (`production`).
+   */
+  targetEnv?: string;
+}
+
+function isProductionName(value: string | undefined): boolean {
+  const raw = (value ?? '').trim().toLowerCase();
+  return raw === 'production' || raw === 'prod';
+}
+
+/**
+ * Whether the write surface is production for the unsigned-row refuse rail
+ * (GAP-417 residual).
+ *
+ * Fail-closed OR: refuse when **either** the operator-resolved `targetEnv`
+ * (`prod` / `production`) **or** `NODE_ENV` is production. That way a CLI
+ * with `NODE_ENV=development` and `--env=prod` still refuses unsigned rows,
+ * and a process that forgets to pass `targetEnv` still refuses when
+ * `NODE_ENV=production`.
+ */
+export function isProductionAuditTarget(
+  targetEnv?: string,
+  nodeEnv: string | undefined = process.env.NODE_ENV,
+): boolean {
+  return isProductionName(targetEnv) || isProductionName(nodeEnv);
+}
+
+/**
  * PostgreSQL-backed audit store using Drizzle ORM.
  * Implements the AuditStore interface for production use.
  *
  * All writes are append-only. The table has no UPDATE or DELETE operations.
  */
 export class DrizzleAuditStore {
+  private readonly options: DrizzleAuditStoreOptions;
+
   /**
-   * @param db     Drizzle client.
-   * @param signer Optional injected row signer (GAP-355 Stage 3). When supplied,
+   * @param db      Drizzle client.
+   * @param signer  Optional injected row signer (GAP-355 Stage 3). When supplied,
    *   every append fetches the row's `seq` from the sequence FIRST (so the signed
    *   bytes can include it — see `nextSeqValues`), signs, and INSERTs with an
    *   explicit `seq` + `signature`. When absent, the DB assigns `seq` and the
    *   `signature` column stays NULL — the honest unsigned state for dev/test.
+   * @param options Optional. Pass `targetEnv` from CLI writers that resolve a
+   *   deployment target independent of `NODE_ENV` (GAP-417 residual).
    */
   constructor(
     private readonly db: Database,
     private readonly signer?: AuditRowSignerFn,
-  ) {}
+    options: DrizzleAuditStoreOptions = {},
+  ) {
+    this.options = options;
+  }
 
   /**
-   * GAP-417 items 1-2 (owner-countersigned 2026-07-25), store-level rail: a
-   * production process must never land an unsigned audit row, regardless of
-   * how it booted. Unsigned rows are indistinguishable from tampering and
-   * permanently stall anchor contiguity once the sweep filters them. The
-   * boot-time assert is the first rail; this is the backstop for any path
-   * that constructs a signer-less store while NODE_ENV=production.
+   * GAP-417 items 1-2 (owner-countersigned 2026-07-25) + residual keying:
+   * a production *surface* must never land an unsigned audit row. Defaults to
+   * `NODE_ENV === 'production'`; CLI writers pass `targetEnv` so a process
+   * with `NODE_ENV=development` that targets prod still fails closed.
+   * Unsigned rows are indistinguishable from tampering and permanently stall
+   * anchor contiguity once the sweep filters them.
    */
   private refuseUnsignedInProduction(): void {
-    if (process.env.NODE_ENV === 'production') {
+    if (isProductionAuditTarget(this.options.targetEnv)) {
       throw new Error(
         'DrizzleAuditStore: refusing to write an UNSIGNED audit row in production — ' +
           'no row signer is injected. An unsigned row is indistinguishable from ' +

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -24,8 +24,13 @@
  */
 
 // Re-export audit stores
-export type { AuditEntry, AuditRowSignable, AuditRowSignerFn } from './audit-store.js';
-export { DrizzleAuditStore } from './audit-store.js';
+export type {
+  AuditEntry,
+  AuditRowSignable,
+  AuditRowSignerFn,
+  DrizzleAuditStoreOptions,
+} from './audit-store.js';
+export { DrizzleAuditStore, isProductionAuditTarget } from './audit-store.js';
 // Re-export client utilities
 export {
   closeAllPools,

--- a/scripts/admin/bootstrap.ts
+++ b/scripts/admin/bootstrap.ts
@@ -173,7 +173,7 @@ async function main(): Promise<void> {
     );
     const eventId = randomUUID();
     try {
-      await new DrizzleAuditStore(db, signer).append({
+      await new DrizzleAuditStore(db, signer, { targetEnv: env }).append({
         id: eventId,
         timestamp: new Date(),
         eventType: 'admin.bootstrap.completed',

--- a/scripts/admin/grant-entitlement.ts
+++ b/scripts/admin/grant-entitlement.ts
@@ -244,9 +244,11 @@ async function main(): Promise<void> {
         ? `[grant-entitlement] audit signing enabled (alg=ed25519, kid=${kid})`
         : '[grant-entitlement] audit row will be written UNSIGNED (no REVEALUI_AUDIT_SIGNING_KEY; dev/test only)',
     );
+    const targetEnv =
+      process.env.REVEALUI_ENV?.trim() || process.env.NODE_ENV?.trim() || 'development';
     const eventId = randomUUID();
     try {
-      await new DrizzleAuditStore(db, signer).append({
+      await new DrizzleAuditStore(db, signer, { targetEnv }).append({
         id: eventId,
         timestamp: new Date(),
         eventType: 'admin.entitlement.granted',


### PR DESCRIPTION
## Summary

GAP-417 residual (rail-2 keying refinement from the #2164 review):

- `DrizzleAuditStore` accepts optional `{ targetEnv }` so CLI writers that resolve an operator target (`prod` / `dev`) independent of `NODE_ENV` still hit the unsigned refuse rail.
- Fail-closed **OR**: refuse when **either** `targetEnv` is `prod`/`production` **or** `NODE_ENV` is production.
- Export `isProductionAuditTarget` + `DrizzleAuditStoreOptions`.
- Wire `scripts/admin/bootstrap.ts` (`targetEnv: env`) and `grant-entitlement.ts` (`REVEALUI_ENV` → `NODE_ENV` → `development`).
- `createAuditStore(db, options?)` passes options through.

Does **not** close GAP-417 fully (item 4 production NULL-signature sweep remains owner-run).

## Test plan

- [x] `pnpm --filter @revealui/db exec vitest run src/__tests__/audit-store.test.ts` (19 pass)
- [x] Local phase-1 CI gate pass
- [ ] Non-author guardrail-2 (security surface: audit refuse rail)

## Security

Hardens fail-closed on unsigned production audit rows for CLI paths. Proposal-shaped only.