### PR TITLE
feat(router): 2.2.3 RSC client nav — payload fetch, abort, hooks

### DIFF
--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -22,7 +22,7 @@ plugin-rsc; Phase 2.2.2 T0–T7 built the engine; **T8** is the first real consu
 | `src/app-router.ts` | `new Router({ rsc: {} })` + three demo routes + layout |
 | `src/entry.rsc.tsx` | `renderRequest` + `createRscStream` (plugin-rsc) + `x-rsc-action` |
 | `src/entry.ssr.tsx` | SSR from teed flight; payload inline owned by router |
-| `src/entry.browser.tsx` | Hydrate + `RouterProvider` + click/popstate RSC fetch (no History patch) |
+| `src/entry.browser.tsx` | Hydrate + `setRscPayloadLoader` + `useRscPayload` (2.2.3 router-owned nav) |
 | `src/pages/*` | Demo pages + server actions |
 
 ## Commands

--- a/apps/rsc-poc/src/entry.browser.tsx
+++ b/apps/rsc-poc/src/entry.browser.tsx
@@ -1,13 +1,17 @@
 /**
- * Browser entry — hydrate from `__RSC_PAYLOAD__`, re-fetch flight on navigation.
- *
- * D3: no `history.pushState` monkey-patch. Interception is click/popstate only
- * (same ownership model as `@revealui/router` `initClient`). Full router-owned
- * RSC payload state lands in 2.2.3; this entry is the consumer-side pattern.
+ * Browser entry — hydrate from `__RSC_PAYLOAD__`, soft-nav via router-owned RSC
+ * fetch (Phase 2.2.3 / ADR D3). No History monkey-patch; no local click listener.
  */
 'use client';
 
-import { RouterProvider } from '@revealui/router';
+import {
+  Link,
+  RouterProvider,
+  useNavigationError,
+  useNavigationStatus,
+  useRscPayload,
+} from '@revealui/router';
+import { RSC_ACCEPT } from '@revealui/router/core';
 import {
   createFromFetch,
   createFromReadableStream,
@@ -23,11 +27,14 @@ import type { RscPayload } from './entry.rsc.tsx';
 const router = createAppRouter();
 
 async function main(): Promise<void> {
-  let setPayload: ((v: RscPayload) => void) | undefined;
-
-  async function fetchRscPayload(url: string): Promise<RscPayload> {
-    return createFromFetch<RscPayload>(fetch(url, { headers: { accept: 'text/x-component' } }));
-  }
+  router.setRscPayloadLoader(async (url, signal) => {
+    return createFromFetch<RscPayload>(
+      fetch(url, {
+        headers: { accept: RSC_ACCEPT },
+        signal,
+      }),
+    );
+  });
 
   const rscBase64 = (globalThis as Record<string, unknown>).__RSC_PAYLOAD__ as string | undefined;
 
@@ -42,29 +49,56 @@ async function main(): Promise<void> {
     });
     initialPayload = await createFromReadableStream<RscPayload>(rscStream);
   } else {
-    initialPayload = await fetchRscPayload(window.location.href);
+    initialPayload = await createFromFetch<RscPayload>(
+      fetch(window.location.href, { headers: { accept: RSC_ACCEPT } }),
+    );
   }
 
-  // Seed match so client hooks see the SSR route without re-running loaders.
-  const initialPath = window.location.pathname;
-  router.seedCurrentMatch(router.match(initialPath));
+  router.seedCurrentMatch(router.match(window.location.pathname));
+  router.applyRscPayload(initialPayload);
+  router.initClient();
 
   function BrowserRoot(): React.ReactNode {
-    const [payload, setPayload_] = React.useState(initialPayload);
+    const payload = useRscPayload<RscPayload>();
+    const status = useNavigationStatus();
+    const navError = useNavigationError();
 
-    React.useEffect(() => {
-      setPayload = (v) => React.startTransition(() => setPayload_(v));
-    }, []);
+    if (!payload) {
+      return <div>Loading…</div>;
+    }
 
-    React.useEffect(() => {
-      return listenNavigation(() => {
-        const path = window.location.pathname;
-        router.seedCurrentMatch(router.match(path));
-        fetchRscPayload(window.location.href).then((p) => setPayload?.(p));
-      });
-    }, []);
-
-    return <RouterProvider router={router}>{payload.root}</RouterProvider>;
+    return (
+      <>
+        {status === 'loading' ? (
+          <div
+            data-router-nav="loading"
+            style={{
+              position: 'fixed',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 2,
+              background: '#3b82f6',
+              zIndex: 50,
+            }}
+          />
+        ) : null}
+        {status === 'error' && navError ? (
+          <div
+            data-router-nav="error"
+            style={{
+              padding: '8px 16px',
+              background: '#fef2f2',
+              borderBottom: '1px solid #fecaca',
+              color: '#991b1b',
+            }}
+          >
+            Navigation failed: {navError.message} <Link to={window.location.pathname}>Retry</Link>
+          </div>
+        ) : null}
+        {payload.root}
+      </>
+    );
   }
 
   setServerCallback(async (id: string, args: unknown[]) => {
@@ -72,7 +106,7 @@ async function main(): Promise<void> {
     const body = await encodeReply(args, { temporaryReferences });
     const headers: Record<string, string> = {
       'x-rsc-action': id,
-      accept: 'text/x-component',
+      accept: RSC_ACCEPT,
     };
     if (typeof body === 'string') {
       headers['content-type'] = 'text/plain;charset=UTF-8';
@@ -85,7 +119,8 @@ async function main(): Promise<void> {
       }),
       { temporaryReferences },
     );
-    setPayload?.(payload);
+    // Action already returned a fresh tree — apply without a second GET.
+    router.applyRscPayload(payload);
     const rv = payload.returnValue;
     if (!rv) return undefined;
     if (!rv.ok) throw rv.data;
@@ -94,7 +129,9 @@ async function main(): Promise<void> {
 
   const browserRoot = (
     <React.StrictMode>
-      <BrowserRoot />
+      <RouterProvider router={router}>
+        <BrowserRoot />
+      </RouterProvider>
     </React.StrictMode>
   );
 
@@ -109,48 +146,9 @@ async function main(): Promise<void> {
 
   if (import.meta.hot) {
     import.meta.hot.on('rsc:update', () => {
-      fetchRscPayload(window.location.href).then((p) => setPayload?.(p));
+      void router.refreshRscPayload(true);
     });
   }
-}
-
-/**
- * Same-origin soft navigation: click + popstate only (no History API patch — D3).
- */
-function listenNavigation(onNavigation: () => void): () => void {
-  window.addEventListener('popstate', onNavigation);
-
-  function onClick(e: MouseEvent): void {
-    const link = (e.target as Element).closest('a');
-    if (
-      link instanceof HTMLAnchorElement &&
-      link.href &&
-      (!link.target || link.target === '_self') &&
-      link.origin === location.origin &&
-      !link.hasAttribute('download') &&
-      e.button === 0 &&
-      !e.metaKey &&
-      !e.ctrlKey &&
-      !e.altKey &&
-      !e.shiftKey &&
-      !e.defaultPrevented
-    ) {
-      e.preventDefault();
-      const url = new URL(link.href);
-      const next = url.pathname + url.search + url.hash;
-      const current = window.location.pathname + window.location.search + window.location.hash;
-      if (next === current) return;
-      window.history.pushState(null, '', next);
-      onNavigation();
-    }
-  }
-
-  document.addEventListener('click', onClick);
-
-  return () => {
-    document.removeEventListener('click', onClick);
-    window.removeEventListener('popstate', onNavigation);
-  };
 }
 
 main();

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -354,6 +354,37 @@ Default `new Router()` (no `rsc` option) is the 0.3.x SPA contract used by
 `src/__tests__/client-mode-compat.test.tsx` (export surface, navigate without
 loaders, 0.3.10 scroll behavior, hooks composition).
 
+## RSC client navigation (2.2.3 / D3)
+
+In `'rsc'` mode, soft navigations fetch flight payloads via a pluggable loader:
+
+```typescript
+import { Router, RouterProvider, useRscPayload, useNavigationStatus } from '@revealui/router'
+import { RSC_ACCEPT } from '@revealui/router/core'
+
+const router = new Router({ rsc: {} })
+router.setRscPayloadLoader(async (url, signal) =>
+  createFromFetch(fetch(url, { headers: { accept: RSC_ACCEPT }, signal })),
+)
+router.applyRscPayload(initialPayload) // SSR hydrate seed
+router.initClient() // popstate + <a> intercept → navigate → fetch
+
+function App() {
+  const payload = useRscPayload<{ root: React.ReactNode }>()
+  const status = useNavigationStatus()
+  return (
+    <RouterProvider router={router}>
+      {status === 'loading' ? <Progress /> : null}
+      {payload?.root}
+    </RouterProvider>
+  )
+}
+```
+
+- New navigations **abort** the previous fetch (`AbortSignal` token).
+- `navigate(to, { skipRscFetch: true })` when a server action already applied a payload.
+- `useNavigationError()` surfaces loader failures.
+
 ## Dev Server
 
 Quick development server:

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.3",
+  "version": "0.4.0-rc.4",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",

--- a/packages/router/src/__tests__/rsc-client-nav.test.ts
+++ b/packages/router/src/__tests__/rsc-client-nav.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Phase 2.2.3 — RSC client navigation (ADR D3).
+ * Client mode must stay byte-compatible; RSC mode fetches via pluggable loader.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveRscClientUrl } from '../negotiate.js';
+import { Router } from '../router.js';
+import type { Route } from '../types.js';
+
+afterEach(() => {
+  window.history.pushState(null, '', '/');
+  const r = new Router();
+  r.dispose();
+});
+
+function createRoute(path: string): Route {
+  return { path, component: () => null };
+}
+
+describe('resolveRscClientUrl', () => {
+  it('uses same-origin path when no endpoint', () => {
+    expect(resolveRscClientUrl('/about', '?q=1', {}, 'http://x')).toBe('http://x/about?q=1');
+  });
+
+  it('prefixes endpoint escape hatch', () => {
+    expect(resolveRscClientUrl('/posts/1', '', { endpoint: '/.rsc' }, 'http://x')).toBe(
+      'http://x/.rsc/posts/1',
+    );
+    expect(resolveRscClientUrl('/', '', { endpoint: '/.rsc' }, 'http://x')).toBe('http://x/.rsc');
+  });
+});
+
+describe('RSC client navigation (2.2.3)', () => {
+  it('does not fetch in client mode', async () => {
+    const loader = vi.fn().mockResolvedValue({ root: 'x' });
+    const router = new Router();
+    router.setRscPayloadLoader(loader);
+    router.register(createRoute('/about'));
+    router.navigate('/about');
+    await Promise.resolve();
+    expect(loader).not.toHaveBeenCalled();
+    expect(router.getNavigationStatus()).toBe('idle');
+  });
+
+  it('fetches payload on navigate in rsc mode', async () => {
+    const payload = { root: 'about-page' };
+    const loader = vi.fn().mockResolvedValue(payload);
+    const router = new Router({ rsc: {} });
+    router.setRscPayloadLoader(loader);
+    router.register(createRoute('/'));
+    router.register(createRoute('/about'));
+    router.applyRscPayload({ root: 'home' });
+
+    const rscListener = vi.fn();
+    router.subscribeRsc(rscListener);
+
+    router.navigate('/about');
+    expect(router.getNavigationStatus()).toBe('loading');
+    expect(rscListener).toHaveBeenCalled();
+
+    await vi.waitFor(() => {
+      expect(router.getNavigationStatus()).toBe('idle');
+    });
+    expect(loader).toHaveBeenCalledOnce();
+    const [url, signal] = loader.mock.calls[0] as [string, AbortSignal];
+    expect(url).toContain('/about');
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(router.getRscPayload()).toEqual(payload);
+  });
+
+  it('aborts prior fetch when a newer navigate starts (D3 token)', async () => {
+    let resolveFirst: (v: unknown) => void = () => {};
+    const first = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    const loader = vi
+      .fn()
+      .mockImplementationOnce((_url: string, signal: AbortSignal) => {
+        return new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+          first.then(resolve);
+        });
+      })
+      .mockResolvedValueOnce({ root: 'second' });
+
+    const router = new Router({ rsc: {} });
+    router.setRscPayloadLoader(loader);
+    router.register(createRoute('/a'));
+    router.register(createRoute('/b'));
+    router.applyRscPayload({ root: 'home' });
+
+    router.navigate('/a');
+    router.navigate('/b');
+    resolveFirst({ root: 'first' });
+
+    await vi.waitFor(() => {
+      expect(router.getRscPayload()).toEqual({ root: 'second' });
+    });
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(router.getNavigationStatus()).toBe('idle');
+  });
+
+  it('records navigation error from loader failure', async () => {
+    const loader = vi.fn().mockRejectedValue(new Error('flight failed'));
+    const router = new Router({ rsc: {} });
+    router.setRscPayloadLoader(loader);
+    router.register(createRoute('/about'));
+    router.applyRscPayload({ root: 'home' });
+
+    router.navigate('/about');
+    await vi.waitFor(() => {
+      expect(router.getNavigationStatus()).toBe('error');
+    });
+    expect(router.getNavigationError()?.message).toBe('flight failed');
+  });
+
+  it('skipRscFetch leaves payload untouched', async () => {
+    const loader = vi.fn().mockResolvedValue({ root: 'new' });
+    const router = new Router({ rsc: {} });
+    router.setRscPayloadLoader(loader);
+    router.register(createRoute('/about'));
+    router.applyRscPayload({ root: 'home' });
+
+    router.navigate('/about', { skipRscFetch: true });
+    await Promise.resolve();
+    expect(loader).not.toHaveBeenCalled();
+    expect(router.getRscPayload()).toEqual({ root: 'home' });
+    expect(router.getCurrentMatch()?.route.path).toBe('/about');
+  });
+
+  it('popstate triggers RSC refresh after initClient', async () => {
+    const loader = vi.fn().mockResolvedValue({ root: 'from-pop' });
+    const router = new Router({ rsc: {} });
+    router.setRscPayloadLoader(loader);
+    router.register(createRoute('/'));
+    router.register(createRoute('/about'));
+    router.applyRscPayload({ root: 'home' });
+    router.initClient();
+
+    window.history.pushState(null, '', '/about');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    await vi.waitFor(() => {
+      expect(loader).toHaveBeenCalled();
+    });
+    expect(router.getCurrentMatch()?.route.path).toBe('/about');
+    router.dispose();
+  });
+
+  it('does not re-fetch when path+search unchanged (hash-only)', async () => {
+    const loader = vi.fn().mockResolvedValue({ root: 'x' });
+    const router = new Router({ rsc: {} });
+    router.setRscPayloadLoader(loader);
+    router.register(createRoute('/about'));
+    router.applyRscPayload({ root: 'home' });
+    // Seed fetch key as if we already have /about payload
+    window.history.pushState(null, '', '/about');
+    router.applyRscPayload({ root: 'about' });
+    loader.mockClear();
+
+    router.navigate('/about#section');
+    await Promise.resolve();
+    expect(loader).not.toHaveBeenCalled();
+    expect(router.getRscPayload()).toEqual({ root: 'about' });
+  });
+});

--- a/packages/router/src/components.tsx
+++ b/packages/router/src/components.tsx
@@ -9,7 +9,7 @@ import {
   useSyncExternalStore,
 } from 'react';
 import type { Router } from './router';
-import type { Location, NavigateOptions, RouteMatch } from './types';
+import type { Location, NavigateOptions, NavigationStatus, RouteMatch } from './types';
 
 /**
  * Router context
@@ -218,6 +218,43 @@ export function useLocation(): Location {
 export function useSearchParams(): URLSearchParams {
   const { search } = useLocation();
   return useMemo(() => new URLSearchParams(search), [search]);
+}
+
+/**
+ * useRscPayload — current RSC flight payload (Phase 2.2.3 / ADR D3).
+ * Requires `setRscPayloadLoader` + `applyRscPayload` on the router instance.
+ */
+export function useRscPayload<T = unknown>(): T | null {
+  const router = useRouter();
+  return useSyncExternalStore(
+    (callback) => router.subscribeRsc(callback),
+    () => router.getRscPayload() as T | null,
+    () => router.getRscPayload() as T | null,
+  );
+}
+
+/**
+ * useNavigationStatus — idle | loading | error for RSC soft navigations.
+ */
+export function useNavigationStatus(): NavigationStatus {
+  const router = useRouter();
+  return useSyncExternalStore(
+    (callback) => router.subscribeRsc(callback),
+    () => router.getNavigationStatus(),
+    () => router.getNavigationStatus(),
+  );
+}
+
+/**
+ * useNavigationError — last RSC navigation error, or null.
+ */
+export function useNavigationError(): Error | null {
+  const router = useRouter();
+  return useSyncExternalStore(
+    (callback) => router.subscribeRsc(callback),
+    () => router.getNavigationError(),
+    () => router.getNavigationError(),
+  );
 }
 
 /**

--- a/packages/router/src/core.ts
+++ b/packages/router/src/core.ts
@@ -3,11 +3,14 @@
  * Does not import React context/hooks (those live in `./components`).
  * Use this from dual-mode route tables shared by server and browser entries.
  */
+
+export { RSC_ACCEPT, resolveRscClientUrl } from './negotiate';
 export { Router } from './router';
 export type {
   Location,
   MiddlewareContext,
   NavigateOptions,
+  NavigationStatus,
   Route,
   RouteMatch,
   RouteMeta,
@@ -16,4 +19,5 @@ export type {
   RouterMode,
   RouterOptions,
   RouterRscOptions,
+  RscPayloadLoader,
 } from './types';

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -47,10 +47,15 @@ export {
   useLocation,
   useMatch,
   useNavigate,
+  useNavigationError,
+  useNavigationStatus,
   useParams,
   useRouter,
+  useRscPayload,
   useSearchParams,
 } from './components';
+// Client RSC helpers (also on ./server for parity)
+export { RSC_ACCEPT, resolveRscClientUrl } from './negotiate';
 // Core router
 export { Router } from './router';
 
@@ -59,6 +64,7 @@ export type {
   Location,
   MiddlewareContext,
   NavigateOptions,
+  NavigationStatus,
   Route,
   RouteMatch,
   RouteMeta,
@@ -67,4 +73,5 @@ export type {
   RouterMode,
   RouterOptions,
   RouterRscOptions,
+  RscPayloadLoader,
 } from './types';

--- a/packages/router/src/negotiate.ts
+++ b/packages/router/src/negotiate.ts
@@ -62,3 +62,25 @@ export function routingPathname(request: Request, rsc?: RouterRscOptions): strin
   const url = new URL(request.url);
   return resolveRscEndpointPath(url.pathname, rsc?.endpoint).pathname;
 }
+
+/**
+ * Absolute URL the browser should request for an RSC soft navigation (2.2.3).
+ * Default: same resource path (content negotiation via `Accept`).
+ * With `endpoint`: prefix the path so the server forces RSC representation.
+ */
+export function resolveRscClientUrl(
+  pathname: string,
+  search = '',
+  rsc?: RouterRscOptions,
+  origin?: string,
+): string {
+  const base = origin ?? (typeof window !== 'undefined' ? window.location.origin : '');
+  const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const q = search && !search.startsWith('?') ? `?${search}` : search;
+  if (!rsc?.endpoint) {
+    return `${base}${path}${q}`;
+  }
+  const prefix = rsc.endpoint.endsWith('/') ? rsc.endpoint.slice(0, -1) : rsc.endpoint;
+  const prefixed = path === '/' ? prefix : `${prefix}${path}`;
+  return `${base}${prefixed}${q}`;
+}

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -2,16 +2,23 @@ import { logger } from '@revealui/utils/logger';
 import type React from 'react';
 import { createElement } from 'react';
 import { isRouterNotFound, isRouterRedirect } from './navigation';
-import { negotiateRepresentation, type Representation, routingPathname } from './negotiate';
+import {
+  negotiateRepresentation,
+  type Representation,
+  resolveRscClientUrl,
+  routingPathname,
+} from './negotiate';
 import type {
   MiddlewareContext,
   NavigateOptions,
+  NavigationStatus,
   Route,
   RouteMatch,
   RouteMiddleware,
   RouteParams,
   RouterMode,
   RouterOptions,
+  RscPayloadLoader,
 } from './types';
 
 declare global {
@@ -118,10 +125,20 @@ export class Router {
   private actionMiddleware: RouteMiddleware[] = [];
   private options: RouterOptions;
   private listeners: Set<() => void> = new Set();
+  /** RSC payload + nav-status subscribers (Phase 2.2.3 / D3). */
+  private rscListeners: Set<() => void> = new Set();
   private currentMatch: RouteMatch | null = null;
   private lastPathname: string | null = null;
   private popstateHandler: (() => void) | null = null;
   private clickHandler: ((e: MouseEvent) => void) | null = null;
+  private rscPayloadLoader: RscPayloadLoader | null = null;
+  private rscPayload: unknown = null;
+  private navigationStatus: NavigationStatus = 'idle';
+  private navigationError: Error | null = null;
+  /** AbortController for in-flight RSC fetch (D3 navigation token). */
+  private navigationAbort: AbortController | null = null;
+  /** Last path+search we issued an RSC fetch for (skip hash-only / duplicate). */
+  private lastRscFetchKey: string | null = null;
 
   constructor(options: RouterOptions = {}) {
     this.options = {
@@ -330,7 +347,9 @@ export class Router {
   }
 
   /**
-   * Navigate to a URL (client-side only)
+   * Navigate to a URL (client-side only).
+   * In `'rsc'` mode with a payload loader set (2.2.3), also fetches the flight
+   * payload after history update (ADR D3). Client mode is unchanged (0.3.x).
    */
   navigate(url: string, options: NavigateOptions = {}): void {
     if (typeof window === 'undefined') {
@@ -358,6 +377,102 @@ export class Router {
     // native scroll restoration (scrollRestoration = 'auto') handles those.
     if (!url.includes('#')) {
       window.scrollTo(0, 0);
+    }
+
+    if (this.mode === 'rsc' && !options.skipRscFetch) {
+      void this.refreshRscPayload();
+    }
+  }
+
+  /**
+   * Install the pluggable RSC payload loader (ADR D11). Required for soft
+   * navigation in `'rsc'` mode. No-op for client mode.
+   */
+  setRscPayloadLoader(loader: RscPayloadLoader | null): void {
+    this.rscPayloadLoader = loader;
+  }
+
+  /**
+   * Seed or replace the current RSC payload without a network fetch
+   * (SSR hydrate, server-action return, HMR).
+   */
+  applyRscPayload(payload: unknown): void {
+    this.rscPayload = payload;
+    this.navigationStatus = 'idle';
+    this.navigationError = null;
+    if (typeof window !== 'undefined') {
+      this.lastRscFetchKey = window.location.pathname + window.location.search;
+    }
+    this.notifyRscListeners();
+  }
+
+  getRscPayload(): unknown {
+    return this.rscPayload;
+  }
+
+  getNavigationStatus(): NavigationStatus {
+    return this.navigationStatus;
+  }
+
+  getNavigationError(): Error | null {
+    return this.navigationError;
+  }
+
+  /**
+   * Subscribe to RSC payload / navigation-status changes (useSyncExternalStore).
+   */
+  subscribeRsc(listener: () => void): () => void {
+    this.rscListeners.add(listener);
+    return () => {
+      this.rscListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Fetch RSC payload for the current browser location (or a forced key).
+   * Cancels any in-flight fetch (D3 navigation token).
+   */
+  async refreshRscPayload(force = false): Promise<void> {
+    if (this.mode !== 'rsc' || !this.rscPayloadLoader) {
+      return;
+    }
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const key = window.location.pathname + window.location.search;
+    if (!force && key === this.lastRscFetchKey && this.navigationStatus !== 'error') {
+      // Hash-only change or duplicate notify — keep existing payload.
+      return;
+    }
+
+    this.navigationAbort?.abort();
+    const ac = new AbortController();
+    this.navigationAbort = ac;
+    this.navigationStatus = 'loading';
+    this.navigationError = null;
+    this.notifyRscListeners();
+
+    const fetchUrl = resolveRscClientUrl(
+      window.location.pathname,
+      window.location.search,
+      this.options.rsc,
+      window.location.origin,
+    );
+
+    try {
+      const payload = await this.rscPayloadLoader(fetchUrl, ac.signal);
+      if (ac.signal.aborted) return;
+      this.rscPayload = payload;
+      this.navigationStatus = 'idle';
+      this.navigationError = null;
+      this.lastRscFetchKey = key;
+      this.notifyRscListeners();
+    } catch (error) {
+      if (ac.signal.aborted) return;
+      this.navigationStatus = 'error';
+      this.navigationError = error instanceof Error ? error : new Error(String(error));
+      this.notifyRscListeners();
     }
   }
 
@@ -441,6 +556,13 @@ export class Router {
     this.flatRoutes = [];
     this.globalMiddleware = [];
     this.actionMiddleware = [];
+    this.rscPayloadLoader = null;
+    this.rscPayload = null;
+    this.navigationStatus = 'idle';
+    this.navigationError = null;
+    this.navigationAbort?.abort();
+    this.navigationAbort = null;
+    this.lastRscFetchKey = null;
   }
 
   private normalizePath(url: string): string {
@@ -467,9 +589,16 @@ export class Router {
     });
   }
 
+  private notifyRscListeners(): void {
+    this.rscListeners.forEach((listener) => {
+      listener();
+    });
+  }
+
   /**
    * Initialize client-side routing.
    * Uses a global flag to prevent duplicate event listeners on HMR re-invocation.
+   * In `'rsc'` mode, popstate also refreshes the RSC payload (ADR D3).
    */
   initClient(): void {
     if (typeof window === 'undefined') {
@@ -492,6 +621,9 @@ export class Router {
       this.lastPathname = window.location.pathname;
       this.currentMatch = this.match(window.location.pathname);
       this.notifyListeners();
+      if (this.mode === 'rsc') {
+        void this.refreshRscPayload();
+      }
     };
     window.addEventListener('popstate', this.popstateHandler);
 
@@ -543,6 +675,9 @@ export class Router {
     }
 
     this.listeners.clear();
+    this.rscListeners.clear();
+    this.navigationAbort?.abort();
+    this.navigationAbort = null;
 
     globalThis.__revealui_router_initialized = false;
   }

--- a/packages/router/src/server.tsx
+++ b/packages/router/src/server.tsx
@@ -29,6 +29,7 @@ export {
   type Representation,
   RSC_ACCEPT,
   RSC_CONTENT_TYPE,
+  resolveRscClientUrl,
   resolveRscEndpointPath,
   routingPathname,
   wantsRscPayload,

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -105,6 +105,20 @@ export interface RouterOptions {
 export type RouterMode = 'client' | 'rsc';
 
 /**
+ * Client RSC navigation status (Phase 2.2.3 / ADR D3).
+ * `'idle'` when no in-flight payload fetch; `'loading'` while fetching;
+ * `'error'` after a failed fetch (see `Router.getNavigationError()`).
+ */
+export type NavigationStatus = 'idle' | 'loading' | 'error';
+
+/**
+ * Pluggable RSC payload loader (ADR D11 — router stays free of RSDW/plugin-rsc).
+ * Called on soft navigation in `'rsc'` mode with an absolute URL and abort signal.
+ * New navigations abort the previous signal (D3 `currentNavigationToken`).
+ */
+export type RscPayloadLoader<T = unknown> = (url: string, signal: AbortSignal) => Promise<T>;
+
+/**
  * Navigation options
  */
 export interface NavigateOptions<TState = unknown> {
@@ -112,6 +126,11 @@ export interface NavigateOptions<TState = unknown> {
   replace?: boolean;
   /** State to pass with navigation */
   state?: TState;
+  /**
+   * Skip RSC payload fetch after history update (RSC mode only).
+   * Used when a server action already returned a fresh payload via `applyRscPayload`.
+   */
+  skipRscFetch?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

GAP-194 Phase **2.2.3** (ADR D3): router owns RSC soft-navigation payload fetch.

### Router (`0.4.0-rc.4`)

- `setRscPayloadLoader` / `applyRscPayload` / `refreshRscPayload`
- `navigate` in RSC mode triggers flight fetch; **aborts** prior request (navigation token)
- `useRscPayload` / `useNavigationStatus` / `useNavigationError`
- `resolveRscClientUrl` for same-URL vs endpoint-prefix fetches
- `skipRscFetch` when a server action already applied a payload
- Client mode unchanged (T9 suite still green)

### `apps/rsc-poc`

- Drops local click/popstate listener
- Uses `initClient` + hooks; server actions call `applyRscPayload`

## Tests

- **174** router tests ( +9 `rsc-client-nav` )
- rsc-poc typecheck + production build green

## Test plan

- [x] Unit suite
- [x] rsc-poc build
- [ ] CI
- [ ] Optional: `pnpm --filter @rsc-poc/app dev` — click Home/Counter/Actions soft-navs with loading bar