### PR TITLE
feat(db): coordination_file_claims.expires_at (GAP-175)

### DIFF
--- a/packages/db/migrations/0037_gap175_file_claims_expires_at.sql
+++ b/packages/db/migrations/0037_gap175_file_claims_expires_at.sql
@@ -1,0 +1,9 @@
+-- GAP-175: propagate file reservation TTL to Neon coordination_file_claims.
+-- Additive: nullable expires_at so existing rows remain valid until swept
+-- (null = legacy; new dual-writes always set a concrete expiry).
+
+ALTER TABLE "coordination_file_claims"
+  ADD COLUMN IF NOT EXISTS "expires_at" timestamp with time zone;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "coordination_file_claims_expires_at_idx"
+  ON "coordination_file_claims" USING btree ("expires_at");

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -128,6 +128,12 @@
       "rationale": "GAP-448 Phase 2-A: ADD COLUMN kit_fulfillments.artifact (jsonb thin package) + customer_id index after P2-1 #2393 created the base table without artifact storage. Hand-written ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS for idempotency, following the 0011/0031 column-addition precedent. Companion Drizzle schema at packages/db/src/schema/kit-fulfillments.ts models artifact via $type<KitFulfillmentArtifact>().",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as prior entries: pnpm --filter @revealui/db db:generate against a clean DB once the broader snapshot-debt backfill happens. Schema already models artifact at the type level."
+    },
+    {
+      "tag": "0037_gap175_file_claims_expires_at",
+      "rationale": "GAP-175: ADD COLUMN coordination_file_claims.expires_at (timestamptz nullable) + btree index so the RevDev daemon dual-write can store file-reservation TTL and sweepExpiredFileClaims can DELETE expired Neon rows. Hand-written ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS for idempotency, following the 0011/0031/0036 column-addition precedent. Companion Drizzle schema at packages/db/src/schema/coordination.ts models expiresAt; daemon writes ISO expires_at on files.reserve.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as prior entries: pnpm --filter @revealui/db db:generate against a clean DB once the broader snapshot-debt backfill happens. Schema already models expiresAt at the type level."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1785760000000,
       "tag": "0036_gap448_kit_fulfillments_artifact",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1785950000000,
+      "tag": "0037_gap175_file_claims_expires_at",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/coordination.ts
+++ b/packages/db/src/schema/coordination.ts
@@ -77,10 +77,16 @@ export const coordinationFileClaims = pgTable(
       .notNull()
       .references(() => coordinationSessions.id, { onDelete: 'cascade' }),
     claimedAt: timestamp('claimed_at', { withTimezone: true }).defaultNow().notNull(),
+    /**
+     * Claim TTL (GAP-175). Null only for pre-GAP-175 rows; new dual-writes always
+     * set this. Neon sweep deletes rows where expires_at < now().
+     */
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
   },
   (table) => [
     primaryKey({ columns: [table.filePath, table.sessionId] }),
     index('coordination_file_claims_session_id_idx').on(table.sessionId),
+    index('coordination_file_claims_expires_at_idx').on(table.expiresAt),
   ],
 );
 


### PR DESCRIPTION
## Summary
Add nullable `expires_at` + index on `coordination_file_claims` for daemon dual-write TTL (GAP-175). Companion revdev PR wires write + sweep.

## Test plan
- [x] migration hand-written SQL + journal entry 0037
- [x] schema Drizzle column