### PR TITLE
test(auth): GAP-464 mock IdP integration + security regression

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -31,8 +31,10 @@
     "@vitest/coverage-v8": "catalog:",
     "happy-dom": "^20.10.6",
     "react": "catalog:",
+    "selfsigned": "2.4.1",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "xml-crypto": "6.1.2"
   },
   "engines": {
     "node": ">=24.13.0"

--- a/packages/auth/src/server/sso/__tests__/helpers/mock-oidc-idp.ts
+++ b/packages/auth/src/server/sso/__tests__/helpers/mock-oidc-idp.ts
@@ -1,0 +1,174 @@
+/**
+ * Minimal mock OIDC IdP for GAP-464 integration tests.
+ * Real RSA keys + jose-signed id_tokens; discovery/token/jwks via fetchImpl.
+ */
+
+import { generateKeyPairSync } from 'node:crypto';
+import { exportJWK, importPKCS8, type JWTPayload, type KeyLike, SignJWT } from 'jose';
+
+export interface MockOidcIdpOptions {
+  issuer?: string;
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export interface MockOidcIdp {
+  issuer: string;
+  clientId: string;
+  clientSecret: string;
+  discoveryUrl: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  jwksUri: string;
+  /** Local KeyLike for direct validateOidcIdToken tests */
+  publicKey: KeyLike;
+  signIdToken: (
+    claims?: Record<string, unknown>,
+    overrides?: {
+      issuer?: string;
+      audience?: string;
+      expSeconds?: number;
+      privateKey?: KeyLike;
+    },
+  ) => Promise<string>;
+  /** fetchImpl that routes discovery, jwks, and token endpoints */
+  fetchImpl: typeof fetch;
+}
+
+export async function createMockOidcIdp(options: MockOidcIdpOptions = {}): Promise<MockOidcIdp> {
+  const issuer = options.issuer ?? 'https://mock-idp.example.com';
+  const clientId = options.clientId ?? 'revealui-sso-client';
+  const clientSecret = options.clientSecret ?? 'mock-client-secret';
+
+  const { publicKey: pubPem, privateKey: privPem } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  const privateKey = await importPKCS8(privPem, 'RS256');
+  const { createPublicKey } = await import('node:crypto');
+  const pub = createPublicKey(pubPem);
+  const jwk = await exportJWK(pub);
+  jwk.alg = 'RS256';
+  jwk.use = 'sig';
+  jwk.kid = 'mock-idp-1';
+
+  const publicKey = (await (
+    await import('jose')
+  ).importJWK({ ...jwk, alg: 'RS256' }, 'RS256')) as KeyLike;
+
+  const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
+  const authorizationEndpoint = `${issuer}/authorize`;
+  const tokenEndpoint = `${issuer}/token`;
+  const jwksUri = `${issuer}/jwks`;
+
+  async function signIdToken(
+    claims: Record<string, unknown> = {},
+    overrides?: {
+      issuer?: string;
+      audience?: string;
+      expSeconds?: number;
+      privateKey?: KeyLike;
+    },
+  ): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    const exp = overrides?.expSeconds ?? now + 3600;
+    const sub = typeof claims.sub === 'string' ? claims.sub : 'user-sub-1';
+    const payload: JWTPayload = { ...claims, sub };
+    return new SignJWT(payload)
+      .setProtectedHeader({ alg: 'RS256', kid: 'mock-idp-1' })
+      .setIssuer(overrides?.issuer ?? issuer)
+      .setAudience(overrides?.audience ?? clientId)
+      .setIssuedAt(now)
+      .setExpirationTime(exp)
+      .setSubject(sub)
+      .sign(overrides?.privateKey ?? privateKey);
+  }
+
+  const discoveryDoc = {
+    issuer,
+    authorization_endpoint: authorizationEndpoint,
+    token_endpoint: tokenEndpoint,
+    jwks_uri: jwksUri,
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256'],
+    scopes_supported: ['openid', 'email', 'profile'],
+  };
+
+  const jwksDoc = { keys: [jwk] };
+
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url === discoveryUrl || url.startsWith(`${discoveryUrl}?`)) {
+      return new Response(JSON.stringify(discoveryDoc), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url === jwksUri || url.startsWith(`${jwksUri}?`)) {
+      return new Response(JSON.stringify(jwksDoc), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url === tokenEndpoint || url.startsWith(`${tokenEndpoint}?`)) {
+      if ((init?.method ?? 'GET').toUpperCase() !== 'POST') {
+        return new Response('method not allowed', { status: 405 });
+      }
+      // undici may pass URLSearchParams; avoid cross-realm instanceof
+      const rawBody = init?.body;
+      const bodyText =
+        rawBody == null
+          ? ''
+          : typeof rawBody === 'string'
+            ? rawBody
+            : typeof (rawBody as { toString?: () => string }).toString === 'function'
+              ? (rawBody as { toString: () => string }).toString()
+              : '';
+      const params = new URLSearchParams(bodyText);
+      // Accept any non-empty code; mock IdP does not track issued codes
+      if (!params.get('code') || params.get('grant_type') !== 'authorization_code') {
+        return new Response(JSON.stringify({ error: 'invalid_request', body: bodyText }), {
+          status: 400,
+        });
+      }
+      if (params.get('client_id') !== clientId || params.get('client_secret') !== clientSecret) {
+        return new Response(JSON.stringify({ error: 'invalid_client' }), { status: 401 });
+      }
+      const idToken = await signIdToken({
+        email: 'alice@example.com',
+        email_verified: true,
+        name: 'Alice Example',
+        groups: ['Engineering', 'Staff'],
+      });
+      return new Response(
+        JSON.stringify({
+          id_token: idToken,
+          access_token: 'mock-access',
+          token_type: 'Bearer',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    return new Response(`not found: ${url}`, { status: 404 });
+  }) as typeof fetch;
+
+  return {
+    issuer,
+    clientId,
+    clientSecret,
+    discoveryUrl,
+    authorizationEndpoint,
+    tokenEndpoint,
+    jwksUri,
+    publicKey,
+    signIdToken,
+    fetchImpl,
+  };
+}

--- a/packages/auth/src/server/sso/__tests__/helpers/mock-saml-idp.ts
+++ b/packages/auth/src/server/sso/__tests__/helpers/mock-saml-idp.ts
@@ -1,0 +1,206 @@
+/**
+ * Minimal mock SAML IdP for GAP-464 integration tests.
+ * Self-signed X509 + xml-crypto enveloped signatures on Response + Assertion.
+ */
+
+import { randomBytes } from 'node:crypto';
+import selfsigned from 'selfsigned';
+import { SignedXml } from 'xml-crypto';
+
+export interface MockSamlIdp {
+  entityId: string;
+  ssoUrl: string;
+  certPem: string;
+  privateKeyPem: string;
+  /** Build IdP metadata XML consumed by parseIdpMetadataXml */
+  metadataXml: string;
+  /**
+   * Build a base64 SAMLResponse (HTTP-POST) signed by this IdP.
+   * When sign is false, returns an unsigned Response for reject tests.
+   */
+  buildPostResponse: (input: {
+    spEntityId: string;
+    acsUrl: string;
+    nameId: string;
+    groups?: string[];
+    sign?: boolean;
+    notOnOrAfterOffsetMs?: number;
+  }) => string;
+}
+
+function stripPemHeaders(pem: string): string {
+  const lines = pem.split('\n');
+  const body: string[] = [];
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t || t.startsWith('-----')) continue;
+    body.push(t);
+  }
+  return body.join('');
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+export function createMockSamlIdp(options?: { entityId?: string }): MockSamlIdp {
+  const entityId = options?.entityId ?? 'https://saml-idp.example.com';
+  const ssoUrl = `${entityId}/sso`;
+
+  const attrs = [{ name: 'commonName', value: 'mock-saml-idp' }];
+  const pems = selfsigned.generate(attrs, {
+    keySize: 2048,
+    days: 1,
+    algorithm: 'sha256',
+  });
+
+  const idpPrivateKeyPem = pems.private;
+  const certPem = pems.cert;
+  const certBody = stripPemHeaders(certPem);
+
+  const metadataXml = `<?xml version="1.0"?>
+<EntityDescriptor entityID="${escapeXml(entityId)}" xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>${certBody}</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <SingleSignOnService
+      Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+      Location="${escapeXml(ssoUrl)}" />
+  </IDPSSODescriptor>
+</EntityDescriptor>`;
+
+  function buildUnsignedAssertion(input: {
+    spEntityId: string;
+    acsUrl: string;
+    nameId: string;
+    groups: string[];
+    issueInstant: string;
+    notOnOrAfter: string;
+    assertionId: string;
+  }): string {
+    const groupAttrs = input.groups
+      .map(
+        (g) =>
+          `<saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">${escapeXml(g)}</saml:AttributeValue>`,
+      )
+      .join('');
+
+    return `<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="${input.assertionId}" IssueInstant="${input.issueInstant}">
+  <saml:Issuer>${escapeXml(entityId)}</saml:Issuer>
+  <saml:Subject>
+    <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">${escapeXml(input.nameId)}</saml:NameID>
+    <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+      <saml:SubjectConfirmationData NotOnOrAfter="${input.notOnOrAfter}" Recipient="${escapeXml(input.acsUrl)}" />
+    </saml:SubjectConfirmation>
+  </saml:Subject>
+  <saml:Conditions NotBefore="${input.issueInstant}" NotOnOrAfter="${input.notOnOrAfter}">
+    <saml:AudienceRestriction>
+      <saml:Audience>${escapeXml(input.spEntityId)}</saml:Audience>
+    </saml:AudienceRestriction>
+  </saml:Conditions>
+  <saml:AuthnStatement AuthnInstant="${input.issueInstant}" SessionIndex="_session1">
+    <saml:AuthnContext>
+      <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+    </saml:AuthnContext>
+  </saml:AuthnStatement>
+  <saml:AttributeStatement>
+    <saml:Attribute Name="email">
+      <saml:AttributeValue>${escapeXml(input.nameId)}</saml:AttributeValue>
+    </saml:Attribute>
+    <saml:Attribute Name="groups">${groupAttrs}</saml:Attribute>
+  </saml:AttributeStatement>
+</saml:Assertion>`;
+  }
+
+  function signXmlEnveloped(xml: string, idAttr: string): string {
+    // Place Signature immediately after Issuer (valid for both Assertion and Response)
+    const issuerPath =
+      "/*[local-name()='Assertion' or local-name()='Response']/*[local-name()='Issuer']";
+    const refPath = `//*[@ID='${idAttr}']`;
+    const sig = new SignedXml({
+      privateKey: idpPrivateKeyPem,
+      publicCert: certPem,
+    });
+    sig.addReference({
+      xpath: refPath,
+      transforms: [
+        'http://www.w3.org/2000/09/xmldsig#enveloped-signature',
+        'http://www.w3.org/2001/10/xml-exc-c14n#',
+      ],
+      digestAlgorithm: 'http://www.w3.org/2001/04/xmlenc#sha256',
+    });
+    sig.signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+    sig.canonicalizationAlgorithm = 'http://www.w3.org/2001/10/xml-exc-c14n#';
+    sig.computeSignature(xml, {
+      location: { reference: issuerPath, action: 'after' },
+      prefix: 'ds',
+    });
+    return sig.getSignedXml();
+  }
+
+  function buildPostResponse(input: {
+    spEntityId: string;
+    acsUrl: string;
+    nameId: string;
+    groups?: string[];
+    sign?: boolean;
+    notOnOrAfterOffsetMs?: number;
+  }): string {
+    const shouldSign = input.sign !== false;
+    const now = new Date();
+    const issueInstant = now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+    const notOnOrAfter = new Date(now.getTime() + (input.notOnOrAfterOffsetMs ?? 5 * 60 * 1000))
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+    const responseId = `_resp_${randomBytes(8).toString('hex')}`;
+    const assertionId = `_assert_${randomBytes(8).toString('hex')}`;
+    const groups = input.groups ?? ['Engineering'];
+
+    let assertion = buildUnsignedAssertion({
+      spEntityId: input.spEntityId,
+      acsUrl: input.acsUrl,
+      nameId: input.nameId,
+      groups,
+      issueInstant,
+      notOnOrAfter,
+      assertionId,
+    });
+
+    if (shouldSign) {
+      assertion = signXmlEnveloped(assertion, assertionId);
+    }
+
+    let response = `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="${responseId}" IssueInstant="${issueInstant}" Destination="${escapeXml(input.acsUrl)}">
+  <saml:Issuer>${escapeXml(entityId)}</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  ${assertion}
+</samlp:Response>`;
+
+    if (shouldSign) {
+      response = signXmlEnveloped(response, responseId);
+    }
+
+    return Buffer.from(response, 'utf8').toString('base64');
+  }
+
+  return {
+    entityId,
+    ssoUrl,
+    certPem,
+    privateKeyPem: idpPrivateKeyPem,
+    metadataXml,
+    buildPostResponse,
+  };
+}

--- a/packages/auth/src/server/sso/__tests__/mock-idp.integration.test.ts
+++ b/packages/auth/src/server/sso/__tests__/mock-idp.integration.test.ts
@@ -1,0 +1,307 @@
+/**
+ * GAP-464 Phase 7 — mock IdP integration + security regression.
+ * Pure-layer end-to-end against real crypto (no HTTP route mocks).
+ */
+
+import { generateKeyPairSync } from 'node:crypto';
+import { importPKCS8, SignJWT } from 'jose';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  buildOidcAuthorizationUrl,
+  exchangeOidcCode,
+  fetchOidcDiscovery,
+  validateOidcIdToken,
+} from '../oidc.js';
+import { mapSsoGroupsToRole } from '../roles.js';
+import {
+  buildSamlAuthorizeUrl,
+  parseIdpMetadataXml,
+  type SamlSpConfig,
+  validateSamlPostResponse,
+} from '../saml.js';
+import { generateSsoState, verifySsoState } from '../state.js';
+import { createMockOidcIdp, type MockOidcIdp } from './helpers/mock-oidc-idp.js';
+import { createMockSamlIdp, type MockSamlIdp } from './helpers/mock-saml-idp.js';
+
+const SP_ENTITY = 'https://app.example.com/sp';
+const ACS = 'https://api.example.com/api/auth/sso/prov-1/callback';
+
+describe('mock OIDC IdP integration (GAP-464 Phase 7)', () => {
+  let idp: MockOidcIdp;
+
+  beforeAll(async () => {
+    process.env.REVEALUI_SECRET = 'mock-idp-integration-secret-for-tests-only';
+    idp = await createMockOidcIdp();
+  });
+
+  it('walks discovery → token exchange → id_token validate → group map', async () => {
+    const discovery = await fetchOidcDiscovery(idp.discoveryUrl, {
+      fetchImpl: idp.fetchImpl,
+      expectedIssuer: idp.issuer,
+    });
+    expect(discovery.ok).toBe(true);
+    if (!discovery.ok) return;
+
+    const state = generateSsoState({
+      accountId: 'acct-1',
+      providerId: 'prov-1',
+      redirectTo: '/home',
+    });
+    // codeVerifier lives inside signed state (unpacked on ACS); not on GenerateSsoStateResult
+    const verified = verifySsoState(state.state, state.cookieValue);
+    expect(verified).not.toBeNull();
+    if (!verified) return;
+
+    const authUrl = buildOidcAuthorizationUrl({
+      authorizationEndpoint: discovery.document.authorization_endpoint,
+      clientId: idp.clientId,
+      redirectUri: ACS,
+      state: state.state,
+      codeChallenge: state.codeChallenge,
+    });
+    expect(authUrl.startsWith(idp.authorizationEndpoint)).toBe(true);
+    expect(authUrl.includes('code_challenge_method=S256')).toBe(true);
+
+    const exchange = await exchangeOidcCode({
+      tokenEndpoint: discovery.document.token_endpoint,
+      clientId: idp.clientId,
+      clientSecret: idp.clientSecret,
+      code: 'mock-auth-code',
+      redirectUri: ACS,
+      codeVerifier: verified.codeVerifier,
+      fetchImpl: idp.fetchImpl,
+    });
+    if (!exchange.ok) {
+      throw new Error(`token exchange failed: ${exchange.reason} ${exchange.message}`);
+    }
+
+    const validated = await validateOidcIdToken({
+      idToken: exchange.tokens.id_token,
+      issuer: idp.issuer,
+      clientId: idp.clientId,
+      jwks: idp.publicKey,
+    });
+    expect(validated.ok).toBe(true);
+    if (!validated.ok) return;
+    expect(validated.claims.email).toBe('alice@example.com');
+    expect(validated.claims.sub).toBe('user-sub-1');
+
+    const roles = mapSsoGroupsToRole({
+      claims: validated.claims.payload as Record<string, unknown>,
+      groupClaim: 'groups',
+      groupRoleMap: { Engineering: 'member', Staff: 'editor' },
+      defaultRole: 'viewer',
+      requireGroupMatch: false,
+    });
+    expect(roles.ok).toBe(true);
+    if (roles.ok) {
+      // highest of member + editor = editor
+      expect(roles.role).toBe('editor');
+      expect(roles.matchedGroups).toContain('Engineering');
+    }
+  });
+
+  it('rejects id_token with wrong issuer (security regression)', async () => {
+    const token = await idp.signIdToken({ sub: 'u1' }, { issuer: 'https://evil.example.com' });
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: idp.issuer,
+      clientId: idp.clientId,
+      jwks: idp.publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_issuer');
+  });
+
+  it('rejects id_token with wrong audience', async () => {
+    const token = await idp.signIdToken({ sub: 'u1' }, { audience: 'other-client' });
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: idp.issuer,
+      clientId: idp.clientId,
+      jwks: idp.publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_audience');
+  });
+
+  it('rejects expired id_token', async () => {
+    const past = Math.floor(Date.now() / 1000) - 120;
+    const token = await idp.signIdToken({ sub: 'u1' }, { expSeconds: past });
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: idp.issuer,
+      clientId: idp.clientId,
+      jwks: idp.publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('expired');
+  });
+
+  it('rejects id_token signed by a different key', async () => {
+    const { privateKey: evilPem } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const evilKey = await importPKCS8(evilPem, 'RS256');
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ sub: 'u1' })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(idp.issuer)
+      .setAudience(idp.clientId)
+      .setIssuedAt(now)
+      .setExpirationTime(now + 3600)
+      .setSubject('u1')
+      .sign(evilKey);
+
+    const result = await validateOidcIdToken({
+      idToken: token,
+      issuer: idp.issuer,
+      clientId: idp.clientId,
+      jwks: idp.publicKey,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid_signature');
+  });
+
+  it('rejects require_group_match when no groups map', async () => {
+    const token = await idp.signIdToken({ sub: 'u1', groups: ['Unknown'] });
+    const validated = await validateOidcIdToken({
+      idToken: token,
+      issuer: idp.issuer,
+      clientId: idp.clientId,
+      jwks: idp.publicKey,
+    });
+    expect(validated.ok).toBe(true);
+    if (!validated.ok) return;
+
+    const roles = mapSsoGroupsToRole({
+      claims: validated.claims.payload as Record<string, unknown>,
+      groupClaim: 'groups',
+      groupRoleMap: { Engineering: 'member' },
+      defaultRole: 'viewer',
+      requireGroupMatch: true,
+    });
+    expect(roles.ok).toBe(false);
+    if (!roles.ok) expect(roles.reason).toBe('require_group_match');
+  });
+});
+
+describe('mock SAML IdP integration (GAP-464 Phase 7)', () => {
+  let idp: MockSamlIdp;
+  let spConfig: SamlSpConfig;
+
+  beforeAll(() => {
+    idp = createMockSamlIdp();
+    const meta = parseIdpMetadataXml(idp.metadataXml);
+    expect(meta.ok).toBe(true);
+    if (!meta.ok) throw new Error('mock IdP metadata must parse');
+
+    spConfig = {
+      spEntityId: SP_ENTITY,
+      callbackUrl: ACS,
+      entryPoint: meta.entryPoint,
+      idpCertPem: meta.idpCertPem,
+    };
+  });
+
+  it('parses IdP metadata and builds SP-initiated AuthnRequest redirect', async () => {
+    expect(spConfig.entryPoint).toBe(idp.ssoUrl);
+    const auth = await buildSamlAuthorizeUrl(spConfig, 'relay-state-token');
+    expect(auth.ok).toBe(true);
+    if (auth.ok) {
+      expect(auth.url.startsWith(idp.ssoUrl)).toBe(true);
+      expect(auth.url.includes('SAMLRequest=')).toBe(true);
+      expect(auth.url.includes('RelayState=')).toBe(true);
+    }
+  });
+
+  it('accepts a signed SAMLResponse from the mock IdP (happy path)', async () => {
+    const samlResponse = idp.buildPostResponse({
+      spEntityId: SP_ENTITY,
+      acsUrl: ACS,
+      nameId: 'bob@example.com',
+      groups: ['Engineering'],
+      sign: true,
+    });
+
+    const result = await validateSamlPostResponse(spConfig, samlResponse);
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      // surface reason for debugging if mock signature layout needs tweak
+      throw new Error(`SAML validate failed: ${result.reason} ${result.message}`);
+    }
+    expect(result.assertion.subject).toBe('bob@example.com');
+    expect(
+      result.assertion.email === 'bob@example.com' || result.assertion.subject.includes('@'),
+    ).toBe(true);
+
+    const roles = mapSsoGroupsToRole({
+      claims: result.assertion.attributes,
+      groupClaim: 'groups',
+      groupRoleMap: { Engineering: 'member' },
+      defaultRole: 'viewer',
+      requireGroupMatch: false,
+    });
+    expect(roles.ok).toBe(true);
+    if (roles.ok) expect(roles.role).toBe('member');
+  });
+
+  it('rejects unsigned SAMLResponse (signature hardline)', async () => {
+    const samlResponse = idp.buildPostResponse({
+      spEntityId: SP_ENTITY,
+      acsUrl: ACS,
+      nameId: 'bob@example.com',
+      sign: false,
+    });
+    const result = await validateSamlPostResponse(spConfig, samlResponse);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason === 'invalid_signature' || result.reason === 'validation_failed').toBe(
+        true,
+      );
+    }
+  });
+
+  it('rejects SAMLResponse when SP is configured with the wrong IdP cert', async () => {
+    const other = createMockSamlIdp({ entityId: 'https://other-idp.example.com' });
+    const samlResponse = idp.buildPostResponse({
+      spEntityId: SP_ENTITY,
+      acsUrl: ACS,
+      nameId: 'bob@example.com',
+      sign: true,
+    });
+    const wrongConfig: SamlSpConfig = {
+      ...spConfig,
+      idpCertPem: other.certPem,
+    };
+    const result = await validateSamlPostResponse(wrongConfig, samlResponse);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason === 'invalid_signature' || result.reason === 'validation_failed').toBe(
+        true,
+      );
+    }
+  });
+
+  it('rejects expired assertion (NotOnOrAfter in the past)', async () => {
+    const samlResponse = idp.buildPostResponse({
+      spEntityId: SP_ENTITY,
+      acsUrl: ACS,
+      nameId: 'bob@example.com',
+      sign: true,
+      // beyond acceptedClockSkewMs (5m) so node-saml rejects NotOnOrAfter
+      notOnOrAfterOffsetMs: -15 * 60 * 1000,
+    });
+    const result = await validateSamlPostResponse(spConfig, samlResponse);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.reason === 'expired' ||
+          result.reason === 'validation_failed' ||
+          result.reason === 'invalid_signature',
+      ).toBe(true);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -982,12 +982,18 @@ importers:
       react:
         specifier: 19.2.8
         version: 19.2.8
+      selfsigned:
+        specifier: 2.4.1
+        version: 2.4.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      xml-crypto:
+        specifier: 6.1.2
+        version: 6.1.2
 
   packages/cache:
     devDependencies:
@@ -4822,6 +4828,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node-forge@1.3.14':
+    resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -7607,6 +7616,10 @@ packages:
       encoding:
         optional: true
 
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
+
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
@@ -8275,6 +8288,10 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  selfsigned@2.4.1:
+    resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
+    engines: {node: '>=10'}
 
   semifies@1.0.0:
     resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
@@ -12179,6 +12196,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node-forge@1.3.14':
+    dependencies:
+      '@types/node': 25.9.5
+
   '@types/node@12.20.55': {}
 
   '@types/node@20.11.0':
@@ -15288,6 +15309,8 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-forge@1.4.0: {}
+
   node-gyp-build@4.8.4: {}
 
   node-releases@2.0.51: {}
@@ -16065,6 +16088,11 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  selfsigned@2.4.1:
+    dependencies:
+      '@types/node-forge': 1.3.14
+      node-forge: 1.4.0
 
   semifies@1.0.0: {}
 


### PR DESCRIPTION
## Summary
GAP-464 Phase 7 residual: mock IdP integration tests with real crypto.

- **Mock OIDC IdP** — discovery / token / JWKS via injectable `fetchImpl`; RSA-signed id_tokens
- **Mock SAML IdP** — metadata parse + signed Response/Assertion (`xml-crypto` + `selfsigned`, devDeps)
- **Security regressions** — wrong issuer/audience, expired token/assertion, foreign key signature, unsigned SAML, wrong IdP cert, `require_group_match`

Pure-layer only (no product runtime change). Does **not** release copy-dependents holds or ship customer “SSO available” claims.

## Test plan
- [x] `pnpm --filter @revealui/auth exec vitest run src/server/sso/__tests__` (83 tests)
- [x] mock-idp.integration.test.ts (11)
- [ ] CI green

## Residual after merge
- Operator docs + formal GAP-464 close train when dogfood-ready