### PR TITLE
fix(claim-gates): 0.1.2 real publish (0.1.1 version burned)

### DIFF
--- a/packages/claim-gates/CHANGELOG.md
+++ b/packages/claim-gates/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/claim-gates
 
+## 0.1.2
+
+### Patch Changes
+
+- Real first publish: include compiled dist (0.1.1 version slot burned by empty/unpublish bootstrap).
+- Emit CLI shebang so npm bin entry is valid.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/claim-gates/package.json
+++ b/packages/claim-gates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/claim-gates",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Fleet claim honesty engines: multi-root claim-drift and related gates (GAP-462).",
   "license": "MIT",
   "type": "module",

--- a/packages/claim-gates/src/cli.ts
+++ b/packages/claim-gates/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import path from 'node:path';
 import { runClaimGates } from './run.js';
 import type { ClaimGateResult, ClaimGatesCliOptions, ClaimProfileName } from './types.js';


### PR DESCRIPTION
## Why

npm **does not free version numbers** after unpublish. Empty bootstrap published then unpublished `@revealui/claim-gates@0.1.1`, so republish of 0.1.1 returns:

`Cannot publish over previously published version "0.1.1"`

## Changes

- Bump to **0.1.2**
- CLI shebang so npm `bin` is valid
- CHANGELOG note

## Owner after merge (or from this worktree now)

```bash
cd ~/revfleet/.wt/claim-gates-0.1.2/packages/claim-gates
npm publish --access public   # browser + hardware key, no --otp
```

Verify: `npm view @revealui/claim-gates dist.unpackedSize` ≈ 300k+.