### PR TITLE
feat(core,router,rsc-poc): 2.3.3 observability without nextjs sentry

### DIFF
--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -24,7 +24,8 @@ plugin-rsc; Phase 2.2.2 T0–T7 built the engine; **T8** is the first real consu
 | `src/entry.ssr.tsx` | SSR from teed flight; payload inline owned by router |
 | `src/entry.browser.tsx` | Hydrate + `setRscPayloadLoader` + `useRscPayload` (2.2.3 router-owned nav) |
 | `src/auth/*` | Dogfood signed-cookie session + `useAction` requireSession (2.3.1) |
-| `src/pages/*` | Demo pages + `/session` + `/errors` (2.3.2 boundaries) |
+| `src/observability/*` | Node + browser init via `@revealui/core/observability` (2.3.3) |
+| `src/pages/*` | Demo pages + `/session` + `/errors` (2.3.2 boundaries + 2.3.3 capture) |
 
 ## Commands
 
@@ -40,6 +41,19 @@ BASE_URL=http://127.0.0.1:4173 pnpm --filter @rsc-poc/app smoke:http
 
 Migration + runtime docs: `packages/router/docs/MIGRATION-RSC.md`,
 `packages/router/docs/RUNTIME-SUPPORT.md`.
+
+## Observability (2.3.3)
+
+Framework-agnostic sink only — **no** `@sentry/nextjs`.
+
+| Runtime | Init | Capture |
+|---------|------|---------|
+| Node / RSC | `src/observability/node.ts` → `initNodeObservability` from entry.rsc | `renderRequest({ onError })` → loader/action/form failures (action id, never body) |
+| Browser | `src/observability/browser.ts` → `initBrowserObservability` from entry.browser | `ErrorBoundary onError` + window handlers |
+
+Request correlation: bind `x-request-id` or `x-correlation-id` per request.
+
+Dogfood: open `/errors/boom` (Node console) or click client throw on `/errors` (browser console).
 
 ## Pin policy
 

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.11",
+    "@revealui/core": "workspace:*",
     "@revealui/router": "workspace:*",
     "@revealui/utils": "workspace:*",
     "@vitejs/plugin-react": "catalog:",

--- a/apps/rsc-poc/src/app-router.server.ts
+++ b/apps/rsc-poc/src/app-router.server.ts
@@ -24,6 +24,7 @@ export function registerServerErrorRoutes(router: Router): void {
     layout: AppLayout,
     meta: { title: 'Forced loader boom' },
     loader: () => {
+      // Intentional throw for 2.3.2 shell + 2.3.3 onError capture (console sink).
       throw new Error('dogfood loader explosion');
     },
   });

--- a/apps/rsc-poc/src/entry.browser.tsx
+++ b/apps/rsc-poc/src/entry.browser.tsx
@@ -25,11 +25,17 @@ import React from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { createAppRouter } from './app-router.ts';
 import type { RscPayload } from './entry.rsc.tsx';
+import {
+  initRscPocBrowserObservability,
+  reportClientRenderError,
+} from './observability/browser.ts';
 import { ErrorFallback } from './pages/error-fallback.tsx';
 
 const router = createAppRouter();
 
 async function main(): Promise<void> {
+  initRscPocBrowserObservability();
+
   router.setRscPayloadLoader(async (url, signal) => {
     const res = await fetch(url, {
       headers: { accept: RSC_ACCEPT },
@@ -110,6 +116,7 @@ async function main(): Promise<void> {
         ) : null}
         <ErrorBoundary
           fallback={ErrorFallback}
+          onError={reportClientRenderError}
           resetKey={
             typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/'
           }

--- a/apps/rsc-poc/src/entry.rsc.tsx
+++ b/apps/rsc-poc/src/entry.rsc.tsx
@@ -1,10 +1,11 @@
 /**
  * RSC entry — renderRequest owns JS actions (T7) and progressive forms (2.2.4).
  * Session login/logout are progressive form endpoints outside the flight path (2.3.1).
+ * Observability: `@revealui/core/observability` Node init (2.3.3).
  */
 
+import { logger } from '@revealui/core/observability/logger';
 import { renderRequest } from '@revealui/router/server';
-import { logger } from '@revealui/utils/logger';
 import {
   createTemporaryReferenceSet,
   decodeAction,
@@ -17,8 +18,15 @@ import type { ReactFormState } from 'react-dom/client';
 import { registerServerErrorRoutes } from './app-router.server.ts';
 import { createAppRouter } from './app-router.ts';
 import { sessionClearCookieHeader, sessionSetCookieHeader, signSession } from './auth/session.ts';
+import {
+  bindRequestIdFromRequest,
+  initRscPocNodeObservability,
+  reportRenderError,
+} from './observability/node.ts';
 import { AppLayout } from './pages/layout.tsx';
 import { NotFoundPage } from './pages/not-found.tsx';
+
+initRscPocNodeObservability();
 
 export interface RscPayload {
   root: React.ReactNode;
@@ -81,6 +89,8 @@ async function handleSessionApi(request: Request): Promise<Response | null> {
 }
 
 async function handler(request: Request): Promise<Response> {
+  bindRequestIdFromRequest(request);
+
   const sessionApi = await handleSessionApi(request);
   if (sessionApi) return sessionApi;
 
@@ -94,6 +104,7 @@ async function handler(request: Request): Promise<Response> {
   return renderRequest(request, {
     router,
     title: 'RSC POC — dual-mode router',
+    onError: reportRenderError,
     loadServerAction: async (id) => {
       const action = await loadServerAction(id);
       return action as (...args: unknown[]) => unknown | Promise<unknown>;

--- a/apps/rsc-poc/src/observability/browser.ts
+++ b/apps/rsc-poc/src/observability/browser.ts
@@ -1,0 +1,24 @@
+/**
+ * Browser entry observability init (Phase 2.3.3).
+ * Sink: `@revealui/core/observability` (structured logger → console in dev).
+ * No `@sentry/nextjs`.
+ */
+'use client';
+
+import { captureException, initBrowserObservability } from '@revealui/core/observability/capture';
+
+const SERVICE = 'rsc-poc';
+
+/** Call once at the start of entry.browser main(). */
+export function initRscPocBrowserObservability(): void {
+  initBrowserObservability({ service: SERVICE });
+}
+
+/** ErrorBoundary onError → capture (no secrets). */
+export function reportClientRenderError(error: Error): void {
+  captureException(error, {
+    service: SERVICE,
+    kind: 'react_error_boundary',
+    pathname: typeof window !== 'undefined' ? window.location.pathname : undefined,
+  });
+}

--- a/apps/rsc-poc/src/observability/node.ts
+++ b/apps/rsc-poc/src/observability/node.ts
@@ -1,0 +1,46 @@
+/**
+ * Node / RSC entry observability init (Phase 2.3.3).
+ * Sink: `@revealui/core/observability` (structured logger → console in dev).
+ * No `@sentry/nextjs`.
+ */
+
+import {
+  bindRequestId,
+  captureActionFailure,
+  captureException,
+  initNodeObservability,
+} from '@revealui/core/observability/capture';
+
+const SERVICE = 'rsc-poc';
+
+/** Call once from entry.rsc (module top-level is fine). */
+export function initRscPocNodeObservability(): void {
+  initNodeObservability({ service: SERVICE });
+}
+
+/** Prefer x-request-id, then x-correlation-id. */
+export function bindRequestIdFromRequest(request: Request): void {
+  const id =
+    request.headers.get('x-request-id') ?? request.headers.get('x-correlation-id') ?? undefined;
+  bindRequestId(id);
+}
+
+export function reportRenderError(
+  error: unknown,
+  meta: { phase: 'action' | 'form' | 'loader'; pathname: string; actionId?: string },
+): void {
+  if (meta.phase === 'action' && meta.actionId) {
+    captureActionFailure(meta.actionId, error, {
+      pathname: meta.pathname,
+      phase: meta.phase,
+      service: SERVICE,
+    });
+    return;
+  }
+  captureException(error, {
+    pathname: meta.pathname,
+    phase: meta.phase,
+    service: SERVICE,
+    kind: meta.phase === 'loader' ? 'loader_failure' : 'form_action_failure',
+  });
+}

--- a/apps/rsc-poc/src/pages/errors.tsx
+++ b/apps/rsc-poc/src/pages/errors.tsx
@@ -1,24 +1,31 @@
 import { ErrorsClient } from './errors-client.tsx';
 
 /**
- * Error dogfood (Phase 2.3.2).
- * - Client throw: caught by ErrorBoundary in entry.browser
- * - Server paths: /errors/not-found (notFound sentinel), /errors/boom (loader 500)
+ * Error + observability dogfood (Phase 2.3.2 / 2.3.3).
+ * - Client throw: ErrorBoundary + captureException (browser console sink)
+ * - Server boom: renderRequest onError → captureException (Node console sink)
+ * - notFound: controlled 404 (not an error capture)
  */
 export function ErrorsPage(): React.ReactNode {
   return (
     <div>
-      <h1>Errors — dogfood (2.3.2)</h1>
+      <h1>Errors — dogfood (2.3.2 + 2.3.3)</h1>
       <p>
-        Client throw is isolated by <code>ErrorBoundary</code>. Server failures use controlled 404 /
-        500 shells from <code>renderRequest</code>.
+        Client throw is isolated by <code>ErrorBoundary</code> and reported via{' '}
+        <code>@revealui/core/observability/capture</code>. Server failures use controlled 404 / 500
+        shells from <code>renderRequest</code>; loader throws also hit the Node capture sink (dev
+        console).
+      </p>
+      <p>
+        Zero <code>@sentry/nextjs</code>. Init: <code>src/observability/node.ts</code> +{' '}
+        <code>browser.ts</code>.
       </p>
       <ul>
         <li>
           <a href="/errors/not-found">Server notFound()</a> (expect 404 shell)
         </li>
         <li>
-          <a href="/errors/boom">Server loader throw</a> (expect 500 shell)
+          <a href="/errors/boom">Server loader throw</a> (expect 500 shell + Node log)
         </li>
       </ul>
       <ErrorsClient />

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/core
 
+## 0.12.3
+
+### Minor Changes
+
+- Phase 2.3.3: `@revealui/core/observability/capture` — `initNodeObservability`,
+  `initBrowserObservability`, `captureException`, `captureActionFailure`,
+  `bindRequestId` (no `@sentry/nextjs`; browser-safe capture entry).
+
 ## 0.12.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/core",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {
@@ -310,11 +310,17 @@
       "import": "./dist/observability/index.js",
       "default": "./dist/observability/index.js"
     },
+    "./observability/capture": {
+      "types": "./dist/observability/capture.d.ts",
+      "import": "./dist/observability/capture.js",
+      "default": "./dist/observability/capture.js"
+    },
     "./observability/logger": {
       "types": "./dist/observability/logger.d.ts",
       "import": "./dist/observability/logger.js",
       "default": "./dist/observability/logger.js"
     },
+
     "./observability/metrics": {
       "types": "./dist/observability/metrics.d.ts",
       "import": "./dist/observability/metrics.js",

--- a/packages/core/src/observability/__tests__/capture.test.ts
+++ b/packages/core/src/observability/__tests__/capture.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLogger, mockLogError } = vi.hoisted(() => {
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    setContext: vi.fn(),
+    clearContext: vi.fn(),
+    child: vi.fn(),
+    addLogHandler: vi.fn(),
+  };
+  const mockLogError = vi.fn();
+  return { mockLogger, mockLogError };
+});
+
+vi.mock('../logger.js', () => ({
+  logger: mockLogger,
+  logError: mockLogError,
+}));
+
+import {
+  bindRequestId,
+  captureActionFailure,
+  captureException,
+  captureMessage,
+  initBrowserObservability,
+  initNodeObservability,
+  resetObservabilityInstallFlagsForTests,
+  sanitizeCaptureContext,
+} from '../capture.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetObservabilityInstallFlagsForTests();
+});
+
+afterEach(() => {
+  resetObservabilityInstallFlagsForTests();
+});
+
+describe('sanitizeCaptureContext', () => {
+  it('strips secret-shaped keys and keeps actionId', () => {
+    const out = sanitizeCaptureContext({
+      actionId: 'act_1',
+      password: 'nope',
+      body: { secret: true },
+      formData: new FormData(),
+      pathname: '/actions',
+    });
+    expect(out).toEqual({ actionId: 'act_1', pathname: '/actions' });
+  });
+});
+
+describe('captureException / captureMessage / captureActionFailure', () => {
+  it('captureException logs via logError', () => {
+    const err = new Error('boom');
+    captureException(err, { kind: 'test' });
+    expect(mockLogError).toHaveBeenCalledWith(err, { kind: 'test' });
+  });
+
+  it('captureException coerces non-Error', () => {
+    captureException('string fail');
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'string fail' }),
+      undefined,
+    );
+  });
+
+  it('captureMessage uses logger.info', () => {
+    captureMessage('hello', { service: 'rsc-poc' });
+    expect(mockLogger.info).toHaveBeenCalledWith('hello', { service: 'rsc-poc' });
+  });
+
+  it('captureActionFailure tags action id and never needs body', () => {
+    const err = new Error('action failed');
+    captureActionFailure('server-action-id', err, { password: 'x' });
+    expect(mockLogError).toHaveBeenCalledWith(err, {
+      actionId: 'server-action-id',
+      kind: 'action_failure',
+    });
+  });
+});
+
+describe('bindRequestId', () => {
+  it('sets requestId on logger when present', () => {
+    bindRequestId('req-abc');
+    expect(mockLogger.setContext).toHaveBeenCalledWith({ requestId: 'req-abc' });
+  });
+
+  it('no-ops on empty', () => {
+    bindRequestId('');
+    bindRequestId(null);
+    expect(mockLogger.setContext).not.toHaveBeenCalled();
+  });
+});
+
+describe('initNodeObservability', () => {
+  it('sets service context and logs init', () => {
+    initNodeObservability({ service: 'rsc-poc', installProcessHandlers: false });
+    expect(mockLogger.setContext).toHaveBeenCalledWith({ service: 'rsc-poc', runtime: 'node' });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'observability: node init',
+      expect.objectContaining({ service: 'rsc-poc', runtime: 'node' }),
+    );
+  });
+});
+
+describe('initBrowserObservability', () => {
+  it('sets service context and logs init', () => {
+    initBrowserObservability({ service: 'rsc-poc', installWindowHandlers: false });
+    expect(mockLogger.setContext).toHaveBeenCalledWith({
+      service: 'rsc-poc',
+      runtime: 'browser',
+    });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'observability: browser init',
+      expect.objectContaining({ service: 'rsc-poc', runtime: 'browser' }),
+    );
+  });
+});

--- a/packages/core/src/observability/capture.ts
+++ b/packages/core/src/observability/capture.ts
@@ -1,0 +1,161 @@
+/**
+ * Framework-agnostic error/event capture (Phase 2.3.3).
+ *
+ * Prefer this over `@sentry/nextjs`. Sink is the structured logger
+ * (`@revealui/core/observability/logger` → console or remote via LoggerConfig).
+ * Browser-safe: no node: builtins. Node handlers are gated on `process`.
+ */
+
+import type { LogContext } from './logger.js';
+import { logError, logger } from './logger.js';
+
+/** Keys that must never ride along on capture context (secrets / bodies). */
+const FORBIDDEN_CONTEXT_KEYS = new Set([
+  'password',
+  'secret',
+  'token',
+  'authorization',
+  'cookie',
+  'cookies',
+  'body',
+  'formdata',
+  'form',
+  'formstate',
+  'credentials',
+  'apikey',
+  'api_key',
+  'sessiontoken',
+]);
+
+export interface CaptureContext extends LogContext {
+  tags?: Record<string, string>;
+}
+
+export interface InitNodeObservabilityOptions {
+  /** Service name for log context (default `app`). */
+  service?: string;
+  /**
+   * Install process `unhandledRejection` / `uncaughtException` handlers.
+   * Default true. Idempotent across multiple calls.
+   */
+  installProcessHandlers?: boolean;
+}
+
+export interface InitBrowserObservabilityOptions {
+  /** Service name for log context (default `app`). */
+  service?: string;
+  /**
+   * Install `window` error + unhandledrejection listeners.
+   * Default true. Idempotent across multiple calls.
+   */
+  installWindowHandlers?: boolean;
+}
+
+let nodeHandlersInstalled = false;
+let browserHandlersInstalled = false;
+
+/**
+ * Strip secret-shaped keys from capture context.
+ * Never logs form bodies or credentials.
+ */
+export function sanitizeCaptureContext(context?: CaptureContext): LogContext | undefined {
+  if (!context) return undefined;
+  const out: LogContext = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (FORBIDDEN_CONTEXT_KEYS.has(key.toLowerCase())) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Capture an exception to the configured sink (console / remote logger).
+ */
+export function captureException(error: unknown, context?: CaptureContext): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logError(err, sanitizeCaptureContext(context));
+}
+
+/**
+ * Capture a non-error event/message.
+ */
+export function captureMessage(message: string, context?: CaptureContext): void {
+  logger.info(message, sanitizeCaptureContext(context));
+}
+
+/**
+ * Capture a failed server action. Pass action id only — never the body.
+ */
+export function captureActionFailure(
+  actionId: string,
+  error: unknown,
+  context?: CaptureContext,
+): void {
+  captureException(error, {
+    ...context,
+    actionId,
+    kind: 'action_failure',
+  });
+}
+
+/**
+ * Bind a request/correlation id onto the default logger context when present.
+ */
+export function bindRequestId(requestId: string | null | undefined): void {
+  if (requestId && requestId.length > 0) {
+    logger.setContext({ requestId });
+  }
+}
+
+/**
+ * Node/SSR init: service context + optional process-level handlers.
+ * Call once from the RSC/Hono entry.
+ */
+export function initNodeObservability(options: InitNodeObservabilityOptions = {}): void {
+  const service = options.service ?? 'app';
+  logger.setContext({ service, runtime: 'node' });
+  logger.info('observability: node init', { service, runtime: 'node' });
+
+  if (options.installProcessHandlers === false) return;
+  if (nodeHandlersInstalled) return;
+  if (typeof process === 'undefined' || typeof process.on !== 'function') return;
+
+  nodeHandlersInstalled = true;
+  process.on('unhandledRejection', (reason: unknown) => {
+    captureException(reason, { kind: 'unhandledRejection' });
+  });
+  process.on('uncaughtException', (err: Error) => {
+    captureException(err, { kind: 'uncaughtException' });
+  });
+}
+
+/**
+ * Browser init: service context + optional window-level handlers.
+ * Call once from the client entry (before hydrate).
+ */
+export function initBrowserObservability(options: InitBrowserObservabilityOptions = {}): void {
+  const service = options.service ?? 'app';
+  logger.setContext({ service, runtime: 'browser' });
+  logger.info('observability: browser init', { service, runtime: 'browser' });
+
+  if (options.installWindowHandlers === false) return;
+  if (browserHandlersInstalled) return;
+  if (typeof window === 'undefined') return;
+
+  browserHandlersInstalled = true;
+  window.addEventListener('error', (event: ErrorEvent) => {
+    captureException(event.error ?? event.message, {
+      kind: 'window.error',
+      filename: event.filename,
+    });
+  });
+  window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+    captureException(event.reason, { kind: 'unhandledrejection' });
+  });
+}
+
+/** Test-only: reset install flags (vitest). */
+export function resetObservabilityInstallFlagsForTests(): void {
+  nodeHandlersInstalled = false;
+  browserHandlersInstalled = false;
+}

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -10,6 +10,7 @@
  */
 
 export * from './alerts.js';
+export * from './capture.js';
 export * from './cron-failure-alert.js';
 export * from './health-check.js';
 export * from './logger.js';

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/router
 
+## 0.4.0-rc.9
+
+### Minor Changes
+
+- Phase 2.3.3: `ErrorBoundary onError` and `renderRequest({ onError })` for
+  framework-agnostic observability (wire `@revealui/core/observability/capture`).
+
 ## 0.4.0-rc.6
 
 ### Patch Changes

--- a/packages/router/docs/MIGRATION-RSC.md
+++ b/packages/router/docs/MIGRATION-RSC.md
@@ -131,6 +131,33 @@ Both paths run `router.useAction(...)` middleware (auth/RBAC).
 - Router does **not** ship `revalidatePath` / tag cache (D4). Use HTTP
   `Cache-Control` + CDN, or `@revealui/cache` when appropriate.
 
+## Observability without Next Sentry (2.3.3)
+
+Do **not** use `@sentry/nextjs` / `withSentryConfig` on dual-mode apps.
+
+Prefer `@revealui/core/observability` (and `/capture`, `/logger` subpaths):
+
+```ts
+// Node / RSC entry
+import { initNodeObservability, captureException, captureActionFailure, bindRequestId } from '@revealui/core/observability/capture'
+initNodeObservability({ service: 'my-app' })
+// per request:
+bindRequestId(request.headers.get('x-request-id'))
+
+// Browser entry
+import { initBrowserObservability, captureException } from '@revealui/core/observability/capture'
+initBrowserObservability({ service: 'my-app' })
+```
+
+Router hooks for the same sink:
+
+| Surface | Hook |
+|---------|------|
+| Loader / action / form failures | `renderRequest({ onError: (err, meta) => … })` — `meta.actionId` only, never bodies |
+| Client render errors | `<ErrorBoundary onError={(err) => captureException(err)} …>` |
+
+Dogfood: `apps/rsc-poc` (`src/observability/*`, `/errors/boom`).
+
 ## What does not migrate 1:1 from Next App Router
 
 | Next | RevealUI router |
@@ -139,10 +166,11 @@ Both paths run `router.useAction(...)` middleware (auth/RBAC).
 | `revalidatePath` / `revalidateTag` | CDN / `@revealui/cache` (D4) |
 | File-based `app/` tree | Programmatic `router.register` |
 | Built-in RSDW bundling | Consumer wires `@vitejs/plugin-rsc` or RSDW (D11) |
+| `@sentry/nextjs` | `@revealui/core/observability/capture` (2.3.3) |
 
 ## Reference app
 
-`apps/rsc-poc` is the dual-mode dogfood harness (GAP-194 Phase 2.2).
+`apps/rsc-poc` is the dual-mode dogfood harness (GAP-194 Phase 2.2–2.3).
 
 ## Runtime support
 

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.8",
+  "version": "0.4.0-rc.9",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",

--- a/packages/router/src/__tests__/error-boundary.test.tsx
+++ b/packages/router/src/__tests__/error-boundary.test.tsx
@@ -73,6 +73,21 @@ describe('ErrorBoundary (2.3.2)', () => {
     spy.mockRestore();
   });
 
+  it('invokes onError for observability (2.3.3)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary fallback={Fallback} onError={onError}>
+        <Boom />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'render boom' }),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    );
+    spy.mockRestore();
+  });
+
   it('Routes uses per-route errorBoundary over router option', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     function RouteFallback({ error }: { error: Error }) {
@@ -157,5 +172,61 @@ describe('renderRequest loader failures (2.3.2)', () => {
     const json = (await res.json()) as { error: boolean; message: string };
     expect(json.error).toBe(true);
     expect(json.message).toMatch(/loader exploded|Something went wrong/);
+  });
+
+  it('invokes onError for loader failures (2.3.3)', async () => {
+    const onError = vi.fn();
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/boom',
+      component: () => null,
+      loader: () => {
+        throw new Error('loader exploded');
+      },
+    });
+    const res = await renderRequest(new Request('http://x/boom'), {
+      router,
+      createRscStream: async () => flightStream('x'),
+      onError,
+    });
+    expect(res.status).toBe(500);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'loader exploded' }), {
+      phase: 'loader',
+      pathname: '/boom',
+    });
+  });
+
+  it('invokes onError for failed JS actions with actionId (2.3.3)', async () => {
+    const onError = vi.fn();
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/',
+      component: () => null,
+    });
+    const res = await renderRequest(
+      new Request('http://x/', {
+        method: 'POST',
+        headers: {
+          'x-rsc-action': 'test-action-id',
+          accept: 'text/x-component',
+        },
+      }),
+      {
+        router,
+        createRscStream: async () => flightStream('x'),
+        loadServerAction: async () => {
+          return async () => {
+            throw new Error('action boom');
+          };
+        },
+        onError,
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'action boom' }), {
+      phase: 'action',
+      pathname: '/',
+      actionId: 'test-action-id',
+    });
   });
 });

--- a/packages/router/src/components.tsx
+++ b/packages/router/src/components.tsx
@@ -282,6 +282,11 @@ export class ErrorBoundary extends Component<
     children: React.ReactNode;
     /** Optional reset key — when it changes, clear the captured error. */
     resetKey?: string;
+    /**
+     * Optional observer (2.3.3). Wire to `@revealui/core/observability/capture`
+     * — never put secrets in the callback side effects.
+     */
+    onError?: (error: Error, info: React.ErrorInfo) => void;
   },
   { error: Error | null }
 > {
@@ -289,6 +294,7 @@ export class ErrorBoundary extends Component<
     fallback: React.ComponentType<{ error: Error }>;
     children: React.ReactNode;
     resetKey?: string;
+    onError?: (error: Error, info: React.ErrorInfo) => void;
   }) {
     super(props);
     this.state = { error: null };
@@ -296,6 +302,10 @@ export class ErrorBoundary extends Component<
 
   static getDerivedStateFromError(error: Error): { error: Error } {
     return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    this.props.onError?.(error, info);
   }
 
   componentDidUpdate(prevProps: { resetKey?: string }): void {

--- a/packages/router/src/server-rsc.tsx
+++ b/packages/router/src/server-rsc.tsx
@@ -93,6 +93,18 @@ export interface RenderRequestOptions {
   title?: string;
   /** Extra headers on the response (e.g. Cache-Control). */
   headers?: HeadersInit;
+  /**
+   * Optional observer for loader / action / form / render failures (2.3.3).
+   * Wire to `@revealui/core/observability/capture`. Never pass request bodies.
+   */
+  onError?: (
+    error: unknown,
+    meta: {
+      phase: 'action' | 'form' | 'loader';
+      pathname: string;
+      actionId?: string;
+    },
+  ) => void;
 }
 
 function defaultHtmlShell(opts: {
@@ -319,6 +331,7 @@ export async function renderRequest(
         } catch (error) {
           if (isRouterRedirect(error)) return redirectResponse(error, representation);
           if (isRouterNotFound(error)) return notFoundResponse(router, representation, error);
+          options.onError?.(error, { phase: 'action', pathname, actionId });
           returnValue = { ok: false, data: error instanceof Error ? error.message : String(error) };
         }
         match = await router.resolve(pathname);
@@ -341,6 +354,7 @@ export async function renderRequest(
         } catch (error) {
           if (isRouterRedirect(error)) return redirectResponse(error, representation);
           if (isRouterNotFound(error)) return notFoundResponse(router, representation, error);
+          options.onError?.(error, { phase: 'form', pathname });
           return new Response('Internal Server Error: server action failed', { status: 500 });
         }
         match = await router.resolve(pathname);
@@ -376,6 +390,7 @@ export async function renderRequest(
         throw error;
       }
       // Phase 2.3.2: loader/render failures → controlled 500 (no stack leak in prod).
+      options.onError?.(error, { phase: 'loader', pathname });
       return internalErrorResponse(error, representation);
     }
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,7 +368,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -608,7 +608,7 @@ importers:
         version: 10.67.0(react@19.2.8)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -670,6 +670,9 @@ importers:
       '@hono/node-server':
         specifier: '>=2.0.5'
         version: 2.0.11(hono@4.12.27)
+      '@revealui/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@revealui/router':
         specifier: workspace:*
         version: link:../../packages/router
@@ -12504,7 +12507,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8


### PR DESCRIPTION
## Summary

GAP-194 **Phase 2.3.3** — framework-agnostic observability for dual-mode router dogfood. Zero `@sentry/nextjs`.

### Core (`@revealui/core` **0.12.3**)
- New `@revealui/core/observability/capture` (browser-safe):
  - `initNodeObservability` / `initBrowserObservability`
  - `captureException` / `captureMessage` / `captureActionFailure` (action id only, never bodies)
  - `bindRequestId` + secret-key sanitize
- Tests: `packages/core/src/observability/__tests__/capture.test.ts`

### Router (`@revealui/router` **0.4.0-rc.9**)
- `ErrorBoundary onError` for client capture
- `renderRequest({ onError })` for loader / action / form failures
- MIGRATION-RSC section for the recipe
- Tests extended in `error-boundary.test.tsx`

### Dogfood (`apps/rsc-poc`)
- `src/observability/node.ts` + `browser.ts`
- Wired from `entry.rsc` / `entry.browser`
- `/errors/boom` appears in Node console sink with request id when `x-request-id` set

## Verification

- [x] `vitest` capture (9) + error-boundary (9)
- [x] `pnpm --filter @rsc-poc/app typecheck` + `build`
- [x] `smoke:http` green; `/errors/boom` logs `kind: loader_failure` (and `requestId` when header present)
- [x] Pre-push phase 1 gate PASS

## Owner

```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```

Next after merge: **2.3.4** request-layer checklist (or stop if parking the train).