### PR TITLE
fix(sync): csrf SSOT + OfflineMutationQueue export (fleet-redundancy C12)

### DIFF
--- a/.changeset/fleet-redundancy-c12-csrf-offline-queue.md
+++ b/.changeset/fleet-redundancy-c12-csrf-offline-queue.md
@@ -1,0 +1,5 @@
+---
+"@revealui/sync": minor
+---
+
+Export OfflineMutationQueue (and OfflineQueueMutation) for demos/apps; use core readCsrfToken SSOT in sync csrfHeaders; add @revealui/core workspace dependency and ./offline-queue package export (fleet-redundancy C12 residual).

--- a/apps/admin/src/lib/utils/csrf.ts
+++ b/apps/admin/src/lib/utils/csrf.ts
@@ -1,20 +1,20 @@
+/**
+ * Admin browser CSRF helpers.
+ *
+ * Cookie reader is the fleet SSOT in `@revealui/core/admin/utils/csrf`
+ * (fleet-redundancy P2-C / 2026-08-07 C12 residual). This module keeps the
+ * admin-only attach predicate (`isCsrfTarget`) and `apiFetch` wrapper.
+ */
+
+import { readCsrfToken } from '@revealui/core/admin/utils/csrf';
+
+/**
+ * Read the `revealui-csrf` cookie value.
+ * Returns null outside a browser context or when the cookie is absent or empty.
+ * Thin null-coalesce over the core SSOT (`readCsrfToken` returns `undefined`).
+ */
 export function getCsrfToken(): string | null {
-  if (typeof document === 'undefined') return null;
-  for (const part of document.cookie.split(';')) {
-    const eqIdx = part.indexOf('=');
-    if (eqIdx === -1) continue;
-    const key = part.slice(0, eqIdx).trim();
-    if (key === 'revealui-csrf') {
-      const raw = part.slice(eqIdx + 1).trim();
-      if (!raw) return null;
-      try {
-        return decodeURIComponent(raw);
-      } catch {
-        return raw;
-      }
-    }
-  }
-  return null;
+  return readCsrfToken() ?? null;
 }
 
 const CSRF_UNSAFE = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);

--- a/docs/decisions/2026-08-07-core-alert-planes.md
+++ b/docs/decisions/2026-08-07-core-alert-planes.md
@@ -1,0 +1,70 @@
+---
+title: "Core alert planes: monitoring vs observability vs cron"
+description: "Document intentional ownership of the three alert surfaces in @revealui/core so agents do not merge them blindly or reintroduce dual cron paths."
+visibility: public
+status: verified
+audience: maintainer
+owner: RevealUI Studio
+last_verified: 2026-08-07
+---
+
+# ADR: Core alert planes (monitoring vs observability vs cron)
+
+**Date:** 2026-08-07  
+**Status:** Accepted  
+**Related:** fleet-redundancy C12 residual (2026-08-07 audit); cron SSOT already in `observability/cron-failure-alert`
+
+## Context
+
+The 2026-08-07 fleet redundancy audit flagged two files both named `alerts.ts` under `@revealui/core`:
+
+| Path | Primary export | Known consumer |
+|------|----------------|----------------|
+| `monitoring/alerts.ts` | `sendAlert` / `sendAlerts` / `alertManager` | `apps/admin` health-monitoring route |
+| `observability/alerts.ts` | `AlertingSystem` / `alerting` | `apps/server` bootstrap |
+| `observability/cron-failure-alert.ts` | `sendCronFailureAlert` | admin + server cron jobs |
+
+Raw scans treat basename collisions as debt. These three surfaces are **not** the same product: one is ops/health delivery, one is rule/threshold evaluation, one is the cron failure fan-out already consolidated.
+
+## Decision
+
+**Keep three intentional planes with fixed ownership.** Do not invent a fourth path. Do not reintroduce admin/server dual cron helpers.
+
+### 1. Cron failures — single module
+
+Use **only** `@revealui/core/observability/cron-failure-alert` (`sendCronFailureAlert`).  
+Apps inject Sentry + optional email. No parallel `cron-alert.ts` / `cron-alerts.ts` in apps.
+
+### 2. Observability rules — `AlertingSystem`
+
+Use **`@revealui/core/observability/alerts`** when you need named rules, cooldowns, channels, and firing/resolved lifecycle (server runtime thresholds).
+
+### 3. Monitoring / process health delivery — `sendAlert`
+
+Use **`@revealui/core/monitoring`** (`sendAlert` / `sendAlerts`) for process-health and ops-style alert delivery already wired through the monitoring package (admin health-monitoring).
+
+### Import guidance
+
+| Need | Import |
+|------|--------|
+| Cron job failed | `cron-failure-alert` |
+| Metric rule fired / resolved | `observability/alerts` (`AlertingSystem`) |
+| Process/health ops alert | `monitoring` (`sendAlert`) |
+
+## Consequences
+
+### Positive
+
+- Agents stop treating the basename collision as accidental clone debt.
+- Cron dual cannot return under "just mirror admin into server."
+- Future consolidation (if any) has a clear target map.
+
+### Negative / deferred
+
+- Two `Alert`-shaped types remain in different planes (monitoring types vs observability types). Full type unify is design-class and out of scope here.
+- Call sites must pick the plane consciously; a single mega-export would hide the wrong default.
+
+## Out of scope
+
+- Folding `monitoring/alerts` into `AlertingSystem` (behavior + Sentry DI differ).
+- Changing presentation or AI deprecation paths.

--- a/packages/core/src/client/admin/utils/csrf.ts
+++ b/packages/core/src/client/admin/utils/csrf.ts
@@ -1,9 +1,10 @@
 /**
- * CSRF helpers for browser clients (admin, auth hooks, agent stream).
+ * CSRF helpers for browser clients (admin, auth hooks, agent stream, sync).
  *
  * Single source of truth for reading the JS-readable `revealui-csrf` cookie
- * (fleet-redundancy P2-C). Consumers: this package's admin APIClient,
- * `@revealui/auth/react` (re-export), `@revealui/ai` useAgentStream.
+ * (fleet-redundancy P2-C; C12 residual 2026-08-07). Consumers: this package's
+ * admin APIClient, `@revealui/auth/react` (re-export), `@revealui/ai`
+ * useAgentStream, `@revealui/sync` csrfHeaders, and apps/admin `apiFetch`.
  *
  * The admin proxy and the api server's csrfMiddleware require any unsafe
  * request carrying a `revealui-session` cookie to echo this cookie as an

--- a/packages/core/src/monitoring/alerts.ts
+++ b/packages/core/src/monitoring/alerts.ts
@@ -1,8 +1,13 @@
 /**
- * Alert System
+ * Alert System (monitoring / process-health plane)
  *
  * Manages alert channels (logger, Sentry, console) and alert delivery.
  * Provides configurable thresholds and aggregation for production.
+ *
+ * Ownership (ADR 2026-08-07-core-alert-planes): this is the **monitoring**
+ * plane (`sendAlert`). Rule/threshold lifecycle lives in
+ * `observability/alerts` (`AlertingSystem`). Cron failures use only
+ * `observability/cron-failure-alert`. Do not reimplement a fourth path.
  */
 
 import { logger } from '../utils/logger-server.js';

--- a/packages/core/src/observability/alerts.ts
+++ b/packages/core/src/observability/alerts.ts
@@ -1,7 +1,12 @@
 /**
- * Alert System
+ * Alert System (observability rule plane)
  *
- * Configure and trigger alerts based on metrics and thresholds
+ * Configure and trigger alerts based on metrics and thresholds.
+ *
+ * Ownership (ADR 2026-08-07-core-alert-planes): this is the **observability**
+ * plane (`AlertingSystem`). Process/health ops delivery is
+ * `monitoring/alerts` (`sendAlert`). Cron failures use only
+ * `cron-failure-alert`. Do not reimplement a fourth path.
  */
 
 import { logger } from './logger.js';

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -7,6 +7,7 @@
     "@electric-sql/react": "^1.0.52",
     "@revealui/cache": "workspace:*",
     "@revealui/contracts": "workspace:*",
+    "@revealui/core": "workspace:*",
     "@revealui/db": "workspace:*",
     "lib0": "^0.2.117",
     "ws": "^8.21.0",
@@ -49,6 +50,11 @@
       "types": "./dist/collab/server-index.d.ts",
       "import": "./dist/collab/server-index.js",
       "default": "./dist/collab/server-index.js"
+    },
+    "./offline-queue": {
+      "types": "./dist/offline-queue.d.ts",
+      "import": "./dist/offline-queue.js",
+      "default": "./dist/offline-queue.js"
     }
   },
   "files": [

--- a/packages/sync/src/csrf.ts
+++ b/packages/sync/src/csrf.ts
@@ -1,35 +1,26 @@
 /**
  * Signed double-submit CSRF support for the admin sync mutation routes.
  *
+ * Cookie reader is the fleet SSOT in `@revealui/core/admin/utils/csrf`
+ * (fleet-redundancy P2-C / 2026-08-07 C12 residual). This module only adds
+ * same-origin header attach for sync hooks.
+ *
  * The admin proxy rejects any unsafe-method `/api/*` request that carries a
  * `revealui-session` cookie without an `X-CSRF-Token` header echoing the
- * JS-readable `revealui-csrf` cookie. Mirrors the attach pattern used by the
- * admin `apiFetch` helper and the core admin `APIClient`.
+ * JS-readable `revealui-csrf` cookie.
  */
 
-const CSRF_COOKIE_NAME = 'revealui-csrf';
+import { readCsrfToken } from '@revealui/core/admin/utils/csrf';
+
 const CSRF_HEADER_NAME = 'X-CSRF-Token';
 
 /**
  * Read the `revealui-csrf` cookie value.
  * Returns null outside a browser context or when the cookie is absent or empty.
+ * Thin null-coalesce over the core SSOT (`readCsrfToken` returns `undefined`).
  */
 export function getCsrfToken(): string | null {
-  if (typeof document === 'undefined') return null;
-  for (const part of document.cookie.split(';')) {
-    const eqIdx = part.indexOf('=');
-    if (eqIdx === -1) continue;
-    if (part.slice(0, eqIdx).trim() === CSRF_COOKIE_NAME) {
-      const raw = part.slice(eqIdx + 1).trim();
-      if (!raw) return null;
-      try {
-        return decodeURIComponent(raw);
-      } catch {
-        return raw;
-      }
-    }
-  }
-  return null;
+  return readCsrfToken() ?? null;
 }
 
 /**

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -126,4 +126,10 @@ export type {
 } from './hooks/useTaskSubmissions.js';
 export { useTaskSubmissions } from './hooks/useTaskSubmissions.js';
 export type { MutationResult } from './mutations.js';
+/**
+ * localStorage-backed offline mutation queue (table/operation shape).
+ * Distinct from conflict-resolution `OfflineMutation` (HTTP replay shape).
+ */
+export type { OfflineMutation as OfflineQueueMutation } from './offline-queue.js';
+export { OfflineMutationQueue } from './offline-queue.js';
 export { ElectricProvider, useElectricConfig } from './provider/index.js';

--- a/packages/sync/src/offline-queue.ts
+++ b/packages/sync/src/offline-queue.ts
@@ -1,6 +1,10 @@
 /**
- * Offline mutation queue  -  stores pending mutations in localStorage
+ * Offline mutation queue — stores pending mutations in localStorage
  * so they survive page reloads and can be flushed when connectivity returns.
+ *
+ * Public surface: import `{ OfflineMutationQueue, type OfflineQueueMutation }`
+ * from `@revealui/sync` (or `@revealui/sync/offline-queue`). The class was
+ * previously internal; demos and apps must not reimplement the same storage key.
  */
 
 /** localStorage key for the persisted queue. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1901,6 +1901,9 @@ importers:
       '@revealui/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@revealui/core':
+        specifier: workspace:*
+        version: link:../core
       '@revealui/db':
         specifier: workspace:*
         version: link:../db


### PR DESCRIPTION
## Summary

Fleet redundancy C12 residuals from the 2026-08-07 audit:

1. **CSRF cookie reader SSOT** — `apps/admin` and `@revealui/sync` now call `readCsrfToken` from `@revealui/core/admin/utils/csrf` instead of reimplementing cookie parse. Admin keeps `isCsrfTarget` / `apiFetch`; sync keeps same-origin `csrfHeaders`.
2. **Public offline queue** — export `OfflineMutationQueue` + `OfflineQueueMutation` from `@revealui/sync` (and `./offline-queue` subpath) so demos stop forking the storage key.
3. **Alert planes ADR** — document intentional ownership of monitoring vs observability vs cron-failure-alert (`docs/decisions/2026-08-07-core-alert-planes.md`).

## Test plan

- [x] `pnpm --filter @revealui/sync test` (258 tests including csrf + offline-queue)
- [x] `pnpm --filter @revealui/core exec vitest run src/client/admin/utils/__tests__/csrf.test.ts`
- [x] `pnpm turbo run build --filter=@revealui/sync...`
- [x] local `pnpm gate -- --phase=1 --changed` PASS
- [ ] CI green on PR
- [ ] After merge + release: land demo-offline-sync#8 (`@revealui/sync` ^0.4.0)

## Notes

- Changeset: `@revealui/sync` **minor** (new public export + core dependency).
- Does not delete AI `mcpToolSource` (REMOVE-BY ai@1.0.0).
- Companion: jv lane refresh #1115; demo consumer #8 (blocked on publish).