### PR TITLE
feat: presigned direct-to-R2 media upload (GAP-215)

### DIFF
--- a/.changeset/gap-215-presigned-r2-upload.md
+++ b/.changeset/gap-215-presigned-r2-upload.md
@@ -1,0 +1,5 @@
+---
+"@revealui/core": minor
+---
+
+Add StorageProvider createPresignedPutUrl, headObject, and getObjectRange for direct-to-R2 media uploads (GAP-215)

--- a/apps/admin/src/app/(backend)/media/__tests__/upload-media.test.ts
+++ b/apps/admin/src/app/(backend)/media/__tests__/upload-media.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { uploadMedia } from '../upload-media.js';
+
+describe('uploadMedia (presign → PUT → confirm)', () => {
+  const apiFetch = vi.fn();
+  const storageFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('presigns, PUTs to storage with signed headers, then confirms', async () => {
+    const file = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'photo.png', {
+      type: 'image/png',
+    });
+
+    apiFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              key: 'media/11111111-1111-4111-8111-111111111111.png',
+              uploadUrl: 'https://r2.example/presign?sig=1',
+              headers: { 'content-type': 'image/png' },
+              expiresAt: '2026-05-18T10:15:00.000Z',
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              id: 'media-1',
+              filename: 'photo.png',
+              mimeType: 'image/png',
+              filesize: 4,
+              url: 'https://media.revealui.com/media/11111111-1111-4111-8111-111111111111.png',
+              alt: null,
+              width: null,
+              height: null,
+              createdAt: '2026-05-18T10:00:00.000Z',
+              updatedAt: '2026-05-18T10:00:00.000Z',
+            },
+          }),
+          { status: 201 },
+        ),
+      );
+
+    storageFetch.mockResolvedValue(new Response(null, { status: 200 }));
+
+    const result = await uploadMedia('https://api.example', file, { apiFetch, storageFetch });
+
+    expect(apiFetch).toHaveBeenNthCalledWith(
+      1,
+      'https://api.example/api/content/media/presign',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          filename: 'photo.png',
+          mimeType: 'image/png',
+          size: 4,
+        }),
+      }),
+    );
+    expect(storageFetch).toHaveBeenCalledWith(
+      'https://r2.example/presign?sig=1',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'content-type': 'image/png' },
+        body: file,
+      }),
+    );
+    expect(apiFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example/api/content/media/confirm',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          key: 'media/11111111-1111-4111-8111-111111111111.png',
+          filename: 'photo.png',
+          mimeType: 'image/png',
+          size: 4,
+        }),
+      }),
+    );
+    expect(result.id).toBe('media-1');
+  });
+
+  it('throws when presign fails', async () => {
+    apiFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Unsupported file type' }), { status: 400 }),
+    );
+    const file = new File([new Uint8Array([1])], 'x.bin', { type: 'application/octet-stream' });
+    await expect(
+      uploadMedia('https://api.example', file, { apiFetch, storageFetch }),
+    ).rejects.toThrow(/Unsupported file type/);
+    expect(storageFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when the storage PUT fails', async () => {
+    apiFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            key: 'media/11111111-1111-4111-8111-111111111111.png',
+            uploadUrl: 'https://r2.example/presign',
+            headers: { 'content-type': 'image/png' },
+            expiresAt: '2026-05-18T10:15:00.000Z',
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    storageFetch.mockResolvedValue(new Response(null, { status: 403 }));
+    const file = new File([new Uint8Array([1])], 'a.png', { type: 'image/png' });
+    await expect(
+      uploadMedia('https://api.example', file, { apiFetch, storageFetch }),
+    ).rejects.toThrow(/Storage upload failed: 403/);
+  });
+
+  it('throws when confirm fails', async () => {
+    apiFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              key: 'media/11111111-1111-4111-8111-111111111111.png',
+              uploadUrl: 'https://r2.example/presign',
+              headers: { 'content-type': 'image/png' },
+              expiresAt: '2026-05-18T10:15:00.000Z',
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'File content does not match' }), { status: 400 }),
+      );
+    storageFetch.mockResolvedValue(new Response(null, { status: 200 }));
+    const file = new File([new Uint8Array([1])], 'a.png', { type: 'image/png' });
+    await expect(
+      uploadMedia('https://api.example', file, { apiFetch, storageFetch }),
+    ).rejects.toThrow(/does not match/);
+  });
+});

--- a/apps/admin/src/app/(backend)/media/page.tsx
+++ b/apps/admin/src/app/(backend)/media/page.tsx
@@ -18,24 +18,14 @@ import {
 } from '@revealui/presentation/client';
 import { type ChangeEvent, useCallback, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/utils/csrf';
+import { type UploadedMediaItem, uploadMedia as uploadMediaDirect } from './upload-media';
 import { useWindowFileDrop } from './use-window-file-drop';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface MediaItem {
-  id: string;
-  filename: string;
-  mimeType: string;
-  filesize: number | null;
-  url: string;
-  alt: string | null;
-  width: number | null;
-  height: number | null;
-  createdAt: string;
-  updatedAt: string;
-}
+type MediaItem = UploadedMediaItem;
 
 interface MediaListResponse {
   success: boolean;
@@ -87,20 +77,7 @@ async function fetchMedia(
 }
 
 async function uploadMedia(serverUrl: string, file: File, alt?: string): Promise<MediaItem> {
-  const formData = new FormData();
-  formData.append('file', file);
-  if (alt) formData.append('alt', alt);
-  const res = await apiFetch(`${serverUrl}/api/content/media`, {
-    method: 'POST',
-    credentials: 'include',
-    body: formData,
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({ error: 'Upload failed' }));
-    throw new Error(body.error ?? `Upload failed: ${res.status}`);
-  }
-  const json = await res.json();
-  return json.data;
+  return uploadMediaDirect(serverUrl, file, { apiFetch }, alt);
 }
 
 async function deleteMediaItem(serverUrl: string, id: string): Promise<void> {

--- a/apps/admin/src/app/(backend)/media/upload-media.ts
+++ b/apps/admin/src/app/(backend)/media/upload-media.ts
@@ -1,0 +1,105 @@
+/**
+ * Admin media upload via presigned direct-to-R2 (GAP-215).
+ *
+ * Flow: POST /media/presign → PUT bytes to storage → POST /media/confirm.
+ * The API function never buffers the file body.
+ */
+
+export interface UploadedMediaItem {
+  id: string;
+  filename: string;
+  mimeType: string;
+  filesize: number | null;
+  url: string;
+  alt: string | null;
+  width: number | null;
+  height: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PresignResponse {
+  success: boolean;
+  data: {
+    key: string;
+    uploadUrl: string;
+    headers: Record<string, string>;
+    expiresAt: string;
+  };
+}
+
+export interface ConfirmResponse {
+  success: boolean;
+  data: UploadedMediaItem;
+  error?: string;
+}
+
+export type ApiFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface UploadMediaDeps {
+  /** Authenticated fetch (CSRF + cookies). Defaults are injected by the page. */
+  apiFetch: ApiFetch;
+  /** Unauthenticated fetch for the cross-origin storage PUT (R2). */
+  storageFetch?: typeof fetch;
+}
+
+/**
+ * Upload a file: presign → direct PUT to object storage → confirm media row.
+ */
+export async function uploadMedia(
+  serverUrl: string,
+  file: File,
+  deps: UploadMediaDeps,
+  alt?: string,
+): Promise<UploadedMediaItem> {
+  const storageFetch = deps.storageFetch ?? fetch;
+
+  const presignRes = await deps.apiFetch(`${serverUrl}/api/content/media/presign`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      filename: file.name,
+      mimeType: file.type,
+      size: file.size,
+    }),
+  });
+  if (!presignRes.ok) {
+    const body = (await presignRes.json().catch(() => ({ error: 'Presign failed' }))) as {
+      error?: string;
+    };
+    throw new Error(body.error ?? `Presign failed: ${presignRes.status}`);
+  }
+  const presignJson = (await presignRes.json()) as PresignResponse;
+  const { key, uploadUrl, headers } = presignJson.data;
+
+  const putRes = await storageFetch(uploadUrl, {
+    method: 'PUT',
+    headers: { ...headers },
+    body: file,
+  });
+  if (!putRes.ok) {
+    throw new Error(`Storage upload failed: ${putRes.status}`);
+  }
+
+  const confirmRes = await deps.apiFetch(`${serverUrl}/api/content/media/confirm`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      key,
+      filename: file.name,
+      mimeType: file.type,
+      size: file.size,
+      ...(alt !== undefined ? { alt } : {}),
+    }),
+  });
+  if (!confirmRes.ok) {
+    const body = (await confirmRes.json().catch(() => ({ error: 'Confirm failed' }))) as {
+      error?: string;
+    };
+    throw new Error(body.error ?? `Confirm failed: ${confirmRes.status}`);
+  }
+  const confirmJson = (await confirmRes.json()) as ConfirmResponse;
+  return confirmJson.data;
+}

--- a/apps/server/src/middleware/__tests__/body-limits.test.ts
+++ b/apps/server/src/middleware/__tests__/body-limits.test.ts
@@ -30,6 +30,12 @@ describe('isMediaUploadRequest', () => {
     expect(isMediaUploadRequest('GET', '/api/content/media')).toBe(false);
     expect(isMediaUploadRequest('POST', '/api/other')).toBe(false);
   });
+
+  it('does not match presign/confirm JSON paths (GAP-215 direct-to-R2)', () => {
+    expect(isMediaUploadRequest('POST', '/api/content/media/presign')).toBe(false);
+    expect(isMediaUploadRequest('POST', '/api/content/media/confirm')).toBe(false);
+    expect(isMediaUploadRequest('POST', '/api/v1/content/media/presign')).toBe(false);
+  });
 });
 
 describe('bodyLimitGate', () => {
@@ -63,6 +69,17 @@ describe('bodyLimitGate', () => {
 
   it('caps non-media routes at 1MB', async () => {
     const res = await makeApp().request('/api/other', { method: 'POST', ...withBody(5) });
+    expect(res.status).toBe(413);
+    expect((await res.json()).error).toContain('1MB');
+  });
+
+  it('caps presign/confirm JSON bodies at 1MB (file bytes never hit the function)', async () => {
+    const app = makeApp();
+    app.post('/api/content/media/presign', (c) => c.json({ ok: true }));
+    const res = await app.request('/api/content/media/presign', {
+      method: 'POST',
+      ...withBody(5),
+    });
     expect(res.status).toBe(413);
     expect((await res.json()).error).toContain('1MB');
   });

--- a/apps/server/src/middleware/body-limits.ts
+++ b/apps/server/src/middleware/body-limits.ts
@@ -1,8 +1,9 @@
 /**
  * Request body-size limits.
  *
- * A single path-aware gate: media uploads (POST to the media collection) get the
- * image per-type ceiling; every other route gets 1MB.
+ * A single path-aware gate: legacy multipart media uploads (POST exact path
+ * `/api/content/media`) get the image per-type ceiling (10MB); every other
+ * route — including POST /media/presign and POST /media/confirm — gets 1MB.
  *
  * Why one middleware instead of separate `app.use('/media/*', big)` +
  * `app.use('*', small)`: Hono runs every matching middleware in registration
@@ -11,9 +12,10 @@
  * 100MB media limit dead code (every media upload was capped at 1MB). Choosing
  * the size inside one middleware avoids that interaction.
  *
- * Larger/video uploads will move to a presigned direct-to-R2 upload path, where
- * the bytes never buffer in the function. The per-type check in the media route
- * remains the authoritative content-size enforcement after parse.
+ * Large/video uploads use the GAP-215 presigned direct-to-R2 path: the client
+ * PUTs bytes to R2, so the API never buffers the file body. Presign/confirm
+ * bodies are tiny JSON and stay under GLOBAL_BODY_LIMIT. The per-type check on
+ * those routes is the authoritative content-size enforcement.
  */
 import { FILE_SIZE_LIMITS } from '@revealui/contracts/entities';
 import type { MiddlewareHandler } from 'hono';
@@ -22,10 +24,17 @@ import { bodyLimit } from 'hono/body-limit';
 /** Default body limit for all routes (1MB). */
 export const GLOBAL_BODY_LIMIT = 1024 * 1024;
 
-/** Body limit for media uploads — the image/document per-type ceiling (10MB). */
+/**
+ * Body limit for legacy multipart media uploads — image/document per-type
+ * ceiling (10MB). Video and larger files must use POST /media/presign.
+ */
 export const MEDIA_UPLOAD_BODY_LIMIT = FILE_SIZE_LIMITS.IMAGE;
 
-/** POST paths that accept a media upload and therefore get the larger body limit. */
+/**
+ * POST paths that accept a legacy multipart media upload and therefore get the
+ * larger body limit. Exact path only — /media/presign and /media/confirm stay
+ * on GLOBAL_BODY_LIMIT (JSON).
+ */
 const MEDIA_UPLOAD_PATHS = new Set(['/api/content/media', '/api/v1/content/media']);
 
 function normalizePath(path: string): string {

--- a/apps/server/src/routes/__tests__/content-media-upload.test.ts
+++ b/apps/server/src/routes/__tests__/content-media-upload.test.ts
@@ -20,13 +20,16 @@ const { mockMediaQueries, mockStorage } = vi.hoisted(() => ({
     deleteMedia: vi.fn(),
   },
   // Stand-in StorageProvider. media.ts depends only on the provider interface
-  // (via getMediaStorage), so the concrete backend (R2 / Vercel Blob) is
-  // irrelevant to these route tests.
+  // (via getMediaStorage), so the concrete backend (R2) is irrelevant to these
+  // route tests.
   mockStorage: {
     provider: 'mock' as const,
     put: vi.fn(),
     del: vi.fn(),
     list: vi.fn(),
+    createPresignedPutUrl: vi.fn(),
+    headObject: vi.fn(),
+    getObjectRange: vi.fn(),
   },
 }));
 
@@ -131,6 +134,234 @@ function makeFile(name: string, type: string): File {
   const bytes = new Uint8Array([...sig, 0x00, 0x00, 0x00, 0x00]);
   return new File([bytes], name, { type });
 }
+
+// ─── POST /media/presign ──────────────────────────────────────────────────────
+
+describe('POST /media/presign', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorage.createPresignedPutUrl.mockResolvedValue({
+      key: 'media/11111111-1111-1111-1111-111111111111.png',
+      url: 'https://acct.r2.cloudflarestorage.com/bucket/media/uuid.png?X-Amz-Signature=abc',
+      headers: { 'content-type': 'image/png' },
+      expiresAt: new Date('2026-05-18T10:15:00.000Z'),
+    });
+  });
+
+  it('returns 401 without authentication', async () => {
+    const app = createApp(null);
+    const res = await app.request('/media/presign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename: 'a.png', mimeType: 'image/png', size: 100 }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for unsupported MIME type', async () => {
+    const app = createApp(USER_A);
+    const res = await app.request('/media/presign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filename: 'evil.exe',
+        mimeType: 'application/x-msdownload',
+        size: 100,
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/unsupported file type/i);
+    expect(mockStorage.createPresignedPutUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 when declared size exceeds per-type limit', async () => {
+    const app = createApp(USER_A);
+    const res = await app.request('/media/presign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filename: 'huge.png',
+        mimeType: 'image/png',
+        size: 10_485_761,
+      }),
+    });
+    expect(res.status).toBe(413);
+    expect(mockStorage.createPresignedPutUrl).not.toHaveBeenCalled();
+  });
+
+  it('allows video sizes up to the VIDEO limit (not the 10MB interim multipart cap)', async () => {
+    mockStorage.createPresignedPutUrl.mockResolvedValue({
+      key: 'media/11111111-1111-1111-1111-111111111111.mp4',
+      url: 'https://acct.r2.cloudflarestorage.com/bucket/media/v.mp4?sig=1',
+      headers: { 'content-type': 'video/mp4' },
+      expiresAt: new Date('2026-05-18T10:15:00.000Z'),
+    });
+    const app = createApp(USER_A);
+    const res = await app.request('/media/presign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filename: 'clip.mp4',
+        mimeType: 'video/mp4',
+        size: 30 * 1024 * 1024,
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockStorage.createPresignedPutUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentType: 'video/mp4',
+        key: expect.stringMatching(/^media\/[a-f0-9-]+\.mp4$/),
+      }),
+    );
+  });
+
+  it('returns uploadUrl + headers + key on success', async () => {
+    const app = createApp(USER_A);
+    const res = await app.request('/media/presign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename: 'a.png', mimeType: 'image/png', size: 100 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.uploadUrl).toContain('X-Amz-Signature');
+    expect(body.data.headers['content-type']).toBe('image/png');
+    expect(body.data.key).toMatch(/^media\/.+\.png$/);
+    expect(body.data.expiresAt).toBe('2026-05-18T10:15:00.000Z');
+  });
+
+  it('returns 502 when the storage provider fails to presign', async () => {
+    mockStorage.createPresignedPutUrl.mockRejectedValue(new Error('signer down'));
+    const app = createApp(USER_A);
+    const res = await app.request('/media/presign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename: 'a.png', mimeType: 'image/png', size: 100 }),
+    });
+    expect(res.status).toBe(502);
+  });
+});
+
+// ─── POST /media/confirm ──────────────────────────────────────────────────────
+
+describe('POST /media/confirm', () => {
+  const validKey = 'media/11111111-1111-4111-8111-111111111111.png';
+  const pngMagic = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorage.headObject.mockResolvedValue({
+      size: 12,
+      contentType: 'image/png',
+      url: 'https://media.revealui.com/media/11111111-1111-4111-8111-111111111111.png',
+    });
+    mockStorage.getObjectRange.mockResolvedValue(pngMagic);
+    mockMediaQueries.createMedia.mockResolvedValue(
+      makeMediaRecord({
+        url: 'https://media.revealui.com/media/11111111-1111-4111-8111-111111111111.png',
+      }),
+    );
+  });
+
+  function confirmBody(overrides: Record<string, unknown> = {}) {
+    return JSON.stringify({
+      key: validKey,
+      filename: 'photo.png',
+      mimeType: 'image/png',
+      size: 12,
+      ...overrides,
+    });
+  }
+
+  it('returns 401 without authentication', async () => {
+    const app = createApp(null);
+    const res = await app.request('/media/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: confirmBody(),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for a key that was not issued by presign', async () => {
+    const app = createApp(USER_A);
+    const res = await app.request('/media/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: confirmBody({ key: 'other/not-ours.png' }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockStorage.headObject).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the object is missing in storage', async () => {
+    mockStorage.headObject.mockRejectedValue(new Error('NoSuchKey object not found'));
+    const app = createApp(USER_A);
+    const res = await app.request('/media/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: confirmBody(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it('returns 400 when stored size does not match declared size', async () => {
+    mockStorage.headObject.mockResolvedValue({
+      size: 99,
+      contentType: 'image/png',
+      url: 'https://media.revealui.com/media/x.png',
+    });
+    const app = createApp(USER_A);
+    const res = await app.request('/media/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: confirmBody(),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/size/i);
+  });
+
+  it('returns 400 when magic bytes do not match the declared type', async () => {
+    mockStorage.getObjectRange.mockResolvedValue(new TextEncoder().encode('<html>evil'));
+    const app = createApp(USER_A);
+    const res = await app.request('/media/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: confirmBody(),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/does not match/i);
+    expect(mockStorage.del).toHaveBeenCalledWith(validKey);
+    expect(mockMediaQueries.createMedia).not.toHaveBeenCalled();
+  });
+
+  it('creates the media row on success', async () => {
+    const app = createApp(USER_A);
+    const res = await app.request('/media/confirm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: confirmBody({ alt: 'A sunset' }),
+    });
+    expect(res.status).toBe(201);
+    expect(mockMediaQueries.createMedia).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        uploadedBy: USER_A.id,
+        mimeType: 'image/png',
+        filesize: 12,
+        alt: 'A sunset',
+        url: 'https://media.revealui.com/media/11111111-1111-4111-8111-111111111111.png',
+      }),
+    );
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe('media-1');
+  });
+});
 
 // ─── POST /media  -  Upload ────────────────────────────────────────────────────
 

--- a/apps/server/src/routes/content/media.ts
+++ b/apps/server/src/routes/content/media.ts
@@ -1,7 +1,9 @@
 /**
  * Media CRUD routes
  *
- * POST /media (upload)
+ * POST /media (legacy multipart upload — still supported for small/dev files)
+ * POST /media/presign (GAP-215: issue direct-to-R2 PUT URL)
+ * POST /media/confirm (GAP-215: HEAD + magic-byte check, create media row)
  * GET /media
  * GET|PATCH|DELETE /media/:id
  */
@@ -25,6 +27,12 @@ import type { ContentVariables } from './index.js';
 
 const app = new OpenAPIHono<{ Variables: ContentVariables }>();
 
+/** Default lifetime of a presigned media PUT URL (15 minutes). */
+const PRESIGN_EXPIRES_SECONDS = 900;
+
+/** Bytes of object prefix fetched on confirm for magic-byte verification. */
+const MAGIC_BYTE_PREFIX_LENGTH = 16;
+
 // =============================================================================
 // Media Schemas
 // =============================================================================
@@ -47,11 +55,314 @@ const MediaSchema = z
   })
   .openapi('Media');
 
+const PresignRequestSchema = z.object({
+  filename: z.string().min(1).max(255),
+  mimeType: z.string().min(1).max(127),
+  size: z.number().int().positive(),
+});
+
+const ConfirmRequestSchema = z.object({
+  key: z.string().min(1).max(512),
+  filename: z.string().min(1).max(255),
+  mimeType: z.string().min(1).max(127),
+  size: z.number().int().positive(),
+  alt: z.string().max(500).optional(),
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function assertAllowedMime(mimeType: string): void {
+  const allowedMimes: readonly string[] = ALL_MIME_TYPES;
+  if (!allowedMimes.includes(mimeType)) {
+    throw new HTTPException(400, {
+      message: `Unsupported file type: ${mimeType}. Allowed: ${allowedMimes.join(', ')}`,
+    });
+  }
+}
+
+function assertWithinSizeLimit(mimeType: string, size: number): void {
+  const sizeLimit = getSizeLimit(mimeType);
+  if (size > sizeLimit) {
+    throw new HTTPException(413, {
+      message: `File too large (${(size / 1024 / 1024).toFixed(1)}MB). Maximum for ${mimeType}: ${(sizeLimit / 1024 / 1024).toFixed(0)}MB`,
+    });
+  }
+}
+
+/**
+ * Storage keys issued by presign are always `media/<uuid>.<ext>` where `ext`
+ * is derived from the verified MIME type. Confirm rejects any other shape so
+ * a client cannot register an arbitrary object under a media row.
+ */
+export function isIssuedMediaKey(key: string, mimeType: string): boolean {
+  const expectedExt = extensionForMimeType(mimeType);
+  const prefix = 'media/';
+  if (!key.startsWith(prefix)) return false;
+  const rest = key.slice(prefix.length);
+  const dot = rest.lastIndexOf('.');
+  if (dot <= 0) return false;
+  const name = rest.slice(0, dot);
+  const ext = rest.slice(dot + 1);
+  if (ext !== expectedExt) return false;
+  // UUID form: 8-4-4-4-12 hex with dashes at fixed positions.
+  if (name.length !== 36) return false;
+  if (name[8] !== '-' || name[13] !== '-' || name[18] !== '-' || name[23] !== '-') {
+    return false;
+  }
+  for (let i = 0; i < name.length; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) continue;
+    const code = name.charCodeAt(i);
+    const isDigit = code >= 48 && code <= 57;
+    const isLowerHex = code >= 97 && code <= 102;
+    const isUpperHex = code >= 65 && code <= 70;
+    if (!(isDigit || isLowerHex || isUpperHex)) return false;
+  }
+  return true;
+}
+
+function contentTypesCompatible(declared: string, stored: string): boolean {
+  // R2 may append charset or return a default; compare the media type token only.
+  const declaredBase = declared.split(';')[0]?.trim().toLowerCase() ?? '';
+  const storedBase = stored.split(';')[0]?.trim().toLowerCase() ?? '';
+  if (declaredBase === storedBase) return true;
+  // Some backends default missing Content-Type to application/octet-stream.
+  if (storedBase === 'application/octet-stream') return true;
+  return false;
+}
+
 // =============================================================================
 // Media Routes
 // =============================================================================
 
-// POST /media (upload)
+// POST /media/presign — issue a direct-to-R2 PUT URL (GAP-215). Static path
+// registered before /media/:id so it is not captured as an id.
+app.openapi(
+  createRoute({
+    method: 'post',
+    path: '/media/presign',
+    tags: ['content'],
+    summary: 'Presign a direct-to-storage media upload',
+    description:
+      'Returns a short-lived presigned PUT URL. The client uploads bytes directly ' +
+      'to object storage, then calls POST /media/confirm. File bytes never buffer ' +
+      'in the API function (GAP-215).',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: PresignRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              success: z.literal(true),
+              data: z.object({
+                key: z.string(),
+                uploadUrl: z.string(),
+                headers: z.record(z.string(), z.string()),
+                expiresAt: z.string().openapi({ type: 'string', format: 'date-time' }),
+              }),
+            }),
+          },
+        },
+        description: 'Presigned upload issued',
+      },
+      400: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Invalid request',
+      },
+      413: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'File too large',
+      },
+    },
+  }),
+  async (c) => {
+    const user = c.get('user');
+    if (!user) throw new HTTPException(401, { message: 'Authentication required' });
+
+    const body = c.req.valid('json');
+    assertAllowedMime(body.mimeType);
+    assertWithinSizeLimit(body.mimeType, body.size);
+
+    const ext = extensionForMimeType(body.mimeType);
+    const key = `media/${crypto.randomUUID()}.${ext}`;
+
+    try {
+      const storage = getMediaStorage();
+      const presigned = await storage.createPresignedPutUrl({
+        key,
+        contentType: body.mimeType,
+        expiresInSeconds: PRESIGN_EXPIRES_SECONDS,
+      });
+      return c.json(
+        {
+          success: true as const,
+          data: {
+            key: presigned.key,
+            uploadUrl: presigned.url,
+            headers: presigned.headers,
+            expiresAt: presigned.expiresAt.toISOString(),
+          },
+        },
+        200,
+      );
+    } catch (presignError) {
+      logger.error('Failed to create presigned media upload URL', undefined, {
+        mimeType: body.mimeType,
+        size: body.size,
+        error: presignError instanceof Error ? presignError.message : 'unknown',
+      });
+      throw new HTTPException(502, {
+        message: 'Failed to prepare media upload. Please try again.',
+      });
+    }
+  },
+);
+
+// POST /media/confirm — re-validate object in storage and create the media row.
+app.openapi(
+  createRoute({
+    method: 'post',
+    path: '/media/confirm',
+    tags: ['content'],
+    summary: 'Confirm a direct-to-storage media upload',
+    description:
+      'After the client PUTs to the presigned URL, confirm HEADs the object, ' +
+      're-checks size and magic bytes, then creates the media DB row (GAP-215).',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: ConfirmRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        content: {
+          'application/json': {
+            schema: z.object({ success: z.literal(true), data: MediaSchema }),
+          },
+        },
+        description: 'Media registered',
+      },
+      400: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'Validation failed',
+      },
+      413: {
+        content: { 'application/json': { schema: ErrorSchema } },
+        description: 'File too large',
+      },
+    },
+  }),
+  async (c) => {
+    const db = c.get('db');
+    const user = c.get('user');
+    if (!user) throw new HTTPException(401, { message: 'Authentication required' });
+
+    const body = c.req.valid('json');
+    assertAllowedMime(body.mimeType);
+    assertWithinSizeLimit(body.mimeType, body.size);
+
+    if (!isIssuedMediaKey(body.key, body.mimeType)) {
+      throw new HTTPException(400, {
+        message: 'Invalid storage key for the declared media type.',
+      });
+    }
+
+    const storage = getMediaStorage();
+
+    let head: { size: number; contentType: string; url: string };
+    try {
+      head = await storage.headObject(body.key);
+    } catch (headError) {
+      const message = headError instanceof Error ? headError.message : 'unknown';
+      if (message.includes('NoSuchKey') || message.includes('not found')) {
+        throw new HTTPException(400, {
+          message: 'Uploaded object not found. Complete the storage PUT before confirming.',
+        });
+      }
+      logger.error('Failed to HEAD media object on confirm', undefined, {
+        key: body.key,
+        error: message,
+      });
+      throw new HTTPException(502, {
+        message: 'Failed to verify uploaded media. Please try again.',
+      });
+    }
+
+    if (head.size !== body.size) {
+      throw new HTTPException(400, {
+        message: `Uploaded object size (${head.size}) does not match declared size (${body.size}).`,
+      });
+    }
+    if (head.size > getSizeLimit(body.mimeType)) {
+      throw new HTTPException(413, {
+        message: `Uploaded object exceeds the size limit for ${body.mimeType}.`,
+      });
+    }
+    if (!contentTypesCompatible(body.mimeType, head.contentType)) {
+      throw new HTTPException(400, {
+        message: `Uploaded object content-type (${head.contentType}) does not match declared type (${body.mimeType}).`,
+      });
+    }
+
+    let prefix: Uint8Array;
+    try {
+      prefix = await storage.getObjectRange(body.key, 0, MAGIC_BYTE_PREFIX_LENGTH - 1);
+    } catch (rangeError) {
+      logger.error('Failed to read media object prefix on confirm', undefined, {
+        key: body.key,
+        error: rangeError instanceof Error ? rangeError.message : 'unknown',
+      });
+      throw new HTTPException(502, {
+        message: 'Failed to verify uploaded media content. Please try again.',
+      });
+    }
+
+    if (!verifyMagicBytes(body.mimeType, prefix)) {
+      // Best-effort cleanup of a rejected object so it cannot linger.
+      try {
+        await storage.del(body.key);
+      } catch (delError) {
+        logger.warn('Failed to delete media object that failed magic-byte check', {
+          key: body.key,
+          error: delError instanceof Error ? delError.message : 'unknown',
+        });
+      }
+      throw new HTTPException(400, {
+        message: `File content does not match its declared type (${body.mimeType}).`,
+      });
+    }
+
+    const item = await mediaQueries.createMedia(db, {
+      id: crypto.randomUUID(),
+      filename: sanitizeFilename(body.filename),
+      mimeType: body.mimeType,
+      filesize: head.size,
+      url: head.url,
+      alt: body.alt ?? null,
+      uploadedBy: user.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    if (!item) throw new HTTPException(500, { message: 'Failed to create media record' });
+    return c.json({ success: true as const, data: item }, 201);
+  },
+);
+
+// POST /media (legacy multipart upload)
 app.openapi(
   createRoute({
     method: 'post',

--- a/packages/core/src/storage/__tests__/_sigv4.test.ts
+++ b/packages/core/src/storage/__tests__/_sigv4.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { awsUriEncode, computeSigV4, EMPTY_SHA256, signS3Request } from '../_sigv4.js';
+import {
+  awsUriEncode,
+  computeSigV4,
+  EMPTY_SHA256,
+  signS3PresignedUrl,
+  signS3Request,
+  UNSIGNED_PAYLOAD,
+} from '../_sigv4.js';
 
 describe('computeSigV4', () => {
   // AWS SigV4 test-suite, `get-vanilla` — the canonical known-answer vector.
@@ -81,5 +88,54 @@ describe('signS3Request', () => {
     expect(url).toBe(
       'https://acct-123.r2.cloudflarestorage.com/media?list-type=2&max-keys=2&prefix=media%2F',
     );
+  });
+
+  it('supports HEAD method', () => {
+    const { url, headers } = signS3Request({
+      method: 'HEAD',
+      bucket: 'media',
+      key: 'a.png',
+      payloadHash: EMPTY_SHA256,
+      now: new Date('2026-05-18T10:00:00.000Z'),
+      ...creds,
+    });
+    expect(url).toBe('https://acct-123.r2.cloudflarestorage.com/media/a.png');
+    expect(headers.authorization).toContain('AWS4-HMAC-SHA256');
+  });
+});
+
+describe('signS3PresignedUrl', () => {
+  const creds = {
+    accountId: 'acct-123',
+    accessKeyId: 'AKIA-TEST',
+    secretAccessKey: 'secret',
+    region: 'auto',
+  } as const;
+
+  it('builds a query-string presigned PUT URL with UNSIGNED-PAYLOAD', () => {
+    const { url, headers } = signS3PresignedUrl({
+      method: 'PUT',
+      bucket: 'media',
+      key: 'uploads/a.bin',
+      expiresInSeconds: 900,
+      signedHeaders: { 'content-type': 'image/png' },
+      now: new Date('2026-05-18T10:00:00.000Z'),
+      ...creds,
+    });
+
+    expect(url.startsWith('https://acct-123.r2.cloudflarestorage.com/media/uploads/a.bin?')).toBe(
+      true,
+    );
+    expect(url).toContain('X-Amz-Algorithm=AWS4-HMAC-SHA256');
+    expect(url).toContain('X-Amz-Credential=AKIA-TEST%2F20260518%2Fauto%2Fs3%2Faws4_request');
+    expect(url).toContain('X-Amz-Date=20260518T100000Z');
+    expect(url).toContain('X-Amz-Expires=900');
+    expect(url).toContain('X-Amz-SignedHeaders=content-type%3Bhost');
+    expect(url).toContain('X-Amz-Signature=');
+    expect(headers).toEqual({ 'content-type': 'image/png' });
+  });
+
+  it('exports UNSIGNED-PAYLOAD for callers that need the constant', () => {
+    expect(UNSIGNED_PAYLOAD).toBe('UNSIGNED-PAYLOAD');
   });
 });

--- a/packages/core/src/storage/__tests__/mock.test.ts
+++ b/packages/core/src/storage/__tests__/mock.test.ts
@@ -154,6 +154,58 @@ describe('createMockProvider', () => {
     });
   });
 
+  describe('createPresignedPutUrl', () => {
+    it('returns a mock presign URL + content-type headers + expiry', async () => {
+      const result = await provider.createPresignedPutUrl({
+        key: 'media/uuid.png',
+        contentType: 'image/png',
+        expiresInSeconds: 120,
+      });
+      expect(result.key).toBe('media/uuid.png');
+      expect(result.headers['content-type']).toBe('image/png');
+      expect(result.url).toContain('mock://storage/presign/media/uuid.png');
+      expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('includes content-length when provided', async () => {
+      const result = await provider.createPresignedPutUrl({
+        key: 'k',
+        contentType: 'video/mp4',
+        contentLength: 99,
+      });
+      expect(result.headers['content-length']).toBe('99');
+    });
+  });
+
+  describe('headObject', () => {
+    it('returns size + contentType + url for a stored object', async () => {
+      await provider.put('media/a.png', new Uint8Array([1, 2, 3]), { contentType: 'image/png' });
+      const result = await provider.headObject('media/a.png');
+      expect(result).toEqual({
+        size: 3,
+        contentType: 'image/png',
+        url: 'mock://storage/media/a.png',
+      });
+    });
+
+    it('throws when the key is missing', async () => {
+      await expect(provider.headObject('missing')).rejects.toThrow(/NoSuchKey/);
+    });
+  });
+
+  describe('getObjectRange', () => {
+    it('returns the inclusive byte slice', async () => {
+      await provider.put('blob', new Uint8Array([10, 20, 30, 40, 50]));
+      await expect(provider.getObjectRange('blob', 1, 3)).resolves.toEqual(
+        new Uint8Array([20, 30, 40]),
+      );
+    });
+
+    it('throws when the key is missing', async () => {
+      await expect(provider.getObjectRange('missing', 0, 15)).rejects.toThrow(/NoSuchKey/);
+    });
+  });
+
   describe('test helpers', () => {
     it('size() returns object count', async () => {
       expect(provider.size()).toBe(0);

--- a/packages/core/src/storage/__tests__/object-storage.test.ts
+++ b/packages/core/src/storage/__tests__/object-storage.test.ts
@@ -23,6 +23,9 @@ function createMockProvider(tag = 'mock'): StorageProvider {
     put: (...args: unknown[]) => mockPut(...args),
     del: (...args: unknown[]) => mockDel(...args),
     list: (...args: unknown[]) => mockList(...args),
+    createPresignedPutUrl: vi.fn(),
+    headObject: vi.fn(),
+    getObjectRange: vi.fn(),
   } as unknown as StorageProvider;
 }
 

--- a/packages/core/src/storage/__tests__/r2.test.ts
+++ b/packages/core/src/storage/__tests__/r2.test.ts
@@ -121,10 +121,10 @@ describe('createR2Provider', () => {
       expect(result.url).toBe('https://cdn.example/a/b.txt');
     });
 
-    it('throws when access="private" is requested (Phase 2a limit) without sending a request', async () => {
+    it('throws when access="private" is requested without sending a request', async () => {
       const provider = createR2Provider(baseConfig());
       await expect(provider.put('p', new Uint8Array([1]), { access: 'private' })).rejects.toThrow(
-        /Phase 2a does not support access: 'private'/,
+        /does not support access: 'private'/,
       );
       expect(requests).toHaveLength(0);
     });
@@ -241,6 +241,109 @@ describe('createR2Provider', () => {
       const provider = createR2Provider(baseConfig());
       await provider.list({ cursor: 'resume-from' });
       expect(requests[0].url).toContain('continuation-token=resume-from');
+    });
+  });
+
+  describe('createPresignedPutUrl', () => {
+    it('returns a query-string SigV4 URL with content-type signed and no network call', async () => {
+      const provider = createR2Provider(baseConfig());
+      const now = new Date('2026-05-18T10:00:00.000Z');
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      const result = await provider.createPresignedPutUrl({
+        key: 'media/uuid.png',
+        contentType: 'image/png',
+        expiresInSeconds: 600,
+      });
+
+      expect(requests).toHaveLength(0);
+      expect(result.key).toBe('media/uuid.png');
+      expect(result.headers['content-type']).toBe('image/png');
+      expect(result.expiresAt.getTime()).toBe(now.getTime() + 600_000);
+      expect(result.url).toContain(
+        'https://acct-123.r2.cloudflarestorage.com/media/media/uuid.png?',
+      );
+      expect(result.url).toContain('X-Amz-Algorithm=AWS4-HMAC-SHA256');
+      expect(result.url).toContain('X-Amz-Expires=600');
+      expect(result.url).toContain('X-Amz-SignedHeaders=content-type%3Bhost');
+      expect(result.url).toContain('X-Amz-Signature=');
+      expect(result.url).toContain(
+        'X-Amz-Credential=AKIA-TEST%2F20260518%2Fauto%2Fs3%2Faws4_request',
+      );
+
+      vi.useRealTimers();
+    });
+
+    it('includes content-length in signed headers when provided', async () => {
+      const provider = createR2Provider(baseConfig());
+      const result = await provider.createPresignedPutUrl({
+        key: 'media/big.mp4',
+        contentType: 'video/mp4',
+        contentLength: 30_000_000,
+      });
+      expect(result.headers['content-length']).toBe('30000000');
+      expect(result.url).toContain('content-length');
+    });
+
+    it('rejects non-positive expiresInSeconds', async () => {
+      const provider = createR2Provider(baseConfig());
+      await expect(
+        provider.createPresignedPutUrl({
+          key: 'k',
+          contentType: 'image/png',
+          expiresInSeconds: 0,
+        }),
+      ).rejects.toThrow(/expiresInSeconds must be positive/);
+    });
+  });
+
+  describe('headObject', () => {
+    it('HEADs the object and returns size + contentType + public url', async () => {
+      responseQueue.push(
+        new Response(null, {
+          status: 200,
+          headers: {
+            'content-length': '2048',
+            'content-type': 'image/png',
+          },
+        }),
+      );
+      const provider = createR2Provider(baseConfig());
+      const result = await provider.headObject('media/a.png');
+
+      expect(requests[0].method).toBe('HEAD');
+      expect(requests[0].url).toBe('https://acct-123.r2.cloudflarestorage.com/media/media/a.png');
+      expect(result).toEqual({
+        size: 2048,
+        contentType: 'image/png',
+        url: 'https://media.revealui.com/media/a.png',
+      });
+    });
+
+    it('throws NoSuchKey on 404', async () => {
+      queueResponse('', 404);
+      const provider = createR2Provider(baseConfig());
+      await expect(provider.headObject('missing')).rejects.toThrow(/NoSuchKey/);
+    });
+  });
+
+  describe('getObjectRange', () => {
+    it('GETs with a Range header and returns the body bytes', async () => {
+      const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+      responseQueue.push(new Response(bytes, { status: 206 }));
+      const provider = createR2Provider(baseConfig());
+      const result = await provider.getObjectRange('media/a.png', 0, 15);
+
+      expect(requests[0].method).toBe('GET');
+      expect(requests[0].headers.range).toBe('bytes=0-15');
+      expect(result).toEqual(bytes);
+    });
+
+    it('rejects inverted ranges without sending a request', async () => {
+      const provider = createR2Provider(baseConfig());
+      await expect(provider.getObjectRange('k', 10, 5)).rejects.toThrow(/invalid range/);
+      expect(requests).toHaveLength(0);
     });
   });
 });

--- a/packages/core/src/storage/_sigv4.ts
+++ b/packages/core/src/storage/_sigv4.ts
@@ -118,9 +118,12 @@ export function computeSigV4(input: CanonicalInput): SigV4Result {
   return { signature, signedHeaders, scope, canonicalQuery };
 }
 
+/** Payload hash token for presigned URLs (body hash unknown at sign time). */
+export const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
+
 /** Inputs for an R2/S3 request signature. */
 export interface SignS3Input {
-  method: 'GET' | 'PUT' | 'DELETE';
+  method: 'GET' | 'PUT' | 'DELETE' | 'HEAD';
   accountId: string;
   bucket: string;
   /** Object key; omit for bucket-level operations (e.g. ListObjectsV2). */
@@ -198,4 +201,87 @@ export function signS3Request(input: SignS3Input): SignedS3Request {
 
   const url = `https://${host}${canonicalPath}${canonicalQuery ? `?${canonicalQuery}` : ''}`;
   return { url, headers };
+}
+
+/** Inputs for a query-string presigned S3/R2 URL (no Authorization header). */
+export interface SignS3PresignedInput {
+  method: 'GET' | 'PUT' | 'DELETE' | 'HEAD';
+  accountId: string;
+  bucket: string;
+  key: string;
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  /** Lifetime of the URL in seconds. */
+  expiresInSeconds: number;
+  /**
+   * Headers the client must send and that are included in the signature
+   * (content-type, content-length, …). Host is always signed and omitted
+   * from the returned headers (fetch sets it from the URL).
+   */
+  signedHeaders?: Record<string, string>;
+  now: Date;
+}
+
+export interface PresignedS3Url {
+  url: string;
+  /** Headers the client must include (signed set minus host). */
+  headers: Record<string, string>;
+}
+
+/**
+ * Build a query-string SigV4 presigned URL for R2/S3.
+ *
+ * Uses UNSIGNED-PAYLOAD so the client does not need to pre-hash the body.
+ * Credential and signature ride in the query string; the client sends only
+ * the signed non-host headers (e.g. content-type) with the request.
+ */
+export function signS3PresignedUrl(input: SignS3PresignedInput): PresignedS3Url {
+  const host = `${input.accountId}.r2.cloudflarestorage.com`;
+  const { amzDate, dateStamp } = toAmzDate(input.now);
+  const scope = `${dateStamp}/${input.region}/${S3_SERVICE}/aws4_request`;
+
+  const encodedKey = input.key
+    .split('/')
+    .map((segment) => awsUriEncode(segment, false))
+    .join('/');
+  const canonicalPath = `/${awsUriEncode(input.bucket, false)}/${encodedKey}`;
+
+  const clientHeaders: Record<string, string> = {};
+  const headersToSign: Record<string, string> = { host };
+  for (const [name, value] of Object.entries(input.signedHeaders ?? {})) {
+    const lower = name.toLowerCase();
+    if (lower === 'host') continue;
+    headersToSign[lower] = value;
+    clientHeaders[lower] = value;
+  }
+
+  const signedHeaderNames = Object.keys(headersToSign).sort().join(';');
+
+  const query: [string, string][] = [
+    ['X-Amz-Algorithm', ALGORITHM],
+    ['X-Amz-Credential', `${input.accessKeyId}/${scope}`],
+    ['X-Amz-Date', amzDate],
+    ['X-Amz-Expires', String(input.expiresInSeconds)],
+    ['X-Amz-SignedHeaders', signedHeaderNames],
+  ];
+
+  const { signature, canonicalQuery } = computeSigV4({
+    method: input.method,
+    canonicalPath,
+    query,
+    headersToSign,
+    payloadHash: UNSIGNED_PAYLOAD,
+    amzDate,
+    region: input.region,
+    service: S3_SERVICE,
+    accessKeyId: input.accessKeyId,
+    secretAccessKey: input.secretAccessKey,
+  });
+
+  const fullQuery = `${canonicalQuery}&${awsUriEncode('X-Amz-Signature', true)}=${awsUriEncode(signature, true)}`;
+  return {
+    url: `https://${host}${canonicalPath}?${fullQuery}`,
+    headers: clientHeaders,
+  };
 }

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -3,9 +3,8 @@
 //
 // Phase 1 (#959): types.ts + index.ts type re-exports.
 // Phase 2a (#959 follow-up): r2 + mock providers + createStorage factory.
-// Phase 2b (#959 follow-up): apps/server media-route cutover onto R2.
-// #1644: legacy Vercel Blob StorageProvider removed once R2 was confirmed in
-//   every production environment — R2 is now the sole non-mock backend.
+// Phase 2b media-route cutover onto R2 (server) + #1644 Vercel Blob removal.
+// Phase 2b presign (GAP-215): createPresignedPutUrl + headObject + getObjectRange.
 
 import { createMockProvider } from './mock.js';
 import { createR2Provider } from './r2.js';
@@ -23,9 +22,12 @@ export { objectStorage } from './object-storage.js';
 // factory below).
 export { createR2Provider } from './r2.js';
 export type {
+  HeadObjectResult,
   ListItem,
   ListOptions,
   ListResult,
+  PresignPutOptions,
+  PresignPutResult,
   PutOptions,
   PutResult,
   R2Config,

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -8,14 +8,17 @@
  * `mock://` scheme so callers can distinguish mock results from real ones
  * without parsing host names.
  *
- * GAP-208 Phase 2a (2026-05-18).
+ * GAP-208 Phase 2a (2026-05-18). Phase 2b (GAP-215): presigned PUT + head + range.
  */
 
 import { toUint8Array } from './_helpers.js';
 import type {
+  HeadObjectResult,
   ListItem,
   ListOptions,
   ListResult,
+  PresignPutOptions,
+  PresignPutResult,
   PutOptions,
   PutResult,
   StorageProvider,
@@ -24,6 +27,7 @@ import type {
 const PROVIDER_TAG = 'mock';
 const MOCK_URL_SCHEME = 'mock://storage';
 const DEFAULT_LIST_LIMIT = 1000;
+const DEFAULT_PRESIGN_EXPIRES_SECONDS = 900;
 
 interface MockEntry {
   body: Uint8Array;
@@ -56,6 +60,65 @@ class MockProvider implements StorageProvider {
       size: body.byteLength,
       provider: PROVIDER_TAG,
     };
+  }
+
+  async createPresignedPutUrl(opts: PresignPutOptions): Promise<PresignPutResult> {
+    const expiresInSeconds = opts.expiresInSeconds ?? DEFAULT_PRESIGN_EXPIRES_SECONDS;
+    if (expiresInSeconds <= 0) {
+      throw new Error('createPresignedPutUrl: expiresInSeconds must be positive');
+    }
+
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + expiresInSeconds * 1000);
+    const headers: Record<string, string> = {
+      'content-type': opts.contentType,
+    };
+    if (opts.contentLength !== undefined) {
+      headers['content-length'] = String(opts.contentLength);
+    }
+
+    // Synthetic presigned URL. Tests that exercise the full client flow call
+    // put() with the same key after "uploading"; route tests mock this method.
+    const params = new URLSearchParams({
+      expires: String(Math.floor(expiresAt.getTime() / 1000)),
+      'content-type': opts.contentType,
+    });
+    return {
+      url: `${MOCK_URL_SCHEME}/presign/${opts.key}?${params.toString()}`,
+      headers,
+      key: opts.key,
+      expiresAt,
+    };
+  }
+
+  async headObject(key: string): Promise<HeadObjectResult> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      throw new Error(`mock HEAD failed for "${key}": NoSuchKey object not found`);
+    }
+    return {
+      size: entry.body.byteLength,
+      contentType: entry.contentType,
+      url: `${MOCK_URL_SCHEME}/${key}`,
+    };
+  }
+
+  async getObjectRange(key: string, start: number, endInclusive: number): Promise<Uint8Array> {
+    if (start < 0 || endInclusive < start) {
+      throw new Error(
+        `getObjectRange: invalid range ${start}-${endInclusive} (start must be >= 0 and endInclusive >= start)`,
+      );
+    }
+    const entry = this.store.get(key);
+    if (!entry) {
+      throw new Error(`mock GET range failed for "${key}": NoSuchKey object not found`);
+    }
+    // Inclusive end, clamped to body length (mirrors S3 range semantics).
+    const end = Math.min(endInclusive, entry.body.byteLength - 1);
+    if (start >= entry.body.byteLength) {
+      return new Uint8Array(0);
+    }
+    return entry.body.slice(start, end + 1);
   }
 
   async del(keyOrUrl: string): Promise<void> {

--- a/packages/core/src/storage/r2.ts
+++ b/packages/core/src/storage/r2.ts
@@ -12,22 +12,27 @@
  *
  * GAP-208 Phase 2a (2026-05-18). Phase 1 (interface + types) shipped in #959.
  * Native client (dropping @aws-sdk/client-s3) landed 2026-06-09.
+ * Phase 2b (GAP-215): createPresignedPutUrl + headObject + getObjectRange for
+ * direct-to-R2 media uploads.
  *
  * Server-only. Do NOT import from client-side code or edge runtime.
  *
- * Known limitation (unchanged from the SDK version): request bodies are
- * buffered fully in memory (see toUint8Array) so the payload can be hashed for
- * SigV4. Streaming uploads (STREAMING-AWS4-HMAC-SHA256-PAYLOAD) are a future
- * enhancement; presigned/private URLs remain Phase 2b.
+ * Known limitation: request bodies for server-side put() are buffered fully in
+ * memory (see toUint8Array) so the payload can be hashed for SigV4. Streaming
+ * uploads (STREAMING-AWS4-HMAC-SHA256-PAYLOAD) are a future enhancement.
+ * Direct client uploads use createPresignedPutUrl and never buffer in the API.
  */
 
 import { toUint8Array } from './_helpers.js';
-import { EMPTY_SHA256, sha256Hex, signS3Request } from './_sigv4.js';
+import { EMPTY_SHA256, sha256Hex, signS3PresignedUrl, signS3Request } from './_sigv4.js';
 import { parseListObjectsV2, s3ErrorFields } from './_xml.js';
 import type {
+  HeadObjectResult,
   ListItem,
   ListOptions,
   ListResult,
+  PresignPutOptions,
+  PresignPutResult,
   PutOptions,
   PutResult,
   R2Config,
@@ -37,6 +42,7 @@ import type {
 const PROVIDER_TAG = 'r2';
 const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 const DEFAULT_LIST_LIMIT = 1000;
+const DEFAULT_PRESIGN_EXPIRES_SECONDS = 900;
 const REGION = 'auto';
 
 class R2Provider implements StorageProvider {
@@ -50,9 +56,9 @@ class R2Provider implements StorageProvider {
   constructor(config: R2Config) {
     if (!config.publicBaseUrl) {
       throw new Error(
-        'R2 provider requires R2Config.publicBaseUrl. Presigned/private URLs ' +
-          'are not supported in Phase 2a. Set publicBaseUrl to either a bound ' +
-          "custom domain (e.g. 'https://media.revealui.com') or the R2 dev URL " +
+        'R2 provider requires R2Config.publicBaseUrl for public media URLs after ' +
+          'upload. Set publicBaseUrl to either a bound custom domain ' +
+          "(e.g. 'https://media.revealui.com') or the R2 dev URL " +
           "('https://<account-id>.r2.cloudflarestorage.com/<bucket>').",
       );
     }
@@ -71,9 +77,9 @@ class R2Provider implements StorageProvider {
   ): Promise<PutResult> {
     if (opts?.access === 'private') {
       throw new Error(
-        "R2 provider Phase 2a does not support access: 'private'. All objects " +
-          'are written under the publicBaseUrl. Presigned/private-URL support ' +
-          'lands in Phase 2b.',
+        "R2 provider does not support access: 'private' for put(). Use " +
+          'createPresignedPutUrl for client direct uploads; public object URLs ' +
+          'still use publicBaseUrl after confirm.',
       );
     }
 
@@ -118,10 +124,112 @@ class R2Provider implements StorageProvider {
 
     return {
       key,
-      url: `${this.publicBaseUrl}/${key}`,
+      url: this.objectPublicUrl(key),
       size: body.byteLength,
       provider: PROVIDER_TAG,
     };
+  }
+
+  async createPresignedPutUrl(opts: PresignPutOptions): Promise<PresignPutResult> {
+    const expiresInSeconds = opts.expiresInSeconds ?? DEFAULT_PRESIGN_EXPIRES_SECONDS;
+    if (expiresInSeconds <= 0) {
+      throw new Error('createPresignedPutUrl: expiresInSeconds must be positive');
+    }
+
+    const signedHeaders: Record<string, string> = {
+      'content-type': opts.contentType,
+    };
+    if (opts.contentLength !== undefined) {
+      signedHeaders['content-length'] = String(opts.contentLength);
+    }
+
+    const now = new Date();
+    const { url, headers } = signS3PresignedUrl({
+      method: 'PUT',
+      accountId: this.accountId,
+      bucket: this.bucket,
+      key: opts.key,
+      region: REGION,
+      accessKeyId: this.accessKeyId,
+      secretAccessKey: this.secretAccessKey,
+      expiresInSeconds,
+      signedHeaders,
+      now,
+    });
+
+    return {
+      url,
+      headers,
+      key: opts.key,
+      expiresAt: new Date(now.getTime() + expiresInSeconds * 1000),
+    };
+  }
+
+  async headObject(key: string): Promise<HeadObjectResult> {
+    const { url, headers } = signS3Request({
+      method: 'HEAD',
+      accountId: this.accountId,
+      bucket: this.bucket,
+      key,
+      region: REGION,
+      accessKeyId: this.accessKeyId,
+      secretAccessKey: this.secretAccessKey,
+      payloadHash: EMPTY_SHA256,
+      now: new Date(),
+    });
+
+    const response = await fetch(url, { method: 'HEAD', headers });
+    if (response.status === 404) {
+      throw new Error(`R2 HEAD failed for "${key}": NoSuchKey object not found`);
+    }
+    if (!response.ok) {
+      throw await storageError('HEAD', key, response);
+    }
+
+    const lengthHeader = response.headers.get('content-length');
+    const size = lengthHeader === null ? 0 : Number(lengthHeader);
+    if (!Number.isFinite(size) || size < 0) {
+      throw new Error(`R2 HEAD failed for "${key}": invalid content-length`);
+    }
+
+    return {
+      size,
+      contentType: response.headers.get('content-type') ?? DEFAULT_CONTENT_TYPE,
+      url: this.objectPublicUrl(key),
+    };
+  }
+
+  async getObjectRange(key: string, start: number, endInclusive: number): Promise<Uint8Array> {
+    if (start < 0 || endInclusive < start) {
+      throw new Error(
+        `getObjectRange: invalid range ${start}-${endInclusive} (start must be >= 0 and endInclusive >= start)`,
+      );
+    }
+
+    const { url, headers } = signS3Request({
+      method: 'GET',
+      accountId: this.accountId,
+      bucket: this.bucket,
+      key,
+      region: REGION,
+      accessKeyId: this.accessKeyId,
+      secretAccessKey: this.secretAccessKey,
+      payloadHash: EMPTY_SHA256,
+      extraHeaders: { range: `bytes=${start}-${endInclusive}` },
+      now: new Date(),
+    });
+
+    const response = await fetch(url, { method: 'GET', headers });
+    if (response.status === 404) {
+      throw new Error(`R2 GET range failed for "${key}": NoSuchKey object not found`);
+    }
+    // 206 Partial Content is the expected success; some backends return 200
+    // with the full object when range is unsupported — still accept it.
+    if (!response.ok && response.status !== 206) {
+      throw await storageError('GET range', key, response);
+    }
+
+    return new Uint8Array(await response.arrayBuffer());
   }
 
   async del(keyOrUrl: string): Promise<void> {
@@ -172,7 +280,7 @@ class R2Provider implements StorageProvider {
     const parsed = parseListObjectsV2(await response.text());
     const items: ListItem[] = parsed.objects.map((entry) => ({
       key: entry.key,
-      url: `${this.publicBaseUrl}/${entry.key}`,
+      url: this.objectPublicUrl(entry.key),
       size: entry.size,
       uploadedAt: entry.lastModified,
     }));
@@ -182,6 +290,10 @@ class R2Provider implements StorageProvider {
       cursor: parsed.nextContinuationToken,
       hasMore: parsed.isTruncated,
     };
+  }
+
+  private objectPublicUrl(key: string): string {
+    return `${this.publicBaseUrl}/${key}`;
   }
 
   private extractKey(keyOrUrl: string): string {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -30,8 +30,73 @@ export interface StorageProvider {
   /** List items, optionally filtered by key prefix. Used by health probes + admin browsing. */
   list(opts?: ListOptions): Promise<ListResult>;
 
+  /**
+   * Issue a short-lived presigned PUT URL so clients upload bytes direct to the
+   * backend (GAP-215 / Phase 2b). File bytes never buffer in the API function.
+   */
+  createPresignedPutUrl(opts: PresignPutOptions): Promise<PresignPutResult>;
+
+  /**
+   * HEAD an object. Used by the media confirm endpoint to re-check size and
+   * content-type after a direct-to-storage upload.
+   */
+  headObject(key: string): Promise<HeadObjectResult>;
+
+  /**
+   * GET a byte range of an object (inclusive end). Used to re-check magic
+   * bytes on confirm without downloading the whole file.
+   */
+  getObjectRange(key: string, start: number, endInclusive: number): Promise<Uint8Array>;
+
   /** Provider tag (e.g. "r2", "mock") — exposed so consumers can adapt URL handling. */
   readonly provider: string;
+}
+
+// ── Presigned PUT (Phase 2b / GAP-215) ───────────────────────────────────────
+
+export interface PresignPutOptions {
+  /** Storage key the client will write (provider-relative, e.g. "media/uuid.jpg"). */
+  key: string;
+
+  /** MIME type the client must send as Content-Type (signed into the URL). */
+  contentType: string;
+
+  /**
+   * Optional declared Content-Length. When set, signed into the request so the
+   * client cannot upload a larger body. Browser fetch cannot set Content-Length
+   * manually, so media direct-upload leaves this unset and re-checks size via
+   * headObject on confirm.
+   */
+  contentLength?: number;
+
+  /** URL lifetime in seconds. Defaults to provider-specific value (typically 900). */
+  expiresInSeconds?: number;
+}
+
+export interface PresignPutResult {
+  /** Fully-qualified presigned PUT URL (query-string SigV4). */
+  url: string;
+
+  /**
+   * Headers the client MUST send with the PUT (at least content-type). Values
+   * are already signed into the URL's X-Amz-SignedHeaders set.
+   */
+  headers: Record<string, string>;
+
+  /** Storage key the URL writes to (echo of PresignPutOptions.key). */
+  key: string;
+
+  /** Absolute expiry of the URL. */
+  expiresAt: Date;
+}
+
+// ── HEAD / range GET ─────────────────────────────────────────────────────────
+
+export interface HeadObjectResult {
+  size: number;
+  contentType: string;
+  /** Public (or mock) URL the object is reachable at for GET. */
+  url: string;
 }
 
 // ── Put ──────────────────────────────────────────────────────────────────────
@@ -125,10 +190,11 @@ export interface R2Config {
   bucket: string;
 
   /**
-   * Optional public base URL for objects (e.g. "https://media.revealui.com" if a
-   * custom domain is bound, or "https://<account-id>.r2.cloudflarestorage.com/<bucket>"
-   * for the dev URL). When set, PutResult.url uses this base. When omitted, PutResult.url
-   * falls back to a presigned URL (private bucket pattern).
+   * Public base URL for objects (e.g. "https://media.revealui.com" if a custom
+   * domain is bound, or the R2 dev URL). Required: PutResult.url, HeadObjectResult.url,
+   * and media rows after confirm use this base. Presigned PUT URLs themselves
+   * target the S3 API endpoint and do not need this, but the final public media
+   * URL still does.
    */
   publicBaseUrl?: string;
 }


### PR DESCRIPTION
## Summary

Closes the durable path for **GAP-215**: media file bytes no longer buffer in the serverless function for the primary upload path.

### What

1. **`@revealui/core` StorageProvider (Phase 2b)**
   - `createPresignedPutUrl` — query-string SigV4 presigned PUT (`UNSIGNED-PAYLOAD`)
   - `headObject` — size + content-type + public URL for confirm
   - `getObjectRange` — first N bytes for magic-byte re-check without full download
   - Implemented on R2 + mock; unit tests covered

2. **Server API**
   - `POST /api/content/media/presign` — auth; MIME + per-type size checks; returns key + uploadUrl + headers + expiresAt
   - `POST /api/content/media/confirm` — auth; HEAD size/type; magic bytes; creates media row; deletes object on magic fail
   - Legacy `POST /api/content/media` multipart kept for small/dev uploads

3. **Admin**
   - Media library upload: presign → PUT to R2 → confirm (`apps/admin/.../upload-media.ts`)

4. **Body limits**
   - Legacy multipart still capped at 10MB (image ceiling)
   - Presign/confirm are JSON under the 1MB global limit (file bytes never hit the function)
   - Video/large sizes work via presign (contract VIDEO limit)

### Why

`POST /media` buffered the full multipart body via `parseBody()` before size checks. Interim 10MB gate (#1051) bounded memory but blocked valid large/video uploads. Direct-to-R2 eliminates the buffering DoS class and restores per-type limits for large files.

### Test plan

- [x] `pnpm --filter @revealui/core test src/storage/__tests__/r2.test.ts src/storage/__tests__/mock.test.ts src/storage/__tests__/_sigv4.test.ts` (60 passed)
- [x] `pnpm --filter server test src/routes/__tests__/content-media-upload.test.ts` (45 passed)
- [x] `pnpm --filter server test src/middleware/__tests__/body-limits.test.ts` (9 passed)
- [x] `pnpm --filter admin test …/upload-media.test.ts` (4 passed)
- [x] Pre-push phase-1 gate (PASS)
- [ ] Manual: upload >10MB video via admin media UI after deploy; confirm R2 object + media row; function does not buffer body

### GAP

- GAP-215 (presigned direct-to-R2 media upload)
- Relates to GAP-208 Phase 2b, #1051 interim body cap, #1038 magic-byte validation

### Residual

- Gap YAML status update needs a separate `.jv` PR
- R2 bucket CORS must allow browser PUT from admin origin (ops if not already set)
