### PR TITLE
fix(test): import core utils via package exports not path

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -395,6 +395,56 @@
       "import": "./dist/utils/request-context.js",
       "default": "./dist/utils/request-context.js"
     },
+    "./utils/getBlockSelect": {
+      "types": "./dist/utils/getBlockSelect.d.ts",
+      "import": "./dist/utils/getBlockSelect.js",
+      "default": "./dist/utils/getBlockSelect.js"
+    },
+    "./utils/stripUnselectedFields": {
+      "types": "./dist/utils/stripUnselectedFields.d.ts",
+      "import": "./dist/utils/stripUnselectedFields.js",
+      "default": "./dist/utils/stripUnselectedFields.js"
+    },
+    "./utils/flattenResult": {
+      "types": "./dist/utils/flattenResult.d.ts",
+      "import": "./dist/utils/flattenResult.js",
+      "default": "./dist/utils/flattenResult.js"
+    },
+    "./utils/isValidID": {
+      "types": "./dist/utils/isValidID.d.ts",
+      "import": "./dist/utils/isValidID.js",
+      "default": "./dist/utils/isValidID.js"
+    },
+    "./utils/getSelectMode": {
+      "types": "./dist/utils/getSelectMode.d.ts",
+      "import": "./dist/utils/getSelectMode.js",
+      "default": "./dist/utils/getSelectMode.js"
+    },
+    "./utils/access-conversion": {
+      "types": "./dist/utils/access-conversion.d.ts",
+      "import": "./dist/utils/access-conversion.js",
+      "default": "./dist/utils/access-conversion.js"
+    },
+    "./utils/field-conversion": {
+      "types": "./dist/utils/field-conversion.d.ts",
+      "import": "./dist/utils/field-conversion.js",
+      "default": "./dist/utils/field-conversion.js"
+    },
+    "./utils/block-conversion": {
+      "types": "./dist/utils/block-conversion.d.ts",
+      "import": "./dist/utils/block-conversion.js",
+      "default": "./dist/utils/block-conversion.js"
+    },
+    "./fieldTraversal": {
+      "types": "./dist/fieldTraversal.d.ts",
+      "import": "./dist/fieldTraversal.js",
+      "default": "./dist/fieldTraversal.js"
+    },
+    "./queries/queryBuilder": {
+      "types": "./dist/queries/queryBuilder.d.ts",
+      "import": "./dist/queries/queryBuilder.js",
+      "default": "./dist/queries/queryBuilder.js"
+    },
     "./error-handling": {
       "types": "./dist/error-handling/index.d.ts",
       "import": "./dist/error-handling/index.js",

--- a/packages/test/src/units/utils/access-conversion.test.ts
+++ b/packages/test/src/units/utils/access-conversion.test.ts
@@ -1,19 +1,18 @@
 /**
  * Unit tests for access conversion utilities
  *
- * Tests actual utilities from packages/core/src/utils/access-conversion.ts
+ * Tests actual utilities from @revealui/core/utils/access-conversion
  */
 
-import { describe, expect, it } from 'vitest';
-import type { RevealUIAccessContext } from '../../../../../packages/core/src/types/access.js';
-import type { RevealUIPermission } from '../../../../../packages/core/src/types/user.js';
+import type { RevealUIAccessContext, RevealUIPermission } from '@revealui/core/types';
 import {
   combineRevealUIAccessRules,
   convertToRevealUIAccessRule,
   createEnhancedAccessRule,
   createRevealUIAccessRule,
   evaluateRevealUIAccessRule,
-} from '../../../../../packages/core/src/utils/access-conversion.js';
+} from '@revealui/core/utils/access-conversion';
+import { describe, expect, it } from 'vitest';
 
 describe('Access Conversion Utilities', () => {
   describe('createRevealUIAccessRule', () => {

--- a/packages/test/src/units/utils/block-conversion.test.ts
+++ b/packages/test/src/units/utils/block-conversion.test.ts
@@ -1,17 +1,17 @@
 /**
  * Unit tests for block conversion utilities
  *
- * Tests actual utilities from packages/core/src/utils/block-conversion.tsx
+ * Tests actual utilities from @revealui/core/utils/block-conversion
  */
 
-import { describe, expect, it } from 'vitest';
-import type { Block, RevealUIBlock } from '../../../../../packages/core/src/types/index.js';
+import type { Block, RevealUIBlock } from '@revealui/core/types';
 import {
   convertFromRevealUIBlock,
   convertToRevealUIBlock,
   enhanceBlockWithRevealUI,
   validateRevealUIBlock,
-} from '../../../../../packages/core/src/utils/block-conversion.js';
+} from '@revealui/core/utils/block-conversion';
+import { describe, expect, it } from 'vitest';
 
 describe('Block Conversion Utilities', () => {
   const createTestBlock = (): Block => ({

--- a/packages/test/src/units/utils/field-conversion.test.ts
+++ b/packages/test/src/units/utils/field-conversion.test.ts
@@ -1,21 +1,17 @@
 /**
  * Unit tests for field conversion utilities
  *
- * Tests actual utilities from packages/core/src/utils/field-conversion.ts
+ * Tests actual utilities from @revealui/core/utils/field-conversion
  */
 
-import { describe, expect, it } from 'vitest';
-import type {
-  Field,
-  FieldValidateArgs,
-  RevealUIField,
-} from '../../../../../packages/core/src/types/index.js';
+import type { Field, FieldValidateArgs, RevealUIField } from '@revealui/core/types';
 import {
   convertFromRevealUIField,
   convertToRevealUIField,
   enhanceFieldWithRevealUI,
   validateRevealUIField,
-} from '../../../../../packages/core/src/utils/field-conversion.js';
+} from '@revealui/core/utils/field-conversion';
+import { describe, expect, it } from 'vitest';
 
 describe('Field Conversion Utilities', () => {
   describe('convertToRevealUIField', () => {

--- a/packages/test/src/units/utils/field-traversal.test.ts
+++ b/packages/test/src/units/utils/field-traversal.test.ts
@@ -1,12 +1,12 @@
 /**
  * Unit tests for field traversal utilities
  *
- * Tests actual utility from packages/core/src/fieldTraversal.ts
+ * Tests actual utility from @revealui/core/fieldTraversal
  */
 
+import { traverseFieldsCore } from '@revealui/core/fieldTraversal';
+import type { Field } from '@revealui/core/types';
 import { describe, expect, it } from 'vitest';
-import { traverseFieldsCore } from '../../../../../packages/core/src/fieldTraversal.js';
-import type { Field } from '../../../../../packages/core/src/types/index.js';
 
 describe('Field Traversal Utilities', () => {
   describe('traverseFieldsCore', () => {

--- a/packages/test/src/units/utils/flattenResult.test.ts
+++ b/packages/test/src/units/utils/flattenResult.test.ts
@@ -1,12 +1,12 @@
 /**
  * Unit tests for flattenResult utility
  *
- * Tests actual utility from packages/core/src/utils/flattenResult.ts
+ * Tests actual utility from @revealui/core/utils/flattenResult
  */
 
+import type { RevealDocument } from '@revealui/core/types';
+import { flattenResult } from '@revealui/core/utils/flattenResult';
 import { describe, expect, it } from 'vitest';
-import type { RevealDocument } from '../../../../../packages/core/src/types/index.js';
-import { flattenResult } from '../../../../../packages/core/src/utils/flattenResult.js';
 
 describe('flattenResult', () => {
   const asRecord = (value: unknown): Record<string, unknown> => value as Record<string, unknown>;

--- a/packages/test/src/units/utils/framework-utilities.test.ts
+++ b/packages/test/src/units/utils/framework-utilities.test.ts
@@ -1,11 +1,11 @@
 /**
  * Unit tests for REAL framework utilities
  *
- * Tests actual utilities from packages/core/src/utils
+ * Tests actual utilities from @revealui/core/utils
  */
 
+import { isValidID } from '@revealui/core/utils/isValidID';
 import { describe, expect, it } from 'vitest';
-import { isValidID } from '../../../../../packages/core/src/utils/isValidID.js';
 
 describe('Framework Utilities (Real Code)', () => {
   describe('isValidID', () => {

--- a/packages/test/src/units/utils/getBlockSelect.test.ts
+++ b/packages/test/src/units/utils/getBlockSelect.test.ts
@@ -1,12 +1,12 @@
 /**
  * Unit tests for getBlockSelect utility
  *
- * Tests actual utility from packages/core/src/utils/getBlockSelect.ts
+ * Tests actual utility from @revealui/core/utils/getBlockSelect
  */
 
+import type { SelectType } from '@revealui/core/types';
+import { getBlockSelect } from '@revealui/core/utils/getBlockSelect';
 import { describe, expect, it } from 'vitest';
-import type { SelectType } from '../../../../../packages/core/src/types/index.js';
-import { getBlockSelect } from '../../../../../packages/core/src/utils/getBlockSelect.js';
 
 describe('getBlockSelect', () => {
   const createTestBlock = () => ({

--- a/packages/test/src/units/utils/getSelectMode.test.ts
+++ b/packages/test/src/units/utils/getSelectMode.test.ts
@@ -1,12 +1,12 @@
 /**
  * Unit tests for getSelectMode utility
  *
- * Tests actual utility from packages/core/src/utils/getSelectMode.ts
+ * Tests actual utility from @revealui/core/utils/getSelectMode
  */
 
+import type { SelectType } from '@revealui/core/types';
+import { getSelectMode } from '@revealui/core/utils/getSelectMode';
 import { describe, expect, it } from 'vitest';
-import type { SelectType } from '../../../../../packages/core/src/types/index.js';
-import { getSelectMode } from '../../../../../packages/core/src/utils/getSelectMode.js';
 
 describe('getSelectMode', () => {
   it('should return "include" for select with truthy values', () => {

--- a/packages/test/src/units/utils/query-builder.test.ts
+++ b/packages/test/src/units/utils/query-builder.test.ts
@@ -1,18 +1,12 @@
 /**
  * Unit tests for query builder utilities
  *
- * Tests actual utilities from packages/core/src/queries/queryBuilder.ts
+ * Tests actual utilities from @revealui/core/queries/queryBuilder
  */
 
+import { buildWhereClause, extractWhereValues } from '@revealui/core/queries/queryBuilder';
+import type { RevealWhere, RevealWhereField } from '@revealui/core/types';
 import { describe, expect, it } from 'vitest';
-import {
-  buildWhereClause,
-  extractWhereValues,
-} from '../../../../../packages/core/src/queries/queryBuilder.js';
-import type {
-  RevealWhere,
-  RevealWhereField,
-} from '../../../../../packages/core/src/types/index.js';
 
 describe('Query Builder Utilities', () => {
   describe('buildWhereClause', () => {

--- a/packages/test/src/units/utils/stripUnselectedFields.test.ts
+++ b/packages/test/src/units/utils/stripUnselectedFields.test.ts
@@ -1,12 +1,12 @@
 /**
  * Unit tests for stripUnselectedFields utility
  *
- * Tests actual utility from packages/core/src/utils/stripUnselectedFields.ts
+ * Tests actual utility from @revealui/core/utils/stripUnselectedFields
  */
 
+import type { Field, SelectType } from '@revealui/core/types';
+import { stripUnselectedFields } from '@revealui/core/utils/stripUnselectedFields';
 import { beforeEach, describe, expect, it } from 'vitest';
-import type { Field, SelectType } from '../../../../../packages/core/src/types/index.js';
-import { stripUnselectedFields } from '../../../../../packages/core/src/utils/stripUnselectedFields.js';
 
 describe('stripUnselectedFields', () => {
   let siblingDoc: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Install-graph follow-up after #2483 / #2487.

`packages/test` unit utils deep-imported `packages/core/src/*` by relative path. This PR:

1. Adds the missing `@revealui/core` package export entries:
   - `./utils/getBlockSelect`, `stripUnselectedFields`, `flattenResult`, `isValidID`, `getSelectMode`
   - `./utils/access-conversion`, `field-conversion`, `block-conversion`
   - `./fieldTraversal`, `./queries/queryBuilder`
2. Rewrites 10 unit test files to import via the install graph (`@revealui/core` was already a dependency of `@revealui/test`).

## Test plan

- [x] `pnpm turbo build --filter=@revealui/core`
- [x] `vitest run src/units/utils` under `@revealui/test` — 12 files / 215 tests pass
- [x] Pre-push phase-1 gate PASS

## Related

- #2487 (PGlite harness via `@revealui/db/testing`) — still needs owner sec-review + merge
- Next install-graph wave: vitest path aliases (server security, admin config/auth)