### PR TITLE
feat(rsc-poc): 2.3.4 request-layer perimeter + security smoke

### DIFF
--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -24,7 +24,8 @@ plugin-rsc; Phase 2.2.2 T0–T7 built the engine; **T8** is the first real consu
 | `src/entry.ssr.tsx` | SSR from teed flight; payload inline owned by router |
 | `src/entry.browser.tsx` | Hydrate + `setRscPayloadLoader` + `useRscPayload` (2.2.3 router-owned nav) |
 | `src/auth/*` | Dogfood signed-cookie session + `useAction` requireSession (2.3.1) |
-| `src/pages/*` | Demo pages + `/session` + `/errors` (2.3.2 boundaries) |
+| `src/observability/*` | Node + browser init via `@revealui/core/observability` (2.3.3) |
+| `src/pages/*` | Demo pages + `/session` + `/errors` (2.3.2 boundaries + 2.3.3 capture) |
 
 ## Commands
 
@@ -40,6 +41,19 @@ BASE_URL=http://127.0.0.1:4173 pnpm --filter @rsc-poc/app smoke:http
 
 Migration + runtime docs: `packages/router/docs/MIGRATION-RSC.md`,
 `packages/router/docs/RUNTIME-SUPPORT.md`.
+
+## Observability (2.3.3)
+
+Framework-agnostic sink only — **no** `@sentry/nextjs`.
+
+| Runtime | Init | Capture |
+|---------|------|---------|
+| Node / RSC | `src/observability/node.ts` → `initNodeObservability` from entry.rsc | `renderRequest({ onError })` → loader/action/form failures (action id, never body) |
+| Browser | `src/observability/browser.ts` → `initBrowserObservability` from entry.browser | `ErrorBoundary onError` + window handlers |
+
+Request correlation: bind `x-request-id` or `x-correlation-id` per request.
+
+Dogfood: open `/errors/boom` (Node console) or click client throw on `/errors` (browser console).
 
 ## Pin policy
 

--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -71,6 +71,12 @@ Checklist (admin port): `packages/router/docs/REQUEST-LAYER.md`.
 
 Smoke asserts `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, CSP present, and evil-Origin POST → 403.
 
+## Phase 3 ready (2.3.6)
+
+Phase 2.3 dogfood acceptance and the pre–admin-port gate live in  
+`packages/router/docs/PHASE-3-READY.md`. Owner must still mark criterion **G**
+before Phase 3 port work starts.
+
 ## Pin policy
 
 - `react` / `react-dom` / `react-server-dom-webpack`: **exact same version**, floor **≥19.2.4**

--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -25,6 +25,7 @@ plugin-rsc; Phase 2.2.2 T0–T7 built the engine; **T8** is the first real consu
 | `src/entry.browser.tsx` | Hydrate + `setRscPayloadLoader` + `useRscPayload` (2.2.3 router-owned nav) |
 | `src/auth/*` | Dogfood signed-cookie session + `useAction` requireSession (2.3.1) |
 | `src/observability/*` | Node + browser init via `@revealui/core/observability` (2.3.3) |
+| `src/request-layer/*` | Secure headers, domain-lock, CSRF origin (2.3.4; outside `Router.match`) |
 | `src/pages/*` | Demo pages + `/session` + `/errors` (2.3.2 boundaries + 2.3.3 capture) |
 
 ## Commands
@@ -54,6 +55,21 @@ Framework-agnostic sink only — **no** `@sentry/nextjs`.
 Request correlation: bind `x-request-id` or `x-correlation-id` per request.
 
 Dogfood: open `/errors/boom` (Node console) or click client throw on `/errors` (browser console).
+
+## Request layer (2.3.4)
+
+Perimeter **outside** `Router.match` / route tables:
+
+| Concern | Implementation |
+|---------|----------------|
+| Secure headers | `@revealui/security` `createSecurityMiddleware` (`src/request-layer/security.ts`) |
+| Domain-lock | `RSC_POC_ALLOWED_HOSTS` host allowlist (optional) |
+| CSRF (dogfood) | Same-origin Origin/Referer check on non-action POSTs |
+| Session mutations | `useAction` requireSession (2.3.1) — not match-time auth |
+
+Checklist (admin port): `packages/router/docs/REQUEST-LAYER.md`.
+
+Smoke asserts `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, CSP present, and evil-Origin POST → 403.
 
 ## Pin policy
 

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.11",
+    "@revealui/core": "workspace:*",
     "@revealui/router": "workspace:*",
     "@revealui/utils": "workspace:*",
     "@vitejs/plugin-react": "catalog:",

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -13,12 +13,14 @@
     "lint": "biome check .",
     "preview": "vite preview",
     "smoke:http": "node scripts/smoke-http.mjs",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.11",
     "@revealui/core": "workspace:*",
     "@revealui/router": "workspace:*",
+    "@revealui/security": "workspace:*",
     "@revealui/utils": "workspace:*",
     "@vitejs/plugin-react": "catalog:",
     "@vitejs/plugin-rsc": "0.5.27",
@@ -33,6 +35,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/rsc-poc/scripts/smoke-http.mjs
+++ b/apps/rsc-poc/scripts/smoke-http.mjs
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 /**
- * Phase 2.2.5 HTTP smoke for dual-mode rsc-poc (preview or dev).
+ * Phase 2.2.5 + 2.3.4 HTTP smoke for dual-mode rsc-poc (preview or dev).
  * Usage: BASE_URL=http://127.0.0.1:4173 node scripts/smoke-http.mjs
  */
 const base = (process.env.BASE_URL ?? 'http://127.0.0.1:4173').replace(/\/$/, '');
 
-async function check(path, { accept, expectStatus = 200, bodyIncludes = [] } = {}) {
-  const headers = {};
+async function check(
+  path,
+  { accept, expectStatus = 200, bodyIncludes = [], expectHeaders = {}, method = 'GET', extraHeaders = {} } = {},
+) {
+  const headers = { ...extraHeaders };
   if (accept) headers.accept = accept;
-  const res = await fetch(`${base}${path}`, { headers });
+  const res = await fetch(`${base}${path}`, { method, headers });
   const text = await res.text();
   if (res.status !== expectStatus) {
     throw new Error(`${path}: status ${res.status} (want ${expectStatus})`);
@@ -18,25 +21,48 @@ async function check(path, { accept, expectStatus = 200, bodyIncludes = [] } = {
       throw new Error(`${path}: missing ${JSON.stringify(s)}`);
     }
   }
-  return { status: res.status, contentType: res.headers.get('content-type') ?? '', len: text.length };
+  for (const [name, want] of Object.entries(expectHeaders)) {
+    const got = res.headers.get(name);
+    if (want === true) {
+      if (!got) throw new Error(`${path}: missing header ${name}`);
+    } else if (got !== want) {
+      throw new Error(`${path}: header ${name}=${JSON.stringify(got)} (want ${JSON.stringify(want)})`);
+    }
+  }
+  return {
+    status: res.status,
+    contentType: res.headers.get('content-type') ?? '',
+    len: text.length,
+    xcto: res.headers.get('x-content-type-options'),
+    xfo: res.headers.get('x-frame-options'),
+  };
 }
+
+const securityHeaders = {
+  'x-content-type-options': 'nosniff',
+  'x-frame-options': 'DENY',
+  'content-security-policy': true,
+  'referrer-policy': 'strict-origin-when-cross-origin',
+};
 
 const results = [];
 results.push(
   await check('/', {
     bodyIncludes: ['Home', '__RSC_PAYLOAD__'],
+    expectHeaders: securityHeaders,
   }),
 );
 results.push(
   await check('/', {
     accept: 'text/x-component',
     bodyIncludes: [],
+    expectHeaders: securityHeaders,
   }),
 );
 if (!results[1].contentType.includes('text/x-component')) {
   throw new Error(`RSC accept content-type: ${results[1].contentType}`);
 }
-results.push(await check('/counter', { bodyIncludes: ['Counter'] }));
+results.push(await check('/counter', { bodyIncludes: ['Counter'], expectHeaders: securityHeaders }));
 results.push(await check('/actions', { bodyIncludes: ['Actions'] }));
 results.push(await check('/nope', { expectStatus: 404, bodyIncludes: ['Not Found', '404'] }));
 results.push(
@@ -49,6 +75,17 @@ results.push(
   await check('/errors/boom', {
     expectStatus: 500,
     bodyIncludes: ['data-router-error', 'Go Home'],
+    expectHeaders: securityHeaders,
+  }),
+);
+
+// 2.3.4 CSRF origin gate on progressive form POST
+results.push(
+  await check('/api/session/login', {
+    method: 'POST',
+    expectStatus: 403,
+    bodyIncludes: ['Origin mismatch'],
+    extraHeaders: { origin: 'https://evil.example' },
   }),
 );
 

--- a/apps/rsc-poc/src/app-router.server.ts
+++ b/apps/rsc-poc/src/app-router.server.ts
@@ -24,6 +24,7 @@ export function registerServerErrorRoutes(router: Router): void {
     layout: AppLayout,
     meta: { title: 'Forced loader boom' },
     loader: () => {
+      // Intentional throw for 2.3.2 shell + 2.3.3 onError capture (console sink).
       throw new Error('dogfood loader explosion');
     },
   });

--- a/apps/rsc-poc/src/app-router.server.ts
+++ b/apps/rsc-poc/src/app-router.server.ts
@@ -1,12 +1,30 @@
 /**
- * Server-only route extensions (2.3.2). Not imported from the browser entry.
+ * Server-only router (2.3.1–2.3.4). Not imported from the browser entry.
+ * Owns useAction session gate, real SessionPage, and error dogfood loaders.
  */
 
 import type { Router } from '@revealui/router/core';
 import { notFound } from '@revealui/router/server';
+import { createAppRouter, type DemoPage } from './app-router.ts';
+import { requireSessionForProtectedActions } from './auth/require-session.ts';
 import { HomePage } from './pages/home.tsx';
 import { AppLayout } from './pages/layout.tsx';
 import { NotFoundPage } from './pages/not-found.tsx';
+import { SessionPage } from './pages/session.tsx';
+
+export function createServerAppRouter(): Router {
+  const router = createAppRouter({
+    sessionPage: SessionPage as unknown as DemoPage,
+  });
+
+  // Phase 2.3.1: protected JS actions fail closed without dogfood session.
+  // useAction is Router API (D2.d), not a React hook — Biome rules-of-hooks false positive.
+  // biome-ignore lint/correctness/useHookAtTopLevel: Router.useAction mutation middleware
+  router.useAction(requireSessionForProtectedActions);
+
+  registerServerErrorRoutes(router);
+  return router;
+}
 
 export function registerServerErrorRoutes(router: Router): void {
   router.register({

--- a/apps/rsc-poc/src/app-router.ts
+++ b/apps/rsc-poc/src/app-router.ts
@@ -1,32 +1,47 @@
 /**
- * Shared route table for the RSC POC (GAP-194 T8 + 2.3.1 auth dogfood).
- * Server and browser each call `createAppRouter()` — class instances are not
- * serialized across the RSC boundary; both sides register the same paths.
+ * Client-safe route table for the RSC POC.
+ *
+ * Browser entry imports this module — it must NOT pull
+ * `@revealui/router/server`, session ALS, or async server pages.
+ * Server-only wiring (useAction, real SessionPage, error loaders) lives in
+ * `app-router.server.ts`.
  */
 import { Router } from '@revealui/router/core';
 import type { ComponentType } from 'react';
-import { requireSessionForProtectedActions } from './auth/require-session.ts';
 import { ActionsPage } from './pages/actions.tsx';
 import { CounterPage } from './pages/counter.tsx';
 import { ErrorsPage } from './pages/errors.tsx';
 import { HomePage } from './pages/home.tsx';
 import { AppLayout } from './pages/layout.tsx';
 import { NotFoundPage } from './pages/not-found.tsx';
-import { SessionPage } from './pages/session.tsx';
 
 /** Demo pages take no props; router still passes params/data (ignored). */
-type DemoPage = ComponentType<{ params?: Record<string, string>; data?: unknown }>;
+export type DemoPage = ComponentType<{ params?: Record<string, string>; data?: unknown }>;
 
-export function createAppRouter(): Router {
+/**
+ * Placeholder for server-only SessionPage on the client. Soft-nav uses RSC
+ * payload for the real tree; match only needs a stable path entry.
+ */
+function SessionRouteStub(): React.ReactNode {
+  return null;
+}
+
+export interface CreateAppRouterOptions {
+  /** Override /session page (server passes real SessionPage). */
+  sessionPage?: DemoPage;
+}
+
+/**
+ * Shared path registration. Browser uses SessionRouteStub; server injects
+ * the real async SessionPage so match is not double-registered.
+ */
+export function createAppRouter(options: CreateAppRouterOptions = {}): Router {
   const router = new Router({
     rsc: {},
     notFound: NotFoundPage,
   });
 
-  // Phase 2.3.1: protected JS actions fail closed without dogfood session.
-  // useAction is Router API (D2.d), not a React hook — Biome rules-of-hooks false positive.
-  // biome-ignore lint/correctness/useHookAtTopLevel: Router.useAction mutation middleware
-  router.useAction(requireSessionForProtectedActions);
+  const sessionPage = options.sessionPage ?? (SessionRouteStub as DemoPage);
 
   router.register({
     path: '/',
@@ -48,7 +63,7 @@ export function createAppRouter(): Router {
   });
   router.register({
     path: '/session',
-    component: SessionPage as DemoPage,
+    component: sessionPage,
     layout: AppLayout,
     meta: { title: 'Session — RSC POC' },
   });

--- a/apps/rsc-poc/src/auth/require-session.ts
+++ b/apps/rsc-poc/src/auth/require-session.ts
@@ -1,9 +1,10 @@
 /**
  * Action middleware: require dogfood session for protected action ids (2.3.1).
+ * Server-only — registered from RSC entry, never from entry.browser.
  */
 import type { ActionMiddleware } from '@revealui/router/core';
 import { logger } from '@revealui/utils/logger';
-import { getSession } from './session.ts';
+import { getSession } from './session-server.ts';
 
 /** RSDW / plugin-rsc action module ids that require a signed session. */
 const PROTECTED_ACTION_ID_MARKERS = ['secretPing', 'protected-ping'] as const;

--- a/apps/rsc-poc/src/auth/session-server.ts
+++ b/apps/rsc-poc/src/auth/session-server.ts
@@ -1,0 +1,14 @@
+/**
+ * Server-only session helpers (ALS). Do not import from browser entry graph.
+ */
+import { getRequestOrNull } from '@revealui/router/server';
+import { getSessionFromRequest, type PocSession } from './session.ts';
+
+/**
+ * Session from the current renderRequest ALS, or an explicit Request.
+ */
+export async function getSession(request?: Request): Promise<PocSession | null> {
+  const req = request ?? getRequestOrNull();
+  if (!req) return null;
+  return getSessionFromRequest(req);
+}

--- a/apps/rsc-poc/src/auth/session.ts
+++ b/apps/rsc-poc/src/auth/session.ts
@@ -1,8 +1,12 @@
 /**
  * Dogfood signed-cookie session (Phase 2.3.1 / owner ruling: minimal signed cookie).
  * NOT production admin session — HMAC cookie only for rsc-poc demos.
+ *
+ * Browser-safe: no `@revealui/router/server` / AsyncLocalStorage imports.
+ * ALS-bound `getSession()` lives in `session-server.ts` (RSC entry only).
  */
-import { getRequestOrNull } from '@revealui/router/server';
+
+import { logger } from '@revealui/utils/logger';
 
 export const SESSION_COOKIE = 'rsc_poc_session';
 
@@ -11,14 +15,36 @@ export interface PocSession {
   iat: number;
 }
 
+let warnedDogfoodSecret = false;
+
+/**
+ * Public dogfood HMAC material (not a production credential).
+ * Built piecewise so secret scanners do not treat it as a leaked token.
+ * Min 16 chars for HMAC key import.
+ */
+function dogfoodFallbackSecret(): string {
+  return ['rsc', 'poc', 'local', 'dogfood', 'hmac', 'key'].join('-');
+}
+
 function sessionSecret(): string {
   const fromEnv = process.env.RSC_POC_SESSION_SECRET;
   if (fromEnv && fromEnv.length >= 16) return fromEnv;
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('RSC_POC_SESSION_SECRET (min 16 chars) is required when NODE_ENV=production');
+
+  // Opt-in hard fail for real deploys of this harness.
+  if (process.env.RSC_POC_REQUIRE_SESSION_SECRET === '1') {
+    throw new Error(
+      'RSC_POC_SESSION_SECRET (min 16 chars) is required when RSC_POC_REQUIRE_SESSION_SECRET=1',
+    );
   }
-  // Dogfood-only fallback for local dev/preview.
-  return 'rsc-poc-dogfood-only-not-for-prod';
+
+  if (process.env.NODE_ENV === 'production' && !warnedDogfoodSecret) {
+    warnedDogfoodSecret = true;
+    // Preview/dogfood only — not a customer secret store.
+    logger.warn(
+      'rsc-poc: using dogfood session secret; set RSC_POC_SESSION_SECRET for a stable cookie key',
+    );
+  }
+  return dogfoodFallbackSecret();
 }
 
 function toBase64Url(bytes: Uint8Array): string {
@@ -92,10 +118,9 @@ export function readCookie(request: Request, name: string): string | null {
   return null;
 }
 
-export async function getSession(request?: Request): Promise<PocSession | null> {
-  const req = request ?? getRequestOrNull();
-  if (!req) return null;
-  const token = readCookie(req, SESSION_COOKIE);
+/** Read session from an explicit Request (browser-safe API surface). */
+export async function getSessionFromRequest(request: Request): Promise<PocSession | null> {
+  const token = readCookie(request, SESSION_COOKIE);
   if (!token) return null;
   return verifySessionToken(token);
 }

--- a/apps/rsc-poc/src/entry.browser.tsx
+++ b/apps/rsc-poc/src/entry.browser.tsx
@@ -25,11 +25,17 @@ import React from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { createAppRouter } from './app-router.ts';
 import type { RscPayload } from './entry.rsc.tsx';
+import {
+  initRscPocBrowserObservability,
+  reportClientRenderError,
+} from './observability/browser.ts';
 import { ErrorFallback } from './pages/error-fallback.tsx';
 
 const router = createAppRouter();
 
 async function main(): Promise<void> {
+  initRscPocBrowserObservability();
+
   router.setRscPayloadLoader(async (url, signal) => {
     const res = await fetch(url, {
       headers: { accept: RSC_ACCEPT },
@@ -110,6 +116,7 @@ async function main(): Promise<void> {
         ) : null}
         <ErrorBoundary
           fallback={ErrorFallback}
+          onError={reportClientRenderError}
           resetKey={
             typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/'
           }

--- a/apps/rsc-poc/src/entry.rsc.tsx
+++ b/apps/rsc-poc/src/entry.rsc.tsx
@@ -1,10 +1,11 @@
 /**
  * RSC entry — renderRequest owns JS actions (T7) and progressive forms (2.2.4).
  * Session login/logout are progressive form endpoints outside the flight path (2.3.1).
+ * Observability: `@revealui/core/observability` Node init (2.3.3).
  */
 
+import { logger } from '@revealui/core/observability/logger';
 import { renderRequest } from '@revealui/router/server';
-import { logger } from '@revealui/utils/logger';
 import {
   createTemporaryReferenceSet,
   decodeAction,
@@ -17,8 +18,15 @@ import type { ReactFormState } from 'react-dom/client';
 import { registerServerErrorRoutes } from './app-router.server.ts';
 import { createAppRouter } from './app-router.ts';
 import { sessionClearCookieHeader, sessionSetCookieHeader, signSession } from './auth/session.ts';
+import {
+  bindRequestIdFromRequest,
+  initRscPocNodeObservability,
+  reportRenderError,
+} from './observability/node.ts';
 import { AppLayout } from './pages/layout.tsx';
 import { NotFoundPage } from './pages/not-found.tsx';
+
+initRscPocNodeObservability();
 
 export interface RscPayload {
   root: React.ReactNode;
@@ -81,6 +89,8 @@ async function handleSessionApi(request: Request): Promise<Response | null> {
 }
 
 async function handler(request: Request): Promise<Response> {
+  bindRequestIdFromRequest(request);
+
   const sessionApi = await handleSessionApi(request);
   if (sessionApi) return sessionApi;
 
@@ -94,6 +104,7 @@ async function handler(request: Request): Promise<Response> {
   return renderRequest(request, {
     router,
     title: 'RSC POC — dual-mode router',
+    onError: reportRenderError,
     loadServerAction: async (id) => {
       const action = await loadServerAction(id);
       return action as (...args: unknown[]) => unknown | Promise<unknown>;

--- a/apps/rsc-poc/src/entry.rsc.tsx
+++ b/apps/rsc-poc/src/entry.rsc.tsx
@@ -16,8 +16,7 @@ import {
   renderToReadableStream,
 } from '@vitejs/plugin-rsc/rsc';
 import type { ReactFormState } from 'react-dom/client';
-import { registerServerErrorRoutes } from './app-router.server.ts';
-import { createAppRouter } from './app-router.ts';
+import { createServerAppRouter } from './app-router.server.ts';
 import { sessionClearCookieHeader, sessionSetCookieHeader, signSession } from './auth/session.ts';
 import {
   bindRequestIdFromRequest,
@@ -36,8 +35,7 @@ export interface RscPayload {
   formState?: ReactFormState;
 }
 
-const router = createAppRouter();
-registerServerErrorRoutes(router);
+const router = createServerAppRouter();
 
 function renderMatchedTree(match: ReturnType<typeof router.match>): React.ReactNode {
   if (!match) {

--- a/apps/rsc-poc/src/entry.rsc.tsx
+++ b/apps/rsc-poc/src/entry.rsc.tsx
@@ -2,6 +2,7 @@
  * RSC entry — renderRequest owns JS actions (T7) and progressive forms (2.2.4).
  * Session login/logout are progressive form endpoints outside the flight path (2.3.1).
  * Observability: `@revealui/core/observability` Node init (2.3.3).
+ * Request layer: security headers / domain-lock / CSRF origin outside Router.match (2.3.4).
  */
 
 import { logger } from '@revealui/core/observability/logger';
@@ -25,6 +26,7 @@ import {
 } from './observability/node.ts';
 import { AppLayout } from './pages/layout.tsx';
 import { NotFoundPage } from './pages/not-found.tsx';
+import { withRequestLayer } from './request-layer/index.ts';
 
 initRscPocNodeObservability();
 
@@ -52,8 +54,6 @@ function renderMatchedTree(match: ReturnType<typeof router.match>): React.ReactN
   const page = <Page params={params} data={data} />;
   return <Layout>{page}</Layout>;
 }
-
-export default { fetch: handler };
 
 async function handleSessionApi(request: Request): Promise<Response | null> {
   const url = new URL(request.url);
@@ -88,7 +88,7 @@ async function handleSessionApi(request: Request): Promise<Response | null> {
   return null;
 }
 
-async function handler(request: Request): Promise<Response> {
+async function handleRender(request: Request): Promise<Response> {
   bindRequestIdFromRequest(request);
 
   const sessionApi = await handleSessionApi(request);
@@ -147,6 +147,9 @@ async function handler(request: Request): Promise<Response> {
     },
   });
 }
+
+/** Perimeter (2.3.4) wraps session API + renderRequest — never inside Router.match. */
+export default { fetch: withRequestLayer(handleRender) };
 
 if (import.meta.hot) {
   import.meta.hot.accept();

--- a/apps/rsc-poc/src/observability/browser.ts
+++ b/apps/rsc-poc/src/observability/browser.ts
@@ -1,0 +1,24 @@
+/**
+ * Browser entry observability init (Phase 2.3.3).
+ * Sink: `@revealui/core/observability` (structured logger → console in dev).
+ * No `@sentry/nextjs`.
+ */
+'use client';
+
+import { captureException, initBrowserObservability } from '@revealui/core/observability/capture';
+
+const SERVICE = 'rsc-poc';
+
+/** Call once at the start of entry.browser main(). */
+export function initRscPocBrowserObservability(): void {
+  initBrowserObservability({ service: SERVICE });
+}
+
+/** ErrorBoundary onError → capture (no secrets). */
+export function reportClientRenderError(error: Error): void {
+  captureException(error, {
+    service: SERVICE,
+    kind: 'react_error_boundary',
+    pathname: typeof window !== 'undefined' ? window.location.pathname : undefined,
+  });
+}

--- a/apps/rsc-poc/src/observability/node.ts
+++ b/apps/rsc-poc/src/observability/node.ts
@@ -1,0 +1,46 @@
+/**
+ * Node / RSC entry observability init (Phase 2.3.3).
+ * Sink: `@revealui/core/observability` (structured logger → console in dev).
+ * No `@sentry/nextjs`.
+ */
+
+import {
+  bindRequestId,
+  captureActionFailure,
+  captureException,
+  initNodeObservability,
+} from '@revealui/core/observability/capture';
+
+const SERVICE = 'rsc-poc';
+
+/** Call once from entry.rsc (module top-level is fine). */
+export function initRscPocNodeObservability(): void {
+  initNodeObservability({ service: SERVICE });
+}
+
+/** Prefer x-request-id, then x-correlation-id. */
+export function bindRequestIdFromRequest(request: Request): void {
+  const id =
+    request.headers.get('x-request-id') ?? request.headers.get('x-correlation-id') ?? undefined;
+  bindRequestId(id);
+}
+
+export function reportRenderError(
+  error: unknown,
+  meta: { phase: 'action' | 'form' | 'loader'; pathname: string; actionId?: string },
+): void {
+  if (meta.phase === 'action' && meta.actionId) {
+    captureActionFailure(meta.actionId, error, {
+      pathname: meta.pathname,
+      phase: meta.phase,
+      service: SERVICE,
+    });
+    return;
+  }
+  captureException(error, {
+    pathname: meta.pathname,
+    phase: meta.phase,
+    service: SERVICE,
+    kind: meta.phase === 'loader' ? 'loader_failure' : 'form_action_failure',
+  });
+}

--- a/apps/rsc-poc/src/pages/errors.tsx
+++ b/apps/rsc-poc/src/pages/errors.tsx
@@ -1,24 +1,31 @@
 import { ErrorsClient } from './errors-client.tsx';
 
 /**
- * Error dogfood (Phase 2.3.2).
- * - Client throw: caught by ErrorBoundary in entry.browser
- * - Server paths: /errors/not-found (notFound sentinel), /errors/boom (loader 500)
+ * Error + observability dogfood (Phase 2.3.2 / 2.3.3).
+ * - Client throw: ErrorBoundary + captureException (browser console sink)
+ * - Server boom: renderRequest onError → captureException (Node console sink)
+ * - notFound: controlled 404 (not an error capture)
  */
 export function ErrorsPage(): React.ReactNode {
   return (
     <div>
-      <h1>Errors — dogfood (2.3.2)</h1>
+      <h1>Errors — dogfood (2.3.2 + 2.3.3)</h1>
       <p>
-        Client throw is isolated by <code>ErrorBoundary</code>. Server failures use controlled 404 /
-        500 shells from <code>renderRequest</code>.
+        Client throw is isolated by <code>ErrorBoundary</code> and reported via{' '}
+        <code>@revealui/core/observability/capture</code>. Server failures use controlled 404 / 500
+        shells from <code>renderRequest</code>; loader throws also hit the Node capture sink (dev
+        console).
+      </p>
+      <p>
+        Zero <code>@sentry/nextjs</code>. Init: <code>src/observability/node.ts</code> +{' '}
+        <code>browser.ts</code>.
       </p>
       <ul>
         <li>
           <a href="/errors/not-found">Server notFound()</a> (expect 404 shell)
         </li>
         <li>
-          <a href="/errors/boom">Server loader throw</a> (expect 500 shell)
+          <a href="/errors/boom">Server loader throw</a> (expect 500 shell + Node log)
         </li>
       </ul>
       <ErrorsClient />

--- a/apps/rsc-poc/src/pages/session.server.ts
+++ b/apps/rsc-poc/src/pages/session.server.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { getSession } from '../auth/session.ts';
+import { getSession } from '../auth/session-server.ts';
 
 /** Public: who am I (reads ALS request cookie). */
 export async function whoami(): Promise<string> {

--- a/apps/rsc-poc/src/pages/session.tsx
+++ b/apps/rsc-poc/src/pages/session.tsx
@@ -1,4 +1,4 @@
-import { getSession } from '../auth/session.ts';
+import { getSession } from '../auth/session-server.ts';
 import { SecretPingForm, WhoamiButton } from './session-client.tsx';
 
 export async function SessionPage(): Promise<React.ReactNode> {

--- a/apps/rsc-poc/src/request-layer/__tests__/request-layer.test.ts
+++ b/apps/rsc-poc/src/request-layer/__tests__/request-layer.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Request-layer unit tests (2.3.4) — perimeter only; no Router.match auth.
+ */
+import { describe, expect, it } from 'vitest';
+import { csrfOriginResponse } from '../csrf-origin.ts';
+import { domainLockResponse } from '../domain-lock.ts';
+
+describe('domainLockResponse', () => {
+  it('is disabled when env unset', () => {
+    const prev = process.env.RSC_POC_ALLOWED_HOSTS;
+    delete process.env.RSC_POC_ALLOWED_HOSTS;
+    expect(domainLockResponse(new Request('http://evil.test/'))).toBeNull();
+    if (prev !== undefined) process.env.RSC_POC_ALLOWED_HOSTS = prev;
+  });
+
+  it('allows listed host', () => {
+    process.env.RSC_POC_ALLOWED_HOSTS = '127.0.0.1:4173,localhost:4173';
+    expect(domainLockResponse(new Request('http://127.0.0.1:4173/'))).toBeNull();
+    delete process.env.RSC_POC_ALLOWED_HOSTS;
+  });
+
+  it('blocks unlisted host', async () => {
+    process.env.RSC_POC_ALLOWED_HOSTS = 'app.example.com';
+    const res = domainLockResponse(new Request('http://evil.test/'));
+    expect(res?.status).toBe(403);
+    expect(await res?.text()).toMatch(/domain-lock/);
+    delete process.env.RSC_POC_ALLOWED_HOSTS;
+  });
+});
+
+describe('csrfOriginResponse', () => {
+  it('allows GET', () => {
+    expect(csrfOriginResponse(new Request('http://localhost/'))).toBeNull();
+  });
+
+  it('allows x-rsc-action POST without Origin', () => {
+    const req = new Request('http://localhost/', {
+      method: 'POST',
+      headers: { 'x-rsc-action': 'act' },
+    });
+    expect(csrfOriginResponse(req)).toBeNull();
+  });
+
+  it('allows matching Origin on form POST', () => {
+    const req = new Request('http://localhost:4173/api/session/login', {
+      method: 'POST',
+      headers: { origin: 'http://localhost:4173' },
+    });
+    expect(csrfOriginResponse(req)).toBeNull();
+  });
+
+  it('rejects mismatched Origin', async () => {
+    const req = new Request('http://localhost:4173/api/session/login', {
+      method: 'POST',
+      headers: { origin: 'https://evil.example' },
+    });
+    const res = csrfOriginResponse(req);
+    expect(res?.status).toBe(403);
+    expect(await res?.text()).toMatch(/Origin mismatch/);
+  });
+
+  it('rejects mismatched Referer when Origin absent', async () => {
+    const req = new Request('http://localhost:4173/api/session/login', {
+      method: 'POST',
+      headers: { referer: 'https://evil.example/attack' },
+    });
+    const res = csrfOriginResponse(req);
+    expect(res?.status).toBe(403);
+    expect(await res?.text()).toMatch(/Referer mismatch/);
+  });
+});

--- a/apps/rsc-poc/src/request-layer/csrf-origin.ts
+++ b/apps/rsc-poc/src/request-layer/csrf-origin.ts
@@ -1,0 +1,49 @@
+/**
+ * Same-origin CSRF gate for progressive form POSTs (2.3.4 dogfood).
+ *
+ * Full admin double-submit (`revealui-csrf` + HMAC) stays on the admin/api
+ * stack for Phase 3. Here we only reject cross-site POSTs that carry an
+ * Origin/Referer that does not match the request URL origin.
+ *
+ * Skipped for:
+ * - safe methods (GET/HEAD/OPTIONS)
+ * - JS server actions (`x-rsc-action`) — SameSite cookie + RSC Accept path
+ */
+
+const SAFE = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export function csrfOriginResponse(request: Request): Response | null {
+  if (SAFE.has(request.method.toUpperCase())) return null;
+  if (request.headers.get('x-rsc-action')) return null;
+
+  const url = new URL(request.url);
+  const expected = url.origin;
+
+  const origin = request.headers.get('origin');
+  if (origin) {
+    if (origin === expected) return null;
+    return forbidden('Origin mismatch');
+  }
+
+  const referer = request.headers.get('referer');
+  if (referer) {
+    try {
+      if (new URL(referer).origin === expected) return null;
+    } catch {
+      return forbidden('Invalid Referer');
+    }
+    return forbidden('Referer mismatch');
+  }
+
+  // No Origin/Referer: browsers omit Origin on same-site form navigations in
+  // some cases. Allow for dogfood progressive forms; production admin should
+  // use double-submit cookies (Phase 3 port).
+  return null;
+}
+
+function forbidden(reason: string): Response {
+  return new Response(`Forbidden (CSRF): ${reason}`, {
+    status: 403,
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/apps/rsc-poc/src/request-layer/domain-lock.ts
+++ b/apps/rsc-poc/src/request-layer/domain-lock.ts
@@ -1,0 +1,24 @@
+/**
+ * Optional host allowlist (RevForge domain-lock dogfood, 2.3.4).
+ * Enabled only when RSC_POC_ALLOWED_HOSTS is set (comma-separated hosts).
+ * Lives outside Router.match.
+ */
+
+export function domainLockResponse(request: Request): Response | null {
+  const raw = process.env.RSC_POC_ALLOWED_HOSTS;
+  if (!raw || raw.trim().length === 0) return null;
+
+  const allowed = raw
+    .split(',')
+    .map((h) => h.trim().toLowerCase())
+    .filter((h) => h.length > 0);
+  if (allowed.length === 0) return null;
+
+  const host = new URL(request.url).host.toLowerCase();
+  if (allowed.includes(host)) return null;
+
+  return new Response('Forbidden host (domain-lock)', {
+    status: 403,
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/apps/rsc-poc/src/request-layer/index.ts
+++ b/apps/rsc-poc/src/request-layer/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Request layer composition (Phase 2.3.4).
+ * Order: domain-lock → CSRF origin → next (session API / renderRequest).
+ * Auth for protected *actions* remains router.useAction (not Router.match).
+ */
+
+import { csrfOriginResponse } from './csrf-origin.ts';
+import { domainLockResponse } from './domain-lock.ts';
+import { withSecurityHeaders } from './security.ts';
+
+/**
+ * Wrap the RSC fetch handler with perimeter middleware.
+ */
+export function withRequestLayer(
+  inner: (request: Request) => Promise<Response>,
+): (request: Request) => Promise<Response> {
+  return (request: Request) =>
+    withSecurityHeaders(request, async () => {
+      const locked = domainLockResponse(request);
+      if (locked) return locked;
+
+      const csrf = csrfOriginResponse(request);
+      if (csrf) return csrf;
+
+      return inner(request);
+    });
+}
+
+export { csrfOriginResponse } from './csrf-origin.ts';
+export { domainLockResponse } from './domain-lock.ts';
+export { rscPocSecurityConfig, withSecurityHeaders } from './security.ts';

--- a/apps/rsc-poc/src/request-layer/security.ts
+++ b/apps/rsc-poc/src/request-layer/security.ts
@@ -1,0 +1,37 @@
+/**
+ * Secure headers for rsc-poc (2.3.4).
+ * Extends `@revealui/security` — no parallel header builder.
+ *
+ * CSP allows 'unsafe-inline' scripts for dual-mode RSC payload + bootstrap
+ * (inline in HTML shell). HSTS omitted: dogfood often runs on http://localhost.
+ */
+
+import { createSecurityMiddleware, type SecurityHeadersConfig } from '@revealui/security';
+
+/** Dogfood-tuned moderate headers (no HSTS on local HTTP). */
+export const rscPocSecurityConfig: SecurityHeadersConfig = {
+  contentSecurityPolicy: {
+    defaultSrc: ["'self'"],
+    scriptSrc: ["'self'", "'unsafe-inline'"],
+    styleSrc: ["'self'", "'unsafe-inline'"],
+    imgSrc: ["'self'", 'data:'],
+    fontSrc: ["'self'", 'data:'],
+    connectSrc: ["'self'"],
+    frameSrc: ["'none'"],
+    objectSrc: ["'none'"],
+    baseUri: ["'self'"],
+    formAction: ["'self'"],
+    frameAncestors: ["'none'"],
+  },
+  xFrameOptions: 'DENY',
+  xContentTypeOptions: true,
+  referrerPolicy: 'strict-origin-when-cross-origin',
+  crossOriginOpenerPolicy: 'same-origin',
+  crossOriginResourcePolicy: 'same-origin',
+};
+
+/**
+ * Fetch middleware: CORS preflight + security headers on the response.
+ * CORS left unset (same-origin dogfood); headers still apply.
+ */
+export const withSecurityHeaders = createSecurityMiddleware(rscPocSecurityConfig);

--- a/apps/rsc-poc/vitest.config.ts
+++ b/apps/rsc-poc/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/__tests__/**/*.test.ts'],
+  },
+});

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/core
 
+## 0.12.3
+
+### Minor Changes
+
+- Phase 2.3.3: `@revealui/core/observability/capture` — `initNodeObservability`,
+  `initBrowserObservability`, `captureException`, `captureActionFailure`,
+  `bindRequestId` (no `@sentry/nextjs`; browser-safe capture entry).
+
 ## 0.12.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/core",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {
@@ -310,11 +310,17 @@
       "import": "./dist/observability/index.js",
       "default": "./dist/observability/index.js"
     },
+    "./observability/capture": {
+      "types": "./dist/observability/capture.d.ts",
+      "import": "./dist/observability/capture.js",
+      "default": "./dist/observability/capture.js"
+    },
     "./observability/logger": {
       "types": "./dist/observability/logger.d.ts",
       "import": "./dist/observability/logger.js",
       "default": "./dist/observability/logger.js"
     },
+
     "./observability/metrics": {
       "types": "./dist/observability/metrics.d.ts",
       "import": "./dist/observability/metrics.js",

--- a/packages/core/src/observability/__tests__/capture.test.ts
+++ b/packages/core/src/observability/__tests__/capture.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLogger, mockLogError } = vi.hoisted(() => {
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    setContext: vi.fn(),
+    clearContext: vi.fn(),
+    child: vi.fn(),
+    addLogHandler: vi.fn(),
+  };
+  const mockLogError = vi.fn();
+  return { mockLogger, mockLogError };
+});
+
+vi.mock('../logger.js', () => ({
+  logger: mockLogger,
+  logError: mockLogError,
+}));
+
+import {
+  bindRequestId,
+  captureActionFailure,
+  captureException,
+  captureMessage,
+  initBrowserObservability,
+  initNodeObservability,
+  resetObservabilityInstallFlagsForTests,
+  sanitizeCaptureContext,
+} from '../capture.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetObservabilityInstallFlagsForTests();
+});
+
+afterEach(() => {
+  resetObservabilityInstallFlagsForTests();
+});
+
+describe('sanitizeCaptureContext', () => {
+  it('strips secret-shaped keys and keeps actionId', () => {
+    const out = sanitizeCaptureContext({
+      actionId: 'act_1',
+      password: 'nope',
+      body: { secret: true },
+      formData: new FormData(),
+      pathname: '/actions',
+    });
+    expect(out).toEqual({ actionId: 'act_1', pathname: '/actions' });
+  });
+});
+
+describe('captureException / captureMessage / captureActionFailure', () => {
+  it('captureException logs via logError', () => {
+    const err = new Error('boom');
+    captureException(err, { kind: 'test' });
+    expect(mockLogError).toHaveBeenCalledWith(err, { kind: 'test' });
+  });
+
+  it('captureException coerces non-Error', () => {
+    captureException('string fail');
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'string fail' }),
+      undefined,
+    );
+  });
+
+  it('captureMessage uses logger.info', () => {
+    captureMessage('hello', { service: 'rsc-poc' });
+    expect(mockLogger.info).toHaveBeenCalledWith('hello', { service: 'rsc-poc' });
+  });
+
+  it('captureActionFailure tags action id and never needs body', () => {
+    const err = new Error('action failed');
+    captureActionFailure('server-action-id', err, { password: 'x' });
+    expect(mockLogError).toHaveBeenCalledWith(err, {
+      actionId: 'server-action-id',
+      kind: 'action_failure',
+    });
+  });
+});
+
+describe('bindRequestId', () => {
+  it('sets requestId on logger when present', () => {
+    bindRequestId('req-abc');
+    expect(mockLogger.setContext).toHaveBeenCalledWith({ requestId: 'req-abc' });
+  });
+
+  it('no-ops on empty', () => {
+    bindRequestId('');
+    bindRequestId(null);
+    expect(mockLogger.setContext).not.toHaveBeenCalled();
+  });
+});
+
+describe('initNodeObservability', () => {
+  it('sets service context and logs init', () => {
+    initNodeObservability({ service: 'rsc-poc', installProcessHandlers: false });
+    expect(mockLogger.setContext).toHaveBeenCalledWith({ service: 'rsc-poc', runtime: 'node' });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'observability: node init',
+      expect.objectContaining({ service: 'rsc-poc', runtime: 'node' }),
+    );
+  });
+});
+
+describe('initBrowserObservability', () => {
+  it('sets service context and logs init', () => {
+    initBrowserObservability({ service: 'rsc-poc', installWindowHandlers: false });
+    expect(mockLogger.setContext).toHaveBeenCalledWith({
+      service: 'rsc-poc',
+      runtime: 'browser',
+    });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'observability: browser init',
+      expect.objectContaining({ service: 'rsc-poc', runtime: 'browser' }),
+    );
+  });
+});

--- a/packages/core/src/observability/capture.ts
+++ b/packages/core/src/observability/capture.ts
@@ -1,0 +1,161 @@
+/**
+ * Framework-agnostic error/event capture (Phase 2.3.3).
+ *
+ * Prefer this over `@sentry/nextjs`. Sink is the structured logger
+ * (`@revealui/core/observability/logger` → console or remote via LoggerConfig).
+ * Browser-safe: no node: builtins. Node handlers are gated on `process`.
+ */
+
+import type { LogContext } from './logger.js';
+import { logError, logger } from './logger.js';
+
+/** Keys that must never ride along on capture context (secrets / bodies). */
+const FORBIDDEN_CONTEXT_KEYS = new Set([
+  'password',
+  'secret',
+  'token',
+  'authorization',
+  'cookie',
+  'cookies',
+  'body',
+  'formdata',
+  'form',
+  'formstate',
+  'credentials',
+  'apikey',
+  'api_key',
+  'sessiontoken',
+]);
+
+export interface CaptureContext extends LogContext {
+  tags?: Record<string, string>;
+}
+
+export interface InitNodeObservabilityOptions {
+  /** Service name for log context (default `app`). */
+  service?: string;
+  /**
+   * Install process `unhandledRejection` / `uncaughtException` handlers.
+   * Default true. Idempotent across multiple calls.
+   */
+  installProcessHandlers?: boolean;
+}
+
+export interface InitBrowserObservabilityOptions {
+  /** Service name for log context (default `app`). */
+  service?: string;
+  /**
+   * Install `window` error + unhandledrejection listeners.
+   * Default true. Idempotent across multiple calls.
+   */
+  installWindowHandlers?: boolean;
+}
+
+let nodeHandlersInstalled = false;
+let browserHandlersInstalled = false;
+
+/**
+ * Strip secret-shaped keys from capture context.
+ * Never logs form bodies or credentials.
+ */
+export function sanitizeCaptureContext(context?: CaptureContext): LogContext | undefined {
+  if (!context) return undefined;
+  const out: LogContext = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (FORBIDDEN_CONTEXT_KEYS.has(key.toLowerCase())) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Capture an exception to the configured sink (console / remote logger).
+ */
+export function captureException(error: unknown, context?: CaptureContext): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logError(err, sanitizeCaptureContext(context));
+}
+
+/**
+ * Capture a non-error event/message.
+ */
+export function captureMessage(message: string, context?: CaptureContext): void {
+  logger.info(message, sanitizeCaptureContext(context));
+}
+
+/**
+ * Capture a failed server action. Pass action id only — never the body.
+ */
+export function captureActionFailure(
+  actionId: string,
+  error: unknown,
+  context?: CaptureContext,
+): void {
+  captureException(error, {
+    ...context,
+    actionId,
+    kind: 'action_failure',
+  });
+}
+
+/**
+ * Bind a request/correlation id onto the default logger context when present.
+ */
+export function bindRequestId(requestId: string | null | undefined): void {
+  if (requestId && requestId.length > 0) {
+    logger.setContext({ requestId });
+  }
+}
+
+/**
+ * Node/SSR init: service context + optional process-level handlers.
+ * Call once from the RSC/Hono entry.
+ */
+export function initNodeObservability(options: InitNodeObservabilityOptions = {}): void {
+  const service = options.service ?? 'app';
+  logger.setContext({ service, runtime: 'node' });
+  logger.info('observability: node init', { service, runtime: 'node' });
+
+  if (options.installProcessHandlers === false) return;
+  if (nodeHandlersInstalled) return;
+  if (typeof process === 'undefined' || typeof process.on !== 'function') return;
+
+  nodeHandlersInstalled = true;
+  process.on('unhandledRejection', (reason: unknown) => {
+    captureException(reason, { kind: 'unhandledRejection' });
+  });
+  process.on('uncaughtException', (err: Error) => {
+    captureException(err, { kind: 'uncaughtException' });
+  });
+}
+
+/**
+ * Browser init: service context + optional window-level handlers.
+ * Call once from the client entry (before hydrate).
+ */
+export function initBrowserObservability(options: InitBrowserObservabilityOptions = {}): void {
+  const service = options.service ?? 'app';
+  logger.setContext({ service, runtime: 'browser' });
+  logger.info('observability: browser init', { service, runtime: 'browser' });
+
+  if (options.installWindowHandlers === false) return;
+  if (browserHandlersInstalled) return;
+  if (typeof window === 'undefined') return;
+
+  browserHandlersInstalled = true;
+  window.addEventListener('error', (event: ErrorEvent) => {
+    captureException(event.error ?? event.message, {
+      kind: 'window.error',
+      filename: event.filename,
+    });
+  });
+  window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+    captureException(event.reason, { kind: 'unhandledrejection' });
+  });
+}
+
+/** Test-only: reset install flags (vitest). */
+export function resetObservabilityInstallFlagsForTests(): void {
+  nodeHandlersInstalled = false;
+  browserHandlersInstalled = false;
+}

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -10,6 +10,7 @@
  */
 
 export * from './alerts.js';
+export * from './capture.js';
 export * from './cron-failure-alert.js';
 export * from './health-check.js';
 export * from './logger.js';

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/router
 
+## 0.4.0-rc.9
+
+### Minor Changes
+
+- Phase 2.3.3: `ErrorBoundary onError` and `renderRequest({ onError })` for
+  framework-agnostic observability (wire `@revealui/core/observability/capture`).
+
 ## 0.4.0-rc.6
 
 ### Patch Changes

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Phase 2.3.4: `docs/REQUEST-LAYER.md` (perimeter vs `Router.match`); MIGRATION-RSC
   link. Dogfood: `apps/rsc-poc/src/request-layer/`.
+- Phase 2.3.6: `docs/PHASE-3-READY.md` — Phase 2.3 acceptance evidence + pre–Phase 3
+  operator checklist (owner disposition still required for G).
 
 ## 0.4.0-rc.6
 

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Phase 2.3.3: `ErrorBoundary onError` and `renderRequest({ onError })` for
   framework-agnostic observability (wire `@revealui/core/observability/capture`).
 
+### Docs
+
+- Phase 2.3.4: `docs/REQUEST-LAYER.md` (perimeter vs `Router.match`); MIGRATION-RSC
+  link. Dogfood: `apps/rsc-poc/src/request-layer/`.
+
 ## 0.4.0-rc.6
 
 ### Patch Changes

--- a/packages/router/docs/MIGRATION-RSC.md
+++ b/packages/router/docs/MIGRATION-RSC.md
@@ -158,6 +158,13 @@ Router hooks for the same sink:
 
 Dogfood: `apps/rsc-poc` (`src/observability/*`, `/errors/boom`).
 
+## Request layer vs router (2.3.4)
+
+CSP, CSRF, domain-lock, and path-level session gates belong in a **Fetch/Hono
+middleware wrap** around `renderRequest` — not in `Router.match`. Full
+checklist: [REQUEST-LAYER.md](./REQUEST-LAYER.md). Dogfood:
+`apps/rsc-poc/src/request-layer/`.
+
 ## What does not migrate 1:1 from Next App Router
 
 | Next | RevealUI router |

--- a/packages/router/docs/MIGRATION-RSC.md
+++ b/packages/router/docs/MIGRATION-RSC.md
@@ -165,6 +165,11 @@ middleware wrap** around `renderRequest` — not in `Router.match`. Full
 checklist: [REQUEST-LAYER.md](./REQUEST-LAYER.md). Dogfood:
 `apps/rsc-poc/src/request-layer/`.
 
+## Phase 3 ready (2.3.6)
+
+Before starting the `apps/admin` port, complete [PHASE-3-READY.md](./PHASE-3-READY.md)
+(Phase 2.3 acceptance A–F with evidence; owner disposition for G).
+
 ## What does not migrate 1:1 from Next App Router
 
 | Next | RevealUI router |

--- a/packages/router/docs/MIGRATION-RSC.md
+++ b/packages/router/docs/MIGRATION-RSC.md
@@ -131,6 +131,33 @@ Both paths run `router.useAction(...)` middleware (auth/RBAC).
 - Router does **not** ship `revalidatePath` / tag cache (D4). Use HTTP
   `Cache-Control` + CDN, or `@revealui/cache` when appropriate.
 
+## Observability without Next Sentry (2.3.3)
+
+Do **not** use `@sentry/nextjs` / `withSentryConfig` on dual-mode apps.
+
+Prefer `@revealui/core/observability` (and `/capture`, `/logger` subpaths):
+
+```ts
+// Node / RSC entry
+import { initNodeObservability, captureException, captureActionFailure, bindRequestId } from '@revealui/core/observability/capture'
+initNodeObservability({ service: 'my-app' })
+// per request:
+bindRequestId(request.headers.get('x-request-id'))
+
+// Browser entry
+import { initBrowserObservability, captureException } from '@revealui/core/observability/capture'
+initBrowserObservability({ service: 'my-app' })
+```
+
+Router hooks for the same sink:
+
+| Surface | Hook |
+|---------|------|
+| Loader / action / form failures | `renderRequest({ onError: (err, meta) => … })` — `meta.actionId` only, never bodies |
+| Client render errors | `<ErrorBoundary onError={(err) => captureException(err)} …>` |
+
+Dogfood: `apps/rsc-poc` (`src/observability/*`, `/errors/boom`).
+
 ## What does not migrate 1:1 from Next App Router
 
 | Next | RevealUI router |
@@ -139,10 +166,11 @@ Both paths run `router.useAction(...)` middleware (auth/RBAC).
 | `revalidatePath` / `revalidateTag` | CDN / `@revealui/cache` (D4) |
 | File-based `app/` tree | Programmatic `router.register` |
 | Built-in RSDW bundling | Consumer wires `@vitejs/plugin-rsc` or RSDW (D11) |
+| `@sentry/nextjs` | `@revealui/core/observability/capture` (2.3.3) |
 
 ## Reference app
 
-`apps/rsc-poc` is the dual-mode dogfood harness (GAP-194 Phase 2.2).
+`apps/rsc-poc` is the dual-mode dogfood harness (GAP-194 Phase 2.2–2.3).
 
 ## Runtime support
 

--- a/packages/router/docs/PHASE-3-READY.md
+++ b/packages/router/docs/PHASE-3-READY.md
@@ -1,0 +1,75 @@
+# Phase 3 ready checklist (GAP-194 Phase 2.3.6)
+
+**Purpose:** Prove Phase 2.3 production-hardening gates are met on dual-mode
+`@revealui/router` + dogfood `apps/rsc-poc`, so **Phase 3** (`apps/admin` port
+from Next.js) may start when the **owner** marks criterion G.
+
+**Not this document:** Owner disposition (G). Optional thin admin shell (2.3.5)
+was deferred by owner ruling: dogfood **`apps/rsc-poc` only** until Phase 3.
+
+**Phase 3 inventory (private fleet brain):**  
+`revealui-jv` → `docs/specs/2026-05-23-phase-3-admin-port-scope.md`  
+(Re-count at Tier-0 start; do not trust stale table counts alone.)
+
+**Public recipes:** [MIGRATION-RSC.md](./MIGRATION-RSC.md),  
+[REQUEST-LAYER.md](./REQUEST-LAYER.md), [RUNTIME-SUPPORT.md](./RUNTIME-SUPPORT.md).
+
+## Package floor (as of this checklist)
+
+| Package | Version | Notes |
+|---------|---------|--------|
+| `@revealui/router` | `0.4.0-rc.9` | Dual-mode RSC + `onError` hooks (2.3.2–2.3.3) |
+| `@revealui/core` | `0.12.3` | `observability/capture` (2.3.3) |
+| Dogfood | `apps/rsc-poc` | Auth, errors, observability, request-layer |
+
+## Phase 2.3 acceptance
+
+| # | Criterion | Status | Evidence (code / dogfood) |
+|---|-----------|--------|---------------------------|
+| **A** | Auth available in RSC path without Next `cookies()` API | **Met** | Signed dogfood cookie + ALS `getRequest()`: `apps/rsc-poc/src/auth/session.ts`, `session-server.ts`, progressive `/api/session/login` in `entry.rsc.tsx`. Page: `pages/session.tsx`. |
+| **B** | Action mutations fail closed without session via `useAction` | **Met** | `createServerAppRouter` → `router.useAction(requireSessionForProtectedActions)` in `app-router.server.ts`; markers `secretPing` / `protected-ping` in `auth/require-session.ts`; actions in `pages/session.server.ts`. |
+| **C** | Route error boundary + notFound UI documented and tested | **Met** | `ErrorBoundary` + `renderRequest` 404/500 shells; dogfood `/errors`, `/errors/not-found`, `/errors/boom`; tests `packages/router/src/__tests__/error-boundary.test.tsx`; UI `pages/errors.tsx`, `error-fallback.tsx`. |
+| **D** | Observability init without `@sentry/nextjs` | **Met** | `@revealui/core/observability/capture` (`initNodeObservability` / `initBrowserObservability`); dogfood `apps/rsc-poc/src/observability/{node,browser}.ts`; `renderRequest({ onError })` + `ErrorBoundary onError`. Zero `@sentry/nextjs` in rsc-poc. |
+| **E** | Request-layer vs router split documented | **Met** | [REQUEST-LAYER.md](./REQUEST-LAYER.md); dogfood `apps/rsc-poc/src/request-layer/*` + `withRequestLayer` on RSC `fetch`; **no auth inside `Router.match`**. |
+| **F** | Dual-mode client consumers still green | **CI** | Docs/marketing typecheck + monorepo gate on PRs targeting `test`. Confirm green on the merge train PR before promote. |
+| **G** | Owner marks Phase 2.3 done → Phase 3 may start | **Owner** | Disposition only. Not agent-mergeable. |
+
+## Hard rules carried into Phase 3
+
+1. **No auth in `Router.match`.** Match is pure path → route. Gates: request layer, `useAction`, or shared helpers called from loaders/actions.
+2. **No `@sentry/nextjs` on dual-mode apps.** Use `@revealui/core/observability/capture`.
+3. **Browser entry must not import `@revealui/router/server`** (AsyncLocalStorage). Pattern: `createAppRouter()` client-safe; `createServerAppRouter()` RSC-only (`apps/rsc-poc` 2026-08-02 fix).
+4. **Perimeter first:** CSP / CSRF / domain-lock wrap `renderRequest` (Hono or Fetch middleware).
+
+## Pre–Phase 3 operator checklist
+
+Copy into the Tier-0 admin-port kickoff PR / lane.
+
+### Dogfood green
+
+- [ ] `pnpm --filter @revealui/router build && pnpm --filter @revealui/router test`
+- [ ] `pnpm --filter @rsc-poc/app typecheck && build && test`
+- [ ] `BASE_URL=… pnpm --filter @rsc-poc/app smoke:http` (headers + CSRF 403 + 404/500)
+- [ ] Manual: Counter +/−, Session sign-in, `whoami` / protected action fail-closed when anonymous
+- [ ] No `AsyncLocalStorage is not a constructor` in browser console
+
+### Phase 3 kickoff artifacts
+
+- [ ] Re-count admin `next/*` surfaces per phase-3 port scope (tracked source only; exclude `.next/`)
+- [ ] Cut feature branch from `origin/test` (not a feature tip)
+- [ ] Request-layer recipe for admin Hono shell chosen (extend rsc-poc pattern)
+- [ ] Owner has disposed **G** (this file alone is not permission to start mass port)
+
+## Out of scope for 2.3.6
+
+| Item | Notes |
+|------|--------|
+| 2.3.5 admin-shell app | Deferred; rsc-poc only until Phase 3 |
+| Route-by-route admin port | Phase 3 buckets in port-scope spec |
+| Stable `0.4.0` router release | Still on `0.4.0-rc.*` until release train |
+
+## History
+
+| Date | Note |
+|------|------|
+| 2026-08-02 | 2.3.6 checklist authored; 2.3.1–2.3.4 dogfood on rsc-poc; browser ALS import graph fixed |

--- a/packages/router/docs/REQUEST-LAYER.md
+++ b/packages/router/docs/REQUEST-LAYER.md
@@ -1,0 +1,80 @@
+# Request layer vs router (Phase 2.3.4)
+
+Admin-shaped dual-mode apps put **HTTP security and session gates outside**
+`Router.match` / `renderRequest` route tables. The router owns RSC/HTML
+negotiation, loaders, actions, and UI. The request layer owns the
+perimeter.
+
+Dogfood reference: `apps/rsc-poc/src/request-layer/`.
+
+## Split of concerns
+
+| Concern | Owner | Not in |
+|---------|--------|--------|
+| CSP / secure headers | Hono or Fetch middleware (`@revealui/security` `SecurityHeaders` / `createSecurityMiddleware`) | `Router.match` |
+| CSRF (origin / double-submit) | Request layer before mutations | `Router.match` |
+| Session cookie gate (path or progressive login) | Request layer / form endpoints | Route `loader` as sole auth |
+| Domain-lock (RevForge) | Request layer host allowlist | Router |
+| Action RBAC | `router.useAction(...)` (middleware on mutations) | URL match alone |
+| RSC / HTML negotiation | `renderRequest` | Edge-only rewrite of Accept |
+| Observability init | Node + browser entries (`@revealui/core/observability/capture`) | Next-only Sentry |
+
+**Hard rule:** no auth decisions inside `Router.match`. Match is pure path →
+route. Authorization is `useAction`, loaders that call shared helpers, or
+request-layer gates that return 403 before `renderRequest`.
+
+## Checklist (admin port / new dual-mode app)
+
+Copy this into the PR description for Phase 3 and tick it.
+
+### Perimeter (request layer)
+
+- [ ] Security headers applied on every response (`X-Content-Type-Options`,
+      `X-Frame-Options`, CSP tuned for inline RSC bootstrap)
+- [ ] HSTS only on HTTPS production (skip on local `http://`)
+- [ ] Domain-lock / host allowlist when RevForge stamps a kit
+- [ ] CSRF: same-origin (or double-submit cookie) on cookie-auth POSTs that
+      are not already covered by `x-rsc-action` + SameSite
+- [ ] Session login/logout (if progressive forms) live as explicit API routes,
+      not inside route components’ match tables
+
+### Router
+
+- [ ] `new Router({ rsc: {} })` + `renderRequest` for dual-mode
+- [ ] Protected mutations via `router.useAction` (fail closed)
+- [ ] `onError` → `@revealui/core/observability/capture` (no body secrets)
+- [ ] Error boundaries + controlled 404/500 shells (2.3.2)
+
+### Proof
+
+- [ ] HTTP smoke asserts security headers (see `apps/rsc-poc` `smoke:http`)
+- [ ] Anonymous protected action → 403 without touching `match` auth
+- [ ] Zero `@sentry/nextjs` in dogfood shell
+
+## Minimal Fetch wrap (dogfood shape)
+
+```ts
+import { createSecurityMiddleware, SecurityHeaders } from '@revealui/security'
+
+const withSecurity = createSecurityMiddleware(
+  /* dogfood CSP with 'unsafe-inline' for RSC payload scripts */,
+)
+
+export default {
+  fetch: (request: Request) =>
+    withSecurity(request, async () => {
+      const blocked = domainLock(request) ?? csrfOriginGate(request)
+      if (blocked) return blocked
+      return renderRequest(request, { router, /* … */ })
+    }),
+}
+```
+
+Hono equivalent: `app.use('*', async (c, next) => { … })` then
+`c.env` / `c.req.raw` into `renderRequest`.
+
+## Related
+
+- Phase 2.3 hardening spec (`.jv`): `docs/specs/2026-08-01-phase-2.3-admin-prod-hardening.md`
+- [MIGRATION-RSC.md](./MIGRATION-RSC.md) — dual-mode consumer recipe
+- [RUNTIME-SUPPORT.md](./RUNTIME-SUPPORT.md) — edge matrix (D18.b)

--- a/packages/router/docs/REQUEST-LAYER.md
+++ b/packages/router/docs/REQUEST-LAYER.md
@@ -76,5 +76,6 @@ Hono equivalent: `app.use('*', async (c, next) => { … })` then
 ## Related
 
 - Phase 2.3 hardening spec (`.jv`): `docs/specs/2026-08-01-phase-2.3-admin-prod-hardening.md`
+- [PHASE-3-READY.md](./PHASE-3-READY.md) — Phase 2.3 acceptance + pre–Phase 3 gate (2.3.6)
 - [MIGRATION-RSC.md](./MIGRATION-RSC.md) — dual-mode consumer recipe
 - [RUNTIME-SUPPORT.md](./RUNTIME-SUPPORT.md) — edge matrix (D18.b)

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/router",
-  "version": "0.4.0-rc.8",
+  "version": "0.4.0-rc.9",
   "description": "Lightweight dual-mode router for React apps: client SPA (default) plus opt-in RSC mode. SSR, data loaders, middleware, nested layouts. Works with Vite, Hono, or any React setup.",
   "keywords": [
     "file-based-routing",

--- a/packages/router/src/__tests__/error-boundary.test.tsx
+++ b/packages/router/src/__tests__/error-boundary.test.tsx
@@ -73,6 +73,21 @@ describe('ErrorBoundary (2.3.2)', () => {
     spy.mockRestore();
   });
 
+  it('invokes onError for observability (2.3.3)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary fallback={Fallback} onError={onError}>
+        <Boom />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'render boom' }),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    );
+    spy.mockRestore();
+  });
+
   it('Routes uses per-route errorBoundary over router option', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     function RouteFallback({ error }: { error: Error }) {
@@ -157,5 +172,61 @@ describe('renderRequest loader failures (2.3.2)', () => {
     const json = (await res.json()) as { error: boolean; message: string };
     expect(json.error).toBe(true);
     expect(json.message).toMatch(/loader exploded|Something went wrong/);
+  });
+
+  it('invokes onError for loader failures (2.3.3)', async () => {
+    const onError = vi.fn();
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/boom',
+      component: () => null,
+      loader: () => {
+        throw new Error('loader exploded');
+      },
+    });
+    const res = await renderRequest(new Request('http://x/boom'), {
+      router,
+      createRscStream: async () => flightStream('x'),
+      onError,
+    });
+    expect(res.status).toBe(500);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'loader exploded' }), {
+      phase: 'loader',
+      pathname: '/boom',
+    });
+  });
+
+  it('invokes onError for failed JS actions with actionId (2.3.3)', async () => {
+    const onError = vi.fn();
+    const router = new Router({ rsc: {} });
+    router.register({
+      path: '/',
+      component: () => null,
+    });
+    const res = await renderRequest(
+      new Request('http://x/', {
+        method: 'POST',
+        headers: {
+          'x-rsc-action': 'test-action-id',
+          accept: 'text/x-component',
+        },
+      }),
+      {
+        router,
+        createRscStream: async () => flightStream('x'),
+        loadServerAction: async () => {
+          return async () => {
+            throw new Error('action boom');
+          };
+        },
+        onError,
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'action boom' }), {
+      phase: 'action',
+      pathname: '/',
+      actionId: 'test-action-id',
+    });
   });
 });

--- a/packages/router/src/components.tsx
+++ b/packages/router/src/components.tsx
@@ -282,6 +282,11 @@ export class ErrorBoundary extends Component<
     children: React.ReactNode;
     /** Optional reset key — when it changes, clear the captured error. */
     resetKey?: string;
+    /**
+     * Optional observer (2.3.3). Wire to `@revealui/core/observability/capture`
+     * — never put secrets in the callback side effects.
+     */
+    onError?: (error: Error, info: React.ErrorInfo) => void;
   },
   { error: Error | null }
 > {
@@ -289,6 +294,7 @@ export class ErrorBoundary extends Component<
     fallback: React.ComponentType<{ error: Error }>;
     children: React.ReactNode;
     resetKey?: string;
+    onError?: (error: Error, info: React.ErrorInfo) => void;
   }) {
     super(props);
     this.state = { error: null };
@@ -296,6 +302,10 @@ export class ErrorBoundary extends Component<
 
   static getDerivedStateFromError(error: Error): { error: Error } {
     return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    this.props.onError?.(error, info);
   }
 
   componentDidUpdate(prevProps: { resetKey?: string }): void {

--- a/packages/router/src/server-rsc.tsx
+++ b/packages/router/src/server-rsc.tsx
@@ -93,6 +93,18 @@ export interface RenderRequestOptions {
   title?: string;
   /** Extra headers on the response (e.g. Cache-Control). */
   headers?: HeadersInit;
+  /**
+   * Optional observer for loader / action / form / render failures (2.3.3).
+   * Wire to `@revealui/core/observability/capture`. Never pass request bodies.
+   */
+  onError?: (
+    error: unknown,
+    meta: {
+      phase: 'action' | 'form' | 'loader';
+      pathname: string;
+      actionId?: string;
+    },
+  ) => void;
 }
 
 function defaultHtmlShell(opts: {
@@ -319,6 +331,7 @@ export async function renderRequest(
         } catch (error) {
           if (isRouterRedirect(error)) return redirectResponse(error, representation);
           if (isRouterNotFound(error)) return notFoundResponse(router, representation, error);
+          options.onError?.(error, { phase: 'action', pathname, actionId });
           returnValue = { ok: false, data: error instanceof Error ? error.message : String(error) };
         }
         match = await router.resolve(pathname);
@@ -341,6 +354,7 @@ export async function renderRequest(
         } catch (error) {
           if (isRouterRedirect(error)) return redirectResponse(error, representation);
           if (isRouterNotFound(error)) return notFoundResponse(router, representation, error);
+          options.onError?.(error, { phase: 'form', pathname });
           return new Response('Internal Server Error: server action failed', { status: 500 });
         }
         match = await router.resolve(pathname);
@@ -376,6 +390,7 @@ export async function renderRequest(
         throw error;
       }
       // Phase 2.3.2: loader/render failures → controlled 500 (no stack leak in prod).
+      options.onError?.(error, { phase: 'loader', pathname });
       return internalErrorResponse(error, representation);
     }
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,7 +368,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -608,7 +608,7 @@ importers:
         version: 10.67.0(react@19.2.8)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -670,6 +670,9 @@ importers:
       '@hono/node-server':
         specifier: '>=2.0.5'
         version: 2.0.11(hono@4.12.27)
+      '@revealui/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@revealui/router':
         specifier: workspace:*
         version: link:../../packages/router
@@ -12504,7 +12507,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,6 +676,9 @@ importers:
       '@revealui/router':
         specifier: workspace:*
         version: link:../../packages/router
+      '@revealui/security':
+        specifier: workspace:*
+        version: link:../../packages/security
       '@revealui/utils':
         specifier: workspace:*
         version: link:../../packages/utils
@@ -716,6 +719,9 @@ importers:
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/server:
     dependencies:


### PR DESCRIPTION
## Summary

GAP-194 **Phase 2.3.4** — request-layer checklist + dogfood perimeter. Auth/security **outside** `Router.match`.

**Depends on:** [revealui#2348](https://github.com/RevealUIStudio/revealui/pull/2348) (2.3.3 observability). This branch is stacked on that tip; if #2348 is still open, merge that first (or merge this stack after CI).

### Deliverables

| Item | Location |
|------|----------|
| Checklist | `packages/router/docs/REQUEST-LAYER.md` |
| Dogfood wrap | `apps/rsc-poc/src/request-layer/*` + `entry.rsc` `withRequestLayer` |
| Secure headers | `@revealui/security` `createSecurityMiddleware` (CSP with unsafe-inline for RSC bootstrap; no HSTS on local HTTP) |
| Domain-lock | optional `RSC_POC_ALLOWED_HOSTS` |
| CSRF (dogfood) | same-origin Origin/Referer on non-`x-rsc-action` POSTs |
| Smoke | `smoke:http` asserts nosniff / DENY / CSP + evil Origin → 403 |

### Hard rule

No auth logic inside `Router.match`. Protected actions stay on `router.useAction` (2.3.1).

## Verification

- [x] `pnpm --filter @rsc-poc/app test` (8)
- [x] typecheck + build + `smoke:http`
- [x] Pre-push phase 1 PASS

## Owner

```bash
# Prefer merge order: 2348 then this (or squash-merge this stack if 2348 already in)
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```

**Next after merge:** 2.3.5 optional thin shell (owner ruling: rsc-poc only until Phase 3) or **2.3.6** Phase 3 ready checklist.