### PR TITLE
feat(server): free entitlement at signup and margin admit shadow

### DIFF
--- a/apps/server/src/lib/__tests__/merge-hosted-entitlement.test.ts
+++ b/apps/server/src/lib/__tests__/merge-hosted-entitlement.test.ts
@@ -1,0 +1,96 @@
+/**
+ * GAP-256 PR-3 — mergeHostedEntitlementUpdate (K21 / HC12 shape).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: vi.fn(() => ({ agents: true })),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => {
+  const mockLog = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+  return { logger: mockLog, createLogger: () => mockLog };
+});
+
+vi.mock('../tier-limits.js', () => ({
+  getHostedLimitsForTier: vi.fn(() => ({
+    maxSites: 1,
+    maxUsers: 3,
+    maxAgentTasks: 1_000,
+  })),
+}));
+
+import {
+  buildHostedEntitlementValues,
+  mergeHostedEntitlementUpdate,
+} from '../hosted-entitlement.js';
+
+describe('mergeHostedEntitlementUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const now = new Date('2026-08-09T00:00:00.000Z');
+
+  it('free_preserve keeps limits and breaker columns', () => {
+    const next = buildHostedEntitlementValues({
+      tier: 'free',
+      status: 'active',
+      mode: 'live',
+      lastEventAt: null,
+      now,
+      source: 'reconciler',
+      limits: { maxSites: 1, maxUsers: 3, maxAgentTasks: 999 },
+    });
+    const merged = mergeHostedEntitlementUpdate({
+      existing: {
+        limits: { maxSites: 1, maxUsers: 3, maxAgentTasks: 250 },
+        source: 'signup',
+        cogsBreakerTrippedAt: new Date('2026-08-01T00:00:00.000Z'),
+        cogsBreakerReason: 'daily',
+      },
+      next,
+      reason: 'free_preserve',
+    });
+    expect(merged.limits.maxAgentTasks).toBe(250);
+    expect(merged.source).toBe('signup');
+    expect(merged.cogsBreakerReason).toBe('daily');
+    expect(merged.cogsBreakerTrippedAt).toEqual(new Date('2026-08-01T00:00:00.000Z'));
+  });
+
+  it('paid_rebuild clears breaker', () => {
+    const next = buildHostedEntitlementValues({
+      tier: 'pro',
+      status: 'active',
+      mode: 'live',
+      lastEventAt: now,
+      now,
+      source: 'stripe',
+    });
+    const merged = mergeHostedEntitlementUpdate({
+      existing: {
+        limits: { maxSites: 1, maxUsers: 3, maxAgentTasks: 0 },
+        source: 'signup',
+        cogsBreakerTrippedAt: now,
+        cogsBreakerReason: 'x',
+      },
+      next,
+      reason: 'paid_rebuild',
+    });
+    expect(merged.cogsBreakerTrippedAt).toBeNull();
+    expect(merged.source).toBe('stripe');
+    expect(merged.tier).toBe('pro');
+  });
+
+  it('accepts signup source on build (HC16)', () => {
+    const next = buildHostedEntitlementValues({
+      tier: 'free',
+      status: 'active',
+      mode: 'live',
+      lastEventAt: null,
+      now,
+      source: 'signup',
+    });
+    expect(next.source).toBe('signup');
+  });
+});

--- a/apps/server/src/lib/admit-free-intake.ts
+++ b/apps/server/src/lib/admit-free-intake.ts
@@ -1,0 +1,121 @@
+/**
+ * GAP-256 PR-3 — admit free intake (I/O wrapper around pure decide).
+ *
+ * Reads latest margin_snapshots; never COUNT(users). Waitlist insert is PR-4.
+ */
+
+import {
+  type AdmissionChannel,
+  type CohortLimits,
+  decideFreeIntake,
+  type GovernorFlags,
+  governorFlagsFromEnv,
+  type MarginSnapshotView,
+  type PayingIntentSignal,
+  type PureAdmitResult,
+} from '@revealui/core/margin-governor';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { marginSnapshots } from '@revealui/db/schema';
+import { desc } from 'drizzle-orm';
+import { getHostedLimitsForTier } from './tier-limits.js';
+
+export type AdmitFreeIntakeInput = {
+  channel: AdmissionChannel;
+  email?: string;
+  payingIntent?: PayingIntentSignal;
+  deploymentMode?: 'hosted' | 'forge' | 'unknown';
+  env?: NodeJS.ProcessEnv;
+  now?: Date;
+};
+
+export type AdmitFreeIntakeResult = PureAdmitResult & {
+  flags: GovernorFlags;
+};
+
+function openLimitsFromTier(): CohortLimits {
+  const free = getHostedLimitsForTier('free');
+  return {
+    maxSites: free.maxSites ?? 1,
+    maxUsers: free.maxUsers ?? 3,
+    maxAgentTasks: free.maxAgentTasks ?? 1_000,
+  };
+}
+
+function detectDeploymentMode(env: NodeJS.ProcessEnv): 'hosted' | 'forge' | 'unknown' {
+  const raw = env.REVEALUI_DEPLOYMENT_MODE?.trim().toLowerCase();
+  if (raw === 'hosted') return 'hosted';
+  if (raw === 'forge') return 'forge';
+  // Overlap window: key presence ≈ hosted (same as isHostedDeployment fallback)
+  if (env.REVEALUI_LICENSE_PRIVATE_KEY) return 'hosted';
+  if (raw) return 'unknown';
+  return 'hosted';
+}
+
+async function loadLatestSnapshot(): Promise<MarginSnapshotView | null> {
+  try {
+    const db = getClient();
+    const [row] = await db
+      .select({
+        id: marginSnapshots.id,
+        mode: marginSnapshots.mode,
+        computedAt: marginSnapshots.computedAt,
+        netCents: marginSnapshots.netCents,
+        freeCostRatio: marginSnapshots.freeCostRatio,
+        projected7dCents: marginSnapshots.projected7dCents,
+      })
+      .from(marginSnapshots)
+      .orderBy(desc(marginSnapshots.computedAt))
+      .limit(1);
+    if (!row) return null;
+    const mode = row.mode;
+    if (mode !== 'open' && mode !== 'lean' && mode !== 'waitlist') {
+      return null;
+    }
+    return {
+      id: row.id,
+      mode,
+      computedAt: row.computedAt,
+      netCents: row.netCents,
+      freeCostRatio: row.freeCostRatio,
+      projected7dCents: row.projected7dCents,
+    };
+  } catch (err) {
+    logger.warn('[admit-free-intake] snapshot read failed; fail-open', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Pre-check free intake. Call **before** signUp / identity create.
+ * PR-3: shadow defaults → always admit (never waitlist response).
+ */
+export async function admitFreeIntake(input: AdmitFreeIntakeInput): Promise<AdmitFreeIntakeResult> {
+  const env = input.env ?? process.env;
+  const flags = governorFlagsFromEnv(env);
+  const snapshot = await loadLatestSnapshot();
+  const result = decideFreeIntake({
+    channel: input.channel,
+    deploymentMode: input.deploymentMode ?? detectDeploymentMode(env),
+    payingIntent: input.payingIntent ?? { kind: 'none' },
+    snapshot,
+    flags,
+    openLimits: openLimitsFromTier(),
+    now: input.now,
+  });
+
+  logger.info('[admit-free-intake]', {
+    channel: input.channel,
+    email: input.email ? '[redacted]' : undefined,
+    decision: result.decision,
+    mode: result.mode,
+    reason: result.reason,
+    shadow: result.shadow,
+    snapshotId: result.snapshotId,
+    governorEnabled: flags.enabled,
+  });
+
+  return { ...result, flags };
+}

--- a/apps/server/src/lib/ensure-free-signup-entitlement.ts
+++ b/apps/server/src/lib/ensure-free-signup-entitlement.ts
@@ -1,0 +1,129 @@
+/**
+ * GAP-256 PR-3 — free entitlement@t0 after hosted signup (K15).
+ *
+ * Finds the personal account for the new user and upserts account_entitlements
+ * with source=signup and cohort limits from admit.
+ */
+
+import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
+import type { CohortLimits } from '@revealui/core/margin-governor';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
+import {
+  buildHostedEntitlementValues,
+  mergeHostedEntitlementUpdate,
+} from './hosted-entitlement.js';
+
+export async function ensureFreeSignupEntitlement(params: {
+  userId: string;
+  cohortLimits: CohortLimits;
+  now?: Date;
+}): Promise<{ accountId: string } | { skipped: true; reason: string }> {
+  const db = getClient();
+  const now = params.now ?? new Date();
+
+  const [membership] = await db
+    .select({
+      accountId: accountMemberships.accountId,
+    })
+    .from(accountMemberships)
+    .where(
+      and(
+        eq(accountMemberships.userId, params.userId),
+        eq(accountMemberships.role, 'owner'),
+        eq(accountMemberships.status, 'active'),
+      ),
+    )
+    .limit(1);
+
+  if (!membership) {
+    logger.warn('[free-signup-entitlement] no owner membership; skip', {
+      userId: params.userId,
+    });
+    return { skipped: true, reason: 'no_owner_membership' };
+  }
+
+  const accountId = membership.accountId;
+  const [existing] = await db
+    .select({
+      limits: accountEntitlements.limits,
+      source: accountEntitlements.source,
+      cogsBreakerTrippedAt: accountEntitlements.cogsBreakerTrippedAt,
+      cogsBreakerReason: accountEntitlements.cogsBreakerReason,
+      tier: accountEntitlements.tier,
+    })
+    .from(accountEntitlements)
+    .where(eq(accountEntitlements.accountId, accountId))
+    .limit(1);
+
+  const next = buildHostedEntitlementValues({
+    tier: 'free',
+    status: 'active',
+    mode: getConfiguredStripeMode() === 'test' ? 'test' : 'live',
+    lastEventAt: null,
+    now,
+    source: 'signup',
+    limits: {
+      maxSites: params.cohortLimits.maxSites,
+      maxUsers: params.cohortLimits.maxUsers,
+      maxAgentTasks: params.cohortLimits.maxAgentTasks,
+    },
+  });
+
+  const merged = mergeHostedEntitlementUpdate({
+    existing: existing
+      ? {
+          limits: existing.limits,
+          source: existing.source,
+          cogsBreakerTrippedAt: existing.cogsBreakerTrippedAt,
+          cogsBreakerReason: existing.cogsBreakerReason,
+          tier: existing.tier,
+        }
+      : null,
+    next,
+    reason: existing ? 'free_preserve' : 'free_preserve',
+  });
+
+  // First insert: use next limits (free_preserve with null existing returns next)
+  const row = {
+    accountId,
+    planId: merged.planId,
+    tier: merged.tier,
+    status: merged.status,
+    features: merged.features,
+    limits: existing ? merged.limits : next.limits,
+    meteringStatus: merged.meteringStatus,
+    mode: merged.mode,
+    source: 'signup' as const,
+    graceUntil: merged.graceUntil,
+    lastEventAt: merged.lastEventAt,
+    updatedAt: merged.updatedAt,
+    cogsBreakerTrippedAt: merged.cogsBreakerTrippedAt,
+    cogsBreakerReason: merged.cogsBreakerReason,
+  };
+
+  if (existing) {
+    // free_preserve keeps old limits — for first signup after race, still ok
+    await db
+      .update(accountEntitlements)
+      .set({
+        ...row,
+        // Only set signup source if not paid
+        source:
+          existing.source === 'stripe' || existing.source === 'grant' ? existing.source : 'signup',
+      })
+      .where(eq(accountEntitlements.accountId, accountId));
+  } else {
+    await db.insert(accountEntitlements).values(row);
+  }
+
+  logger.info('[free-signup-entitlement] upserted', {
+    accountId,
+    userId: params.userId,
+    maxAgentTasks: params.cohortLimits.maxAgentTasks,
+  });
+
+  return { accountId };
+}

--- a/apps/server/src/lib/hosted-entitlement.ts
+++ b/apps/server/src/lib/hosted-entitlement.ts
@@ -96,6 +96,10 @@ export function buildHostedEntitlementValues(params: {
   now: Date;
   /** GAP-444 — defaults to stripe (paid path). CLI grants pass `grant`. */
   source?: EntitlementSource;
+  /** Override limits (free cohort lean / paid-pending). Default: tier map. */
+  limits?: ReturnType<typeof getHostedLimitsForTier>;
+  /** Override features (paid-pending may zero AI). Default: getFeaturesForTier. */
+  features?: Record<string, boolean>;
 }): {
   planId: HostedTier;
   tier: HostedTier;
@@ -113,8 +117,8 @@ export function buildHostedEntitlementValues(params: {
     planId: params.tier,
     tier: params.tier,
     status: params.status,
-    features: toFeatureRecord(getFeaturesForTier(params.tier)),
-    limits: getHostedLimitsForTier(params.tier),
+    features: params.features ?? toFeatureRecord(getFeaturesForTier(params.tier)),
+    limits: params.limits ?? getHostedLimitsForTier(params.tier),
     meteringStatus:
       params.status === 'active' || params.status === 'trialing' ? 'active' : 'paused',
     mode: params.mode,
@@ -122,5 +126,82 @@ export function buildHostedEntitlementValues(params: {
     graceUntil: params.graceUntil ?? null,
     lastEventAt: params.lastEventAt,
     updatedAt: params.now,
+  };
+}
+
+/** Existing entitlement row fields needed for free_preserve merge (K21). */
+export interface AccountEntitlementMergeExisting {
+  limits: ReturnType<typeof getHostedLimitsForTier> | Record<string, unknown>;
+  source: EntitlementSource | string;
+  cogsBreakerTrippedAt?: Date | null;
+  cogsBreakerReason?: string | null;
+  tier?: string;
+}
+
+export type MergeHostedEntitlementReason =
+  | 'free_preserve'
+  | 'paid_rebuild'
+  | 'paid_pending_create'
+  | 'breaker_clear';
+
+/**
+ * Single free-row merge helper (K21). All free writers must call this —
+ * no raw `.set(values)` on free/signup rows without going through here.
+ */
+export function mergeHostedEntitlementUpdate(params: {
+  existing: AccountEntitlementMergeExisting | null;
+  next: ReturnType<typeof buildHostedEntitlementValues>;
+  reason: MergeHostedEntitlementReason;
+}): ReturnType<typeof buildHostedEntitlementValues> & {
+  cogsBreakerTrippedAt: Date | null;
+  cogsBreakerReason: string | null;
+} {
+  const { existing, next, reason } = params;
+
+  if (reason === 'paid_rebuild') {
+    return {
+      ...next,
+      cogsBreakerTrippedAt: null,
+      cogsBreakerReason: null,
+    };
+  }
+
+  if (reason === 'paid_pending_create') {
+    return {
+      ...next,
+      source: 'signup',
+      cogsBreakerTrippedAt: null,
+      cogsBreakerReason: null,
+    };
+  }
+
+  if (reason === 'breaker_clear') {
+    return {
+      ...next,
+      cogsBreakerTrippedAt: null,
+      cogsBreakerReason: null,
+    };
+  }
+
+  // free_preserve: keep limits + breaker + signup source when healing free rows
+  if (existing) {
+    const keepSource =
+      existing.source === 'signup' || existing.source === 'grant'
+        ? (existing.source as EntitlementSource)
+        : next.source;
+    return {
+      ...next,
+      limits: existing.limits as ReturnType<typeof getHostedLimitsForTier>,
+      source: keepSource === 'stripe' ? next.source : keepSource,
+      cogsBreakerTrippedAt: existing.cogsBreakerTrippedAt ?? null,
+      cogsBreakerReason: existing.cogsBreakerReason ?? null,
+    };
+  }
+
+  // First free insert (no existing)
+  return {
+    ...next,
+    cogsBreakerTrippedAt: null,
+    cogsBreakerReason: null,
   };
 }

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -5,6 +5,9 @@
  *
  * This route is rate-limited and enforces the tier-based user limit
  * (enforceUserLimit middleware is applied in index.ts).
+ *
+ * GAP-256 PR-3: margin admit **before** signUp (K13); free entitlement@t0 after
+ * successful hosted signup (K15). Shadow defaults → never 202 waitlist here.
  */
 
 import { isSignupAllowed, signUp } from '@revealui/auth/server';
@@ -12,6 +15,8 @@ import { SignUpRequestSchema } from '@revealui/contracts';
 import { logger } from '@revealui/core/observability/logger';
 import { zValidator } from '@revealui/openapi';
 import { Hono } from 'hono';
+import { admitFreeIntake } from '../lib/admit-free-intake.js';
+import { ensureFreeSignupEntitlement } from '../lib/ensure-free-signup-entitlement.js';
 
 const app = new Hono();
 
@@ -27,6 +32,26 @@ app.post('/signup', zValidator('json', SignUpRequestSchema), async (c) => {
     return c.json({ success: false, error: 'Signups are currently restricted' }, 403);
   }
 
+  // GAP-256: admit **before** any users insert (K13). Shadow → always admit.
+  const admit = await admitFreeIntake({
+    channel: 'free_signup',
+    email,
+    payingIntent: { kind: 'none' },
+  });
+
+  if (admit.decision === 'waitlist') {
+    // PR-4 enforce path — PR-3 shadow should not reach here with default flags.
+    return c.json(
+      {
+        success: false,
+        error: 'WAITLISTED',
+        code: admit.code,
+        message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+      },
+      202,
+    );
+  }
+
   const result = await signUp(email, password, name, {
     userAgent: c.req.header('user-agent'),
     ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
@@ -37,7 +62,28 @@ app.post('/signup', zValidator('json', SignUpRequestSchema), async (c) => {
     return c.json({ success: false, error: result.error }, 400);
   }
 
-  logger.info('New user registered via API', { userId: result.user?.id });
+  // Free entitlement@t0 (K15) — best-effort; never fail the signup response
+  if (result.user?.id) {
+    try {
+      await ensureFreeSignupEntitlement({
+        userId: result.user.id,
+        cohortLimits: admit.cohortLimits,
+      });
+    } catch (err) {
+      logger.error(
+        '[signup] free entitlement@t0 failed (non-fatal)',
+        err instanceof Error ? err : undefined,
+        { userId: result.user.id },
+      );
+    }
+  }
+
+  logger.info('New user registered via API', {
+    userId: result.user?.id,
+    admitMode: admit.mode,
+    admitReason: admit.reason,
+    shadow: admit.shadow,
+  });
   return c.json({ success: true, user: { id: result.user?.id, email: result.user?.email } }, 201);
 });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,11 @@
       "import": "./dist/deployment-mode.js",
       "default": "./dist/deployment-mode.js"
     },
+    "./margin-governor": {
+      "types": "./dist/margin-governor.d.ts",
+      "import": "./dist/margin-governor.js",
+      "default": "./dist/margin-governor.js"
+    },
     "./revforge-license": {
       "types": "./dist/revforge-license.d.ts",
       "import": "./dist/revforge-license.js",

--- a/packages/core/src/__tests__/margin-governor.test.ts
+++ b/packages/core/src/__tests__/margin-governor.test.ts
@@ -1,0 +1,131 @@
+/**
+ * GAP-256 PR-3 — pure decide (HC1 shadow, HC3 waitlist snapshot still admits, HC6 no COUNT).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  decideFreeIntake,
+  freeCohortLimitsForMode,
+  governorFlagsFromEnv,
+  paidPendingLimits,
+} from '../margin-governor.js';
+
+const openLimits = { maxSites: 1, maxUsers: 3, maxAgentTasks: 1_000 };
+
+describe('freeCohortLimitsForMode / paidPendingLimits', () => {
+  it('lean only trims maxAgentTasks', () => {
+    expect(freeCohortLimitsForMode('lean', openLimits, 250)).toEqual({
+      maxSites: 1,
+      maxUsers: 3,
+      maxAgentTasks: 250,
+    });
+  });
+
+  it('paid-pending is zero tasks (K20)', () => {
+    expect(paidPendingLimits().maxAgentTasks).toBe(0);
+  });
+});
+
+describe('governorFlagsFromEnv', () => {
+  it('defaults shadow true when enabled', () => {
+    const f = governorFlagsFromEnv({ MARGIN_GOVERNOR_ENABLED: 'true' });
+    expect(f.enabled).toBe(true);
+    expect(f.shadow).toBe(true);
+  });
+
+  it('allows enforce when SHADOW=false', () => {
+    const f = governorFlagsFromEnv({
+      MARGIN_GOVERNOR_ENABLED: 'true',
+      MARGIN_GOVERNOR_SHADOW: 'false',
+    });
+    expect(f.shadow).toBe(false);
+  });
+});
+
+describe('decideFreeIntake', () => {
+  const now = new Date('2026-08-09T12:00:00.000Z');
+
+  it('admits when governor disabled (HC1 open path)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: null,
+      flags: { enabled: false, shadow: true, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.cohortLimits.maxAgentTasks).toBe(1_000);
+      expect(r.reason).toBe('governor_disabled');
+    }
+  });
+
+  it('shadow + waitlist snapshot still admits (HC3)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: {
+        id: 'snap-1',
+        mode: 'waitlist',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: true, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.mode).toBe('shadow');
+      expect(r.reason).toContain('waitlist');
+      expect(r.shadow).toBe(true);
+    }
+  });
+
+  it('enforce waitlist returns WAITLISTED without inventing users (HC2 shape)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: {
+        id: 'snap-2',
+        mode: 'waitlist',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('waitlist');
+    if (r.decision === 'waitlist') {
+      expect(r.httpStatus).toBe(202);
+      expect(r.code).toBe('WAITLISTED');
+    }
+  });
+
+  it('paying-intent bypasses waitlist', () => {
+    const r = decideFreeIntake({
+      channel: 'paid_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'checkout', tier: 'pro' },
+      snapshot: {
+        id: 'snap-3',
+        mode: 'waitlist',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.mode).toBe('bypass');
+    }
+  });
+
+  it('does not reference user COUNT (HC6 — pure API surface)', () => {
+    // Module has no users import; smoke the API only.
+    expect(typeof decideFreeIntake).toBe('function');
+  });
+});

--- a/packages/core/src/margin-governor.ts
+++ b/packages/core/src/margin-governor.ts
@@ -1,0 +1,229 @@
+/**
+ * GAP-256 PR-3 — pure margin admission decide (no DB, no I/O).
+ *
+ * Call sites: apps/server admitFreeIntake (reads snapshot, then this).
+ * HARD: never call after users insert for free_signup; pure module has no COUNT.
+ *
+ * @see docs/specs/2026-08-09-gap-256-margin-admission-layers-2-3.md
+ */
+
+export type AdmissionChannel =
+  | 'free_signup'
+  | 'paid_signup'
+  | 'paid_checkout'
+  | 'invite_accept'
+  | 'admin_provision'
+  | 'waitlist_claim_free'
+  | 'waitlist_claim_paid';
+
+export type PayingIntentSignal =
+  | { kind: 'none' }
+  | { kind: 'checkout'; tier: 'pro' | 'max' | 'enterprise' }
+  | { kind: 'existing_paid'; accountId: string; tier: string; status: 'active' };
+
+export type CohortLimits = {
+  maxSites: number;
+  maxUsers: number;
+  maxAgentTasks: number;
+};
+
+export type SnapshotMode = 'open' | 'lean' | 'waitlist';
+
+/** Minimal snapshot view for pure decide (from margin_snapshots row). */
+export interface MarginSnapshotView {
+  id: string;
+  mode: SnapshotMode;
+  computedAt: Date;
+  netCents?: number;
+  freeCostRatio?: string | null;
+  projected7dCents?: number | null;
+}
+
+export interface GovernorFlags {
+  /** Master; off → admit always with open limits */
+  enabled: boolean;
+  /**
+   * When true (default for first enable): compute mode for logs but never
+   * waitlist / never lean-enforce on admit (always admit).
+   */
+  shadow: boolean;
+  /** Hours after which a snapshot is ignored (fail-open to open). Default 36. */
+  staleHours: number;
+}
+
+export type PureAdmitResult =
+  | {
+      decision: 'admit';
+      mode: SnapshotMode | 'bypass' | 'disabled' | 'shadow';
+      cohortLimits: CohortLimits;
+      snapshotId: string | null;
+      reason: string;
+      shadow: boolean;
+    }
+  | {
+      decision: 'waitlist';
+      mode: 'waitlist';
+      reason: string;
+      snapshotId: string | null;
+      shadow: false;
+      httpStatus: 202;
+      code: 'WAITLISTED';
+    };
+
+/** Open free cohort = standard hosted free limits (caller supplies base). */
+export function freeCohortLimitsForMode(
+  mode: 'open' | 'lean',
+  openLimits: CohortLimits,
+  leanMaxAgentTasks = 250,
+): CohortLimits {
+  if (mode === 'lean') {
+    return {
+      maxSites: openLimits.maxSites,
+      maxUsers: openLimits.maxUsers,
+      maxAgentTasks: leanMaxAgentTasks,
+    };
+  }
+  return { ...openLimits };
+}
+
+/** Paid-signup pending only — never free cohort (K20). */
+export function paidPendingLimits(): CohortLimits {
+  return { maxSites: 1, maxUsers: 1, maxAgentTasks: 0 };
+}
+
+export function governorFlagsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): GovernorFlags {
+  const enabled = env.MARGIN_GOVERNOR_ENABLED === 'true';
+  // When master is on, shadow defaults true unless explicitly false
+  const shadowExplicit = env.MARGIN_GOVERNOR_SHADOW;
+  const shadow =
+    shadowExplicit === 'false' ? false : shadowExplicit === 'true' ? true : enabled ? true : true;
+  const staleHours = parsePositiveInt(env.MARGIN_SNAPSHOT_STALE_HOURS, 36);
+  return { enabled, shadow, staleHours };
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function isPayingBypass(channel: AdmissionChannel, payingIntent: PayingIntentSignal): boolean {
+  if (
+    channel === 'paid_signup' ||
+    channel === 'paid_checkout' ||
+    channel === 'invite_accept' ||
+    channel === 'admin_provision' ||
+    channel === 'waitlist_claim_paid'
+  ) {
+    return true;
+  }
+  if (payingIntent.kind === 'checkout' || payingIntent.kind === 'existing_paid') {
+    return true;
+  }
+  return false;
+}
+
+function isSnapshotStale(
+  snapshot: MarginSnapshotView | null,
+  now: Date,
+  staleHours: number,
+): boolean {
+  if (!snapshot) return true;
+  const ageMs = now.getTime() - snapshot.computedAt.getTime();
+  return ageMs > staleHours * 3_600_000;
+}
+
+/**
+ * Pure admit decision for free intake.
+ * Does not touch users table, COUNT, or waitlist I/O.
+ */
+export function decideFreeIntake(input: {
+  channel: AdmissionChannel;
+  deploymentMode: 'hosted' | 'forge' | 'unknown';
+  payingIntent: PayingIntentSignal;
+  snapshot: MarginSnapshotView | null;
+  flags: GovernorFlags;
+  openLimits: CohortLimits;
+  leanMaxAgentTasks?: number;
+  now?: Date;
+}): PureAdmitResult {
+  const now = input.now ?? new Date();
+  const leanTasks = input.leanMaxAgentTasks ?? 250;
+  const openLimits = input.openLimits;
+
+  if (input.deploymentMode === 'forge') {
+    return {
+      decision: 'admit',
+      mode: 'disabled',
+      cohortLimits: freeCohortLimitsForMode('open', openLimits, leanTasks),
+      snapshotId: null,
+      reason: 'forge_deployment',
+      shadow: false,
+    };
+  }
+
+  if (isPayingBypass(input.channel, input.payingIntent)) {
+    return {
+      decision: 'admit',
+      mode: 'bypass',
+      // Bypass waitlist only — paid_signup must NOT use free cohort (caller uses paidPendingLimits)
+      cohortLimits: freeCohortLimitsForMode('open', openLimits, leanTasks),
+      snapshotId: input.snapshot?.id ?? null,
+      reason: 'paying_intent_bypass',
+      shadow: false,
+    };
+  }
+
+  if (!input.flags.enabled) {
+    return {
+      decision: 'admit',
+      mode: 'disabled',
+      cohortLimits: freeCohortLimitsForMode('open', openLimits, leanTasks),
+      snapshotId: input.snapshot?.id ?? null,
+      reason: 'governor_disabled',
+      shadow: false,
+    };
+  }
+
+  const stale = isSnapshotStale(input.snapshot, now, input.flags.staleHours);
+  const rawMode: SnapshotMode = stale ? 'open' : (input.snapshot?.mode ?? 'open');
+  const snapshotId = input.snapshot?.id ?? null;
+
+  // Shadow: always admit; attach would-be mode for logs
+  if (input.flags.shadow) {
+    const cohortMode = rawMode === 'lean' ? 'lean' : 'open';
+    return {
+      decision: 'admit',
+      mode: 'shadow',
+      cohortLimits: freeCohortLimitsForMode(cohortMode, openLimits, leanTasks),
+      snapshotId,
+      reason: stale ? `shadow_stale_would_${rawMode}` : `shadow_would_${rawMode}`,
+      shadow: true,
+    };
+  }
+
+  // Enforce path (PR-4): waitlist when mode is waitlist
+  if (rawMode === 'waitlist') {
+    return {
+      decision: 'waitlist',
+      mode: 'waitlist',
+      reason: stale ? 'stale_fail_open_blocked' : 'snapshot_waitlist',
+      snapshotId,
+      shadow: false,
+      httpStatus: 202,
+      code: 'WAITLISTED',
+    };
+  }
+
+  const cohortMode = rawMode === 'lean' ? 'lean' : 'open';
+  return {
+    decision: 'admit',
+    mode: rawMode,
+    cohortLimits: freeCohortLimitsForMode(cohortMode, openLimits, leanTasks),
+    snapshotId,
+    reason: stale ? 'stale_fail_open' : `snapshot_${rawMode}`,
+    shadow: false,
+  };
+}


### PR DESCRIPTION
## Summary

**GAP-256 PR-3** (on top of #2500 schema + #2501 snapshot, both on `test`).

### What
- **`@revealui/core/margin-governor`** — pure `decideFreeIntake`, `freeCohortLimitsForMode`, `paidPendingLimits`, `governorFlagsFromEnv`
- **`admitFreeIntake`** — loads latest `margin_snapshots`, pure decide; **before** `signUp` (K13)
- **`ensureFreeSignupEntitlement`** — free@t0 `source=signup` after hosted signup (K15)
- **`mergeHostedEntitlementUpdate`** — free_preserve / paid_rebuild / paid_pending (K21)
- **Server `POST /api/auth/signup`** — admit → signUp → free entitlement (best-effort)

### Shadow defaults
- `MARGIN_GOVERNOR_ENABLED` default off → always admit
- When enabled, `MARGIN_GOVERNOR_SHADOW` defaults **true** → never 202 waitlist (HC3)
- Waitlist 202 path coded but only when enforce (`SHADOW=false`) — PR-4 product surface

### Tests
- core: margin-governor pure (9)
- server: merge helper + signup source

### Non-goals
- admin/passkey/OAuth pre-admit (PR-3b)
- waitlist enforce UX (PR-4)
- paid_signup (PR-4b)

## Test plan
- [x] vitest core margin-governor + server merge/source
- [x] local phase-1 gate PASS
- [ ] CI green