### PR TITLE
fix(admin): monorepo version in footer, not over settings gear

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
@@ -11,6 +11,19 @@ import sentryModule from '@sentry/nextjs'
 import { withRevealUI } from '@revealui/core/nextjs/withRevealUI'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Monorepo product version for dashboard chrome (not apps/admin's private 0.1.0 stub).
+// NEXT_PUBLIC_ so client sidebar/footer can read it; inlined at build time.
+function readMonorepoVersion() {
+  try {
+    const raw = readFileSync(path.join(__dirname, '../../package.json'), 'utf8')
+    const pkg = JSON.parse(raw)
+    return typeof pkg.version === 'string' && pkg.version.length > 0 ? pkg.version : '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+}
+const monorepoVersion = readMonorepoVersion()
 
 // Pro package (@revealui/ai) is Fair Source (FSL-1.1-MIT) and normally present.
 // If someone removes it from a fork, alias all subpaths to a stub for graceful degradation.
@@ -47,6 +60,10 @@ const proAIAliases = hasProAI ? {} : {
 const nextConfig = {
   reactStrictMode: true,
   distDir: '.next',
+  env: {
+    NEXT_PUBLIC_APP_VERSION: monorepoVersion,
+    APP_VERSION: monorepoVersion,
+  },
   // Use standalone output for all environments including Vercel
   // Required for monorepo workspace packages to resolve correctly in serverless
   output: 'standalone',

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "private": true,
   "description": "RevealUI admin dashboard",
   "license": "MIT",

--- a/apps/admin/src/app/(backend)/layout.tsx
+++ b/apps/admin/src/app/(backend)/layout.tsx
@@ -33,6 +33,8 @@ const isFleetMode = process.env.REVEALUI_FLEET_MODE === 'true';
 // GAP-260 P4-1: which product posture is this process. FreeTierBanner uses
 // this to stop pointing self-host at a Stripe checkout it has no keys for.
 const isHosted = isHostedDeployment(process.env);
+// Monorepo product version (next.config env from root package.json).
+const appVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? process.env.APP_VERSION ?? '0.0.0';
 const ADMIN_ROLES = new Set(['owner', 'admin', 'super-admin']);
 
 export default async function Layout({ children }: Args) {
@@ -58,6 +60,7 @@ export default async function Layout({ children }: Args) {
             isFleetMode={isFleetMode}
             isHosted={isHosted}
             isAdmin={isAdmin}
+            appVersion={appVersion}
           >
             {children}
           </AdminSidebarLayout>

--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -135,7 +135,15 @@ const bottomItems: NavItem[] = [
   },
 ];
 
-function AdminSidebarContent({ siteName, isAdmin }: { siteName: string; isAdmin: boolean }) {
+function AdminSidebarContent({
+  siteName,
+  isAdmin,
+  appVersion,
+}: {
+  siteName: string;
+  isAdmin: boolean;
+  appVersion: string;
+}) {
   const pathname = usePathname();
 
   const isCurrent = (href: string) => {
@@ -193,7 +201,16 @@ function AdminSidebarContent({ siteName, isAdmin }: { siteName: string; isAdmin:
         </SidebarSection>
       </SidebarBody>
       <SidebarFooter>
-        <p className="text-xs text-muted-foreground">{siteName} Admin</p>
+        {/* Version sits in the footer row — never on/over nav icons (settings gear). */}
+        <div className="flex items-center justify-between gap-2">
+          <p className="min-w-0 truncate text-xs text-muted-foreground">{siteName} Admin</p>
+          <span
+            className="shrink-0 text-xs tabular-nums text-muted-foreground"
+            title="Application version"
+          >
+            v{appVersion}
+          </span>
+        </div>
       </SidebarFooter>
     </Sidebar>
   );
@@ -205,17 +222,22 @@ export function AdminSidebarLayout({
   isFleetMode = false,
   isHosted = false,
   isAdmin = true,
+  appVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0',
 }: {
   children: React.ReactNode;
   siteName?: string;
   isFleetMode?: boolean;
   isHosted?: boolean;
   isAdmin?: boolean;
+  /** Product version from monorepo package.json (build-time NEXT_PUBLIC_APP_VERSION). */
+  appVersion?: string;
 }) {
   return (
     <SidebarLayout
       navbar={<span />}
-      sidebar={<AdminSidebarContent siteName={siteName} isAdmin={isAdmin} />}
+      sidebar={
+        <AdminSidebarContent siteName={siteName} isAdmin={isAdmin} appVersion={appVersion} />
+      }
     >
       {isFleetMode ? null : <FreeTierBanner isHosted={isHosted} />}
       {children}

--- a/apps/admin/src/lib/components/__tests__/adminChromeBranding.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/adminChromeBranding.test.tsx
@@ -48,6 +48,18 @@ describe('admin chrome white-label branding', () => {
       expect(screen.getByText('RevealUI')).toBeDefined();
       expect(screen.getByText('RevealUI Admin')).toBeDefined();
     });
+
+    it('shows app version in the footer, not over nav icons', () => {
+      render(
+        <AdminSidebarLayout siteName="Acme" appVersion="0.4.0">
+          content
+        </AdminSidebarLayout>,
+      );
+      expect(screen.getByText('v0.4.0')).toBeDefined();
+      // Settings gear row is a separate nav item; version is footer-only.
+      expect(screen.getByText('Settings')).toBeDefined();
+      expect(screen.queryByText('v0.1.0')).toBeNull();
+    });
   });
 
   describe('AdminDashboard', () => {

--- a/packages/core/src/client/admin/components/AdminDashboard.tsx
+++ b/packages/core/src/client/admin/components/AdminDashboard.tsx
@@ -503,8 +503,13 @@ function DashboardHome({
             <div className="flex items-center">
               <h1 className="text-2xl font-bold text-foreground">{`${siteName} Admin`}</h1>
             </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-muted-foreground">v0.1.0</span>
+            <div className="flex shrink-0 items-center gap-3">
+              <span
+                className="shrink-0 text-sm tabular-nums text-muted-foreground"
+                title="Application version"
+              >
+                v{process.env.NEXT_PUBLIC_APP_VERSION ?? process.env.APP_VERSION ?? '0.0.0'}
+              </span>
               <SignOutButton />
             </div>
           </div>

--- a/packages/core/src/client/admin/page.tsx
+++ b/packages/core/src/client/admin/page.tsx
@@ -45,8 +45,13 @@ export function RootPage({ config }: RootPageProps) {
             <div className="flex items-center">
               <h1 className="text-2xl font-bold text-foreground">{`${siteName} Admin`}</h1>
             </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-muted-foreground">v0.1.0</span>
+            <div className="flex shrink-0 items-center gap-3">
+              <span
+                className="shrink-0 text-sm tabular-nums text-muted-foreground"
+                title="Application version"
+              >
+                v{process.env.NEXT_PUBLIC_APP_VERSION ?? process.env.APP_VERSION ?? '0.0.0'}
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Hardcoded **v0.1.0** (stale `apps/admin` package stub) showed in core admin chrome and sat poorly relative to controls / settings gear.

### Fix
- Read monorepo root `package.json` version at build (`next.config.mjs` → `NEXT_PUBLIC_APP_VERSION` / `APP_VERSION`)
- Sidebar: version in **footer** row (`tabular-nums`, shrink-0), never on nav icons
- Core `AdminDashboard` / `RootPage`: same env version beside sign-out, not hardcoded
- Bump `apps/admin/package.json` to **0.4.0** to match product

### Test
- [x] AdminSidebarLayout branding tests (version + no v0.1.0)

## After merge
Redeploy admin for prod to pick up build-time version.