### PR TITLE
feat(harnesses): temp-artifact lifecycle control layer (GAP-295)

### DIFF
--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -61,6 +61,11 @@
       "import": "./dist/hotfix/index.js",
       "default": "./dist/hotfix/index.js"
     },
+    "./tmpscript": {
+      "types": "./dist/tmpscript/index.d.ts",
+      "import": "./dist/tmpscript/index.js",
+      "default": "./dist/tmpscript/index.js"
+    },
     "./gates": {
       "types": "./dist/gates/index.d.ts",
       "import": "./dist/gates/index.js",

--- a/packages/harnesses/src/__tests__/tmpscript-registry.test.ts
+++ b/packages/harnesses/src/__tests__/tmpscript-registry.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  confirmTmpscript,
+  loadManifest,
+  pendingEntries,
+  registerTmpscript,
+  sweepTmpscript,
+} from '../tmpscript/index.js';
+
+function tempStore(): {
+  controlPath: string;
+  legacyPath: string;
+  dir: string;
+  filePath: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'rvui-tmpscript-'));
+  const filePath = join(dir, 'helper.sh');
+  writeFileSync(filePath, '#!/bin/sh\necho ok\n', 'utf8');
+  return {
+    dir,
+    filePath,
+    controlPath: join(dir, 'manifest.json'),
+    legacyPath: join(dir, 'legacy-manifest.json'),
+  };
+}
+
+describe('tmpscript control-layer registry (GAP-295)', () => {
+  it('registers pending and lists it', () => {
+    const paths = tempStore();
+    const e = registerTmpscript(
+      {
+        path: paths.filePath,
+        purpose: 'owner installer',
+        validate: 'true',
+      },
+      paths,
+    );
+    expect(e.status).toBe('pending');
+    expect(e.path).toBe(paths.filePath);
+    const pending = pendingEntries(loadManifest(paths));
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.purpose).toBe('owner installer');
+  });
+
+  it('confirm validates then deletes and clears pending', () => {
+    const paths = tempStore();
+    const e = registerTmpscript(
+      {
+        path: paths.filePath,
+        purpose: 'verify',
+        validate: 'exit 0',
+      },
+      paths,
+    );
+    let ran = false;
+    confirmTmpscript(e.id, {
+      ...paths,
+      runValidate: () => {
+        ran = true;
+      },
+      unlinkPath: () => {
+        /* no-op */
+      },
+      pathExists: () => true,
+    });
+    expect(ran).toBe(true);
+    expect(pendingEntries(loadManifest(paths))).toHaveLength(0);
+    expect(loadManifest(paths).entries[0]?.status).toBe('confirmed');
+  });
+
+  it('confirm leaves pending when validate fails', () => {
+    const paths = tempStore();
+    const e = registerTmpscript(
+      {
+        path: paths.filePath,
+        purpose: 'bad',
+        validate: 'false',
+      },
+      paths,
+    );
+    expect(() =>
+      confirmTmpscript(e.id, {
+        ...paths,
+        runValidate: () => {
+          throw new Error('fail');
+        },
+      }),
+    ).toThrow(/validation FAILED/);
+    expect(pendingEntries(loadManifest(paths))).toHaveLength(1);
+  });
+
+  it('migrates legacy claude store once into control path', () => {
+    const paths = tempStore();
+    writeFileSync(
+      paths.legacyPath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            id: 'legacy-helper-1',
+            path: paths.filePath,
+            purpose: 'old adapter entry',
+            validate: null,
+            session: '0',
+            created: new Date().toISOString(),
+            status: 'pending',
+            confirmed: null,
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const m = loadManifest({
+      controlPath: paths.controlPath,
+      legacyPath: paths.legacyPath,
+      migrate: true,
+    });
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0]?.id).toBe('legacy-helper-1');
+    const m2 = loadManifest({
+      controlPath: paths.controlPath,
+      legacyPath: join(paths.dir, 'missing.json'),
+      migrate: true,
+    });
+    expect(m2.entries[0]?.id).toBe('legacy-helper-1');
+  });
+
+  it('sweep prunes old confirmed entries', () => {
+    const paths = tempStore();
+    const e = registerTmpscript(
+      {
+        path: paths.filePath,
+        purpose: 'keep briefly',
+      },
+      paths,
+    );
+    confirmTmpscript(e.id, {
+      ...paths,
+      pathExists: () => false,
+      unlinkPath: () => {
+        /* none */
+      },
+    });
+    const r = sweepTmpscript({
+      ...paths,
+      pathExists: () => false,
+    });
+    expect(r.remaining).toBe(1);
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -41,10 +41,10 @@ import {
 } from './content/index.js';
 import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
 import { runHotfixCli } from './hotfix/cli.js';
-import { runTmpscriptCli } from './tmpscript/cli.js';
 import { checkManager, materializeManager } from './manager/index.js';
 import { InferenceService } from './server/inference-service.js';
 import { runSessionCli } from './session/cli.js';
+import { runTmpscriptCli } from './tmpscript/cli.js';
 import { WorkboardManager } from './workboard/workboard-manager.js';
 
 const DATA_DIR = join(homedir(), '.local', 'share', 'revealui');

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -41,6 +41,7 @@ import {
 } from './content/index.js';
 import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
 import { runHotfixCli } from './hotfix/cli.js';
+import { runTmpscriptCli } from './tmpscript/cli.js';
 import { checkManager, materializeManager } from './manager/index.js';
 import { InferenceService } from './server/inference-service.js';
 import { runSessionCli } from './session/cli.js';
@@ -531,6 +532,11 @@ async function main() {
     process.exit(code);
   }
 
+  if (command === 'tmpscript' || command === 'temp-script') {
+    const code = runTmpscriptCli(args);
+    process.exit(code);
+  }
+
   if (command === 'inference') {
     const [subcommand, tierArg] = args;
     const inference = new InferenceService();
@@ -725,6 +731,7 @@ Commands:
   manager materialize [--project p] Write manager.json + .revealui/content + Cursor/OpenCode surfaces + equal stubs
   manager check [--project p]       Verify project manager present and valid
   hotfix <subcommand>               Durable-debt registry (long-term fixes only; GAP-405)
+  tmpscript <subcommand>            Temp-artifact lifecycle (GAP-295 control layer)
   inference status                  Local AI profile (tier, mem, engines)
   inference apply <tier>            idle|daily|snaps|heavy (host control plane)
 
@@ -743,6 +750,11 @@ Hotfix Subcommands (prefer durable root-cause fixes; register only as debt):
   hotfix register --title T --symptom S --temporary X --durable D
   hotfix resolve <id> --pr URL | --note TEXT
   hotfix promote <id> --gap GAP-N
+
+Tmpscript Subcommands (one-shot helpers; confirm validates then deletes):
+  tmpscript check | list | store | sweep
+  tmpscript register <path> --purpose "..." [--validate "cmd"]
+  tmpscript confirm <id|path>
 
 Default content generator: ${DEFAULT_CONTENT_GENERATOR_ID} → ${MANAGER_CONTENT_OUTPUT}
 `);

--- a/packages/harnesses/src/tmpscript/cli.ts
+++ b/packages/harnesses/src/tmpscript/cli.ts
@@ -1,0 +1,137 @@
+/**
+ * CLI handler for `revealui-harnesses tmpscript …`
+ */
+
+import { controlManifestPath } from './paths.js';
+import {
+  ageDays,
+  confirmTmpscript,
+  formatCheckLines,
+  pendingEntries,
+  registerTmpscript,
+  sweepTmpscript,
+} from './registry.js';
+import { loadManifest } from './store.js';
+
+function parseArgs(argv: string[]): {
+  _: string[];
+  purpose?: string;
+  validate?: string;
+} {
+  const opts: ReturnType<typeof parseArgs> = { _: [] };
+  let i = 0;
+  while (i < argv.length) {
+    const a = argv[i] ?? '';
+    const next = (): string => {
+      i += 1;
+      return argv[i] ?? '';
+    };
+    if (a === '--purpose') opts.purpose = next();
+    else if (a === '--validate') opts.validate = next();
+    else if (a.startsWith('--')) {
+      throw new Error(`tmpscript: unknown flag ${a}`);
+    } else opts._.push(a);
+    i += 1;
+  }
+  return opts;
+}
+
+function usage(): string {
+  return `Usage (RevealUI control layer — temp-artifact lifecycle, GAP-295):
+  revealui-harnesses tmpscript register <path> --purpose "..." [--validate "cmd"]
+  revealui-harnesses tmpscript confirm  <id|path>
+  revealui-harnesses tmpscript list | check | sweep | store
+
+confirm runs --validate (if set; must exit 0) then deletes the file.
+check is warn-only (session-boundary hooks). Store: ${controlManifestPath()}
+`;
+}
+
+/**
+ * Run tmpscript subcommand. Returns process exit code (0 ok, 1 error).
+ */
+export function runTmpscriptCli(argv: string[]): number {
+  const [cmd, ...rest] = argv;
+  try {
+    const opts = parseArgs(rest);
+    const target = opts._[0];
+
+    switch (cmd) {
+      case 'register': {
+        if (!target) {
+          process.stderr.write(
+            'usage: tmpscript register <path> --purpose "..." [--validate "cmd"]\n',
+          );
+          return 1;
+        }
+        const e = registerTmpscript({
+          path: target,
+          purpose: opts.purpose,
+          validate: opts.validate ?? null,
+        });
+        process.stdout.write(`tmpscript: registered ${e.id} (${e.path})\n`);
+        process.stdout.write(
+          `tmpscript: after it has served its purpose run: revealui-harnesses tmpscript confirm ${e.id}\n`,
+        );
+        process.stdout.write(`tmpscript: store: ${controlManifestPath()}\n`);
+        return 0;
+      }
+      case 'confirm': {
+        if (!target) {
+          process.stderr.write('usage: tmpscript confirm <id|path>\n');
+          return 1;
+        }
+        const e = confirmTmpscript(target);
+        process.stdout.write(`tmpscript: ${e.id} confirmed + cleaned\n`);
+        if (e.path) process.stdout.write(`  path: ${e.path}\n`);
+        return 0;
+      }
+      case 'check': {
+        for (const line of formatCheckLines()) process.stdout.write(`${line}\n`);
+        return 0;
+      }
+      case 'list': {
+        const m = loadManifest();
+        if (m.entries.length === 0) {
+          process.stdout.write('tmpscript: no tracked temp scripts\n');
+          process.stdout.write(`  store: ${controlManifestPath()}\n`);
+          return 0;
+        }
+        for (const e of m.entries) {
+          const age = ageDays(e.created).toFixed(1);
+          process.stdout.write(
+            `${e.status.padEnd(9)} ${e.id}  (${age}d)  ${e.path}\n` +
+              `          purpose: ${e.purpose}` +
+              (e.validate ? `\n          validate: ${e.validate}` : '') +
+              '\n',
+          );
+        }
+        process.stdout.write(`  store: ${controlManifestPath()}\n`);
+        return 0;
+      }
+      case 'sweep': {
+        const r = sweepTmpscript();
+        process.stdout.write(
+          `tmpscript: sweep done — ${r.removedFiles} file(s) removed, ${r.prunedEntries} old entr(ies) pruned, ${r.remaining} tracked\n`,
+        );
+        return 0;
+      }
+      case 'store': {
+        process.stdout.write(`${controlManifestPath()}\n`);
+        process.stdout.write(`pending: ${pendingEntries().length}\n`);
+        return 0;
+      }
+      case 'help':
+      case undefined:
+        process.stdout.write(usage());
+        return 0;
+      default:
+        process.stderr.write(`tmpscript: unknown command ${cmd}\n`);
+        process.stderr.write(usage());
+        return 1;
+    }
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+}

--- a/packages/harnesses/src/tmpscript/index.ts
+++ b/packages/harnesses/src/tmpscript/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Temp-artifact lifecycle registry (RevealUI control layer, GAP-295).
+ *
+ * Claude Studio `~/.claude/scripts/tmpscript.js` is a thin adapter that
+ * forwards here. Store: ~/.local/share/revealui/tmp-scripts/manifest.json
+ */
+
+export { runTmpscriptCli } from './cli.js';
+export {
+  controlManifestPath,
+  controlTmpscriptDir,
+  legacyClaudeManifestPath,
+  revealuiDataDir,
+} from './paths.js';
+export {
+  ageDays,
+  confirmTmpscript,
+  ENTRY_RETENTION_DAYS,
+  findEntry,
+  formatCheckLines,
+  PENDING_TTL_DAYS,
+  pendingEntries,
+  registerTmpscript,
+  sweepTmpscript,
+} from './registry.js';
+export { loadManifest, saveManifest } from './store.js';
+export type {
+  ConfirmTmpscriptOptions,
+  RegisterTmpscriptInput,
+  SweepTmpscriptResult,
+  TmpscriptEntry,
+  TmpscriptManifest,
+  TmpscriptStatus,
+  TmpscriptStoreOptions,
+} from './types.js';

--- a/packages/harnesses/src/tmpscript/paths.ts
+++ b/packages/harnesses/src/tmpscript/paths.ts
@@ -1,0 +1,32 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Same data root as harness daemon sock / hotfix store. */
+export function revealuiDataDir(): string {
+  return join(homedir(), '.local', 'share', 'revealui');
+}
+
+/** Canonical control-layer temp-artifact registry directory. */
+export function controlTmpscriptDir(): string {
+  return join(revealuiDataDir(), 'tmp-scripts');
+}
+
+export function controlManifestPath(): string {
+  return join(controlTmpscriptDir(), 'manifest.json');
+}
+
+/**
+ * Legacy Studio-adapter store (pre-cutover). Read for one-time migration only;
+ * never write here after cutover.
+ */
+export function legacyClaudeManifestPath(): string {
+  return join(homedir(), '.claude', 'tmp-scripts', 'manifest.json');
+}
+
+export function ensureControlTmpscriptDir(): void {
+  const dir = controlTmpscriptDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+}

--- a/packages/harnesses/src/tmpscript/registry.ts
+++ b/packages/harnesses/src/tmpscript/registry.ts
@@ -1,0 +1,179 @@
+import { execSync } from 'node:child_process';
+import { existsSync, unlinkSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { controlManifestPath } from './paths.js';
+import { loadManifest, saveManifest } from './store.js';
+import type {
+  ConfirmTmpscriptOptions,
+  RegisterTmpscriptInput,
+  SweepTmpscriptResult,
+  TmpscriptEntry,
+  TmpscriptManifest,
+  TmpscriptStoreOptions,
+} from './types.js';
+
+/** Days after which a still-pending entry is expired for sweep. */
+export const PENDING_TTL_DAYS = 7;
+/** Days after confirm before the manifest entry is pruned. */
+export const ENTRY_RETENTION_DAYS = 30;
+
+export function ageDays(iso: string): number {
+  return (Date.now() - Date.parse(iso)) / 86400000;
+}
+
+export function findEntry(m: TmpscriptManifest, key: string): TmpscriptEntry | undefined {
+  const resolved = resolve(key);
+  return m.entries.find((e) => e.id === key || e.path === key || e.path === resolved);
+}
+
+export function pendingEntries(m?: TmpscriptManifest): TmpscriptEntry[] {
+  const manifest = m ?? loadManifest();
+  return manifest.entries.filter((e) => e.status === 'pending');
+}
+
+export function registerTmpscript(
+  input: RegisterTmpscriptInput,
+  options?: TmpscriptStoreOptions & { pathExists?: (p: string) => boolean },
+): TmpscriptEntry {
+  const resolved = resolve(input.path);
+  const pathExists = options?.pathExists ?? existsSync;
+  if (!pathExists(resolved)) {
+    throw new Error(`tmpscript: file not found: ${resolved}`);
+  }
+
+  const m = loadManifest(options);
+  if (findEntry(m, resolved)) {
+    throw new Error(`tmpscript: already registered: ${resolved}`);
+  }
+
+  const id = input.id?.trim() || `${basename(resolved)}-${Date.now().toString(36)}`;
+  if (findEntry(m, id)) {
+    throw new Error(`tmpscript: id already exists: ${id}`);
+  }
+
+  const entry: TmpscriptEntry = {
+    id,
+    path: resolved,
+    purpose: input.purpose?.trim() || '(no purpose given)',
+    validate: input.validate?.trim() || null,
+    session: String(process.ppid || 0),
+    created: new Date().toISOString(),
+    status: 'pending',
+    confirmed: null,
+  };
+  m.entries.push(entry);
+  saveManifest(m, options);
+  return entry;
+}
+
+function defaultRunValidate(cmd: string): void {
+  // shell:true is intentional: validate is a user-authored shell fragment
+  // (same contract as the legacy Claude adapter).
+  execSync(cmd, {
+    stdio: 'inherit',
+    timeout: 60_000,
+    shell: process.env.SHELL || '/bin/sh',
+  });
+}
+
+/**
+ * Run optional validate command (must exit 0), then delete the file and mark
+ * confirmed. Validation failure leaves status pending and keeps the file.
+ */
+export function confirmTmpscript(key: string, options?: ConfirmTmpscriptOptions): TmpscriptEntry {
+  const m = loadManifest(options);
+  const e = findEntry(m, key);
+  if (!e) {
+    throw new Error(`tmpscript: no entry for: ${key}`);
+  }
+  if (e.status === 'confirmed') {
+    return e;
+  }
+
+  if (e.validate) {
+    const run = options?.runValidate ?? defaultRunValidate;
+    try {
+      run(e.validate);
+    } catch {
+      throw new Error(`tmpscript: validation FAILED — ${e.id} stays pending, file kept`);
+    }
+  }
+
+  const pathExists = options?.pathExists ?? existsSync;
+  const unlink = options?.unlinkPath ?? unlinkSync;
+  if (pathExists(e.path)) {
+    try {
+      unlink(e.path);
+    } catch {
+      /* already gone or unreadable — still confirm so lifecycle closes */
+    }
+  }
+
+  e.status = 'confirmed';
+  e.confirmed = new Date().toISOString();
+  saveManifest(m, options);
+  return e;
+}
+
+/**
+ * Remove expired pending files, leftover confirmed files, mark expired
+ * pending confirmed, prune old confirmed entries.
+ */
+export function sweepTmpscript(options?: ConfirmTmpscriptOptions): SweepTmpscriptResult {
+  const m = loadManifest(options);
+  const pathExists = options?.pathExists ?? existsSync;
+  const unlink = options?.unlinkPath ?? unlinkSync;
+  let removedFiles = 0;
+
+  for (const e of m.entries) {
+    const exists = pathExists(e.path);
+    const stale = e.status === 'pending' && ageDays(e.created) > PENDING_TTL_DAYS;
+    const leftover = e.status === 'confirmed' && exists;
+    if (exists && (stale || leftover)) {
+      try {
+        unlink(e.path);
+        removedFiles += 1;
+      } catch {
+        /* keep going */
+      }
+      if (stale) {
+        e.status = 'confirmed';
+        e.confirmed = new Date().toISOString();
+        e.sweptAsExpired = true;
+      }
+    } else if (stale && !exists) {
+      e.status = 'confirmed';
+      e.confirmed = new Date().toISOString();
+      e.sweptAsExpired = true;
+    }
+  }
+
+  const before = m.entries.length;
+  m.entries = m.entries.filter((e) => {
+    if (e.status !== 'confirmed' || !e.confirmed) return true;
+    return ageDays(e.confirmed) <= ENTRY_RETENTION_DAYS;
+  });
+  saveManifest(m, options);
+  return {
+    removedFiles,
+    prunedEntries: before - m.entries.length,
+    remaining: m.entries.length,
+  };
+}
+
+/** Format session-boundary check (warn-only; always informational). */
+export function formatCheckLines(m?: TmpscriptManifest): string[] {
+  const pending = pendingEntries(m);
+  if (pending.length === 0) return [];
+  const lines: string[] = [
+    `[tmpscript] ${pending.length} temp script(s) awaiting confirm+cleanup:`,
+  ];
+  for (const e of pending) {
+    const days = ageDays(e.created).toFixed(1);
+    const missing = existsSync(e.path) ? '' : ' (file MISSING — confirm to close)';
+    lines.push(`  ${e.id} — ${e.purpose} — ${days}d old${missing}`);
+    lines.push(`    → revealui-harnesses tmpscript confirm ${e.id}`);
+  }
+  lines.push(`[tmpscript] store: ${controlManifestPath()}`);
+  return lines;
+}

--- a/packages/harnesses/src/tmpscript/store.ts
+++ b/packages/harnesses/src/tmpscript/store.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  controlManifestPath,
+  ensureControlTmpscriptDir,
+  legacyClaudeManifestPath,
+} from './paths.js';
+import type { TmpscriptManifest, TmpscriptStoreOptions } from './types.js';
+
+const EMPTY: TmpscriptManifest = { version: 1, entries: [] };
+
+function parseManifest(raw: string): TmpscriptManifest | null {
+  try {
+    const data = JSON.parse(raw) as TmpscriptManifest;
+    if (data && Array.isArray(data.entries)) {
+      return { version: 1, store: data.store, entries: data.entries };
+    }
+  } catch {
+    /* corrupt */
+  }
+  return null;
+}
+
+/**
+ * Load control-layer manifest. If missing/empty, one-time import from the
+ * legacy `~/.claude/tmp-scripts` adapter store (does not delete legacy).
+ */
+export function loadManifest(options?: TmpscriptStoreOptions): TmpscriptManifest {
+  const controlPath = options?.controlPath ?? controlManifestPath();
+  const legacyPath = options?.legacyPath ?? legacyClaudeManifestPath();
+  const migrate = options?.migrate !== false;
+
+  if (existsSync(controlPath)) {
+    const parsed = parseManifest(readFileSync(controlPath, 'utf8'));
+    if (parsed) return parsed;
+  }
+
+  if (migrate && existsSync(legacyPath)) {
+    const legacy = parseManifest(readFileSync(legacyPath, 'utf8'));
+    if (legacy && legacy.entries.length > 0) {
+      const migrated: TmpscriptManifest = {
+        version: 1,
+        store: controlPath,
+        entries: legacy.entries,
+      };
+      saveManifest(migrated, { controlPath });
+      return migrated;
+    }
+  }
+
+  return { ...EMPTY, store: controlPath, entries: [] };
+}
+
+export function saveManifest(m: TmpscriptManifest, options?: { controlPath?: string }): void {
+  const controlPath = options?.controlPath ?? controlManifestPath();
+  ensureControlTmpscriptDir();
+  const out: TmpscriptManifest = {
+    version: 1,
+    store: controlPath,
+    entries: m.entries,
+  };
+  writeFileSync(controlPath, `${JSON.stringify(out, null, 2)}\n`, 'utf8');
+}

--- a/packages/harnesses/src/tmpscript/types.ts
+++ b/packages/harnesses/src/tmpscript/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Temp-artifact lifecycle registry (RevealUI control layer).
+ *
+ * One-shot helpers (installers, verifiers, repro scripts) must be registered,
+ * validated, and cleaned — not left orphaned in $HOME or repo roots.
+ * GAP-295 control-layer conversion of the Claude Studio adapter.
+ */
+
+export type TmpscriptStatus = 'pending' | 'confirmed';
+
+export interface TmpscriptEntry {
+  id: string;
+  path: string;
+  purpose: string;
+  validate: string | null;
+  session: string;
+  created: string;
+  status: TmpscriptStatus;
+  confirmed: string | null;
+  /** Set when sweep auto-closed an expired pending entry. */
+  sweptAsExpired?: boolean;
+}
+
+export interface TmpscriptManifest {
+  version: 1;
+  /** Control-layer store path this manifest was last written to. */
+  store?: string;
+  entries: TmpscriptEntry[];
+}
+
+export interface RegisterTmpscriptInput {
+  path: string;
+  purpose?: string;
+  validate?: string | null;
+  id?: string;
+}
+
+export interface TmpscriptStoreOptions {
+  controlPath?: string;
+  legacyPath?: string;
+  migrate?: boolean;
+}
+
+export interface ConfirmTmpscriptOptions extends TmpscriptStoreOptions {
+  /** Injected for tests; default runs validate via shell execSync. */
+  runValidate?: (cmd: string) => void;
+  /** Injected for tests; default fs.unlinkSync. */
+  unlinkPath?: (filePath: string) => void;
+  pathExists?: (filePath: string) => boolean;
+}
+
+export interface SweepTmpscriptResult {
+  removedFiles: number;
+  prunedEntries: number;
+  remaining: number;
+}

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     'src/manager/index.ts',
     'src/hooks/index.ts',
     'src/hotfix/index.ts',
+    'src/tmpscript/index.ts',
     'src/gates/index.ts',
   ],
   // CJS for Claude-hook thin adapters (createRequire); ESM for monorepo/node apps.


### PR DESCRIPTION
## Summary
Control-layer conversion of the temp-script lifecycle (GAP-295), same shape as GAP-405 hotfix:

- `revealui-harnesses tmpscript` register / confirm / list / check / sweep / store
- Store: `~/.local/share/revealui/tmp-scripts/manifest.json`
- One-time migrate from legacy `~/.claude/tmp-scripts/manifest.json`
- confirm runs optional validate then deletes the file
- Package export `@revealui/harnesses/tmpscript`

Claude thin adapter: claude-config companion PR.

## Test plan
- [x] vitest tmpscript-registry (5) + full harnesses 487
- [x] build + local gate phase 1 PASS
- [x] smoke register / confirm / store