### PR TITLE
chore(release): promote admin founder UX (#2478) to main

### DIFF
--- a/apps/admin/src/lib/components/AdminSidebarLayout.tsx
+++ b/apps/admin/src/lib/components/AdminSidebarLayout.tsx
@@ -31,13 +31,19 @@ import {
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { FreeTierBanner } from '@/components/FreeTierBanner';
+import { useLicense } from '@/lib/providers/LicenseProvider';
+import { shouldShowUpgradeNavItem } from './should-show-upgrade-nav';
 import { UpgradeDialog } from './UpgradeDialog';
+
+export { shouldShowUpgradeNavItem } from './should-show-upgrade-nav';
 
 interface NavItem {
   href: string;
   label: string;
   icon: ReactNode;
   adminOnly?: boolean;
+  /** When true, only render if the account still has a higher paid tier to buy. */
+  upgradeOnly?: boolean;
 }
 
 const iconClass = 'size-5';
@@ -125,6 +131,7 @@ const bottomItems: NavItem[] = [
   {
     href: '/upgrade',
     label: 'Upgrade',
+    upgradeOnly: true,
     icon: <IconStar data-slot="icon" className={iconClass} aria-hidden="true" />,
   },
   {
@@ -139,19 +146,32 @@ function AdminSidebarContent({
   siteName,
   isAdmin,
   appVersion,
+  isFleetMode,
 }: {
   siteName: string;
   isAdmin: boolean;
   appVersion: string;
+  isFleetMode: boolean;
 }) {
   const pathname = usePathname();
+  const { tier, isLoading, resolveError } = useLicense();
 
   const isCurrent = (href: string) => {
     if (href === '/') return pathname === '/';
     return pathname.startsWith(href);
   };
 
-  const visibleBottomItems = isAdmin ? bottomItems : bottomItems.filter((item) => !item.adminOnly);
+  const showUpgrade = shouldShowUpgradeNavItem(tier, {
+    isFleetMode,
+    isLoading,
+    resolveError,
+  });
+
+  const visibleBottomItems = bottomItems.filter((item) => {
+    if (item.adminOnly && !isAdmin) return false;
+    if (item.upgradeOnly && !showUpgrade) return false;
+    return true;
+  });
 
   return (
     <Sidebar>
@@ -202,7 +222,7 @@ function AdminSidebarContent({
       </SidebarBody>
       <SidebarFooter>
         {/* Version sits in the footer row — never on/over nav icons (settings gear). */}
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center justify-between gap-2">
           <p className="min-w-0 truncate text-xs text-muted-foreground">{siteName} Admin</p>
           <span
             className="shrink-0 text-xs tabular-nums text-muted-foreground"
@@ -236,7 +256,12 @@ export function AdminSidebarLayout({
     <SidebarLayout
       navbar={<span />}
       sidebar={
-        <AdminSidebarContent siteName={siteName} isAdmin={isAdmin} appVersion={appVersion} />
+        <AdminSidebarContent
+          siteName={siteName}
+          isAdmin={isAdmin}
+          appVersion={appVersion}
+          isFleetMode={isFleetMode}
+        />
       }
     >
       {isFleetMode ? null : <FreeTierBanner isHosted={isHosted} />}

--- a/apps/admin/src/lib/components/__tests__/adminChromeBranding.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/adminChromeBranding.test.tsx
@@ -8,8 +8,16 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/',
 }));
 
+const licenseMock = vi.hoisted(() => ({
+  tier: 'pro' as string,
+  features: {} as Record<string, unknown>,
+  isLoading: false,
+  resolveError: null as null | string,
+  refetch: () => {},
+}));
+
 vi.mock('@/lib/providers/LicenseProvider', () => ({
-  useLicense: () => ({ tier: 'pro', features: {}, isLoading: false, refetch: () => {} }),
+  useLicense: () => licenseMock,
 }));
 
 // The admin chrome must show the kit's brand, never the framework name,
@@ -20,6 +28,9 @@ const saved: Record<string, string | undefined> = {};
 
 describe('admin chrome white-label branding', () => {
   beforeEach(() => {
+    licenseMock.tier = 'pro';
+    licenseMock.isLoading = false;
+    licenseMock.resolveError = null;
     for (const key of ENV_KEYS) {
       saved[key] = process.env[key];
     }
@@ -59,6 +70,32 @@ describe('admin chrome white-label branding', () => {
       // Settings gear row is a separate nav item; version is footer-only.
       expect(screen.getByText('Settings')).toBeDefined();
       expect(screen.queryByText('v0.1.0')).toBeNull();
+    });
+
+    it('shows Upgrade for free/pro when a higher tier exists', () => {
+      licenseMock.tier = 'free';
+      licenseMock.isLoading = false;
+      licenseMock.resolveError = null;
+      render(<AdminSidebarLayout>content</AdminSidebarLayout>);
+      expect(screen.getByText('Upgrade')).toBeDefined();
+    });
+
+    it('hides Upgrade for enterprise (founder / top tier)', () => {
+      licenseMock.tier = 'enterprise';
+      licenseMock.isLoading = false;
+      licenseMock.resolveError = null;
+      render(<AdminSidebarLayout>content</AdminSidebarLayout>);
+      expect(screen.queryByText('Upgrade')).toBeNull();
+    });
+
+    it('hides Upgrade for max when only enterprise remains above', () => {
+      // getTiersFromCurrent('max') still returns enterprise — product choice:
+      // still show Upgrade for max so Max can buy Enterprise.
+      licenseMock.tier = 'max';
+      licenseMock.isLoading = false;
+      licenseMock.resolveError = null;
+      render(<AdminSidebarLayout>content</AdminSidebarLayout>);
+      expect(screen.getByText('Upgrade')).toBeDefined();
     });
   });
 

--- a/apps/admin/src/lib/components/__tests__/shouldShowUpgradeNavItem.test.ts
+++ b/apps/admin/src/lib/components/__tests__/shouldShowUpgradeNavItem.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowUpgradeNavItem } from '../should-show-upgrade-nav';
+
+describe('shouldShowUpgradeNavItem', () => {
+  const base = { isFleetMode: false, isLoading: false, resolveError: null };
+
+  it('shows for free and pro', () => {
+    expect(shouldShowUpgradeNavItem('free', base)).toBe(true);
+    expect(shouldShowUpgradeNavItem('pro', base)).toBe(true);
+  });
+
+  it('shows for max (enterprise still above)', () => {
+    expect(shouldShowUpgradeNavItem('max', base)).toBe(true);
+  });
+
+  it('hides for enterprise (top commercial tier / founder grant)', () => {
+    expect(shouldShowUpgradeNavItem('enterprise', base)).toBe(false);
+  });
+
+  it('hides in fleet mode', () => {
+    expect(shouldShowUpgradeNavItem('free', { ...base, isFleetMode: true })).toBe(false);
+  });
+
+  it('hides while loading or on resolve error', () => {
+    expect(shouldShowUpgradeNavItem('free', { ...base, isLoading: true })).toBe(false);
+    expect(shouldShowUpgradeNavItem('free', { ...base, resolveError: 'unavailable' })).toBe(false);
+  });
+});

--- a/apps/admin/src/lib/components/should-show-upgrade-nav.ts
+++ b/apps/admin/src/lib/components/should-show-upgrade-nav.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether the sidebar "Upgrade" item should show.
+ *
+ * Mirrors commercial ladder free < pro < max < enterprise (see
+ * `@revealui/contracts/pricing` TIER_RANK / getTiersFromCurrent). Enterprise
+ * is the top grant (founder / operator) — no higher plan, no Upgrade nav.
+ * Fleet kits never show Stripe upgrade. While tier is loading or resolution
+ * failed, hide upsell (GAP-454: do not invent free/upsell on unknown).
+ */
+
+const TIER_RANK: Record<string, number> = {
+  free: 0,
+  pro: 1,
+  max: 2,
+  enterprise: 3,
+};
+
+const TOP_RANK = TIER_RANK.enterprise;
+
+export function shouldShowUpgradeNavItem(
+  tier: string,
+  options: {
+    isFleetMode: boolean;
+    isLoading: boolean;
+    resolveError: unknown;
+  },
+): boolean {
+  if (options.isFleetMode) return false;
+  if (options.isLoading || options.resolveError) return false;
+  const rank = TIER_RANK[tier];
+  if (rank === undefined) return false;
+  return rank < TOP_RANK;
+}

--- a/apps/admin/src/lib/components/should-show-upgrade-nav.ts
+++ b/apps/admin/src/lib/components/should-show-upgrade-nav.ts
@@ -8,14 +8,15 @@
  * failed, hide upsell (GAP-454: do not invent free/upsell on unknown).
  */
 
-const TIER_RANK: Record<string, number> = {
+const TIER_RANK = {
   free: 0,
   pro: 1,
   max: 2,
   enterprise: 3,
-};
+} as const;
 
-const TOP_RANK = TIER_RANK.enterprise;
+/** Enterprise is the commercial top; no higher plan to upsell into. */
+const TOP_RANK: number = TIER_RANK.enterprise;
 
 export function shouldShowUpgradeNavItem(
   tier: string,
@@ -27,7 +28,7 @@ export function shouldShowUpgradeNavItem(
 ): boolean {
   if (options.isFleetMode) return false;
   if (options.isLoading || options.resolveError) return false;
-  const rank = TIER_RANK[tier];
-  if (rank === undefined) return false;
+  if (!(tier in TIER_RANK)) return false;
+  const rank = TIER_RANK[tier as keyof typeof TIER_RANK];
   return rank < TOP_RANK;
 }

--- a/packages/presentation/src/__tests__/components/sidebar-layout.test.tsx
+++ b/packages/presentation/src/__tests__/components/sidebar-layout.test.tsx
@@ -55,4 +55,17 @@ describe('SidebarLayout', () => {
     );
     expect(screen.getByRole('main')).toBeInTheDocument();
   });
+
+  it('constrains the shell so nested flex content cannot force page x-scroll', () => {
+    const { container } = render(
+      <SidebarLayout navbar={<div>Nav</div>} sidebar={<div>Side</div>}>
+        <p>Content</p>
+      </SidebarLayout>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/overflow-x-hidden/);
+    expect(root.className).toMatch(/max-w-\[100vw\]/);
+    const main = screen.getByRole('main');
+    expect(main.className).toMatch(/min-w-0/);
+  });
 });

--- a/packages/presentation/src/components/sidebar-layout.tsx
+++ b/packages/presentation/src/components/sidebar-layout.tsx
@@ -94,9 +94,12 @@ export function SidebarLayout({
   const [showSidebar, setShowSidebar] = useState(false);
 
   return (
-    <div className="relative isolate flex min-h-svh w-full bg-background max-lg:flex-col">
+    // Nested flex/fixed shells need min-w-0 + max-w full-viewport so wide
+    // children (tables, pre, grids) do not force document-level horizontal
+    // scroll. Inner content may still overflow-x-auto when intentionally wide.
+    <div className="relative isolate flex min-h-svh w-full max-w-[100vw] overflow-x-hidden bg-background max-lg:flex-col">
       {/* Sidebar on desktop */}
-      <div className="fixed inset-y-0 left-0 w-64 max-lg:hidden">{sidebar}</div>
+      <div className="fixed inset-y-0 left-0 z-10 w-64 max-lg:hidden">{sidebar}</div>
 
       {/* Sidebar on mobile */}
       <MobileSidebar open={showSidebar} close={() => setShowSidebar(false)}>
@@ -104,7 +107,7 @@ export function SidebarLayout({
       </MobileSidebar>
 
       {/* Navbar on mobile */}
-      <header className="flex items-center px-4 lg:hidden">
+      <header className="flex min-w-0 items-center px-4 lg:hidden">
         <div className="py-2.5">
           <NavbarItem onClick={() => setShowSidebar(true)} aria-label="Open navigation">
             <OpenMenuIcon />
@@ -113,10 +116,10 @@ export function SidebarLayout({
         <div className="min-w-0 flex-1">{navbar}</div>
       </header>
 
-      {/* Content */}
-      <main className="flex flex-1 flex-col pb-2 lg:min-w-0 lg:pt-2 lg:pr-2 lg:pl-64">
-        <div className="grow p-6 lg:rounded-lg lg:bg-card lg:p-10 lg:shadow-xs lg:ring-1 lg:ring-border">
-          <div className="mx-auto max-w-6xl">{children}</div>
+      {/* Content — min-w-0 is required for flex children to shrink below content width */}
+      <main className="flex min-w-0 flex-1 flex-col pb-2 lg:pt-2 lg:pr-2 lg:pl-64">
+        <div className="min-w-0 grow p-6 lg:rounded-lg lg:bg-card lg:p-10 lg:shadow-xs lg:ring-1 lg:ring-border">
+          <div className="mx-auto min-w-0 max-w-6xl overflow-x-auto">{children}</div>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary

Promote `test` → `main` after [revealui#2478](https://github.com/RevealUIStudio/revealui/pull/2478) (founder upgrade chrome + nested layout overflow + TOP_RANK tsc fix).

## Includes

- Hide Upgrade nav for enterprise / top tier
- SidebarLayout overflow fix (no document-level x-scroll)
- `shouldShowUpgradeNavItem` TOP_RANK type narrowing for admin build

## Deploy

Vercel production deploys from `main`. After merge, verify admin.revealui.com:
- enterprise session: no Upgrade in left nav
- nested admin pages: no document horizontal scroll

## Merge method

**Create a merge commit** (not squash) per fleet promote policy.