### PR TITLE
feat(marketing): proof-grade bar and homepage allure pass

### DIFF
--- a/apps/marketing/app/content/__tests__/proof-deployers.test.ts
+++ b/apps/marketing/app/content/__tests__/proof-deployers.test.ts
@@ -4,7 +4,7 @@ import { SITE } from '../site';
 
 describe('PROOF_DEPLOYERS (FDE secondary band)', () => {
   it('keeps the open-source H2 identity separate from the deployers H3', () => {
-    expect(PROOF_SECTION.heading).toBe('Inspect the code before you commit to it.');
+    expect(PROOF_SECTION.heading).toBe('Read the code before you build on it.');
     expect(PROOF_DEPLOYERS.heading).toBe('Built for people who deploy, not only demo.');
     expect(PROOF_DEPLOYERS.heading).not.toEqual(PROOF_SECTION.heading);
   });

--- a/apps/marketing/app/content/claims-evidence.ts
+++ b/apps/marketing/app/content/claims-evidence.ts
@@ -7,8 +7,15 @@ export type {
   CoveredFile,
   EvidenceKind,
   EvidenceRef,
+  ProofGrade,
 } from './claims-evidence/types.js';
-export { COVERED_FILES } from './claims-evidence/types.js';
+export {
+  COVERED_FILES,
+  CRITICAL_PROOF_FILES,
+  effectiveProofGrade,
+  isCriticalMarketingClaim,
+  isProofGradeSufficient,
+} from './claims-evidence/types.js';
 
 import { blogBodyClaims } from './claims-evidence/blog-body-claims.js';
 import { blogMetaClaims } from './claims-evidence/blog-meta-claims.js';

--- a/apps/marketing/app/content/claims-evidence/claims-part-1.ts
+++ b/apps/marketing/app/content/claims-evidence/claims-part-1.ts
@@ -54,12 +54,14 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO.eyebrow',
+    proofGrade: 'behavior',
     text: 'Open source. Self-hostable.',
     evidence: [LICENSE_MIT, SELF_HOST],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO.h1',
+    proofGrade: 'outcome',
     text: 'Build it once. Every product after starts ahead.',
     evidence: [
       {
@@ -79,6 +81,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO_OWNERSHIP.h1',
+    proofGrade: 'outcome',
     text: 'Run your whole business on one runtime you own.',
     evidence: [
       {
@@ -98,12 +101,14 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO.subtitle.sentence1',
+    proofGrade: 'outcome',
     text: 'RevealUI is the self-hosted runtime where your business and the AI agents that run it live under one roof.',
     evidence: [SELF_HOST, AGENT_ROUTES, TIER_GATES],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO.subtitle.sentence2',
+    proofGrade: 'outcome',
     text: 'Every agent is a governed and audited user that lives on your infrastructure.',
     evidence: [
       AGENT_ROUTES,
@@ -133,12 +138,14 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO.subtitle.support',
+    proofGrade: 'behavior',
     text: 'It runs on any AI provider you choose.',
     evidence: [PROVIDERS, OPEN_WEIGHT],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO_FOUNDATION.h1',
+    proofGrade: 'outcome',
     text: 'The foundation your business runs on.',
     evidence: [
       {
@@ -151,6 +158,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_HERO_L2.h1',
+    proofGrade: 'outcome',
     text: 'Ship your next product on the work your last one finished.',
     evidence: [
       {
@@ -170,7 +178,8 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.heading',
-    text: 'Vendor sprawl, or framework-only. Pick neither.',
+    proofGrade: 'outcome',
+    text: 'Stop buying a separate product for each slice of the stack.',
     evidence: [
       {
         kind: 'code',
@@ -182,13 +191,15 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.body',
-    text: 'You either glue together an auth vendor, a headless CMS, Stripe code, and a job runner, or you pick an agent framework and rebuild all four underneath it. RevealUI is the third option: the whole set arrives wired into one runtime that you own.',
+    proofGrade: 'outcome',
+    text: 'Most teams stitch sign-in, content, billing, and agents from different vendors. Or they pick an agent framework and rebuild the rest underneath it. RevealUI is the third path: one self-hosted runtime for the business and the agents that run it.',
     evidence: [AUTH_SESSIONS, COLLECTIONS, BILLING, LICENSE_MIT],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.rows[0].sprawl',
-    text: 'A separate auth vendor, per seat',
+    proofGrade: 'path',
+    text: 'A separate auth product, priced per seat',
     evidence: [
       {
         kind: 'url',
@@ -200,13 +211,15 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.rows[0].revealui',
-    text: 'Sessions with RBAC and ABAC, built in',
+    proofGrade: 'behavior',
+    text: 'Sign-in, roles, and policies built in',
     evidence: [AUTH_SESSIONS, RBAC_ABAC],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.rows[1].sprawl',
-    text: 'A headless CMS, plus a team to wire it',
+    proofGrade: 'path',
+    text: 'A CMS plus a team to wire it',
     evidence: [
       {
         kind: 'url',
@@ -218,24 +231,28 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.rows[1].revealui',
-    text: 'Collections with an admin UI and REST API',
+    proofGrade: 'behavior',
+    text: 'Your content model, with admin UI and API',
     evidence: [COLLECTIONS, OPEN_STANDARDS],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.rows[2].revealui',
-    text: 'Checkout, webhooks, and reconciliation crons',
+    proofGrade: 'behavior',
+    text: 'Checkout, subscriptions, and webhook handling',
     evidence: [BILLING, WEBHOOKS, RECONCILE],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.rows[3].revealui',
-    text: 'Content tools over MCP; collections surface as resources unless you opt out',
+    proofGrade: 'behavior',
+    text: 'Agents use the same data and gates as your team',
     evidence: [MCP_CONTENT, MCP_RESOURCE_DEFAULT],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.footnote',
+    proofGrade: 'behavior',
     text: 'Capability comparison only; a monthly cost estimate lives on the pricing page. (interpolated: Pro price from pricing-fallbacks)',
     match: 'path',
     evidence: [PRICING_FALLBACKS, DEPLOY_TARGETS],
@@ -243,43 +260,50 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.heading',
-    text: 'From one command to a working stack in 60 seconds.',
+    proofGrade: 'outcome',
+    text: 'From one command to a running stack in about a minute.',
     evidence: [CLI_CREATE],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.body',
-    text: 'The stack runs locally in 60 seconds, Stripe starts in test mode, and agents connect over MCP.',
+    proofGrade: 'outcome',
+    text: 'Install on your machine. Take a test payment. Connect an agent to the same data your admin UI already uses.',
     evidence: [CLI_CREATE, BILLING, MCP_CONTENT],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.mockupCaption.prefix',
+    proofGrade: 'path',
     text: 'Local screenshot from a fresh',
     evidence: [CLI_CREATE],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.mockupCaption.suffix',
+    proofGrade: 'path',
     text: '. The three beats below describe the steps.',
     evidence: [CLI_CREATE],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.beats[0].body',
-    text: 'One command. Auth, content, admin UI, the Stripe webhook handler, and MCP server scaffolding all running locally in 60 seconds.',
+    proofGrade: 'behavior',
+    text: 'One command. Sign-in, content, admin UI, billing hooks, and agent tooling run locally in about a minute.',
     evidence: [CLI_CREATE, AUTH_SESSIONS, WEBHOOKS, MCP_CONTENT],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.beats[1].title',
+    proofGrade: 'behavior',
     text: 'Customer flow, end to end.',
     evidence: [BILLING],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.beats[1].body',
-    text: 'A user signs up, picks a plan, and Stripe test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
+    proofGrade: 'behavior',
+    text: 'A user signs up, picks a plan, and test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
     evidence: [
       AUTH_SESSIONS,
       BILLING,
@@ -293,25 +317,29 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.beats[2].body',
-    text: 'Wire an LLM provider and your agents read your sites, users, and content over MCP, with every call passing the same auth and tier gates your human users pass.',
+    proofGrade: 'behavior',
+    text: 'Connect a model. Agents read and write the same content your team does, under the same sign-in and plan rules.',
     evidence: [PROVIDERS, MCP_CONTENT, TIER_GATES],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[0].answer',
-    text: 'No. Open standards end-to-end: OAuth, JWT, Stripe webhooks, MCP, and OpenAPI, over plain Postgres. Deploy anywhere Node runs, and take your data, your code, and your infrastructure with you. RevealUI is the runtime, not the prison.',
+    proofGrade: 'behavior',
+    text: 'No. You keep your data in plain Postgres, your code in your repo, and your deploy on infrastructure you choose. Open standards throughout. RevealUI is the runtime, not the prison. Details live in the docs.',
     evidence: [OPEN_STANDARDS, POSTGRES, SELF_HOST],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[1].answer',
-    text: 'Every PR clears a 3-phase gate before it lands: Biome, Vitest unit and integration tests, Playwright end-to-end tests, CodeQL, and Gitleaks. This site and the agency site at revealuistudio.com both run on RevealUI in production.',
+    proofGrade: 'behavior',
+    text: 'Changes clear automated tests and security checks before they land. This site and the agency site at revealuistudio.com both run on RevealUI in production today.',
     evidence: [CI_GATE, THIS_SITE],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[2].question',
-    text: 'How is this different from stitching together separate auth, database, CMS, and background-job services?',
+    proofGrade: 'path',
+    text: 'How is this different from stitching separate tools together?',
     evidence: [
       { kind: 'code', ref: 'packages', note: 'question copy; the answer carries the claims' },
     ],
@@ -319,19 +347,22 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[2].answer',
-    text: 'Each of those covers one slice: a real-time database, a Postgres-plus-auth backend, a session service, a jobs runner. RevealUI is the whole runtime: auth, content, billing, admin UI, and an agent layer, self-hosted at every tier. (Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.)',
+    proofGrade: 'outcome',
+    text: 'Each vendor covers one slice. RevealUI is the whole runtime: people, content, billing, admin, and agents, self-hosted at all tiers. Deploy targets such as Vercel, Cloudflare, and Fly are places it runs, not competitors.',
     evidence: [AUTH_SESSIONS, COLLECTIONS, BILLING, AGENT_ROUTES, DEPLOY_TARGETS],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[3].answer',
-    text: 'Yes. 24 of 31 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
+    proofGrade: 'behavior',
+    text: 'Yes. Most packages are MIT forever. A small Pro set is Fair Source and converts to MIT two years after each release. Self-host the full stack on your infrastructure at any tier. License detail is on the Fair Source page.',
     evidence: [LICENSE_SPLIT, LICENSE_MIT, SELF_HOST, POSTGRES],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[4].question',
-    text: 'What does "agent-native" actually mean in code?',
+    proofGrade: 'path',
+    text: 'What does agent-native mean for my product?',
     evidence: [
       {
         kind: 'code',
@@ -343,43 +374,50 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[4].answer',
-    text: 'Agents authenticate like users and pass the same tier gates your customers pass. The content MCP server ships discovery and read tools, collections surface as discoverable MCP resources by default (set mcpResource: false to opt out), and writes go through the same REST API your app uses.',
+    proofGrade: 'behavior',
+    text: 'Agents sign in like users and face the same plan rules. They work on your content through the same APIs your app uses. How the wire protocol works is covered in the docs.',
     evidence: [TIER_GATES, MCP_CONTENT, MCP_RESOURCE_DEFAULT, OPEN_STANDARDS],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[5].question',
+    proofGrade: 'path',
     text: 'How does AI inference work?',
     evidence: [OPEN_WEIGHT],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[5].answer',
-    text: 'Agents run on an open-weight model on your own infrastructure by default, with Claude, GPT, or any other provider one config line away. See the local AI docs at revealui.com/local-ai for the full pathway.',
+    proofGrade: 'behavior',
+    text: 'By default, agents run on an open-weight model on infrastructure you own. Add Claude, GPT, or another provider when you choose. The local AI page walks through the full path.',
     evidence: [OPEN_WEIGHT, PROVIDERS],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[6].question',
+    proofGrade: 'path',
     text: 'How do agent payments work?',
     evidence: [X402],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_FAQ.items[6].answer',
-    text: 'RevealUI implements the HTTP 402 payment protocol so agents can pay each other over standard HTTP, with the payment rails still in development. See the agents section of the pricing page for the current status.',
+    proofGrade: 'behavior',
+    text: 'RevealUI speaks the HTTP 402 payment protocol so agents can pay over standard HTTP. Payment rails are still in development. See the agents section on the pricing page for current status.',
     evidence: [X402],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_GET_STARTED.heading',
-    text: 'Your stack is one command away.',
+    proofGrade: 'outcome',
+    text: 'Start on your machine today.',
     evidence: [CLI_CREATE],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_GET_STARTED.body',
-    text: 'Spin it up on your machine in minutes. Flip to live mode when you are ready to charge real customers.',
+    proofGrade: 'outcome',
+    text: 'Install free. Open the admin UI. Go live when you are ready to charge customers.',
     evidence: [
       CLI_CREATE,
       {
@@ -392,7 +430,8 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_GET_STARTED.cli.caption',
-    text: 'Local dev stack in 60 seconds. No credit card.',
+    proofGrade: 'behavior',
+    text: 'Local stack in about a minute. No credit card.',
     evidence: [
       CLI_CREATE,
       {
@@ -405,7 +444,8 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'home.ts',
     exportPath: 'HOME_GET_STARTED.newsletter.label',
-    text: 'Not ready to start? Get product updates and engineering insights.',
+    proofGrade: 'path',
+    text: 'Not ready to start? Get product updates when they ship.',
     evidence: [
       {
         kind: 'code',
@@ -417,6 +457,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES_SECTION.eyebrow',
+    proofGrade: 'behavior',
     text: 'Five primitives. One login.',
     evidence: [
       AUTH_SESSIONS,
@@ -430,6 +471,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES_SECTION.heading',
+    proofGrade: 'outcome',
     text: 'The five things every business runs on.',
     evidence: [
       {
@@ -442,25 +484,29 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES_SECTION.body',
-    text: 'Each primitive ships as an API and an admin surface, and your agents work the same objects your team does.',
+    proofGrade: 'outcome',
+    text: 'Each one ships ready for your team and for agents. One login covers the whole set.',
     evidence: [OPEN_STANDARDS, COLLECTIONS, AGENT_ROUTES],
   },
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES_SECTION.docsLink.label',
+    proofGrade: 'path',
     text: 'See the primitive reference →',
     evidence: [DOCS],
   },
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES[0].body',
-    text: 'Your team signs in with sessions and works under RBAC and ABAC policies.',
+    proofGrade: 'outcome',
+    text: 'Your team signs in once. Roles and policies decide who can do what.',
     evidence: [AUTH_SESSIONS, RBAC_ABAC],
   },
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES[1].body',
-    text: 'Collections give you a CMS, rich text, and media, with an admin UI generated from your schema.',
+    proofGrade: 'outcome',
+    text: 'Define your content once. The admin UI and API come with it.',
     evidence: [
       COLLECTIONS,
       { kind: 'code', ref: 'packages/core/src/richtext', note: 'Lexical rich text' },
@@ -469,7 +515,8 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES[2].body',
-    text: 'Catalogs and feature gates decide what each tier can do, for your people and your agents.',
+    proofGrade: 'outcome',
+    text: 'Plans and feature gates decide what each customer and agent can use.',
     evidence: [
       TIER_GATES,
       TIER_LIMITS,
@@ -479,36 +526,42 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES[3].body',
-    text: 'Stripe checkout, subscriptions, and webhook reconciliation come pre-wired.',
+    proofGrade: 'behavior',
+    text: 'Checkout and subscriptions ship ready, including webhook handling.',
     evidence: [BILLING, WEBHOOKS, RECONCILE],
   },
   {
     file: 'primitives.ts',
     exportPath: 'HOME_PRIMITIVES[4].body',
-    text: 'Agents run on an open-weight model you host, with any provider one config line away.',
+    proofGrade: 'outcome',
+    text: 'Agents run on models you host by default. Add a hosted provider when you choose.',
     evidence: [OPEN_WEIGHT, PROVIDERS],
   },
   {
     file: 'proof.ts',
     exportPath: 'PROOF_SECTION.heading',
-    text: 'Inspect the code before you commit to it.',
+    proofGrade: 'outcome',
+    text: 'Read the code before you build on it.',
     evidence: [REPO],
   },
   {
     file: 'proof.ts',
     exportPath: 'PROOF_SECTION.body',
-    text: 'The entire runtime sits in the public repo under an open license. Read it, run it, or fork it before you build on it.',
+    proofGrade: 'behavior',
+    text: 'The whole runtime lives in a public repo under an open license. Inspect it, run it, or fork it before you commit.',
     evidence: [REPO, LICENSE_MIT],
   },
   {
     file: 'proof.ts',
     exportPath: 'PROOF_TRUST.body',
-    text: 'Your security team can read every line. The whole runtime is open source, MIT or Fair Source, sitting in the repo. There is no closed binary to explain away when procurement comes asking.',
+    proofGrade: 'behavior',
+    text: 'Your security team can read the full source. The runtime is open source, MIT or Fair Source, in the public repo. There is no closed binary to explain when procurement asks.',
     evidence: [REPO, LICENSE_SPLIT],
   },
   {
     file: 'proof.ts',
     exportPath: 'PROOF_TRUST.changelogCta.label',
+    proofGrade: 'path',
     text: 'See what shipped this month →',
     evidence: [
       { kind: 'url', ref: 'https://github.com/RevealUIStudio/revealui/blob/main/CHANGELOG.md' },
@@ -517,18 +570,21 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'proof.ts',
     exportPath: 'LIVE_METRICS.heading',
+    proofGrade: 'behavior',
     text: 'Every number here is pinned to the codebase.',
     evidence: [LICENSE_SPLIT],
   },
   {
     file: 'proof.ts',
     exportPath: 'LIVE_METRICS.body',
-    text: 'These counts are validated on every PR by the claim-drift gate. If the code changes and a number drifts, the build fails before it can ship.',
+    proofGrade: 'behavior',
+    text: 'These counts are checked on each pull request. If the code changes and a number drifts, the build fails before it can ship.',
     evidence: [LICENSE_SPLIT, CI_GATE],
   },
   {
     file: 'proof.ts',
     exportPath: 'PROOF_DEPLOYERS.heading',
+    proofGrade: 'outcome',
     text: 'Built for people who deploy, not only demo.',
     evidence: [
       {
@@ -541,6 +597,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'proof.ts',
     exportPath: 'PROOF_DEPLOYERS.body',
+    proofGrade: 'outcome',
     text: 'Some buyers install RevealUI themselves. Some hire us, or their own forward-deployed engineer, to stamp and hand over a fleet. Either way the outcome is the same: a self-hosted runtime where the business and its agents live under one roof, on infrastructure the customer owns.',
     evidence: [
       REPO,
@@ -559,6 +616,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'proof.ts',
     exportPath: 'PROOF_DEPLOYERS.foil',
+    proofGrade: 'outcome',
     text: 'Cloud agent platforms rent you an outcome. A forward-deployed engagement leaves a runtime the customer runs.',
     evidence: [
       REPO,
@@ -572,42 +630,49 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_SECTION.heading',
+    proofGrade: 'outcome',
     text: 'Start free. Pay when you scale.',
     evidence: [LICENSE_MIT, TIER_LIMITS],
   },
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_SECTION.body',
-    text: 'Self-host the open-source stack at no cost. Pro, Max, and Enterprise add runtime entitlements and an agent task allowance. Pro and Max include a 7-day free trial.',
+    proofGrade: 'behavior',
+    text: 'Self-host the open stack at no cost. Pro, Max, and Enterprise add agent capacity and support. Pro and Max include a 7-day free trial.',
     evidence: [LICENSE_MIT, TIER_GATES, TIER_LIMITS, TRIAL],
   },
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_TIERS[0].description',
-    text: '24 of 31 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
+    proofGrade: 'behavior',
+    text: 'Run the open stack on your own infrastructure. Most packages stay MIT forever. No telemetry.',
     evidence: [LICENSE_SPLIT, NO_TELEMETRY],
   },
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_TIERS[0].features[3]',
+    proofGrade: 'behavior',
     text: 'Bring your own model (open-weight default)',
     evidence: [OPEN_WEIGHT, PROVIDERS],
   },
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_TIERS[1].description',
-    text: 'Pro adds the AI primitives, an agent task allowance, and priority support.',
+    proofGrade: 'behavior',
+    text: 'Add the AI layer, an agent task allowance, and priority support when you scale agents.',
     evidence: [TIER_GATES, TIER_LIMITS],
   },
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_TIERS[1].features[1]',
+    proofGrade: 'behavior',
     text: '10,000 agent tasks / month included',
     evidence: [TIER_LIMITS],
   },
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_TIERS[1].features[2]',
+    proofGrade: 'behavior',
     text: 'Pro AI features (agents, MCP, memory), beta in production',
     evidence: [
       TIER_GATES,
@@ -618,18 +683,21 @@ export const claimsPart1: readonly ClaimEntry[] = [
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_LINKS[0].description',
-    text: 'Max adds AI memory and advanced inference.',
+    proofGrade: 'behavior',
+    text: 'Max adds durable agent memory and advanced inference.',
     evidence: [MEMORY, { kind: 'code', ref: 'packages/ai/src/inference', note: 'inference layer' }],
   },
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_FOOTER.caption.prefix',
+    proofGrade: 'behavior',
     text: 'Deploys to Vercel, Cloudflare, Fly, Hetzner, or self-host.',
     evidence: [DEPLOY_TARGETS],
   },
   {
     file: 'pricing-teaser.ts',
     exportPath: 'PRICING_TEASER_FOOTER.caption.suffix',
+    proofGrade: 'behavior',
     text: 'produces a standard Node bundle.',
     evidence: [{ kind: 'command', ref: 'pnpm build', note: 'turbo build to a plain Node bundle' }],
   },

--- a/apps/marketing/app/content/claims-evidence/types.ts
+++ b/apps/marketing/app/content/claims-evidence/types.ts
@@ -7,6 +7,11 @@
 // covered file gains prose with no entry here, when an entry's text no longer
 // matches the copy, or when a cited code path stops existing.
 //
+// Proof grade (owner 2026-08-09): path existence is not enough for primary
+// funnel copy. Critical homepage surfaces require proofGrade 'behavior' or
+// 'outcome' so marketing stays true and buyer-facing, with technical depth
+// in the docs app. See isCriticalMarketingClaim + findCriticalProofGradeViolations.
+//
 // Granularity: one entry per copy FIELD (a field may hold more than one
 // sentence); the evidence array carries one ref per distinct claim in the
 // field, with the claim named in `note`. Line numbers never appear in `ref`
@@ -21,6 +26,14 @@
 // and the test is not .skip/.todo. Required on every capability-shaped claim
 // (see scripts/validate/capability-claims.ts).
 export type EvidenceKind = 'code' | 'command' | 'url' | 'metric' | 'test';
+
+/**
+ * Strength of the claim↔evidence link (human-reviewed).
+ * - path: cited artifact exists (machine floor; default for non-critical).
+ * - behavior: cited artifact does what the sentence claims.
+ * - outcome: buyer-facing wording still entailed by that behavior.
+ */
+export type ProofGrade = 'path' | 'behavior' | 'outcome';
 
 export interface EvidenceRef {
   /** What kind of artifact proves the claim. */
@@ -44,6 +57,46 @@ export interface ClaimEntry {
   readonly text: string;
   readonly match?: 'text' | 'path';
   readonly evidence: readonly EvidenceRef[];
+  /**
+   * Human-reviewed proof strength. Required at 'behavior' or 'outcome' for
+   * critical homepage funnel fields (see isCriticalMarketingClaim).
+   * Omitted entries are treated as 'path'.
+   */
+  readonly proofGrade?: ProofGrade;
+}
+
+/** Homepage primary funnel modules that carry the proof-grade bar. */
+export const CRITICAL_PROOF_FILES: readonly string[] = [
+  'home.ts',
+  'primitives.ts',
+  'proof.ts',
+  'pricing-teaser.ts',
+] as const;
+
+/**
+ * True when a claim must carry proofGrade 'behavior' or 'outcome'.
+ * Competitor-framing cells, chrome labels, and captions stay at path floor.
+ */
+export function isCriticalMarketingClaim(file: string, exportPath: string): boolean {
+  if (!CRITICAL_PROOF_FILES.includes(file)) return false;
+  if (exportPath.includes('.sprawl')) return false;
+  if (exportPath.includes('.agentOnly')) return false;
+  if (exportPath.includes('.question')) return false;
+  if (exportPath.includes('mockupCaption')) return false;
+  if (exportPath.includes('newsletter')) return false;
+  if (exportPath.includes('changelogCta')) return false;
+  if (exportPath.includes('docsLink')) return false;
+  if (exportPath.includes('validatorLabel')) return false;
+  if (exportPath.includes('.cta') || exportPath.endsWith('.cta')) return false;
+  return true;
+}
+
+export function effectiveProofGrade(entry: Pick<ClaimEntry, 'proofGrade'>): ProofGrade {
+  return entry.proofGrade ?? 'path';
+}
+
+export function isProofGradeSufficient(grade: ProofGrade): boolean {
+  return grade === 'behavior' || grade === 'outcome';
 }
 
 /** Files whose prose the validator requires to be fully indexed. */

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -17,6 +17,9 @@
 // Every prose sentence in this file is indexed in ./claims-evidence.ts with
 // the code that proves it (owner directive); the collections-over-MCP claims
 // reflect default-on resources (mcpResource !== false; opt out with false).
+// 2026-08-09: proof-grade + allure pass. Outcome language on problem/demo/FAQ/
+// get-started; locked positioning subtitle and L1 H1 unchanged. Technical
+// depth points at docs / local-ai / pricing rather than dumping stack lists.
 
 import { SUBSCRIPTION_PRICE_FALLBACKS } from '../lib/pricing-fallbacks';
 import { SITE } from './site';
@@ -86,8 +89,8 @@ export interface ProblemRow {
 
 export const HOME_PROBLEM = {
   eyebrow: 'The problem',
-  heading: 'Vendor sprawl, or framework-only. Pick neither.',
-  body: 'You either glue together an auth vendor, a headless CMS, Stripe code, and a job runner, or you pick an agent framework and rebuild all four underneath it. RevealUI is the third option: the whole set arrives wired into one runtime that you own.',
+  heading: 'Stop buying a separate product for each slice of the stack.',
+  body: 'Most teams stitch sign-in, content, billing, and agents from different vendors. Or they pick an agent framework and rebuild the rest underneath it. RevealUI is the third path: one self-hosted runtime for the business and the agents that run it.',
   tableAriaLabel: 'Vendor sprawl vs agent-framework vs RevealUI comparison',
   columns: {
     capability: 'Capability',
@@ -97,28 +100,28 @@ export const HOME_PROBLEM = {
   },
   rows: [
     {
-      capability: 'Auth + RBAC + sessions',
-      sprawl: 'A separate auth vendor, per seat',
+      capability: 'Sign-in and permissions',
+      sprawl: 'A separate auth product, priced per seat',
       agentOnly: 'Bring your own',
-      revealui: 'Sessions with RBAC and ABAC, built in',
+      revealui: 'Sign-in, roles, and policies built in',
     },
     {
-      capability: 'CMS + admin UI',
-      sprawl: 'A headless CMS, plus a team to wire it',
+      capability: 'Content and admin',
+      sprawl: 'A CMS plus a team to wire it',
       agentOnly: 'Bring your own',
-      revealui: 'Collections with an admin UI and REST API',
+      revealui: 'Your content model, with admin UI and API',
     },
     {
-      capability: 'Stripe billing + webhooks',
-      sprawl: 'Stripe + your code',
+      capability: 'Billing',
+      sprawl: 'Stripe + your glue',
       agentOnly: 'Bring your own',
-      revealui: 'Checkout, webhooks, and reconciliation crons',
+      revealui: 'Checkout, subscriptions, and webhook handling',
     },
     {
-      capability: 'Agent access to your data',
+      capability: 'Agents on your data',
       sprawl: 'One-off integrations',
       agentOnly: 'Tool registry only',
-      revealui: 'Content tools over MCP; collections surface as resources unless you opt out',
+      revealui: 'Agents use the same data and gates as your team',
     },
   ] as readonly ProblemRow[],
   footnote: `Capability comparison only; a monthly cost estimate lives on the pricing page. RevealUI Pro is ${SUBSCRIPTION_PRICE_FALLBACKS.pro.price}/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.`,
@@ -136,8 +139,8 @@ export interface DemoBeat {
 
 export const HOME_DEMO = {
   eyebrow: 'Watch it work',
-  heading: 'From one command to a working stack in 60 seconds.',
-  body: 'The stack runs locally in 60 seconds, Stripe starts in test mode, and agents connect over MCP.',
+  heading: 'From one command to a running stack in about a minute.',
+  body: 'Install on your machine. Take a test payment. Connect an agent to the same data your admin UI already uses.',
   mockupCaption: {
     prefix: 'Local screenshot from a fresh',
     code: 'npx create-revealui',
@@ -147,17 +150,17 @@ export const HOME_DEMO = {
     {
       n: '01',
       title: 'Spin up a stack.',
-      body: 'One command. Auth, content, admin UI, the Stripe webhook handler, and MCP server scaffolding all running locally in 60 seconds.',
+      body: 'One command. Sign-in, content, admin UI, billing hooks, and agent tooling run locally in about a minute.',
     },
     {
       n: '02',
       title: 'Customer flow, end to end.',
-      body: 'A user signs up, picks a plan, and Stripe test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
+      body: 'A user signs up, picks a plan, and test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
     },
     {
       n: '03',
-      title: 'Agent-native, by default.',
-      body: 'Wire an LLM provider and your agents read your sites, users, and content over MCP, with every call passing the same auth and tier gates your human users pass.',
+      title: 'Agents on your data.',
+      body: 'Connect a model. Agents read and write the same content your team does, under the same sign-in and plan rules.',
     },
   ] as readonly DemoBeat[],
 } as const;
@@ -178,38 +181,37 @@ export const HOME_FAQ = {
     {
       question: 'Will I get locked in?',
       answer:
-        'No. Open standards end-to-end: OAuth, JWT, Stripe webhooks, MCP, and OpenAPI, over plain Postgres. Deploy anywhere Node runs, and take your data, your code, and your infrastructure with you. RevealUI is the runtime, not the prison.',
+        'No. You keep your data in plain Postgres, your code in your repo, and your deploy on infrastructure you choose. Open standards throughout. RevealUI is the runtime, not the prison. Details live in the docs.',
     },
     {
       question: 'Is it production-ready?',
       answer:
-        'Every PR clears a 3-phase gate before it lands: Biome, Vitest unit and integration tests, Playwright end-to-end tests, CodeQL, and Gitleaks. This site and the agency site at revealuistudio.com both run on RevealUI in production.',
+        'Changes clear automated tests and security checks before they land. This site and the agency site at revealuistudio.com both run on RevealUI in production today.',
     },
     {
-      question:
-        'How is this different from stitching together separate auth, database, CMS, and background-job services?',
+      question: 'How is this different from stitching separate tools together?',
       answer:
-        'Each of those covers one slice: a real-time database, a Postgres-plus-auth backend, a session service, a jobs runner. RevealUI is the whole runtime: auth, content, billing, admin UI, and an agent layer, self-hosted at every tier. (Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.)',
+        'Each vendor covers one slice. RevealUI is the whole runtime: people, content, billing, admin, and agents, self-hosted at all tiers. Deploy targets such as Vercel, Cloudflare, and Fly are places it runs, not competitors.',
     },
     {
       question: 'Can I self-host?',
       answer:
-        'Yes. 24 of 31 packages are MIT and stay MIT, forever. The 5 Pro packages are Fair Source (FSL-1.1-MIT) and auto-convert to MIT two years after each release. Self-host the entire stack on your own infrastructure at any tier, with no vendor-specific edge runtimes and no proprietary database.',
+        'Yes. Most packages are MIT forever. A small Pro set is Fair Source and converts to MIT two years after each release. Self-host the full stack on your infrastructure at any tier. License detail is on the Fair Source page.',
     },
     {
-      question: 'What does "agent-native" actually mean in code?',
+      question: 'What does agent-native mean for my product?',
       answer:
-        'Agents authenticate like users and pass the same tier gates your customers pass. The content MCP server ships discovery and read tools, collections surface as discoverable MCP resources by default (set mcpResource: false to opt out), and writes go through the same REST API your app uses.',
+        'Agents sign in like users and face the same plan rules. They work on your content through the same APIs your app uses. How the wire protocol works is covered in the docs.',
     },
     {
       question: 'How does AI inference work?',
       answer:
-        'Agents run on an open-weight model on your own infrastructure by default, with Claude, GPT, or any other provider one config line away. See the local AI docs at revealui.com/local-ai for the full pathway.',
+        'By default, agents run on an open-weight model on infrastructure you own. Add Claude, GPT, or another provider when you choose. The local AI page walks through the full path.',
     },
     {
       question: 'How do agent payments work?',
       answer:
-        'RevealUI implements the HTTP 402 payment protocol so agents can pay each other over standard HTTP, with the payment rails still in development. See the agents section of the pricing page for the current status.',
+        'RevealUI speaks the HTTP 402 payment protocol so agents can pay over standard HTTP. Payment rails are still in development. See the agents section on the pricing page for current status.',
     },
   ] as readonly FaqItem[],
 } as const;
@@ -219,8 +221,8 @@ export const HOME_FAQ = {
 // ---------------------------------------------------------------------------
 
 export const HOME_GET_STARTED = {
-  heading: 'Your stack is one command away.',
-  body: 'Spin it up on your machine in minutes. Flip to live mode when you are ready to charge real customers.',
+  heading: 'Start on your machine today.',
+  body: 'Install free. Open the admin UI. Go live when you are ready to charge customers.',
   cta: {
     primary: { label: 'Start free', href: SITE.urls.signup } satisfies Cta,
     secondary: { label: 'Read the docs', href: SITE.urls.docs } satisfies Cta,
@@ -230,9 +232,9 @@ export const HOME_GET_STARTED = {
   // CTA, not competing with the hero's primary/secondary buttons.
   cli: {
     command: ['npx', 'create-revealui@latest', 'my-app'],
-    caption: 'Local dev stack in 60 seconds. No credit card.',
+    caption: 'Local stack in about a minute. No credit card.',
   },
   newsletter: {
-    label: 'Not ready to start? Get product updates and engineering insights.',
+    label: 'Not ready to start? Get product updates when they ship.',
   },
 } as const;

--- a/apps/marketing/app/content/pricing-teaser.ts
+++ b/apps/marketing/app/content/pricing-teaser.ts
@@ -1,6 +1,8 @@
 // Sourced from: app/components/landing/PricingTeaser.tsx (Phase 1c, no copy changes).
 // Per the internal marketing-overhaul plan §4.4.
 // Tier copy lives here; runtime pricing (prices/periods) fetched from /api/pricing in the component.
+// 2026-08-09: outcome-first Free/Pro teaser; package-count license math stays
+// on Fair Source / pricing pages, not the homepage pitch.
 
 import type { LicenseTierId } from '@revealui/contracts/pricing';
 import { SITE } from './site';
@@ -18,7 +20,7 @@ export interface TeaserTier {
 export const PRICING_TEASER_SECTION = {
   eyebrow: 'Pricing',
   heading: 'Start free. Pay when you scale.',
-  body: 'Self-host the open-source stack at no cost. Pro, Max, and Enterprise add runtime entitlements and an agent task allowance. Pro and Max include a 7-day free trial.',
+  body: 'Self-host the open stack at no cost. Pro, Max, and Enterprise add agent capacity and support. Pro and Max include a 7-day free trial.',
 } as const;
 
 // Free and Pro get full cards, since they cover the self-serve path most
@@ -29,7 +31,7 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
     id: 'free',
     name: 'Free',
     description:
-      '24 of 31 packages are MIT, forever. The 5 Pro packages are Fair Source (FSL) and convert to MIT after two years. There is no telemetry.',
+      'Run the open stack on your own infrastructure. Most packages stay MIT forever. No telemetry.',
     features: [
       'Full primitive stack',
       'Admin dashboard + API',
@@ -43,7 +45,8 @@ export const PRICING_TEASER_TIERS: readonly TeaserTier[] = [
   {
     id: 'pro',
     name: 'Pro',
-    description: 'Pro adds the AI primitives, an agent task allowance, and priority support.',
+    description:
+      'Add the AI layer, an agent task allowance, and priority support when you scale agents.',
     features: [
       'Everything in Free',
       '10,000 agent tasks / month included',
@@ -67,7 +70,7 @@ export const PRICING_TEASER_LINKS: readonly TeaserLink[] = [
   {
     id: 'max',
     name: 'Max',
-    description: 'Max adds AI memory and advanced inference.',
+    description: 'Max adds durable agent memory and advanced inference.',
     href: '/pricing',
   },
   {

--- a/apps/marketing/app/content/primitives.ts
+++ b/apps/marketing/app/content/primitives.ts
@@ -6,6 +6,8 @@
 // (currently 14, per docs/MARKETING_METRICS.md §1); never hardcoded here.
 //
 // Every sentence in HOME_PRIMITIVES is indexed in content/claims-evidence.ts.
+// 2026-08-09: outcome language for buyers; RBAC/ABAC and protocol jargon
+// moved to docs (docs link on the section).
 
 import { SITE } from './site';
 
@@ -23,35 +25,35 @@ export interface HomePrimitive {
 export const HOME_PRIMITIVES_SECTION = {
   eyebrow: 'Five primitives. One login.',
   heading: 'The five things every business runs on.',
-  body: 'Each primitive ships as an API and an admin surface, and your agents work the same objects your team does.',
+  body: 'Each one ships ready for your team and for agents. One login covers the whole set.',
   docsLink: { label: 'See the primitive reference →', href: SITE.urls.docs },
 } as const;
 
 export const HOME_PRIMITIVES: readonly HomePrimitive[] = [
   {
     label: 'People',
-    body: 'Your team signs in with sessions and works under RBAC and ABAC policies.',
+    body: 'Your team signs in once. Roles and policies decide who can do what.',
     // Brand accent (not emerald — that name was a retired palette alias).
     color: 'brand',
   },
   {
     label: 'Content',
-    body: 'Collections give you a CMS, rich text, and media, with an admin UI generated from your schema.',
+    body: 'Define your content once. The admin UI and API come with it.',
     color: 'blue',
   },
   {
     label: 'Offers',
-    body: 'Catalogs and feature gates decide what each tier can do, for your people and your agents.',
+    body: 'Plans and feature gates decide what each customer and agent can use.',
     color: 'amber',
   },
   {
     label: 'Payments',
-    body: 'Stripe checkout, subscriptions, and webhook reconciliation come pre-wired.',
+    body: 'Checkout and subscriptions ship ready, including webhook handling.',
     color: 'cyan',
   },
   {
     label: 'Agents',
-    body: 'Agents run on an open-weight model you host, with any provider one config line away.',
+    body: 'Agents run on models you host by default. Add a hosted provider when you choose.',
     color: 'violet',
   },
 ] as const;

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -18,13 +18,15 @@
 // led with the same unproven audit-trail claim); and the local-AI beat (its
 // own page covers this). What remains is what a buyer needs to decide whether
 // to trust the repo: it is inspectable, and the numbers are checkable.
+//
+// 2026-08-09: light allure polish; keep inspectability and metric honesty.
 
 import { METRICS, SITE } from './site';
 
 export const PROOF_SECTION = {
   eyebrow: 'Open source',
-  heading: 'Inspect the code before you commit to it.',
-  body: 'The entire runtime sits in the public repo under an open license. Read it, run it, or fork it before you build on it.',
+  heading: 'Read the code before you build on it.',
+  body: 'The whole runtime lives in a public repo under an open license. Inspect it, run it, or fork it before you commit.',
   repoLinkLabel: 'View the repo on GitHub',
 } as const;
 
@@ -32,7 +34,7 @@ export const PROOF_SECTION = {
 // answers is whether their security team can read the code, not what
 // framework it runs on.
 export const PROOF_TRUST = {
-  body: 'Your security team can read every line. The whole runtime is open source, MIT or Fair Source, sitting in the repo. There is no closed binary to explain away when procurement comes asking.',
+  body: 'Your security team can read the full source. The runtime is open source, MIT or Fair Source, in the public repo. There is no closed binary to explain when procurement asks.',
   linkLabel: 'Read the LICENSE',
   linkHref: SITE.urls.repoLicense,
   changelogCta: {
@@ -67,7 +69,7 @@ export interface LiveMetric {
 export const LIVE_METRICS = {
   eyebrow: 'Live from the repo',
   heading: 'Every number here is pinned to the codebase.',
-  body: 'These counts are validated on every PR by the claim-drift gate. If the code changes and a number drifts, the build fails before it can ship.',
+  body: 'These counts are checked on each pull request. If the code changes and a number drifts, the build fails before it can ship.',
   metrics: [
     { value: METRICS.packages, label: 'packages' },
     { value: METRICS.apps, label: 'apps' },

--- a/scripts/validate/__tests__/claims-evidence.test.ts
+++ b/scripts/validate/__tests__/claims-evidence.test.ts
@@ -8,6 +8,7 @@ import type {
   CoveredFile,
 } from '../../../apps/marketing/app/content/claims-evidence.ts';
 import {
+  findCriticalProofGradeViolations,
   findMissingRouteEntries,
   findUntrackedCodeEvidence,
   isTrackedPath,
@@ -58,6 +59,60 @@ describe('isTrackedPath', () => {
 
   it('does not match a directory with no tracked files under it', () => {
     expect(isTrackedPath(tracked, 'packages/nonexistent-pkg/src')).toBe(false);
+  });
+});
+
+describe('findCriticalProofGradeViolations', () => {
+  function claim(
+    file: string,
+    exportPath: string,
+    proofGrade?: ClaimEntry['proofGrade'],
+  ): ClaimEntry {
+    return {
+      file,
+      exportPath,
+      text: 'placeholder text long enough to pass the prose floor',
+      evidence: [{ kind: 'code', ref: 'packages' }],
+      proofGrade,
+    };
+  }
+
+  it('flags a critical homepage claim with no proofGrade (path default)', () => {
+    expect(findCriticalProofGradeViolations([claim('home.ts', 'HOME_HERO.h1')])).toEqual([
+      { file: 'home.ts', exportPath: 'HOME_HERO.h1', grade: 'path' },
+    ]);
+  });
+
+  it('flags a critical claim graded only path', () => {
+    expect(
+      findCriticalProofGradeViolations([claim('home.ts', 'HOME_PROBLEM.body', 'path')]),
+    ).toEqual([{ file: 'home.ts', exportPath: 'HOME_PROBLEM.body', grade: 'path' }]);
+  });
+
+  it('passes critical claims graded behavior or outcome', () => {
+    expect(
+      findCriticalProofGradeViolations([
+        claim('home.ts', 'HOME_HERO.h1', 'behavior'),
+        claim('primitives.ts', 'HOME_PRIMITIVES[0].body', 'outcome'),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('skips competitor-framing, FAQ questions, and chrome fields', () => {
+    expect(
+      findCriticalProofGradeViolations([
+        claim('home.ts', 'HOME_PROBLEM.rows[0].sprawl'),
+        claim('home.ts', 'HOME_FAQ.items[0].question'),
+        claim('home.ts', 'HOME_GET_STARTED.newsletter.label'),
+        claim('proof.ts', 'PROOF_TRUST.changelogCta.label'),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('skips non-critical files even without a grade', () => {
+    expect(
+      findCriticalProofGradeViolations([claim('products.ts', 'PRODUCTS_PAGE_HERO.h1')]),
+    ).toEqual([]);
   });
 });
 

--- a/scripts/validate/claims-evidence.ts
+++ b/scripts/validate/claims-evidence.ts
@@ -28,6 +28,11 @@
  *      unstaged local-only paths too; those would 404 on the public GitHub
  *      deep link this page renders for `code` refs.
  *
+ *   6. proof grade — critical homepage funnel claims must declare
+ *      proofGrade 'behavior' or 'outcome' (owner 2026-08-09). Path-only
+ *      citations are not enough for hero / problem / primitives / proof /
+ *      pricing-teaser product claims.
+ *
  * Usage:
  *   tsx scripts/validate/claims-evidence.ts          # exit 1 on violations
  *   tsx scripts/validate/claims-evidence.ts --warn   # warn-only (exit 0)
@@ -42,6 +47,9 @@ import {
   type ClaimEntry,
   COVERED_FILES,
   type CoveredFile,
+  effectiveProofGrade,
+  isCriticalMarketingClaim,
+  isProofGradeSufficient,
   NON_COPY_KEYS,
 } from '../../apps/marketing/app/content/claims-evidence.js';
 import { CONTENT_FILE_ROUTES } from '../../apps/marketing/app/content/claims-routes.js';
@@ -158,6 +166,30 @@ export function findUntrackedCodeEvidence(
       if (ev.kind === 'code' && untrackedRefs.has(ev.ref)) {
         results.push({ file: claim.file, exportPath: claim.exportPath, ref: ev.ref });
       }
+    }
+  }
+  return results;
+}
+
+export interface CriticalProofGradeViolation {
+  readonly file: string;
+  readonly exportPath: string;
+  readonly grade: string;
+}
+
+/**
+ * Critical homepage funnel claims that lack proofGrade behavior|outcome.
+ * Pure; exported for tests.
+ */
+export function findCriticalProofGradeViolations(
+  claims: readonly ClaimEntry[],
+): CriticalProofGradeViolation[] {
+  const results: CriticalProofGradeViolation[] = [];
+  for (const claim of claims) {
+    if (!isCriticalMarketingClaim(claim.file, claim.exportPath)) continue;
+    const grade = effectiveProofGrade(claim);
+    if (!isProofGradeSufficient(grade)) {
+      results.push({ file: claim.file, exportPath: claim.exportPath, grade });
     }
   }
   return results;
@@ -333,10 +365,17 @@ async function run(): Promise<void> {
     );
   }
 
+  // 6. Proof grade: critical homepage funnel claims need behavior|outcome.
+  for (const weak of findCriticalProofGradeViolations(CLAIMS)) {
+    violations.push(
+      `${weak.file} :: ${weak.exportPath} — critical claim needs proofGrade 'behavior' or 'outcome' (got '${weak.grade}'). Path-only is not enough for primary funnel copy.`,
+    );
+  }
+
   const coveredCount = CLAIMS.length;
   if (violations.length === 0) {
     console.log(
-      `claims-evidence: ${coveredCount} indexed claims across ${COVERED_FILES.length} covered content modules + ${BLOG_POST_METADATA.length} live blog posts (title+excerpt+body), all matched, all evidence paths present.`,
+      `claims-evidence: ${coveredCount} indexed claims across ${COVERED_FILES.length} covered content modules + ${BLOG_POST_METADATA.length} live blog posts (title+excerpt+body), all matched, all evidence paths present, critical proof grades sufficient.`,
     );
     process.exit(0);
   }
@@ -346,7 +385,7 @@ async function run(): Promise<void> {
     console.error(`  ✗ ${v}`);
   }
   console.error(
-    '\nFix: index the sentence in apps/marketing/app/content/claims-evidence.ts with the code that proves it, update the stale entry, or restore the cited path. Copy with no proof does not ship.',
+    '\nFix: index the sentence in apps/marketing/app/content/claims-evidence.ts with the code that proves it, set proofGrade behavior|outcome on critical homepage fields, update the stale entry, or restore the cited path. Copy with no proof does not ship.',
   );
   process.exit(warnOnly ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

Implements the owner-directed **proof-grade + allure** program (not a blank-site rebuild):

1. **`proofGrade` on claims-evidence** (`path` | `behavior` | `outcome`)
2. **Critical homepage funnel gate** — `home.ts`, `primitives.ts`, `proof.ts`, `pricing-teaser.ts` product claims must be `behavior` or `outcome` (path-only is not enough)
3. **Homepage rewrite** for true + alluring outcome language; technical depth points at docs / Fair Source / local-ai / pricing
4. **Locked positioning unchanged** — L1 H1 and subtitle sentences (ADR 2026-07-09 / copy-voice)

## What changed (copy)

| Surface | Direction |
|---------|-----------|
| Problem | Buyer outcome framing; less stack jargon in table |
| Demo / FAQ / Get started | Clearer, docs for wire protocol detail |
| Primitives | Roles/plans/checkout language; docs link for reference |
| Proof | Inspectability polish |
| Pricing teaser | Outcome-first Free/Pro; license math stays on Fair Source |

## Proof system

- Extends existing claims-evidence ratchet (1,420 claims still green)
- New pure helpers + unit tests for critical grade violations
- `pnpm validate:claims-evidence` / `validate:claims` / `validate:marketing-voice` green

## Out of scope (as planned)

- GAP-465 counsel (parked)
- Waiting copy-dependents
- products / local-ai / for-operators pass (next train)
- Nuclear blank rebuild of marketing

## Test plan

- [x] `pnpm validate:claims-evidence`
- [x] `pnpm validate:claims`
- [x] `pnpm validate:marketing-voice`
- [x] `pnpm gate --phase=1 --changed`
- [x] Vitest: claims-evidence tests, hero-variant, proof-deployers, content tests
- [ ] Spot-check `/` after merge to test deploy
- [ ] GAP-466 promote when intentional for prod

## Owner follow-ups

- After green CI on `test`, promote when customer-visible (GAP-466 lockstep)
- Next: products / local-ai / for-operators same bar