### PR TITLE
fix(ci): security gate build works for promote into main

### DIFF
--- a/.github/workflows/archive-check.yml
+++ b/.github/workflows/archive-check.yml
@@ -58,17 +58,20 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
-      # SCOPED install: harnesses + dev only (not full monorepo; not security).
-      # Full install timed out on unrelated PRs. archive-check only needs
-      # dist/gates (archive-check helpers), not hooks/policy → build:gates.
-      - name: Install (harnesses + dev)
-        run: pnpm install --frozen-lockfile --filter @revealui/harnesses --filter @revealui/dev
-
-      # The gate fails closed if it cannot resolve the shared module, so the
-      # build is a hard prerequisite. build:gates avoids @revealui/security DTS
-      # (sparse checkout has no security source; GAP-381 policy crypto).
-      - name: Build the shared gates module
-        run: pnpm --filter @revealui/harnesses run build:gates
+      # SCOPED install + gates-only build. Full monorepo install timed out.
+      # Fall back when package.json lacks build:gates (older base tips).
+      - name: Install + build shared gates module
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile --filter @revealui/harnesses --filter @revealui/dev
+          if grep -q '"build:gates"' packages/harnesses/package.json; then
+            pnpm --filter @revealui/harnesses run build:gates
+          else
+            pnpm --filter @revealui/harnesses exec tsup --config tsup.gates-cjs.ts
+            if [[ ! -f packages/harnesses/dist/gates/index.js && -f packages/harnesses/dist/gates/index.cjs ]]; then
+              cp packages/harnesses/dist/gates/index.cjs packages/harnesses/dist/gates/index.js
+            fi
+          fi
 
       # jv#871: a gate is not wired until CI has observed it green AND red.
       # Seeding a violation into the repo cannot prove the red half, because

--- a/.github/workflows/sec-audit-label-guard.yml
+++ b/.github/workflows/sec-audit-label-guard.yml
@@ -93,12 +93,17 @@ jobs:
       - name: Build @revealui/harnesses gates only (guardrail2-verdict, GAP-408)
         run: |
           set -euo pipefail
-          # Sparse checkout has packages/harnesses + packages/dev only — no turbo.json
-          # and no @revealui/security source. Full `harnesses build` DTS needs security
-          # (GAP-381 policy crypto). Gates code does not; build:gates emits dist/gates
-          # without that dep (same sparse model as pre-#2449).
+          # See security-review-gate.yml: sparse checkout + promote base=main fallback.
           pnpm install --frozen-lockfile --filter @revealui/harnesses --filter @revealui/dev
-          pnpm --filter @revealui/harnesses run build:gates
+          if grep -q '"build:gates"' packages/harnesses/package.json; then
+            pnpm --filter @revealui/harnesses run build:gates
+          else
+            echo "build:gates missing on this ref — tsup.gates-cjs.ts fallback"
+            pnpm --filter @revealui/harnesses exec tsup --config tsup.gates-cjs.ts
+            if [[ ! -f packages/harnesses/dist/gates/index.js && -f packages/harnesses/dist/gates/index.cjs ]]; then
+              cp packages/harnesses/dist/gates/index.cjs packages/harnesses/dist/gates/index.js
+            fi
+          fi
 
       - name: Guard the clearance label
         env:

--- a/.github/workflows/security-review-gate.yml
+++ b/.github/workflows/security-review-gate.yml
@@ -98,12 +98,19 @@ jobs:
       - name: Build @revealui/harnesses gates only (guardrail2-verdict, GAP-408)
         run: |
           set -euo pipefail
-          # Sparse checkout has packages/harnesses + packages/dev only — no turbo.json
-          # and no @revealui/security source. Full `harnesses build` DTS needs security
-          # (GAP-381 policy crypto). Gates code does not; build:gates emits dist/gates
-          # without that dep (same sparse model as pre-#2449).
+          # Sparse: harnesses+dev only. Full harnesses build DTS needs security
+          # (GAP-381). Gates do not. Promote PRs (base=main) check out main tip
+          # which may lack build:gates — fall back to tsup.gates-cjs.ts.
           pnpm install --frozen-lockfile --filter @revealui/harnesses --filter @revealui/dev
-          pnpm --filter @revealui/harnesses run build:gates
+          if grep -q '"build:gates"' packages/harnesses/package.json; then
+            pnpm --filter @revealui/harnesses run build:gates
+          else
+            echo "build:gates missing on this ref — tsup.gates-cjs.ts fallback"
+            pnpm --filter @revealui/harnesses exec tsup --config tsup.gates-cjs.ts
+            if [[ ! -f packages/harnesses/dist/gates/index.js && -f packages/harnesses/dist/gates/index.cjs ]]; then
+              cp packages/harnesses/dist/gates/index.cjs packages/harnesses/dist/gates/index.js
+            fi
+          fi
 
       - name: Evaluate review gate
         env:

--- a/scripts/ci/build-harnesses-gates.sh
+++ b/scripts/ci/build-harnesses-gates.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Build dist/gates for lightweight pull_request_target / sparse-checkout jobs
+# (security-review-gate, sec-audit-label-guard, archive-check).
+#
+# Constraints:
+#   - Sparse checkout typically has packages/harnesses + packages/dev only
+#   - No turbo.json, no @revealui/security source
+#   - Full `pnpm --filter @revealui/harnesses build` DTS needs security after GAP-381
+#
+# Prefer build:gates when present (test tip). Fall back to tsup.gates-cjs.ts
+# when the base ref is still main (or an older tip) without that script.
+set -euo pipefail
+
+pnpm install --frozen-lockfile --filter @revealui/harnesses --filter @revealui/dev
+
+if grep -q '"build:gates"' packages/harnesses/package.json 2>/dev/null; then
+  pnpm --filter @revealui/harnesses run build:gates
+else
+  echo "build:gates not in package.json — falling back to tsup.gates-cjs.ts"
+  pnpm --filter @revealui/harnesses exec tsup --config tsup.gates-cjs.ts
+fi
+
+# gates-resolver prefers dist/gates/index.js; gates-cjs only emits .cjs
+if [[ ! -f packages/harnesses/dist/gates/index.js && -f packages/harnesses/dist/gates/index.cjs ]]; then
+  cp packages/harnesses/dist/gates/index.cjs packages/harnesses/dist/gates/index.js
+  echo "copied index.cjs → index.js for gates-resolver"
+fi


### PR DESCRIPTION
## Why

Promote **#2452** (`test` → `main`) failed **Security review gate** with:

```text
None of the selected packages has a "build:gates" script
```

`pull_request_target` checks out **base** (`main`). Main tip does not yet have `build:gates` (only on `test` after #2451). The workflow on default/`test` already called `build:gates`.

## Fix

Inline fallback in security-review-gate, sec-audit-label-guard, archive-check:

1. Prefer `build:gates` when present
2. Else `tsup --config tsup.gates-cjs.ts` + copy `index.cjs` → `index.js` for gates-resolver

## After merge

Re-run / re-open promote #2452 so the base workflow picks this up.