### PR TITLE
ci(gate): hard-fail leftover docs public markdown mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,12 @@ jobs:
       - name: API docs drift
         run: pnpm validate:api-docs
 
+      - name: Docs public mirror (hard fail)
+        # ADR 2026-07-29: monorepo docs/ is SoT; fail if leftover generated
+        # apps/docs/public/**/*.md reappear (except docs-pro). Mirrors local
+        # gate step in scripts/gates/ci-gate.ts (fleet-redundancy C12).
+        run: pnpm validate:docs-public-mirror
+
       - name: Claims evidence validation (hard fail)
         # Every prose sentence in covered marketing content must carry a
         # claims-evidence entry citing the code that proves it. Sibling of

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -360,6 +360,14 @@ async function gate(): Promise<void> {
         args: ['validate:api-docs'],
       },
       {
+        // ADR 2026-07-29 virtual serve: monorepo docs/ is SoT. Fail if leftover
+        // generated apps/docs/public/**/*.md reappear (not docs-pro). Script
+        // shipped in #2347; wired into phase-1 + CI for fleet-redundancy C12.
+        name: 'Docs public mirror (hard fail)',
+        command: 'pnpm',
+        args: ['validate:docs-public-mirror'],
+      },
+      {
         // The .claude config surface (rules/agents/skills) is materialized
         // from revcon profiles with a sha256 manifest; tracked copies must
         // match it exactly (no local edits, no hand-added strays). Mirrored


### PR DESCRIPTION
## Summary

Fleet-redundancy C12 prevention after #2347:

- Wire `pnpm validate:docs-public-mirror` into local phase-1 gate (`scripts/gates/ci-gate.ts`)
- Mirror the same hard-fail step in CI Quality (`.github/workflows/ci.yml`)

Script already shipped in #2347; without gate wiring it only ran when operators remembered.

## Test plan

- [x] `pnpm validate:docs-public-mirror`
- [x] `pnpm gate --phase=1 --changed`
- [ ] CI green

Related: fleet-redundancy lane (active), jv#992.