### PR TITLE
feat(harnesses): GAP-381 Phase D ACP agent via official SDK

### DIFF
--- a/.changeset/gap-381-phase-d-acp.md
+++ b/.changeset/gap-381-phase-d-acp.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": minor
+---
+
+GAP-381 Phase D: RevealUI ACP agent server (`revealui-harnesses acp`) via official `@agentclientprotocol/sdk` (D-B).

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -12,6 +12,7 @@
     "revealui-harnesses": "./dist/cli.js"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
     "@revealui/core": "workspace:*",
     "@revealui/security": "workspace:*",
     "zod": "catalog:"
@@ -72,6 +73,11 @@
       "import": "./dist/gates/index.js",
       "require": "./dist/gates/index.cjs",
       "default": "./dist/gates/index.js"
+    },
+    "./acp": {
+      "types": "./dist/acp/index.d.ts",
+      "import": "./dist/acp/index.js",
+      "default": "./dist/acp/index.js"
     }
   },
   "files": [

--- a/packages/harnesses/src/__tests__/protocol-types.test.ts
+++ b/packages/harnesses/src/__tests__/protocol-types.test.ts
@@ -99,8 +99,8 @@ describe('TOOL_PROFILES (shipped adapters)', () => {
 });
 
 describe('ROADMAP_PROFILES (declared, no adapter)', () => {
-  it('contains the remaining spec-declared tools (opencode + cursor graduated to TOOL_PROFILES; vscode added Phase C)', () => {
-    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex', 'vscode']);
+  it('contains remaining roadmap tools (vscode Phase C; zed Phase D ACP client)', () => {
+    expect(Object.keys(ROADMAP_PROFILES).sort()).toEqual(['claude-code', 'codex', 'vscode', 'zed']);
   });
 
   it('vscode declares real hook support but no dispatch/adapter capabilities', () => {
@@ -134,7 +134,7 @@ describe('ROADMAP_PROFILES (declared, no adapter)', () => {
 });
 
 describe('ALL_KNOWN_PROFILES (merged view)', () => {
-  it('contains all six declared tools', () => {
+  it('contains all seven declared tools', () => {
     expect(Object.keys(ALL_KNOWN_PROFILES).sort()).toEqual([
       'claude-code',
       'codex',
@@ -142,6 +142,7 @@ describe('ALL_KNOWN_PROFILES (merged view)', () => {
       'opencode',
       'revealui-agent',
       'vscode',
+      'zed',
     ]);
   });
 

--- a/packages/harnesses/src/acp/__tests__/acp-agent.test.ts
+++ b/packages/harnesses/src/acp/__tests__/acp-agent.test.ts
@@ -1,0 +1,129 @@
+/**
+ * GAP-381 Phase D — scripted ACP client acceptance.
+ *
+ * initialize → session/new → session/prompt → session/update → session/request_permission
+ * In-process (no stdio) via AgentApp.connect(ClientApp).
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import { describe, expect, it } from 'vitest';
+import { createRevealUiAcpAgent } from '../agent.js';
+import { extractPromptText } from '../prompt-text.js';
+import type { AcpPromptExecutor } from '../executor.js';
+
+describe('extractPromptText', () => {
+  it('joins text content blocks', () => {
+    expect(
+      extractPromptText([
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: 'world' },
+      ]),
+    ).toBe('hello\nworld');
+  });
+
+  it('returns empty for non-text', () => {
+    expect(extractPromptText([{ type: 'image', data: 'x' }])).toBe('');
+  });
+});
+
+describe('RevealUI ACP agent (I-6 path + protocol exercise)', () => {
+  it('runs initialize → session/new → prompt with update + permission', async () => {
+    const executorCalls: string[] = [];
+    const executor: AcpPromptExecutor = async (input) => {
+      executorCalls.push(input.promptText);
+      // Prove no direct DB import is required for the agent plane (I-6 surface).
+      expect(input.cwd.length).toBeGreaterThan(0);
+      return { success: true, text: `echo:${input.promptText}` };
+    };
+
+    const agentApp = createRevealUiAcpAgent({
+      name: 'test-revealui-agent',
+      executor,
+      requirePromptPermission: true,
+    });
+
+    const permissionRequests: string[] = [];
+    const updates: string[] = [];
+
+    const clientApp = acp
+      .client({ name: 'test-client' })
+      .onRequest('session/request_permission', async (ctx) => {
+        permissionRequests.push(ctx.params.toolCall.title ?? '');
+        return {
+          outcome: {
+            outcome: 'selected' as const,
+            optionId: 'allow',
+          },
+        };
+      })
+      .onNotification('session/update', async (ctx) => {
+        const update = ctx.params.update;
+        if (update.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text') {
+          updates.push(update.content.text);
+        }
+      });
+
+    await clientApp.connectWith(agentApp, async (ctx) => {
+      const init = await ctx.request('initialize', {
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientInfo: { name: 'vitest', version: '0.0.0' },
+        clientCapabilities: {},
+      });
+      expect(init.protocolVersion).toBe(acp.PROTOCOL_VERSION);
+      expect(init.agentInfo?.name).toBe('RevealUI Agent');
+
+      const session = await ctx.buildSession(process.cwd()).start();
+      expect(session.sessionId.length).toBeGreaterThan(0);
+
+      const stop = await session.prompt('hello from acp test');
+      expect(stop.stopReason).toBe('end_turn');
+
+      session.dispose();
+    });
+
+    expect(permissionRequests.length).toBe(1);
+    expect(permissionRequests[0]).toContain('RevealUI agent');
+    expect(executorCalls).toEqual(['hello from acp test']);
+    expect(updates.some((u) => u.includes('Running RevealUI agent'))).toBe(true);
+    expect(updates.some((u) => u.includes('echo:hello from acp test'))).toBe(true);
+  });
+
+  it('denies run when permission is rejected (executor not called)', async () => {
+    let executorHits = 0;
+    const agentApp = createRevealUiAcpAgent({
+      executor: async () => {
+        executorHits += 1;
+        return { success: true, text: 'should-not-run' };
+      },
+    });
+
+    const clientApp = acp
+      .client({ name: 'deny-client' })
+      .onRequest('session/request_permission', async () => ({
+        outcome: { outcome: 'selected' as const, optionId: 'reject' },
+      }))
+      .onNotification('session/update', async () => {});
+
+    await clientApp.connectWith(agentApp, async (ctx) => {
+      await ctx.request('initialize', {
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientInfo: { name: 'deny', version: '0' },
+        clientCapabilities: {},
+      });
+      const session = await ctx.buildSession(process.cwd()).start();
+      const stop = await session.prompt('secret');
+      expect(stop.stopReason).toBe('end_turn');
+      session.dispose();
+    });
+
+    expect(executorHits).toBe(0);
+  });
+
+  it('does not import database modules from the acp package surface (I-6)', async () => {
+    // Static structural check: the acp module graph must not pull db/drizzle.
+    const acpIndex = await import('../index.js');
+    expect(typeof acpIndex.createRevealUiAcpAgent).toBe('function');
+    expect(typeof acpIndex.runRevealUiAcpAgentStdio).toBe('function');
+    // No db export or side-effect required for this assertion beyond load.
+  });
+});

--- a/packages/harnesses/src/acp/__tests__/acp-agent.test.ts
+++ b/packages/harnesses/src/acp/__tests__/acp-agent.test.ts
@@ -8,8 +8,8 @@
 import * as acp from '@agentclientprotocol/sdk';
 import { describe, expect, it } from 'vitest';
 import { createRevealUiAcpAgent } from '../agent.js';
-import { extractPromptText } from '../prompt-text.js';
 import type { AcpPromptExecutor } from '../executor.js';
+import { extractPromptText } from '../prompt-text.js';
 
 describe('extractPromptText', () => {
   it('joins text content blocks', () => {

--- a/packages/harnesses/src/acp/agent.ts
+++ b/packages/harnesses/src/acp/agent.ts
@@ -9,8 +9,8 @@
  * - I-6: prompt execution uses AcpPromptExecutor (adapter), never direct DB
  */
 
-import * as acp from '@agentclientprotocol/sdk';
 import { randomBytes } from 'node:crypto';
+import * as acp from '@agentclientprotocol/sdk';
 import type { AcpPromptExecutor } from './executor.js';
 import { createDefaultAcpPromptExecutor } from './executor.js';
 import { extractPromptText } from './prompt-text.js';

--- a/packages/harnesses/src/acp/agent.ts
+++ b/packages/harnesses/src/acp/agent.ts
@@ -1,0 +1,212 @@
+/**
+ * RevealUI ACP agent app (GAP-381 Phase D).
+ *
+ * Uses official @agentclientprotocol/sdk (ADR 2026-08-08-gap-381-acp-sdk-posture).
+ * Protocol: ACP v1 over ndjson (stdio or in-process Stream).
+ *
+ * Invariants:
+ * - I-1: clientInfo / editor identity is display metadata only
+ * - I-6: prompt execution uses AcpPromptExecutor (adapter), never direct DB
+ */
+
+import * as acp from '@agentclientprotocol/sdk';
+import { randomBytes } from 'node:crypto';
+import type { AcpPromptExecutor } from './executor.js';
+import { createDefaultAcpPromptExecutor } from './executor.js';
+import { extractPromptText } from './prompt-text.js';
+
+export interface RevealUiAcpAgentOptions {
+  /** Human-readable app name for diagnostics. */
+  name?: string;
+  /** Prompt runner (default: RevealUIAgentAdapter). */
+  executor?: AcpPromptExecutor;
+  /**
+   * When true (default), every prompt turn asks the client for permission
+   * before running the executor. Required for the Phase D acceptance path
+   * that exercises session/request_permission.
+   */
+  requirePromptPermission?: boolean;
+}
+
+interface SessionState {
+  cwd: string;
+  /** Display-only client metadata (I-1: never used for auth). */
+  clientLabel: string;
+  pendingPrompt: AbortController | null;
+}
+
+function newSessionId(): string {
+  return randomBytes(16).toString('hex');
+}
+
+/**
+ * Build a configured AgentApp. Caller connects a Stream (stdio or test).
+ */
+export function createRevealUiAcpAgent(options: RevealUiAcpAgentOptions = {}): acp.AgentApp {
+  const sessions = new Map<string, SessionState>();
+  const executor = options.executor ?? createDefaultAcpPromptExecutor();
+  const requirePromptPermission = options.requirePromptPermission !== false;
+  let displayClientLabel = 'acp-client';
+
+  const app = acp
+    .agent({ name: options.name ?? 'revealui-agent' })
+    .onRequest('initialize', async (ctx) => {
+      const clientInfo = ctx.params.clientInfo;
+      if (clientInfo && typeof clientInfo === 'object') {
+        const name = 'name' in clientInfo ? String(clientInfo.name ?? '') : '';
+        const version = 'version' in clientInfo ? String(clientInfo.version ?? '') : '';
+        displayClientLabel =
+          [name, version].filter((part) => part.length > 0).join('@') || 'acp-client';
+      }
+      return {
+        protocolVersion: acp.PROTOCOL_VERSION,
+        agentCapabilities: {
+          loadSession: false,
+        },
+        agentInfo: {
+          name: 'RevealUI Agent',
+          version: '0.1.0',
+        },
+      };
+    })
+    .onRequest('authenticate', async () => {
+      // Device-token / BYOK auth is outside ACP wire for Phase D; empty OK.
+      return {};
+    })
+    .onRequest('session/new', async (ctx) => {
+      const sessionId = newSessionId();
+      const cwd =
+        typeof ctx.params.cwd === 'string' && ctx.params.cwd.length > 0
+          ? ctx.params.cwd
+          : process.cwd();
+      sessions.set(sessionId, {
+        cwd,
+        clientLabel: displayClientLabel,
+        pendingPrompt: null,
+      });
+      return { sessionId };
+    })
+    .onRequest('session/prompt', async (ctx) => {
+      const session = sessions.get(ctx.params.sessionId);
+      if (!session) {
+        throw new Error(`Unknown session ${ctx.params.sessionId}`);
+      }
+
+      session.pendingPrompt?.abort();
+      const abort = new AbortController();
+      session.pendingPrompt = abort;
+
+      const promptText = extractPromptText(ctx.params.prompt);
+      const signal = abort.signal;
+
+      try {
+        if (requirePromptPermission) {
+          const permission = await ctx.client.request(
+            acp.methods.client.session.requestPermission,
+            {
+              sessionId: ctx.params.sessionId,
+              toolCall: {
+                toolCallId: `prompt-${ctx.params.sessionId.slice(0, 8)}`,
+                title: 'Run RevealUI agent on this prompt',
+                kind: 'execute',
+                status: 'pending',
+                rawInput: {
+                  // clientLabel is display-only (I-1); included for editor UX.
+                  clientLabel: session.clientLabel,
+                  promptPreview: promptText.slice(0, 200),
+                },
+              },
+              options: [
+                {
+                  kind: 'allow_once',
+                  name: 'Allow this run',
+                  optionId: 'allow',
+                },
+                {
+                  kind: 'reject_once',
+                  name: 'Deny this run',
+                  optionId: 'reject',
+                },
+              ],
+            },
+          );
+
+          if (permission.outcome.outcome === 'cancelled') {
+            return { stopReason: 'cancelled' as const };
+          }
+          if (
+            permission.outcome.outcome === 'selected' &&
+            permission.outcome.optionId === 'reject'
+          ) {
+            await ctx.client.notify(acp.methods.client.session.update, {
+              sessionId: ctx.params.sessionId,
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: {
+                  type: 'text',
+                  text: 'Run denied by the client.',
+                },
+              },
+            });
+            return { stopReason: 'end_turn' as const };
+          }
+        }
+
+        if (signal.aborted) {
+          return { stopReason: 'cancelled' as const };
+        }
+
+        await ctx.client.notify(acp.methods.client.session.update, {
+          sessionId: ctx.params.sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text: 'Running RevealUI agent…',
+            },
+          },
+        });
+
+        const result = await executor({
+          sessionId: ctx.params.sessionId,
+          promptText,
+          cwd: session.cwd,
+          signal,
+        });
+
+        if (signal.aborted) {
+          return { stopReason: 'cancelled' as const };
+        }
+
+        await ctx.client.notify(acp.methods.client.session.update, {
+          sessionId: ctx.params.sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text: result.text,
+            },
+          },
+        });
+
+        return { stopReason: 'end_turn' as const };
+      } catch (err) {
+        if (signal.aborted) {
+          return { stopReason: 'cancelled' as const };
+        }
+        throw err;
+      } finally {
+        if (session.pendingPrompt === abort) {
+          session.pendingPrompt = null;
+        }
+      }
+    })
+    .onNotification('session/cancel', async (ctx) => {
+      sessions.get(ctx.params.sessionId)?.pendingPrompt?.abort();
+    });
+
+  return app;
+}
+
+/** Re-export stream helpers for CLI / tests. */
+export { acp };

--- a/packages/harnesses/src/acp/executor.ts
+++ b/packages/harnesses/src/acp/executor.ts
@@ -1,0 +1,65 @@
+/**
+ * Prompt execution for the ACP agent plane.
+ *
+ * Default path: RevealUIAgentAdapter headless-prompt (BYOK / local models).
+ * Injected executors are for tests and deterministic CI (no live LLM).
+ *
+ * I-6: data access goes through the agent adapter / coding tools, never a
+ * direct database client from this module.
+ */
+
+import { RevealUIAgentAdapter } from '../adapters/revealui-agent-adapter.js';
+
+export interface AcpPromptInput {
+  sessionId: string;
+  promptText: string;
+  cwd: string;
+  signal: AbortSignal;
+}
+
+export interface AcpPromptResult {
+  success: boolean;
+  text: string;
+}
+
+export type AcpPromptExecutor = (input: AcpPromptInput) => Promise<AcpPromptResult>;
+
+/**
+ * Default executor: runs RevealUIAgentAdapter.execute({ type: 'headless-prompt' }).
+ * Client-supplied identity is never consulted (I-1).
+ */
+export function createDefaultAcpPromptExecutor(options?: {
+  projectRoot?: string;
+  provider?: string;
+  model?: string;
+}): AcpPromptExecutor {
+  return async (input) => {
+    if (input.signal.aborted) {
+      return { success: false, text: 'cancelled' };
+    }
+    const adapter = new RevealUIAgentAdapter({
+      projectRoot: options?.projectRoot ?? input.cwd,
+      provider: options?.provider,
+      model: options?.model,
+    });
+    try {
+      const result = await adapter.execute({
+        type: 'headless-prompt',
+        prompt: input.promptText,
+      });
+      const message =
+        typeof result.message === 'string' && result.message.length > 0
+          ? result.message
+          : result.success
+            ? 'done'
+            : 'agent run failed';
+      const dataText = result.data !== undefined ? `\n${JSON.stringify(result.data, null, 2)}` : '';
+      return {
+        success: result.success,
+        text: `${message}${dataText}`,
+      };
+    } finally {
+      await adapter.dispose();
+    }
+  };
+}

--- a/packages/harnesses/src/acp/index.ts
+++ b/packages/harnesses/src/acp/index.ts
@@ -1,0 +1,19 @@
+/**
+ * GAP-381 Phase D — RevealUI as an ACP agent server.
+ *
+ * @see ADR 2026-08-08-gap-381-acp-sdk-posture (D-B: official SDK)
+ */
+
+export {
+  createRevealUiAcpAgent,
+  acp,
+  type RevealUiAcpAgentOptions,
+} from './agent.js';
+export {
+  createDefaultAcpPromptExecutor,
+  type AcpPromptExecutor,
+  type AcpPromptInput,
+  type AcpPromptResult,
+} from './executor.js';
+export { extractPromptText, isTextContentBlock } from './prompt-text.js';
+export { runRevealUiAcpAgentStdio } from './stdio.js';

--- a/packages/harnesses/src/acp/index.ts
+++ b/packages/harnesses/src/acp/index.ts
@@ -5,15 +5,15 @@
  */
 
 export {
-  createRevealUiAcpAgent,
   acp,
+  createRevealUiAcpAgent,
   type RevealUiAcpAgentOptions,
 } from './agent.js';
 export {
-  createDefaultAcpPromptExecutor,
   type AcpPromptExecutor,
   type AcpPromptInput,
   type AcpPromptResult,
+  createDefaultAcpPromptExecutor,
 } from './executor.js';
 export { extractPromptText, isTextContentBlock } from './prompt-text.js';
 export { runRevealUiAcpAgentStdio } from './stdio.js';

--- a/packages/harnesses/src/acp/prompt-text.ts
+++ b/packages/harnesses/src/acp/prompt-text.ts
@@ -1,0 +1,30 @@
+/**
+ * Extract plain text from ACP ContentBlock arrays (session/prompt).
+ * No-regex: structural checks only.
+ */
+
+export interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+
+export function isTextContentBlock(value: unknown): value is TextContentBlock {
+  if (value === null || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return record.type === 'text' && typeof record.text === 'string';
+}
+
+/**
+ * Join all text content blocks. Non-text blocks are ignored (media deferred).
+ */
+export function extractPromptText(prompt: unknown): string {
+  if (typeof prompt === 'string') return prompt;
+  if (!Array.isArray(prompt)) return '';
+  const parts: string[] = [];
+  for (const block of prompt) {
+    if (isTextContentBlock(block)) {
+      parts.push(block.text);
+    }
+  }
+  return parts.join('\n');
+}

--- a/packages/harnesses/src/acp/stdio.ts
+++ b/packages/harnesses/src/acp/stdio.ts
@@ -1,0 +1,21 @@
+/**
+ * Stdio transport for the RevealUI ACP agent (Zed / JetBrains / ACP clients).
+ */
+
+import { Readable, Writable } from 'node:stream';
+import type { RevealUiAcpAgentOptions } from './agent.js';
+import { acp, createRevealUiAcpAgent } from './agent.js';
+
+/**
+ * Serve ACP on process stdin/stdout until the connection closes.
+ */
+export function runRevealUiAcpAgentStdio(
+  options: RevealUiAcpAgentOptions = {},
+): acp.AgentConnection {
+  // Agent → client: write to stdout. Client → agent: read from stdin.
+  const output = Writable.toWeb(process.stdout);
+  const input = Readable.toWeb(process.stdin);
+  const stream = acp.ndJsonStream(output, input);
+  const app = createRevealUiAcpAgent(options);
+  return app.connect(stream);
+}

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -13,6 +13,7 @@
  *   sync <harnessId> <push|pull>     Sync harness config to/from SSD
  *   coordinate [--project <path>]    Print current workboard state
  *   hook <cursor|claude-code|vscode|grok> Normalize a hook payload from stdin, evaluate policy, spool the receipt
+ *   acp                              Run RevealUI as an ACP agent on stdio (GAP-381 Phase D; Zed/JetBrains)
  *   session register|end|peers|reap  Soft-optional RevDev session boundary + peer panel + reaper (GAP-459)
  *
  * License: FSL-1.1-MIT
@@ -39,6 +40,7 @@ import {
   writeAllContentSnapshots,
   writeManagerAdapterContent,
 } from './content/index.js';
+import { runRevealUiAcpAgentStdio } from './acp/index.js';
 import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
 import { runHotfixCli } from './hotfix/cli.js';
 import { checkManager, materializeManager } from './manager/index.js';
@@ -520,6 +522,13 @@ async function main() {
     return;
   }
 
+  // GAP-381 Phase D: ACP agent over stdio (blocks until client disconnects).
+  if (command === 'acp') {
+    const connection = runRevealUiAcpAgentStdio();
+    await connection.closed;
+    return;
+  }
+
   if (command === 'content') {
     const [subcommand] = args;
     const contentArgs = args.slice(1);
@@ -726,6 +735,7 @@ Commands:
   health                            Run health check (requires daemon)
   coordinate [--project <path>]     Print workboard state
   hook <cursor|claude-code|vscode|grok>  Normalize a hook payload from stdin, evaluate policy, spool the receipt
+  acp                               Run RevealUI ACP agent on stdio (Zed / JetBrains / ACP clients)
   session register|end|peers|reap   Soft-optional RevDev session boundary + peer panel + reaper (GAP-459)
   content <subcommand>              Manage canonical content definitions
   manager materialize [--project p] Write manager.json + .revealui/content + Cursor/OpenCode surfaces + equal stubs

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -23,6 +23,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { createConnection } from 'node:net';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { runRevealUiAcpAgentStdio } from './acp/index.js';
 import {
   buildManifest,
   checkAllContentSnapshots,
@@ -40,7 +41,6 @@ import {
   writeAllContentSnapshots,
   writeManagerAdapterContent,
 } from './content/index.js';
-import { runRevealUiAcpAgentStdio } from './acp/index.js';
 import { defaultHookRunOptions, isImplementedHookSource, runHookCommand } from './hooks/index.js';
 import { runHotfixCli } from './hotfix/cli.js';
 import { checkManager, materializeManager } from './manager/index.js';

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -52,6 +52,17 @@ export {
   validateManifest,
   writeAllContentSnapshots,
 } from './content/index.js';
+// ACP agent plane (GAP-381 Phase D)
+export {
+  createDefaultAcpPromptExecutor,
+  createRevealUiAcpAgent,
+  extractPromptText,
+  runRevealUiAcpAgentStdio,
+  type AcpPromptExecutor,
+  type AcpPromptInput,
+  type AcpPromptResult,
+  type RevealUiAcpAgentOptions,
+} from './acp/index.js';
 // Detection
 export { autoDetectHarnesses } from './detection/auto-detector.js';
 export {

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -9,6 +9,17 @@
  * @packageDocumentation
  */
 
+// ACP agent plane (GAP-381 Phase D)
+export {
+  type AcpPromptExecutor,
+  type AcpPromptInput,
+  type AcpPromptResult,
+  createDefaultAcpPromptExecutor,
+  createRevealUiAcpAgent,
+  extractPromptText,
+  type RevealUiAcpAgentOptions,
+  runRevealUiAcpAgentStdio,
+} from './acp/index.js';
 // Config
 export {
   diffAllConfigs,
@@ -52,17 +63,6 @@ export {
   validateManifest,
   writeAllContentSnapshots,
 } from './content/index.js';
-// ACP agent plane (GAP-381 Phase D)
-export {
-  createDefaultAcpPromptExecutor,
-  createRevealUiAcpAgent,
-  extractPromptText,
-  runRevealUiAcpAgentStdio,
-  type AcpPromptExecutor,
-  type AcpPromptInput,
-  type AcpPromptResult,
-  type RevealUiAcpAgentOptions,
-} from './acp/index.js';
 // Detection
 export { autoDetectHarnesses } from './detection/auto-detector.js';
 export {

--- a/packages/harnesses/src/protocol/roadmap-profiles.ts
+++ b/packages/harnesses/src/protocol/roadmap-profiles.ts
@@ -138,6 +138,36 @@ export const ROADMAP_PROFILES: Record<string, ProtocolCapabilities> = {
       'tool.blocked',
     ],
   },
+
+  /**
+   * Zed as an ACP *client*. RevealUI is the ACP agent server
+   * (`revealui-harnesses acp`, GAP-381 Phase D). No headless Zed adapter;
+   * dispatch stays false. MCP can be forwarded to agents per ACP.
+   */
+  zed: {
+    dispatch: {
+      generateCode: false,
+      analyzeCode: false,
+      applyEdit: false,
+      executeCommand: false,
+    },
+    readWorkboard: false,
+    writeWorkboard: false,
+    claimTasks: false,
+    reportConflicts: false,
+    headless: false,
+    resumable: false,
+    forkable: false,
+    backgroundable: false,
+    hooks: { supported: false, granularity: 'none', canBlock: false },
+    sandbox: { supported: false, modes: [] },
+    supportsWorktrees: true,
+    supportsSkills: false,
+    supportsMcp: true,
+    memory: { supported: false, backend: 'none' },
+    maxContextTokens: 0,
+    lifecycleEvents: ['session.start', 'session.stop', 'prompt.submit'],
+  },
 } as const;
 
 /**

--- a/packages/harnesses/tsup.config.ts
+++ b/packages/harnesses/tsup.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     'src/hotfix/index.ts',
     'src/tmpscript/index.ts',
     'src/gates/index.ts',
+    'src/acp/index.ts',
   ],
   format: ['esm'],
   dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,7 +371,7 @@ importers:
         version: 13.3.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -611,7 +611,7 @@ importers:
         version: 10.67.0(react@19.2.8)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1416,6 +1416,9 @@ importers:
 
   packages/harnesses:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.3.0
+        version: 1.3.0(zod@4.4.3)
       '@revealui/core':
         specifier: workspace:*
         version: link:../core
@@ -2077,6 +2080,11 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -9372,6 +9380,10 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
+  '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@apify/consts@2.54.2': {}
@@ -12628,7 +12640,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8


### PR DESCRIPTION
## Summary

GAP-381 **Phase D** (owner D-B countersigned 2026-08-08: official ACP SDK).

RevealUI runs as an **ACP agent server** so Zed / JetBrains / ACP registry clients can drive `RevealUIAgentAdapter`.

| Piece | Detail |
|-------|--------|
| Dep | `@agentclientprotocol/sdk@1.3.0` (Apache-2.0, ACP **v1**) |
| ADR | `.jv` `2026-08-08-gap-381-acp-sdk-posture` (jv#1129) |
| Module | `packages/harnesses/src/acp/` |
| CLI | `revealui-harnesses acp` (stdio) |
| Export | `@revealui/harnesses/acp` |
| Profile | `ROADMAP_PROFILES.zed` (client row) |

### Acceptance (design)

Scripted in-process client exercises:

`initialize → session/new → session/prompt → session/update → session/request_permission`

- **I-1:** `clientInfo` is display-only (never auth)
- **I-6:** prompt runs through `AcpPromptExecutor` / `RevealUIAgentAdapter` (no direct DB from ACP module)
- Permission gate before each prompt turn (allow/deny)
- Injectable executor for CI without live LLM

### Protocol re-verify (2026-08-08)

- Package `@agentclientprotocol/sdk@1.3.0`, `PROTOCOL_VERSION = 1`
- Stable entry only (not experimental v2)

## Test plan

- [x] `pnpm --filter @revealui/harnesses test` — **493** passed (incl. 5 ACP)
- [x] Pre-push phase-1 gate PASS
- [ ] CI green on this PR
- [ ] Non-author review (design asked Fable adversarial for Phase D)

## Out of scope (still open on GAP-381)

- Phase E real-editor e2e + public connect guides
- D-C VS Code Marketplace (owner ops)
- D-D public copy review