### PR TITLE
fix(setup): Stripe 22 nested promotion for Starter Kit promo code

### DIFF
--- a/examples/starter-kit/OWNER-LAUNCH.md
+++ b/examples/starter-kit/OWNER-LAUNCH.md
@@ -59,13 +59,17 @@ Creates coupon `starter_kit_pro_month_1` (100% once) + promo `STARTERKITPRO1`.
 Email **STARTERKITPRO1** with the GitHub invite. Constants live in
 `scripts/setup/starter-kit-pro-coupon.ts` (do not invent alternate ids).
 
-Raw Stripe CLI equivalent (only if seeder unavailable):
+Raw Stripe CLI equivalent (only if seeder unavailable; Stripe API 2025+ nested promotion):
 
 ```bash
 export STRIPE_API_KEY="$(revvault get --full revealui/prod/stripe/secret-key)"
 stripe coupons create --duration=once --percent-off=100 \
   --name="Starter Kit first Pro month" --id="starter_kit_pro_month_1"
-stripe promotion_codes create --coupon=starter_kit_pro_month_1 --code=STARTERKITPRO1
+# Do NOT pass top-level --coupon (unknown parameter on current API).
+stripe promotion_codes create \
+  --code=STARTERKITPRO1 \
+  -d "promotion[type]=coupon" \
+  -d "promotion[coupon]=starter_kit_pro_month_1"
 ```
 
 ## 5. Manual fulfillment SOP (every sale until automated)

--- a/scripts/setup/__tests__/starter-kit-pro-coupon.test.ts
+++ b/scripts/setup/__tests__/starter-kit-pro-coupon.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { STARTER_KIT_PRO_COUPON } from '../starter-kit-pro-coupon.js';
+import { promotionCodeCreateParams, STARTER_KIT_PRO_COUPON } from '../starter-kit-pro-coupon.js';
 
 describe('STARTER_KIT_PRO_COUPON (GAP-434)', () => {
   it('locks the owner-ruled coupon and promo code ids', () => {
@@ -11,5 +11,18 @@ describe('STARTER_KIT_PRO_COUPON (GAP-434)', () => {
 
   it('uses a human-readable promo code (no spaces, uppercase-friendly)', () => {
     expect(STARTER_KIT_PRO_COUPON.promotionCode).toMatch(/^[A-Z0-9_]+$/);
+  });
+
+  it('builds Stripe 22 nested promotion shape (not top-level coupon)', () => {
+    const params = promotionCodeCreateParams('starter_kit_pro_month_1', 'STARTERKITPRO1', {
+      revealui_gap: 'GAP-434',
+    });
+    expect(params).toEqual({
+      promotion: { type: 'coupon', coupon: 'starter_kit_pro_month_1' },
+      code: 'STARTERKITPRO1',
+      metadata: { revealui_gap: 'GAP-434' },
+    });
+    // Top-level coupon is rejected by Stripe 22 ("Received unknown parameter: coupon").
+    expect(params).not.toHaveProperty('coupon');
   });
 });

--- a/scripts/setup/seed-starter-kit-pro-coupon.ts
+++ b/scripts/setup/seed-starter-kit-pro-coupon.ts
@@ -22,7 +22,7 @@ import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { config } from 'dotenv';
 import type Stripe from 'stripe';
-import { STARTER_KIT_PRO_COUPON } from './starter-kit-pro-coupon.js';
+import { promotionCodeCreateParams, STARTER_KIT_PRO_COUPON } from './starter-kit-pro-coupon.js';
 
 config({ path: resolve(import.meta.dirname, '../../.env') });
 
@@ -53,11 +53,16 @@ async function findPromotionCode(
   couponId: string,
   code: string,
 ): Promise<Stripe.PromotionCode | null> {
-  // Prefer list by coupon; fall back to code match across pages (small volume).
+  // Exact code filter (case-insensitive on Stripe side).
+  const byCode = await stripe.promotionCodes.list({ code, limit: 10 });
+  const codeMatch = byCode.data.find(
+    (p) => p.code.toUpperCase() === code.toUpperCase() && p.promotion?.type === 'coupon',
+  );
+  if (codeMatch) return codeMatch;
+
+  // Fallback: list by coupon id (still supported on list params).
   const listed = await stripe.promotionCodes.list({ coupon: couponId, limit: 100 });
-  const match = listed.data.find((p) => p.code === code);
-  if (match) return match;
-  return null;
+  return listed.data.find((p) => p.code.toUpperCase() === code.toUpperCase()) ?? null;
 }
 
 async function main(): Promise<void> {
@@ -123,14 +128,12 @@ async function main(): Promise<void> {
   } else if (!coupon) {
     throw new Error('internal: coupon required before promotion code');
   } else {
-    const promo = await stripe.promotionCodes.create({
-      coupon: couponId,
-      code: promotionCode,
-      metadata: {
+    const promo = await stripe.promotionCodes.create(
+      promotionCodeCreateParams(couponId, promotionCode, {
         revealui_gap: 'GAP-434',
         revealui_purpose: 'starter_kit_first_pro_month',
-      },
-    });
+      }),
+    );
     console.log(`  ✓ created promotion code: ${promo.code} id=${promo.id}`);
   }
 
@@ -143,7 +146,15 @@ Verify:
 `);
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+// Only run when executed as a CLI script (not when imported by tests).
+const isDirectRun =
+  typeof process.argv[1] === 'string' &&
+  (process.argv[1].endsWith('seed-starter-kit-pro-coupon.ts') ||
+    process.argv[1].endsWith('seed-starter-kit-pro-coupon.js'));
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/scripts/setup/starter-kit-pro-coupon.ts
+++ b/scripts/setup/starter-kit-pro-coupon.ts
@@ -1,5 +1,5 @@
 /**
- * GAP-434 — first-month-of-Pro coupon catalog (pure constants).
+ * GAP-434 — first-month-of-Pro coupon catalog (pure constants + create shape).
  *
  * The seed script and docs must agree on IDs so support can email a stable
  * promotion code after each Starter Kit sale.
@@ -15,3 +15,26 @@ export const STARTER_KIT_PRO_COUPON = {
   /** Human-facing promo code emailed with GitHub invite. */
   promotionCode: 'STARTERKITPRO1',
 } as const;
+
+/**
+ * Stripe SDK 22+ requires promotion codes to reference a coupon via nested
+ * `promotion`, not top-level `coupon` (rejected: "Received unknown parameter: coupon").
+ */
+export function promotionCodeCreateParams(
+  couponId: string,
+  code: string,
+  metadata: Record<string, string>,
+): {
+  promotion: { type: 'coupon'; coupon: string };
+  code: string;
+  metadata: Record<string, string>;
+} {
+  return {
+    promotion: {
+      type: 'coupon',
+      coupon: couponId,
+    },
+    code,
+    metadata,
+  };
+}


### PR DESCRIPTION
## Summary

Live seed of GAP-434 coupon created `starter_kit_pro_month_1` then failed creating `STARTERKITPRO1` with:

`Received unknown parameter: coupon`

Stripe SDK 22 `PromotionCodeCreateParams` requires:

```ts
promotion: { type: 'coupon', coupon: couponId }
```

not top-level `coupon`.

## Fix

- `promotionCodeCreateParams()` helper + unit test (red-path regression for top-level coupon)
- Seeder uses nested shape; list lookup prefers `code` filter
- OWNER-LAUNCH CLI example updated

## Owner after merge

Coupon already exists on live. Re-run:

```bash
cd ~/revfleet/revealui
git pull --ff-only origin test
export STRIPE_SECRET_KEY="\$(revvault get --full revealui/prod/stripe/secret-key)"
pnpm stripe:seed:starter-kit-coupon
pnpm stripe:seed:starter-kit-coupon -- --check
```

Expect: coupon exists + promotion code created/verified.