### PR TITLE
feat(server,db): GAP-444 founder API super-admin + entitlement source

### DIFF
--- a/apps/server/src/lib/__tests__/api-roles.test.ts
+++ b/apps/server/src/lib/__tests__/api-roles.test.ts
@@ -2,7 +2,7 @@
  * GAP-444 — platform super-admin elevation + hasApiRole semantics.
  */
 import { describe, expect, it } from 'vitest';
-import { hasApiRole, isPlatformSuperAdmin, type ApiAuthUser } from '../api-roles.js';
+import { type ApiAuthUser, hasApiRole, isPlatformSuperAdmin } from '../api-roles.js';
 
 function user(partial: Partial<ApiAuthUser> & Pick<ApiAuthUser, 'id' | 'role'>): ApiAuthUser {
   return {

--- a/apps/server/src/lib/__tests__/api-roles.test.ts
+++ b/apps/server/src/lib/__tests__/api-roles.test.ts
@@ -1,0 +1,94 @@
+/**
+ * GAP-444 — platform super-admin elevation + hasApiRole semantics.
+ */
+import { describe, expect, it } from 'vitest';
+import { hasApiRole, isPlatformSuperAdmin, type ApiAuthUser } from '../api-roles.js';
+
+function user(partial: Partial<ApiAuthUser> & Pick<ApiAuthUser, 'id' | 'role'>): ApiAuthUser {
+  return {
+    email: partial.email ?? 'founder@example.com',
+    name: partial.name ?? 'Founder',
+    emailVerified: partial.emailVerified ?? true,
+    _json: partial._json,
+    id: partial.id,
+    role: partial.role,
+  };
+}
+
+describe('isPlatformSuperAdmin', () => {
+  it('returns true for verified user with super-admin in _json.roles', () => {
+    expect(
+      isPlatformSuperAdmin(
+        user({
+          id: 'u1',
+          role: 'viewer',
+          emailVerified: true,
+          _json: { roles: ['super-admin'] },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when email is not verified', () => {
+    expect(
+      isPlatformSuperAdmin(
+        user({
+          id: 'u1',
+          role: 'viewer',
+          emailVerified: false,
+          _json: { roles: ['super-admin'] },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false without super-admin role marker', () => {
+    expect(
+      isPlatformSuperAdmin(
+        user({
+          id: 'u1',
+          role: 'admin',
+          emailVerified: true,
+          _json: { roles: ['tenant-admin'] },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for null/undefined user', () => {
+    expect(isPlatformSuperAdmin(null)).toBe(false);
+    expect(isPlatformSuperAdmin(undefined)).toBe(false);
+  });
+});
+
+describe('hasApiRole', () => {
+  it('matches the DB role column', () => {
+    const admin = user({ id: 'a', role: 'admin' });
+    expect(hasApiRole(admin, 'admin')).toBe(true);
+    expect(hasApiRole(admin, 'owner')).toBe(false);
+  });
+
+  it('elevates super-admin to admin and owner gates only', () => {
+    const founder = user({
+      id: 'f',
+      role: 'viewer',
+      emailVerified: true,
+      _json: { roles: ['super-admin'] },
+    });
+    expect(hasApiRole(founder, 'admin')).toBe(true);
+    expect(hasApiRole(founder, 'owner')).toBe(true);
+    expect(hasApiRole(founder, 'admin', 'owner')).toBe(true);
+    expect(hasApiRole(founder, 'editor')).toBe(false);
+    expect(hasApiRole(founder, 'agent')).toBe(false);
+  });
+
+  it('does not elevate unverified super-admin markers', () => {
+    const founder = user({
+      id: 'f',
+      role: 'viewer',
+      emailVerified: false,
+      _json: { roles: ['super-admin'] },
+    });
+    expect(hasApiRole(founder, 'admin', 'owner')).toBe(false);
+  });
+});

--- a/apps/server/src/lib/__tests__/hosted-entitlement-source.test.ts
+++ b/apps/server/src/lib/__tests__/hosted-entitlement-source.test.ts
@@ -1,0 +1,48 @@
+/**
+ * GAP-444 — entitlement source lockstep on buildHostedEntitlementValues.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: vi.fn(() => ({ agents: true })),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => {
+  const mockLog = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+  return { logger: mockLog, createLogger: () => mockLog };
+});
+
+vi.mock('../tier-limits.js', () => ({
+  getHostedLimitsForTier: vi.fn(() => ({ maxSites: 1, maxUsers: 1, maxAgentTasks: 10 })),
+}));
+
+import { buildHostedEntitlementValues } from '../hosted-entitlement.js';
+
+describe('buildHostedEntitlementValues source (GAP-444)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const base = {
+    tier: 'pro' as const,
+    status: 'active',
+    mode: 'live' as const,
+    lastEventAt: null,
+    now: new Date('2026-07-31T00:00:00.000Z'),
+  };
+
+  it('defaults source to stripe for paid paths', () => {
+    const values = buildHostedEntitlementValues(base);
+    expect(values.source).toBe('stripe');
+  });
+
+  it('accepts grant for CLI gifts', () => {
+    const values = buildHostedEntitlementValues({ ...base, source: 'grant' });
+    expect(values.source).toBe('grant');
+  });
+
+  it('accepts reconciler for heal path', () => {
+    const values = buildHostedEntitlementValues({ ...base, source: 'reconciler' });
+    expect(values.source).toBe('reconciler');
+  });
+});

--- a/apps/server/src/lib/api-roles.ts
+++ b/apps/server/src/lib/api-roles.ts
@@ -1,0 +1,54 @@
+/**
+ * API role helpers (GAP-444).
+ *
+ * Pure — no Hono / session / DB imports so unit tests and route handlers can
+ * share the same elevation semantics without pulling the auth package graph.
+ */
+
+/**
+ * Minimal user shape for API role checks.
+ * Session path already returns full DB user (includes `_json` + `emailVerified`).
+ * Device-token path selects the same load-bearing fields.
+ */
+export interface ApiAuthUser {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  role: string;
+  emailVerified?: boolean | null;
+  _json?: unknown;
+}
+
+function rolesFromJson(json: unknown): string[] {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) {
+    return [];
+  }
+  const roles = (json as { roles?: unknown }).roles;
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+  return roles.filter((role): role is string => typeof role === 'string');
+}
+
+/**
+ * Platform founder / super-admin from the admin engine's `_json.roles` plane.
+ * Not a tenant `owner` — out-of-band platform elevation (GAP-444 A2).
+ * Requires verified email so an unverified row cannot elevate.
+ */
+export function isPlatformSuperAdmin(user: ApiAuthUser | null | undefined): boolean {
+  if (!user) return false;
+  if (user.emailVerified !== true) return false;
+  return rolesFromJson(user._json).includes('super-admin');
+}
+
+/**
+ * Whether the user satisfies any of the given DB roles, or is a platform
+ * super-admin when the required set includes `admin` or `owner`.
+ */
+export function hasApiRole(user: ApiAuthUser | null | undefined, ...roles: string[]): boolean {
+  if (!user) return false;
+  if (roles.includes(user.role)) return true;
+  if (!isPlatformSuperAdmin(user)) return false;
+  // Super-admin elevates to platform admin/owner gates only, not editor/agent.
+  return roles.includes('admin') || roles.includes('owner');
+}

--- a/apps/server/src/lib/hosted-entitlement.ts
+++ b/apps/server/src/lib/hosted-entitlement.ts
@@ -20,6 +20,14 @@ import { getHostedLimitsForTier } from './tier-limits.js';
 export type HostedTier = 'free' | LicenseTier;
 
 /**
+ * How an entitlement row was written (GAP-444).
+ * - `stripe` — webhook / checkout path (counts toward MRR)
+ * - `grant` — admin CLI gift (excluded from MRR)
+ * - `reconciler` — entitlement-consistency heal (counts as non-gift)
+ */
+export type EntitlementSource = 'stripe' | 'grant' | 'reconciler';
+
+/**
  * Known feature keys, derived from the canonical `FeatureFlags` record. Used
  * to warn on unexpected keys. Derived rather than listed: a hardcoded copy
  * drifted when vaultDesktop/vaultRotation/devkitProfiles shipped, making
@@ -85,6 +93,8 @@ export function buildHostedEntitlementValues(params: {
   graceUntil?: Date | null;
   lastEventAt: Date | null;
   now: Date;
+  /** GAP-444 — defaults to stripe (paid path). CLI grants pass `grant`. */
+  source?: EntitlementSource;
 }): {
   planId: HostedTier;
   tier: HostedTier;
@@ -93,6 +103,7 @@ export function buildHostedEntitlementValues(params: {
   limits: ReturnType<typeof getHostedLimitsForTier>;
   meteringStatus: string;
   mode: 'live' | 'test';
+  source: EntitlementSource;
   graceUntil: Date | null;
   lastEventAt: Date | null;
   updatedAt: Date;
@@ -106,6 +117,7 @@ export function buildHostedEntitlementValues(params: {
     meteringStatus:
       params.status === 'active' || params.status === 'trialing' ? 'active' : 'paused',
     mode: params.mode,
+    source: params.source ?? 'stripe',
     graceUntil: params.graceUntil ?? null,
     lastEventAt: params.lastEventAt,
     updatedAt: params.now,

--- a/apps/server/src/middleware/auth.ts
+++ b/apps/server/src/middleware/auth.ts
@@ -11,30 +11,46 @@
 
 import { createHash } from 'node:crypto';
 import { getSession } from '@revealui/auth/server';
+import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { userDevices, users } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
 import type { MiddlewareHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import { type ApiAuthUser, hasApiRole, isPlatformSuperAdmin } from '../lib/api-roles.js';
 import { extractRequestContext } from '../lib/request-context.js';
+
+export type { ApiAuthUser } from '../lib/api-roles.js';
+export { hasApiRole, isPlatformSuperAdmin } from '../lib/api-roles.js';
 
 export interface AuthOptions {
   /** If true, unauthenticated requests get 401. If false, session is set but not required. */
   required?: boolean;
 }
 
+/** Once-per-process elevation log so super-admin is visible without spamming. */
+const elevatedOnce = new Set<string>();
+
 /** Hash a bearer token for comparison against stored tokenHash. */
 function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
+}
+
+function noteSuperAdminElevation(user: ApiAuthUser): void {
+  if (!isPlatformSuperAdmin(user)) return;
+  if (elevatedOnce.has(user.id)) return;
+  elevatedOnce.add(user.id);
+  logger.info('platform super-admin elevated for API request', {
+    userId: user.id,
+    dbRole: user.role,
+  });
 }
 
 /**
  * Resolve user from a Bearer token. Returns null if token is invalid or expired.
  * Updates lastSeen on the device row (fire-and-forget).
  */
-async function resolveDeviceToken(
-  token: string,
-): Promise<{ id: string; email: string | null; name: string | null; role: string } | null> {
+async function resolveDeviceToken(token: string): Promise<ApiAuthUser | null> {
   const db = getClient();
   const hash = hashToken(token);
   const now = new Date();
@@ -54,7 +70,14 @@ async function resolveDeviceToken(
   if (device.tokenExpiresAt && device.tokenExpiresAt < now) return null;
 
   const [user] = await db
-    .select({ id: users.id, email: users.email, name: users.name, role: users.role })
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      role: users.role,
+      emailVerified: users.emailVerified,
+      _json: users._json,
+    })
     .from(users)
     .where(eq(users.id, device.userId))
     .limit(1);
@@ -116,16 +139,18 @@ export const authMiddleware = (options: AuthOptions = {}): MiddlewareHandler => 
 
 /**
  * Require specific roles. Must be used after authMiddleware({ required: true }).
+ * Platform super-admin satisfies `admin` / `owner` requirements (GAP-444).
  */
 export const requireRole = (...roles: string[]): MiddlewareHandler => {
   return async (c, next) => {
-    const user = c.get('user');
+    const user = c.get('user') as ApiAuthUser | undefined;
     if (!user) {
       throw new HTTPException(401, { message: 'Authentication required' });
     }
-    if (!roles.includes(user.role)) {
+    if (!hasApiRole(user, ...roles)) {
       throw new HTTPException(403, { message: 'Insufficient permissions' });
     }
+    noteSuperAdminElevation(user);
     await next();
   };
 };

--- a/apps/server/src/routes/__tests__/billing-metrics.test.ts
+++ b/apps/server/src/routes/__tests__/billing-metrics.test.ts
@@ -111,6 +111,8 @@ vi.mock('@revealui/db/schema', () => ({
     accountId: 'accountEntitlements.accountId',
     tier: 'accountEntitlements.tier',
     status: 'accountEntitlements.status',
+    mode: 'accountEntitlements.mode',
+    source: 'accountEntitlements.source',
   },
   billingCatalog: {
     stripePriceId: 'billingCatalog.stripePriceId',
@@ -157,6 +159,7 @@ vi.mock('@revealui/db/schema', () => ({
 
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((_col: unknown, _val: unknown) => `eq(${String(_col)},${String(_val)})`),
+  ne: vi.fn((_col: unknown, _val: unknown) => `ne(${String(_col)},${String(_val)})`),
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
   desc: vi.fn((_col: unknown) => `desc(${String(_col)})`),
   gt: vi.fn((_col: unknown, _val: unknown) => `gt(${String(_col)},${String(_val)})`),
@@ -230,6 +233,8 @@ interface UserContext {
   email: string | null;
   name: string;
   role: string;
+  emailVerified?: boolean;
+  _json?: unknown;
 }
 
 const ADMIN_USER: UserContext = {
@@ -251,6 +256,16 @@ const REGULAR_USER: UserContext = {
   email: 'user@example.com',
   name: 'Regular User',
   role: 'user',
+};
+
+/** GAP-444: founder with engine super-admin marker, DB role still viewer. */
+const SUPER_ADMIN_USER: UserContext = {
+  id: 'founder',
+  email: 'founder@example.com',
+  name: 'Founder',
+  role: 'viewer',
+  emailVerified: true,
+  _json: { roles: ['super-admin'] },
 };
 
 function createBillingApp(user?: UserContext) {
@@ -401,6 +416,14 @@ describe('Billing Metrics', { timeout: 60_000 }, () => {
     it('returns 200 for owner user', async () => {
       queueMetricsResults({});
       const app = createBillingApp(OWNER_USER);
+      const res = await app.request(get('/metrics'));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 for platform super-admin (GAP-444)', async () => {
+      queueMetricsResults({});
+      const app = createBillingApp(SUPER_ADMIN_USER);
       const res = await app.request(get('/metrics'));
 
       expect(res.status).toBe(200);

--- a/apps/server/src/routes/analytics.ts
+++ b/apps/server/src/routes/analytics.ts
@@ -27,6 +27,7 @@ import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, eq, gte, isNull, sql } from 'drizzle-orm';
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../lib/api-roles.js';
 
 interface UserContext {
   id: string;
@@ -60,7 +61,7 @@ function requireUser(c: Context): UserContext {
  */
 function requireAdmin(c: Context): UserContext {
   const user = requireUser(c);
-  if (user.role !== 'admin') {
+  if (!hasApiRole(user, 'admin')) {
     throw new HTTPException(403, { message: 'Admin role required' });
   }
   return user;

--- a/apps/server/src/routes/billing-health.ts
+++ b/apps/server/src/routes/billing-health.ts
@@ -15,6 +15,7 @@ import { accountEntitlements, licenses, processedWebhookEvents } from '@revealui
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, count, eq, gt, gte, ne } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../lib/api-roles.js';
 
 const app = new OpenAPIHono<{
   Variables: { user: { id: string; role: string } | undefined };
@@ -63,7 +64,7 @@ app.openapi(billingHealthRoute, async (c) => {
   if (!user) {
     throw new HTTPException(401, { message: 'Authentication required' });
   }
-  if (user.role !== 'admin' && user.role !== 'owner') {
+  if (!hasApiRole(user, 'admin', 'owner')) {
     throw new HTTPException(403, { message: 'Admin or owner role required' });
   }
 

--- a/apps/server/src/routes/billing.ts
+++ b/apps/server/src/routes/billing.ts
@@ -22,9 +22,23 @@ import {
   users,
 } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
-import { and, count, countDistinct, desc, eq, gt, gte, isNull, lt, lte, sql } from 'drizzle-orm';
+import {
+  and,
+  count,
+  countDistinct,
+  desc,
+  eq,
+  gt,
+  gte,
+  isNull,
+  lt,
+  lte,
+  ne,
+  sql,
+} from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import Stripe from 'stripe';
+import { hasApiRole } from '../lib/api-roles.js';
 import { getServices, type ProtectedStripe } from '../lib/services-loader.js';
 import { getHostedLimitsForTier } from '../lib/tier-limits.js';
 import { MRR_TIER_PRICE_FALLBACK_CENTS } from '../lib/tier-pricing.js';
@@ -2630,7 +2644,7 @@ app.openapi(refundRoute, async (c) => {
   if (!user) {
     throw new HTTPException(401, { message: 'Authentication required' });
   }
-  if (user.role !== 'admin' && user.role !== 'owner') {
+  if (!hasApiRole(user, 'admin', 'owner')) {
     throw new HTTPException(403, { message: 'Admin access required to issue refunds' });
   }
 
@@ -2747,7 +2761,7 @@ app.openapi(metricsRoute, async (c) => {
   if (!user) {
     throw new HTTPException(401, { message: 'Authentication required' });
   }
-  if (user.role !== 'admin' && user.role !== 'owner') {
+  if (!hasApiRole(user, 'admin', 'owner')) {
     throw new HTTPException(403, { message: 'Admin access required to view revenue metrics' });
   }
 
@@ -2790,14 +2804,21 @@ app.openapi(metricsRoute, async (c) => {
   const activeSubscriptions = subStats?.activeCount ?? 0;
   const totalCustomers = subStats?.uniqueCustomers ?? 0;
 
-  // 2. Tier breakdown from entitlements (active subscriptions only)
+  // 2. Tier breakdown from paid live entitlements only (GAP-444: exclude gifts).
+  // Mode-scoped to `live` so test-mode comps and sandbox rows never inflate MRR.
   const tierRows = await db
     .select({
       tier: accountEntitlements.tier,
       tierCount: count(),
     })
     .from(accountEntitlements)
-    .where(eq(accountEntitlements.status, 'active'))
+    .where(
+      and(
+        eq(accountEntitlements.status, 'active'),
+        eq(accountEntitlements.mode, 'live'),
+        ne(accountEntitlements.source, 'grant'),
+      ),
+    )
     .groupBy(accountEntitlements.tier);
 
   const tierBreakdown = { pro: 0, max: 0, enterprise: 0 };

--- a/apps/server/src/routes/content/batch.ts
+++ b/apps/server/src/routes/content/batch.ts
@@ -17,8 +17,8 @@ import * as postQueries from '@revealui/db/queries/posts';
 import * as siteQueries from '@revealui/db/queries/sites';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
-import type { ContentVariables } from './index.js';
 import { hasApiRole } from '../../lib/api-roles.js';
+import type { ContentVariables } from './index.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 

--- a/apps/server/src/routes/content/batch.ts
+++ b/apps/server/src/routes/content/batch.ts
@@ -18,6 +18,7 @@ import * as siteQueries from '@revealui/db/queries/sites';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
 import type { ContentVariables } from './index.js';
+import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -288,7 +289,8 @@ app.openapi(
     const db = c.get('db');
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-    if (user.role !== 'admin') throw new HTTPException(403, { message: 'Admin access required' });
+    if (!hasApiRole(user, 'admin'))
+      throw new HTTPException(403, { message: 'Admin access required' });
 
     const { collection, items } = c.req.valid('json');
 
@@ -342,7 +344,8 @@ app.openapi(
     const db = c.get('db');
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-    if (user.role !== 'admin') throw new HTTPException(403, { message: 'Admin access required' });
+    if (!hasApiRole(user, 'admin'))
+      throw new HTTPException(403, { message: 'Admin access required' });
 
     const { collection, items } = c.req.valid('json');
 
@@ -396,7 +399,8 @@ app.openapi(
     const db = c.get('db');
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-    if (user.role !== 'admin') throw new HTTPException(403, { message: 'Admin access required' });
+    if (!hasApiRole(user, 'admin'))
+      throw new HTTPException(403, { message: 'Admin access required' });
 
     const { collection, items } = c.req.valid('json');
 

--- a/apps/server/src/routes/content/export.ts
+++ b/apps/server/src/routes/content/export.ts
@@ -22,6 +22,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { ErrorSchema } from '../_helpers/content-schemas.js';
 import type { ContentVariables } from './index.js';
+import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -198,7 +199,7 @@ app.openapi(
   async (c) => {
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-    if (user.role !== 'admin') {
+    if (!hasApiRole(user, 'admin')) {
       throw new HTTPException(403, { message: 'Admin access required' });
     }
 

--- a/apps/server/src/routes/content/export.ts
+++ b/apps/server/src/routes/content/export.ts
@@ -20,9 +20,9 @@ import { pages } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, eq, isNull } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../../lib/api-roles.js';
 import { ErrorSchema } from '../_helpers/content-schemas.js';
 import type { ContentVariables } from './index.js';
-import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 

--- a/apps/server/src/routes/content/media.ts
+++ b/apps/server/src/routes/content/media.ts
@@ -17,11 +17,11 @@ import { logger } from '@revealui/core/observability/logger';
 import * as mediaQueries from '@revealui/db/queries/media';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../../lib/api-roles.js';
 import { getMediaStorage } from '../../lib/storage.js';
 import { ErrorSchema, IdParam } from '../_helpers/content-schemas.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import type { ContentVariables } from './index.js';
-import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 

--- a/apps/server/src/routes/content/media.ts
+++ b/apps/server/src/routes/content/media.ts
@@ -21,6 +21,7 @@ import { getMediaStorage } from '../../lib/storage.js';
 import { ErrorSchema, IdParam } from '../_helpers/content-schemas.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import type { ContentVariables } from './index.js';
+import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -205,7 +206,7 @@ app.openapi(
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
     const { mimeType, limit, offset } = c.req.valid('query');
     // Non-admin users only see their own uploads (R5-C5 multi-tenancy fix)
-    const uploadedBy = user.role === 'admin' ? undefined : user.id;
+    const uploadedBy = hasApiRole(user, 'admin') ? undefined : user.id;
     const filterOpts = { mimeType, uploadedBy };
     const [data, totalDocs] = await Promise.all([
       mediaQueries.getAllMedia(db, { ...filterOpts, limit, offset }),
@@ -252,7 +253,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const item = await mediaQueries.getMediaById(db, id);
     if (!item) throw new HTTPException(404, { message: 'Media not found' });
-    if (user.role !== 'admin' && item.uploadedBy !== user.id) {
+    if (!hasApiRole(user, 'admin') && item.uploadedBy !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     return c.json({ success: true as const, data: item }, 200);
@@ -298,7 +299,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const existing = await mediaQueries.getMediaById(db, id);
     if (!existing) throw new HTTPException(404, { message: 'Media not found' });
-    if (user.role !== 'admin' && existing.uploadedBy !== user.id) {
+    if (!hasApiRole(user, 'admin') && existing.uploadedBy !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     const body = c.req.valid('json');
@@ -335,7 +336,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const existing = await mediaQueries.getMediaById(db, id);
     if (!existing) throw new HTTPException(404, { message: 'Media not found' });
-    if (user.role !== 'admin' && existing.uploadedBy !== user.id) {
+    if (!hasApiRole(user, 'admin') && existing.uploadedBy !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     // Delete the stored object (best-effort  -  the DB record takes priority).

--- a/apps/server/src/routes/content/orders.ts
+++ b/apps/server/src/routes/content/orders.ts
@@ -16,6 +16,7 @@ import { ErrorSchema, IdParam } from '../_helpers/content-schemas.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
+import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -110,7 +111,7 @@ app.openapi(
     const { status, limit, offset } = c.req.valid('query');
 
     // Admin sees all orders; non-admin sees only their own
-    const customerId = user.role === 'admin' ? undefined : user.id;
+    const customerId = hasApiRole(user, 'admin') ? undefined : user.id;
     const filterOpts = { customerId, status };
     const [data, totalDocs] = await Promise.all([
       orderQueries.getAllOrders(db, { ...filterOpts, limit, offset }),
@@ -219,7 +220,7 @@ app.openapi(
     if (!order) throw new HTTPException(404, { message: 'Order not found' });
 
     // Non-admin can only view their own orders
-    if (user.role !== 'admin' && order.customerId !== user.id) {
+    if (!hasApiRole(user, 'admin') && order.customerId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
 
@@ -263,7 +264,8 @@ app.openapi(
     const db = c.get('db');
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-    if (user.role !== 'admin') throw new HTTPException(403, { message: 'Admin access required' });
+    if (!hasApiRole(user, 'admin'))
+      throw new HTTPException(403, { message: 'Admin access required' });
 
     const { id } = c.req.valid('param');
     const existing = await orderQueries.getOrderById(db, id);

--- a/apps/server/src/routes/content/orders.ts
+++ b/apps/server/src/routes/content/orders.ts
@@ -11,12 +11,12 @@ import * as orderQueries from '@revealui/db/queries/orders';
 import { ORDER_STATUSES } from '@revealui/db/schema/products';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../../lib/api-roles.js';
 import { asNonEmptyTuple } from '../../lib/type-guards.js';
 import { ErrorSchema, IdParam } from '../_helpers/content-schemas.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
-import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 

--- a/apps/server/src/routes/content/pages.ts
+++ b/apps/server/src/routes/content/pages.ts
@@ -21,6 +21,7 @@ import {
 } from '../_helpers/content-schemas.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
+import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -119,7 +120,7 @@ app.openapi(
       const data = await pageQueries.getPagesBySite(db, siteId, { status: 'published' });
       return c.json({ success: true as const, data: data.map(serializePage) }, 200);
     }
-    if (user.role !== 'admin' && site.ownerId !== user.id) {
+    if (!hasApiRole(user, 'admin') && site.ownerId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     const data = await pageQueries.getPagesBySite(db, siteId, { status });
@@ -185,7 +186,7 @@ app.openapi(
     }
     const existingSite = await siteQueries.getSiteById(db, siteId);
     if (!existingSite) throw new HTTPException(404, { message: 'Site not found' });
-    if (user.role !== 'admin' && existingSite.ownerId !== user.id) {
+    if (!hasApiRole(user, 'admin') && existingSite.ownerId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     const page = await pageQueries.createPage(db, {
@@ -229,7 +230,7 @@ app.openapi(
       }
       return c.json({ success: true as const, data: serializePage(page) }, 200);
     }
-    if (user.role !== 'admin') {
+    if (!hasApiRole(user, 'admin')) {
       const site = await siteQueries.getSiteById(db, page.siteId);
       if (!site || site.ownerId !== user.id) {
         throw new HTTPException(403, { message: 'Forbidden' });
@@ -287,7 +288,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const existing = await pageQueries.getPageById(db, id);
     if (!existing) throw new HTTPException(404, { message: 'Page not found' });
-    if (user.role !== 'admin') {
+    if (!hasApiRole(user, 'admin')) {
       const site = await siteQueries.getSiteById(db, existing.siteId);
       if (!site || site.ownerId !== user.id) {
         throw new HTTPException(403, { message: 'Forbidden' });
@@ -342,7 +343,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const existing = await pageQueries.getPageById(db, id);
     if (!existing) throw new HTTPException(404, { message: 'Page not found' });
-    if (user.role !== 'admin') {
+    if (!hasApiRole(user, 'admin')) {
       const site = await siteQueries.getSiteById(db, existing.siteId);
       if (!site || site.ownerId !== user.id) {
         throw new HTTPException(403, { message: 'Forbidden' });

--- a/apps/server/src/routes/content/pages.ts
+++ b/apps/server/src/routes/content/pages.ts
@@ -11,6 +11,7 @@ import * as pageQueries from '@revealui/db/queries/pages';
 import * as siteQueries from '@revealui/db/queries/sites';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../../lib/api-roles.js';
 import { asNonEmptyTuple } from '../../lib/type-guards.js';
 import {
   ErrorSchema,
@@ -21,7 +22,6 @@ import {
 } from '../_helpers/content-schemas.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
-import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 

--- a/apps/server/src/routes/content/posts.ts
+++ b/apps/server/src/routes/content/posts.ts
@@ -11,6 +11,7 @@ import { POST_STATUSES } from '@revealui/contracts/entities';
 import * as postQueries from '@revealui/db/queries/posts';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../../lib/api-roles.js';
 import { asNonEmptyTuple } from '../../lib/type-guards.js';
 import {
   ErrorSchema,
@@ -22,7 +23,6 @@ import {
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
-import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 

--- a/apps/server/src/routes/content/posts.ts
+++ b/apps/server/src/routes/content/posts.ts
@@ -22,6 +22,7 @@ import {
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
+import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -130,7 +131,7 @@ app.openapi(
       );
     }
     // Non-admin users can only read their own posts
-    const effectiveAuthorId = user.role === 'admin' ? authorId : user.id;
+    const effectiveAuthorId = hasApiRole(user, 'admin') ? authorId : user.id;
     const filterOpts = { status, authorId: effectiveAuthorId };
     const [data, totalDocs] = await Promise.all([
       postQueries.getAllPosts(db, { ...filterOpts, limit, offset }),
@@ -245,7 +246,7 @@ app.openapi(
       }
       return c.json({ success: true as const, data: serializePost(post) }, 200);
     }
-    if (user.role !== 'admin' && post.authorId !== user.id) {
+    if (!hasApiRole(user, 'admin') && post.authorId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     return c.json({ success: true as const, data: serializePost(post) }, 200);
@@ -283,7 +284,7 @@ app.openapi(
       }
       return c.json({ success: true as const, data: serializePost(post) }, 200);
     }
-    if (user.role !== 'admin' && post.authorId !== user.id) {
+    if (!hasApiRole(user, 'admin') && post.authorId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     return c.json({ success: true as const, data: serializePost(post) }, 200);
@@ -339,7 +340,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const existing = await postQueries.getPostById(db, id);
     if (!existing) throw new HTTPException(404, { message: 'Post not found' });
-    if (user.role !== 'admin' && existing.authorId !== user.id) {
+    if (!hasApiRole(user, 'admin') && existing.authorId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     const body = c.req.valid('json');
@@ -391,7 +392,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const existing = await postQueries.getPostById(db, id);
     if (!existing) throw new HTTPException(404, { message: 'Post not found' });
-    if (user.role !== 'admin' && existing.authorId !== user.id) {
+    if (!hasApiRole(user, 'admin') && existing.authorId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     await postQueries.deletePost(db, id);

--- a/apps/server/src/routes/content/products.ts
+++ b/apps/server/src/routes/content/products.ts
@@ -12,12 +12,12 @@ import * as productQueries from '@revealui/db/queries/products';
 import { PRODUCT_STATUSES } from '@revealui/db/schema/products';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../../lib/api-roles.js';
 import { asNonEmptyTuple } from '../../lib/type-guards.js';
 import { ErrorSchema, IdParam, SlugField } from '../_helpers/content-schemas.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
-import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 

--- a/apps/server/src/routes/content/products.ts
+++ b/apps/server/src/routes/content/products.ts
@@ -17,6 +17,7 @@ import { ErrorSchema, IdParam, SlugField } from '../_helpers/content-schemas.js'
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
+import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -133,7 +134,7 @@ app.openapi(
     }
 
     // Admin sees all; non-admin sees only published
-    const effectiveStatus = user.role === 'admin' ? status : 'published';
+    const effectiveStatus = hasApiRole(user, 'admin') ? status : 'published';
     const filterOpts = { status: effectiveStatus };
     const [data, totalDocs] = await Promise.all([
       productQueries.getAllProducts(db, { ...filterOpts, limit, offset }),
@@ -196,7 +197,8 @@ app.openapi(
     const db = c.get('db');
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-    if (user.role !== 'admin') throw new HTTPException(403, { message: 'Admin access required' });
+    if (!hasApiRole(user, 'admin'))
+      throw new HTTPException(403, { message: 'Admin access required' });
 
     const body = c.req.valid('json');
     const product = await productQueries.createProduct(db, {
@@ -242,7 +244,7 @@ app.openapi(
     }
 
     // Non-admin users can only see published products
-    if (user && user.role !== 'admin' && product.status !== 'published') {
+    if (user && !hasApiRole(user, 'admin') && product.status !== 'published') {
       throw new HTTPException(404, { message: 'Product not found' });
     }
 
@@ -295,7 +297,8 @@ app.openapi(
     const db = c.get('db');
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-    if (user.role !== 'admin') throw new HTTPException(403, { message: 'Admin access required' });
+    if (!hasApiRole(user, 'admin'))
+      throw new HTTPException(403, { message: 'Admin access required' });
 
     const { id } = c.req.valid('param');
     const existing = await productQueries.getProductById(db, id);
@@ -332,7 +335,8 @@ app.openapi(
     const db = c.get('db');
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-    if (user.role !== 'admin') throw new HTTPException(403, { message: 'Admin access required' });
+    if (!hasApiRole(user, 'admin'))
+      throw new HTTPException(403, { message: 'Admin access required' });
 
     const { id } = c.req.valid('param');
     const existing = await productQueries.getProductById(db, id);

--- a/apps/server/src/routes/content/sessions.ts
+++ b/apps/server/src/routes/content/sessions.ts
@@ -237,7 +237,7 @@ function applyDraftPatch(draft: Record<string, unknown>, path: string, value: un
       throw pathError(segments.slice(1).join('.'), 'theme paths are theme.<token> only');
     }
     const token = segments[1];
-    if (!token || !EDITABLE_THEME_TOKEN_NAMES.has(token)) {
+    if (!(token && EDITABLE_THEME_TOKEN_NAMES.has(token))) {
       throw pathError(token ?? 'theme', 'not an allowlisted design token');
     }
     if (typeof value !== 'string') {

--- a/apps/server/src/routes/content/sites.ts
+++ b/apps/server/src/routes/content/sites.ts
@@ -15,6 +15,7 @@ import { ErrorSchema, IdParam, SlugField } from '../_helpers/content-schemas.js'
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
+import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
@@ -192,7 +193,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const site = await siteQueries.getSiteById(db, id);
     if (!site) throw new HTTPException(404, { message: 'Site not found' });
-    if (user.role !== 'admin' && site.ownerId !== user.id) {
+    if (!hasApiRole(user, 'admin') && site.ownerId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     return c.json({ success: true as const, data: serializeSite(site) }, 200);
@@ -240,7 +241,7 @@ app.openapi(
     const body = c.req.valid('json');
     const existing = await siteQueries.getSiteById(db, id);
     if (!existing) throw new HTTPException(404, { message: 'Site not found' });
-    if (user.role !== 'admin' && existing.ownerId !== user.id) {
+    if (!hasApiRole(user, 'admin') && existing.ownerId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     const site = await siteQueries.updateSite(db, id, body);
@@ -276,7 +277,7 @@ app.openapi(
     const { id } = c.req.valid('param');
     const existing = await siteQueries.getSiteById(db, id);
     if (!existing) throw new HTTPException(404, { message: 'Site not found' });
-    if (user.role !== 'admin' && existing.ownerId !== user.id) {
+    if (!hasApiRole(user, 'admin') && existing.ownerId !== user.id) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
     await siteQueries.deleteSite(db, id);

--- a/apps/server/src/routes/content/sites.ts
+++ b/apps/server/src/routes/content/sites.ts
@@ -10,12 +10,12 @@ import { cleanupVectorDataForSite } from '@revealui/db/cleanup';
 import * as siteQueries from '@revealui/db/queries/sites';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../../lib/api-roles.js';
 import { asNonEmptyTuple } from '../../lib/type-guards.js';
 import { ErrorSchema, IdParam, SlugField } from '../_helpers/content-schemas.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString, nullableDateToString } from '../_helpers/serialize.js';
 import type { ContentVariables } from './index.js';
-import { hasApiRole } from '../../lib/api-roles.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 

--- a/apps/server/src/routes/cron/reconcile-entitlements.ts
+++ b/apps/server/src/routes/cron/reconcile-entitlements.ts
@@ -262,6 +262,7 @@ app.post('/reconcile-entitlements', async (c) => {
       // event win and re-open the WH-3 window PR-1 closed.
       lastEventAt: missing ? null : (row.entLastEventAt ?? null),
       now,
+      source: 'reconciler',
     });
 
     if (missing) {

--- a/apps/server/src/routes/marketplace.ts
+++ b/apps/server/src/routes/marketplace.ts
@@ -28,6 +28,7 @@ import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { createSafeFetch } from '@revealui/security/server';
 import { and, asc, eq, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../lib/api-roles.js';
 import { getServices, type ProtectedStripe } from '../lib/services-loader.js';
 import { authMiddleware } from '../middleware/auth.js';
 import {
@@ -516,7 +517,7 @@ app.openapi(
     if (!existing) throw new HTTPException(404, { message: 'Server not found' });
 
     // Only the developer who published it (or an admin) can unpublish
-    if (existing.developerId !== user.id && user.role !== 'admin') {
+    if (existing.developerId !== user.id && !hasApiRole(user, 'admin')) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
 

--- a/apps/server/src/routes/rag-index.ts
+++ b/apps/server/src/routes/rag-index.ts
@@ -15,6 +15,7 @@ import { ragDocuments } from '@revealui/db/schema/rag';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, count, eq, isNotNull, max } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../lib/api-roles.js';
 
 type Variables = {
   db: DatabaseClient;
@@ -32,7 +33,7 @@ function assertWorkspaceAccess(
     throw new HTTPException(401, { message: 'Authentication required' });
   }
   // In multi-tenant mode, workspaceId must match the tenant context (admin bypass)
-  if (tenant && workspaceId !== tenant.id && user.role !== 'admin') {
+  if (tenant && workspaceId !== tenant.id && !hasApiRole(user, 'admin')) {
     throw new HTTPException(403, { message: 'Access denied for this workspace' });
   }
 }

--- a/apps/server/src/routes/revmarket.ts
+++ b/apps/server/src/routes/revmarket.ts
@@ -46,6 +46,7 @@ import {
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, desc, eq, ilike, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { hasApiRole } from '../lib/api-roles.js';
 import { authMiddleware } from '../middleware/auth.js';
 import {
   buildPaymentRequired,
@@ -55,7 +56,6 @@ import {
   verifyPayment,
 } from '../middleware/x402.js';
 import { getExecutorStatus, getTaskProgress } from '../services/revmarket-executor.js';
-import { hasApiRole } from '../lib/api-roles.js';
 
 // =============================================================================
 // Helpers

--- a/apps/server/src/routes/revmarket.ts
+++ b/apps/server/src/routes/revmarket.ts
@@ -55,6 +55,7 @@ import {
   verifyPayment,
 } from '../middleware/x402.js';
 import { getExecutorStatus, getTaskProgress } from '../services/revmarket-executor.js';
+import { hasApiRole } from '../lib/api-roles.js';
 
 // =============================================================================
 // Helpers
@@ -394,7 +395,7 @@ app.openapi(
       .limit(1);
 
     if (!existing) throw new HTTPException(404, { message: 'Agent not found' });
-    if (existing.publisherId !== user.id && user.role !== 'admin') {
+    if (existing.publisherId !== user.id && !hasApiRole(user, 'admin')) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
 
@@ -463,7 +464,7 @@ app.openapi(
       .limit(1);
 
     if (!existing) throw new HTTPException(404, { message: 'Agent not found' });
-    if (existing.publisherId !== user.id && user.role !== 'admin') {
+    if (existing.publisherId !== user.id && !hasApiRole(user, 'admin')) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
 
@@ -553,7 +554,7 @@ app.openapi(
       .limit(1);
 
     if (!agent) throw new HTTPException(404, { message: 'Agent not found' });
-    if (agent.publisherId !== user.id && user.role !== 'admin') {
+    if (agent.publisherId !== user.id && !hasApiRole(user, 'admin')) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
 
@@ -802,7 +803,7 @@ app.openapi(
       .limit(1);
 
     if (!task) throw new HTTPException(404, { message: 'Task not found' });
-    if (task.submitterId !== user.id && user.role !== 'admin') {
+    if (task.submitterId !== user.id && !hasApiRole(user, 'admin')) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
 
@@ -871,7 +872,7 @@ app.openapi(
       .limit(1);
 
     if (!task) throw new HTTPException(404, { message: 'Task not found' });
-    if (task.submitterId !== user.id && user.role !== 'admin') {
+    if (task.submitterId !== user.id && !hasApiRole(user, 'admin')) {
       throw new HTTPException(403, { message: 'Forbidden' });
     }
 
@@ -1176,7 +1177,7 @@ app.openapi(
   async (c) => {
     const user = c.get('user');
     if (!user) throw new HTTPException(401, { message: 'Unauthorized' });
-    if (user.role !== 'admin') throw new HTTPException(403, { message: 'Admin only' });
+    if (!hasApiRole(user, 'admin')) throw new HTTPException(403, { message: 'Admin only' });
 
     return c.json(getExecutorStatus());
   },

--- a/apps/server/src/routes/webhooks.ts
+++ b/apps/server/src/routes/webhooks.ts
@@ -765,6 +765,7 @@ async function syncHostedSubscriptionState(
     graceUntil: params.graceUntil ?? null,
     lastEventAt: params.eventTimestamp ?? null,
     now,
+    source: 'stripe',
   });
 
   let entitlementApplied = false;

--- a/packages/db/migrations/0033_gap444_entitlement_source.sql
+++ b/packages/db/migrations/0033_gap444_entitlement_source.sql
@@ -1,0 +1,10 @@
+-- GAP-444: entitlement source marker so gifted (grant) accounts do not pollute MRR.
+-- stripe = Stripe webhook path; grant = admin CLI / manual gift; reconciler = heal path.
+-- Default 'stripe' keeps existing paid rows honest; re-run grant-entitlement to mark comps.
+
+ALTER TABLE "account_entitlements" ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'stripe' NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "account_entitlements" ADD CONSTRAINT "account_entitlements_source_check" CHECK (source IN ('stripe', 'grant', 'reconciler'));
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -104,6 +104,12 @@
       "rationale": "GAP-260 P4-5: CREATE TABLE license_jti_revocations for per-token (jti) denylist revocation without rotating the vendor Ed25519 key. Hand-written CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS for idempotency, following the 0010/0021/0025 table-creation precedent. Companion Drizzle schema at packages/db/src/schema/license-jti-revocations.ts; app-layer sticky denylist at packages/db/src/license-jti-denylist.ts (fail-open for unknown jtis, sticky once observed revoked).",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. Schema modeled for ORM typing; denylist writes/reads go through Drizzle."
+    },
+    {
+      "tag": "0033_gap444_entitlement_source",
+      "rationale": "GAP-444: ADD COLUMN account_entitlements.source (text NOT NULL DEFAULT 'stripe') + CHECK (stripe|grant|reconciler) so gifted entitlements can be excluded from MRR. Hand-written with ADD COLUMN IF NOT EXISTS + DO $$ ADD CONSTRAINT ... EXCEPTION WHEN duplicate_object for idempotency, following the 0023/0015 column+check precedent. Companion Drizzle schema change at packages/db/src/schema/accounts.ts models source + check + index; buildHostedEntitlementValues locksteps stripe/grant/reconciler writers.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as prior entries: `pnpm --filter @revealui/db db:generate` against a clean DB once the broader snapshot-debt backfill happens. Schema at accounts.ts already reflects source at the type level."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1785250000000,
       "tag": "0032_gap260_license_jti_revocations",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1785330000000,
+      "tag": "0033_gap444_entitlement_source",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/accounts.ts
+++ b/packages/db/src/schema/accounts.ts
@@ -128,6 +128,8 @@ export const accountEntitlements = pgTable(
       .default({}),
     meteringStatus: text('metering_status').notNull().default('active'),
     mode: text('mode').notNull().default('live'),
+    // GAP-444: paid vs gifted vs reconciler-heal. MRR excludes source='grant'.
+    source: text('source').notNull().default('stripe'),
     graceUntil: timestamp('grace_until', { withTimezone: true }),
     lastEventAt: timestamp('last_event_at', { withTimezone: true }),
     updatedAt: timestamp('updated_at', { withTimezone: true })
@@ -140,6 +142,7 @@ export const accountEntitlements = pgTable(
     index('account_entitlements_status_idx').on(table.status),
     index('account_entitlements_account_status_idx').on(table.accountId, table.status),
     index('account_entitlements_mode_idx').on(table.mode),
+    index('account_entitlements_source_idx').on(table.source),
     check('account_entitlements_tier_check', sql`tier IN ('free', 'pro', 'max', 'enterprise')`),
     check(
       'account_entitlements_status_check',
@@ -150,6 +153,7 @@ export const accountEntitlements = pgTable(
       sql`metering_status IN ('active', 'paused', 'exceeded')`,
     ),
     check('account_entitlements_mode_check', sql`mode IN ('live', 'test')`),
+    check('account_entitlements_source_check', sql`source IN ('stripe', 'grant', 'reconciler')`),
   ],
 );
 

--- a/scripts/admin/grant-entitlement.ts
+++ b/scripts/admin/grant-entitlement.ts
@@ -212,6 +212,8 @@ async function main(): Promise<void> {
     // stale replayed event cannot win.
     lastEventAt: existing ? (existing.lastEventAt ?? null) : null,
     now: new Date(),
+    // GAP-444: gifted rows must not count as Stripe revenue in MRR.
+    source: 'grant',
   });
 
   console.log(


### PR DESCRIPTION
## Summary

Implements **GAP-444**:

1. **Platform super-admin on the Hono API** — `isPlatformSuperAdmin` / `hasApiRole` read `_json.roles` (requires `emailVerified`), elevate to `admin`/`owner` gates only. Device-token auth now selects `_json` + `emailVerified`. `requireRole` and server admin checks use the helper.
2. **Entitlement `source` column** — migration `0033` (`stripe` | `grant` | `reconciler`). `buildHostedEntitlementValues` locksteps writers; grant CLI sets `grant`; webhooks `stripe`; reconciler `reconciler`.
3. **MRR honesty** — `/billing/metrics` tier breakdown counts only `status=active`, `mode=live`, and `source <> grant`.

## Tests

- `api-roles.test.ts` (7)
- `hosted-entitlement-source.test.ts` (3)
- `billing-metrics.test.ts` (21, including super-admin access)

## Operator follow-up

- Deploy runs migration 0033.
- Re-run `pnpm admin:grant-entitlement` for existing gifted accounts so `source` flips from default `stripe` to `grant` (otherwise they still count in MRR until re-granted).

## GAP close

Leave GAP-444 open until this lands on `test` (and optionally re-grant comps). Planning close is a separate jv PR after merge.

