### PR TITLE
fix(harnesses): ESM-only content; CJS gates sequential build

### DIFF
--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -83,7 +83,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsup --config tsup.gates-cjs.ts",
     "clean": "rm -rf dist",
     "dev": "tsup --watch",
     "lint": "biome check .",

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -1,5 +1,16 @@
 import { defineConfig } from 'tsup';
 
+/**
+ * ESM package build (all public entry points, including content).
+ *
+ * CJS for `./gates` is a second sequential step (`tsup.gates-cjs.ts`) so
+ * content stays ESM-only — dual-format content hit empty-import-meta and a
+ * broken snapshot path (import.meta.url). package.json only exposes
+ * `require` on `./gates`.
+ *
+ * Run via package.json: `tsup && tsup --config tsup.gates-cjs.ts` (sequential;
+ * tsup multi-config runs configs in parallel and would race with clean).
+ */
 export default defineConfig({
   entry: [
     'src/index.ts',
@@ -12,8 +23,7 @@ export default defineConfig({
     'src/hotfix/index.ts',
     'src/gates/index.ts',
   ],
-  // CJS for Claude-hook thin adapters (createRequire); ESM for monorepo/node apps.
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   sourcemap: false,
   clean: true,

--- a/packages/harnesses/tsup.gates-cjs.ts
+++ b/packages/harnesses/tsup.gates-cjs.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+/**
+ * CJS build for Claude-hook thin adapters (createRequire on `./gates` only).
+ * Sequential after the ESM build — see tsup.config.ts.
+ */
+export default defineConfig({
+  entry: {
+    'gates/index': 'src/gates/index.ts',
+  },
+  format: ['cjs'],
+  dts: false,
+  sourcemap: false,
+  clean: false,
+});


### PR DESCRIPTION
## Summary
Dual ESM+CJS for all entries caused tsup `empty-import-meta` on `content/snapshot.ts` and a non-functional CJS content path.

- ESM build: all entries including content (clean)
- Sequential CJS: `./gates` only (`tsup.gates-cjs.ts`) for Claude-hook `createRequire`
- Matches `package.json` exports (`require` only on `./gates`)

## Test plan
- [x] `pnpm --filter @revealui/harnesses build` — no import.meta warning
- [x] only `dist/gates/index.cjs` under dist
- [x] createRequire gates CJS + ESM content import smoke
- [x] package tests previously green on same tree (482)