### PR TITLE
feat(router): T5–T7 redirect/notFound, ALS, x-rsc-action

### DIFF
--- a/.changeset/router-0-4-0-rc2-t5-t7.md
+++ b/.changeset/router-0-4-0-rc2-t5-t7.md
@@ -1,0 +1,5 @@
+---
+"@revealui/router": minor
+---
+
+RSC mode T5–T7: redirect/notFound throw-sentinels (307/308), request ALS getRequest, x-rsc-action dispatch with actionMiddleware before loadServerAction (ADR D2/D6/D10).

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -334,6 +334,9 @@ export default {
 - `Accept: text/x-component` → flight body (`Vary: accept`)
 - Otherwise → HTML with chunked base64 `self.__RSC_PAYLOAD__=...` + bootstrap
 - Endpoint escape hatch forces RSC when CDNs mishandle `Vary`
+- `redirect(path)` / `notFound()` throw-sentinels → 307/308 or 404 (from `@revealui/router/server`)
+- `getRequest()` via ALS inside `renderRequest` / `runWithRequest`
+- `x-rsc-action` POST: `useAction` middleware then `loadServerAction` + `returnValue` on stream ctx
 
 ## Dev Server
 

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",

--- a/packages/router/src/__tests__/t5-t7.test.ts
+++ b/packages/router/src/__tests__/t5-t7.test.ts
@@ -184,7 +184,13 @@ describe('T7 server actions', () => {
   it('runs loadServerAction and passes returnValue to createRscStream', async () => {
     const router = new Router({ rsc: {} });
     router.register({ path: '/', component: () => null });
-    const load = vi.fn(async () => async (n: number) => n * 2);
+    const load = vi.fn(async (_id: string) => {
+      return async (...args: unknown[]) => {
+        const n = args[0];
+        if (typeof n !== 'number') throw new Error('expected number arg');
+        return n * 2;
+      };
+    });
     let returnValue: unknown;
     const res = await renderRequest(
       new Request('http://x/', {

--- a/packages/router/src/__tests__/t5-t7.test.ts
+++ b/packages/router/src/__tests__/t5-t7.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import { getServerActionId, RSC_ACTION_HEADER } from '../actions.js';
+import { notFound, RouterNotFound, RouterRedirect, redirect } from '../navigation.js';
+import { getRequest, getRequestOrNull, runWithRequest } from '../request-context.js';
+import { Router } from '../router.js';
+import { renderRequest } from '../server-rsc.js';
+
+function flightStream(text: string): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(enc.encode(text));
+      controller.close();
+    },
+  });
+}
+
+describe('T5 redirect / notFound', () => {
+  it('redirect() throws RouterRedirect', () => {
+    expect(() => redirect('/login')).toThrow(RouterRedirect);
+    try {
+      redirect('/login', { permanent: true });
+    } catch (e) {
+      expect(e).toBeInstanceOf(RouterRedirect);
+      expect((e as RouterRedirect).path).toBe('/login');
+      expect((e as RouterRedirect).permanent).toBe(true);
+    }
+  });
+
+  it('notFound() throws RouterNotFound', () => {
+    expect(() => notFound()).toThrow(RouterNotFound);
+  });
+
+  it('HTML redirect yields 307 Location', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/secure',
+      component: () => null,
+      loader: async () => {
+        redirect('/login');
+      },
+    });
+    const res = await renderRequest(new Request('http://x/secure'), {
+      router,
+      createRscStream: async () => flightStream('x'),
+    });
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe('/login');
+  });
+
+  it('HTML permanent redirect yields 308', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/old',
+      component: () => null,
+      loader: async () => {
+        redirect('/new', { permanent: true });
+      },
+    });
+    const res = await renderRequest(new Request('http://x/old'), {
+      router,
+      createRscStream: async () => flightStream('x'),
+    });
+    expect(res.status).toBe(308);
+    expect(res.headers.get('Location')).toBe('/new');
+  });
+
+  it('RSC redirect yields JSON body with path', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/secure',
+      component: () => null,
+      loader: async () => {
+        redirect('/login');
+      },
+    });
+    const res = await renderRequest(
+      new Request('http://x/secure', { headers: { accept: 'text/x-component' } }),
+      {
+        router,
+        createRscStream: async () => flightStream('x'),
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Router-Redirect')).toBe('/login');
+    const body = await res.json();
+    expect(body).toEqual({ redirect: '/login', permanent: false });
+  });
+
+  it('notFound yields 404 HTML', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/gone',
+      component: () => null,
+      loader: async () => {
+        notFound();
+      },
+    });
+    const res = await renderRequest(new Request('http://x/gone'), {
+      router,
+      createRscStream: async () => flightStream('x'),
+    });
+    expect(res.status).toBe(404);
+    const html = await res.text();
+    expect(html).toContain('404');
+  });
+});
+
+describe('T6 getRequest ALS', () => {
+  it('getRequest throws outside context', () => {
+    expect(() => getRequest()).toThrow(/outside a request context/);
+    expect(getRequestOrNull()).toBeNull();
+  });
+
+  it('getRequest returns bound request inside runWithRequest', () => {
+    const r = new Request('http://x/a');
+    const got = runWithRequest(r, () => getRequest());
+    expect(got).toBe(r);
+  });
+
+  it('renderRequest binds getRequest during createRscStream', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    let seen: string | undefined;
+    await renderRequest(new Request('http://x/'), {
+      router,
+      createRscStream: async () => {
+        seen = getRequest().url;
+        return flightStream('ok');
+      },
+    });
+    expect(seen).toBe('http://x/');
+  });
+});
+
+describe('T7 server actions', () => {
+  it('getServerActionId reads x-rsc-action on POST', () => {
+    const r = new Request('http://x/', {
+      method: 'POST',
+      headers: { [RSC_ACTION_HEADER]: 'act-1' },
+    });
+    expect(getServerActionId(r)).toBe('act-1');
+    expect(getServerActionId(new Request('http://x/'))).toBeNull();
+  });
+
+  it('actionMiddleware can block with 403', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    router.useAction(async () => false);
+    const res = await renderRequest(
+      new Request('http://x/', {
+        method: 'POST',
+        headers: { [RSC_ACTION_HEADER]: 'act-1', accept: 'text/x-component' },
+      }),
+      {
+        router,
+        createRscStream: async () => flightStream('x'),
+        loadServerAction: async () => async () => 'nope',
+      },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('actionMiddleware can redirect', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    router.useAction(async () => '/login');
+    const res = await renderRequest(
+      new Request('http://x/', {
+        method: 'POST',
+        headers: { [RSC_ACTION_HEADER]: 'act-1' },
+      }),
+      {
+        router,
+        createRscStream: async () => flightStream('x'),
+        loadServerAction: async () => async () => 'nope',
+      },
+    );
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe('/login');
+  });
+
+  it('runs loadServerAction and passes returnValue to createRscStream', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    const load = vi.fn(async () => async (n: number) => n * 2);
+    let returnValue: unknown;
+    const res = await renderRequest(
+      new Request('http://x/', {
+        method: 'POST',
+        headers: {
+          [RSC_ACTION_HEADER]: 'double',
+          accept: 'text/x-component',
+        },
+      }),
+      {
+        router,
+        loadServerAction: load,
+        decodeActionArgs: async () => [21],
+        createRscStream: async (_req, ctx) => {
+          returnValue = ctx.returnValue;
+          return flightStream(`rv:${JSON.stringify(ctx.returnValue)}`);
+        },
+      },
+    );
+    expect(load).toHaveBeenCalledWith('double');
+    expect(returnValue).toEqual({ ok: true, data: 42 });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('rv:{"ok":true,"data":42}');
+  });
+
+  it('requires loadServerAction when x-rsc-action present', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    await expect(
+      renderRequest(
+        new Request('http://x/', {
+          method: 'POST',
+          headers: { [RSC_ACTION_HEADER]: 'x' },
+        }),
+        {
+          router,
+          createRscStream: async () => flightStream('x'),
+        },
+      ),
+    ).rejects.toThrow(/loadServerAction/);
+  });
+});

--- a/packages/router/src/actions.ts
+++ b/packages/router/src/actions.ts
@@ -1,0 +1,36 @@
+/**
+ * Server-action transport helpers (ADR D2 / T7).
+ */
+
+import type { MiddlewareContext, RouteMiddleware } from './types';
+
+/** Header carrying the opaque server-action id (RSDW convention). */
+export const RSC_ACTION_HEADER = 'x-rsc-action';
+
+export function getServerActionId(request: Request): string | null {
+  if (request.method !== 'POST') return null;
+  const id = request.headers.get(RSC_ACTION_HEADER);
+  return id && id.length > 0 ? id : null;
+}
+
+export function isServerActionRequest(request: Request): boolean {
+  return getServerActionId(request) !== null;
+}
+
+/**
+ * Run action middleware chain before loadServerAction (D2.d).
+ * - `false` → abort (403)
+ * - `string` → redirect path
+ * - `true` → continue
+ */
+export async function runActionMiddleware(
+  middleware: RouteMiddleware[],
+  context: MiddlewareContext,
+): Promise<true | false | string> {
+  for (const mw of middleware) {
+    const result = await mw(context);
+    if (result === false) return false;
+    if (typeof result === 'string') return result;
+  }
+  return true;
+}

--- a/packages/router/src/navigation.ts
+++ b/packages/router/src/navigation.ts
@@ -1,0 +1,41 @@
+/**
+ * Redirect / notFound throw-sentinels (ADR D6 / T5).
+ * Caught by `renderRequest` — do not catch these in user loaders without rethrowing.
+ */
+
+export class RouterRedirect extends Error {
+  readonly path: string;
+  readonly permanent: boolean;
+
+  constructor(path: string, options?: { permanent?: boolean }) {
+    super(`RouterRedirect: ${path}`);
+    this.name = 'RouterRedirect';
+    this.path = path;
+    this.permanent = options?.permanent ?? false;
+  }
+}
+
+export class RouterNotFound extends Error {
+  constructor(message = 'Not Found') {
+    super(message);
+    this.name = 'RouterNotFound';
+  }
+}
+
+/** Throw a redirect sentinel. Initial HTML → 307/308; RSC navigation → JSON body. */
+export function redirect(path: string, options?: { permanent?: boolean }): never {
+  throw new RouterRedirect(path, options);
+}
+
+/** Throw a not-found sentinel → 404 + RouterOptions.notFound when available. */
+export function notFound(): never {
+  throw new RouterNotFound();
+}
+
+export function isRouterRedirect(error: unknown): error is RouterRedirect {
+  return error instanceof RouterRedirect;
+}
+
+export function isRouterNotFound(error: unknown): error is RouterNotFound {
+  return error instanceof RouterNotFound;
+}

--- a/packages/router/src/request-context.ts
+++ b/packages/router/src/request-context.ts
@@ -1,0 +1,38 @@
+/**
+ * Request AsyncLocalStorage (ADR D10 / T6).
+ * Edge-safe: uses `async_hooks` AsyncLocalStorage (supported on Node 24,
+ * Cloudflare Workers, Vercel Edge, Deno, Bun per D18.b). No fs/path/Buffer.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const requestStorage = new AsyncLocalStorage<Request>();
+
+/** Run `fn` with `request` bound for `getRequest()`. */
+export function runWithRequest<T>(request: Request, fn: () => T): T {
+  return requestStorage.run(request, fn);
+}
+
+/** Run async work with `request` bound. */
+export function runWithRequestAsync<T>(request: Request, fn: () => Promise<T>): Promise<T> {
+  return requestStorage.run(request, fn);
+}
+
+/**
+ * Active request for the current async context (server actions / loaders).
+ * Throws if called outside `runWithRequest` / `renderRequest`.
+ */
+export function getRequest(): Request {
+  const req = requestStorage.getStore();
+  if (!req) {
+    throw new Error(
+      'getRequest() called outside a request context. Use renderRequest or runWithRequest.',
+    );
+  }
+  return req;
+}
+
+/** Soft variant for optional request access. */
+export function getRequestOrNull(): Request | null {
+  return requestStorage.getStore() ?? null;
+}

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,6 +1,7 @@
 import { logger } from '@revealui/utils/logger';
 import type React from 'react';
 import { createElement } from 'react';
+import { isRouterNotFound, isRouterRedirect } from './navigation';
 import { negotiateRepresentation, type Representation, routingPathname } from './negotiate';
 import type {
   MiddlewareContext,
@@ -310,6 +311,10 @@ export class Router {
       try {
         matched.data = await matched.route.loader(matched.params);
       } catch (error) {
+        // Control-flow sentinels (T5) must not be logged as loader failures.
+        if (isRouterRedirect(error) || isRouterNotFound(error)) {
+          throw error;
+        }
         logger.error(
           'Route loader error',
           error instanceof Error ? error : new Error(String(error)),

--- a/packages/router/src/server-rsc.tsx
+++ b/packages/router/src/server-rsc.tsx
@@ -1,10 +1,18 @@
+import { getServerActionId, runActionMiddleware } from './actions';
 import { encodeBase64Chunked, readStreamToUint8Array } from './base64';
+import {
+  isRouterNotFound,
+  isRouterRedirect,
+  type RouterNotFound,
+  RouterRedirect,
+} from './navigation';
 import {
   negotiateRepresentation,
   type Representation,
   RSC_CONTENT_TYPE,
   routingPathname,
 } from './negotiate';
+import { runWithRequestAsync } from './request-context';
 import type { Router } from './router';
 import type { RouteMatch } from './types';
 
@@ -16,6 +24,10 @@ export interface RscRenderContext {
   pathname: string;
   match: RouteMatch | null;
   representation: Representation;
+  /** Set after a successful server action (T7). */
+  returnValue?: { ok: boolean; data: unknown };
+  /** Opaque action id when this request is a mutation. */
+  actionId?: string;
 }
 
 export interface RenderRequestOptions {
@@ -41,6 +53,16 @@ export interface RenderRequestOptions {
    * Injected after the RSC payload script when using the default HTML shell.
    */
   loadBootstrapScriptContent?: () => Promise<string>;
+  /**
+   * Load a server action by opaque id (T7). Required when the request carries
+   * `x-rsc-action`. Consumer wires RSDW `loadServerAction` / plugin-rsc.
+   */
+  loadServerAction?: (id: string) => Promise<(...args: unknown[]) => unknown | Promise<unknown>>;
+  /**
+   * Decode action arguments from the request body (T7).
+   * Defaults to empty args when omitted.
+   */
+  decodeActionArgs?: (request: Request) => Promise<unknown[]>;
   formState?: unknown;
   title?: string;
   /** Extra headers on the response (e.g. Cache-Control). */
@@ -78,6 +100,55 @@ function escapeHtml(s: string): string {
     .replaceAll('"', '&quot;');
 }
 
+function redirectResponse(redirect: RouterRedirect, representation: Representation): Response {
+  if (representation === 'html') {
+    const status = redirect.permanent ? 308 : 307;
+    return new Response(null, {
+      status,
+      headers: { Location: redirect.path },
+    });
+  }
+  // RSC navigation: JSON body with redirect signal (ADR D6).
+  return new Response(JSON.stringify({ redirect: redirect.path, permanent: redirect.permanent }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-Router-Redirect': redirect.path,
+    },
+  });
+}
+
+function notFoundResponse(
+  router: Router,
+  representation: Representation,
+  _error: RouterNotFound,
+): Response {
+  const NotFound = router.getOptions().notFound;
+  if (representation === 'html' && NotFound) {
+    // Minimal shell naming the notFound component (full RSC tree is consumer-owned).
+    const html = defaultHtmlShell({
+      title: 'Not Found',
+      rscPayloadBase64: '',
+      bootstrap: '',
+      bodyHtml: '<div id="root" data-router-not-found="1"></div>',
+    });
+    return new Response(html, {
+      status: 404,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+  if (representation === 'html') {
+    return new Response('<!DOCTYPE html><html><body><h1>404 - Not Found</h1></body></html>', {
+      status: 404,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+  return new Response(JSON.stringify({ notFound: true }), {
+    status: 404,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+}
+
 /**
  * Build the inline `self.__RSC_PAYLOAD__=...` assignment from a flight stream
  * half (after tee). Chunked base64 (ADR D15).
@@ -90,48 +161,26 @@ export async function inlineRscPayloadScript(
   return `self.__RSC_PAYLOAD__=${JSON.stringify(b64)};`;
 }
 
-/**
- * RSC-mode request handler (T3 negotiation + T4 render pipeline).
- *
- * - `Accept: text/x-component` (or endpoint path) → flight `text/x-component`
- * - otherwise → HTML with teed payload inlined as `__RSC_PAYLOAD__` + bootstrap
- *
- * Requires `router.mode === 'rsc'`. Client-mode callers should use `createSSRHandler`.
- */
-export async function renderRequest(
+async function finishRender(
   request: Request,
   options: RenderRequestOptions,
+  ctx: RscRenderContext,
 ): Promise<Response> {
-  const { router } = options;
-  if (router.mode !== 'rsc') {
-    throw new Error(
-      'renderRequest requires Router in rsc mode: new Router({ rsc: {} }). Client mode: use createSSRHandler.',
-    );
-  }
-
-  const rscOpts = router.getOptions().rsc;
-  const representation = negotiateRepresentation(request, rscOpts);
-  const pathname = routingPathname(request, rscOpts);
-  const match = await router.resolve(pathname);
-
-  const ctx: RscRenderContext = { pathname, match, representation };
   const rscStream = await options.createRscStream(request, ctx);
 
   const extra = new Headers(options.headers);
-  // Content negotiation requires Vary so caches do not mix HTML and flight.
   if (!extra.has('Vary')) {
     extra.set('Vary', 'accept');
   }
 
-  if (representation === 'rsc') {
+  if (ctx.representation === 'rsc') {
     extra.set('Content-Type', `${RSC_CONTENT_TYPE};charset=utf-8`);
     return new Response(rscStream, {
-      status: match ? 200 : 404,
+      status: ctx.match ? 200 : 404,
       headers: extra,
     });
   }
 
-  // HTML path: tee flight stream — one half inlined as base64, one half for optional SSR.
   const [forPayload, forSsr] = rscStream.tee();
   const bootstrap = options.loadBootstrapScriptContent
     ? await options.loadBootstrapScriptContent()
@@ -145,27 +194,113 @@ export async function renderRequest(
       formState: options.formState,
     });
     extra.set('Content-Type', 'text/html; charset=utf-8');
+    const status = ctx.match ? 200 : 404;
     if (typeof htmlResult === 'string') {
-      return new Response(htmlResult, { status: match ? 200 : 404, headers: extra });
+      return new Response(htmlResult, { status, headers: extra });
     }
-    return new Response(htmlResult, { status: match ? 200 : 404, headers: extra });
+    return new Response(htmlResult, { status, headers: extra });
   }
 
-  // Minimal shell when consumer does not provide SSR renderHtml.
   const bytes = await readStreamToUint8Array(forPayload);
-  // Drain the other tee half so the producer is not backpressured.
   await readStreamToUint8Array(forSsr);
   const b64 = encodeBase64Chunked(bytes);
   const title =
     options.title ??
-    (typeof match?.route.meta?.title === 'string' ? match.route.meta.title : 'RevealUI');
+    (typeof ctx.match?.route.meta?.title === 'string' ? ctx.match.route.meta.title : 'RevealUI');
   const html = defaultHtmlShell({
     title,
     rscPayloadBase64: b64,
     bootstrap,
   });
   extra.set('Content-Type', 'text/html; charset=utf-8');
-  return new Response(html, { status: match ? 200 : 404, headers: extra });
+  return new Response(html, { status: ctx.match ? 200 : 404, headers: extra });
+}
+
+/**
+ * RSC-mode request handler (T3–T7).
+ *
+ * - Content negotiation + endpoint strip (T3)
+ * - Flight / HTML with teed `__RSC_PAYLOAD__` (T4)
+ * - `redirect` / `notFound` sentinels (T5)
+ * - Request ALS for `getRequest()` (T6)
+ * - `x-rsc-action` + actionMiddleware (T7)
+ */
+export async function renderRequest(
+  request: Request,
+  options: RenderRequestOptions,
+): Promise<Response> {
+  return runWithRequestAsync(request, async () => {
+    const { router } = options;
+    if (router.mode !== 'rsc') {
+      throw new Error(
+        'renderRequest requires Router in rsc mode: new Router({ rsc: {} }). Client mode: use createSSRHandler.',
+      );
+    }
+
+    const rscOpts = router.getOptions().rsc;
+    const representation = negotiateRepresentation(request, rscOpts);
+    const pathname = routingPathname(request, rscOpts);
+
+    try {
+      const actionId = getServerActionId(request);
+      let returnValue: RscRenderContext['returnValue'];
+      let match: RouteMatch | null = null;
+
+      if (actionId) {
+        // Match without loader for middleware context (params/meta only).
+        match = router.match(pathname);
+        const mwResult = await runActionMiddleware(router.getActionMiddleware(), {
+          pathname,
+          params: match?.params ?? {},
+          meta: match?.route.meta,
+        });
+        if (mwResult === false) {
+          return new Response('Forbidden', { status: 403 });
+        }
+        if (typeof mwResult === 'string') {
+          // Action middleware string return = temporary redirect (same as route mw).
+          return redirectResponse(new RouterRedirect(mwResult), representation);
+        }
+
+        if (!options.loadServerAction) {
+          throw new Error(
+            'renderRequest: loadServerAction is required when x-rsc-action is present',
+          );
+        }
+        const action = await options.loadServerAction(actionId);
+        const args = options.decodeActionArgs ? await options.decodeActionArgs(request) : [];
+        try {
+          const data = await action(...args);
+          returnValue = { ok: true, data };
+        } catch (error) {
+          if (isRouterRedirect(error)) return redirectResponse(error, representation);
+          if (isRouterNotFound(error)) return notFoundResponse(router, representation, error);
+          returnValue = { ok: false, data: error instanceof Error ? error.message : String(error) };
+        }
+        // Re-resolve after mutation so loaders see fresh data.
+        match = await router.resolve(pathname);
+      } else {
+        match = await router.resolve(pathname);
+      }
+
+      const ctx: RscRenderContext = {
+        pathname,
+        match,
+        representation,
+        returnValue,
+        actionId: actionId ?? undefined,
+      };
+      return await finishRender(request, options, ctx);
+    } catch (error) {
+      if (isRouterRedirect(error)) {
+        return redirectResponse(error, representation);
+      }
+      if (isRouterNotFound(error)) {
+        return notFoundResponse(router, representation, error);
+      }
+      throw error;
+    }
+  });
 }
 
 /**

--- a/packages/router/src/server.tsx
+++ b/packages/router/src/server.tsx
@@ -5,11 +5,25 @@ import { RouterProvider, Routes } from './components';
 import { Router } from './router';
 import type { Route } from './types';
 
-// RSC dual-mode surface (T3/T4) — re-exported from ./server for a single subpath.
+// RSC dual-mode surface (T3–T7) — re-exported from ./server for a single subpath.
+export {
+  getServerActionId,
+  isServerActionRequest,
+  RSC_ACTION_HEADER,
+  runActionMiddleware,
+} from './actions';
 export {
   encodeBase64Chunked,
   readStreamToUint8Array,
 } from './base64';
+export {
+  isRouterNotFound,
+  isRouterRedirect,
+  notFound,
+  RouterNotFound,
+  RouterRedirect,
+  redirect,
+} from './navigation';
 export {
   negotiateRepresentation,
   type Representation,
@@ -19,6 +33,12 @@ export {
   routingPathname,
   wantsRscPayload,
 } from './negotiate';
+export {
+  getRequest,
+  getRequestOrNull,
+  runWithRequest,
+  runWithRequestAsync,
+} from './request-context';
 export {
   inlineRscPayloadScript,
   type RenderRequestOptions,

--- a/packages/router/tsup.config.ts
+++ b/packages/router/tsup.config.ts
@@ -10,7 +10,15 @@ export default defineConfig({
   splitting: false,
   sourcemap: false,
   clean: true,
-  external: ['react', 'react-dom', 'hono', '@hono/node-server', /^@revealui\//],
+  external: [
+    'react',
+    'react-dom',
+    'hono',
+    '@hono/node-server',
+    'node:async_hooks',
+    'async_hooks',
+    /^@revealui\//,
+  ],
   esbuildOptions(options) {
     options.jsx = 'automatic';
   },


### PR DESCRIPTION
## Summary

GAP-194 Phase 2.2.2 **T5–T7** on `@revealui/router` **0.4.0-rc.2**.

**Stack:** includes **#2333** (T3/T4) tip. Prefer merge **#2333 first** then this, or merge this alone (contains T3–T7).

### T5 — redirect / notFound (ADR D6)
- `redirect(path, { permanent? })` / `notFound()` throw-sentinels
- HTML: **307** / **308** + `Location`
- RSC Accept: JSON `{ redirect, permanent }` + `X-Router-Redirect`
- `notFound` → 404 (+ optional `RouterOptions.notFound` shell)
- Loaders rethrow sentinels without error logging

### T6 — ALS `getRequest` (ADR D10)
- `runWithRequest` / `getRequest` / `getRequestOrNull`
- `renderRequest` always binds request for actions/loaders

### T7 — Server actions (ADR D2 / D2.d)
- `x-rsc-action` detection
- `useAction` middleware → 403 or redirect before `loadServerAction`
- `returnValue` on `RscRenderContext` for post-mutation flight

### Tests
**151** unit tests green · pre-push phase-1 **PASS**

## Not in this PR
T8 rsc-poc rewire onto `renderRequest` (next)