### PR TITLE
fix(ci): E2E smoke API boots under NODE_ENV=development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,10 +788,11 @@ jobs:
       - name: Start API server
         run: pnpm --filter server start &
         env:
+          # Long-running serve() lives on the dev path in index.ts; production
+          # NODE_ENV is the Vercel serverless entry (worker.ts owns Fly prod).
           SKIP_ENV_VALIDATION: "true"
-          NODE_ENV: "production"
+          NODE_ENV: "development"
           POSTGRES_URL: "postgresql://test:test@localhost:5432/smoke"
-          CORS_ORIGIN: "http://localhost:4000,http://localhost:3000"
           REVEALUI_SECRET: "e2e-smoke-secret-at-least-32-chars-long"
           REVEALUI_PUBLIC_SERVER_URL: "http://localhost:3004"
           REVEALUI_KEK: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"


### PR DESCRIPTION
## Summary

Unblocks promote **#2344** E2E Smoke.

After #2349 (Prism / license import + admin env), smoke still failed because the API start step used `NODE_ENV=production`. In that mode `apps/server/src/index.ts` is the **Vercel serverless** path and **does not** call `serve()`. Long-running listen is only on the **dev** path (and Fly uses `worker.js`).

This PR sets smoke API start back to `NODE_ENV=development` so `:3004` binds. Production deploy paths are unchanged.

## Verify

- `grep -A8 "Start API server" .github/workflows/ci.yml` shows `NODE_ENV: "development"`
- After merge, re-check E2E Smoke on #2344
