### PR TITLE
fix(router): hydrate seed + revive rsc-poc (GAP-194 T0)

### DIFF
--- a/.changeset/router-seed-current-match.md
+++ b/.changeset/router-seed-current-match.md
@@ -1,0 +1,5 @@
+---
+"@revealui/router": patch
+---
+
+Fix SSR hydrate so loader data is available via getCurrentMatch/useData on first client paint. Add Router.seedCurrentMatch and lock 0.3.x contract that client navigate does not run loaders or middleware.

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -23,9 +23,9 @@ export const METRICS = {
   /** Packages in `packages/` directories. Source: claim-drift countPackages. */
   packages: 31,
   /** Apps in `apps/`. Source: claim-drift countApps. */
-  apps: 5,
+  apps: 6,
   /** Workspaces (packages + apps). Source: claim-drift countWorkspaces. */
-  workspaces: 36,
+  workspaces: 37,
   /** Test files across the monorepo. Source: claim-drift countTestFiles. */
   testFiles: 1162,
   /** UI components in `packages/presentation/`. Source: claim-drift countUIComponents. */

--- a/apps/rsc-poc/.gitignore
+++ b/apps/rsc-poc/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.vite
+.turbo
+*.log

--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -1,6 +1,6 @@
 # `@rsc-poc/app` — GAP-194 RSC POC (T0 revive)
 
-> **Status (2026-07-31):** Restored from tag `archive/rsc-poc-spike` @ `918f5e083` for Phase 2.2.2 **T0 revive-POC gate**. Deps re-baselined to React/RSDW **19.2.7** lockstep (CVE floor ≥19.2.4) and `@vitejs/plugin-rsc` **0.5.27**. Survives into 2.2.x as the integration harness (not deleted until greenfield ships).
+> **Status (2026-07-31):** Restored from tag `archive/rsc-poc-spike` @ `918f5e083` for Phase 2.2.2 **T0 revive-POC gate**. Deps re-baselined to React/RSDW **19.2.8** lockstep (CVE floor ≥19.2.4; GHSA-wx67-qw84-cm4g) and `@vitejs/plugin-rsc` **0.5.27**. Survives into 2.2.x as the integration harness (not deleted until greenfield ships).
 
 ## What this is
 

--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -1,0 +1,48 @@
+# `@rsc-poc/app` — GAP-194 RSC POC (T0 revive)
+
+> **Status (2026-07-31):** Restored from tag `archive/rsc-poc-spike` @ `918f5e083` for Phase 2.2.2 **T0 revive-POC gate**. Deps re-baselined to React/RSDW **19.2.7** lockstep (CVE floor ≥19.2.4) and `@vitejs/plugin-rsc` **0.5.27**. Survives into 2.2.x as the integration harness (not deleted until greenfield ships).
+
+## What this is
+
+Sandbox that proved React Server Components work with Vite + Hono + `@vitejs/plugin-rsc` during Phase 2.1 (2026-05-18). It does **not** yet use `@revealui/router` 0.4 RSC mode (that is T8 after the core engine). Today it uses a pathname-dispatch shim; the kickoff replaces that once dual-mode lands.
+
+## Authoritative docs
+
+- Kickoff (T0–T9): `.jv/docs/specs/2026-05-23-phase-2.2.2-router-rsc-core-engine-kickoff.md`
+- RSC ADR: `.jv/docs/decisions/2026-05-18-rsc-router-greenfield.md`
+- Design re-audit: `.jv/docs/audits/2026-07-04-rsc-router-design-reaudit.md`
+- Gap: `.jv/docs/gaps/GAP-194.yml`
+
+## T0 acceptance (from Phase 2.1)
+
+| Id | Criterion |
+|----|-----------|
+| A | RSC render |
+| B | Hydrate |
+| C | Server-action round-trip |
+| D | Production build |
+| E | HMR |
+
+## Commands
+
+```bash
+# from monorepo root (worktree OK)
+pnpm install
+pnpm --filter @rsc-poc/app build
+pnpm --filter @rsc-poc/app dev
+```
+
+## Entries
+
+| File | Role |
+|------|------|
+| `src/entry.rsc.tsx` | RSC render entry |
+| `src/entry.ssr.tsx` | SSR + `tee()` / payload inline (D15 pattern) |
+| `src/entry.browser.tsx` | Hydrate + action callback (history monkey-patch must **not** carry into 0.4 — D3) |
+| `src/pages/*` | Demo pages + server actions |
+
+## Pin policy
+
+- `react` / `react-dom` / `react-server-dom-webpack`: **exact same version**, floor **≥19.2.4**
+- `@vitejs/plugin-rsc`: pin exact (0.5.27 at T0)
+- `vite`: workspace catalog

--- a/apps/rsc-poc/index.html
+++ b/apps/rsc-poc/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RSC POC — Phase 2.1 spike</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entry.browser.tsx"></script>
+  </body>
+</html>

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@rsc-poc/app",
+  "version": "0.1.0",
+  "description": "GAP-194 Phase 2.1 RSC POC sandbox — revived for Phase 2.2.2 T0 gate (archive/rsc-poc-spike). Integration harness for dual-mode @revealui/router 0.4 RSC work.",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=24.13.0"
+  },
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite dev",
+    "lint": "biome check .",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^2.0.11",
+    "@revealui/router": "workspace:*",
+    "@vitejs/plugin-react": "catalog:",
+    "@vitejs/plugin-rsc": "0.5.27",
+    "hono": "4.12.27",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "react-server-dom-webpack": "19.2.7"
+  },
+  "devDependencies": {
+    "@revealui/dev": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -20,9 +20,9 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitejs/plugin-rsc": "0.5.27",
     "hono": "4.12.27",
-    "react": "19.2.7",
-    "react-dom": "19.2.7",
-    "react-server-dom-webpack": "19.2.7"
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "react-server-dom-webpack": "19.2.8"
   },
   "devDependencies": {
     "@revealui/dev": "workspace:*",

--- a/apps/rsc-poc/src/entry.browser.tsx
+++ b/apps/rsc-poc/src/entry.browser.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import {
+  createFromFetch,
+  createFromReadableStream,
+  createTemporaryReferenceSet,
+  encodeReply,
+  setServerCallback,
+} from '@vitejs/plugin-rsc/browser';
+import React from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import type { RscPayload } from './entry.rsc.tsx';
+
+async function main(): Promise<void> {
+  let setPayload: ((v: RscPayload) => void) | undefined;
+
+  async function fetchRscPayload(url: string): Promise<RscPayload> {
+    return createFromFetch<RscPayload>(fetch(url, { headers: { accept: 'text/x-component' } }));
+  }
+
+  const rscBase64 = (globalThis as Record<string, unknown>).__RSC_PAYLOAD__ as string | undefined;
+
+  let initialPayload: RscPayload;
+  if (rscBase64) {
+    const rscBytes = Uint8Array.from(atob(rscBase64), (c) => c.charCodeAt(0));
+    const rscStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(rscBytes);
+        controller.close();
+      },
+    });
+    initialPayload = await createFromReadableStream<RscPayload>(rscStream);
+  } else {
+    initialPayload = await fetchRscPayload(window.location.href);
+  }
+
+  function BrowserRoot(): React.ReactNode {
+    const [payload, setPayload_] = React.useState(initialPayload);
+
+    React.useEffect(() => {
+      setPayload = (v) => React.startTransition(() => setPayload_(v));
+    }, []);
+
+    React.useEffect(() => {
+      return listenNavigation(() => {
+        fetchRscPayload(window.location.href).then((p) => setPayload?.(p));
+      });
+    }, []);
+
+    return payload.root;
+  }
+
+  setServerCallback(async (id: string, args: unknown[]) => {
+    const temporaryReferences = createTemporaryReferenceSet();
+    const body = await encodeReply(args, { temporaryReferences });
+    const headers: Record<string, string> = {
+      'x-rsc-action': id,
+      accept: 'text/x-component',
+    };
+    if (typeof body === 'string') {
+      headers['content-type'] = 'text/plain;charset=UTF-8';
+    }
+    const payload = await createFromFetch<RscPayload>(
+      fetch(window.location.href, {
+        method: 'POST',
+        headers,
+        body: body as BodyInit,
+      }),
+      { temporaryReferences },
+    );
+    setPayload?.(payload);
+    const rv = payload.returnValue;
+    if (!rv) return undefined;
+    if (!rv.ok) throw rv.data;
+    return rv.data;
+  });
+
+  const browserRoot = (
+    <React.StrictMode>
+      <BrowserRoot />
+    </React.StrictMode>
+  );
+
+  const mountEl = document.getElementById('root');
+  if (mountEl && rscBase64) {
+    hydrateRoot(document, browserRoot, { formState: initialPayload.formState });
+  } else if (mountEl) {
+    createRoot(mountEl).render(browserRoot);
+  } else {
+    hydrateRoot(document, browserRoot, { formState: initialPayload.formState });
+  }
+
+  if (import.meta.hot) {
+    import.meta.hot.on('rsc:update', () => {
+      fetchRscPayload(window.location.href).then((p) => setPayload?.(p));
+    });
+  }
+}
+
+function listenNavigation(onNavigation: () => void): () => void {
+  window.addEventListener('popstate', onNavigation);
+
+  const oldPushState = window.history.pushState.bind(window.history);
+  window.history.pushState = (...args: Parameters<typeof window.history.pushState>) => {
+    const res = oldPushState(...args);
+    onNavigation();
+    return res;
+  };
+
+  const oldReplaceState = window.history.replaceState.bind(window.history);
+  window.history.replaceState = (...args: Parameters<typeof window.history.replaceState>) => {
+    const res = oldReplaceState(...args);
+    onNavigation();
+    return res;
+  };
+
+  function onClick(e: MouseEvent): void {
+    const link = (e.target as Element).closest('a');
+    if (
+      link instanceof HTMLAnchorElement &&
+      link.href &&
+      (!link.target || link.target === '_self') &&
+      link.origin === location.origin &&
+      !link.hasAttribute('download') &&
+      e.button === 0 &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
+      !e.shiftKey &&
+      !e.defaultPrevented
+    ) {
+      e.preventDefault();
+      history.pushState(null, '', link.href);
+    }
+  }
+
+  document.addEventListener('click', onClick);
+
+  return () => {
+    document.removeEventListener('click', onClick);
+    window.removeEventListener('popstate', onNavigation);
+    window.history.pushState = oldPushState;
+    window.history.replaceState = oldReplaceState;
+  };
+}
+
+main();

--- a/apps/rsc-poc/src/entry.rsc.tsx
+++ b/apps/rsc-poc/src/entry.rsc.tsx
@@ -1,0 +1,133 @@
+import {
+  createTemporaryReferenceSet,
+  decodeAction,
+  decodeFormState,
+  decodeReply,
+  loadServerAction,
+  renderToReadableStream,
+} from '@vitejs/plugin-rsc/rsc';
+import type { ReactFormState } from 'react-dom/client';
+import { ActionsPage } from './pages/actions.tsx';
+import { CounterPage } from './pages/counter.tsx';
+import { HomePage } from './pages/home.tsx';
+
+export interface RscPayload {
+  root: React.ReactNode;
+  returnValue?: { ok: boolean; data: unknown };
+  formState?: ReactFormState;
+}
+
+function resolvePageComponent(pathname: string): React.ReactNode {
+  if (pathname === '/counter') {
+    return <CounterPage />;
+  }
+  if (pathname === '/actions') {
+    return <ActionsPage />;
+  }
+  return <HomePage />;
+}
+
+function NavBar(): React.ReactNode {
+  return (
+    <nav
+      style={{
+        padding: '12px 16px',
+        borderBottom: '1px solid #e5e7eb',
+        marginBottom: '24px',
+        display: 'flex',
+        gap: '16px',
+      }}
+    >
+      <a href="/">Home</a>
+      <a href="/counter">Counter</a>
+      <a href="/actions">Actions</a>
+    </nav>
+  );
+}
+
+function Layout({ children }: { children: React.ReactNode }): React.ReactNode {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>RSC POC — Phase 2.1 spike</title>
+      </head>
+      <body>
+        <NavBar />
+        <main style={{ padding: '0 16px' }}>{children}</main>
+      </body>
+    </html>
+  );
+}
+
+export default { fetch: handler };
+
+async function handler(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+
+  let returnValue: RscPayload['returnValue'] | undefined;
+  let formState: ReactFormState | undefined;
+  let temporaryReferences: unknown | undefined;
+  let actionStatus: number | undefined;
+
+  const actionId = request.headers.get('x-rsc-action');
+  const isFormAction = request.method === 'POST' && !actionId;
+
+  if (actionId) {
+    const contentType = request.headers.get('content-type');
+    const body = contentType?.startsWith('multipart/form-data')
+      ? await request.formData()
+      : await request.text();
+    temporaryReferences = createTemporaryReferenceSet();
+    const args = await decodeReply(body, { temporaryReferences });
+    const action = await loadServerAction(actionId);
+    try {
+      const data = await (action as (...a: unknown[]) => Promise<unknown>)(...(args as unknown[]));
+      returnValue = { ok: true, data };
+    } catch (e) {
+      returnValue = { ok: false, data: e };
+      actionStatus = 500;
+    }
+  } else if (isFormAction) {
+    const formData = await request.formData();
+    const decodedAction = await decodeAction(formData);
+    try {
+      const result = await decodedAction();
+      formState = await decodeFormState(result, formData);
+    } catch {
+      return new Response('Internal Server Error: server action failed', { status: 500 });
+    }
+  }
+
+  const page = resolvePageComponent(url.pathname);
+  const rscPayload: RscPayload = {
+    root: <Layout>{page}</Layout>,
+    formState,
+    returnValue,
+  };
+  const rscStream = renderToReadableStream<RscPayload>(rscPayload, { temporaryReferences });
+
+  const isRscRequest =
+    url.pathname.endsWith('.rsc') || request.headers.get('accept') === 'text/x-component';
+  if (isRscRequest) {
+    return new Response(rscStream, {
+      status: actionStatus,
+      headers: { 'content-type': 'text/x-component;charset=utf-8' },
+    });
+  }
+
+  const ssrEntry = await import.meta.viteRsc.loadModule<typeof import('./entry.ssr.tsx')>(
+    'ssr',
+    'index',
+  );
+  const htmlStream = await ssrEntry.renderHTML(rscStream, { formState });
+
+  return new Response(htmlStream, {
+    headers: { 'content-type': 'text/html' },
+  });
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/apps/rsc-poc/src/entry.ssr.tsx
+++ b/apps/rsc-poc/src/entry.ssr.tsx
@@ -1,0 +1,45 @@
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr';
+import React from 'react';
+import type { ReactFormState } from 'react-dom/client';
+import { renderToReadableStream } from 'react-dom/server.edge';
+import type { RscPayload } from './entry.rsc.tsx';
+
+export async function renderHTML(
+  rscStream: ReadableStream<Uint8Array>,
+  options: { formState?: ReactFormState },
+): Promise<ReadableStream<Uint8Array>> {
+  const [rscStream1, rscStream2] = rscStream.tee();
+
+  let payload: Promise<RscPayload> | undefined;
+  function SsrRoot(): React.ReactNode {
+    payload ??= createFromReadableStream<RscPayload>(rscStream1);
+    return React.use(payload).root;
+  }
+
+  const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent('index');
+
+  const chunks: Uint8Array[] = [];
+  const reader = rscStream2.getReader();
+  const _encoder = new TextEncoder();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const rscBytes = chunks.reduce((acc, c) => {
+    const merged = new Uint8Array(acc.length + c.length);
+    merged.set(acc);
+    merged.set(c, acc.length);
+    return merged;
+  }, new Uint8Array(0));
+  const rscBase64 = btoa(String.fromCharCode(...rscBytes));
+
+  const rscInlineScript = `self.__RSC_PAYLOAD__="${rscBase64}";`;
+
+  const htmlStream = await renderToReadableStream(<SsrRoot />, {
+    bootstrapScriptContent: rscInlineScript + bootstrapScriptContent,
+    formState: options.formState,
+  });
+
+  return htmlStream;
+}

--- a/apps/rsc-poc/src/pages/action-form.tsx
+++ b/apps/rsc-poc/src/pages/action-form.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+interface ActionFormProps {
+  action: (formData: FormData) => Promise<string>;
+}
+
+export function ActionForm({ action }: ActionFormProps): React.ReactNode {
+  const [result, setResult] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    startTransition(async () => {
+      const res = await action(formData);
+      setResult(res);
+    });
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
+        <input
+          type="text"
+          name="message"
+          placeholder="Type a message"
+          style={{ padding: '6px 10px', border: '1px solid #d1d5db', borderRadius: '4px' }}
+        />
+        <button type="submit" disabled={isPending}>
+          {isPending ? 'Sending…' : 'Send to server'}
+        </button>
+      </form>
+      {result !== null && (
+        <div
+          style={{
+            padding: '10px 14px',
+            background: '#f0fdf4',
+            border: '1px solid #bbf7d0',
+            borderRadius: '4px',
+          }}
+        >
+          {result}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/rsc-poc/src/pages/actions.server.ts
+++ b/apps/rsc-poc/src/pages/actions.server.ts
@@ -1,0 +1,8 @@
+'use server';
+
+export async function submitMessage(formData: FormData): Promise<string> {
+  const message = formData.get('message');
+  const value = typeof message === 'string' ? message : '';
+  process.stdout.write(`[server-action] submitMessage called with: ${value}\n`);
+  return `Server received: "${value}" at ${new Date().toISOString()}`;
+}

--- a/apps/rsc-poc/src/pages/actions.tsx
+++ b/apps/rsc-poc/src/pages/actions.tsx
@@ -1,0 +1,16 @@
+import { ActionForm } from './action-form.tsx';
+import { submitMessage } from './actions.server.ts';
+
+export function ActionsPage(): React.ReactNode {
+  return (
+    <div>
+      <h1>Actions — Server Action</h1>
+      <p>
+        Submitting the form below invokes a <code>&apos;use server&apos;</code> action. The action
+        logs <code>[server-action]</code> to the <strong>server</strong> console and returns a
+        string that updates the UI — proving a full round-trip.
+      </p>
+      <ActionForm action={submitMessage} />
+    </div>
+  );
+}

--- a/apps/rsc-poc/src/pages/counter.tsx
+++ b/apps/rsc-poc/src/pages/counter.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+
+export function Counter(): React.ReactNode {
+  const [count, setCount] = useState(0);
+
+  function decrement(): void {
+    setCount((c) => c - 1);
+  }
+
+  function increment(): void {
+    setCount((c) => c + 1);
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <button type="button" onClick={decrement}>
+        -
+      </button>
+      <span>Count: {count}</span>
+      <button type="button" onClick={increment}>
+        +
+      </button>
+    </div>
+  );
+}
+
+export function CounterPage(): React.ReactNode {
+  return (
+    <div>
+      <h1>Counter — Client Component</h1>
+      <p>
+        This component uses <code>useState</code> and runs in the browser. Clicking the buttons
+        below proves hydration is working.
+      </p>
+      <Counter />
+    </div>
+  );
+}

--- a/apps/rsc-poc/src/pages/home.tsx
+++ b/apps/rsc-poc/src/pages/home.tsx
@@ -1,0 +1,19 @@
+import { Counter } from './counter.tsx';
+
+export function HomePage(): React.ReactNode {
+  return (
+    <div>
+      <h1>Home — Server Component</h1>
+      <p>
+        Rendered on the server at <code>{new Date().toISOString()}</code> in{' '}
+        <code>{process.env.NODE_ENV}</code> mode.
+      </p>
+      <p>
+        The timestamp above is stamped at RSC serialization time, not at request time in the browser
+        — proving server execution.
+      </p>
+      <h2>Client component embedded below</h2>
+      <Counter />
+    </div>
+  );
+}

--- a/apps/rsc-poc/tsconfig.json
+++ b/apps/rsc-poc/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["node", "@vitejs/plugin-rsc/types", "vite/client"]
+  },
+  "include": ["src/**/*", "vite.config.ts"],
+  "exclude": ["node_modules", "dist", ".vite"]
+}

--- a/apps/rsc-poc/vite.config.ts
+++ b/apps/rsc-poc/vite.config.ts
@@ -1,0 +1,16 @@
+import react from '@vitejs/plugin-react';
+import rsc from '@vitejs/plugin-rsc';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [
+    rsc({
+      entries: {
+        rsc: './src/entry.rsc.tsx',
+        ssr: './src/entry.ssr.tsx',
+        client: './src/entry.browser.tsx',
+      },
+    }),
+    react(),
+  ],
+});

--- a/docs/LAUNCH-CHECKLIST.md
+++ b/docs/LAUNCH-CHECKLIST.md
@@ -21,7 +21,7 @@ All gates must pass on the `main` branch before deploy.
 
 - [ ] `pnpm gate` passes all three phases (quality, typecheck, test + build) **(blocking)**
 - [ ] `pnpm lint` reports zero errors (Biome 2) **(blocking)**
-- [ ] `pnpm typecheck:all` clean across all 36 workspaces **(blocking)**
+- [ ] `pnpm typecheck:all` clean across all 37 workspaces **(blocking)**
 - [ ] `pnpm test` passes the full test suite **(blocking)**
 - [ ] `pnpm build` succeeds for all apps and packages **(blocking)**
 - [ ] `pnpm validate:structure` confirms workspace structure integrity **(blocking)**

--- a/docs/MARKETING_METRICS.md
+++ b/docs/MARKETING_METRICS.md
@@ -26,8 +26,8 @@ Source: `pnpm tsx scripts/validate/claim-drift.ts` on `origin/test` 2026-07-27 (
 | Metric | Canonical value | Source of truth (script ref) | Notes |
 |---|---|---|---|
 | Packages in `packages/` | **31** | `countPackages()` — `.ts`-bearing dir | Stale memory `reference_npm_account_topology` ("36") superseded by this. |
-| Apps in `apps/` | **5** | `countApps()` | admin / server / docs / marketing / license-signer (GAP-260 P4-2). |
-| Workspaces (monorepo total) | **36** | `countWorkspaces()` (= 31 packages + 5 apps) | |
+| Apps in `apps/` | **6** | `countApps()` | admin / server / docs / marketing / license-signer / rsc-poc (GAP-194 T0 harness). |
+| Workspaces (monorepo total) | **37** | `countWorkspaces()` (= 31 packages + 6 apps) | |
 | Test files | **1162** | `countTestFiles()` — `*.test.ts` / `*.spec.ts` walking | Marketing copy should say "900+ tests" or quote the exact ground-truth number, never "20,000+" (the stale claim). claim-drift allows site.ts METRICS.testFiles within tolerance 100. |
 | UI components in `packages/presentation/` | **65** | `countUIComponents()` | Marketing copy says "65 native React components" or similar. |
 | **MCP servers** | **13** | `countMCPServers()` — `.ts` files in `packages/mcp/src/servers/` excluding `_`-prefixed | Includes `adapter.ts` (BaseAdapter + Vercel/Stripe/Neon subclasses); Supabase launcher removed (13 count). |

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -130,7 +130,7 @@ cd revealui
 pnpm install
 pnpm gate                # Run the full CI gate locally
 pnpm test                # Run the full test suite
-pnpm typecheck:all       # Typecheck all 36 workspaces
+pnpm typecheck:all       # Typecheck all 37 workspaces
 pnpm validate:claims     # Run the marketing/docs claim-drift gate
 ```
 

--- a/docs/blog/01-why-we-built-revealui.md
+++ b/docs/blog/01-why-we-built-revealui.md
@@ -229,7 +229,7 @@ This is the part that's genuinely hard to replicate by stitching services togeth
 
 Some numbers on what's actually shipped:
 
-- **36 workspaces** across the monorepo (5 apps, 31 packages with 24 MIT, 5 Fair Source, 2 internal)
+- **37 workspaces** across the monorepo (6 apps, 31 packages with 24 MIT, 5 Fair Source, 2 internal)
 - **97 database tables** via Drizzle ORM on NeonDB (Postgres)
 - **65 UI components** in `@revealui/presentation`, with one third-party runtime dependency (`tailwind-merge`), built directly on Tailwind v4 and React, with `cva` and `cn` vendored in-package
 - **13 first-party MCP servers** in `@revealui/mcp`

--- a/docs/security/INFORMATION_SECURITY_POLICY.md
+++ b/docs/security/INFORMATION_SECURITY_POLICY.md
@@ -132,7 +132,7 @@ RevealUI does not store credit card numbers or payment method details. All payme
 All changes pass through the CI gate before reaching `test` or `main`:
 
 1. **Quality** (parallel): Biome lint (hard fail), security audits (warn), structure checks (warn)
-2. **Type checking** (serial): TypeScript strict mode across all 36 workspaces
+2. **Type checking** (serial): TypeScript strict mode across all 37 workspaces
 3. **Test + Build** (parallel): Vitest (full suite, hard fail), Turborepo build verification
 
 ### Branch Pipeline

--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
       "fast-uri": ">=3.1.2",
       "ip-address": ">=10.2.0",
       "postcss": ">=8.5.10",
-      "react": ">=19.2.4",
-      "react-dom": ">=19.2.4",
+      "react": "19.2.8",
+      "react-dom": "19.2.8",
       "basic-ftp": ">=5.3.0",
       "underscore": ">=1.13.8",
       "express-rate-limit": ">=8.2.2",
@@ -117,7 +117,8 @@
       "@revealui/contracts": "workspace:*",
       "@revealui/db": "workspace:*",
       "sharp": ">=0.35.0",
-      "@hono/node-server": ">=2.0.5"
+      "@hono/node-server": ">=2.0.5",
+      "react-server-dom-webpack": "19.2.8"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -128,6 +128,7 @@ const router = new Router(options)
 - `initClient()` - Initialize client-side routing (popstate + link-click listeners)
 - `dispose()` - Remove client-side event listeners (call before unmounting or on HMR teardown)
 - `use(...middleware)` - Add global middleware (runs before all route middleware)
+- `seedCurrentMatch(match)` - Seed the current match (and loader data) without re-running middleware/loaders — used by SSR `hydrate()` so `useData()` works on first client paint. Client `navigate()` still does not run loaders (0.3.x SPA contract).
 
 ### Components
 

--- a/packages/router/src/__tests__/hydrate.test.tsx
+++ b/packages/router/src/__tests__/hydrate.test.tsx
@@ -55,6 +55,7 @@ describe('hydrate', () => {
     };
     const router = {
       match: vi.fn().mockReturnValue(match),
+      seedCurrentMatch: vi.fn(),
       initClient: vi.fn(),
     };
 
@@ -62,6 +63,7 @@ describe('hydrate', () => {
 
     expect(router.match).toHaveBeenCalledWith('/docs');
     expect(match.data).toEqual({ title: 'Docs Page' });
+    expect(router.seedCurrentMatch).toHaveBeenCalledWith(match);
     expect(router.initClient).toHaveBeenCalledOnce();
     expect(hydrateRootMock).toHaveBeenCalledWith(
       document.getElementById('root'),
@@ -80,6 +82,7 @@ describe('hydrate', () => {
 
     const router = {
       match: vi.fn(),
+      seedCurrentMatch: vi.fn(),
       initClient: vi.fn(),
     };
     const root = document.getElementById('app-root');
@@ -87,7 +90,33 @@ describe('hydrate', () => {
     await hydrate(router as never, root);
 
     expect(router.match).not.toHaveBeenCalled();
+    expect(router.seedCurrentMatch).not.toHaveBeenCalled();
     expect(router.initClient).toHaveBeenCalledOnce();
     expect(hydrateRootMock).toHaveBeenCalledWith(root, expect.any(Object));
+  });
+
+  it('seeds getCurrentMatch so loader data survives the first client read', async () => {
+    const { Router } = await import('../router.js');
+
+    document.body.innerHTML = `
+      <div id="root"></div>
+      <script id="__REVEALUI_DATA__" type="application/json">
+        {"route":"/docs","data":{"title":"Docs Page"}}
+      </script>
+    `;
+    window.history.replaceState({}, '', '/docs');
+
+    const router = new Router();
+    router.register({
+      path: '/docs',
+      component: () => null,
+      loader: async () => ({ title: 'Should not re-run' }),
+    });
+
+    await hydrate(router);
+
+    const current = router.getCurrentMatch();
+    expect(current).not.toBeNull();
+    expect(current?.data).toEqual({ title: 'Docs Page' });
   });
 });

--- a/packages/router/src/__tests__/router.test.ts
+++ b/packages/router/src/__tests__/router.test.ts
@@ -312,6 +312,41 @@ describe('Router', () => {
     });
   });
 
+  describe('0.3.x client navigation contract (no loaders / middleware)', () => {
+    // Live SPA consumers (marketing, docs, agency) only call navigate()/match.
+    // resolve() is the SSR/data path. Keep this contract explicit for D16
+    // client-mode byte-compat when 0.4 dual-mode lands.
+    it('does not run route loaders on navigate', () => {
+      const loader = vi.fn().mockResolvedValue({ ok: true });
+      const router = new Router();
+      router.register(createRoute('/about', { loader }));
+      router.navigate('/about');
+      expect(loader).not.toHaveBeenCalled();
+      expect(router.getCurrentMatch()?.data).toBeUndefined();
+    });
+
+    it('does not run middleware on navigate', () => {
+      const middleware = vi.fn().mockReturnValue(true);
+      const router = new Router();
+      router.register(createRoute('/about', { middleware: [middleware] }));
+      router.navigate('/about');
+      expect(middleware).not.toHaveBeenCalled();
+    });
+
+    it('seedCurrentMatch retains data across getCurrentMatch reads', () => {
+      const router = new Router();
+      router.register(createRoute('/about'));
+      const match = router.match('/about');
+      expect(match).not.toBeNull();
+      if (!match) return;
+      match.data = { from: 'ssr' };
+      router.seedCurrentMatch(match);
+      expect(router.getCurrentMatch()?.data).toEqual({ from: 'ssr' });
+      // Second read must keep the same seeded object (stable pathname cache)
+      expect(router.getCurrentMatch()?.data).toEqual({ from: 'ssr' });
+    });
+  });
+
   describe('navigate (client-side)', () => {
     it('calls history.pushState on navigate', () => {
       const router = new Router();

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -359,6 +359,23 @@ export class Router {
   }
 
   /**
+   * Seed the current match without re-running middleware or loaders.
+   *
+   * Used by SSR hydration to apply `__REVEALUI_DATA__` so `useData()` /
+   * `getCurrentMatch()` keep loader results across the first client paint.
+   * Client-side `navigate()` still uses plain `match()` only (no loaders);
+   * that is intentional for 0.3.x SPA consumers.
+   */
+  seedCurrentMatch(match: RouteMatch | null): void {
+    this.currentMatch = match;
+    if (typeof window !== 'undefined') {
+      this.lastPathname = window.location.pathname;
+    } else {
+      this.lastPathname = null;
+    }
+  }
+
+  /**
    * Get all registered routes
    */
   getRoutes(): Route[] {

--- a/packages/router/src/server.tsx
+++ b/packages/router/src/server.tsx
@@ -158,11 +158,14 @@ export async function hydrate(router: Router, rootElement: HTMLElement | null = 
   const dataScript = document.getElementById('__REVEALUI_DATA__');
   const ssrData = dataScript ? JSON.parse(dataScript.textContent || '{}') : {};
 
-  // If we have SSR data with a route, resolve it to seed the router's current match
+  // If we have SSR data with a route, seed the router's current match (including
+  // loader data). Mutating a local match object is not enough: getCurrentMatch()
+  // re-matches on first read unless lastPathname/currentMatch are seeded.
   if (ssrData.route) {
     const match = router.match(window.location.pathname);
     if (match) {
       match.data = ssrData.data;
+      router.seedCurrentMatch(match);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         version: 16.4.0
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-devtools-mcp:
         specifier: ^0.4.0
         version: 0.4.0
@@ -361,13 +361,13 @@ importers:
         version: link:../../packages/utils
       '@sentry/nextjs':
         specifier: ^10.63.0
-        version: 10.67.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20))
+        version: 10.67.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20))
       '@simplewebauthn/browser':
         specifier: 'catalog:'
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -382,25 +382,25 @@ importers:
         version: 0.46.0(typescript@6.0.3)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       prism-react-renderer:
         specifier: ^2.4.1
-        version: 2.4.1(react@19.2.7)
+        version: 2.4.1(react@19.2.8)
       qrcode.react:
         specifier: ^4.2.0
-        version: 4.2.0(react@19.2.7)
+        version: 4.2.0(react@19.2.8)
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       react-hook-form:
         specifier: ^7.81.0
-        version: 7.82.0(react@19.2.7)
+        version: 7.82.0(react@19.2.8)
       react-markdown:
         specifier: 'catalog:'
-        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.8)
       remark-gfm:
         specifier: 'catalog:'
         version: 4.0.1
@@ -431,7 +431,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -485,13 +485,13 @@ importers:
         version: 0.8.212
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       react-markdown:
         specifier: 'catalog:'
-        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.8)
       remark-gfm:
         specifier: 'catalog:'
         version: 4.0.1
@@ -507,7 +507,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -604,19 +604,19 @@ importers:
         version: link:../../packages/router
       '@sentry/react':
         specifier: ^10.63.0
-        version: 10.67.0(react@19.2.7)
+        version: 10.67.0(react@19.2.8)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       react-markdown:
         specifier: 'catalog:'
-        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.8)
       remark-gfm:
         specifier: 'catalog:'
         version: 4.0.1
@@ -635,7 +635,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.5
@@ -677,19 +677,19 @@ importers:
         version: 6.0.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
         specifier: 0.5.27
-        version: 0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 0.5.27(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.8)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       hono:
         specifier: 4.12.27
         version: 4.12.27
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       react-server-dom-webpack:
         specifier: 19.2.8
-        version: 19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1))
+        version: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1))
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -851,7 +851,7 @@ importers:
         version: link:../dev
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -860,10 +860,10 @@ importers:
         version: 29.0.1(@noble/hashes@1.8.0)
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -944,7 +944,7 @@ importers:
         version: 13.3.0
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.5
@@ -959,7 +959,7 @@ importers:
         version: 20.11.0
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1126,7 +1126,7 @@ importers:
         version: 0.46.0(typescript@6.0.3)
       '@lexical/react':
         specifier: ^0.46.0
-        version: 0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31)
+        version: 0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31)
       '@lexical/rich-text':
         specifier: ^0.46.0
         version: 0.46.0(typescript@6.0.3)
@@ -1171,10 +1171,10 @@ importers:
         version: 8.22.0
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       yjs:
         specifier: 'catalog:'
         version: 13.6.31
@@ -1187,7 +1187,7 @@ importers:
         version: link:../dev
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -1316,7 +1316,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -1340,10 +1340,10 @@ importers:
         version: 29.0.1(@noble/hashes@1.8.0)
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(@microsoft/api-extractor@7.58.11(@types/node@25.9.5))(jiti@2.7.0)(postcss@8.5.20)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
@@ -1542,10 +1542,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(@microsoft/api-extractor@7.58.11(@types/node@25.9.5))(jiti@2.7.0)(postcss@8.5.20)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
@@ -1566,10 +1566,10 @@ importers:
         version: link:../tokens
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.6.0
@@ -1582,7 +1582,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -1670,7 +1670,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.5
@@ -1679,10 +1679,10 @@ importers:
         version: 19.2.17
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.11(@types/node@25.9.5))(jiti@2.7.0)(postcss@8.5.20)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
@@ -1799,10 +1799,10 @@ importers:
         version: 8.5.20
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.3
@@ -1860,7 +1860,7 @@ importers:
     dependencies:
       '@electric-sql/react':
         specifier: ^1.0.52
-        version: 1.0.53(react@19.2.7)
+        version: 1.0.53(react@19.2.8)
       '@revealui/cache':
         specifier: workspace:*
         version: link:../cache
@@ -1891,7 +1891,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -1903,10 +1903,10 @@ importers:
         version: 29.0.1(@noble/hashes@1.8.0)
       react:
         specifier: '>=19.2.4'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: '>=19.2.4'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1964,7 +1964,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: 'catalog:'
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -8033,8 +8033,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-dom@19.2.7:
-    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
       react: '>=19.2.4'
 
@@ -8061,8 +8061,8 @@ packages:
       react-dom: '>=19.2.4'
       webpack: ^5.59.0
 
-  react@19.2.7:
-    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -9823,12 +9823,12 @@ snapshots:
 
   '@electric-sql/pglite@0.5.4': {}
 
-  '@electric-sql/react@1.0.53(react@19.2.7)':
+  '@electric-sql/react@1.0.53(react@19.2.8)':
     dependencies:
       '@electric-sql/client': 1.5.24
-      use-sync-external-store: 1.6.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -9954,18 +9954,18 @@ snapshots:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/react-dom@2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  '@floating-ui/react@0.27.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@floating-ui/react@0.27.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/utils': 0.2.12
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tabbable: 6.5.0
 
   '@floating-ui/utils@0.2.12': {}
@@ -10304,7 +10304,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@lexical/devtools-core@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
+  '@lexical/devtools-core@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
     dependencies:
       '@lexical/html': 0.46.0(typescript@6.0.3)
       '@lexical/link': 0.46.0(typescript@6.0.3)
@@ -10312,8 +10312,8 @@ snapshots:
       '@lexical/table': 0.46.0(typescript@6.0.3)
       '@lexical/utils': 0.46.0(typescript@6.0.3)
       lexical: 0.46.0(typescript@6.0.3)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -10421,10 +10421,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31)':
+  '@lexical/react@0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.31)':
     dependencies:
-      '@floating-ui/react': 0.27.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@lexical/devtools-core': 0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      '@floating-ui/react': 0.27.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@lexical/devtools-core': 0.46.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@lexical/dragon': 0.46.0(typescript@6.0.3)
       '@lexical/extension': 0.46.0(typescript@6.0.3)
       '@lexical/hashtag': 0.46.0(typescript@6.0.3)
@@ -10442,8 +10442,8 @@ snapshots:
       '@lexical/utils': 0.46.0(typescript@6.0.3)
       '@lexical/yjs': 0.46.0(typescript@6.0.3)(yjs@13.6.31)
       lexical: 0.46.0(typescript@6.0.3)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       typescript: 6.0.3
       yjs: 13.6.31
@@ -11263,7 +11263,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.67.0
 
-  '@sentry/nextjs@10.67.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20))':
+  '@sentry/nextjs@10.67.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -11273,11 +11273,11 @@ snapshots:
       '@sentry/core': 10.67.0
       '@sentry/node': 10.67.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
-      '@sentry/react': 10.67.0(react@19.2.7)
+      '@sentry/react': 10.67.0(react@19.2.8)
       '@sentry/server-utils': 10.67.0
       '@sentry/vercel-edge': 10.67.0
       '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20))
-      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -11325,12 +11325,12 @@ snapshots:
       '@sentry/conventions': 0.16.0
       '@sentry/core': 10.67.0
 
-  '@sentry/react@10.67.0(react@19.2.7)':
+  '@sentry/react@10.67.0(react@19.2.8)':
     dependencies:
       '@sentry/browser': 10.67.0
       '@sentry/conventions': 0.16.0
       '@sentry/core': 10.67.0
-      react: 19.2.7
+      react: 19.2.8
 
   '@sentry/replay-canvas@10.67.0':
     dependencies:
@@ -11976,12 +11976,12 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -12494,10 +12494,10 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
-      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
 
   '@vercel/static-build@2.9.21':
     dependencies:
@@ -12523,21 +12523,21 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  '@vitejs/plugin-rsc@0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-rsc@0.5.27(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.8)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       es-module-lexer: 2.3.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       srvx: 0.11.22
       strip-literal: 3.1.0
       turbo-stream: 3.2.0
       vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
-      react-server-dom-webpack: 19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1))
+      react-server-dom-webpack: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1))
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -15122,16 +15122,16 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.44
       caniuse-lite: 1.0.30001806
       postcss: 8.5.20
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.11
       '@next/swc-darwin-x64': 16.2.11
@@ -15540,11 +15540,11 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prism-react-renderer@2.4.1(react@19.2.7):
+  prism-react-renderer@2.4.1(react@19.2.8):
     dependencies:
       '@types/prismjs': 1.26.6
       clsx: 2.1.1
-      react: 19.2.7
+      react: 19.2.8
 
   prismjs@1.30.0: {}
 
@@ -15610,9 +15610,9 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qrcode.react@4.2.0(react@19.2.7):
+  qrcode.react@4.2.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   qs@6.15.3:
     dependencies:
@@ -15643,18 +15643,18 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
-  react-dom@19.2.7(react@19.2.7):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
       scheduler: 0.27.0
 
-  react-hook-form@7.82.0(react@19.2.7):
+  react-hook-form@7.82.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   react-is@17.0.2: {}
 
-  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.8):
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
@@ -15663,7 +15663,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
-      react: 19.2.7
+      react: 19.2.8
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       unified: 11.0.5
@@ -15672,16 +15672,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-server-dom-webpack@19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)):
+  react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       webpack: 5.108.4(esbuild@0.28.1)
       webpack-sources: 3.5.1
 
-  react@19.2.7: {}
+  react@19.2.8: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -16240,10 +16240,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@babel/core': 7.29.7
 
@@ -16589,9 +16589,9 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  use-sync-external-store@1.6.0(react@19.2.7):
+  use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   util-deprecate@1.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ overrides:
   fast-uri: '>=3.1.2'
   ip-address: '>=10.2.0'
   postcss: '>=8.5.10'
-  react: '>=19.2.4'
-  react-dom: '>=19.2.4'
+  react: 19.2.8
+  react-dom: 19.2.8
   basic-ftp: '>=5.3.0'
   underscore: '>=1.13.8'
   express-rate-limit: '>=8.2.2'
@@ -162,6 +162,7 @@ overrides:
   '@revealui/db': workspace:*
   sharp: '>=0.35.0'
   '@hono/node-server': '>=2.0.5'
+  react-server-dom-webpack: 19.2.8
 
 importers:
 
@@ -390,10 +391,10 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.8)
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       react-hook-form:
         specifier: ^7.81.0
@@ -484,10 +485,10 @@ importers:
         specifier: ^0.8.212
         version: 0.8.212
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       react-markdown:
         specifier: 'catalog:'
@@ -609,10 +610,10 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       react-markdown:
         specifier: 'catalog:'
@@ -682,10 +683,10 @@ importers:
         specifier: 4.12.27
         version: 4.12.27
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       react-server-dom-webpack:
         specifier: 19.2.8
@@ -859,10 +860,10 @@ importers:
         specifier: 29.0.1
         version: 29.0.1(@noble/hashes@1.8.0)
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       typescript:
         specifier: 'catalog:'
@@ -958,7 +959,7 @@ importers:
         specifier: ^20.10.6
         version: 20.11.0
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       typescript:
         specifier: 'catalog:'
@@ -1170,10 +1171,10 @@ importers:
         specifier: 'catalog:'
         version: 8.22.0
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       yjs:
         specifier: 'catalog:'
@@ -1339,10 +1340,10 @@ importers:
         specifier: 29.0.1
         version: 29.0.1(@noble/hashes@1.8.0)
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       tsup:
         specifier: 'catalog:'
@@ -1541,10 +1542,10 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       tsup:
         specifier: 'catalog:'
@@ -1565,10 +1566,10 @@ importers:
         specifier: workspace:*
         version: link:../tokens
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       tailwind-merge:
         specifier: ^3.3.1
@@ -1678,10 +1679,10 @@ importers:
         specifier: 'catalog:'
         version: 19.2.17
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       tsup:
         specifier: ^8.5.1
@@ -1798,10 +1799,10 @@ importers:
         specifier: '>=8.5.10'
         version: 8.5.20
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       tailwindcss:
         specifier: ^4.3.2
@@ -1902,10 +1903,10 @@ importers:
         specifier: 29.0.1
         version: 29.0.1(@noble/hashes@1.8.0)
       react:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: '>=19.2.4'
+        specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       typescript:
         specifier: 'catalog:'
@@ -2431,7 +2432,7 @@ packages:
   '@electric-sql/react@1.0.53':
     resolution: {integrity: sha512-iOEqvhtOrPKRCgCXe4pd96x/TfjxQw3ipr5GS76tPjA8qz/1cKFpYsbp2+iwc1LqsXVOsVkmVOOdwtx2SScVAg==}
     peerDependencies:
-      react: '>=19.2.4'
+      react: 19.2.8
     peerDependenciesMeta:
       react:
         optional: true
@@ -2633,14 +2634,14 @@ packages:
   '@floating-ui/react-dom@2.1.9':
     resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
+      react: 19.2.8
+      react-dom: 19.2.8
 
   '@floating-ui/react@0.27.20':
     resolution: {integrity: sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==}
     peerDependencies:
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
+      react: 19.2.8
+      react-dom: 19.2.8
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
@@ -3048,8 +3049,8 @@ packages:
   '@lexical/devtools-core@0.46.0':
     resolution: {integrity: sha512-9J5dRO/tZXM/ROeSRvnkfMvfGa4AbOjDQmVFhK1WiuoPNBoC45m4hijE4R3/l/Z6xvjinc804PfAsAxVjgVVnA==}
     peerDependencies:
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
+      react: 19.2.8
+      react-dom: 19.2.8
       typescript: '>=5.2'
     peerDependenciesMeta:
       typescript:
@@ -3154,8 +3155,8 @@ packages:
   '@lexical/react@0.46.0':
     resolution: {integrity: sha512-yYz09UTTSVFFpU6Zku/m4LLGgg6qjnz83PoPf7rxx7/IuZHcJK6dCaApXZUdilMHf+A1gGG0W4UNXGjWVaX1nw==}
     peerDependencies:
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
+      react: 19.2.8
+      react-dom: 19.2.8
       typescript: '>=5.2'
       yjs: '>=13.5.22'
     peerDependenciesMeta:
@@ -4105,7 +4106,7 @@ packages:
     resolution: {integrity: sha512-fS0DplcP9eMxBIRurPC/uxa4NrFK+l9ZsnvQo7wZvNutc7DpTAH0hgFt6laVNCe57s1pFo+OZuKsYBA6JDvH4Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: '>=19.2.4'
+      react: 19.2.8
 
   '@sentry/replay-canvas@10.67.0':
     resolution: {integrity: sha512-neNA4T6MFtZzMdKYetiR+LZd9BNSd0q2szMn0wk+A15PqHE/IN7a34V6JZc9rCtmzB0wldh0eWGOBb49MSNKjA==}
@@ -4678,8 +4679,8 @@ packages:
       '@testing-library/dom': ^10.0.0
       '@types/react': ^18.0.0 || ^19.0.0
       '@types/react-dom': ^18.0.0 || ^19.0.0
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
+      react: 19.2.8
+      react-dom: 19.2.8
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4967,7 +4968,7 @@ packages:
       '@sveltejs/kit': ^1 || ^2
       next: '>=16.2.11'
       nuxt: '>= 3'
-      react: '>=19.2.4'
+      react: 19.2.8
       svelte: '>= 4'
       vue: ^3
       vue-router: ^4
@@ -5012,9 +5013,9 @@ packages:
   '@vitejs/plugin-rsc@0.5.27':
     resolution: {integrity: sha512-s1fd5DUkPXk86DDHPM/kP93WrvI0MoA8klxdDZmD1fMSaA9xujfgunsm8ZoUH0FemR+63vNalFsIDR0AJH4ktg==}
     peerDependencies:
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
-      react-server-dom-webpack: '*'
+      react: 19.2.8
+      react-dom: 19.2.8
+      react-server-dom-webpack: 19.2.8
       vite: 8.0.16
     peerDependenciesMeta:
       react-server-dom-webpack:
@@ -7518,8 +7519,8 @@ packages:
       '@opentelemetry/api': ^1.1.0
       '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
+      react: 19.2.8
+      react-dom: 19.2.8
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -7942,7 +7943,7 @@ packages:
   prism-react-renderer@2.4.1:
     resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
     peerDependencies:
-      react: '>=19.2.4'
+      react: 19.2.8
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -8001,7 +8002,7 @@ packages:
   qrcode.react@4.2.0:
     resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
     peerDependencies:
-      react: '>=19.2.4'
+      react: 19.2.8
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -8036,13 +8037,13 @@ packages:
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: '>=19.2.4'
+      react: 19.2.8
 
   react-hook-form@7.82.0:
     resolution: {integrity: sha512-Zw/uFZ2dO+02GHlBn7JFGn8kZJ7LdM33B/0BXOovzFay+CMhf94JMw5BVu+F1tVkUKjNvBuaE3fz5BJhga10Tg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: '>=19.2.4'
+      react: 19.2.8
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -8051,14 +8052,14 @@ packages:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
-      react: '>=19.2.4'
+      react: 19.2.8
 
   react-server-dom-webpack@19.2.8:
     resolution: {integrity: sha512-rFO1VJZ+cH9ZH6hGy9+qmIsmZHZpCMKJZXhWHqT71UnSfg+w+W+gwrwp58MVzMqdFquG8GF1c6C8q0OGphkEdg==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: '>=19.2.4'
-      react-dom: '>=19.2.4'
+      react: 19.2.8
+      react-dom: 19.2.8
       webpack: ^5.59.0
 
   react@19.2.8:
@@ -8521,7 +8522,7 @@ packages:
     peerDependencies:
       '@babel/core': '*'
       babel-plugin-macros: '*'
-      react: '>=19.2.4'
+      react: 19.2.8
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -8894,7 +8895,7 @@ packages:
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
-      react: '>=19.2.4'
+      react: 19.2.8
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,7 +367,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -607,7 +607,7 @@ importers:
         version: 10.67.0(react@19.2.7)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react:
         specifier: '>=19.2.4'
         version: 19.2.7
@@ -663,6 +663,52 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  apps/rsc-poc:
+    dependencies:
+      '@hono/node-server':
+        specifier: '>=2.0.5'
+        version: 2.0.11(hono@4.12.27)
+      '@revealui/router':
+        specifier: workspace:*
+        version: link:../../packages/router
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitejs/plugin-rsc':
+        specifier: 0.5.27
+        version: 0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      hono:
+        specifier: 4.12.27
+        version: 4.12.27
+      react:
+        specifier: '>=19.2.4'
+        version: 19.2.7
+      react-dom:
+        specifier: '>=19.2.4'
+        version: 19.2.7(react@19.2.7)
+      react-server-dom-webpack:
+        specifier: 19.2.7
+        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1))
+    devDependencies:
+      '@revealui/dev':
+        specifier: workspace:*
+        version: link:../../packages/dev
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.5
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 8.0.16
+        version: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   apps/server:
     dependencies:
@@ -4963,6 +5009,17 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitejs/plugin-rsc@0.5.27':
+    resolution: {integrity: sha512-s1fd5DUkPXk86DDHPM/kP93WrvI0MoA8klxdDZmD1fMSaA9xujfgunsm8ZoUH0FemR+63vNalFsIDR0AJH4ktg==}
+    peerDependencies:
+      react: '>=19.2.4'
+      react-dom: '>=19.2.4'
+      react-server-dom-webpack: '*'
+      vite: 8.0.16
+    peerDependenciesMeta:
+      react-server-dom-webpack:
+        optional: true
+
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
@@ -5137,6 +5194,10 @@ packages:
     engines: {node: '>=10.13.0'}
     peerDependencies:
       acorn: ^8.14.0
+
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
 
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
@@ -6741,6 +6802,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.15.0:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
@@ -7989,6 +8053,14 @@ packages:
       '@types/react': '>=18'
       react: '>=19.2.4'
 
+  react-server-dom-webpack@19.2.7:
+    resolution: {integrity: sha512-bYfuvqPJnHB4CHo2Ze7fQyJAO77TUu1W/aKFt81ICXbLiOTg5jHaO/NPDlpvGWUALoEGaGb7Oi1uXAaO+Bw6jw==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: '>=19.2.4'
+      react-dom: '>=19.2.4'
+      webpack: ^5.59.0
+
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -8421,6 +8493,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   stripe@22.3.2:
     resolution: {integrity: sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==}
     engines: {node: '>=18'}
@@ -8703,6 +8778,9 @@ packages:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
 
+  turbo-stream@3.2.0:
+    resolution: {integrity: sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ==}
+
   turbo@2.10.5:
     resolution: {integrity: sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ==}
     hasBin: true
@@ -8910,6 +8988,14 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: 8.0.16
+    peerDependenciesMeta:
+      vite:
         optional: true
 
   vitest@4.1.10:
@@ -12408,7 +12494,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -12436,6 +12522,22 @@ snapshots:
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+
+  '@vitejs/plugin-rsc@0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      es-module-lexer: 2.3.1
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      srvx: 0.11.22
+      strip-literal: 3.1.0
+      turbo-stream: 3.2.0
+      vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+    optionalDependencies:
+      react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1))
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -12661,6 +12763,10 @@ snapshots:
       acorn: 8.17.0
 
   acorn-import-phases@1.0.4(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn-loose@8.5.2:
     dependencies:
       acorn: 8.17.0
 
@@ -14180,6 +14286,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
@@ -15564,6 +15672,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      webpack: 5.108.4(esbuild@0.28.1)
+      webpack-sources: 3.5.1
+
   react@19.2.7: {}
 
   read-yaml-file@1.1.0:
@@ -16103,6 +16220,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   stripe@22.3.2(@types/node@25.9.5):
     optionalDependencies:
       '@types/node': 25.9.5
@@ -16367,6 +16488,8 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
+  turbo-stream@3.2.0: {}
+
   turbo@2.10.5:
     optionalDependencies:
       '@turbo/darwin-64': 2.10.5
@@ -16595,6 +16718,10 @@ snapshots:
       terser: 5.49.0
       tsx: 4.23.1
       yaml: 2.9.0
+
+  vitefu@1.1.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   vitest@4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,7 +367,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -607,7 +607,7 @@ importers:
         version: 10.67.0(react@19.2.7)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react:
         specifier: '>=19.2.4'
         version: 19.2.7
@@ -677,7 +677,7 @@ importers:
         version: 6.0.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
         specifier: 0.5.27
-        version: 0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       hono:
         specifier: 4.12.27
         version: 4.12.27
@@ -688,8 +688,8 @@ importers:
         specifier: '>=19.2.4'
         version: 19.2.7(react@19.2.7)
       react-server-dom-webpack:
-        specifier: 19.2.7
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1))
+        specifier: 19.2.8
+        version: 19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1))
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -8053,8 +8053,8 @@ packages:
       '@types/react': '>=18'
       react: '>=19.2.4'
 
-  react-server-dom-webpack@19.2.7:
-    resolution: {integrity: sha512-bYfuvqPJnHB4CHo2Ze7fQyJAO77TUu1W/aKFt81ICXbLiOTg5jHaO/NPDlpvGWUALoEGaGb7Oi1uXAaO+Bw6jw==}
+  react-server-dom-webpack@19.2.8:
+    resolution: {integrity: sha512-rFO1VJZ+cH9ZH6hGy9+qmIsmZHZpCMKJZXhWHqT71UnSfg+w+W+gwrwp58MVzMqdFquG8GF1c6C8q0OGphkEdg==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
       react: '>=19.2.4'
@@ -12494,7 +12494,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -12523,7 +12523,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  '@vitejs/plugin-rsc@0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-rsc@0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       es-module-lexer: 2.3.1
@@ -12537,7 +12537,7 @@ snapshots:
       vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
-      react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1))
+      react-server-dom-webpack: 19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1))
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -15672,7 +15672,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)):
+  react-server-dom-webpack@19.2.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,8 +35,8 @@ catalog:
   jsdom: 29.1.1
   next: ^16.2.11
   pg: ^8.22.0
-  react: ^19.2.7
-  react-dom: ^19.2.7
+  react: ^19.2.8
+  react-dom: ^19.2.8
   react-markdown: ^10.1.0
   remark-gfm: ^4.0.1
   stripe: ^22.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,8 +35,8 @@ catalog:
   jsdom: 29.1.1
   next: ^16.2.11
   pg: ^8.22.0
-  react: ^19.2.8
-  react-dom: ^19.2.8
+  react: 19.2.8
+  react-dom: 19.2.8
   react-markdown: ^10.1.0
   remark-gfm: ^4.0.1
   stripe: ^22.3.0


### PR DESCRIPTION
## Summary

Systematic routing pass for GAP-194 / `@revealui/router`:

1. **Hydrate fix** — `Router.seedCurrentMatch()` so SSR `__REVEALUI_DATA__` loader data survives first client `getCurrentMatch()` / `useData()`.
2. **0.3.x contracts** — tests lock that client `navigate()` does **not** run loaders or middleware (SPA reality for marketing/docs/agency).
3. **T0 revive** — restore `apps/rsc-poc` from `archive/rsc-poc-spike`, rebaseline React/RSDW **19.2.7** lockstep + `@vitejs/plugin-rsc` **0.5.27**; production **build green** (criterion D).
4. **Claim-drift** — bump monorepo apps 5→6 / workspaces 36→37 after rsc-poc returns.

Inventories (Hono content API, admin Next port tiers, SPA routes) live in `.jv/docs/inventories/2026-07-31-*` (private planning).

## Test plan

- [x] `pnpm --filter @revealui/router test` (116 green)
- [x] `pnpm --filter @rsc-poc/app build` (T0-D)
- [x] pre-push phase-1 gate PASS
- [ ] Manual T0 A/B/C/E via `pnpm --filter @rsc-poc/app dev` (render, hydrate, action, HMR)
- [ ] Do **not** start dual-mode 0.4 engine until A–E signed

## Notes

- Target: `test`
- Does not implement `@revealui/router` 0.4 RSC (T1+ deferred)
- GAP-194 remains open / design-complete