### PR TITLE
fix(harnesses): slim ACP agent prompt for free-tier LLM TPM

### DIFF
--- a/packages/ai/src/__tests__/integration/agent-dispatch.test.ts
+++ b/packages/ai/src/__tests__/integration/agent-dispatch.test.ts
@@ -49,7 +49,7 @@ async function buildLLMClient(): Promise<LLMClient | null> {
     return new LLMClient({
       provider: 'groq',
       apiKey: process.env.GROQ_API_KEY,
-      model: process.env.LLM_MODEL ?? 'qwen/qwen3-32b',
+      model: process.env.LLM_MODEL ?? 'llama-3.3-70b-versatile',
     });
   }
 

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -646,7 +646,7 @@ export class LLMClient {
  *
  * Provider defaults:
  *   inference-snaps → nemotron-3-nano   (base URL defaults to http://localhost:9090/v1)
- *   groq            → qwen/qwen3-32b
+ *   groq            → llama-3.3-70b-versatile
  *   ollama          → gemma4:e2b        (base URL defaults to http://localhost:11434)
  *   anthropic       → claude-sonnet-4-6 (base URL defaults to https://api.anthropic.com/v1)
  *   openai          → gpt-4o            (base URL defaults to https://api.openai.com/v1)
@@ -712,7 +712,7 @@ export function createLLMClientFromEnv(): LLMClient {
   } else if (provider === 'groq') {
     apiKey = process.env.GROQ_API_KEY;
     baseURL = process.env.GROQ_BASE_URL;
-    defaultModel = 'qwen/qwen3-32b';
+    defaultModel = 'llama-3.3-70b-versatile';
   } else if (provider === 'ollama') {
     apiKey = 'ollama'; // Ollama ignores the API key
     // Ollama's OpenAI-compatible endpoint lives at /v1

--- a/packages/ai/src/llm/providers/groq.ts
+++ b/packages/ai/src/llm/providers/groq.ts
@@ -24,7 +24,7 @@ export interface GroqProviderConfig extends Omit<LLMProviderConfig, 'apiKey'> {
   apiKey: string;
   /** Defaults to https://api.groq.com/openai/v1 */
   baseURL?: string;
-  /** Defaults to qwen/qwen3-32b */
+  /** Defaults to llama-3.3-70b-versatile (current Groq free-tier catalog) */
   model?: string;
 }
 
@@ -35,12 +35,13 @@ export class GroqProvider implements LLMProvider {
     this.inner = new OpenAICompatProvider({
       ...config,
       baseURL: config.baseURL ?? 'https://api.groq.com/openai/v1',
-      model: config.model ?? 'qwen/qwen3-32b',
+      // Retired catalog id qwen/qwen3-32b (404). Prefer versatile Llama for tools.
+      model: config.model ?? 'llama-3.3-70b-versatile',
     });
   }
 
   capabilities(): ReasonerCapabilities {
-    // Profile for the default model (qwen/qwen3-32b). Groq exposes no embeddings endpoint.
+    // Profile for the default model. Groq exposes no embeddings endpoint.
     return {
       providerTag: 'groq',
       tools: true,

--- a/packages/harnesses/src/__tests__/agent-instructions.test.ts
+++ b/packages/harnesses/src/__tests__/agent-instructions.test.ts
@@ -1,0 +1,59 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildAgentInstructions,
+  DEFAULT_AGENT_RULES_MAX_CHARS,
+  shouldIncludeAgentRules,
+} from '../adapters/agent-instructions.js';
+
+const prevEnv = process.env.REVEALUI_AGENT_INCLUDE_RULES;
+
+afterEach(() => {
+  if (prevEnv === undefined) {
+    delete process.env.REVEALUI_AGENT_INCLUDE_RULES;
+  } else {
+    process.env.REVEALUI_AGENT_INCLUDE_RULES = prevEnv;
+  }
+});
+
+describe('buildAgentInstructions', () => {
+  it('defaults to slim instructions without dumping rules', () => {
+    delete process.env.REVEALUI_AGENT_INCLUDE_RULES;
+    const root = mkdtempSync(join(tmpdir(), 'agent-instr-'));
+    mkdirSync(join(root, '.claude', 'rules'), { recursive: true });
+    writeFileSync(join(root, '.claude', 'rules', 'huge.md'), `${'x'.repeat(20_000)}\n`);
+
+    const text = buildAgentInstructions({ projectRoot: root });
+    expect(text.length).toBeLessThan(2_000);
+    expect(text).toContain('RevealUI coding agent');
+    expect(text).not.toContain('huge');
+  });
+
+  it('caps rules when includeRules is enabled', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-instr-'));
+    mkdirSync(join(root, '.claude', 'rules'), { recursive: true });
+    writeFileSync(join(root, '.claude', 'rules', 'a.md'), `${'a'.repeat(10_000)}\n`);
+
+    const text = buildAgentInstructions({
+      projectRoot: root,
+      includeRules: true,
+      maxRulesChars: 500,
+    });
+    expect(text).toContain('Project rules');
+    expect(text.length).toBeLessThan(BASE_PLUS_CAP);
+    expect(text).toMatch(/truncated|omitted/i);
+  });
+
+  it('shouldIncludeAgentRules reads env', () => {
+    delete process.env.REVEALUI_AGENT_INCLUDE_RULES;
+    expect(shouldIncludeAgentRules()).toBe(false);
+    process.env.REVEALUI_AGENT_INCLUDE_RULES = '1';
+    expect(shouldIncludeAgentRules()).toBe(true);
+    expect(shouldIncludeAgentRules(false)).toBe(false);
+  });
+});
+
+/** base ~400 + cap 500 + headers */
+const BASE_PLUS_CAP = 2_000 + DEFAULT_AGENT_RULES_MAX_CHARS;

--- a/packages/harnesses/src/adapters/agent-instructions.ts
+++ b/packages/harnesses/src/adapters/agent-instructions.ts
@@ -1,0 +1,91 @@
+/**
+ * System instructions for the RevealUI coding / headless agent.
+ *
+ * Default is slim: free-tier LLM APIs (e.g. Groq 12k TPM) cannot hold a full
+ * monorepo `.claude/rules` dump (~60KB) plus tool schemas in one request.
+ * Opt in to project rules with REVEALUI_AGENT_INCLUDE_RULES=1 (still capped).
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Hard cap when rules are included (chars). ~2–3k tokens of rules max. */
+export const DEFAULT_AGENT_RULES_MAX_CHARS = 4_000;
+
+const BASE_INSTRUCTIONS = [
+  'You are the RevealUI coding agent. You help with software development tasks in this project.',
+  'Use the available tools to read, write, edit, search, and execute commands.',
+  'Always read files before modifying them. Prefer surgical edits over full rewrites.',
+  'Follow project conventions; use tools to inspect the repo instead of assuming large rule dumps.',
+  'Keep tool results and replies concise. Prefer paths and diffs over pasting whole files.',
+  '',
+].join('\n');
+
+export interface BuildAgentInstructionsOptions {
+  projectRoot: string;
+  /**
+   * When true, append truncated `.claude/rules/*.md` content.
+   * Default: false (env REVEALUI_AGENT_INCLUDE_RULES=1 enables).
+   */
+  includeRules?: boolean;
+  /** Max characters of rules content after base instructions (default 4000). */
+  maxRulesChars?: number;
+}
+
+/**
+ * Whether to include project rules. Explicit option wins; else env.
+ */
+export function shouldIncludeAgentRules(includeRules?: boolean): boolean {
+  if (includeRules !== undefined) {
+    return includeRules;
+  }
+  const env = process.env.REVEALUI_AGENT_INCLUDE_RULES?.trim().toLowerCase();
+  return env === '1' || env === 'true' || env === 'yes';
+}
+
+/**
+ * Build system instructions for headless / ACP agent runs.
+ */
+export function buildAgentInstructions(options: BuildAgentInstructionsOptions): string {
+  const includeRules = shouldIncludeAgentRules(options.includeRules);
+  if (!includeRules) {
+    return BASE_INSTRUCTIONS;
+  }
+
+  const maxRulesChars = options.maxRulesChars ?? DEFAULT_AGENT_RULES_MAX_CHARS;
+  const parts: string[] = [BASE_INSTRUCTIONS, '## Project rules (truncated)', ''];
+  let used = 0;
+
+  try {
+    const rulesDir = join(options.projectRoot, '.claude', 'rules');
+    const ruleFiles = readdirSync(rulesDir)
+      .filter((f) => f.endsWith('.md'))
+      .sort();
+
+    for (const file of ruleFiles) {
+      if (used >= maxRulesChars) {
+        break;
+      }
+      const content = readFileSync(join(rulesDir, file), 'utf8');
+      const header = `### ${file.replace(/\.md$/, '')}\n`;
+      const remaining = maxRulesChars - used;
+      const body =
+        content.length + header.length <= remaining
+          ? content
+          : `${content.slice(0, Math.max(0, remaining - header.length - 20))}\n…[truncated]`;
+      const chunk = `${header}${body}\n\n`;
+      parts.push(chunk);
+      used += chunk.length;
+    }
+
+    if (used >= maxRulesChars) {
+      parts.push(
+        '(Further project rules omitted to stay within LLM context limits. Set a higher REVEALUI_AGENT_RULES_MAX_CHARS or use a higher-TPM provider for full rules.)\n',
+      );
+    }
+  } catch {
+    // No rules directory — base only
+  }
+
+  return parts.join('\n');
+}

--- a/packages/harnesses/src/adapters/revealui-agent-adapter.ts
+++ b/packages/harnesses/src/adapters/revealui-agent-adapter.ts
@@ -46,12 +46,14 @@ export interface RevealUIAgentConfig {
   includeRules?: boolean;
 }
 
-const DEFAULT_CONFIG: Required<Omit<RevealUIAgentConfig, 'provider' | 'model' | 'workboardPath'>> =
-  {
-    projectRoot: process.cwd(),
-    maxIterations: 10,
-    timeoutMs: 120_000,
-  };
+// includeRules omitted so undefined → env REVEALUI_AGENT_INCLUDE_RULES (shouldIncludeAgentRules)
+const DEFAULT_CONFIG: Required<
+  Omit<RevealUIAgentConfig, 'provider' | 'model' | 'workboardPath' | 'includeRules'>
+> = {
+  projectRoot: process.cwd(),
+  maxIterations: 10,
+  timeoutMs: 120_000,
+};
 
 /**
  * RevealUI's standalone coding agent adapter.

--- a/packages/harnesses/src/adapters/revealui-agent-adapter.ts
+++ b/packages/harnesses/src/adapters/revealui-agent-adapter.ts
@@ -7,8 +7,6 @@
  * directly. This is RevealUI's own coding agent.
  */
 
-import { readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import type { GeneratedFiles, ProtocolConfig } from '../protocol/adapter.js';
 import type { ProtocolCapabilities } from '../protocol/capabilities.js';
 import { TOOL_PROFILES } from '../protocol/capabilities.js';
@@ -22,6 +20,7 @@ import type {
   HarnessEvent,
   HarnessInfo,
 } from '../types/core.js';
+import { buildAgentInstructions } from './agent-instructions.js';
 
 /**
  * Configuration for the RevealUI Agent Adapter.
@@ -40,6 +39,11 @@ export interface RevealUIAgentConfig {
   timeoutMs?: number;
   /** Workboard path for coordination (default: REVEALUI_WORKBOARD_PATH env) */
   workboardPath?: string;
+  /**
+   * Include truncated `.claude/rules` in system prompt (default: false / env).
+   * Full monorepo rules exceed free-tier LLM TPM (e.g. Groq 12k).
+   */
+  includeRules?: boolean;
 }
 
 const DEFAULT_CONFIG: Required<Omit<RevealUIAgentConfig, 'provider' | 'model' | 'workboardPath'>> =
@@ -312,7 +316,10 @@ export class RevealUIAgentAdapter implements HarnessAdapter {
     const agent = {
       id: 'revealui-coding-agent',
       name: 'RevealUI Coding Agent',
-      instructions: this.buildInstructions(),
+      instructions: buildAgentInstructions({
+        projectRoot,
+        includeRules: this.config.includeRules,
+      }),
       tools,
       config: {},
       getContext: () => ({ projectRoot, workingDirectory: projectRoot }),
@@ -365,38 +372,6 @@ export class RevealUIAgentAdapter implements HarnessAdapter {
       message: output,
       data: { taskId, output },
     };
-  }
-
-  /**
-   * Build system instructions from the content layer.
-   * Loads rules from .claude/rules/ as a baseline (they are the canonical content).
-   */
-  private buildInstructions(): string {
-    const lines: string[] = [
-      'You are the RevealUI coding agent. You help with software development tasks in this project.',
-      'Use the available tools to read, write, edit, search, and execute commands.',
-      'Always read files before modifying them. Prefer surgical edits over full rewrites.',
-      'Follow project conventions discovered via the project_context tool.',
-      '',
-    ];
-
-    // Load project rules if available (static ESM imports — require() is undefined under "type":"module")
-    try {
-      const projectRoot = this.config.projectRoot ?? process.cwd();
-      const rulesDir = join(projectRoot, '.claude', 'rules');
-
-      const ruleFiles: string[] = readdirSync(rulesDir);
-      for (const file of ruleFiles) {
-        if (file.endsWith('.md')) {
-          const content = readFileSync(join(rulesDir, file), 'utf8');
-          lines.push(`## ${file.replace('.md', '')}`, content, '');
-        }
-      }
-    } catch {
-      // No rules directory  -  proceed with base instructions
-    }
-
-    return lines.join('\n');
   }
 
   onEvent(handler: (event: HarnessEvent) => void): () => void {


### PR DESCRIPTION
## Summary

Headless ACP agent was loading **every** `.claude/rules/*.md` (~63KB) into the system prompt. With tool schemas that exceeded Groq free-tier **12k TPM** (~17k tokens requested).

**Durable fix:**
- Default **slim** system instructions (no full rules dump)
- Opt-in: `REVEALUI_AGENT_INCLUDE_RULES=1` with a **4k char cap**
- Groq default model: `llama-3.3-70b-versatile` (retired `qwen/qwen3-32b`)

## Test plan

- [x] `vitest` agent-instructions tests
- [x] Local phase-1 gate green on push
- [ ] CI green
- [ ] Zed RevealUI + Groq short prompt under 12k TPM