### PR TITLE
feat(router): 0.4.0-rc.0 dual-mode scaffold + GAP-194 T0 smoke

### DIFF
--- a/.changeset/router-0-4-0-rc-mode.md
+++ b/.changeset/router-0-4-0-rc-mode.md
@@ -1,0 +1,5 @@
+---
+"@revealui/router": minor
+---
+
+Dual-mode scaffold (0.4.0-rc.0): `RouterOptions.rsc` selects RSC mode; default remains client-compatible with 0.3.x. Adds `router.mode`, `useAction` / action middleware chain (ADR D2.d), and optional peers for `react-server-dom-webpack` + `@vitejs/plugin-rsc`.

--- a/apps/rsc-poc/T0-SMOKE-2026-07-31.md
+++ b/apps/rsc-poc/T0-SMOKE-2026-07-31.md
@@ -1,0 +1,20 @@
+# T0 revive-POC smoke — 2026-07-31
+
+Branch base: `origin/test` after revealui **#2326** merge (`75529a595`).  
+Worktree: `.wt/rsc-router-t0-t1`. Runner: Playwright Chromium + curl.
+
+| Id | Criterion | Result | Evidence |
+|----|-----------|--------|----------|
+| **A** | Server Component + RSC wire format | **PASS** | HTML `200 text/html` with `__RSC_PAYLOAD__`; `Accept: text/x-component` → `content-type: text/x-component` flight payload (~6.7KB). Home h1: `Home — Server Component`. |
+| **B** | Client hydrate interactive | **PASS** | `/counter`: click `+` twice → `Count: 2` (Playwright). |
+| **C** | Server action round-trip | **PASS** | `/actions`: submit `t0-smoke-probe` → UI shows `Server received: "t0-smoke-probe" at <iso>`. |
+| **D** | Production build | **PASS** | `pnpm --filter @rsc-poc/app build` exit 0 (rsc + client + ssr dist). |
+| **E** | HMR | **PASS** | Edit `home.tsx` title → h1 updates to include `T0-HMR-*` without full manual rebuild; file restored after. |
+
+**Verdict:** T0 revive-POC gate **green**. Cleared for Phase 2.2.2 T1+ (dual-mode core engine) per kickoff.
+
+**Notes**
+
+- Bare form POST without React action encoding returns 500 (progressive-enhancement path not exercised by ActionForm; JS path is the acceptance path for C).
+- Smoke artifacts: `.t0-smoke/results.json` in worktree (gitignored if under app; keep evidence in this file).
+- React lockstep **19.2.8** (GHSA-wx67-qw84-cm4g) already on test via #2326.

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -114,6 +114,8 @@ app.get('*', createSSRHandler(routes, {
 
 ```typescript
 const router = new Router(options)
+// Dual-mode (0.4.0-rc): omit rsc → client (default, SPA). Pass rsc: {} → RSC mode.
+// const rscRouter = new Router({ rsc: { endpoint: '/.rsc' } }) // endpoint optional CDN escape hatch
 ```
 
 **Methods:**
@@ -128,6 +130,8 @@ const router = new Router(options)
 - `initClient()` - Initialize client-side routing (popstate + link-click listeners)
 - `dispose()` - Remove client-side event listeners (call before unmounting or on HMR teardown)
 - `use(...middleware)` - Add global middleware (runs before all route middleware)
+- `useAction(...middleware)` - Middleware for server actions (RSC mode; ADR D2.d)
+- `mode` - `'client'` | `'rsc'` (derived from `options.rsc`)
 - `seedCurrentMatch(match)` - Seed the current match (and loader data) without re-running middleware/loaders — used by SSR `hydrate()` so `useData()` works on first client paint. Client `navigate()` still does not run loaders (0.3.x SPA contract).
 
 ### Components

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/router",
-  "version": "0.3.11",
-  "description": "Lightweight file-based router for React apps with SSR, data loaders, middleware, and nested layouts. No framework required — works with Vite, Hono, or any React setup.",
+  "version": "0.4.0-rc.0",
+  "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",
     "middleware",
@@ -50,7 +50,17 @@
   "main": "./dist/index.js",
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-server-dom-webpack": "^19.2.8",
+    "@vitejs/plugin-rsc": "^0.5.27"
+  },
+  "peerDependenciesMeta": {
+    "react-server-dom-webpack": {
+      "optional": true
+    },
+    "@vitejs/plugin-rsc": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/router/src/__tests__/router.test.ts
+++ b/packages/router/src/__tests__/router.test.ts
@@ -312,6 +312,45 @@ describe('Router', () => {
     });
   });
 
+  describe('dual-mode (0.4.0-rc scaffold T1/T2)', () => {
+    it('defaults to client mode when rsc is omitted', () => {
+      const router = new Router();
+      expect(router.mode).toBe('client');
+      expect(router.getOptions().rsc).toBeUndefined();
+    });
+
+    it('selects rsc mode when rsc options object is provided', () => {
+      const router = new Router({ rsc: {} });
+      expect(router.mode).toBe('rsc');
+    });
+
+    it('selects rsc mode with endpoint escape hatch', () => {
+      const router = new Router({ rsc: { endpoint: '/.rsc' } });
+      expect(router.mode).toBe('rsc');
+      expect(router.getOptions().rsc?.endpoint).toBe('/.rsc');
+    });
+
+    it('keeps client-mode navigate contract when rsc is unset', () => {
+      const loader = vi.fn().mockResolvedValue({ ok: true });
+      const router = new Router();
+      router.register(createRoute('/about', { loader }));
+      router.navigate('/about');
+      expect(router.mode).toBe('client');
+      expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('stores action middleware separately from route middleware', () => {
+      const routeMw = vi.fn().mockReturnValue(true);
+      const actionMw = vi.fn().mockReturnValue(true);
+      const router = new Router({ rsc: {} });
+      router.use(routeMw);
+      router.useAction(actionMw);
+      expect(router.getActionMiddleware()).toHaveLength(1);
+      router.clear();
+      expect(router.getActionMiddleware()).toHaveLength(0);
+    });
+  });
+
   describe('0.3.x client navigation contract (no loaders / middleware)', () => {
     // Live SPA consumers (marketing, docs, agency) only call navigate()/match.
     // resolve() is the SSR/data path. Keep this contract explicit for D16

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -64,5 +64,7 @@ export type {
   RouteMeta,
   RouteMiddleware,
   RouteParams,
+  RouterMode,
   RouterOptions,
+  RouterRscOptions,
 } from './types';

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -8,6 +8,7 @@ import type {
   RouteMatch,
   RouteMiddleware,
   RouteParams,
+  RouterMode,
   RouterOptions,
 } from './types';
 
@@ -112,6 +113,7 @@ export class Router {
   private routes: Route[] = [];
   private flatRoutes: Route[] = [];
   private globalMiddleware: RouteMiddleware[] = [];
+  private actionMiddleware: RouteMiddleware[] = [];
   private options: RouterOptions;
   private listeners: Set<() => void> = new Set();
   private currentMatch: RouteMatch | null = null;
@@ -127,10 +129,34 @@ export class Router {
   }
 
   /**
-   * Add global middleware that runs before all routes.
+   * Runtime mode: `'client'` (default, 0.3.x) or `'rsc'` when `options.rsc` is set.
+   * ADR D1 / L3 — per-instance constructor selection.
+   */
+  get mode(): RouterMode {
+    return this.options.rsc !== undefined ? 'rsc' : 'client';
+  }
+
+  /**
+   * Add global middleware that runs before all routes (navigation).
    */
   use(...middleware: RouteMiddleware[]): void {
     this.globalMiddleware.push(...middleware);
+  }
+
+  /**
+   * Middleware for server-action invocations (ADR D2.d).
+   * Separate from route navigation middleware: mutations must not skip auth/RBAC
+   * just because they bypass the loader path.
+   */
+  useAction(...middleware: RouteMiddleware[]): void {
+    this.actionMiddleware.push(...middleware);
+  }
+
+  /**
+   * Snapshot of action middleware (for RSC server handler in later T-steps).
+   */
+  getActionMiddleware(): RouteMiddleware[] {
+    return [...this.actionMiddleware];
   }
 
   /**
@@ -389,6 +415,7 @@ export class Router {
     this.routes = [];
     this.flatRoutes = [];
     this.globalMiddleware = [];
+    this.actionMiddleware = [];
   }
 
   private normalizePath(url: string): string {

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -66,6 +66,20 @@ export interface RouteMatch<TData = unknown> {
 }
 
 /**
+ * Dual-mode selector for GAP-194 Phase 2.2 (`@revealui/router` 0.4).
+ * - `undefined` / omit → `'client'` (0.3.x behavior, default)
+ * - `{ endpoint?: string }` → `'rsc'` (server-driven; endpoint is CDN-Vary escape hatch)
+ */
+export interface RouterRscOptions {
+  /**
+   * Optional URL prefix for RSC payloads when content negotiation via
+   * `Accept: text/x-component` is unsafe (CDN ignores `Vary: accept`).
+   * Default path is same-URL negotiation per ADR D1.
+   */
+  endpoint?: string;
+}
+
+/**
  * Router configuration options
  */
 export interface RouterOptions {
@@ -75,7 +89,20 @@ export interface RouterOptions {
   notFound?: ComponentType;
   /** Error boundary component */
   errorBoundary?: ComponentType<{ error: Error }>;
+  /**
+   * Opt into RSC mode (ADR D1 / L3). Omitted or `undefined` keeps client mode
+   * byte-compatible with 0.3.x SPA consumers (marketing, docs, agency).
+   */
+  rsc?: RouterRscOptions;
+  /**
+   * Pluggable fetch for server-action transport (ADR D9). Defaults to
+   * `globalThis.fetch` when RSC mode is active.
+   */
+  serverActionTransport?: typeof fetch;
 }
+
+/** Runtime mode derived from `RouterOptions.rsc`. */
+export type RouterMode = 'client' | 'rsc';
 
 /**
  * Navigation options

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1659,9 +1659,15 @@ importers:
       '@revealui/utils':
         specifier: workspace:*
         version: link:../utils
+      '@vitejs/plugin-rsc':
+        specifier: ^0.5.27
+        version: 0.5.27(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20)))(react@19.2.8)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       hono:
         specifier: 4.12.27
         version: 4.12.27
+      react-server-dom-webpack:
+        specifier: 19.2.8
+        version: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20))
     devDependencies:
       '@revealui/dev':
         specifier: workspace:*
@@ -12524,6 +12530,22 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
+  '@vitejs/plugin-rsc@0.5.27(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20)))(react@19.2.8)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      es-module-lexer: 2.3.1
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      srvx: 0.11.22
+      strip-literal: 3.1.0
+      turbo-stream: 3.2.0
+      vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+    optionalDependencies:
+      react-server-dom-webpack: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20))
+
   '@vitejs/plugin-rsc@0.5.27(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.8)(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -15672,6 +15694,15 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)(postcss@8.5.20)):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      webpack: 5.108.4(esbuild@0.28.1)(postcss@8.5.20)
+      webpack-sources: 3.5.1
 
   react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.108.4(esbuild@0.28.1)):
     dependencies:


### PR DESCRIPTION
## Summary

GAP-194 continuation after **#2326** on `test`:

### T0 (revive-POC) — **A–E PASS**
Evidence: `apps/rsc-poc/T0-SMOKE-2026-07-31.md` (Playwright + build).

| Criterion | Result |
|-----------|--------|
| A Server Component + flight | PASS |
| B Client hydrate (counter) | PASS |
| C Server action round-trip | PASS |
| D Production build | PASS |
| E HMR | PASS |

### T1/T2 dual-mode scaffold
- `@revealui/router` **0.4.0-rc.0**
- `RouterOptions.rsc` → `router.mode === 'rsc'` (default client = 0.3-compatible)
- `useAction` / `getActionMiddleware` (ADR D2.d)
- Optional peers: `react-server-dom-webpack`, `@vitejs/plugin-rsc`
- 121 unit tests green

**Not in this PR:** T3 content negotiation, T4 `renderRequest`, full RSC handler (next sessions).

## Test plan
- [x] `pnpm --filter @revealui/router test` (121)
- [x] Playwright A–E on rsc-poc
- [x] pre-push phase-1 PASS