### PR TITLE
docs(starter-kit): GAP-434 owner runbook after private seed

### DIFF
--- a/examples/starter-kit/OWNER-LAUNCH.md
+++ b/examples/starter-kit/OWNER-LAUNCH.md
@@ -1,109 +1,163 @@
 # Owner launch checklist (GAP-434)
 
-Agent-prepared. Run from a real shell. Polar credentials and M-11 escape
-hatch are disposition-shaped.
+Agent-prepared. Polar dashboard, Stripe live coupon, and GitHub org
+settings are **owner-only**. Agent cannot merge PRs or create Polar products.
 
-## Status (2026-08-02)
+## Status (2026-08-02, post-seed)
 
 | Item | State |
 |------|--------|
-| Kit content (npm, Postgres-only) | on revealui `test` / `examples/starter-kit` (#2245) |
-| Standalone CI | `.github/workflows/starter-kit-standalone.yml` in monorepo |
-| Marketing listing | revealui#2358 (`/pricing#starter-kit`) |
-| Private repo `RevealUIStudio/revealui-starter-kit` | **empty** (created, never seeded) |
-| Polar product $299 | not live |
+| Kit content (npm, Postgres-only) | revealui `test` `examples/starter-kit` (#2245) |
+| Marketing listing | **MERGED** #2358 — `/pricing#starter-kit` |
+| Private seed | **DONE** — `d9b6f2c` on `RevealUIStudio/revealui-starter-kit` |
+| Assembler hygiene | monorepo #2361 merged; private drop PR may still be open (#1) |
+| Polar product $299 | **not live** (blocker for buy CTA) |
 | Stripe first-month-Pro coupon | not seeded |
-| `SITE.urls.starterKitCheckout` | empty until Polar URL exists |
+| `SITE.urls.starterKitCheckout` | `''` until Polar URL exists |
+| Branch protection on private `main` | API returns 403 (GitHub free private: rulesets/protection need Pro or public). Rely on fleet M-11 hook on this machine + **stop using no-protection** after seed. |
 
-## 1. Seed the private buyer repo (one-time)
-
-The private repo must receive the kit as its **root** (not nested under
-`examples/`). After #2245 the kit is npm-resolvable; buyers never need the
-monorepo.
+## 0. Hygiene merges (if still open)
 
 ```bash
-# From any machine with fleet git identity + SSH:
-SOURCE="$HOME/revfleet/revealui"   # or a clean worktree on origin/test
-git -C "$SOURCE" fetch origin test
-git -C "$SOURCE" switch --detach origin/test
-
-SEED="$HOME/tmp/revealui-starter-kit-seed"
-rm -rf "$SEED"
-bash "$SOURCE/examples/starter-kit/scripts/assemble-private-seed.sh" \
-  --source "$SOURCE/examples/starter-kit" \
-  --out "$SEED"
-
-cd "$SEED"
-git init -b main
-git add .
-git -c user.name="RevealUI Studio" \
-    -c user.email="43050008+joshua-v-dev@users.noreply.github.com" \
-    commit -S -m "chore: seed RevealUI Starter Kit (GAP-434)"
-
-git remote add origin git@github.com-revealui:RevealUIStudio/revealui-starter-kit.git
-
-# Empty remote has no PR base — one authorized direct push to main:
-git config revealui.hooks.no-protection true
-git push -u origin main
-git config --unset revealui.hooks.no-protection
+gh pr merge 1 -R RevealUIStudio/revealui-starter-kit --merge   # drop assembler from buyer tree
+# monorepo exclude already on test if #2361 merged
 ```
 
-Verify: `gh api repos/RevealUIStudio/revealui-starter-kit/commits --jq '.[0].sha'`
+## 1. Seed private buyer repo — DONE
 
-## 2. Branch protection (after seed has a commit)
+Seed commit: `d9b6f2c`. Re-seed only if content drifts; use:
 
-In GitHub UI or `gh api` (repo settings mutation, owner-only):
+```bash
+bash examples/starter-kit/scripts/assemble-private-seed.sh \
+  --source examples/starter-kit \
+  --out "$HOME/tmp/revealui-starter-kit-seed"
+# then PR into main on the private repo (no more direct main push)
+```
 
-- Require signed commits
-- Require status checks when CI exists on that repo
-- No force-push to `main`
+## 2. Branch protection (best-effort on free private)
 
-## 3. Polar product ($299)
+GitHub returned: *Upgrade to GitHub Pro or make this repository public* for
+rulesets/branch-protection API on this private repo.
 
-1. Create/open Polar org for RevealUI Studio.
-2. Product: **RevealUI Starter Kit**, one-time **$299**.
-3. Benefits: license key (or download token) + **private GitHub repo access**
-   to `RevealUIStudio/revealui-starter-kit`.
-4. Copy the public checkout URL.
-5. In revealui (follow-up PR or same day):
+Practical options:
+
+1. **Org/GitHub Pro** on the private repo, then enable classic protection:
+   Settings → Branches → Protect `main` → require PR, signed commits, no force-push.
+2. **Leave free private** and enforce process: never re-enable
+   `revealui.hooks.no-protection` for this remote; all changes via PR + review.
+3. Do **not** make the kit public until you intentionally open-source it.
+
+## 3. Polar product ($299) — do this next
+
+Docs: [GitHub repository access benefits](https://polar.sh/docs/features/benefits/github-access)
+
+### 3a. Org + GitHub app
+
+1. Sign in at [polar.sh](https://polar.sh) (GitHub login OK).
+2. Create or open the **RevealUI Studio** organization (or your studio org slug).
+3. Connect GitHub for benefits: install the **Polar GitHub App** on
+   `RevealUIStudio` with access to **`revealui-starter-kit`** (private).
+
+### 3b. Benefit
+
+1. Dashboard → **Benefits** → **+ New Benefit**  
+   https://polar.sh/dashboard (then Products → Benefits)
+2. Type: **GitHub Repository Access**
+3. Repository: `RevealUIStudio/revealui-starter-kit`
+4. Access: collaborator (read) is enough for clone; lifetime for one-time purchase
+5. Save benefit
+
+### 3c. Product
+
+1. **Products** → **+ New Product**
+2. Name: `RevealUI Starter Kit`
+3. Description (honest): content-only kit (recipes + Postgres bootstrap +
+   create-revealui path). Not a Pro subscription. Not a full Fleet stamp.
+4. Pricing: **one-time** **$299 USD**
+5. Attach benefit: the GitHub repo access benefit from 3b
+6. Optional: license key benefit if you want a purchase ID for support mail
+7. Publish / enable checkout
+8. Copy the **public checkout URL** (product or checkout link from Polar UI)
+
+### 3d. Wire marketing (agent can PR once you paste the URL)
+
+```bash
+# Owner: set the URL in a one-line PR, or hand the URL to an agent:
+# SITE.urls.starterKitCheckout = 'https://polar.sh/<org>/<product-or-checkout>'
+```
+
+In monorepo:
 
 ```ts
 // apps/marketing/app/content/site.ts
-starterKitCheckout: 'https://polar.sh/...',  // paste Polar product URL
+starterKitCheckout: 'https://polar.sh/...',  // paste Polar product/checkout URL
 ```
 
-Marketing CTA flips from email-reserve to **Buy on Polar** automatically.
+`/pricing#starter-kit` CTA becomes **Buy the Starter Kit on Polar**.
 
 ## 4. Stripe first-month-of-Pro coupon
 
-Not a catalog product. Create once in Stripe live (or test, then live):
+Live Stripe (after you confirm mode). Example with Stripe CLI + revvault:
 
-- Duration: once / 1 month
-- Percent or amount: 100% of first Pro month
-- Name: e.g. `starter_kit_pro_month_1`
-- Deliver code (or auto-apply token) with Polar purchase confirmation /
-  Substack invite email.
+```bash
+# Load live secret WITHOUT printing it:
+export STRIPE_API_KEY="$(revvault get --full revealui/prod/stripe/secret-key)"
 
-Optional later: wire env `REVEALUI_STARTER_KIT_PRO_COUPON` if checkout should
-auto-apply; not required for first sale.
+stripe coupons create \
+  --duration=once \
+  --percent-off=100 \
+  --name="Starter Kit first Pro month" \
+  --id="starter_kit_pro_month_1"
+
+# Create a promotion code customers can type (or email manually):
+stripe promotion_codes create \
+  --coupon=starter_kit_pro_month_1 \
+  --code=STARTERKITPRO1
+```
+
+Deliver code with purchase confirmation / Substack invite. Not auto-wired into
+checkout unless you later set an env and product path.
+
+If `revvault` path differs on your machine: `revvault list | grep stripe`.
 
 ## 5. Manual Substack invite
 
-At launch volume: each buyer gets a private Substack section invite by hand
-(owner ruling 2026-07-26). Automate only when volume justifies it.
+At launch volume: invite each buyer to the private Substack section by hand
+(owner ruling 2026-07-26).
 
 ## 6. Acceptance test
 
-1. Real Polar checkout (owner card OK; refund after).
-2. Repo access lands.
-3. Fresh clone of private repo (no monorepo above it):
-   `pnpm install && pnpm test && pnpm recipe:action`
-4. Optional: `bash scripts/bootstrap.sh` if Postgres recipes are in scope.
-5. Marketing: `/pricing#starter-kit` primary CTA is Polar URL.
-6. Record listing URL + test purchase evidence on GAP-434 and close.
+1. Polar checkout with owner card (refund after).
+2. GitHub invite to `revealui-starter-kit` lands for the buyer account.
+3. Fresh clone (no monorepo parent):
+
+   ```bash
+   git clone git@github.com:RevealUIStudio/revealui-starter-kit.git /tmp/kit-smoke
+   cd /tmp/kit-smoke
+   pnpm install && pnpm test && pnpm recipe:action
+   ```
+
+4. Marketing primary CTA is Polar URL (not mailto).
+5. Record listing URL + test purchase on GAP-434; close gap.
+
+## Owner paste block (this session)
+
+```bash
+# A) Hygiene (if PR still open)
+gh pr merge 1 -R RevealUIStudio/revealui-starter-kit --merge
+
+# B) Polar: complete §3 in the Polar dashboard (no CLI in fleet today)
+
+# C) After Polar URL exists — give agent one line, e.g.:
+#    "wire starterKitCheckout https://polar.sh/...."
+# Or edit site.ts yourself on a branch from origin/test and open a PR.
+
+# D) Coupon (§4) when ready for Pro upsell
+```
 
 ## Do not
 
-- Claim Polar checkout live before step 3.
-- Ship monorepo-only docker build paths as the buyer path (retired by #2245).
-- Put secrets in the private seed; buyers run `generate-secrets` / bootstrap.
+- Claim Polar checkout live before §3 publish.
+- Re-enable `revealui.hooks.no-protection` for routine pushes.
+- Put secrets in the private seed.
+- Invent more homepage marketing copy for the kit before Polar is live.


### PR DESCRIPTION
## Summary

Refresh `examples/starter-kit/OWNER-LAUNCH.md` for the post-seed state:

- Seed marked DONE (`d9b6f2c`)
- Polar §3 expanded (GitHub App benefit + \$299 product + checkout URL)
- Branch protection: free private API limit noted
- Stripe coupon CLI recipe via revvault
- Owner paste block for this session

## Owner next

1. Merge hygiene starter-kit#1 if open
2. Create Polar product (docs in OWNER-LAUNCH §3)
3. Reply with Polar checkout URL → agent wires \`SITE.urls.starterKitCheckout\`