### PR TITLE
feat(router): T3/T4 content negotiation and renderRequest

### DIFF
--- a/.changeset/router-0-4-0-rc-render-request.md
+++ b/.changeset/router-0-4-0-rc-render-request.md
@@ -1,0 +1,5 @@
+---
+"@revealui/router": minor
+---
+
+RSC mode T3/T4: content negotiation (`Accept: text/x-component` + endpoint escape hatch) and `renderRequest` with teed flight stream, chunked `__RSC_PAYLOAD__` base64 inline, and injectible `createRscStream` (ADR D1/D11/D15).

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -307,6 +307,34 @@ createSSRHandler(routes, {
 })
 ```
 
+## RSC mode (0.4.0-rc+)
+
+```typescript
+import { Router } from '@revealui/router'
+import { renderRequest } from '@revealui/router/server'
+
+const router = new Router({ rsc: {} }) // or { rsc: { endpoint: '/.rsc' } }
+router.registerRoutes(routes)
+
+export default {
+  async fetch(request: Request) {
+    return renderRequest(request, {
+      router,
+      // Wire your bundler/RSDW pipeline here (ADR D11 — router stays plugin-agnostic)
+      createRscStream: async (request, ctx) => {
+        // return a text/x-component flight ReadableStream for ctx.pathname
+        return myRscFlightStream(request, ctx)
+      },
+      loadBootstrapScriptContent: async () => myClientBootstrap(),
+    })
+  },
+}
+```
+
+- `Accept: text/x-component` → flight body (`Vary: accept`)
+- Otherwise → HTML with chunked base64 `self.__RSC_PAYLOAD__=...` + bootstrap
+- Endpoint escape hatch forces RSC when CDNs mishandle `Vary`
+
 ## Dev Server
 
 Quick development server:

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.0",
+  "version": "0.4.0-rc.1",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",

--- a/packages/router/src/__tests__/negotiate.test.ts
+++ b/packages/router/src/__tests__/negotiate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  negotiateRepresentation,
+  resolveRscEndpointPath,
+  routingPathname,
+  wantsRscPayload,
+} from '../negotiate.js';
+import { Router } from '../router.js';
+
+function req(url: string, accept?: string): Request {
+  const headers = accept ? { accept } : undefined;
+  return new Request(url, { headers });
+}
+
+describe('negotiate (T3)', () => {
+  it('wantsRscPayload detects text/x-component Accept', () => {
+    expect(wantsRscPayload(req('http://x/', 'text/html'))).toBe(false);
+    expect(wantsRscPayload(req('http://x/', 'text/x-component'))).toBe(true);
+    expect(wantsRscPayload(req('http://x/', 'text/html, text/x-component;q=0.9'))).toBe(true);
+  });
+
+  it('resolveRscEndpointPath strips endpoint prefix', () => {
+    expect(resolveRscEndpointPath('/posts/1', undefined)).toEqual({
+      pathname: '/posts/1',
+      forceRsc: false,
+    });
+    expect(resolveRscEndpointPath('/.rsc/posts/1', '/.rsc')).toEqual({
+      pathname: '/posts/1',
+      forceRsc: true,
+    });
+    expect(resolveRscEndpointPath('/.rsc', '/.rsc')).toEqual({
+      pathname: '/',
+      forceRsc: true,
+    });
+    expect(resolveRscEndpointPath('/about', '/.rsc')).toEqual({
+      pathname: '/about',
+      forceRsc: false,
+    });
+  });
+
+  it('negotiateRepresentation prefers Accept then HTML', () => {
+    expect(negotiateRepresentation(req('http://x/about'), {})).toBe('html');
+    expect(negotiateRepresentation(req('http://x/about', 'text/x-component'), {})).toBe('rsc');
+  });
+
+  it('negotiateRepresentation forces rsc on endpoint path', () => {
+    expect(negotiateRepresentation(req('http://x/.rsc/about'), { endpoint: '/.rsc' })).toBe('rsc');
+    expect(
+      negotiateRepresentation(req('http://x/.rsc/about', 'text/html'), { endpoint: '/.rsc' }),
+    ).toBe('rsc');
+  });
+
+  it('routingPathname strips endpoint for matching', () => {
+    expect(routingPathname(req('http://x/.rsc/posts/9'), { endpoint: '/.rsc' })).toBe('/posts/9');
+  });
+
+  it('Router.negotiate is html in client mode', () => {
+    const router = new Router();
+    expect(router.negotiate(req('http://x/', 'text/x-component'))).toBe('html');
+  });
+
+  it('Router.negotiate uses rsc options in rsc mode', () => {
+    const router = new Router({ rsc: { endpoint: '/.rsc' } });
+    expect(router.negotiate(req('http://x/.rsc/a'))).toBe('rsc');
+    expect(router.negotiate(req('http://x/a'))).toBe('html');
+    expect(router.negotiate(req('http://x/a', 'text/x-component'))).toBe('rsc');
+    expect(router.routingPathname(req('http://x/.rsc/a'))).toBe('/a');
+  });
+});

--- a/packages/router/src/__tests__/server-rsc.test.ts
+++ b/packages/router/src/__tests__/server-rsc.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { encodeBase64Chunked, readStreamToUint8Array } from '../base64.js';
+import { Router } from '../router.js';
+import { inlineRscPayloadScript, renderRequest } from '../server-rsc.js';
+
+function flightStream(text: string): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(enc.encode(text));
+      controller.close();
+    },
+  });
+}
+
+describe('base64 chunked (T4 / D15)', () => {
+  it('encodes empty and small payloads', () => {
+    expect(encodeBase64Chunked(new Uint8Array(0))).toBe('');
+    const bytes = new TextEncoder().encode('hello-rsc');
+    expect(encodeBase64Chunked(bytes)).toBe(btoa('hello-rsc'));
+  });
+
+  it('encodes large payloads without throwing (no spread stack blow)', () => {
+    const big = new Uint8Array(200_000);
+    for (let i = 0; i < big.length; i++) big[i] = i % 256;
+    const b64 = encodeBase64Chunked(big);
+    expect(b64.length).toBeGreaterThan(1000);
+    // Round-trip first 100 bytes via atob of whole is heavy; spot-check length formula
+    expect(b64.length).toBe(Math.ceil(big.length / 3) * 4);
+  });
+});
+
+describe('renderRequest (T3/T4)', () => {
+  it('throws when router is not in rsc mode', async () => {
+    const router = new Router();
+    await expect(
+      renderRequest(new Request('http://localhost/'), {
+        router,
+        createRscStream: async () => flightStream('x'),
+      }),
+    ).rejects.toThrow(/rsc mode/);
+  });
+
+  it('returns text/x-component when Accept asks for RSC', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null, meta: { title: 'Home' } });
+    const res = await renderRequest(
+      new Request('http://localhost/', { headers: { accept: 'text/x-component' } }),
+      {
+        router,
+        createRscStream: async () => flightStream('1:flight-payload'),
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/x-component');
+    expect(res.headers.get('vary')?.toLowerCase()).toContain('accept');
+    const body = await res.text();
+    expect(body).toBe('1:flight-payload');
+  });
+
+  it('returns HTML with __RSC_PAYLOAD__ when Accept is HTML', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null, meta: { title: 'Home' } });
+    const res = await renderRequest(new Request('http://localhost/'), {
+      router,
+      createRscStream: async () => flightStream('flight-bytes'),
+      loadBootstrapScriptContent: async () => '/*boot*/',
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const html = await res.text();
+    expect(html).toContain('__RSC_PAYLOAD__');
+    expect(html).toContain(btoa('flight-bytes'));
+    expect(html).toContain('/*boot*/');
+    expect(html).toContain('<title>Home</title>');
+  });
+
+  it('endpoint path forces RSC even without Accept', async () => {
+    const router = new Router({ rsc: { endpoint: '/.rsc' } });
+    router.register({ path: '/about', component: () => null });
+    const res = await renderRequest(new Request('http://localhost/.rsc/about'), {
+      router,
+      createRscStream: async (_req, ctx) => {
+        expect(ctx.pathname).toBe('/about');
+        expect(ctx.representation).toBe('rsc');
+        return flightStream('endpoint-flight');
+      },
+    });
+    expect(res.headers.get('content-type')).toContain('text/x-component');
+    expect(await res.text()).toBe('endpoint-flight');
+  });
+
+  it('returns 404 status when no route matches', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    const res = await renderRequest(
+      new Request('http://localhost/missing', { headers: { accept: 'text/x-component' } }),
+      {
+        router,
+        createRscStream: async () => flightStream('x'),
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('inlineRscPayloadScript produces assignable JSON string', async () => {
+    const script = await inlineRscPayloadScript(flightStream('abc'));
+    expect(script.startsWith('self.__RSC_PAYLOAD__=')).toBe(true);
+    expect(script).toContain(JSON.stringify(btoa('abc')));
+  });
+
+  it('readStreamToUint8Array concatenates chunks', async () => {
+    const enc = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode('ab'));
+        c.enqueue(enc.encode('cd'));
+        c.close();
+      },
+    });
+    const bytes = await readStreamToUint8Array(stream);
+    expect(new TextDecoder().decode(bytes)).toBe('abcd');
+  });
+});

--- a/packages/router/src/base64.ts
+++ b/packages/router/src/base64.ts
@@ -11,9 +11,8 @@ export function encodeBase64Chunked(bytes: Uint8Array): string {
     const slice = bytes.subarray(i, Math.min(i + CHUNK, bytes.length));
     // Build string without spread — loop keeps stack flat for large slices.
     let part = '';
-    for (let j = 0; j < slice.length; j++) {
-      // biome-ignore lint/style/noNonNullAssertion: bounds-checked
-      part += String.fromCharCode(slice[j]!);
+    for (const byte of slice) {
+      part += String.fromCharCode(byte);
     }
     binary += part;
   }

--- a/packages/router/src/base64.ts
+++ b/packages/router/src/base64.ts
@@ -1,0 +1,45 @@
+/**
+ * Chunked base64 encode for RSC payload inlining (ADR D15).
+ * Avoids `String.fromCharCode(...spread)` which blows the call stack on large payloads.
+ */
+const CHUNK = 0x8000;
+
+export function encodeBase64Chunked(bytes: Uint8Array): string {
+  if (bytes.length === 0) return '';
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, Math.min(i + CHUNK, bytes.length));
+    // Build string without spread — loop keeps stack flat for large slices.
+    let part = '';
+    for (let j = 0; j < slice.length; j++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds-checked
+      part += String.fromCharCode(slice[j]!);
+    }
+    binary += part;
+  }
+  return btoa(binary);
+}
+
+/** Collect a full ReadableStream into one Uint8Array (edge-safe, no Buffer). */
+export async function readStreamToUint8Array(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      total += value.length;
+    }
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.length;
+  }
+  return out;
+}

--- a/packages/router/src/negotiate.ts
+++ b/packages/router/src/negotiate.ts
@@ -1,0 +1,64 @@
+import type { RouterRscOptions } from './types';
+
+/** Wire content type for RSC flight payloads (ADR D1 / D2). */
+export const RSC_CONTENT_TYPE = 'text/x-component';
+
+/** Accept token that selects the RSC representation. */
+export const RSC_ACCEPT = 'text/x-component';
+
+export type Representation = 'html' | 'rsc';
+
+/**
+ * True when the request asks for an RSC flight payload via content negotiation.
+ * Uses standard `Accept` (not Next's custom `RSC: 1` header) per ADR D1.
+ */
+export function wantsRscPayload(request: Request): boolean {
+  const accept = request.headers.get('accept') ?? '';
+  // Substring match is intentional: Accept can list multiple types with q-values.
+  return accept.includes(RSC_ACCEPT);
+}
+
+/**
+ * If `endpoint` is configured (CDN Vary escape hatch), strip that prefix so
+ * routing sees the resource path. Example: endpoint `/.rsc` + path `/.rsc/posts/1`
+ * → pathname `/posts/1`, forceRsc true.
+ */
+export function resolveRscEndpointPath(
+  pathname: string,
+  endpoint?: string,
+): { pathname: string; forceRsc: boolean } {
+  if (!endpoint) {
+    return { pathname, forceRsc: false };
+  }
+  const prefix = endpoint.endsWith('/') ? endpoint.slice(0, -1) : endpoint;
+  if (pathname === prefix) {
+    return { pathname: '/', forceRsc: true };
+  }
+  if (pathname.startsWith(`${prefix}/`)) {
+    const rest = pathname.slice(prefix.length);
+    return { pathname: rest.startsWith('/') ? rest : `/${rest}`, forceRsc: true };
+  }
+  return { pathname, forceRsc: false };
+}
+
+/**
+ * Decide HTML vs RSC representation for a request in RSC mode (ADR D1).
+ * - Endpoint path → always RSC
+ * - Else `Accept: text/x-component` → RSC
+ * - Else HTML
+ */
+export function negotiateRepresentation(request: Request, rsc?: RouterRscOptions): Representation {
+  const url = new URL(request.url);
+  const { forceRsc } = resolveRscEndpointPath(url.pathname, rsc?.endpoint);
+  if (forceRsc) return 'rsc';
+  if (wantsRscPayload(request)) return 'rsc';
+  return 'html';
+}
+
+/**
+ * Pathname used for route matching after endpoint stripping.
+ */
+export function routingPathname(request: Request, rsc?: RouterRscOptions): string {
+  const url = new URL(request.url);
+  return resolveRscEndpointPath(url.pathname, rsc?.endpoint).pathname;
+}

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,6 +1,7 @@
 import { logger } from '@revealui/utils/logger';
 import type React from 'react';
 import { createElement } from 'react';
+import { negotiateRepresentation, routingPathname, type Representation } from './negotiate';
 import type {
   MiddlewareContext,
   NavigateOptions,
@@ -164,6 +165,25 @@ export class Router {
    */
   getOptions(): RouterOptions {
     return this.options;
+  }
+
+  /**
+   * Content negotiation for RSC mode (ADR D1 / T3).
+   * Client mode always returns `'html'`.
+   */
+  negotiate(request: Request): Representation {
+    if (this.mode !== 'rsc') return 'html';
+    return negotiateRepresentation(request, this.options.rsc);
+  }
+
+  /**
+   * Pathname used for matching after optional RSC endpoint prefix strip.
+   */
+  routingPathname(request: Request): string {
+    if (this.mode !== 'rsc') {
+      return new URL(request.url).pathname;
+    }
+    return routingPathname(request, this.options.rsc);
   }
 
   /**

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,7 +1,7 @@
 import { logger } from '@revealui/utils/logger';
 import type React from 'react';
 import { createElement } from 'react';
-import { negotiateRepresentation, routingPathname, type Representation } from './negotiate';
+import { negotiateRepresentation, type Representation, routingPathname } from './negotiate';
 import type {
   MiddlewareContext,
   NavigateOptions,

--- a/packages/router/src/server-rsc.tsx
+++ b/packages/router/src/server-rsc.tsx
@@ -1,0 +1,177 @@
+import { encodeBase64Chunked, readStreamToUint8Array } from './base64';
+import {
+  negotiateRepresentation,
+  RSC_CONTENT_TYPE,
+  routingPathname,
+  type Representation,
+} from './negotiate';
+import type { Router } from './router';
+import type { RouteMatch } from './types';
+
+/**
+ * Context passed to the consumer when creating an RSC flight stream.
+ * Route match is already resolved against the (endpoint-stripped) pathname.
+ */
+export interface RscRenderContext {
+  pathname: string;
+  match: RouteMatch | null;
+  representation: Representation;
+}
+
+export interface RenderRequestOptions {
+  /** Router instance (must be in `'rsc'` mode for negotiation). */
+  router: Router;
+  /**
+   * Produce the RSC flight stream for this request.
+   * Consumer typically wires `react-server-dom-webpack` / `@vitejs/plugin-rsc`
+   * here so the router stays free of a hard bundler dep (ADR D11).
+   */
+  createRscStream: (request: Request, ctx: RscRenderContext) => Promise<ReadableStream<Uint8Array>>;
+  /**
+   * Optional HTML SSR from an RSC stream (plugin-rsc SSR path).
+   * When omitted, a minimal document shell is used with `__RSC_PAYLOAD__` inlined.
+   */
+  renderHtml?: (args: {
+    rscStream: ReadableStream<Uint8Array>;
+    bootstrapScriptContent: string;
+    formState?: unknown;
+  }) => Promise<ReadableStream<Uint8Array> | string>;
+  /**
+   * Bootstrap / client entry script content (ADR D11).
+   * Injected after the RSC payload script when using the default HTML shell.
+   */
+  loadBootstrapScriptContent?: () => Promise<string>;
+  formState?: unknown;
+  title?: string;
+  /** Extra headers on the response (e.g. Cache-Control). */
+  headers?: HeadersInit;
+}
+
+function defaultHtmlShell(opts: {
+  title: string;
+  rscPayloadBase64: string;
+  bootstrap: string;
+  bodyHtml?: string;
+}): string {
+  const body = opts.bodyHtml ?? '<div id="root"></div>';
+  const payloadScript = `self.__RSC_PAYLOAD__=${JSON.stringify(opts.rscPayloadBase64)};`;
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>${escapeHtml(opts.title)}</title>
+</head>
+<body>
+${body}
+<script>${payloadScript}</script>
+<script type="module">${opts.bootstrap}</script>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+/**
+ * Build the inline `self.__RSC_PAYLOAD__=...` assignment from a flight stream
+ * half (after tee). Chunked base64 (ADR D15).
+ */
+export async function inlineRscPayloadScript(
+  rscStream: ReadableStream<Uint8Array>,
+): Promise<string> {
+  const bytes = await readStreamToUint8Array(rscStream);
+  const b64 = encodeBase64Chunked(bytes);
+  return `self.__RSC_PAYLOAD__=${JSON.stringify(b64)};`;
+}
+
+/**
+ * RSC-mode request handler (T3 negotiation + T4 render pipeline).
+ *
+ * - `Accept: text/x-component` (or endpoint path) → flight `text/x-component`
+ * - otherwise → HTML with teed payload inlined as `__RSC_PAYLOAD__` + bootstrap
+ *
+ * Requires `router.mode === 'rsc'`. Client-mode callers should use `createSSRHandler`.
+ */
+export async function renderRequest(
+  request: Request,
+  options: RenderRequestOptions,
+): Promise<Response> {
+  const { router } = options;
+  if (router.mode !== 'rsc') {
+    throw new Error(
+      'renderRequest requires Router in rsc mode: new Router({ rsc: {} }). Client mode: use createSSRHandler.',
+    );
+  }
+
+  const rscOpts = router.getOptions().rsc;
+  const representation = negotiateRepresentation(request, rscOpts);
+  const pathname = routingPathname(request, rscOpts);
+  const match = await router.resolve(pathname);
+
+  const ctx: RscRenderContext = { pathname, match, representation };
+  const rscStream = await options.createRscStream(request, ctx);
+
+  const extra = new Headers(options.headers);
+  // Content negotiation requires Vary so caches do not mix HTML and flight.
+  if (!extra.has('Vary')) {
+    extra.set('Vary', 'accept');
+  }
+
+  if (representation === 'rsc') {
+    extra.set('Content-Type', `${RSC_CONTENT_TYPE};charset=utf-8`);
+    return new Response(rscStream, {
+      status: match ? 200 : 404,
+      headers: extra,
+    });
+  }
+
+  // HTML path: tee flight stream — one half inlined as base64, one half for optional SSR.
+  const [forPayload, forSsr] = rscStream.tee();
+  const bootstrap = options.loadBootstrapScriptContent
+    ? await options.loadBootstrapScriptContent()
+    : '';
+
+  if (options.renderHtml) {
+    const payloadScript = await inlineRscPayloadScript(forPayload);
+    const htmlResult = await options.renderHtml({
+      rscStream: forSsr,
+      bootstrapScriptContent: payloadScript + bootstrap,
+      formState: options.formState,
+    });
+    extra.set('Content-Type', 'text/html; charset=utf-8');
+    if (typeof htmlResult === 'string') {
+      return new Response(htmlResult, { status: match ? 200 : 404, headers: extra });
+    }
+    return new Response(htmlResult, { status: match ? 200 : 404, headers: extra });
+  }
+
+  // Minimal shell when consumer does not provide SSR renderHtml.
+  const bytes = await readStreamToUint8Array(forPayload);
+  // Drain the other tee half so the producer is not backpressured.
+  await readStreamToUint8Array(forSsr);
+  const b64 = encodeBase64Chunked(bytes);
+  const title =
+    options.title ??
+    (typeof match?.route.meta?.title === 'string' ? match.route.meta.title : 'RevealUI');
+  const html = defaultHtmlShell({
+    title,
+    rscPayloadBase64: b64,
+    bootstrap,
+  });
+  extra.set('Content-Type', 'text/html; charset=utf-8');
+  return new Response(html, { status: match ? 200 : 404, headers: extra });
+}
+
+/**
+ * Convenience: HTML template fragment for a matched route component name (tests / shells).
+ */
+export function routeTitle(match: RouteMatch | null, fallback = 'RevealUI'): string {
+  const t = match?.route.meta?.title;
+  return typeof t === 'string' && t.length > 0 ? t : fallback;
+}

--- a/packages/router/src/server-rsc.tsx
+++ b/packages/router/src/server-rsc.tsx
@@ -1,9 +1,9 @@
 import { encodeBase64Chunked, readStreamToUint8Array } from './base64';
 import {
   negotiateRepresentation,
+  type Representation,
   RSC_CONTENT_TYPE,
   routingPathname,
-  type Representation,
 } from './negotiate';
 import type { Router } from './router';
 import type { RouteMatch } from './types';

--- a/packages/router/src/server.tsx
+++ b/packages/router/src/server.tsx
@@ -12,19 +12,19 @@ export {
 } from './base64';
 export {
   negotiateRepresentation,
-  resolveRscEndpointPath,
-  routingPathname,
+  type Representation,
   RSC_ACCEPT,
   RSC_CONTENT_TYPE,
+  resolveRscEndpointPath,
+  routingPathname,
   wantsRscPayload,
-  type Representation,
 } from './negotiate';
 export {
   inlineRscPayloadScript,
-  renderRequest,
-  routeTitle,
   type RenderRequestOptions,
   type RscRenderContext,
+  renderRequest,
+  routeTitle,
 } from './server-rsc';
 
 /**

--- a/packages/router/src/server.tsx
+++ b/packages/router/src/server.tsx
@@ -5,6 +5,28 @@ import { RouterProvider, Routes } from './components';
 import { Router } from './router';
 import type { Route } from './types';
 
+// RSC dual-mode surface (T3/T4) — re-exported from ./server for a single subpath.
+export {
+  encodeBase64Chunked,
+  readStreamToUint8Array,
+} from './base64';
+export {
+  negotiateRepresentation,
+  resolveRscEndpointPath,
+  routingPathname,
+  RSC_ACCEPT,
+  RSC_CONTENT_TYPE,
+  wantsRscPayload,
+  type Representation,
+} from './negotiate';
+export {
+  inlineRscPayloadScript,
+  renderRequest,
+  routeTitle,
+  type RenderRequestOptions,
+  type RscRenderContext,
+} from './server-rsc';
+
 /**
  * SSR Options
  */


### PR DESCRIPTION
## Summary

GAP-194 Phase 2.2.2 **T3 + T4** on `@revealui/router` **0.4.0-rc.1** (after #2330).

### T3 — Content negotiation (ADR D1)
- `wantsRscPayload` / `negotiateRepresentation` / `resolveRscEndpointPath`
- `Router.negotiate(request)` + `routingPathname(request)`
- `Accept: text/x-component` → RSC; endpoint prefix forces RSC (CDN Vary escape hatch)

### T4 — `renderRequest` (ADR D11/D15)
- Injectible `createRscStream` (no hard plugin-rsc dep)
- RSC response: `text/x-component` + `Vary: accept`
- HTML: tee flight stream, **chunked** base64 `__RSC_PAYLOAD__`, optional `renderHtml` / bootstrap
- Edge-safe (no `node:*`, no spread `fromCharCode`)

### Tests
- **137** unit tests green (negotiate + server-rsc coverage)

## Not in this PR
T5 redirect/notFound, T6 ALS, T7 action endpoint wiring, T8 rsc-poc rewire

## Test plan
- [x] `pnpm --filter @revealui/router test`
- [x] pre-push phase-1 PASS