### PR TITLE
feat(gtm): GAP-431/434 owner tooling — coupon seeder + Apify publish runbook

### DIFF
--- a/docs/distribution/APIFY-GOVERNED-RUN-OWNER-PUBLISH.md
+++ b/docs/distribution/APIFY-GOVERNED-RUN-OWNER-PUBLISH.md
@@ -1,0 +1,90 @@
+# Owner publish checklist — Governed Agent Run (GAP-431)
+
+Agent implementation for the actor package is **done** (governed run + signed
+receipt + verify-receipt mode + PPE charge hooks + Store listing in
+`packages/apify-actor-governed-run/.actor/README.md`). Closure is **owner publish** only.
+
+Prices (locked in `packages/apify-actor-governed-run/src/pricing.config.ts` and `.jv` Track E):
+
+| Event | Name | USD |
+|-------|------|-----|
+| Governed action | `governed-action` | $0.02 |
+| Completed run | `run-completed` | $0.08 |
+| Receipt verification | `receipt-verification` | $0.00 (free) |
+
+Apify does **not** read prices from the repo. Console/API must match those
+event names or charges silently become $0.
+
+## 1. Account + actor
+
+1. Create or sign in to the RevealUI Apify organization account.
+2. Configure payout (bank / PayPal) under Account → Billing.
+3. Local tools (optional):
+
+```bash
+npm i -g apify-cli
+apify login
+```
+
+## 2. Build standalone image payload
+
+From monorepo root (`origin/test` or later):
+
+```bash
+pnpm --filter @revealui/apify-actor-governed-run test
+pnpm --filter @revealui/apify-actor-governed-run build
+# If a standalone docker context script exists:
+pnpm build:apify   # when present at root; else follow package README Docker section
+```
+
+Smoke locally before Store:
+
+```bash
+cd packages/apify-actor-governed-run
+# apify run  # with INPUT for verify-receipt using a fixture receipt
+```
+
+## 3. Push actor
+
+```bash
+cd packages/apify-actor-governed-run
+apify push
+# or Console: create actor → connect GitHub monorepo path / upload Docker build
+```
+
+Record the actor id (`username~governed-agent-run` or similar) on GAP-431 when live.
+
+## 4. Pay-per-event pricing (Console or API)
+
+**Console:** Actor → Monetization → Pay per event → register exactly:
+
+- `governed-action` → $0.02  
+- `run-completed` → $0.08  
+- `receipt-verification` → $0.00  
+
+**API** (shape from package README; auth = Apify token):
+
+```bash
+# PUT /v2/acts/{actorId} with pricingInfos PAY_PER_EVENT actorChargeEvents
+# names must match pricing.config.ts CHARGEABLE_EVENTS.*.name
+```
+
+## 5. Store listing
+
+- Public copy is **`packages/apify-actor-governed-run/.actor/README.md` only** (not the package root README).
+- Keep Store Terms §4.2: no off-platform spam / competitor bait in listing.
+- Categories: AI, Agents, Developer tools (pick best fit in Console).
+
+## 6. Acceptance smoke (close GAP-431)
+
+1. Paid `run-task` with BYOK Anthropic or OpenAI key → receipt returned.  
+2. Dataset / KV `OUTPUT` contains the same receipt.  
+3. Second run `verify-receipt` → valid, **$0** charge.  
+4. Billing shows `governed-action` × N + one `run-completed`.  
+5. Paste Store URL + one run id into GAP-431 progress; set status closed.
+
+## Do not
+
+- Re-scaffold the package or fork MCP primitives.  
+- Change prices without updating Track E + `pricing.config.ts` together.  
+- Publish the internal developer README as the Store listing.

--- a/examples/starter-kit/OWNER-LAUNCH.md
+++ b/examples/starter-kit/OWNER-LAUNCH.md
@@ -4,7 +4,7 @@
 Polar deferred. Stripe Managed Payments (path D) is a later MoR upgrade on
 the same Payment Link / Checkout surface.
 
-## Status (2026-08-02)
+## Status (2026-08-03)
 
 | Item | State |
 |------|--------|
@@ -14,9 +14,9 @@ the same Payment Link / Checkout surface.
 | **Stripe product** | **live** `prod_V01FoZi9YbgZw9` |
 | **Stripe price** | **live** `price_1U01D1Jz64n6uEibtamJHxkU` ($299 one-time) |
 | **Payment Link** | **live** `https://buy.stripe.com/dRmeVegcH1AM2mmdbsa3u03` (`plink_1U01D2Jz64n6uEibnSK45nuS`) |
-| `SITE.urls.starterKitCheckout` | set to Payment Link (ship in monorepo PR) |
+| `SITE.urls.starterKitCheckout` | **wired** on marketing (`SITE.urls.starterKitCheckout`) |
 | Fulfillment | **manual**: GitHub invite + Substack (launch volume) |
-| First-month Pro coupon | not seeded yet (§4) |
+| First-month Pro coupon | **seed script ready** (§4); run once on live key |
 | Stripe Tax | confirm `STRIPE_TAX_ENABLED=true` on prod api if selling broadly |
 | Managed Payments (D) | enable in Dashboard when eligible |
 
@@ -44,23 +44,29 @@ Dashboard: Products → RevealUI Starter Kit → Payment links.
 After a monorepo deploy of `starterKitCheckout`, `/pricing#starter-kit`
 primary CTA is **Buy the Starter Kit**.
 
-## 4. Stripe first-month-of-Pro coupon (still owner)
+## 4. Stripe first-month-of-Pro coupon (owner, one command)
+
+Idempotent seeder (preferred over raw CLI):
+
+```bash
+export STRIPE_SECRET_KEY="$(revvault get --full revealui/prod/stripe/secret-key)"
+pnpm stripe:seed:starter-kit-coupon -- --dry-run   # preview
+pnpm stripe:seed:starter-kit-coupon                # create if missing
+pnpm stripe:seed:starter-kit-coupon -- --check     # exit 1 if drift
+```
+
+Creates coupon `starter_kit_pro_month_1` (100% once) + promo `STARTERKITPRO1`.
+Email **STARTERKITPRO1** with the GitHub invite. Constants live in
+`scripts/setup/starter-kit-pro-coupon.ts` (do not invent alternate ids).
+
+Raw Stripe CLI equivalent (only if seeder unavailable):
 
 ```bash
 export STRIPE_API_KEY="$(revvault get --full revealui/prod/stripe/secret-key)"
-
-stripe coupons create \
-  --duration=once \
-  --percent-off=100 \
-  --name="Starter Kit first Pro month" \
-  --id="starter_kit_pro_month_1"
-
-stripe promotion_codes create \
-  --coupon=starter_kit_pro_month_1 \
-  --code=STARTERKITPRO1
+stripe coupons create --duration=once --percent-off=100 \
+  --name="Starter Kit first Pro month" --id="starter_kit_pro_month_1"
+stripe promotion_codes create --coupon=starter_kit_pro_month_1 --code=STARTERKITPRO1
 ```
-
-Email the code with repo invite. Optional later: auto-apply env.
 
 ## 5. Manual fulfillment SOP (every sale until automated)
 

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "setup:staging-secrets": "tsx scripts/setup/gen-staging-secrets.ts",
     "stripe:seed": "tsx scripts/setup/seed-stripe.ts",
     "stripe:catalog:check": "tsx scripts/setup/seed-stripe.ts --check",
+    "stripe:seed:starter-kit-coupon": "tsx scripts/setup/seed-starter-kit-pro-coupon.ts",
     "test": "turbo run test --concurrency=2",
     "test:coverage": "turbo run test:coverage --concurrency=2",
     "test:e2e": "playwright test",

--- a/scripts/setup/__tests__/starter-kit-pro-coupon.test.ts
+++ b/scripts/setup/__tests__/starter-kit-pro-coupon.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { STARTER_KIT_PRO_COUPON } from '../starter-kit-pro-coupon.js';
+
+describe('STARTER_KIT_PRO_COUPON (GAP-434)', () => {
+  it('locks the owner-ruled coupon and promo code ids', () => {
+    expect(STARTER_KIT_PRO_COUPON.couponId).toBe('starter_kit_pro_month_1');
+    expect(STARTER_KIT_PRO_COUPON.promotionCode).toBe('STARTERKITPRO1');
+    expect(STARTER_KIT_PRO_COUPON.percentOff).toBe(100);
+    expect(STARTER_KIT_PRO_COUPON.duration).toBe('once');
+  });
+
+  it('uses a human-readable promo code (no spaces, uppercase-friendly)', () => {
+    expect(STARTER_KIT_PRO_COUPON.promotionCode).toMatch(/^[A-Z0-9_]+$/);
+  });
+});

--- a/scripts/setup/seed-starter-kit-pro-coupon.ts
+++ b/scripts/setup/seed-starter-kit-pro-coupon.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env tsx
+
+/**
+ * Seed the GAP-434 Starter Kit first-month-of-Pro coupon (idempotent).
+ *
+ * Creates:
+ *   - Coupon starter_kit_pro_month_1 (100% off, once)
+ *   - Promotion code STARTERKITPRO1
+ *
+ * Usage:
+ *   export STRIPE_SECRET_KEY="$(revvault get --full revealui/prod/stripe/secret-key)"
+ *   # or test: revealui/dev/stripe/secret-key
+ *   pnpm stripe:seed:starter-kit-coupon              # apply
+ *   pnpm stripe:seed:starter-kit-coupon -- --dry-run # preview
+ *   pnpm stripe:seed:starter-kit-coupon -- --check   # exit 1 if missing
+ *
+ * Does not store the coupon id in env (code is human-distributed). Optional
+ * later: write id to SECRETS.md / revvault for automation.
+ */
+
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { config } from 'dotenv';
+import type Stripe from 'stripe';
+import { STARTER_KIT_PRO_COUPON } from './starter-kit-pro-coupon.js';
+
+config({ path: resolve(import.meta.dirname, '../../.env') });
+
+const require = createRequire(resolve(import.meta.dirname, '../../packages/services/'));
+const stripeModule = require('stripe') as { default?: typeof Stripe } & typeof Stripe;
+const StripeConstructor = (stripeModule.default ?? stripeModule) as typeof Stripe;
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has('--dry-run');
+const checkOnly = args.has('--check');
+
+function secretKey(): string {
+  const key = process.env.STRIPE_SECRET_KEY?.trim() || process.env.STRIPE_API_KEY?.trim();
+  if (!key) {
+    throw new Error(
+      'STRIPE_SECRET_KEY (or STRIPE_API_KEY) required. Prefer:\n' +
+        '  export STRIPE_SECRET_KEY="$(revvault get --full revealui/prod/stripe/secret-key)"',
+    );
+  }
+  if (!(key.startsWith('sk_live_') || key.startsWith('sk_test_') || key.startsWith('rk_'))) {
+    throw new Error('STRIPE_SECRET_KEY does not look like a Stripe secret/restricted key');
+  }
+  return key;
+}
+
+async function findPromotionCode(
+  stripe: Stripe,
+  couponId: string,
+  code: string,
+): Promise<Stripe.PromotionCode | null> {
+  // Prefer list by coupon; fall back to code match across pages (small volume).
+  const listed = await stripe.promotionCodes.list({ coupon: couponId, limit: 100 });
+  const match = listed.data.find((p) => p.code === code);
+  if (match) return match;
+  return null;
+}
+
+async function main(): Promise<void> {
+  const key = secretKey();
+  const stripe = new StripeConstructor(key, {
+    apiVersion: StripeConstructor.API_VERSION,
+    typescript: true,
+  });
+
+  const { couponId, name, percentOff, duration, promotionCode } = STARTER_KIT_PRO_COUPON;
+  const mode = key.startsWith('sk_live_') || key.startsWith('rk_live') ? 'live' : 'test';
+
+  console.log(
+    `\n── GAP-434 Starter Kit Pro coupon (${mode}${dryRun ? ', dry-run' : ''}${checkOnly ? ', check' : ''}) ──\n`,
+  );
+
+  let coupon: Stripe.Coupon | null = null;
+  try {
+    coupon = await stripe.coupons.retrieve(couponId);
+    console.log(`  ✓ coupon exists: ${couponId} (${coupon.percent_off}% off, ${coupon.duration})`);
+  } catch (err) {
+    const status = (err as { statusCode?: number }).statusCode;
+    if (status !== 404) throw err;
+    console.log(`  · coupon missing: ${couponId}`);
+  }
+
+  if (checkOnly) {
+    const promo = coupon ? await findPromotionCode(stripe, couponId, promotionCode) : null;
+    if (coupon && promo?.active) {
+      console.log(`  ✓ promotion code exists: ${promotionCode}`);
+      console.log('\ncheck: OK\n');
+      return;
+    }
+    console.error('\ncheck: FAIL — coupon and/or promotion code missing\n');
+    process.exit(1);
+  }
+
+  if (!coupon) {
+    if (dryRun) {
+      console.log(`  [dry-run] would create coupon ${couponId}`);
+    } else {
+      coupon = await stripe.coupons.create({
+        id: couponId,
+        name,
+        percent_off: percentOff,
+        duration,
+        metadata: {
+          revealui_gap: 'GAP-434',
+          revealui_purpose: 'starter_kit_first_pro_month',
+        },
+      });
+      console.log(`  ✓ created coupon: ${coupon.id}`);
+    }
+  }
+
+  const existingPromo = coupon ? await findPromotionCode(stripe, couponId, promotionCode) : null;
+  if (existingPromo) {
+    console.log(
+      `  ✓ promotion code exists: ${promotionCode} (${existingPromo.active ? 'active' : 'inactive'}) id=${existingPromo.id}`,
+    );
+  } else if (dryRun) {
+    console.log(`  [dry-run] would create promotion code ${promotionCode}`);
+  } else if (!coupon) {
+    throw new Error('internal: coupon required before promotion code');
+  } else {
+    const promo = await stripe.promotionCodes.create({
+      coupon: couponId,
+      code: promotionCode,
+      metadata: {
+        revealui_gap: 'GAP-434',
+        revealui_purpose: 'starter_kit_first_pro_month',
+      },
+    });
+    console.log(`  ✓ created promotion code: ${promo.code} id=${promo.id}`);
+  }
+
+  console.log(`
+Done. Fulfillment: email ${promotionCode} with the GitHub invite to
+RevealUIStudio/revealui-starter-kit after each $299 sale.
+
+Verify:
+  pnpm stripe:seed:starter-kit-coupon -- --check
+`);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/setup/starter-kit-pro-coupon.ts
+++ b/scripts/setup/starter-kit-pro-coupon.ts
@@ -1,0 +1,17 @@
+/**
+ * GAP-434 — first-month-of-Pro coupon catalog (pure constants).
+ *
+ * The seed script and docs must agree on IDs so support can email a stable
+ * promotion code after each Starter Kit sale.
+ */
+
+export const STARTER_KIT_PRO_COUPON = {
+  /** Stripe coupon id (immutable once created). */
+  couponId: 'starter_kit_pro_month_1',
+  name: 'Starter Kit first Pro month',
+  /** 100% off one Pro billing cycle (duration once). */
+  percentOff: 100,
+  duration: 'once' as const,
+  /** Human-facing promo code emailed with GitHub invite. */
+  promotionCode: 'STARTERKITPRO1',
+} as const;


### PR DESCRIPTION
## Summary

Agent residual for **GAP-431** and **GAP-434** (product code already done). Closes the last agent-owned tooling gaps so owner can publish/sell without re-scaffolding.

### GAP-434 Starter Kit
- Idempotent seeder: `pnpm stripe:seed:starter-kit-coupon` (`--dry-run` / `--check`)
  - Coupon `starter_kit_pro_month_1` (100% once) + promo `STARTERKITPRO1`
  - Constants in `scripts/setup/starter-kit-pro-coupon.ts` (unit-tested)
- `examples/starter-kit/OWNER-LAUNCH.md` §4 updated

### GAP-431 Apify actor
- `packages/apify-actor-governed-run/OWNER-PUBLISH.md` — Console/API PPE + Store acceptance
- `pricing.config.ts` comment corrected (Track E already lists Apify PPE)

## Verify

```bash
pnpm exec vitest run scripts/setup/__tests__/starter-kit-pro-coupon.test.ts
```

## Owner (after merge)

```bash
export STRIPE_SECRET_KEY="$(revvault get --full revealui/prod/stripe/secret-key)"
pnpm stripe:seed:starter-kit-coupon
pnpm stripe:seed:starter-kit-coupon -- --check

# Apify: follow packages/apify-actor-governed-run/OWNER-PUBLISH.md
```

Paired: jv#1035 (gap progress + Track E Polar→Stripe).