### PR TITLE
fix(admin): stamp revealui-role on MFA session establish

### DIFF
--- a/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
@@ -59,6 +59,10 @@ vi.mock('@revealui/db', () => ({
   getClient: vi.fn(() => mockDb),
 }));
 
+vi.mock('@revealui/db/queries/users', () => ({
+  getUserById: vi.fn(async () => ({ id: 'user-123', role: 'admin' })),
+}));
+
 vi.mock('@revealui/db/schema', () => ({
   passkeys: {
     credentialId: 'credential_id',
@@ -293,6 +297,8 @@ describe('POST /api/auth/mfa/verify-setup', () => {
     );
     const setCookie = response.headers.get('set-cookie') ?? '';
     expect(setCookie).toMatch(/revealui-session=session-after-mfa-setup/);
+    // Keep role cookie aligned with session rotation after enroll
+    expect(response.cookies.get('revealui-role')?.value).toBe(mockSession.user.role);
   });
 
   it('should return 400 on invalid code', async () => {
@@ -404,6 +410,10 @@ describe('POST /api/auth/mfa/verify', () => {
     const sessionCookie = response.cookies.get('revealui-session');
     expect(sessionCookie?.value).toBe('new-session-token');
 
+    // Proxy admin-only paths (/settings) require revealui-role; MFA must stamp it
+    const roleCookie = response.cookies.get('revealui-role');
+    expect(roleCookie?.value).toBe('admin');
+
     // Check mfa-pending cookie was cleared
     const mfaCookie = response.cookies.get('mfa-pending');
     expect(mfaCookie?.value).toBe('');
@@ -514,6 +524,9 @@ describe('POST /api/auth/mfa/backup', () => {
     // Check session cookie was set
     const sessionCookie = response.cookies.get('revealui-session');
     expect(sessionCookie?.value).toBe('new-session-token');
+
+    const roleCookie = response.cookies.get('revealui-role');
+    expect(roleCookie?.value).toBe('admin');
 
     // Check mfa-pending cookie was cleared
     const mfaCookie = response.cookies.get('mfa-pending');

--- a/apps/admin/src/app/api/auth/mfa/backup/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/backup/route.ts
@@ -6,12 +6,14 @@
  * Step 2 of MFA login flow (backup path): validates a one-time backup code
  * when the user's authenticator app is unavailable.
  * Reads userId from the `mfa-pending` signed cookie (set during sign-in).
- * On success, creates a full session and sets the `revealui-session` cookie.
+ * On success, creates a full session and sets `revealui-session` + `revealui-role`.
  */
 
 import { rotateSession, verifyBackupCode, verifyCookiePayload } from '@revealui/auth/server';
 import config from '@revealui/config';
 import { MFABackupCodeRequestContract } from '@revealui/contracts';
+import { getClient } from '@revealui/db';
+import { getUserById } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
@@ -20,7 +22,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
-import { sessionCookieDomain } from '@/lib/utils/session-cookies';
+import { sessionCookieDomain, setRoleCookie } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -101,6 +103,8 @@ async function backupHandler(request: NextRequest): Promise<NextResponse> {
       metadata: { mfaVerified: true },
     });
 
+    const user = await getUserById(getClient(), payload.userId);
+
     const response = NextResponse.json({
       success: true,
       remainingCodes: result.remainingCodes,
@@ -115,6 +119,7 @@ async function backupHandler(request: NextRequest): Promise<NextResponse> {
       maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
       domain: sessionCookieDomain({ logIfMissing: true }),
     });
+    setRoleCookie(response, user?.role, { maxAge: 60 * 60 * 24 });
 
     // Clear the mfa-pending cookie
     response.cookies.set('mfa-pending', '', {

--- a/apps/admin/src/app/api/auth/mfa/verify-setup/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify-setup/route.ts
@@ -18,7 +18,7 @@ import {
 } from '@/lib/utils/error-response';
 import { rejectRecoverySession } from '@/lib/utils/recovery-guard';
 import { extractRequestContext } from '@/lib/utils/request-context';
-import { sessionCookieDomain } from '@/lib/utils/session-cookies';
+import { sessionCookieDomain, setRoleCookie } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -96,6 +96,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       maxAge: 60 * 60 * 24,
       domain: sessionCookieDomain({ logIfMissing: true }),
     });
+    // Keep role cookie in lockstep when rotating the session after MFA enroll.
+    setRoleCookie(response, session.user.role, { maxAge: 60 * 60 * 24 });
     return response;
   } catch (error) {
     logger.error('Error verifying MFA setup', { error });

--- a/apps/admin/src/app/api/auth/mfa/verify/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify/route.ts
@@ -5,12 +5,15 @@
  *
  * Step 2 of MFA login flow: validates a TOTP code from the user's authenticator app.
  * Reads userId from the `mfa-pending` signed cookie (set during sign-in).
- * On success, creates a full session and sets the `revealui-session` cookie.
+ * On success, creates a full session and sets `revealui-session` + `revealui-role`
+ * (role cookie is required for proxy admin-only paths such as /settings).
  */
 
 import { rotateSession, verifyCookiePayload, verifyMFACode } from '@revealui/auth/server';
 import config from '@revealui/config';
 import { MFAVerifyRequestContract } from '@revealui/contracts';
+import { getClient } from '@revealui/db';
+import { getUserById } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
@@ -19,7 +22,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
-import { sessionCookieDomain } from '@/lib/utils/session-cookies';
+import { sessionCookieDomain, setRoleCookie } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -101,6 +104,10 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       metadata: { mfaVerified: true },
     });
 
+    // Role for proxy gate — sign-in skips setting it when MFA is required;
+    // this is the real session-establish step and must stamp the cookie.
+    const user = await getUserById(getClient(), payload.userId);
+
     const response = NextResponse.json({ success: true });
 
     // Set session cookie (same pattern as sign-in route)
@@ -112,6 +119,7 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
       domain: sessionCookieDomain({ logIfMissing: true }),
     });
+    setRoleCookie(response, user?.role, { maxAge: 60 * 60 * 24 });
 
     // Clear the mfa-pending cookie
     response.cookies.set('mfa-pending', '', {

--- a/apps/admin/src/app/api/auth/recovery/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/recovery/__tests__/routes.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/lib/email', () => ({
 
 // Mock the database
 const mockGetUserByEmail = vi.fn();
+const mockGetUserById = vi.fn();
 
 vi.mock('@revealui/db', () => ({
   getClient: vi.fn(() => ({})),
@@ -48,6 +49,7 @@ vi.mock('@revealui/db', () => ({
 
 vi.mock('@revealui/db/queries/users', () => ({
   getUserByEmail: (...args: unknown[]) => mockGetUserByEmail(...args),
+  getUserById: (...args: unknown[]) => mockGetUserById(...args),
 }));
 
 const mockCreateMagicLink = vi.mocked(authServer.createMagicLink);
@@ -68,6 +70,7 @@ function createJsonRequest(url: string, body: unknown): NextRequest {
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetUserByEmail.mockResolvedValue(null);
+  mockGetUserById.mockResolvedValue({ id: 'user-456', role: 'admin' });
 });
 
 // ============================================================================
@@ -193,6 +196,9 @@ describe('POST /api/auth/recovery/verify', () => {
     // Check session cookie was set
     const sessionCookie = response.cookies.get('revealui-session');
     expect(sessionCookie?.value).toBe('recovery-session-token');
+    // Role cookie required for proxy admin-only paths (parity with MFA verify)
+    expect(response.cookies.get('revealui-role')?.value).toBe('admin');
+    expect(mockGetUserById).toHaveBeenCalledWith(expect.anything(), 'user-456');
   });
 
   it('should return 401 for invalid token', async () => {
@@ -243,6 +249,8 @@ describe('POST /api/auth/recovery/verify', () => {
 
   it('should set recovery session with 30-minute expiry', async () => {
     mockVerifyMagicLink.mockResolvedValue({ userId: 'user-789' });
+    mockDeleteAllUserSessions.mockResolvedValue(undefined);
+    mockGetUserById.mockResolvedValue({ id: 'user-789', role: 'owner' });
     mockCreateSession.mockResolvedValue({
       token: 'recovery-token',
       session: { id: 'session-id' } as never,
@@ -252,7 +260,9 @@ describe('POST /api/auth/recovery/verify', () => {
     const request = createJsonRequest('http://localhost:4000/api/auth/recovery/verify', {
       token: 'valid-token',
     });
-    await handler(request);
+    const response = await handler(request);
+    expect(response.status).toBe(200);
+    expect(response.cookies.get('revealui-role')?.value).toBe('owner');
     const after = Date.now();
 
     const sessionCall = mockCreateSession.mock.calls[0];

--- a/apps/admin/src/app/api/auth/recovery/verify/route.ts
+++ b/apps/admin/src/app/api/auth/recovery/verify/route.ts
@@ -9,6 +9,8 @@
 
 import { createSession, deleteAllUserSessions, verifyMagicLink } from '@revealui/auth/server';
 import { RecoveryVerifyRequestSchema } from '@revealui/contracts';
+import { getClient } from '@revealui/db';
+import { getUserById } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
@@ -17,7 +19,7 @@ import {
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
-import { sessionCookieDomain } from '@/lib/utils/session-cookies';
+import { sessionCookieDomain, setRoleCookie } from '@/lib/utils/session-cookies';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -81,6 +83,8 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       ipAddress,
     });
 
+    const user = await getUserById(getClient(), verified.userId);
+
     const response = NextResponse.json({ success: true });
 
     // Set session cookie (same pattern as sign-in / MFA verify routes)
@@ -92,6 +96,7 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       maxAge: 30 * 60, // 30 minutes (matches session expiry)
       domain: sessionCookieDomain({ logIfMissing: true }),
     });
+    setRoleCookie(response, user?.role, { maxAge: 30 * 60 });
 
     return response;
   } catch (error) {

--- a/apps/admin/src/lib/utils/session-cookies.ts
+++ b/apps/admin/src/lib/utils/session-cookies.ts
@@ -82,6 +82,32 @@ export function requireSessionCookieDomain(): string | undefined {
   return process.env.SESSION_COOKIE_DOMAIN || undefined;
 }
 
+/** Default maxAge for role hint: 7 days (matches non-MFA sign-in). */
+const ROLE_COOKIE_MAX_AGE_DEFAULT = 60 * 60 * 24 * 7;
+
+/**
+ * Set `revealui-role` for the proxy role-aware gate (admin-only paths like
+ * /settings, /users). Must be set on every session-establishing response —
+ * not only password sign-in. MFA verify/backup historically omitted this and
+ * left MFA users on a session-only cookie: dashboard worked, Settings bounced
+ * to /welcome?denied=admin.
+ */
+export function setRoleCookie(
+  response: NextResponse,
+  role: string | null | undefined,
+  options?: { maxAge?: number },
+): void {
+  const userRole = role && role.length > 0 ? role : 'viewer';
+  response.cookies.set(ROLE_COOKIE, userRole, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: options?.maxAge ?? ROLE_COOKIE_MAX_AGE_DEFAULT,
+    domain: sessionCookieDomain(),
+  });
+}
+
 /**
  * Expire the auth cookies with the same attributes they were set with:
  * `revealui-session` / `revealui-role` domain-scoped in production,


### PR DESCRIPTION
## Problem

Owner could sign in (MFA) and see the dashboard, but **Settings** redirected to `/welcome?denied=admin`.

- Dashboard only needs `revealui-session`
- `/settings` and `/users` need `revealui-role` in `owner|admin|super-admin` (proxy gate)
- Password sign-in with MFA returns early after `mfa-pending` and **does not** set role
- MFA verify/backup only set `revealui-session` → role cookie missing or stale → denied

DB role was already `admin`; this is a cookie stamp gap on MFA paths.

## Fix

- `setRoleCookie()` helper on session cookie utils
- MFA verify / backup / verify-setup + recovery magic-link stamp `revealui-role` from DB (or session user)
- Unit assertions on role cookie for MFA verify/backup/verify-setup

## After deploy

Sign out → sign in (email/password + MFA) → Settings should open. Groq API keys path then works for GAP-360.

## Test plan

- [ ] CI unit tests for MFA routes
- [ ] Live: MFA login → /settings (no denied=admin)