### PR TITLE
fix(admin): passkey login sets mfaVerified for step-up APIs

### DIFF
--- a/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
@@ -832,7 +832,13 @@ describe('POST /api/auth/passkey/authenticate-verify', () => {
     expect(data.success).toBe(true);
     expect(data.user.email).toBe('user@example.com');
     expect(mockVerifyAuthentication).toHaveBeenCalled();
-    expect(mockRotateSession).toHaveBeenCalledWith('user-123', expect.any(Object));
+    // Passkey login is AAL2 — session must carry mfaVerified for API key save, etc.
+    expect(mockRotateSession).toHaveBeenCalledWith(
+      'user-123',
+      expect.objectContaining({
+        metadata: { mfaVerified: true, mfaMethod: 'passkey' },
+      }),
+    );
 
     // Session cookie should be set
     const sessionCookie = response.cookies.get('revealui-session');

--- a/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
@@ -121,7 +121,10 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
       );
     }
 
-    // Passkeys are inherently MFA  -  create session directly (no TOTP check)
+    // Passkeys are phishing-resistant MFA (WebAuthn). Create a full session
+    // with mfaVerified so requireSessionWithMfa (API keys, GDPR, etc.) accepts
+    // this session without a second TOTP prompt. Matches TOTP verify/backup
+    // and MFA setup verify-setup session metadata.
     const userAgent = request.headers.get('user-agent') ?? undefined;
     const ipAddress =
       request.headers.get('x-real-ip') ||
@@ -131,6 +134,7 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
     const { token: sessionToken } = await rotateSession(storedPasskey.userId, {
       userAgent,
       ipAddress,
+      metadata: { mfaVerified: true, mfaMethod: 'passkey' },
     });
 
     const response = NextResponse.json({


### PR DESCRIPTION
## Summary
API key save (and other `requireSessionWithMfa` surfaces) returned **MFA verification required** after a successful **passkey** login even when TOTP was enrolled and the UI showed MFA enabled.

### Cause
- Enforcement checks `session.metadata.mfaVerified === true` (step-up in **this** session).
- Account-level `mfa_enabled` only proves MFA is configured.
- TOTP verify/backup/setup set `mfaVerified: true`; **passkey authenticate-verify did not**.

### Fix
Passkey login is phishing-resistant MFA. On successful authenticate-verify, call `rotateSession` with:
```ts
metadata: { mfaVerified: true, mfaMethod: 'passkey' }
```

### Test
- [x] passkey `authenticate-verify` unit test asserts session metadata

### Workaround (until deploy)
Sign in with password + authenticator app (or backup code), then Save Key; or open `/mfa` and complete TOTP once on this session.