### PR TITLE
chore(ai): set Ollama daily default to qwen2.5:3b

### DIFF
--- a/apps/docs/public/docs-pro/ai/index.md
+++ b/apps/docs/public/docs-pro/ai/index.md
@@ -30,7 +30,7 @@ Run a local model with Ollama (default path) or install a Canonical Inference Sn
 
 ```bash
 # Default path
-ollama pull gemma4:e2b
+ollama pull qwen2.5:3b
 ollama pull nomic-embed-text
 
 # OR planned path (run + manage the snap yourself for now)

--- a/apps/docs/public/docs-pro/inference/index.md
+++ b/apps/docs/public/docs-pro/inference/index.md
@@ -70,7 +70,7 @@ When `INFERENCE_SNAPS_BASE_URL` is set, the LLM client auto-detects it as the pr
 Run any open source model locally via the RevealUI harness.
 
 ```bash
-ollama pull gemma4:e2b            # Chat model (Gemma 4 — Apache 2.0)
+ollama pull qwen2.5:3b            # Chat model (daily default — fits ~4GB WSL)
 ollama pull nomic-embed-text      # Embedding model
 ```
 

--- a/apps/marketing/app/content/claims-evidence/blog-body-claims.ts
+++ b/apps/marketing/app/content/claims-evidence/blog-body-claims.ts
@@ -7473,7 +7473,7 @@ export const blogBodyClaims: readonly ClaimEntry[] = [
   {
     file: 'blog/five-primitives',
     exportPath: 'body.68',
-    text: '**Ollama** (fallback)  -  Any open source GGUF model (chat: `gemma4:e2b`, embeddings: `nomic-embed-text`)',
+    text: '**Ollama** (fallback)  -  Any open source GGUF model (chat: `qwen2.5:3b`, embeddings: `nomic-embed-text`)',
     evidence: [
       { kind: 'code', ref: 'docs/blog/05-five-primitives.md', note: 'body source paragraph 68' },
       {
@@ -8045,7 +8045,7 @@ export const blogBodyClaims: readonly ClaimEntry[] = [
   {
     file: 'blog/local-first-ai-stack',
     exportPath: 'body.13',
-    text: 'As a fallback, **Ollama** supports any open source GGUF model (default: `gemma4:e2b`):',
+    text: 'As a fallback, **Ollama** supports any open source GGUF model (default: `qwen2.5:3b`):',
     evidence: [
       {
         kind: 'code',

--- a/apps/marketing/app/content/claims-evidence/claims-part-3.ts
+++ b/apps/marketing/app/content/claims-evidence/claims-part-3.ts
@@ -433,7 +433,7 @@ export const claimsPart3: readonly ClaimEntry[] = [
   {
     file: 'local-ai.ts',
     exportPath: 'LOCAL_AI_SECTION.snippet.lines[1].note',
-    text: 'gemma4 on your box, port 11434',
+    text: 'qwen2.5:3b on your box, port 11434',
     evidence: [OLLAMA],
   },
   {

--- a/apps/marketing/app/content/claims-evidence/shared-refs.ts
+++ b/apps/marketing/app/content/claims-evidence/shared-refs.ts
@@ -376,7 +376,7 @@ export const LLM_CLIENT: EvidenceRef = {
 export const OLLAMA: EvidenceRef = {
   kind: 'code',
   ref: 'packages/ai/src/llm/providers/ollama.ts',
-  note: 'Ollama adapter, default gemma4:e2b, port 11434',
+  note: 'Ollama adapter, default qwen2.5:3b (DEFAULT_DAILY_OLLAMA_MODEL), port 11434',
 };
 export const OPENAI_COMPAT: EvidenceRef = {
   kind: 'code',

--- a/apps/marketing/app/content/local-ai.ts
+++ b/apps/marketing/app/content/local-ai.ts
@@ -17,7 +17,7 @@
 // cost + sovereignty + good-enough-for-most-work economics, NEVER on parity,
 // "free", "turnkey", or "faster". Frontier stays the opt-in escalation. The
 // provider snippet is grep-accurate to packages/ai/src/llm/client.ts
-// (LLM_PROVIDER; inference-snaps default nemotron-3-nano :9090, ollama gemma4 :11434).
+// (LLM_PROVIDER; inference-snaps default nemotron-3-nano :9090, ollama qwen2.5:3b :11434).
 // Positioning guardrail (Phase C): ownership stays the lead; local AI is its proof.
 //
 // claims-ratchet 2026-07-12: frontier-mode provider naming scoped to the shipped
@@ -59,7 +59,7 @@ export const LOCAL_AI_SECTION = {
         code: 'LLM_PROVIDER=inference-snaps',
         note: 'nemotron-3-nano on your box, port 9090 (default runner)',
       },
-      { code: 'LLM_PROVIDER=ollama', note: 'gemma4 on your box, port 11434' },
+      { code: 'LLM_PROVIDER=ollama', note: 'qwen2.5:3b on your box, port 11434' },
     ],
   },
   dogfood:

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -157,7 +157,8 @@ app.openapi(agentStreamRoute, async (c) => {
         provider: localProvider as LLMConfig['provider'],
         apiKey: localProvider,
         baseURL: localBaseURL,
-        model: process.env.LLM_MODEL ?? 'gemma4:e2b',
+        // Lockstep packages/ai DEFAULT_DAILY_OLLAMA_MODEL when ollama
+        model: process.env.LLM_MODEL ?? 'qwen2.5:3b',
       });
     } catch {
       return c.json(

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -99,7 +99,7 @@ const memory = {
 | Path | Chat | Embeddings | Notes |
 | ---- | ---- | ---------- | ----- |
 | **Ubuntu Inference Snaps** (canonical default — Studio lifecycle pending) | Yes | Depends on model | Canonical snap runtime  -  hardware-aware, single command install, OpenAI-compatible API |
-| Ollama | Yes | Yes | Any open source GGUF model, local inference. Default chat: `gemma4:e2b`, embed: `nomic-embed-text` |
+| Ollama | Yes | Yes | Any open source GGUF model, local inference. Default chat: `qwen2.5:3b`, embed: `nomic-embed-text` |
 
 ### Inference Snaps Models
 

--- a/docs/LOCAL_FIRST.md
+++ b/docs/LOCAL_FIRST.md
@@ -78,7 +78,7 @@ Each snap serves an OpenAI-compatible API at `http://localhost:<port>/v1`.
 Install Ollama, then pull a model:
 ```bash
 ollama serve &
-ollama pull gemma4:e2b
+ollama pull qwen2.5:3b
 ollama pull nomic-embed-text   # for embeddings
 ```
 

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -844,7 +844,7 @@ RevealUI AI defaults to open source models running on your own hardware. It neve
 
 | Path | Runtime | Notes |
 |------|---------|-------|
-| **Ollama** | Local GGUF models | Any open source GGUF model. Default: `gemma4:e2b` |
+| **Ollama** | Local GGUF models | Any open source GGUF model. Default: `qwen2.5:3b` |
 | **Groq** | Cloud, your own key | Bring your own key, opt-in via `GROQ_API_KEY` |
 | **Anthropic** | Cloud, your own key | Bring your own key, opt-in via `ANTHROPIC_API_KEY`. Calls Anthropic's OpenAI-compatible endpoint directly. No proprietary Anthropic SDK. |
 | **OpenAI** | Cloud, your own key | Bring your own key, opt-in via `OPENAI_API_KEY` |

--- a/docs/architecture/ai-stack.md
+++ b/docs/architecture/ai-stack.md
@@ -17,7 +17,7 @@ All LLM access flows through `LLMClient`, a factory that wraps inference backend
 | Path | Chat | Embeddings | Key Env Var | Notes |
 |------|------|-----------|-------------|-------|
 | **Ubuntu Inference Snaps** | yes | depends on model | `INFERENCE_SNAPS_BASE_URL` | Canonical snap runtime  -  US-origin allowlist only: Nemotron 3 Nano/Omni, Gemma 3/4 |
-| **Ollama** | yes | yes | `OLLAMA_BASE_URL` | Any open source GGUF model. Chat: `gemma4:e2b`, Embed: `nomic-embed-text` |
+| **Ollama** | yes | yes | `OLLAMA_BASE_URL` | Any open source GGUF model. Chat: `qwen2.5:3b`, Embed: `nomic-embed-text` |
 
 ### Auto-Detection Priority
 

--- a/docs/blog/04-local-first-ai-stack.md
+++ b/docs/blog/04-local-first-ai-stack.md
@@ -59,11 +59,11 @@ gemma3 status
 
 Each snap serves an OpenAI-compatible API locally. The `@revealui/ai` package auto-detects the running snap and routes agent calls to it. The same agent orchestration, memory system, and MCP integrations work with any supported inference path  -  because they all expose OpenAI-compatible `/v1/chat/completions` endpoints.
 
-As a fallback, **Ollama** supports any open source GGUF model (default: `gemma4:e2b`):
+As a fallback, **Ollama** supports any open source GGUF model (default: `qwen2.5:3b`):
 
 ```bash
 ollama serve &
-ollama pull gemma4:e2b
+ollama pull qwen2.5:3b
 ```
 
 No API key. No usage bill. No data leaving your machine.
@@ -82,7 +82,7 @@ direnv allow        # Nix builds and activates the full dev environment
 sudo snap install nemotron-3-nano
 
 # Or use Ollama
-ollama pull gemma4:e2b
+ollama pull qwen2.5:3b
 ```
 
 No `apt install`, no `brew install`, no conda environment. Every developer on the project gets the same toolchain regardless of what's on their system. It works the same on a Ryzen laptop as it does on a Mac or a Linux CI runner.
@@ -99,7 +99,7 @@ flake.nix
 └── devShell
     └── nodejs, pnpm, biome          # Standard RevealUI toolchain
 
-sudo snap install nemotron-3-nano    # Or: ollama pull gemma4:e2b
+sudo snap install nemotron-3-nano    # Or: ollama pull qwen2.5:3b
 └── OpenAI-compatible API served locally
 
 @revealui/ai                         # Agent orchestration routes to local model

--- a/docs/blog/05-five-primitives.md
+++ b/docs/blog/05-five-primitives.md
@@ -434,7 +434,7 @@ The `@revealui/ai` package is loaded dynamically. If the license is free, the im
 RevealUI defaults to open-weight models (no API key, no cloud bill, no vendor lock-in). Cloud providers (Groq, HuggingFace, and OpenAI-compatible endpoints) are opt-in via environment variables. The inference path is auto-detected:
 
 1. **Ubuntu Inference Snaps** (recommended)  -  Canonical snap runtime (US-origin allowlist: Nemotron-3-nano, Gemma 3/4, Nemotron Omni)
-2. **Ollama** (fallback)  -  Any open source GGUF model (chat: `gemma4:e2b`, embeddings: `nomic-embed-text`)
+2. **Ollama** (fallback)  -  Any open source GGUF model (chat: `qwen2.5:3b`, embeddings: `nomic-embed-text`)
 
 ### CRDT-based memory system
 

--- a/packages/ai/src/__tests__/integration/agent-dispatch.test.ts
+++ b/packages/ai/src/__tests__/integration/agent-dispatch.test.ts
@@ -10,7 +10,7 @@
  *   pnpm --filter @revealui/ai test:integration
  *
  * Prerequisites:
- *   - Ollama running: `ollama serve` + `ollama pull gemma4:e2b`
+ *   - Ollama running: `ollama serve` + `ollama pull qwen2.5:3b`
  *   - OR set GROQ_API_KEY in env
  */
 
@@ -40,7 +40,7 @@ async function buildLLMClient(): Promise<LLMClient | null> {
       provider: 'ollama',
       apiKey: 'ollama',
       baseURL: `${ollamaBase}/v1`,
-      model: process.env.LLM_MODEL ?? 'gemma4:e2b',
+      model: process.env.LLM_MODEL ?? 'qwen2.5:3b',
     });
   }
 

--- a/packages/ai/src/llm/__tests__/local-ai-profile.test.ts
+++ b/packages/ai/src/llm/__tests__/local-ai-profile.test.ts
@@ -85,6 +85,7 @@ describe('local-ai-profile', () => {
 
   it('profileDefaultsForTier covers all tiers', () => {
     expect(profileDefaultsForTier('daily').provider).toBe('ollama');
+    expect(profileDefaultsForTier('daily').model).toBe('qwen2.5:3b');
     expect(profileDefaultsForTier('snaps').provider).toBe('inference-snaps');
     expect(profileDefaultsForTier('heavy').model).toBe('nemotron-3-nano');
     expect(profileDefaultsForTier('idle').provider).toBeNull();

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -39,7 +39,10 @@ import {
 import { OllamaProvider, type OllamaProviderConfig } from './providers/ollama.js';
 import { OpenAIProvider, type OpenAIProviderConfig } from './providers/openai.js';
 import { type OpenAICompatConfig, OpenAICompatProvider } from './providers/openai-compat.js';
-import { DEFAULT_US_ORIGIN_INFERENCE_SNAP } from './providers/us-origin-snaps.js';
+import {
+  DEFAULT_DAILY_OLLAMA_MODEL,
+  DEFAULT_US_ORIGIN_INFERENCE_SNAP,
+} from './providers/us-origin-snaps.js';
 import { XaiProvider, type XaiProviderConfig } from './providers/xai.js';
 import { type CacheStats, ResponseCache, type ResponseCacheOptions } from './response-cache.js';
 import {
@@ -647,7 +650,7 @@ export class LLMClient {
  * Provider defaults:
  *   inference-snaps → nemotron-3-nano   (base URL defaults to http://localhost:9090/v1)
  *   groq            → qwen/qwen3-32b
- *   ollama          → gemma4:e2b        (base URL defaults to http://localhost:11434)
+ *   ollama          → DEFAULT_DAILY_OLLAMA_MODEL (qwen2.5:3b; base URL http://localhost:11434)
  *   anthropic       → claude-sonnet-4-6 (base URL defaults to https://api.anthropic.com/v1)
  *   openai          → gpt-4o            (base URL defaults to https://api.openai.com/v1)
  *   xai             → grok-4.5          (base URL defaults to https://api.x.ai/v1)
@@ -718,7 +721,7 @@ export function createLLMClientFromEnv(): LLMClient {
     // Ollama's OpenAI-compatible endpoint lives at /v1
     const ollamaBase = process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434';
     baseURL = ollamaBase.endsWith('/v1') ? ollamaBase : `${ollamaBase}/v1`;
-    defaultModel = 'gemma4:e2b';
+    defaultModel = DEFAULT_DAILY_OLLAMA_MODEL;
   } else if (provider === 'inference-snaps') {
     apiKey = 'inference-snaps'; // inference-snaps ignores the API key
     // Defaults to Canonical's Inference Snap local service on port 9090; override

--- a/packages/ai/src/llm/local-ai-profile.ts
+++ b/packages/ai/src/llm/local-ai-profile.ts
@@ -173,7 +173,7 @@ export function profileDefaultsForTier(
         model: DEFAULT_DAILY_OLLAMA_MODEL,
         baseURL: 'http://127.0.0.1:11434',
         keepAlive: '0',
-        note: 'Ollama small US model; weights unload after each request',
+        note: 'Ollama daily default (qwen2.5:3b); weights unload after each request',
       };
     case 'snaps':
       return {

--- a/packages/ai/src/llm/providers/ollama.ts
+++ b/packages/ai/src/llm/providers/ollama.ts
@@ -19,12 +19,13 @@ import type {
   ReasonerCapabilities,
 } from './base.js';
 import { OpenAICompatProvider } from './openai-compat.js';
+import { DEFAULT_DAILY_OLLAMA_MODEL } from './us-origin-snaps.js';
 
 export interface OllamaProviderConfig extends Omit<LLMProviderConfig, 'apiKey'> {
   apiKey?: string;
   /** Defaults to http://localhost:11434/v1 */
   baseURL?: string;
-  /** Chat model. Defaults to gemma4:e2b  -  run `ollama pull gemma4:e2b` first */
+  /** Chat model. Defaults to DEFAULT_DAILY_OLLAMA_MODEL — run `ollama pull` first */
   model?: string;
   /** Embedding model. Defaults to nomic-embed-text  -  run `ollama pull nomic-embed-text` first */
   embedModel?: string;
@@ -44,12 +45,12 @@ export class OllamaProvider implements LLMProvider {
       // Ollama ignores the API key but the OpenAI client requires a non-empty value
       apiKey: config.apiKey ?? 'ollama',
       baseURL,
-      model: config.model ?? 'gemma4:e2b',
+      model: config.model ?? DEFAULT_DAILY_OLLAMA_MODEL,
     });
   }
 
   capabilities(): ReasonerCapabilities {
-    // Profile for the default model (gemma4:e2b, text-only).
+    // Profile for the default daily Ollama model (text + tools; no vision).
     return {
       providerTag: 'ollama',
       tools: true,

--- a/packages/ai/src/llm/providers/us-origin-snaps.ts
+++ b/packages/ai/src/llm/providers/us-origin-snaps.ts
@@ -53,8 +53,13 @@ export const DEFAULT_US_ORIGIN_INFERENCE_SNAP: UsOriginInferenceSnapId = 'nemotr
 /** Preferred snap on constrained hosts (profile `snaps` tier). */
 export const DEFAULT_LOW_RAM_INFERENCE_SNAP: UsOriginInferenceSnapId = 'gemma3';
 
-/** Preferred Ollama model for profile `daily` tier (fits ~4GB WSL). */
-export const DEFAULT_DAILY_OLLAMA_MODEL = 'gemma3:1b';
+/**
+ * Preferred Ollama chat model for profile `daily` tier and bare Ollama defaults.
+ * ~1.9GB Q4; quality step up from 1.5b-class while still fitting ~4GB WSL with
+ * Studio + unload-after-request (`OLLAMA_KEEP_ALIVE=0`). One model at a time.
+ * Ollama accepts any GGUF; US-origin hardline remains Inference Snaps only.
+ */
+export const DEFAULT_DAILY_OLLAMA_MODEL = 'qwen2.5:3b';
 
 /** Operator escape env var. Never set in customer seed or CI green paths. */
 export const NON_US_MODELS_ESCAPE_ENV = 'REVEALUI_ALLOW_NON_US_MODELS';

--- a/packages/ai/src/llm/token-counter.ts
+++ b/packages/ai/src/llm/token-counter.ts
@@ -56,6 +56,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   // Groq (Qwen  -  Apache 2.0)
   'qwen/qwen3-32b': { input: 0.59, output: 0.79, cacheWrite: 0, cacheRead: 0 },
   // Ollama (self-hosted  -  no cost)
+  'qwen2.5:3b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
   'gemma4:e2b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
   'gemma4:e4b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },
   'gemma4:26b': { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 },

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -269,7 +269,8 @@ async function detectProvider(): Promise<{
       signal: AbortSignal.timeout(2000),
     });
     if (res.ok) {
-      return { available: true, provider: 'ollama', model: 'gemma4:e2b', projectRoot };
+      // Lockstep packages/ai DEFAULT_DAILY_OLLAMA_MODEL
+      return { available: true, provider: 'ollama', model: 'qwen2.5:3b', projectRoot };
     }
   } catch {
     // not running

--- a/packages/harnesses/src/server/inference-service.ts
+++ b/packages/harnesses/src/server/inference-service.ts
@@ -85,7 +85,8 @@ export const PRODUCT_INFERENCE_SNAPS: ReadonlyArray<readonly [string, string]> =
 const KNOWN_SNAPS = PRODUCT_INFERENCE_SNAPS;
 const SNAP_IDS = PRODUCT_INFERENCE_SNAPS.map(([id]) => id);
 
-const DEFAULT_DAILY_OLLAMA = 'gemma3:1b';
+// Lockstep packages/ai DEFAULT_DAILY_OLLAMA_MODEL (cannot hard-require @revealui/ai).
+const DEFAULT_DAILY_OLLAMA = 'qwen2.5:3b';
 const DEFAULT_SNAPS_SNAP = 'gemma3';
 const DEFAULT_HEAVY_SNAP = 'nemotron-3-nano';
 
@@ -414,7 +415,7 @@ export class InferenceService {
         model: DEFAULT_DAILY_OLLAMA,
         baseURL: 'http://127.0.0.1:11434',
         keepAlive: '0',
-        note: 'Ollama small US model; weights unload after each request',
+        note: 'Ollama daily default (qwen2.5:3b); weights unload after each request',
       };
     } else if (tier === 'snaps') {
       await this.ollamaStop();


### PR DESCRIPTION
## Summary

- Product Ollama daily default is now **`qwen2.5:3b`** via `DEFAULT_DAILY_OLLAMA_MODEL` (fits ~4GB WSL; ~1.9GB; one model at a time).
- Bare Ollama provider + `createLLMClientFromEnv` use the same constant (was `gemma4:e2b` / daily `gemma3:1b`).
- Lockstep: harnesses `InferenceService`, free-tier agent-stream fallback, CLI status, marketing claims, and pull docs.

## Why

Studio hosts on 4GB WSL cannot run multi-GB concurrent loads. Operator policy: one local model installed and loaded at a time. `qwen2.5:3b` is the quality step up that still fits with Studio + unload-after-request.

US-origin hardline remains **Inference Snaps only** (unchanged). Ollama continues to accept any GGUF; product daily default is this single SSOT.

## Test plan

- [x] `vitest run src/llm/__tests__/local-ai-profile.test.ts` (6 pass)
- [x] Pre-push phase-1 gate PASS
- [ ] CI full suite on PR
- [x] Operator profile on this machine: `daily` / `qwen2.5:3b` / `keepAlive=0`
- [x] `ollama list` shows only `qwen2.5:3b`