### PR TITLE
fix(marketing): ClaimsPage coverage timeout (blocks #2440)

### DIFF
--- a/apps/marketing/app/routes/__tests__/ClaimsPage.test.tsx
+++ b/apps/marketing/app/routes/__tests__/ClaimsPage.test.tsx
@@ -39,12 +39,11 @@ describe('ClaimsPage', () => {
   });
 
   it('deep-links "code" evidence to the public GitHub repo', async () => {
-    render(<ClaimsPage />);
-    const allLinks = await screen.findAllByRole('link');
+    const { container } = render(<ClaimsPage />);
+    // Wait for ledger rows (page is large; full a11y link tree times out under coverage).
+    await screen.findAllByTestId('claim-row');
     const codeEvidenceHrefPrefix = 'https://github.com/RevealUIStudio/revealui/blob/main/';
-    const codeLinks = allLinks.filter((link) =>
-      (link.getAttribute('href') ?? '').startsWith(codeEvidenceHrefPrefix),
-    );
+    const codeLinks = container.querySelectorAll(`a[href^="${codeEvidenceHrefPrefix}"]`);
     expect(codeLinks.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Why
`revealui#2440` (promote test→main) is blocked by required **Coverage** failure.

`apps/marketing` `ClaimsPage` test `deep-links "code" evidence…` timed out at 30s under v8 coverage: `findAllByRole('link')` walks the full claims ledger accessibility tree.

## Fix
- Wait for `claim-row` test ids (page ready)
- Query `a[href^="…/blob/main/"]` via `container.querySelectorAll` (assertion intent unchanged)

## Proof
Local:
- `vitest run app/routes/__tests__/ClaimsPage.test.tsx` — 5/5 pass (~5.6s)
- same with `--coverage` — 5/5 pass (~8s); deep-links ~1.7s
- pre-push phase-1 gate PASS

## Follow-up
After merge to `test`, #2440 re-runs Coverage and can promote with merge-commit.