### PR TITLE
chore(release): promote Phase E connect guides to main

### DIFF
--- a/apps/docs/app/lib/slug-manifest.ts
+++ b/apps/docs/app/lib/slug-manifest.ts
@@ -6,7 +6,7 @@
  * Used by the markdown resolver to translate flat URLs
  * (docs.revealui.com/admin-guide) into file fetches
  * (/admin-guide.md served from public/).
- * Generated: 74 entries.
+ * Generated: 81 entries.
  */
 
 export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
@@ -45,6 +45,7 @@ export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
   'blog/15-dashboard-agent-chat': 'blog/15-dashboard-agent-chat.md',
   'blog/16-ui-of-the-future': 'blog/16-ui-of-the-future.md',
   'blog/17-shareable-upside': 'blog/17-shareable-upside.md',
+  'blog/18-open-runtime-for-fde-work': 'blog/18-open-runtime-for-fde-work.md',
   'build-your-business': 'BUILD_YOUR_BUSINESS.md',
   'component-catalog': 'COMPONENT_CATALOG.md',
   'core-stability': 'CORE_STABILITY.md',
@@ -55,6 +56,9 @@ export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
   'decisions/2026-06-13-collab-snapshot-durability':
     'decisions/2026-06-13-collab-snapshot-durability.md',
   'decisions/2026-06-14-stripe-mode-coherence': 'decisions/2026-06-14-stripe-mode-coherence.md',
+  'decisions/2026-07-29-docs-publish-plane-virtual-serve':
+    'decisions/2026-07-29-docs-publish-plane-virtual-serve.md',
+  'decisions/2026-08-07-core-alert-planes': 'decisions/2026-08-07-core-alert-planes.md',
   'environment-variables-guide': 'ENVIRONMENT-VARIABLES-GUIDE.md',
   examples: 'EXAMPLES.md',
   'fair-source': 'FAIR_SOURCE.md',
@@ -64,10 +68,14 @@ export const SLUG_TO_PATH: Readonly<Record<string, string>> = Object.freeze({
   'fleet/revskills': 'fleet/revskills.md',
   'fleet/revvault': 'fleet/revvault.md',
   forge: 'FORGE.md',
+  'forge-sso-setup': 'FORGE_SSO_SETUP.md',
   'guides/authentication': 'guides/authentication.md',
   'guides/billing': 'guides/billing.md',
   'guides/collections': 'guides/collections.md',
+  'guides/connect-acp': 'guides/connect-acp.md',
+  'guides/connect-cursor': 'guides/connect-cursor.md',
   'guides/connect-opencode': 'guides/connect-opencode.md',
+  'guides/connect-vscode': 'guides/connect-vscode.md',
   'guides/deployment': 'guides/deployment.md',
   'guides/quick-start': 'guides/quick-start.md',
   'guides/readme': 'guides/README.md',

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -53,7 +53,10 @@ Six **[design principles](./JOSHUA.md)** govern every architectural decision: Ju
 ## Agent Coordination
 
 - [Harness Protocol](./HARNESS_PROTOCOL.md): Agent normalization, capability model, lifecycle events, and the adapter/coordinator surface shipped in `@revealui/harnesses`
-- [Connect OpenCode](./guides/connect-opencode.md): Connect the OpenCode CLI to a RevealUI instance through the governed MCP endpoint
+- [Connect OpenCode](./guides/connect-opencode.md): OpenCode CLI via governed MCP
+- [Connect Cursor](./guides/connect-cursor.md): Cursor hooks + governed MCP
+- [Connect VS Code](./guides/connect-vscode.md): Copilot agent-plugin bundle
+- [Connect ACP (Zed / JetBrains)](./guides/connect-acp.md): RevealUI ACP agent on stdio
 - [Blog: Three AI Agents, One Codebase](./blog/03-multi-agent-coordination.md): The problem that led to the Holster
 
 ## Pro & Enterprise

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -62,7 +62,10 @@ revealui/dev/admin-password
 revealui/dev/admin-session-cookie
 revealui/dev/electric/service-url
 revealui/dev/founder-license-key    # RVUI-<tier>-<32hex>; founder dev license consumed by revdev daemon
-revealui/dev/mcp/opencode-device-token   # rvui_dev_* device token minted via the studio-auth link/verify flow; used as REVEALUI_MCP_TOKEN by MCP clients (e.g. OpenCode)
+revealui/dev/mcp/opencode-device-token   # rvui_dev_* device token (studio-auth link/verify); REVEALUI_MCP_TOKEN for OpenCode and other MCP clients
+revealui/dev/mcp/cursor-device-token     # optional alias; same mint shape; Cursor .cursor/mcp.json uses ${env:REVEALUI_MCP_TOKEN}
+revealui/dev/mcp/vscode-device-token     # optional alias; same mint shape; VS Code .mcp.json uses ${input:revealui-mcp-token} (prompt, not env)
+revealui/dev/mcp/cli-token              # optional alias used by operator launchers (e.g. rfg); never commit the value
 # Stripe TEST-mode keys (dev namespace) — used by local dev + the CI integration suite.
 revealui/dev/stripe/restricted-ci-test     # rk_test_* restricted (Write: PaymentIntents/Products/Prices/Checkout) — mirrored to CI as STRIPE_SECRET_KEY (see CI / publishing)
 revealui/dev/stripe/secret-key             # sk_test_* full test secret (broader; CI uses the restricted key above)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -21,6 +21,13 @@ Practical, step-by-step guides for building with RevealUI.
 - [Billing](./billing.md) -- Stripe checkout, subscriptions, webhooks, pricing tiers
 - [Deployment](./deployment.md) -- Vercel, Docker, self-hosted, environment variables
 
+## Connect editors (governed agents)
+
+- [Connect OpenCode](./connect-opencode.md) -- OpenCode CLI via governed MCP
+- [Connect Cursor](./connect-cursor.md) -- Cursor hooks + governed MCP
+- [Connect VS Code](./connect-vscode.md) -- Copilot agent plugin bundle
+- [Connect ACP (Zed / JetBrains)](./connect-acp.md) -- `revealui-harnesses acp` on stdio
+
 ## Reference
 
 For package-level API documentation, see the [API Reference](/api).

--- a/docs/guides/connect-acp.md
+++ b/docs/guides/connect-acp.md
@@ -1,0 +1,106 @@
+---
+title: "Connect ACP (Zed and JetBrains)"
+description: "Run RevealUI as an Agent Client Protocol agent over stdio for Zed, JetBrains, and other ACP clients."
+visibility: public
+status: verified
+audience: developer
+---
+
+# Connect ACP (Zed and JetBrains)
+
+RevealUI can act as an **ACP agent** (Agent Client Protocol v1) over stdio.
+Editors such as Zed and JetBrains connect as the ACP client. The agent
+process is `revealui-harnesses acp`. Protocol work uses the official
+`@agentclientprotocol/sdk` (ADR `2026-08-08-gap-381-acp-sdk-posture`).
+
+## What governance means here
+
+ACP is the **editor control plane** for prompts and permissions. The
+**RevealUI data plane** for customer data remains the governed MCP endpoint
+and REST surfaces. Do not treat ACP wire identity as a substitute for a
+RevealUI device token on data-plane calls.
+
+- **I-1 (identity).** Client metadata from `initialize` is display-only. It
+  is not used for authorization.
+- **I-6 (no collection bypass).** Prompt execution goes through an executor
+  adapter, not a direct database path. Data access that needs your
+  collections should still go through governed MCP or REST as a normal user.
+- **Permissions.** By default each prompt turn asks the client for
+  permission before the executor runs (`session/request_permission`).
+
+## Prerequisites
+
+- An ACP client (Zed with ACP agents, JetBrains ACP support, or another
+  ACP-compatible host).
+- `@revealui/harnesses` installed so `revealui-harnesses` is on `PATH`.
+- Optional but recommended: a RevealUI device token and MCP config in the
+  client for data-plane tools (same mint as [Connect OpenCode](./connect-opencode.md)).
+
+## 1. Run the agent on stdio
+
+```bash
+revealui-harnesses acp
+```
+
+The process speaks ACP v1 as ndjson on stdin/stdout until the client
+disconnects. Do not write human logs to stdout; they corrupt the protocol
+stream. Diagnostics go to stderr.
+
+## 2. Register the agent in the client
+
+Exact UI differs by editor. The common shape is:
+
+1. Open the editor's ACP / external agents settings.
+2. Add an agent whose command is `revealui-harnesses` with argument `acp`
+   (or the absolute path to the binary).
+3. Start a session from the agent panel.
+
+Zed documents ACP agent registration in its ACP registry docs
+(https://zed.dev/acp). Re-verify the click-path against your Zed version
+before writing customer runbooks.
+
+## 3. Expected session shape
+
+A healthy session follows:
+
+1. `initialize` (protocol version + agent info)
+2. `session/new`
+3. `session/prompt` (client may see a permission request first)
+4. `session/update` streaming from the agent while work runs
+5. Completion or cancel
+
+Scripted coverage of this path lives in
+`packages/harnesses/src/acp/__tests__/acp-agent.test.ts` (Phase D acceptance).
+
+## 4. Wire data-plane MCP when you need collections
+
+ACP does not replace MCP for collection tools. Configure the editor's MCP
+client (or a companion process) with the governed endpoint and
+`REVEALUI_MCP_TOKEN`, the same way as Cursor or OpenCode. Revoking that
+token stops data-plane access on the next MCP request even if the ACP
+session stays open.
+
+## Rotating or revoking access
+
+- **Device token:** revoke in RevealUI; update env or client secrets.
+- **Agent process:** stop the ACP session in the editor; the stdio process
+  exits when the client disconnects.
+
+## Troubleshooting
+
+- **Protocol parse errors:** something wrote non-JSON to stdout. Keep only
+  `revealui-harnesses acp` on that stream.
+- **Unknown session errors:** the client reused a session id after process
+  restart. Start `session/new` again.
+- **Permission prompts every turn:** default Phase D posture. Disable only
+  if you intentionally change agent options in code; customer builds should
+  keep human approval for consequential prompts.
+
+## Sources
+
+- CLI entry: `packages/harnesses/src/cli.ts` (`acp` command)
+- Agent app: `packages/harnesses/src/acp/agent.ts`
+- Stdio transport: `packages/harnesses/src/acp/stdio.ts`
+- Acceptance tests: `packages/harnesses/src/acp/__tests__/acp-agent.test.ts`
+- Dependency posture: official `@agentclientprotocol/sdk` (GAP-381 D-B),
+  pinned in `@revealui/harnesses` package.json

--- a/docs/guides/connect-cursor.md
+++ b/docs/guides/connect-cursor.md
@@ -1,0 +1,164 @@
+---
+title: "Connect Cursor"
+description: "Wire Cursor hooks and the governed MCP endpoint so Cursor is a governed and audited user of your RevealUI data."
+visibility: public
+status: verified
+audience: developer
+---
+
+# Connect Cursor
+
+Cursor can call your RevealUI instance through the governed Model Context
+Protocol (MCP) endpoint, and RevealUI can observe Cursor's agent loop through
+command-based hooks. Every MCP tool call runs as a specific authenticated
+RevealUI user. Hooks can spool receipts into the audit path when you flush
+them. This guide covers a project-level setup from a fresh Cursor install.
+
+## What governance means here
+
+Cursor brings its own models (including Grok when you enable it in Cursor).
+RevealUI never hosts a frontier model and never ships a proprietary model
+SDK. RevealUI provides the governed data layer: identity, authorization, and
+an audit trail for what agents do **through RevealUI**.
+
+- **Authenticated.** MCP requests carry your own device token. There is no
+  shared service key on this path.
+- **Authorized.** The same role-based and row-level rules that govern a human
+  request govern the agent request.
+- **Audited.** Tool calls through the governed MCP endpoint write receipts.
+  Hook events can spool receipts via `revealui-harnesses hook cursor`.
+- **Revocable.** Revoking the device token stops MCP access on the next
+  request. The server re-validates the token every time
+  (`apps/server/src/middleware/auth.ts`), not only when a session starts.
+
+### Honest limits (read before you ship this to customers)
+
+Cursor is a closed-source product with its own cloud surfaces. Grok models
+available inside Cursor are Cursor's product, trained in part on Cursor
+usage data. RevealUI receipts record what happened on the RevealUI layer
+(MCP tools, hooks that flush into your instance). They are **not** a claim
+that Cursor itself phones home nothing, and they are not a substitute for
+Cursor Team or Enterprise hook policy if you need org-wide enforcement.
+
+User-level hook config is user-removable unless pinned by Cursor Team or
+Enterprise policy. Treat local hooks as advisory until your org pins them.
+
+## Prerequisites
+
+- A RevealUI account on the instance you want to connect to.
+- Cursor installed (desktop agent with hooks + MCP support).
+- `revealui-harnesses` on your `PATH` (from the monorepo or a published
+  `@revealui/harnesses` install), so hook commands resolve.
+- A device token minted through the studio-auth device flow (same mint as
+  OpenCode and other MCP clients).
+
+## 1. Mint a device token
+
+Use the same studio-auth link/verify flow described in
+[Connect OpenCode](./connect-opencode.md#1-mint-a-device-token). The token has
+the shape `rvui_dev_<64 hex characters>`. Treat it like a password.
+
+## 2. Store the token in the environment
+
+```bash
+export REVEALUI_MCP_TOKEN="rvui_dev_your_token_here"
+```
+
+Never commit the token. Prefer revvault on operator machines
+(`revealui/dev/mcp/cursor-device-token` or the shared
+`revealui/dev/mcp/opencode-device-token` path if you reuse one token).
+
+## 3. Wire governed MCP into `.cursor/mcp.json`
+
+Cursor resolves secrets with `${env:NAME}` (not OpenCode's `{env:NAME}`).
+
+```jsonc
+// .cursor/mcp.json
+{
+  "mcpServers": {
+    "revealui": {
+      "url": "https://<your-host>/api/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:REVEALUI_MCP_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Replace `<your-host>` with your instance. The file must never contain a
+literal token value.
+
+The leak-proof helper that builds this shape is
+`protocolConfigToCursorMcpConfig` in `@revealui/harnesses`
+(`packages/harnesses/src/protocol/config-normalizer.ts`).
+
+## 4. Install command-based hooks
+
+Generate or hand-write `.cursor/hooks.json` so every documented Cursor hook
+event runs the same command:
+
+```jsonc
+// .cursor/hooks.json
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "sessionEnd": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "preToolUse": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "postToolUse": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "beforeShellExecution": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "afterShellExecution": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "beforeMCPExecution": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "afterMCPExecution": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "beforeReadFile": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "afterFileEdit": [{ "command": "revealui-harnesses hook cursor", "type": "command" }],
+    "stop": [{ "command": "revealui-harnesses hook cursor", "type": "command" }]
+  }
+}
+```
+
+From a monorepo checkout you can also generate the hooks file via the
+`cursor` content generator (`CursorGenerator` → `.cursor/hooks.json`).
+
+The hook CLI reads JSON on stdin, evaluates local policy, spools a receipt,
+and prints the permission decision. Invalid stdin defaults to allow so a
+bad payload does not crash Cursor's hook pipeline.
+
+## 5. Confirm MCP
+
+In Cursor, open the MCP panel and confirm the `revealui` server is
+connected. List tools and run a low-risk call (for example list sites) that
+your account is allowed to execute.
+
+## 6. Confirm hooks
+
+Trigger any tool call and confirm `revealui-harnesses hook cursor` runs
+(watch for the process, or inspect the local spool if flush is not yet
+configured). Live flush into `POST /api/harness/receipts` uses the same
+device-token auth as MCP when you enable it.
+
+## Rotating or revoking the token
+
+Revoke the device token in RevealUI and mint a new one. Update
+`REVEALUI_MCP_TOKEN`. Revocation takes effect on the next MCP request.
+
+## Troubleshooting
+
+- **401 on MCP:** missing, expired, or revoked token. Re-export
+  `REVEALUI_MCP_TOKEN` and restart Cursor if it cached the env.
+- **Hook command not found:** install `@revealui/harnesses` or put
+  `revealui-harnesses` on `PATH`.
+- **Tool missing from discovery:** MCP only lists tools your account may
+  run. That is authorization, not a Cursor bug.
+- **Hooks feel optional:** user-level hooks are removable. Use Cursor Team
+  or Enterprise policy when you need org-wide enforcement.
+
+## Sources
+
+- Cursor MCP env substitution `${env:NAME}`: Cursor MCP docs (verified in
+  `protocolConfigToCursorMcpConfig` comments, 2026-07-17).
+- Hook generator: `packages/harnesses/src/content/generators/cursor.ts`
+- Hook CLI: `packages/harnesses/src/cli.ts` (`hook cursor`)
+- Per-request bearer validation: `apps/server/src/middleware/auth.ts`
+- Device mint and revoke: `apps/server/src/routes/studio-auth.ts`

--- a/docs/guides/connect-cursor.md
+++ b/docs/guides/connect-cursor.md
@@ -29,7 +29,7 @@ an audit trail for what agents do **through RevealUI**.
   Hook events can spool receipts via `revealui-harnesses hook cursor`.
 - **Revocable.** Revoking the device token stops MCP access on the next
   request. The server re-validates the token every time
-  (`apps/server/src/middleware/auth.ts`), not only when a session starts.
+  (`apps/server/src/middleware/auth.ts:26`), not only when a session starts.
 
 ### Honest limits (read before you ship this to customers)
 
@@ -123,7 +123,8 @@ From a monorepo checkout you can also generate the hooks file via the
 
 The hook CLI reads JSON on stdin, evaluates local policy, spools a receipt,
 and prints the permission decision. Invalid stdin defaults to allow so a
-bad payload does not crash Cursor's hook pipeline.
+bad payload does not crash Cursor's hook pipeline
+(`packages/harnesses/src/cli.ts:506`).
 
 ## 5. Confirm MCP
 

--- a/docs/guides/connect-cursor.md
+++ b/docs/guides/connect-cursor.md
@@ -28,8 +28,7 @@ an audit trail for what agents do **through RevealUI**.
 - **Audited.** Tool calls through the governed MCP endpoint write receipts.
   Hook events can spool receipts via `revealui-harnesses hook cursor`.
 - **Revocable.** Revoking the device token stops MCP access on the next
-  request. The server re-validates the token on every request
-  (`apps/server/src/middleware/auth.ts:26`), not only when a session starts.
+  request. The server re-validates the token on every request (`apps/server/src/middleware/auth.ts:26`), not only when a session starts.
 
 ### Honest limits (read before you ship this to customers)
 
@@ -122,9 +121,7 @@ From a monorepo checkout you can also generate the hooks file via the
 `cursor` content generator (`CursorGenerator` → `.cursor/hooks.json`).
 
 The hook CLI reads JSON on stdin, evaluates local policy, spools a receipt,
-and prints the permission decision. Invalid stdin defaults to allow
-(`packages/harnesses/src/cli.ts:506`) so a bad payload does not crash
-Cursor's hook pipeline.
+and prints the permission decision. Invalid stdin defaults to allow (`packages/harnesses/src/cli.ts:506`) so a bad payload does not crash Cursor's hook pipeline.
 
 ## 5. Confirm MCP
 

--- a/docs/guides/connect-cursor.md
+++ b/docs/guides/connect-cursor.md
@@ -28,7 +28,7 @@ an audit trail for what agents do **through RevealUI**.
 - **Audited.** Tool calls through the governed MCP endpoint write receipts.
   Hook events can spool receipts via `revealui-harnesses hook cursor`.
 - **Revocable.** Revoking the device token stops MCP access on the next
-  request. The server re-validates the token every time
+  request. The server re-validates the token on every request
   (`apps/server/src/middleware/auth.ts:26`), not only when a session starts.
 
 ### Honest limits (read before you ship this to customers)
@@ -122,9 +122,9 @@ From a monorepo checkout you can also generate the hooks file via the
 `cursor` content generator (`CursorGenerator` → `.cursor/hooks.json`).
 
 The hook CLI reads JSON on stdin, evaluates local policy, spools a receipt,
-and prints the permission decision. Invalid stdin defaults to allow so a
-bad payload does not crash Cursor's hook pipeline
-(`packages/harnesses/src/cli.ts:506`).
+and prints the permission decision. Invalid stdin defaults to allow
+(`packages/harnesses/src/cli.ts:506`) so a bad payload does not crash
+Cursor's hook pipeline.
 
 ## 5. Confirm MCP
 

--- a/docs/guides/connect-vscode.md
+++ b/docs/guides/connect-vscode.md
@@ -13,9 +13,9 @@ governed MCP endpoint, with hook receipts running as command-based plugin
 hooks. This guide uses the project-local plugin bundle that
 `@revealui/harnesses` generates under `.revealui/vscode-plugin/`.
 
-Package-level detail (org allowlists, Preview cadence) lives in the monorepo
-at `packages/harnesses/docs/vscode-agent-plugin.md` (package docs, not a
-served docs-site page).
+For install and org-policy notes that are not repeated here, see the package
+doc path `packages/harnesses/docs/vscode-agent-plugin.md` in the monorepo
+checkout (not a served docs.revealui.com page).
 
 ## What governance means here
 

--- a/docs/guides/connect-vscode.md
+++ b/docs/guides/connect-vscode.md
@@ -1,0 +1,135 @@
+---
+title: "Connect VS Code"
+description: "Install the RevealUI VS Code agent-plugin bundle so Copilot agent mode uses governed MCP and command-based hooks."
+visibility: public
+status: verified
+audience: developer
+---
+
+# Connect VS Code
+
+VS Code Copilot agent mode can reach a RevealUI instance through the
+governed MCP endpoint, with hook receipts running as command-based plugin
+hooks. This guide uses the project-local plugin bundle that
+`@revealui/harnesses` generates under `.revealui/vscode-plugin/`.
+
+Package-level detail (org allowlists, Preview cadence) lives in
+[`packages/harnesses/docs/vscode-agent-plugin.md`](../../packages/harnesses/docs/vscode-agent-plugin.md).
+
+## What governance means here
+
+VS Code and GitHub Copilot bring their own models. RevealUI provides the
+governed data layer: identity, authorization, and audit receipts for agent
+actions that go through RevealUI.
+
+- **Authenticated.** MCP requests use a device token you supply once via a
+  password-masked VS Code input (not a committed secret).
+- **Authorized.** Collection and tool access use the same rules as a human
+  session for that user.
+- **Audited.** Governed MCP tool calls leave receipts. Hooks run
+  `revealui-harnesses hook vscode` and can spool events for flush into
+  `POST /api/harness/receipts`.
+- **Revocable.** Revoking the device token stops the next MCP request.
+
+### Honest limits
+
+VS Code agent plugins are in Preview with a high release cadence. Re-verify
+against current Microsoft docs before a customer rollout. Marketplace
+publishing is an owner operation (design decision D-C) and is not required
+for local install. Enterprise MCP access is also governed by GitHub Copilot
+org policy; a local `.mcp.json` does not bypass an org registry-only mode.
+
+## Prerequisites
+
+- VS Code with Copilot agent mode available on your account.
+- `revealui-harnesses` on your `PATH`.
+- A RevealUI device token (same mint as [Connect OpenCode](./connect-opencode.md)).
+
+## 1. Mint a device token
+
+Follow [Connect OpenCode §1](./connect-opencode.md#1-mint-a-device-token). Store
+the value in revvault if you want a durable path
+(`revealui/dev/mcp/vscode-device-token` or the shared
+`revealui/dev/mcp/opencode-device-token`).
+
+## 2. Generate the plugin bundle
+
+From a RevealUI monorepo or a project that already materializes harness
+content, generate the VS Code plugin so you get:
+
+- `.revealui/vscode-plugin/plugin.json` (hooks + path reference to MCP config)
+- A separate `.mcp.json` (or the path your generator expects) produced via
+  `protocolConfigToVSCodeMcpConfig` with your MCP URL
+
+Hand-written equivalent for `.mcp.json` (never put a literal token in the
+file):
+
+```jsonc
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "revealui-mcp-token",
+      "description": "RevealUI governed MCP device token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "revealui": {
+      "type": "http",
+      "url": "https://<your-host>/api/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:revealui-mcp-token}"
+      }
+    }
+  }
+}
+```
+
+VS Code prompts for the token on first use and stores it. Substitution uses
+`${input:id}`, not an environment variable.
+
+## 3. Register the local plugin
+
+VS Code does not auto-discover project plugins. Add the absolute path of the
+generated bundle:
+
+```jsonc
+// settings.json (user or workspace)
+{
+  "chat.pluginLocations": {
+    "/absolute/path/to/project/.revealui/vscode-plugin": true
+  }
+}
+```
+
+## 4. Confirm
+
+1. Reload VS Code.
+2. Open agent chat and confirm the RevealUI MCP tools are available after
+   you complete the token prompt.
+3. Run a permitted tool call and confirm a receipt path (MCP audit and/or
+   hook spool).
+
+## Rotating or revoking the token
+
+Revoke the device token in RevealUI. Clear or update the stored VS Code
+input and mint a new token. The next MCP request will re-validate.
+
+## Troubleshooting
+
+- **Token prompt never appears:** check that `.mcp.json` is the path
+  `plugin.json` references and that `inputs[].id` matches `${input:…}`.
+- **Tools missing under Registry only org policy:** an admin must list
+  RevealUI's MCP endpoint in the org internal MCP registry (see the
+  package doc). Local config alone is not enough.
+- **Hook command not found:** put `revealui-harnesses` on `PATH`.
+
+## Sources
+
+- Generator: `packages/harnesses/src/content/generators/vscode.ts`
+- MCP fragment: `protocolConfigToVSCodeMcpConfig` in
+  `packages/harnesses/src/protocol/config-normalizer.ts`
+- Install and org allowlist notes:
+  `packages/harnesses/docs/vscode-agent-plugin.md`
+- Per-request bearer validation: `apps/server/src/middleware/auth.ts`

--- a/docs/guides/connect-vscode.md
+++ b/docs/guides/connect-vscode.md
@@ -13,8 +13,9 @@ governed MCP endpoint, with hook receipts running as command-based plugin
 hooks. This guide uses the project-local plugin bundle that
 `@revealui/harnesses` generates under `.revealui/vscode-plugin/`.
 
-Package-level detail (org allowlists, Preview cadence) lives in
-[`packages/harnesses/docs/vscode-agent-plugin.md`](../../packages/harnesses/docs/vscode-agent-plugin.md).
+Package-level detail (org allowlists, Preview cadence) lives in the monorepo
+at `packages/harnesses/docs/vscode-agent-plugin.md` (package docs, not a
+served docs-site page).
 
 ## What governance means here
 


### PR DESCRIPTION
## Summary

Promote `test` → `main` for GAP-381 Phase E public connect guides (#2469) and any test tip commits not yet on main.

Includes connect-cursor / connect-vscode / connect-acp, SECRETS aliases, docs slug-manifest.

## Residual (owner, not this PR)

- Real-editor e2e
- D-C Marketplace
- D-D final copy sign-off