### PR TITLE
docs(router): 2.2.5 migration guide, runtime matrix, edge-safety tests

### DIFF
--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -33,7 +33,12 @@ pnpm install
 pnpm --filter @revealui/router build
 pnpm --filter @rsc-poc/app build
 pnpm --filter @rsc-poc/app dev
+# after preview/dev is up:
+BASE_URL=http://127.0.0.1:4173 pnpm --filter @rsc-poc/app smoke:http
 ```
+
+Migration + runtime docs: `packages/router/docs/MIGRATION-RSC.md`,
+`packages/router/docs/RUNTIME-SUPPORT.md`.
 
 ## Pin policy
 

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -12,6 +12,7 @@
     "dev": "vite dev",
     "lint": "biome check .",
     "preview": "vite preview",
+    "smoke:http": "node scripts/smoke-http.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/rsc-poc/scripts/smoke-http.mjs
+++ b/apps/rsc-poc/scripts/smoke-http.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Phase 2.2.5 HTTP smoke for dual-mode rsc-poc (preview or dev).
+ * Usage: BASE_URL=http://127.0.0.1:4173 node scripts/smoke-http.mjs
+ */
+const base = (process.env.BASE_URL ?? 'http://127.0.0.1:4173').replace(/\/$/, '');
+
+async function check(path, { accept, expectStatus = 200, bodyIncludes = [] } = {}) {
+  const headers = {};
+  if (accept) headers.accept = accept;
+  const res = await fetch(`${base}${path}`, { headers });
+  const text = await res.text();
+  if (res.status !== expectStatus) {
+    throw new Error(`${path}: status ${res.status} (want ${expectStatus})`);
+  }
+  for (const s of bodyIncludes) {
+    if (!text.includes(s)) {
+      throw new Error(`${path}: missing ${JSON.stringify(s)}`);
+    }
+  }
+  return { status: res.status, contentType: res.headers.get('content-type') ?? '', len: text.length };
+}
+
+const results = [];
+results.push(
+  await check('/', {
+    bodyIncludes: ['Home', '__RSC_PAYLOAD__'],
+  }),
+);
+results.push(
+  await check('/', {
+    accept: 'text/x-component',
+    bodyIncludes: [],
+  }),
+);
+if (!results[1].contentType.includes('text/x-component')) {
+  throw new Error(`RSC accept content-type: ${results[1].contentType}`);
+}
+results.push(await check('/counter', { bodyIncludes: ['Counter'] }));
+results.push(await check('/actions', { bodyIncludes: ['Actions'] }));
+results.push(await check('/nope', { expectStatus: 404, bodyIncludes: ['Not Found', '404'] }));
+
+console.log(JSON.stringify({ ok: true, base, results }, null, 2));

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Patch Changes
 
-- Phase 2.2.5: migration guide (`docs/MIGRATION-RSC.md`), D18.b runtime support
-  table (`docs/RUNTIME-SUPPORT.md`), edge-safety contract tests, coverage gate
-  raised to ≥80% lines/statements on dual-mode sources.
+- Phase 2.2.5: migration guide and D18.b runtime matrix under package
+  `docs/` (repo docs; not npm `files`), edge-safety contract tests, coverage
+  gate raised to ≥80% lines/statements on dual-mode sources.
 
 ## 0.4.0-rc.5
 

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @revealui/router
 
+## 0.4.0-rc.6
+
+### Patch Changes
+
+- Phase 2.2.5: migration guide (`docs/MIGRATION-RSC.md`), D18.b runtime support
+  table (`docs/RUNTIME-SUPPORT.md`), edge-safety contract tests, coverage gate
+  raised to ≥80% lines/statements on dual-mode sources.
+
+## 0.4.0-rc.5
+
+### Minor Changes
+
+- Phase 2.2.4: progressive form actions (`decodeFormAction` / `decodeFormState`)
+  on `renderRequest`, `getRouterRedirect` for client action redirects.
+
+## 0.4.0-rc.4
+
+### Minor Changes
+
+- Phase 2.2.3: RSC client soft-nav (`setRscPayloadLoader`, `useRscPayload`,
+  abort token, navigation status hooks).
+
+## 0.4.0-rc.3
+
+### Patch Changes
+
+- Phase 2.2 T8 packaging: `/core`, `/server` (RSC-safe), `/server-ssr` (SPA).
+
 ## 0.3.11
 
 ### Patch Changes

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -8,18 +8,29 @@ audience: user
 
 # @revealui/router
 
-Lightweight file-based router for React apps with SSR, data loaders, middleware, and nested layouts. No framework required  -  works with Vite, Hono, or any React setup.
+Lightweight dual-mode router for React apps: client SPA (default) plus opt-in
+RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono,
+or any React setup.
+
+## Docs (0.4 dual-mode)
+
+| Doc | Topic |
+|-----|--------|
+| [docs/MIGRATION-RSC.md](./docs/MIGRATION-RSC.md) | Client → RSC opt-in migration |
+| [docs/RUNTIME-SUPPORT.md](./docs/RUNTIME-SUPPORT.md) | D18.b runtime matrix (Node / Edge / Workers) |
 
 ## Features
 
+- **Dual-mode (0.4)**  -  `new Router()` SPA, or `new Router({ rsc: {} })` for RSC
 - **File-based routing**  -  named params (`:id`), wildcards (`*path`), optional segments
 - **Nested routes**  -  composable layouts that stack automatically
 - **Data loaders**  -  async per-route data loading with typed access via `useData()`
 - **Middleware**  -  global + per-route, supports blocking and redirects
-- **SSR + streaming**  -  Hono integration with `renderToReadableStream`
-- **Client-side navigation**  -  History API, link interception, back/forward
+- **SSR + streaming**  -  Hono integration with `renderToReadableStream` (SPA) + `renderRequest` (RSC)
+- **Client-side navigation**  -  History API, link interception, back/forward; RSC soft-nav flight fetch
 - **Type-safe**  -  full TypeScript support, generic route data types
 - **React 18/19**  -  uses `useSyncExternalStore` for stable rendering
+- **Edge-first (D18.b)**  -  Web Platform APIs on the RSC path; ALS `getRequest()`
 
 ## Installation
 

--- a/packages/router/docs/MIGRATION-RSC.md
+++ b/packages/router/docs/MIGRATION-RSC.md
@@ -1,0 +1,149 @@
+---
+title: "Migrate to RSC mode (@revealui/router 0.4)"
+description: "Opt-in dual-mode migration: keep client SPA, or enable RSC with renderRequest and payload loaders."
+visibility: public
+status: verified
+audience: user
+---
+
+# Migrate to RSC mode
+
+`@revealui/router` **0.4** is dual-mode. Existing SPA consumers keep the 0.3.x
+contract by default. RSC is **opt-in** via the constructor.
+
+## Mode selection (ADR D1 / L3)
+
+| Construct | Mode | Behavior |
+|-----------|------|----------|
+| `new Router()` | `client` | 0.3.x SPA: History API, loaders only on `resolve()`, no flight fetch |
+| `new Router({ rsc: {} })` | `rsc` | Content negotiation (`Accept: text/x-component`) + soft-nav flight |
+| `new Router({ rsc: { endpoint: '/.rsc' } })` | `rsc` | CDN `Vary: accept` escape hatch — RSC URLs under that prefix |
+
+```ts
+// SPA (marketing, docs, agency) — no change required
+const router = new Router()
+router.registerRoutes(routes)
+
+// RSC app — opt in
+const router = new Router({ rsc: {} })
+```
+
+## Client SPA → stay on client mode
+
+1. Keep `import { Router, RouterProvider, Routes, Link } from '@revealui/router'`.
+2. Do **not** pass `rsc` in options.
+3. SPA SSR stays on `@revealui/router/server-ssr` (`createSSRHandler`, `hydrate`).
+
+Compat suite: `src/__tests__/client-mode-compat.test.tsx` (T9 / D16).
+
+## Client SPA → opt into RSC
+
+### 1. Shared route table
+
+```ts
+import { Router } from '@revealui/router/core' // no createContext — RSC-safe
+
+export function createAppRouter() {
+  const router = new Router({ rsc: {} })
+  router.register({ path: '/', component: Home, layout: AppLayout })
+  // ...
+  return router
+}
+```
+
+Use `@revealui/router/core` for route modules imported from server entries so the
+plugin-rsc graph never pulls React client context.
+
+### 2. Server entry (`renderRequest`)
+
+```ts
+import { renderRequest } from '@revealui/router/server'
+// Wire plugin-rsc / RSDW yourself (ADR D11)
+await renderRequest(request, {
+  router,
+  createRscStream: async (req, ctx) => /* flight stream */,
+  loadServerAction: (id) => loadServerAction(id),
+  decodeActionArgs: (req) => decodeReply(...),
+  decodeFormAction: (fd) => decodeAction(fd),       // progressive forms (2.2.4)
+  decodeFormState: (result, fd) => decodeFormState(result, fd),
+  loadBootstrapScriptContent: () => /* client bootstrap */,
+  renderHtml: async ({ rscStream, bootstrapScriptContent, formState }) => /* SSR */,
+})
+```
+
+Import map:
+
+| Subpath | Use |
+|---------|-----|
+| `@revealui/router` | Client components/hooks |
+| `@revealui/router/core` | `Router` class + types (server + client shared) |
+| `@revealui/router/server` | `renderRequest`, `redirect`, `notFound`, `getRequest` |
+| `@revealui/router/server-ssr` | SPA-only `createSSRHandler` / `hydrate` |
+
+### 3. Browser entry (soft navigation)
+
+```ts
+import {
+  RouterProvider,
+  useRscPayload,
+  useNavigationStatus,
+} from '@revealui/router'
+import { RSC_ACCEPT } from '@revealui/router/core'
+
+const router = createAppRouter()
+router.setRscPayloadLoader(async (url, signal) =>
+  createFromFetch(fetch(url, { headers: { accept: RSC_ACCEPT }, signal })),
+)
+router.applyRscPayload(initialPayload) // from __RSC_PAYLOAD__ or first fetch
+router.initClient()
+
+function App() {
+  const payload = useRscPayload<{ root: React.ReactNode }>()
+  const status = useNavigationStatus()
+  return (
+    <RouterProvider router={router}>
+      {status === 'loading' ? <Progress /> : null}
+      {payload?.root}
+    </RouterProvider>
+  )
+}
+```
+
+### 4. Server actions + progressive forms
+
+| Path | Request | Router options |
+|------|---------|----------------|
+| JS | `POST` + `x-rsc-action` + `Accept: text/x-component` | `loadServerAction`, `decodeActionArgs` |
+| No JS | `POST` form body, no action header | `decodeFormAction`, `decodeFormState` |
+
+Both paths run `router.useAction(...)` middleware (auth/RBAC).
+
+`redirect('/path')` from an action:
+
+- HTML representation → **307/308** + `Location`
+- RSC representation → **200** JSON + `X-Router-Redirect`  
+  Client: `getRouterRedirect(response)` then `router.navigate(path)`.
+
+### 5. CDN / caching (D1 / D4)
+
+- Default negotiation needs **`Vary: accept`** on the origin (or edge config).
+- Broken CDNs: set `rsc: { endpoint: '/.rsc' }` and fetch prefixed URLs.
+- Router does **not** ship `revalidatePath` / tag cache (D4). Use HTTP
+  `Cache-Control` + CDN, or `@revealui/cache` when appropriate.
+
+## What does not migrate 1:1 from Next App Router
+
+| Next | RevealUI router |
+|------|-----------------|
+| `loading.tsx` / `error.tsx` | Compose `Suspense` + route `errorBoundary` (D5) |
+| `revalidatePath` / `revalidateTag` | CDN / `@revealui/cache` (D4) |
+| File-based `app/` tree | Programmatic `router.register` |
+| Built-in RSDW bundling | Consumer wires `@vitejs/plugin-rsc` or RSDW (D11) |
+
+## Reference app
+
+`apps/rsc-poc` is the dual-mode dogfood harness (GAP-194 Phase 2.2).
+
+## Runtime support
+
+See [RUNTIME-SUPPORT.md](./RUNTIME-SUPPORT.md) (D18.b matrix).

--- a/packages/router/docs/RUNTIME-SUPPORT.md
+++ b/packages/router/docs/RUNTIME-SUPPORT.md
@@ -1,0 +1,54 @@
+---
+title: "Runtime support (@revealui/router 0.4)"
+description: "D18.b edge-first runtime matrix for dual-mode router."
+visibility: public
+status: verified
+audience: user
+---
+
+# Runtime support (D18.b)
+
+Phase 2.2 targets **edge-first** design: Web Platform APIs on the RSC render and
+dispatch path. Node-only APIs are not used in `@revealui/router/server`.
+
+## Support matrix
+
+| Runtime | Client mode | RSC mode (`renderRequest`) | `getRequest()` ALS | Notes |
+|---------|-------------|----------------------------|--------------------|-------|
+| **Node 24+** | ✅ | ✅ | ✅ `node:async_hooks` | CI default |
+| **Vercel Edge** | ✅ | ✅ | ✅ | ALS since ~2023 |
+| **Cloudflare Workers** | ✅ | ✅ | ✅ | ALS since 2024 |
+| **Deno Deploy** | ✅ | ✅ | ✅ | |
+| **Bun** | ✅ | ✅ | ✅ | |
+| **Netlify Edge / Fastly Compute** | ✅ | ⚠️ | ⚠️ | Mixed ALS; if `getRequest()` is unavailable, pass `Request` explicitly and avoid ALS-dependent helpers (D9 transport escape) |
+
+## Edge-safe checklist (enforced in tests)
+
+On the dual-mode RSC path (`server-rsc`, `actions`, `negotiate`, `navigation`,
+`base64`, `request-context`, `router` core):
+
+| Use | Avoid |
+|-----|--------|
+| `URL`, `Request`/`Response`, `fetch` | `node:fs`, `node:path` |
+| `ReadableStream` / `tee()` | `Buffer` for payload encode |
+| `TextEncoder` / `TextDecoder` | `String.fromCharCode(...spread)` on large payloads |
+| `AsyncLocalStorage` (`node:async_hooks` or runtime polyfill) | Hard `node:crypto` (use WebCrypto if needed) |
+| Chunked base64 (`encodeBase64Chunked`) | Stack-blowing spreads |
+
+SPA-only **`@revealui/router/server-ssr`** intentionally uses `react-dom/server`
+and is **not** for the plugin-rsc “react-server” graph. Import it only from
+Node/Vite client-mode SSR entries.
+
+## Verification
+
+- Unit: `src/__tests__/edge-safety.test.ts` (import ban + ALS smoke + Web stream path)
+- Package coverage gate: ≥80% lines/statements on package sources (2.2.5)
+- Dogfood: `apps/rsc-poc` build + preview smoke
+
+## Selection guidance
+
+1. **Default self-host / Vercel Node:** full dual-mode, no special flags.
+2. **Edge (Workers / Vercel Edge / Deno / Bun):** use `renderRequest` + Web
+   APIs; keep secrets and heavy I/O out of the request path.
+3. **Edge without ALS:** do not call `getRequest()`; thread `Request` through
+   loaders/actions yourself; keep `serverActionTransport` if you customize fetch.

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -55,8 +55,7 @@
     }
   },
   "files": [
-    "dist",
-    "docs"
+    "dist"
   ],
   "main": "./dist/index.js",
   "peerDependencies": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.5",
+  "version": "0.4.0-rc.6",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",
@@ -55,7 +55,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "docs"
   ],
   "main": "./dist/index.js",
   "peerDependencies": {

--- a/packages/router/src/__tests__/edge-safety.test.ts
+++ b/packages/router/src/__tests__/edge-safety.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Phase 2.2.5 / D18.b — edge-first surface contract.
+ * Static ban on Node-only modules in RSC path sources + ALS / stream smokes.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { encodeBase64Chunked, readStreamToUint8Array } from '../base64.js';
+import {
+  getRequest,
+  getRequestOrNull,
+  runWithRequest,
+  runWithRequestAsync,
+} from '../request-context.js';
+import { Router } from '../router.js';
+import { renderRequest } from '../server-rsc.js';
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** RSC / dual-mode sources that must stay free of Node-only I/O modules. */
+const EDGE_PATH_FILES = [
+  'actions.ts',
+  'base64.ts',
+  'navigation.ts',
+  'negotiate.ts',
+  'request-context.ts',
+  'router.ts',
+  'server-rsc.tsx',
+  'types.ts',
+] as const;
+
+const BANNED_IMPORT = /from\s+['"]node:(fs|path|crypto|buffer|http|https|net|os|child_process)['"]/;
+const BANNED_REQUIRE = /require\(\s*['"]node:(fs|path|crypto|buffer)['"]\s*\)/;
+const BANNED_BUFFER = /\bBuffer\.(from|alloc|isBuffer)\b/;
+
+describe('D18.b edge-safe RSC sources', () => {
+  it('edge-path source files are present', () => {
+    const names = new Set(readdirSync(srcDir));
+    for (const file of EDGE_PATH_FILES) {
+      expect(names.has(file), `missing ${file}`).toBe(true);
+    }
+  });
+
+  it('does not import Node-only I/O modules on the RSC path', () => {
+    const offenders: string[] = [];
+    for (const file of EDGE_PATH_FILES) {
+      const text = readFileSync(join(srcDir, file), 'utf8');
+      if (BANNED_IMPORT.test(text) || BANNED_REQUIRE.test(text) || BANNED_BUFFER.test(text)) {
+        offenders.push(file);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('request-context uses AsyncLocalStorage only (documented edge ALS)', () => {
+    const text = readFileSync(join(srcDir, 'request-context.ts'), 'utf8');
+    expect(text).toMatch(/AsyncLocalStorage/);
+    expect(text).toMatch(/async_hooks/);
+    expect(text).not.toMatch(BANNED_IMPORT);
+  });
+
+  it('server-ssr is isolated (may use react-dom/server; not part of edge RSC graph)', () => {
+    const text = readFileSync(join(srcDir, 'server-ssr.tsx'), 'utf8');
+    expect(text).toMatch(/react-dom\/server/);
+    // RSC barrel may mention server-ssr in docs comments, but must not import it.
+    const serverBarrel = readFileSync(join(srcDir, 'server.tsx'), 'utf8');
+    expect(serverBarrel).not.toMatch(/from\s+['"]\.\/server-ssr['"]/);
+    expect(serverBarrel).not.toMatch(/from\s+['"]react-dom\/server['"]/);
+  });
+});
+
+describe('Web-platform smoke (edge-portable APIs)', () => {
+  it('chunked base64 round-trips Uint8Array without Buffer', async () => {
+    const bytes = new TextEncoder().encode('edge-payload-✓');
+    const b64 = encodeBase64Chunked(bytes);
+    expect(b64.length).toBeGreaterThan(0);
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(bytes);
+        c.close();
+      },
+    });
+    const out = await readStreamToUint8Array(stream);
+    expect(new TextDecoder().decode(out)).toBe('edge-payload-✓');
+  });
+
+  it('ALS getRequest works under runWithRequest (Node/edge ALS)', () => {
+    const req = new Request('https://example.test/a');
+    expect(getRequestOrNull()).toBeNull();
+    const seen = runWithRequest(req, () => getRequest());
+    expect(seen).toBe(req);
+  });
+
+  it('renderRequest negotiates RSC with only Web Request/Response/Streams', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    const flight = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new TextEncoder().encode('1:edge'));
+        c.close();
+      },
+    });
+    const res = await renderRequest(
+      new Request('https://edge.test/', { headers: { accept: 'text/x-component' } }),
+      {
+        router,
+        createRscStream: async () => flight,
+      },
+    );
+    expect(res.headers.get('content-type')).toMatch(/text\/x-component/);
+    expect(res.headers.get('vary')?.toLowerCase()).toContain('accept');
+    expect(await res.text()).toBe('1:edge');
+  });
+
+  it('runWithRequestAsync binds request across await', async () => {
+    const req = new Request('https://example.test/async');
+    const seen = await runWithRequestAsync(req, async () => {
+      await Promise.resolve();
+      return getRequest().url;
+    });
+    expect(seen).toBe('https://example.test/async');
+  });
+});

--- a/packages/router/vitest.config.ts
+++ b/packages/router/vitest.config.ts
@@ -2,10 +2,20 @@ import { createVitestConfig } from '@revealui/dev/vitest';
 
 export default createVitestConfig({
   environment: 'jsdom',
+  // 2.2.5 acceptance: ≥80% on dual-mode sources (measured ~89% lines 2026-08-01).
+  coverageExclude: [
+    'src/**/*.test.ts',
+    'src/**/*.test.tsx',
+    'src/__tests__/**',
+    'src/core.ts',
+    'src/index.ts',
+    'src/types.ts',
+    'src/server.tsx',
+  ],
   thresholds: {
-    lines: 60,
-    functions: 60,
-    branches: 55,
-    statements: 60,
+    lines: 80,
+    functions: 80,
+    branches: 70,
+    statements: 80,
   },
 });


### PR DESCRIPTION
## Summary

GAP-194 Phase **2.2.5** — tests + docs closeout for dual-mode `@revealui/router`.

### Docs (in-repo `packages/router/docs/`)

- **MIGRATION-RSC.md** — client → RSC opt-in, import map, actions/forms, CDN notes
- **RUNTIME-SUPPORT.md** — D18.b matrix (Node 24, Vercel Edge, CF Workers, Deno, Bun)

(Repo docs only — not listed in npm `files` per boundary gate.)

### Tests / gates

- `edge-safety.test.ts` — Node I/O import ban on RSC path; ALS + stream + `renderRequest` smokes
- Coverage thresholds **≥80%** lines/statements (~89% measured)
- `apps/rsc-poc` `smoke:http` for HTML / RSC Accept / 404

### Version

`0.4.0-rc.6`

## Verified

- 191 router tests
- coverage gate green
- boundary validation green
- rsc-poc smoke:http green

## Test plan

- [x] Unit + edge-safety + coverage
- [x] HTTP smoke
- [ ] CI