### PR TITLE
feat(admin): GAP-464 Admin SSO config UI + test-connection

### DIFF
--- a/apps/admin/src/app/(backend)/settings/layout.tsx
+++ b/apps/admin/src/app/(backend)/settings/layout.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from 'react';
 const NAV_ITEMS = [
   { href: '/settings/account', label: 'Account' },
   { href: '/settings/security', label: 'Security' },
+  { href: '/settings/sso', label: 'SSO' },
   { href: '/settings/api-keys', label: 'API Keys' },
   { href: '/settings/local-ai', label: 'Local AI' },
 ] as const;

--- a/apps/admin/src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx
@@ -89,11 +89,18 @@ const PROVIDER: SsoProvider = {
 function mockFetchSequence(
   handlers: Array<(url: string, init?: RequestInit) => Promise<Response> | Response>,
 ) {
+  if (handlers.length === 0) {
+    throw new Error('mockFetchSequence requires at least one handler');
+  }
   let i = 0;
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
-    const handler = handlers[Math.min(i, handlers.length - 1)];
+    const index = Math.min(i, handlers.length - 1);
+    const handler = handlers[index];
     i += 1;
+    if (!handler) {
+      throw new Error(`mockFetchSequence: missing handler at index ${index}`);
+    }
     return handler(url, init);
   });
 }

--- a/apps/admin/src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx
@@ -1,0 +1,225 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseLicense = vi.fn();
+
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+vi.mock('@/lib/components/LicenseGate', () => ({
+  LicenseGate: ({ feature, children }: { feature: string; children: ReactNode }) => {
+    const { features, isLoading } = mockUseLicense() as {
+      features: Record<string, boolean> | null;
+      isLoading: boolean;
+    };
+    if (isLoading) return <div>loading</div>;
+    if (!(features?.[feature] ?? false)) {
+      return <div>Enterprise SSO requires upgrade</div>;
+    }
+    return <>{children}</>;
+  },
+}));
+
+vi.mock('@revealui/presentation', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: ReactNode }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock('@revealui/presentation/client', () => ({
+  Field: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Label: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+    <span {...props}>{children}</span>
+  ),
+}));
+
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: (...args: Parameters<typeof fetch>) => fetch(...args),
+}));
+
+import SsoSettingsClient, { providerToForm, type SsoProvider } from '../sso-settings-client';
+
+const PROVIDER: SsoProvider = {
+  id: 'sso_1',
+  accountId: 'acct-1',
+  providerType: 'oidc',
+  name: 'Okta',
+  enabled: false,
+  issuer: 'https://idp.example.com',
+  discoveryUrl: null,
+  clientId: 'client-1',
+  clientSecretRef: 'REVEALUI_SSO_CLIENT_SECRET',
+  groupClaim: 'groups',
+  groupRoleMap: {},
+  defaultRole: 'member',
+  requireGroupMatch: false,
+  allowPasswordFallback: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function mockFetchSequence(
+  handlers: Array<(url: string, init?: RequestInit) => Promise<Response> | Response>,
+) {
+  let i = 0;
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const handler = handlers[Math.min(i, handlers.length - 1)];
+    i += 1;
+    return handler(url, init);
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseLicense.mockReturnValue({ features: { sso: true }, isLoading: false });
+});
+
+describe('providerToForm', () => {
+  it('maps provider fields into form state', () => {
+    const form = providerToForm(PROVIDER);
+    expect(form.name).toBe('Okta');
+    expect(form.clientSecretRef).toBe('REVEALUI_SSO_CLIENT_SECRET');
+    expect(form.enabled).toBe(false);
+  });
+});
+
+describe('SsoSettingsClient', () => {
+  it('shows upgrade gate when sso feature is false', () => {
+    mockUseLicense.mockReturnValue({ features: { sso: false }, isLoading: false });
+    vi.stubGlobal('fetch', vi.fn());
+    render(<SsoSettingsClient />);
+    expect(screen.getByText(/Enterprise SSO requires upgrade/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Add provider/i })).not.toBeInTheDocument();
+  });
+
+  it('lists providers after bootstrap', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([
+        () =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ accountId: 'acct-1', ssoFeature: true, membershipRole: 'owner' }),
+          } as Response),
+        () =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ providers: [PROVIDER] }),
+          } as Response),
+      ]),
+    );
+
+    render(<SsoSettingsClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Okta')).toBeInTheDocument();
+    });
+    expect(screen.getByText('https://idp.example.com')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+
+  it('opens create form with OIDC-only fields and secret-ref hint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([
+        () =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ accountId: 'acct-1', ssoFeature: true, membershipRole: 'owner' }),
+          } as Response),
+        () =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ providers: [] }),
+          } as Response),
+      ]),
+    );
+
+    render(<SsoSettingsClient />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Add provider/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Add provider/i }));
+    expect(screen.getByText(/Add OIDC provider/i)).toBeInTheDocument();
+    expect(screen.getByText(/Never paste the secret value/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Test connection/i })).toBeInTheDocument();
+  });
+
+  it('runs test connection and shows discovery preview', async () => {
+    const fetchMock = mockFetchSequence([
+      () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ accountId: 'acct-1', ssoFeature: true, membershipRole: 'owner' }),
+        } as Response),
+      () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ providers: [] }),
+        } as Response),
+      () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+            discovery: {
+              issuer: 'https://idp.example.com',
+              authorizationEndpoint: 'https://idp.example.com/authorize',
+              tokenEndpoint: 'https://idp.example.com/token',
+              jwksUri: 'https://idp.example.com/jwks',
+              scopesSupported: ['openid', 'email'],
+            },
+            claimStructurePreview: {
+              standardClaims: ['sub', 'email'],
+              groupClaim: 'groups',
+              notes: ['Dry-run discovery does not issue tokens.'],
+            },
+          }),
+        } as Response),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<SsoSettingsClient />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Add provider/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Add provider/i }));
+
+    fireEvent.change(screen.getByPlaceholderText('Okta Production'), {
+      target: { value: 'Okta' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('https://your-org.okta.com'), {
+      target: { value: 'https://idp.example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Test connection/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Discovery OK/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Claim structure preview/i)).toBeInTheDocument();
+    expect(screen.getByText(/https:\/\/idp\.example\.com\/jwks/)).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx
@@ -32,12 +32,32 @@ vi.mock('@revealui/presentation', () => ({
     </button>
   ),
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Select: ({
+    children,
+    ...props
+  }: React.SelectHTMLAttributes<HTMLSelectElement> & { children?: ReactNode }) => (
+    <select {...props}>{children}</select>
+  ),
 }));
 
 vi.mock('@revealui/presentation/client', () => ({
   Field: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Label: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
     <span {...props}>{children}</span>
+  ),
+  Checkbox: ({
+    checked,
+    onChange,
+  }: {
+    checked?: boolean;
+    onChange?: (checked: boolean) => void;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onChange?.(e.target.checked)}
+      aria-label="checkbox"
+    />
   ),
 }));
 

--- a/apps/admin/src/app/(backend)/settings/sso/page.tsx
+++ b/apps/admin/src/app/(backend)/settings/sso/page.tsx
@@ -1,0 +1,12 @@
+/**
+ * Settings · Enterprise SSO — server shell.
+ *
+ * Client page owns list/create/edit/test-connection. LicenseGate (feature sso)
+ * hides the panel without Enterprise entitlement; API still fail-closes.
+ */
+
+import SsoSettingsClient from './sso-settings-client';
+
+export default function SsoSettingsPage() {
+  return <SsoSettingsClient />;
+}

--- a/apps/admin/src/app/(backend)/settings/sso/sso-settings-client.tsx
+++ b/apps/admin/src/app/(backend)/settings/sso/sso-settings-client.tsx
@@ -1,0 +1,743 @@
+'use client';
+
+const SUCCESS_DISMISS_MS = 5_000;
+const ERROR_DISMISS_MS = 8_000;
+
+import { Button, Input } from '@revealui/presentation';
+import { Field, Label } from '@revealui/presentation/client';
+import { useCallback, useEffect, useState } from 'react';
+import { LicenseGate } from '@/lib/components/LicenseGate';
+import { apiFetch } from '@/lib/utils/csrf';
+
+export interface SsoProvider {
+  id: string;
+  accountId: string;
+  providerType: 'oidc' | 'saml';
+  name: string;
+  enabled: boolean;
+  issuer: string;
+  discoveryUrl: string | null;
+  clientId: string | null;
+  clientSecretRef: string | null;
+  groupClaim: string;
+  groupRoleMap: Record<string, string>;
+  defaultRole: string;
+  requireGroupMatch: boolean;
+  allowPasswordFallback: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SsoFormState {
+  name: string;
+  issuer: string;
+  discoveryUrl: string;
+  clientId: string;
+  clientSecretRef: string;
+  groupClaim: string;
+  defaultRole: string;
+  requireGroupMatch: boolean;
+  enabled: boolean;
+}
+
+export interface TestConnectionResult {
+  ok: boolean;
+  reason?: string;
+  message?: string;
+  discoveryUrl?: string;
+  discovery?: {
+    issuer: string;
+    authorizationEndpoint: string;
+    tokenEndpoint: string;
+    jwksUri: string;
+    scopesSupported: string[];
+  };
+  claimStructurePreview?: {
+    standardClaims: string[];
+    groupClaim: string;
+    notes: string[];
+  };
+}
+
+const EMPTY_FORM: SsoFormState = {
+  name: '',
+  issuer: '',
+  discoveryUrl: '',
+  clientId: '',
+  clientSecretRef: '',
+  groupClaim: 'groups',
+  defaultRole: 'member',
+  requireGroupMatch: false,
+  enabled: false,
+};
+
+function apiBase(): string {
+  return (process.env.NEXT_PUBLIC_API_URL ?? '').trim().replace(/\/+$/, '');
+}
+
+function accountsUrl(path: string): string {
+  const base = apiBase();
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return base ? `${base}/api/accounts${suffix}` : `/api/accounts${suffix}`;
+}
+
+export function providerToForm(p: SsoProvider): SsoFormState {
+  return {
+    name: p.name,
+    issuer: p.issuer,
+    discoveryUrl: p.discoveryUrl ?? '',
+    clientId: p.clientId ?? '',
+    clientSecretRef: p.clientSecretRef ?? '',
+    groupClaim: p.groupClaim,
+    defaultRole: p.defaultRole,
+    requireGroupMatch: p.requireGroupMatch,
+    enabled: p.enabled,
+  };
+}
+
+export default function SsoSettingsClient() {
+  return (
+    <LicenseGate feature="sso">
+      <SsoSettingsContent />
+    </LicenseGate>
+  );
+}
+
+function SsoSettingsContent() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [accountId, setAccountId] = useState<string | null>(null);
+  const [providers, setProviders] = useState<SsoProvider[]>([]);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<SsoFormState>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<TestConnectionResult | null>(null);
+  const [testedOk, setTestedOk] = useState(false);
+  const [enableConfirm, setEnableConfirm] = useState(false);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const currentRes = await fetch(accountsUrl('/current'), { credentials: 'include' });
+      if (currentRes.status === 401) {
+        setError('Sign in required to manage SSO.');
+        setLoading(false);
+        return;
+      }
+      if (!currentRes.ok) {
+        setError('Unable to resolve account for SSO settings.');
+        setLoading(false);
+        return;
+      }
+      const current = (await currentRes.json()) as {
+        accountId: string | null;
+        ssoFeature: boolean;
+      };
+      if (!current.accountId) {
+        setError('No account membership found. SSO is configured per account.');
+        setLoading(false);
+        return;
+      }
+      if (!current.ssoFeature) {
+        // LicenseGate should hide, but API is source of truth for entitlement
+        setError('SSO is not enabled for this account.');
+        setAccountId(current.accountId);
+        setLoading(false);
+        return;
+      }
+      setAccountId(current.accountId);
+
+      const listRes = await fetch(accountsUrl(`/${current.accountId}/sso-providers`), {
+        credentials: 'include',
+      });
+      if (listRes.status === 403) {
+        setError('SSO is not enabled for this account.');
+        setLoading(false);
+        return;
+      }
+      if (!listRes.ok) {
+        setError('Unable to load SSO providers.');
+        setLoading(false);
+        return;
+      }
+      const data = (await listRes.json()) as { providers: SsoProvider[] };
+      setProviders(data.providers);
+    } catch {
+      setError('Unable to reach the server. Please check your connection and try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!success) return;
+    const timer = setTimeout(() => setSuccess(null), SUCCESS_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [success]);
+
+  useEffect(() => {
+    if (!error) return;
+    const timer = setTimeout(() => setError(null), ERROR_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [error]);
+
+  function openCreate() {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setTestResult(null);
+    setTestedOk(false);
+    setEnableConfirm(false);
+    setShowForm(true);
+  }
+
+  function openEdit(provider: SsoProvider) {
+    setEditingId(provider.id);
+    setForm(providerToForm(provider));
+    setTestResult(null);
+    setTestedOk(false);
+    setEnableConfirm(false);
+    setShowForm(true);
+  }
+
+  function cancelForm() {
+    setShowForm(false);
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setTestResult(null);
+    setTestedOk(false);
+    setEnableConfirm(false);
+  }
+
+  function updateField<K extends keyof SsoFormState>(key: K, value: SsoFormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    // Requiring re-test when connection-relevant fields change
+    if (key === 'issuer' || key === 'discoveryUrl' || key === 'groupClaim') {
+      setTestedOk(false);
+      setTestResult(null);
+    }
+  }
+
+  async function handleTestConnection() {
+    if (!accountId) return;
+    if (!form.issuer.trim()) {
+      setError('Issuer is required to test the connection.');
+      return;
+    }
+    setTesting(true);
+    setError(null);
+    try {
+      const res = await apiFetch(accountsUrl(`/${accountId}/sso-providers/test-connection`), {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          issuer: form.issuer.trim(),
+          discoveryUrl: form.discoveryUrl.trim() || undefined,
+          groupClaim: form.groupClaim.trim() || 'groups',
+          providerId: editingId ?? undefined,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as TestConnectionResult & {
+        error?: string;
+      };
+      if (!res.ok) {
+        setError(data.error ?? 'Test connection failed.');
+        setTestedOk(false);
+        setTestResult(null);
+        return;
+      }
+      setTestResult(data);
+      setTestedOk(data.ok === true);
+      if (data.ok) {
+        setSuccess('Discovery succeeded. You can enable this provider when ready.');
+      } else {
+        setError(data.message ?? 'Discovery failed. Check issuer and discovery URL.');
+      }
+    } catch {
+      setError('Unable to reach the server. Please check your connection and try again.');
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function handleSave() {
+    if (!accountId) return;
+    if (!(form.name.trim() && form.issuer.trim())) {
+      setError('Name and issuer are required.');
+      return;
+    }
+    if (form.enabled && !testedOk && !enableConfirm) {
+      setEnableConfirm(true);
+      setError(
+        'Enable requires a successful test connection, or confirm enable without a test below.',
+      );
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        name: form.name.trim(),
+        providerType: 'oidc' as const,
+        issuer: form.issuer.trim(),
+        discoveryUrl: form.discoveryUrl.trim() || null,
+        clientId: form.clientId.trim() || null,
+        clientSecretRef: form.clientSecretRef.trim() || null,
+        groupClaim: form.groupClaim.trim() || 'groups',
+        defaultRole: form.defaultRole,
+        requireGroupMatch: form.requireGroupMatch,
+        enabled: form.enabled,
+      };
+
+      const url = editingId
+        ? accountsUrl(`/${accountId}/sso-providers/${editingId}`)
+        : accountsUrl(`/${accountId}/sso-providers`);
+      const method = editingId ? 'PATCH' : 'POST';
+
+      const res = await apiFetch(url, {
+        method,
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        provider?: SsoProvider;
+        error?: string;
+      };
+      if (!res.ok) {
+        setError(data.error ?? 'Unable to save SSO provider.');
+        return;
+      }
+      setSuccess(editingId ? 'SSO provider updated.' : 'SSO provider created.');
+      cancelForm();
+      await load();
+    } catch {
+      setError('Unable to reach the server. Please check your connection and try again.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(providerId: string) {
+    if (!accountId) return;
+    if (
+      !window.confirm('Remove this SSO provider? Users will no longer be able to sign in with it.')
+    ) {
+      return;
+    }
+    setError(null);
+    try {
+      const res = await apiFetch(accountsUrl(`/${accountId}/sso-providers/${providerId}`), {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error ?? 'Unable to remove SSO provider.');
+        return;
+      }
+      setSuccess('SSO provider removed.');
+      await load();
+    } catch {
+      setError('Unable to reach the server. Please check your connection and try again.');
+    }
+  }
+
+  async function handleToggleEnabled(provider: SsoProvider, enabled: boolean) {
+    if (!accountId) return;
+    if (enabled && !window.confirm('Enable this provider without a fresh test connection?')) {
+      return;
+    }
+    setError(null);
+    try {
+      const res = await apiFetch(accountsUrl(`/${accountId}/sso-providers/${provider.id}`), {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error ?? 'Unable to update provider.');
+        return;
+      }
+      setSuccess(enabled ? 'Provider enabled.' : 'Provider disabled.');
+      await load();
+    } catch {
+      setError('Unable to reach the server. Please check your connection and try again.');
+    }
+  }
+
+  return (
+    <div className="min-h-screen">
+      <div className="p-4 sm:p-6 max-w-2xl">
+        {success && (
+          <output className="mb-6 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
+            <span className="h-2 w-2 rounded-full bg-success" />
+            {success}
+          </output>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-6 flex items-center gap-2 rounded-lg border border-error/30 bg-error/10 px-4 py-3 text-sm text-error"
+          >
+            <span className="h-2 w-2 rounded-full bg-error" />
+            {error}
+          </div>
+        )}
+
+        {loading && (
+          <section
+            aria-busy="true"
+            aria-label="Loading SSO settings"
+            className="rounded-xl border border-border bg-card p-5"
+          >
+            <div className="h-5 w-48 animate-pulse rounded bg-foreground/10" />
+            <div className="mt-3 h-4 w-72 animate-pulse rounded bg-foreground/10" />
+          </section>
+        )}
+
+        {!loading && (
+          <>
+            <div className="mb-6 rounded-xl border border-border bg-card p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h1 className="text-base font-semibold text-foreground">Enterprise SSO</h1>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Connect an OIDC identity provider (Okta, Azure AD, Google Workspace, Keycloak).
+                    Store client secrets as env/revvault references only. Never paste raw secrets
+                    here.
+                  </p>
+                </div>
+                {!showForm && (
+                  <Button type="button" variant="neutral" size="sm" onClick={openCreate}>
+                    Add provider
+                  </Button>
+                )}
+              </div>
+
+              {providers.length === 0 && !showForm && (
+                <p className="mt-5 text-sm text-muted-foreground">
+                  No SSO providers configured yet.
+                </p>
+              )}
+
+              {providers.length > 0 && !showForm && (
+                <ul className="mt-5 space-y-3">
+                  {providers.map((p) => (
+                    <li
+                      key={p.id}
+                      className="flex flex-col gap-3 rounded-lg border border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-sm font-medium text-foreground">{p.name}</span>
+                          <span
+                            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                              p.enabled
+                                ? 'bg-success/10 text-success'
+                                : 'bg-muted text-muted-foreground'
+                            }`}
+                          >
+                            {p.enabled ? 'Enabled' : 'Disabled'}
+                          </span>
+                          <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                            {p.providerType}
+                          </span>
+                        </div>
+                        <p className="mt-0.5 truncate text-xs text-muted-foreground">{p.issuer}</p>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          type="button"
+                          appearance="outline"
+                          variant="neutral"
+                          size="sm"
+                          onClick={() => void handleToggleEnabled(p, !p.enabled)}
+                          className="text-xs"
+                        >
+                          {p.enabled ? 'Disable' : 'Enable'}
+                        </Button>
+                        <Button
+                          type="button"
+                          appearance="ghost"
+                          variant="neutral"
+                          size="sm"
+                          onClick={() => openEdit(p)}
+                          className="text-xs"
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          type="button"
+                          appearance="ghost"
+                          variant="neutral"
+                          size="sm"
+                          onClick={() => void handleDelete(p.id)}
+                          className="text-xs text-muted-foreground hover:text-error"
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {showForm && (
+              <div className="rounded-xl border border-border bg-card p-5">
+                <h2 className="text-base font-semibold text-foreground">
+                  {editingId ? 'Edit OIDC provider' : 'Add OIDC provider'}
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  SAML configuration is planned. OIDC only for this release.
+                </p>
+
+                <div className="mt-5 flex flex-col gap-4">
+                  <Field>
+                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Display name
+                    </Label>
+                    <Input
+                      value={form.name}
+                      onChange={(e) => updateField('name', e.target.value)}
+                      placeholder="Okta Production"
+                    />
+                  </Field>
+
+                  <Field>
+                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Issuer
+                    </Label>
+                    <Input
+                      value={form.issuer}
+                      onChange={(e) => updateField('issuer', e.target.value)}
+                      placeholder="https://your-org.okta.com"
+                    />
+                  </Field>
+
+                  <Field>
+                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Discovery URL (optional)
+                    </Label>
+                    <Input
+                      value={form.discoveryUrl}
+                      onChange={(e) => updateField('discoveryUrl', e.target.value)}
+                      placeholder="https://…/.well-known/openid-configuration"
+                    />
+                  </Field>
+
+                  <Field>
+                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Client ID
+                    </Label>
+                    <Input
+                      value={form.clientId}
+                      onChange={(e) => updateField('clientId', e.target.value)}
+                      placeholder="0oa…"
+                      autoComplete="off"
+                    />
+                  </Field>
+
+                  <Field>
+                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Client secret reference
+                    </Label>
+                    <Input
+                      value={form.clientSecretRef}
+                      onChange={(e) => updateField('clientSecretRef', e.target.value)}
+                      placeholder="REVEALUI_SSO_CLIENT_SECRET or revvault path"
+                      autoComplete="off"
+                    />
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Env var name or revvault path only. Never paste the secret value.
+                    </p>
+                  </Field>
+
+                  <Field>
+                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Group claim
+                    </Label>
+                    <Input
+                      value={form.groupClaim}
+                      onChange={(e) => updateField('groupClaim', e.target.value)}
+                      placeholder="groups"
+                    />
+                  </Field>
+
+                  <Field>
+                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Default role
+                    </Label>
+                    <select
+                      value={form.defaultRole}
+                      onChange={(e) => updateField('defaultRole', e.target.value)}
+                      className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
+                    >
+                      <option value="viewer">viewer</option>
+                      <option value="member">member</option>
+                      <option value="editor">editor</option>
+                      <option value="admin">admin</option>
+                    </select>
+                  </Field>
+
+                  <label className="flex items-center gap-2 text-sm text-foreground">
+                    <input
+                      type="checkbox"
+                      checked={form.requireGroupMatch}
+                      onChange={(e) => updateField('requireGroupMatch', e.target.checked)}
+                      className="rounded border-border"
+                    />
+                    Require group match (reject login when no group maps)
+                  </label>
+
+                  <label className="flex items-center gap-2 text-sm text-foreground">
+                    <input
+                      type="checkbox"
+                      checked={form.enabled}
+                      onChange={(e) => {
+                        const next = e.target.checked;
+                        if (next && !testedOk) {
+                          setEnableConfirm(false);
+                        }
+                        updateField('enabled', next);
+                      }}
+                      className="rounded border-border"
+                    />
+                    Enabled
+                    {!testedOk && form.enabled && (
+                      <span className="text-xs text-warning-foreground/80">
+                        (test connection first, or confirm on save)
+                      </span>
+                    )}
+                  </label>
+
+                  {form.enabled && !testedOk && (
+                    <label className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+                      <input
+                        type="checkbox"
+                        checked={enableConfirm}
+                        onChange={(e) => setEnableConfirm(e.target.checked)}
+                        className="mt-0.5"
+                      />
+                      I understand discovery was not tested successfully. Enable anyway.
+                    </label>
+                  )}
+
+                  <div className="flex flex-wrap gap-2 pt-2">
+                    <Button
+                      type="button"
+                      variant="neutral"
+                      size="sm"
+                      onClick={() => void handleTestConnection()}
+                      disabled={testing || !form.issuer.trim()}
+                    >
+                      {testing ? 'Testing…' : 'Test connection'}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="success"
+                      size="sm"
+                      onClick={() => void handleSave()}
+                      disabled={saving}
+                    >
+                      {saving ? 'Saving…' : editingId ? 'Save changes' : 'Create provider'}
+                    </Button>
+                    <Button
+                      type="button"
+                      appearance="ghost"
+                      variant="neutral"
+                      size="sm"
+                      onClick={cancelForm}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+
+                  {testResult && (
+                    <div
+                      className={`mt-2 rounded-lg border px-4 py-3 text-sm ${
+                        testResult.ok
+                          ? 'border-success/30 bg-success/10 text-success'
+                          : 'border-error/30 bg-error/10 text-error'
+                      }`}
+                    >
+                      <p className="font-medium">
+                        {testResult.ok ? 'Discovery OK' : 'Discovery failed'}
+                      </p>
+                      {testResult.discoveryUrl && (
+                        <p className="mt-1 break-all text-xs opacity-90">
+                          {testResult.discoveryUrl}
+                        </p>
+                      )}
+                      {testResult.ok && testResult.discovery && (
+                        <dl className="mt-3 space-y-1 text-xs text-foreground">
+                          <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Authorization</dt>
+                            <dd className="truncate text-right">
+                              {testResult.discovery.authorizationEndpoint}
+                            </dd>
+                          </div>
+                          <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Token</dt>
+                            <dd className="truncate text-right">
+                              {testResult.discovery.tokenEndpoint}
+                            </dd>
+                          </div>
+                          <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">JWKS</dt>
+                            <dd className="truncate text-right">{testResult.discovery.jwksUri}</dd>
+                          </div>
+                          {testResult.discovery.scopesSupported.length > 0 && (
+                            <div className="flex justify-between gap-4">
+                              <dt className="text-muted-foreground">Scopes</dt>
+                              <dd className="text-right">
+                                {testResult.discovery.scopesSupported.join(', ')}
+                              </dd>
+                            </div>
+                          )}
+                        </dl>
+                      )}
+                      {testResult.ok && testResult.claimStructurePreview && (
+                        <div className="mt-3 text-xs text-foreground">
+                          <p className="font-medium text-muted-foreground">
+                            Claim structure preview
+                          </p>
+                          <p className="mt-1">
+                            Standard: {testResult.claimStructurePreview.standardClaims.join(', ')}
+                          </p>
+                          <p>
+                            Group claim: <code>{testResult.claimStructurePreview.groupClaim}</code>
+                          </p>
+                          <ul className="mt-1 list-inside list-disc text-muted-foreground">
+                            {testResult.claimStructurePreview.notes.map((note) => (
+                              <li key={note}>{note}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                      {!testResult.ok && testResult.message && (
+                        <p className="mt-1 text-xs">{testResult.message}</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(backend)/settings/sso/sso-settings-client.tsx
+++ b/apps/admin/src/app/(backend)/settings/sso/sso-settings-client.tsx
@@ -3,8 +3,8 @@
 const SUCCESS_DISMISS_MS = 5_000;
 const ERROR_DISMISS_MS = 8_000;
 
-import { Button, Input } from '@revealui/presentation';
-import { Field, Label } from '@revealui/presentation/client';
+import { Button, Input, Select } from '@revealui/presentation';
+import { Checkbox, Field, Label } from '@revealui/presentation/client';
 import { useCallback, useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
@@ -244,6 +244,7 @@ function SsoSettingsContent() {
           providerId: editingId ?? undefined,
         }),
       });
+      // empty-catch-ok: JSON-parse fallback for an error-response body; `{}` is the safe shape so `data.error` evaluates to undefined and the UI falls back to the generic error text below.
       const data = (await res.json().catch(() => ({}))) as TestConnectionResult & {
         error?: string;
       };
@@ -308,6 +309,7 @@ function SsoSettingsContent() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
+      // empty-catch-ok: JSON-parse fallback for an error-response body; `{}` is the safe shape so `data.error` evaluates to undefined and the UI falls back to the generic error text below.
       const data = (await res.json().catch(() => ({}))) as {
         provider?: SsoProvider;
         error?: string;
@@ -340,6 +342,7 @@ function SsoSettingsContent() {
         credentials: 'include',
       });
       if (!res.ok) {
+        // empty-catch-ok: JSON-parse fallback for an error-response body; `{}` is the safe shape so `data.error` evaluates to undefined and the UI falls back to the generic error text below.
         const data = (await res.json().catch(() => ({}))) as { error?: string };
         setError(data.error ?? 'Unable to remove SSO provider.');
         return;
@@ -365,6 +368,7 @@ function SsoSettingsContent() {
         body: JSON.stringify({ enabled }),
       });
       if (!res.ok) {
+        // empty-catch-ok: JSON-parse fallback for an error-response body; `{}` is the safe shape so `data.error` evaluates to undefined and the UI falls back to the generic error text below.
         const data = (await res.json().catch(() => ({}))) as { error?: string };
         setError(data.error ?? 'Unable to update provider.');
         return;
@@ -580,59 +584,53 @@ function SsoSettingsContent() {
                     <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
                       Default role
                     </Label>
-                    <select
+                    <Select
                       value={form.defaultRole}
                       onChange={(e) => updateField('defaultRole', e.target.value)}
-                      className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
                     >
                       <option value="viewer">viewer</option>
                       <option value="member">member</option>
                       <option value="editor">editor</option>
                       <option value="admin">admin</option>
-                    </select>
+                    </Select>
                   </Field>
 
-                  <label className="flex items-center gap-2 text-sm text-foreground">
-                    <input
-                      type="checkbox"
+                  <div className="flex items-center gap-2 text-sm text-foreground">
+                    <Checkbox
                       checked={form.requireGroupMatch}
-                      onChange={(e) => updateField('requireGroupMatch', e.target.checked)}
-                      className="rounded border-border"
+                      onChange={(checked) => updateField('requireGroupMatch', checked)}
                     />
-                    Require group match (reject login when no group maps)
-                  </label>
+                    <span>Require group match (reject login when no group maps)</span>
+                  </div>
 
-                  <label className="flex items-center gap-2 text-sm text-foreground">
-                    <input
-                      type="checkbox"
+                  <div className="flex flex-wrap items-center gap-2 text-sm text-foreground">
+                    <Checkbox
                       checked={form.enabled}
-                      onChange={(e) => {
-                        const next = e.target.checked;
-                        if (next && !testedOk) {
+                      onChange={(checked) => {
+                        if (checked && !testedOk) {
                           setEnableConfirm(false);
                         }
-                        updateField('enabled', next);
+                        updateField('enabled', checked);
                       }}
-                      className="rounded border-border"
                     />
-                    Enabled
+                    <span>Enabled</span>
                     {!testedOk && form.enabled && (
                       <span className="text-xs text-warning-foreground/80">
                         (test connection first, or confirm on save)
                       </span>
                     )}
-                  </label>
+                  </div>
 
                   {form.enabled && !testedOk && (
-                    <label className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
-                      <input
-                        type="checkbox"
+                    <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+                      <Checkbox
                         checked={enableConfirm}
-                        onChange={(e) => setEnableConfirm(e.target.checked)}
-                        className="mt-0.5"
+                        onChange={(checked) => setEnableConfirm(checked)}
                       />
-                      I understand discovery was not tested successfully. Enable anyway.
-                    </label>
+                      <span>
+                        I understand discovery was not tested successfully. Enable anyway.
+                      </span>
+                    </div>
                   )}
 
                   <div className="flex flex-wrap gap-2 pt-2">

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -137,6 +137,7 @@ import pricingRoute from './routes/pricing.js';
 import ragIndexRoute from './routes/rag-index.js';
 import revmarketRoute from './routes/revmarket.js';
 import rotationRoute from './routes/rotation.js';
+import ssoProvidersRoute from './routes/sso-providers.js';
 import studioAuthRoute from './routes/studio-auth.js';
 import terminalAuthRoute from './routes/terminal-auth.js';
 import { createTerminalRoute } from './routes/terminal-ws.js';
@@ -499,6 +500,8 @@ const DEFAULT_RATE_LIMITS: RateLimitsConfig = {
     'auth-signup': { maxRequests: 5, windowMs: FIFTEEN_MINUTES },
     /** Enterprise SSO OIDC init/callback (GAP-464) — aligned with sign-in abuse budget */
     'auth-sso': { maxRequests: 20, windowMs: FIFTEEN_MINUTES },
+    /** Enterprise SSO provider admin CRUD + test-connection (GAP-464) */
+    'sso-providers': { maxRequests: 30, windowMs: ONE_MINUTE },
     'billing-checkout': { maxRequests: 10, windowMs: FIFTEEN_MINUTES },
     'billing-upgrade': { maxRequests: 5, windowMs: FIFTEEN_MINUTES },
     'billing-downgrade': { maxRequests: 5, windowMs: FIFTEEN_MINUTES },
@@ -986,6 +989,9 @@ app.use('/api/v1/auth/signup', routeLimit('auth-signup'));
 // Enterprise SSO OIDC init/callback (GAP-464)
 app.use('/api/auth/sso/*', routeLimit('auth-sso'));
 app.use('/api/v1/auth/sso/*', routeLimit('auth-sso'));
+// Enterprise SSO provider admin config (GAP-464)
+app.use('/api/accounts/*', routeLimit('sso-providers'));
+app.use('/api/v1/accounts/*', routeLimit('sso-providers'));
 const userLimit = enforceUserLimit(() => users);
 app.post('/api/auth/signup', userLimit);
 app.post('/api/v1/auth/signup', userLimit);
@@ -1245,6 +1251,7 @@ app.route('/api/license', licenseRoute);
 app.route('/api/kits', kitsRoute);
 app.route('/api/auth', authRoute);
 app.route('/api/auth', authSsoRoute);
+app.route('/api/accounts', ssoProvidersRoute);
 app.route('/api/billing', billingRoute);
 app.route('/api/contact', contactRoute);
 app.route('/api/v1/contact', contactRoute);
@@ -1338,6 +1345,7 @@ app.route('/api/v1/license', licenseRoute);
 app.route('/api/v1/kits', kitsRoute);
 app.route('/api/v1/auth', authRoute);
 app.route('/api/v1/auth', authSsoRoute);
+app.route('/api/v1/accounts', ssoProvidersRoute);
 app.route('/api/v1/billing', billingRoute);
 app.use('/api/v1/webhooks/*', rateLimitMiddleware(rateLimitsConfig.routes.webhook));
 app.route('/api/v1/webhooks', webhooksRoute);

--- a/apps/server/src/routes/__tests__/sso-providers.test.ts
+++ b/apps/server/src/routes/__tests__/sso-providers.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAccountHasSsoFeature,
+  mockMembershipLimit,
+  mockProviderSelectLimit,
+  mockProviderSelectWhere,
+  mockInsertValues,
+  mockUpdateWhere,
+  mockFetchOidcDiscovery,
+  mockDb,
+} = vi.hoisted(() => {
+  const mockMembershipLimit = vi.fn();
+  const mockProviderSelectLimit = vi.fn();
+  const mockProviderSelectWhere = vi.fn();
+  const mockInsertValues = vi.fn();
+  const mockUpdateWhere = vi.fn();
+
+  const mockDb = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  };
+
+  return {
+    mockAccountHasSsoFeature: vi.fn(),
+    mockMembershipLimit,
+    mockProviderSelectLimit,
+    mockProviderSelectWhere,
+    mockInsertValues,
+    mockUpdateWhere,
+    mockFetchOidcDiscovery: vi.fn(),
+    mockDb,
+  };
+});
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../lib/account-entitlement.js', () => ({
+  accountHasSsoFeature: (...args: unknown[]) => mockAccountHasSsoFeature(...args),
+}));
+
+vi.mock('../../middleware/entitlements.js', () => ({
+  getEntitlementsFromContext: (c: { get: (key: string) => unknown }) =>
+    c.get('entitlements') ?? {
+      userId: null,
+      accountId: null,
+      membershipRole: null,
+      subscriptionStatus: null,
+      graceUntil: null,
+      tier: 'free',
+      features: {},
+      limits: {},
+      resolvedAt: new Date(),
+    },
+  entitlementMiddleware: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+vi.mock('@revealui/db', () => ({
+  getClient: () => mockDb,
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  accountMemberships: {
+    accountId: 'accountMemberships.accountId',
+    userId: 'accountMemberships.userId',
+    role: 'accountMemberships.role',
+    status: 'accountMemberships.status',
+  },
+  accountSsoProviders: {
+    id: 'accountSsoProviders.id',
+    accountId: 'accountSsoProviders.accountId',
+    providerType: 'accountSsoProviders.providerType',
+    name: 'accountSsoProviders.name',
+    enabled: 'accountSsoProviders.enabled',
+    issuer: 'accountSsoProviders.issuer',
+    discoveryUrl: 'accountSsoProviders.discoveryUrl',
+    clientId: 'accountSsoProviders.clientId',
+    clientSecretRef: 'accountSsoProviders.clientSecretRef',
+    groupClaim: 'accountSsoProviders.groupClaim',
+    groupRoleMap: 'accountSsoProviders.groupRoleMap',
+    defaultRole: 'accountSsoProviders.defaultRole',
+    requireGroupMatch: 'accountSsoProviders.requireGroupMatch',
+    allowPasswordFallback: 'accountSsoProviders.allowPasswordFallback',
+    createdAt: 'accountSsoProviders.createdAt',
+    updatedAt: 'accountSsoProviders.updatedAt',
+    deletedAt: 'accountSsoProviders.deletedAt',
+  },
+}));
+
+vi.mock('@revealui/auth/server', () => ({
+  fetchOidcDiscovery: (...args: unknown[]) => mockFetchOidcDiscovery(...args),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  eq: vi.fn((col: unknown, val: unknown) => ({ _eq: [col, val] })),
+  isNull: vi.fn((col: unknown) => ({ _isNull: col })),
+}));
+
+import { Hono } from 'hono';
+import type { HTTPException } from 'hono/http-exception';
+import ssoProvidersRoute, {
+  buildDiscoveryUrl,
+  claimStructurePreview,
+  isAllowedDefaultRole,
+  isMutationRole,
+} from '../sso-providers.js';
+
+const USER = {
+  id: 'user-1',
+  email: 'owner@example.com',
+  name: 'Owner',
+  role: 'admin',
+};
+
+const PROVIDER_ROW = {
+  id: 'sso_abc',
+  accountId: 'acct-1',
+  providerType: 'oidc',
+  name: 'Okta',
+  enabled: false,
+  issuer: 'https://idp.example.com',
+  discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
+  clientId: 'client-1',
+  clientSecretRef: 'REVEALUI_SSO_CLIENT_SECRET',
+  groupClaim: 'groups',
+  groupRoleMap: { Engineering: 'member' },
+  defaultRole: 'member',
+  requireGroupMatch: false,
+  allowPasswordFallback: false,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  deletedAt: null,
+};
+
+function createApp(user: typeof USER | null = USER) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (user) c.set('user', user);
+    c.set('entitlements', {
+      userId: user?.id ?? null,
+      accountId: 'acct-1',
+      membershipRole: 'owner',
+      subscriptionStatus: 'active',
+      graceUntil: null,
+      tier: 'enterprise',
+      features: { sso: true },
+      limits: {},
+      resolvedAt: new Date(),
+    });
+    await next();
+  });
+  app.onError((err, c) => {
+    if (err && typeof err === 'object' && 'status' in err && 'message' in err) {
+      const httpErr = err as HTTPException;
+      return c.json({ error: httpErr.message }, httpErr.status);
+    }
+    return c.json({ error: 'Internal error' }, 500);
+  });
+  app.route('/api/accounts', ssoProvidersRoute);
+  return app;
+}
+
+function wireMembership(role = 'owner') {
+  mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role }]);
+}
+
+function wireProviderList(rows: unknown[] = [PROVIDER_ROW]) {
+  // list path: select().from().where() → array (no limit)
+  mockProviderSelectWhere.mockResolvedValue(rows);
+  mockProviderSelectLimit.mockResolvedValue(rows.slice(0, 1));
+}
+
+function setupDbMocks() {
+  mockDb.select.mockImplementation(() => {
+    return {
+      from: (table: { accountId?: string; userId?: string; issuer?: string }) => {
+        const isMembership = table != null && 'userId' in table && !('issuer' in table);
+        const whereFn = (...args: unknown[]) => {
+          if (isMembership) {
+            return {
+              limit: (...limitArgs: unknown[]) => mockMembershipLimit(...limitArgs),
+            };
+          }
+          return {
+            limit: (...limitArgs: unknown[]) => mockProviderSelectLimit(...limitArgs),
+            then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+              Promise.resolve(mockProviderSelectWhere(...args)).then(resolve, reject),
+          };
+        };
+        return { where: whereFn };
+      },
+    };
+  });
+
+  mockDb.insert.mockReturnValue({
+    values: (...args: unknown[]) => mockInsertValues(...args),
+  });
+  mockDb.update.mockReturnValue({
+    set: () => ({
+      where: (...args: unknown[]) => mockUpdateWhere(...args),
+    }),
+  });
+}
+
+describe('pure helpers', () => {
+  it('buildDiscoveryUrl uses discoveryUrl when set', () => {
+    expect(buildDiscoveryUrl('https://idp.example.com/', 'https://custom/.well-known')).toBe(
+      'https://custom/.well-known',
+    );
+  });
+
+  it('buildDiscoveryUrl derives from issuer', () => {
+    expect(buildDiscoveryUrl('https://idp.example.com/')).toBe(
+      'https://idp.example.com/.well-known/openid-configuration',
+    );
+  });
+
+  it('isAllowedDefaultRole / isMutationRole', () => {
+    expect(isAllowedDefaultRole('member')).toBe(true);
+    expect(isAllowedDefaultRole('owner')).toBe(false);
+    expect(isMutationRole('owner')).toBe(true);
+    expect(isMutationRole('member')).toBe(false);
+  });
+
+  it('claimStructurePreview includes group claim', () => {
+    const preview = claimStructurePreview('roles');
+    expect(preview.groupClaim).toBe('roles');
+    expect(preview.standardClaims).toContain('sub');
+  });
+});
+
+describe('SSO provider CRUD + entitlement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDbMocks();
+    mockAccountHasSsoFeature.mockResolvedValue(true);
+    wireMembership('owner');
+    wireProviderList([PROVIDER_ROW]);
+    mockInsertValues.mockResolvedValue(undefined);
+    mockUpdateWhere.mockResolvedValue(undefined);
+    mockFetchOidcDiscovery.mockResolvedValue({
+      ok: true,
+      document: {
+        issuer: 'https://idp.example.com',
+        authorization_endpoint: 'https://idp.example.com/authorize',
+        token_endpoint: 'https://idp.example.com/token',
+        jwks_uri: 'https://idp.example.com/jwks',
+        scopes_supported: ['openid', 'email', 'profile'],
+      },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const app = createApp(null);
+    const res = await app.request('/api/accounts/acct-1/sso-providers');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when sso feature is false', async () => {
+    mockAccountHasSsoFeature.mockResolvedValue(false);
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers');
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/SSO is not enabled/i);
+  });
+
+  it('returns 404 on account mismatch (no membership)', async () => {
+    mockMembershipLimit.mockResolvedValue([]);
+    const app = createApp();
+    const res = await app.request('/api/accounts/other-acct/sso-providers');
+    expect(res.status).toBe(404);
+  });
+
+  it('lists providers for entitled member', async () => {
+    // membership first via limit, then list via where promise
+    mockMembershipLimit.mockResolvedValueOnce([{ accountId: 'acct-1', role: 'owner' }]);
+    mockProviderSelectWhere.mockResolvedValueOnce([PROVIDER_ROW]);
+
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      providers: Array<{ id: string; clientSecretRef: string }>;
+    };
+    expect(body.providers).toHaveLength(1);
+    expect(body.providers[0]?.id).toBe('sso_abc');
+    // secret ref path only — never a resolved secret value
+    expect(body.providers[0]?.clientSecretRef).toBe('REVEALUI_SSO_CLIENT_SECRET');
+  });
+
+  it('rejects mutation for non-owner non-admin membership', async () => {
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'member' }]);
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Okta',
+        providerType: 'oidc',
+        issuer: 'https://idp.example.com',
+        clientId: 'c1',
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('creates an OIDC provider (disabled by default)', async () => {
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
+    // after insert, loadProviderForAccount uses select limit
+    mockProviderSelectLimit.mockResolvedValue([PROVIDER_ROW]);
+
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Okta',
+        providerType: 'oidc',
+        issuer: 'https://idp.example.com',
+        clientId: 'client-1',
+        clientSecretRef: 'REVEALUI_SSO_CLIENT_SECRET',
+      }),
+    });
+    expect(res.status).toBe(201);
+    expect(mockInsertValues).toHaveBeenCalled();
+    const insertArg = mockInsertValues.mock.calls[0]?.[0] as {
+      enabled: boolean;
+      clientSecretRef: string;
+      providerType: string;
+    };
+    expect(insertArg.enabled).toBe(false);
+    expect(insertArg.clientSecretRef).toBe('REVEALUI_SSO_CLIENT_SECRET');
+    expect(insertArg.providerType).toBe('oidc');
+  });
+
+  it('rejects SAML create (planned)', async () => {
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Azure SAML',
+        providerType: 'saml',
+        issuer: 'https://login.microsoftonline.com/tenant',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/OIDC/i);
+  });
+
+  it('returns 404 when provider id is not on the account', async () => {
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
+    mockProviderSelectLimit.mockResolvedValue([]);
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers/wrong-id');
+    expect(res.status).toBe(404);
+  });
+
+  it('test-connection dry-runs discovery without creating a session', async () => {
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers/test-connection', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        issuer: 'https://idp.example.com',
+        groupClaim: 'groups',
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      discovery: { jwksUri: string };
+      claimStructurePreview: { groupClaim: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.discovery.jwksUri).toBe('https://idp.example.com/jwks');
+    expect(body.claimStructurePreview.groupClaim).toBe('groups');
+    expect(mockFetchOidcDiscovery).toHaveBeenCalled();
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it('test-connection returns ok:false on discovery failure', async () => {
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
+    mockFetchOidcDiscovery.mockResolvedValue({
+      ok: false,
+      reason: 'fetch_failed',
+      message: 'discovery HTTP 500',
+    });
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers/test-connection', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ issuer: 'https://idp.example.com' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; reason: string };
+    expect(body.ok).toBe(false);
+    expect(body.reason).toBe('fetch_failed');
+  });
+
+  it('GET /current reports ssoFeature false when not entitled', async () => {
+    mockAccountHasSsoFeature.mockResolvedValue(false);
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
+    const app = createApp();
+    const res = await app.request('/api/accounts/current');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { accountId: string; ssoFeature: boolean };
+    expect(body.accountId).toBe('acct-1');
+    expect(body.ssoFeature).toBe(false);
+  });
+});

--- a/apps/server/src/routes/sso-providers.ts
+++ b/apps/server/src/routes/sso-providers.ts
@@ -1,0 +1,775 @@
+/**
+ * Account-scoped SSO provider admin API (GAP-464).
+ *
+ * GET    /accounts/current
+ * GET    /accounts/:accountId/sso-providers
+ * POST   /accounts/:accountId/sso-providers
+ * GET    /accounts/:accountId/sso-providers/:providerId
+ * PATCH  /accounts/:accountId/sso-providers/:providerId
+ * DELETE /accounts/:accountId/sso-providers/:providerId
+ * POST   /accounts/:accountId/sso-providers/test-connection
+ * POST   /accounts/:accountId/sso-providers/:providerId/test-connection
+ *
+ * Mounted at /api and /api/v1 so paths are /api/accounts/...
+ *
+ * Security hardlines:
+ * - Auth required
+ * - Membership on path accountId (never trust path alone)
+ * - accountHasSsoFeature fail-closed → 403
+ * - Provider rows always selected/updated with accountId + id
+ * - client_secret_ref stored as path string only; never resolved or logged
+ * - Mutations require owner/admin membership role
+ */
+
+import { randomUUID } from 'node:crypto';
+import { fetchOidcDiscovery } from '@revealui/auth/server';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { accountMemberships, accountSsoProviders } from '@revealui/db/schema';
+import { and, eq, isNull } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { accountHasSsoFeature } from '../lib/account-entitlement.js';
+import { getEntitlementsFromContext } from '../middleware/entitlements.js';
+
+const app = new Hono();
+
+const ALLOWED_DEFAULT_ROLES = new Set(['viewer', 'member', 'editor', 'admin']);
+const MUTATION_ROLES = new Set(['owner', 'admin']);
+
+interface UserContext {
+  id: string;
+  email: string | null;
+  name: string;
+  role: string;
+}
+
+interface MembershipRow {
+  accountId: string;
+  role: string;
+}
+
+interface ProviderPublic {
+  id: string;
+  accountId: string;
+  providerType: 'oidc' | 'saml';
+  name: string;
+  enabled: boolean;
+  issuer: string;
+  discoveryUrl: string | null;
+  clientId: string | null;
+  /** Vault path / env var name only — never a resolved secret */
+  clientSecretRef: string | null;
+  groupClaim: string;
+  groupRoleMap: Record<string, string>;
+  defaultRole: string;
+  requireGroupMatch: boolean;
+  allowPasswordFallback: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CreateBody {
+  name?: unknown;
+  providerType?: unknown;
+  issuer?: unknown;
+  discoveryUrl?: unknown;
+  clientId?: unknown;
+  clientSecretRef?: unknown;
+  groupClaim?: unknown;
+  groupRoleMap?: unknown;
+  defaultRole?: unknown;
+  requireGroupMatch?: unknown;
+  allowPasswordFallback?: unknown;
+  enabled?: unknown;
+}
+
+interface UpdateBody extends CreateBody {}
+
+interface TestConnectionBody {
+  issuer?: unknown;
+  discoveryUrl?: unknown;
+  groupClaim?: unknown;
+  providerId?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+export function buildDiscoveryUrl(issuer: string, discoveryUrl?: string | null): string {
+  if (discoveryUrl && discoveryUrl.trim().length > 0) {
+    return discoveryUrl.trim();
+  }
+  const base = issuer.replace(/\/+$/, '');
+  return `${base}/.well-known/openid-configuration`;
+}
+
+export function isAllowedDefaultRole(role: string): boolean {
+  return ALLOWED_DEFAULT_ROLES.has(role);
+}
+
+export function isMutationRole(role: string): boolean {
+  return MUTATION_ROLES.has(role);
+}
+
+export function claimStructurePreview(groupClaim: string): {
+  standardClaims: string[];
+  groupClaim: string;
+  notes: string[];
+} {
+  return {
+    standardClaims: ['sub', 'iss', 'aud', 'exp', 'iat', 'email', 'email_verified', 'name'],
+    groupClaim,
+    notes: [
+      'Dry-run discovery does not issue tokens. Claim values appear only after a real SSO login.',
+      `Groups are read from the "${groupClaim}" claim when mapping roles.`,
+    ],
+  };
+}
+
+function requireUser(c: { get: (key: string) => unknown }): UserContext {
+  const user = c.get('user') as UserContext | undefined;
+  if (!user?.id) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+  return user;
+}
+
+function asNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new HTTPException(400, { message: `${field} is required` });
+  }
+  return value.trim();
+}
+
+function asOptionalString(value: unknown): string | null {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value !== 'string') {
+    throw new HTTPException(400, { message: 'Expected string or null' });
+  }
+  return value.trim();
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  if (typeof value !== 'boolean') {
+    throw new HTTPException(400, { message: 'Expected boolean' });
+  }
+  return value;
+}
+
+function asGroupRoleMap(value: unknown): Record<string, string> {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new HTTPException(400, { message: 'groupRoleMap must be an object' });
+  }
+  const out: Record<string, string> = {};
+  for (const [key, mapped] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof mapped !== 'string' || mapped.trim().length === 0) {
+      throw new HTTPException(400, { message: 'groupRoleMap values must be non-empty strings' });
+    }
+    if (!isAllowedDefaultRole(mapped.trim()) && mapped.trim() !== 'owner') {
+      throw new HTTPException(400, {
+        message: `groupRoleMap role "${mapped}" is not allowed`,
+      });
+    }
+    // Never allow map values of owner via untrusted config? Spec: never grant admin
+    // from unmapped groups. Explicit map to admin is allowed. Owner is account-level
+    // and should not come from IdP maps in MVP.
+    if (mapped.trim() === 'owner') {
+      throw new HTTPException(400, { message: 'groupRoleMap cannot assign owner' });
+    }
+    out[key] = mapped.trim();
+  }
+  return out;
+}
+
+function toPublic(row: {
+  id: string;
+  accountId: string;
+  providerType: string;
+  name: string;
+  enabled: boolean;
+  issuer: string;
+  discoveryUrl: string | null;
+  clientId: string | null;
+  clientSecretRef: string | null;
+  groupClaim: string;
+  groupRoleMap: unknown;
+  defaultRole: string;
+  requireGroupMatch: boolean;
+  allowPasswordFallback: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}): ProviderPublic {
+  return {
+    id: row.id,
+    accountId: row.accountId,
+    providerType: row.providerType as 'oidc' | 'saml',
+    name: row.name,
+    enabled: row.enabled,
+    issuer: row.issuer,
+    discoveryUrl: row.discoveryUrl,
+    clientId: row.clientId,
+    clientSecretRef: row.clientSecretRef,
+    groupClaim: row.groupClaim,
+    groupRoleMap: (row.groupRoleMap ?? {}) as Record<string, string>,
+    defaultRole: row.defaultRole,
+    requireGroupMatch: row.requireGroupMatch,
+    allowPasswordFallback: row.allowPasswordFallback,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+async function loadMembership(userId: string, accountId: string): Promise<MembershipRow | null> {
+  const db = getClient();
+  const [row] = await db
+    .select({
+      accountId: accountMemberships.accountId,
+      role: accountMemberships.role,
+    })
+    .from(accountMemberships)
+    .where(
+      and(
+        eq(accountMemberships.userId, userId),
+        eq(accountMemberships.accountId, accountId),
+        eq(accountMemberships.status, 'active'),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Auth + membership + SSO entitlement for path accountId.
+ * Returns membership role when authorized.
+ */
+async function authorizeAccountAccess(
+  c: { get: (key: string) => unknown },
+  accountId: string,
+  opts: { mutation: boolean },
+): Promise<{ user: UserContext; membership: MembershipRow }> {
+  const user = requireUser(c);
+  if (!accountId || accountId.trim().length === 0) {
+    throw new HTTPException(400, { message: 'accountId is required' });
+  }
+
+  const membership = await loadMembership(user.id, accountId);
+  if (!membership) {
+    // Account mismatch / non-member: do not leak existence
+    throw new HTTPException(404, { message: 'Account not found' });
+  }
+
+  if (opts.mutation && !isMutationRole(membership.role)) {
+    throw new HTTPException(403, {
+      message: 'Only account owners and admins can manage SSO providers',
+    });
+  }
+
+  const db = getClient();
+  const entitled = await accountHasSsoFeature(db, accountId);
+  if (!entitled) {
+    throw new HTTPException(403, { message: 'SSO is not enabled for this account' });
+  }
+
+  return { user, membership };
+}
+
+async function loadProviderForAccount(
+  providerId: string,
+  accountId: string,
+): Promise<ReturnType<typeof toPublic> | null> {
+  const db = getClient();
+  const [row] = await db
+    .select()
+    .from(accountSsoProviders)
+    .where(
+      and(
+        eq(accountSsoProviders.id, providerId),
+        eq(accountSsoProviders.accountId, accountId),
+        isNull(accountSsoProviders.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+  return toPublic(row);
+}
+
+function logConfigChange(
+  action: string,
+  fields: {
+    accountId: string;
+    providerId?: string;
+    userId: string;
+    issuer?: string;
+  },
+): void {
+  logger.info('sso_config_changed', {
+    event: 'sso_config_changed',
+    action,
+    accountId: fields.accountId,
+    providerId: fields.providerId,
+    userId: fields.userId,
+    issuer: fields.issuer,
+    // Never log clientSecretRef resolved values; ref path is ok if needed later
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GET /current — resolve caller's account for admin UI bootstrap
+// ---------------------------------------------------------------------------
+
+app.get('/current', async (c) => {
+  const user = requireUser(c);
+  const entitlements = getEntitlementsFromContext(c);
+  const accountId = entitlements.accountId;
+
+  if (!accountId) {
+    return c.json(
+      {
+        accountId: null,
+        membershipRole: null,
+        ssoFeature: false,
+      },
+      200,
+    );
+  }
+
+  // Re-check membership + entitlement explicitly (fail closed on race)
+  const membership = await loadMembership(user.id, accountId);
+  if (!membership) {
+    return c.json(
+      {
+        accountId: null,
+        membershipRole: null,
+        ssoFeature: false,
+      },
+      200,
+    );
+  }
+
+  const db = getClient();
+  const ssoFeature = await accountHasSsoFeature(db, accountId);
+
+  return c.json(
+    {
+      accountId,
+      membershipRole: membership.role,
+      ssoFeature,
+    },
+    200,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// POST /:accountId/sso-providers/test-connection (before :providerId routes)
+// ---------------------------------------------------------------------------
+
+app.post('/:accountId/sso-providers/test-connection', async (c) => {
+  const accountId = c.req.param('accountId');
+  await authorizeAccountAccess(c, accountId, { mutation: true });
+
+  let body: TestConnectionBody = {};
+  try {
+    body = (await c.req.json()) as TestConnectionBody;
+  } catch {
+    body = {};
+  }
+
+  let issuer = typeof body.issuer === 'string' ? body.issuer.trim() : '';
+  let discoveryUrl =
+    typeof body.discoveryUrl === 'string' && body.discoveryUrl.trim().length > 0
+      ? body.discoveryUrl.trim()
+      : null;
+  let groupClaim =
+    typeof body.groupClaim === 'string' && body.groupClaim.trim().length > 0
+      ? body.groupClaim.trim()
+      : 'groups';
+
+  const providerId =
+    typeof body.providerId === 'string' && body.providerId.trim().length > 0
+      ? body.providerId.trim()
+      : null;
+
+  if (providerId) {
+    const existing = await loadProviderForAccount(providerId, accountId);
+    if (!existing) {
+      throw new HTTPException(404, { message: 'SSO provider not found' });
+    }
+    if (!issuer) issuer = existing.issuer;
+    if (!discoveryUrl) discoveryUrl = existing.discoveryUrl;
+    if (groupClaim === 'groups' && existing.groupClaim) groupClaim = existing.groupClaim;
+  }
+
+  if (!issuer) {
+    throw new HTTPException(400, { message: 'issuer is required for test connection' });
+  }
+
+  const url = buildDiscoveryUrl(issuer, discoveryUrl);
+  const result = await fetchOidcDiscovery(url, { expectedIssuer: issuer });
+
+  if (!result.ok) {
+    return c.json(
+      {
+        ok: false as const,
+        reason: result.reason,
+        message: result.message,
+        discoveryUrl: url,
+      },
+      200,
+    );
+  }
+
+  const doc = result.document;
+  return c.json(
+    {
+      ok: true as const,
+      discoveryUrl: url,
+      discovery: {
+        issuer: doc.issuer,
+        authorizationEndpoint: doc.authorization_endpoint,
+        tokenEndpoint: doc.token_endpoint,
+        jwksUri: doc.jwks_uri,
+        userinfoEndpoint: doc.userinfo_endpoint ?? null,
+        endSessionEndpoint: doc.end_session_endpoint ?? null,
+        scopesSupported: doc.scopes_supported ?? [],
+        responseTypesSupported: doc.response_types_supported ?? [],
+        codeChallengeMethodsSupported: doc.code_challenge_methods_supported ?? [],
+      },
+      claimStructurePreview: claimStructurePreview(groupClaim),
+    },
+    200,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// POST /:accountId/sso-providers/:providerId/test-connection
+// ---------------------------------------------------------------------------
+
+app.post('/:accountId/sso-providers/:providerId/test-connection', async (c) => {
+  const accountId = c.req.param('accountId');
+  const providerId = c.req.param('providerId');
+  await authorizeAccountAccess(c, accountId, { mutation: true });
+
+  const existing = await loadProviderForAccount(providerId, accountId);
+  if (!existing) {
+    throw new HTTPException(404, { message: 'SSO provider not found' });
+  }
+
+  const url = buildDiscoveryUrl(existing.issuer, existing.discoveryUrl);
+  const result = await fetchOidcDiscovery(url, { expectedIssuer: existing.issuer });
+
+  if (!result.ok) {
+    return c.json(
+      {
+        ok: false as const,
+        reason: result.reason,
+        message: result.message,
+        discoveryUrl: url,
+      },
+      200,
+    );
+  }
+
+  const doc = result.document;
+  return c.json(
+    {
+      ok: true as const,
+      discoveryUrl: url,
+      discovery: {
+        issuer: doc.issuer,
+        authorizationEndpoint: doc.authorization_endpoint,
+        tokenEndpoint: doc.token_endpoint,
+        jwksUri: doc.jwks_uri,
+        userinfoEndpoint: doc.userinfo_endpoint ?? null,
+        endSessionEndpoint: doc.end_session_endpoint ?? null,
+        scopesSupported: doc.scopes_supported ?? [],
+        responseTypesSupported: doc.response_types_supported ?? [],
+        codeChallengeMethodsSupported: doc.code_challenge_methods_supported ?? [],
+      },
+      claimStructurePreview: claimStructurePreview(existing.groupClaim),
+    },
+    200,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// GET /:accountId/sso-providers
+// ---------------------------------------------------------------------------
+
+app.get('/:accountId/sso-providers', async (c) => {
+  const accountId = c.req.param('accountId');
+  await authorizeAccountAccess(c, accountId, { mutation: false });
+
+  const db = getClient();
+  const rows = await db
+    .select()
+    .from(accountSsoProviders)
+    .where(
+      and(eq(accountSsoProviders.accountId, accountId), isNull(accountSsoProviders.deletedAt)),
+    );
+
+  return c.json({ providers: rows.map(toPublic) }, 200);
+});
+
+// ---------------------------------------------------------------------------
+// POST /:accountId/sso-providers
+// ---------------------------------------------------------------------------
+
+app.post('/:accountId/sso-providers', async (c) => {
+  const accountId = c.req.param('accountId');
+  const { user } = await authorizeAccountAccess(c, accountId, { mutation: true });
+
+  let body: CreateBody;
+  try {
+    body = (await c.req.json()) as CreateBody;
+  } catch {
+    throw new HTTPException(400, { message: 'Invalid JSON body' });
+  }
+
+  const name = asNonEmptyString(body.name, 'name');
+  const providerTypeRaw = asNonEmptyString(body.providerType ?? 'oidc', 'providerType');
+  if (providerTypeRaw !== 'oidc') {
+    throw new HTTPException(400, {
+      message: 'Only OIDC providers are supported in this release. SAML is planned.',
+    });
+  }
+
+  const issuer = asNonEmptyString(body.issuer, 'issuer');
+  const discoveryUrl = asOptionalString(body.discoveryUrl);
+  const clientId = asOptionalString(body.clientId);
+  const clientSecretRef = asOptionalString(body.clientSecretRef);
+  const groupClaim =
+    typeof body.groupClaim === 'string' && body.groupClaim.trim().length > 0
+      ? body.groupClaim.trim()
+      : 'groups';
+  const groupRoleMap = asGroupRoleMap(body.groupRoleMap);
+  const defaultRole =
+    typeof body.defaultRole === 'string' && body.defaultRole.trim().length > 0
+      ? body.defaultRole.trim()
+      : 'member';
+  if (!isAllowedDefaultRole(defaultRole)) {
+    throw new HTTPException(400, { message: `defaultRole "${defaultRole}" is not allowed` });
+  }
+  const requireGroupMatch = asBoolean(body.requireGroupMatch, false);
+  const allowPasswordFallback = asBoolean(body.allowPasswordFallback, false);
+  // Default disabled until test-connection succeeds (UI); server allows explicit true
+  const enabled = asBoolean(body.enabled, false);
+
+  const id = `sso_${randomUUID().replace(/-/g, '')}`;
+  const db = getClient();
+
+  try {
+    await db.insert(accountSsoProviders).values({
+      id,
+      accountId,
+      providerType: 'oidc',
+      name,
+      enabled,
+      issuer,
+      discoveryUrl,
+      clientId,
+      clientSecretRef,
+      groupClaim,
+      groupRoleMap,
+      defaultRole,
+      requireGroupMatch,
+      allowPasswordFallback,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (
+      message.includes('account_sso_providers_account_issuer_active_idx') ||
+      message.includes('unique')
+    ) {
+      throw new HTTPException(409, {
+        message: 'An SSO provider with this issuer already exists for the account',
+      });
+    }
+    throw err;
+  }
+
+  const created = await loadProviderForAccount(id, accountId);
+  if (!created) {
+    throw new HTTPException(500, { message: 'Failed to load created provider' });
+  }
+
+  logConfigChange('create', {
+    accountId,
+    providerId: id,
+    userId: user.id,
+    issuer,
+  });
+
+  return c.json({ provider: created }, 201);
+});
+
+// ---------------------------------------------------------------------------
+// GET /:accountId/sso-providers/:providerId
+// ---------------------------------------------------------------------------
+
+app.get('/:accountId/sso-providers/:providerId', async (c) => {
+  const accountId = c.req.param('accountId');
+  const providerId = c.req.param('providerId');
+  await authorizeAccountAccess(c, accountId, { mutation: false });
+
+  const provider = await loadProviderForAccount(providerId, accountId);
+  if (!provider) {
+    throw new HTTPException(404, { message: 'SSO provider not found' });
+  }
+  return c.json({ provider }, 200);
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /:accountId/sso-providers/:providerId
+// ---------------------------------------------------------------------------
+
+app.patch('/:accountId/sso-providers/:providerId', async (c) => {
+  const accountId = c.req.param('accountId');
+  const providerId = c.req.param('providerId');
+  const { user } = await authorizeAccountAccess(c, accountId, { mutation: true });
+
+  const existing = await loadProviderForAccount(providerId, accountId);
+  if (!existing) {
+    throw new HTTPException(404, { message: 'SSO provider not found' });
+  }
+
+  let body: UpdateBody;
+  try {
+    body = (await c.req.json()) as UpdateBody;
+  } catch {
+    throw new HTTPException(400, { message: 'Invalid JSON body' });
+  }
+
+  if (body.providerType !== undefined) {
+    const pt = asNonEmptyString(body.providerType, 'providerType');
+    if (pt !== 'oidc') {
+      throw new HTTPException(400, {
+        message: 'Only OIDC providers are supported in this release. SAML is planned.',
+      });
+    }
+  }
+
+  const patch: Partial<{
+    name: string;
+    enabled: boolean;
+    issuer: string;
+    discoveryUrl: string | null;
+    clientId: string | null;
+    clientSecretRef: string | null;
+    groupClaim: string;
+    groupRoleMap: Record<string, string>;
+    defaultRole: string;
+    requireGroupMatch: boolean;
+    allowPasswordFallback: boolean;
+    updatedAt: Date;
+  }> = { updatedAt: new Date() };
+
+  if (body.name !== undefined) patch.name = asNonEmptyString(body.name, 'name');
+  if (body.issuer !== undefined) patch.issuer = asNonEmptyString(body.issuer, 'issuer');
+  if (body.discoveryUrl !== undefined) patch.discoveryUrl = asOptionalString(body.discoveryUrl);
+  if (body.clientId !== undefined) patch.clientId = asOptionalString(body.clientId);
+  if (body.clientSecretRef !== undefined) {
+    patch.clientSecretRef = asOptionalString(body.clientSecretRef);
+  }
+  if (body.groupClaim !== undefined) {
+    patch.groupClaim = asNonEmptyString(body.groupClaim, 'groupClaim');
+  }
+  if (body.groupRoleMap !== undefined) patch.groupRoleMap = asGroupRoleMap(body.groupRoleMap);
+  if (body.defaultRole !== undefined) {
+    const role = asNonEmptyString(body.defaultRole, 'defaultRole');
+    if (!isAllowedDefaultRole(role)) {
+      throw new HTTPException(400, { message: `defaultRole "${role}" is not allowed` });
+    }
+    patch.defaultRole = role;
+  }
+  if (body.requireGroupMatch !== undefined) {
+    patch.requireGroupMatch = asBoolean(body.requireGroupMatch, false);
+  }
+  if (body.allowPasswordFallback !== undefined) {
+    patch.allowPasswordFallback = asBoolean(body.allowPasswordFallback, false);
+  }
+  if (body.enabled !== undefined) {
+    patch.enabled = asBoolean(body.enabled, false);
+  }
+
+  const db = getClient();
+  try {
+    await db
+      .update(accountSsoProviders)
+      .set(patch)
+      .where(
+        and(
+          eq(accountSsoProviders.id, providerId),
+          eq(accountSsoProviders.accountId, accountId),
+          isNull(accountSsoProviders.deletedAt),
+        ),
+      );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (
+      message.includes('account_sso_providers_account_issuer_active_idx') ||
+      message.includes('unique')
+    ) {
+      throw new HTTPException(409, {
+        message: 'An SSO provider with this issuer already exists for the account',
+      });
+    }
+    throw err;
+  }
+
+  const updated = await loadProviderForAccount(providerId, accountId);
+  if (!updated) {
+    throw new HTTPException(404, { message: 'SSO provider not found' });
+  }
+
+  logConfigChange('update', {
+    accountId,
+    providerId,
+    userId: user.id,
+    issuer: updated.issuer,
+  });
+
+  return c.json({ provider: updated }, 200);
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /:accountId/sso-providers/:providerId (soft delete)
+// ---------------------------------------------------------------------------
+
+app.delete('/:accountId/sso-providers/:providerId', async (c) => {
+  const accountId = c.req.param('accountId');
+  const providerId = c.req.param('providerId');
+  const { user } = await authorizeAccountAccess(c, accountId, { mutation: true });
+
+  const existing = await loadProviderForAccount(providerId, accountId);
+  if (!existing) {
+    throw new HTTPException(404, { message: 'SSO provider not found' });
+  }
+
+  const db = getClient();
+  const now = new Date();
+  await db
+    .update(accountSsoProviders)
+    .set({ deletedAt: now, enabled: false, updatedAt: now })
+    .where(
+      and(
+        eq(accountSsoProviders.id, providerId),
+        eq(accountSsoProviders.accountId, accountId),
+        isNull(accountSsoProviders.deletedAt),
+      ),
+    );
+
+  logConfigChange('delete', {
+    accountId,
+    providerId,
+    userId: user.id,
+    issuer: existing.issuer,
+  });
+
+  return c.json({ ok: true }, 200);
+});
+
+export default app;


### PR DESCRIPTION
## Summary

GAP-464 Admin SSO configuration UI + account-scoped CRUD API with OIDC test-connection dry-run.

### Server (`/api/accounts/...`)
- `GET /current` — resolve caller account + `ssoFeature`
- `GET|POST /:accountId/sso-providers`
- `GET|PATCH|DELETE /:accountId/sso-providers/:providerId`
- `POST /:accountId/sso-providers/test-connection` (+ per-provider variant)
- Membership-scoped access; mutations require owner/admin
- `accountHasSsoFeature` fail-closed → 403
- Account mismatch / non-member → 404
- Stores `client_secret_ref` path only (never resolved/logged)
- OIDC only; SAML create rejected as planned
- Rate limit `sso-providers` on `/api/accounts/*`

### Admin UI (`/settings/sso`)
- Settings nav entry + `LicenseGate feature="sso"`
- List / create / edit / soft-delete OIDC providers
- Test connection: discovery dry-run + claim structure preview (no session)
- Enable prefers successful test; confirm-to-enable-without-test allowed

## Security surface
- Auth required; membership + entitlement on every path
- Never load provider by id alone (always `accountId` + `id`)
- Secrets: ref strings only; no resolved secret logging
- Mutations rate-limited; soft-delete clears `enabled`

## Tests
- Route unit: 15 tests (401, 403 entitlement, 404 mismatch, CRUD, SAML reject, test-connection)
- Component RTL: 5 tests (gate, list, form, test-connection preview)

```
pnpm --filter server exec vitest run src/routes/__tests__/sso-providers.test.ts
# 15 passed
cd apps/admin && pnpm exec vitest run 'src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx'
# 5 passed
```

Local pre-push gate phase 1: PASS

## Residuals
- SAML admin UI (out of scope)
- SCIM / full audit event types beyond `sso_config_changed` logger
- Claim-gates copy release train (still waiting on full capability close)
- Optional: require successful test-connection server-side before first enable

## Owner actions
Do not self-merge. Review + merge when green:
```
gh pr merge <N> --merge
```