### PR TITLE
feat(auth): GAP-464 Phase 3 SAML SP-initiated SSO

### DIFF
--- a/apps/server/src/routes/__tests__/auth-sso.test.ts
+++ b/apps/server/src/routes/__tests__/auth-sso.test.ts
@@ -68,6 +68,10 @@ vi.mock('@revealui/db/schema', () => ({
     discoveryUrl: 'accountSsoProviders.discoveryUrl',
     clientId: 'accountSsoProviders.clientId',
     clientSecretRef: 'accountSsoProviders.clientSecretRef',
+    samlMetadataUrl: 'accountSsoProviders.samlMetadataUrl',
+    samlMetadataXml: 'accountSsoProviders.samlMetadataXml',
+    samlSpEntityId: 'accountSsoProviders.samlSpEntityId',
+    signingCertPem: 'accountSsoProviders.signingCertPem',
     groupClaim: 'accountSsoProviders.groupClaim',
     groupRoleMap: 'accountSsoProviders.groupRoleMap',
     defaultRole: 'accountSsoProviders.defaultRole',
@@ -91,6 +95,11 @@ vi.mock('@revealui/auth/server', () => ({
   mapSsoGroupsToRole: (...args: unknown[]) => mockMapSsoGroupsToRole(...args),
   upsertSsoUser: (...args: unknown[]) => mockUpsertSsoUser(...args),
   createSession: (...args: unknown[]) => mockCreateSession(...args),
+  buildSamlAuthorizeUrl: vi.fn(),
+  buildSamlSpMetadata: vi.fn(),
+  fetchIdpMetadata: vi.fn(),
+  parseIdpMetadataXml: vi.fn(),
+  validateSamlPostResponse: vi.fn(),
 }));
 
 import { Hono } from 'hono';

--- a/apps/server/src/routes/auth-sso.ts
+++ b/apps/server/src/routes/auth-sso.ts
@@ -1,30 +1,38 @@
 /**
- * Enterprise SSO OIDC routes (GAP-464 Phase 2 residual).
+ * Enterprise SSO routes (GAP-464) — OIDC + SAML SP-initiated.
  *
- * GET /sso/:providerId/init?accountId=&redirectTo=
- * GET /sso/:providerId/callback
+ * GET  /sso/:providerId/init?accountId=&redirectTo=
+ * GET  /sso/:providerId/callback          (OIDC code)
+ * POST /sso/:providerId/callback          (SAML ACS HTTP-POST)
+ * GET  /sso/saml/metadata?accountId=&providerId=  (SP metadata XML)
  *
  * Mounted at /api/auth (and /api/v1/auth) so paths are /api/auth/sso/...
  *
  * Security hardlines:
- * - Provider load is always account-scoped (id + accountId + enabled + oidc)
+ * - Provider load is always account-scoped (id + accountId + enabled)
  * - accountHasSsoFeature on init and callback (fail closed)
  * - Signed sso_state cookie (HMAC via REVEALUI_SECRET)
- * - id_token signature validation required (never skip)
+ * - id_token / SAML Response signature validation required (never skip)
  * - Open-redirect: only relative paths starting with /
  * - Client secrets from env refs only; never logged
  */
 
 import {
   buildOidcAuthorizationUrl,
+  buildSamlAuthorizeUrl,
+  buildSamlSpMetadata,
   createOidcRemoteJwkSet,
   createSession,
   exchangeOidcCode,
+  fetchIdpMetadata,
   fetchOidcDiscovery,
   generateSsoState,
   mapSsoGroupsToRole,
+  parseIdpMetadataXml,
+  type SamlSpConfig,
   upsertSsoUser,
   validateOidcIdToken,
+  validateSamlPostResponse,
   verifySsoState,
 } from '@revealui/auth/server';
 import { logger } from '@revealui/core/observability/logger';
@@ -155,17 +163,32 @@ interface LoadedSsoProvider {
   discoveryUrl: string | null;
   clientId: string | null;
   clientSecretRef: string | null;
+  samlMetadataUrl: string | null;
+  samlMetadataXml: string | null;
+  samlSpEntityId: string | null;
+  signingCertPem: string | null;
   groupClaim: string;
   groupRoleMap: Record<string, string>;
   defaultRole: string;
   requireGroupMatch: boolean;
 }
 
-async function loadEnabledOidcProvider(
+async function loadEnabledSsoProvider(
   providerId: string,
   accountId: string,
+  providerType?: 'oidc' | 'saml',
 ): Promise<LoadedSsoProvider | null> {
   const db = getClient();
+  const filters = [
+    eq(accountSsoProviders.id, providerId),
+    eq(accountSsoProviders.accountId, accountId),
+    eq(accountSsoProviders.enabled, true),
+    isNull(accountSsoProviders.deletedAt),
+  ];
+  if (providerType) {
+    filters.push(eq(accountSsoProviders.providerType, providerType));
+  }
+
   const [row] = await db
     .select({
       id: accountSsoProviders.id,
@@ -176,27 +199,103 @@ async function loadEnabledOidcProvider(
       discoveryUrl: accountSsoProviders.discoveryUrl,
       clientId: accountSsoProviders.clientId,
       clientSecretRef: accountSsoProviders.clientSecretRef,
+      samlMetadataUrl: accountSsoProviders.samlMetadataUrl,
+      samlMetadataXml: accountSsoProviders.samlMetadataXml,
+      samlSpEntityId: accountSsoProviders.samlSpEntityId,
+      signingCertPem: accountSsoProviders.signingCertPem,
       groupClaim: accountSsoProviders.groupClaim,
       groupRoleMap: accountSsoProviders.groupRoleMap,
       defaultRole: accountSsoProviders.defaultRole,
       requireGroupMatch: accountSsoProviders.requireGroupMatch,
     })
     .from(accountSsoProviders)
-    .where(
-      and(
-        eq(accountSsoProviders.id, providerId),
-        eq(accountSsoProviders.accountId, accountId),
-        eq(accountSsoProviders.enabled, true),
-        eq(accountSsoProviders.providerType, 'oidc'),
-        isNull(accountSsoProviders.deletedAt),
-      ),
-    )
+    .where(and(...filters))
     .limit(1);
 
   if (!row) return null;
   return {
     ...row,
     groupRoleMap: (row.groupRoleMap ?? {}) as Record<string, string>,
+  };
+}
+
+/** @deprecated use loadEnabledSsoProvider — kept name for existing tests that mock select only */
+async function loadEnabledOidcProvider(
+  providerId: string,
+  accountId: string,
+): Promise<LoadedSsoProvider | null> {
+  return loadEnabledSsoProvider(providerId, accountId, 'oidc');
+}
+
+/**
+ * Resolve SAML SP config from provider row + optional metadata.
+ * IdP cert is required (signature hardline).
+ */
+export async function resolveSamlSpConfig(
+  provider: LoadedSsoProvider,
+  callbackUrl: string,
+): Promise<{ ok: true; config: SamlSpConfig } | { ok: false; reason: string; message: string }> {
+  const spEntityId =
+    (provider.samlSpEntityId && provider.samlSpEntityId.trim()) ||
+    process.env.REVEALUI_SSO_SP_ENTITY_ID?.trim() ||
+    callbackUrl;
+
+  let entryPoint: string | null = null;
+  let idpCertPem: string | null =
+    provider.signingCertPem && provider.signingCertPem.trim().length > 0
+      ? provider.signingCertPem
+      : null;
+
+  if (provider.samlMetadataXml && provider.samlMetadataXml.trim().length > 0) {
+    const parsed = parseIdpMetadataXml(provider.samlMetadataXml);
+    if (parsed.ok) {
+      entryPoint = parsed.entryPoint;
+      if (!idpCertPem) idpCertPem = parsed.idpCertPem;
+    }
+  }
+
+  if (!entryPoint && provider.samlMetadataUrl && provider.samlMetadataUrl.trim().length > 0) {
+    const fetched = await fetchIdpMetadata(provider.samlMetadataUrl);
+    if (fetched.ok) {
+      entryPoint = fetched.entryPoint;
+      if (!idpCertPem) idpCertPem = fetched.idpCertPem;
+    } else {
+      return {
+        ok: false,
+        reason: `metadata_${fetched.reason}`,
+        message: fetched.message,
+      };
+    }
+  }
+
+  // Last resort: issuer as entryPoint only when it looks like an absolute URL path endpoint
+  if (!entryPoint && provider.issuer.startsWith('https://') && provider.issuer.includes('/')) {
+    entryPoint = provider.issuer;
+  }
+
+  if (!entryPoint) {
+    return {
+      ok: false,
+      reason: 'missing_entry_point',
+      message: 'SAML provider needs metadata (XML/URL) with SingleSignOnService Location',
+    };
+  }
+  if (!idpCertPem) {
+    return {
+      ok: false,
+      reason: 'missing_idp_cert',
+      message: 'SAML provider needs signingCertPem or cert in IdP metadata',
+    };
+  }
+
+  return {
+    ok: true,
+    config: {
+      spEntityId,
+      callbackUrl,
+      entryPoint,
+      idpCertPem,
+    },
   };
 }
 
@@ -217,6 +316,51 @@ function clientIp(c: {
 }
 
 // ---------------------------------------------------------------------------
+// GET /sso/saml/metadata — SP metadata for customer IdP configuration
+// ---------------------------------------------------------------------------
+
+app.get('/sso/saml/metadata', async (c) => {
+  const accountId = c.req.query('accountId');
+  const providerId = c.req.query('providerId');
+  if (!accountId || !providerId) {
+    return c.json({ error: 'accountId and providerId query parameters are required' }, 400);
+  }
+
+  const provider = await loadEnabledSsoProvider(providerId, accountId, 'saml');
+  if (!provider) {
+    return c.json({ error: 'SSO provider not found' }, 404);
+  }
+
+  const db = getClient();
+  const entitled = await accountHasSsoFeature(db, accountId);
+  if (!entitled) {
+    return c.json({ error: 'SSO is not enabled for this account' }, 403);
+  }
+
+  const callbackUrl = `${apiBaseUrl()}/api/auth/sso/${providerId}/callback`;
+  const resolved = await resolveSamlSpConfig(provider, callbackUrl);
+  if (!resolved.ok) {
+    return c.json({ error: resolved.message }, 500);
+  }
+
+  try {
+    const xml = buildSamlSpMetadata(resolved.config);
+    return new Response(xml, {
+      status: 200,
+      headers: { 'Content-Type': 'application/samlmetadata+xml; charset=utf-8' },
+    });
+  } catch (err) {
+    logger.error('sso_metadata_failed', {
+      event: 'sso_metadata_failed',
+      providerId,
+      accountId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return c.json({ error: 'Failed to generate SP metadata' }, 500);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // GET /sso/:providerId/init
 // ---------------------------------------------------------------------------
 
@@ -234,7 +378,7 @@ app.get('/sso/:providerId/init', async (c) => {
     return c.json({ error: 'accountId query parameter is required' }, 400);
   }
 
-  const provider = await loadEnabledOidcProvider(providerId, accountId);
+  const provider = await loadEnabledSsoProvider(providerId, accountId);
   if (!provider) {
     logger.warn('sso_login_failure', {
       event: 'sso_login_failure',
@@ -257,6 +401,62 @@ app.get('/sso/:providerId/init', async (c) => {
     return c.json({ error: 'SSO is not enabled for this account' }, 403);
   }
 
+  let stateResult: ReturnType<typeof generateSsoState>;
+  try {
+    stateResult = generateSsoState({
+      accountId,
+      providerId,
+      redirectTo,
+    });
+  } catch (err) {
+    logger.error('sso_login_failure', {
+      event: 'sso_login_failure',
+      reason: 'state_generation_failed',
+      providerId,
+      accountId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return c.json({ error: 'SSO state generation failed' }, 500);
+  }
+
+  const callbackUrl = `${apiBaseUrl()}/api/auth/sso/${providerId}/callback`;
+
+  // ---- SAML SP-initiated ----
+  if (provider.providerType === 'saml') {
+    const resolved = await resolveSamlSpConfig(provider, callbackUrl);
+    if (!resolved.ok) {
+      logger.warn('sso_login_failure', {
+        event: 'sso_login_failure',
+        reason: resolved.reason,
+        providerId,
+        accountId,
+        message: resolved.message,
+      });
+      return c.json({ error: 'SSO provider is misconfigured' }, 500);
+    }
+
+    const auth = await buildSamlAuthorizeUrl(resolved.config, stateResult.state);
+    if (!auth.ok) {
+      logger.warn('sso_login_failure', {
+        event: 'sso_login_failure',
+        reason: `saml_${auth.reason}`,
+        providerId,
+        accountId,
+        message: auth.message,
+      });
+      return c.json({ error: 'SSO AuthnRequest failed' }, 502);
+    }
+
+    const headers = new Headers();
+    headers.set('Location', auth.url);
+    appendSetCookie(
+      headers,
+      setCookieHeader(SSO_STATE_COOKIE, stateResult.cookieValue, SSO_STATE_MAX_AGE),
+    );
+    return new Response(null, { status: 302, headers });
+  }
+
+  // ---- OIDC ----
   if (!provider.clientId) {
     logger.warn('sso_login_failure', {
       event: 'sso_login_failure',
@@ -292,29 +492,10 @@ app.get('/sso/:providerId/init', async (c) => {
     return c.json({ error: 'SSO discovery failed' }, 502);
   }
 
-  let stateResult: ReturnType<typeof generateSsoState>;
-  try {
-    stateResult = generateSsoState({
-      accountId,
-      providerId,
-      redirectTo,
-    });
-  } catch (err) {
-    logger.error('sso_login_failure', {
-      event: 'sso_login_failure',
-      reason: 'state_generation_failed',
-      providerId,
-      accountId,
-      message: err instanceof Error ? err.message : String(err),
-    });
-    return c.json({ error: 'SSO state generation failed' }, 500);
-  }
-
-  const redirectUri = `${apiBaseUrl()}/api/auth/sso/${providerId}/callback`;
   const authUrl = buildOidcAuthorizationUrl({
     authorizationEndpoint: discovery.document.authorization_endpoint,
     clientId: provider.clientId,
-    redirectUri,
+    redirectUri: callbackUrl,
     state: stateResult.state,
     codeChallenge: stateResult.codeChallenge,
     nonce: stateResult.state.slice(0, 32),
@@ -529,6 +710,187 @@ app.get('/sso/:providerId/callback', async (c) => {
     userId: user.id,
     issuer: provider.issuer,
     role: roleResult.role,
+    providerType: 'oidc',
+  });
+
+  return new Response(null, { status: 302, headers });
+});
+
+// ---------------------------------------------------------------------------
+// POST /sso/:providerId/callback — SAML ACS (HTTP-POST binding)
+// ---------------------------------------------------------------------------
+
+app.post('/sso/:providerId/callback', async (c) => {
+  const providerId = c.req.param('providerId');
+  const ip = clientIp(c);
+  const userAgent = c.req.header('user-agent') ?? undefined;
+
+  const fail = (reason: string, extra?: Record<string, unknown>): Response => {
+    logger.warn('sso_login_failure', {
+      event: 'sso_login_failure',
+      reason,
+      providerId,
+      providerType: 'saml',
+      ...extra,
+    });
+    const headers = new Headers();
+    appendSetCookie(headers, clearCookieHeader(SSO_STATE_COOKIE));
+    const redirect = loginErrorRedirect(reason);
+    for (const [k, v] of redirect.headers.entries()) {
+      if (k.toLowerCase() === 'set-cookie') {
+        headers.append(k, v);
+      } else {
+        headers.set(k, v);
+      }
+    }
+    return new Response(null, { status: 302, headers });
+  };
+
+  let body: Record<string, string>;
+  try {
+    body = (await c.req.parseBody()) as Record<string, string>;
+  } catch {
+    return fail('invalid_body');
+  }
+
+  const samlResponse =
+    typeof body.SAMLResponse === 'string'
+      ? body.SAMLResponse
+      : typeof body.samlResponse === 'string'
+        ? body.samlResponse
+        : '';
+  const relayState =
+    typeof body.RelayState === 'string'
+      ? body.RelayState
+      : typeof body.relayState === 'string'
+        ? body.relayState
+        : '';
+
+  const stateCookie = readCookie(c.req.header('cookie'), SSO_STATE_COOKIE);
+  const verified = verifySsoState(relayState, stateCookie);
+  if (!verified) {
+    return fail('invalid_state');
+  }
+  if (verified.providerId !== providerId) {
+    return fail('provider_mismatch', { stateProviderId: verified.providerId });
+  }
+  if (!samlResponse) {
+    return fail('missing_saml_response', { accountId: verified.accountId });
+  }
+
+  const provider = await loadEnabledSsoProvider(providerId, verified.accountId, 'saml');
+  if (!provider) {
+    return fail('provider_not_found', { accountId: verified.accountId });
+  }
+
+  const db = getClient();
+  const entitled = await accountHasSsoFeature(db, verified.accountId);
+  if (!entitled) {
+    return fail('entitlement_denied', { accountId: verified.accountId });
+  }
+
+  const callbackUrl = `${apiBaseUrl()}/api/auth/sso/${providerId}/callback`;
+  const resolved = await resolveSamlSpConfig(provider, callbackUrl);
+  if (!resolved.ok) {
+    return fail(resolved.reason, {
+      accountId: verified.accountId,
+      message: resolved.message,
+    });
+  }
+
+  const validated = await validateSamlPostResponse(resolved.config, samlResponse);
+  if (!validated.ok) {
+    return fail(`saml_${validated.reason}`, {
+      accountId: verified.accountId,
+      message: validated.message,
+    });
+  }
+
+  const roleResult = mapSsoGroupsToRole({
+    claims: validated.assertion.attributes,
+    groupClaim: provider.groupClaim,
+    groupRoleMap: provider.groupRoleMap,
+    defaultRole: provider.defaultRole,
+    requireGroupMatch: provider.requireGroupMatch,
+  });
+
+  if (!roleResult.ok) {
+    return fail(roleResult.reason, {
+      accountId: verified.accountId,
+      groups: roleResult.groups,
+      message: roleResult.message,
+    });
+  }
+
+  let user: Awaited<ReturnType<typeof upsertSsoUser>>;
+  try {
+    user = await upsertSsoUser({
+      providerId: provider.id,
+      accountId: provider.accountId,
+      subject: validated.assertion.subject,
+      email: validated.assertion.email,
+      emailVerified: Boolean(validated.assertion.email),
+      name: validated.assertion.name,
+      role: roleResult.role,
+    });
+  } catch (err) {
+    logger.error('sso_login_failure', {
+      event: 'sso_login_failure',
+      reason: 'jit_failed',
+      providerId,
+      accountId: verified.accountId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return fail('jit_failed', { accountId: verified.accountId });
+  }
+
+  let token: string;
+  try {
+    const session = await createSession(user.id, {
+      persistent: true,
+      userAgent,
+      ipAddress: ip,
+      metadata: {
+        authMethod: 'sso',
+        ssoProviderId: provider.id,
+        issuer: provider.issuer,
+        accountId: provider.accountId,
+        providerType: 'saml',
+      },
+    });
+    token = session.token;
+  } catch (err) {
+    logger.error('sso_login_failure', {
+      event: 'sso_login_failure',
+      reason: 'session_failed',
+      providerId,
+      accountId: verified.accountId,
+      userId: user.id,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return fail('session_failed', { accountId: verified.accountId });
+  }
+
+  const safePath = safeSsoRedirectPath(verified.redirectTo);
+  const location = new URL(safePath, publicAppBaseUrl()).toString();
+  const domain = sessionCookieDomain();
+  const headers = new Headers();
+  headers.set('Location', location);
+  appendSetCookie(headers, setCookieHeader(SESSION_COOKIE, token, 60 * 60 * 24 * 7, domain));
+  appendSetCookie(
+    headers,
+    setCookieHeader(ROLE_COOKIE, user.role ?? 'viewer', 60 * 60 * 24 * 7, domain),
+  );
+  appendSetCookie(headers, clearCookieHeader(SSO_STATE_COOKIE));
+
+  logger.info('sso_login_success', {
+    event: 'sso_login_success',
+    providerId: provider.id,
+    accountId: provider.accountId,
+    userId: user.id,
+    issuer: provider.issuer,
+    role: roleResult.role,
+    providerType: 'saml',
   });
 
   return new Response(null, { status: 302, headers });

--- a/apps/server/src/routes/auth-sso.ts
+++ b/apps/server/src/routes/auth-sso.ts
@@ -236,9 +236,7 @@ export async function resolveSamlSpConfig(
   callbackUrl: string,
 ): Promise<{ ok: true; config: SamlSpConfig } | { ok: false; reason: string; message: string }> {
   const spEntityId =
-    (provider.samlSpEntityId && provider.samlSpEntityId.trim()) ||
-    process.env.REVEALUI_SSO_SP_ENTITY_ID?.trim() ||
-    callbackUrl;
+    provider.samlSpEntityId?.trim() || process.env.REVEALUI_SSO_SP_ENTITY_ID?.trim() || callbackUrl;
 
   let entryPoint: string | null = null;
   let idpCertPem: string | null =
@@ -322,7 +320,7 @@ function clientIp(c: {
 app.get('/sso/saml/metadata', async (c) => {
   const accountId = c.req.query('accountId');
   const providerId = c.req.query('providerId');
-  if (!accountId || !providerId) {
+  if (!(accountId && providerId)) {
     return c.json({ error: 'accountId and providerId query parameters are required' }, 400);
   }
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -10,6 +10,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@node-saml/node-saml": "5.1.0",
     "@revealui/config": "workspace:*",
     "@revealui/contracts": "workspace:*",
     "@revealui/core": "workspace:*",
@@ -22,12 +23,12 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@revealui/dev": "workspace:*",
     "@simplewebauthn/browser": "catalog:",
     "@testing-library/react": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@vitest/coverage-v8": "catalog:",
-    "@revealui/dev": "workspace:*",
     "happy-dom": "^20.10.6",
     "react": "catalog:",
     "typescript": "catalog:",

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -136,10 +136,14 @@ export {
 } from './session.js';
 // Signed Cookie
 export { signCookiePayload, verifyCookiePayload } from './signed-cookie.js';
-// Enterprise SSO pure layer (GAP-464) — routes/JIT/entitlement in follow-up PRs
+// Enterprise SSO pure layer (GAP-464) — OIDC + SAML SP helpers
 export {
   type BuildOidcAuthorizationUrlInput,
+  type BuildSamlAuthorizeUrlFailureReason,
+  type BuildSamlAuthorizeUrlResult,
   buildOidcAuthorizationUrl,
+  buildSamlAuthorizeUrl,
+  buildSamlSpMetadata,
   createOidcRemoteJwkSet,
   type ExchangeOidcCodeFailureReason,
   type ExchangeOidcCodeInput,
@@ -149,6 +153,7 @@ export {
   extractGroupsFromClaim,
   type FetchOidcDiscoveryOptions,
   type FetchOidcDiscoveryResult,
+  fetchIdpMetadata,
   fetchOidcDiscovery,
   type GenerateSsoStateInput,
   type GenerateSsoStateResult,
@@ -160,18 +165,27 @@ export {
   type MapSsoGroupsInput,
   type MapSsoGroupsResult,
   mapSsoGroupsToRole,
+  normalizeIdpCertPem,
   normalizeSsoUserRole,
   type OidcDiscoveryDocument,
   type OidcDiscoveryFailureReason,
+  type ParseIdpMetadataFailureReason,
+  type ParseIdpMetadataResult,
+  parseIdpMetadataXml,
+  type SamlSpConfig,
   type SsoStatePayload,
   type UpsertSsoUserInput,
   upsertSsoUser,
   type ValidatedIdTokenClaims,
+  type ValidatedSamlAssertion,
   type ValidateIdTokenFailureReason,
   type ValidateIdTokenResult,
   type ValidateOidcIdTokenOptions,
+  type ValidateSamlResponseFailureReason,
+  type ValidateSamlResponseResult,
   type VerifiedSsoState,
   validateOidcIdToken,
+  validateSamlPostResponse,
   verifySsoState,
 } from './sso/index.js';
 export type { Storage } from './storage/index.js';

--- a/packages/auth/src/server/sso/__tests__/saml.test.ts
+++ b/packages/auth/src/server/sso/__tests__/saml.test.ts
@@ -1,0 +1,213 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildSamlAuthorizeUrl,
+  buildSamlSpMetadata,
+  fetchIdpMetadata,
+  normalizeIdpCertPem,
+  parseIdpMetadataXml,
+  validateSamlPostResponse,
+  type SamlSpConfig,
+} from '../saml.js';
+
+const SP_ENTITY = 'https://app.example.com/sp';
+const CALLBACK = 'https://api.example.com/api/auth/sso/prov-1/callback';
+const ENTRY = 'https://idp.example.com/sso';
+
+function makeRsaCertPair(): { certPem: string; privateKeyPem: string } {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  // node-saml expects CERTIFICATE for idpCert; SPKI public key is accepted as PUBLIC KEY
+  // Convert SPKI to a self-signed-looking CERT is heavy; PUBLIC KEY PEM works for some paths.
+  // Use publicKey as cert body with CERTIFICATE label only when base64 — normalizeIdpCertPem
+  // wraps bare base64. For generateKeyPairSync SPKI, pass as PUBLIC KEY via normalize:
+  return { certPem: publicKey, privateKeyPem: privateKey };
+}
+
+function sampleMetadata(entityId: string, ssoUrl: string, certBody: string): string {
+  return `<?xml version="1.0"?>
+<EntityDescriptor entityID="${entityId}" xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>${certBody}</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <SingleSignOnService
+      Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+      Location="${ssoUrl}" />
+  </IDPSSODescriptor>
+</EntityDescriptor>`;
+}
+
+describe('normalizeIdpCertPem', () => {
+  it('passes through existing PEM blocks', () => {
+    const pem = '-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----';
+    expect(normalizeIdpCertPem(pem)).toBe(pem);
+  });
+
+  it('wraps bare base64 in a CERTIFICATE PEM block', () => {
+    const bare = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A';
+    const out = normalizeIdpCertPem(bare);
+    expect(out.includes('BEGIN CERTIFICATE')).toBe(true);
+    expect(out.includes(bare)).toBe(true);
+  });
+});
+
+describe('parseIdpMetadataXml', () => {
+  it('extracts entityID, HTTP-Redirect SSO Location, and cert', () => {
+    const certBody = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA';
+    const xml = sampleMetadata('https://idp.example.com', ENTRY, certBody);
+    const result = parseIdpMetadataXml(xml);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.entityId).toBe('https://idp.example.com');
+      expect(result.entryPoint).toBe(ENTRY);
+      expect(result.idpCertPem.includes('BEGIN CERTIFICATE')).toBe(true);
+    }
+  });
+
+  it('rejects empty xml', () => {
+    const result = parseIdpMetadataXml('');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_xml');
+  });
+
+  it('rejects metadata without entityID', () => {
+    const result = parseIdpMetadataXml('<EntityDescriptor></EntityDescriptor>');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_entity_id');
+  });
+
+  it('rejects metadata without SSO location', () => {
+    const xml = `<EntityDescriptor entityID="https://idp.example.com"></EntityDescriptor>`;
+    const result = parseIdpMetadataXml(xml);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_sso_url');
+  });
+
+  it('rejects metadata without certificate', () => {
+    const xml = `<?xml version="1.0"?>
+<EntityDescriptor entityID="https://idp.example.com">
+  <IDPSSODescriptor>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="${ENTRY}" />
+  </IDPSSODescriptor>
+</EntityDescriptor>`;
+    const result = parseIdpMetadataXml(xml);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_cert');
+  });
+});
+
+describe('fetchIdpMetadata', () => {
+  it('fetches and parses metadata', async () => {
+    const certBody = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA';
+    const xml = sampleMetadata('https://idp.example.com', ENTRY, certBody);
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => xml,
+    });
+    const result = await fetchIdpMetadata('https://idp.example.com/metadata', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.entityId).toBe('https://idp.example.com');
+      expect(result.entryPoint).toBe(ENTRY);
+    }
+  });
+
+  it('fails closed on HTTP error', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    const result = await fetchIdpMetadata('https://idp.example.com/metadata', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('buildSamlSpMetadata + authorize URL', () => {
+  const { certPem } = makeRsaCertPair();
+
+  const config: SamlSpConfig = {
+    spEntityId: SP_ENTITY,
+    callbackUrl: CALLBACK,
+    entryPoint: ENTRY,
+    idpCertPem: certPem,
+  };
+
+  it('builds SP metadata containing entityID and ACS', () => {
+    const meta = buildSamlSpMetadata(config);
+    expect(meta.includes('EntityDescriptor')).toBe(true);
+    expect(meta.includes(SP_ENTITY)).toBe(true);
+    expect(meta.includes(CALLBACK) || meta.includes('AssertionConsumerService')).toBe(true);
+  });
+
+  it('builds an HTTP-Redirect AuthnRequest URL against the IdP entryPoint', async () => {
+    const result = await buildSamlAuthorizeUrl(config, 'relay-state-token');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.url.startsWith(ENTRY)).toBe(true);
+      expect(result.url.includes('SAMLRequest=')).toBe(true);
+      expect(result.url.includes('RelayState=')).toBe(true);
+    }
+  });
+
+  it('rejects authorize URL without IdP cert', async () => {
+    const result = await buildSamlAuthorizeUrl({ ...config, idpCertPem: '' }, 'relay');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_cert');
+  });
+});
+
+describe('validateSamlPostResponse', () => {
+  const { certPem } = makeRsaCertPair();
+  const config: SamlSpConfig = {
+    spEntityId: SP_ENTITY,
+    callbackUrl: CALLBACK,
+    entryPoint: ENTRY,
+    idpCertPem: certPem,
+  };
+
+  it('rejects missing SAMLResponse', async () => {
+    const result = await validateSamlPostResponse(config, '');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_response');
+  });
+
+  it('rejects missing IdP cert', async () => {
+    const result = await validateSamlPostResponse(
+      { ...config, idpCertPem: '' },
+      Buffer.from('<Response/>').toString('base64'),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing_cert');
+  });
+
+  it('rejects unsigned / garbage SAMLResponse (signature hardline)', async () => {
+    const unsigned = Buffer.from(
+      `<?xml version="1.0"?>
+      <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+        ID="_r1" Version="2.0" IssueInstant="2020-01-01T00:00:00Z"
+        Destination="${CALLBACK}">
+        <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">https://idp.example.com</saml:Issuer>
+        <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
+      </samlp:Response>`,
+    ).toString('base64');
+    const result = await validateSamlPostResponse(config, unsigned);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // node-saml reports signature / validation failure for unsigned docs
+      expect(
+        result.reason === 'invalid_signature' ||
+          result.reason === 'validation_failed' ||
+          result.reason === 'expired',
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/auth/src/server/sso/__tests__/saml.test.ts
+++ b/packages/auth/src/server/sso/__tests__/saml.test.ts
@@ -6,8 +6,8 @@ import {
   fetchIdpMetadata,
   normalizeIdpCertPem,
   parseIdpMetadataXml,
-  validateSamlPostResponse,
   type SamlSpConfig,
+  validateSamlPostResponse,
 } from '../saml.js';
 
 const SP_ENTITY = 'https://app.example.com/sp';

--- a/packages/auth/src/server/sso/index.ts
+++ b/packages/auth/src/server/sso/index.ts
@@ -1,9 +1,9 @@
 /**
  * Enterprise SSO pure layer (GAP-464).
  *
- * OIDC discovery + id_token validation, code exchange, signed SSO state,
- * group→role mapping, JIT user upsert. HTTP routes + account entitlement gate
- * live in apps/server.
+ * OIDC discovery + id_token validation, code exchange, SAML SP helpers,
+ * signed SSO state, group→role mapping, JIT user upsert. HTTP routes +
+ * account entitlement gate live in apps/server.
  */
 
 export {
@@ -41,6 +41,22 @@ export {
   type MapSsoGroupsResult,
   mapSsoGroupsToRole,
 } from './roles.js';
+export {
+  type BuildSamlAuthorizeUrlFailureReason,
+  type BuildSamlAuthorizeUrlResult,
+  buildSamlAuthorizeUrl,
+  buildSamlSpMetadata,
+  fetchIdpMetadata,
+  normalizeIdpCertPem,
+  type ParseIdpMetadataFailureReason,
+  type ParseIdpMetadataResult,
+  parseIdpMetadataXml,
+  type SamlSpConfig,
+  type ValidateSamlResponseFailureReason,
+  type ValidateSamlResponseResult,
+  type ValidatedSamlAssertion,
+  validateSamlPostResponse,
+} from './saml.js';
 export {
   type GenerateSsoStateInput,
   type GenerateSsoStateResult,

--- a/packages/auth/src/server/sso/index.ts
+++ b/packages/auth/src/server/sso/index.ts
@@ -52,9 +52,9 @@ export {
   type ParseIdpMetadataResult,
   parseIdpMetadataXml,
   type SamlSpConfig,
+  type ValidatedSamlAssertion,
   type ValidateSamlResponseFailureReason,
   type ValidateSamlResponseResult,
-  type ValidatedSamlAssertion,
   validateSamlPostResponse,
 } from './saml.js';
 export {

--- a/packages/auth/src/server/sso/saml.ts
+++ b/packages/auth/src/server/sso/saml.ts
@@ -1,0 +1,501 @@
+/**
+ * Enterprise SAML 2.0 SP helpers (GAP-464 Phase 3).
+ *
+ * Wraps @node-saml/node-saml so HTTP routes get typed ok/err results matching
+ * the OIDC pure layer. Hardlines:
+ * - Never accept a Response without IdP certificate material (signature path).
+ * - SP-initiated AuthnRequest only for MVP (IdP-initiated is a follow-up).
+ * - InResponseTo checked when present (replay resistance).
+ */
+
+import { SAML, ValidateInResponseTo, type Profile } from '@node-saml/node-saml';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SamlSpConfig {
+  /** Service Provider entity ID (audience) */
+  spEntityId: string;
+  /** ACS callback URL (POST) */
+  callbackUrl: string;
+  /** IdP SingleSignOnService HTTP-Redirect or HTTP-POST location */
+  entryPoint: string;
+  /**
+   * IdP signing certificate PEM (CERTIFICATE or PUBLIC KEY).
+   * REQUIRED for validation — unsigned responses are rejected.
+   */
+  idpCertPem: string;
+  /** Optional SP signing private key PEM (signed AuthnRequest) */
+  spPrivateKeyPem?: string;
+  /** Optional SP public cert PEM (metadata + request signing) */
+  spPublicCertPem?: string;
+  /** Clock skew for NotOnOrAfter (ms, default 5 minutes) */
+  acceptedClockSkewMs?: number;
+}
+
+export type ParseIdpMetadataFailureReason =
+  | 'missing_xml'
+  | 'missing_entity_id'
+  | 'missing_sso_url'
+  | 'missing_cert';
+
+export type ParseIdpMetadataResult =
+  | {
+      ok: true;
+      entityId: string;
+      entryPoint: string;
+      idpCertPem: string;
+    }
+  | { ok: false; reason: ParseIdpMetadataFailureReason; message: string };
+
+export type BuildSamlAuthorizeUrlFailureReason = 'missing_config' | 'missing_cert' | 'build_failed';
+
+export type BuildSamlAuthorizeUrlResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: BuildSamlAuthorizeUrlFailureReason; message: string };
+
+export type ValidateSamlResponseFailureReason =
+  | 'missing_response'
+  | 'missing_cert'
+  | 'invalid_signature'
+  | 'expired'
+  | 'audience_mismatch'
+  | 'replay'
+  | 'missing_name_id'
+  | 'logged_out'
+  | 'validation_failed';
+
+export interface ValidatedSamlAssertion {
+  /** NameID value (maps to SSO subject) */
+  subject: string;
+  email?: string;
+  name?: string;
+  /** Attribute bag for group mapping (keys as claim names) */
+  attributes: Record<string, unknown>;
+  /** Full node-saml profile for advanced callers */
+  profile: Profile;
+}
+
+export type ValidateSamlResponseResult =
+  | { ok: true; assertion: ValidatedSamlAssertion }
+  | { ok: false; reason: ValidateSamlResponseFailureReason; message: string };
+
+// ---------------------------------------------------------------------------
+// PEM helpers
+// ---------------------------------------------------------------------------
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Normalize a certificate string to PEM CERTIFICATE block if bare base64.
+ */
+export function normalizeIdpCertPem(cert: string): string {
+  const trimmed = cert.trim();
+  if (trimmed.includes('BEGIN CERTIFICATE') || trimmed.includes('BEGIN PUBLIC KEY')) {
+    return trimmed;
+  }
+  // Strip whitespace from bare base64
+  let compact = '';
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i] as string;
+    if (ch !== ' ' && ch !== '\n' && ch !== '\r' && ch !== '\t') {
+      compact += ch;
+    }
+  }
+  const lines: string[] = [];
+  for (let i = 0; i < compact.length; i += 64) {
+    lines.push(compact.slice(i, i + 64));
+  }
+  return `-----BEGIN CERTIFICATE-----\n${lines.join('\n')}\n-----END CERTIFICATE-----`;
+}
+
+// ---------------------------------------------------------------------------
+// IdP metadata parse (string scans; no authored regex)
+// ---------------------------------------------------------------------------
+
+function extractXmlAttribute(xml: string, tagHint: string, attrName: string): string | null {
+  // Find a tag containing tagHint, then attrName="..."
+  let searchFrom = 0;
+  while (searchFrom < xml.length) {
+    const tagStart = xml.indexOf('<', searchFrom);
+    if (tagStart === -1) return null;
+    const tagEnd = xml.indexOf('>', tagStart);
+    if (tagEnd === -1) return null;
+    const tag = xml.slice(tagStart, tagEnd + 1);
+    if (tag.includes(tagHint) && !tag.startsWith('</') && !tag.startsWith('<!--')) {
+      const attrKey = `${attrName}="`;
+      const attrPos = tag.indexOf(attrKey);
+      if (attrPos !== -1) {
+        const valueStart = attrPos + attrKey.length;
+        const valueEnd = tag.indexOf('"', valueStart);
+        if (valueEnd !== -1) {
+          return tag.slice(valueStart, valueEnd);
+        }
+      }
+    }
+    searchFrom = tagEnd + 1;
+  }
+  return null;
+}
+
+function extractFirstX509Certificate(xml: string): string | null {
+  const open = '<X509Certificate>';
+  const openAlt = '<ds:X509Certificate>';
+  let start = xml.indexOf(open);
+  let openLen = open.length;
+  if (start === -1) {
+    start = xml.indexOf(openAlt);
+    openLen = openAlt.length;
+  }
+  if (start === -1) return null;
+  const contentStart = start + openLen;
+  const close = xml.indexOf('</', contentStart);
+  if (close === -1) return null;
+  return xml.slice(contentStart, close).trim();
+}
+
+function extractSsoLocation(xml: string): string | null {
+  // Prefer HTTP-Redirect SingleSignOnService Location
+  let searchFrom = 0;
+  let fallback: string | null = null;
+  while (searchFrom < xml.length) {
+    const tagStart = xml.indexOf('SingleSignOnService', searchFrom);
+    if (tagStart === -1) break;
+    // Walk back to '<'
+    let open = tagStart;
+    while (open > 0 && xml[open] !== '<') open--;
+    const tagEnd = xml.indexOf('>', tagStart);
+    if (tagEnd === -1) break;
+    const tag = xml.slice(open, tagEnd + 1);
+    const bindingKey = 'Binding="';
+    const locKey = 'Location="';
+    const bindingPos = tag.indexOf(bindingKey);
+    const locPos = tag.indexOf(locKey);
+    if (locPos !== -1) {
+      const valueStart = locPos + locKey.length;
+      const valueEnd = tag.indexOf('"', valueStart);
+      if (valueEnd !== -1) {
+        const location = tag.slice(valueStart, valueEnd);
+        if (bindingPos !== -1) {
+          const bStart = bindingPos + bindingKey.length;
+          const bEnd = tag.indexOf('"', bStart);
+          const binding = bEnd !== -1 ? tag.slice(bStart, bEnd) : '';
+          if (binding.includes('HTTP-Redirect')) {
+            return location;
+          }
+          if (!fallback) fallback = location;
+        } else if (!fallback) {
+          fallback = location;
+        }
+      }
+    }
+    searchFrom = tagEnd + 1;
+  }
+  return fallback;
+}
+
+/**
+ * Parse IdP metadata XML for entityID, SSO entry point, and signing cert.
+ * Uses linear string scans (no authored regex) for CodeQL / no-regex hardline.
+ */
+export function parseIdpMetadataXml(xml: string): ParseIdpMetadataResult {
+  if (!isNonEmptyString(xml)) {
+    return { ok: false, reason: 'missing_xml', message: 'IdP metadata XML is required' };
+  }
+
+  const entityId =
+    extractXmlAttribute(xml, 'EntityDescriptor', 'entityID') ||
+    extractXmlAttribute(xml, 'md:EntityDescriptor', 'entityID');
+  if (!entityId) {
+    return {
+      ok: false,
+      reason: 'missing_entity_id',
+      message: 'IdP metadata missing EntityDescriptor entityID',
+    };
+  }
+
+  const entryPoint = extractSsoLocation(xml);
+  if (!entryPoint) {
+    return {
+      ok: false,
+      reason: 'missing_sso_url',
+      message: 'IdP metadata missing SingleSignOnService Location',
+    };
+  }
+
+  const rawCert = extractFirstX509Certificate(xml);
+  if (!rawCert) {
+    return {
+      ok: false,
+      reason: 'missing_cert',
+      message: 'IdP metadata missing X509Certificate',
+    };
+  }
+
+  return {
+    ok: true,
+    entityId,
+    entryPoint,
+    idpCertPem: normalizeIdpCertPem(rawCert),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SAML service construction
+// ---------------------------------------------------------------------------
+
+function createSamlInstance(config: SamlSpConfig): SAML {
+  const idpCert = normalizeIdpCertPem(config.idpCertPem);
+  const options: ConstructorParameters<typeof SAML>[0] = {
+    callbackUrl: config.callbackUrl,
+    entryPoint: config.entryPoint,
+    issuer: config.spEntityId,
+    idpCert,
+    audience: config.spEntityId,
+    wantAssertionsSigned: true,
+    wantAuthnResponseSigned: true,
+    validateInResponseTo: ValidateInResponseTo.ifPresent,
+    acceptedClockSkewMs: config.acceptedClockSkewMs ?? 5 * 60 * 1000,
+    identifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+  };
+  if (config.spPrivateKeyPem) {
+    options.privateKey = config.spPrivateKeyPem;
+  }
+  if (config.spPublicCertPem) {
+    options.publicCert = config.spPublicCertPem;
+  }
+  return new SAML(options);
+}
+
+// ---------------------------------------------------------------------------
+// SP metadata + AuthnRequest redirect
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate SP metadata XML for customer IdP configuration.
+ */
+export function buildSamlSpMetadata(config: SamlSpConfig): string {
+  if (!isNonEmptyString(config.idpCertPem)) {
+    throw new Error('idpCertPem is required to construct SP metadata service');
+  }
+  const saml = createSamlInstance(config);
+  // decryptionCert null when no encryption; publicCert optional for signing
+  return saml.generateServiceProviderMetadata(
+    null,
+    config.spPublicCertPem ? config.spPublicCertPem : null,
+  );
+}
+
+/**
+ * Build SP-initiated AuthnRequest redirect URL (HTTP-Redirect binding).
+ * `relayState` should be the signed SSO state token (CSRF + account binding).
+ */
+export async function buildSamlAuthorizeUrl(
+  config: SamlSpConfig,
+  relayState: string,
+): Promise<BuildSamlAuthorizeUrlResult> {
+  if (!isNonEmptyString(config.callbackUrl) || !isNonEmptyString(config.entryPoint)) {
+    return {
+      ok: false,
+      reason: 'missing_config',
+      message: 'callbackUrl and entryPoint are required',
+    };
+  }
+  if (!isNonEmptyString(config.idpCertPem)) {
+    return {
+      ok: false,
+      reason: 'missing_cert',
+      message: 'IdP signing certificate is required',
+    };
+  }
+  if (!isNonEmptyString(config.spEntityId)) {
+    return {
+      ok: false,
+      reason: 'missing_config',
+      message: 'spEntityId is required',
+    };
+  }
+
+  try {
+    const saml = createSamlInstance(config);
+    const url = await saml.getAuthorizeUrlAsync(relayState, undefined, {});
+    return { ok: true, url };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'build_failed',
+      message: err instanceof Error ? err.message : 'Failed to build SAML AuthnRequest URL',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response validation
+// ---------------------------------------------------------------------------
+
+function mapValidateError(err: unknown): {
+  reason: ValidateSamlResponseFailureReason;
+  message: string;
+} {
+  const message = err instanceof Error ? err.message : 'SAML response validation failed';
+  const lower = message.toLowerCase();
+
+  if (lower.includes('signature') || lower.includes('invalid document')) {
+    return { reason: 'invalid_signature', message };
+  }
+  if (lower.includes('expired') || lower.includes('notonorafter') || lower.includes('not before')) {
+    return { reason: 'expired', message };
+  }
+  if (lower.includes('audience')) {
+    return { reason: 'audience_mismatch', message };
+  }
+  if (lower.includes('inresponseto') || lower.includes('replay')) {
+    return { reason: 'replay', message };
+  }
+  return { reason: 'validation_failed', message };
+}
+
+function profileToAssertion(profile: Profile): ValidatedSamlAssertion | null {
+  const subject = typeof profile.nameID === 'string' ? profile.nameID.trim() : '';
+  if (!subject) return null;
+
+  const attributes: Record<string, unknown> = {};
+  // Profile is a claim bag ([attributeName: string]: unknown) plus fixed fields
+  for (const [key, value] of Object.entries(profile)) {
+    if (key === 'getAssertionXml' || key === 'getAssertion' || key === 'getSamlResponseXml') {
+      continue;
+    }
+    if (typeof value === 'function') continue;
+    attributes[key] = value;
+  }
+
+  if (typeof profile.email === 'string') {
+    attributes.email = profile.email;
+  }
+  const msGroups = profile['http://schemas.microsoft.com/ws/2008/06/identity/claims/groups'];
+  if (Array.isArray(msGroups)) {
+    attributes.groups = msGroups;
+  }
+  if (typeof profile.mail === 'string') {
+    attributes.mail = profile.mail;
+  }
+
+  const email =
+    (typeof profile.email === 'string' && profile.email) ||
+    (typeof profile.mail === 'string' && profile.mail) ||
+    (subject.includes('@') ? subject : undefined);
+
+  const displayName = profile.displayName;
+  const cn = profile.cn;
+  const name =
+    (typeof displayName === 'string' && displayName) || (typeof cn === 'string' && cn) || undefined;
+
+  return {
+    subject,
+    email,
+    name,
+    attributes,
+    profile,
+  };
+}
+
+/**
+ * Validate a SAMLResponse from HTTP-POST binding.
+ * Requires IdP cert; rejects unsigned / bad-signature responses.
+ */
+export async function validateSamlPostResponse(
+  config: SamlSpConfig,
+  samlResponseBase64: string,
+): Promise<ValidateSamlResponseResult> {
+  if (!isNonEmptyString(samlResponseBase64)) {
+    return {
+      ok: false,
+      reason: 'missing_response',
+      message: 'SAMLResponse is required',
+    };
+  }
+  if (!isNonEmptyString(config.idpCertPem)) {
+    return {
+      ok: false,
+      reason: 'missing_cert',
+      message: 'IdP signing certificate is required; unsigned responses are rejected',
+    };
+  }
+
+  try {
+    const saml = createSamlInstance(config);
+    const { profile, loggedOut } = await saml.validatePostResponseAsync({
+      SAMLResponse: samlResponseBase64,
+    });
+
+    if (loggedOut) {
+      return {
+        ok: false,
+        reason: 'logged_out',
+        message: 'SAML response was a logout response',
+      };
+    }
+    if (!profile) {
+      return {
+        ok: false,
+        reason: 'validation_failed',
+        message: 'SAML validation returned no profile',
+      };
+    }
+
+    const assertion = profileToAssertion(profile);
+    if (!assertion) {
+      return {
+        ok: false,
+        reason: 'missing_name_id',
+        message: 'SAML assertion missing NameID / subject',
+      };
+    }
+
+    return { ok: true, assertion };
+  } catch (err) {
+    const mapped = mapValidateError(err);
+    return { ok: false, reason: mapped.reason, message: mapped.message };
+  }
+}
+
+/**
+ * Fetch and parse IdP metadata from a URL (test-connection + seed entryPoint/cert).
+ */
+export async function fetchIdpMetadata(
+  metadataUrl: string,
+  options?: { fetchImpl?: typeof fetch; timeoutMs?: number },
+): Promise<ParseIdpMetadataResult> {
+  if (!isNonEmptyString(metadataUrl)) {
+    return { ok: false, reason: 'missing_xml', message: 'metadata URL is required' };
+  }
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const timeoutMs = options?.timeoutMs ?? 10_000;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(metadataUrl, { signal: controller.signal });
+      if (!res.ok) {
+        return {
+          ok: false,
+          reason: 'missing_xml',
+          message: `IdP metadata fetch failed with HTTP ${res.status}`,
+        };
+      }
+      const text = await res.text();
+      return parseIdpMetadataXml(text);
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'missing_xml',
+      message: err instanceof Error ? err.message : 'IdP metadata fetch failed',
+    };
+  }
+}

--- a/packages/auth/src/server/sso/saml.ts
+++ b/packages/auth/src/server/sso/saml.ts
@@ -8,7 +8,7 @@
  * - InResponseTo checked when present (replay resistance).
  */
 
-import { SAML, ValidateInResponseTo, type Profile } from '@node-saml/node-saml';
+import { type Profile, SAML, ValidateInResponseTo } from '@node-saml/node-saml';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -99,8 +99,7 @@ export function normalizeIdpCertPem(cert: string): string {
   }
   // Strip whitespace from bare base64
   let compact = '';
-  for (let i = 0; i < trimmed.length; i++) {
-    const ch = trimmed[i] as string;
+  for (const ch of trimmed) {
     if (ch !== ' ' && ch !== '\n' && ch !== '\r' && ch !== '\t') {
       compact += ch;
     }
@@ -297,7 +296,7 @@ export async function buildSamlAuthorizeUrl(
   config: SamlSpConfig,
   relayState: string,
 ): Promise<BuildSamlAuthorizeUrlResult> {
-  if (!isNonEmptyString(config.callbackUrl) || !isNonEmptyString(config.entryPoint)) {
+  if (!(isNonEmptyString(config.callbackUrl) && isNonEmptyString(config.entryPoint))) {
     return {
       ok: false,
       reason: 'missing_config',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -924,6 +924,9 @@ importers:
 
   packages/auth:
     dependencies:
+      '@node-saml/node-saml':
+        specifier: 5.1.0
+        version: 5.1.0
       '@revealui/config':
         specifier: workspace:*
         version: link:../config
@@ -3358,6 +3361,10 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@node-saml/node-saml@5.1.0':
+    resolution: {integrity: sha512-t3cJnZ4aC7HhPZ6MGylGZULvUtBOZ6FzuUndaHGXjmIZHXnLfC/7L8a57O9Q9V7AxJGKAiRM5zu2wNm9EsvQpw==}
+    engines: {node: '>= 18'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -4830,6 +4837,9 @@ packages:
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -4861,6 +4871,12 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/xml-encryption@1.2.4':
+    resolution: {integrity: sha512-I69K/WW1Dv7j6O3jh13z0X8sLWJRXbu5xnHDl9yHzUNDUBtUoBY058eb5s+x/WG6yZC1h8aKdI2EoyEPjyEh+Q==}
+
+  '@types/xml2js@0.4.14':
+    resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
@@ -5168,6 +5184,14 @@ packages:
 
   '@x402/core@2.19.0':
     resolution: {integrity: sha512-IPQIHzIrwvbri1339QWHvwtiTTDbGsrF5Yff0LZfufmVXNdOSYbjY8oz6vZg7+4W13f7/k81NUMAFoDOU4gswQ==}
+
+  '@xmldom/is-dom-node@1.0.1':
+    resolution: {integrity: sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==}
+    engines: {node: '>= 16'}
+
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -9194,15 +9218,46 @@ packages:
     resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
     engines: {node: '>= 6.0'}
 
+  xml-crypto@6.1.2:
+    resolution: {integrity: sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==}
+    engines: {node: '>=16'}
+
+  xml-encryption@3.1.0:
+    resolution: {integrity: sha512-PV7qnYpoAMXbf1kvQkqMScLeQpjCMixddAKq9PtqVrho8HnYbBOWNfG0kA4R7zxQDo7w9kiYAyzS/ullAyO55Q==}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xmlcreate@2.0.4:
     resolution: {integrity: sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==}
+
+  xpath@0.0.32:
+    resolution: {integrity: sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==}
+    engines: {node: '>=0.6.0'}
+
+  xpath@0.0.33:
+    resolution: {integrity: sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==}
+    engines: {node: '>=0.6.0'}
+
+  xpath@0.0.34:
+    resolution: {integrity: sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==}
+    engines: {node: '>=0.6.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -10698,6 +10753,23 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@node-saml/node-saml@5.1.0':
+    dependencies:
+      '@types/debug': 4.1.13
+      '@types/qs': 6.15.1
+      '@types/xml-encryption': 1.2.4
+      '@types/xml2js': 0.4.14
+      '@xmldom/is-dom-node': 1.0.1
+      '@xmldom/xmldom': 0.8.13
+      debug: 4.4.3
+      xml-crypto: 6.1.2
+      xml-encryption: 3.1.0
+      xml2js: 0.6.2
+      xmlbuilder: 15.1.1
+      xpath: 0.0.34
+    transitivePeerDependencies:
+      - supports-color
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -12125,6 +12197,8 @@ snapshots:
 
   '@types/prismjs@1.26.6': {}
 
+  '@types/qs@6.15.1': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -12152,6 +12226,14 @@ snapshots:
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.5
+
+  '@types/xml-encryption@1.2.4':
+    dependencies:
+      '@types/node': 25.9.5
+
+  '@types/xml2js@0.4.14':
     dependencies:
       '@types/node': 25.9.5
 
@@ -12772,6 +12854,10 @@ snapshots:
   '@x402/core@2.19.0':
     dependencies:
       zod: 3.25.76
+
+  '@xmldom/is-dom-node@1.0.1': {}
+
+  '@xmldom/xmldom@0.8.13': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -16999,11 +17085,38 @@ snapshots:
     dependencies:
       os-paths: 4.4.0
 
+  xml-crypto@6.1.2:
+    dependencies:
+      '@xmldom/is-dom-node': 1.0.1
+      '@xmldom/xmldom': 0.8.13
+      xpath: 0.0.33
+
+  xml-encryption@3.1.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      escape-html: 1.0.3
+      xpath: 0.0.32
+
   xml-name-validator@5.0.0: {}
+
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.6.1
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
+  xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
 
   xmlcreate@2.0.4: {}
+
+  xpath@0.0.32: {}
+
+  xpath@0.0.33: {}
+
+  xpath@0.0.34: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- Pure SAML layer in `@revealui/auth` (metadata parse, AuthnRequest URL, SP metadata, ACS validate via `@node-saml/node-saml`)
- Server routes: SAML branch on `init`, `POST /sso/:providerId/callback` ACS, `GET /sso/saml/metadata`
- Signature required (unsigned responses rejected); enterprise entitlement still fail-closed

## Context
GAP-464 / revealui#449 Phase 3. OIDC + schema + admin UI already on `test`. This unlocks SP-initiated SAML so copy-dependents can later cue enterprise claims after full closeout.

## Test plan
- [x] `pnpm --filter @revealui/auth exec vitest run src/server/sso/__tests__` (72 tests)
- [x] `pnpm --filter server exec vitest run src/routes/__tests__/auth-sso.test.ts` (15 tests)
- [x] Pre-push gate PASS
- [ ] CI green on PR
- [ ] Security review (area:security) before merge disposition

## Residual (not this PR)
- Customer docs / drop "(planned)" only after gap close
- copy-dependents hold release after full acceptance
- Mock IdP E2E integration residual