### PR TITLE
feat(ai): GAP-297 hardware capability profiles (3 tiers)

### DIFF
--- a/.changeset/gap-297-hardware-capability-profiles.md
+++ b/.changeset/gap-297-hardware-capability-profiles.md
@@ -1,0 +1,5 @@
+---
+"@revealui/ai": minor
+---
+
+Add hardware capability profiles (constrained / mainstream / workstation) for GAP-297 local-inference vocabulary. Additive; no default path change when unconfigured.

--- a/packages/ai/docs/HARDWARE-CAPABILITY-PROFILES.md
+++ b/packages/ai/docs/HARDWARE-CAPABILITY-PROFILES.md
@@ -1,0 +1,40 @@
+# Hardware capability profiles (GAP-297)
+
+Three named, extendable host tiers for **local-inference vocabulary**. They do not replace operator runtime apply (`local-ai-profile.ts`: idle / daily / snaps / heavy).
+
+| Tier | Intent |
+|------|--------|
+| `constrained` | Low-RAM WSL / no dedicated GPU (owner machine reference) |
+| `mainstream` | Typical laptop/desktop |
+| `workstation` | High-RAM / high-VRAM local host |
+
+## Usage
+
+```ts
+import {
+  resolveHardwareCapabilityProfile,
+  listHardwareCapabilityPresets,
+} from '@revealui/ai/llm/hardware-capability-profile';
+
+// Default path: no profile configured
+resolveHardwareCapabilityProfile(null); // → null (no behavior change)
+
+// Stock preset
+const constrained = resolveHardwareCapabilityProfile('constrained');
+
+// User override (copy + fields)
+const custom = resolveHardwareCapabilityProfile({
+  tier: 'constrained',
+  id: 'my-wsl',
+  ramGbTypical: 4.7,
+  note: 'personal WSL budget',
+});
+```
+
+## GAP-296
+
+Boundary map entries may cite `tier: constrained | mainstream | workstation` instead of repeating raw RAM/VRAM specs. Verdict evidence still lives in the GAP-296 living doc.
+
+## Extension
+
+Copy a preset object, set `id`, override fields, pass to `resolveHardwareCapabilityProfile`. Overrides set `isOverride: true` and `extends: <tier>`.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/ai",
   "version": "0.9.1",
-  "description": "AI runtime for agent-driven products — agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
+  "description": "AI runtime for agent-driven products \u2014 agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
   "keywords": [
     "agent",
     "ai",
@@ -199,6 +199,11 @@
       "types": "./dist/inference/task-decomposer.d.ts",
       "import": "./dist/inference/task-decomposer.js",
       "default": "./dist/inference/task-decomposer.js"
+    },
+    "./llm/hardware-capability-profile": {
+      "types": "./dist/llm/hardware-capability-profile.d.ts",
+      "import": "./dist/llm/hardware-capability-profile.js",
+      "default": "./dist/llm/hardware-capability-profile.js"
     }
   },
   "files": [

--- a/packages/ai/src/llm/__tests__/hardware-capability-profile.test.ts
+++ b/packages/ai/src/llm/__tests__/hardware-capability-profile.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONSTRAINED_PRESET,
+  getHardwareCapabilityPreset,
+  hardwareTierForLocalAiTier,
+  isHardwareCapabilityTier,
+  isModelSizeViable,
+  listHardwareCapabilityPresets,
+  resolveHardwareCapabilityProfile,
+} from '../hardware-capability-profile.js';
+
+describe('hardware-capability-profile (GAP-297)', () => {
+  it('ships exactly three presets', () => {
+    const presets = listHardwareCapabilityPresets();
+    expect(presets.map((p) => p.id).sort()).toEqual(['constrained', 'mainstream', 'workstation']);
+  });
+
+  it('constrained is the owner-machine reference (low RAM, no VRAM floor)', () => {
+    expect(CONSTRAINED_PRESET.ramGbMin).toBeLessThanOrEqual(8);
+    expect(CONSTRAINED_PRESET.vramGbMin).toBe(0);
+    expect(CONSTRAINED_PRESET.viableModelSizes).toEqual(['nano', 'small']);
+    expect(CONSTRAINED_PRESET.capabilityHints['security-design']).toBe('frontier-only');
+  });
+
+  it('resolve(null) is no-op (default dev path unchanged)', () => {
+    expect(resolveHardwareCapabilityProfile(null)).toBeNull();
+    expect(resolveHardwareCapabilityProfile(undefined)).toBeNull();
+  });
+
+  it('resolve(tier string) returns a deep clone of the preset', () => {
+    const a = resolveHardwareCapabilityProfile('mainstream');
+    const b = getHardwareCapabilityPreset('mainstream');
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+    if (a) a.description = 'mutated';
+    expect(getHardwareCapabilityPreset('mainstream').description).not.toBe('mutated');
+  });
+
+  it('resolve(override) merges capabilityHints and marks isOverride', () => {
+    const resolved = resolveHardwareCapabilityProfile({
+      tier: 'constrained',
+      id: 'owner-wsl-custom',
+      ramGbTypical: 4.7,
+      capabilityHints: { 'auto-classify': 'local-OK' },
+      note: 'custom override for tests',
+    });
+    expect(resolved?.id).toBe('owner-wsl-custom');
+    expect(resolved?.isOverride).toBe(true);
+    expect(resolved?.extends).toBe('constrained');
+    expect(resolved?.ramGbTypical).toBe(4.7);
+    expect(resolved?.capabilityHints['auto-classify']).toBe('local-OK');
+    // base hints preserved when not overridden
+    expect(resolved?.capabilityHints['security-design']).toBe('frontier-only');
+  });
+
+  it('unknown tier throws (fail loud)', () => {
+    expect(() => resolveHardwareCapabilityProfile('tpu-cluster' as 'constrained')).toThrow(
+      /Unknown hardware capability tier/,
+    );
+    expect(isHardwareCapabilityTier('constrained')).toBe(true);
+    expect(isHardwareCapabilityTier('tpu-cluster')).toBe(false);
+  });
+
+  it('model size viability is set-membership on the profile list', () => {
+    const c = getHardwareCapabilityPreset('constrained');
+    const w = getHardwareCapabilityPreset('workstation');
+    expect(isModelSizeViable(c, 'large')).toBe(false);
+    expect(isModelSizeViable(w, 'large')).toBe(true);
+  });
+
+  it('maps local-ai runtime tiers to hardware vocabulary without applying env', () => {
+    expect(hardwareTierForLocalAiTier('daily')).toBe('constrained');
+    expect(hardwareTierForLocalAiTier('heavy')).toBe('mainstream');
+  });
+});

--- a/packages/ai/src/llm/hardware-capability-profile.ts
+++ b/packages/ai/src/llm/hardware-capability-profile.ts
@@ -1,0 +1,241 @@
+/**
+ * Hardware capability profiles (GAP-297).
+ *
+ * Named, extendable host tiers for local-inference vocabulary — distinct from
+ * `local-ai-profile.ts` (operator runtime apply: idle/daily/snaps/heavy).
+ *
+ * Tiers (owner directive 2026-07-09):
+ *   - constrained  — low-RAM WSL / no dedicated GPU (owner machine reference)
+ *   - mainstream   — typical laptop/desktop with mid GPU or solid CPU RAM
+ *   - workstation  — high-VRAM / high-RAM local inference host
+ *
+ * Zero required config: absent profile → resolve returns null (no behavior
+ * change to the default dev path). GAP-296 boundary entries may cite `tier`
+ * instead of repeating raw hardware specs.
+ */
+
+export type HardwareCapabilityTier = 'constrained' | 'mainstream' | 'workstation';
+
+/** GAP-296-aligned verdict vocabulary for capability hints. */
+export type CapabilityVerdict = 'local-OK' | 'primitives-only' | 'frontier-only';
+
+export type CpuClass = 'low' | 'mid' | 'high';
+
+export interface HardwareCapabilityProfile {
+  /** Stable id (preset id or user override id). */
+  id: string;
+  /** One of the three shipping tiers. */
+  tier: HardwareCapabilityTier;
+  /** Short human description. */
+  description: string;
+  /** Minimum usable host RAM (GiB) for this tier. */
+  ramGbMin: number;
+  /** Typical host RAM (GiB) used in docs / boundary pins. */
+  ramGbTypical: number;
+  /** Minimum dedicated GPU VRAM (GiB). 0 = CPU-only / iGPU acceptable. */
+  vramGbMin: number;
+  cpuClass: CpuClass;
+  /**
+   * Inference Snap / Ollama size classes viable on this tier.
+   * Values are size labels, not model names (model catalog churns faster).
+   */
+  viableModelSizes: Array<'nano' | 'small' | 'medium' | 'large'>;
+  /**
+   * Default expected verdicts for common capability classes.
+   * Living evidence still lives in GAP-296; this is hardware vocabulary only.
+   */
+  capabilityHints: Partial<
+    Record<
+      | 'product-inference'
+      | 'embeddings'
+      | 'auto-classify'
+      | 'security-design'
+      | 'multi-repo-synthesis'
+      | 'mechanical-build'
+      | 'guardrail-verify'
+      | 'reasoner-loop',
+      CapabilityVerdict
+    >
+  >;
+  /** Free-text operator note. */
+  note?: string;
+  /** When true, this profile is a user override of a preset (not a stock preset). */
+  isOverride?: boolean;
+  /** Preset id this override extends (if any). */
+  extends?: HardwareCapabilityTier;
+}
+
+/** Stock preset ids == tier names for the three shipping tiers. */
+export const HARDWARE_CAPABILITY_PRESET_IDS = [
+  'constrained',
+  'mainstream',
+  'workstation',
+] as const satisfies readonly HardwareCapabilityTier[];
+
+/**
+ * Constrained — owner WSL2 reference (~4–8 GiB usable, no dedicated GPU).
+ * Aligns with system-tune wsl-low-ram and local-ai "heavy needs care" notes.
+ */
+export const CONSTRAINED_PRESET: HardwareCapabilityProfile = {
+  id: 'constrained',
+  tier: 'constrained',
+  description:
+    'Low-RAM self-host (WSL2 ~4–8 GiB usable, no dedicated GPU). Prefer nano/small models; unload after use.',
+  ramGbMin: 4,
+  ramGbTypical: 6,
+  vramGbMin: 0,
+  cpuClass: 'low',
+  viableModelSizes: ['nano', 'small'],
+  capabilityHints: {
+    'product-inference': 'local-OK',
+    embeddings: 'local-OK',
+    'auto-classify': 'primitives-only',
+    'security-design': 'frontier-only',
+    'multi-repo-synthesis': 'frontier-only',
+    'mechanical-build': 'local-OK',
+    'guardrail-verify': 'frontier-only',
+    'reasoner-loop': 'primitives-only',
+  },
+  note: 'Owner-machine reference tier (2026-07-09). Do not treat as a behavior change to unconfigured hosts.',
+};
+
+/** Mainstream — typical modern laptop/desktop. */
+export const MAINSTREAM_PRESET: HardwareCapabilityProfile = {
+  id: 'mainstream',
+  tier: 'mainstream',
+  description:
+    'Typical dev laptop/desktop (16–32 GiB RAM, optional mid-tier GPU). Small/medium local models viable.',
+  ramGbMin: 12,
+  ramGbTypical: 16,
+  vramGbMin: 0,
+  cpuClass: 'mid',
+  viableModelSizes: ['nano', 'small', 'medium'],
+  capabilityHints: {
+    'product-inference': 'local-OK',
+    embeddings: 'local-OK',
+    'auto-classify': 'primitives-only',
+    'security-design': 'frontier-only',
+    'multi-repo-synthesis': 'frontier-only',
+    'mechanical-build': 'local-OK',
+    'guardrail-verify': 'frontier-only',
+    'reasoner-loop': 'primitives-only',
+  },
+};
+
+/** Workstation — high-VRAM / high-RAM local inference host. */
+export const WORKSTATION_PRESET: HardwareCapabilityProfile = {
+  id: 'workstation',
+  tier: 'workstation',
+  description:
+    'High-RAM / high-VRAM workstation. Medium and large local models viable; still pin security design to frontier when required.',
+  ramGbMin: 32,
+  ramGbTypical: 64,
+  vramGbMin: 12,
+  cpuClass: 'high',
+  viableModelSizes: ['nano', 'small', 'medium', 'large'],
+  capabilityHints: {
+    'product-inference': 'local-OK',
+    embeddings: 'local-OK',
+    'auto-classify': 'local-OK',
+    'security-design': 'frontier-only',
+    'multi-repo-synthesis': 'primitives-only',
+    'mechanical-build': 'local-OK',
+    'guardrail-verify': 'frontier-only',
+    'reasoner-loop': 'local-OK',
+  },
+};
+
+const PRESETS: Record<HardwareCapabilityTier, HardwareCapabilityProfile> = {
+  constrained: CONSTRAINED_PRESET,
+  mainstream: MAINSTREAM_PRESET,
+  workstation: WORKSTATION_PRESET,
+};
+
+export function listHardwareCapabilityPresets(): HardwareCapabilityProfile[] {
+  return HARDWARE_CAPABILITY_PRESET_IDS.map((id) => structuredClone(PRESETS[id]));
+}
+
+export function getHardwareCapabilityPreset(
+  tier: HardwareCapabilityTier,
+): HardwareCapabilityProfile {
+  return structuredClone(PRESETS[tier]);
+}
+
+export function isHardwareCapabilityTier(value: string): value is HardwareCapabilityTier {
+  return value === 'constrained' || value === 'mainstream' || value === 'workstation';
+}
+
+/**
+ * Deep-merge user override onto a preset. Unknown tier throws.
+ * Arrays and nested objects in `override` replace (not concat) when provided.
+ */
+export function resolveHardwareCapabilityProfile(
+  input:
+    | HardwareCapabilityTier
+    | (Partial<HardwareCapabilityProfile> & { tier: HardwareCapabilityTier })
+    | null
+    | undefined,
+): HardwareCapabilityProfile | null {
+  if (input == null) return null;
+  if (typeof input === 'string') {
+    if (!isHardwareCapabilityTier(input)) {
+      throw new Error(
+        `Unknown hardware capability tier "${input}". Valid: constrained | mainstream | workstation`,
+      );
+    }
+    return getHardwareCapabilityPreset(input);
+  }
+  if (!isHardwareCapabilityTier(input.tier)) {
+    throw new Error(
+      `Unknown hardware capability tier "${String(input.tier)}". Valid: constrained | mainstream | workstation`,
+    );
+  }
+  const base = getHardwareCapabilityPreset(input.tier);
+  const merged: HardwareCapabilityProfile = {
+    ...base,
+    ...input,
+    tier: input.tier,
+    capabilityHints: {
+      ...base.capabilityHints,
+      ...(input.capabilityHints ?? {}),
+    },
+    viableModelSizes: input.viableModelSizes ?? base.viableModelSizes,
+    isOverride: true,
+    extends: input.tier,
+    id: input.id ?? `${input.tier}-override`,
+  };
+  return merged;
+}
+
+/**
+ * Soft map from local-ai runtime tiers → hardware vocabulary.
+ * idle/daily/snaps → constrained; heavy → mainstream (operator still chooses).
+ * Does not auto-apply anything — callers opt in.
+ */
+export function hardwareTierForLocalAiTier(
+  localAiTier: 'idle' | 'daily' | 'snaps' | 'heavy',
+): HardwareCapabilityTier {
+  switch (localAiTier) {
+    case 'idle':
+    case 'daily':
+    case 'snaps':
+      return 'constrained';
+    case 'heavy':
+      return 'mainstream';
+    default: {
+      const _exhaustive: never = localAiTier;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Whether a model size class is listed as viable on the profile.
+ * Unknown sizes are not viable (fail closed for vocabulary, not a runtime gate).
+ */
+export function isModelSizeViable(
+  profile: HardwareCapabilityProfile,
+  size: 'nano' | 'small' | 'medium' | 'large',
+): boolean {
+  return profile.viableModelSizes.includes(size);
+}


### PR DESCRIPTION
## Summary

GAP-297: three **extendable hardware capability profiles** for local-inference vocabulary (not the operator runtime apply path).

| Tier | Role |
|------|------|
| `constrained` | Owner WSL / low-RAM, no VRAM floor |
| `mainstream` | Typical laptop/desktop |
| `workstation` | High-RAM / high-VRAM |

- `resolveHardwareCapabilityProfile(null)` → **null** (default dev path unchanged)
- Overrides merge onto presets (`isOverride`, `extends`)
- Soft map from local-ai runtime tiers → hardware tier (opt-in helper only)
- Docs: `packages/ai/docs/HARDWARE-CAPABILITY-PROFILES.md`
- Export: `@revealui/ai/llm/hardware-capability-profile`

Distinct from `local-ai-profile.ts` (idle/daily/snaps/heavy).

## Test plan

- [x] `pnpm --filter @revealui/ai exec vitest run src/llm/__tests__/hardware-capability-profile.test.ts` (8/8)
- [x] Pre-push gate phase 1 PASS (after harnesses build in worktree)

## Residual

- Optional: GAP-296 living doc cites tier ids (.jv)
- Consumers (GAP-294/293) can import later