### PR TITLE
feat(security,harnesses): GAP-381 policy snapshot Ed25519 (I-5 residual)

### DIFF
--- a/.changeset/gap-381-policy-snapshot-crypto.md
+++ b/.changeset/gap-381-policy-snapshot-crypto.md
@@ -1,0 +1,6 @@
+---
+"@revealui/security": minor
+"@revealui/harnesses": minor
+---
+
+GAP-381 I-5: Ed25519 sign/verify for harness policy snapshots; enforced tier only when signature verifies.

--- a/.github/workflows/archive-check.yml
+++ b/.github/workflows/archive-check.yml
@@ -58,18 +58,18 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
-      # SCOPED install, not a full monorepo one. This gate needs exactly one
-      # package built; installing all 27 workspaces cold took over 10 minutes
-      # and hit the job timeout before the check ever ran, turning this gate
-      # into a red X on unrelated PRs. Same shape as security-review-gate.yml,
-      # which is the other lightweight gate job in this repo.
-      - name: Install (harnesses only)
-        run: pnpm install --frozen-lockfile --filter @revealui/harnesses
+      # SCOPED install: harnesses + its workspace deps (not the full monorepo).
+      # Full install took 10+ minutes and timed out on unrelated PRs. Same shape
+      # as security-review-gate.yml. `...` includes deps such as
+      # @revealui/security (GAP-381 policy crypto) required for harnesses DTS.
+      - name: Install (harnesses + deps)
+        run: pnpm install --frozen-lockfile --filter @revealui/harnesses...
 
       # The gate fails closed if it cannot resolve the shared module, so the
-      # build is a hard prerequisite rather than an optimization.
+      # build is a hard prerequisite rather than an optimization. Build deps
+      # first so @revealui/security/server types exist for tsup DTS.
       - name: Build the shared gates module
-        run: pnpm --filter @revealui/harnesses build
+        run: pnpm turbo run build --filter=@revealui/harnesses...
 
       # jv#871: a gate is not wired until CI has observed it green AND red.
       # Seeding a violation into the repo cannot prove the red half, because

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,13 +104,15 @@ jobs:
         # into src/ (GAP-421 §6.2): doc-currency.ts resolves its
         # SHARED_FLEET_RULES detection tuples from dist/gates, and
         # structure.ts resolves checkManager from dist/manager (manager-resolver.cjs,
-        # mirroring gates-resolver.cjs). Building just this one package is
-        # cheap relative to the whole monorepo (Quality is install-only
-        # otherwise). Absence degrades gracefully for doc-currency (warn +
-        # shared-rules-skipped run) but fails closed for the manager check
-        # (GAP-406 hard-fail posture), so this step must run before Structure
-        # validation and the path-gated manager-only check below.
-        run: pnpm --filter @revealui/harnesses build
+        # mirroring gates-resolver.cjs). Absence degrades gracefully for
+        # doc-currency (warn + shared-rules-skipped run) but fails closed for
+        # the manager check (GAP-406 hard-fail posture), so this step must run
+        # before Structure validation and the path-gated manager-only check
+        # below.
+        # `...` includes workspace deps (e.g. @revealui/security for policy
+        # snapshot crypto / GAP-381 I-5) so DTS can resolve @revealui/security/server.
+        # turbo ^build order applies.
+        run: pnpm turbo run build --filter=@revealui/harnesses...
         env:
           SKIP_ENV_VALIDATION: "true"
 

--- a/.github/workflows/sec-audit-label-guard.yml
+++ b/.github/workflows/sec-audit-label-guard.yml
@@ -93,8 +93,9 @@ jobs:
       - name: Build @revealui/harnesses (guardrail2-verdict gates module, GAP-408)
         run: |
           set -euo pipefail
-          pnpm install --frozen-lockfile --filter @revealui/harnesses
-          pnpm --filter @revealui/harnesses build
+          # Include workspace deps (e.g. @revealui/security) for harnesses DTS.
+          pnpm install --frozen-lockfile --filter @revealui/harnesses...
+          pnpm turbo run build --filter=@revealui/harnesses...
 
       - name: Guard the clearance label
         env:

--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -98,8 +98,9 @@ jobs:
       - name: Build @revealui/harnesses (guardrail2-verdict gates module, GAP-408)
         run: |
           set -euo pipefail
-          pnpm install --frozen-lockfile --filter @revealui/harnesses
-          pnpm --filter @revealui/harnesses build
+          # Include workspace deps (e.g. @revealui/security) for harnesses DTS.
+          pnpm install --frozen-lockfile --filter @revealui/harnesses...
+          pnpm turbo run build --filter=@revealui/harnesses...
 
       - name: Evaluate review gate
         env:

--- a/apps/server/src/routes/__tests__/harness-receipts.test.ts
+++ b/apps/server/src/routes/__tests__/harness-receipts.test.ts
@@ -164,7 +164,7 @@ describe('GAP-381 Phase A: POST /api/harness/receipts', () => {
     expect(entry.payload.userId).not.toBe('forged@attacker.example');
   });
 
-  it('I-5: coerces client enforcementTier=enforced to advisory until signatures exist', async () => {
+  it('I-5: coerces client enforcementTier=enforced to advisory without a verifiable snapshot', async () => {
     const result = await handleReceiptsPost(USER, 'acct_1', {
       source: 'vscode',
       kind: 'pre-shell',
@@ -190,12 +190,28 @@ describe('GAP-381 Phase A: POST /api/harness/receipts', () => {
     expect(key).toContain(USER.id);
   });
 
-  it('GET /policy-snapshot returns advisory structure-only document', async () => {
-    const app = mountWithAuth({ user: USER, deviceAuth: true });
-    const res = await app.request('/api/harness/policy-snapshot');
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { enforcementTier: string; rules: unknown[] };
-    expect(body.enforcementTier).toBe('advisory');
-    expect(Array.isArray(body.rules)).toBe(true);
+  it('GET /policy-snapshot returns advisory structure-only document without signing keys', async () => {
+    const prev = {
+      policy: process.env.REVEALUI_POLICY_SIGNING_KEY,
+      audit: process.env.REVEALUI_AUDIT_SIGNING_KEY,
+    };
+    delete process.env.REVEALUI_POLICY_SIGNING_KEY;
+    delete process.env.REVEALUI_AUDIT_SIGNING_KEY;
+    try {
+      const app = mountWithAuth({ user: USER, deviceAuth: true });
+      const res = await app.request('/api/harness/policy-snapshot');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        enforcementTier: string;
+        rules: unknown[];
+        keyId: string;
+      };
+      expect(body.enforcementTier).toBe('advisory');
+      expect(body.keyId).toBe('unsigned-structure-only');
+      expect(Array.isArray(body.rules)).toBe(true);
+    } finally {
+      if (prev.policy) process.env.REVEALUI_POLICY_SIGNING_KEY = prev.policy;
+      if (prev.audit) process.env.REVEALUI_AUDIT_SIGNING_KEY = prev.audit;
+    }
   });
 });

--- a/apps/server/src/routes/harness-receipts.ts
+++ b/apps/server/src/routes/harness-receipts.ts
@@ -20,6 +20,13 @@
 import { createHash } from 'node:crypto';
 import { checkRateLimit } from '@revealui/auth/server';
 import { logger } from '@revealui/core/observability/logger';
+import {
+  createPolicySnapshotSignerFromEnv,
+  signPolicySnapshot,
+  UNSIGNED_POLICY_KEY_ID,
+  UNSIGNED_POLICY_SIGNATURE,
+  verifyPolicySnapshot,
+} from '@revealui/security/server';
 import type { Handler, MiddlewareHandler } from 'hono';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -119,6 +126,11 @@ interface ReceiptBody {
   raw?: unknown;
   /** Client may send precomputed digest; otherwise we hash a safe subset. */
   rawDigest?: unknown;
+  /**
+   * Optional policy snapshot the client used for an `enforced` claim (I-5).
+   * Server re-verifies the signature before accepting `enforced`.
+   */
+  policySnapshot?: unknown;
 }
 
 function asString(v: unknown): string | undefined {
@@ -176,10 +188,43 @@ export async function handleReceiptsPost(
     if (!TIERS.has(tier)) {
       throw new HTTPException(400, { message: `Invalid enforcementTier: ${tier}` });
     }
-    // I-5: never accept client claim of enforced without signature verification.
-    // Until policy-snapshot crypto lands, force advisory on ingest storage.
-    const enforcementTier: 'enforced' | 'advisory' =
-      tier === 'enforced' ? 'advisory' : (tier as 'advisory');
+    // I-5: never accept client claim of enforced without re-verifying a signed
+    // policy snapshot the client attaches (or default advisory).
+    let enforcementTier: 'enforced' | 'advisory' = 'advisory';
+    if (tier === 'enforced') {
+      const snap = item.policySnapshot;
+      if (snap && typeof snap === 'object') {
+        const doc = snap as {
+          version?: unknown;
+          issuedAt?: unknown;
+          rules?: unknown;
+          keyId?: unknown;
+          signature?: unknown;
+        };
+        if (
+          typeof doc.version === 'number' &&
+          typeof doc.issuedAt === 'string' &&
+          Array.isArray(doc.rules) &&
+          typeof doc.keyId === 'string' &&
+          typeof doc.signature === 'string'
+        ) {
+          const { resolvePublicKey } = createPolicySnapshotSignerFromEnv(process.env);
+          const verified = verifyPolicySnapshot(
+            {
+              version: doc.version,
+              issuedAt: doc.issuedAt,
+              rules: doc.rules,
+              keyId: doc.keyId,
+              signature: doc.signature,
+            },
+            resolvePublicKey,
+          );
+          if (verified.valid) {
+            enforcementTier = 'enforced';
+          }
+        }
+      }
+    }
 
     const decision = asString(item.decision);
     if (decision !== undefined && !DECISIONS.has(decision)) {
@@ -227,18 +272,35 @@ export const postReceiptsHandler: Handler = async (c) => {
 };
 
 /**
- * Policy snapshot for offline hook evaluation. Structure-only / advisory
- * until a signing primitive lands in @revealui/security (I-5).
+ * Policy snapshot for offline hook evaluation (I-5).
+ * When a policy (or audit fallback) Ed25519 key is configured, the document
+ * is signed and `enforcementTier` is `enforced`. Without a key, structure-only
+ * advisory placeholders are returned so hooks still boot.
  */
 export const getPolicySnapshotHandler: Handler = async (c) => {
-  return c.json({
+  const issuedAt = new Date().toISOString();
+  const body = {
     version: 1,
-    keyId: 'unsigned-structure-only',
-    signature: 'unsigned',
-    issuedAt: new Date().toISOString(),
-    enforcementTier: 'advisory' as const,
+    issuedAt,
+    // Empty deny-list is a valid signed product state until org policy UI lands.
     rules: [] as const,
-    note: 'Structure-only snapshot; cryptographic enforcement is not available yet',
+  };
+  const { cryptoSigner, mode } = createPolicySnapshotSignerFromEnv(process.env);
+  if (mode === 'unsigned' || !cryptoSigner) {
+    return c.json({
+      ...body,
+      keyId: UNSIGNED_POLICY_KEY_ID,
+      signature: UNSIGNED_POLICY_SIGNATURE,
+      enforcementTier: 'advisory' as const,
+      note: 'Structure-only snapshot; set REVEALUI_POLICY_SIGNING_KEY (or audit signing key) for cryptographic enforcement',
+    });
+  }
+  const signed = signPolicySnapshot(body, cryptoSigner);
+  return c.json({
+    ...body,
+    keyId: signed.keyId,
+    signature: signed.signature,
+    enforcementTier: 'enforced' as const,
   });
 };
 

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@revealui/core": "workspace:*",
+    "@revealui/security": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/harnesses/src/__tests__/hook-policy.test.ts
+++ b/packages/harnesses/src/__tests__/hook-policy.test.ts
@@ -56,7 +56,23 @@ describe('loadPolicySnapshot', () => {
     expect(!result.valid && result.reason).toBe('invalid-shape');
   });
 
-  it('loads a structurally well-formed snapshot', async () => {
+  it('loads a structurally well-formed unsigned snapshot without cryptoVerified', async () => {
+    const path = join(dir, 'snapshot.json');
+    const snapshot = {
+      version: 1,
+      keyId: 'unsigned-structure-only',
+      signature: 'unsigned',
+      issuedAt: new Date().toISOString(),
+      rules: [{ source: 'cursor', kind: 'pre-shell', permission: 'deny', reason: 'no shell' }],
+    };
+    await writeFile(path, JSON.stringify(snapshot), 'utf8');
+    const result = await loadPolicySnapshot(path);
+    expect(result.valid).toBe(true);
+    expect(result.valid && result.cryptoVerified).toBe(false);
+    expect(result.valid && result.snapshot.rules).toHaveLength(1);
+  });
+
+  it('loads a structure-only signed-looking snapshot as not cryptoVerified without public key', async () => {
     const path = join(dir, 'snapshot.json');
     const snapshot = {
       version: 1,
@@ -66,9 +82,26 @@ describe('loadPolicySnapshot', () => {
       rules: [{ source: 'cursor', kind: 'pre-shell', permission: 'deny', reason: 'no shell' }],
     };
     await writeFile(path, JSON.stringify(snapshot), 'utf8');
-    const result = await loadPolicySnapshot(path);
-    expect(result.valid).toBe(true);
-    expect(result.valid && result.snapshot.rules).toHaveLength(1);
+    const prev = {
+      policy: process.env.REVEALUI_POLICY_PUBLIC_KEY,
+      audit: process.env.REVEALUI_AUDIT_PUBLIC_KEY,
+      policyPriv: process.env.REVEALUI_POLICY_SIGNING_KEY,
+      auditPriv: process.env.REVEALUI_AUDIT_SIGNING_KEY,
+    };
+    delete process.env.REVEALUI_POLICY_PUBLIC_KEY;
+    delete process.env.REVEALUI_AUDIT_PUBLIC_KEY;
+    delete process.env.REVEALUI_POLICY_SIGNING_KEY;
+    delete process.env.REVEALUI_AUDIT_SIGNING_KEY;
+    try {
+      const result = await loadPolicySnapshot(path);
+      expect(result.valid).toBe(true);
+      expect(result.valid && result.cryptoVerified).toBe(false);
+    } finally {
+      if (prev.policy) process.env.REVEALUI_POLICY_PUBLIC_KEY = prev.policy;
+      if (prev.audit) process.env.REVEALUI_AUDIT_PUBLIC_KEY = prev.audit;
+      if (prev.policyPriv) process.env.REVEALUI_POLICY_SIGNING_KEY = prev.policyPriv;
+      if (prev.auditPriv) process.env.REVEALUI_AUDIT_SIGNING_KEY = prev.auditPriv;
+    }
   });
 });
 
@@ -87,6 +120,7 @@ describe('evaluatePolicy', () => {
     const decision = evaluatePolicy(
       {
         valid: true,
+        cryptoVerified: false,
         snapshot: {
           version: 1,
           keyId: 'k1',
@@ -105,6 +139,7 @@ describe('evaluatePolicy', () => {
     const decision = evaluatePolicy(
       {
         valid: true,
+        cryptoVerified: false,
         snapshot: {
           version: 1,
           keyId: 'k1',
@@ -137,12 +172,16 @@ describe('evaluatePolicy', () => {
         },
       ],
     };
-    expect(evaluatePolicy({ valid: true, snapshot }, toolEvent).permission).toBe('ask');
+    expect(
+      evaluatePolicy({ valid: true, cryptoVerified: false, snapshot }, toolEvent).permission,
+    ).toBe('ask');
 
     const otherTool = normalizeCursorHookEvent(
       { hook_event_name: 'preToolUse', tool_name: 'SafeTool' },
       'advisory',
     );
-    expect(evaluatePolicy({ valid: true, snapshot }, otherTool).permission).toBe('allow');
+    expect(
+      evaluatePolicy({ valid: true, cryptoVerified: false, snapshot }, otherTool).permission,
+    ).toBe('allow');
   });
 });

--- a/packages/harnesses/src/hooks/policy.ts
+++ b/packages/harnesses/src/hooks/policy.ts
@@ -8,25 +8,21 @@
  * snapshot degrades to advisory mode and SAYS SO -- it never silently
  * claims enforcement it cannot back up.
  *
- * SIGNING DEVIATION (recorded per the build brief, do not remove without
- * updating the report this shipped with): design doc §5 says to reuse an
- * existing signing primitive from `@revealui/security`, auditing at build
- * time for the exact fit. That package (`packages/security/src/*`) ships
- * only symmetric AES-GCM encryption (`encryption.ts`) and SHA-256/384/512
- * digests -- no asymmetric sign/verify primitive. The fleet's one Ed25519
- * sign/verify precedent (`packages/core/src/license.ts`, via `jose`) is
- * NOT in `@revealui/security` and pulling `jose` into `@revealui/harnesses`
- * would add a new dependency, which this build is scoped to avoid. Per the
- * documented fallback: this module does STRUCTURE validation only --
- * `PolicySnapshotSchema` requires `signature` and `keyId` fields to be
- * present and well-formed, but never cryptographically verifies them.
- * TODO(security, blocks a real "enforced" claim beyond structural validity):
- * once a signing primitive lands in `@revealui/security` (or `jose` is
- * accepted as a dependency here), replace `parsePolicySnapshot`'s structural
- * check with an actual signature verification before returning `valid: true`.
+ * Cryptographic verification (GAP-381 residual, 2026-08-07): uses
+ * `@revealui/security/server` Ed25519 (same wire format as audit Stage 3).
+ * A structurally valid but unsigned / unverified snapshot still evaluates
+ * rules (denies can only tighten) but reports `cryptoVerified: false` so
+ * receipts stay `advisory`. Only a verified signature yields
+ * `cryptoVerified: true` and allows an `enforced` receipt tier.
  */
 
 import { readFile } from 'node:fs/promises';
+import {
+  createPolicySnapshotSignerFromEnv,
+  UNSIGNED_POLICY_KEY_ID,
+  UNSIGNED_POLICY_SIGNATURE,
+  verifyPolicySnapshot,
+} from '@revealui/security/server';
 import { z } from 'zod';
 import type {
   HarnessHookEvent,
@@ -44,9 +40,9 @@ export interface PolicySnapshotRule {
 }
 
 /**
- * A policy snapshot as read from disk. `signature` + `keyId` are present in
- * the schema so the format is ready for real verification (see the TODO
- * above); today they are checked for well-formedness only.
+ * A policy snapshot as read from disk. `signature` + `keyId` are required
+ * fields; cryptographic validity is reported via `cryptoVerified` on the
+ * load result, not by inventing a second document shape.
  */
 export interface PolicySnapshot {
   readonly version: number;
@@ -91,17 +87,29 @@ export type PolicySnapshotInvalidReason =
   | 'missing'
   | 'unreadable'
   | 'invalid-json'
-  | 'invalid-shape';
+  | 'invalid-shape'
+  | 'invalid-signature';
 
 export type PolicySnapshotLoadResult =
-  | { readonly valid: true; readonly snapshot: PolicySnapshot }
+  | {
+      readonly valid: true;
+      readonly snapshot: PolicySnapshot;
+      /**
+       * True only when the Ed25519 signature verified against a known public
+       * key. Receipts may claim `enforced` only when this is true (I-5).
+       */
+      readonly cryptoVerified: boolean;
+    }
   | { readonly valid: false; readonly reason: PolicySnapshotInvalidReason };
 
 /**
- * Load + structurally validate a policy snapshot from `path`. Never throws:
- * every failure mode (missing file, unreadable, malformed JSON, wrong
- * shape) collapses to `{ valid: false, reason }` so the caller's advisory
- * fallback (design invariant I-5) is unconditional.
+ * Load + validate a policy snapshot from `path`. Never throws: every
+ * failure mode collapses to `{ valid: false, reason }` so the caller's
+ * advisory fallback (design invariant I-5) is unconditional.
+ *
+ * When a public key is available (env), cryptographic verification is
+ * required for non-placeholder signatures: a bad signature is
+ * `invalid-signature` (not a silent valid document).
  */
 export async function loadPolicySnapshot(path: string): Promise<PolicySnapshotLoadResult> {
   let contents: string;
@@ -125,7 +133,27 @@ export async function loadPolicySnapshot(path: string): Promise<PolicySnapshotLo
     return { valid: false, reason: 'invalid-shape' };
   }
 
-  return { valid: true, snapshot: result.data };
+  const snapshot = result.data;
+  const isPlaceholder =
+    snapshot.signature === UNSIGNED_POLICY_SIGNATURE || snapshot.keyId === UNSIGNED_POLICY_KEY_ID;
+
+  if (isPlaceholder) {
+    return { valid: true, snapshot, cryptoVerified: false };
+  }
+
+  const { resolvePublicKey, mode } = createPolicySnapshotSignerFromEnv(process.env);
+  if (mode === 'unsigned') {
+    // Structurally valid signed-looking document but no local public key:
+    // apply rules defensively, never claim enforced (I-5).
+    return { valid: true, snapshot, cryptoVerified: false };
+  }
+
+  const verified = verifyPolicySnapshot(snapshot, resolvePublicKey);
+  if (!verified.valid) {
+    return { valid: false, reason: 'invalid-signature' };
+  }
+
+  return { valid: true, snapshot, cryptoVerified: true };
 }
 
 /** The local policy decision for one hook event. */

--- a/packages/harnesses/src/hooks/run-hook.ts
+++ b/packages/harnesses/src/hooks/run-hook.ts
@@ -172,16 +172,15 @@ export async function runHookCommand(
 
   const snapshotResult = await loadPolicySnapshot(options.snapshotPath);
   // Honest enforcement tier (design invariant I-5): a receipt may claim
-  // `enforced` ONLY when the policy's authenticity is actually established.
-  // `loadPolicySnapshot` does STRUCTURE validation only today -- it does not
-  // cryptographically verify the snapshot signature (see policy.ts TODO), and
-  // no org/team config-pinning detection exists yet either. Until at least one
-  // of those lands, the tier is always `advisory`: a structurally valid
-  // snapshot's deny/ask rules are STILL applied by `evaluatePolicy` below (they
-  // can only tighten, never weaken -- defense in depth), but the receipt never
-  // overclaims enforcement it cannot back up. Flip this to a real conditional
-  // the moment signature verification ships.
-  const enforcementTier = 'advisory' as const;
+  // `enforced` ONLY when the policy signature cryptographically verifies
+  // (`cryptoVerified`). Structurally valid / unsigned snapshots still apply
+  // deny/ask rules below (they can only tighten), but the receipt stays
+  // `advisory` so we never overclaim enforcement. Org/team hook-config
+  // pinning is a separate future signal and is not claimed here.
+  const enforcementTier =
+    snapshotResult.valid && snapshotResult.cryptoVerified
+      ? ('enforced' as const)
+      : ('advisory' as const);
 
   const event = normalizeHookEvent(source, rawInput, enforcementTier);
   const decision = evaluatePolicy(snapshotResult, event);

--- a/packages/security/src/__tests__/policy-snapshot-signing.test.ts
+++ b/packages/security/src/__tests__/policy-snapshot-signing.test.ts
@@ -1,0 +1,126 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { createPolicySnapshotSignerFromEnv } from '../policy-snapshot-signer-env.js';
+import {
+  createPolicySnapshotSigner,
+  policySnapshotSignableBytes,
+  signPolicySnapshot,
+  UNSIGNED_POLICY_KEY_ID,
+  UNSIGNED_POLICY_SIGNATURE,
+  verifyPolicySnapshot,
+} from '../policy-snapshot-signing.js';
+
+function makeKeypair(): { privateKeyPem: string; publicKeyPem: string } {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  return {
+    privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    publicKeyPem: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+  };
+}
+
+describe('policy snapshot signing (GAP-381 I-5)', () => {
+  it('signs and verifies a snapshot round-trip', () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = createPolicySnapshotSigner(privateKeyPem, 'policy-kid-1');
+    const body = {
+      version: 1,
+      issuedAt: '2026-08-07T12:00:00.000Z',
+      rules: [{ kind: 'pre-shell', permission: 'deny', reason: 'no shell' }],
+    };
+    const { keyId, signature } = signPolicySnapshot(body, signer);
+    expect(keyId).toBe('policy-kid-1');
+    expect(signature.startsWith('v1.ed25519.policy-kid-1.')).toBe(true);
+
+    const result = verifyPolicySnapshot({ ...body, keyId, signature }, (kid) =>
+      kid === 'policy-kid-1' ? publicKeyPem : null,
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails when rules are tampered after signing', () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const signer = createPolicySnapshotSigner(privateKeyPem, 'k1');
+    const body = {
+      version: 1,
+      issuedAt: '2026-08-07T12:00:00.000Z',
+      rules: [] as const,
+    };
+    const { keyId, signature } = signPolicySnapshot(body, signer);
+    const tampered = {
+      version: 1,
+      issuedAt: body.issuedAt,
+      rules: [{ kind: 'pre-tool', permission: 'deny' as const, reason: 'attacker' }],
+      keyId,
+      signature,
+    };
+    expect(
+      verifyPolicySnapshot(tampered, (kid) => (kid === 'k1' ? publicKeyPem : null)).valid,
+    ).toBe(false);
+  });
+
+  it('rejects unsigned structure-only placeholders', () => {
+    const result = verifyPolicySnapshot(
+      {
+        version: 1,
+        issuedAt: '2026-08-07T12:00:00.000Z',
+        rules: [],
+        keyId: UNSIGNED_POLICY_KEY_ID,
+        signature: UNSIGNED_POLICY_SIGNATURE,
+      },
+      () => null,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/unsigned/i);
+  });
+
+  it('canonical bytes are stable for the same body', () => {
+    const body = {
+      version: 2,
+      issuedAt: '2026-08-07T00:00:00.000Z',
+      rules: [{ b: 2, a: 1 }],
+    };
+    const a = policySnapshotSignableBytes(body);
+    const b = policySnapshotSignableBytes(body);
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+});
+
+describe('createPolicySnapshotSignerFromEnv', () => {
+  it('unsigned mode when no keys configured', () => {
+    const resolution = createPolicySnapshotSignerFromEnv({});
+    expect(resolution.mode).toBe('unsigned');
+    expect(resolution.cryptoSigner).toBeUndefined();
+  });
+
+  it('signed mode from REVEALUI_POLICY_SIGNING_KEY', () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const resolution = createPolicySnapshotSignerFromEnv({
+      REVEALUI_POLICY_SIGNING_KEY: privateKeyPem,
+      REVEALUI_POLICY_PUBLIC_KEY: publicKeyPem,
+      REVEALUI_POLICY_SIGNING_KID: 'env-kid',
+    });
+    expect(resolution.mode).toBe('signed');
+    expect(resolution.kid).toBe('env-kid');
+    expect(resolution.cryptoSigner).toBeDefined();
+
+    const body = { version: 1, issuedAt: '2026-08-07T12:00:00.000Z', rules: [] };
+    const signed = signPolicySnapshot(body, resolution.cryptoSigner!);
+    expect(
+      verifyPolicySnapshot(
+        { ...body, keyId: signed.keyId, signature: signed.signature },
+        resolution.resolvePublicKey,
+      ).valid,
+    ).toBe(true);
+  });
+
+  it('falls back to audit signing key when policy key absent', () => {
+    const { privateKeyPem, publicKeyPem } = makeKeypair();
+    const resolution = createPolicySnapshotSignerFromEnv({
+      REVEALUI_AUDIT_SIGNING_KEY: privateKeyPem,
+      REVEALUI_AUDIT_PUBLIC_KEY: publicKeyPem,
+      REVEALUI_AUDIT_SIGNING_KID: 'audit-kid',
+    });
+    expect(resolution.mode).toBe('signed');
+    expect(resolution.kid).toBe('audit-kid');
+  });
+});

--- a/packages/security/src/policy-snapshot-signer-env.ts
+++ b/packages/security/src/policy-snapshot-signer-env.ts
@@ -1,0 +1,93 @@
+/**
+ * Compose a policy-snapshot signer + public-key resolver from env (GAP-381 I-5).
+ *
+ * Preferred keys:
+ *   REVEALUI_POLICY_SIGNING_KEY / REVEALUI_POLICY_PUBLIC_KEY / REVEALUI_POLICY_SIGNING_KID
+ *
+ * Fallback (dogfood / single key fleet): audit Stage-3 keys
+ *   REVEALUI_AUDIT_SIGNING_KEY / REVEALUI_AUDIT_PUBLIC_KEY / REVEALUI_AUDIT_SIGNING_KID
+ *
+ * Fallback is intentional: policy signing must not invent a second secret
+ * store before operators can mint a dedicated keypair. Prefer dedicated
+ * policy keys in production so audit and policy rotate independently.
+ */
+
+import { createPrivateKey, createPublicKey, type KeyObject } from 'node:crypto';
+import { deriveAuditKid, normalizeEnvPem } from './audit-signer-env.js';
+import type { Ed25519AuditRowSigner } from './audit-signing.js';
+import { createPolicySnapshotSigner } from './policy-snapshot-signing.js';
+
+export type PolicySignerEnv = Record<string, string | undefined>;
+
+export interface PolicySnapshotSignerResolution {
+  /** Crypto signer, or undefined when no key is configured (unsigned mode). */
+  readonly cryptoSigner: Ed25519AuditRowSigner | undefined;
+  readonly mode: 'signed' | 'unsigned';
+  readonly kid?: string;
+  /**
+   * Resolve kid → public key for verify paths. Always defined; returns null
+   * when the kid is unknown or unsigned mode has no published key.
+   */
+  readonly resolvePublicKey: (kid: string) => string | KeyObject | null;
+}
+
+function readPrivatePem(env: PolicySignerEnv): string | undefined {
+  const policy = env.REVEALUI_POLICY_SIGNING_KEY?.trim();
+  if (policy && policy.length > 0) return normalizeEnvPem(policy);
+  const audit = env.REVEALUI_AUDIT_SIGNING_KEY?.trim();
+  if (audit && audit.length > 0) return normalizeEnvPem(audit);
+  return undefined;
+}
+
+function readPublicPem(env: PolicySignerEnv, privatePem: string | undefined): string | undefined {
+  const policy = env.REVEALUI_POLICY_PUBLIC_KEY?.trim();
+  if (policy && policy.length > 0) return normalizeEnvPem(policy);
+  const audit = env.REVEALUI_AUDIT_PUBLIC_KEY?.trim();
+  if (audit && audit.length > 0) return normalizeEnvPem(audit);
+  if (privatePem) {
+    // Derive SPKI public from private so signed mode always has a verifier.
+    const priv = createPrivateKey(privatePem);
+    return createPublicKey(priv).export({ type: 'spki', format: 'pem' }).toString();
+  }
+  return undefined;
+}
+
+function resolveKid(env: PolicySignerEnv, publicKey: KeyObject): string {
+  const override =
+    env.REVEALUI_POLICY_SIGNING_KID?.trim() || env.REVEALUI_AUDIT_SIGNING_KID?.trim();
+  return override && override.length > 0 ? override : deriveAuditKid(publicKey);
+}
+
+/**
+ * Compose policy snapshot signer + public resolver from env.
+ * A present-but-broken private key throws (fail loud), same as audit compose.
+ */
+export function createPolicySnapshotSignerFromEnv(
+  env: PolicySignerEnv = process.env,
+): PolicySnapshotSignerResolution {
+  const privatePem = readPrivatePem(env);
+  if (!privatePem) {
+    return {
+      cryptoSigner: undefined,
+      mode: 'unsigned',
+      resolvePublicKey: () => null,
+    };
+  }
+
+  const publicPem = readPublicPem(env, privatePem);
+  if (!publicPem) {
+    throw new Error(
+      'createPolicySnapshotSignerFromEnv: private key present but public key could not be resolved',
+    );
+  }
+  const publicKey = createPublicKey(publicPem);
+  const kid = resolveKid(env, publicKey);
+  const cryptoSigner = createPolicySnapshotSigner(privatePem, kid);
+
+  return {
+    cryptoSigner,
+    mode: 'signed',
+    kid,
+    resolvePublicKey: (requestedKid: string) => (requestedKid === kid ? publicPem : null),
+  };
+}

--- a/packages/security/src/policy-snapshot-signing.ts
+++ b/packages/security/src/policy-snapshot-signing.ts
@@ -1,0 +1,106 @@
+/**
+ * Ed25519 sign/verify for GAP-381 policy snapshots (design I-5).
+ *
+ * Reuses the Stage-3 audit wire format and JCS canonicalization so one
+ * verifier mental model covers audit rows and policy documents:
+ *
+ *   v1.ed25519.<kid>.<base64url(signature)>
+ *
+ * Signed fields: `version`, `issuedAt`, `rules` only. `keyId` and
+ * `signature` are never inside the signed payload (they describe the
+ * signature). A missing or invalid signature must never produce an
+ * "enforced" claim (load path returns invalid / cryptoVerified:false).
+ */
+
+import { createPublicKey, type KeyObject } from 'node:crypto';
+import {
+  type AuditRowSigner,
+  Ed25519AuditRowSigner,
+  type Ed25519VerifyResult,
+  type PublicKeyResolver,
+  verifyEd25519AuditSignature,
+} from './audit-signing.js';
+import { canonicalizeJcs } from './jcs.js';
+
+/** Integrity-bearing body of a policy snapshot (excludes signature fields). */
+export interface PolicySnapshotSignable {
+  readonly version: number;
+  readonly issuedAt: string;
+  readonly rules: readonly unknown[];
+}
+
+/** Full snapshot document as served / cached on disk. */
+export interface PolicySnapshotDocument extends PolicySnapshotSignable {
+  readonly keyId: string;
+  readonly signature: string;
+}
+
+/** Structure-only placeholder values (server unsigned mode). */
+export const UNSIGNED_POLICY_KEY_ID = 'unsigned-structure-only';
+export const UNSIGNED_POLICY_SIGNATURE = 'unsigned';
+
+/**
+ * Canonical bytes signed for a policy snapshot. Field order is fixed by JCS;
+ * only these three fields are integrity-bearing.
+ */
+export function policySnapshotSignableBytes(body: PolicySnapshotSignable): Uint8Array {
+  const canonical = canonicalizeJcs({
+    version: body.version,
+    issuedAt: body.issuedAt,
+    rules: body.rules,
+  });
+  return new TextEncoder().encode(canonical);
+}
+
+/**
+ * Sign a policy snapshot body. Returns the wire `keyId` + `signature` to
+ * attach to the document (never re-embeds them into the signed payload).
+ */
+export function signPolicySnapshot(
+  body: PolicySnapshotSignable,
+  signer: AuditRowSigner,
+): { readonly keyId: string; readonly signature: string } {
+  const { value } = signer.sign(policySnapshotSignableBytes(body));
+  return { keyId: signer.kid, signature: value };
+}
+
+/**
+ * Verify a policy snapshot signature. Structure-only / placeholder values
+ * (`unsigned`) return `{ valid: false }` without throwing.
+ */
+export function verifyPolicySnapshot(
+  document: PolicySnapshotDocument,
+  resolvePublicKey: PublicKeyResolver,
+): Ed25519VerifyResult {
+  if (
+    document.signature === UNSIGNED_POLICY_SIGNATURE ||
+    document.keyId === UNSIGNED_POLICY_KEY_ID
+  ) {
+    return { valid: false, reason: 'unsigned structure-only snapshot' };
+  }
+  return verifyEd25519AuditSignature(
+    policySnapshotSignableBytes({
+      version: document.version,
+      issuedAt: document.issuedAt,
+      rules: document.rules,
+    }),
+    document.signature,
+    resolvePublicKey,
+  );
+}
+
+/**
+ * Build an Ed25519 signer for policy snapshots from a PKCS#8 PEM + kid.
+ * Same constructor rules as audit row signing (non-empty kid, no `.`).
+ */
+export function createPolicySnapshotSigner(
+  privateKeyPem: string,
+  kid: string,
+): Ed25519AuditRowSigner {
+  return new Ed25519AuditRowSigner(privateKeyPem, kid);
+}
+
+/** Parse a public key PEM for kid-keyed resolvers. */
+export function policyPublicKeyFromPem(publicKeyPem: string): KeyObject {
+  return createPublicKey(publicKeyPem);
+}

--- a/packages/security/src/server.ts
+++ b/packages/security/src/server.ts
@@ -122,6 +122,25 @@ export {
   PrivacyPolicyManager,
   privacyPolicyManager,
 } from './gdpr.js';
+export type {
+  PolicySignerEnv,
+  PolicySnapshotSignerResolution,
+} from './policy-snapshot-signer-env.js';
+export { createPolicySnapshotSignerFromEnv } from './policy-snapshot-signer-env.js';
+// GAP-381 policy snapshot Ed25519 (I-5 enforced tier honesty)
+export type {
+  PolicySnapshotDocument,
+  PolicySnapshotSignable,
+} from './policy-snapshot-signing.js';
+export {
+  createPolicySnapshotSigner,
+  policyPublicKeyFromPem,
+  policySnapshotSignableBytes,
+  signPolicySnapshot,
+  UNSIGNED_POLICY_KEY_ID,
+  UNSIGNED_POLICY_SIGNATURE,
+  verifyPolicySnapshot,
+} from './policy-snapshot-signing.js';
 // SSRF protection
 export {
   assertPublicUrl,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,7 +371,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -611,7 +611,7 @@ importers:
         version: 10.67.0(react@19.2.8)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1419,6 +1419,9 @@ importers:
       '@revealui/core':
         specifier: workspace:*
         version: link:../core
+      '@revealui/security':
+        specifier: workspace:*
+        version: link:../security
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -12625,7 +12628,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8


### PR DESCRIPTION
## Why (GAP-381 residual)

Phase A landed unsigned structure-only policy snapshots and forced receipts to `advisory` (I-5). Design residual: **cryptographic policy-snapshot verification** before any honest `enforced` tier claim.

Phase D ACP remains **owner D-B** blocked; not in this PR.

## What

### `@revealui/security`
- `policy-snapshot-signing.ts` — JCS signable bytes + Ed25519 via existing Stage-3 wire format `v1.ed25519.<kid>.<sig>`
- `policy-snapshot-signer-env.ts` — compose from `REVEALUI_POLICY_SIGNING_KEY` / public key, **fallback** to audit Stage-3 keys for dogfood
- Exported from `@revealui/security/server`

### `@revealui/harnesses`
- `loadPolicySnapshot` sets `cryptoVerified` only after Ed25519 verify
- `runHookCommand` sets `enforcementTier: 'enforced'` **only** when `cryptoVerified`
- Depends on `@revealui/security` (CLI/node only)

### `apps/server`
- `GET /api/harness/policy-snapshot` signs when a key is configured; otherwise structure-only advisory
- `POST /receipts` accepts `enforced` only if the body includes a `policySnapshot` the server re-verifies

## Proof

- `@revealui/security` tests: **777** (incl. 7 new policy-snapshot)
- `@revealui/harnesses` tests: **488**
- `harness-receipts.test.ts`: **6**
- pre-push phase-1 gate: **PASS**
- `pnpm validate:boundary`: **PASS**

## Security

**area:security** — guardrail-2 verdict required before merge. Do not treat green CI alone as merge-ready.

## Operator

```bash
# dedicated (preferred) or reuse audit keypair:
revvault set revealui/dev/policy/signing-key   # PKCS#8 PEM
# env: REVEALUI_POLICY_SIGNING_KEY / REVEALUI_POLICY_PUBLIC_KEY
# fallback: REVEALUI_AUDIT_SIGNING_KEY / REVEALUI_AUDIT_PUBLIC_KEY
```

## Still open on GAP-381

- Phase D ACP (owner **D-B** SDK vs in-repo)
- Phase E real-editor e2e
- D-C Marketplace, D-D copy