### PR TITLE
feat(knowledge-graph): revkg extract CLI for P3 LLM episode ingest

### DIFF
--- a/packages/knowledge-graph/src/cli/revkg.ts
+++ b/packages/knowledge-graph/src/cli/revkg.ts
@@ -11,6 +11,10 @@
  *   revkg claims-check [--root] [--repo] [--fleet] [--publish] [--json]
  *       Parse claims-evidence, verify path evidence exists; with --publish ingest
  *       claim-scan documents edges into the graph (GAP-462 Phase 3).
+ *   revkg extract [--file <path>] [--source <s>] [--dry-run] [--json]
+ *       P3 LLM structured extraction from free text (stdin if no --file);
+ *       ingests via ingestEpisode unless --dry-run. Requires @revealui/ai +
+ *       local/env LLM (Ollama / snaps). Completer is dynamic-import only.
  *
  * Connects to Neon via its own pool (`@revealui/db`'s `createPool`, DATABASE_URL
  * / POSTGRES_URL resolved by `getConnectionIdentity`) rather than the shared
@@ -84,7 +88,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   const positionals: string[] = [];
   const flags = new Map<string, string>();
   const bools = new Set<string>();
-  const boolFlags = new Set(['fleet', 'json', 'publish']);
+  const boolFlags = new Set(['fleet', 'json', 'publish', 'dry-run']);
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === undefined) continue;
@@ -444,6 +448,100 @@ async function cmdClaimsCheck(args: ParsedArgs): Promise<void> {
   }
 }
 
+async function cmdExtract(args: ParsedArgs): Promise<void> {
+  const file = args.flags.get('file');
+  let text: string;
+  if (file) {
+    const body = readTextFile(file);
+    if (body === null) fail(`cannot read ${file}`);
+    text = body;
+  } else if (args.positionals.length > 0) {
+    text = args.positionals.join(' ');
+  } else {
+    // stdin
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    }
+    text = Buffer.concat(chunks).toString('utf8');
+  }
+  if (!text.trim()) fail('extract requires text (--file, positionals, or stdin)');
+
+  const { extractEpisodeFromText } = await import('../extractors/llm-episode.js');
+  const source = args.flags.get('source') ?? 'revkg-extract';
+  const siteId = args.flags.get('site') ?? hostname();
+  const dryRun = args.bools.has('dry-run');
+
+  const complete = await loadLlmCompleter();
+  const { extraction, ingest } = await extractEpisodeFromText(text, {
+    complete,
+    source,
+    siteId,
+    episodeType: 'agent-fact',
+  });
+
+  if (args.bools.has('json')) {
+    out(JSON.stringify({ extraction, dryRun }, null, 2));
+  } else {
+    out(`extracted ${extraction.nodes.length} nodes, ${extraction.edges.length} edges`);
+    for (const n of extraction.nodes.slice(0, 20)) {
+      out(`  [${n.kind}] ${n.naturalKey}`);
+    }
+    for (const e of extraction.edges.slice(0, 20)) {
+      out(`  (${e.relation}) ${e.fact.slice(0, 80)}`);
+    }
+  }
+
+  if (dryRun) {
+    out('dry-run: not ingested');
+    return;
+  }
+
+  const { exec, close } = await getExecutor();
+  try {
+    const embedder = await loadEmbedder();
+    const result = await ingestEpisode(exec, ingest, { embedder, recordOutbox: true });
+    out(
+      `ingested episodeId=${result.episodeId} nodes=${result.nodeCount} edges=${result.edgeCount}`,
+    );
+  } finally {
+    await close();
+  }
+}
+
+/** Dynamic @revealui/ai chat → JSON string completer for P3 extract. */
+async function loadLlmCompleter(): Promise<(prompt: string, userText: string) => Promise<string>> {
+  try {
+    const specifier = '@revealui/ai';
+    const ai = (await import(specifier)) as {
+      createLLMClientFromEnv: () => {
+        chat(
+          messages: Array<{ role: string; content: string }>,
+          options?: { temperature?: number; maxTokens?: number },
+        ): Promise<{ content?: string; text?: string; message?: { content?: string } }>;
+      };
+    };
+    const client = ai.createLLMClientFromEnv();
+    return async (prompt: string, userText: string): Promise<string> => {
+      const res = await client.chat(
+        [
+          { role: 'system', content: prompt },
+          { role: 'user', content: userText },
+        ],
+        { temperature: 0.1, maxTokens: 4096 },
+      );
+      if (typeof res.content !== 'string' || !res.content.trim()) {
+        throw new Error('LLM returned empty content for extract');
+      }
+      return res.content;
+    };
+  } catch (err) {
+    fail(
+      `extract requires @revealui/ai + LLM env (Ollama/snaps): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
   const args = parseArgs(rest);
@@ -469,8 +567,11 @@ async function main(): Promise<void> {
     case 'claims-check':
       await cmdClaimsCheck(args);
       break;
+    case 'extract':
+      await cmdExtract(args);
+      break;
     default:
-      out('usage: revkg <scan|search|node|neighbors|at|drift|claims-check> [...]');
+      out('usage: revkg <scan|search|node|neighbors|at|drift|claims-check|extract> [...]');
       process.exit(command ? 1 : 0);
   }
 }


### PR DESCRIPTION
## Summary

Wires GAP-349 P3 `extractEpisodeFromText` into the CLI:

```bash
revkg extract --file note.md --source agent-session --dry-run
revkg extract --file note.md --source agent-session   # ingest to Neon
echo 'text' | revkg extract --source stdin --json
```

- Dynamic import of `@revealui/ai` `createLLMClientFromEnv` (no hard dep edge beyond optional)
- `--dry-run` prints candidates without write
- Deterministic `scan` path unchanged

## Test plan

- [x] Local phase-1 gate PASS on push
- [ ] CI green
- [ ] Optional dogfood with local Ollama: `revkg extract --file … --dry-run`