### PR TITLE
feat(admin,server): GAP-464 Admin SAML config UI + API

### DIFF
--- a/apps/admin/src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/sso/__tests__/sso-settings-client.test.tsx
@@ -59,6 +59,7 @@ vi.mock('@revealui/presentation/client', () => ({
       aria-label="checkbox"
     />
   ),
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
 }));
 
 vi.mock('@/lib/utils/csrf', () => ({
@@ -77,6 +78,10 @@ const PROVIDER: SsoProvider = {
   discoveryUrl: null,
   clientId: 'client-1',
   clientSecretRef: 'REVEALUI_SSO_CLIENT_SECRET',
+  samlMetadataUrl: null,
+  samlMetadataXml: null,
+  samlSpEntityId: null,
+  hasSigningCert: false,
   groupClaim: 'groups',
   groupRoleMap: {},
   defaultRole: 'member',
@@ -84,6 +89,20 @@ const PROVIDER: SsoProvider = {
   allowPasswordFallback: false,
   createdAt: '2026-01-01T00:00:00.000Z',
   updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const SAML_PROVIDER: SsoProvider = {
+  ...PROVIDER,
+  id: 'sso_saml_1',
+  providerType: 'saml',
+  name: 'Azure SAML',
+  issuer: 'https://sts.windows.net/tenant/',
+  clientId: null,
+  clientSecretRef: null,
+  samlMetadataUrl: 'https://idp.example.com/metadata.xml',
+  samlMetadataXml: null,
+  samlSpEntityId: null,
+  hasSigningCert: true,
 };
 
 function mockFetchSequence(
@@ -161,7 +180,7 @@ describe('SsoSettingsClient', () => {
     expect(screen.getByText('Disabled')).toBeInTheDocument();
   });
 
-  it('opens create form with OIDC-only fields and secret-ref hint', async () => {
+  it('opens create form with OIDC fields and secret-ref hint by default', async () => {
     vi.stubGlobal(
       'fetch',
       mockFetchSequence([
@@ -189,6 +208,63 @@ describe('SsoSettingsClient', () => {
     expect(screen.getByText(/Add OIDC provider/i)).toBeInTheDocument();
     expect(screen.getByText(/Never paste the secret value/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Test connection/i })).toBeInTheDocument();
+  });
+
+  it('switches create form to SAML metadata fields', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([
+        () =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ accountId: 'acct-1', ssoFeature: true, membershipRole: 'owner' }),
+          } as Response),
+        () =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ providers: [] }),
+          } as Response),
+      ]),
+    );
+
+    render(<SsoSettingsClient />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Add provider/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Add provider/i }));
+
+    fireEvent.change(screen.getByDisplayValue('OIDC'), { target: { value: 'saml' } });
+    expect(screen.getByText(/Add SAML provider/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/metadata\.xml/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Never paste the secret value/i)).not.toBeInTheDocument();
+  });
+
+  it('lists SAML providers with type badge', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchSequence([
+        () =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ accountId: 'acct-1', ssoFeature: true, membershipRole: 'owner' }),
+          } as Response),
+        () =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ providers: [SAML_PROVIDER] }),
+          } as Response),
+      ]),
+    );
+
+    render(<SsoSettingsClient />);
+    await waitFor(() => {
+      expect(screen.getByText('Azure SAML')).toBeInTheDocument();
+    });
+    expect(screen.getByText('saml')).toBeInTheDocument();
   });
 
   it('runs test connection and shows discovery preview', async () => {

--- a/apps/admin/src/app/(backend)/settings/sso/sso-settings-client.tsx
+++ b/apps/admin/src/app/(backend)/settings/sso/sso-settings-client.tsx
@@ -4,21 +4,27 @@ const SUCCESS_DISMISS_MS = 5_000;
 const ERROR_DISMISS_MS = 8_000;
 
 import { Button, Input, Select } from '@revealui/presentation';
-import { Checkbox, Field, Label } from '@revealui/presentation/client';
+import { Checkbox, Field, Label, Textarea } from '@revealui/presentation/client';
 import { useCallback, useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
 import { apiFetch } from '@/lib/utils/csrf';
 
+export type SsoProviderType = 'oidc' | 'saml';
+
 export interface SsoProvider {
   id: string;
   accountId: string;
-  providerType: 'oidc' | 'saml';
+  providerType: SsoProviderType;
   name: string;
   enabled: boolean;
   issuer: string;
   discoveryUrl: string | null;
   clientId: string | null;
   clientSecretRef: string | null;
+  samlMetadataUrl: string | null;
+  samlMetadataXml: string | null;
+  samlSpEntityId: string | null;
+  hasSigningCert: boolean;
   groupClaim: string;
   groupRoleMap: Record<string, string>;
   defaultRole: string;
@@ -29,11 +35,15 @@ export interface SsoProvider {
 }
 
 export interface SsoFormState {
+  providerType: SsoProviderType;
   name: string;
   issuer: string;
   discoveryUrl: string;
   clientId: string;
   clientSecretRef: string;
+  samlMetadataUrl: string;
+  samlMetadataXml: string;
+  samlSpEntityId: string;
   groupClaim: string;
   defaultRole: string;
   requireGroupMatch: boolean;
@@ -44,13 +54,21 @@ export interface TestConnectionResult {
   ok: boolean;
   reason?: string;
   message?: string;
+  warning?: string;
   discoveryUrl?: string;
+  metadataUrl?: string | null;
   discovery?: {
     issuer: string;
     authorizationEndpoint: string;
     tokenEndpoint: string;
     jwksUri: string;
     scopesSupported: string[];
+  };
+  saml?: {
+    entityId: string;
+    entryPoint: string;
+    hasSigningCert: boolean;
+    issuerMatchesMetadata: boolean;
   };
   claimStructurePreview?: {
     standardClaims: string[];
@@ -60,11 +78,15 @@ export interface TestConnectionResult {
 }
 
 const EMPTY_FORM: SsoFormState = {
+  providerType: 'oidc',
   name: '',
   issuer: '',
   discoveryUrl: '',
   clientId: '',
   clientSecretRef: '',
+  samlMetadataUrl: '',
+  samlMetadataXml: '',
+  samlSpEntityId: '',
   groupClaim: 'groups',
   defaultRole: 'member',
   requireGroupMatch: false,
@@ -83,11 +105,15 @@ function accountsUrl(path: string): string {
 
 export function providerToForm(p: SsoProvider): SsoFormState {
   return {
+    providerType: p.providerType,
     name: p.name,
     issuer: p.issuer,
     discoveryUrl: p.discoveryUrl ?? '',
     clientId: p.clientId ?? '',
     clientSecretRef: p.clientSecretRef ?? '',
+    samlMetadataUrl: p.samlMetadataUrl ?? '',
+    samlMetadataXml: p.samlMetadataXml ?? '',
+    samlSpEntityId: p.samlSpEntityId ?? '',
     groupClaim: p.groupClaim,
     defaultRole: p.defaultRole,
     requireGroupMatch: p.requireGroupMatch,
@@ -142,7 +168,6 @@ function SsoSettingsContent() {
         return;
       }
       if (!current.ssoFeature) {
-        // LicenseGate should hide, but API is source of truth for entitlement
         setError('SSO is not enabled for this account.');
         setAccountId(current.accountId);
         setLoading(false);
@@ -217,32 +242,68 @@ function SsoSettingsContent() {
 
   function updateField<K extends keyof SsoFormState>(key: K, value: SsoFormState[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
-    // Requiring re-test when connection-relevant fields change
-    if (key === 'issuer' || key === 'discoveryUrl' || key === 'groupClaim') {
+    const connectionKeys: Array<keyof SsoFormState> = [
+      'providerType',
+      'issuer',
+      'discoveryUrl',
+      'groupClaim',
+      'samlMetadataUrl',
+      'samlMetadataXml',
+    ];
+    if (connectionKeys.includes(key)) {
       setTestedOk(false);
       setTestResult(null);
     }
   }
 
+  function canTestConnection(): boolean {
+    if (!form.issuer.trim()) return false;
+    if (form.providerType === 'saml') {
+      return Boolean(form.samlMetadataUrl.trim() || form.samlMetadataXml.trim());
+    }
+    return true;
+  }
+
   async function handleTestConnection() {
     if (!accountId) return;
     if (!form.issuer.trim()) {
-      setError('Issuer is required to test the connection.');
+      setError(
+        form.providerType === 'saml'
+          ? 'IdP entity ID (issuer) is required to test the connection.'
+          : 'Issuer is required to test the connection.',
+      );
+      return;
+    }
+    if (form.providerType === 'saml' && !canTestConnection()) {
+      setError('Provide IdP metadata URL or paste metadata XML to test.');
       return;
     }
     setTesting(true);
     setError(null);
     try {
+      const body =
+        form.providerType === 'saml'
+          ? {
+              providerType: 'saml' as const,
+              issuer: form.issuer.trim(),
+              samlMetadataUrl: form.samlMetadataUrl.trim() || undefined,
+              samlMetadataXml: form.samlMetadataXml.trim() || undefined,
+              groupClaim: form.groupClaim.trim() || 'groups',
+              providerId: editingId ?? undefined,
+            }
+          : {
+              providerType: 'oidc' as const,
+              issuer: form.issuer.trim(),
+              discoveryUrl: form.discoveryUrl.trim() || undefined,
+              groupClaim: form.groupClaim.trim() || 'groups',
+              providerId: editingId ?? undefined,
+            };
+
       const res = await apiFetch(accountsUrl(`/${accountId}/sso-providers/test-connection`), {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          issuer: form.issuer.trim(),
-          discoveryUrl: form.discoveryUrl.trim() || undefined,
-          groupClaim: form.groupClaim.trim() || 'groups',
-          providerId: editingId ?? undefined,
-        }),
+        body: JSON.stringify(body),
       });
       // empty-catch-ok: JSON-parse fallback for an error-response body; `{}` is the safe shape so `data.error` evaluates to undefined and the UI falls back to the generic error text below.
       const data = (await res.json().catch(() => ({}))) as TestConnectionResult & {
@@ -257,9 +318,13 @@ function SsoSettingsContent() {
       setTestResult(data);
       setTestedOk(data.ok === true);
       if (data.ok) {
-        setSuccess('Discovery succeeded. You can enable this provider when ready.');
+        setSuccess(
+          form.providerType === 'saml'
+            ? 'IdP metadata validated. You can enable this provider when ready.'
+            : 'Discovery succeeded. You can enable this provider when ready.',
+        );
       } else {
-        setError(data.message ?? 'Discovery failed. Check issuer and discovery URL.');
+        setError(data.message ?? 'Test failed. Check issuer and metadata / discovery URL.');
       }
     } catch {
       setError('Unable to reach the server. Please check your connection and try again.');
@@ -270,8 +335,23 @@ function SsoSettingsContent() {
 
   async function handleSave() {
     if (!accountId) return;
-    if (!(form.name.trim() && form.issuer.trim())) {
-      setError('Name and issuer are required.');
+    if (!form.name.trim()) {
+      setError('Name is required.');
+      return;
+    }
+    if (!form.issuer.trim()) {
+      setError(
+        form.providerType === 'saml'
+          ? 'IdP entity ID (issuer) is required.'
+          : 'Name and issuer are required.',
+      );
+      return;
+    }
+    if (
+      form.providerType === 'saml' &&
+      !(form.samlMetadataUrl.trim() || form.samlMetadataXml.trim())
+    ) {
+      setError('SAML providers require a metadata URL or metadata XML.');
       return;
     }
     if (form.enabled && !testedOk && !enableConfirm) {
@@ -285,18 +365,32 @@ function SsoSettingsContent() {
     setSaving(true);
     setError(null);
     try {
-      const payload = {
-        name: form.name.trim(),
-        providerType: 'oidc' as const,
-        issuer: form.issuer.trim(),
-        discoveryUrl: form.discoveryUrl.trim() || null,
-        clientId: form.clientId.trim() || null,
-        clientSecretRef: form.clientSecretRef.trim() || null,
-        groupClaim: form.groupClaim.trim() || 'groups',
-        defaultRole: form.defaultRole,
-        requireGroupMatch: form.requireGroupMatch,
-        enabled: form.enabled,
-      };
+      const payload =
+        form.providerType === 'saml'
+          ? {
+              name: form.name.trim(),
+              providerType: 'saml' as const,
+              issuer: form.issuer.trim(),
+              samlMetadataUrl: form.samlMetadataUrl.trim() || null,
+              samlMetadataXml: form.samlMetadataXml.trim() || null,
+              samlSpEntityId: form.samlSpEntityId.trim() || null,
+              groupClaim: form.groupClaim.trim() || 'groups',
+              defaultRole: form.defaultRole,
+              requireGroupMatch: form.requireGroupMatch,
+              enabled: form.enabled,
+            }
+          : {
+              name: form.name.trim(),
+              providerType: 'oidc' as const,
+              issuer: form.issuer.trim(),
+              discoveryUrl: form.discoveryUrl.trim() || null,
+              clientId: form.clientId.trim() || null,
+              clientSecretRef: form.clientSecretRef.trim() || null,
+              groupClaim: form.groupClaim.trim() || 'groups',
+              defaultRole: form.defaultRole,
+              requireGroupMatch: form.requireGroupMatch,
+              enabled: form.enabled,
+            };
 
       const url = editingId
         ? accountsUrl(`/${accountId}/sso-providers/${editingId}`)
@@ -380,6 +474,14 @@ function SsoSettingsContent() {
     }
   }
 
+  const formTitle = editingId
+    ? form.providerType === 'saml'
+      ? 'Edit SAML provider'
+      : 'Edit OIDC provider'
+    : form.providerType === 'saml'
+      ? 'Add SAML provider'
+      : 'Add OIDC provider';
+
   return (
     <div className="min-h-screen">
       <div className="p-4 sm:p-6 max-w-2xl">
@@ -418,9 +520,9 @@ function SsoSettingsContent() {
                 <div>
                   <h1 className="text-base font-semibold text-foreground">Enterprise SSO</h1>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    Connect an OIDC identity provider (Okta, Azure AD, Google Workspace, Keycloak).
-                    Store client secrets as env/revvault references only. Never paste raw secrets
-                    here.
+                    Connect an OIDC or SAML identity provider (Okta, Azure AD, Google Workspace,
+                    Keycloak). Store client secrets as env/revvault references only. Never paste raw
+                    secrets here.
                   </p>
                 </div>
                 {!showForm && (
@@ -501,14 +603,35 @@ function SsoSettingsContent() {
 
             {showForm && (
               <div className="rounded-xl border border-border bg-card p-5">
-                <h2 className="text-base font-semibold text-foreground">
-                  {editingId ? 'Edit OIDC provider' : 'Add OIDC provider'}
-                </h2>
+                <h2 className="text-base font-semibold text-foreground">{formTitle}</h2>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  SAML configuration is planned. OIDC only for this release.
+                  {form.providerType === 'saml'
+                    ? 'Paste IdP metadata URL or XML. Optional SP entity ID overrides the default ACS-based entity ID.'
+                    : 'OIDC discovery + client credentials. Secrets as references only.'}
                 </p>
 
                 <div className="mt-5 flex flex-col gap-4">
+                  <Field>
+                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                      Protocol
+                    </Label>
+                    <Select
+                      value={form.providerType}
+                      onChange={(e) =>
+                        updateField('providerType', e.target.value === 'saml' ? 'saml' : 'oidc')
+                      }
+                      disabled={Boolean(editingId)}
+                    >
+                      <option value="oidc">OIDC</option>
+                      <option value="saml">SAML</option>
+                    </Select>
+                    {editingId && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Protocol is fixed after create. Remove and re-add to switch.
+                      </p>
+                    )}
+                  </Field>
+
                   <Field>
                     <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
                       Display name
@@ -516,62 +639,111 @@ function SsoSettingsContent() {
                     <Input
                       value={form.name}
                       onChange={(e) => updateField('name', e.target.value)}
-                      placeholder="Okta Production"
+                      placeholder={
+                        form.providerType === 'saml' ? 'Azure AD SAML' : 'Okta Production'
+                      }
                     />
                   </Field>
 
                   <Field>
                     <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                      Issuer
+                      {form.providerType === 'saml' ? 'IdP entity ID (issuer)' : 'Issuer'}
                     </Label>
                     <Input
                       value={form.issuer}
                       onChange={(e) => updateField('issuer', e.target.value)}
-                      placeholder="https://your-org.okta.com"
+                      placeholder={
+                        form.providerType === 'saml'
+                          ? 'https://sts.windows.net/…/'
+                          : 'https://your-org.okta.com'
+                      }
                     />
                   </Field>
 
-                  <Field>
-                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                      Discovery URL (optional)
-                    </Label>
-                    <Input
-                      value={form.discoveryUrl}
-                      onChange={(e) => updateField('discoveryUrl', e.target.value)}
-                      placeholder="https://…/.well-known/openid-configuration"
-                    />
-                  </Field>
+                  {form.providerType === 'oidc' && (
+                    <>
+                      <Field>
+                        <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                          Discovery URL (optional)
+                        </Label>
+                        <Input
+                          value={form.discoveryUrl}
+                          onChange={(e) => updateField('discoveryUrl', e.target.value)}
+                          placeholder="https://…/.well-known/openid-configuration"
+                        />
+                      </Field>
+
+                      <Field>
+                        <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                          Client ID
+                        </Label>
+                        <Input
+                          value={form.clientId}
+                          onChange={(e) => updateField('clientId', e.target.value)}
+                          placeholder="0oa…"
+                          autoComplete="off"
+                        />
+                      </Field>
+
+                      <Field>
+                        <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                          Client secret reference
+                        </Label>
+                        <Input
+                          value={form.clientSecretRef}
+                          onChange={(e) => updateField('clientSecretRef', e.target.value)}
+                          placeholder="REVEALUI_SSO_CLIENT_SECRET or revvault path"
+                          autoComplete="off"
+                        />
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Env var name or revvault path only. Never paste the secret value.
+                        </p>
+                      </Field>
+                    </>
+                  )}
+
+                  {form.providerType === 'saml' && (
+                    <>
+                      <Field>
+                        <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                          IdP metadata URL
+                        </Label>
+                        <Input
+                          value={form.samlMetadataUrl}
+                          onChange={(e) => updateField('samlMetadataUrl', e.target.value)}
+                          placeholder="https://idp.example.com/metadata.xml"
+                        />
+                      </Field>
+
+                      <Field>
+                        <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                          IdP metadata XML (optional if URL set)
+                        </Label>
+                        <Textarea
+                          value={form.samlMetadataXml}
+                          onChange={(e) => updateField('samlMetadataXml', e.target.value)}
+                          placeholder="<EntityDescriptor …>"
+                          rows={6}
+                          className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        />
+                      </Field>
+
+                      <Field>
+                        <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                          SP entity ID (optional override)
+                        </Label>
+                        <Input
+                          value={form.samlSpEntityId}
+                          onChange={(e) => updateField('samlSpEntityId', e.target.value)}
+                          placeholder="Defaults to ACS callback URL or REVEALUI_SSO_SP_ENTITY_ID"
+                        />
+                      </Field>
+                    </>
+                  )}
 
                   <Field>
                     <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                      Client ID
-                    </Label>
-                    <Input
-                      value={form.clientId}
-                      onChange={(e) => updateField('clientId', e.target.value)}
-                      placeholder="0oa…"
-                      autoComplete="off"
-                    />
-                  </Field>
-
-                  <Field>
-                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                      Client secret reference
-                    </Label>
-                    <Input
-                      value={form.clientSecretRef}
-                      onChange={(e) => updateField('clientSecretRef', e.target.value)}
-                      placeholder="REVEALUI_SSO_CLIENT_SECRET or revvault path"
-                      autoComplete="off"
-                    />
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Env var name or revvault path only. Never paste the secret value.
-                    </p>
-                  </Field>
-
-                  <Field>
-                    <Label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                      Group claim
+                      Group claim / attribute
                     </Label>
                     <Input
                       value={form.groupClaim}
@@ -639,7 +811,7 @@ function SsoSettingsContent() {
                       variant="neutral"
                       size="sm"
                       onClick={() => void handleTestConnection()}
-                      disabled={testing || !form.issuer.trim()}
+                      disabled={testing || !canTestConnection()}
                     >
                       {testing ? 'Testing…' : 'Test connection'}
                     </Button>
@@ -672,7 +844,13 @@ function SsoSettingsContent() {
                       }`}
                     >
                       <p className="font-medium">
-                        {testResult.ok ? 'Discovery OK' : 'Discovery failed'}
+                        {testResult.ok
+                          ? form.providerType === 'saml'
+                            ? 'Metadata OK'
+                            : 'Discovery OK'
+                          : form.providerType === 'saml'
+                            ? 'Metadata failed'
+                            : 'Discovery failed'}
                       </p>
                       {testResult.discoveryUrl && (
                         <p className="mt-1 break-all text-xs opacity-90">
@@ -706,6 +884,27 @@ function SsoSettingsContent() {
                             </div>
                           )}
                         </dl>
+                      )}
+                      {testResult.ok && testResult.saml && (
+                        <dl className="mt-3 space-y-1 text-xs text-foreground">
+                          <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Entity ID</dt>
+                            <dd className="truncate text-right">{testResult.saml.entityId}</dd>
+                          </div>
+                          <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">SSO entry</dt>
+                            <dd className="truncate text-right">{testResult.saml.entryPoint}</dd>
+                          </div>
+                          <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Signing cert</dt>
+                            <dd className="text-right">
+                              {testResult.saml.hasSigningCert ? 'present' : 'missing'}
+                            </dd>
+                          </div>
+                        </dl>
+                      )}
+                      {testResult.warning && (
+                        <p className="mt-2 text-xs text-warning-foreground">{testResult.warning}</p>
                       )}
                       {testResult.ok && testResult.claimStructurePreview && (
                         <div className="mt-3 text-xs text-foreground">

--- a/apps/server/src/routes/__tests__/sso-providers.test.ts
+++ b/apps/server/src/routes/__tests__/sso-providers.test.ts
@@ -8,6 +8,8 @@ const {
   mockInsertValues,
   mockUpdateWhere,
   mockFetchOidcDiscovery,
+  mockParseIdpMetadataXml,
+  mockFetchIdpMetadata,
   mockDb,
 } = vi.hoisted(() => {
   const mockMembershipLimit = vi.fn();
@@ -30,6 +32,8 @@ const {
     mockInsertValues,
     mockUpdateWhere,
     mockFetchOidcDiscovery: vi.fn(),
+    mockParseIdpMetadataXml: vi.fn(),
+    mockFetchIdpMetadata: vi.fn(),
     mockDb,
   };
 });
@@ -79,6 +83,10 @@ vi.mock('@revealui/db/schema', () => ({
     discoveryUrl: 'accountSsoProviders.discoveryUrl',
     clientId: 'accountSsoProviders.clientId',
     clientSecretRef: 'accountSsoProviders.clientSecretRef',
+    samlMetadataUrl: 'accountSsoProviders.samlMetadataUrl',
+    samlMetadataXml: 'accountSsoProviders.samlMetadataXml',
+    samlSpEntityId: 'accountSsoProviders.samlSpEntityId',
+    signingCertPem: 'accountSsoProviders.signingCertPem',
     groupClaim: 'accountSsoProviders.groupClaim',
     groupRoleMap: 'accountSsoProviders.groupRoleMap',
     defaultRole: 'accountSsoProviders.defaultRole',
@@ -92,6 +100,8 @@ vi.mock('@revealui/db/schema', () => ({
 
 vi.mock('@revealui/auth/server', () => ({
   fetchOidcDiscovery: (...args: unknown[]) => mockFetchOidcDiscovery(...args),
+  parseIdpMetadataXml: (...args: unknown[]) => mockParseIdpMetadataXml(...args),
+  fetchIdpMetadata: (...args: unknown[]) => mockFetchIdpMetadata(...args),
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -126,6 +136,10 @@ const PROVIDER_ROW = {
   discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
   clientId: 'client-1',
   clientSecretRef: 'REVEALUI_SSO_CLIENT_SECRET',
+  samlMetadataUrl: null,
+  samlMetadataXml: null,
+  samlSpEntityId: null,
+  signingCertPem: null,
   groupClaim: 'groups',
   groupRoleMap: { Engineering: 'member' },
   defaultRole: 'member',
@@ -134,6 +148,21 @@ const PROVIDER_ROW = {
   createdAt: new Date('2026-01-01T00:00:00.000Z'),
   updatedAt: new Date('2026-01-01T00:00:00.000Z'),
   deletedAt: null,
+};
+
+const SAML_PROVIDER_ROW = {
+  ...PROVIDER_ROW,
+  id: 'sso_saml',
+  providerType: 'saml',
+  name: 'Azure SAML',
+  issuer: 'https://sts.windows.net/tenant/',
+  discoveryUrl: null,
+  clientId: null,
+  clientSecretRef: null,
+  samlMetadataUrl: 'https://idp.example.com/metadata.xml',
+  samlMetadataXml: null,
+  samlSpEntityId: null,
+  signingCertPem: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----',
 };
 
 function createApp(user: typeof USER | null = USER) {
@@ -338,7 +367,7 @@ describe('SSO provider CRUD + entitlement', () => {
     expect(insertArg.providerType).toBe('oidc');
   });
 
-  it('rejects SAML create (planned)', async () => {
+  it('rejects SAML create without metadata', async () => {
     mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
     const app = createApp();
     const res = await app.request('/api/accounts/acct-1/sso-providers', {
@@ -352,7 +381,63 @@ describe('SSO provider CRUD + entitlement', () => {
     });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toMatch(/OIDC/i);
+    expect(body.error).toMatch(/metadata/i);
+  });
+
+  it('creates a SAML provider with metadata URL', async () => {
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
+    mockProviderSelectLimit.mockResolvedValue([SAML_PROVIDER_ROW]);
+
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Azure SAML',
+        providerType: 'saml',
+        issuer: 'https://sts.windows.net/tenant/',
+        samlMetadataUrl: 'https://idp.example.com/metadata.xml',
+      }),
+    });
+    expect(res.status).toBe(201);
+    const insertArg = mockInsertValues.mock.calls[0]?.[0] as {
+      providerType: string;
+      samlMetadataUrl: string;
+      clientId: string | null;
+    };
+    expect(insertArg.providerType).toBe('saml');
+    expect(insertArg.samlMetadataUrl).toBe('https://idp.example.com/metadata.xml');
+    expect(insertArg.clientId).toBeNull();
+  });
+
+  it('test-connection validates SAML metadata XML dry-run', async () => {
+    mockMembershipLimit.mockResolvedValue([{ accountId: 'acct-1', role: 'owner' }]);
+    mockParseIdpMetadataXml.mockReturnValue({
+      ok: true,
+      entityId: 'https://sts.windows.net/tenant/',
+      entryPoint: 'https://login.microsoftonline.com/sso',
+      idpCertPem: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----',
+    });
+    const app = createApp();
+    const res = await app.request('/api/accounts/acct-1/sso-providers/test-connection', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        providerType: 'saml',
+        issuer: 'https://sts.windows.net/tenant/',
+        samlMetadataXml: '<EntityDescriptor entityID="https://sts.windows.net/tenant/"/>',
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      saml: { entityId: string; entryPoint: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.saml.entityId).toBe('https://sts.windows.net/tenant/');
+    expect(body.saml.entryPoint).toBe('https://login.microsoftonline.com/sso');
+    expect(mockParseIdpMetadataXml).toHaveBeenCalled();
+    expect(mockFetchOidcDiscovery).not.toHaveBeenCalled();
   });
 
   it('returns 404 when provider id is not on the account', async () => {

--- a/apps/server/src/routes/sso-providers.ts
+++ b/apps/server/src/routes/sso-providers.ts
@@ -22,7 +22,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { fetchOidcDiscovery } from '@revealui/auth/server';
+import { fetchIdpMetadata, fetchOidcDiscovery, parseIdpMetadataXml } from '@revealui/auth/server';
 import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { accountMemberships, accountSsoProviders } from '@revealui/db/schema';
@@ -60,6 +60,11 @@ interface ProviderPublic {
   clientId: string | null;
   /** Vault path / env var name only — never a resolved secret */
   clientSecretRef: string | null;
+  samlMetadataUrl: string | null;
+  samlMetadataXml: string | null;
+  samlSpEntityId: string | null;
+  /** Present when stored; never return PEM body contents as a secret — PEM is IdP public cert */
+  hasSigningCert: boolean;
   groupClaim: string;
   groupRoleMap: Record<string, string>;
   defaultRole: string;
@@ -76,6 +81,10 @@ interface CreateBody {
   discoveryUrl?: unknown;
   clientId?: unknown;
   clientSecretRef?: unknown;
+  samlMetadataUrl?: unknown;
+  samlMetadataXml?: unknown;
+  samlSpEntityId?: unknown;
+  signingCertPem?: unknown;
   groupClaim?: unknown;
   groupRoleMap?: unknown;
   defaultRole?: unknown;
@@ -87,10 +96,13 @@ interface CreateBody {
 interface UpdateBody extends CreateBody {}
 
 interface TestConnectionBody {
+  providerType?: unknown;
   issuer?: unknown;
   discoveryUrl?: unknown;
   groupClaim?: unknown;
   providerId?: unknown;
+  samlMetadataUrl?: unknown;
+  samlMetadataXml?: unknown;
 }
 
 // ---------------------------------------------------------------------------
@@ -195,6 +207,10 @@ function toPublic(row: {
   discoveryUrl: string | null;
   clientId: string | null;
   clientSecretRef: string | null;
+  samlMetadataUrl?: string | null;
+  samlMetadataXml?: string | null;
+  samlSpEntityId?: string | null;
+  signingCertPem?: string | null;
   groupClaim: string;
   groupRoleMap: unknown;
   defaultRole: string;
@@ -203,6 +219,7 @@ function toPublic(row: {
   createdAt: Date;
   updatedAt: Date;
 }): ProviderPublic {
+  const signing = row.signingCertPem?.trim() ?? '';
   return {
     id: row.id,
     accountId: row.accountId,
@@ -213,6 +230,11 @@ function toPublic(row: {
     discoveryUrl: row.discoveryUrl,
     clientId: row.clientId,
     clientSecretRef: row.clientSecretRef,
+    samlMetadataUrl: row.samlMetadataUrl ?? null,
+    // Return XML so admins can re-edit; it is IdP public metadata, not a secret
+    samlMetadataXml: row.samlMetadataXml ?? null,
+    samlSpEntityId: row.samlSpEntityId ?? null,
+    hasSigningCert: signing.length > 0,
     groupClaim: row.groupClaim,
     groupRoleMap: (row.groupRoleMap ?? {}) as Record<string, string>,
     defaultRole: row.defaultRole,
@@ -221,6 +243,20 @@ function toPublic(row: {
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
+}
+
+function asProviderType(value: unknown, fallback: 'oidc' | 'saml' = 'oidc'): 'oidc' | 'saml' {
+  const raw = typeof value === 'string' ? value.trim().toLowerCase() : fallback;
+  if (raw === 'oidc' || raw === 'saml') return raw;
+  throw new HTTPException(400, { message: 'providerType must be oidc or saml' });
+}
+
+function requireSamlMetadata(metadataUrl: string | null, metadataXml: string | null): void {
+  if (!(metadataUrl || metadataXml)) {
+    throw new HTTPException(400, {
+      message: 'SAML providers require samlMetadataUrl or samlMetadataXml',
+    });
+  }
 }
 
 async function loadMembership(userId: string, accountId: string): Promise<MembershipRow | null> {
@@ -367,6 +403,91 @@ app.get('/current', async (c) => {
 // POST /:accountId/sso-providers/test-connection (before :providerId routes)
 // ---------------------------------------------------------------------------
 
+async function runOidcTestConnection(
+  issuer: string,
+  discoveryUrl: string | null,
+  groupClaim: string,
+): Promise<Record<string, unknown>> {
+  const url = buildDiscoveryUrl(issuer, discoveryUrl);
+  const result = await fetchOidcDiscovery(url, { expectedIssuer: issuer });
+
+  if (!result.ok) {
+    return {
+      ok: false as const,
+      reason: result.reason,
+      message: result.message,
+      discoveryUrl: url,
+    };
+  }
+
+  const doc = result.document;
+  return {
+    ok: true as const,
+    discoveryUrl: url,
+    discovery: {
+      issuer: doc.issuer,
+      authorizationEndpoint: doc.authorization_endpoint,
+      tokenEndpoint: doc.token_endpoint,
+      jwksUri: doc.jwks_uri,
+      userinfoEndpoint: doc.userinfo_endpoint ?? null,
+      endSessionEndpoint: doc.end_session_endpoint ?? null,
+      scopesSupported: doc.scopes_supported ?? [],
+      responseTypesSupported: doc.response_types_supported ?? [],
+      codeChallengeMethodsSupported: doc.code_challenge_methods_supported ?? [],
+    },
+    claimStructurePreview: claimStructurePreview(groupClaim),
+  };
+}
+
+async function runSamlTestConnection(
+  issuer: string,
+  metadataUrl: string | null,
+  metadataXml: string | null,
+  groupClaim: string,
+): Promise<Record<string, unknown>> {
+  if (!(metadataUrl || metadataXml)) {
+    throw new HTTPException(400, {
+      message: 'samlMetadataUrl or samlMetadataXml is required for SAML test connection',
+    });
+  }
+
+  const parsed = metadataXml
+    ? parseIdpMetadataXml(metadataXml)
+    : await fetchIdpMetadata(metadataUrl as string);
+
+  if (!parsed.ok) {
+    return {
+      ok: false as const,
+      reason: parsed.reason,
+      message: parsed.message,
+      metadataUrl: metadataUrl ?? undefined,
+    };
+  }
+
+  const issuerMismatch =
+    issuer.length > 0 &&
+    parsed.entityId.length > 0 &&
+    issuer.replace(/\/+$/, '') !== parsed.entityId.replace(/\/+$/, '');
+
+  return {
+    ok: true as const,
+    metadataUrl: metadataUrl ?? null,
+    saml: {
+      entityId: parsed.entityId,
+      entryPoint: parsed.entryPoint,
+      hasSigningCert: true,
+      issuerMatchesMetadata: !issuerMismatch,
+    },
+    claimStructurePreview: claimStructurePreview(groupClaim),
+    ...(issuerMismatch
+      ? {
+          warning:
+            'Configured issuer does not match IdP metadata entityID. Update issuer to the entityID before enabling.',
+        }
+      : {}),
+  };
+}
+
 app.post('/:accountId/sso-providers/test-connection', async (c) => {
   const accountId = c.req.param('accountId');
   await authorizeAccountAccess(c, accountId, { mutation: true });
@@ -378,10 +499,19 @@ app.post('/:accountId/sso-providers/test-connection', async (c) => {
     body = {};
   }
 
+  let providerType: 'oidc' | 'saml' = asProviderType(body.providerType ?? 'oidc');
   let issuer = typeof body.issuer === 'string' ? body.issuer.trim() : '';
   let discoveryUrl =
     typeof body.discoveryUrl === 'string' && body.discoveryUrl.trim().length > 0
       ? body.discoveryUrl.trim()
+      : null;
+  let samlMetadataUrl =
+    typeof body.samlMetadataUrl === 'string' && body.samlMetadataUrl.trim().length > 0
+      ? body.samlMetadataUrl.trim()
+      : null;
+  let samlMetadataXml =
+    typeof body.samlMetadataXml === 'string' && body.samlMetadataXml.trim().length > 0
+      ? body.samlMetadataXml.trim()
       : null;
   let groupClaim =
     typeof body.groupClaim === 'string' && body.groupClaim.trim().length > 0
@@ -398,8 +528,11 @@ app.post('/:accountId/sso-providers/test-connection', async (c) => {
     if (!existing) {
       throw new HTTPException(404, { message: 'SSO provider not found' });
     }
+    providerType = existing.providerType;
     if (!issuer) issuer = existing.issuer;
     if (!discoveryUrl) discoveryUrl = existing.discoveryUrl;
+    if (!samlMetadataUrl) samlMetadataUrl = existing.samlMetadataUrl;
+    if (!samlMetadataXml) samlMetadataXml = existing.samlMetadataXml;
     if (groupClaim === 'groups' && existing.groupClaim) groupClaim = existing.groupClaim;
   }
 
@@ -407,41 +540,14 @@ app.post('/:accountId/sso-providers/test-connection', async (c) => {
     throw new HTTPException(400, { message: 'issuer is required for test connection' });
   }
 
-  const url = buildDiscoveryUrl(issuer, discoveryUrl);
-  const result = await fetchOidcDiscovery(url, { expectedIssuer: issuer });
-
-  if (!result.ok) {
+  if (providerType === 'saml') {
     return c.json(
-      {
-        ok: false as const,
-        reason: result.reason,
-        message: result.message,
-        discoveryUrl: url,
-      },
+      await runSamlTestConnection(issuer, samlMetadataUrl, samlMetadataXml, groupClaim),
       200,
     );
   }
 
-  const doc = result.document;
-  return c.json(
-    {
-      ok: true as const,
-      discoveryUrl: url,
-      discovery: {
-        issuer: doc.issuer,
-        authorizationEndpoint: doc.authorization_endpoint,
-        tokenEndpoint: doc.token_endpoint,
-        jwksUri: doc.jwks_uri,
-        userinfoEndpoint: doc.userinfo_endpoint ?? null,
-        endSessionEndpoint: doc.end_session_endpoint ?? null,
-        scopesSupported: doc.scopes_supported ?? [],
-        responseTypesSupported: doc.response_types_supported ?? [],
-        codeChallengeMethodsSupported: doc.code_challenge_methods_supported ?? [],
-      },
-      claimStructurePreview: claimStructurePreview(groupClaim),
-    },
-    200,
-  );
+  return c.json(await runOidcTestConnection(issuer, discoveryUrl, groupClaim), 200);
 });
 
 // ---------------------------------------------------------------------------
@@ -458,39 +564,20 @@ app.post('/:accountId/sso-providers/:providerId/test-connection', async (c) => {
     throw new HTTPException(404, { message: 'SSO provider not found' });
   }
 
-  const url = buildDiscoveryUrl(existing.issuer, existing.discoveryUrl);
-  const result = await fetchOidcDiscovery(url, { expectedIssuer: existing.issuer });
-
-  if (!result.ok) {
+  if (existing.providerType === 'saml') {
     return c.json(
-      {
-        ok: false as const,
-        reason: result.reason,
-        message: result.message,
-        discoveryUrl: url,
-      },
+      await runSamlTestConnection(
+        existing.issuer,
+        existing.samlMetadataUrl,
+        existing.samlMetadataXml,
+        existing.groupClaim,
+      ),
       200,
     );
   }
 
-  const doc = result.document;
   return c.json(
-    {
-      ok: true as const,
-      discoveryUrl: url,
-      discovery: {
-        issuer: doc.issuer,
-        authorizationEndpoint: doc.authorization_endpoint,
-        tokenEndpoint: doc.token_endpoint,
-        jwksUri: doc.jwks_uri,
-        userinfoEndpoint: doc.userinfo_endpoint ?? null,
-        endSessionEndpoint: doc.end_session_endpoint ?? null,
-        scopesSupported: doc.scopes_supported ?? [],
-        responseTypesSupported: doc.response_types_supported ?? [],
-        codeChallengeMethodsSupported: doc.code_challenge_methods_supported ?? [],
-      },
-      claimStructurePreview: claimStructurePreview(existing.groupClaim),
-    },
+    await runOidcTestConnection(existing.issuer, existing.discoveryUrl, existing.groupClaim),
     200,
   );
 });
@@ -530,17 +617,19 @@ app.post('/:accountId/sso-providers', async (c) => {
   }
 
   const name = asNonEmptyString(body.name, 'name');
-  const providerTypeRaw = asNonEmptyString(body.providerType ?? 'oidc', 'providerType');
-  if (providerTypeRaw !== 'oidc') {
-    throw new HTTPException(400, {
-      message: 'Only OIDC providers are supported in this release. SAML is planned.',
-    });
-  }
+  const providerType = asProviderType(body.providerType ?? 'oidc');
 
   const issuer = asNonEmptyString(body.issuer, 'issuer');
   const discoveryUrl = asOptionalString(body.discoveryUrl);
   const clientId = asOptionalString(body.clientId);
   const clientSecretRef = asOptionalString(body.clientSecretRef);
+  const samlMetadataUrl = asOptionalString(body.samlMetadataUrl);
+  const samlMetadataXml = asOptionalString(body.samlMetadataXml);
+  const samlSpEntityId = asOptionalString(body.samlSpEntityId);
+  const signingCertPem = asOptionalString(body.signingCertPem);
+  if (providerType === 'saml') {
+    requireSamlMetadata(samlMetadataUrl, samlMetadataXml);
+  }
   const groupClaim =
     typeof body.groupClaim === 'string' && body.groupClaim.trim().length > 0
       ? body.groupClaim.trim()
@@ -565,13 +654,17 @@ app.post('/:accountId/sso-providers', async (c) => {
     await db.insert(accountSsoProviders).values({
       id,
       accountId,
-      providerType: 'oidc',
+      providerType,
       name,
       enabled,
       issuer,
-      discoveryUrl,
-      clientId,
-      clientSecretRef,
+      discoveryUrl: providerType === 'oidc' ? discoveryUrl : null,
+      clientId: providerType === 'oidc' ? clientId : null,
+      clientSecretRef: providerType === 'oidc' ? clientSecretRef : null,
+      samlMetadataUrl: providerType === 'saml' ? samlMetadataUrl : null,
+      samlMetadataXml: providerType === 'saml' ? samlMetadataXml : null,
+      samlSpEntityId: providerType === 'saml' ? samlSpEntityId : null,
+      signingCertPem: providerType === 'saml' ? signingCertPem : null,
       groupClaim,
       groupRoleMap,
       defaultRole,
@@ -643,11 +736,12 @@ app.patch('/:accountId/sso-providers/:providerId', async (c) => {
     throw new HTTPException(400, { message: 'Invalid JSON body' });
   }
 
+  // providerType is immutable after create (avoid half-migrated OIDC/SAML rows)
   if (body.providerType !== undefined) {
-    const pt = asNonEmptyString(body.providerType, 'providerType');
-    if (pt !== 'oidc') {
+    const pt = asProviderType(body.providerType);
+    if (pt !== existing.providerType) {
       throw new HTTPException(400, {
-        message: 'Only OIDC providers are supported in this release. SAML is planned.',
+        message: 'providerType cannot be changed after create; remove and re-add the provider',
       });
     }
   }
@@ -659,6 +753,10 @@ app.patch('/:accountId/sso-providers/:providerId', async (c) => {
     discoveryUrl: string | null;
     clientId: string | null;
     clientSecretRef: string | null;
+    samlMetadataUrl: string | null;
+    samlMetadataXml: string | null;
+    samlSpEntityId: string | null;
+    signingCertPem: string | null;
     groupClaim: string;
     groupRoleMap: Record<string, string>;
     defaultRole: string;
@@ -673,6 +771,18 @@ app.patch('/:accountId/sso-providers/:providerId', async (c) => {
   if (body.clientId !== undefined) patch.clientId = asOptionalString(body.clientId);
   if (body.clientSecretRef !== undefined) {
     patch.clientSecretRef = asOptionalString(body.clientSecretRef);
+  }
+  if (body.samlMetadataUrl !== undefined) {
+    patch.samlMetadataUrl = asOptionalString(body.samlMetadataUrl);
+  }
+  if (body.samlMetadataXml !== undefined) {
+    patch.samlMetadataXml = asOptionalString(body.samlMetadataXml);
+  }
+  if (body.samlSpEntityId !== undefined) {
+    patch.samlSpEntityId = asOptionalString(body.samlSpEntityId);
+  }
+  if (body.signingCertPem !== undefined) {
+    patch.signingCertPem = asOptionalString(body.signingCertPem);
   }
   if (body.groupClaim !== undefined) {
     patch.groupClaim = asNonEmptyString(body.groupClaim, 'groupClaim');
@@ -693,6 +803,14 @@ app.patch('/:accountId/sso-providers/:providerId', async (c) => {
   }
   if (body.enabled !== undefined) {
     patch.enabled = asBoolean(body.enabled, false);
+  }
+
+  if (existing.providerType === 'saml') {
+    const nextUrl =
+      patch.samlMetadataUrl !== undefined ? patch.samlMetadataUrl : existing.samlMetadataUrl;
+    const nextXml =
+      patch.samlMetadataXml !== undefined ? patch.samlMetadataXml : existing.samlMetadataXml;
+    requireSamlMetadata(nextUrl, nextXml);
   }
 
   const db = getClient();


### PR DESCRIPTION
## Summary
GAP-464 residual after Phase 3 SAML SP layer (#2409): make SAML operable from Admin.

### Server (`sso-providers`)
- Accept `providerType: saml` on create (was hard-rejected)
- Persist `samlMetadataUrl` / `samlMetadataXml` / `samlSpEntityId` / optional `signingCertPem`
- Public shape includes SAML fields + `hasSigningCert` (no PEM body in list responses except XML metadata which is IdP public config)
- `providerType` immutable after create
- `test-connection` dry-run for SAML via `parseIdpMetadataXml` / `fetchIdpMetadata`

### Admin (`settings/sso`)
- Protocol select: OIDC | SAML
- SAML fields: IdP entity ID, metadata URL, metadata XML (`Textarea` from presentation/client), optional SP entity ID
- Test connection preview for SAML metadata

## Security
Auth/federation admin surface. Non-author review before merge. Do not self-merge.

## Test plan
- [x] `vitest` apps/server `sso-providers.test.ts` (17 passed)
- [x] `vitest` admin `sso-settings-client.test.tsx` (7 passed)
- [x] Local phase-1 gate / pre-push PASS
- [ ] CI green
- [ ] Non-author security review

## Residual after land
Mock IdP e2e, customer docs / drop planned markers, formal GAP-464 close + copy-dependents.

## Peer note
Hands off `auth-sso` ACS tests if `.wt/gap-464-acs-tests` still in flight.