### PR TITLE
chore(release): version packages (sync 0.4.0, core 0.13.0, ai 0.10.0, harnesses 0.13.0)

### DIFF
--- a/.changeset/fleet-redundancy-c12-csrf-offline-queue.md
+++ b/.changeset/fleet-redundancy-c12-csrf-offline-queue.md
@@ -1,5 +1,0 @@
----
-"@revealui/sync": minor
----
-
-Export OfflineMutationQueue (and OfflineQueueMutation) for demos/apps; use core readCsrfToken SSOT in sync csrfHeaders; add @revealui/core workspace dependency and ./offline-queue package export (fleet-redundancy C12 residual).

--- a/.changeset/gap-215-presigned-r2-upload.md
+++ b/.changeset/gap-215-presigned-r2-upload.md
@@ -1,5 +1,0 @@
----
-"@revealui/core": minor
----
-
-Add StorageProvider createPresignedPutUrl, headObject, and getObjectRange for direct-to-R2 media uploads (GAP-215)

--- a/.changeset/gap-297-hardware-capability-profiles.md
+++ b/.changeset/gap-297-hardware-capability-profiles.md
@@ -1,5 +1,0 @@
----
-"@revealui/ai": minor
----
-
-Add hardware capability profiles (constrained / mainstream / workstation) for GAP-297 local-inference vocabulary. Additive; no default path change when unconfigured.

--- a/.changeset/gap-362-token-economy-rule.md
+++ b/.changeset/gap-362-token-economy-rule.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": minor
----
-
-Add control-layer `token-economy` hardline rule (GAP-362) to preamble tier 1.

--- a/.changeset/gap-381-phase-a-receipts.md
+++ b/.changeset/gap-381-phase-a-receipts.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-GAP-381 Phase A: flushSpoolAsync POSTs to /api/harness/receipts; server ingest route.

--- a/apps/license-signer/CHANGELOG.md
+++ b/apps/license-signer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/license-signer
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+
 ## 0.1.3
 
 ### Patch Changes

--- a/apps/license-signer/package.json
+++ b/apps/license-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/license-signer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Isolated license JWT mint service (GAP-260 P4-2). Holds the signing private key; HMAC-authed internal mint API.",
   "private": true,
   "type": "module",

--- a/apps/rsc-poc/CHANGELOG.md
+++ b/apps/rsc-poc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @rsc-poc/app
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsc-poc/app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "GAP-194 Phase 2.1 RSC POC sandbox — revived for Phase 2.2.2 T0 gate (archive/rsc-poc-spike). Integration harness for dual-mode @revealui/router 0.4 RSC work.",
   "private": true,
   "type": "module",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @revealui/ai
 
+## 0.10.0
+
+### Minor Changes
+
+- 86048ac: Add hardware capability profiles (constrained / mainstream / workstation) for GAP-297 local-inference vocabulary. Additive; no default path change when unconfigured.
+
+### Patch Changes
+
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/ai",
-  "version": "0.9.1",
-  "description": "AI runtime for agent-driven products \u2014 agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
+  "version": "0.10.0",
+  "description": "AI runtime for agent-driven products — agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
   "keywords": [
     "agent",
     "ai",

--- a/packages/apify-actor-governed-run/CHANGELOG.md
+++ b/packages/apify-actor-governed-run/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @revealui/apify-actor-governed-run
 
+## 0.1.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/apify-actor-governed-run/package.json
+++ b/packages/apify-actor-governed-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/apify-actor-governed-run",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Apify pay-per-event actor: runs an AI agent task and returns a cryptographically signed, offline-verifiable receipt of every action (GAP-431).",
   "type": "module",

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/auth
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/auth",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Database-backed session auth for Hono and Next.js — bcrypt, OAuth, brute-force protection, rate limiting, password reset. Ships with RevealUI.",
   "keywords": [
     "auth",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @revealui/cli
 
+## 0.9.6
+
 ## 0.9.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/cli",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Create RevealUI projects with a single command",
   "keywords": [
     "cli",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/core
 
+## 0.13.0
+
+### Minor Changes
+
+- fcd7273: Add StorageProvider createPresignedPutUrl, headObject, and getObjectRange for direct-to-R2 media uploads (GAP-215)
+
 ## 0.12.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/core",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {

--- a/packages/create-revealui/CHANGELOG.md
+++ b/packages/create-revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-revealui
 
+## 0.5.19
+
+### Patch Changes
+
+- @revealui/cli@0.9.6
+
 ## 0.5.18
 
 ### Patch Changes

--- a/packages/create-revealui/package.json
+++ b/packages/create-revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-revealui",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "Create a new RevealUI project",
   "keywords": [
     "cli",

--- a/packages/engines/CHANGELOG.md
+++ b/packages/engines/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @revealui/engines
 
+## 0.4.12
+
+### Patch Changes
+
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+  - @revealui/auth@0.5.2
+  - @revealui/services@0.7.11
+
 ## 0.4.11
 
 ### Patch Changes

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/engines",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": true,
   "description": "Unified entry point for the five RevealUI business primitives: people, content, offers, payments, agents.",
   "license": "FSL-1.1-MIT",

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @revealui/harnesses
 
+## 0.13.0
+
+### Minor Changes
+
+- 04d7fdb: Add control-layer `token-economy` hardline rule (GAP-362) to preamble tier 1.
+
+### Patch Changes
+
+- bcd515f: GAP-381 Phase A: flushSpoolAsync POSTs to /api/harness/receipts; server ingest route.
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "AI harness integration — CLI, content definitions, and CI gates; the coordination daemon lives in RevDev.",
   "repository": {
     "type": "git",

--- a/packages/knowledge-graph/CHANGELOG.md
+++ b/packages/knowledge-graph/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @revealui/knowledge-graph
 
+## 0.1.7
+
 ## 0.1.6
 
 ## 0.1.5

--- a/packages/knowledge-graph/package.json
+++ b/packages/knowledge-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/knowledge-graph",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Fleet knowledge graph — bi-temporal, content-addressed graph (ontology, deterministic IDs, deterministic ingestion, hybrid search) over Neon + pgvector. GAP-340.",
   "keywords": [
     "knowledge-graph",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/mcp
 
+## 0.8.5
+
+### Patch Changes
+
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+  - @revealui/knowledge-graph@0.1.7
+
 ## 0.8.4
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/mcp",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Model Context Protocol framework — first-party server launchers, adapter pattern, tool discovery, and an incubating multi-server hypervisor (not app-mounted by default; ADR-007).",
   "repository": {
     "type": "git",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/RevealUIStudio/revealui",
     "source": "github"
   },
-  "version": "0.8.4",
+  "version": "0.8.5",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@revealui/mcp",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/revealui/CHANGELOG.md
+++ b/packages/revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # revealui
 
+## 0.1.14
+
+### Patch Changes
+
+- create-revealui@0.5.19
+
 ## 0.1.13
 
 ### Patch Changes

--- a/packages/revealui/package.json
+++ b/packages/revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revealui",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "description": "RevealUI — open-source agentic business runtime. Meta-installer that proxies to create-revealui. NOT published: npm rejects bare 'revealui' as too similar to 'reveal-ui'; use 'create-revealui' (npm create revealui) or '@revealui/core' instead.",
   "keywords": [

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/services
 
+## 0.7.11
+
+### Patch Changes
+
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+
 ## 0.7.10
 
 ### Patch Changes

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/services",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "External service integrations, Stripe (payment processing + circuit breaker) and email (Gmail API delivery). Ships with RevealUI.",
   "repository": {
     "type": "git",

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @revealui/sync
 
+## 0.4.0
+
+### Minor Changes
+
+- 320b98b: Export OfflineMutationQueue (and OfflineQueueMutation) for demos/apps; use core readCsrfToken SSOT in sync csrfHeaders; add @revealui/core workspace dependency and ./offline-queue package export (fleet-redundancy C12 residual).
+
+### Patch Changes
+
+- Updated dependencies [fcd7273]
+  - @revealui/core@0.13.0
+
 ## 0.3.20
 
 ### Patch Changes

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/sync",
-  "version": "0.3.20",
+  "version": "0.4.0",
   "description": "Real-time sync layer wrapping ElectricSQL and Yjs CRDT — offline queue, shape cache, conflict resolution, collaborative documents. Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Release version batch

Applies `pnpm changeset:version` on `origin/test` for 5 pending changesets.

### Notable bumps
| Package | To |
|---------|-----|
| `@revealui/sync` | **0.4.0** (OfflineMutationQueue export) |
| `@revealui/core` | **0.13.0** (presigned R2) |
| `@revealui/ai` | **0.10.0** (hardware capability profiles) |
| `@revealui/harnesses` | **0.13.0** (token-economy + receipts) |
| `@revealui/mcp` | 0.8.5 (+ server.json lockstep) |
| + patch cascade | auth, cli, services, … |

### After merge
1. Promote `test` → `main` (merge commit)
2. Dispatch `release.yml` on `main` for OIDC npm publish (unblocks demo-offline-sync `^0.4.0`)