### PR TITLE
feat(auth): GAP-464 Phase 2 OIDC pure layer

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -18,6 +18,7 @@
     "@simplewebauthn/server": "^13.3.2",
     "bcryptjs": "catalog:",
     "drizzle-orm": "catalog:",
+    "jose": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -136,6 +136,36 @@ export {
 } from './session.js';
 // Signed Cookie
 export { signCookiePayload, verifyCookiePayload } from './signed-cookie.js';
+// Enterprise SSO pure layer (GAP-464) — routes/JIT/entitlement in follow-up PRs
+export {
+  type BuildOidcAuthorizationUrlInput,
+  buildOidcAuthorizationUrl,
+  createOidcRemoteJwkSet,
+  extractGroupsFromClaim,
+  type FetchOidcDiscoveryOptions,
+  type FetchOidcDiscoveryResult,
+  fetchOidcDiscovery,
+  type GenerateSsoStateInput,
+  type GenerateSsoStateResult,
+  generateSsoState,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+  type KeyLike,
+  type MapSsoGroupsFailureReason,
+  type MapSsoGroupsInput,
+  type MapSsoGroupsResult,
+  mapSsoGroupsToRole,
+  type OidcDiscoveryDocument,
+  type OidcDiscoveryFailureReason,
+  type SsoStatePayload,
+  type ValidatedIdTokenClaims,
+  type ValidateIdTokenFailureReason,
+  type ValidateIdTokenResult,
+  type ValidateOidcIdTokenOptions,
+  type VerifiedSsoState,
+  validateOidcIdToken,
+  verifySsoState,
+} from './sso/index.js';
 export type { Storage } from './storage/index.js';
 export {
   createStorage,

--- a/packages/auth/src/server/sso/__tests__/oidc.test.ts
+++ b/packages/auth/src/server/sso/__tests__/oidc.test.ts
@@ -72,6 +72,26 @@ describe('fetchOidcDiscovery', () => {
     }
   });
 
+  it('normalizes trailing slashes when matching expectedIssuer', async () => {
+    const doc = {
+      issuer: `${ISSUER}/`,
+      authorization_endpoint: `${ISSUER}/authorize`,
+      token_endpoint: `${ISSUER}/token`,
+      jwks_uri: `${ISSUER}/jwks`,
+    };
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => doc,
+    });
+
+    const result = await fetchOidcDiscovery(`${ISSUER}/.well-known/openid-configuration`, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      expectedIssuer: `${ISSUER}///`,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it('rejects missing required fields', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/auth/src/server/sso/__tests__/oidc.test.ts
+++ b/packages/auth/src/server/sso/__tests__/oidc.test.ts
@@ -1,0 +1,315 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { exportJWK, importPKCS8, SignJWT } from 'jose';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { buildOidcAuthorizationUrl, fetchOidcDiscovery, validateOidcIdToken } from '../oidc.js';
+
+const ISSUER = 'https://idp.example.com';
+const CLIENT_ID = 'revealui-sso-client';
+const OTHER_ISSUER = 'https://evil.example.com';
+const OTHER_AUD = 'other-client';
+
+let privateKeyPem: string;
+let publicKey: CryptoKey;
+let privateKey: CryptoKey;
+
+beforeAll(async () => {
+  const { publicKey: pubPem, privateKey: privPem } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  privateKeyPem = privPem;
+  privateKey = await importPKCS8(privateKeyPem, 'RS256');
+  // Import public key via JWK for jwtVerify KeyLike
+  const { createPublicKey } = await import('node:crypto');
+  const pub = createPublicKey(pubPem);
+  const jwk = await exportJWK(pub);
+  const { importJWK } = await import('jose');
+  publicKey = (await importJWK({ ...jwk, alg: 'RS256' }, 'RS256')) as CryptoKey;
+});
+
+async function signIdToken(
+  claims: Record<string, unknown>,
+  options?: { issuer?: string; audience?: string; expSeconds?: number; key?: CryptoKey },
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const exp = options?.expSeconds ?? now + 3600;
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'RS256' })
+    .setIssuer(options?.issuer ?? ISSUER)
+    .setAudience(options?.audience ?? CLIENT_ID)
+    .setIssuedAt(now)
+    .setExpirationTime(exp)
+    .setSubject(typeof claims.sub === 'string' ? claims.sub : 'user-sub-1')
+    .sign(options?.key ?? privateKey);
+}
+
+describe('fetchOidcDiscovery', () => {
+  it('parses a valid discovery document', async () => {
+    const doc = {
+      issuer: ISSUER,
+      authorization_endpoint: `${ISSUER}/authorize`,
+      token_endpoint: `${ISSUER}/token`,
+      jwks_uri: `${ISSUER}/jwks`,
+      scopes_supported: ['openid', 'email'],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => doc,
+    });
+
+    const result = await fetchOidcDiscovery(`${ISSUER}/.well-known/openid-configuration`, {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      expectedIssuer: ISSUER,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.document.issuer).toBe(ISSUER);
+      expect(result.document.authorization_endpoint).toBe(`${ISSUER}/authorize`);
+      expect(result.document.token_endpoint).toBe(`${ISSUER}/token`);
+      expect(result.document.jwks_uri).toBe(`${ISSUER}/jwks`);
+    }
+  });
+
+  it('rejects missing required fields', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ issuer: ISSUER }),
+    });
+    const result = await fetchOidcDiscovery(
+      'https://idp.example.com/.well-known/openid-configuration',
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('missing_required_fields');
+    }
+  });
+
+  it('rejects issuer mismatch', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        issuer: OTHER_ISSUER,
+        authorization_endpoint: `${OTHER_ISSUER}/a`,
+        token_endpoint: `${OTHER_ISSUER}/t`,
+        jwks_uri: `${OTHER_ISSUER}/j`,
+      }),
+    });
+    const result = await fetchOidcDiscovery(
+      'https://idp.example.com/.well-known/openid-configuration',
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        expectedIssuer: ISSUER,
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('issuer_mismatch');
+    }
+  });
+
+  it('rejects fetch failures', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'));
+    const result = await fetchOidcDiscovery(
+      'https://idp.example.com/.well-known/openid-configuration',
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('fetch_failed');
+    }
+  });
+});
+
+describe('buildOidcAuthorizationUrl', () => {
+  it('includes PKCE S256 and required OIDC params', () => {
+    const url = buildOidcAuthorizationUrl({
+      authorizationEndpoint: `${ISSUER}/authorize`,
+      clientId: CLIENT_ID,
+      redirectUri: 'https://app.example.com/api/auth/sso/prov/callback',
+      state: 'state-value',
+      codeChallenge: 'challenge-value',
+    });
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('response_type')).toBe('code');
+    expect(parsed.searchParams.get('client_id')).toBe(CLIENT_ID);
+    expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(parsed.searchParams.get('code_challenge')).toBe('challenge-value');
+    expect(parsed.searchParams.get('state')).toBe('state-value');
+    expect(parsed.searchParams.get('scope')).toContain('openid');
+  });
+});
+
+describe('validateOidcIdToken', () => {
+  it('accepts a happy-path signed id_token', async () => {
+    const token = await signIdToken({
+      sub: 'user-42',
+      email: 'user@example.com',
+      email_verified: true,
+      name: 'Test User',
+      groups: ['Engineering'],
+    });
+
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims.sub).toBe('user-42');
+      expect(result.claims.email).toBe('user@example.com');
+      expect(result.claims.emailVerified).toBe(true);
+      expect(result.claims.name).toBe('Test User');
+      expect(result.claims.payload.groups).toEqual(['Engineering']);
+    }
+  });
+
+  it('rejects missing token', async () => {
+    const result = await validateOidcIdToken({
+      idToken: '',
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'missing_token' });
+  });
+
+  it('rejects when jwks key is missing', async () => {
+    const result = await validateOidcIdToken({
+      idToken: 'a.b.c',
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: null as unknown as CryptoKey,
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'missing_key' });
+  });
+
+  it('rejects tampered signature', async () => {
+    const token = await signIdToken({ sub: 'user-1' });
+    const parts = token.split('.');
+    // Flip last char of signature
+    const sig = parts[2] as string;
+    const flipped = sig.slice(0, -1) + (sig.endsWith('A') ? 'B' : 'A');
+    const tampered = `${parts[0]}.${parts[1]}.${flipped}`;
+
+    const result = await validateOidcIdToken({
+      idToken: tampered,
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_signature');
+    }
+  });
+
+  it('rejects wrong issuer', async () => {
+    const token = await signIdToken({ sub: 'user-1' }, { issuer: OTHER_ISSUER });
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_issuer');
+    }
+  });
+
+  it('rejects wrong audience', async () => {
+    const token = await signIdToken({ sub: 'user-1' }, { audience: OTHER_AUD });
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_audience');
+    }
+  });
+
+  it('rejects expired token', async () => {
+    const token = await signIdToken(
+      { sub: 'user-1' },
+      { expSeconds: Math.floor(Date.now() / 1000) - 120 },
+    );
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+      clockToleranceSeconds: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('expired');
+    }
+  });
+
+  it('rejects token signed with a different key', async () => {
+    const other = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const otherPriv = await importPKCS8(other.privateKey, 'RS256');
+    const token = await signIdToken({ sub: 'user-1' }, { key: otherPriv });
+
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_signature');
+    }
+  });
+
+  it('rejects malformed compact JWT', async () => {
+    const result = await validateOidcIdToken({
+      idToken: 'not-a-jwt',
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(['malformed', 'invalid_signature']).toContain(result.reason);
+    }
+  });
+
+  it('rejects token missing sub', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    // SignJWT always sets sub via setSubject; build a JWT without sub manually
+    const token = await new SignJWT({ email: 'x@example.com' })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(ISSUER)
+      .setAudience(CLIENT_ID)
+      .setIssuedAt(now)
+      .setExpirationTime(now + 3600)
+      .sign(privateKey);
+
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: ISSUER,
+      clientId: CLIENT_ID,
+      jwks: publicKey,
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'missing_sub' });
+  });
+});

--- a/packages/auth/src/server/sso/__tests__/oidc.test.ts
+++ b/packages/auth/src/server/sso/__tests__/oidc.test.ts
@@ -216,10 +216,17 @@ describe('validateOidcIdToken', () => {
   it('rejects tampered signature', async () => {
     const token = await signIdToken({ sub: 'user-1' });
     const parts = token.split('.');
-    // Flip last char of signature
-    const sig = parts[2] as string;
-    const flipped = sig.slice(0, -1) + (sig.endsWith('A') ? 'B' : 'A');
-    const tampered = `${parts[0]}.${parts[1]}.${flipped}`;
+    const sigB64 = parts[2] as string;
+    // Flip a middle signature *byte* after base64url decode. Flipping only the
+    // last base64url character is flaky: trailing alphabet members can be
+    // padding-equivalent and decode to the same RSA signature bytes, so
+    // verification still succeeds (CI saw expected true to be false).
+    const sigBytes = Buffer.from(sigB64, 'base64url');
+    expect(sigBytes.length).toBeGreaterThan(8);
+    const mid = Math.floor(sigBytes.length / 2);
+    sigBytes[mid] = (sigBytes[mid] as number) ^ 0xff;
+    const tampered = `${parts[0]}.${parts[1]}.${sigBytes.toString('base64url')}`;
+    expect(tampered).not.toBe(token);
 
     const result = await validateOidcIdToken({
       idToken: tampered,

--- a/packages/auth/src/server/sso/__tests__/roles.test.ts
+++ b/packages/auth/src/server/sso/__tests__/roles.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import { extractGroupsFromClaim, mapSsoGroupsToRole } from '../roles.js';
+
+describe('extractGroupsFromClaim', () => {
+  it('reads string array groups', () => {
+    expect(extractGroupsFromClaim({ groups: ['Eng', 'Admins'] }, 'groups')).toEqual([
+      'Eng',
+      'Admins',
+    ]);
+  });
+
+  it('reads a single string group', () => {
+    expect(extractGroupsFromClaim({ groups: 'Engineering' }, 'groups')).toEqual(['Engineering']);
+  });
+
+  it('splits comma/space separated strings', () => {
+    expect(extractGroupsFromClaim({ groups: 'a, b, c' }, 'groups')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns empty for missing claim', () => {
+    expect(extractGroupsFromClaim({}, 'groups')).toEqual([]);
+  });
+
+  it('uses custom group claim key', () => {
+    expect(extractGroupsFromClaim({ memberOf: ['X'] }, 'memberOf')).toEqual(['X']);
+  });
+});
+
+describe('mapSsoGroupsToRole', () => {
+  const base = {
+    groupClaim: 'groups',
+    groupRoleMap: {
+      Engineering: 'member',
+      'IdP-Admins': 'admin',
+      Viewers: 'viewer',
+    } as Record<string, string>,
+    defaultRole: 'member',
+    requireGroupMatch: false,
+  };
+
+  it('uses default_role when no groups present', () => {
+    const result = mapSsoGroupsToRole({ ...base, claims: {} });
+    expect(result).toEqual({
+      ok: true,
+      role: 'member',
+      matchedGroups: [],
+      groups: [],
+    });
+  });
+
+  it('maps a single matching group', () => {
+    const result = mapSsoGroupsToRole({
+      ...base,
+      claims: { groups: ['Engineering'] },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.role).toBe('member');
+      expect(result.matchedGroups).toEqual(['Engineering']);
+    }
+  });
+
+  it('picks highest privilege when multiple groups map', () => {
+    const result = mapSsoGroupsToRole({
+      ...base,
+      claims: { groups: ['Viewers', 'IdP-Admins', 'Engineering'] },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.role).toBe('admin');
+      expect(result.matchedGroups).toEqual(['Viewers', 'IdP-Admins', 'Engineering']);
+    }
+  });
+
+  it('ignores unmapped groups and uses default_role (never admin from unmapped)', () => {
+    const result = mapSsoGroupsToRole({
+      ...base,
+      claims: { groups: ['SuperUsers', 'Domain Admins', 'random-unmapped'] },
+      defaultRole: 'viewer',
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      role: 'viewer',
+      matchedGroups: [],
+    });
+    // Explicit: role is default, not admin, despite privileged-looking IdP group names
+    if (result.ok) {
+      expect(result.role).not.toBe('admin');
+    }
+  });
+
+  it('never grants admin solely because an unmapped group looks privileged', () => {
+    const result = mapSsoGroupsToRole({
+      groupClaim: 'groups',
+      groupRoleMap: {},
+      defaultRole: 'member',
+      requireGroupMatch: false,
+      claims: { groups: ['admin', 'Administrators', 'Global-Admins'] },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.role).toBe('member');
+      expect(result.role).not.toBe('admin');
+      expect(result.matchedGroups).toEqual([]);
+    }
+  });
+
+  it('rejects when require_group_match and no map hits', () => {
+    const result = mapSsoGroupsToRole({
+      ...base,
+      requireGroupMatch: true,
+      claims: { groups: ['Unmapped-Group'] },
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'require_group_match',
+      groups: ['Unmapped-Group'],
+    });
+  });
+
+  it('rejects when require_group_match and groups claim missing', () => {
+    const result = mapSsoGroupsToRole({
+      ...base,
+      requireGroupMatch: true,
+      claims: {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('require_group_match');
+    }
+  });
+
+  it('allows map hit when require_group_match is true', () => {
+    const result = mapSsoGroupsToRole({
+      ...base,
+      requireGroupMatch: true,
+      claims: { groups: ['Engineering', 'noise'] },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.role).toBe('member');
+      expect(result.matchedGroups).toEqual(['Engineering']);
+    }
+  });
+
+  it('allows explicit map to admin (intentional config)', () => {
+    const result = mapSsoGroupsToRole({
+      ...base,
+      claims: { groups: ['IdP-Admins'] },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.role).toBe('admin');
+    }
+  });
+
+  it('fails closed on empty default_role', () => {
+    const result = mapSsoGroupsToRole({
+      ...base,
+      defaultRole: '',
+      claims: {},
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'invalid_default_role' });
+  });
+});

--- a/packages/auth/src/server/sso/__tests__/state.test.ts
+++ b/packages/auth/src/server/sso/__tests__/state.test.ts
@@ -1,0 +1,145 @@
+import crypto from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateSsoState, verifySsoState } from '../state.js';
+
+const SECRET = 'test-secret-key-for-sso-hmac-signing-only';
+
+describe('sso state', () => {
+  const prevSecret = process.env.REVEALUI_SECRET;
+
+  beforeEach(() => {
+    process.env.REVEALUI_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    if (prevSecret === undefined) {
+      delete process.env.REVEALUI_SECRET;
+    } else {
+      process.env.REVEALUI_SECRET = prevSecret;
+    }
+  });
+
+  describe('generateSsoState', () => {
+    it('returns state, cookieValue, and codeChallenge', () => {
+      const result = generateSsoState({
+        accountId: 'acc_1',
+        providerId: 'prov_1',
+        redirectTo: '/app',
+      });
+      expect(result.state).toBeTruthy();
+      expect(result.cookieValue).toContain('.');
+      expect(result.cookieValue.startsWith(result.state)).toBe(true);
+      expect(result.codeChallenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('encodes accountId, providerId, redirectTo, nonce, codeVerifier', () => {
+      const { state } = generateSsoState({
+        accountId: 'acc_abc',
+        providerId: 'prov_xyz',
+        redirectTo: '/settings',
+      });
+      const decoded = JSON.parse(Buffer.from(state, 'base64url').toString()) as Record<
+        string,
+        unknown
+      >;
+      expect(decoded.accountId).toBe('acc_abc');
+      expect(decoded.providerId).toBe('prov_xyz');
+      expect(decoded.redirectTo).toBe('/settings');
+      expect(typeof decoded.nonce).toBe('string');
+      expect(typeof decoded.codeVerifier).toBe('string');
+    });
+
+    it('throws when REVEALUI_SECRET is missing', () => {
+      delete process.env.REVEALUI_SECRET;
+      expect(() => generateSsoState({ accountId: 'a', providerId: 'p', redirectTo: '/' })).toThrow(
+        'REVEALUI_SECRET',
+      );
+    });
+
+    it('throws when accountId or providerId is empty', () => {
+      expect(() => generateSsoState({ accountId: '', providerId: 'p', redirectTo: '/' })).toThrow(
+        'accountId and providerId',
+      );
+    });
+
+    it('generates unique nonces', () => {
+      const a = generateSsoState({ accountId: 'a', providerId: 'p', redirectTo: '/' });
+      const b = generateSsoState({ accountId: 'a', providerId: 'p', redirectTo: '/' });
+      expect(a.state).not.toBe(b.state);
+    });
+  });
+
+  describe('verifySsoState', () => {
+    it('round-trips generate → verify', () => {
+      const { state, cookieValue } = generateSsoState({
+        accountId: 'acc_1',
+        providerId: 'prov_1',
+        redirectTo: '/dashboard',
+      });
+      const verified = verifySsoState(state, cookieValue);
+      expect(verified).toMatchObject({
+        accountId: 'acc_1',
+        providerId: 'prov_1',
+        redirectTo: '/dashboard',
+      });
+      expect(verified?.nonce).toBeTruthy();
+      expect(verified?.codeVerifier).toBeTruthy();
+    });
+
+    it('returns null when state is null', () => {
+      expect(verifySsoState(null, 'x.y')).toBeNull();
+    });
+
+    it('returns null when cookie is null', () => {
+      expect(verifySsoState('state', null)).toBeNull();
+    });
+
+    it('returns null when cookie has no HMAC separator', () => {
+      expect(verifySsoState('abc', 'nodot')).toBeNull();
+    });
+
+    it('returns null when state does not match cookie state', () => {
+      const { cookieValue } = generateSsoState({
+        accountId: 'a',
+        providerId: 'p',
+        redirectTo: '/',
+      });
+      expect(verifySsoState('tampered-state-value', cookieValue)).toBeNull();
+    });
+
+    it('returns null when HMAC is tampered', () => {
+      const { state, cookieValue } = generateSsoState({
+        accountId: 'a',
+        providerId: 'p',
+        redirectTo: '/',
+      });
+      const tampered = `${cookieValue.slice(0, -4)}ffff`;
+      expect(verifySsoState(state, tampered)).toBeNull();
+    });
+
+    it('returns null when HMAC has wrong length', () => {
+      const { state } = generateSsoState({
+        accountId: 'a',
+        providerId: 'p',
+        redirectTo: '/',
+      });
+      expect(verifySsoState(state, `${state}.short`)).toBeNull();
+    });
+
+    it('returns null for valid HMAC but malformed payload shape', () => {
+      const badState = Buffer.from(JSON.stringify({ foo: 'bar' })).toString('base64url');
+      const hmac = crypto.createHmac('sha256', SECRET).update(badState).digest('hex');
+      expect(verifySsoState(badState, `${badState}.${hmac}`)).toBeNull();
+    });
+
+    it('throws when REVEALUI_SECRET is missing during verify', () => {
+      const { state, cookieValue } = generateSsoState({
+        accountId: 'a',
+        providerId: 'p',
+        redirectTo: '/',
+      });
+      delete process.env.REVEALUI_SECRET;
+      expect(() => verifySsoState(state, cookieValue)).toThrow('REVEALUI_SECRET');
+    });
+  });
+});

--- a/packages/auth/src/server/sso/index.ts
+++ b/packages/auth/src/server/sso/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Enterprise SSO pure layer (GAP-464).
+ *
+ * OIDC discovery + id_token validation, signed SSO state, group→role mapping.
+ * HTTP routes / JIT / entitlement gate land in follow-up PRs.
+ */
+
+export {
+  type BuildOidcAuthorizationUrlInput,
+  buildOidcAuthorizationUrl,
+  createOidcRemoteJwkSet,
+  type FetchOidcDiscoveryOptions,
+  type FetchOidcDiscoveryResult,
+  fetchOidcDiscovery,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+  type KeyLike,
+  type OidcDiscoveryDocument,
+  type OidcDiscoveryFailureReason,
+  type ValidatedIdTokenClaims,
+  type ValidateIdTokenFailureReason,
+  type ValidateIdTokenResult,
+  type ValidateOidcIdTokenOptions,
+  validateOidcIdToken,
+} from './oidc.js';
+
+export {
+  extractGroupsFromClaim,
+  type MapSsoGroupsFailureReason,
+  type MapSsoGroupsInput,
+  type MapSsoGroupsResult,
+  mapSsoGroupsToRole,
+} from './roles.js';
+
+export {
+  type GenerateSsoStateInput,
+  type GenerateSsoStateResult,
+  generateSsoState,
+  type SsoStatePayload,
+  type VerifiedSsoState,
+  verifySsoState,
+} from './state.js';

--- a/packages/auth/src/server/sso/oidc.ts
+++ b/packages/auth/src/server/sso/oidc.ts
@@ -1,0 +1,408 @@
+/**
+ * OIDC discovery + id_token validation (GAP-464 Phase 2).
+ *
+ * Security hardlines:
+ * - Never accept id_token without cryptographic signature validation (JWKS / key).
+ * - Validate issuer, audience (client_id), and exp on every token.
+ */
+
+import {
+  createRemoteJWKSet,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+  type JWTVerifyOptions,
+  type JWTVerifyResult,
+  jwtVerify,
+  type KeyLike,
+} from 'jose';
+
+/** Asymmetric algorithms used by enterprise IdPs; `none` is never allowed. */
+const ID_TOKEN_ALGORITHMS: string[] = [
+  'RS256',
+  'RS384',
+  'RS512',
+  'ES256',
+  'ES384',
+  'ES512',
+  'PS256',
+  'PS384',
+  'PS512',
+  'EdDSA',
+];
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+export interface OidcDiscoveryDocument {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  jwks_uri: string;
+  userinfo_endpoint?: string;
+  end_session_endpoint?: string;
+  scopes_supported?: string[];
+  response_types_supported?: string[];
+  code_challenge_methods_supported?: string[];
+}
+
+export type OidcDiscoveryFailureReason =
+  | 'fetch_failed'
+  | 'invalid_json'
+  | 'missing_required_fields'
+  | 'issuer_mismatch';
+
+export type FetchOidcDiscoveryResult =
+  | { ok: true; document: OidcDiscoveryDocument }
+  | { ok: false; reason: OidcDiscoveryFailureReason; message: string };
+
+export interface FetchOidcDiscoveryOptions {
+  /**
+   * Optional expected issuer. When set, the document's `issuer` must match
+   * (after trailing-slash normalization).
+   */
+  expectedIssuer?: string;
+  /** Injectable fetch for tests (defaults to global fetch) */
+  fetchImpl?: typeof fetch;
+  /** Request timeout ms (default 10_000) */
+  timeoutMs?: number;
+}
+
+const DISCOVERY_REQUIRED = [
+  'issuer',
+  'authorization_endpoint',
+  'token_endpoint',
+  'jwks_uri',
+] as const;
+
+function normalizeIssuer(issuer: string): string {
+  return issuer.replace(/\/+$/, '');
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Fetch and parse an OIDC discovery document (openid-configuration).
+ */
+export async function fetchOidcDiscovery(
+  discoveryUrl: string,
+  options: FetchOidcDiscoveryOptions = {},
+): Promise<FetchOidcDiscoveryResult> {
+  if (!isNonEmptyString(discoveryUrl)) {
+    return {
+      ok: false,
+      reason: 'missing_required_fields',
+      message: 'discoveryUrl is required',
+    };
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(discoveryUrl, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+      redirect: 'follow',
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    const message = err instanceof Error ? err.message : 'discovery fetch failed';
+    return { ok: false, reason: 'fetch_failed', message };
+  }
+  clearTimeout(timer);
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      reason: 'fetch_failed',
+      message: `discovery HTTP ${response.status}`,
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return { ok: false, reason: 'invalid_json', message: 'discovery response is not JSON' };
+  }
+
+  if (!body || typeof body !== 'object') {
+    return { ok: false, reason: 'invalid_json', message: 'discovery response is not an object' };
+  }
+
+  const record = body as Record<string, unknown>;
+  for (const key of DISCOVERY_REQUIRED) {
+    if (!isNonEmptyString(record[key])) {
+      return {
+        ok: false,
+        reason: 'missing_required_fields',
+        message: `discovery document missing ${key}`,
+      };
+    }
+  }
+
+  const document: OidcDiscoveryDocument = {
+    issuer: record.issuer as string,
+    authorization_endpoint: record.authorization_endpoint as string,
+    token_endpoint: record.token_endpoint as string,
+    jwks_uri: record.jwks_uri as string,
+  };
+
+  if (isNonEmptyString(record.userinfo_endpoint)) {
+    document.userinfo_endpoint = record.userinfo_endpoint;
+  }
+  if (isNonEmptyString(record.end_session_endpoint)) {
+    document.end_session_endpoint = record.end_session_endpoint;
+  }
+  if (Array.isArray(record.scopes_supported)) {
+    document.scopes_supported = record.scopes_supported.filter(
+      (s): s is string => typeof s === 'string',
+    );
+  }
+  if (Array.isArray(record.response_types_supported)) {
+    document.response_types_supported = record.response_types_supported.filter(
+      (s): s is string => typeof s === 'string',
+    );
+  }
+  if (Array.isArray(record.code_challenge_methods_supported)) {
+    document.code_challenge_methods_supported = record.code_challenge_methods_supported.filter(
+      (s): s is string => typeof s === 'string',
+    );
+  }
+
+  if (options.expectedIssuer) {
+    if (normalizeIssuer(document.issuer) !== normalizeIssuer(options.expectedIssuer)) {
+      return {
+        ok: false,
+        reason: 'issuer_mismatch',
+        message: `discovery issuer "${document.issuer}" does not match expected "${options.expectedIssuer}"`,
+      };
+    }
+  }
+
+  return { ok: true, document };
+}
+
+// ---------------------------------------------------------------------------
+// Authorization URL (pure)
+// ---------------------------------------------------------------------------
+
+export interface BuildOidcAuthorizationUrlInput {
+  authorizationEndpoint: string;
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  /** Default: openid email profile */
+  scope?: string;
+  /** Optional OIDC nonce (distinct from SSO state nonce) */
+  nonce?: string;
+}
+
+/**
+ * Build the OIDC authorization redirect URL (code + PKCE S256).
+ */
+export function buildOidcAuthorizationUrl(input: BuildOidcAuthorizationUrlInput): string {
+  const url = new URL(input.authorizationEndpoint);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', input.clientId);
+  url.searchParams.set('redirect_uri', input.redirectUri);
+  url.searchParams.set('scope', input.scope ?? 'openid email profile');
+  url.searchParams.set('state', input.state);
+  url.searchParams.set('code_challenge', input.codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  if (input.nonce) {
+    url.searchParams.set('nonce', input.nonce);
+  }
+  return url.toString();
+}
+
+// ---------------------------------------------------------------------------
+// id_token validation
+// ---------------------------------------------------------------------------
+
+export type ValidateIdTokenFailureReason =
+  | 'missing_token'
+  | 'missing_key'
+  | 'invalid_signature'
+  | 'invalid_issuer'
+  | 'invalid_audience'
+  | 'expired'
+  | 'not_yet_valid'
+  | 'missing_sub'
+  | 'malformed';
+
+export interface ValidatedIdTokenClaims {
+  sub: string;
+  email?: string;
+  emailVerified?: boolean;
+  name?: string;
+  preferredUsername?: string;
+  /** Full verified JWT payload (includes groups, custom claims, etc.) */
+  payload: JWTPayload;
+}
+
+export type ValidateIdTokenResult =
+  | { ok: true; claims: ValidatedIdTokenClaims }
+  | { ok: false; reason: ValidateIdTokenFailureReason; message: string };
+
+export interface ValidateOidcIdTokenOptions {
+  idToken: string;
+  /** Expected `iss` (must match provider.issuer) */
+  issuer: string;
+  /** Expected `aud` (OIDC client_id) */
+  clientId: string;
+  /**
+   * Key material for signature verification.
+   * Pass a remote JWKS getter (`createRemoteJWKSet(new URL(jwks_uri))`),
+   * a local JWK set, or a single KeyLike from tests.
+   * REQUIRED — unsigned tokens are never accepted.
+   */
+  jwks: JWTVerifyGetKey | KeyLike | Uint8Array;
+  /** Clock skew tolerance in seconds (default 30) */
+  clockToleranceSeconds?: number;
+}
+
+function mapJoseError(err: unknown): { reason: ValidateIdTokenFailureReason; message: string } {
+  const message = err instanceof Error ? err.message : 'id_token validation failed';
+  const code =
+    err &&
+    typeof err === 'object' &&
+    'code' in err &&
+    typeof (err as { code: unknown }).code === 'string'
+      ? (err as { code: string }).code
+      : '';
+  const claim =
+    err &&
+    typeof err === 'object' &&
+    'claim' in err &&
+    typeof (err as { claim: unknown }).claim === 'string'
+      ? (err as { claim: string }).claim
+      : '';
+
+  // Prefer jose error codes / claim names over message regex (avoids "exp" matching "expected")
+  if (code === 'ERR_JWT_EXPIRED' || claim === 'exp') {
+    return { reason: 'expired', message };
+  }
+  if (code === 'ERR_JWT_CLAIM_VALIDATION_FAILED' || claim) {
+    if (claim === 'iss' || /"iss"/i.test(message)) {
+      return { reason: 'invalid_issuer', message };
+    }
+    if (claim === 'aud' || /"aud"/i.test(message)) {
+      return { reason: 'invalid_audience', message };
+    }
+    if (claim === 'nbf' || /"nbf"/i.test(message)) {
+      return { reason: 'not_yet_valid', message };
+    }
+  }
+  if (
+    code === 'ERR_JWS_SIGNATURE_VERIFICATION_FAILED' ||
+    code === 'ERR_JWS_INVALID' ||
+    /signature verification failed|jws signature/i.test(message)
+  ) {
+    return { reason: 'invalid_signature', message };
+  }
+  if (code === 'ERR_JWT_INVALID' || /compact jws|invalid token/i.test(message)) {
+    return { reason: 'malformed', message };
+  }
+
+  return { reason: 'invalid_signature', message };
+}
+
+/**
+ * Validate an OIDC id_token: signature (JWKS), issuer, audience, exp.
+ *
+ * Hardline: `jwks` is required. Callers must not pass a no-op key or skip verify.
+ */
+export async function validateOidcIdToken(
+  options: ValidateOidcIdTokenOptions,
+): Promise<ValidateIdTokenResult> {
+  const { idToken, issuer, clientId, jwks, clockToleranceSeconds = 30 } = options;
+
+  if (!isNonEmptyString(idToken)) {
+    return { ok: false, reason: 'missing_token', message: 'id_token is required' };
+  }
+  if (jwks == null) {
+    return {
+      ok: false,
+      reason: 'missing_key',
+      message: 'JWKS / verification key is required; unsigned id_tokens are rejected',
+    };
+  }
+  if (!isNonEmptyString(issuer)) {
+    return { ok: false, reason: 'invalid_issuer', message: 'expected issuer is required' };
+  }
+  if (!isNonEmptyString(clientId)) {
+    return { ok: false, reason: 'invalid_audience', message: 'clientId (audience) is required' };
+  }
+
+  // Prefer asymmetric algorithms used by enterprise IdPs; reject `none`
+  const verifyOptions: JWTVerifyOptions = {
+    issuer: normalizeIssuer(issuer),
+    audience: clientId,
+    clockTolerance: clockToleranceSeconds,
+    algorithms: ID_TOKEN_ALGORITHMS,
+  };
+
+  let payload: JWTPayload;
+  try {
+    // jose types KeyLike and JWTVerifyGetKey as separate overloads — narrow first
+    let verified: JWTVerifyResult;
+    if (typeof jwks === 'function') {
+      verified = await jwtVerify(idToken, jwks, verifyOptions);
+    } else {
+      verified = await jwtVerify(idToken, jwks, verifyOptions);
+    }
+    payload = verified.payload;
+  } catch (err) {
+    return { ok: false, ...mapJoseError(err) };
+  }
+
+  if (!isNonEmptyString(payload.sub)) {
+    return { ok: false, reason: 'missing_sub', message: 'id_token missing sub claim' };
+  }
+
+  const claims: ValidatedIdTokenClaims = {
+    sub: payload.sub,
+    payload,
+  };
+
+  if (typeof payload.email === 'string' && payload.email.length > 0) {
+    claims.email = payload.email;
+  }
+  if (typeof payload.email_verified === 'boolean') {
+    claims.emailVerified = payload.email_verified;
+  } else if (payload.email_verified === 'true') {
+    claims.emailVerified = true;
+  } else if (payload.email_verified === 'false') {
+    claims.emailVerified = false;
+  }
+  if (typeof payload.name === 'string' && payload.name.length > 0) {
+    claims.name = payload.name;
+  }
+  if (typeof payload.preferred_username === 'string' && payload.preferred_username.length > 0) {
+    claims.preferredUsername = payload.preferred_username;
+  }
+
+  return { ok: true, claims };
+}
+
+/**
+ * Create a remote JWKS key resolver from a discovery `jwks_uri`.
+ * Thin wrapper so route code does not import jose directly.
+ */
+export function createOidcRemoteJwkSet(jwksUri: string): JWTVerifyGetKey {
+  if (!isNonEmptyString(jwksUri)) {
+    throw new Error('jwksUri is required');
+  }
+  return createRemoteJWKSet(new URL(jwksUri));
+}
+
+export type { JWTPayload, JWTVerifyGetKey, KeyLike };

--- a/packages/auth/src/server/sso/oidc.ts
+++ b/packages/auth/src/server/sso/oidc.ts
@@ -75,8 +75,13 @@ const DISCOVERY_REQUIRED = [
   'jwks_uri',
 ] as const;
 
+/** Strip trailing `/` without regex (CodeQL: avoid poly ReDoS on uncontrolled issuer). */
 function normalizeIssuer(issuer: string): string {
-  return issuer.replace(/\/+$/, '');
+  let end = issuer.length;
+  while (end > 0 && issuer.charCodeAt(end - 1) === 47 /* '/' */) {
+    end -= 1;
+  }
+  return end === issuer.length ? issuer : issuer.slice(0, end);
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/packages/auth/src/server/sso/roles.ts
+++ b/packages/auth/src/server/sso/roles.ts
@@ -1,0 +1,154 @@
+/**
+ * SSO group → role mapping (GAP-464).
+ *
+ * Security hardlines:
+ * - Map only via explicit group_role_map hits.
+ * - Empty mapped set + require_group_match → reject.
+ * - Never grant `admin` from an unmapped group (unmapped groups are ignored).
+ * - When no map hits and require_group_match is false → default_role.
+ */
+
+export interface MapSsoGroupsInput {
+  /** Raw IdP claims (id_token payload or SAML attribute bag) */
+  claims: Record<string, unknown>;
+  /** Claim key that holds group membership (default on providers: `groups`) */
+  groupClaim: string;
+  /** IdP group name → RevealUI role */
+  groupRoleMap: Record<string, string>;
+  /** Used when no groups map and requireGroupMatch is false */
+  defaultRole: string;
+  /** When true, login fails unless at least one group maps to a role */
+  requireGroupMatch: boolean;
+}
+
+export type MapSsoGroupsFailureReason = 'require_group_match' | 'invalid_default_role';
+
+export type MapSsoGroupsResult =
+  | {
+      ok: true;
+      role: string;
+      /** Groups present on the token that hit group_role_map */
+      matchedGroups: string[];
+      /** All groups extracted from the claim (mapped + unmapped) */
+      groups: string[];
+    }
+  | {
+      ok: false;
+      reason: MapSsoGroupsFailureReason;
+      message: string;
+      groups: string[];
+    };
+
+/** Privilege rank for resolving multiple mapped roles (higher wins). */
+const ROLE_RANK: Record<string, number> = {
+  viewer: 1,
+  member: 2,
+  editor: 3,
+  admin: 4,
+  owner: 5,
+};
+
+/**
+ * Extract a string array of groups from a claim value.
+ * Accepts string[], a single string, or a space/comma-separated string.
+ */
+export function extractGroupsFromClaim(
+  claims: Record<string, unknown>,
+  groupClaim: string,
+): string[] {
+  const raw = claims[groupClaim];
+  if (raw == null) return [];
+
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((g): g is string => typeof g === 'string' && g.length > 0)
+      .map((g) => g.trim())
+      .filter((g) => g.length > 0);
+  }
+
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    // Single group name, or space/comma-separated list from some IdPs
+    if (trimmed.includes(',') || trimmed.includes(' ')) {
+      return trimmed
+        .split(/[,\s]+/)
+        .map((g) => g.trim())
+        .filter((g) => g.length > 0);
+    }
+    return [trimmed];
+  }
+
+  return [];
+}
+
+function pickHighestRole(roles: string[]): string {
+  let best = roles[0] as string;
+  let bestRank = ROLE_RANK[best] ?? 0;
+  for (let i = 1; i < roles.length; i++) {
+    const role = roles[i] as string;
+    const rank = ROLE_RANK[role] ?? 0;
+    if (rank > bestRank) {
+      best = role;
+      bestRank = rank;
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolve a single RevealUI role from IdP groups + provider mapping config.
+ *
+ * Unmapped groups never contribute a role (including never implying admin).
+ * Only explicit map values and the configured default_role assign roles.
+ */
+export function mapSsoGroupsToRole(input: MapSsoGroupsInput): MapSsoGroupsResult {
+  const { claims, groupClaim, groupRoleMap, defaultRole, requireGroupMatch } = input;
+
+  if (!defaultRole || typeof defaultRole !== 'string') {
+    return {
+      ok: false,
+      reason: 'invalid_default_role',
+      message: 'default_role must be a non-empty string',
+      groups: [],
+    };
+  }
+
+  const groups = extractGroupsFromClaim(claims, groupClaim);
+  const matchedGroups: string[] = [];
+  const mappedRoles: string[] = [];
+
+  for (const group of groups) {
+    const mapped = groupRoleMap[group];
+    if (typeof mapped === 'string' && mapped.length > 0) {
+      matchedGroups.push(group);
+      mappedRoles.push(mapped);
+    }
+    // Unmapped groups intentionally ignored — never grant admin (or any role) from them
+  }
+
+  if (mappedRoles.length > 0) {
+    return {
+      ok: true,
+      role: pickHighestRole(mappedRoles),
+      matchedGroups,
+      groups,
+    };
+  }
+
+  if (requireGroupMatch) {
+    return {
+      ok: false,
+      reason: 'require_group_match',
+      message: 'No IdP groups matched group_role_map and require_group_match is enabled',
+      groups,
+    };
+  }
+
+  return {
+    ok: true,
+    role: defaultRole,
+    matchedGroups: [],
+    groups,
+  };
+}

--- a/packages/auth/src/server/sso/state.ts
+++ b/packages/auth/src/server/sso/state.ts
@@ -1,0 +1,151 @@
+/**
+ * Enterprise SSO signed state cookie (GAP-464).
+ *
+ * Separate from social OAuth generateOAuthState / verifyOAuthState so enterprise
+ * IdP bindings (accountId + providerId + PKCE) never overload provider enums.
+ *
+ * Cookie value: `<state>.<hmac-hex>` where state is base64url(JSON payload)
+ * and HMAC-SHA256 is over the state string using REVEALUI_SECRET.
+ */
+
+import crypto from 'node:crypto';
+
+export interface SsoStatePayload {
+  accountId: string;
+  providerId: string;
+  redirectTo: string;
+  nonce: string;
+  codeVerifier: string;
+}
+
+export interface GenerateSsoStateInput {
+  accountId: string;
+  providerId: string;
+  redirectTo: string;
+}
+
+export interface GenerateSsoStateResult {
+  /** Opaque state query param sent to the IdP */
+  state: string;
+  /** Value for the httpOnly SSO state cookie (`state.hmac`) */
+  cookieValue: string;
+  /** S256 PKCE code_challenge for the authorization request */
+  codeChallenge: string;
+}
+
+export interface VerifiedSsoState {
+  accountId: string;
+  providerId: string;
+  redirectTo: string;
+  nonce: string;
+  codeVerifier: string;
+}
+
+function requireSecret(): string {
+  const secret = process.env.REVEALUI_SECRET;
+  if (!secret) {
+    throw new Error(
+      'REVEALUI_SECRET is required for SSO state signing. ' +
+        'Set it in your environment variables.',
+    );
+  }
+  return secret;
+}
+
+/**
+ * Generate a signed SSO state token with PKCE verifier.
+ */
+export function generateSsoState(input: GenerateSsoStateInput): GenerateSsoStateResult {
+  const { accountId, providerId, redirectTo } = input;
+  if (!(accountId && providerId)) {
+    throw new Error('accountId and providerId are required for SSO state');
+  }
+
+  const nonce = crypto.randomBytes(16).toString('hex');
+  const codeVerifier = crypto.randomBytes(32).toString('base64url');
+  const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+
+  const payload: SsoStatePayload = {
+    accountId,
+    providerId,
+    redirectTo,
+    nonce,
+    codeVerifier,
+  };
+  const state = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const secret = requireSecret();
+  // lgtm[js/insufficient-password-hash] - HMAC-SHA256 for SSO CSRF state, not password hashing
+  const hmac = crypto.createHmac('sha256', secret).update(state).digest('hex');
+
+  return {
+    state,
+    cookieValue: `${state}.${hmac}`,
+    codeChallenge,
+  };
+}
+
+/**
+ * Verify a signed SSO state token from the callback.
+ * Returns null on any integrity / shape failure (does not throw for bad input).
+ */
+export function verifySsoState(
+  state: string | null | undefined,
+  cookieValue: string | null | undefined,
+): VerifiedSsoState | null {
+  if (!(state && cookieValue)) return null;
+
+  const dotIdx = cookieValue.lastIndexOf('.');
+  if (dotIdx === -1) return null;
+
+  const storedState = cookieValue.substring(0, dotIdx);
+  const storedHmac = cookieValue.substring(dotIdx + 1);
+
+  if (
+    storedState.length !== state.length ||
+    !crypto.timingSafeEqual(Buffer.from(storedState), Buffer.from(state))
+  ) {
+    return null;
+  }
+
+  const secret = requireSecret();
+  // lgtm[js/insufficient-password-hash] - HMAC-SHA256 for SSO CSRF state, not password hashing
+  const expectedHmac = crypto.createHmac('sha256', secret).update(state).digest('hex');
+
+  // Both are hex-encoded SHA-256 HMACs — must be exactly 64 hex characters.
+  if (storedHmac.length !== 64 || expectedHmac.length !== 64) return null;
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(storedHmac, 'hex'), Buffer.from(expectedHmac, 'hex'))) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(state, 'base64url').toString(),
+    ) as Partial<SsoStatePayload>;
+    if (
+      typeof parsed.accountId !== 'string' ||
+      typeof parsed.providerId !== 'string' ||
+      typeof parsed.redirectTo !== 'string' ||
+      typeof parsed.nonce !== 'string' ||
+      typeof parsed.codeVerifier !== 'string' ||
+      !parsed.accountId ||
+      !parsed.providerId ||
+      !parsed.nonce ||
+      !parsed.codeVerifier
+    ) {
+      return null;
+    }
+    return {
+      accountId: parsed.accountId,
+      providerId: parsed.providerId,
+      redirectTo: parsed.redirectTo,
+      nonce: parsed.nonce,
+      codeVerifier: parsed.codeVerifier,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,7 +371,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -611,7 +611,7 @@ importers:
         version: 10.67.0(react@19.2.8)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -948,6 +948,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+      jose:
+        specifier: 'catalog:'
+        version: 5.10.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -12516,7 +12519,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8


### PR DESCRIPTION
## Summary

GAP-464 Phase 2 (first slice): enterprise SSO **OIDC pure layer** under `@revealui/auth` — no HTTP routes yet.

Implements design [2026-08-02-enterprise-sso.md](https://github.com/RevealUIStudio/revealui-jv) / public tracker #449.

### Delivered
- **OIDC discovery** — fetch/parse openid-configuration (`issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`) with optional issuer match
- **id_token validation** — JWKS/signature required; validates issuer, audience (`client_id`), exp; rejects `none` alg; asymmetric suite only
- **SSO signed state** — separate from social OAuth (`generateSsoState` / `verifySsoState`): `accountId` + `providerId` + nonce + redirect + PKCE verifier
- **Group → role mapping** — `group_claim` + `group_role_map`; empty + `require_group_match` → reject; **never** grant `admin` from unmapped groups; `default_role` otherwise
- **Vitest** unit coverage (happy path + security rejects + role matrix + state HMAC)

### Security surface
This is a **security-classed** change (auth federation primitives).

- Needs **non-author** guardrail-2 review / owner disposition before merge
- **Do not self-merge**
- Owner merge when green: `gh pr merge <N> --merge` (create merge commit; no squash auto)

### Not in this PR (next)
- HTTP init/callback routes (`apps/server` auth-sso)
- JIT user + `sso_identities` link
- Enterprise entitlement gate on init/callback
- Admin UI / test-connection
- SAML MVP (Phase 3)

## Test plan
- [x] `pnpm --filter @revealui/auth exec vitest run src/server/sso` — 44 passed
- [x] `pnpm --filter @revealui/auth test` — 582 passed / 19 skipped
- [x] `pnpm --filter @revealui/auth typecheck`
- [x] Pre-push gate phase 1 PASS

## Files
- `packages/auth/src/server/sso/{oidc,roles,state,index}.ts`
- `packages/auth/src/server/sso/__tests__/*`
- `packages/auth/src/server/index.ts` (exports)
- `packages/auth/package.json` + lockfile (`jose` catalog dep)

Refs: GAP-464, #449, schema via #2368