### PR TITLE
docs(harnesses): prefer gh -R in disposition-actions (all sessions)

### DIFF
--- a/.claude/rules/disposition-actions.md
+++ b/.claude/rules/disposition-actions.md
@@ -35,6 +35,21 @@ Stop at the open PR. List the exact one-line owner command under owner actions.
 Do not re-send a blocked command or accomplish the disposition through another
 tool.
 
+## Owner-action `gh` form (all sessions, all harnesses)
+
+Prefer short `-R owner/repo` over long `--repo`. Always pin the repo so the
+command works from any cwd. Prefer unquoted label values when the label has no
+spaces. Canonical clearance example:
+
+```bash
+gh pr edit 2482 -R RevealUIStudio/revealui --add-label sec-review:approved
+```
+
+Same shape for other owner one-liners: `gh pr merge <n> -R owner/repo …`,
+`gh pr view <n> -R owner/repo …`, `gh pr checks <n> -R owner/repo`. Hooks that
+print clearance commands (for example sec-review-pending) already use `-R`;
+agent wrap-ups and skills must match.
+
 ## References
 
 - Sibling: tracker-first, quality-over-speed, durable-solutions

--- a/.revealui/content/rules/disposition-actions.md
+++ b/.revealui/content/rules/disposition-actions.md
@@ -35,6 +35,21 @@ Stop at the open PR. List the exact one-line owner command under owner actions.
 Do not re-send a blocked command or accomplish the disposition through another
 tool.
 
+## Owner-action `gh` form (all sessions, all harnesses)
+
+Prefer short `-R owner/repo` over long `--repo`. Always pin the repo so the
+command works from any cwd. Prefer unquoted label values when the label has no
+spaces. Canonical clearance example:
+
+```bash
+gh pr edit 2482 -R RevealUIStudio/revealui --add-label sec-review:approved
+```
+
+Same shape for other owner one-liners: `gh pr merge <n> -R owner/repo …`,
+`gh pr view <n> -R owner/repo …`, `gh pr checks <n> -R owner/repo`. Hooks that
+print clearance commands (for example sec-review-pending) already use `-R`;
+agent wrap-ups and skills must match.
+
 ## References
 
 - Sibling: tracker-first, quality-over-speed, durable-solutions

--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -68,7 +68,7 @@
     },
     {
       "relativePath": ".revealui/content/rules/disposition-actions.md",
-      "sha256": "184c2b6094fd21c96b06172dc0c29df05dfd903b78ff0d149e00c3e61ecf2a78"
+      "sha256": "fb1c2059ffd7f32e89f00938a3f743e405ff66e99b8f71e2bf09dc9ba091827c"
     },
     {
       "relativePath": ".revealui/content/rules/durable-solutions.md",

--- a/packages/harnesses/src/content/definitions/rules/disposition-actions.ts
+++ b/packages/harnesses/src/content/definitions/rules/disposition-actions.ts
@@ -49,6 +49,21 @@ Stop at the open PR. List the exact one-line owner command under owner actions.
 Do not re-send a blocked command or accomplish the disposition through another
 tool.
 
+## Owner-action \`gh\` form (all sessions, all harnesses)
+
+Prefer short \`-R owner/repo\` over long \`--repo\`. Always pin the repo so the
+command works from any cwd. Prefer unquoted label values when the label has no
+spaces. Canonical clearance example:
+
+\`\`\`bash
+gh pr edit 2482 -R RevealUIStudio/revealui --add-label sec-review:approved
+\`\`\`
+
+Same shape for other owner one-liners: \`gh pr merge <n> -R owner/repo …\`,
+\`gh pr view <n> -R owner/repo …\`, \`gh pr checks <n> -R owner/repo\`. Hooks that
+print clearance commands (for example sec-review-pending) already use \`-R\`;
+agent wrap-ups and skills must match.
+
 ## References
 
 - Sibling: tracker-first, quality-over-speed, durable-solutions


### PR DESCRIPTION
## Summary

Control-layer SSOT for every harness session: \`disposition-actions\` rule now requires short \`-R owner/repo\` (not long \`--repo\`) on owner-action one-liners.

- Definition + content snapshot + \`.revealui/content\` materialize + \`.claude/rules\` lockstep
- Canonical: \`gh pr edit 2482 -R RevealUIStudio/revealui --add-label sec-review:approved\`

Touches \`packages/harnesses/\` so security-review gate may HOLD until owner clearance (process, not a code defect).

## Test plan

- [x] content snapshot + content tree freshness green locally
- [x] rules lockstep green
- [ ] CI green