### PR TITLE
fix(marketing): drop stale Polar comment on Starter Kit section

### DIFF
--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -453,7 +453,7 @@ export function PricingPage() {
         </div>
       </section>
 
-      {/* GAP-434 Starter Kit — one-time content product (Polar when live) */}
+      {/* GAP-434 Starter Kit — one-time content product (Stripe Payment Link) */}
       <section id="starter-kit" className="py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="mx-auto max-w-3xl rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border sm:p-10">


### PR DESCRIPTION
## Summary
GAP-434 is Stripe Payment Link; PricingPage section comment still said Polar.

## Owner
```bash
gh pr merge <N> --repo RevealUIStudio/revealui --squash
```