### PR TITLE
feat(server): GAP-448 P2-B full kit package tar.gz + R2 upload

### DIFF
--- a/apps/server/src/jobs/__tests__/kit-stamp-agency.test.ts
+++ b/apps/server/src/jobs/__tests__/kit-stamp-agency.test.ts
@@ -3,6 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockInsertValues = vi.fn().mockResolvedValue(undefined);
 const mockUpdateSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
 const mockSelectLimit = vi.fn();
+const mockUpload = vi.fn();
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  kitFulfillments: {
+    id: 'id',
+    stripeEventId: 'stripe_event_id',
+  },
+  users: { id: 'id', email: 'email' },
+}));
 
 vi.mock('@revealui/db/client', () => ({
   getClient: () => ({
@@ -18,6 +31,10 @@ vi.mock('@revealui/db/client', () => ({
   }),
 }));
 
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ a, b })),
+}));
+
 vi.mock('../../lib/webhook-emails.js', () => ({
   sendAgencyKitPackageEmail: vi.fn().mockResolvedValue(undefined),
 }));
@@ -26,17 +43,28 @@ vi.mock('../../lib/kit-download-token.js', () => ({
   mintKitDownloadToken: vi.fn().mockReturnValue('signed.token'),
 }));
 
+vi.mock('../../lib/kit-stamp-storage.js', () => ({
+  uploadAgencyKitTarball: (...args: unknown[]) => mockUpload(...args),
+}));
+
 import { kitStampAgencyHandler } from '../kit-stamp-agency.js';
 
 describe('kitStampAgencyHandler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.REVEALUI_SECRET = 'test-secret';
+    delete process.env.REVEALUI_KIT_STAMP_MODE;
+    delete process.env.REVEALUI_KIT_STAMP_RUN;
+    delete process.env.REVEALUI_REVFROGE_ROOT;
     mockSelectLimit.mockResolvedValue([]);
+    mockUpload.mockResolvedValue({
+      key: 'kits/test/x/y.tar.gz',
+      url: 'https://media.example/kits/test/x/y.tar.gz',
+      size: 100,
+    });
   });
 
-  it('creates fulfillment and marks ready with artifact', async () => {
-    // first select: no existing; second select in email path N/A with empty user
+  it('creates fulfillment and marks ready with artifact (thin default)', async () => {
     mockSelectLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([{ email: 'buyer@ex.com' }]);
 
     const result = await kitStampAgencyHandler(
@@ -52,9 +80,46 @@ describe('kitStampAgencyHandler', () => {
     );
 
     expect(result.status).toBe('ready');
+    expect(result.mode).toBe('thin');
     expect(result.fulfillmentId).toBeTruthy();
     expect(mockInsertValues).toHaveBeenCalled();
     expect(mockUpdateSet).toHaveBeenCalled();
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('full mode uploads tar.gz and sets artifact_uri', async () => {
+    process.env.REVEALUI_KIT_STAMP_MODE = 'full';
+    mockSelectLimit.mockResolvedValueOnce([]);
+
+    const result = await kitStampAgencyHandler(
+      {
+        stripeEventId: 'evt_full_1',
+        licenseId: 'lic_1',
+        userId: 'user_1',
+        customerId: 'cus_1',
+        livemode: false,
+        branding: { company: 'Buyer Co', email: 'buyer@ex.com', slug: 'buyer-co' },
+      },
+      { id: 'job_full' } as never,
+    );
+
+    expect(result.status).toBe('ready');
+    expect(result.mode).toBe('full');
+    expect(result.stampSource).toBe('package');
+    expect(mockUpload).toHaveBeenCalledOnce();
+    expect(mockUpload.mock.calls[0]?.[0]).toMatchObject({
+      slug: 'buyer-co',
+      livemode: false,
+    });
+    expect(Buffer.isBuffer(mockUpload.mock.calls[0]?.[0].body)).toBe(true);
+    // last update should include artifactUri
+    const readyCall = mockUpdateSet.mock.calls.find(
+      (c) => c[0] && typeof c[0] === 'object' && (c[0] as { status?: string }).status === 'ready',
+    );
+    expect(readyCall?.[0]).toMatchObject({
+      status: 'ready',
+      artifactUri: 'https://media.example/kits/test/x/y.tar.gz',
+    });
   });
 
   it('short-circuits when already ready', async () => {
@@ -78,11 +143,9 @@ describe('kitStampAgencyHandler', () => {
       { id: 'job_2' } as never,
     );
 
-    expect(result).toEqual({
-      fulfillmentId: 'ful_existing',
-      status: 'ready',
-      deduplicated: true,
-    });
+    expect(result.fulfillmentId).toBe('ful_existing');
+    expect(result.status).toBe('ready');
+    expect(result.deduplicated).toBe(true);
     expect(mockInsertValues).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/jobs/kit-stamp-agency.ts
+++ b/apps/server/src/jobs/kit-stamp-agency.ts
@@ -1,13 +1,17 @@
 /**
- * Job handler: kit.stamp.agency (GAP-448 Phase 2 P2-A).
+ * Job handler: kit.stamp.agency (GAP-448 Phase 2).
  *
  * After Agency Perpetual (max) purchase mint succeeds, this job:
  * 1. Upserts kit_fulfillments by stripe_event_id
- * 2. Builds thin kit artifact (START-HERE + revforge.json + manifest)
+ * 2. Builds kit artifact (thin text package, or full tar.gz + R2 when mode=full)
  * 3. Marks ready (no private keys stored)
  * 4. Emails buyer a signed download URL (best-effort)
  *
  * Failures after mint must not reverse payment/mint — retry via job queue.
+ *
+ * Modes (REVEALUI_KIT_STAMP_MODE):
+ * - thin (default): jsonb artifact only (P2-A)
+ * - full: package tar.gz → R2 artifact_uri; optional stamp.sh on long workers
  */
 
 import { randomUUID } from 'node:crypto';
@@ -18,6 +22,9 @@ import { kitFulfillments, users } from '@revealui/db/schema';
 import { eq } from 'drizzle-orm';
 import { mintKitDownloadToken } from '../lib/kit-download-token.js';
 import { buildAgencyKitArtifact, resolveAgencyKitBranding } from '../lib/kit-stamp-artifact.js';
+import { resolveKitStampMode } from '../lib/kit-stamp-mode.js';
+import { produceFullKitArchive } from '../lib/kit-stamp-run.js';
+import { uploadAgencyKitTarball } from '../lib/kit-stamp-storage.js';
 import { sendAgencyKitPackageEmail } from '../lib/webhook-emails.js';
 
 export interface KitStampAgencyPayload extends Record<string, unknown> {
@@ -38,6 +45,8 @@ export interface KitStampAgencyResult {
   fulfillmentId: string;
   status: string;
   deduplicated?: boolean;
+  mode?: 'thin' | 'full';
+  stampSource?: 'package' | 'revforge-stamp';
 }
 
 function apiPublicBase(): string {
@@ -55,20 +64,21 @@ export async function kitStampAgencyHandler(
   // Infer client type from getClient(); root @revealui/db Database is types/database.
   const db = getClient();
   const { stripeEventId, licenseId, userId, customerId, livemode, branding: brandingIn } = data;
+  const mode = resolveKitStampMode();
 
   if (!(stripeEventId && licenseId && customerId)) {
     throw new Error('kit.stamp.agency requires stripeEventId, licenseId, customerId');
   }
 
-  // Idempotent: already ready
+  // Idempotent: already ready (thin needs artifact; full needs uri or artifact)
   const [existing] = await db
     .select()
     .from(kitFulfillments)
     .where(eq(kitFulfillments.stripeEventId, stripeEventId))
     .limit(1);
 
-  if (existing?.status === 'ready' && existing.artifact) {
-    return { fulfillmentId: existing.id, status: 'ready', deduplicated: true };
+  if (existing?.status === 'ready' && (existing.artifact || existing.artifactUri)) {
+    return { fulfillmentId: existing.id, status: 'ready', deduplicated: true, mode };
   }
 
   // Resolve buyer email
@@ -115,17 +125,44 @@ export async function kitStampAgencyHandler(
   }
 
   try {
-    const artifact = buildAgencyKitArtifact({
+    const packageFormat = mode === 'full' ? 'tar.gz' : 'text';
+    let artifact = buildAgencyKitArtifact({
       branding,
       licenseId,
       livemode: Boolean(livemode),
+      packageFormat,
     });
+
+    let artifactUri: string | null = null;
+    let stampSource: 'package' | 'revforge-stamp' | undefined;
+
+    if (mode === 'full') {
+      const produced = await produceFullKitArchive({ branding, artifact });
+      stampSource = produced.stampSource;
+      artifact = { ...artifact, stampSource, packageFormat: 'tar.gz' };
+
+      const uploaded = await uploadAgencyKitTarball({
+        fulfillmentId,
+        slug: branding.slug,
+        livemode: Boolean(livemode),
+        body: produced.tarGz,
+      });
+      artifactUri = uploaded.url;
+
+      logger.info('Agency kit full package uploaded', {
+        fulfillmentId,
+        key: uploaded.key,
+        size: uploaded.size,
+        stampSource,
+      });
+    }
 
     await db
       .update(kitFulfillments)
       .set({
         status: 'ready',
         artifact,
+        artifactUri,
         error: null,
         updatedAt: new Date(),
       })
@@ -147,7 +184,7 @@ export async function kitStampAgencyHandler(
       });
     }
 
-    return { fulfillmentId, status: 'ready' };
+    return { fulfillmentId, status: 'ready', mode, stampSource };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'unknown';
     await db

--- a/apps/server/src/lib/__tests__/kit-stamp-mode.test.ts
+++ b/apps/server/src/lib/__tests__/kit-stamp-mode.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { resolveKitStampMode } from '../kit-stamp-mode.js';
+
+describe('resolveKitStampMode', () => {
+  it('defaults to thin', () => {
+    expect(resolveKitStampMode({})).toBe('thin');
+    expect(resolveKitStampMode({ REVEALUI_KIT_STAMP_MODE: '' })).toBe('thin');
+    expect(resolveKitStampMode({ REVEALUI_KIT_STAMP_MODE: 'weird' })).toBe('thin');
+  });
+
+  it('accepts full (case-insensitive)', () => {
+    expect(resolveKitStampMode({ REVEALUI_KIT_STAMP_MODE: 'full' })).toBe('full');
+    expect(resolveKitStampMode({ REVEALUI_KIT_STAMP_MODE: 'FULL' })).toBe('full');
+  });
+});

--- a/apps/server/src/lib/__tests__/kit-stamp-storage.test.ts
+++ b/apps/server/src/lib/__tests__/kit-stamp-storage.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { uploadAgencyKitTarball } from '../kit-stamp-storage.js';
+
+describe('uploadAgencyKitTarball', () => {
+  it('puts under kits/{env}/{id}/slug-agency-founding-kit.tar.gz', async () => {
+    const put = vi.fn().mockResolvedValue({
+      key: 'kits/test/ful-1/buyer-co-agency-founding-kit.tar.gz',
+      url: 'https://media.example/kits/test/ful-1/buyer-co-agency-founding-kit.tar.gz',
+      size: 99,
+      provider: 'mock',
+    });
+    const result = await uploadAgencyKitTarball({
+      fulfillmentId: 'ful-1',
+      slug: 'buyer-co',
+      livemode: false,
+      body: Buffer.from('gzip-bytes'),
+      storage: { put, del: vi.fn(), list: vi.fn(), provider: 'mock' },
+    });
+    expect(put).toHaveBeenCalledWith(
+      'kits/test/ful-1/buyer-co-agency-founding-kit.tar.gz',
+      expect.any(Buffer),
+      expect.objectContaining({ contentType: 'application/gzip' }),
+    );
+    expect(result.url).toContain('buyer-co-agency-founding-kit.tar.gz');
+    expect(result.size).toBe(99);
+  });
+
+  it('uses live prefix when livemode', async () => {
+    const put = vi.fn().mockResolvedValue({
+      key: 'k',
+      url: 'https://x/k',
+      size: 1,
+      provider: 'mock',
+    });
+    await uploadAgencyKitTarball({
+      fulfillmentId: 'ful-2',
+      slug: 'acme',
+      livemode: true,
+      body: Buffer.from('x'),
+      storage: { put, del: vi.fn(), list: vi.fn(), provider: 'mock' },
+    });
+    expect(put.mock.calls[0]?.[0]).toMatch(/^kits\/live\//);
+  });
+});

--- a/apps/server/src/lib/__tests__/kit-stamp-tarball.test.ts
+++ b/apps/server/src/lib/__tests__/kit-stamp-tarball.test.ts
@@ -1,0 +1,45 @@
+import { gunzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import { buildAgencyKitArtifact } from '../kit-stamp-artifact.js';
+import { buildAgencyKitPackageTarGz, buildUstarHeader, packUstar } from '../kit-stamp-tarball.js';
+
+describe('buildUstarHeader', () => {
+  it('writes a 512-byte block with path and size', () => {
+    const h = buildUstarHeader('START-HERE.md', 42, 1_700_000_000);
+    expect(h.length).toBe(512);
+    expect(h.subarray(0, 13).toString('utf8')).toBe('START-HERE.md');
+    expect(h.subarray(257, 263).toString('utf8')).toBe('ustar\0');
+  });
+});
+
+describe('packUstar + buildAgencyKitPackageTarGz', () => {
+  it('packs thin kit files into a gunzippable archive with no private keys', () => {
+    const art = buildAgencyKitArtifact({
+      branding: {
+        company: 'Buyer Co',
+        slug: 'buyer-co',
+        brand: '#1a56db',
+        email: 'buyer@example.com',
+      },
+      licenseId: 'lic_1',
+      livemode: false,
+      packageFormat: 'tar.gz',
+    });
+    const tarGz = buildAgencyKitPackageTarGz(art, { mtimeSec: 1_700_000_000 });
+    expect(tarGz.length).toBeGreaterThan(100);
+    const raw = gunzipSync(tarGz);
+    const asText = raw.toString('utf8');
+    expect(asText).toContain('START-HERE.md');
+    expect(asText).toContain('revforge.json');
+    expect(asText).toContain('manifest.json');
+    expect(asText).toContain('Buyer Co');
+    expect(asText).not.toMatch(/PRIVATE_KEY|BEGIN PRIVATE/i);
+  });
+
+  it('pads file data to 512-byte blocks', () => {
+    const ustar = packUstar([{ path: 'a.txt', data: 'hi' }], 0);
+    // header + "hi" + pad + 2 end blocks
+    expect(ustar.length % 512).toBe(0);
+    expect(ustar.length).toBeGreaterThanOrEqual(512 * 4);
+  });
+});

--- a/apps/server/src/lib/kit-stamp-artifact.ts
+++ b/apps/server/src/lib/kit-stamp-artifact.ts
@@ -1,17 +1,21 @@
 /**
- * GAP-448 Phase 2 (P2-A): build a thin Agency Founding Kit package.
+ * GAP-448 Phase 2: build Agency Founding Kit package metadata.
  *
- * Not a full monorepo tarball (that is P2-B on a long-running worker).
- * Output is START-HERE.md + revforge.json + manifest for stamp.sh --config
- * or buyer handoff. Never embeds REVEALUI_LICENSE_PRIVATE_KEY.
+ * P2-A thin: START-HERE + revforge.json + manifest (jsonb + text download).
+ * P2-B full: same files packed as tar.gz and uploaded to R2 (artifact_uri);
+ * optional local stamp.sh on long workers (REVEALUI_KIT_STAMP_RUN=1).
+ * Never embeds REVEALUI_LICENSE_PRIVATE_KEY.
  *
  * Types mirror packages/db kit-fulfillments schema (kept local so pure unit
  * tests do not need @revealui/db dist).
  */
 
 const DEFAULT_BRAND = '#1a56db';
-const TEMPLATE_VERSION = 'agency-founding-kit-p2a-1';
+const TEMPLATE_VERSION = 'agency-founding-kit-p2b-1';
 const DEFAULT_IMAGE_TAG = 'latest';
+
+export type KitPackageFormat = 'text' | 'tar.gz';
+export type KitStampSource = 'package' | 'revforge-stamp';
 
 export interface KitFulfillmentBranding {
   company: string;
@@ -22,6 +26,10 @@ export interface KitFulfillmentBranding {
 
 export interface KitFulfillmentArtifact {
   version: 1;
+  /** Delivery shape: text multi-file (thin) or tar.gz via artifact_uri (full). */
+  packageFormat?: KitPackageFormat;
+  /** How the full archive was produced (P2-B). */
+  stampSource?: KitStampSource;
   manifest: {
     product: 'agency-founding-kit';
     tier: 'max';
@@ -41,6 +49,7 @@ export interface BuildAgencyKitArtifactInput {
   branding: KitFulfillmentBranding;
   licenseId: string;
   livemode: boolean;
+  packageFormat?: KitPackageFormat;
 }
 
 /**
@@ -79,6 +88,7 @@ export function resolveAgencyKitBranding(input: {
 
 export function buildAgencyKitArtifact(input: BuildAgencyKitArtifactInput): KitFulfillmentArtifact {
   const { branding, licenseId, livemode } = input;
+  const packageFormat = input.packageFormat ?? 'text';
   const startHereMarkdown = [
     `# RevealUI Agency Founding Kit — ${branding.company}`,
     '',
@@ -109,6 +119,10 @@ export function buildAgencyKitArtifact(input: BuildAgencyKitArtifactInput): KitF
     'The included `revforge.json` is pre-filled for your branding. `maxSites: 10` is the',
     'Agency perpetual default when using `--license-tier max --license-perpetual`.',
     '',
+    packageFormat === 'tar.gz'
+      ? 'This download is a **.tar.gz** archive (START-HERE.md, revforge.json, manifest.json).'
+      : 'This download is a multi-file text package (extract sections between ---FILE--- markers).',
+    '',
     '## Support',
     '',
     'One year of support is included with purchase. Reply to your license email or open',
@@ -137,6 +151,7 @@ export function buildAgencyKitArtifact(input: BuildAgencyKitArtifactInput): KitF
 
   return {
     version: 1,
+    packageFormat,
     manifest: {
       product: 'agency-founding-kit',
       tier: 'max',

--- a/apps/server/src/lib/kit-stamp-mode.ts
+++ b/apps/server/src/lib/kit-stamp-mode.ts
@@ -1,0 +1,20 @@
+/**
+ * GAP-448 Phase 2-B: kit stamp delivery mode.
+ *
+ * - thin (default): jsonb package only (P2-A)
+ * - full: tar.gz package uploaded to object storage (artifact_uri); optional
+ *   local RevForge stamp.sh when REVEALUI_REVFROGE_ROOT is set (long worker)
+ */
+
+export type KitStampMode = 'thin' | 'full';
+
+/**
+ * Resolve stamp mode from env. Unknown values fall back to thin (safe default).
+ */
+export function resolveKitStampMode(env: NodeJS.ProcessEnv = process.env): KitStampMode {
+  const raw = env.REVEALUI_KIT_STAMP_MODE?.trim().toLowerCase();
+  if (raw === 'full') {
+    return 'full';
+  }
+  return 'thin';
+}

--- a/apps/server/src/lib/kit-stamp-run.ts
+++ b/apps/server/src/lib/kit-stamp-run.ts
@@ -1,0 +1,169 @@
+/**
+ * GAP-448 P2-B: optional local RevForge stamp.sh for long-running workers.
+ *
+ * Default full mode produces a package tar (START-HERE + revforge.json) without
+ * invoking stamp.sh — safe on Vercel serverless. When REVEALUI_REVFROGE_ROOT
+ * points at a revforge checkout and REVEALUI_KIT_STAMP_RUN=1, run stamp.sh into
+ * a temp dir and tar the output (operator/Fly worker path).
+ *
+ * Never mints a second license JWT: FORGE_STAMP_LICENSE_CMD echoes a stub so
+ * stamp.sh does not need revvault signing keys. Buyer already has the SaaS JWT.
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { logger } from '@revealui/core/observability/logger';
+import type { KitFulfillmentArtifact, KitFulfillmentBranding } from './kit-stamp-artifact.js';
+import { buildAgencyKitPackageTarGz, packUstar } from './kit-stamp-tarball.js';
+
+export type KitStampSource = 'package' | 'revforge-stamp';
+
+export interface ProduceFullKitArchiveInput {
+  branding: KitFulfillmentBranding;
+  artifact: KitFulfillmentArtifact;
+  /** Already-minted SaaS license JWT if available (not stored in DB by default). */
+  licenseJwt?: string | null;
+}
+
+export interface ProduceFullKitArchiveResult {
+  tarGz: Buffer;
+  stampSource: KitStampSource;
+}
+
+function stampRunEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.REVEALUI_KIT_STAMP_RUN === '1' || env.REVEALUI_KIT_STAMP_RUN === 'true';
+}
+
+function revforgeRoot(env: NodeJS.ProcessEnv = process.env): string | null {
+  const root = env.REVEALUI_REVFROGE_ROOT?.trim() || env.REVEALUI_REVFROGE_PATH?.trim();
+  return root && root.length > 0 ? root : null;
+}
+
+async function collectFilesRecursive(
+  dir: string,
+  base = dir,
+): Promise<Array<{ path: string; data: Buffer }>> {
+  const out: Array<{ path: string; data: Buffer }> = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const ent of entries) {
+    const abs = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      out.push(...(await collectFilesRecursive(abs, base)));
+    } else if (ent.isFile()) {
+      const data = await readFile(abs);
+      out.push({ path: relative(base, abs).split('\\').join('/'), data });
+    }
+  }
+  return out;
+}
+
+async function runStampSh(opts: {
+  revforgeRoot: string;
+  configPath: string;
+  outDir: string;
+  licenseJwt?: string | null;
+}): Promise<void> {
+  const stampSh = join(opts.revforgeRoot, 'stamp.sh');
+  const stampStat = await stat(stampSh).catch(() => null);
+  if (!stampStat?.isFile()) {
+    throw new Error(`stamp.sh not found at ${stampSh}`);
+  }
+
+  const stubDir = await mkdtemp(join(tmpdir(), 'kit-stamp-lic-'));
+  const stubPath = join(stubDir, 'issuer.sh');
+  const jwtLine = (opts.licenseJwt?.trim() || 'stub.agency.kit.jwt').replace(/'/g, '');
+  await writeFile(stubPath, `#!/usr/bin/env bash\nprintf '%s\\n' '${jwtLine}'\n`, {
+    mode: 0o755,
+  });
+
+  const publicKey =
+    process.env.REVEALUI_LICENSE_PUBLIC_KEY?.trim() ||
+    '-----BEGIN PUBLIC KEY-----\nSTUB\n-----END PUBLIC KEY-----';
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(
+        'bash',
+        [
+          stampSh,
+          '--config',
+          opts.configPath,
+          '--output',
+          opts.outDir,
+          '--password',
+          'ChangeMeOnFirstLogin!',
+        ],
+        {
+          cwd: opts.revforgeRoot,
+          env: {
+            ...process.env,
+            FORGE_STAMP_LICENSE_CMD: stubPath,
+            REVEALUI_LICENSE_PUBLIC_KEY: publicKey,
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+      let stderr = '';
+      child.stderr?.on('data', (c: Buffer) => {
+        stderr += c.toString();
+      });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`stamp.sh exited ${code}: ${stderr.slice(0, 800)}`));
+        }
+      });
+    });
+  } finally {
+    await rm(stubDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Produce the full-mode archive: package tar, or RevForge stamp output when configured.
+ */
+export async function produceFullKitArchive(
+  input: ProduceFullKitArchiveInput,
+): Promise<ProduceFullKitArchiveResult> {
+  const root = revforgeRoot();
+  if (!(stampRunEnabled() && root)) {
+    return {
+      tarGz: buildAgencyKitPackageTarGz(input.artifact),
+      stampSource: 'package',
+    };
+  }
+
+  const work = await mkdtemp(join(tmpdir(), 'kit-stamp-work-'));
+  try {
+    const configPath = join(work, 'revforge.json');
+    await writeFile(configPath, `${JSON.stringify(input.artifact.revforgeJson, null, 2)}\n`);
+    const outDir = join(work, 'out');
+    await runStampSh({
+      revforgeRoot: root,
+      configPath,
+      outDir,
+      licenseJwt: input.licenseJwt,
+    });
+    const files = await collectFilesRecursive(outDir);
+    if (files.length === 0) {
+      throw new Error('stamp.sh produced no files');
+    }
+    const tarGz = gzipSync(packUstar(files), { level: 9 });
+    return { tarGz, stampSource: 'revforge-stamp' };
+  } catch (err) {
+    logger.warn('RevForge stamp.sh failed; falling back to package tar.gz', {
+      detail: err instanceof Error ? err.message : 'unknown',
+    });
+    return {
+      tarGz: buildAgencyKitPackageTarGz(input.artifact),
+      stampSource: 'package',
+    };
+  } finally {
+    await rm(work, { recursive: true, force: true });
+  }
+}

--- a/apps/server/src/lib/kit-stamp-storage.ts
+++ b/apps/server/src/lib/kit-stamp-storage.ts
@@ -1,0 +1,48 @@
+/**
+ * GAP-448 P2-B: upload Agency kit tarball to object storage (R2).
+ *
+ * Uses the same media storage provider as uploads. Objects live under an
+ * unguessable key prefix; buyer download still goes through signed tokens.
+ */
+
+import type { StorageProvider } from '@revealui/core/storage';
+
+export interface UploadAgencyKitTarballInput {
+  fulfillmentId: string;
+  slug: string;
+  livemode: boolean;
+  body: Buffer;
+  /** Inject storage in tests. */
+  storage?: StorageProvider;
+}
+
+export interface UploadAgencyKitTarballResult {
+  key: string;
+  url: string;
+  size: number;
+}
+
+/**
+ * Upload kit tarball. Throws when R2 is not configured (full mode requires it).
+ */
+export async function uploadAgencyKitTarball(
+  input: UploadAgencyKitTarballInput,
+): Promise<UploadAgencyKitTarballResult> {
+  // Lazy media storage so unit tests can inject a mock without loading config.
+  const storage = input.storage ?? (await import('./storage.js')).getMediaStorage();
+  const envPrefix = input.livemode ? 'live' : 'test';
+  const safeSlug = input.slug.replace(/[^a-z0-9-]+/gi, '-').slice(0, 48) || 'package';
+  const key = `kits/${envPrefix}/${input.fulfillmentId}/${safeSlug}-agency-founding-kit.tar.gz`;
+
+  const result = await storage.put(key, input.body, {
+    contentType: 'application/gzip',
+    access: 'public',
+    cacheControl: 'private, max-age=0, no-store',
+    metadata: {
+      product: 'agency-founding-kit',
+      fulfillment: input.fulfillmentId,
+    },
+  });
+
+  return { key: result.key, url: result.url, size: result.size };
+}

--- a/apps/server/src/lib/kit-stamp-tarball.ts
+++ b/apps/server/src/lib/kit-stamp-tarball.ts
@@ -1,0 +1,111 @@
+/**
+ * GAP-448 P2-B: pack Agency kit files into a gzipped ustar archive.
+ *
+ * Pure Node (no archiver dependency). Never embeds private key material.
+ */
+
+import { gzipSync } from 'node:zlib';
+import type { KitFulfillmentArtifact } from './kit-stamp-artifact.js';
+
+export interface TarFileEntry {
+  /** Path inside the archive (posix, no leading slash). */
+  path: string;
+  data: Buffer | string;
+}
+
+const BLOCK = 512;
+const USTAR_MAGIC = 'ustar\0';
+const USTAR_VERSION = '00';
+
+function encodeOctal(value: number, length: number): string {
+  // ustar numeric fields are null-terminated octal ASCII padded with leading zeros
+  const body = value.toString(8);
+  const pad = Math.max(0, length - 1 - body.length);
+  return `${'0'.repeat(pad)}${body}\0`;
+}
+
+function checksumOfHeader(header: Buffer): number {
+  let sum = 0;
+  for (let i = 0; i < BLOCK; i++) {
+    sum += header[i] ?? 0;
+  }
+  return sum;
+}
+
+function writeString(buf: Buffer, offset: number, value: string, length: number): void {
+  const slice = Buffer.alloc(length, 0);
+  slice.write(value.slice(0, length), 0, 'utf8');
+  slice.copy(buf, offset);
+}
+
+/**
+ * Build a single ustar header block for a regular file.
+ */
+export function buildUstarHeader(path: string, size: number, mtimeSec: number): Buffer {
+  if (path.length > 100) {
+    throw new Error(`tar path exceeds 100 bytes: ${path}`);
+  }
+  const header = Buffer.alloc(BLOCK, 0);
+  writeString(header, 0, path, 100);
+  writeString(header, 100, encodeOctal(0o644, 8), 8); // mode
+  writeString(header, 108, encodeOctal(0, 8), 8); // uid
+  writeString(header, 116, encodeOctal(0, 8), 8); // gid
+  writeString(header, 124, encodeOctal(size, 12), 12); // size
+  writeString(header, 136, encodeOctal(mtimeSec, 12), 12); // mtime
+  // checksum field (148-155) filled with spaces while computing
+  header.fill(0x20, 148, 156);
+  writeString(header, 156, '0', 1); // typeflag regular file
+  // linkname 157-256 left zero
+  writeString(header, 257, USTAR_MAGIC, 6);
+  writeString(header, 263, USTAR_VERSION, 2);
+  const sum = checksumOfHeader(header);
+  writeString(header, 148, encodeOctal(sum, 8), 8);
+  return header;
+}
+
+/**
+ * Pack files into an uncompressed ustar stream (two zero blocks at end).
+ */
+export function packUstar(files: TarFileEntry[], mtimeSec = Math.floor(Date.now() / 1000)): Buffer {
+  const chunks: Buffer[] = [];
+  for (const file of files) {
+    const data = typeof file.data === 'string' ? Buffer.from(file.data, 'utf8') : file.data;
+    const header = buildUstarHeader(file.path.replace(/^\//, ''), data.length, mtimeSec);
+    chunks.push(header, data);
+    const pad = (BLOCK - (data.length % BLOCK)) % BLOCK;
+    if (pad > 0) {
+      chunks.push(Buffer.alloc(pad, 0));
+    }
+  }
+  // end of archive
+  chunks.push(Buffer.alloc(BLOCK * 2, 0));
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Gzip a ustar buffer (standard .tar.gz).
+ */
+export function gzipUstar(ustar: Buffer): Buffer {
+  return gzipSync(ustar, { level: 9 });
+}
+
+/**
+ * Pack Agency Founding Kit thin files as a downloadable .tar.gz.
+ */
+export function buildAgencyKitPackageTarGz(
+  artifact: KitFulfillmentArtifact,
+  opts?: { mtimeSec?: number },
+): Buffer {
+  const files: TarFileEntry[] = [
+    { path: 'START-HERE.md', data: artifact.startHereMarkdown },
+    {
+      path: 'revforge.json',
+      data: `${JSON.stringify(artifact.revforgeJson, null, 2)}\n`,
+    },
+    {
+      path: 'manifest.json',
+      data: `${JSON.stringify(artifact.manifest, null, 2)}\n`,
+    },
+  ];
+  return gzipUstar(packUstar(files, opts?.mtimeSec));
+}

--- a/apps/server/src/routes/kits.ts
+++ b/apps/server/src/routes/kits.ts
@@ -1,8 +1,11 @@
 /**
- * Agency Founding Kit download (GAP-448 Phase 2 P2-A).
+ * Agency Founding Kit download (GAP-448 Phase 2).
  *
  * GET /api/kits/agency-founding/download?token=…
  * Token is HMAC-signed short TTL; no session required when the token is valid.
+ *
+ * P2-A thin: text multi-file body from jsonb artifact.
+ * P2-B full: redirect to R2 public URL when artifact_uri is set; else text fallback.
  */
 
 import { getClient } from '@revealui/db';
@@ -19,7 +22,7 @@ const downloadRoute = createRoute({
   method: 'get',
   path: '/agency-founding/download',
   tags: ['Kits'],
-  summary: 'Download Agency Founding Kit thin package (signed token)',
+  summary: 'Download Agency Founding Kit package (signed token)',
   request: {
     query: z.object({
       token: z.string().min(1).openapi({ description: 'Signed download token' }),
@@ -27,13 +30,14 @@ const downloadRoute = createRoute({
   },
   responses: {
     200: {
-      description: 'Plain-text multi-file kit package',
+      description: 'Kit package (text multi-file or redirected tarball)',
       content: {
         'text/plain': {
           schema: z.string(),
         },
       },
     },
+    302: { description: 'Redirect to object-storage tarball (full mode)' },
     400: { description: 'Missing or invalid token' },
     404: { description: 'Fulfillment not ready' },
     410: { description: 'Token expired' },
@@ -57,7 +61,17 @@ app.openapi(downloadRoute, async (c) => {
     .where(eq(kitFulfillments.id, verified.fulfillmentId))
     .limit(1);
 
-  if (row?.status !== 'ready' || !row.artifact) {
+  if (row?.status !== 'ready') {
+    throw new HTTPException(404, { message: 'Kit package not available' });
+  }
+
+  // P2-B full: signed token gates redirect to unguessable object URL
+  const uri = row.artifactUri?.trim();
+  if (uri && (uri.startsWith('https://') || uri.startsWith('http://'))) {
+    return c.redirect(uri, 302);
+  }
+
+  if (!row.artifact) {
     throw new HTTPException(404, { message: 'Kit package not available' });
   }
 

--- a/docs/distribution/AGENCY-FOUNDING-KIT-FULFILLMENT.md
+++ b/docs/distribution/AGENCY-FOUNDING-KIT-FULFILLMENT.md
@@ -3,7 +3,7 @@
 Operator + automation notes after a buyer completes **Agency Perpetual**
 checkout (`POST /api/billing/checkout-perpetual` with `tier: max`).
 
-## Automated today (Phase 1 + Phase 2 P2-A)
+## Automated today (Phase 1 + Phase 2 P2-A / P2-B)
 
 1. Stripe Checkout (authenticated) for Agency Perpetual ($8,499).
 2. Webhook `checkout.session.completed` + `mode=payment` + `tier=max` →
@@ -13,16 +13,36 @@ checkout (`POST /api/billing/checkout-perpetual` with `tier: max`).
 4. Optional GitHub team provision when `github_username` metadata is set.
 5. **Phase 2:** enqueue durable job `kit.stamp.agency` (idempotency key
    `kit.stamp.agency:${stripeEventId}`).
-6. Job builds a **thin kit package** (START-HERE.md, revforge.json, manifest)
-   into `kit_fulfillments.artifact` — no private keys, no full monorepo zip.
+6. Job builds the kit package (no private keys):
+   - **thin (default):** START-HERE.md + revforge.json + manifest in
+     `kit_fulfillments.artifact` (jsonb); download is multi-file text.
+   - **full (`REVEALUI_KIT_STAMP_MODE=full`):** same files packed as `.tar.gz`,
+     uploaded to R2 under `kits/{test|live}/{fulfillmentId}/…tar.gz`,
+     URL stored in `kit_fulfillments.artifact_uri`. Download route redirects
+     after the signed token check. Requires R2 env (same as media).
 7. Buyer receives `sendAgencyKitPackageEmail` with a signed 48h download URL:
    `GET /api/kits/agency-founding/download?token=…`
 8. Optional checkout session metadata for branding:
    `company` / `kit_company`, `slug` / `kit_slug`, `brand` / `kit_brand`.
 
-## Operator full stamp (RevForge, still available)
+### Full mode on a long worker (optional stamp.sh)
 
-Thin package is enough for buyer activation with the JWT. For a full Docker
+On Fly/operator hosts with a revforge checkout (not Vercel serverless):
+
+```bash
+export REVEALUI_KIT_STAMP_MODE=full
+export REVEALUI_KIT_STAMP_RUN=1
+export REVEALUI_REVFROGE_ROOT=/path/to/revforge
+# R2_* vars required for upload
+# Optional: REVEALUI_LICENSE_PUBLIC_KEY for stamp.sh bake-in
+```
+
+When stamp.sh fails or is unset, full mode still uploads the **package** tar
+(config files only). Buyer JWT remains the SaaS license email (no second mint).
+
+## Operator manual stamp (RevForge)
+
+Thin/full package is enough for buyer activation with the JWT. For a full Docker
 Fleet kit on a machine with revvault:
 
 ```bash
@@ -41,9 +61,9 @@ revvault export-env -- \
 # maxSites 10 is applied automatically for max + perpetual (GAP-448).
 ```
 
-## Not automated yet (P2-B residual)
+## Residual (gap close)
 
-- Long-running worker that runs full `stamp.sh` and uploads a kit tarball to R2
+- e2e test-mode purchase → mint → stamp → download dry-run (P2-T1)
 - Unauthenticated Payment Link for $8,499 (prefer keep auth checkout)
 
 ## Marketing

--- a/packages/db/src/schema/kit-fulfillments.ts
+++ b/packages/db/src/schema/kit-fulfillments.ts
@@ -25,9 +25,13 @@ export interface KitFulfillmentBranding {
   email?: string;
 }
 
-/** Thin package files for operator stamp or buyer download (P2-A). */
+/** Package files for operator stamp or buyer download (P2-A thin / P2-B full). */
 export interface KitFulfillmentArtifact {
   version: 1;
+  /** text = multi-file body; tar.gz = object at artifact_uri (P2-B). */
+  packageFormat?: 'text' | 'tar.gz';
+  /** How full archive was produced when mode=full. */
+  stampSource?: 'package' | 'revforge-stamp';
   manifest: {
     product: 'agency-founding-kit';
     tier: 'max';


### PR DESCRIPTION
## Summary

GAP-448 Phase 2-B: when `REVEALUI_KIT_STAMP_MODE=full`, the `kit.stamp.agency` job packs the Agency Founding Kit as a **`.tar.gz`**, uploads it to **R2**, stores the public URL in `kit_fulfillments.artifact_uri`, and the download route **redirects** after the signed token check.

Thin mode (default) is unchanged (P2-A text package in jsonb).

## Behavior

| Mode | Env | Result |
|------|-----|--------|
| thin (default) | unset / other | jsonb artifact + text download |
| full package | `REVEALUI_KIT_STAMP_MODE=full` | tar.gz → R2 → `artifact_uri` (needs R2_* like media) |
| full + stamp.sh | full + `REVEALUI_KIT_STAMP_RUN=1` + `REVEALUI_REVFORGE_ROOT` | run stamp.sh on long worker; fall back to package tar on failure |

No second license mint. No private keys in artifact/DB.

## Files

- `kit-stamp-tarball.ts` — pure ustar + gzip
- `kit-stamp-storage.ts` — R2 put under `kits/{test|live}/…`
- `kit-stamp-run.ts` — optional local stamp.sh
- `kit-stamp-mode.ts` — env resolver
- handler + kits download route + fulfillment doc

## Tests

15 unit tests (mode, tarball, storage, artifact, handler thin+full).

## Residual (gap not closed)

- P2-T1 e2e test-mode purchase dry-run
- Owner enable full mode in prod worker env when ready

## Owner

```bash
gh pr merge 2396 --merge
# optional prod / long worker:
# REVEALUI_KIT_STAMP_MODE=full
# REVEALUI_KIT_STAMP_RUN=1
# REVEALUI_REVFORGE_ROOT=/path/to/revforge
# (+ R2_*)
```