### PR TITLE
feat(auth): account membership owners get platform admin (not super-admin)

### DIFF
--- a/apps/admin/src/lib/access/roles/isAdminRole.ts
+++ b/apps/admin/src/lib/access/roles/isAdminRole.ts
@@ -1,10 +1,16 @@
 /**
- * Whether a user's top-level `role` string grants admin access — the set the
- * proxy.ts `revealui-role` cookie gate checks.
+ * Whether a user's top-level `role` string grants CMS shell admin access —
+ * the set the proxy.ts `revealui-role` cookie gate checks.
  *
- * The admin set is {owner, admin, super-admin}: `owner` is the highest DB role
- * (assigned to the bootstrap admin), `admin` is the standard admin role, and
- * `super-admin` is a forward-compat app-layer role.
+ * Bounds (see packages/auth platform-roles + ADR role planes):
+ * - `owner` — highest DB column role (bootstrap / primary operator)
+ * - `admin` — standard CMS shell admin (hosted account owners promoted here)
+ * - `super-admin` — cookie-compat only; canonical storage is `_json.roles`,
+ *   not `users.role` (CHECK forbids super-admin on the column)
+ *
+ * Super-admin is platform operator power, not "first SaaS customer".
+ * Account membership owner ≠ shell admin until users.role is admin/owner
+ * (ensureAccountOwnerPlatformAdmin on account provision).
  *
  * Centralized so every auth route (sign-in, sign-up, OAuth callback, passkey)
  * derives the cookie identically. They historically drifted: the #306 role

--- a/apps/admin/src/lib/auth/roles.ts
+++ b/apps/admin/src/lib/auth/roles.ts
@@ -11,8 +11,12 @@
  * owner/admin/editor/viewer/agent/contributor, so the app-level 'super-admin'
  * CANNOT live there — it lives in `_json.roles`. A first user promoted to DB
  * role 'admin'/'owner' but with no `_json.roles` is denied by every engine gate
- * (the founder's bug). Canonical owner shape (per #1219): DB role='owner' +
- * _json.roles=['super-admin'].
+ * (the founder's bug). Canonical **system** bootstrap shape (per #1219): DB
+ * role='owner' + _json.roles=['super-admin'].
+ *
+ * Separate from hosted **account membership owner** → shell admin (users.role
+ * admin, never super-admin): packages/auth ensureAccountOwnerPlatformAdmin.
+ * ADR: 2026-08-05-role-planes-owner-admin-super-admin.
  *
  * A typed Drizzle write is required for the same reason ./tos.ts documents: the
  * engine's dynamic-SQL create path can write `roles` into `_json`, but the

--- a/apps/server/src/routes/webhooks/helpers.ts
+++ b/apps/server/src/routes/webhooks/helpers.ts
@@ -9,6 +9,7 @@
  * duplicate processing across Vercel multi-region deployments.
  */
 
+import { ensureAccountOwnerPlatformAdmin } from '@revealui/auth/server';
 import {
   coversRenewalBound,
   readLicenseExp,
@@ -518,6 +519,10 @@ export async function ensureHostedAccount(
     createdAt: now,
     updatedAt: now,
   });
+
+  // Account owner → platform shell admin (not super-admin). Same rule as
+  // signup personal-account provision (packages/auth platform-roles).
+  await ensureAccountOwnerPlatformAdmin(tx as Database, userId);
 
   logger.info('Hosted billing account created from Stripe webhook', {
     accountId,

--- a/packages/auth/src/server/__tests__/auth.test.ts
+++ b/packages/auth/src/server/__tests__/auth.test.ts
@@ -58,6 +58,18 @@ vi.mock('../audit-bridge.js', () => ({
   auditLoginFailure: (...args: unknown[]) => mockAuditLoginFailure(...args),
 }));
 
+const mockEnsureAccountOwnerPlatformAdmin = vi.fn();
+vi.mock('../platform-roles.js', () => ({
+  ensureAccountOwnerPlatformAdmin: (...args: unknown[]) =>
+    mockEnsureAccountOwnerPlatformAdmin(...args),
+}));
+
+const mockIsHostedDeployment = vi.fn(() => false);
+vi.mock('@revealui/core/deployment-mode', () => ({
+  isHostedDeployment: (...args: unknown[]) => mockIsHostedDeployment(...args),
+  detectDeploymentMode: vi.fn(() => 'forge'),
+}));
+
 // Chain mocks for drizzle-orm query builder
 const mockReturning = vi.fn();
 const mockInsertValues = vi.fn().mockReturnValue({ returning: mockReturning });
@@ -510,10 +522,16 @@ describe('auth', () => {
     // the hosted case sets it explicitly.
     beforeEach(() => {
       delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+      mockIsHostedDeployment.mockReturnValue(false);
+      mockEnsureAccountOwnerPlatformAdmin.mockResolvedValue({
+        previousRole: 'viewer',
+        nextRole: 'admin',
+        updated: true,
+      });
     });
 
     it('provisions a personal account + owner membership on hosted SaaS', async () => {
-      process.env.REVEALUI_LICENSE_PRIVATE_KEY = 'test-signing-key';
+      mockIsHostedDeployment.mockReturnValue(true);
       mockLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       const result = await signUp('acct@example.com', 'StrongPass1', 'Acct User');
@@ -532,6 +550,8 @@ describe('auth', () => {
       expect(
         valueCalls.some((v) => v.role === 'owner' && v.status === 'active' && Boolean(v.accountId)),
       ).toBe(true);
+      // Platform shell admin (not super-admin) for account owner
+      expect(mockEnsureAccountOwnerPlatformAdmin).toHaveBeenCalled();
     });
 
     it('creates user and returns session token on success', async () => {

--- a/packages/auth/src/server/__tests__/platform-roles.test.ts
+++ b/packages/auth/src/server/__tests__/platform-roles.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ensureAccountOwnerPlatformAdmin,
+  isPlatformShellAdminRole,
+  PLATFORM_SHELL_ADMIN_ROLES,
+  platformRoleForAccountOwner,
+} from '../platform-roles.js';
+
+describe('platformRoleForAccountOwner', () => {
+  it('leaves owner and admin unchanged', () => {
+    expect(platformRoleForAccountOwner('owner')).toBe('owner');
+    expect(platformRoleForAccountOwner('admin')).toBe('admin');
+  });
+
+  it('promotes viewer and other non-admin roles to admin', () => {
+    expect(platformRoleForAccountOwner('viewer')).toBe('admin');
+    expect(platformRoleForAccountOwner('editor')).toBe('admin');
+    expect(platformRoleForAccountOwner('contributor')).toBe('admin');
+    expect(platformRoleForAccountOwner('agent')).toBe('admin');
+  });
+
+  it('never returns super-admin (not a users.role value)', () => {
+    expect(platformRoleForAccountOwner('viewer')).not.toBe('super-admin');
+    expect(PLATFORM_SHELL_ADMIN_ROLES.has('super-admin')).toBe(false);
+  });
+});
+
+describe('isPlatformShellAdminRole', () => {
+  it('accepts owner, admin, super-admin cookie values', () => {
+    expect(isPlatformShellAdminRole('owner')).toBe(true);
+    expect(isPlatformShellAdminRole('admin')).toBe(true);
+    expect(isPlatformShellAdminRole('super-admin')).toBe(true);
+  });
+
+  it('rejects viewer and empty', () => {
+    expect(isPlatformShellAdminRole('viewer')).toBe(false);
+    expect(isPlatformShellAdminRole(null)).toBe(false);
+    expect(isPlatformShellAdminRole(undefined)).toBe(false);
+  });
+});
+
+describe('ensureAccountOwnerPlatformAdmin', () => {
+  function mockDb(existing: { id: string; role: string } | null) {
+    const limit = vi.fn().mockResolvedValue(existing ? [existing] : []);
+    const whereSelect = vi.fn().mockReturnValue({ limit });
+    const from = vi.fn().mockReturnValue({ where: whereSelect });
+    const select = vi.fn().mockReturnValue({ from });
+
+    const whereUpdate = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn().mockReturnValue({ where: whereUpdate });
+    const update = vi.fn().mockReturnValue({ set });
+
+    return {
+      db: { select, update } as never,
+      select,
+      update,
+      set,
+      whereUpdate,
+    };
+  }
+
+  it('no-ops when user missing', async () => {
+    const { db, update } = mockDb(null);
+    const result = await ensureAccountOwnerPlatformAdmin(db, 'missing');
+    expect(result).toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when already admin', async () => {
+    const { db, update } = mockDb({ id: 'u1', role: 'admin' });
+    const result = await ensureAccountOwnerPlatformAdmin(db, 'u1');
+    expect(result).toEqual({ previousRole: 'admin', nextRole: 'admin', updated: false });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('promotes viewer to admin', async () => {
+    const { db, update, set, whereUpdate } = mockDb({ id: 'u1', role: 'viewer' });
+    const result = await ensureAccountOwnerPlatformAdmin(db, 'u1');
+    expect(result).toEqual({ previousRole: 'viewer', nextRole: 'admin', updated: true });
+    expect(update).toHaveBeenCalled();
+    expect(set).toHaveBeenCalledWith({ role: 'admin' });
+    expect(whereUpdate).toHaveBeenCalled();
+  });
+});

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -14,6 +14,7 @@ import type { SignInResult, SignUpResult, User } from '../types.js';
 import { auditLoginFailure, auditLoginSuccess } from './audit-bridge.js';
 import { clearFailedAttempts, isAccountLocked, recordFailedAttempt } from './brute-force.js';
 import { validatePasswordStrength } from './password-validation.js';
+import { ensureAccountOwnerPlatformAdmin } from './platform-roles.js';
 import { checkRateLimit } from './rate-limit.js';
 import { createSession, rotateSession } from './session.js';
 
@@ -544,6 +545,10 @@ export async function signUp(
           createdAt: now,
           updatedAt: now,
         });
+        // First membership owner of a hosted account gets platform shell
+        // admin (users.role), not super-admin. Unlocks /settings + API keys
+        // without granting fleet control-plane power.
+        await ensureAccountOwnerPlatformAdmin(db, user.id);
       } catch {
         logger.error(
           'Failed to provision personal account at signup (billing webhook will backfill)',

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -115,6 +115,13 @@ export {
   validatePasswordStrength,
 } from './password-validation.js';
 export {
+  ensureAccountOwnerPlatformAdmin,
+  isPlatformShellAdminRole,
+  PLATFORM_SHELL_ADMIN_COOKIE_ROLES,
+  PLATFORM_SHELL_ADMIN_ROLES,
+  platformRoleForAccountOwner,
+} from './platform-roles.js';
+export {
   checkRateLimit,
   configureRateLimit,
   getRateLimitStatus,

--- a/packages/auth/src/server/platform-roles.ts
+++ b/packages/auth/src/server/platform-roles.ts
@@ -1,0 +1,78 @@
+/**
+ * Platform role plane (users.role + _json.roles) — durable bounds.
+ *
+ * Orthogonal to billing:
+ * - account_memberships.role (owner|admin|member) — workspace seat
+ * - account_entitlements.tier — paid features
+ *
+ * Super-admin is platform operator only (lives in _json.roles, never as
+ * the sole meaning of "first user of a customer account").
+ *
+ * Account membership owner of a hosted workspace gets CMS shell access
+ * via users.role = admin so proxy isAdminRole + /settings (API keys) work.
+ * That is NOT super-admin.
+ */
+
+import type { Database } from '@revealui/db/client';
+import { users } from '@revealui/db/schema';
+import { eq } from 'drizzle-orm';
+
+/** DB column values that already pass isAdminRole / shell admin cookie gate. */
+export const PLATFORM_SHELL_ADMIN_ROLES: ReadonlySet<string> = new Set(['owner', 'admin']);
+
+/**
+ * Cookie/proxy admin set (isAdminRole). Includes super-admin for cookie
+ * compatibility; super-admin must not be written to users.role (CHECK forbids it).
+ */
+export const PLATFORM_SHELL_ADMIN_COOKIE_ROLES: ReadonlySet<string> = new Set([
+  'owner',
+  'admin',
+  'super-admin',
+]);
+
+/**
+ * When a user becomes (or is) billing account owner, ensure they can use
+ * workspace admin surfaces. Promote non-admin DB roles to `admin`.
+ * Never demote owner/admin. Never assign super-admin.
+ */
+export function platformRoleForAccountOwner(currentRole: string): string {
+  if (PLATFORM_SHELL_ADMIN_ROLES.has(currentRole)) {
+    return currentRole;
+  }
+  return 'admin';
+}
+
+export function isPlatformShellAdminRole(role: string | null | undefined): boolean {
+  return role != null && PLATFORM_SHELL_ADMIN_COOKIE_ROLES.has(role);
+}
+
+/**
+ * Promote users.role to admin when the user is (or becomes) an account
+ * membership owner and currently lacks shell admin. Idempotent; never demotes.
+ *
+ * Call sites: personal-account provision at signup, Stripe ensureHostedAccount,
+ * grant-entitlement --create-account, OAuth hosted provision.
+ */
+export async function ensureAccountOwnerPlatformAdmin(
+  db: Database,
+  userId: string,
+): Promise<{ previousRole: string; nextRole: string; updated: boolean } | null> {
+  const [row] = await db
+    .select({ id: users.id, role: users.role })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!row) {
+    return null;
+  }
+
+  const previousRole = row.role;
+  const nextRole = platformRoleForAccountOwner(previousRole);
+  if (nextRole === previousRole) {
+    return { previousRole, nextRole, updated: false };
+  }
+
+  await db.update(users).set({ role: nextRole }).where(eq(users.id, userId));
+  return { previousRole, nextRole, updated: true };
+}

--- a/scripts/admin/backfill-account-owner-platform-admin.ts
+++ b/scripts/admin/backfill-account-owner-platform-admin.ts
@@ -1,0 +1,72 @@
+/**
+ * Backfill: membership owner + users.role=viewer → platform admin.
+ *
+ * Durable residual for accounts provisioned before ensureAccountOwnerPlatformAdmin.
+ * Dry-run by default. Never grants super-admin.
+ *
+ * Usage:
+ *   revvault run --env DATABASE_URL=revealui/prod/db/postgres-url -- \
+ *     pnpm exec tsx scripts/admin/backfill-account-owner-platform-admin.ts
+ *   ... -- --apply
+ */
+
+import { ensureAccountOwnerPlatformAdmin } from '@revealui/auth/server';
+import { getClient } from '@revealui/db/client';
+import { accountMemberships, users } from '@revealui/db/schema';
+import { and, eq, isNull, or } from 'drizzle-orm';
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+  const db = getClient();
+
+  const rows = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      role: users.role,
+      membershipRole: accountMemberships.role,
+    })
+    .from(users)
+    .innerJoin(
+      accountMemberships,
+      and(
+        eq(accountMemberships.userId, users.id),
+        eq(accountMemberships.role, 'owner'),
+        eq(accountMemberships.status, 'active'),
+      ),
+    )
+    .where(
+      and(
+        isNull(users.deletedAt),
+        or(eq(users.role, 'viewer'), eq(users.role, 'editor'), eq(users.role, 'contributor')),
+      ),
+    );
+
+  // Dedupe users (multiple accounts unlikely but safe)
+  const byUser = new Map<string, (typeof rows)[0]>();
+  for (const row of rows) {
+    byUser.set(row.userId, row);
+  }
+
+  console.log(`[backfill] candidates: ${byUser.size} (dry-run=${!apply})`);
+  for (const row of byUser.values()) {
+    console.log(`  ${row.email ?? row.userId}  users.role=${row.role} → admin`);
+  }
+
+  if (!apply) {
+    console.log('[backfill] re-run with --apply to update');
+    return;
+  }
+
+  let updated = 0;
+  for (const userId of byUser.keys()) {
+    const result = await ensureAccountOwnerPlatformAdmin(db, userId);
+    if (result?.updated) updated += 1;
+  }
+  console.log(`[backfill] updated: ${updated}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/admin/grant-entitlement.ts
+++ b/scripts/admin/grant-entitlement.ts
@@ -148,6 +148,9 @@ async function main(): Promise<void> {
         createdAt: now,
         updatedAt: now,
       });
+      // Account owner → platform shell admin (not super-admin). Mirrors signup.
+      const { ensureAccountOwnerPlatformAdmin } = await import('@revealui/auth/server');
+      await ensureAccountOwnerPlatformAdmin(db, user.id);
     }
   }
 


### PR DESCRIPTION
## Summary
Durable role-plane fix: hosted **account membership owners** were left as `users.role=viewer`, so proxy blocked `/settings` (API keys) despite membership owner + paid tier.

### Rule (ADR: jv#1090)
| Role | Meaning |
|------|---------|
| **super-admin** | Platform operator only (`_json.roles`) — system bootstrap, never SaaS customer default |
| **owner** (DB) | Highest shell role — self-host bootstrap |
| **admin** (DB) | CMS shell — **what account owners get** |
| membership **owner** | Billing seat — orthogonal until shell promoted |

### Code
- `packages/auth` `ensureAccountOwnerPlatformAdmin` / `platformRoleForAccountOwner`
- Wired: signup personal account, Stripe `ensureHostedAccount`, grant-entitlement `--create-account`
- Backfill: `scripts/admin/backfill-account-owner-platform-admin.ts` (dry-run default)
- Tests: platform-roles + auth hosted provision

### Not in this PR
- Temporary SQL elevates for walks
- Granting super-admin to customers

## Security
Auth/RBAC surface — needs non-author guardrail-2 verdict before merge. **Do not merge until verdict.**

## Test plan
- [x] `vitest` platform-roles + auth signUp suite
- [ ] After merge: dry-run then `--apply` backfill on prod (owner)
- [ ] Sign in Gmail Pro/Max → `/settings/api-keys` works after backfill + re-login

## Owner after merge
```bash
revvault run --env DATABASE_URL=revealui/prod/db/postgres-url -- \
  pnpm exec tsx scripts/admin/backfill-account-owner-platform-admin.ts
# then --apply when dry-run looks right; users must re-login for cookie
```