### PR TITLE
fix(core): forge license boot SSOT + redundancy optionals

### DIFF
--- a/apps/admin/src/__tests__/instrumentation-license-gate.test.ts
+++ b/apps/admin/src/__tests__/instrumentation-license-gate.test.ts
@@ -1,11 +1,10 @@
 /**
  * GAP-436 (owner-ruled 2026-07-26) — admin's Forge boot license enforcement
- * block in instrumentation.ts `register()` mirrors apps/server's
- * `validateLicenseAtStartup` (see apps/server/src/lib/validate-startup.ts).
- * That block is not extracted into a separately-tested function (see the
- * TODO in instrumentation.ts), so this exercises `register()` directly with
- * the minimal mocking needed to reach the license gate without running the
- * unrelated production-only telemetry/engine-init branches.
+ * in instrumentation.ts `register()` calls
+ * `@revealui/core/revforge-license-boot` (shared with apps/server
+ * `validateLicenseAtStartup` after fleet-redundancy 2026-08-02). This
+ * exercises `register()` with the minimal mocking needed to reach the
+ * license gate without production-only telemetry/engine-init branches.
  *
  * Proves:
  *  1. A plain self-host boot (forge-mode-detected, no license key) with

--- a/apps/admin/src/instrumentation.ts
+++ b/apps/admin/src/instrumentation.ts
@@ -32,85 +32,19 @@ export async function register() {
   }
 
   // ── Forge boot license enforcement ─────────────────────────────────
-  // Mirrors apps/server validateLicenseAtStartup / detectDeploymentMode.
-  // Hosted SaaS (REVEALUI_DEPLOYMENT_MODE=hosted, or legacy private-key
-  // presence) is a no-op; Forge hard-fails on missing/invalid customer JWT.
-  // GAP-260 P4-1: MODE is the durable signal so admin can boot hosted with
-  // the signing private key ABSENT (signer isolation).
+  // Shared with apps/server via @revealui/core/revforge-license-boot
+  // (fleet-redundancy 2026-08-02). Hosted is a no-op; Forge hard-fails on
+  // missing/invalid customer JWT (GAP-260 / GAP-436).
   //
-  // We use process.exit(1) rather than `throw` because Next.js's
-  // instrumentation.ts contract is "never throw — it kills the entire
-  // runtime". process.exit(1) is the *intentional* kill, distinct from
-  // accidental crashes that the surrounding try/catch swallows.
-  //
-  // TODO: extract this block to @revealui/core/revforge-license-boot once
-  // the same pattern is needed in a third app. Today (api + admin) the
-  // ~25-line duplication is preferable to a new package boundary.
-  const { detectDeploymentMode } = await import('@revealui/core/deployment-mode');
-  if (process.env.SKIP_ENV_VALIDATION !== 'true' && detectDeploymentMode(process.env) === 'forge') {
-    // GAP-436 (owner-ruled 2026-07-26): a self-hosted boot with NO license key
-    // at all, that explicitly opts in via REVEALUI_ALLOW_UNLICENSED_SELF_HOST=
-    // true, is the plain OSS/self-host or marketplace-template path — not a
-    // RevForge-stamped kit (RevForge always mints and bakes a license key at
-    // stamp time). Mirrors apps/server/src/lib/validate-startup.ts
-    // validateLicenseAtStartup; the flag does nothing unless explicitly set,
-    // so a stamped kit's enforcement below is unchanged. A present-but-invalid
-    // key is still rejected regardless of this flag.
-    if (
-      !process.env.REVEALUI_LICENSE_KEY &&
-      process.env.REVEALUI_ALLOW_UNLICENSED_SELF_HOST === 'true'
-    ) {
-      const { logger } = await import('@revealui/core/observability/logger');
-      logger.info('no license key — running Free (OSS) tier');
-    } else {
-      const failures: string[] = [];
-      if (!process.env.REVEALUI_LICENSE_KEY) {
-        failures.push(
-          'REVEALUI_LICENSE_KEY is required for RevForge deployments. ' +
-            'Run bin/revvault-bootstrap.sh to materialize docker/.env from revvault, ' +
-            'or contact the operator who stamped this kit. A plain self-host deployment ' +
-            'that intends to run without a license should set ' +
-            'REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true to boot at Free (OSS) tier instead.',
-        );
-      }
-      if (!process.env.REVEALUI_LICENSE_PUBLIC_KEY) {
-        failures.push(
-          'REVEALUI_LICENSE_PUBLIC_KEY is required for RevForge deployments. ' +
-            'Stamped kits embed this value in docker/.env.example.',
-        );
-      }
-      if (failures.length === 0) {
-        try {
-          const { validateLicenseKey } = await import('@revealui/core/license');
-          // Restore real newlines in a single-line PEM (split/join, no authored
-          // regex — mirrors @revealui/core/license normalizePem). GAP-259 P0-4.
-          const publicKey = (process.env.REVEALUI_LICENSE_PUBLIC_KEY ?? '').split('\\n').join('\n');
-          const payload = await validateLicenseKey(
-            process.env.REVEALUI_LICENSE_KEY ?? '',
-            publicKey,
-          );
-          if (!payload) {
-            failures.push(
-              'REVEALUI_LICENSE_KEY is invalid, expired beyond grace, ' +
-                'or signed with a key that does not match REVEALUI_LICENSE_PUBLIC_KEY. ' +
-                'Contact the operator who stamped this kit to re-issue the license.',
-            );
-          }
-        } catch (err) {
-          failures.push(
-            `License validation failed unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-      }
-      if (failures.length > 0) {
-        // Logger may not be initialized yet — write directly to stderr so
-        // the failure is visible in Docker logs.
-        process.stderr.write(
-          `LICENSE VALIDATION FAILED:\n${failures.map((m) => `  - ${m}`).join('\n')}\n`,
-        );
-        process.exit(1);
-      }
-    }
+  // process.exit(1) rather than throw: Next.js instrumentation contract is
+  // "never throw — it kills the entire runtime". exit(1) is the intentional kill.
+  try {
+    const { validateForgeLicenseAtStartup } = await import('@revealui/core/revforge-license-boot');
+    await validateForgeLicenseAtStartup(process.env);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
   }
 
   try {

--- a/apps/server/src/lib/validate-startup.ts
+++ b/apps/server/src/lib/validate-startup.ts
@@ -11,12 +11,11 @@ import {
   deploymentModeKeyConsistencyError,
   detectDeploymentMode as detectDeploymentModeCore,
 } from '@revealui/core/deployment-mode';
-import {
-  computeKeyId,
-  hostMatchesLicensedDomains,
-  validateLicenseKey,
-} from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
+import {
+  ALLOW_UNLICENSED_SELF_HOST_ENV,
+  validateForgeLicenseAtStartup,
+} from '@revealui/core/revforge-license-boot';
 import { normalizeEnvPem } from '@revealui/core/security';
 import { getClient } from '@revealui/db/client';
 import { billingCatalog } from '@revealui/db/schema';
@@ -139,20 +138,6 @@ export function detectDeploymentMode(
 ): DeploymentMode {
   return detectDeploymentModeCore(env, options);
 }
-
-/**
- * GAP-436 (owner-ruled 2026-07-26): a self-hosted boot with NO license key at
- * all is the plain OSS/self-host/template path (`docker-compose.yml`, the
- * Railway marketplace template) — not a RevForge-stamped kit. RevForge always
- * mints and bakes a `REVEALUI_LICENSE_KEY` at stamp time (`forge/stamp.sh`),
- * so a genuinely stamped kit never reaches the unlicensed branch below.
- *
- * Setting this to `'true'` opts a self-hosted (forge-mode-detected) boot into
- * Free (OSS) tier instead of the hard license requirement. It changes NOTHING
- * unless explicitly set — RevForge-stamped kits, and any deployment that
- * doesn't know about this flag, keep today's hard refusal unchanged.
- */
-const ALLOW_UNLICENSED_SELF_HOST_ENV = 'REVEALUI_ALLOW_UNLICENSED_SELF_HOST';
 
 /** The two license-material keys the plain self-host opt-in makes optional. */
 const FORGE_LICENSE_KEYS = ['REVEALUI_LICENSE_KEY', 'REVEALUI_LICENSE_PUBLIC_KEY'] as const;
@@ -517,167 +502,14 @@ export function validateStartup(
 }
 
 /**
- * Extracts the `kid` (key id) from a JWT's protected header WITHOUT verifying
- * the signature. Returns undefined when the token is malformed or carries no
- * `kid` (older tokens issued before the issuer paired a public key). Uses only
- * built-in parsers (base64url decode + JSON.parse): no authored regex and no
- * jose import at the boot layer. Used purely to sharpen the error message once
- * cryptographic verification has ALREADY failed; never as a verification step.
- */
-function decodeJwtKid(jwt: string): string | undefined {
-  const headerSegment = jwt.split('.')[0];
-  if (!headerSegment) return undefined;
-  try {
-    const header: unknown = JSON.parse(Buffer.from(headerSegment, 'base64url').toString('utf8'));
-    if (header && typeof header === 'object' && 'kid' in header) {
-      const { kid } = header as { kid?: unknown };
-      return typeof kid === 'string' ? kid : undefined;
-    }
-  } catch {
-    // Malformed header segment. Fall through; the caller's generic
-    // "invalid license" path surfaces the real failure.
-  }
-  return undefined;
-}
-
-/**
- * Boot-time license enforcement for self-hosted (Forge) deployments.
+ * Forge / self-host license boot gate.
  *
- * The hosted SaaS deployment (apps/server on Vercel for revealui.com) signs
- * license JWTs for paying subscribers, so REVEALUI_LICENSE_PRIVATE_KEY is
- * always set there — entitlement comes from `account_entitlements` rows,
- * not from an env-var JWT. Boot-time license enforcement is a no-op in
- * that mode.
- *
- * Self-hosted Forge customer deployments don't have the studio's signing
- * key — they only consume a JWT signed by the studio, plus the matching
- * public key. We detect Forge mode by the absence of
- * REVEALUI_LICENSE_PRIVATE_KEY and, when in that mode:
- *
- *   - REVEALUI_LICENSE_KEY must be set (the studio-issued JWT)
- *   - REVEALUI_LICENSE_PUBLIC_KEY must be set (master verification key)
- *   - The JWT must verify cleanly (signature + expiry, with the
- *     subscription grace window from `@revealui/core/license`)
- *
- * Throws on any failure so the API refuses to boot rather than silently
- * degrading to free tier (which is `initializeLicense`'s default
- * behavior). This is the gate that makes a stamped Forge kit honor its
- * license — without it, an expired or tampered key would still let the
- * stack come up.
- *
- * GAP-436 (owner-ruled 2026-07-26): the one exception is a COMPLETELY
- * ABSENT license key on a deployment that explicitly opts in via
- * `REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true` — the plain OSS/self-host or
- * marketplace-template path, which has no license to begin with. A present
- * key (valid, invalid, expired, or wrong-keypair) is still verified exactly
- * as before regardless of that flag, so it can never be used to downgrade a
- * genuinely stamped kit's enforcement.
- *
- * Honors `SKIP_ENV_VALIDATION=true` so Docker-build contexts and tests
- * can compile without live credentials present. Takes `env` as an
- * argument (defaulted to `process.env`) so tests can pass explicit
- * fixtures.
+ * Implementation lives in `@revealui/core/revforge-license-boot` so apps/admin
+ * instrumentation and this API boot path cannot drift (fleet-redundancy 2026-08-02).
+ * Re-exported under the historical name for existing server callers and tests.
  */
 export async function validateLicenseAtStartup(env: EnvMap = process.env as EnvMap): Promise<void> {
-  if (env.SKIP_ENV_VALIDATION === 'true') {
-    return;
-  }
-
-  // Mode detection: absence of the signing key = self-hosted deployment
-  // (RevForge-stamped kit OR a plain self-host / marketplace-template boot).
-  if (detectDeploymentMode(env) !== 'forge') {
-    return;
-  }
-
-  if (!env.REVEALUI_LICENSE_KEY) {
-    if (env[ALLOW_UNLICENSED_SELF_HOST_ENV] === 'true') {
-      logger.info('no license key — running Free (OSS) tier');
-      return;
-    }
-    throw new Error(
-      'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_KEY is required for RevForge deployments. ' +
-        'Run bin/revvault-bootstrap.sh to materialize docker/.env from revvault, ' +
-        'or contact the operator who stamped this kit. A plain self-host deployment that ' +
-        `intends to run without a license should set ${ALLOW_UNLICENSED_SELF_HOST_ENV}=true to ` +
-        'boot at Free (OSS) tier instead.',
-    );
-  }
-  if (!env.REVEALUI_LICENSE_PUBLIC_KEY) {
-    throw new Error(
-      'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_PUBLIC_KEY is required for RevForge deployments. ' +
-        'Stamped kits embed this value in docker/.env.example; check that it survived the bootstrap step.',
-    );
-  }
-
-  // Restore real newlines if the public key landed as a single-line PEM
-  // (the .env-encoded format that stamp.sh produces). Split/join, no authored
-  // regex — mirrors @revealui/core/license normalizePem. GAP-259 P0-4.
-  const publicKey = env.REVEALUI_LICENSE_PUBLIC_KEY.split('\\n').join('\n');
-  // Phase 1 audit B-2: bind the license to a specific customer when the
-  // operator has provided REVEALUI_LICENSED_CUSTOMER_ID. Without this, a
-  // leaked JWT from one customer would license another customer's
-  // deployment. Hosted mode does not set this — the deployment IS the
-  // customer. Forge stamping should set it (revforge#NN tracking).
-  const expectedCustomerId = env.REVEALUI_LICENSED_CUSTOMER_ID || undefined;
-  const payload = await validateLicenseKey(env.REVEALUI_LICENSE_KEY, publicKey, expectedCustomerId);
-  if (!payload) {
-    // Sharpen the most common (and most confusing) stamping failure: the kit
-    // baked a REVEALUI_LICENSE_PUBLIC_KEY that is not the verification key for
-    // the issued JWT. Our issuer embeds a `kid` (a short digest of the paired
-    // public key) in every token, so a token whose kid does not match the
-    // configured public key's id was provably signed by a different key. We
-    // consult the kid only HERE, after cryptographic verification has already
-    // failed, so a public key that is correct but merely formatted differently
-    // (validateLicenseKey verifies key material, not PEM bytes) can never reach
-    // this branch and produce a false "wrong key" message.
-    const tokenKid = decodeJwtKid(env.REVEALUI_LICENSE_KEY);
-    if (tokenKid !== undefined) {
-      const expectedKid = await computeKeyId(publicKey);
-      if (tokenKid !== expectedKid) {
-        throw new Error(
-          'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_PUBLIC_KEY does not match the key that ' +
-            `signed REVEALUI_LICENSE_KEY (license key id "${tokenKid}", configured public key id ` +
-            `"${expectedKid}"). The stamped kit baked the wrong public key. Re-issue the license ` +
-            'with the matching keypair, or bake the public key that pairs with the signing key, ' +
-            'then re-run bin/revvault-bootstrap.sh. Contact the operator who stamped this kit.',
-        );
-      }
-    }
-    throw new Error(
-      'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_KEY is invalid, expired beyond grace, ' +
-        'signed with a key that does not match REVEALUI_LICENSE_PUBLIC_KEY, or its ' +
-        'customerId does not match REVEALUI_LICENSED_CUSTOMER_ID (if set). ' +
-        'Contact the operator who stamped this kit to re-issue the license.',
-    );
-  }
-
-  // Domain binding: when the license restricts domains, the configured public
-  // server URL must resolve to a licensed host. The allowed domains come from
-  // the signed JWT `domains` claim (cryptographically bound), so this cannot
-  // be bypassed by editing an env var. REVEALUI_PUBLIC_SERVER_URL presence is
-  // enforced separately in validateStartup's forge-mode REQUIRED list (prod);
-  // when it is absent here (e.g. dev), skip — request-time `requireDomain` is
-  // the per-request gate. localhost/127.0.0.1 pass via the shared matcher so a
-  // trial kit on its default http://localhost still boots.
-  if (payload.domains && payload.domains.length > 0) {
-    const publicUrl = (env.REVEALUI_PUBLIC_SERVER_URL ?? env.NEXT_PUBLIC_SERVER_URL ?? '').trim();
-    if (publicUrl) {
-      let host = '';
-      try {
-        host = new URL(publicUrl).hostname;
-      } catch {
-        host = '';
-      }
-      if (!hostMatchesLicensedDomains(host, payload.domains)) {
-        throw new Error(
-          'LICENSE VALIDATION FAILED: this license is restricted to ' +
-            `[${payload.domains.join(', ')}], but REVEALUI_PUBLIC_SERVER_URL host ` +
-            `"${host || '(unparseable)'}" is not among them. Set REVEALUI_PUBLIC_SERVER_URL ` +
-            'to a licensed domain, or contact the operator who stamped this kit.',
-        );
-      }
-    }
-  }
+  await validateForgeLicenseAtStartup(env);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
     "validate:react-floor": "tsx scripts/validate/react-rsc-floor.ts",
     "validate:docs-imports": "tsx scripts/validate/docs-import-drift.ts",
     "validate:api-docs": "tsx scripts/validate/api-docs-drift.ts",
+    "validate:docs-public-mirror": "tsx scripts/validate/docs-public-mirror.ts",
     "validate:citations": "tsx scripts/validate/citation-check.ts",
     "validate:changesets": "tsx scripts/validate/mixed-changesets.ts",
     "validate:changelogs": "tsx scripts/validate/changelog-format.ts",

--- a/packages/ai/src/orchestration/runtime.ts
+++ b/packages/ai/src/orchestration/runtime.ts
@@ -13,7 +13,11 @@ import type { AgentSkillProvider } from '../skills/integration/agent-skill-provi
 import type { ApprovalCallback, Tool, ToolResult } from '../tools/base.js';
 import { ToolCallDeduplicator } from '../tools/deduplicator.js';
 import type { MCPToolSource, McpClientLike } from '../tools/mcp-adapter.js';
-import { createToolsFromMcpClient, discoverMCPTools } from '../tools/mcp-adapter.js';
+import {
+  createToolsFromMcpClient,
+  discoverMCPTools,
+  warnHypervisorMcpPathDeprecated,
+} from '../tools/mcp-adapter.js';
 import type { McpToolCallEvent } from '../tools/mcp-events.js';
 import { createWebSearchTool } from '../tools/web/duck-duck-go.js';
 import type { Agent, AgentResult, Task } from './agent.js';
@@ -118,6 +122,9 @@ export class AgentRuntime {
   private isShuttingDown = false;
 
   constructor(config: RuntimeConfig = {}) {
+    if (config.mcpToolSource) {
+      warnHypervisorMcpPathDeprecated('AgentRuntime mcpToolSource');
+    }
     this.config = {
       maxIterations: config.maxIterations ?? 10,
       timeout: config.timeout ?? 60000, // 60 seconds

--- a/packages/ai/src/tools/mcp-adapter.ts
+++ b/packages/ai/src/tools/mcp-adapter.ts
@@ -25,6 +25,25 @@ import { z } from 'zod/v4';
 import type { Tool, ToolResult } from './base.js';
 import { emitMcpEvent, type McpEventSink, type McpToolCallEvent } from './mcp-events.js';
 
+/** One-time process warning for the hypervisor MCP tool path (REMOVE-BY ai@1.0.0). */
+let hypervisorPathWarned = false;
+
+export function warnHypervisorMcpPathDeprecated(site: string): void {
+  if (hypervisorPathWarned) return;
+  hypervisorPathWarned = true;
+  process.emitWarning(
+    `@revealui/ai: ${site} is deprecated. Prefer mcpClients / createToolsFromMcpClient (Stage 5.1a). ` +
+      'REMOVE-BY: @revealui/ai 1.0.0. See packages/ai/src/tools/mcp-adapter.ts.',
+    'DeprecationWarning',
+    'REVEALUI_AI_MCP_HYPERVISOR_DEPRECATED',
+  );
+}
+
+/** Test-only: reset the one-time deprecation warn latch. */
+export function resetHypervisorMcpPathWarningForTests(): void {
+  hypervisorPathWarned = false;
+}
+
 export interface MCPTool {
   name: string;
   description: string;
@@ -803,6 +822,7 @@ export interface DiscoverMCPToolsOptions {
  * ```
  */
 export function discoverMCPTools(source: MCPToolSource, options?: DiscoverMCPToolsOptions): Tool[] {
+  warnHypervisorMcpPathDeprecated('discoverMCPTools() / MCPToolSource');
   return source.getAllTools().map(({ namespacedName, serverName, tool }) => {
     const zodSchema = jsonSchemaToZod(tool.inputSchema);
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,11 @@
       "import": "./dist/revforge-license.js",
       "default": "./dist/revforge-license.js"
     },
+    "./revforge-license-boot": {
+      "types": "./dist/revforge-license-boot.d.ts",
+      "import": "./dist/revforge-license-boot.js",
+      "default": "./dist/revforge-license-boot.js"
+    },
     "./features": {
       "types": "./dist/features.d.ts",
       "import": "./dist/features.js",

--- a/packages/core/src/__tests__/revforge-license-boot.test.ts
+++ b/packages/core/src/__tests__/revforge-license-boot.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared Forge license boot gate (admin + server).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  detectDeploymentMode,
+  validateLicenseKey,
+  computeKeyId,
+  hostMatchesLicensedDomains,
+  loggerInfo,
+} = vi.hoisted(() => ({
+  detectDeploymentMode: vi.fn(),
+  validateLicenseKey: vi.fn(),
+  computeKeyId: vi.fn(),
+  hostMatchesLicensedDomains: vi.fn(),
+  loggerInfo: vi.fn(),
+}));
+
+vi.mock('../deployment-mode.js', () => ({
+  detectDeploymentMode: (...args: unknown[]) => detectDeploymentMode(...args),
+}));
+
+vi.mock('../license.js', () => ({
+  validateLicenseKey: (...args: unknown[]) => validateLicenseKey(...args),
+  computeKeyId: (...args: unknown[]) => computeKeyId(...args),
+  hostMatchesLicensedDomains: (...args: unknown[]) => hostMatchesLicensedDomains(...args),
+}));
+
+vi.mock('../observability/logger.js', () => ({
+  logger: { info: loggerInfo, warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  ALLOW_UNLICENSED_SELF_HOST_ENV,
+  decodeJwtKid,
+  validateForgeLicenseAtStartup,
+} from '../revforge-license-boot.js';
+
+describe('validateForgeLicenseAtStartup', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('no-ops when SKIP_ENV_VALIDATION=true', async () => {
+    await expect(
+      validateForgeLicenseAtStartup({ SKIP_ENV_VALIDATION: 'true' }),
+    ).resolves.toBeUndefined();
+    expect(detectDeploymentMode).not.toHaveBeenCalled();
+  });
+
+  it('no-ops in hosted mode', async () => {
+    detectDeploymentMode.mockReturnValue('hosted');
+    await expect(validateForgeLicenseAtStartup({})).resolves.toBeUndefined();
+  });
+
+  it('allows Free (OSS) tier with opt-in and no key', async () => {
+    detectDeploymentMode.mockReturnValue('forge');
+    await expect(
+      validateForgeLicenseAtStartup({ [ALLOW_UNLICENSED_SELF_HOST_ENV]: 'true' }),
+    ).resolves.toBeUndefined();
+    expect(loggerInfo).toHaveBeenCalledWith('no license key — running Free (OSS) tier');
+  });
+
+  it('throws when forge mode has no key and no opt-in', async () => {
+    detectDeploymentMode.mockReturnValue('forge');
+    await expect(validateForgeLicenseAtStartup({})).rejects.toThrow(
+      /REVEALUI_LICENSE_KEY is required/,
+    );
+  });
+
+  it('throws when public key missing', async () => {
+    detectDeploymentMode.mockReturnValue('forge');
+    await expect(validateForgeLicenseAtStartup({ REVEALUI_LICENSE_KEY: 'a.b.c' })).rejects.toThrow(
+      /REVEALUI_LICENSE_PUBLIC_KEY is required/,
+    );
+  });
+
+  it('throws when validateLicenseKey rejects', async () => {
+    detectDeploymentMode.mockReturnValue('forge');
+    validateLicenseKey.mockResolvedValue(null);
+    await expect(
+      validateForgeLicenseAtStartup({
+        REVEALUI_LICENSE_KEY: 'a.b.c',
+        REVEALUI_LICENSE_PUBLIC_KEY: 'pem',
+      }),
+    ).rejects.toThrow(/invalid, expired beyond grace/);
+  });
+
+  it('accepts a valid payload', async () => {
+    detectDeploymentMode.mockReturnValue('forge');
+    validateLicenseKey.mockResolvedValue({ tier: 'pro', customerId: 'acme' });
+    await expect(
+      validateForgeLicenseAtStartup({
+        REVEALUI_LICENSE_KEY: 'a.b.c',
+        REVEALUI_LICENSE_PUBLIC_KEY: 'pem',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('decodeJwtKid', () => {
+  it('returns kid from a well-formed header segment', () => {
+    const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', kid: 'abc' })).toString('base64url');
+    expect(decodeJwtKid(`${header}.payload.sig`)).toBe('abc');
+  });
+
+  it('returns undefined for garbage', () => {
+    expect(decodeJwtKid('not-a-jwt')).toBeUndefined();
+  });
+});

--- a/packages/core/src/revforge-license-boot.ts
+++ b/packages/core/src/revforge-license-boot.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared Forge / self-host license boot gate for apps/admin + apps/server.
+ *
+ * Extracted from the intentional admin/server dual after the 2026-08-02 fleet
+ * redundancy audit. Server previously owned the full check (customer id, kid
+ * mismatch, domain binding); admin had a shortened copy. One implementation
+ * so the two cannot drift (instrumentation.ts TODO resolved).
+ *
+ * Throws on failure. Callers that must not throw (Next.js instrumentation)
+ * catch and `process.exit(1)`.
+ */
+
+import {
+  type DeploymentMode,
+  detectDeploymentMode as detectDeploymentModeCore,
+} from './deployment-mode.js';
+import { computeKeyId, hostMatchesLicensedDomains, validateLicenseKey } from './license.js';
+import { logger } from './observability/logger.js';
+
+export type EnvMap = Record<string, string | undefined>;
+
+/**
+ * GAP-436 (owner-ruled 2026-07-26): plain OSS/self-host opt-in when no key is
+ * present. Stamped RevForge kits always bake a key, so they never hit this.
+ */
+export const ALLOW_UNLICENSED_SELF_HOST_ENV = 'REVEALUI_ALLOW_UNLICENSED_SELF_HOST';
+
+/**
+ * Extracts the `kid` (key id) from a JWT protected header WITHOUT verifying
+ * the signature. Used only to sharpen error messages after cryptographic
+ * verification has already failed.
+ */
+export function decodeJwtKid(jwt: string): string | undefined {
+  const headerSegment = jwt.split('.')[0];
+  if (!headerSegment) return undefined;
+  try {
+    const header: unknown = JSON.parse(Buffer.from(headerSegment, 'base64url').toString('utf8'));
+    if (header && typeof header === 'object' && 'kid' in header) {
+      const { kid } = header as { kid?: unknown };
+      return typeof kid === 'string' ? kid : undefined;
+    }
+  } catch {
+    // Malformed header — caller surfaces generic invalid-license error.
+  }
+  return undefined;
+}
+
+/**
+ * Forge-mode license enforcement at process boot.
+ *
+ * - Hosted mode: no-op.
+ * - Forge mode + no key + ALLOW_UNLICENSED_SELF_HOST: Free (OSS) tier log, return.
+ * - Forge mode otherwise: require key + public key, verify JWT, optional
+ *   customerId + domain binding.
+ *
+ * Honors `SKIP_ENV_VALIDATION=true` for Docker build / tests.
+ */
+export async function validateForgeLicenseAtStartup(
+  env: EnvMap = process.env as EnvMap,
+): Promise<void> {
+  if (env.SKIP_ENV_VALIDATION === 'true') {
+    return;
+  }
+
+  const mode: DeploymentMode = detectDeploymentModeCore(env);
+  if (mode !== 'forge') {
+    return;
+  }
+
+  if (!env.REVEALUI_LICENSE_KEY) {
+    if (env[ALLOW_UNLICENSED_SELF_HOST_ENV] === 'true') {
+      logger.info('no license key — running Free (OSS) tier');
+      return;
+    }
+    throw new Error(
+      'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_KEY is required for RevForge deployments. ' +
+        'Run bin/revvault-bootstrap.sh to materialize docker/.env from revvault, ' +
+        'or contact the operator who stamped this kit. A plain self-host deployment that ' +
+        `intends to run without a license should set ${ALLOW_UNLICENSED_SELF_HOST_ENV}=true to ` +
+        'boot at Free (OSS) tier instead.',
+    );
+  }
+  if (!env.REVEALUI_LICENSE_PUBLIC_KEY) {
+    throw new Error(
+      'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_PUBLIC_KEY is required for RevForge deployments. ' +
+        'Stamped kits embed this value in docker/.env.example; check that it survived the bootstrap step.',
+    );
+  }
+
+  // Restore real newlines if the public key landed as a single-line PEM
+  // (stamp.sh .env encoding). Split/join, no authored regex — mirrors
+  // @revealui/core/license normalizePem. GAP-259 P0-4.
+  const publicKey = env.REVEALUI_LICENSE_PUBLIC_KEY.split('\\n').join('\n');
+  const expectedCustomerId = env.REVEALUI_LICENSED_CUSTOMER_ID || undefined;
+  const payload = await validateLicenseKey(env.REVEALUI_LICENSE_KEY, publicKey, expectedCustomerId);
+  if (!payload) {
+    const tokenKid = decodeJwtKid(env.REVEALUI_LICENSE_KEY);
+    if (tokenKid !== undefined) {
+      const expectedKid = await computeKeyId(publicKey);
+      if (tokenKid !== expectedKid) {
+        throw new Error(
+          'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_PUBLIC_KEY does not match the key that ' +
+            `signed REVEALUI_LICENSE_KEY (license key id "${tokenKid}", configured public key id ` +
+            `"${expectedKid}"). The stamped kit baked the wrong public key. Re-issue the license ` +
+            'with the matching keypair, or bake the public key that pairs with the signing key, ' +
+            'then re-run bin/revvault-bootstrap.sh. Contact the operator who stamped this kit.',
+        );
+      }
+    }
+    throw new Error(
+      'LICENSE VALIDATION FAILED: REVEALUI_LICENSE_KEY is invalid, expired beyond grace, ' +
+        'signed with a key that does not match REVEALUI_LICENSE_PUBLIC_KEY, or its ' +
+        'customerId does not match REVEALUI_LICENSED_CUSTOMER_ID (if set). ' +
+        'Contact the operator who stamped this kit to re-issue the license.',
+    );
+  }
+
+  if (payload.domains && payload.domains.length > 0) {
+    const publicUrl = (env.REVEALUI_PUBLIC_SERVER_URL ?? env.NEXT_PUBLIC_SERVER_URL ?? '').trim();
+    if (publicUrl) {
+      let host = '';
+      try {
+        host = new URL(publicUrl).hostname;
+      } catch {
+        host = '';
+      }
+      if (!hostMatchesLicensedDomains(host, payload.domains)) {
+        throw new Error(
+          'LICENSE VALIDATION FAILED: this license is restricted to ' +
+            `[${payload.domains.join(', ')}], but REVEALUI_PUBLIC_SERVER_URL host ` +
+            `"${host || '(unparseable)'}" is not among them. Set REVEALUI_PUBLIC_SERVER_URL ` +
+            'to a licensed domain, or contact the operator who stamped this kit.',
+        );
+      }
+    }
+  }
+}

--- a/packages/test/load-tests/load/README.md
+++ b/packages/test/load-tests/load/README.md
@@ -79,6 +79,14 @@ pnpm test:perf:analyze
 - **Payment Processing**: 95% of requests < 3s
 - **Error Rate**: < 1-2% depending on endpoint
 
+## Baseline files
+
+`baseline.json`, `endpoints.json`, and `targets.json` are **hand-maintained**
+operator targets for the autocannon dry-run / analyze scripts. They are not
+live CI result dumps. Do not commit a `current-results.json` twin that only
+mirrors `baseline.json` (that kills regression signal — fleet-redundancy audit
+2026-08-02).
+
 ## Running All Tests
 
 ```bash

--- a/scripts/validate/docs-public-mirror.ts
+++ b/scripts/validate/docs-public-mirror.ts
@@ -1,0 +1,58 @@
+/**
+ * Fail when leftover generated markdown sits under apps/docs/public/
+ * (ADR 2026-07-29 virtual serve — monorepo docs/ is the only authoring SoT).
+ *
+ * Hand-authored exception: apps/docs/public/docs-pro/
+ *
+ * Fix: pnpm --filter docs clean:public-mirror
+ * Or:  node apps/docs/scripts/clean-public-mirror.mjs
+ */
+
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(fileURLToPath(new URL('.', import.meta.url)), '../..');
+const publicDir = join(repoRoot, 'apps/docs/public');
+
+function collectLeftoverMd(dir: string, acc: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return acc;
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    let st: ReturnType<typeof statSync>;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      if (name === 'docs-pro') continue;
+      collectLeftoverMd(full, acc);
+    } else if (st.isFile() && name.endsWith('.md')) {
+      acc.push(relative(publicDir, full));
+    }
+  }
+  return acc;
+}
+
+const leftovers = collectLeftoverMd(publicDir);
+if (leftovers.length > 0) {
+  console.error(
+    `[docs-public-mirror] ${leftovers.length} leftover generated .md file(s) under apps/docs/public/ (not docs-pro).\n` +
+      'ADR 2026-07-29: do not materialize monorepo docs/ into public/*.md.\n' +
+      'Run: pnpm --filter docs clean:public-mirror\n\n' +
+      leftovers
+        .slice(0, 40)
+        .map((p) => `  - ${p}`)
+        .join('\n') +
+      (leftovers.length > 40 ? `\n  ... and ${leftovers.length - 40} more` : ''),
+  );
+  process.exit(1);
+}
+
+console.log('[docs-public-mirror] OK — no leftover generated public markdown.');


### PR DESCRIPTION
## Summary

Fleet-redundancy residual optionals from the 2026-08-02 audit:

1. **Forge license boot SSOT** — `@revealui/core/revforge-license-boot` shared by `apps/server` `validateLicenseAtStartup` and `apps/admin` instrumentation.
2. **AI hypervisor path** — one-time DeprecationWarning for `mcpToolSource` / `discoverMCPTools` (REMOVE-BY `@revealui/ai` 1.0.0).
3. **`pnpm validate:docs-public-mirror`** — fails if leftover generated public markdown reappears.
4. **Load-test README** — baseline files are hand-maintained targets.

Cron-alert dual already SSOT in core; no change needed.

## Test plan

- [x] core revforge-license-boot tests (9)
- [x] server validateLicenseAtStartup tests (19)
- [x] admin instrumentation-license-gate (4)
- [x] validate:docs-public-mirror
- [x] pnpm gate --phase=1 --changed
- [ ] CI green

Lane reopen: separate jv PR.