### PR TITLE
fix(server,marketing): restore /api/og + public site SEO fixes

### DIFF
--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { BuiltWithRevealUI, GitHubIcon, LinkedInIcon, XIcon } from '@revealui/presentation';
+import { BuiltWithRevealUI, GitHubIcon, LinkedInIcon } from '@revealui/presentation';
 import {
   FOOTER_CLAIMS_LEDGER_NOTE,
   FOOTER_COLUMNS,
@@ -66,13 +66,6 @@ export function Footer() {
                 aria-label="GitHub"
               >
                 <GitHubIcon className="size-5" />
-              </a>
-              <a
-                href={SITE.urls.x}
-                className="text-muted-foreground hover:text-foreground transition-colors"
-                aria-label="RevealUI on X"
-              >
-                <XIcon className="size-5" />
               </a>
               <a
                 href={SITE.urls.linkedin}

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -71,7 +71,10 @@ export const SITE = {
     fslSoftware: 'https://fsl.software/',
     fslSpecText: 'https://fsl.software/FSL-1.1-MIT.template.md',
     adminLogin: 'https://admin.revealui.com/login',
-    x: 'https://x.com/revealui',
+    /**
+     * X/Twitter handle is not live yet (x.com/revealui 404 as of 2026-08 audit).
+     * Omit from public nav until the account exists; do not reintroduce a dead href.
+     */
     linkedin: 'https://www.linkedin.com/company/revealui',
     repoChangelog: 'https://github.com/RevealUIStudio/revealui/blob/main/CHANGELOG.md',
     repoLicense: 'https://github.com/RevealUIStudio/revealui/blob/main/LICENSE',

--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://revealui.com/local-ai</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://revealui.com/pricing</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
@@ -79,6 +84,16 @@
     <loc>https://revealui.com/support</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://revealui.com/sla</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://revealui.com/refund-policy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
   </url>
   <url>
     <loc>https://revealui.com/status</loc>

--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -40,6 +40,12 @@
     }
   ],
   "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.revealui.com" }],
+      "destination": "https://revealui.com/:path*",
+      "permanent": true
+    },
     { "source": "/docs", "destination": "https://docs.revealui.com", "permanent": true },
     {
       "source": "/docs/:path*",

--- a/apps/server/src/lib/__tests__/lazy-hono-route.test.ts
+++ b/apps/server/src/lib/__tests__/lazy-hono-route.test.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { describe, expect, it, vi } from 'vitest';
-import { createLazyHonoRoute } from '../lazy-hono-route.js';
+import { createLazyHonoRoute, mountRelativeUrl } from '../lazy-hono-route.js';
 
 describe('createLazyHonoRoute', () => {
   it('does not call the loader until a request hits the proxy', async () => {
@@ -22,5 +22,56 @@ describe('createLazyHonoRoute', () => {
     const res2 = await proxy.request('/');
     expect(await res2.text()).toBe('lazy-ok');
     expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('rewrites absolute mount paths so child GET / matches under app.route', async () => {
+    const child = new Hono();
+    child.get('/', (c) => c.text(`og:${c.req.query('title') ?? 'default'}`));
+
+    const parent = new Hono();
+    parent.route(
+      '/api/og',
+      createLazyHonoRoute(async () => ({ default: child })),
+    );
+
+    const res = await parent.request('/api/og?title=Hello');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('og:Hello');
+
+    const bare = await parent.request('/api/og');
+    expect(bare.status).toBe(200);
+    expect(await bare.text()).toBe('og:default');
+  });
+
+  it('rewrites nested remaining paths under the mount base', async () => {
+    const child = new Hono();
+    child.get('/preview', (c) => c.text('preview-ok'));
+
+    const parent = new Hono();
+    parent.route(
+      '/api/og',
+      createLazyHonoRoute(async () => ({ default: child })),
+    );
+
+    const res = await parent.request('/api/og/preview');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('preview-ok');
+  });
+});
+
+describe('mountRelativeUrl', () => {
+  it('strips the matched basePath and keeps the query string', async () => {
+    const probe = new Hono();
+    let seen: string | undefined;
+    probe.all('*', (c) => {
+      seen = mountRelativeUrl(c).toString();
+      return c.text('ok');
+    });
+
+    const parent = new Hono();
+    parent.route('/api/og', probe);
+    await parent.request('https://api.example.com/api/og?title=Studio');
+
+    expect(seen).toBe('https://api.example.com/?title=Studio');
   });
 });

--- a/apps/server/src/lib/lazy-hono-route.ts
+++ b/apps/server/src/lib/lazy-hono-route.ts
@@ -7,10 +7,36 @@
  *
  * This helper mounts a proxy that dynamic-imports the real sub-app on the
  * first request to that path only. Health and other routes never load it.
+ *
+ * Path rewrite (2026-08 public-sites audit): parent `app.route('/api/og', proxy)`
+ * matches correctly, but `app.fetch(c.req.raw)` re-dispatches the absolute
+ * path (`/api/og`) against the child, which only defines `GET /`. That produced
+ * production 404s for every OG image. Rewrite to a mount-relative path using
+ * the matched route's `basePath` before calling the child.
  */
+import type { Context } from 'hono';
 import { Hono } from 'hono';
 
 type HonoApp = Hono;
+
+/**
+ * Path the child sub-app expects (relative to its mount), including query.
+ * `matchedRoutes` basePath is `/api/og` when the parent mounts us there;
+ * without stripping, child `GET /` never matches.
+ */
+export function mountRelativeUrl(c: Context): URL {
+  const absolute = new URL(c.req.raw.url);
+  const matched = c.req.matchedRoutes;
+  const base = matched.length > 0 ? (matched[matched.length - 1]?.basePath ?? '') : '';
+  let rest = absolute.pathname;
+  if (base && base !== '/' && rest.startsWith(base)) {
+    rest = rest.slice(base.length) || '/';
+  }
+  if (!rest.startsWith('/')) {
+    rest = `/${rest}`;
+  }
+  return new URL(`${rest}${absolute.search}`, absolute.origin);
+}
 
 export function createLazyHonoRoute(loader: () => Promise<{ default: HonoApp }>): HonoApp {
   let cached: HonoApp | undefined;
@@ -31,13 +57,14 @@ export function createLazyHonoRoute(loader: () => Promise<{ default: HonoApp }>)
   // When parent does app.route('/api/og', proxy), remaining path is '/' or '/*'.
   proxy.all('*', async (c) => {
     const app = await getApp();
+    const req = new Request(mountRelativeUrl(c), c.req.raw);
     // Node/Vercel request() paths often have no ExecutionContext; only pass it
     // when present so unit tests and serverless both work.
     try {
       const exec = c.executionCtx;
-      return app.fetch(c.req.raw, c.env, exec);
+      return app.fetch(req, c.env, exec);
     } catch {
-      return app.fetch(c.req.raw, c.env);
+      return app.fetch(req, c.env);
     }
   });
   return proxy;


### PR DESCRIPTION
## Summary

Public-site audit (2026-08) follow-up for **revealui.com** and the shared API.

### Root cause: `/api/og` 404 in production

`createLazyHonoRoute` re-dispatched `c.req.raw` (absolute path `/api/og`) into a child app that only defines `GET /`. Parent `app.route('/api/og', …)` matching never reached the handler. Reproduced with a minimal Hono mount; fixed by rewriting to the mount-relative URL via `matchedRoutes[].basePath`.

### Marketing

- Sitemap: add `/local-ai`, `/sla`, `/refund-policy`
- Remove dead footer X link (`x.com/revealui` 404)
- Vercel: permanent redirect `www.revealui.com` → apex

### Tests

- Extended `lazy-hono-route` tests: nested `/api/og?title=…` and nested remaining path
- Local proof: 4/4 pass

## Test plan

- [ ] CI phase 1 green
- [ ] After merge + API deploy: `curl -sI 'https://api.revealui.com/api/og?title=Hello' | head` → 200 `image/png`
- [ ] Marketing deploy: sitemap lists new routes; footer has GitHub + LinkedIn only
- [ ] `https://www.revealui.com/` → 301/308 to apex

## Notes

Local pre-push full monorepo gate could not complete DTS builds in a partial worktree install; content-freshness CLI check was green with harnesses dist (`No changes (37 files)`). CI is the authority.