### PR TITLE
feat(harnesses): stream-safe-secrets control-layer rule (GAP-468)

### DIFF
--- a/.claude/rules/stream-safe-secrets.md
+++ b/.claude/rules/stream-safe-secrets.md
@@ -1,0 +1,50 @@
+# Stream-Safe Secrets
+
+**Status:** HARDLINE. ADR `2026-08-05-stream-safe-secrets` (.jv). GAP-468.
+
+Every secret lives in revvault. How values reach a process is constrained so
+YouTube/OBS, agent transcripts, and `pnpm` argv echoes never show them.
+
+## Rules
+
+1. **Path on the command line, value only in the child environment.**
+   ```bash
+   revvault run --env KEY=vault/path -- <cmd>
+   with-secrets stripe neon -- <cmd>
+   ```
+2. **Never** expand `$(revvault get …)` into CLI flags or export lines that
+   other tools will print. PreToolUse denies that shape for agents.
+3. **Never** pass credential-bearing URLs as flags
+   (e.g. `--database-url 'postgresql://user:pass@…'`). Prefer
+   `NEON_DATABASE_URL` / `POSTGRES_URL` via `revvault run` / namespaces.
+4. **Stream mode** (`STREAM_SAFE=1` / `stream-safe`): `revvault get` refuses
+   TTY print and `--clip` unless `REVVAULT_ALLOW_PRINT=1`. Piped script use
+   (non-TTY stdout) still works.
+5. **Vault-private mode** (`vault-private` / `REVVAULT_ALLOW_PRINT=1`): only
+   place for full `get --full` / `--clip`. Keep the window out of OBS capture.
+6. **Fail loud** with the revvault **path** when a secret is missing — never a
+   silent default and never echo the value.
+
+## Dual terminal modes
+
+| Mode | Prompt cue | Allowed |
+|------|------------|---------|
+| Stream | `stream` | Paths + run / with-secrets |
+| Vault-private | `VAULT` | Full get / clip (break-glass) |
+
+## Namespaces
+
+`revealui/env/<ns>` bundles (e.g. `stripe`, `neon`) feed `with-secrets` and
+`revvault run --namespace`. Prefer namespaces for stream paste recipes.
+
+## What this rules out
+
+- Teaching-only "don't paste secrets" without `revvault run` / hook deny
+- Dual secret stores for stream vs private (one vault, two **output** modes)
+- Logging or printing secret values in CI, agents, or docs
+
+## References
+
+- Plane A adapter: `~/.claude/rules/secrets.md`
+- CLI: `revvault run`, stream-safe get gate
+- Shell: revkit `stream-safe`, `vault-private`, `with-secrets`

--- a/.revealui/content/rules/stream-safe-secrets.md
+++ b/.revealui/content/rules/stream-safe-secrets.md
@@ -1,0 +1,50 @@
+# Stream-Safe Secrets
+
+**Status:** HARDLINE. ADR `2026-08-05-stream-safe-secrets` (.jv). GAP-468.
+
+Every secret lives in revvault. How values reach a process is constrained so
+YouTube/OBS, agent transcripts, and `pnpm` argv echoes never show them.
+
+## Rules
+
+1. **Path on the command line, value only in the child environment.**
+   ```bash
+   revvault run --env KEY=vault/path -- <cmd>
+   with-secrets stripe neon -- <cmd>
+   ```
+2. **Never** expand `$(revvault get …)` into CLI flags or export lines that
+   other tools will print. PreToolUse denies that shape for agents.
+3. **Never** pass credential-bearing URLs as flags
+   (e.g. `--database-url 'postgresql://user:pass@…'`). Prefer
+   `NEON_DATABASE_URL` / `POSTGRES_URL` via `revvault run` / namespaces.
+4. **Stream mode** (`STREAM_SAFE=1` / `stream-safe`): `revvault get` refuses
+   TTY print and `--clip` unless `REVVAULT_ALLOW_PRINT=1`. Piped script use
+   (non-TTY stdout) still works.
+5. **Vault-private mode** (`vault-private` / `REVVAULT_ALLOW_PRINT=1`): only
+   place for full `get --full` / `--clip`. Keep the window out of OBS capture.
+6. **Fail loud** with the revvault **path** when a secret is missing — never a
+   silent default and never echo the value.
+
+## Dual terminal modes
+
+| Mode | Prompt cue | Allowed |
+|------|------------|---------|
+| Stream | `stream` | Paths + run / with-secrets |
+| Vault-private | `VAULT` | Full get / clip (break-glass) |
+
+## Namespaces
+
+`revealui/env/<ns>` bundles (e.g. `stripe`, `neon`) feed `with-secrets` and
+`revvault run --namespace`. Prefer namespaces for stream paste recipes.
+
+## What this rules out
+
+- Teaching-only "don't paste secrets" without `revvault run` / hook deny
+- Dual secret stores for stream vs private (one vault, two **output** modes)
+- Logging or printing secret values in CI, agents, or docs
+
+## References
+
+- Plane A adapter: `~/.claude/rules/secrets.md`
+- CLI: `revvault run`, stream-safe get gate
+- Shell: revkit `stream-safe`, `vault-private`, `with-secrets`

--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -91,6 +91,10 @@
       "sha256": "8607d1d76c2800137808a5a5e72185ad2a632a0fb1553b59d55b3246b412d647"
     },
     {
+      "relativePath": ".revealui/content/rules/stream-safe-secrets.md",
+      "sha256": "a8dd8ee4f106df0590c05f7e68a21c056a8338fd035af290e20a04d161326f0c"
+    },
+    {
       "relativePath": ".revealui/content/rules/tailwind.md",
       "sha256": "498578c8bc2c7d3370667efd6a60d17c09903ab774659ce5a031b3acdb70e6d3"
     },

--- a/packages/harnesses/src/__tests__/content-api.test.ts
+++ b/packages/harnesses/src/__tests__/content-api.test.ts
@@ -47,18 +47,18 @@ describe('Content Public API', () => {
   describe('listContent', () => {
     it('returns correct counts', () => {
       const summary = listContent();
-      expect(summary.rules).toBe(15);
+      expect(summary.rules).toBe(16);
       expect(summary.commands).toBe(4);
       expect(summary.agents).toBe(6);
       expect(summary.skills).toBe(10);
       expect(summary.preambles).toBe(4);
-      expect(summary.total).toBe(35);
+      expect(summary.total).toBe(36);
     });
 
     it('accepts an explicit manifest', () => {
       const manifest = buildManifest();
       const summary = listContent(manifest);
-      expect(summary.total).toBe(35);
+      expect(summary.total).toBe(36);
     });
   });
 

--- a/packages/harnesses/src/__tests__/content-api.test.ts
+++ b/packages/harnesses/src/__tests__/content-api.test.ts
@@ -7,7 +7,7 @@ describe('Content Public API', () => {
       const manifest = buildManifest();
       expect(manifest.version).toBe(1);
       expect(manifest.generatedAt).toBeTruthy();
-      expect(manifest.rules.length).toBe(15);
+      expect(manifest.rules.length).toBe(16);
       expect(manifest.commands.length).toBe(4);
       expect(manifest.agents.length).toBe(6);
       expect(manifest.skills.length).toBe(10);

--- a/packages/harnesses/src/content/definitions/preambles/index.ts
+++ b/packages/harnesses/src/content/definitions/preambles/index.ts
@@ -15,6 +15,8 @@ export const preambles: PreambleTier[] = [
       'adapter-only',
       // HARDLINE every session: no underscore-silence of unused (owner 2026-07-29)
       'unused-declarations',
+      // HARDLINE: stream-safe revvault (GAP-468 / ADR 2026-08-05)
+      'stream-safe-secrets',
     ],
   },
   {

--- a/packages/harnesses/src/content/definitions/rules/index.ts
+++ b/packages/harnesses/src/content/definitions/rules/index.ts
@@ -11,6 +11,7 @@ import { monorepoRule } from './monorepo.js';
 import { parameterizationRule } from './parameterization.js';
 import { qualityOverSpeedRule } from './quality-over-speed.js';
 import { skillsUsageRule } from './skills-usage.js';
+import { streamSafeSecretsRule } from './stream-safe-secrets.js';
 import { tailwindRule } from './tailwind.js';
 import { trackerFirstRule } from './tracker-first.js';
 import { unusedDeclarationsRule } from './unused-declarations.js';
@@ -28,6 +29,7 @@ export const rules: Rule[] = [
   parameterizationRule,
   qualityOverSpeedRule,
   skillsUsageRule,
+  streamSafeSecretsRule,
   tailwindRule,
   trackerFirstRule,
   unusedDeclarationsRule,

--- a/packages/harnesses/src/content/definitions/rules/stream-safe-secrets.ts
+++ b/packages/harnesses/src/content/definitions/rules/stream-safe-secrets.ts
@@ -27,7 +27,7 @@ YouTube/OBS, agent transcripts, and \`pnpm\` argv echoes never show them.
    revvault run --env KEY=vault/path -- <cmd>
    with-secrets stripe neon -- <cmd>
    \`\`\`
-2. **Never** expand \`\$(revvault get …)\` into CLI flags or export lines that
+2. **Never** expand \`$(revvault get …)\` into CLI flags or export lines that
    other tools will print. PreToolUse denies that shape for agents.
 3. **Never** pass credential-bearing URLs as flags
    (e.g. \`--database-url 'postgresql://user:pass@…'\`). Prefer

--- a/packages/harnesses/src/content/definitions/rules/stream-safe-secrets.ts
+++ b/packages/harnesses/src/content/definitions/rules/stream-safe-secrets.ts
@@ -1,0 +1,67 @@
+import type { Rule } from '../../schemas/rule.js';
+
+/**
+ * Stream-safe revvault use: paths on argv, values only in child env (GAP-468).
+ * Owner ADR 2026-08-05-stream-safe-secrets (.jv).
+ */
+export const streamSafeSecretsRule: Rule = {
+  id: 'stream-safe-secrets',
+  tier: 'oss',
+  name: 'Stream-Safe Secrets',
+  description:
+    'Never put secret values on argv or stream-captured TTY; use revvault run / with-secrets; vault-private only for full print',
+  scope: 'global',
+  preambleTier: 1,
+  tags: ['secrets', 'hardline', 'revvault', 'stream', 'obs'],
+  content: `# Stream-Safe Secrets
+
+**Status:** HARDLINE. ADR \`2026-08-05-stream-safe-secrets\` (.jv). GAP-468.
+
+Every secret lives in revvault. How values reach a process is constrained so
+YouTube/OBS, agent transcripts, and \`pnpm\` argv echoes never show them.
+
+## Rules
+
+1. **Path on the command line, value only in the child environment.**
+   \`\`\`bash
+   revvault run --env KEY=vault/path -- <cmd>
+   with-secrets stripe neon -- <cmd>
+   \`\`\`
+2. **Never** expand \`\$(revvault get …)\` into CLI flags or export lines that
+   other tools will print. PreToolUse denies that shape for agents.
+3. **Never** pass credential-bearing URLs as flags
+   (e.g. \`--database-url 'postgresql://user:pass@…'\`). Prefer
+   \`NEON_DATABASE_URL\` / \`POSTGRES_URL\` via \`revvault run\` / namespaces.
+4. **Stream mode** (\`STREAM_SAFE=1\` / \`stream-safe\`): \`revvault get\` refuses
+   TTY print and \`--clip\` unless \`REVVAULT_ALLOW_PRINT=1\`. Piped script use
+   (non-TTY stdout) still works.
+5. **Vault-private mode** (\`vault-private\` / \`REVVAULT_ALLOW_PRINT=1\`): only
+   place for full \`get --full\` / \`--clip\`. Keep the window out of OBS capture.
+6. **Fail loud** with the revvault **path** when a secret is missing — never a
+   silent default and never echo the value.
+
+## Dual terminal modes
+
+| Mode | Prompt cue | Allowed |
+|------|------------|---------|
+| Stream | \`stream\` | Paths + run / with-secrets |
+| Vault-private | \`VAULT\` | Full get / clip (break-glass) |
+
+## Namespaces
+
+\`revealui/env/<ns>\` bundles (e.g. \`stripe\`, \`neon\`) feed \`with-secrets\` and
+\`revvault run --namespace\`. Prefer namespaces for stream paste recipes.
+
+## What this rules out
+
+- Teaching-only "don't paste secrets" without \`revvault run\` / hook deny
+- Dual secret stores for stream vs private (one vault, two **output** modes)
+- Logging or printing secret values in CI, agents, or docs
+
+## References
+
+- Plane A adapter: \`~/.claude/rules/secrets.md\`
+- CLI: \`revvault run\`, stream-safe get gate
+- Shell: revkit \`stream-safe\`, \`vault-private\`, \`with-secrets\`
+`,
+};


### PR DESCRIPTION
Preamble-tier control-layer hardline for stream-safe revvault use. Pairs with revvault#156, revkit#167, claude-config hooks.