### PR TITLE
feat(harnesses): CJS gates for Claude-hook adapter (GAP-375 optionals)

### DIFF
--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -64,6 +64,7 @@
     "./gates": {
       "types": "./dist/gates/index.d.ts",
       "import": "./dist/gates/index.js",
+      "require": "./dist/gates/index.cjs",
       "default": "./dist/gates/index.js"
     }
   },

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
     'src/hotfix/index.ts',
     'src/gates/index.ts',
   ],
-  format: ['esm'],
+  // CJS for Claude-hook thin adapters (createRequire); ESM for monorepo/node apps.
+  format: ['esm', 'cjs'],
   dts: true,
   sourcemap: false,
   clean: true,


### PR DESCRIPTION
## Summary
Emit CJS for \`@revealui/harnesses/gates\` so Claude PreToolUse can \`createRequire\` pure \`checkSecReviewLabelApply\` (thin adapter residual).

## Test plan
- [x] harnesses build produces \`dist/gates/index.cjs\`
- [x] pre-push PASS