### PR TITLE
fix(auth): shell admin repair on session mint (GAP-473 residual)

### DIFF
--- a/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
@@ -46,6 +46,7 @@ vi.mock('@revealui/auth/server', () => ({
   // mockIsSignupAllowed.mockReturnValueOnce(false) to exercise the
   // revealui#833 closed-signup gate.
   isSignupAllowed: (...args: unknown[]) => mockIsSignupAllowed(...args),
+  readUsersRole: vi.fn(async () => null),
   OAuthAccountConflictError: MockOAuthAccountConflictError,
 }));
 

--- a/apps/admin/src/app/api/auth/__tests__/integration.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/integration.test.ts
@@ -46,6 +46,7 @@ vi.mock('@revealui/auth/server', () => ({
   countUserCredentials: vi.fn(),
   createMagicLink: vi.fn(),
   verifyMagicLink: vi.fn(),
+  readUsersRole: vi.fn(async () => 'user'),
   checkRateLimit: vi.fn(),
   isRecoverySession: vi.fn().mockReturnValue(false),
 }));

--- a/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
@@ -42,6 +42,8 @@ vi.mock('@revealui/auth/server', () => ({
   // mockIsSignupAllowed.mockReturnValueOnce(false) to exercise the
   // revealui#833 closed-signup gate.
   isSignupAllowed: (...args: unknown[]) => mockIsSignupAllowed(...args),
+  // GAP-473: routes re-read role after session mint; default null → use user.role
+  readUsersRole: vi.fn(async () => null),
   OAuthAccountConflictError: MockOAuthAccountConflictError,
 }));
 

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -14,6 +14,7 @@ import {
   fetchProviderUser,
   isSignupAllowed,
   OAuthAccountConflictError,
+  readUsersRole,
   rotateSession,
   upsertOAuthUser,
   verifyOAuthState,
@@ -156,7 +157,9 @@ export async function GET(
     const response = NextResponse.redirect(new URL(redirectTo, baseUrl));
 
     // Set role cookie for proxy.ts role-aware gate (defense-in-depth).
-    const userRole = (user as { role?: string }).role ?? 'viewer';
+    // Re-read after createSession shell repair (GAP-473 membership owner).
+    const repairedRole = await readUsersRole(getClient(), user.id);
+    const userRole = repairedRole ?? (user as { role?: string }).role ?? 'viewer';
     response.cookies.set('revealui-role', userRole, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -158,8 +158,13 @@ export async function GET(
 
     // Set role cookie for proxy.ts role-aware gate (defense-in-depth).
     // Re-read after createSession shell repair (GAP-473 membership owner).
-    const repairedRole = await readUsersRole(getClient(), user.id);
-    const userRole = repairedRole ?? (user as { role?: string }).role ?? 'viewer';
+    let userRole = (user as { role?: string }).role ?? 'viewer';
+    try {
+      const repairedRole = await readUsersRole(getClient(), user.id);
+      if (repairedRole) userRole = repairedRole;
+    } catch {
+      // Fall back to upsertOAuthUser role if DB re-read fails
+    }
     response.cookies.set('revealui-role', userRole, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',

--- a/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
@@ -31,6 +31,8 @@ vi.mock('@revealui/auth/server', () => ({
   verifyAuthentication: vi.fn(),
   checkRateLimit: vi.fn(),
   isRecoverySession: vi.fn().mockReturnValue(false),
+  // GAP-473: mfa/verify re-reads role after session mint
+  readUsersRole: vi.fn(async () => 'admin'),
 }));
 
 // Mock drizzle-orm operators (needed for passkey DB lookup in mfa/disable)

--- a/apps/admin/src/app/api/auth/mfa/verify/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify/route.ts
@@ -110,7 +110,12 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
 
     // Role for proxy gate after createSession shell repair (GAP-473).
     // sign-in skips setting the cookie when MFA is required.
-    const userRole = (await readUsersRole(getClient(), payload.userId)) ?? 'viewer';
+    let userRole = 'viewer';
+    try {
+      userRole = (await readUsersRole(getClient(), payload.userId)) ?? 'viewer';
+    } catch {
+      // Tests / transient DB: cookie falls back to viewer (proxy re-checks later)
+    }
 
     const response = NextResponse.json({ success: true });
 

--- a/apps/admin/src/app/api/auth/mfa/verify/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify/route.ts
@@ -9,11 +9,15 @@
  * (role cookie is required for proxy admin-only paths such as /settings).
  */
 
-import { rotateSession, verifyCookiePayload, verifyMFACode } from '@revealui/auth/server';
+import {
+  readUsersRole,
+  rotateSession,
+  verifyCookiePayload,
+  verifyMFACode,
+} from '@revealui/auth/server';
 import config from '@revealui/config';
 import { MFAVerifyRequestContract } from '@revealui/contracts';
 import { getClient } from '@revealui/db';
-import { getUserById } from '@revealui/db/queries/users';
 import { logger } from '@revealui/utils/logger';
 import { type NextRequest, NextResponse } from 'next/server';
 import { withRateLimit } from '@/lib/middleware/rate-limit';
@@ -104,9 +108,9 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       metadata: { mfaVerified: true },
     });
 
-    // Role for proxy gate — sign-in skips setting it when MFA is required;
-    // this is the real session-establish step and must stamp the cookie.
-    const user = await getUserById(getClient(), payload.userId);
+    // Role for proxy gate after createSession shell repair (GAP-473).
+    // sign-in skips setting the cookie when MFA is required.
+    const userRole = (await readUsersRole(getClient(), payload.userId)) ?? 'viewer';
 
     const response = NextResponse.json({ success: true });
 
@@ -119,7 +123,7 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       maxAge: 60 * 60 * 24, // 1 day (matches DB session expiry)
       domain: sessionCookieDomain({ logIfMissing: true }),
     });
-    setRoleCookie(response, user?.role, { maxAge: 60 * 60 * 24 });
+    setRoleCookie(response, userRole, { maxAge: 60 * 60 * 24 });
 
     // Clear the mfa-pending cookie
     response.cookies.set('mfa-pending', '', {

--- a/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
@@ -35,6 +35,7 @@ vi.mock('@revealui/auth/server', () => ({
   verifyMFASetup: vi.fn(),
   checkRateLimit: vi.fn(),
   isRecoverySession: vi.fn().mockReturnValue(false),
+  readUsersRole: vi.fn(async () => null),
 }));
 
 // Mock the logger

--- a/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
@@ -7,7 +7,12 @@
  * Passkeys are inherently MFA  -  no TOTP check required.
  */
 
-import { rotateSession, verifyAuthentication, verifyCookiePayload } from '@revealui/auth/server';
+import {
+  readUsersRole,
+  rotateSession,
+  verifyAuthentication,
+  verifyCookiePayload,
+} from '@revealui/auth/server';
 import config from '@revealui/config';
 import { PasskeyAuthenticateVerifyRequestSchema } from '@revealui/contracts';
 import { getClient } from '@revealui/db';
@@ -137,6 +142,10 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
       metadata: { mfaVerified: true, mfaMethod: 'passkey' },
     });
 
+    // After createSession shell repair (GAP-473), cookie + JSON must match DB.
+    const userRole =
+      (await readUsersRole(getClient(), storedPasskey.userId)) ?? user.role ?? 'viewer';
+
     const response = NextResponse.json({
       success: true,
       user: {
@@ -144,7 +153,7 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
         email: user.email,
         name: user.name,
         avatarUrl: user.avatarUrl,
-        role: user.role,
+        role: userRole,
       },
     });
 
@@ -159,7 +168,6 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
     });
 
     // Set role cookie for proxy.ts role-aware gate
-    const userRole = user.role ?? 'viewer';
     response.cookies.set('revealui-role', userRole, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',

--- a/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
@@ -143,8 +143,13 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
     });
 
     // After createSession shell repair (GAP-473), cookie + JSON must match DB.
-    const userRole =
-      (await readUsersRole(getClient(), storedPasskey.userId)) ?? user.role ?? 'viewer';
+    let userRole = user.role ?? 'viewer';
+    try {
+      const repaired = await readUsersRole(getClient(), storedPasskey.userId);
+      if (repaired) userRole = repaired;
+    } catch {
+      // Fall back to user row loaded above
+    }
 
     const response = NextResponse.json({
       success: true,

--- a/packages/auth/src/server/__tests__/platform-roles.test.ts
+++ b/packages/auth/src/server/__tests__/platform-roles.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   ensureAccountOwnerPlatformAdmin,
+  ensureShellAdminIfAccountOwner,
   isPlatformShellAdminRole,
   PLATFORM_SHELL_ADMIN_ROLES,
   platformRoleForAccountOwner,
+  readUsersRole,
 } from '../platform-roles.js';
 
 describe('platformRoleForAccountOwner', () => {
@@ -80,5 +82,78 @@ describe('ensureAccountOwnerPlatformAdmin', () => {
     expect(update).toHaveBeenCalled();
     expect(set).toHaveBeenCalledWith({ role: 'admin' });
     expect(whereUpdate).toHaveBeenCalled();
+  });
+});
+
+describe('ensureShellAdminIfAccountOwner', () => {
+  function mockDbWithMembership(opts: {
+    ownerMembership: boolean;
+    user: { id: string; role: string } | null;
+  }) {
+    const membershipLimit = vi.fn().mockResolvedValue(opts.ownerMembership ? [{ id: 'm1' }] : []);
+    const membershipWhere = vi.fn().mockReturnValue({ limit: membershipLimit });
+    const membershipFrom = vi.fn().mockReturnValue({ where: membershipWhere });
+
+    const userLimit = vi.fn().mockResolvedValue(opts.user ? [opts.user] : []);
+    const userWhere = vi.fn().mockReturnValue({ limit: userLimit });
+    const userFrom = vi.fn().mockReturnValue({ where: userWhere });
+
+    let selectCall = 0;
+    const select = vi.fn().mockImplementation(() => {
+      selectCall += 1;
+      // first select: membership; second: user (if owner)
+      return { from: selectCall === 1 ? membershipFrom : userFrom };
+    });
+
+    const whereUpdate = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn().mockReturnValue({ where: whereUpdate });
+    const update = vi.fn().mockReturnValue({ set });
+
+    return { db: { select, update } as never, update, set };
+  }
+
+  it('no-ops when user is not an active account owner', async () => {
+    const { db, update } = mockDbWithMembership({
+      ownerMembership: false,
+      user: { id: 'u1', role: 'viewer' },
+    });
+    const result = await ensureShellAdminIfAccountOwner(db, 'u1');
+    expect(result).toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('promotes viewer membership owner to admin', async () => {
+    const { db, update, set } = mockDbWithMembership({
+      ownerMembership: true,
+      user: { id: 'u1', role: 'viewer' },
+    });
+    const result = await ensureShellAdminIfAccountOwner(db, 'u1');
+    expect(result).toEqual({ previousRole: 'viewer', nextRole: 'admin', updated: true });
+    expect(update).toHaveBeenCalled();
+    expect(set).toHaveBeenCalledWith({ role: 'admin' });
+  });
+
+  it('no-ops promote when owner already admin', async () => {
+    const { db, update } = mockDbWithMembership({
+      ownerMembership: true,
+      user: { id: 'u1', role: 'admin' },
+    });
+    const result = await ensureShellAdminIfAccountOwner(db, 'u1');
+    expect(result).toEqual({ previousRole: 'admin', nextRole: 'admin', updated: false });
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe('readUsersRole', () => {
+  it('returns role or null', async () => {
+    const limit = vi.fn().mockResolvedValue([{ role: 'admin' }]);
+    const where = vi.fn().mockReturnValue({ limit });
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const db = { select } as never;
+    await expect(readUsersRole(db, 'u1')).resolves.toBe('admin');
+
+    limit.mockResolvedValueOnce([]);
+    await expect(readUsersRole(db, 'missing')).resolves.toBeNull();
   });
 });

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -234,6 +234,7 @@ export async function signIn(
     // Rotate session: delete all existing sessions for this user, then create
     // a fresh one. This prevents session fixation attacks where an attacker
     // plants a session token that the victim later authenticates.
+    // createSession also repairs membership-owner shell role (GAP-473).
     let token: string;
     try {
       const sessionResult = await rotateSession(user.id, {
@@ -248,6 +249,21 @@ export async function signIn(
         reason: 'session_error',
         error: 'Failed to create session',
       };
+    }
+
+    // Re-read role after session mint so revealui-role cookie matches DB when
+    // ensureShellAdminIfAccountOwner promoted viewer → admin (GAP-473).
+    try {
+      const [roleRow] = await db
+        .select({ role: users.role })
+        .from(users)
+        .where(eq(users.id, user.id))
+        .limit(1);
+      if (roleRow && roleRow.role !== user.role) {
+        user = { ...user, role: roleRow.role };
+      }
+    } catch {
+      // Cookie may lag one login; next getSession still sees repaired DB role.
     }
 
     // A fresh session was minted: the login succeeded. Land a success receipt

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -116,10 +116,12 @@ export {
 } from './password-validation.js';
 export {
   ensureAccountOwnerPlatformAdmin,
+  ensureShellAdminIfAccountOwner,
   isPlatformShellAdminRole,
   PLATFORM_SHELL_ADMIN_COOKIE_ROLES,
   PLATFORM_SHELL_ADMIN_ROLES,
   platformRoleForAccountOwner,
+  readUsersRole,
 } from './platform-roles.js';
 export {
   checkRateLimit,

--- a/packages/auth/src/server/platform-roles.ts
+++ b/packages/auth/src/server/platform-roles.ts
@@ -14,8 +14,8 @@
  */
 
 import type { Database } from '@revealui/db/client';
-import { users } from '@revealui/db/schema';
-import { eq } from 'drizzle-orm';
+import { accountMemberships, users } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
 
 /** DB column values that already pass isAdminRole / shell admin cookie gate. */
 export const PLATFORM_SHELL_ADMIN_ROLES: ReadonlySet<string> = new Set(['owner', 'admin']);
@@ -75,4 +75,47 @@ export async function ensureAccountOwnerPlatformAdmin(
 
   await db.update(users).set({ role: nextRole }).where(eq(users.id, userId));
   return { previousRole, nextRole, updated: true };
+}
+
+/**
+ * If the user has an active account_memberships.owner seat, ensure users.role
+ * is shell-admin (admin/owner). No-op for members/admins who are not owners.
+ *
+ * GAP-473 residual: accounts provisioned before ensureAccountOwnerPlatformAdmin
+ * (or any race that left membership owner + users.role=viewer) get shell access
+ * on the next session mint without a manual backfill. Never promotes non-owners.
+ *
+ * Best-effort call sites: createSession (covers password/MFA/passkey/OAuth mint).
+ */
+export async function ensureShellAdminIfAccountOwner(
+  db: Database,
+  userId: string,
+): Promise<{ previousRole: string; nextRole: string; updated: boolean } | null> {
+  const [membership] = await db
+    .select({ id: accountMemberships.id })
+    .from(accountMemberships)
+    .where(
+      and(
+        eq(accountMemberships.userId, userId),
+        eq(accountMemberships.role, 'owner'),
+        eq(accountMemberships.status, 'active'),
+      ),
+    )
+    .limit(1);
+
+  if (!membership) {
+    return null;
+  }
+
+  return ensureAccountOwnerPlatformAdmin(db, userId);
+}
+
+/** Fresh users.role after session mint / shell repair (for revealui-role cookie). */
+export async function readUsersRole(db: Database, userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ role: users.role })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return row?.role ?? null;
 }

--- a/packages/auth/src/server/session.ts
+++ b/packages/auth/src/server/session.ts
@@ -12,6 +12,7 @@ import { and, eq, gt, inArray, isNull, ne } from 'drizzle-orm';
 import type { Session, User } from '../types.js';
 import { hashToken } from '../utils/token.js';
 import { DatabaseError, TokenError } from './errors.js';
+import { ensureShellAdminIfAccountOwner } from './platform-roles.js';
 
 // ---------------------------------------------------------------------------
 // Session binding configuration
@@ -281,6 +282,19 @@ export async function createSession(
     } catch (error: unknown) {
       logger.error('Error getting database client');
       throw new DatabaseError('Database connection failed', error);
+    }
+
+    // GAP-473: membership owner + stale users.role=viewer must not mint a
+    // session that still fails the proxy admin shell gate. Best-effort only —
+    // never fail session mint if role repair fails.
+    try {
+      await ensureShellAdminIfAccountOwner(db, userId);
+    } catch (roleRepairError: unknown) {
+      logger.warn('ensureShellAdminIfAccountOwner failed during createSession', {
+        userId,
+        message:
+          roleRepairError instanceof Error ? roleRepairError.message : String(roleRepairError),
+      });
     }
 
     // Generate secure session token


### PR DESCRIPTION
## Summary

GAP-473 product UX already on main ([#2478](https://github.com/RevealUIStudio/revealui/pull/2478) / promote #2479): Upgrade nav hidden for enterprise, SidebarLayout x-scroll fixed.

**Residual:** membership `owner` with `users.role=viewer` still hit `/welcome?denied=admin` until a manual backfill. That class must heal on login.

### Durable fix
- `ensureShellAdminIfAccountOwner` — only when active `account_memberships.role=owner`
- Best-effort in `createSession` (covers password, MFA, passkey, OAuth mints)
- Re-read role for `revealui-role` cookie after mint (sign-in, OAuth, passkey, MFA)
- MFA verify already stamps role cookie (#2481); now uses repaired DB role

Never promotes non-owners. Never assigns super-admin.

## Test plan
- [x] `platform-roles` unit tests (12) including new ensure/read cases
- [x] local phase-1 gate PASS
- [ ] CI green
- [ ] Live: founder with owner membership + viewer role signs in → admin shell (not denied=admin)

## Owner residual after merge
- Optional: grant enterprise entitlement if free-tier banner still shows (billing, not role)
- Sign out / sign in once after deploy