### PR TITLE
fix(ci): allow empty changelog sections in GitHub release step

### DIFF
--- a/.github/scripts/create-github-releases.cjs
+++ b/.github/scripts/create-github-releases.cjs
@@ -55,6 +55,11 @@ function buildPackageDirMap(packagesRoot) {
 /**
  * Extract the body of the `## <version>` section from a changesets CHANGELOG.
  *
+ * Returns:
+ *   - `null` if the `## <version>` heading is absent
+ *   - `''` if the heading exists but the section has no body (dependency-only bump)
+ *   - the section text otherwise
+ *
  * The section ends at the first line that is not changesets section content.
  * Changesets only ever emits blank lines, `###` change-type headings, `-`/`*`
  * bullets, and indented continuation lines inside a section, so any other
@@ -94,7 +99,9 @@ function extractChangelogSection(changelogText, version) {
   }
   while (start < end && lines[start].trim() === '') start += 1;
   while (end > start && lines[end - 1].trim() === '') end -= 1;
-  if (start >= end) return null;
+  // Empty section is valid: changesets often emits `## x.y.z` with no body for
+  // dependency-only bumps (e.g. knowledge-graph 0.1.8). Missing heading only.
+  if (start >= end) return '';
   return lines.slice(start, end).join('\n');
 }
 
@@ -152,7 +159,12 @@ async function run({ github, context, core }) {
       continue;
     }
 
-    let body = section;
+    // Empty body after a present heading (dependency-only bump). GitHub requires
+    // a non-empty release body in practice for a useful release page.
+    let body =
+      section.length > 0
+        ? section
+        : '_No package-level changes in this release (dependency bumps only). See the package CHANGELOG.md._';
     if (body.length > MAX_BODY_CHARS) {
       core.warning(`${tag}: changelog section is ${body.length} chars; truncating to ${MAX_BODY_CHARS}.`);
       body = `${body.slice(0, MAX_BODY_CHARS)}\n\n_Truncated — see ${relativeChangelogPath} for the full entry._`;


### PR DESCRIPTION
## Summary

`release.yml` published packages and tags successfully, then failed on **Create GitHub releases** because `@revealui/knowledge-graph@0.1.8` had a bare `## 0.1.8` heading (no bullets). Changesets does this for dependency-only bumps.

**Before:** empty section → `null` → hard fail after npm publish  
**After:** empty section → `''` → placeholder body; missing heading still fails

## Context

- Run: https://github.com/RevealUIStudio/revealui/actions/runs/31235736595
- npm: security 0.7.0, harnesses 0.14.0, and peers published
- Missing GH release for knowledge-graph@0.1.8 was created manually for this train

## Test plan

- [x] Local unit: empty / full / missing section via `extractChangelogSection`
- [ ] Land → next release train does not fail on empty sections