### PR TITLE
feat(router): 2.2.4 progressive form actions + redirect-from-action

### DIFF
--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -20,7 +20,7 @@ plugin-rsc; Phase 2.2.2 T0–T7 built the engine; **T8** is the first real consu
 | Piece | Role |
 |-------|------|
 | `src/app-router.ts` | `new Router({ rsc: {} })` + three demo routes + layout |
-| `src/entry.rsc.tsx` | `renderRequest` + `createRscStream` (plugin-rsc) + `x-rsc-action` |
+| `src/entry.rsc.tsx` | `renderRequest` + JS actions + progressive `decodeFormAction` (2.2.4) |
 | `src/entry.ssr.tsx` | SSR from teed flight; payload inline owned by router |
 | `src/entry.browser.tsx` | Hydrate + `setRscPayloadLoader` + `useRscPayload` (2.2.3 router-owned nav) |
 | `src/pages/*` | Demo pages + server actions |

--- a/apps/rsc-poc/src/entry.browser.tsx
+++ b/apps/rsc-poc/src/entry.browser.tsx
@@ -5,6 +5,7 @@
 'use client';
 
 import {
+  getRouterRedirect,
   Link,
   RouterProvider,
   useNavigationError,
@@ -111,14 +112,20 @@ async function main(): Promise<void> {
     if (typeof body === 'string') {
       headers['content-type'] = 'text/plain;charset=UTF-8';
     }
-    const payload = await createFromFetch<RscPayload>(
-      fetch(window.location.href, {
-        method: 'POST',
-        headers,
-        body: body as BodyInit,
-      }),
-      { temporaryReferences },
-    );
+    const response = await fetch(window.location.href, {
+      method: 'POST',
+      headers,
+      body: body as BodyInit,
+    });
+    // redirect() from action → X-Router-Redirect (ADR D6 / 2.2.4).
+    const redirectTo = getRouterRedirect(response);
+    if (redirectTo) {
+      router.navigate(redirectTo);
+      return undefined;
+    }
+    const payload = await createFromFetch<RscPayload>(Promise.resolve(response), {
+      temporaryReferences,
+    });
     // Action already returned a fresh tree — apply without a second GET.
     router.applyRscPayload(payload);
     const rv = payload.returnValue;

--- a/apps/rsc-poc/src/entry.rsc.tsx
+++ b/apps/rsc-poc/src/entry.rsc.tsx
@@ -1,8 +1,6 @@
 /**
- * RSC entry — T8 rewire onto `@revealui/router` `renderRequest` + registered routes.
- * Pathname if/else shim removed; match + actions owned by the dual-mode router.
+ * RSC entry — renderRequest owns JS actions (T7) and progressive forms (2.2.4).
  */
-
 import { renderRequest } from '@revealui/router/server';
 import {
   createTemporaryReferenceSet,
@@ -44,27 +42,10 @@ function renderMatchedTree(match: ReturnType<typeof router.match>): React.ReactN
 export default { fetch: handler };
 
 async function handler(request: Request): Promise<Response> {
-  let formState: ReactFormState | undefined;
   let temporaryReferences: unknown | undefined;
-
-  // Progressive form POST (no x-rsc-action) stays in the consumer until 2.2.4
-  // progressive-enhancement is first-class on the router.
-  const actionId = request.headers.get('x-rsc-action');
-  const isFormAction = request.method === 'POST' && !actionId;
-  if (isFormAction) {
-    const formData = await request.formData();
-    const decodedAction = await decodeAction(formData);
-    try {
-      const result = await decodedAction();
-      formState = await decodeFormState(result, formData);
-    } catch {
-      return new Response('Internal Server Error: server action failed', { status: 500 });
-    }
-  }
 
   return renderRequest(request, {
     router,
-    formState,
     title: 'RSC POC — dual-mode router',
     loadServerAction: async (id) => {
       const action = await loadServerAction(id);
@@ -79,11 +60,18 @@ async function handler(request: Request): Promise<Response> {
       const args = await decodeReply(body, { temporaryReferences });
       return args as unknown[];
     },
+    decodeFormAction: async (formData) => {
+      const decoded = await decodeAction(formData);
+      return decoded as () => unknown | Promise<unknown>;
+    },
+    decodeFormState: async (result, formData) => {
+      return decodeFormState(result, formData);
+    },
     createRscStream: async (_req, ctx) => {
       router.seedCurrentMatch(ctx.match);
       const rscPayload: RscPayload = {
         root: renderMatchedTree(ctx.match),
-        formState,
+        formState: ctx.formState as ReactFormState | undefined,
         returnValue: ctx.returnValue,
       };
       return renderToReadableStream<RscPayload>(rscPayload, { temporaryReferences });

--- a/apps/rsc-poc/src/pages/action-form.tsx
+++ b/apps/rsc-poc/src/pages/action-form.tsx
@@ -1,39 +1,47 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useState } from 'react';
 
 interface ActionFormProps {
+  /** Server action — used as React 19 form `action` (JS + progressive enhancement). */
   action: (formData: FormData) => Promise<string>;
 }
 
+/**
+ * Progressive-enhancement form (2.2.4 / ADR D2).
+ * - With JS: React form actions → `x-rsc-action` flight path.
+ * - Without JS: native POST → router `decodeFormAction` → HTML + formState.
+ */
 export function ActionForm({ action }: ActionFormProps): React.ReactNode {
   const [result, setResult] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
+  const [pending, setPending] = useState(false);
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    startTransition(async () => {
+  async function formAction(formData: FormData): Promise<void> {
+    setPending(true);
+    try {
       const res = await action(formData);
       setResult(res);
-    });
+    } finally {
+      setPending(false);
+    }
   }
 
   return (
     <div>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
+      <form action={formAction} style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
         <input
           type="text"
           name="message"
           placeholder="Type a message"
           style={{ padding: '6px 10px', border: '1px solid #d1d5db', borderRadius: '4px' }}
         />
-        <button type="submit" disabled={isPending}>
-          {isPending ? 'Sending…' : 'Send to server'}
+        <button type="submit" disabled={pending}>
+          {pending ? 'Sending…' : 'Send to server'}
         </button>
       </form>
       {result !== null && (
         <div
+          data-action-result=""
           style={{
             padding: '10px 14px',
             background: '#f0fdf4',

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -385,6 +385,29 @@ function App() {
 - `navigate(to, { skipRscFetch: true })` when a server action already applied a payload.
 - `useNavigationError()` surfaces loader failures.
 
+## Server actions + progressive forms (2.2.4 / D2)
+
+```typescript
+import { renderRequest, redirect } from '@revealui/router/server'
+
+// JS path: POST + x-rsc-action → loadServerAction + returnValue on flight
+// Form path (no JS): POST multipart/urlencoded → decodeFormAction + formState HTML
+
+await renderRequest(request, {
+  router,
+  loadServerAction: (id) => loadServerAction(id),
+  decodeActionArgs: (req) => decodeReply(...),
+  decodeFormAction: (formData) => decodeAction(formData),
+  decodeFormState: (result, formData) => decodeFormState(result, formData),
+  createRscStream: async (req, ctx) => { /* ctx.formState | ctx.returnValue */ },
+})
+
+// From any action/loader:
+redirect('/done') // HTML 307/308 or RSC X-Router-Redirect header
+```
+
+Client helper: `getRouterRedirect(response)` after action fetch; navigate when set.
+
 ## Dev Server
 
 Quick development server:

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.4",
+  "version": "0.4.0-rc.5",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",

--- a/packages/router/src/__tests__/form-actions.test.ts
+++ b/packages/router/src/__tests__/form-actions.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Phase 2.2.4 — progressive form actions (ADR D2 form path) + redirect-from-action.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getRouterRedirect,
+  isFormActionRequest,
+  RSC_ACTION_HEADER,
+  RSC_REDIRECT_HEADER,
+} from '../actions.js';
+import { redirect } from '../navigation.js';
+import { Router } from '../router.js';
+import { renderRequest } from '../server-rsc.js';
+
+function flightStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+function formPost(path = 'http://x/', fields: Record<string, string> = {}): Request {
+  const body = new URLSearchParams(fields);
+  return new Request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+}
+
+describe('isFormActionRequest', () => {
+  it('detects urlencoded POST without x-rsc-action', () => {
+    expect(isFormActionRequest(formPost())).toBe(true);
+  });
+
+  it('rejects JS action posts', () => {
+    const r = new Request('http://x/', {
+      method: 'POST',
+      headers: {
+        [RSC_ACTION_HEADER]: 'id',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: 'a=1',
+    });
+    expect(isFormActionRequest(r)).toBe(false);
+  });
+
+  it('rejects GET', () => {
+    expect(isFormActionRequest(new Request('http://x/'))).toBe(false);
+  });
+});
+
+describe('2.2.4 progressive form actions', () => {
+  it('runs decodeFormAction and passes formState to createRscStream', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    let seenFormState: unknown;
+    const decodeFormAction = vi.fn(async () => async () => 'ok-result');
+    const decodeFormState = vi.fn(async (result: unknown) => ({ message: result }));
+
+    const res = await renderRequest(formPost('http://x/', { message: 'hi' }), {
+      router,
+      decodeFormAction,
+      decodeFormState,
+      createRscStream: async (_req, ctx) => {
+        seenFormState = ctx.formState;
+        expect(ctx.formAction).toBe(true);
+        return flightStream('form-ok');
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(decodeFormAction).toHaveBeenCalledOnce();
+    expect(decodeFormState).toHaveBeenCalledOnce();
+    expect(decodeFormState.mock.calls[0]?.[0]).toBe('ok-result');
+    const fd = decodeFormState.mock.calls[0]?.[1] as FormData;
+    expect(typeof fd.get).toBe('function');
+    expect(fd.get('message')).toBe('hi');
+    expect(seenFormState).toEqual({ message: 'ok-result' });
+  });
+
+  it('actionMiddleware blocks form posts with 403', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    router.useAction(async () => false);
+    const res = await renderRequest(formPost(), {
+      router,
+      decodeFormAction: async () => async () => 'nope',
+      createRscStream: async () => flightStream('x'),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('redirect() from form action yields 307 HTML Location', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    const res = await renderRequest(formPost(), {
+      router,
+      decodeFormAction: async () => async () => {
+        redirect('/done');
+      },
+      createRscStream: async () => flightStream('x'),
+    });
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe('/done');
+  });
+
+  it('redirect() from JS action yields X-Router-Redirect on RSC accept', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    const res = await renderRequest(
+      new Request('http://x/', {
+        method: 'POST',
+        headers: {
+          [RSC_ACTION_HEADER]: 'go',
+          accept: 'text/x-component',
+        },
+      }),
+      {
+        router,
+        loadServerAction: async () => async () => {
+          redirect('/after');
+        },
+        createRscStream: async () => flightStream('x'),
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get(RSC_REDIRECT_HEADER)).toBe('/after');
+    expect(getRouterRedirect(res)).toBe('/after');
+  });
+
+  it('form action failure returns 500', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    const res = await renderRequest(formPost(), {
+      router,
+      decodeFormAction: async () => async () => {
+        throw new Error('boom');
+      },
+      createRscStream: async () => flightStream('x'),
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it('POST without decodeFormAction is a normal resolve (not form path)', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    let formActionFlag: boolean | undefined;
+    const res = await renderRequest(formPost(), {
+      router,
+      createRscStream: async (_req, ctx) => {
+        formActionFlag = ctx.formAction;
+        return flightStream('plain');
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(formActionFlag).toBeUndefined();
+  });
+});

--- a/packages/router/src/__tests__/form-actions.test.ts
+++ b/packages/router/src/__tests__/form-actions.test.ts
@@ -58,7 +58,10 @@ describe('2.2.4 progressive form actions', () => {
     router.register({ path: '/', component: () => null });
     let seenFormState: unknown;
     const decodeFormAction = vi.fn(async () => async () => 'ok-result');
-    const decodeFormState = vi.fn(async (result: unknown) => ({ message: result }));
+    const decodeFormState = vi.fn(async (result: unknown, formData: FormData) => {
+      expect(formData.get('message')).toBe('hi');
+      return { message: result };
+    });
 
     const res = await renderRequest(formPost('http://x/', { message: 'hi' }), {
       router,
@@ -74,10 +77,6 @@ describe('2.2.4 progressive form actions', () => {
     expect(res.status).toBe(200);
     expect(decodeFormAction).toHaveBeenCalledOnce();
     expect(decodeFormState).toHaveBeenCalledOnce();
-    expect(decodeFormState.mock.calls[0]?.[0]).toBe('ok-result');
-    const fd = decodeFormState.mock.calls[0]?.[1] as FormData;
-    expect(typeof fd.get).toBe('function');
-    expect(fd.get('message')).toBe('hi');
     expect(seenFormState).toEqual({ message: 'ok-result' });
   });
 

--- a/packages/router/src/actions.ts
+++ b/packages/router/src/actions.ts
@@ -1,11 +1,14 @@
 /**
- * Server-action transport helpers (ADR D2 / T7).
+ * Server-action transport helpers (ADR D2 / T7 / 2.2.4 progressive forms).
  */
 
 import type { MiddlewareContext, RouteMiddleware } from './types';
 
 /** Header carrying the opaque server-action id (RSDW convention). */
 export const RSC_ACTION_HEADER = 'x-rsc-action';
+
+/** Header on RSC-nav redirect responses (ADR D6). */
+export const RSC_REDIRECT_HEADER = 'X-Router-Redirect';
 
 export function getServerActionId(request: Request): string | null {
   if (request.method !== 'POST') return null;
@@ -15,6 +18,28 @@ export function getServerActionId(request: Request): string | null {
 
 export function isServerActionRequest(request: Request): boolean {
   return getServerActionId(request) !== null;
+}
+
+/**
+ * Progressive-enhancement form POST (ADR D2 form path): POST without
+ * `x-rsc-action`, typically `multipart/form-data` or urlencoded body.
+ */
+export function isFormActionRequest(request: Request): boolean {
+  if (request.method !== 'POST') return false;
+  if (getServerActionId(request)) return false;
+  const contentType = request.headers.get('content-type') ?? '';
+  return (
+    contentType.includes('multipart/form-data') ||
+    contentType.includes('application/x-www-form-urlencoded')
+  );
+}
+
+/**
+ * Read redirect path from an RSC navigation / action response (ADR D6).
+ */
+export function getRouterRedirect(response: Response): string | null {
+  const path = response.headers.get(RSC_REDIRECT_HEADER);
+  return path && path.length > 0 ? path : null;
 }
 
 /**

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -37,6 +37,14 @@
  * ```
  */
 
+// Client RSC helpers (also on ./server for parity)
+export {
+  getRouterRedirect,
+  isFormActionRequest,
+  isServerActionRequest,
+  RSC_ACTION_HEADER,
+  RSC_REDIRECT_HEADER,
+} from './actions';
 // React components and hooks
 export {
   Link,
@@ -54,7 +62,6 @@ export {
   useRscPayload,
   useSearchParams,
 } from './components';
-// Client RSC helpers (also on ./server for parity)
 export { RSC_ACCEPT, resolveRscClientUrl } from './negotiate';
 // Core router
 export { Router } from './router';

--- a/packages/router/src/server-rsc.tsx
+++ b/packages/router/src/server-rsc.tsx
@@ -1,4 +1,9 @@
-import { getServerActionId, runActionMiddleware } from './actions';
+import {
+  getServerActionId,
+  isFormActionRequest,
+  RSC_REDIRECT_HEADER,
+  runActionMiddleware,
+} from './actions';
 import { encodeBase64Chunked, readStreamToUint8Array } from './base64';
 import {
   isRouterNotFound,
@@ -24,10 +29,17 @@ export interface RscRenderContext {
   pathname: string;
   match: RouteMatch | null;
   representation: Representation;
-  /** Set after a successful server action (T7). */
+  /** Set after a successful JS server action (T7 / 2.2.4). */
   returnValue?: { ok: boolean; data: unknown };
-  /** Opaque action id when this request is a mutation. */
+  /** Opaque action id when this request is a JS mutation. */
   actionId?: string;
+  /**
+   * Progressive form POST state (2.2.4 / D2 form path).
+   * Prefer this over options.formState when both exist (request-derived).
+   */
+  formState?: unknown;
+  /** True when this request ran a progressive form action (no x-rsc-action). */
+  formAction?: boolean;
 }
 
 export interface RenderRequestOptions {
@@ -63,6 +75,20 @@ export interface RenderRequestOptions {
    * Defaults to empty args when omitted.
    */
   decodeActionArgs?: (request: Request) => Promise<unknown[]>;
+  /**
+   * Progressive enhancement form path (2.2.4 / ADR D2): decode `$ACTION_ID`
+   * from FormData into a zero-arg invoker (plugin-rsc `decodeAction`).
+   */
+  decodeFormAction?: (formData: FormData) => Promise<() => unknown | Promise<unknown>>;
+  /**
+   * Map form action result → form state for HTML re-render (plugin-rsc
+   * `decodeFormState`). Optional; when omitted, result is used as formState.
+   */
+  decodeFormState?: (result: unknown, formData: FormData) => Promise<unknown>;
+  /**
+   * Seed form state when the consumer already ran the form (legacy). Prefer
+   * `decodeFormAction` so the router owns middleware + redirect handling.
+   */
   formState?: unknown;
   title?: string;
   /** Extra headers on the response (e.g. Cache-Control). */
@@ -113,9 +139,29 @@ function redirectResponse(redirect: RouterRedirect, representation: Representati
     status: 200,
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
-      'X-Router-Redirect': redirect.path,
+      [RSC_REDIRECT_HEADER]: redirect.path,
     },
   });
+}
+
+async function runActionMiddlewareGate(
+  router: Router,
+  pathname: string,
+  match: RouteMatch | null,
+  representation: Representation,
+): Promise<Response | null> {
+  const mwResult = await runActionMiddleware(router.getActionMiddleware(), {
+    pathname,
+    params: match?.params ?? {},
+    meta: match?.route.meta,
+  });
+  if (mwResult === false) {
+    return new Response('Forbidden', { status: 403 });
+  }
+  if (typeof mwResult === 'string') {
+    return redirectResponse(new RouterRedirect(mwResult), representation);
+  }
+  return null;
 }
 
 function notFoundResponse(
@@ -217,13 +263,14 @@ async function finishRender(
 }
 
 /**
- * RSC-mode request handler (T3–T7).
+ * RSC-mode request handler (T3–T7 + 2.2.4 form path).
  *
  * - Content negotiation + endpoint strip (T3)
  * - Flight / HTML with teed `__RSC_PAYLOAD__` (T4)
  * - `redirect` / `notFound` sentinels (T5)
  * - Request ALS for `getRequest()` (T6)
  * - `x-rsc-action` + actionMiddleware (T7)
+ * - Progressive form POST without `x-rsc-action` (2.2.4 / D2)
  */
 export async function renderRequest(
   request: Request,
@@ -245,22 +292,14 @@ export async function renderRequest(
       const actionId = getServerActionId(request);
       let returnValue: RscRenderContext['returnValue'];
       let match: RouteMatch | null = null;
+      let formState: unknown = options.formState;
+      let formAction = false;
 
       if (actionId) {
-        // Match without loader for middleware context (params/meta only).
+        // JS server-action path (ADR D2): x-rsc-action + Accept flight.
         match = router.match(pathname);
-        const mwResult = await runActionMiddleware(router.getActionMiddleware(), {
-          pathname,
-          params: match?.params ?? {},
-          meta: match?.route.meta,
-        });
-        if (mwResult === false) {
-          return new Response('Forbidden', { status: 403 });
-        }
-        if (typeof mwResult === 'string') {
-          // Action middleware string return = temporary redirect (same as route mw).
-          return redirectResponse(new RouterRedirect(mwResult), representation);
-        }
+        const blocked = await runActionMiddlewareGate(router, pathname, match, representation);
+        if (blocked) return blocked;
 
         if (!options.loadServerAction) {
           throw new Error(
@@ -277,7 +316,26 @@ export async function renderRequest(
           if (isRouterNotFound(error)) return notFoundResponse(router, representation, error);
           returnValue = { ok: false, data: error instanceof Error ? error.message : String(error) };
         }
-        // Re-resolve after mutation so loaders see fresh data.
+        match = await router.resolve(pathname);
+      } else if (isFormActionRequest(request) && options.decodeFormAction) {
+        // Progressive form path (ADR D2 / 2.2.4): no x-rsc-action, FormData body.
+        formAction = true;
+        match = router.match(pathname);
+        const blocked = await runActionMiddlewareGate(router, pathname, match, representation);
+        if (blocked) return blocked;
+
+        const formData = await request.formData();
+        const decodedAction = await options.decodeFormAction(formData);
+        try {
+          const result = await decodedAction();
+          formState = options.decodeFormState
+            ? await options.decodeFormState(result, formData)
+            : result;
+        } catch (error) {
+          if (isRouterRedirect(error)) return redirectResponse(error, representation);
+          if (isRouterNotFound(error)) return notFoundResponse(router, representation, error);
+          return new Response('Internal Server Error: server action failed', { status: 500 });
+        }
         match = await router.resolve(pathname);
       } else {
         match = await router.resolve(pathname);
@@ -289,8 +347,12 @@ export async function renderRequest(
         representation,
         returnValue,
         actionId: actionId ?? undefined,
+        formState,
+        formAction: formAction || undefined,
       };
-      return await finishRender(request, options, ctx);
+      // Prefer request-derived formState for HTML shell when present.
+      const finishOptions = formState !== undefined ? { ...options, formState } : options;
+      return await finishRender(request, finishOptions, ctx);
     } catch (error) {
       if (isRouterRedirect(error)) {
         return redirectResponse(error, representation);

--- a/packages/router/src/server.tsx
+++ b/packages/router/src/server.tsx
@@ -7,9 +7,12 @@
  */
 
 export {
+  getRouterRedirect,
   getServerActionId,
+  isFormActionRequest,
   isServerActionRequest,
   RSC_ACTION_HEADER,
+  RSC_REDIRECT_HEADER,
   runActionMiddleware,
 } from './actions';
 export {


### PR DESCRIPTION
## Summary

GAP-194 Phase **2.2.4** (ADR D2 form path): progressive enhancement forms + redirect-from-action on the dual-mode router.

### Router (`0.4.0-rc.5`)

- `isFormActionRequest` — POST without `x-rsc-action` + form content-types
- `renderRequest` options: `decodeFormAction` / `decodeFormState`
- Form path runs **actionMiddleware** (same as JS actions)
- `redirect()` from form → HTML 307/308; from JS action + RSC accept → `X-Router-Redirect`
- `getRouterRedirect(response)` client helper
- `ctx.formState` / `ctx.formAction` on `RscRenderContext`

### `apps/rsc-poc`

- Form handling moved into `renderRequest` (no consumer pre-handler)
- `ActionForm` uses React 19 form `action` (JS + no-JS progressive path)
- Browser action callback follows `X-Router-Redirect`

## Tests

- **183** router tests (+9 form-actions)
- rsc-poc typecheck + production build green

## Test plan

- [x] Unit suite
- [x] rsc-poc build
- [ ] CI
- [ ] Optional: form submit with JS and without (progressive HTML)