### PR TITLE
feat(core): Vite withRevealUI sibling (GAP-194 Tier 0 3.0)

### DIFF
--- a/apps/rsc-poc/README.md
+++ b/apps/rsc-poc/README.md
@@ -19,6 +19,7 @@ plugin-rsc; Phase 2.2.2 T0–T7 built the engine; **T8** is the first real consu
 
 | Piece | Role |
 |-------|------|
+| `vite.config.ts` | `@revealui/core/vite/withRevealUI` (Tier 0 step 3.0 dogfood) |
 | `src/app-router.ts` | `new Router({ rsc: {} })` + three demo routes + layout |
 | `src/entry.rsc.tsx` | `renderRequest` + JS actions + progressive `decodeFormAction` (2.2.4) |
 | `src/entry.ssr.tsx` | SSR from teed flight; payload inline owned by router |

--- a/apps/rsc-poc/vite.config.ts
+++ b/apps/rsc-poc/vite.config.ts
@@ -1,16 +1,31 @@
+import { withRevealUI } from '@revealui/core/vite/withRevealUI';
 import react from '@vitejs/plugin-react';
 import rsc from '@vitejs/plugin-rsc';
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-  plugins: [
-    rsc({
-      entries: {
-        rsc: './src/entry.rsc.tsx',
-        ssr: './src/entry.ssr.tsx',
-        client: './src/entry.browser.tsx',
-      },
-    }),
-    react(),
-  ],
-});
+/**
+ * Dogfood `@revealui/core/vite/withRevealUI` (GAP-194 Tier 0 step 3.0).
+ * Perimeter CSP/CSRF still live in `src/request-layer` (2.3.4); this only
+ * injects REVEALUI_* define + baseline dev/preview headers.
+ */
+export default defineConfig(
+  withRevealUI(
+    {
+      plugins: [
+        rsc({
+          entries: {
+            rsc: './src/entry.rsc.tsx',
+            ssr: './src/entry.ssr.tsx',
+            client: './src/entry.browser.tsx',
+          },
+        }),
+        react(),
+      ],
+    },
+    {
+      // Dogfood shell is not the admin product UI; request-layer owns gates.
+      admin: false,
+      configPath: './revealui.config.ts',
+    },
+  ),
+);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -285,6 +285,16 @@
       "import": "./dist/nextjs/withRevealUI.js",
       "default": "./dist/nextjs/withRevealUI.js"
     },
+    "./vite": {
+      "types": "./dist/vite/index.d.ts",
+      "import": "./dist/vite/index.js",
+      "default": "./dist/vite/index.js"
+    },
+    "./vite/withRevealUI": {
+      "types": "./dist/vite/withRevealUI.d.ts",
+      "import": "./dist/vite/withRevealUI.js",
+      "default": "./dist/vite/withRevealUI.js"
+    },
     "./utils/logger": {
       "types": "./dist/utils/logger.d.ts",
       "import": "./dist/utils/logger.js",

--- a/packages/core/src/__tests__/vite/withRevealUI.test.ts
+++ b/packages/core/src/__tests__/vite/withRevealUI.test.ts
@@ -1,0 +1,133 @@
+/**
+ * withRevealUI (Vite) tests — config merge, define inject, admin headers,
+ * and the hard lock that `@revealui/config` is never aliased (same class of
+ * regression as nextjs/withRevealUI, 2026-06-10).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { type WithRevealUIOptions, withRevealUI } from '../../vite/withRevealUI.js';
+
+describe('withRevealUI (vite) — default options', () => {
+  it('returns a Vite config object', () => {
+    const result = withRevealUI();
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('object');
+  });
+
+  it('injects default REVEALUI_* process.env defines', () => {
+    const result = withRevealUI();
+    expect(result.define).toMatchObject({
+      'process.env.REVEALUI_CONFIG_PATH': JSON.stringify('./revealui.config.ts'),
+      'process.env.REVEALUI_ADMIN_ENABLED': JSON.stringify('true'),
+      'process.env.REVEALUI_ADMIN_ROUTE': JSON.stringify('/admin'),
+      'process.env.REVEALUI_API_ROUTE': JSON.stringify('/api'),
+    });
+  });
+
+  it('preserves existing define entries', () => {
+    const result = withRevealUI({ define: { __APP__: JSON.stringify('x') } });
+    expect(result.define?.__APP__).toBe(JSON.stringify('x'));
+    expect(result.define?.['process.env.REVEALUI_CONFIG_PATH']).toBe(
+      JSON.stringify('./revealui.config.ts'),
+    );
+  });
+});
+
+describe('withRevealUI (vite) — custom options', () => {
+  it('accepts custom configPath', () => {
+    const result = withRevealUI({}, { configPath: './my-config.ts' });
+    expect(result.define?.['process.env.REVEALUI_CONFIG_PATH']).toBe(
+      JSON.stringify('./my-config.ts'),
+    );
+  });
+
+  it('accepts admin disabled', () => {
+    const result = withRevealUI({}, { admin: false });
+    expect(result.define?.['process.env.REVEALUI_ADMIN_ENABLED']).toBe(JSON.stringify('false'));
+  });
+
+  it('accepts custom admin and api routes', () => {
+    const options: WithRevealUIOptions = {
+      adminRoute: '/dashboard',
+      apiRoute: '/v1',
+    };
+    const result = withRevealUI({}, options);
+    expect(result.define?.['process.env.REVEALUI_ADMIN_ROUTE']).toBe(JSON.stringify('/dashboard'));
+    expect(result.define?.['process.env.REVEALUI_API_ROUTE']).toBe(JSON.stringify('/v1'));
+  });
+});
+
+describe('withRevealUI (vite) — config merging', () => {
+  it('spreads existing vite config properties', () => {
+    const result = withRevealUI({
+      base: '/app/',
+      plugins: [],
+    });
+    expect(result.base).toBe('/app/');
+    expect(result.plugins).toEqual([]);
+  });
+
+  it('preserves existing resolve.alias entries without adding @revealui/config', () => {
+    const result = withRevealUI({
+      resolve: {
+        alias: { '@reveal-config': './revealui.config.ts' },
+      },
+    });
+    const alias = result.resolve?.alias;
+    expect(alias).toEqual({ '@reveal-config': './revealui.config.ts' });
+    if (alias && !Array.isArray(alias)) {
+      expect(alias['@revealui/config']).toBeUndefined();
+    }
+  });
+
+  it('throws when consumer aliases @revealui/config (record form)', () => {
+    expect(() =>
+      withRevealUI({
+        resolve: {
+          alias: { '@revealui/config': './revealui.config.ts' },
+        },
+      }),
+    ).toThrow(/do not alias @revealui\/config/);
+  });
+
+  it('throws when consumer aliases @revealui/config (array form)', () => {
+    expect(() =>
+      withRevealUI({
+        resolve: {
+          alias: [{ find: '@revealui/config', replacement: './revealui.config.ts' }],
+        },
+      }),
+    ).toThrow(/do not alias @revealui\/config/);
+  });
+});
+
+describe('withRevealUI (vite) — headers', () => {
+  it('injects baseline admin headers on server and preview when admin enabled', () => {
+    const result = withRevealUI();
+    expect(result.server?.headers).toMatchObject({
+      'X-Frame-Options': 'SAMEORIGIN',
+      'X-Content-Type-Options': 'nosniff',
+    });
+    expect(result.preview?.headers).toMatchObject({
+      'X-Frame-Options': 'SAMEORIGIN',
+      'X-Content-Type-Options': 'nosniff',
+    });
+  });
+
+  it('does not inject admin headers when admin is disabled', () => {
+    const result = withRevealUI({}, { admin: false });
+    expect(result.server?.headers?.['X-Frame-Options']).toBeUndefined();
+    expect(result.preview?.headers?.['X-Frame-Options']).toBeUndefined();
+  });
+
+  it('merges with existing server headers', () => {
+    const result = withRevealUI({
+      server: { headers: { 'X-Custom': '1' } },
+    });
+    expect(result.server?.headers).toMatchObject({
+      'X-Custom': '1',
+      'X-Frame-Options': 'SAMEORIGIN',
+      'X-Content-Type-Options': 'nosniff',
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,8 @@ export {
 // project into every route that transitively imports from '@revealui/core'.
 // Import it directly from '@revealui/core/nextjs/withRevealUI' in next.config.mjs.
 export { getRevealUI as getRevealUINext } from './nextjs/index.js';
+// Vite integration: same rule — import `@revealui/core/vite/withRevealUI` from
+// vite.config.ts only (GAP-194 Phase 3 Tier 0 step 3.0).
 // Plugins
 export { formBuilderPlugin } from './plugins/form-builder.js';
 export { nestedDocsPlugin } from './plugins/nested-docs.js';

--- a/packages/core/src/vite/index.ts
+++ b/packages/core/src/vite/index.ts
@@ -1,0 +1,11 @@
+// RevealUI Vite integration barrel.
+//
+// `withRevealUI` is re-exported here for convenience. Config-time consumers
+// may also import from `@revealui/core/vite/withRevealUI` directly (mirrors
+// the Next.js subpath that stays out of runtime NFT graphs).
+
+export {
+  type ViteUserConfig,
+  type WithRevealUIOptions,
+  withRevealUI,
+} from './withRevealUI.js';

--- a/packages/core/src/vite/withRevealUI.ts
+++ b/packages/core/src/vite/withRevealUI.ts
@@ -1,0 +1,145 @@
+/**
+ * Vite configuration wrapper for RevealUI dual-mode apps.
+ *
+ * Sibling of `@revealui/core/nextjs/withRevealUI` for the GAP-194 admin port
+ * (Phase 3 Tier 0 step 3.0). Config-time only — import from
+ * `@revealui/core/vite/withRevealUI` in `vite.config.ts`, never from the
+ * package root (keeps Node path helpers out of app runtime graphs).
+ *
+ * MUST NOT alias the `@revealui/config` package specifier: that is a real
+ * workspace package (type-safe env config). Aliasing it to the app's
+ * revealui.config.ts shadows the package in every SSR bundle (prod
+ * passkey/MFA 500s, 2026-06-10). Apps load CMS config via relative imports
+ * or their own `@reveal-config` alias.
+ *
+ * Path-scoped headers (admin-only CSP, CSRF) belong in the request layer
+ * (`packages/router/docs/REQUEST-LAYER.md`), not Vite's global
+ * `server.headers`. When `admin` is true this helper only injects a baseline
+ * pair on dev/preview servers for early dogfood.
+ */
+
+/**
+ * Minimal Vite config surface used by withRevealUI.
+ * Defined locally so `@revealui/core` does not depend on `vite` types.
+ * Consumers pass their full UserConfig; we only read/merge these fields.
+ */
+export interface ViteUserConfig {
+  define?: Record<string, unknown>;
+  resolve?: {
+    alias?: Record<string, string> | Array<{ find: string | RegExp; replacement: string }>;
+    [key: string]: unknown;
+  };
+  server?: {
+    headers?: Record<string, string>;
+    [key: string]: unknown;
+  };
+  preview?: {
+    headers?: Record<string, string>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface WithRevealUIOptions {
+  /** Path to the RevealUI config file (relative to the Vite project root) */
+  configPath?: string;
+  /** Whether to enable admin UI env flags + baseline dev/preview headers */
+  admin?: boolean;
+  /** Admin route path (documented for consumers; request-layer owns path gates) */
+  adminRoute?: string;
+  /** API route path */
+  apiRoute?: string;
+}
+
+const FORBIDDEN_CONFIG_ALIAS = '@revealui/config';
+
+type ViteAlias = Record<string, string> | Array<{ find: string | RegExp; replacement: string }>;
+
+function revealUIDefine(options: Required<WithRevealUIOptions>): Record<string, string> {
+  return {
+    'process.env.REVEALUI_CONFIG_PATH': JSON.stringify(options.configPath),
+    'process.env.REVEALUI_ADMIN_ENABLED': JSON.stringify(options.admin.toString()),
+    'process.env.REVEALUI_ADMIN_ROUTE': JSON.stringify(options.adminRoute),
+    'process.env.REVEALUI_API_ROUTE': JSON.stringify(options.apiRoute),
+  };
+}
+
+function assertNoConfigAlias(alias: ViteAlias | undefined): void {
+  if (!alias) return;
+  if (Array.isArray(alias)) {
+    for (const entry of alias) {
+      if (entry.find === FORBIDDEN_CONFIG_ALIAS) {
+        throw new Error(
+          'withRevealUI: do not alias @revealui/config to revealui.config.ts — ' +
+            'that shadows the env-config package (use @reveal-config instead)',
+        );
+      }
+    }
+    return;
+  }
+  if (Object.hasOwn(alias, FORBIDDEN_CONFIG_ALIAS)) {
+    throw new Error(
+      'withRevealUI: do not alias @revealui/config to revealui.config.ts — ' +
+        'that shadows the env-config package (use @reveal-config instead)',
+    );
+  }
+}
+
+function mergeHeaders(
+  existing: Record<string, string> | undefined,
+  inject: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!inject) return existing;
+  return { ...existing, ...inject };
+}
+
+/**
+ * Vite configuration wrapper for RevealUI.
+ *
+ * Injects `process.env.REVEALUI_*` via `define`, never aliases
+ * `@revealui/config`, and optionally sets baseline X-Frame-Options /
+ * X-Content-Type-Options on `server` + `preview` when admin is enabled.
+ */
+export function withRevealUI(
+  viteConfig: ViteUserConfig = {},
+  options: WithRevealUIOptions = {},
+): ViteUserConfig {
+  const resolved: Required<WithRevealUIOptions> = {
+    configPath: options.configPath ?? './revealui.config.ts',
+    admin: options.admin ?? true,
+    adminRoute: options.adminRoute ?? '/admin',
+    apiRoute: options.apiRoute ?? '/api',
+  };
+
+  assertNoConfigAlias(viteConfig.resolve?.alias);
+
+  const adminHeaders: Record<string, string> | undefined = resolved.admin
+    ? {
+        'X-Frame-Options': 'SAMEORIGIN',
+        'X-Content-Type-Options': 'nosniff',
+      }
+    : undefined;
+
+  return {
+    ...viteConfig,
+    define: {
+      ...viteConfig.define,
+      ...revealUIDefine(resolved),
+    },
+    resolve: viteConfig.resolve
+      ? {
+          ...viteConfig.resolve,
+          // Passthrough only — never inject @revealui/config (see module doc).
+          alias: viteConfig.resolve.alias,
+        }
+      : viteConfig.resolve,
+    server: {
+      ...viteConfig.server,
+      headers: mergeHeaders(viteConfig.server?.headers, adminHeaders),
+    },
+    preview: {
+      ...viteConfig.preview,
+      headers: mergeHeaders(viteConfig.preview?.headers, adminHeaders),
+    },
+  };
+}

--- a/packages/router/docs/PHASE-3-READY.md
+++ b/packages/router/docs/PHASE-3-READY.md
@@ -73,3 +73,4 @@ Copy into the Tier-0 admin-port kickoff PR / lane.
 | Date | Note |
 |------|------|
 | 2026-08-02 | 2.3.6 checklist authored; 2.3.1–2.3.4 dogfood on rsc-poc; browser ALS import graph fixed |
+| 2026-08-02 | Tier 0 **3.0** pre-stage: `@revealui/core/vite/withRevealUI` (+ rsc-poc dogfood). Still owner **G** before mass admin port / `apps/admin-vite` (3.1). |

--- a/packages/router/docs/REQUEST-LAYER.md
+++ b/packages/router/docs/REQUEST-LAYER.md
@@ -73,6 +73,23 @@ export default {
 Hono equivalent: `app.use('*', async (c, next) => { … })` then
 `c.env` / `c.req.raw` into `renderRequest`.
 
+## Vite boot helper (Tier 0 step 3.0)
+
+Config-time sibling of Next `withRevealUI`:
+
+```ts
+import { withRevealUI } from '@revealui/core/vite/withRevealUI'
+import { defineConfig } from 'vite'
+
+export default defineConfig(withRevealUI({ plugins: [/* … */] }, { admin: true }))
+```
+
+Injects `process.env.REVEALUI_*` via `define` and optional baseline
+dev/preview headers. **Does not** own CSP/CSRF/session (this document does).
+**Must not** alias `@revealui/config` (use `@reveal-config` for CMS config).
+
+Dogfood: `apps/rsc-poc/vite.config.ts`.
+
 ## Related
 
 - Phase 2.3 hardening spec (`.jv`): `docs/specs/2026-08-01-phase-2.3-admin-prod-hardening.md`


### PR DESCRIPTION
## Summary

Phase 3 **Tier 0 step 3.0** for GAP-194 (Next.js → RevealUI-native admin): ship `@revealui/core/vite/withRevealUI` as the config-time peer of the Next.js helper so dual-mode Vite apps can boot without `next.config`.

- Injects `process.env.REVEALUI_*` via Vite `define`
- Refuses `@revealui/config` resolve aliases (same 2026-06-10 shadowing lock as Next)
- Optional baseline `X-Frame-Options` / `X-Content-Type-Options` on `server` + `preview` when `admin: true`
- Dogfood: `apps/rsc-poc/vite.config.ts` (`admin: false`; perimeter stays in request-layer)
- Docs: `REQUEST-LAYER.md` + `PHASE-3-READY.md` history

Does **not** start mass admin port or `apps/admin-vite` (3.1). Owner criterion **G** still gates Phase 3 port; this is the explicitly pre-stageable Tier 0 blocker.

## Test plan

- [x] `pnpm --filter @revealui/core exec vitest run src/__tests__/vite/withRevealUI.test.ts` (13)
- [x] `pnpm --filter @revealui/core build` → `dist/vite/*`
- [x] `pnpm --filter @rsc-poc/app typecheck && test && build`
- [x] `pnpm gate --phase=1 --changed` PASS

## Owner

```bash
# merge when CI green (proposal-shaped; no self-merge):
gh pr merge <N> --squash
```