### PR TITLE
feat(knowledge-graph): P3 LLM episode extraction core

### DIFF
--- a/packages/knowledge-graph/src/__tests__/llm-episode.test.ts
+++ b/packages/knowledge-graph/src/__tests__/llm-episode.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { extractEpisodeFromText } from '../extractors/llm-episode.js';
+
+describe('extractEpisodeFromText', () => {
+  it('maps valid model JSON to EpisodeIngestInput', async () => {
+    const complete = async () =>
+      JSON.stringify({
+        nodes: [
+          {
+            kind: 'gap',
+            name: 'GAP-349',
+            naturalKey: 'gap:GAP-349',
+            summary: 'Fleet knowledge graph',
+          },
+        ],
+        edges: [
+          {
+            sourceKind: 'gap',
+            sourceNaturalKey: 'gap:GAP-349',
+            targetKind: 'package',
+            targetNaturalKey: 'revealui/packages/knowledge-graph',
+            relation: 'depends-on',
+            fact: 'GAP-349 owns @revealui/knowledge-graph',
+          },
+        ],
+      });
+
+    const { extraction, ingest } = await extractEpisodeFromText('note about GAP-349', {
+      complete,
+      source: 'test-session',
+      siteId: 'test-host',
+    });
+
+    expect(extraction.nodes).toHaveLength(1);
+    expect(ingest.nodes[0]?.naturalKey).toBe('gap:GAP-349');
+    expect(ingest.edges[0]?.relation).toBe('depends-on');
+    expect(ingest.episode.episodeType).toBe('agent-fact');
+  });
+
+  it('rejects invalid model JSON shape (prove-red for bad completer)', async () => {
+    await expect(
+      extractEpisodeFromText('x', {
+        complete: async () => JSON.stringify({ nodes: [{ kind: 'not-a-kind' }] }),
+        source: 't',
+        siteId: 'h',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('clips long input before calling completer', async () => {
+    let seen = '';
+    await extractEpisodeFromText('y'.repeat(50_000), {
+      complete: async (_p, user) => {
+        seen = user;
+        return JSON.stringify({ nodes: [], edges: [] });
+      },
+      source: 't',
+      siteId: 'h',
+      maxInputChars: 100,
+    });
+    expect(seen.length).toBe(100);
+  });
+});

--- a/packages/knowledge-graph/src/extractors/index.ts
+++ b/packages/knowledge-graph/src/extractors/index.ts
@@ -12,6 +12,14 @@ export {
 export { dbSchemaExtractor } from './db-schema.js';
 export { docsFrontmatterExtractor } from './docs-frontmatter.js';
 export { gitExtractor } from './git.js';
+export {
+  type ExtractEpisodeOptions,
+  extractEpisodeFromText,
+  LLM_EXTRACTION_PROMPT,
+  type LlmCompleter,
+  type LlmExtraction,
+  LlmExtractionSchema,
+} from './llm-episode.js';
 export { routesExtractor } from './routes.js';
 export * from './shared.js';
 export { tsProjectExtractor } from './ts-project.js';

--- a/packages/knowledge-graph/src/extractors/llm-episode.ts
+++ b/packages/knowledge-graph/src/extractors/llm-episode.ts
@@ -1,0 +1,139 @@
+/**
+ * P3 — LLM structured extraction for unstructured episodes (GAP-349).
+ *
+ * Deterministic Tier-1 extractors remain the default for `revkg scan`.
+ * This module turns free-text (handoffs, memories, agent notes) into
+ * candidate nodes/edges via a caller-supplied completer (typically
+ * `@revealui/ai` Ollama chat with JSON mode). No hard import of @revealui/ai
+ * so the package stays installable without Pro optional deps.
+ *
+ * Contradictions: when relation is `supersedes` / `blocks`, the engine still
+ * applies additive ingest; temporal invalidation of prior edges is a follow-on
+ * once resolution ladder lands (P3 residual).
+ */
+
+import { z } from 'zod';
+import type { EpisodeIngestInput } from '../ingest/engine.js';
+import { EDGE_RELATIONS, NODE_KINDS } from '../ontology/index.js';
+import type { EdgeInput, EpisodeInput, NodeInput } from '../types.js';
+
+const ExtractedNodeSchema = z.object({
+  kind: z.enum(NODE_KINDS),
+  name: z.string().min(1).max(200),
+  naturalKey: z.string().min(1).max(500),
+  repo: z.string().max(100).optional(),
+  summary: z.string().max(2000).optional(),
+});
+
+const ExtractedEdgeSchema = z.object({
+  sourceNaturalKey: z.string().min(1).max(500),
+  targetNaturalKey: z.string().min(1).max(500),
+  sourceKind: z.enum(NODE_KINDS),
+  targetKind: z.enum(NODE_KINDS),
+  relation: z.enum(EDGE_RELATIONS),
+  fact: z.string().min(1).max(2000),
+  repo: z.string().max(100).optional(),
+});
+
+export const LlmExtractionSchema = z.object({
+  nodes: z.array(ExtractedNodeSchema).max(50),
+  edges: z.array(ExtractedEdgeSchema).max(100),
+});
+
+export type LlmExtraction = z.infer<typeof LlmExtractionSchema>;
+
+/** JSON-schema-ish prompt body (string) so callers do not need zod-to-json. */
+export const LLM_EXTRACTION_PROMPT = `You extract knowledge-graph candidates from text.
+Return ONLY valid JSON matching:
+{
+  "nodes": [{ "kind": string, "name": string, "naturalKey": string, "repo"?: string, "summary"?: string }],
+  "edges": [{ "sourceNaturalKey": string, "targetNaturalKey": string, "sourceKind": string, "targetKind": string, "relation": string, "fact": string, "repo"?: string }]
+}
+Kinds: ${NODE_KINDS.join(', ')}
+Relations: ${EDGE_RELATIONS.join(', ')}
+Rules: naturalKey stable and path-like when possible; never invent secrets; prefer concept/relates-to when unsure.`;
+
+export type LlmCompleter = (prompt: string, userText: string) => Promise<string>;
+
+export interface ExtractEpisodeOptions {
+  /** Injected LLM JSON completer (tests stub; production wires @revealui/ai). */
+  complete: LlmCompleter;
+  source: string;
+  siteId: string;
+  episodeType?: EpisodeInput['episodeType'];
+  referenceTime?: Date;
+  /** Max characters of user text sent to the model (default 24k). */
+  maxInputChars?: number;
+}
+
+/**
+ * Run LLM extraction and map to EpisodeIngestInput for ingestEpisode().
+ * Throws ZodError if the model returns invalid JSON shape.
+ */
+export async function extractEpisodeFromText(
+  text: string,
+  options: ExtractEpisodeOptions,
+): Promise<{ extraction: LlmExtraction; ingest: EpisodeIngestInput }> {
+  const maxIn = options.maxInputChars ?? 24_000;
+  const clipped = text.length > maxIn ? text.slice(0, maxIn) : text;
+  const raw = await options.complete(LLM_EXTRACTION_PROMPT, clipped);
+  const jsonText = extractJsonObject(raw);
+  const parsed = LlmExtractionSchema.parse(JSON.parse(jsonText) as unknown);
+  const referenceTime = options.referenceTime ?? new Date();
+
+  const nodes: NodeInput[] = parsed.nodes.map((n) => ({
+    kind: n.kind,
+    name: n.name,
+    naturalKey: n.naturalKey,
+    repo: n.repo,
+    summary: n.summary,
+  }));
+
+  const edges: EdgeInput[] = parsed.edges.map((e) => ({
+    source: { kind: e.sourceKind, naturalKey: e.sourceNaturalKey },
+    target: { kind: e.targetKind, naturalKey: e.targetNaturalKey },
+    relation: e.relation,
+    fact: e.fact,
+    repo: e.repo,
+  }));
+
+  return {
+    extraction: parsed,
+    ingest: {
+      episode: {
+        episodeType: options.episodeType ?? 'agent-fact',
+        source: options.source,
+        siteId: options.siteId,
+        content: clipped,
+        referenceTime,
+      },
+      nodes,
+      edges,
+    },
+  };
+}
+
+/** Prefer fenced JSON or first {...} object; zero authored regex. */
+function extractJsonObject(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('{')) {
+    return trimmed;
+  }
+  const fence = '```';
+  const startFence = trimmed.indexOf(fence);
+  if (startFence >= 0) {
+    const after = trimmed.slice(startFence + fence.length);
+    const nl = after.indexOf('\n');
+    const bodyStart = nl >= 0 ? nl + 1 : 0;
+    const endFence = after.indexOf(fence, bodyStart);
+    if (endFence > bodyStart) {
+      return after.slice(bodyStart, endFence).trim();
+    }
+  }
+  const brace = trimmed.indexOf('{');
+  const last = trimmed.lastIndexOf('}');
+  if (brace >= 0 && last > brace) {
+    return trimmed.slice(brace, last + 1);
+  }
+  return trimmed;
+}


### PR DESCRIPTION
## Summary

GAP-349 **P3 core**: `extractEpisodeFromText` turns free text into Zod-validated graph candidates (`EpisodeIngestInput`) via an **injectable** LLM completer (no hard `@revealui/ai` import).

- Schema: nodes/edges capped; kinds/relations from ontology
- Input clip (default 24k chars)
- Unit tests with mock completer (prove invalid shape fails)

Follow-ups (not this PR): wire Ollama completer in CLI, memory/handoff ingest adapters, contradiction invalidation ladder.

## Test plan

- [x] `vitest` llm-episode tests (3)
- [x] local phase-1 gate (push)
- [ ] CI green