### PR TITLE
chore(release): version packages (GAP-381 Phase D ACP)

### DIFF
--- a/.changeset/gap-381-phase-d-acp.md
+++ b/.changeset/gap-381-phase-d-acp.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": minor
----
-
-GAP-381 Phase D: RevealUI ACP agent server (`revealui-harnesses acp`) via official `@agentclientprotocol/sdk` (D-B).

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/harnesses
 
+## 0.15.0
+
+### Minor Changes
+
+- 3e52708: GAP-381 Phase D: RevealUI ACP agent server (`revealui-harnesses acp`) via official `@agentclientprotocol/sdk` (D-B).
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "AI harness integration — CLI, content definitions, and CI gates; the coordination daemon lives in RevDev.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Apply the pending Phase D changeset so `release.yml` can publish a new harnesses version.

| Package | Bump |
|---------|------|
| `@revealui/harnesses` | **0.14.0 → 0.15.0** (minor) |

Changelog: GAP-381 Phase D ACP agent (`revealui-harnesses acp`) via `@agentclientprotocol/sdk` (D-B).

## After merge

1. Promote `test` → `main` (version only)
2. `gh workflow run release.yml --ref main`

**Note:** [#2464](https://github.com/RevealUIStudio/revealui/pull/2464) already put Phase D **code** on main at 0.14.0. A premature `release.yml` run no-op'd. This PR is required before npm gets 0.15.0.

Closes the empty promote [#2466](https://github.com/RevealUIStudio/revealui/pull/2466) (test→main with no version commit).

## Test plan

- [x] `pnpm changeset:version` applied
- [x] Pre-push phase-1 gate PASS
- [ ] CI green
- [ ] Land → promote → release