### PR TITLE
feat(knowledge-graph): P3 handoff ingest + contradiction invalidation

### DIFF
--- a/packages/knowledge-graph/src/__tests__/contradiction.test.ts
+++ b/packages/knowledge-graph/src/__tests__/contradiction.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  findContradictingEdges,
+  invalidateContradictions,
+  naturalKeysSimilar,
+  normalizeNaturalKey,
+} from '../ingest/contradiction.js';
+import { ingestEpisode } from '../ingest/engine.js';
+import { createKgTestDb, type KgTestDb } from './test-db.js';
+
+describe('natural key similarity', () => {
+  it('normalizes separators', () => {
+    expect(normalizeNaturalKey('Foo/Bar_Baz')).toBe('foo-bar-baz');
+    expect(naturalKeysSimilar('Foo/Bar', 'foo-bar')).toBe(true);
+  });
+});
+
+describe('invalidateContradictions', () => {
+  let db: KgTestDb;
+
+  beforeEach(async () => {
+    db = await createKgTestDb();
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it('invalidates current edges with same endpoints+relation but different fact', async () => {
+    const t0 = new Date('2026-08-01T00:00:00.000Z');
+    const t1 = new Date('2026-08-09T00:00:00.000Z');
+
+    await ingestEpisode(db.exec, {
+      episode: {
+        episodeType: 'manual',
+        source: 'test-old',
+        siteId: 'test',
+        referenceTime: t0,
+      },
+      nodes: [
+        { kind: 'package', name: 'kg', naturalKey: 'pkg/kg' },
+        { kind: 'gap', name: 'GAP-349', naturalKey: 'gap:GAP-349' },
+      ],
+      edges: [
+        {
+          source: { kind: 'gap', naturalKey: 'gap:GAP-349' },
+          target: { kind: 'package', naturalKey: 'pkg/kg' },
+          relation: 'depends-on',
+          fact: 'old claim',
+          validAt: t0,
+        },
+      ],
+    });
+
+    const newEdge = {
+      source: { kind: 'gap' as const, naturalKey: 'gap:GAP-349' },
+      target: { kind: 'package' as const, naturalKey: 'pkg/kg' },
+      relation: 'depends-on' as const,
+      fact: 'new claim',
+      validAt: t1,
+    };
+
+    const hits = await findContradictingEdges(db.exec, newEdge, { at: t1 });
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+    expect(hits[0]?.fact).toBe('old claim');
+
+    const invalidated = await invalidateContradictions(db.exec, [newEdge], {
+      siteId: 'test',
+      invalidAt: t1,
+      recordOutbox: false,
+    });
+    expect(invalidated.length).toBeGreaterThanOrEqual(1);
+
+    const after = await findContradictingEdges(db.exec, newEdge, { at: t1 });
+    expect(after).toHaveLength(0);
+  });
+
+  it('ingestEpisode with invalidateContradictions opts in', async () => {
+    const t0 = new Date('2026-08-01T00:00:00.000Z');
+    const t1 = new Date('2026-08-09T00:00:00.000Z');
+
+    await ingestEpisode(db.exec, {
+      episode: {
+        episodeType: 'manual',
+        source: 'test-old',
+        siteId: 'test',
+        referenceTime: t0,
+      },
+      nodes: [
+        { kind: 'package', name: 'kg', naturalKey: 'pkg/kg' },
+        { kind: 'gap', name: 'GAP-349', naturalKey: 'gap:GAP-349' },
+      ],
+      edges: [
+        {
+          source: { kind: 'gap', naturalKey: 'gap:GAP-349' },
+          target: { kind: 'package', naturalKey: 'pkg/kg' },
+          relation: 'depends-on',
+          fact: 'old claim',
+          validAt: t0,
+        },
+      ],
+    });
+
+    const result = await ingestEpisode(
+      db.exec,
+      {
+        episode: {
+          episodeType: 'manual',
+          source: 'test-new',
+          siteId: 'test',
+          referenceTime: t1,
+        },
+        nodes: [
+          { kind: 'package', name: 'kg', naturalKey: 'pkg/kg' },
+          { kind: 'gap', name: 'GAP-349', naturalKey: 'gap:GAP-349' },
+        ],
+        edges: [
+          {
+            source: { kind: 'gap', naturalKey: 'gap:GAP-349' },
+            target: { kind: 'package', naturalKey: 'pkg/kg' },
+            relation: 'depends-on',
+            fact: 'new claim',
+            validAt: t1,
+          },
+        ],
+      },
+      { invalidateContradictions: true, recordOutbox: false },
+    );
+
+    expect(result.invalidatedEdgeIds.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/knowledge-graph/src/__tests__/handoff-memory.test.ts
+++ b/packages/knowledge-graph/src/__tests__/handoff-memory.test.ts
@@ -1,0 +1,21 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadMarkdownSources, textSourceToEpisode } from '../extractors/handoff-memory.js';
+
+describe('handoff/memory adapters', () => {
+  it('loads markdown sources and maps GAP mentions', () => {
+    const dir = join(tmpdir(), `kg-handoff-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'note.md'), '# Session\nWorked on GAP-349 knowledge graph.\n', 'utf8');
+
+    const sources = loadMarkdownSources(dir);
+    expect(sources).toHaveLength(1);
+
+    const ep = textSourceToEpisode(sources[0]!, { siteId: 'test', sourceLabel: 'test' });
+    expect(ep.nodes.some((n) => n.kind === 'concept')).toBe(true);
+    expect(ep.nodes.some((n) => n.naturalKey === 'gap:GAP-349')).toBe(true);
+    expect(ep.edges.some((e) => e.relation === 'relates-to')).toBe(true);
+  });
+});

--- a/packages/knowledge-graph/src/__tests__/llm-episode.test.ts
+++ b/packages/knowledge-graph/src/__tests__/llm-episode.test.ts
@@ -60,4 +60,39 @@ describe('extractEpisodeFromText', () => {
     });
     expect(seen.length).toBe(100);
   });
+
+  it('coerces null optional repo/summary from model JSON', async () => {
+    const complete = async () =>
+      JSON.stringify({
+        nodes: [
+          {
+            kind: 'concept',
+            name: 'x',
+            naturalKey: 'concept:x',
+            repo: null,
+            summary: null,
+          },
+        ],
+        edges: [
+          {
+            sourceKind: 'concept',
+            sourceNaturalKey: 'concept:x',
+            targetKind: 'gap',
+            targetNaturalKey: 'gap:GAP-349',
+            relation: 'relates-to',
+            fact: 'x relates to GAP-349',
+            repo: null,
+          },
+        ],
+      });
+
+    const { extraction, ingest } = await extractEpisodeFromText('x', {
+      complete,
+      source: 't',
+      siteId: 'h',
+    });
+    expect(extraction.nodes[0]?.repo).toBeUndefined();
+    expect(ingest.nodes[0]?.repo).toBeUndefined();
+    expect(ingest.edges[0]?.repo).toBeUndefined();
+  });
 });

--- a/packages/knowledge-graph/src/__tests__/llm-episode.test.ts
+++ b/packages/knowledge-graph/src/__tests__/llm-episode.test.ts
@@ -40,7 +40,7 @@ describe('extractEpisodeFromText', () => {
   it('rejects invalid model JSON shape (prove-red for bad completer)', async () => {
     await expect(
       extractEpisodeFromText('x', {
-        complete: async () => JSON.stringify({ nodes: [{ kind: 'not-a-kind' }] }),
+        complete: async () => JSON.stringify({ nodes: [{ kind: 'gap' }] }),
         source: 't',
         siteId: 'h',
       }),
@@ -59,6 +59,52 @@ describe('extractEpisodeFromText', () => {
       maxInputChars: 100,
     });
     expect(seen.length).toBe(100);
+  });
+
+  it('derives naturalKey from name when model omits it', async () => {
+    const complete = async () =>
+      JSON.stringify({
+        nodes: [{ kind: 'gap', name: 'GAP-349' }],
+        edges: [],
+      });
+    const { extraction } = await extractEpisodeFromText('x', {
+      complete,
+      source: 't',
+      siteId: 'h',
+    });
+    expect(extraction.nodes[0]?.naturalKey).toBe('concept:gap-349');
+  });
+
+  it('maps unknown kinds/relations to concept/relates-to', async () => {
+    const complete = async () =>
+      JSON.stringify({
+        nodes: [
+          {
+            kind: 'not-a-real-kind',
+            name: 'x',
+            naturalKey: 'concept:x',
+          },
+        ],
+        edges: [
+          {
+            sourceKind: 'not-a-real-kind',
+            sourceNaturalKey: 'concept:x',
+            targetKind: 'gap',
+            targetNaturalKey: 'gap:GAP-349',
+            relation: 'invented-rel',
+            fact: 'x invented',
+          },
+        ],
+      });
+
+    const { extraction } = await extractEpisodeFromText('x', {
+      complete,
+      source: 't',
+      siteId: 'h',
+    });
+    expect(extraction.nodes[0]?.kind).toBe('concept');
+    expect(extraction.edges[0]?.sourceKind).toBe('concept');
+    expect(extraction.edges[0]?.relation).toBe('relates-to');
   });
 
   it('coerces null optional repo/summary from model JSON', async () => {

--- a/packages/knowledge-graph/src/cli/revkg.ts
+++ b/packages/knowledge-graph/src/cli/revkg.ts
@@ -11,10 +11,15 @@
  *   revkg claims-check [--root] [--repo] [--fleet] [--publish] [--json]
  *       Parse claims-evidence, verify path evidence exists; with --publish ingest
  *       claim-scan documents edges into the graph (GAP-462 Phase 3).
- *   revkg extract [--file <path>] [--source <s>] [--dry-run] [--json]
+ *   revkg extract [--file <path>] [--source <s>] [--dry-run] [--json] [--no-invalidate]
  *       P3 LLM structured extraction from free text (stdin if no --file);
  *       ingests via ingestEpisode unless --dry-run. Requires @revealui/ai +
  *       local/env LLM (Ollama / snaps). Completer is dynamic-import only.
+ *       By default invalidates prior edges with same endpoints+relation but
+ *       different fact (P3 contradiction ladder).
+ *   revkg ingest-handoffs --dir <path> [--limit n] [--dry-run] [--json] [--no-invalidate]
+ *       P3 deterministic handoff/memory markdown → episodes (no LLM). Explicit
+ *       publish only; default path is rolling handoffs when --dir omitted.
  *
  * Connects to Neon via its own pool (`@revealui/db`'s `createPool`, DATABASE_URL
  * / POSTGRES_URL resolved by `getConnectionIdentity`) rather than the shared
@@ -88,7 +93,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   const positionals: string[] = [];
   const flags = new Map<string, string>();
   const bools = new Set<string>();
-  const boolFlags = new Set(['fleet', 'json', 'publish', 'dry-run']);
+  const boolFlags = new Set(['fleet', 'json', 'publish', 'dry-run', 'no-invalidate']);
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === undefined) continue;
@@ -500,10 +505,95 @@ async function cmdExtract(args: ParsedArgs): Promise<void> {
   const { exec, close } = await getExecutor();
   try {
     const embedder = await loadEmbedder();
-    const result = await ingestEpisode(exec, ingest, { embedder, recordOutbox: true });
+    const invalidate = !args.bools.has('no-invalidate');
+    const result = await ingestEpisode(exec, ingest, {
+      embedder,
+      recordOutbox: true,
+      invalidateContradictions: invalidate,
+    });
     out(
-      `ingested episodeId=${result.episodeId} nodes=${result.nodeCount} edges=${result.edgeCount}`,
+      `ingested episodeId=${result.episodeId} nodes=${result.nodeCount} edges=${result.edgeCount} invalidated=${result.invalidatedEdgeIds.length}`,
     );
+  } finally {
+    await close();
+  }
+}
+
+/**
+ * Deterministic handoff/memory ingest (no LLM). Explicit publish only.
+ * Default dir: REVFLEET_HANDOFFS or ~/revfleet/.jv/docs/handoffs/rolling.
+ */
+async function cmdIngestHandoffs(args: ParsedArgs): Promise<void> {
+  const { loadMarkdownSources, textSourceToEpisode } = await import(
+    '../extractors/handoff-memory.js'
+  );
+  const defaultDir =
+    process.env.REVFLEET_HANDOFFS ??
+    join(process.env.HOME ?? '', 'revfleet/.jv/docs/handoffs/rolling');
+  const dir = args.flags.get('dir') ?? defaultDir;
+  const limitRaw = args.flags.get('limit');
+  const limit = limitRaw !== undefined ? Number.parseInt(limitRaw, 10) : 50;
+  if (!Number.isFinite(limit) || limit < 1) fail('--limit must be a positive integer');
+
+  const sources = loadMarkdownSources(dir, { limit });
+  if (sources.length === 0) {
+    out(`no markdown sources under ${dir}`);
+    return;
+  }
+
+  const siteId = args.flags.get('site') ?? hostname();
+  const dryRun = args.bools.has('dry-run');
+  const invalidate = !args.bools.has('no-invalidate');
+  const episodes = sources.map((s) =>
+    textSourceToEpisode(s, { siteId, sourceLabel: `handoff:${s.path}` }),
+  );
+
+  if (args.bools.has('json')) {
+    out(
+      JSON.stringify(
+        {
+          dir,
+          dryRun,
+          count: episodes.length,
+          episodes: episodes.map((e) => ({
+            source: e.episode.source,
+            nodes: e.nodes.length,
+            edges: e.edges.length,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    out(`handoffs: ${episodes.length} file(s) from ${dir}`);
+    for (const e of episodes.slice(0, 20)) {
+      out(`  ${e.episode.source} → ${e.nodes.length}n/${e.edges.length}e`);
+    }
+  }
+
+  if (dryRun) {
+    out('dry-run: not ingested');
+    return;
+  }
+
+  const { exec, close } = await getExecutor();
+  try {
+    const embedder = await loadEmbedder();
+    let nodes = 0;
+    let edges = 0;
+    let invalidated = 0;
+    for (const ep of episodes) {
+      const result = await ingestEpisode(exec, ep, {
+        embedder,
+        recordOutbox: true,
+        invalidateContradictions: invalidate,
+      });
+      nodes += result.nodeCount;
+      edges += result.edgeCount;
+      invalidated += result.invalidatedEdgeIds.length;
+    }
+    out(`ingested nodes=${nodes} edges=${edges} invalidated=${invalidated}`);
   } finally {
     await close();
   }
@@ -570,8 +660,13 @@ async function main(): Promise<void> {
     case 'extract':
       await cmdExtract(args);
       break;
+    case 'ingest-handoffs':
+      await cmdIngestHandoffs(args);
+      break;
     default:
-      out('usage: revkg <scan|search|node|neighbors|at|drift|claims-check|extract> [...]');
+      out(
+        'usage: revkg <scan|search|node|neighbors|at|drift|claims-check|extract|ingest-handoffs> [...]',
+      );
       process.exit(command ? 1 : 0);
   }
 }

--- a/packages/knowledge-graph/src/extractors/handoff-memory.ts
+++ b/packages/knowledge-graph/src/extractors/handoff-memory.ts
@@ -1,0 +1,127 @@
+/**
+ * P3 deterministic adapters: handoff fragments + free-form memory files →
+ * EpisodeIngestInput without requiring an LLM.
+ *
+ * Explicit publish only (OQ2 held). Paths are recorded in contentRef; secrets
+ * never appear as node values.
+ */
+
+import { readdirSync, readFileSync, type Stats, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import type { EpisodeIngestInput } from '../ingest/engine.js';
+
+export interface TextSource {
+  path: string;
+  text: string;
+}
+
+const MAX_FILE_CHARS = 48_000;
+
+/**
+ * Load markdown fragments under a handoffs/rolling directory (or any dir of .md).
+ */
+export function loadMarkdownSources(dir: string, options?: { limit?: number }): TextSource[] {
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const limit = options?.limit ?? 50;
+  const out: TextSource[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.md')) continue;
+    const path = join(dir, name);
+    let st: Stats;
+    try {
+      st = statSync(path);
+    } catch {
+      continue;
+    }
+    if (!st.isFile()) continue;
+    let text: string;
+    try {
+      text = readFileSync(path, 'utf8');
+    } catch {
+      continue;
+    }
+    if (text.length > MAX_FILE_CHARS) text = text.slice(0, MAX_FILE_CHARS);
+    out.push({ path, text });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/**
+ * Deterministic episode from a handoff/memory file: one concept node per file
+ * plus a documents edge to a gap/lane id if the first GAP-NNN token is found
+ * without regex (substring scan for "GAP-" + digits).
+ */
+export function textSourceToEpisode(
+  source: TextSource,
+  options: { siteId: string; sourceLabel?: string; referenceTime?: Date },
+): EpisodeIngestInput {
+  const referenceTime = options.referenceTime ?? new Date();
+  const base = basename(source.path);
+  const naturalKey = `handoff-or-memory:${base}`;
+  const gapId = findGapId(source.text);
+
+  const nodes: EpisodeIngestInput['nodes'] = [
+    {
+      kind: 'concept',
+      name: base,
+      naturalKey,
+      summary: source.text.slice(0, 280).replaceAll('\n', ' '),
+      attributes: { path: source.path },
+    },
+  ];
+
+  const edges: EpisodeIngestInput['edges'] = [];
+  if (gapId) {
+    nodes.push({
+      kind: 'gap',
+      name: gapId,
+      naturalKey: `gap:${gapId}`,
+    });
+    edges.push({
+      source: { kind: 'concept', naturalKey },
+      target: { kind: 'gap', naturalKey: `gap:${gapId}` },
+      relation: 'relates-to',
+      fact: `${base} mentions ${gapId}`,
+    });
+  }
+
+  return {
+    episode: {
+      episodeType: 'memory',
+      source: options.sourceLabel ?? `file:${source.path}`,
+      siteId: options.siteId,
+      content: source.text.slice(0, 8000),
+      contentRef: { path: source.path },
+      referenceTime,
+    },
+    nodes,
+    edges,
+  };
+}
+
+/** Find first GAP-NNN id by character scan (no authored regex). */
+function findGapId(text: string): string | null {
+  const marker = 'GAP-';
+  let from = 0;
+  while (from < text.length) {
+    const i = text.indexOf(marker, from);
+    if (i < 0) return null;
+    let j = i + marker.length;
+    let digits = '';
+    while (j < text.length) {
+      const c = text[j];
+      if (c === undefined || c < '0' || c > '9') break;
+      digits += c;
+      j++;
+    }
+    if (digits.length > 0) return `GAP-${digits}`;
+    from = i + marker.length;
+  }
+  return null;
+}

--- a/packages/knowledge-graph/src/extractors/handoff-memory.ts
+++ b/packages/knowledge-graph/src/extractors/handoff-memory.ts
@@ -6,7 +6,7 @@
  * never appear as node values.
  */
 
-import { readdirSync, readFileSync, type Stats, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import type { EpisodeIngestInput } from '../ingest/engine.js';
 
@@ -19,6 +19,9 @@ const MAX_FILE_CHARS = 48_000;
 
 /**
  * Load markdown fragments under a handoffs/rolling directory (or any dir of .md).
+ *
+ * Single open/read path (no stat-then-read) so CodeQL does not flag TOCTOU
+ * between existence check and content load.
  */
 export function loadMarkdownSources(dir: string, options?: { limit?: number }): TextSource[] {
   let names: string[];
@@ -32,15 +35,9 @@ export function loadMarkdownSources(dir: string, options?: { limit?: number }): 
   for (const name of names) {
     if (!name.endsWith('.md')) continue;
     const path = join(dir, name);
-    let st: Stats;
-    try {
-      st = statSync(path);
-    } catch {
-      continue;
-    }
-    if (!st.isFile()) continue;
     let text: string;
     try {
+      // readFileSync fails closed for dirs / missing paths (EISDIR, ENOENT, …)
       text = readFileSync(path, 'utf8');
     } catch {
       continue;

--- a/packages/knowledge-graph/src/extractors/index.ts
+++ b/packages/knowledge-graph/src/extractors/index.ts
@@ -13,6 +13,11 @@ export { dbSchemaExtractor } from './db-schema.js';
 export { docsFrontmatterExtractor } from './docs-frontmatter.js';
 export { gitExtractor } from './git.js';
 export {
+  loadMarkdownSources,
+  type TextSource,
+  textSourceToEpisode,
+} from './handoff-memory.js';
+export {
   type ExtractEpisodeOptions,
   extractEpisodeFromText,
   LLM_EXTRACTION_PROMPT,

--- a/packages/knowledge-graph/src/extractors/llm-episode.ts
+++ b/packages/knowledge-graph/src/extractors/llm-episode.ts
@@ -7,9 +7,10 @@
  * `@revealui/ai` Ollama chat with JSON mode). No hard import of @revealui/ai
  * so the package stays installable without Pro optional deps.
  *
- * Contradictions: when relation is `supersedes` / `blocks`, the engine still
- * applies additive ingest; temporal invalidation of prior edges is a follow-on
- * once resolution ladder lands (P3 residual).
+ * Contradictions: ingest stays additive by default. Pass
+ * `invalidateContradictions: true` to ingestEpisode (or use CLI
+ * `extract` / `ingest-handoffs`) to temporally invalidate prior edges that
+ * share endpoints+relation but differ in fact (invalidate-not-delete).
  */
 
 import { z } from 'zod';
@@ -17,12 +18,21 @@ import type { EpisodeIngestInput } from '../ingest/engine.js';
 import { EDGE_RELATIONS, NODE_KINDS } from '../ontology/index.js';
 import type { EdgeInput, EpisodeInput, NodeInput } from '../types.js';
 
+/** Models often emit null for optional fields — coerce null → undefined. */
+const optionalRepo = z.preprocess(
+  (v) => (v === null || v === undefined || v === '' ? undefined : v),
+  z.string().max(100).optional(),
+);
+
 const ExtractedNodeSchema = z.object({
   kind: z.enum(NODE_KINDS),
   name: z.string().min(1).max(200),
   naturalKey: z.string().min(1).max(500),
-  repo: z.string().max(100).optional(),
-  summary: z.string().max(2000).optional(),
+  repo: optionalRepo,
+  summary: z.preprocess(
+    (v) => (v === null || v === undefined ? undefined : v),
+    z.string().max(2000).optional(),
+  ),
 });
 
 const ExtractedEdgeSchema = z.object({
@@ -32,7 +42,7 @@ const ExtractedEdgeSchema = z.object({
   targetKind: z.enum(NODE_KINDS),
   relation: z.enum(EDGE_RELATIONS),
   fact: z.string().min(1).max(2000),
-  repo: z.string().max(100).optional(),
+  repo: optionalRepo,
 });
 
 export const LlmExtractionSchema = z.object({

--- a/packages/knowledge-graph/src/extractors/llm-episode.ts
+++ b/packages/knowledge-graph/src/extractors/llm-episode.ts
@@ -15,7 +15,14 @@
 
 import { z } from 'zod';
 import type { EpisodeIngestInput } from '../ingest/engine.js';
-import { EDGE_RELATIONS, NODE_KINDS } from '../ontology/index.js';
+import {
+  EDGE_RELATIONS,
+  isEdgeRelation,
+  isNodeKind,
+  LEARNED_KIND,
+  LEARNED_RELATION,
+  NODE_KINDS,
+} from '../ontology/index.js';
 import type { EdgeInput, EpisodeInput, NodeInput } from '../types.js';
 
 /** Models often emit null for optional fields — coerce null → undefined. */
@@ -24,26 +31,81 @@ const optionalRepo = z.preprocess(
   z.string().max(100).optional(),
 );
 
-const ExtractedNodeSchema = z.object({
-  kind: z.enum(NODE_KINDS),
-  name: z.string().min(1).max(200),
-  naturalKey: z.string().min(1).max(500),
-  repo: optionalRepo,
-  summary: z.preprocess(
-    (v) => (v === null || v === undefined ? undefined : v),
-    z.string().max(2000).optional(),
-  ),
-});
+/** Small models invent kinds; map unknown → concept (spec §5 learned fallback). */
+const coercedKind = z.preprocess((v) => {
+  if (typeof v === 'string' && isNodeKind(v)) return v;
+  return LEARNED_KIND;
+}, z.enum(NODE_KINDS));
 
-const ExtractedEdgeSchema = z.object({
-  sourceNaturalKey: z.string().min(1).max(500),
-  targetNaturalKey: z.string().min(1).max(500),
-  sourceKind: z.enum(NODE_KINDS),
-  targetKind: z.enum(NODE_KINDS),
-  relation: z.enum(EDGE_RELATIONS),
-  fact: z.string().min(1).max(2000),
-  repo: optionalRepo,
-});
+/** Small models invent relations; map unknown → relates-to. */
+const coercedRelation = z.preprocess((v) => {
+  if (typeof v === 'string' && isEdgeRelation(v)) return v;
+  return LEARNED_RELATION;
+}, z.enum(EDGE_RELATIONS));
+
+/** Prefer model naturalKey; else derive from name (small-model resilience). */
+function deriveNaturalKey(raw: unknown, name: unknown): string | undefined {
+  if (typeof raw === 'string' && raw.trim().length > 0) return raw.trim().slice(0, 500);
+  if (typeof name === 'string' && name.trim().length > 0) {
+    return `concept:${name.trim().slice(0, 200).toLowerCase().replaceAll(' ', '-')}`;
+  }
+  return undefined;
+}
+
+const ExtractedNodeSchema = z.preprocess(
+  (input) => {
+    if (input === null || typeof input !== 'object') return input;
+    const o = input as Record<string, unknown>;
+    const naturalKey = deriveNaturalKey(o.naturalKey, o.name);
+    return naturalKey === undefined ? o : { ...o, naturalKey };
+  },
+  z.object({
+    kind: coercedKind,
+    name: z.string().min(1).max(200),
+    naturalKey: z.string().min(1).max(500),
+    repo: optionalRepo,
+    summary: z.preprocess(
+      (v) => (v === null || v === undefined ? undefined : v),
+      z.string().max(2000).optional(),
+    ),
+  }),
+);
+
+const ExtractedEdgeSchema = z.preprocess(
+  (input) => {
+    if (input === null || typeof input !== 'object') return input;
+    const o = input as Record<string, unknown>;
+    const sourceNaturalKey =
+      typeof o.sourceNaturalKey === 'string' && o.sourceNaturalKey.trim()
+        ? o.sourceNaturalKey
+        : deriveNaturalKey(undefined, o.sourceName ?? o.source);
+    const targetNaturalKey =
+      typeof o.targetNaturalKey === 'string' && o.targetNaturalKey.trim()
+        ? o.targetNaturalKey
+        : deriveNaturalKey(undefined, o.targetName ?? o.target);
+    const fact =
+      typeof o.fact === 'string' && o.fact.trim()
+        ? o.fact
+        : typeof o.relation === 'string'
+          ? `${String(sourceNaturalKey ?? 'source')} ${o.relation} ${String(targetNaturalKey ?? 'target')}`
+          : undefined;
+    return {
+      ...o,
+      ...(sourceNaturalKey !== undefined ? { sourceNaturalKey } : {}),
+      ...(targetNaturalKey !== undefined ? { targetNaturalKey } : {}),
+      ...(fact !== undefined ? { fact } : {}),
+    };
+  },
+  z.object({
+    sourceNaturalKey: z.string().min(1).max(500),
+    targetNaturalKey: z.string().min(1).max(500),
+    sourceKind: coercedKind,
+    targetKind: coercedKind,
+    relation: coercedRelation,
+    fact: z.string().min(1).max(2000),
+    repo: optionalRepo,
+  }),
+);
 
 export const LlmExtractionSchema = z.object({
   nodes: z.array(ExtractedNodeSchema).max(50),

--- a/packages/knowledge-graph/src/index.ts
+++ b/packages/knowledge-graph/src/index.ts
@@ -14,7 +14,10 @@ export {
   additiveExtractors,
   type Extractor,
   type ExtractorContext,
+  loadMarkdownSources,
   type ScanProduct,
+  type TextSource,
+  textSourceToEpisode,
   tier1Extractors,
 } from './extractors/index.js';
 export {
@@ -28,8 +31,13 @@ export {
   applyOp,
   applyOps,
   applyScan,
+  type ContradictingEdge,
+  findContradictingEdges,
   type IngestOptions,
   ingestEpisode,
+  invalidateContradictions,
+  naturalKeysSimilar,
+  normalizeNaturalKey,
   type ScanInput,
 } from './ingest/index.js';
 export {

--- a/packages/knowledge-graph/src/ingest/contradiction.ts
+++ b/packages/knowledge-graph/src/ingest/contradiction.ts
@@ -1,0 +1,115 @@
+/**
+ * P3 contradiction handling — temporal invalidation, never delete.
+ *
+ * When a new edge is ingested, any *current* edge with the same
+ * (source, target, relation) triple and a *different* fact is treated as
+ * contradicted and gets `invalid_at` set (spec §6 invalidate-not-delete).
+ *
+ * Similarity ladder step 3 (cheap): if two natural keys normalize equal after
+ * lowercasing and collapsing separators, they share a node alias opportunity
+ * (caller may apply aliasOp separately).
+ */
+
+import { deriveNodeId } from '../ids.js';
+import type { EdgeRelation, NodeKind } from '../ontology/index.js';
+import type { EdgeInput, KgExecutor } from '../types.js';
+import { applyOp } from './merge.js';
+
+export interface ContradictingEdge {
+  id: string;
+  fact: string;
+  validAt: string;
+}
+
+/**
+ * Find current edges that share endpoints+relation but differ in fact text.
+ */
+export async function findContradictingEdges(
+  exec: KgExecutor,
+  edge: EdgeInput,
+  options?: { at?: Date },
+): Promise<ContradictingEdge[]> {
+  const sourceId = deriveNodeId(edge.source.kind as NodeKind, edge.source.naturalKey);
+  const targetId = deriveNodeId(edge.target.kind as NodeKind, edge.target.naturalKey);
+  const relation = edge.relation as EdgeRelation;
+  const at = options?.at ?? new Date();
+
+  const rows = await exec.query<{
+    id: string;
+    fact: string;
+    valid_at: string;
+  }>(
+    `SELECT id, fact, valid_at
+     FROM kg_edges
+     WHERE source_id = $1
+       AND target_id = $2
+       AND relation = $3
+       AND valid_at <= $4::timestamptz
+       AND (invalid_at IS NULL OR invalid_at > $4::timestamptz)
+       AND (expired_at IS NULL OR expired_at > $4::timestamptz)
+       AND fact IS DISTINCT FROM $5`,
+    [sourceId, targetId, relation, at.toISOString(), edge.fact],
+  );
+
+  return rows.map((r) => ({
+    id: r.id,
+    fact: r.fact,
+    validAt: r.valid_at,
+  }));
+}
+
+/**
+ * Invalidate all contradicting current edges for each new edge.
+ * Returns invalidated edge ids.
+ */
+export async function invalidateContradictions(
+  exec: KgExecutor,
+  edges: EdgeInput[],
+  options: {
+    siteId: string;
+    invalidAt?: Date;
+    recordOutbox?: boolean;
+  },
+): Promise<string[]> {
+  const invalidAt = options.invalidAt ?? new Date();
+  const invalidated: string[] = [];
+  const seen = new Set<string>();
+
+  for (const edge of edges) {
+    const hits = await findContradictingEdges(exec, edge, { at: invalidAt });
+    for (const hit of hits) {
+      if (seen.has(hit.id)) continue;
+      seen.add(hit.id);
+      await applyOp(
+        exec,
+        { t: 'invalidate', edgeId: hit.id, invalidAt: invalidAt.toISOString() },
+        { siteId: options.siteId, recordOutbox: options.recordOutbox ?? true },
+      );
+      invalidated.push(hit.id);
+    }
+  }
+
+  return invalidated;
+}
+
+/** Cheap natural-key normalization for entity-resolution ladder step 3. */
+export function normalizeNaturalKey(key: string): string {
+  return Array.from(key.toLowerCase())
+    .map((c) => {
+      if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) return c;
+      return '-';
+    })
+    .join('')
+    .split('-')
+    .filter((p) => p.length > 0)
+    .join('-');
+}
+
+/**
+ * True when two natural keys collapse to the same normalized form
+ * (suggests alias / merge candidate; does not write aliases).
+ */
+export function naturalKeysSimilar(a: string, b: string): boolean {
+  if (a === b) return true;
+  return normalizeNaturalKey(a) === normalizeNaturalKey(b);
+}

--- a/packages/knowledge-graph/src/ingest/engine.ts
+++ b/packages/knowledge-graph/src/ingest/engine.ts
@@ -35,6 +35,7 @@ import type {
   NodeInput,
   ScanApplyResult,
 } from '../types.js';
+import { invalidateContradictions as runInvalidateContradictions } from './contradiction.js';
 import { backfillEdgeEmbedding, backfillNodeEmbedding } from './embed.js';
 import { applyOps } from './merge.js';
 
@@ -43,6 +44,13 @@ export interface IngestOptions {
   embedder?: Embedder;
   /** Record every applied op into `kg_outbox` for offline replay. */
   recordOutbox?: boolean;
+  /**
+   * When true, after additive edge insert, invalidate any *current* edge with
+   * the same (source, target, relation) triple and a different fact
+   * (invalidate-not-delete; P3 contradiction ladder). Default false so MCP
+   * agent-fact publish stays purely additive unless the caller opts in.
+   */
+  invalidateContradictions?: boolean;
 }
 
 export interface ScanInput {
@@ -255,13 +263,23 @@ export async function ingestEpisode(
   await exec.transaction((tx) =>
     applyOps(tx, ops, { siteId: input.episode.siteId, recordOutbox: options.recordOutbox }),
   );
+
+  let invalidatedEdgeIds: string[] = [];
+  if (options.invalidateContradictions && input.edges.length > 0) {
+    invalidatedEdgeIds = await runInvalidateContradictions(exec, input.edges, {
+      siteId: input.episode.siteId,
+      invalidAt: referenceTime,
+      recordOutbox: options.recordOutbox,
+    });
+  }
+
   await applyEmbeddings(exec, options.embedder, nodeOps, edgeOps);
 
   return {
     episodeId,
     nodeCount: nodeOps.length,
     edgeCount: edgeOps.length,
-    invalidatedEdgeIds: [],
+    invalidatedEdgeIds,
     ops,
   };
 }

--- a/packages/knowledge-graph/src/ingest/index.ts
+++ b/packages/knowledge-graph/src/ingest/index.ts
@@ -1,4 +1,11 @@
 export {
+  type ContradictingEdge,
+  findContradictingEdges,
+  invalidateContradictions,
+  naturalKeysSimilar,
+  normalizeNaturalKey,
+} from './contradiction.js';
+export {
   backfillEdgeEmbedding,
   backfillNodeEmbedding,
 } from './embed.js';


### PR DESCRIPTION
## Summary

P3 residual for GAP-349:

- **Handoff/memory adapters** — deterministic markdown → `EpisodeIngestInput` (no LLM); `revkg ingest-handoffs --dir …`
- **Contradiction ladder** — `findContradictingEdges` / `invalidateContradictions` (invalidate-not-delete); opt-in on `ingestEpisode({ invalidateContradictions: true })`; default on for `extract` and `ingest-handoffs` (use `--no-invalidate` to skip)
- **Natural-key similarity** — cheap normalize for entity-resolution ladder step 3
- **LLM null coerce** — model `repo: null` / `summary: null` no longer fails Zod (dogfood fix)

## Test plan

- [x] `vitest` contradiction + handoff-memory + llm-episode (null coerce)
- [x] Local pre-push phase-1 gate
- [ ] CI green on `test`
- [ ] Optional: `revkg extract --dry-run` against Ollama after merge/build
- [ ] Optional: `revkg ingest-handoffs --dir … --dry-run`