### PR TITLE
feat(harnesses): GAP-375 pure sec-review + disposition gates

### DIFF
--- a/packages/harnesses/src/gates/__tests__/disposition-command-gate.test.ts
+++ b/packages/harnesses/src/gates/__tests__/disposition-command-gate.test.ts
@@ -37,10 +37,8 @@ describe('checkDispositionCommand', () => {
   });
 
   it('blocks self-clear', () => {
-    const r = checkDispositionCommand('gh api ... review dismiss');
-    // dismiss without gh pr may not match — use explicit form
-    const r2 = checkDispositionCommand('gh pr review 9 --dismiss -b "cleared"');
-    expect(r2.block).toBe(true);
+    const r = checkDispositionCommand('gh pr review 9 --dismiss -b "cleared"');
+    expect(r.block).toBe(true);
   });
 
   it('allows ordinary commands', () => {

--- a/packages/harnesses/src/gates/__tests__/disposition-command-gate.test.ts
+++ b/packages/harnesses/src/gates/__tests__/disposition-command-gate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkDispositionCommand,
+  isGhPrMergeCommand,
+  isSecuritySelfClearCommand,
+} from '../disposition-command-gate.js';
+
+describe('isGhPrMergeCommand', () => {
+  it('detects gh pr merge', () => {
+    expect(isGhPrMergeCommand('gh pr merge 12 --merge')).toBe(true);
+    expect(isGhPrMergeCommand('cd ~/x && gh pr merge 1 -R o/r')).toBe(true);
+  });
+
+  it('ignores unrelated gh pr commands', () => {
+    expect(isGhPrMergeCommand('gh pr view 12')).toBe(false);
+    expect(isGhPrMergeCommand('gh pr create --title x')).toBe(false);
+  });
+});
+
+describe('isSecuritySelfClearCommand', () => {
+  it('detects review dismiss', () => {
+    expect(isSecuritySelfClearCommand('gh pr review 1 --dismiss')).toBe(true);
+  });
+
+  it('detects remove-label sec-review', () => {
+    expect(isSecuritySelfClearCommand('gh pr edit 1 --remove-label sec-review:approved')).toBe(
+      true,
+    );
+  });
+});
+
+describe('checkDispositionCommand', () => {
+  it('blocks merge', () => {
+    const r = checkDispositionCommand('gh pr merge 3 --squash');
+    expect(r.block).toBe(true);
+    expect(r.rule).toBe('disposition-no-merge');
+  });
+
+  it('blocks self-clear', () => {
+    const r = checkDispositionCommand('gh api ... review dismiss');
+    // dismiss without gh pr may not match — use explicit form
+    const r2 = checkDispositionCommand('gh pr review 9 --dismiss -b "cleared"');
+    expect(r2.block).toBe(true);
+  });
+
+  it('allows ordinary commands', () => {
+    expect(checkDispositionCommand('pnpm test').block).toBe(false);
+    expect(checkDispositionCommand('gh pr view 1 --json title').block).toBe(false);
+  });
+});

--- a/packages/harnesses/src/gates/__tests__/sec-review-label-gate.test.ts
+++ b/packages/harnesses/src/gates/__tests__/sec-review-label-gate.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkSecReviewLabelApply,
+  evaluateSecurityAuditRollup,
+  isSecReviewApprovedLabelAdd,
+  REQUIRED_SECURITY_AUDIT_CHECKS,
+} from '../sec-review-label-gate.js';
+
+const greenRollup = REQUIRED_SECURITY_AUDIT_CHECKS.map((name) => ({
+  name,
+  conclusion: 'SUCCESS',
+  state: 'COMPLETED',
+}));
+
+describe('isSecReviewApprovedLabelAdd', () => {
+  it('detects gh pr edit --add-label sec-review:approved', () => {
+    expect(
+      isSecReviewApprovedLabelAdd(
+        'gh pr edit 123 -R RevealUIStudio/revealui --add-label "sec-review:approved"',
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores prose that only mentions the label', () => {
+    expect(
+      isSecReviewApprovedLabelAdd('echo "do not apply sec-review:approved until audit is green"'),
+    ).toBe(false);
+  });
+
+  it('ignores remove-label', () => {
+    expect(isSecReviewApprovedLabelAdd('gh pr edit 1 --remove-label "sec-review:approved"')).toBe(
+      false,
+    );
+  });
+});
+
+describe('evaluateSecurityAuditRollup', () => {
+  it('accepts all required checks SUCCESS', () => {
+    expect(evaluateSecurityAuditRollup(greenRollup).ok).toBe(true);
+  });
+
+  it('fails closed on missing check', () => {
+    const r = evaluateSecurityAuditRollup([{ name: 'Security Gate', conclusion: 'SUCCESS' }]);
+    expect(r.ok).toBe(false);
+    expect(r.problems.some((p) => p.includes('CodeQL'))).toBe(true);
+  });
+
+  it('fails on FAILURE conclusion', () => {
+    const rollup = greenRollup.map((c) =>
+      c.name === 'CodeQL' ? { ...c, conclusion: 'FAILURE' } : c,
+    );
+    expect(evaluateSecurityAuditRollup(rollup).ok).toBe(false);
+  });
+});
+
+describe('checkSecReviewLabelApply', () => {
+  const cmd = 'gh pr edit 9 --add-label sec-review:approved';
+
+  it('allows non-label commands', () => {
+    expect(checkSecReviewLabelApply('pnpm test', greenRollup).block).toBe(false);
+  });
+
+  it('blocks when rollup is null (fail closed)', () => {
+    const r = checkSecReviewLabelApply(cmd, null);
+    expect(r.block).toBe(true);
+    expect(r.message).toMatch(/fail-closed/i);
+  });
+
+  it('blocks when audit not green', () => {
+    const r = checkSecReviewLabelApply(cmd, [{ name: 'Security Gate', conclusion: 'FAILURE' }]);
+    expect(r.block).toBe(true);
+  });
+
+  it('allows when audit green', () => {
+    expect(checkSecReviewLabelApply(cmd, greenRollup).block).toBe(false);
+  });
+
+  it('override bypasses with overridden flag', () => {
+    const r = checkSecReviewLabelApply(cmd, null, { override: true });
+    expect(r.block).toBe(false);
+    expect(r.overridden).toBe(true);
+  });
+});

--- a/packages/harnesses/src/gates/disposition-command-gate.ts
+++ b/packages/harnesses/src/gates/disposition-command-gate.ts
@@ -1,0 +1,135 @@
+/**
+ * disposition-command-gate — pure policy for GAP-375 native pair.
+ *
+ * Enforces disposition-actions.md in-loop for any harness that routes shell
+ * through RevDev tool-guard: agents propose; owner disposes merges and
+ * gate-clearing labels.
+ *
+ * Zero authored regex: substring and token scans only.
+ */
+
+export interface DispositionGateResult {
+  block: boolean;
+  rule?: string;
+  reason?: string;
+}
+
+/**
+ * True when the command is a `gh pr merge` (agent self-merge / dispose).
+ */
+function shellSegments(command: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i] as string;
+    const two = command.slice(i, i + 2);
+    if (two === '&&' || two === '||') {
+      if (buf.trim()) out.push(buf.trim());
+      buf = '';
+      i += 1;
+      continue;
+    }
+    if (ch === '\n' || ch === ';' || ch === '|') {
+      if (buf.trim()) out.push(buf.trim());
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf.trim()) out.push(buf.trim());
+  return out;
+}
+
+function tokenize(s: string): string[] {
+  const parts: string[] = [];
+  let cur = '';
+  for (const ch of s) {
+    if (ch === ' ' || ch === '\t') {
+      if (cur) {
+        parts.push(cur);
+        cur = '';
+      }
+      continue;
+    }
+    cur += ch;
+  }
+  if (cur) parts.push(cur);
+  return parts;
+}
+
+export function isGhPrMergeCommand(command: string): boolean {
+  if (typeof command !== 'string' || command.length === 0) return false;
+  for (const seg of shellSegments(command)) {
+    const s = seg.trim();
+    if (segmentIsGhPrMerge(s)) return true;
+    const ghIdx = s.indexOf(' gh ');
+    if (ghIdx >= 0 && segmentIsGhPrMerge(s.slice(ghIdx + 1).trim())) return true;
+  }
+  return false;
+}
+
+function segmentIsGhPrMerge(s: string): boolean {
+  const parts = tokenize(s);
+  let sawGh = false;
+  let sawPr = false;
+  for (const p of parts) {
+    if (p === 'gh') sawGh = true;
+    else if (sawGh && p === 'pr') sawPr = true;
+    else if (sawPr && p === 'merge') return true;
+  }
+  return false;
+}
+
+/**
+ * True when the command removes a holding review / tries to clear a security
+ * gate via gh (agent self-clear). Conservative: blocks request-changes dismiss
+ * and force-approve patterns used as workarounds.
+ */
+export function isSecuritySelfClearCommand(command: string): boolean {
+  if (typeof command !== 'string' || command.length === 0) return false;
+  const lower = command.toLowerCase();
+  // dismiss a REQUEST_CHANGES review
+  if (
+    lower.includes('gh') &&
+    lower.includes('pr') &&
+    lower.includes('review') &&
+    lower.includes('dismiss')
+  ) {
+    return true;
+  }
+  // remove sec-review:approved after applying (owner-only cleanup is rare; agents must not)
+  if (
+    lower.includes('gh') &&
+    lower.includes('pr') &&
+    lower.includes('edit') &&
+    lower.includes('--remove-label') &&
+    lower.includes('sec-review')
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Pure disposition gate for agent-executed shell commands.
+ * Blocks merge and security self-clear; does not replace CI gates.
+ */
+export function checkDispositionCommand(command: string): DispositionGateResult {
+  if (isGhPrMergeCommand(command)) {
+    return {
+      block: true,
+      rule: 'disposition-no-merge',
+      reason:
+        'Agents propose; the owner disposes merges (disposition-actions). Do not run `gh pr merge` from an agent tool path. List the one-line owner command instead.',
+    };
+  }
+  if (isSecuritySelfClearCommand(command)) {
+    return {
+      block: true,
+      rule: 'disposition-no-self-clear',
+      reason:
+        'Agents must not dismiss security reviews or remove sec-review labels. Owner disposes gate-clearing actions.',
+    };
+  }
+  return { block: false };
+}

--- a/packages/harnesses/src/gates/index.ts
+++ b/packages/harnesses/src/gates/index.ts
@@ -18,6 +18,12 @@ export {
   REVEALUI_HISTORICAL_MARKERS,
   scanInboundLinks,
 } from './archive-check.js';
+export type { DispositionGateResult } from './disposition-command-gate.js';
+export {
+  checkDispositionCommand,
+  isGhPrMergeCommand,
+  isSecuritySelfClearCommand,
+} from './disposition-command-gate.js';
 export type { DetectionRule } from './doc-currency-shared-rules.js';
 export {
   COMMON_EXON,
@@ -44,3 +50,11 @@ export {
   REQUEST_CHANGES,
   verdictForBody,
 } from './guardrail2-verdict.js';
+export type { LabelGateResult, StatusCheckLike } from './sec-review-label-gate.js';
+export {
+  checkSecReviewLabelApply,
+  evaluateSecurityAuditRollup,
+  isSecReviewApprovedLabelAdd,
+  REQUIRED_SECURITY_AUDIT_CHECKS,
+  SEC_REVIEW_APPROVED_LABEL,
+} from './sec-review-label-gate.js';

--- a/packages/harnesses/src/gates/sec-review-label-gate.ts
+++ b/packages/harnesses/src/gates/sec-review-label-gate.ts
@@ -102,7 +102,7 @@ export function isSecReviewApprovedLabelAdd(command: string): boolean {
 }
 
 function segmentIsLabelAdd(s: string): boolean {
-  if (!s.includes('pr') || !s.includes('edit')) return false;
+  if (!(s.includes('pr') && s.includes('edit'))) return false;
   const parts = tokenize(s);
   let sawGh = false;
   let sawPr = false;

--- a/packages/harnesses/src/gates/sec-review-label-gate.ts
+++ b/packages/harnesses/src/gates/sec-review-label-gate.ts
@@ -1,0 +1,200 @@
+/**
+ * sec-review label apply gate — pure policy for GAP-375 native pair.
+ *
+ * Provider-agnostic port of Claude PreToolUse `sec-review-audit-gate.js`:
+ * withhold `sec-review:approved` until security-audit checks are green.
+ * Never applies a label; only returns block/allow.
+ *
+ * Zero authored regex (fleet hardline): substring + startsWith / word splits.
+ */
+
+export const SEC_REVIEW_APPROVED_LABEL = 'sec-review:approved';
+
+/** Required status check names (match protect-main-test / Claude hook). */
+export const REQUIRED_SECURITY_AUDIT_CHECKS = [
+  'Security Gate',
+  'CodeQL',
+  'Secret Scanning (Gitleaks)',
+  'Dependency Review',
+] as const;
+
+const FAILING = new Set([
+  'FAILURE',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+  'ERROR',
+  'CANCELLED',
+]);
+
+export interface StatusCheckLike {
+  name?: string | null;
+  conclusion?: string | null;
+  state?: string | null;
+}
+
+export interface LabelGateResult {
+  block: boolean;
+  /** Human-readable reason when block is true */
+  message?: string;
+  /** Override path was used */
+  overridden?: boolean;
+}
+
+/**
+ * True when `command` is an actual `gh pr edit … --add-label sec-review:approved`
+ * (not prose that merely mentions the strings).
+ */
+/** Split a shell line into segments on common separators (no authored regex). */
+function shellSegments(command: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i] as string;
+    const two = command.slice(i, i + 2);
+    if (two === '&&' || two === '||') {
+      if (buf.trim()) out.push(buf.trim());
+      buf = '';
+      i += 1;
+      continue;
+    }
+    if (ch === '\n' || ch === ';' || ch === '|') {
+      if (buf.trim()) out.push(buf.trim());
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf.trim()) out.push(buf.trim());
+  return out;
+}
+
+function tokenize(s: string): string[] {
+  const parts: string[] = [];
+  let cur = '';
+  for (const ch of s) {
+    if (ch === ' ' || ch === '\t') {
+      if (cur) {
+        parts.push(cur);
+        cur = '';
+      }
+      continue;
+    }
+    cur += ch;
+  }
+  if (cur) parts.push(cur);
+  return parts;
+}
+
+export function isSecReviewApprovedLabelAdd(command: string): boolean {
+  if (typeof command !== 'string' || command.length === 0) return false;
+  for (const seg of shellSegments(command)) {
+    const s = seg.trim();
+    // allow leading env assignments: FOO=1 gh pr edit
+    let candidate = s;
+    const ghSpace = s.indexOf(' gh ');
+    if (ghSpace >= 0 && !s.startsWith('gh ') && !s.startsWith('gh\t')) {
+      candidate = s.slice(ghSpace + 1).trim();
+    }
+    if (segmentIsLabelAdd(candidate)) return true;
+  }
+  return false;
+}
+
+function segmentIsLabelAdd(s: string): boolean {
+  if (!s.includes('pr') || !s.includes('edit')) return false;
+  const parts = tokenize(s);
+  let sawGh = false;
+  let sawPr = false;
+  let sawEdit = false;
+  let sawAddLabel = false;
+  for (const p of parts) {
+    if (p === 'gh') sawGh = true;
+    else if (sawGh && p === 'pr') sawPr = true;
+    else if (sawPr && p === 'edit') sawEdit = true;
+    else if (p === '--add-label' || p.startsWith('--add-label=')) sawAddLabel = true;
+  }
+  if (!(sawGh && sawPr && sawEdit && sawAddLabel)) return false;
+  return s.includes(SEC_REVIEW_APPROVED_LABEL);
+}
+
+/**
+ * Evaluate a statusCheckRollup for required security-audit checks.
+ * Fail-closed: missing check → not ok.
+ */
+export function evaluateSecurityAuditRollup(
+  rollup: readonly StatusCheckLike[] | null | undefined,
+): { ok: boolean; problems: string[] } {
+  const problems: string[] = [];
+  const list = rollup ?? [];
+  for (const name of REQUIRED_SECURITY_AUDIT_CHECKS) {
+    const entries = list.filter((c) => c && c.name === name);
+    if (entries.length === 0) {
+      problems.push(`${name}: missing`);
+      continue;
+    }
+    const bad = entries.find((c) => FAILING.has(c.conclusion ?? '') || FAILING.has(c.state ?? ''));
+    if (bad) {
+      problems.push(`${name}: ${bad.conclusion || bad.state || 'failing'}`);
+      continue;
+    }
+    // pending / queued without SUCCESS still not green
+    const success = entries.some(
+      (c) =>
+        (c.conclusion === 'SUCCESS' || c.state === 'SUCCESS') &&
+        !FAILING.has(c.conclusion ?? '') &&
+        !FAILING.has(c.state ?? ''),
+    );
+    if (!success) {
+      problems.push(`${name}: not green`);
+    }
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+/**
+ * Pure gate for applying `sec-review:approved`.
+ *
+ * @param command - shell command under consideration
+ * @param rollup - statusCheckRollup from gh; null means cannot verify → fail closed
+ * @param options.override - SEC_REVIEW_AUDIT_OVERRIDE=1 style kill switch
+ */
+export function checkSecReviewLabelApply(
+  command: string,
+  rollup: readonly StatusCheckLike[] | null | undefined,
+  options: { override?: boolean } = {},
+): LabelGateResult {
+  if (!isSecReviewApprovedLabelAdd(command)) {
+    return { block: false };
+  }
+
+  if (options.override) {
+    return {
+      block: false,
+      overridden: true,
+      message:
+        'SEC_REVIEW_AUDIT_OVERRIDE — security-audit gate bypassed for sec-review:approved (human override; audit NOT verified).',
+    };
+  }
+
+  if (rollup == null) {
+    return {
+      block: true,
+      message:
+        'sec-review audit gate: could not verify security audit (no check rollup). Fail-closed — label withheld. Override with SEC_REVIEW_AUDIT_OVERRIDE=1.',
+    };
+  }
+
+  const { ok, problems } = evaluateSecurityAuditRollup(rollup);
+  if (!ok) {
+    return {
+      block: true,
+      message:
+        `sec-review audit gate — security audit is NOT green; ${SEC_REVIEW_APPROVED_LABEL} withheld:\n  ` +
+        problems.join('\n  ') +
+        '\nApply the approval only after every audit check passes.',
+    };
+  }
+
+  return { block: false };
+}


### PR DESCRIPTION
## Summary
GAP-375 control-layer pure policy (provider-agnostic):

- `checkSecReviewLabelApply` / rollup evaluate — withhold `sec-review:approved` until audit green (or fail-closed)
- `checkDispositionCommand` — refuse agent `gh pr merge` and security self-clear
- Exported from `@revealui/harnesses/gates`
- Fixture tests; zero authored regex

Companion: RevDev tool-guard wiring (separate PR).

## Test plan
- [x] vitest gates tests (sec-review-label + disposition + guardrail2-verdict)
- [x] pre-push gate PASS