### PR TITLE
feat(billing): seed shared agent overage metered price (GAP-212)

### DIFF
--- a/scripts/setup/__tests__/seed-stripe.test.ts
+++ b/scripts/setup/__tests__/seed-stripe.test.ts
@@ -1,6 +1,6 @@
 /**
- * GAP-212 — seed-stripe unit coverage: meter creation, meter env, tax constants,
- * idempotency, and dry-run zero-writes. Stripe SDK is fully mocked.
+ * GAP-212 — seed-stripe unit coverage: meter creation, overage price, meter env,
+ * tax constants, idempotency, and dry-run zero-writes. Stripe SDK is fully mocked.
  *
  * Imports stripe-billing-meter (not the CLI seeder) so tests need no dotenv /
  * Stripe package resolution from packages/services.
@@ -13,23 +13,38 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AGENT_METER_DISPLAY_NAME,
   AGENT_METER_EVENT_NAME,
+  AGENT_OVERAGE_ENV_KEY,
+  AGENT_OVERAGE_PRICE_KEY,
+  AGENT_OVERAGE_PRODUCT_KEY,
+  AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL,
   applyAgentMeterEnv,
+  ensureAgentOveragePrice,
   ensureBillingMeter,
   PRICE_TAX_BEHAVIOR,
   PRODUCT_TAX_CODE,
 } from '../stripe-billing-meter.js';
 
-type MeterListResult = {
-  autoPagingToArray: (opts: { limit: number }) => Promise<Stripe.Billing.Meter[]>;
+type AutoPageList<T> = {
+  autoPagingToArray: (opts: { limit: number }) => Promise<T[]>;
 };
 
-function mockStripe(meters: Stripe.Billing.Meter[] = []) {
-  const list = vi.fn(
-    (): MeterListResult => ({
+function mockStripe(
+  opts: {
+    meters?: Stripe.Billing.Meter[];
+    products?: Stripe.Product[];
+    prices?: Stripe.Price[];
+  } = {},
+) {
+  const meters = opts.meters ?? [];
+  const products = opts.products ?? [];
+  const prices = opts.prices ?? [];
+
+  const metersList = vi.fn(
+    (): AutoPageList<Stripe.Billing.Meter> => ({
       autoPagingToArray: vi.fn(async () => meters),
     }),
   );
-  const create = vi.fn(async (params: Stripe.Billing.MeterCreateParams) => ({
+  const metersCreate = vi.fn(async (params: Stripe.Billing.MeterCreateParams) => ({
     id: 'mtr_created',
     object: 'billing.meter',
     event_name: params.event_name,
@@ -37,20 +52,62 @@ function mockStripe(meters: Stripe.Billing.Meter[] = []) {
     status: 'active',
   }));
 
+  const productsList = vi.fn(
+    (): AutoPageList<Stripe.Product> => ({
+      autoPagingToArray: vi.fn(async () => products),
+    }),
+  );
+  const productsCreate = vi.fn(async (params: Stripe.ProductCreateParams) => ({
+    id: 'prod_overage',
+    object: 'product',
+    name: params.name,
+    metadata: params.metadata ?? {},
+    active: true,
+  }));
+  const productsUpdate = vi.fn();
+
+  const pricesList = vi.fn(
+    (): AutoPageList<Stripe.Price> => ({
+      autoPagingToArray: vi.fn(async () => prices),
+    }),
+  );
+  const pricesCreate = vi.fn(async (params: Stripe.PriceCreateParams) => ({
+    id: 'price_overage_new',
+    object: 'price',
+    lookup_key: params.lookup_key ?? null,
+    unit_amount_decimal: params.unit_amount_decimal ?? null,
+    recurring: params.recurring
+      ? {
+          interval: params.recurring.interval,
+          usage_type: params.recurring.usage_type ?? 'licensed',
+          meter: params.recurring.meter ?? null,
+        }
+      : null,
+    metadata: params.metadata ?? {},
+    active: true,
+  }));
+  const pricesUpdate = vi.fn();
+
   return {
     stripe: {
-      billing: {
-        meters: { list, create },
-      },
+      billing: { meters: { list: metersList, create: metersCreate } },
+      products: { list: productsList, create: productsCreate, update: productsUpdate },
+      prices: { list: pricesList, create: pricesCreate, update: pricesUpdate },
     } as unknown as Stripe,
-    list,
-    create,
+    metersList,
+    metersCreate,
+    productsList,
+    productsCreate,
+    pricesList,
+    pricesCreate,
+    pricesUpdate,
   };
 }
 
 const silentLog = {
   info: () => {},
   success: () => {},
+  warn: () => {},
 };
 
 describe('tax + meter constants (GAP-212)', () => {
@@ -63,6 +120,13 @@ describe('tax + meter constants (GAP-212)', () => {
     expect(AGENT_METER_EVENT_NAME).toBe('agent_task_overage');
     expect(AGENT_METER_DISPLAY_NAME).toBe('Agent task overage');
   });
+
+  it('locks provisional overage rate to Track B Starter unit economics ($0.001/task)', () => {
+    // unit_amount_decimal is in cents: 0.1¢ = $0.001
+    expect(AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL).toBe('0.1');
+    expect(AGENT_OVERAGE_PRICE_KEY).toBe('revealui_agent_task_overage');
+    expect(AGENT_OVERAGE_ENV_KEY).toBe('STRIPE_AGENT_OVERAGE_PRICE_ID');
+  });
 });
 
 describe('applyAgentMeterEnv (GAP-212 step 2)', () => {
@@ -70,12 +134,20 @@ describe('applyAgentMeterEnv (GAP-212 step 2)', () => {
     const envVars: Record<string, string> = { STRIPE_PRICE_PRO_MONTHLY: 'price_x' };
     applyAgentMeterEnv(envVars);
     expect(envVars.STRIPE_AGENT_METER_EVENT_NAME).toBe(AGENT_METER_EVENT_NAME);
+    expect(envVars[AGENT_OVERAGE_ENV_KEY]).toBeUndefined();
   });
 
-  it('is mapped in revvault-vercel.toml so --sync-revvault can publish it', async () => {
+  it('sets STRIPE_AGENT_OVERAGE_PRICE_ID when an overage price id is provided', () => {
+    const envVars: Record<string, string> = {};
+    applyAgentMeterEnv(envVars, 'price_overage_live');
+    expect(envVars[AGENT_OVERAGE_ENV_KEY]).toBe('price_overage_live');
+  });
+
+  it('maps overage + meter env keys in revvault-vercel.toml', async () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const manifest = await readFile(resolve(here, '../../sync/revvault-vercel.toml'), 'utf8');
     expect(manifest.includes('STRIPE_AGENT_METER_EVENT_NAME')).toBe(true);
+    expect(manifest.includes('STRIPE_AGENT_OVERAGE_PRICE_ID')).toBe(true);
   });
 });
 
@@ -91,17 +163,17 @@ describe('ensureBillingMeter', () => {
       display_name: AGENT_METER_DISPLAY_NAME,
       status: 'active',
     } as Stripe.Billing.Meter;
-    const { stripe, list, create } = mockStripe([existing]);
+    const { stripe, metersList, metersCreate } = mockStripe({ meters: [existing] });
 
     const result = await ensureBillingMeter(stripe, false, silentLog);
 
     expect(result).toEqual(existing);
-    expect(create).not.toHaveBeenCalled();
-    expect(list).toHaveBeenCalledWith({ status: 'active' });
+    expect(metersCreate).not.toHaveBeenCalled();
+    expect(metersList).toHaveBeenCalledWith({ status: 'active' });
   });
 
   it('creates the meter when missing (live path)', async () => {
-    const { stripe, create } = mockStripe([]);
+    const { stripe, metersCreate } = mockStripe({ meters: [] });
 
     const result = await ensureBillingMeter(stripe, false, silentLog);
 
@@ -109,8 +181,8 @@ describe('ensureBillingMeter', () => {
       id: 'mtr_created',
       event_name: AGENT_METER_EVENT_NAME,
     });
-    expect(create).toHaveBeenCalledOnce();
-    const params = create.mock.calls[0][0] as Stripe.Billing.MeterCreateParams;
+    expect(metersCreate).toHaveBeenCalledOnce();
+    const params = metersCreate.mock.calls[0][0] as Stripe.Billing.MeterCreateParams;
     expect(params.event_name).toBe(AGENT_METER_EVENT_NAME);
     expect(params.display_name).toBe(AGENT_METER_DISPLAY_NAME);
     expect(params.default_aggregation).toEqual({ formula: 'sum' });
@@ -122,37 +194,113 @@ describe('ensureBillingMeter', () => {
   });
 
   it('dry-run: lists but never creates when meter is missing', async () => {
-    const { stripe, list, create } = mockStripe([]);
+    const { stripe, metersList, metersCreate } = mockStripe({ meters: [] });
 
     const result = await ensureBillingMeter(stripe, true, silentLog);
 
     expect(result).toBeNull();
-    expect(list).toHaveBeenCalledOnce();
-    expect(create).not.toHaveBeenCalled();
+    expect(metersList).toHaveBeenCalledOnce();
+    expect(metersCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('ensureAgentOveragePrice (GAP-212 step 1, shared SKU)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('dry-run: returns existing meter without create', async () => {
-    const existing = {
-      id: 'mtr_dry',
-      event_name: AGENT_METER_EVENT_NAME,
-      status: 'active',
-    } as Stripe.Billing.Meter;
-    const { stripe, create } = mockStripe([existing]);
+  it('returns existing metered price without create (idempotent)', async () => {
+    const product = {
+      id: 'prod_exist',
+      metadata: { revealui_product_key: AGENT_OVERAGE_PRODUCT_KEY },
+      active: true,
+    } as unknown as Stripe.Product;
+    const price = {
+      id: 'price_exist',
+      lookup_key: AGENT_OVERAGE_PRICE_KEY,
+      unit_amount_decimal: AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL,
+      recurring: { usage_type: 'metered', interval: 'month', meter: 'mtr_x' },
+      metadata: { revealui_price_key: AGENT_OVERAGE_PRICE_KEY },
+      active: true,
+    } as unknown as Stripe.Price;
+    const { stripe, productsCreate, pricesCreate } = mockStripe({
+      products: [product],
+      prices: [price],
+    });
 
-    const result = await ensureBillingMeter(stripe, true, silentLog);
+    const id = await ensureAgentOveragePrice(stripe, 'mtr_x', false, silentLog);
 
-    expect(result?.id).toBe('mtr_dry');
-    expect(create).not.toHaveBeenCalled();
+    expect(id).toBe('price_exist');
+    expect(productsCreate).not.toHaveBeenCalled();
+    expect(pricesCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates product + metered price linked to the meter', async () => {
+    const { stripe, productsCreate, pricesCreate } = mockStripe({ products: [], prices: [] });
+
+    const id = await ensureAgentOveragePrice(stripe, 'mtr_live', false, silentLog);
+
+    expect(id).toBe('price_overage_new');
+    expect(productsCreate).toHaveBeenCalledOnce();
+    expect(pricesCreate).toHaveBeenCalledOnce();
+    const priceParams = pricesCreate.mock.calls[0][0] as Stripe.PriceCreateParams;
+    expect(priceParams.lookup_key).toBe(AGENT_OVERAGE_PRICE_KEY);
+    expect(priceParams.unit_amount_decimal).toBe(AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL);
+    expect(priceParams.tax_behavior).toBe(PRICE_TAX_BEHAVIOR);
+    expect(priceParams.recurring).toEqual({
+      interval: 'month',
+      usage_type: 'metered',
+      meter: 'mtr_live',
+    });
+  });
+
+  it('dry-run: zero price creates when product missing', async () => {
+    const { stripe, productsCreate, pricesCreate } = mockStripe({ products: [], prices: [] });
+
+    const id = await ensureAgentOveragePrice(stripe, 'mtr_x', true, silentLog);
+
+    expect(id).toBeNull();
+    expect(productsCreate).not.toHaveBeenCalled();
+    expect(pricesCreate).not.toHaveBeenCalled();
+  });
+
+  it('dry-run with existing product: would create price only (no write)', async () => {
+    const product = {
+      id: 'prod_exist',
+      metadata: { revealui_product_key: AGENT_OVERAGE_PRODUCT_KEY },
+      active: true,
+    } as unknown as Stripe.Product;
+    const { stripe, pricesCreate } = mockStripe({ products: [product], prices: [] });
+
+    const id = await ensureAgentOveragePrice(stripe, 'mtr_x', true, silentLog);
+
+    expect(id).toBeNull();
+    expect(pricesCreate).not.toHaveBeenCalled();
+  });
+
+  it('skips price create when meter id is missing', async () => {
+    const product = {
+      id: 'prod_exist',
+      metadata: { revealui_product_key: AGENT_OVERAGE_PRODUCT_KEY },
+      active: true,
+    } as unknown as Stripe.Product;
+    const { stripe, pricesCreate } = mockStripe({ products: [product], prices: [] });
+
+    const id = await ensureAgentOveragePrice(stripe, null, false, silentLog);
+
+    expect(id).toBeNull();
+    expect(pricesCreate).not.toHaveBeenCalled();
   });
 });
 
 describe('seed-stripe.ts wiring (source lock)', () => {
-  it('wires meter helpers, tax fields, direct-run guard, and applyAgentMeterEnv', async () => {
+  it('wires meter + overage helpers, tax fields, and direct-run guard', async () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const content = await readFile(resolve(here, '..', 'seed-stripe.ts'), 'utf8');
     expect(content.includes('tax_behavior: PRICE_TAX_BEHAVIOR')).toBe(true);
     expect(content.includes('tax_code: PRODUCT_TAX_CODE')).toBe(true);
-    expect(content.includes('applyAgentMeterEnv(envVars)')).toBe(true);
+    expect(content.includes('applyAgentMeterEnv(envVars, overagePriceId)')).toBe(true);
+    expect(content.includes('ensureAgentOveragePrice')).toBe(true);
     expect(content.includes("from './stripe-billing-meter.js'")).toBe(true);
     expect(content.includes('pathToFileURL')).toBe(true);
     expect(content.includes('isDirectRun')).toBe(true);

--- a/scripts/setup/seed-stripe.ts
+++ b/scripts/setup/seed-stripe.ts
@@ -34,6 +34,7 @@ import type Stripe from 'stripe';
 import { RELEVANT_STRIPE_WEBHOOK_EVENTS } from '../../packages/contracts/src/stripe-webhook-events.js';
 import {
   applyAgentMeterEnv,
+  ensureAgentOveragePrice,
   ensureBillingMeter,
   PRICE_TAX_BEHAVIOR,
   PRODUCT_TAX_CODE,
@@ -55,7 +56,11 @@ import { syncToRevvault } from './stripe-revvault-sync.js';
 export {
   AGENT_METER_DISPLAY_NAME,
   AGENT_METER_EVENT_NAME,
+  AGENT_OVERAGE_ENV_KEY,
+  AGENT_OVERAGE_PRICE_KEY,
+  AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL,
   applyAgentMeterEnv,
+  ensureAgentOveragePrice,
   ensureBillingMeter,
   PRICE_TAX_BEHAVIOR,
   PRODUCT_TAX_CODE,
@@ -762,12 +767,16 @@ async function main(): Promise<void> {
 
   // ── Stripe Billing Meter (Track B agent task overage)
   log.header('Stripe Billing Meter');
-  await ensureBillingMeter(stripe, dryRun, log);
+  const meter = await ensureBillingMeter(stripe, dryRun, log);
+
+  // Shared metered overage price (Pro/Max checkout line item)
+  log.header('Agent Task Overage Price');
+  const overagePriceId = await ensureAgentOveragePrice(stripe, meter?.id ?? null, dryRun, log);
 
   // ── Products & prices
   log.header('Products & Prices');
   const { envVars, subscriptionProducts, catalogEntries } = await syncCatalog(stripe, dryRun);
-  applyAgentMeterEnv(envVars);
+  applyAgentMeterEnv(envVars, overagePriceId);
 
   // Reconcile orphan products (convergent IaC: archive undeclared managed products)
   log.header('Catalog Reconciliation');

--- a/scripts/setup/stripe-billing-meter.ts
+++ b/scripts/setup/stripe-billing-meter.ts
@@ -4,6 +4,10 @@
  * Extracted from seed-stripe.ts so unit tests can exercise meter create /
  * idempotency / dry-run without importing the seeder CLI (dotenv + Stripe
  * require + import.meta main). GAP-212.
+ *
+ * Runtime attaches a single shared metered price to Pro/Max checkouts via
+ * STRIPE_AGENT_OVERAGE_PRICE_ID (Enterprise is unlimited — no overage item).
+ * Code-over-docs: that is one SKU, not three per-tier rows.
  */
 
 import type Stripe from 'stripe';
@@ -11,6 +15,20 @@ import type Stripe from 'stripe';
 /** Track B meter event name (runtime fallback matches this literal). */
 export const AGENT_METER_EVENT_NAME = 'agent_task_overage';
 export const AGENT_METER_DISPLAY_NAME = 'Agent task overage';
+
+/** Product + price handles for the shared overage SKU. */
+export const AGENT_OVERAGE_PRODUCT_KEY = 'revealui_agent_task_overage';
+export const AGENT_OVERAGE_PRICE_KEY = 'revealui_agent_task_overage';
+export const AGENT_OVERAGE_PRODUCT_NAME = 'RevealUI agent task overage';
+export const AGENT_OVERAGE_ENV_KEY = 'STRIPE_AGENT_OVERAGE_PRICE_ID';
+
+/**
+ * Provisional per-task rate in **cents** as a decimal string (Stripe
+ * unit_amount_decimal). $0.001/task = 0.1¢, aligned to offerings-canonical
+ * Track B Starter credit unit economics until the owner sets a distinct
+ * overage ladder. Early-access overage is not yet revenue-active.
+ */
+export const AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL = '0.1';
 
 /** Stripe Tax: SaaS product class. */
 export const PRODUCT_TAX_CODE = 'txcd_10103000';
@@ -21,11 +39,13 @@ export const PRICE_TAX_BEHAVIOR: Stripe.PriceCreateParams.TaxBehavior = 'exclusi
 export interface SeedStripeLog {
   info: (msg: string) => void;
   success: (msg: string) => void;
+  warn?: (msg: string) => void;
 }
 
 const defaultLog: SeedStripeLog = {
   info: (msg) => console.log(`  i ${msg}`),
   success: (msg) => console.log(`  ✓ ${msg}`),
+  warn: (msg) => console.log(`  ! ${msg}`),
 };
 
 /**
@@ -70,10 +90,122 @@ export async function ensureBillingMeter(
 }
 
 /**
- * Attach the meter event-name env var that runtime + revvault manifests expect.
- * Always applied after catalog sync so --sync-revvault / --sync-vercel pick it up
- * (GAP-212 step 2).
+ * Idempotently ensure the shared metered overage product + price exist and
+ * return the active price id for STRIPE_AGENT_OVERAGE_PRICE_ID.
+ *
+ * Requires a Billing Meter id (from ensureBillingMeter). On dry-run with no
+ * existing meter/price, returns null (no write).
  */
-export function applyAgentMeterEnv(envVars: Record<string, string>): void {
+export async function ensureAgentOveragePrice(
+  stripe: Stripe,
+  meterId: string | null,
+  dryRun: boolean,
+  log: SeedStripeLog = defaultLog,
+): Promise<string | null> {
+  log.info('');
+  log.info(`Overage product key: ${AGENT_OVERAGE_PRODUCT_KEY}`);
+
+  const allProducts = await stripe.products
+    .list({ active: true })
+    .autoPagingToArray({ limit: 10_000 });
+  let product = allProducts.find(
+    (p) => p.metadata?.revealui_product_key === AGENT_OVERAGE_PRODUCT_KEY,
+  );
+
+  if (!product) {
+    if (dryRun) {
+      log.info(`Would create product: ${AGENT_OVERAGE_PRODUCT_NAME}`);
+      return null;
+    }
+    product = await stripe.products.create({
+      name: AGENT_OVERAGE_PRODUCT_NAME,
+      description:
+        'Metered agent-task overage for Pro/Max subscriptions (shared SKU). Linked to the agent_task_overage Billing Meter.',
+      tax_code: PRODUCT_TAX_CODE,
+      // Intentionally no revealui_track / revealui_tier: catalog orphan
+      // reconciliation treats those as managed CATALOG products and would
+      // archive this shared overage SKU (see isManagedProduct).
+      metadata: {
+        revealui_product_key: AGENT_OVERAGE_PRODUCT_KEY,
+      },
+      unit_label: 'task',
+    });
+    log.success(`Created product: ${product.id}`);
+  } else {
+    log.success(`Product exists: ${product.id}`);
+  }
+
+  const existingPrices = await stripe.prices
+    .list({ product: product.id, active: true })
+    .autoPagingToArray({ limit: 10_000 });
+
+  const matching = existingPrices.find(
+    (p) =>
+      (p.lookup_key === AGENT_OVERAGE_PRICE_KEY ||
+        p.metadata?.revealui_price_key === AGENT_OVERAGE_PRICE_KEY) &&
+      p.recurring?.usage_type === 'metered' &&
+      p.unit_amount_decimal === AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL,
+  );
+
+  if (matching) {
+    log.success(`Overage price exists: ${matching.id}`);
+    return matching.id;
+  }
+
+  if (!meterId) {
+    log.warn?.(
+      'No Billing Meter id — cannot create metered overage price (dry-run without meter, or meter create failed)',
+    );
+    return null;
+  }
+
+  if (dryRun) {
+    log.info(
+      `Would create metered price: ${AGENT_OVERAGE_PRICE_KEY} ($${Number(AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL) / 100}/task, meter ${meterId})`,
+    );
+    return null;
+  }
+
+  // Archive stale handles with different amount so lookup_key can transfer.
+  const stale = existingPrices.find(
+    (p) =>
+      p.lookup_key === AGENT_OVERAGE_PRICE_KEY ||
+      p.metadata?.revealui_price_key === AGENT_OVERAGE_PRICE_KEY,
+  );
+  if (stale) {
+    await stripe.prices.update(stale.id, { active: false });
+    log.warn?.(`Archived stale overage price: ${stale.id}`);
+  }
+
+  const price = await stripe.prices.create({
+    product: product.id,
+    currency: 'usd',
+    // Sub-cent rate: 0.1¢ = $0.001/task (Track B Starter unit economics).
+    unit_amount_decimal: AGENT_OVERAGE_UNIT_AMOUNT_DECIMAL,
+    lookup_key: AGENT_OVERAGE_PRICE_KEY,
+    transfer_lookup_key: true,
+    metadata: { revealui_price_key: AGENT_OVERAGE_PRICE_KEY },
+    tax_behavior: PRICE_TAX_BEHAVIOR,
+    recurring: {
+      interval: 'month',
+      usage_type: 'metered',
+      meter: meterId,
+    },
+  });
+
+  log.success(`Created overage price: ${price.id}`);
+  return price.id;
+}
+
+/**
+ * Attach meter event-name (+ optional overage price id) for revvault / Vercel.
+ */
+export function applyAgentMeterEnv(
+  envVars: Record<string, string>,
+  overagePriceId?: string | null,
+): void {
   envVars.STRIPE_AGENT_METER_EVENT_NAME = AGENT_METER_EVENT_NAME;
+  if (overagePriceId) {
+    envVars[AGENT_OVERAGE_ENV_KEY] = overagePriceId;
+  }
 }


### PR DESCRIPTION
## Summary

Continues GAP-212 after #2402: seed the **shared** metered overage SKU that Pro/Max checkout already attaches via `STRIPE_AGENT_OVERAGE_PRICE_ID`.

Code-over-docs: runtime uses **one** overage price for Pro and Max (Enterprise unlimited). Not three per-tier catalog rows.

### Changes
- `ensureAgentOveragePrice()` in `stripe-billing-meter.ts`: product + metered price linked to the Billing Meter
- Provisional rate **$0.001/task** (`unit_amount_decimal: "0.1"` cents) = Track B Starter unit economics until owner sets a distinct overage ladder
- `applyAgentMeterEnv` also writes `STRIPE_AGENT_OVERAGE_PRICE_ID` when the price exists
- Wired into `pnpm stripe:seed` after meter ensure
- Unit tests: create / idempotent / dry-run / no meter

### Owner after merge
```bash
pnpm stripe:seed -- --dry-run   # preview
pnpm stripe:seed -- --sync-revvault
# then revvault sync vercel --apply when ready
```

### Test plan
- [x] 15 seed-stripe unit tests + price-match suite
- [ ] CI Quality green
- [ ] Optional: live dry-run seed with test key