### PR TITLE
feat(router,rsc-poc): 2.3.2 error boundaries + controlled loader 500s

### DIFF
--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -24,7 +24,7 @@ plugin-rsc; Phase 2.2.2 T0–T7 built the engine; **T8** is the first real consu
 | `src/entry.ssr.tsx` | SSR from teed flight; payload inline owned by router |
 | `src/entry.browser.tsx` | Hydrate + `setRscPayloadLoader` + `useRscPayload` (2.2.3 router-owned nav) |
 | `src/auth/*` | Dogfood signed-cookie session + `useAction` requireSession (2.3.1) |
-| `src/pages/*` | Demo pages + server actions + `/session` |
+| `src/pages/*` | Demo pages + `/session` + `/errors` (2.3.2 boundaries) |
 
 ## Commands
 

--- a/apps/rsc-poc/scripts/smoke-http.mjs
+++ b/apps/rsc-poc/scripts/smoke-http.mjs
@@ -39,5 +39,17 @@ if (!results[1].contentType.includes('text/x-component')) {
 results.push(await check('/counter', { bodyIncludes: ['Counter'] }));
 results.push(await check('/actions', { bodyIncludes: ['Actions'] }));
 results.push(await check('/nope', { expectStatus: 404, bodyIncludes: ['Not Found', '404'] }));
+results.push(
+  await check('/errors/not-found', {
+    expectStatus: 404,
+    bodyIncludes: ['Not Found', 'data-router-not-found'],
+  }),
+);
+results.push(
+  await check('/errors/boom', {
+    expectStatus: 500,
+    bodyIncludes: ['data-router-error', 'Go Home'],
+  }),
+);
 
 console.log(JSON.stringify({ ok: true, base, results }, null, 2));

--- a/apps/rsc-poc/src/app-router.server.ts
+++ b/apps/rsc-poc/src/app-router.server.ts
@@ -1,0 +1,30 @@
+/**
+ * Server-only route extensions (2.3.2). Not imported from the browser entry.
+ */
+
+import type { Router } from '@revealui/router/core';
+import { notFound } from '@revealui/router/server';
+import { HomePage } from './pages/home.tsx';
+import { AppLayout } from './pages/layout.tsx';
+import { NotFoundPage } from './pages/not-found.tsx';
+
+export function registerServerErrorRoutes(router: Router): void {
+  router.register({
+    path: '/errors/not-found',
+    component: NotFoundPage,
+    layout: AppLayout,
+    meta: { title: 'Forced notFound' },
+    loader: () => {
+      notFound();
+    },
+  });
+  router.register({
+    path: '/errors/boom',
+    component: HomePage,
+    layout: AppLayout,
+    meta: { title: 'Forced loader boom' },
+    loader: () => {
+      throw new Error('dogfood loader explosion');
+    },
+  });
+}

--- a/apps/rsc-poc/src/app-router.ts
+++ b/apps/rsc-poc/src/app-router.ts
@@ -8,6 +8,7 @@ import type { ComponentType } from 'react';
 import { requireSessionForProtectedActions } from './auth/require-session.ts';
 import { ActionsPage } from './pages/actions.tsx';
 import { CounterPage } from './pages/counter.tsx';
+import { ErrorsPage } from './pages/errors.tsx';
 import { HomePage } from './pages/home.tsx';
 import { AppLayout } from './pages/layout.tsx';
 import { NotFoundPage } from './pages/not-found.tsx';
@@ -50,6 +51,12 @@ export function createAppRouter(): Router {
     component: SessionPage as DemoPage,
     layout: AppLayout,
     meta: { title: 'Session — RSC POC' },
+  });
+  router.register({
+    path: '/errors',
+    component: ErrorsPage as DemoPage,
+    layout: AppLayout,
+    meta: { title: 'Errors — RSC POC' },
   });
 
   return router;

--- a/apps/rsc-poc/src/entry.browser.tsx
+++ b/apps/rsc-poc/src/entry.browser.tsx
@@ -5,6 +5,7 @@
 'use client';
 
 import {
+  ErrorBoundary,
   getRouterRedirect,
   Link,
   RouterProvider,
@@ -24,17 +25,25 @@ import React from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { createAppRouter } from './app-router.ts';
 import type { RscPayload } from './entry.rsc.tsx';
+import { ErrorFallback } from './pages/error-fallback.tsx';
 
 const router = createAppRouter();
 
 async function main(): Promise<void> {
   router.setRscPayloadLoader(async (url, signal) => {
-    return createFromFetch<RscPayload>(
-      fetch(url, {
-        headers: { accept: RSC_ACCEPT },
-        signal,
-      }),
-    );
+    const res = await fetch(url, {
+      headers: { accept: RSC_ACCEPT },
+      signal,
+    });
+    // Soft-nav hit a controlled 500 JSON body (2.3.2) — surface via navigation error.
+    if (res.status >= 500 && res.headers.get('X-Router-Error') === '1') {
+      const body = (await res.json()) as { message?: string };
+      throw new Error(body.message ?? 'Navigation failed');
+    }
+    if (!res.ok) {
+      throw new Error(`Navigation failed (${res.status})`);
+    }
+    return createFromFetch<RscPayload>(Promise.resolve(res));
   });
 
   const rscBase64 = (globalThis as Record<string, unknown>).__RSC_PAYLOAD__ as string | undefined;
@@ -95,9 +104,18 @@ async function main(): Promise<void> {
             }}
           >
             Navigation failed: {navError.message} <Link to={window.location.pathname}>Retry</Link>
+            {' · '}
+            <Link to="/">Home</Link>
           </div>
         ) : null}
-        {payload.root}
+        <ErrorBoundary
+          fallback={ErrorFallback}
+          resetKey={
+            typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/'
+          }
+        >
+          {payload.root}
+        </ErrorBoundary>
       </>
     );
   }

--- a/apps/rsc-poc/src/entry.rsc.tsx
+++ b/apps/rsc-poc/src/entry.rsc.tsx
@@ -14,6 +14,7 @@ import {
   renderToReadableStream,
 } from '@vitejs/plugin-rsc/rsc';
 import type { ReactFormState } from 'react-dom/client';
+import { registerServerErrorRoutes } from './app-router.server.ts';
 import { createAppRouter } from './app-router.ts';
 import { sessionClearCookieHeader, sessionSetCookieHeader, signSession } from './auth/session.ts';
 import { AppLayout } from './pages/layout.tsx';
@@ -26,6 +27,7 @@ export interface RscPayload {
 }
 
 const router = createAppRouter();
+registerServerErrorRoutes(router);
 
 function renderMatchedTree(match: ReturnType<typeof router.match>): React.ReactNode {
   if (!match) {

--- a/apps/rsc-poc/src/pages/error-fallback.tsx
+++ b/apps/rsc-poc/src/pages/error-fallback.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+/**
+ * Client fallback for ErrorBoundary (2.3.2). No stack dump in UI.
+ */
+export function ErrorFallback({ error }: { error: Error }): React.ReactNode {
+  const isProd = process.env.NODE_ENV === 'production';
+  return (
+    <div
+      data-router-error-boundary=""
+      style={{
+        padding: '2rem',
+        textAlign: 'center',
+        border: '1px solid #fecaca',
+        background: '#fef2f2',
+        borderRadius: 8,
+        margin: '16px 0',
+      }}
+    >
+      <h2>Something went wrong</h2>
+      <p>{isProd ? 'Please try again or go home.' : error.message}</p>
+      <p>
+        <a href="/">Go Home</a>
+        {' · '}
+        <a href="/errors">Back to Errors</a>
+      </p>
+    </div>
+  );
+}

--- a/apps/rsc-poc/src/pages/errors-client.tsx
+++ b/apps/rsc-poc/src/pages/errors-client.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useState } from 'react';
+
+function Bomb(): React.ReactNode {
+  throw new Error('client render boom (dogfood)');
+}
+
+export function ErrorsClient(): React.ReactNode {
+  const [explode, setExplode] = useState(false);
+
+  return (
+    <section style={{ marginTop: 24 }}>
+      <h2>Client render throw</h2>
+      <button type="button" onClick={() => setExplode(true)} data-errors-client-boom="">
+        Throw in client tree
+      </button>
+      {explode ? <Bomb /> : null}
+    </section>
+  );
+}

--- a/apps/rsc-poc/src/pages/errors.tsx
+++ b/apps/rsc-poc/src/pages/errors.tsx
@@ -1,0 +1,27 @@
+import { ErrorsClient } from './errors-client.tsx';
+
+/**
+ * Error dogfood (Phase 2.3.2).
+ * - Client throw: caught by ErrorBoundary in entry.browser
+ * - Server paths: /errors/not-found (notFound sentinel), /errors/boom (loader 500)
+ */
+export function ErrorsPage(): React.ReactNode {
+  return (
+    <div>
+      <h1>Errors — dogfood (2.3.2)</h1>
+      <p>
+        Client throw is isolated by <code>ErrorBoundary</code>. Server failures use controlled 404 /
+        500 shells from <code>renderRequest</code>.
+      </p>
+      <ul>
+        <li>
+          <a href="/errors/not-found">Server notFound()</a> (expect 404 shell)
+        </li>
+        <li>
+          <a href="/errors/boom">Server loader throw</a> (expect 500 shell)
+        </li>
+      </ul>
+      <ErrorsClient />
+    </div>
+  );
+}

--- a/apps/rsc-poc/src/pages/layout.tsx
+++ b/apps/rsc-poc/src/pages/layout.tsx
@@ -25,6 +25,7 @@ export function AppLayout({ children }: { children: React.ReactNode }): React.Re
           <a href="/counter">Counter</a>
           <a href="/actions">Actions</a>
           <a href="/session">Session</a>
+          <a href="/errors">Errors</a>
         </nav>
         <main style={{ padding: '0 16px' }}>{children}</main>
       </body>

--- a/apps/rsc-poc/src/pages/not-found.tsx
+++ b/apps/rsc-poc/src/pages/not-found.tsx
@@ -1,10 +1,12 @@
 export function NotFoundPage(): React.ReactNode {
   return (
-    <div style={{ padding: '2rem', textAlign: 'center' }}>
+    <div data-router-not-found="" style={{ padding: '2rem', textAlign: 'center' }}>
       <h1>404 — Not Found</h1>
-      <p>No route matched this path.</p>
+      <p>No route matched this path (or a loader called notFound()).</p>
       <p>
         <a href="/">Go Home</a>
+        {' · '}
+        <a href="/errors">Error dogfood</a>
       </p>
     </div>
   );

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.7",
+  "version": "0.4.0-rc.8",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",

--- a/packages/router/src/__tests__/error-boundary.test.tsx
+++ b/packages/router/src/__tests__/error-boundary.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Phase 2.3.2 — error boundaries + notFound + loader 500 path.
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/utils/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { ErrorBoundary, RouterProvider, Routes } from '../components.js';
+import { notFound } from '../navigation.js';
+import { Router } from '../router.js';
+import { renderRequest } from '../server-rsc.js';
+
+afterEach(() => {
+  cleanup();
+  window.history.pushState(null, '', '/');
+});
+
+function Boom(): React.ReactNode {
+  throw new Error('render boom');
+}
+
+function Fallback({ error }: { error: Error }): React.ReactNode {
+  return <div data-testid="fallback">caught: {error.message}</div>;
+}
+
+function Ok(): React.ReactNode {
+  return <div data-testid="ok">ok</div>;
+}
+
+function flightStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+describe('ErrorBoundary (2.3.2)', () => {
+  it('catches child render errors and shows fallback', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary fallback={Fallback}>
+        <Boom />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId('fallback').textContent).toContain('render boom');
+    spy.mockRestore();
+  });
+
+  it('clears error when resetKey changes', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <ErrorBoundary fallback={Fallback} resetKey="a">
+        <Boom />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId('fallback')).toBeTruthy();
+    rerender(
+      <ErrorBoundary fallback={Fallback} resetKey="b">
+        <Ok />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId('ok').textContent).toBe('ok');
+    spy.mockRestore();
+  });
+
+  it('Routes uses per-route errorBoundary over router option', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    function RouteFallback({ error }: { error: Error }) {
+      return <div data-testid="route-fb">{error.message}</div>;
+    }
+    function RouterFallback() {
+      return <div data-testid="router-fb">router</div>;
+    }
+    const router = new Router({ errorBoundary: RouterFallback });
+    router.register({
+      path: '/',
+      component: Boom,
+      errorBoundary: RouteFallback,
+    });
+    router.seedCurrentMatch(router.match('/'));
+    render(
+      <RouterProvider router={router}>
+        <Routes />
+      </RouterProvider>,
+    );
+    expect(screen.getByTestId('route-fb').textContent).toBe('render boom');
+    expect(screen.queryByTestId('router-fb')).toBeNull();
+    spy.mockRestore();
+  });
+});
+
+describe('renderRequest loader failures (2.3.2)', () => {
+  it('notFound() from loader yields 404', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/gone',
+      component: () => null,
+      loader: () => {
+        notFound();
+      },
+    });
+    const res = await renderRequest(new Request('http://x/gone'), {
+      router,
+      createRscStream: async () => flightStream('x'),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('generic loader throw yields controlled 500 HTML without stack', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/boom',
+      component: () => null,
+      loader: () => {
+        throw new Error('loader exploded');
+      },
+    });
+    const res = await renderRequest(new Request('http://x/boom'), {
+      router,
+      createRscStream: async () => flightStream('x'),
+    });
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).toContain('data-router-error');
+    expect(body).toContain('Go Home');
+    expect(body).not.toContain('at Object.loader');
+  });
+
+  it('generic loader throw on RSC accept returns JSON error', async () => {
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/boom',
+      component: () => null,
+      loader: () => {
+        throw new Error('loader exploded');
+      },
+    });
+    const res = await renderRequest(
+      new Request('http://x/boom', { headers: { accept: 'text/x-component' } }),
+      {
+        router,
+        createRscStream: async () => flightStream('x'),
+      },
+    );
+    expect(res.status).toBe(500);
+    expect(res.headers.get('X-Router-Error')).toBe('1');
+    const json = (await res.json()) as { error: boolean; message: string };
+    expect(json.error).toBe(true);
+    expect(json.message).toMatch(/loader exploded|Something went wrong/);
+  });
+});

--- a/packages/router/src/components.tsx
+++ b/packages/router/src/components.tsx
@@ -56,14 +56,16 @@ export function Routes() {
   const { route, params, data } = match;
   const RouteComponent = route.component;
   const Layout = route.layout;
+  // Per-route boundary wins (D5 / 2.3.2); fall back to router-level.
+  const ErrorFallback = route.errorBoundary ?? options.errorBoundary;
 
   const element = <RouteComponent params={params} data={data} />;
   const wrapped = Layout ? <Layout>{element}</Layout> : element;
 
   return (
     <MatchContext.Provider value={match}>
-      {options.errorBoundary ? (
-        <RouteErrorBoundary fallback={options.errorBoundary}>{wrapped}</RouteErrorBoundary>
+      {ErrorFallback ? (
+        <RouteErrorBoundary fallback={ErrorFallback}>{wrapped}</RouteErrorBoundary>
       ) : (
         wrapped
       )}
@@ -271,15 +273,22 @@ function NotFound() {
 }
 
 /**
- * RouteErrorBoundary - Catches render errors in route components
+ * RouteErrorBoundary - Catches render errors in route components.
+ * Exported as `ErrorBoundary` for RSC consumers that wrap flight roots (2.3.2).
  */
-class RouteErrorBoundary extends Component<
-  { fallback: React.ComponentType<{ error: Error }>; children: React.ReactNode },
+export class ErrorBoundary extends Component<
+  {
+    fallback: React.ComponentType<{ error: Error }>;
+    children: React.ReactNode;
+    /** Optional reset key — when it changes, clear the captured error. */
+    resetKey?: string;
+  },
   { error: Error | null }
 > {
   constructor(props: {
     fallback: React.ComponentType<{ error: Error }>;
     children: React.ReactNode;
+    resetKey?: string;
   }) {
     super(props);
     this.state = { error: null };
@@ -287,6 +296,12 @@ class RouteErrorBoundary extends Component<
 
   static getDerivedStateFromError(error: Error): { error: Error } {
     return { error };
+  }
+
+  componentDidUpdate(prevProps: { resetKey?: string }): void {
+    if (prevProps.resetKey !== this.props.resetKey && this.state.error) {
+      this.setState({ error: null });
+    }
   }
 
   render() {
@@ -297,6 +312,9 @@ class RouteErrorBoundary extends Component<
     return this.props.children;
   }
 }
+
+/** @deprecated Use `ErrorBoundary` — kept as alias for internal Routes. */
+const RouteErrorBoundary = ErrorBoundary;
 
 /**
  * Navigate - Component for declarative navigation

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -47,6 +47,7 @@ export {
 } from './actions';
 // React components and hooks
 export {
+  ErrorBoundary,
   Link,
   Navigate,
   RouterProvider,

--- a/packages/router/src/navigation.ts
+++ b/packages/router/src/navigation.ts
@@ -33,9 +33,16 @@ export function notFound(): never {
 }
 
 export function isRouterRedirect(error: unknown): error is RouterRedirect {
-  return error instanceof RouterRedirect;
+  // Name check survives duplicate module copies under plugin-rsc bundling.
+  return (
+    error instanceof RouterRedirect ||
+    (typeof error === 'object' && error !== null && (error as Error).name === 'RouterRedirect')
+  );
 }
 
 export function isRouterNotFound(error: unknown): error is RouterNotFound {
-  return error instanceof RouterNotFound;
+  return (
+    error instanceof RouterNotFound ||
+    (typeof error === 'object' && error !== null && (error as Error).name === 'RouterNotFound')
+  );
 }

--- a/packages/router/src/server-rsc.tsx
+++ b/packages/router/src/server-rsc.tsx
@@ -367,8 +367,57 @@ export async function renderRequest(
       if (isRouterNotFound(error)) {
         return notFoundResponse(router, representation, error);
       }
-      throw error;
+      // Misconfiguration (missing callbacks) should fail loud for developers.
+      if (
+        error instanceof Error &&
+        (error.message.includes('loadServerAction is required') ||
+          error.message.includes('renderRequest requires Router'))
+      ) {
+        throw error;
+      }
+      // Phase 2.3.2: loader/render failures → controlled 500 (no stack leak in prod).
+      return internalErrorResponse(error, representation);
     }
+  });
+}
+
+/**
+ * Safe 500 for unexpected loader/render failures (2.3.2).
+ * HTML gets a minimal recovery shell; RSC gets JSON so soft-nav can surface it.
+ */
+function internalErrorResponse(error: unknown, representation: Representation): Response {
+  const message = error instanceof Error && error.message ? error.message : 'Internal Server Error';
+  const publicMessage =
+    process.env.NODE_ENV === 'production' ? 'Something went wrong. Please try again.' : message;
+
+  if (representation === 'rsc') {
+    return new Response(JSON.stringify({ error: true, message: publicMessage }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-Router-Error': '1',
+      },
+    });
+  }
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>Error</title>
+</head>
+<body>
+<div id="root" data-router-error="1" style="padding:2rem;text-align:center;font-family:system-ui,sans-serif">
+  <h1>Something went wrong</h1>
+  <p>${escapeHtml(publicMessage)}</p>
+  <p><a href="/">Go Home</a></p>
+</div>
+</body>
+</html>`;
+  return new Response(html, {
+    status: 500,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
   });
 }
 

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -54,6 +54,11 @@ export interface Route<TData = unknown, TProps = Record<string, unknown>> {
   meta?: RouteMeta;
   /** Optional middleware that runs before this route's loader */
   middleware?: RouteMiddleware[];
+  /**
+   * Per-route render error boundary (ADR D5 / Phase 2.3.2).
+   * Wins over `RouterOptions.errorBoundary` when both are set.
+   */
+  errorBoundary?: ComponentType<{ error: Error }>;
   /** Nested child routes  -  children inherit parent's layout and middleware */
   children?: Route[];
 }


### PR DESCRIPTION
## Summary

Phase **2.3.2** error isolation dogfood (GAP-194).

### Router (`0.4.0-rc.8`)

- Export **`ErrorBoundary`** (+ `resetKey`) for RSC flight roots
- Per-route **`errorBoundary`** on `Route` (wins over router option)
- `renderRequest`: loader `notFound()` → 404; unexpected throws → safe **500** HTML / JSON (`X-Router-Error`) without stack in production
- Sentinel detection by **name** (plugin-rsc multi-copy safe)

### rsc-poc

- `/errors` client throw (boundary) + links to server notFound/boom
- Soft-nav surfaces 500 JSON as navigation error strip
- Smoke checks 404/500 dogfood paths

## Tests

- **198** router tests (+6 error-boundary)
- rsc-poc typecheck + build + `smoke:http` green

## Test plan

- [x] Unit tests
- [x] HTTP smoke (/, RSC, 404, /errors/not-found, /errors/boom)
- [ ] CI
- [ ] Manual: `/errors` → client throw isolated; soft-nav to boom shows nav error strip