### PR TITLE
fix(harnesses): optionalDependency @revealui/ai for ACP headless resolve

### DIFF
--- a/.changeset/harnesses-acp-optional-ai.md
+++ b/.changeset/harnesses-acp-optional-ai.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": patch
+---
+
+Declare `@revealui/ai` as an optionalDependency so ACP headless prompts resolve the agent runtime in monorepo and install graphs (no hand symlinks / NODE_PATH).

--- a/docs/guides/connect-acp.md
+++ b/docs/guides/connect-acp.md
@@ -33,6 +33,15 @@ RevealUI device token on data-plane calls.
 - An ACP client (Zed with ACP agents, JetBrains ACP support, or another
   ACP-compatible host).
 - `@revealui/harnesses` installed so `revealui-harnesses` is on `PATH`.
+- **Headless agent prompts (default ACP executor):** `@revealui/ai` must resolve
+  next to harnesses. It is an **optionalDependency** of `@revealui/harnesses`
+  (same pattern as `@revealui/cli`). After a normal monorepo `pnpm install`, the
+  workspace link is present. Outside the monorepo, install both packages so Node
+  can load the agent runtime (`npm install @revealui/harnesses @revealui/ai`).
+- **LLM credentials / local inference:** the default executor uses
+  `createLLMClientFromEnv` from `@revealui/ai` (for example `LLM_PROVIDER` plus
+  the matching API key, or Inference Snaps / Ollama base URLs). Protocol session
+  setup works without a model; prompt execution needs a configured provider.
 - Optional but recommended: a RevealUI device token and MCP config in the
   client for data-plane tools (same mint as [Connect OpenCode](./connect-opencode.md)).
 
@@ -95,6 +104,14 @@ session stays open.
 - **Permission prompts every turn:** default Phase D posture. Disable only
   if you intentionally change agent options in code; customer builds should
   keep human approval for consequential prompts.
+- **`@revealui/ai is not installed` in the agent reply:** Node could not
+  resolve the optional agent runtime. From the monorepo root run
+  `pnpm install` (harnesses declares `@revealui/ai` as an optionalDependency).
+  Outside the monorepo install `@revealui/ai` next to harnesses. Do not
+  hand-symlink `node_modules`; fix the package graph.
+- **Agent loads then fails on the model call:** check LLM env / local
+  inference (see Prerequisites). ACP permissions and session plumbing are
+  separate from provider reachability.
 
 ## Sources
 

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -17,6 +17,9 @@
     "@revealui/security": "workspace:*",
     "zod": "catalog:"
   },
+  "optionalDependencies": {
+    "@revealui/ai": "workspace:*"
+  },
   "devDependencies": {
     "@revealui/dev": "workspace:*",
     "@types/node": "^25.9.4",

--- a/packages/harnesses/src/__tests__/optional-ai-resolve.test.ts
+++ b/packages/harnesses/src/__tests__/optional-ai-resolve.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Durable ACP / headless-agent resolve path for @revealui/ai.
+ *
+ * Root cause fixed by optionalDependency (same posture as @revealui/cli):
+ * without a package graph edge, monorepo `revealui-harnesses acp` cannot
+ * dynamic-import the agent runtime. Do not replace this with NODE_PATH or
+ * hand symlinks.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageJsonPath = join(dirname(fileURLToPath(import.meta.url)), '../../package.json');
+
+describe('@revealui/ai optionalDependency (ACP headless runtime)', () => {
+  it('declares @revealui/ai as an optionalDependency', () => {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      optionalDependencies?: Record<string, string>;
+      dependencies?: Record<string, string>;
+    };
+    expect(pkg.optionalDependencies?.['@revealui/ai']).toMatch(/workspace/);
+    // Keep the hard-require boundary: not a required dependency.
+    expect(pkg.dependencies?.['@revealui/ai']).toBeUndefined();
+  });
+
+  it('resolves the subpaths the headless adapter dynamic-imports', async () => {
+    const [runtime, client, tools] = await Promise.all([
+      import('@revealui/ai/orchestration/streaming-runtime'),
+      import('@revealui/ai/llm/client'),
+      import('@revealui/ai/tools/coding'),
+    ]);
+    expect(typeof runtime.StreamingAgentRuntime).toBe('function');
+    expect(typeof client.createLLMClientFromEnv).toBe('function');
+    expect(typeof tools.createCodingTools).toBe('function');
+  });
+});

--- a/packages/harnesses/src/adapters/revealui-agent-adapter.ts
+++ b/packages/harnesses/src/adapters/revealui-agent-adapter.ts
@@ -234,17 +234,18 @@ export class RevealUIAgentAdapter implements HarnessAdapter {
 
   /**
    * Run a headless prompt through the coding agent.
-   * Lazy-imports @revealui/ai to avoid hard dependency at module load time.
-   * Types are inferred from the dynamic imports  -  no compile-time @revealui/ai dependency.
+   * Lazy-imports @revealui/ai so harnesses can build without a hard type dependency.
+   * Runtime resolve: package.json optionalDependency `@revealui/ai` (same posture as
+   * `@revealui/cli`) so monorepo ACP and npm installs link the package when present.
+   * Types come from dynamic import only — no compile-time import of @revealui/ai.
    */
   private async runHeadlessPrompt(
     prompt: string,
     maxTurns?: number,
     timeoutMs?: number,
   ): Promise<HarnessCommandResult> {
-    // Lazy import  -  @revealui/ai is an optional peer. Dynamic import()
-    // deliberately uses string literals so TS doesn't resolve the types
-    // at build time (the harnesses package has no dependency on @revealui/ai).
+    // Lazy import — optionalDependency at install time; string paths so TypeScript
+    // does not hard-require @revealui/ai types at harnesses build time.
     const aiRuntimePath = '@revealui/ai/orchestration/streaming-runtime';
     const aiClientPath = '@revealui/ai/llm/client';
     const aiToolsPath = '@revealui/ai/tools/coding';
@@ -264,7 +265,7 @@ export class RevealUIAgentAdapter implements HarnessAdapter {
         success: false,
         command: 'headless-prompt',
         message:
-          '@revealui/ai is not installed. Install it to use the RevealUI agent: npm install @revealui/ai',
+          '@revealui/ai is not installed or failed to load. Install it next to @revealui/harnesses (optionalDependency): npm install @revealui/ai — monorepo: pnpm install from the workspace root so the optional workspace link is present.',
       };
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1444,6 +1444,10 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+    optionalDependencies:
+      '@revealui/ai':
+        specifier: workspace:*
+        version: link:../ai
 
   packages/knowledge-graph:
     dependencies:


### PR DESCRIPTION
## Summary

Zed ACP sessions reached the headless executor and returned `@revealui/ai is not installed` because `@revealui/harnesses` had **no package graph edge** to `@revealui/ai`. Node could not resolve the lazy imports used by `RevealUIAgentAdapter` / ACP default executor when running `node packages/harnesses/dist/cli.js acp`.

**Durable fix (not NODE_PATH / hand symlinks):** declare `@revealui/ai` as an `optionalDependency` with `workspace:*`, matching `@revealui/cli`. After `pnpm install`, monorepo ACP resolves the runtime. Outside the monorepo, install `@revealui/ai` next to harnesses (optionalDependency installs when available).

- Keep build-time hard-require boundary: dynamic string imports only; not a required `dependencies` entry.
- Public guide `connect-acp.md`: prerequisites (AI package + LLM env) and troubleshooting.
- Contract tests for optionalDependency declaration + the three subpaths the adapter loads.
- Changeset patch for `@revealui/harnesses`.

## Test plan

- [x] `pnpm --filter @revealui/harnesses exec vitest run src/__tests__/optional-ai-resolve.test.ts`
- [x] `node` dynamic import of `@revealui/ai/orchestration/streaming-runtime` from `packages/harnesses` after install
- [x] Local phase-1 gate green on push
- [ ] CI green on PR
- [ ] After merge: monorepo `pnpm install`, restart Zed RevealUI agent, send a prompt (expect no install message; model path still needs LLM/local inference)

## Owner notes

No merge auth requested. Not security-classed (package graph + docs).