### PR TITLE
fix(gap-448): perpetual mint maxSites 10 + webhook tests (onto test)

### DIFF
--- a/apps/server/src/lib/__tests__/tier-limits-perpetual.test.ts
+++ b/apps/server/src/lib/__tests__/tier-limits-perpetual.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getHostedLimitsForTier, getPerpetualLicenseMintLimits } from '../tier-limits.js';
+
+describe('getPerpetualLicenseMintLimits (GAP-448 Agency Founding Kit)', () => {
+  it('Agency / max perpetual is capped at 10 client deployments', () => {
+    expect(getPerpetualLicenseMintLimits('max')).toEqual({
+      maxSites: 10,
+      maxUsers: 100,
+    });
+  });
+
+  it('does not loosen hosted Max multi-site limits (15 sites)', () => {
+    expect(getHostedLimitsForTier('max').maxSites).toBe(15);
+    expect(getPerpetualLicenseMintLimits('max').maxSites).toBe(10);
+  });
+
+  it('pro perpetual keeps five sites', () => {
+    expect(getPerpetualLicenseMintLimits('pro')).toEqual({
+      maxSites: 5,
+      maxUsers: 25,
+    });
+  });
+
+  it('enterprise perpetual omits site/user caps', () => {
+    expect(getPerpetualLicenseMintLimits('enterprise')).toEqual({});
+  });
+});

--- a/apps/server/src/lib/tier-limits.ts
+++ b/apps/server/src/lib/tier-limits.ts
@@ -25,3 +25,19 @@ export function getHostedLimitsForTier(tier: HostedTierId): HostedTierLimits {
   if (tier === 'pro') return { maxSites: 5, maxUsers: 25, maxAgentTasks: 10_000 };
   return { maxSites: 1, maxUsers: 3, maxAgentTasks: 1_000 };
 }
+
+/**
+ * JWT maxSites/maxUsers for perpetual (one-time) license mints.
+ *
+ * Agency Perpetual / Agency Founding Kit (GAP-448) is Max-tier with a **10 client
+ * deployment** cap per offerings-canonical Track C and PERPETUAL_TIERS features.
+ * That is intentionally tighter than hosted Max multi-site limits (15 sites above).
+ */
+export function getPerpetualLicenseMintLimits(
+  tier: HostedTierId,
+): Pick<HostedTierLimits, 'maxSites' | 'maxUsers'> {
+  if (tier === 'enterprise') return {};
+  if (tier === 'max') return { maxSites: 10, maxUsers: 100 };
+  if (tier === 'pro') return { maxSites: 5, maxUsers: 25 };
+  return { maxSites: 1, maxUsers: 3 };
+}

--- a/apps/server/src/routes/__tests__/webhook-handler.test.ts
+++ b/apps/server/src/routes/__tests__/webhook-handler.test.ts
@@ -445,11 +445,40 @@ describe('POST /stripe webhook  -  handler tests', () => {
       const app = createApp();
       await app.request(postStripe(event));
 
+      // Pro perpetual site/user caps (getPerpetualLicenseMintLimits)
       expect(vi.mocked(mintModule.mintLicenseKey)).toHaveBeenCalledWith({
         tier: 'pro',
         customerId: 'cus_perp',
         perpetual: true,
         expiresInSeconds: null,
+        maxSites: 5,
+        maxUsers: 25,
+      });
+    });
+
+    it('Agency / max perpetual mints maxSites 10 (GAP-448 Founding Kit cap)', async () => {
+      mockDbSelectChain.limit.mockResolvedValueOnce([{ id: 'user_perp_max' }]);
+      const event = makePerpetualEvent('evt_perp_agency_max', {
+        metadata: {
+          tier: 'max',
+          perpetual: 'true',
+          revealui_user_id: 'user_perp_max',
+        },
+        customer: 'cus_perp_max',
+        customer_email: 'agency@test.com',
+      });
+      mockConstructEvent.mockReturnValueOnce(event);
+
+      const app = createApp();
+      await app.request(postStripe(event));
+
+      expect(vi.mocked(mintModule.mintLicenseKey)).toHaveBeenCalledWith({
+        tier: 'max',
+        customerId: 'cus_perp_max',
+        perpetual: true,
+        expiresInSeconds: null,
+        maxSites: 10,
+        maxUsers: 100,
       });
     });
 

--- a/apps/server/src/routes/webhooks/stripe-route.ts
+++ b/apps/server/src/routes/webhooks/stripe-route.ts
@@ -32,6 +32,7 @@ import type Stripe from 'stripe';
 import { sendCronFailureAlert } from '../../lib/cron-alerts.js';
 import { recordJtisForRevokedCustomerLicenses } from '../../lib/license-jti-revocation.js';
 import type { ProtectedStripe } from '../../lib/services-loader.js';
+import { getPerpetualLicenseMintLimits } from '../../lib/tier-limits.js';
 import {
   provisionGitHubAccess,
   sendCancellationConfirmationEmail,
@@ -543,11 +544,21 @@ app.openapi(stripeWebhookRoute, async (c) => {
 
                 // null expiresInSeconds = no exp claim — perpetual license never expires
                 // GAP-260 P4-3: mint via signer when flagged, else local private key.
+                // GAP-448: Agency Perpetual (max) mints with maxSites 10 (client deployments).
+                const perpetualLimits = getPerpetualLicenseMintLimits(
+                  tier as 'free' | 'pro' | 'max' | 'enterprise',
+                );
                 const licenseKey = await mintLicenseKey({
                   tier,
                   customerId,
                   perpetual: true,
                   expiresInSeconds: null,
+                  ...(perpetualLimits.maxSites !== undefined
+                    ? { maxSites: perpetualLimits.maxSites }
+                    : {}),
+                  ...(perpetualLimits.maxUsers !== undefined
+                    ? { maxUsers: perpetualLimits.maxUsers }
+                    : {}),
                 });
 
                 await ctx.db.insert(licenses).values({


### PR DESCRIPTION
## Summary

Clean rebase of GAP-448 residual mint path onto current `test` (supersedes conflicted #2386).

Marketing residual already on `test` via #2383. This PR keeps only the **server mint residual**:

- `getPerpetualLicenseMintLimits` (Agency/max perpetual **maxSites 10**, pro 5)
- Stripe webhook perpetual mint passes those caps
- Unit tests for tier-limits + webhook mint assertions

## Why not force-push #2386

Force-with-lease is blocked here; this branch is a clean rebased tip for peers to merge instead.

## Test plan

- [x] `tier-limits-perpetual.test.ts` 4/4
- [x] phase-1 gate PASS
- [ ] CI green on PR

## Related

- Closes residual of GAP-448 after #2378 / #2383
- Supersedes #2386 (CONFLICTING)