### PR TITLE
feat(validate): dockerfile deps COPY lockstep (GAP-379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,13 @@ jobs:
         # match it exactly. Mirrors the local gate step in scripts/gates/ci-gate.ts.
         run: pnpm validate:rules-lockstep
 
+      - name: Dockerfile deps COPY lockstep (hard fail)
+        # GAP-379: server/admin deps-stage package.json COPY lists must cover
+        # the pnpm --filter <app>... workspace closure. Names the exact missing
+        # COPY line on failure. Worker whole-tree Dockerfiles are out of scope.
+        # Mirrors the local gate step in scripts/gates/ci-gate.ts.
+        run: pnpm validate:dockerfile-deps
+
       - name: Project manager check (path-gated hard fail)
         # GAP-406: when a PR (or push) touches .revealui or packages/harnesses,
         # hard-fail if manager.json is missing/invalid. Extends validate:structure

--- a/package.json
+++ b/package.json
@@ -263,6 +263,7 @@
     "validate:seed-wiring": "tsx scripts/validate/seed-script-wiring.ts",
     "validate:stripe-client": "tsx scripts/validate/stripe-client.ts",
     "validate:pricing-lockstep": "tsx scripts/validate/pricing-lockstep.ts",
+    "validate:dockerfile-deps": "tsx scripts/validate/dockerfile-deps-lockstep.ts",
     "validate:secret-paths": "vitest run scripts/sync/__tests__/secret-paths-lockstep.test.ts",
     "validate:doc-currency": "tsx scripts/validate/doc-currency.ts",
     "validate:rules-lockstep": "tsx scripts/validate/rules-lockstep.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -369,6 +369,15 @@ async function gate(): Promise<void> {
         args: ['validate:rules-lockstep'],
       },
       {
+        // GAP-379: deps-stage COPY package.json lists in server/admin
+        // Dockerfiles must cover the pnpm --filter <app>... workspace
+        // closure. Whole-tree-copy Dockerfiles (worker) are out of scope.
+        // Mirrored in CI by the Quality job step in .github/workflows/ci.yml.
+        name: 'Dockerfile deps COPY lockstep (hard fail)',
+        command: 'pnpm',
+        args: ['validate:dockerfile-deps'],
+      },
+      {
         // Every prose sentence in covered marketing content files must carry
         // a claims-evidence entry citing the code that proves it; cited paths
         // must exist. Sibling of claim-drift: that gate pins the numbers,

--- a/scripts/validate/README.md
+++ b/scripts/validate/README.md
@@ -82,6 +82,7 @@ Documentation link checking runs separately via `pnpm --filter docs check:links`
 | `mixed-changesets.ts`    | `pnpm validate:changesets`     | Flag mixed OSS/Pro changesets              |
 | `changelog-format.ts`    | `pnpm validate:changelogs`     | Enforce changelog format                   |
 | `pricing-lockstep.ts`    | `pnpm validate:pricing-lockstep` | Keep pricing sources in lockstep         |
+| `dockerfile-deps-lockstep.ts` | `pnpm validate:dockerfile-deps` | Keep Dockerfile package.json COPY lists in lockstep with the app workspace closure (GAP-379) |
 | `prod-env.ts`            | `pnpm validate:prod-env`       | Validate production env configuration      |
 | `gitignore-pro.ts`       | `pnpm validate:gitignore`      | Enforce Pro-package gitignore policy       |
 | `seed-script-wiring.ts`  | `pnpm validate:seed-wiring`    | Verify seed scripts are wired correctly    |

--- a/scripts/validate/__tests__/dockerfile-deps-lockstep.test.ts
+++ b/scripts/validate/__tests__/dockerfile-deps-lockstep.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Dockerfile deps-stage COPY lockstep unit tests (GAP-379).
+ * Pure parsers + comparison against fixture Dockerfiles (no pnpm, no monorepo install).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  findMissingCopies,
+  isWholeTreePackageCopy,
+  parseCopiedWorkspacePackageDirs,
+  parseWorkspaceClosurePaths,
+  suggestedCopyLine,
+} from '../dockerfile-deps-lockstep.js';
+
+describe('parseCopiedWorkspacePackageDirs', () => {
+  it('extracts packages/* and apps/* package.json COPY sources', () => {
+    const text = `
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY packages/ai/package.json ./packages/ai/
+COPY packages/setup/package.json      ./packages/setup/
+COPY apps/server/package.json ./apps/server/
+COPY --from=deps /app/packages ./packages
+COPY packages ./packages
+`;
+    expect([...parseCopiedWorkspacePackageDirs(text)].sort()).toEqual([
+      'apps/server',
+      'packages/ai',
+      'packages/setup',
+    ]);
+  });
+
+  it('ignores root package.json and multi-stage COPY', () => {
+    const text = `
+COPY package.json ./
+COPY --from=builder /app/apps/server/package.json ./apps/server/package.json
+`;
+    expect(parseCopiedWorkspacePackageDirs(text).size).toBe(0);
+  });
+});
+
+describe('isWholeTreePackageCopy', () => {
+  it('detects worker-style whole packages/ copy without per-package lists', () => {
+    const text = `
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages ./packages
+COPY apps/server ./apps/server
+`;
+    expect(isWholeTreePackageCopy(text)).toBe(true);
+  });
+
+  it('is false when individual package.json COPYs exist', () => {
+    const text = `
+COPY packages/ai/package.json ./packages/ai/
+COPY packages ./packages
+`;
+    expect(isWholeTreePackageCopy(text)).toBe(false);
+  });
+});
+
+describe('parseWorkspaceClosurePaths', () => {
+  it('keeps only packages/ and apps/ dirs under the repo root', () => {
+    const root = '/repo';
+    const out = [
+      '/repo/apps/server',
+      '/repo/packages/setup',
+      '/repo',
+      '/other/packages/ai',
+      '',
+    ].join('\n');
+    expect([...parseWorkspaceClosurePaths(out, root)].sort()).toEqual([
+      'apps/server',
+      'packages/setup',
+    ]);
+  });
+});
+
+describe('findMissingCopies + suggestedCopyLine', () => {
+  it('names every closure member without a COPY', () => {
+    const closure = new Set(['apps/server', 'packages/ai', 'packages/setup']);
+    const copied = new Set(['apps/server', 'packages/ai']);
+    expect(findMissingCopies(closure, copied)).toEqual(['packages/setup']);
+    expect(suggestedCopyLine('packages/setup')).toBe(
+      'COPY packages/setup/package.json ./packages/setup/',
+    );
+  });
+
+  it('returns empty when COPY list covers the full closure (extras allowed)', () => {
+    const closure = new Set(['apps/server', 'packages/ai']);
+    const copied = new Set(['apps/server', 'packages/ai', 'packages/cache']);
+    expect(findMissingCopies(closure, copied)).toEqual([]);
+  });
+});

--- a/scripts/validate/dockerfile-deps-lockstep.ts
+++ b/scripts/validate/dockerfile-deps-lockstep.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env tsx
+/**
+ * Dockerfile deps-stage COPY lockstep (GAP-379)
+ *
+ * Each app's Docker image installs with `pnpm install --filter <app>...`, which
+ * needs every workspace package.json in that filter's dependency closure on
+ * disk before install. Hardcoded COPY lists lag when a new workspace dep
+ * joins the graph (revealui#1926 / @revealui/setup). This gate computes the
+ * closure and hard-fails when a member lacks a package.json COPY line.
+ *
+ * Covers per-package COPY Dockerfiles (server + admin, plain + .forge).
+ * Skips whole-tree-copy Dockerfiles (e.g. Dockerfile.worker copies packages/).
+ *
+ * Zero authored regex: path substring + whitespace splitting only.
+ *
+ * Usage:
+ *   pnpm validate:dockerfile-deps
+ *
+ * Failure shape (exact missing COPY named):
+ *   ✗ apps/server/Dockerfile.forge missing workspace package.json COPY:
+ *       packages/setup
+ *     add: COPY packages/setup/package.json ./packages/setup/
+ *
+ * Exit codes:
+ *   0 = every targeted Dockerfile covers its filter's workspace closure
+ *   1 = missing COPY line(s), missing Dockerfile, or pnpm list failed
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = path.resolve(import.meta.dirname, '../..');
+
+export interface DockerfileTarget {
+  /** pnpm package filter name (without the trailing `...`). */
+  filterName: string;
+  /** Repo-relative Dockerfile path. */
+  dockerfileRel: string;
+}
+
+/**
+ * Per-package package.json COPY Dockerfiles only.
+ * Dockerfile.worker (and any whole-tree copy) is intentionally absent.
+ */
+export const TARGETS: DockerfileTarget[] = [
+  { filterName: 'server', dockerfileRel: 'apps/server/Dockerfile' },
+  { filterName: 'server', dockerfileRel: 'apps/server/Dockerfile.forge' },
+  { filterName: 'admin', dockerfileRel: 'apps/admin/Dockerfile' },
+  { filterName: 'admin', dockerfileRel: 'apps/admin/Dockerfile.forge' },
+];
+
+const PACKAGE_JSON_SUFFIX = '/package.json';
+
+/** Collapse runs of spaces/tabs without regex. */
+function splitWhitespace(text: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  for (const ch of text) {
+    if (ch === ' ' || ch === '\t') {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * Workspace package dirs referenced by `COPY packages/.../package.json` /
+ * `COPY apps/.../package.json` lines. Root `COPY package.json …` is ignored.
+ * Multi-stage `COPY --from=…` and whole-tree `COPY packages ./packages` are ignored.
+ */
+export function parseCopiedWorkspacePackageDirs(dockerfileText: string): Set<string> {
+  const result = new Set<string>();
+  for (const rawLine of dockerfileText.split('\n')) {
+    const line = rawLine.trim();
+    if (!line.startsWith('COPY ')) continue;
+    const rest = line.slice('COPY '.length);
+    if (rest.startsWith('--from')) continue;
+
+    for (const token of splitWhitespace(rest)) {
+      if (!token.endsWith(PACKAGE_JSON_SUFFIX)) continue;
+      if (!(token.startsWith('packages/') || token.startsWith('apps/'))) continue;
+      const dir = token.slice(0, token.length - PACKAGE_JSON_SUFFIX.length);
+      if (dir.length > 0) result.add(dir);
+    }
+  }
+  return result;
+}
+
+/**
+ * True when the Dockerfile copies the packages tree as a unit and never lists
+ * individual package.json paths (worker-style). Such files are out of scope.
+ */
+export function isWholeTreePackageCopy(dockerfileText: string): boolean {
+  if (parseCopiedWorkspacePackageDirs(dockerfileText).size > 0) return false;
+  for (const rawLine of dockerfileText.split('\n')) {
+    const line = rawLine.trim();
+    if (!line.startsWith('COPY ')) continue;
+    const rest = line.slice('COPY '.length);
+    if (rest.startsWith('--from')) continue;
+    const tokens = splitWhitespace(rest);
+    // Last token is the destination; sources are the rest.
+    for (const token of tokens.slice(0, Math.max(0, tokens.length - 1))) {
+      if (token === 'packages' || token === './packages') return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Convert `pnpm list --parseable` absolute paths into repo-relative posix dirs
+ * under packages/ or apps/ (the monorepo root path is dropped if present).
+ */
+export function parseWorkspaceClosurePaths(parseableOutput: string, repoRoot: string): Set<string> {
+  const root = path.resolve(repoRoot);
+  const rootPrefix = root.endsWith(path.sep) ? root : root + path.sep;
+  const result = new Set<string>();
+
+  for (const raw of parseableOutput.split('\n')) {
+    const abs = raw.trim();
+    if (abs.length === 0) continue;
+    const resolved = path.resolve(abs);
+    if (resolved === root) continue;
+    if (!resolved.startsWith(rootPrefix)) continue;
+    const relPosix = path.relative(root, resolved).split(path.sep).join('/');
+    if (relPosix.startsWith('packages/') || relPosix.startsWith('apps/')) {
+      result.add(relPosix);
+    }
+  }
+  return result;
+}
+
+export function findMissingCopies(closure: Set<string>, copied: Set<string>): string[] {
+  const missing: string[] = [];
+  for (const pkg of [...closure].sort()) {
+    if (!copied.has(pkg)) missing.push(pkg);
+  }
+  return missing;
+}
+
+/** Suggested Dockerfile line for a missing workspace package. */
+export function suggestedCopyLine(packageDir: string): string {
+  return `COPY ${packageDir}/package.json ./${packageDir}/`;
+}
+
+export function listWorkspaceClosure(repoRoot: string, filterName: string): Set<string> {
+  const out = execFileSync(
+    'pnpm',
+    ['--filter', `${filterName}...`, 'list', '--depth', '-1', '--parseable'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    },
+  );
+  return parseWorkspaceClosurePaths(out, repoRoot);
+}
+
+export interface TargetResult {
+  dockerfileRel: string;
+  filterName: string;
+  skipped: boolean;
+  skipReason?: string;
+  closureSize: number;
+  copiedSize: number;
+  missing: string[];
+}
+
+export function checkTarget(
+  repoRoot: string,
+  target: DockerfileTarget,
+  closure: Set<string>,
+): TargetResult {
+  const abs = path.join(repoRoot, target.dockerfileRel);
+  if (!fs.existsSync(abs)) {
+    return {
+      dockerfileRel: target.dockerfileRel,
+      filterName: target.filterName,
+      skipped: false,
+      closureSize: closure.size,
+      copiedSize: 0,
+      missing: [`<Dockerfile missing on disk: ${target.dockerfileRel}>`],
+    };
+  }
+
+  const text = fs.readFileSync(abs, 'utf8');
+  if (isWholeTreePackageCopy(text)) {
+    return {
+      dockerfileRel: target.dockerfileRel,
+      filterName: target.filterName,
+      skipped: true,
+      skipReason: 'whole-tree packages/ copy (no per-package package.json COPY list)',
+      closureSize: closure.size,
+      copiedSize: 0,
+      missing: [],
+    };
+  }
+
+  const copied = parseCopiedWorkspacePackageDirs(text);
+  const missing = findMissingCopies(closure, copied);
+  return {
+    dockerfileRel: target.dockerfileRel,
+    filterName: target.filterName,
+    skipped: false,
+    closureSize: closure.size,
+    copiedSize: copied.size,
+    missing,
+  };
+}
+
+export function main(repoRoot: string = ROOT, targets: DockerfileTarget[] = TARGETS): number {
+  const closures = new Map<string, Set<string>>();
+  const results: TargetResult[] = [];
+  let failed = false;
+
+  for (const target of targets) {
+    let closure = closures.get(target.filterName);
+    if (!closure) {
+      try {
+        closure = listWorkspaceClosure(repoRoot, target.filterName);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`✗ pnpm list failed for filter "${target.filterName}...": ${message}`);
+        return 1;
+      }
+      if (closure.size === 0) {
+        console.error(
+          `✗ pnpm --filter "${target.filterName}..." list returned no workspace packages`,
+        );
+        return 1;
+      }
+      closures.set(target.filterName, closure);
+    }
+
+    const result = checkTarget(repoRoot, target, closure);
+    results.push(result);
+
+    if (result.skipped) {
+      console.log(`○ ${result.dockerfileRel}: skipped (${result.skipReason})`);
+      continue;
+    }
+
+    if (result.missing.length > 0) {
+      failed = true;
+      console.error(
+        `✗ ${result.dockerfileRel} missing workspace package.json COPY ` +
+          `(filter ${result.filterName}..., ${result.closureSize} package(s) in closure):`,
+      );
+      for (const pkg of result.missing) {
+        if (pkg.startsWith('<')) {
+          console.error(`    ${pkg}`);
+          continue;
+        }
+        console.error(`    ${pkg}`);
+        console.error(`      add: ${suggestedCopyLine(pkg)}`);
+      }
+      continue;
+    }
+
+    console.log(
+      `✓ ${result.dockerfileRel}: ${result.closureSize} closure package(s) covered ` +
+        `(${result.copiedSize} package.json COPY line(s); filter ${result.filterName}...)`,
+    );
+  }
+
+  if (failed) {
+    console.error('');
+    console.error(
+      'Dockerfile deps-stage COPY lists must include every workspace package in the ' +
+        'app filter closure. See GAP-379 / revealui#1926.',
+    );
+    return 1;
+  }
+
+  const checked = results.filter((r) => !r.skipped).length;
+  console.log(
+    `✓ dockerfile-deps lockstep: ${checked} Dockerfile(s) in lockstep with workspace closure`,
+  );
+  return 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary

Adds a CI/gate validator that keeps each app Dockerfile's deps-stage `COPY …/package.json` list in lockstep with the pnpm workspace dependency closure (`pnpm --filter <app>... list --depth -1 --parseable`).

This is the durable fix for the class of failure that made Forge builds red when `@revealui/setup` joined server's closure without a matching COPY (revealui#1926 / GAP-379).

### Coverage
- `apps/server/Dockerfile`
- `apps/server/Dockerfile.forge`
- `apps/admin/Dockerfile`
- `apps/admin/Dockerfile.forge`
- **Skipped:** whole-tree-copy Dockerfiles (`Dockerfile.worker` copies `packages/`)

### Behavior
- Hard-fails naming the exact missing package and the suggested COPY line
- Extra COPY lines beyond the closure are allowed
- Zero authored regex (path substring + whitespace split)

### Wiring
- `pnpm validate:dockerfile-deps`
- `pnpm gate` (ci-gate.ts)
- `.github/workflows/ci.yml` Quality job

## Test plan
- [x] Current Dockerfiles pass (`pnpm validate:dockerfile-deps` exit 0)
- [x] Unit tests for pure parsers (7 tests)
- [x] Prove fail mode: removing `packages/setup` COPY from `Dockerfile.forge` exits 1 with:
  ```
  ✗ apps/server/Dockerfile.forge missing workspace package.json COPY ...
      packages/setup
        add: COPY packages/setup/package.json ./packages/setup/
  ```