### PR TITLE
fix(server): REVFORGE env names (not REVFROGE typo)

### DIFF
--- a/apps/server/src/jobs/__tests__/kit-stamp-agency.test.ts
+++ b/apps/server/src/jobs/__tests__/kit-stamp-agency.test.ts
@@ -55,7 +55,7 @@ describe('kitStampAgencyHandler', () => {
     process.env.REVEALUI_SECRET = 'test-secret';
     delete process.env.REVEALUI_KIT_STAMP_MODE;
     delete process.env.REVEALUI_KIT_STAMP_RUN;
-    delete process.env.REVEALUI_REVFROGE_ROOT;
+    delete process.env.REVEALUI_REVFORGE_ROOT;
     mockSelectLimit.mockResolvedValue([]);
     mockUpload.mockResolvedValue({
       key: 'kits/test/x/y.tar.gz',

--- a/apps/server/src/lib/kit-stamp-mode.ts
+++ b/apps/server/src/lib/kit-stamp-mode.ts
@@ -3,7 +3,7 @@
  *
  * - thin (default): jsonb package only (P2-A)
  * - full: tar.gz package uploaded to object storage (artifact_uri); optional
- *   local RevForge stamp.sh when REVEALUI_REVFROGE_ROOT is set (long worker)
+ *   local RevForge stamp.sh when REVEALUI_REVFORGE_ROOT is set (long worker)
  */
 
 export type KitStampMode = 'thin' | 'full';

--- a/apps/server/src/lib/kit-stamp-run.ts
+++ b/apps/server/src/lib/kit-stamp-run.ts
@@ -2,7 +2,7 @@
  * GAP-448 P2-B: optional local RevForge stamp.sh for long-running workers.
  *
  * Default full mode produces a package tar (START-HERE + revforge.json) without
- * invoking stamp.sh — safe on Vercel serverless. When REVEALUI_REVFROGE_ROOT
+ * invoking stamp.sh — safe on Vercel serverless. When REVEALUI_REVFORGE_ROOT
  * points at a revforge checkout and REVEALUI_KIT_STAMP_RUN=1, run stamp.sh into
  * a temp dir and tar the output (operator/Fly worker path).
  *
@@ -38,7 +38,7 @@ function stampRunEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 function revforgeRoot(env: NodeJS.ProcessEnv = process.env): string | null {
-  const root = env.REVEALUI_REVFROGE_ROOT?.trim() || env.REVEALUI_REVFROGE_PATH?.trim();
+  const root = env.REVEALUI_REVFORGE_ROOT?.trim() || env.REVEALUI_REVFORGE_PATH?.trim();
   return root && root.length > 0 ? root : null;
 }
 

--- a/docs/distribution/AGENCY-FOUNDING-KIT-FULFILLMENT.md
+++ b/docs/distribution/AGENCY-FOUNDING-KIT-FULFILLMENT.md
@@ -32,7 +32,7 @@ On Fly/operator hosts with a revforge checkout (not Vercel serverless):
 ```bash
 export REVEALUI_KIT_STAMP_MODE=full
 export REVEALUI_KIT_STAMP_RUN=1
-export REVEALUI_REVFROGE_ROOT=/path/to/revforge
+export REVEALUI_REVFORGE_ROOT=/path/to/revforge
 # R2_* vars required for upload
 # Optional: REVEALUI_LICENSE_PUBLIC_KEY for stamp.sh bake-in
 ```


### PR DESCRIPTION
## Summary

Rename misspelled env vars from P2-B:

- `REVEALUI_REVFROGE_ROOT` → `REVEALUI_REVFORGE_ROOT`
- `REVEALUI_REVFROGE_PATH` → `REVEALUI_REVFORGE_PATH`

Missed landing with #2396 (rename commit was after the merge tip).

## Files

- `kit-stamp-run.ts`, `kit-stamp-mode.ts`, handler test, fulfillment doc

No behavior change beyond correct env names for optional local stamp.sh.