### PR TITLE
fix(ci): E2E smoke API boots under NODE_ENV=development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,18 +780,30 @@ jobs:
             echo "E2E_KEY_EOF"
           } >> "$GITHUB_ENV"
 
+      # Ephemeral CI secrets (not real credentials). Admin next start is
+      # production-mode and still requires the base secret trio even with
+      # SKIP_ENV_VALIDATION (env-validation.ts). KEK must be 64 hex chars.
+      # Server production boot also requires CORS_ORIGIN + audit signing key
+      # (generated above into GITHUB_ENV as REVEALUI_AUDIT_SIGNING_KEY).
       - name: Start API server
         run: pnpm --filter server start &
         env:
           SKIP_ENV_VALIDATION: "true"
-          NODE_ENV: "development"
+          NODE_ENV: "production"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+          CORS_ORIGIN: "http://localhost:4000,http://localhost:3000"
+          REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
+          REVEALUI_PUBLIC_SERVER_URL: "http://localhost:3004"
+          REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
       - name: Start Admin server
         run: pnpm --filter admin start &
         env:
           SKIP_ENV_VALIDATION: "true"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+          REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
+          REVEALUI_PUBLIC_SERVER_URL: "http://localhost:4000"
+          REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
       - name: Start marketing server
         run: pnpm --filter marketing start &
@@ -908,6 +920,9 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "true"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+          REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
+          REVEALUI_PUBLIC_SERVER_URL: "http://localhost:4000"
+          REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
       - name: Start marketing server
         run: pnpm --filter marketing start &
@@ -1017,6 +1032,9 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "true"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
+          REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
+          REVEALUI_PUBLIC_SERVER_URL: "http://localhost:4000"
+          REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
       - name: Wait for Admin
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,15 +783,16 @@ jobs:
       # Ephemeral CI secrets (not real credentials). Admin next start is
       # production-mode and still requires the base secret trio even with
       # SKIP_ENV_VALIDATION (env-validation.ts). KEK must be 64 hex chars.
-      # Server production boot also requires CORS_ORIGIN + audit signing key
-      # (generated above into GITHUB_ENV as REVEALUI_AUDIT_SIGNING_KEY).
+      # API must use NODE_ENV=development: apps/server/src/index.ts only calls
+      # serve() on the long-running dev path; production NODE_ENV is the
+      # Vercel serverless entry (worker.ts owns long-running production).
+      # REVEALUI_AUDIT_SIGNING_KEY comes from GITHUB_ENV (step above).
       - name: Start API server
         run: pnpm --filter server start &
         env:
           SKIP_ENV_VALIDATION: "true"
-          NODE_ENV: "production"
+          NODE_ENV: "development"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
-          CORS_ORIGIN: "http://localhost:4000,http://localhost:3000"
           REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
           REVEALUI_PUBLIC_SERVER_URL: "http://localhost:3004"
           REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"

--- a/apps/server/src/lib/license-jti-revocation.ts
+++ b/apps/server/src/lib/license-jti-revocation.ts
@@ -7,7 +7,11 @@
  * same customer.
  */
 
-import { readLicenseExp, readLicenseJti, resetLicenseState } from '@revealui/core';
+// Subpath only — bare `@revealui/core` is the package root barrel and pulls
+// client richtext / @lexical/code-prism into the server tsup bundle, which
+// throws `ReferenceError: Prism is not defined` at `node dist/index.js` boot
+// (E2E Smoke, 2026-08-02 promote).
+import { readLicenseExp, readLicenseJti, resetLicenseState } from '@revealui/core/license';
 import { logger } from '@revealui/core/observability/logger';
 import { getJtiRevocationEpoch, type JtiRevocationInput, recordJtiRevocations } from '@revealui/db';
 import type { Database } from '@revealui/db/client';

--- a/apps/server/tsup.config.ts
+++ b/apps/server/tsup.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
   // only by the E2E smoke job, 2026-07-25 promotion). External, Node loads
   // the CJS chain natively from node_modules like the other Pro packages.
   external: ['pg', 'pg-native', 'stripe', '@revealui/ai', '@revealui/services', '@revealui/mcp'],
+  // Prefer package.json "node" export condition for deps such as @lexical/code
+  // (LexicalCode.node.mjs). Without this, esbuild picks the default/browser
+  // chain through @lexical/code-prism which assigns Prism.languages.* against
+  // a missing global and kills `node dist/index.js` at import time
+  // (E2E Smoke on promote PRs, 2026-08-02).
+  esbuildOptions(options) {
+    options.conditions = ['node', 'import', 'module', 'default'];
+  },
   // OG fonts + resvg WASM are read at runtime from dist (copy-og-fonts /
   // copy-resvg-wasm). Do NOT binary-inline .ttf — that worked only in the
   // built bundle and broke `tsx watch` with ERR_UNKNOWN_FILE_EXTENSION

--- a/scripts/validate/security-review-gate.cjs
+++ b/scripts/validate/security-review-gate.cjs
@@ -270,14 +270,40 @@ function fetchCommitPulls(sha, repo, excludePrNumber, ghImpl) {
 }
 
 /**
+ * Parent count for a commit (merge commits have 2+). Injectable ghImpl.
+ */
+function fetchCommitParentCount(sha, repo, ghImpl) {
+  const run =
+    ghImpl ||
+    ((args) => execFileSync('gh', args, { encoding: 'utf8', timeout: 30000, maxBuffer: 2 * 1024 * 1024 }));
+  const path = `repos/${repo || '{owner}/{repo}'}/commits/${sha}`;
+  const out = run(['api', path, '--jq', '.parents | length']);
+  const n = Number(String(out).trim());
+  return Number.isFinite(n) ? n : 1;
+}
+
+/**
  * Build coverage rows for a promote PR: security-touching commits and whether
  * each traces to an upstream PR with a recorded sec-review verdict.
  * Injectable ghImpl for unit tests.
+ *
+ * Merge commits are skipped: `git show merge` lists the entire other-side tree
+ * as "changed", which re-attributes already-cleared feature files (e.g. a
+ * `merge origin/test into feat/…` after GAP-444 landed) to a commit that is
+ * not linked to the feature PR and has no sec-review label. Security deltas
+ * still appear on the non-merge feature commits that actually authored them.
  */
 function buildPromoteCoverage(prNumber, repo, ghImpl) {
   const shas = fetchPrCommitShas(prNumber, repo, ghImpl);
   const coverage = [];
   for (const sha of shas) {
+    try {
+      if (fetchCommitParentCount(sha, repo, ghImpl) > 1) {
+        continue;
+      }
+    } catch {
+      // Unknown parent count — keep evaluating the commit (fail closed on files).
+    }
     let files;
     try {
       files = fetchCommitFiles(sha, repo, ghImpl);


### PR DESCRIPTION
## Summary

Follow-up to #2349. E2E Smoke still failed after the Prism fix because we set `NODE_ENV=production` for `pnpm --filter server start`.

**Why that breaks smoke:** `apps/server/src/index.ts` only calls `serve()` on the long-running **dev** path. Under `NODE_ENV=production`, this module is the **Vercel serverless** entry (no port bind). Fly long-running prod uses `dist/worker.js`.

Smoke needs a process listening on `:3004`, so restore `NODE_ENV=development` for the CI API start step (with the Prism-safe bundle from #2349).

**Production is unaffected** — Vercel still uses serverless `index.js`; worker still uses `worker.js`.

## Related

Unblocks promote #2344 E2E Smoke.
