### PR TITLE
feat(router,rsc-poc): 2.3.1 actionId middleware + dogfood signed session

### DIFF
--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -23,7 +23,8 @@ plugin-rsc; Phase 2.2.2 T0–T7 built the engine; **T8** is the first real consu
 | `src/entry.rsc.tsx` | `renderRequest` + JS actions + progressive `decodeFormAction` (2.2.4) |
 | `src/entry.ssr.tsx` | SSR from teed flight; payload inline owned by router |
 | `src/entry.browser.tsx` | Hydrate + `setRscPayloadLoader` + `useRscPayload` (2.2.3 router-owned nav) |
-| `src/pages/*` | Demo pages + server actions |
+| `src/auth/*` | Dogfood signed-cookie session + `useAction` requireSession (2.3.1) |
+| `src/pages/*` | Demo pages + server actions + `/session` |
 
 ## Commands
 

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.11",
     "@revealui/router": "workspace:*",
+    "@revealui/utils": "workspace:*",
     "@vitejs/plugin-react": "catalog:",
     "@vitejs/plugin-rsc": "0.5.27",
     "hono": "4.12.27",

--- a/apps/rsc-poc/src/app-router.ts
+++ b/apps/rsc-poc/src/app-router.ts
@@ -1,15 +1,17 @@
 /**
- * Shared route table for the RSC POC (GAP-194 T8).
+ * Shared route table for the RSC POC (GAP-194 T8 + 2.3.1 auth dogfood).
  * Server and browser each call `createAppRouter()` — class instances are not
  * serialized across the RSC boundary; both sides register the same paths.
  */
 import { Router } from '@revealui/router/core';
 import type { ComponentType } from 'react';
+import { requireSessionForProtectedActions } from './auth/require-session.ts';
 import { ActionsPage } from './pages/actions.tsx';
 import { CounterPage } from './pages/counter.tsx';
 import { HomePage } from './pages/home.tsx';
 import { AppLayout } from './pages/layout.tsx';
 import { NotFoundPage } from './pages/not-found.tsx';
+import { SessionPage } from './pages/session.tsx';
 
 /** Demo pages take no props; router still passes params/data (ignored). */
 type DemoPage = ComponentType<{ params?: Record<string, string>; data?: unknown }>;
@@ -19,6 +21,11 @@ export function createAppRouter(): Router {
     rsc: {},
     notFound: NotFoundPage,
   });
+
+  // Phase 2.3.1: protected JS actions fail closed without dogfood session.
+  // useAction is Router API (D2.d), not a React hook — Biome rules-of-hooks false positive.
+  // biome-ignore lint/correctness/useHookAtTopLevel: Router.useAction mutation middleware
+  router.useAction(requireSessionForProtectedActions);
 
   router.register({
     path: '/',
@@ -37,6 +44,12 @@ export function createAppRouter(): Router {
     component: ActionsPage as DemoPage,
     layout: AppLayout,
     meta: { title: 'Actions — RSC POC' },
+  });
+  router.register({
+    path: '/session',
+    component: SessionPage as DemoPage,
+    layout: AppLayout,
+    meta: { title: 'Session — RSC POC' },
   });
 
   return router;

--- a/apps/rsc-poc/src/auth/require-session.ts
+++ b/apps/rsc-poc/src/auth/require-session.ts
@@ -1,0 +1,41 @@
+/**
+ * Action middleware: require dogfood session for protected action ids (2.3.1).
+ */
+import type { ActionMiddleware } from '@revealui/router/core';
+import { logger } from '@revealui/utils/logger';
+import { getSession } from './session.ts';
+
+/** RSDW / plugin-rsc action module ids that require a signed session. */
+const PROTECTED_ACTION_ID_MARKERS = ['secretPing', 'protected-ping'] as const;
+
+function isProtectedActionId(actionId: string | null | undefined): boolean {
+  if (!actionId) return false;
+  return PROTECTED_ACTION_ID_MARKERS.some((m) => actionId.includes(m));
+}
+
+/**
+ * Fail closed (403) when a protected action runs without a valid session cookie.
+ * Public actions (e.g. submitMessage) and progressive forms stay open unless marked.
+ */
+export const requireSessionForProtectedActions: ActionMiddleware = async (ctx) => {
+  if (ctx.formAction) {
+    // Progressive public forms stay open; protect only JS actions by id for dogfood.
+    return true;
+  }
+  if (!isProtectedActionId(ctx.actionId)) {
+    return true;
+  }
+  const session = await getSession();
+  if (!session) {
+    logger.warn('rsc-poc: protected action blocked — no session', {
+      actionId: ctx.actionId ?? undefined,
+      pathname: ctx.pathname,
+    });
+    return false;
+  }
+  logger.info('rsc-poc: protected action authorized', {
+    sub: session.sub,
+    actionId: ctx.actionId ?? undefined,
+  });
+  return true;
+};

--- a/apps/rsc-poc/src/auth/session.ts
+++ b/apps/rsc-poc/src/auth/session.ts
@@ -1,0 +1,109 @@
+/**
+ * Dogfood signed-cookie session (Phase 2.3.1 / owner ruling: minimal signed cookie).
+ * NOT production admin session — HMAC cookie only for rsc-poc demos.
+ */
+import { getRequestOrNull } from '@revealui/router/server';
+
+export const SESSION_COOKIE = 'rsc_poc_session';
+
+export interface PocSession {
+  sub: string;
+  iat: number;
+}
+
+function sessionSecret(): string {
+  const fromEnv = process.env.RSC_POC_SESSION_SECRET;
+  if (fromEnv && fromEnv.length >= 16) return fromEnv;
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('RSC_POC_SESSION_SECRET (min 16 chars) is required when NODE_ENV=production');
+  }
+  // Dogfood-only fallback for local dev/preview.
+  return 'rsc-poc-dogfood-only-not-for-prod';
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function fromBase64Url(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  const b64 = s.replaceAll('-', '+').replaceAll('_', '/') + pad;
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function hmacKey(): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(sessionSecret()),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  );
+}
+
+export async function signSession(session: PocSession): Promise<string> {
+  const payload = toBase64Url(new TextEncoder().encode(JSON.stringify(session)));
+  const key = await hmacKey();
+  const sig = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload)),
+  );
+  return `${payload}.${toBase64Url(sig)}`;
+}
+
+export async function verifySessionToken(token: string): Promise<PocSession | null> {
+  const parts = token.split('.');
+  if (parts.length !== 2) return null;
+  const [payload, sigB64] = parts;
+  if (!(payload && sigB64)) return null;
+  const key = await hmacKey();
+  const sigBytes = fromBase64Url(sigB64);
+  const ok = await crypto.subtle.verify(
+    'HMAC',
+    key,
+    sigBytes.buffer.slice(
+      sigBytes.byteOffset,
+      sigBytes.byteOffset + sigBytes.byteLength,
+    ) as ArrayBuffer,
+    new TextEncoder().encode(payload),
+  );
+  if (!ok) return null;
+  try {
+    const json = new TextDecoder().decode(fromBase64Url(payload));
+    const parsed = JSON.parse(json) as PocSession;
+    if (typeof parsed.sub !== 'string' || typeof parsed.iat !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get('cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const [k, ...rest] = part.trim().split('=');
+    if (k === name) return decodeURIComponent(rest.join('='));
+  }
+  return null;
+}
+
+export async function getSession(request?: Request): Promise<PocSession | null> {
+  const req = request ?? getRequestOrNull();
+  if (!req) return null;
+  const token = readCookie(req, SESSION_COOKIE);
+  if (!token) return null;
+  return verifySessionToken(token);
+}
+
+export function sessionSetCookieHeader(token: string): string {
+  return `${SESSION_COOKIE}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=86400`;
+}
+
+export function sessionClearCookieHeader(): string {
+  return `${SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
+}

--- a/apps/rsc-poc/src/entry.rsc.tsx
+++ b/apps/rsc-poc/src/entry.rsc.tsx
@@ -1,7 +1,10 @@
 /**
  * RSC entry — renderRequest owns JS actions (T7) and progressive forms (2.2.4).
+ * Session login/logout are progressive form endpoints outside the flight path (2.3.1).
  */
+
 import { renderRequest } from '@revealui/router/server';
+import { logger } from '@revealui/utils/logger';
 import {
   createTemporaryReferenceSet,
   decodeAction,
@@ -12,6 +15,7 @@ import {
 } from '@vitejs/plugin-rsc/rsc';
 import type { ReactFormState } from 'react-dom/client';
 import { createAppRouter } from './app-router.ts';
+import { sessionClearCookieHeader, sessionSetCookieHeader, signSession } from './auth/session.ts';
 import { AppLayout } from './pages/layout.tsx';
 import { NotFoundPage } from './pages/not-found.tsx';
 
@@ -41,8 +45,49 @@ function renderMatchedTree(match: ReturnType<typeof router.match>): React.ReactN
 
 export default { fetch: handler };
 
+async function handleSessionApi(request: Request): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (request.method !== 'POST') return null;
+
+  if (url.pathname === '/api/session/login') {
+    const form = await request.formData();
+    const subRaw = form.get('sub');
+    const sub = typeof subRaw === 'string' && subRaw.length > 0 ? subRaw : 'demo';
+    const token = await signSession({ sub, iat: Date.now() });
+    logger.info('rsc-poc: session login', { sub });
+    return new Response(null, {
+      status: 303,
+      headers: {
+        Location: '/session',
+        'Set-Cookie': sessionSetCookieHeader(token),
+      },
+    });
+  }
+
+  if (url.pathname === '/api/session/logout') {
+    logger.info('rsc-poc: session logout');
+    return new Response(null, {
+      status: 303,
+      headers: {
+        Location: '/session',
+        'Set-Cookie': sessionClearCookieHeader(),
+      },
+    });
+  }
+
+  return null;
+}
+
 async function handler(request: Request): Promise<Response> {
+  const sessionApi = await handleSessionApi(request);
+  if (sessionApi) return sessionApi;
+
   let temporaryReferences: unknown | undefined;
+
+  logger.debug('rsc-poc: renderRequest', {
+    method: request.method,
+    path: new URL(request.url).pathname,
+  });
 
   return renderRequest(request, {
     router,

--- a/apps/rsc-poc/src/pages/layout.tsx
+++ b/apps/rsc-poc/src/pages/layout.tsx
@@ -24,6 +24,7 @@ export function AppLayout({ children }: { children: React.ReactNode }): React.Re
           <a href="/">Home</a>
           <a href="/counter">Counter</a>
           <a href="/actions">Actions</a>
+          <a href="/session">Session</a>
         </nav>
         <main style={{ padding: '0 16px' }}>{children}</main>
       </body>

--- a/apps/rsc-poc/src/pages/session-client.tsx
+++ b/apps/rsc-poc/src/pages/session-client.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { secretPing, whoami } from './session.server.ts';
+
+export function WhoamiButton(): React.ReactNode {
+  const [text, setText] = useState<string | null>(null);
+  const [pending, start] = useTransition();
+
+  return (
+    <div>
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => {
+          start(async () => {
+            setText(await whoami());
+          });
+        }}
+      >
+        {pending ? '…' : 'whoami()'}
+      </button>
+      {text !== null && (
+        <pre data-whoami="" style={{ marginTop: 8 }}>
+          {text}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export function SecretPingForm(): React.ReactNode {
+  const [text, setText] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, start] = useTransition();
+
+  return (
+    <div>
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => {
+          start(async () => {
+            setError(null);
+            try {
+              setText(await secretPing());
+            } catch (e) {
+              setText(null);
+              setError(e instanceof Error ? e.message : String(e));
+            }
+          });
+        }}
+      >
+        {pending ? '…' : 'secretPing()'}
+      </button>
+      {text !== null && (
+        <pre data-secret-ok="" style={{ marginTop: 8, color: '#166534' }}>
+          {text}
+        </pre>
+      )}
+      {error !== null && (
+        <pre data-secret-err="" style={{ marginTop: 8, color: '#991b1b' }}>
+          {error}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/apps/rsc-poc/src/pages/session.server.ts
+++ b/apps/rsc-poc/src/pages/session.server.ts
@@ -1,0 +1,23 @@
+'use server';
+
+import { getSession } from '../auth/session.ts';
+
+/** Public: who am I (reads ALS request cookie). */
+export async function whoami(): Promise<string> {
+  const session = await getSession();
+  if (!session) return 'anonymous';
+  return `signed-in as ${session.sub} (iat ${new Date(session.iat).toISOString()})`;
+}
+
+/**
+ * Protected mutation — action id contains `secretPing` so useAction middleware
+ * returns 403 without a valid dogfood session cookie.
+ */
+export async function secretPing(): Promise<string> {
+  const session = await getSession();
+  if (!session) {
+    // Defense in depth if middleware is misconfigured.
+    throw new Error('unauthorized');
+  }
+  return `secret ok for ${session.sub} at ${new Date().toISOString()}`;
+}

--- a/apps/rsc-poc/src/pages/session.tsx
+++ b/apps/rsc-poc/src/pages/session.tsx
@@ -1,0 +1,44 @@
+import { getSession } from '../auth/session.ts';
+import { SecretPingForm, WhoamiButton } from './session-client.tsx';
+
+export async function SessionPage(): Promise<React.ReactNode> {
+  const session = await getSession();
+
+  return (
+    <div>
+      <h1>Session — dogfood auth (2.3.1)</h1>
+      <p>
+        Minimal <strong>signed HttpOnly cookie</strong> (owner ruling). Not admin session. Sign-in
+        uses progressive form POST to <code>/api/session/login</code>.
+      </p>
+      <p data-session-status="">
+        Server view: {session ? `signed-in as ${session.sub}` : 'anonymous'}
+      </p>
+
+      <section style={{ marginTop: 24 }}>
+        <h2>Sign in / out</h2>
+        <form
+          method="POST"
+          action="/api/session/login"
+          style={{ display: 'flex', gap: 8, marginBottom: 12 }}
+        >
+          <input type="hidden" name="sub" value="demo" />
+          <button type="submit">Sign in as demo</button>
+        </form>
+        <form method="POST" action="/api/session/logout">
+          <button type="submit">Sign out</button>
+        </form>
+      </section>
+
+      <section style={{ marginTop: 24 }}>
+        <h2>Public action</h2>
+        <WhoamiButton />
+      </section>
+
+      <section style={{ marginTop: 24 }}>
+        <h2>Protected action (useAction → 403 if anonymous)</h2>
+        <SecretPingForm />
+      </section>
+    </div>
+  );
+}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.6",
+  "version": "0.4.0-rc.7",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",

--- a/packages/router/src/__tests__/t5-t7.test.ts
+++ b/packages/router/src/__tests__/t5-t7.test.ts
@@ -162,6 +162,43 @@ describe('T7 server actions', () => {
     expect(res.status).toBe(403);
   });
 
+  it('actionMiddleware receives actionId for selective auth (2.3.1)', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({ path: '/', component: () => null });
+    const seen: Array<string | null | undefined> = [];
+    router.useAction(async (ctx) => {
+      seen.push(ctx.actionId);
+      return !ctx.actionId?.includes('secret');
+    });
+    const blocked = await renderRequest(
+      new Request('http://x/', {
+        method: 'POST',
+        headers: { [RSC_ACTION_HEADER]: 'mod#secretPing', accept: 'text/x-component' },
+      }),
+      {
+        router,
+        createRscStream: async () => flightStream('x'),
+        loadServerAction: async () => async () => 'nope',
+      },
+    );
+    expect(blocked.status).toBe(403);
+    expect(seen).toEqual(['mod#secretPing']);
+
+    const allowed = await renderRequest(
+      new Request('http://x/', {
+        method: 'POST',
+        headers: { [RSC_ACTION_HEADER]: 'mod#public', accept: 'text/x-component' },
+      }),
+      {
+        router,
+        createRscStream: async () => flightStream('ok'),
+        loadServerAction: async () => async () => 'yes',
+      },
+    );
+    expect(allowed.status).toBe(200);
+    expect(seen).toEqual(['mod#secretPing', 'mod#public']);
+  });
+
   it('actionMiddleware can redirect', async () => {
     const router = new Router({ rsc: {} });
     router.register({ path: '/', component: () => null });

--- a/packages/router/src/actions.ts
+++ b/packages/router/src/actions.ts
@@ -2,7 +2,7 @@
  * Server-action transport helpers (ADR D2 / T7 / 2.2.4 progressive forms).
  */
 
-import type { MiddlewareContext, RouteMiddleware } from './types';
+import type { ActionMiddleware, ActionMiddlewareContext } from './types';
 
 /** Header carrying the opaque server-action id (RSDW convention). */
 export const RSC_ACTION_HEADER = 'x-rsc-action';
@@ -43,14 +43,14 @@ export function getRouterRedirect(response: Response): string | null {
 }
 
 /**
- * Run action middleware chain before loadServerAction (D2.d).
+ * Run action middleware chain before loadServerAction / form actions (D2.d).
  * - `false` → abort (403)
  * - `string` → redirect path
  * - `true` → continue
  */
 export async function runActionMiddleware(
-  middleware: RouteMiddleware[],
-  context: MiddlewareContext,
+  middleware: ActionMiddleware[],
+  context: ActionMiddlewareContext,
 ): Promise<true | false | string> {
   for (const mw of middleware) {
     const result = await mw(context);

--- a/packages/router/src/core.ts
+++ b/packages/router/src/core.ts
@@ -7,6 +7,8 @@
 export { RSC_ACCEPT, resolveRscClientUrl } from './negotiate';
 export { Router } from './router';
 export type {
+  ActionMiddleware,
+  ActionMiddlewareContext,
   Location,
   MiddlewareContext,
   NavigateOptions,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -68,6 +68,8 @@ export { Router } from './router';
 
 // Types
 export type {
+  ActionMiddleware,
+  ActionMiddlewareContext,
   Location,
   MiddlewareContext,
   NavigateOptions,

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -9,6 +9,7 @@ import {
   routingPathname,
 } from './negotiate';
 import type {
+  ActionMiddleware,
   MiddlewareContext,
   NavigateOptions,
   NavigationStatus,
@@ -122,7 +123,7 @@ export class Router {
   private routes: Route[] = [];
   private flatRoutes: Route[] = [];
   private globalMiddleware: RouteMiddleware[] = [];
-  private actionMiddleware: RouteMiddleware[] = [];
+  private actionMiddleware: ActionMiddleware[] = [];
   private options: RouterOptions;
   private listeners: Set<() => void> = new Set();
   /** RSC payload + nav-status subscribers (Phase 2.2.3 / D3). */
@@ -167,14 +168,14 @@ export class Router {
    * Separate from route navigation middleware: mutations must not skip auth/RBAC
    * just because they bypass the loader path.
    */
-  useAction(...middleware: RouteMiddleware[]): void {
+  useAction(...middleware: ActionMiddleware[]): void {
     this.actionMiddleware.push(...middleware);
   }
 
   /**
-   * Snapshot of action middleware (for RSC server handler in later T-steps).
+   * Snapshot of action middleware (for RSC server handler / D2.d).
    */
-  getActionMiddleware(): RouteMiddleware[] {
+  getActionMiddleware(): ActionMiddleware[] {
     return [...this.actionMiddleware];
   }
 

--- a/packages/router/src/server-rsc.tsx
+++ b/packages/router/src/server-rsc.tsx
@@ -149,11 +149,14 @@ async function runActionMiddlewareGate(
   pathname: string,
   match: RouteMatch | null,
   representation: Representation,
+  actionMeta: { actionId?: string | null; formAction?: boolean },
 ): Promise<Response | null> {
   const mwResult = await runActionMiddleware(router.getActionMiddleware(), {
     pathname,
     params: match?.params ?? {},
     meta: match?.route.meta,
+    actionId: actionMeta.actionId,
+    formAction: actionMeta.formAction,
   });
   if (mwResult === false) {
     return new Response('Forbidden', { status: 403 });
@@ -298,7 +301,9 @@ export async function renderRequest(
       if (actionId) {
         // JS server-action path (ADR D2): x-rsc-action + Accept flight.
         match = router.match(pathname);
-        const blocked = await runActionMiddlewareGate(router, pathname, match, representation);
+        const blocked = await runActionMiddlewareGate(router, pathname, match, representation, {
+          actionId,
+        });
         if (blocked) return blocked;
 
         if (!options.loadServerAction) {
@@ -321,7 +326,9 @@ export async function renderRequest(
         // Progressive form path (ADR D2 / 2.2.4): no x-rsc-action, FormData body.
         formAction = true;
         match = router.match(pathname);
-        const blocked = await runActionMiddlewareGate(router, pathname, match, representation);
+        const blocked = await runActionMiddlewareGate(router, pathname, match, representation, {
+          formAction: true,
+        });
         if (blocked) return blocked;
 
         const formData = await request.formData();

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -21,6 +21,24 @@ export interface MiddlewareContext {
 }
 
 /**
+ * Context for server-action middleware (ADR D2.d / Phase 2.3.1).
+ * Extends navigation middleware context with mutation identity.
+ */
+export interface ActionMiddlewareContext extends MiddlewareContext {
+  /** Opaque RSDW action id when POST carries `x-rsc-action`. */
+  actionId?: string | null;
+  /** True for progressive form POST (no x-rsc-action). */
+  formAction?: boolean;
+}
+
+/**
+ * Middleware for mutations (`useAction`). Same control flow as route middleware.
+ */
+export type ActionMiddleware = (
+  context: ActionMiddlewareContext,
+) => boolean | string | Promise<boolean | string>;
+
+/**
  * Route configuration
  */
 export interface Route<TData = unknown, TProps = Record<string, unknown>> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,6 +673,9 @@ importers:
       '@revealui/router':
         specifier: workspace:*
         version: link:../../packages/router
+      '@revealui/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

Phase **2.3.1** (auth-in-RSC dogfood) after owner rulings:

| Ruling | Choice |
|--------|--------|
| Dogfood | rsc-poc only |
| Observability | core path (`@revealui/utils/logger` dogfood; core facade preferred in prod) |
| Session | minimal signed HttpOnly cookie |

### Router (`0.4.0-rc.7`)

- `ActionMiddlewareContext` adds `actionId` + `formAction`
- `useAction` middleware receives mutation identity for selective RBAC
- Test: selective block by `actionId` includes `secret`

### rsc-poc

- `/session` — sign-in/out progressive forms (`/api/session/*`)
- HMAC cookie `rsc_poc_session` (dogfood secret; prod requires `RSC_POC_SESSION_SECRET`)
- `secretPing` protected via `useAction(requireSessionForProtectedActions)` → **403** when anonymous
- `whoami` public action

## Companion

jv owner-rulings PR: https://github.com/RevealUIStudio/revealui-jv/pull/988

## Test plan

- [x] 192 router tests
- [x] rsc-poc typecheck + build
- [ ] CI
- [ ] Manual: open `/session`, secretPing fails anonymous; sign in; secretPing ok