### PR TITLE
docs(sync): GAP-339 signup/bundle vault paths + scoped sync runbook

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -509,3 +509,12 @@ Settings pairing UI for the flow.
 
 **Review date:** 2027-07-18 (annual)
 **Owner:** RevealUI Studio (RevDev daemon maintainer)
+
+## GAP-339 vault paths (signup / bundle flags)
+
+| Path | Consumers | Notes |
+|------|-----------|--------|
+| `revealui/prod/admin/signup-open` | admin `REVEALUI_SIGNUP_OPEN` | Boolean string; self-serve funnel gate |
+| `revealui/prod/api/bundle-pro` | api `REVEALUI_BUNDLE_PRO` | Pro bundle flag |
+
+Scoped sync runbook: [docs/security/REVVAULT-VERCEL-SCOPED-SYNC.md](./security/REVVAULT-VERCEL-SCOPED-SYNC.md).

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -94,7 +94,7 @@ _Machine-generated from [`scripts/sync/secret-paths.ts`](../scripts/sync/secret-
 spec, the Vercel/Fly sync manifests, or their sensitivity markers. Change `secret-paths.ts`
 and re-run the renderer._
 
-Production runtime paths synced to Vercel + Fly (109 paths). `sensitive` = the
+Production runtime paths synced to Vercel + Fly (111 paths). `sensitive` = the
 value is never UI/API-revealable after write (credentials + private signing keys).
 
 | Path | Kind | Sensitive | Consumers | Notes |
@@ -104,7 +104,9 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/admin/api-key` | credential | yes | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/admin/email` | public-config | no | vercel:admin |  |
 | `revealui/prod/admin/password` | credential | yes | vercel:admin |  |
+| `revealui/prod/admin/signup-open` | public-config | no | vercel:admin | Boolean string; self-serve signup funnel gate (true/false) |
 | `revealui/prod/alert-email` | public-config | no | vercel:api, fly:worker | required@boot; required at prod boot - apps/server refuses to start without it |
+| `revealui/prod/api/bundle-pro` | public-config | no | vercel:api | Pro bundle flag for hosted API |
 | `revealui/prod/audit/signing-private-key` | signing-private | yes | vercel:api, vercel:admin, fly:worker | required@boot; Ed25519 PKCS#8 PEM - signs every audit row; only signing surfaces read it, no fallback |
 | `revealui/prod/audit/signing-public-key` | signing-public | no | vercel:api, vercel:admin, fly:worker | Ed25519 SPKI PEM - published for offline receipt verification; derivable from the private key. See docs/security/AUDIT_RECEIPTS.md (Stage 4: row verify free; root download Max) |
 | `revealui/prod/billing/portal-config-id` | public-config | no | fly:worker | → migrating to `revealui/prod/stripe/billing-portal-config-id` (since 2026-07-01); R18 - Fly-side duplicate of the stripe/ canonical; converge in P3-3 |

--- a/docs/security/REVVAULT-VERCEL-SCOPED-SYNC.md
+++ b/docs/security/REVVAULT-VERCEL-SCOPED-SYNC.md
@@ -1,0 +1,66 @@
+# Revvault → Vercel scoped sync (GAP-339)
+
+Unscoped `revvault sync vercel --apply` rewrites **every** sensitive var the
+manifest knows about. Vercel does not return secret values for comparison, so
+those rows show `~` even when unchanged. If any vault path still holds a
+non-prod value (especially `REVEALUI_LICENSE_PRIVATE_KEY`), a blanket apply can
+brick hosted license verification.
+
+## Sanctioned pattern
+
+### 1. Prefer scoped apply (revvault ≥ this GAP-339 CLI)
+
+```bash
+cd ~/revfleet/revealui
+
+# Dry-run one project + one key (no writes)
+revvault sync vercel \
+  --manifest scripts/sync/revvault-vercel.toml \
+  --project revealui-admin \
+  --key REVEALUI_SIGNUP_OPEN
+
+# Apply only that key after the vault value is verified correct
+revvault sync vercel \
+  --manifest scripts/sync/revvault-vercel.toml \
+  --project revealui-admin \
+  --key REVEALUI_SIGNUP_OPEN \
+  --apply
+```
+
+Repeat `--project` / `--key` as needed. Never run unscoped `--apply` until every
+`~` row has been verified vault == intended prod (owner checklist on GAP-339).
+
+### 2. Single-key break-glass (vault-private terminal only)
+
+When the CLI is older than scoped filters, or for one-off fixes:
+
+```bash
+# Vault-private terminal (REVVAULT_ALLOW_PRINT / vault-private). Never on stream.
+# Paths only on argv; value never appears in chat or agent tool logs.
+
+revvault get --full revealui/prod/admin/signup-open | \
+  vercel env add REVEALUI_SIGNUP_OPEN production --force
+```
+
+Prefer `revvault run` / `with-secrets` patterns for app commands. Full print is
+break-glass only (ADR stream-safe secrets).
+
+### 3. New vars from this gap
+
+| Env | Project | Vault path | Owner set |
+|-----|---------|------------|-----------|
+| `REVEALUI_SIGNUP_OPEN` | revealui-admin | `revealui/prod/admin/signup-open` | `true` / `false` string |
+| `REVEALUI_BUNDLE_PRO` | revealui-api | `revealui/prod/api/bundle-pro` | as deployed |
+
+```bash
+revvault set revealui/prod/admin/signup-open   # enter true or false
+revvault set revealui/prod/api/bundle-pro
+```
+
+Then scoped sync as above. Agents do **not** run `--apply` without named owner auth.
+
+### 4. Related
+
+- GAP-260 P4-4 license private key drop (separate owner cutover)
+- GAP-230 / GAP-231 Electric corrupt rows
+- `scripts/sync/revvault-vercel.toml` — manifest SSOT

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -113,6 +113,10 @@ REVEALUI_PREVIEW_TOKEN_SECRET = { path = "revealui/prod/preview-token-secret", s
 REVEALUI_CRON_SECRET = { path = "revealui/prod/cron-secret", sensitive = true }
 REVEALUI_ALERT_EMAIL = "revealui/prod/alert-email"
 
+# Pro bundle feature flag (boolean string). Must live in vault (GAP-339).
+# Owner must: revvault set revealui/prod/api/bundle-pro
+REVEALUI_BUNDLE_PRO = "revealui/prod/api/bundle-pro"
+
 # Storage — Cloudflare R2 (canonical, S3-compatible). All five set together.
 R2_ACCOUNT_ID         = "revealui/prod/r2/account-id"
 R2_ACCESS_KEY_ID      = { path = "revealui/prod/r2/access-key-id", sensitive = true }
@@ -132,6 +136,10 @@ EMAIL_REPLY_TO                = "revealui/prod/email/reply-to"
 PASSKEY_ORIGIN         = "revealui/prod/passkey/origin"
 PASSKEY_RP_ID          = "revealui/prod/passkey/rp-id"
 PASSKEY_RP_NAME        = "revealui/prod/passkey/rp-name"
+
+# Signup gate (boolean string true|false). Source of truth for self-serve funnel.
+# Owner must: revvault set revealui/prod/admin/signup-open  (value true/false)
+REVEALUI_SIGNUP_OPEN  = "revealui/prod/admin/signup-open"
 SESSION_COOKIE_DOMAIN  = "revealui/prod/session-cookie-domain"
 CORS_ORIGIN            = "revealui/prod/cors-origin"
 # REVEALUI_CORS_ORIGINS dropped 2026-05-09: code falls back to CORS_ORIGIN
@@ -218,6 +226,10 @@ REVEALUI_SECRET              = { path = "revealui/prod/secret", sensitive = true
 PASSKEY_ORIGIN         = "revealui/prod/passkey/origin"
 PASSKEY_RP_ID          = "revealui/prod/passkey/rp-id"
 PASSKEY_RP_NAME        = "revealui/prod/passkey/rp-name"
+
+# Signup gate (boolean string true|false). Source of truth for self-serve funnel.
+# Owner must: revvault set revealui/prod/admin/signup-open  (value true/false)
+REVEALUI_SIGNUP_OPEN  = "revealui/prod/admin/signup-open"
 
 # Cron + alerting (parity with api)
 REVEALUI_CRON_SECRET = { path = "revealui/prod/cron-secret", sensitive = true }

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -313,6 +313,26 @@ export const SECRET_PATHS: SecretPathDef[] = [
     tier: 'prod',
     consumers: ['vercel:admin'],
   },
+  // Self-serve funnel + Pro bundle flags (GAP-339). Public-config booleans;
+  // declared here so secret-paths lockstep matches revvault-vercel.toml.
+  {
+    path: 'revealui/prod/admin/signup-open',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'prod',
+    consumers: ['vercel:admin'],
+    envVars: ['REVEALUI_SIGNUP_OPEN'],
+    note: 'Boolean string; self-serve signup funnel gate (true/false)',
+  },
+  {
+    path: 'revealui/prod/api/bundle-pro',
+    kind: 'public-config',
+    sensitive: false,
+    tier: 'prod',
+    consumers: ['vercel:api'],
+    envVars: ['REVEALUI_BUNDLE_PRO'],
+    note: 'Pro bundle flag for hosted API',
+  },
   // ── Storage - Cloudflare R2 ───────────────────────────────────────────────
   {
     path: 'revealui/prod/r2/account-id',


### PR DESCRIPTION
## Summary

GAP-339 agent residual (no prod apply, no secret values):

1. **Manifest** — map unvaulted prod flags into `revvault-vercel.toml`:
   - admin `REVEALUI_SIGNUP_OPEN` → `revealui/prod/admin/signup-open`
   - api `REVEALUI_BUNDLE_PRO` → `revealui/prod/api/bundle-pro`
2. **Runbook** — `docs/security/REVVAULT-VERCEL-SCOPED-SYNC.md` (scoped `--project`/`--key`, single-key break-glass)
3. **SECRETS.md** index rows for the two paths

Pairs with revvault#159 (CLI filters).

## Owner residual

```bash
revvault set revealui/prod/admin/signup-open
revvault set revealui/prod/api/bundle-pro
# after revvault scoped CLI is on PATH:
revvault sync vercel --manifest scripts/sync/revvault-vercel.toml \
  --project revealui-admin --key REVEALUI_SIGNUP_OPEN --apply
# etc.
```

Also still owner: verify every unscoped `~` row before any full apply; GAP-230/231 Electric rows.

## Test plan

- [x] Manifest TOML still parses (human review)
- [x] Pre-push gate PASS