### PR TITLE
feat(server,harnesses): GAP-381 Phase A harness receipts ingest

### DIFF
--- a/.changeset/gap-381-phase-a-receipts.md
+++ b/.changeset/gap-381-phase-a-receipts.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": patch
+---
+
+GAP-381 Phase A: flushSpoolAsync POSTs to /api/harness/receipts; server ingest route.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -123,6 +123,7 @@ import devkitRoute from './routes/devkit.js';
 import errorsRoute from './routes/errors.js';
 import gdprRoute from './routes/gdpr.js';
 import ghcrRoute from './routes/ghcr.js';
+import { mountHarnessReceipts } from './routes/harness-receipts.js';
 import healthRoute from './routes/health.js';
 import jobsRoute from './routes/jobs/index.js';
 import kitsRoute from './routes/kits.js';
@@ -1277,6 +1278,8 @@ app.route('/api/mcp/usage', mcpUsageRoute);
 // (auth → entitlements → requireFeature('mcp') → Streamable HTTP), so it does
 // not shadow the /api/mcp/usage route mounted above.
 mountMcpEndpoint(app);
+// GAP-381 Phase A: harness hook receipts + policy snapshot (device-token only)
+mountHarnessReceipts(app);
 app.route('/api/content', contentRoute);
 app.route('/api/rag', ragIndexRoute);
 app.route('/api/admin', adminObservabilityRoute);

--- a/apps/server/src/lib/harness-receipt-audit.ts
+++ b/apps/server/src/lib/harness-receipt-audit.ts
@@ -1,0 +1,89 @@
+/**
+ * Harness hook receipt writer (GAP-381 Phase A).
+ *
+ * Appends one `harness.hook.*` audit_log row per ingested hook event through
+ * the single `DrizzleAuditStore` door (same door as MCP tool receipts).
+ * Failures throw so the route can fail closed (I-3).
+ *
+ * Retention (design §8 D-A): rows live in the shared `audit_log` table and
+ * follow the same account GDPR export/delete and platform retention policy
+ * as every other audit receipt. No parallel harness-only store.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { classifyAuditWriteFailure, recordAuditWriteResult } from '@revealui/core/security';
+import { getClient } from '@revealui/db';
+import { createAuditStore } from './audit-signer.js';
+
+export interface HarnessReceiptAuditInput {
+  /** User resolved from the verified device token only (I-1). */
+  userId: string;
+  accountId: string | null;
+  /** Editor source: cursor | claude-code | vscode | opencode | grok */
+  source: string;
+  /** Normalized event kind (session-start, pre-tool, …). */
+  kind: string;
+  /** Honest enforcement tier from the client decision (must not invent 'enforced'). */
+  enforcementTier: 'enforced' | 'advisory';
+  /** Local policy decision: allow | deny | ask | none */
+  decision?: string;
+  toolName?: string;
+  conversationId?: string;
+  generationId?: string;
+  modelId?: string;
+  /** sha256 hex of canonical JSON of raw payload; never store raw secrets. */
+  rawDigest?: string;
+  /** Client-supplied display email under raw only — stored as metadata, never as userId. */
+  displayEmail?: string;
+}
+
+/**
+ * Write one harness.hook receipt. Throws when the audit door fails so the
+ * ingest route returns 5xx instead of silently dropping governance evidence.
+ */
+export async function recordHarnessHookAudit(input: HarnessReceiptAuditInput): Promise<string> {
+  const id = randomUUID();
+  const timestamp = new Date();
+  const eventType = `harness.hook.${input.kind}`;
+  const severity = input.decision === 'deny' ? 'warn' : 'info';
+  const agentId = `harness:${input.source}`;
+
+  const payload: Record<string, unknown> = {
+    userId: input.userId,
+    accountId: input.accountId,
+    source: input.source,
+    kind: input.kind,
+    enforcementTier: input.enforcementTier,
+  };
+  if (input.decision !== undefined) payload.decision = input.decision;
+  if (input.toolName !== undefined) payload.toolName = input.toolName;
+  if (input.conversationId !== undefined) payload.conversationId = input.conversationId;
+  if (input.generationId !== undefined) payload.generationId = input.generationId;
+  if (input.modelId !== undefined) payload.modelId = input.modelId;
+  if (input.rawDigest !== undefined) payload.rawDigest = input.rawDigest;
+  // Display-only metadata; never used as auth identity (I-1).
+  if (input.displayEmail !== undefined) payload.displayEmail = input.displayEmail;
+
+  try {
+    await createAuditStore(getClient()).append({
+      id,
+      timestamp,
+      eventType,
+      severity,
+      agentId,
+      sessionId: input.conversationId ?? undefined,
+      payload,
+      policyViolations: [],
+    });
+    recordAuditWriteResult({ ok: true, eventId: id, eventType });
+    return id;
+  } catch (err) {
+    recordAuditWriteResult({
+      ok: false,
+      reason: classifyAuditWriteFailure(err),
+      eventId: id,
+      eventType,
+    });
+    throw err;
+  }
+}

--- a/apps/server/src/routes/__tests__/harness-receipts.test.ts
+++ b/apps/server/src/routes/__tests__/harness-receipts.test.ts
@@ -1,0 +1,201 @@
+/**
+ * GAP-381 Phase A — harness receipts ingest.
+ *
+ * Covers design invariants:
+ *   I-1  identity from token user only (forged display email does not become userId)
+ *   I-2  device-token requirement (cookie/session rejected)
+ *   I-7  rate limit headers present after auth
+ *
+ * Audit append is mocked at the store door so we do not need PGlite for the
+ * route shape tests; recordHarnessHookAudit is still exercised via the mock.
+ */
+
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const appendMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../lib/audit-signer.js', () => ({
+  createAuditStore: () => ({ append: appendMock }),
+}));
+
+vi.mock('@revealui/db', () => ({
+  getClient: () => ({}),
+}));
+
+vi.mock('@revealui/core/security', () => ({
+  classifyAuditWriteFailure: () => 'unknown',
+  recordAuditWriteResult: vi.fn(),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/auth/server', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({
+    allowed: true,
+    remaining: 100,
+    resetAt: Date.now() + 60_000,
+  }),
+}));
+
+vi.mock('../../middleware/auth.js', () => ({
+  authMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+vi.mock('../../middleware/entitlements.js', () => ({
+  entitlementMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+  getEntitlementsFromContext: (c: { get: (k: string) => unknown }) =>
+    c.get('entitlements') ?? { accountId: null },
+}));
+
+vi.mock('../../middleware/license.js', () => ({
+  requireFeature: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+import { checkRateLimit } from '@revealui/auth/server';
+import {
+  createHarnessReceiptsApp,
+  handleReceiptsPost,
+  harnessReceiptRateLimit,
+  requireDeviceToken,
+} from '../harness-receipts.js';
+
+const USER = { id: 'user_token_owner', role: 'admin', email: 'owner@example.com' };
+
+function mountWithAuth(opts: { user?: typeof USER | null; deviceAuth?: boolean }): Hono {
+  const app = new Hono();
+  app.use('/api/harness/*', async (c, next) => {
+    if (opts.user) {
+      c.set('user', opts.user);
+      c.set('session', {
+        id: opts.deviceAuth ? 'device-token' : 'cookie-session',
+        deviceAuth: opts.deviceAuth === true,
+      });
+      c.set('entitlements', { accountId: 'acct_1' });
+    }
+    await next();
+  });
+  if (opts.user) {
+    app.use('/api/harness/*', requireDeviceToken);
+    app.use('/api/harness/*', harnessReceiptRateLimit);
+  }
+  app.route('/api/harness', createHarnessReceiptsApp());
+  return app;
+}
+
+describe('GAP-381 Phase A: POST /api/harness/receipts', () => {
+  beforeEach(() => {
+    appendMock.mockClear();
+    vi.mocked(checkRateLimit).mockClear();
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      allowed: true,
+      remaining: 100,
+      resetAt: Date.now() + 60_000,
+    });
+  });
+
+  it('I-2: rejects unauthenticated requests with 401', async () => {
+    const app = mountWithAuth({ user: null });
+    const res = await app.request('/api/harness/receipts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'cursor', kind: 'pre-tool' }),
+    });
+    // No user middleware → handler may 401 from requireDeviceToken never running;
+    // without auth middleware the route still runs if we only mounted the app.
+    // When user is null we did not mount requireDeviceToken — force via handleReceiptsPost?
+    // Re-mount with requireDeviceToken always and no user:
+    const strict = new Hono();
+    strict.use('/api/harness/*', requireDeviceToken);
+    strict.route('/api/harness', createHarnessReceiptsApp());
+    const r2 = await strict.request('/api/harness/receipts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'cursor', kind: 'pre-tool' }),
+    });
+    expect(r2.status).toBe(401);
+    expect(res.status).not.toBe(201);
+  });
+
+  it('I-2: rejects cookie sessions without deviceAuth', async () => {
+    const app = mountWithAuth({ user: USER, deviceAuth: false });
+    const res = await app.request('/api/harness/receipts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'cursor', kind: 'pre-tool', enforcementTier: 'advisory' }),
+    });
+    expect(res.status).toBe(401);
+    const text = await res.text();
+    expect(text.toLowerCase()).toMatch(/device token|authentication/);
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a device-token session and writes harness.hook receipt (I-3 door)', async () => {
+    const app = mountWithAuth({ user: USER, deviceAuth: true });
+    const res = await app.request('/api/harness/receipts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        source: 'cursor',
+        kind: 'pre-tool',
+        enforcementTier: 'advisory',
+        decision: 'allow',
+        toolName: 'Shell',
+        identity: { conversationId: 'conv-1', modelId: 'grok-4.5' },
+        raw: { user_email: 'forged@attacker.example', command: 'ls' },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { success: boolean; accepted: number; ids: string[] };
+    expect(body.success).toBe(true);
+    expect(body.accepted).toBe(1);
+    expect(body.ids).toHaveLength(1);
+    expect(appendMock).toHaveBeenCalledTimes(1);
+    const entry = appendMock.mock.calls[0]?.[0] as {
+      eventType: string;
+      payload: Record<string, unknown>;
+    };
+    expect(entry.eventType).toBe('harness.hook.pre-tool');
+    // I-1: token owner is the userId, not forged email
+    expect(entry.payload.userId).toBe(USER.id);
+    expect(entry.payload.displayEmail).toBe('forged@attacker.example');
+    expect(entry.payload.userId).not.toBe('forged@attacker.example');
+  });
+
+  it('I-5: coerces client enforcementTier=enforced to advisory until signatures exist', async () => {
+    const result = await handleReceiptsPost(USER, 'acct_1', {
+      source: 'vscode',
+      kind: 'pre-shell',
+      enforcementTier: 'enforced',
+      decision: 'deny',
+    });
+    expect(result.accepted).toBe(1);
+    const entry = appendMock.mock.calls[0]?.[0] as { payload: { enforcementTier: string } };
+    expect(entry.payload.enforcementTier).toBe('advisory');
+  });
+
+  it('I-7: sets rate-limit headers on device-auth path', async () => {
+    const app = mountWithAuth({ user: USER, deviceAuth: true });
+    const res = await app.request('/api/harness/receipts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'claude-code', kind: 'stop', enforcementTier: 'advisory' }),
+    });
+    expect(res.status).toBe(201);
+    expect(res.headers.get('X-RateLimit-Limit')).toBeTruthy();
+    expect(checkRateLimit).toHaveBeenCalled();
+    const key = vi.mocked(checkRateLimit).mock.calls[0]?.[0] as string;
+    expect(key).toContain(USER.id);
+  });
+
+  it('GET /policy-snapshot returns advisory structure-only document', async () => {
+    const app = mountWithAuth({ user: USER, deviceAuth: true });
+    const res = await app.request('/api/harness/policy-snapshot');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { enforcementTier: string; rules: unknown[] };
+    expect(body.enforcementTier).toBe('advisory');
+    expect(Array.isArray(body.rules)).toBe(true);
+  });
+});

--- a/apps/server/src/routes/harness-receipts.ts
+++ b/apps/server/src/routes/harness-receipts.ts
@@ -253,12 +253,13 @@ export function createHarnessReceiptsApp(): Hono {
 /**
  * Mount under /api/harness and /api/v1/harness with the governed chain.
  */
-export function mountHarnessReceipts(app: Hono): void {
+/** Accept OpenAPIHono or Hono mounts without forcing BlankEnv. */
+export function mountHarnessReceipts(app: Pick<Hono, 'use' | 'route'>): void {
   const chain: MiddlewareHandler[] = [
-    authMiddleware,
+    authMiddleware({ required: true }),
     requireDeviceToken,
     harnessReceiptRateLimit,
-    entitlementMiddleware,
+    entitlementMiddleware(),
     requireFeature('mcp', { mode: 'entitlements' }),
   ];
 

--- a/apps/server/src/routes/harness-receipts.ts
+++ b/apps/server/src/routes/harness-receipts.ts
@@ -1,0 +1,273 @@
+/**
+ * Harness hook receipts ingest (GAP-381 Phase A).
+ *
+ *   POST /api/harness/receipts  — batch ingest of spool records
+ *   GET  /api/harness/policy-snapshot — current policy document (advisory until signed)
+ *
+ * Chain: authMiddleware → requireDeviceToken → per-token rate limit →
+ * requireFeature('mcp') → handler.
+ *
+ * Trust (design I-1 / I-2):
+ *   - Authorization identity is the device-token user only.
+ *   - Cookie sessions are rejected on this route (no cookie fallthrough).
+ *   - Editor identity fields (email, etc.) are display metadata only.
+ *
+ * Retention (design §8 D-A proposal for owner countersign via merge):
+ *   Rows use shared `audit_log` retention (GDPR export/delete with the account).
+ *   No separate harness store.
+ */
+
+import { createHash } from 'node:crypto';
+import { checkRateLimit } from '@revealui/auth/server';
+import { logger } from '@revealui/core/observability/logger';
+import type { Handler, MiddlewareHandler } from 'hono';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { recordHarnessHookAudit } from '../lib/harness-receipt-audit.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { entitlementMiddleware, getEntitlementsFromContext } from '../middleware/entitlements.js';
+import { requireFeature } from '../middleware/license.js';
+
+const SOURCES = new Set(['cursor', 'claude-code', 'vscode', 'opencode', 'grok']);
+const KINDS = new Set([
+  'session-start',
+  'session-end',
+  'pre-tool',
+  'post-tool',
+  'pre-shell',
+  'post-shell',
+  'pre-mcp',
+  'post-mcp',
+  'file-edit',
+  'prompt-submit',
+  'stop',
+]);
+const TIERS = new Set(['enforced', 'advisory']);
+const DECISIONS = new Set(['allow', 'deny', 'ask', 'none']);
+
+/** Per-token ingest budget (I-7). Tunable via env for tests. */
+const RECEIPT_RATE_MAX = Number(process.env.HARNESS_RECEIPT_RATE_MAX) || 120;
+const RECEIPT_RATE_WINDOW_MS = Number(process.env.HARNESS_RECEIPT_RATE_WINDOW_MS) || 60_000;
+const MAX_BATCH = 50;
+
+interface ApiAuthUser {
+  id: string;
+  role?: string;
+  email?: string;
+}
+
+interface DeviceSession {
+  id?: string;
+  deviceAuth?: boolean;
+}
+
+/**
+ * Reject cookie/session auth on this route. Only `rvui_dev_` device tokens
+ * (auth middleware sets session.deviceAuth) may ingest receipts (I-2).
+ */
+export const requireDeviceToken: MiddlewareHandler = async (c, next) => {
+  const user = c.get('user') as ApiAuthUser | undefined;
+  const session = c.get('session') as DeviceSession | undefined;
+  if (!user?.id) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+  if (!session?.deviceAuth) {
+    throw new HTTPException(401, {
+      message: 'Device token required (rvui_dev_ Bearer); cookie sessions are not accepted',
+    });
+  }
+  await next();
+};
+
+/** Per-user rate limit after identity is known (I-7). */
+export const harnessReceiptRateLimit: MiddlewareHandler = async (c, next) => {
+  const user = c.get('user') as ApiAuthUser | undefined;
+  const key = `harness-receipts:${user?.id ?? 'anon'}`;
+  try {
+    const result = await checkRateLimit(key, {
+      maxAttempts: RECEIPT_RATE_MAX,
+      windowMs: RECEIPT_RATE_WINDOW_MS,
+    });
+    c.header('X-RateLimit-Limit', String(RECEIPT_RATE_MAX));
+    c.header('X-RateLimit-Remaining', String(result.remaining));
+    c.header('X-RateLimit-Reset', String(result.resetAt));
+    if (!result.allowed) {
+      const retryAfter = Math.ceil((result.resetAt - Date.now()) / 1000);
+      c.header('Retry-After', String(retryAfter));
+      throw new HTTPException(429, { message: 'Too many harness receipt requests' });
+    }
+  } catch (error) {
+    if (error instanceof HTTPException) throw error;
+    // Fail closed on storage errors for this governance path.
+    logger.error('harness receipt rate limit storage failure', { error: String(error) });
+    throw new HTTPException(503, { message: 'Rate limit unavailable' });
+  }
+  await next();
+};
+
+interface ReceiptBody {
+  source?: unknown;
+  kind?: unknown;
+  enforcementTier?: unknown;
+  decision?: unknown;
+  toolName?: unknown;
+  identity?: {
+    conversationId?: unknown;
+    generationId?: unknown;
+    modelId?: unknown;
+  };
+  raw?: unknown;
+  /** Client may send precomputed digest; otherwise we hash a safe subset. */
+  rawDigest?: unknown;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function digestRaw(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  try {
+    const json = JSON.stringify(raw);
+    return createHash('sha256').update(json).digest('hex');
+  } catch {
+    return undefined;
+  }
+}
+
+/** Pull display-only email from raw without treating it as identity. */
+function displayEmailFromRaw(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const o = raw as Record<string, unknown>;
+  return asString(o.user_email) ?? asString(o.userEmail) ?? asString(o.email);
+}
+
+export async function handleReceiptsPost(
+  user: ApiAuthUser,
+  accountId: string | null,
+  body: unknown,
+): Promise<{ accepted: number; ids: string[] }> {
+  const items: ReceiptBody[] = Array.isArray(body)
+    ? (body as ReceiptBody[])
+    : body && typeof body === 'object' && Array.isArray((body as { receipts?: unknown }).receipts)
+      ? (body as { receipts: ReceiptBody[] }).receipts
+      : body && typeof body === 'object'
+        ? [body as ReceiptBody]
+        : [];
+
+  if (items.length === 0) {
+    throw new HTTPException(400, { message: 'Expected a receipt object or { receipts: [] }' });
+  }
+  if (items.length > MAX_BATCH) {
+    throw new HTTPException(400, { message: `Batch size exceeds max ${MAX_BATCH}` });
+  }
+
+  const ids: string[] = [];
+  for (const item of items) {
+    const source = asString(item.source);
+    const kind = asString(item.kind);
+    const tier = asString(item.enforcementTier) ?? 'advisory';
+    if (!(source && SOURCES.has(source))) {
+      throw new HTTPException(400, { message: `Invalid source: ${String(item.source)}` });
+    }
+    if (!(kind && KINDS.has(kind))) {
+      throw new HTTPException(400, { message: `Invalid kind: ${String(item.kind)}` });
+    }
+    if (!TIERS.has(tier)) {
+      throw new HTTPException(400, { message: `Invalid enforcementTier: ${tier}` });
+    }
+    // I-5: never accept client claim of enforced without signature verification.
+    // Until policy-snapshot crypto lands, force advisory on ingest storage.
+    const enforcementTier: 'enforced' | 'advisory' =
+      tier === 'enforced' ? 'advisory' : (tier as 'advisory');
+
+    const decision = asString(item.decision);
+    if (decision !== undefined && !DECISIONS.has(decision)) {
+      throw new HTTPException(400, { message: `Invalid decision: ${decision}` });
+    }
+
+    const identity = item.identity && typeof item.identity === 'object' ? item.identity : {};
+    const rawDigest = asString(item.rawDigest) ?? digestRaw(item.raw);
+
+    const id = await recordHarnessHookAudit({
+      userId: user.id,
+      accountId,
+      source,
+      kind,
+      enforcementTier,
+      decision,
+      toolName: asString(item.toolName),
+      conversationId: asString(identity.conversationId),
+      generationId: asString(identity.generationId),
+      modelId: asString(identity.modelId),
+      rawDigest,
+      displayEmail: displayEmailFromRaw(item.raw),
+    });
+    ids.push(id);
+  }
+
+  return { accepted: ids.length, ids };
+}
+
+export const postReceiptsHandler: Handler = async (c) => {
+  const user = c.get('user') as ApiAuthUser | undefined;
+  if (!user?.id) {
+    throw new HTTPException(401, { message: 'Authentication required' });
+  }
+  const entitlements = getEntitlementsFromContext(c);
+  const accountId = entitlements?.accountId ?? null;
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    throw new HTTPException(400, { message: 'Invalid JSON body' });
+  }
+  const result = await handleReceiptsPost(user, accountId, body);
+  return c.json({ success: true, ...result }, 201);
+};
+
+/**
+ * Policy snapshot for offline hook evaluation. Structure-only / advisory
+ * until a signing primitive lands in @revealui/security (I-5).
+ */
+export const getPolicySnapshotHandler: Handler = async (c) => {
+  return c.json({
+    version: 1,
+    keyId: 'unsigned-structure-only',
+    signature: 'unsigned',
+    issuedAt: new Date().toISOString(),
+    enforcementTier: 'advisory' as const,
+    rules: [] as const,
+    note: 'Structure-only snapshot; cryptographic enforcement is not available yet',
+  });
+};
+
+/** Pure route app (auth applied by mountHarnessReceipts). */
+export function createHarnessReceiptsApp(): Hono {
+  const app = new Hono();
+  app.post('/receipts', postReceiptsHandler);
+  app.get('/policy-snapshot', getPolicySnapshotHandler);
+  return app;
+}
+
+/**
+ * Mount under /api/harness and /api/v1/harness with the governed chain.
+ */
+export function mountHarnessReceipts(app: Hono): void {
+  const chain: MiddlewareHandler[] = [
+    authMiddleware,
+    requireDeviceToken,
+    harnessReceiptRateLimit,
+    entitlementMiddleware,
+    requireFeature('mcp', { mode: 'entitlements' }),
+  ];
+
+  const receipts = createHarnessReceiptsApp();
+
+  for (const prefix of ['/api/harness', '/api/v1/harness'] as const) {
+    for (const mw of chain) {
+      app.use(`${prefix}/*`, mw);
+    }
+    app.route(prefix, receipts);
+  }
+}

--- a/apps/server/src/routes/harness-receipts.ts
+++ b/apps/server/src/routes/harness-receipts.ts
@@ -252,9 +252,10 @@ export function createHarnessReceiptsApp(): Hono {
 
 /**
  * Mount under /api/harness and /api/v1/harness with the governed chain.
+ * App typing matches mountMcpEndpoint (OpenAPIHono is not Hono&lt;BlankEnv&gt;).
  */
-/** Accept OpenAPIHono or Hono mounts without forcing BlankEnv. */
-export function mountHarnessReceipts(app: Pick<Hono, 'use' | 'route'>): void {
+// biome-ignore lint/suspicious/noExplicitAny: same as mountMcpEndpoint — OpenAPIHono Env vs Hono BlankEnv
+export function mountHarnessReceipts(app: Hono<any, any, any>): void {
   const chain: MiddlewareHandler[] = [
     authMiddleware({ required: true }),
     requireDeviceToken,

--- a/packages/harnesses/src/__tests__/hook-spool.test.ts
+++ b/packages/harnesses/src/__tests__/hook-spool.test.ts
@@ -113,9 +113,10 @@ describe('flushSpool', () => {
     }
   });
 
-  it('reports not-implemented when an endpoint IS configured -- Phase A ships the real POST', () => {
+  it('reports not-implemented on sync flush when endpoint is set (use flushSpoolAsync)', () => {
     const result = flushSpool('/tmp/spool.jsonl', {
       endpoint: 'https://example.com/api/harness/receipts',
+      token: 'rvui_dev_test',
     });
     expect(result.flushed).toBe(false);
     expect(result.reason).toBe('not-implemented');

--- a/packages/harnesses/src/hooks/index.ts
+++ b/packages/harnesses/src/hooks/index.ts
@@ -38,4 +38,9 @@ export {
   runHookCommand,
 } from './run-hook.js';
 export type { FlushConfig, FlushResult, SpoolAppendResult, SpoolRecord } from './spool.js';
-export { appendToSpool, DEFAULT_SPOOL_MAX_BYTES, flushSpool } from './spool.js';
+export {
+  appendToSpool,
+  DEFAULT_SPOOL_MAX_BYTES,
+  flushSpool,
+  flushSpoolAsync,
+} from './spool.js';

--- a/packages/harnesses/src/hooks/spool.ts
+++ b/packages/harnesses/src/hooks/spool.ts
@@ -11,7 +11,7 @@
  * keeps appending to a fresh one, and it warns on every rotation.
  */
 
-import { appendFile, mkdir, open, rename } from 'node:fs/promises';
+import { appendFile, mkdir, open, readFile, rename } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { HarnessHookEvent } from '../types/hook-event.js';
 import type { PolicyDecision } from './policy.js';
@@ -120,12 +120,10 @@ let warnedNotConfigured = false;
 /**
  * Attempt to flush the local spool to the receipts-ingest server.
  *
- * SPOOL-ONLY MODE (multi-editor harness design doc §6, Phase B acceptance):
- * `POST /api/harness/receipts` does not exist yet -- it ships in Phase A.
- * When `config.endpoint` is unset this no-ops with a single warn line (not
- * one per call) and never throws; when it IS set, this still returns
- * `not-implemented` today rather than guessing at a wire format Phase A
- * hasn't shipped. Wiring the real POST is Phase A's job.
+ * When `config.endpoint` is unset: spool-only mode (warn once, never throw).
+ * When set with a token: POST the spool lines as `{ receipts: [...] }` to
+ * `POST /api/harness/receipts` (GAP-381 Phase A). Failures return
+ * `request-failed` without throwing so hooks never block on network.
  */
 export function flushSpool(spoolPath: string, config: FlushConfig): FlushResult {
   if (!config.endpoint) {
@@ -138,7 +136,85 @@ export function flushSpool(spoolPath: string, config: FlushConfig): FlushResult 
     return { flushed: false, reason: 'not-configured' };
   }
 
+  if (!config.token) {
+    return { flushed: false, reason: 'not-configured' };
+  }
+
+  // Sync API cannot await fetch. Callers that can await should use flushSpoolAsync.
   return { flushed: false, reason: 'not-implemented' };
+}
+
+/** Map a spool line to the Phase A ingest receipt body. */
+function spoolRecordToReceipt(record: SpoolRecord): Record<string, unknown> {
+  const { event, decision } = record;
+  return {
+    source: event.source,
+    kind: event.kind,
+    enforcementTier: event.enforcementTier,
+    decision: decision.permission,
+    toolName: event.toolName,
+    identity: event.identity,
+    raw: event.raw,
+  };
+}
+
+/**
+ * Async flush used by the hook CLI after spool append (GAP-381 Phase A).
+ * Reads NDJSON spool, POSTs to `POST /api/harness/receipts` with the device token.
+ */
+export async function flushSpoolAsync(
+  spoolPath: string,
+  config: FlushConfig,
+): Promise<FlushResult> {
+  if (!config.endpoint) {
+    return flushSpool(spoolPath, config);
+  }
+  if (!config.token) {
+    return { flushed: false, reason: 'not-configured' };
+  }
+
+  let text: string;
+  try {
+    text = await readFile(spoolPath, 'utf8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return { flushed: true };
+    return { flushed: false, reason: 'request-failed' };
+  }
+
+  const lines = text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  if (lines.length === 0) return { flushed: true };
+
+  const receipts: Record<string, unknown>[] = [];
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as SpoolRecord;
+      if (parsed?.event && parsed?.decision) {
+        receipts.push(spoolRecordToReceipt(parsed));
+      }
+    } catch {
+      // Skip corrupt lines; do not abort the batch.
+    }
+  }
+  if (receipts.length === 0) return { flushed: true };
+
+  try {
+    const res = await fetch(config.endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${config.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ receipts }),
+    });
+    if (!res.ok) return { flushed: false, reason: 'request-failed' };
+    return { flushed: true };
+  } catch {
+    return { flushed: false, reason: 'request-failed' };
+  }
 }
 
 /** Test-only: reset the single-warn latch between test cases. */

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -81,6 +81,7 @@ export {
   defaultHookRunOptions,
   evaluatePolicy,
   flushSpool,
+  flushSpoolAsync,
   getDefaultPolicySnapshotPath,
   getDefaultSpoolPath,
   getHarnessDataDir,


### PR DESCRIPTION
## Summary
**GAP-381 Phase A** — `POST /api/harness/receipts` + `GET /api/harness/policy-snapshot`.

Per GAP-381 design §6 Phase A / invariants I-1, I-2, I-3 door, I-5, I-7.

### Server
- Device-token only (cookie sessions **401**; I-2)
- Per-user rate limit (I-7)
- `requireFeature('mcp')` + entitlements
- Audit via single `DrizzleAuditStore` door as `harness.hook.{kind}`
- Client `enforcementTier: enforced` coerced to **advisory** until policy-snapshot crypto exists (I-5)
- Forged `user_email` in raw is display metadata only; `payload.userId` is token owner (I-1)
- **Retention (D-A):** shared `audit_log` / GDPR account retention (no parallel store)

### Harnesses
- `flushSpoolAsync` POSTs spool NDJSON as `{ receipts: [...] }`
- Sync `flushSpool` still returns `not-implemented` when endpoint set (call async path)

## Owner countersign (design §8 D-A)
Merging this PR **approves** the net-new ingest surface name `POST /api/harness/receipts` and retention policy above. If you want a different name or retention, reject and specify.

## Security
- `area:security` — do **not** merge without guardrail-2 verdict
- Independent non-author review required (not self-merge)

## Test plan
- [x] `vitest run src/routes/__tests__/harness-receipts.test.ts` (6/6)
- [x] `vitest run src/__tests__/hook-spool.test.ts` (6/6)
- [x] Local pre-push gate phase 1 PASS
- [ ] CI full gate
- [ ] Guardrail-2 recorded verdict

## Residual after merge
- Policy-snapshot **signature** verification (still structure-only)
- Phase D ACP (needs D-B)
- Phase E real-editor e2e