### PR TITLE
chore(release): promote harnesses 0.15.0 to main

### DIFF
--- a/.changeset/gap-381-phase-d-acp.md
+++ b/.changeset/gap-381-phase-d-acp.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": minor
----
-
-GAP-381 Phase D: RevealUI ACP agent server (`revealui-harnesses acp`) via official `@agentclientprotocol/sdk` (D-B).

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/harnesses
 
+## 0.15.0
+
+### Minor Changes
+
+- 3e52708: GAP-381 Phase D: RevealUI ACP agent server (`revealui-harnesses acp`) via official `@agentclientprotocol/sdk` (D-B).
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "AI harness integration — CLI, content definitions, and CI gates; the coordination daemon lives in RevDev.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Promote `test` → `main` so npm can publish `@revealui/harnesses@0.15.0` (GAP-381 Phase D version bump from #2467).

| Package | Version |
|---------|---------|
| `@revealui/harnesses` | 0.14.0 → **0.15.0** |

Phase D code already on main via #2464; this lands the version/changelog only.

## After merge

```bash
gh workflow run release.yml --ref main
```

## Test plan

- [ ] CI / promotion-gate / Security review green
- [ ] Merge with merge commit
- [ ] release.yml publishes harnesses 0.15.0