### PR TITLE
chore(release): version packages (GAP-381 I-5 security+harnesses)

### DIFF
--- a/.changeset/gap-381-policy-snapshot-crypto.md
+++ b/.changeset/gap-381-policy-snapshot-crypto.md
@@ -1,6 +1,0 @@
----
-"@revealui/security": minor
-"@revealui/harnesses": minor
----
-
-GAP-381 I-5: Ed25519 sign/verify for harness policy snapshots; enforced tier only when signature verifies.

--- a/apps/license-signer/CHANGELOG.md
+++ b/apps/license-signer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/license-signer
 
+## 0.1.5
+
+### Patch Changes
+
+- @revealui/core@0.13.1
+
 ## 0.1.4
 
 ### Patch Changes

--- a/apps/license-signer/package.json
+++ b/apps/license-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/license-signer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Isolated license JWT mint service (GAP-260 P4-2). Holds the signing private key; HMAC-authed internal mint API.",
   "private": true,
   "type": "module",

--- a/apps/rsc-poc/CHANGELOG.md
+++ b/apps/rsc-poc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rsc-poc/app
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [9cf46d6]
+  - @revealui/security@0.7.0
+  - @revealui/core@0.13.1
+
 ## 0.1.2
 
 ### Patch Changes

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsc-poc/app",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "GAP-194 Phase 2.1 RSC POC sandbox — revived for Phase 2.2.2 T0 gate (archive/rsc-poc-spike). Integration harness for dual-mode @revealui/router 0.4 RSC work.",
   "private": true,
   "type": "module",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/ai
 
+## 0.10.1
+
+### Patch Changes
+
+- @revealui/core@0.13.1
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/ai",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AI runtime for agent-driven products — agents, memory, LLM providers (Inference Snaps, Ollama, OpenAI-compatible), tools, and orchestration. Anthropic-SDK-free.",
   "keywords": [
     "agent",

--- a/packages/apify-actor-governed-run/CHANGELOG.md
+++ b/packages/apify-actor-governed-run/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/apify-actor-governed-run
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [9cf46d6]
+  - @revealui/security@0.7.0
+
 ## 0.1.2
 
 ## 0.1.1

--- a/packages/apify-actor-governed-run/package.json
+++ b/packages/apify-actor-governed-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/apify-actor-governed-run",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Apify pay-per-event actor: runs an AI agent task and returns a cryptographically signed, offline-verifiable receipt of every action (GAP-431).",
   "type": "module",

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/auth
 
+## 0.5.3
+
+### Patch Changes
+
+- Updated dependencies [9cf46d6]
+  - @revealui/security@0.7.0
+  - @revealui/core@0.13.1
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/auth",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Database-backed session auth for Hono and Next.js — bcrypt, OAuth, brute-force protection, rate limiting, password reset. Ships with RevealUI.",
   "keywords": [
     "auth",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/cli
 
+## 0.9.7
+
+### Patch Changes
+
+- @revealui/setup@0.7.4
+
 ## 0.9.6
 
 ## 0.9.5

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/cli",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Create RevealUI projects with a single command",
   "keywords": [
     "cli",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/core
 
+## 0.13.1
+
+### Patch Changes
+
+- Updated dependencies [9cf46d6]
+  - @revealui/security@0.7.0
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/core",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "RevealUI's runtime engine — admin UI, REST API, auth, rich text, plugin system, and access control. The heart of the open-source platform.",
   "license": "MIT",
   "dependencies": {

--- a/packages/create-revealui/CHANGELOG.md
+++ b/packages/create-revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-revealui
 
+## 0.5.20
+
+### Patch Changes
+
+- @revealui/cli@0.9.7
+
 ## 0.5.19
 
 ### Patch Changes

--- a/packages/create-revealui/package.json
+++ b/packages/create-revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-revealui",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "Create a new RevealUI project",
   "keywords": [
     "cli",

--- a/packages/engines/CHANGELOG.md
+++ b/packages/engines/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @revealui/engines
 
+## 0.4.13
+
+### Patch Changes
+
+- @revealui/auth@0.5.3
+- @revealui/core@0.13.1
+- @revealui/services@0.7.12
+
 ## 0.4.12
 
 ### Patch Changes

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/engines",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "private": true,
   "description": "Unified entry point for the five RevealUI business primitives: people, content, offers, payments, agents.",
   "license": "FSL-1.1-MIT",

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @revealui/harnesses
 
+## 0.14.0
+
+### Minor Changes
+
+- 9cf46d6: GAP-381 I-5: Ed25519 sign/verify for harness policy snapshots; enforced tier only when signature verifies.
+
+### Patch Changes
+
+- Updated dependencies [9cf46d6]
+  - @revealui/security@0.7.0
+  - @revealui/core@0.13.1
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "AI harness integration — CLI, content definitions, and CI gates; the coordination daemon lives in RevDev.",
   "repository": {
     "type": "git",

--- a/packages/knowledge-graph/CHANGELOG.md
+++ b/packages/knowledge-graph/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @revealui/knowledge-graph
 
+## 0.1.8
+
 ## 0.1.7
 
 ## 0.1.6

--- a/packages/knowledge-graph/package.json
+++ b/packages/knowledge-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/knowledge-graph",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Fleet knowledge graph — bi-temporal, content-addressed graph (ontology, deterministic IDs, deterministic ingestion, hybrid search) over Neon + pgvector. GAP-340.",
   "keywords": [
     "knowledge-graph",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @revealui/mcp
 
+## 0.8.6
+
+### Patch Changes
+
+- Updated dependencies [9cf46d6]
+  - @revealui/security@0.7.0
+  - @revealui/core@0.13.1
+  - @revealui/setup@0.7.4
+  - @revealui/knowledge-graph@0.1.8
+
 ## 0.8.5
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/mcp",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Model Context Protocol framework — first-party server launchers, adapter pattern, tool discovery, and an incubating multi-server hypervisor (not app-mounted by default; ADR-007).",
   "repository": {
     "type": "git",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/RevealUIStudio/revealui",
     "source": "github"
   },
-  "version": "0.8.5",
+  "version": "0.8.6",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@revealui/mcp",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"

--- a/packages/revealui/CHANGELOG.md
+++ b/packages/revealui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # revealui
 
+## 0.1.15
+
+### Patch Changes
+
+- create-revealui@0.5.20
+
 ## 0.1.14
 
 ### Patch Changes

--- a/packages/revealui/package.json
+++ b/packages/revealui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revealui",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "description": "RevealUI — open-source agentic business runtime. Meta-installer that proxies to create-revealui. NOT published: npm rejects bare 'revealui' as too similar to 'reveal-ui'; use 'create-revealui' (npm create revealui) or '@revealui/core' instead.",
   "keywords": [

--- a/packages/security/CHANGELOG.md
+++ b/packages/security/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/security
 
+## 0.7.0
+
+### Minor Changes
+
+- 9cf46d6: GAP-381 I-5: Ed25519 sign/verify for harness policy snapshots; enforced tier only when signature verifies.
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/security",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Security primitives — CSP/CORS/HSTS headers, RBAC + ABAC policy engine, encryption helpers, audit logging, GDPR compliance. Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/services
 
+## 0.7.12
+
+### Patch Changes
+
+- @revealui/core@0.13.1
+
 ## 0.7.11
 
 ### Patch Changes

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/services",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "External service integrations, Stripe (payment processing + circuit breaker) and email (Gmail API delivery). Ships with RevealUI.",
   "repository": {
     "type": "git",

--- a/packages/setup/CHANGELOG.md
+++ b/packages/setup/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/setup
 
+## 0.7.4
+
+### Patch Changes
+
+- Updated dependencies [9cf46d6]
+  - @revealui/security@0.7.0
+
 ## 0.7.3
 
 ### Patch Changes

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/setup",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Setup utilities for new projects — environment config, database init, secrets validation. Used by @revealui/cli.",
   "keywords": [
     "cli",

--- a/packages/sync/CHANGELOG.md
+++ b/packages/sync/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/sync
 
+## 0.4.1
+
+### Patch Changes
+
+- @revealui/core@0.13.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/sync",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Real-time sync layer wrapping ElectricSQL and Yjs CRDT — offline queue, shape cache, conflict resolution, collaborative documents. Ships with RevealUI.",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary

Apply the pending GAP-381 I-5 changeset after promote #2452 landed on main.

| Package | Bump |
|---------|------|
| `@revealui/security` | 0.6.1 → **0.7.0** (minor) |
| `@revealui/harnesses` | 0.13.0 → **0.14.0** (minor) |
| dependents | patch via `updateInternalDependencies` |

Changelog: Ed25519 sign/verify for harness policy snapshots; enforced tier only when signature verifies.

## After merge

1. Promote `test` → `main` (version bumps only; no feature work)
2. Dispatch **Release OSS Packages** on `main` (or `pnpm release:oss` when ready)

```bash
gh workflow run release.yml --ref main
# optional dry-run:
gh workflow run release.yml --ref main -f dry-run=true
```

## Test plan

- [x] `pnpm changeset:version` applied cleanly
- [x] Pre-push phase-1 gate PASS
- [ ] CI green on this PR
- [ ] Land → promote → release