### PR TITLE
fix(server,ci): unbreak E2E smoke + promote security-review gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,18 +780,30 @@ jobs:
             echo "E2E_KEY_EOF"
           } >> "$GITHUB_ENV"
 
+      # Ephemeral CI secrets (not real credentials). Admin next start is
+      # production-mode and still requires the base secret trio even with
+      # SKIP_ENV_VALIDATION (env-validation.ts). KEK must be 64 hex chars.
+      # Server production boot also requires CORS_ORIGIN + audit signing key
+      # (generated above into GITHUB_ENV as REVEALUI_AUDIT_SIGNING_KEY).
       - name: Start API server
         run: pnpm --filter server start &
         env:
           SKIP_ENV_VALIDATION: "true"
-          NODE_ENV: "development"
+          NODE_ENV: "production"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+          CORS_ORIGIN: "http://localhost:4000,http://localhost:3000"
+          REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
+          REVEALUI_PUBLIC_SERVER_URL: "http://localhost:3004"
+          REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
       - name: Start Admin server
         run: pnpm --filter admin start &
         env:
           SKIP_ENV_VALIDATION: "true"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+          REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
+          REVEALUI_PUBLIC_SERVER_URL: "http://localhost:4000"
+          REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
       - name: Start marketing server
         run: pnpm --filter marketing start &
@@ -908,6 +920,9 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "true"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+          REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
+          REVEALUI_PUBLIC_SERVER_URL: "http://localhost:4000"
+          REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
       - name: Start marketing server
         run: pnpm --filter marketing start &
@@ -1017,6 +1032,9 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "true"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+          REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
+          REVEALUI_PUBLIC_SERVER_URL: "http://localhost:4000"
+          REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
       - name: Wait for Admin
         run: |

--- a/apps/server/src/lib/license-jti-revocation.ts
+++ b/apps/server/src/lib/license-jti-revocation.ts
@@ -7,7 +7,11 @@
  * same customer.
  */
 
-import { readLicenseExp, readLicenseJti, resetLicenseState } from '@revealui/core';
+// Subpath only — bare `@revealui/core` is the package root barrel and pulls
+// client richtext / @lexical/code-prism into the server tsup bundle, which
+// throws `ReferenceError: Prism is not defined` at `node dist/index.js` boot
+// (E2E Smoke, 2026-08-02 promote).
+import { readLicenseExp, readLicenseJti, resetLicenseState } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
 import { getJtiRevocationEpoch, type JtiRevocationInput, recordJtiRevocations } from '@revealui/db';
 import type { Database } from '@revealui/db/client';

--- a/apps/server/tsup.config.ts
+++ b/apps/server/tsup.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
   // only by the E2E smoke job, 2026-07-25 promotion). External, Node loads
   // the CJS chain natively from node_modules like the other Pro packages.
   external: ['pg', 'pg-native', 'stripe', '@revealui/ai', '@revealui/services', '@revealui/mcp'],
+  // Prefer package.json "node" export condition for deps such as @lexical/code
+  // (LexicalCode.node.mjs). Without this, esbuild picks the default/browser
+  // chain through @lexical/code-prism which assigns Prism.languages.* against
+  // a missing global and kills `node dist/index.js` at import time
+  // (E2E Smoke on promote PRs, 2026-08-02).
+  esbuildOptions(options) {
+    options.conditions = ['node', 'import', 'module', 'default'];
+  },
   // OG fonts + resvg WASM are read at runtime from dist (copy-og-fonts /
   // copy-resvg-wasm). Do NOT binary-inline .ttf — that worked only in the
   // built bundle and broke `tsx watch` with ERR_UNKNOWN_FILE_EXTENSION

--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -270,14 +270,40 @@ function fetchCommitPulls(sha, repo, excludePrNumber, ghImpl) {
 }
 
 /**
+ * Parent count for a commit (merge commits have 2+). Injectable ghImpl.
+ */
+function fetchCommitParentCount(sha, repo, ghImpl) {
+  const run =
+    ghImpl ||
+    ((args) => execFileSync('gh', args, { encoding: 'utf8', timeout: 30000, maxBuffer: 2 * 1024 * 1024 }));
+  const path = `repos/${repo || '{owner}/{repo}'}/commits/${sha}`;
+  const out = run(['api', path, '--jq', '.parents | length']);
+  const n = Number(String(out).trim());
+  return Number.isFinite(n) ? n : 1;
+}
+
+/**
  * Build coverage rows for a promote PR: security-touching commits and whether
  * each traces to an upstream PR with a recorded sec-review verdict.
  * Injectable ghImpl for unit tests.
+ *
+ * Merge commits are skipped: `git show merge` lists the entire other-side tree
+ * as "changed", which re-attributes already-cleared feature files (e.g. a
+ * `merge origin/test into feat/…` after GAP-444 landed) to a commit that is
+ * not linked to the feature PR and has no sec-review label. Security deltas
+ * still appear on the non-merge feature commits that actually authored them.
  */
 function buildPromoteCoverage(prNumber, repo, ghImpl) {
   const shas = fetchPrCommitShas(prNumber, repo, ghImpl);
   const coverage = [];
   for (const sha of shas) {
+    try {
+      if (fetchCommitParentCount(sha, repo, ghImpl) > 1) {
+        continue;
+      }
+    } catch {
+      // Unknown parent count — keep evaluating the commit (fail closed on files).
+    }
     let files;
     try {
       files = fetchCommitFiles(sha, repo, ghImpl);


### PR DESCRIPTION
## Summary

Fixes the CI failures that blocked promote **#2344** (`test` → `main`).

### E2E Smoke (servers never started)

1. **Server `Prism is not defined`** — `license-jti-revocation.ts` imported from the bare `@revealui/core` barrel, so tsup pulled client Lexical/`@lexical/code-prism` into the API bundle. Switched to `@revealui/core/license`. Also prefer package `"node"` export conditions in server esbuild.
2. **Admin missing secrets** — production `next start` still requires `REVEALUI_SECRET` / `REVEALUI_PUBLIC_SERVER_URL` / `REVEALUI_KEK` even with `SKIP_ENV_VALIDATION`. Provision ephemeral CI values for smoke / a11y / visual jobs. Server also gets `CORS_ORIGIN` under `NODE_ENV=production`.

### Security review gate on promote

GAP-458 falsely held on **merge commits** (e.g. `merge origin/test into feat/…`) that re-list already-cleared security files. Skip merge commits (parent count > 1) when building promote coverage; real security deltas remain on non-merge feature commits.

## Verify

- Local: clean server build no longer emits `LexicalCodePrism*`; import gets past Prism to normal boot checks.
- CI: E2E Smoke + Security review gate on this PR and re-run on #2344 after merge to `test`.

## After merge to test

Promote #2344 head advances with `test`; re-check gates then:

```bash
gh pr merge 2344 -R RevealUIStudio/revealui --merge
```
