### PR TITLE
fix(harnesses): harden tdd and debugging control-layer skills

### DIFF
--- a/.changeset/harnesses-tdd-debug-skills.md
+++ b/.changeset/harnesses-tdd-debug-skills.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": patch
+---
+
+Harden control-layer `revealui-tdd` (seams, vertical slices, test anti-patterns) and `revealui-debugging` (red-capable feedback loop first, multi-hypothesis, instrument/cleanup).

--- a/.revealui/content/skills/revealui-debugging/SKILL.md
+++ b/.revealui/content/skills/revealui-debugging/SKILL.md
@@ -1,58 +1,136 @@
 ---
 name: RevealUI Debugging
-description: "Systematic debugging workflow for RevealUI. Use when encountering any bug, test failure,\nunexpected behavior, error, or broken functionality. Prevents shotgun debugging."
+description: "Disciplined bug diagnosis for RevealUI: build a red-capable feedback loop first, then minimise, multi-hypothesis, instrument, fix, and regression-test. Use on bugs, failures, or unexpected behavior."
 ---
 
 # RevealUI Debugging Workflow
 
-When something breaks, follow this process. Do not skip steps.
+When something breaks, follow this process. Do not skip phases. Skip a phase only when you can name why.
 
-## The Process
+**Redact secrets** in every command, log, and artifact shown to the user. Use `<REDACTED>`. Prefer `revvault run` / env injection so credentials never appear in argv or chat. See stream-safe secrets rules.
 
-### 1. Reproduce
+## Phase 1  -  Build a red-capable feedback loop
 
-- Get the exact error message, stack trace, or unexpected output
-- Find the minimal reproduction case
-- Confirm it reproduces consistently (not flaky)
-- If it only fails under `turbo run test`, see `$revealui-testing` for concurrency triage
+**This is the skill.** Everything else consumes the loop. If you have a **tight** pass/fail signal that goes red on **this** bug, you will find the cause. If you do not, staring at code will not save you.
 
-### 2. Hypothesize
+Spend disproportionate effort here. Be aggressive and creative. Refuse to give up early.
 
-- Form ONE specific hypothesis about the root cause
-- Write it down before changing any code
-- Base it on evidence (error message, stack trace, git blame), not intuition
+### Ways to construct a loop (try roughly in this order)
 
-### 3. Validate
+1. **Failing test** at a seam that reaches the bug (unit, integration, or e2e)  -  prefer `$revealui-tdd`
+2. **HTTP / curl script** against a running dev server
+3. **CLI invocation** with a fixture input, diffing stdout against known-good
+4. **Headless browser** (Playwright) asserting DOM, console, or network
+5. **Replay** a captured payload/event through the path in isolation
+6. **Throwaway harness** that exercises one code path with mocked deps
+7. **Property / fuzz** when the bug is intermittent wrong output
+8. **Bisection harness** when the bug appeared between two known states (`git bisect run`)
+9. **Differential** old vs new version or config on the same input
+10. **Human-in-the-loop script** only as last resort  -  structured steps, captured output
 
-- Design a test or check that confirms/refutes your hypothesis
-- Run it
-- If refuted, form a new hypothesis  -  do not stack unrelated fixes
+### Tighten the loop
 
-### 4. Fix Narrowly
+- Faster (narrow scope, skip unrelated init)
+- Sharper (assert the user's exact symptom, not "did not crash")
+- More deterministic (pin time, seed RNG, isolate network/fs)
 
-- Change the minimum code to fix the root cause
-- Do not refactor surrounding code
-- Do not fix adjacent issues you noticed along the way (file them separately)
+A 30-second flaky loop is barely better than no loop. Aim for seconds and a stable verdict.
 
-### 5. Verify
+### Non-deterministic bugs
 
-- Run the original failing test/scenario
-- Run `pnpm --filter <package> test` to check for regressions
-- Run `npx biome check --write <file>` on changed files
+Raise the **reproduction rate** until the bug is debuggable (loop the trigger, stress, narrow timing). A 50% flake is usable; 1% is not.
 
-### 6. Commit
+### When you cannot build a loop
 
-- One commit for the fix
-- Format: `fix(scope): description of what was broken`
+Stop. List what you tried. Ask for environment access, a redacted artifact (HAR, logs), or permission for temporary instrumentation. Do **not** hypothesise without a loop.
+
+### Completion criterion
+
+Phase 1 is done only when you can name **one command** you have **already run** (show redacted invocation + output) that is:
+
+- [ ] **Red-capable**  -  drives the bug path and asserts the **user's exact symptom**
+- [ ] **Deterministic** (or high enough repro rate to debug)
+- [ ] **Fast**  -  seconds when possible
+- [ ] **Agent-runnable** without unsupervised production writes
+
+If you catch yourself theorising before this command exists, stop.
+
+## Phase 2  -  Reproduce and minimise
+
+Run the loop. Watch it go red.
+
+Confirm:
+
+- [ ] Failure matches what the **user** described (wrong bug = wrong fix)
+- [ ] Reproducible (or high enough rate)
+- [ ] Exact symptom captured (message, wrong output, timing)
+
+**Minimise:** cut inputs, callers, config, and steps one at a time; re-run after each cut. Keep only load-bearing elements. The minimised repro becomes the regression test in Phase 5.
+
+## Phase 3  -  Hypothesise (several, ranked)
+
+Generate **3–5 ranked, falsifiable hypotheses** before testing any.
+
+Format: "If X is the cause, then changing Y will make the bug disappear / changing Z will make it worse."
+
+If you cannot state the prediction, sharpen or discard the hypothesis.
+
+Show the ranked list to the user when available (domain knowledge re-ranks cheaply). Do not block forever if they are AFK  -  proceed with your ranking.
+
+Do not start with a single pet theory.
+
+## Phase 4  -  Instrument
+
+Each probe maps to a specific prediction. **Change one variable at a time.**
+
+Preference order:
+
+1. Debugger / REPL if available
+2. Targeted logs at boundaries that distinguish hypotheses
+3. Never "log everything and grep"
+
+Tag every temporary log with a unique prefix, e.g. `[DEBUG-a4f2]`, so cleanup is one grep.
+
+**Perf branch:** establish a baseline measurement first (timing, profiler, query plan), then bisect. Measure before "fixing."
+
+## Phase 5  -  Fix and regression test
+
+Write the regression test **before** the permanent fix when a **correct seam** exists (see `$revealui-tdd`).
+
+A correct seam exercises the **real bug pattern** as it occurs at the call site. A shallow unit that cannot reproduce the chain gives false confidence.
+
+If no correct seam exists, that is a finding: note it for architecture follow-up after the fix.
+
+When a seam exists:
+
+1. Turn the minimised repro into a failing test
+2. Watch it fail
+3. Apply the minimal fix
+4. Watch it pass
+5. Re-run the Phase 1 loop against the original (un-minimised) scenario
+
+## Phase 6  -  Cleanup and post-mortem
+
+Required before done:
+
+- [ ] Phase 1 loop is green on the original scenario
+- [ ] Regression test passes (or missing seam is documented)
+- [ ] All `[DEBUG-...]` instrumentation removed (`grep` the prefix)
+- [ ] Throwaway harnesses deleted or clearly marked temporary
+- [ ] Correct hypothesis stated in commit / PR message
+
+Then ask: **what would have prevented this?** If the answer is architectural (no good seam, tangled callers), file a follow-up  -  after the fix is in.
 
 ## Anti-Patterns
 
+- Hypothesising before a red-capable loop
 - Changing multiple things at once ("shotgun debugging")
 - Fixing symptoms instead of root causes
-- Adding try/catch blocks to silence errors
-- Increasing timeouts to hide race conditions
-- Reverting to "known good" without understanding what broke
-- Asking "does this fix it?" without a hypothesis
+- Adding try/catch to silence errors
+- Increasing timeouts to hide races
+- Reverting to "known good" without understanding the break
+- Asking "does this fix it?" without a prediction
+- Leaving untagged debug logs or secret values in logs
 
 ## Common RevealUI Debugging Paths
 
@@ -63,3 +141,11 @@ When something breaks, follow this process. Do not skip steps.
 | Test passes alone, fails in gate | Concurrency pressure  -  see `$revealui-testing` |
 | Supabase error in unexpected path | Import boundary violation  -  see `$revealui-db` |
 | Biome error after edit | Run `npx biome check --write <file>` |
+| Agent tool denied / unexpected auth | Tool governance / permission path in `@revealui/ai` |
+| "Docs say X, runtime does Y" | Trust **code** (primary source); fix the doc after |
+
+## Commit
+
+- One commit for the fix when possible
+- Format: `fix(scope): description of what was broken`
+- Name the winning hypothesis in the body when non-obvious

--- a/.revealui/content/skills/revealui-tdd/SKILL.md
+++ b/.revealui/content/skills/revealui-tdd/SKILL.md
@@ -1,20 +1,44 @@
 ---
 name: RevealUI TDD
-description: "Test-driven development workflow for RevealUI. Use when implementing any feature,\nfixing bugs, adding functionality, or writing new code. Enforces write-test-first,\nred-green-refactor cycle. Works with Vitest and React Testing Library."
+description: "Test-driven development for RevealUI: agree seams first, then red-green vertical slices with Vitest. Use when implementing features, fixing bugs, or writing tests."
 ---
 
 # RevealUI TDD Workflow
 
 Follow this cycle for every code change. No exceptions.
 
-## The Cycle
+## What a good test is
 
-1. **Write a failing test**  -  describe the expected behavior
-2. **Run it**  -  confirm it fails for the right reason
-3. **Write minimal implementation**  -  just enough to pass
+Tests verify **behavior through public interfaces**, not implementation details. Code can change entirely; tests should survive. A good test reads like a specification ("user can checkout with a valid cart") and fails only when behavior changes.
+
+Expected values must come from an **independent source of truth** (spec, known-good literal, worked example). Do not recompute the expected value the same way the production code does.
+
+## Seams (agree before writing tests)
+
+A **seam** is the public boundary you test at: the interface where you observe behavior without reaching inside. Tests live at seams, never against private internals.
+
+**Before writing any test**, list the seams under test and confirm them (with the user when available):
+
+- Prefer existing public package exports (`@revealui/*` entry points) over new seams.
+- Prefer the highest seam that still catches the bug or feature (integration over pure unit when the bug needs the call chain).
+- Prefer fewer seams. Do not add a seam "just for testability" if the real interface can express the behavior.
+
+Ask: "What is the public interface, and which seams should we test?"
+
+For module shape questions (depth, interface size, locality), keep tests at the agreed seam and escalate design redesigns rather than testing past the interface.
+
+## The red-green cycle (vertical slices)
+
+Work in **vertical slices**, not horizontal bulk:
+
+1. **Write one failing test** at a confirmed seam  -  one behavior, one assertion focus
+2. **Run it**  -  confirm it fails for the **right** reason (not import/setup noise)
+3. **Write minimal implementation**  -  just enough to pass; no speculative features
 4. **Run it**  -  confirm it passes
-5. **Refactor**  -  clean up, then run tests again
-6. **Commit**  -  one commit per cycle
+5. **Tiny cleanup only**  -  rename for clarity, extract only what this slice needs. Broad redesign belongs in review, not in the red-green loop
+6. **Commit**  -  one commit per slice when the change is ready to land
+
+**Tracer bullet:** each slice is a thin complete path that teaches the next slice. Do not write all tests first, then all implementation (horizontal slicing).
 
 ## Commands
 
@@ -38,8 +62,8 @@ pnpm --filter @revealui/<package> test -- --coverage
 ## What to Test
 
 - Public API surface of each module
-- Error paths and edge cases
-- Integration points between packages
+- Error paths and edge cases at the agreed seams
+- Integration points between packages when the seam is inter-package
 
 ## What NOT to Test
 
@@ -53,8 +77,10 @@ For concurrency tuning, flaky test triage, and Pro/OSS test boundaries, see the 
 
 ## Anti-Patterns
 
-- Writing implementation before the test
-- Writing tests that pass immediately (test must fail first)
-- Testing implementation details instead of behavior
-- Skipping the refactor step
-- Large commits with multiple features
+- **Implementation before red**  -  writing code before a failing test
+- **Green on arrival**  -  tests that pass immediately (never proved red)
+- **Implementation-coupled**  -  mocking internal collaborators, testing private methods, or asserting via side channels (raw DB) instead of the public interface. Tell: test breaks on refactor with no behavior change
+- **Tautological**  -  expected value recomputed the same way as the code (`expect(add(a,b)).toBe(a+b)`). Cannot disagree with the code
+- **Horizontal slicing**  -  all tests first, then all implementation; tests lock imagined shape instead of learned behavior
+- **Testing past the seam**  -  reaching into internals because the module is the wrong shape; fix the seam or file a design follow-up
+- **Large multi-feature commits**  -  many slices in one commit without a green checkpoint

--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -128,7 +128,7 @@
     },
     {
       "relativePath": ".revealui/content/skills/revealui-debugging/SKILL.md",
-      "sha256": "e78d583b7bd0574107f6d3fc5e4ee20d2db53ea3f4b0a12d5ff428d169bb0ad8"
+      "sha256": "e6cd0857fee361483c7d932880a855a579c8e9705152c92c64aa51e63ca94fd3"
     },
     {
       "relativePath": ".revealui/content/skills/revealui-review/SKILL.md",
@@ -140,7 +140,7 @@
     },
     {
       "relativePath": ".revealui/content/skills/revealui-tdd/SKILL.md",
-      "sha256": "fdb25f906b7613b3dd24c95f9b3e581557c042c82a1acf2c0bfa91d039bb5e4e"
+      "sha256": "18251bd58c25168f0ae3d1f5303838921eba9995c8789bab2ab5e496ab3f80b2"
     },
     {
       "relativePath": ".revealui/content/skills/revealui-testing/SKILL.md",

--- a/packages/harnesses/src/content/definitions/skills/revealui-debugging.ts
+++ b/packages/harnesses/src/content/definitions/skills/revealui-debugging.ts
@@ -5,7 +5,7 @@ export const revealuiDebuggingSkill: Skill = {
   tier: 'pro',
   name: 'RevealUI Debugging',
   description:
-    'Systematic debugging workflow for RevealUI. Use when encountering any bug, test failure,\nunexpected behavior, error, or broken functionality. Prevents shotgun debugging.',
+    'Disciplined bug diagnosis for RevealUI: build a red-capable feedback loop first, then minimise, multi-hypothesis, instrument, fix, and regression-test. Use on bugs, failures, or unexpected behavior.',
   disableModelInvocation: false,
   skipFrontmatter: false,
   filePatterns: [],
@@ -13,54 +13,132 @@ export const revealuiDebuggingSkill: Skill = {
   references: {},
   content: `# RevealUI Debugging Workflow
 
-When something breaks, follow this process. Do not skip steps.
+When something breaks, follow this process. Do not skip phases. Skip a phase only when you can name why.
 
-## The Process
+**Redact secrets** in every command, log, and artifact shown to the user. Use \`<REDACTED>\`. Prefer \`revvault run\` / env injection so credentials never appear in argv or chat. See stream-safe secrets rules.
 
-### 1. Reproduce
+## Phase 1  -  Build a red-capable feedback loop
 
-- Get the exact error message, stack trace, or unexpected output
-- Find the minimal reproduction case
-- Confirm it reproduces consistently (not flaky)
-- If it only fails under \`turbo run test\`, see \`$revealui-testing\` for concurrency triage
+**This is the skill.** Everything else consumes the loop. If you have a **tight** pass/fail signal that goes red on **this** bug, you will find the cause. If you do not, staring at code will not save you.
 
-### 2. Hypothesize
+Spend disproportionate effort here. Be aggressive and creative. Refuse to give up early.
 
-- Form ONE specific hypothesis about the root cause
-- Write it down before changing any code
-- Base it on evidence (error message, stack trace, git blame), not intuition
+### Ways to construct a loop (try roughly in this order)
 
-### 3. Validate
+1. **Failing test** at a seam that reaches the bug (unit, integration, or e2e)  -  prefer \`$revealui-tdd\`
+2. **HTTP / curl script** against a running dev server
+3. **CLI invocation** with a fixture input, diffing stdout against known-good
+4. **Headless browser** (Playwright) asserting DOM, console, or network
+5. **Replay** a captured payload/event through the path in isolation
+6. **Throwaway harness** that exercises one code path with mocked deps
+7. **Property / fuzz** when the bug is intermittent wrong output
+8. **Bisection harness** when the bug appeared between two known states (\`git bisect run\`)
+9. **Differential** old vs new version or config on the same input
+10. **Human-in-the-loop script** only as last resort  -  structured steps, captured output
 
-- Design a test or check that confirms/refutes your hypothesis
-- Run it
-- If refuted, form a new hypothesis  -  do not stack unrelated fixes
+### Tighten the loop
 
-### 4. Fix Narrowly
+- Faster (narrow scope, skip unrelated init)
+- Sharper (assert the user's exact symptom, not "did not crash")
+- More deterministic (pin time, seed RNG, isolate network/fs)
 
-- Change the minimum code to fix the root cause
-- Do not refactor surrounding code
-- Do not fix adjacent issues you noticed along the way (file them separately)
+A 30-second flaky loop is barely better than no loop. Aim for seconds and a stable verdict.
 
-### 5. Verify
+### Non-deterministic bugs
 
-- Run the original failing test/scenario
-- Run \`pnpm --filter <package> test\` to check for regressions
-- Run \`npx biome check --write <file>\` on changed files
+Raise the **reproduction rate** until the bug is debuggable (loop the trigger, stress, narrow timing). A 50% flake is usable; 1% is not.
 
-### 6. Commit
+### When you cannot build a loop
 
-- One commit for the fix
-- Format: \`fix(scope): description of what was broken\`
+Stop. List what you tried. Ask for environment access, a redacted artifact (HAR, logs), or permission for temporary instrumentation. Do **not** hypothesise without a loop.
+
+### Completion criterion
+
+Phase 1 is done only when you can name **one command** you have **already run** (show redacted invocation + output) that is:
+
+- [ ] **Red-capable**  -  drives the bug path and asserts the **user's exact symptom**
+- [ ] **Deterministic** (or high enough repro rate to debug)
+- [ ] **Fast**  -  seconds when possible
+- [ ] **Agent-runnable** without unsupervised production writes
+
+If you catch yourself theorising before this command exists, stop.
+
+## Phase 2  -  Reproduce and minimise
+
+Run the loop. Watch it go red.
+
+Confirm:
+
+- [ ] Failure matches what the **user** described (wrong bug = wrong fix)
+- [ ] Reproducible (or high enough rate)
+- [ ] Exact symptom captured (message, wrong output, timing)
+
+**Minimise:** cut inputs, callers, config, and steps one at a time; re-run after each cut. Keep only load-bearing elements. The minimised repro becomes the regression test in Phase 5.
+
+## Phase 3  -  Hypothesise (several, ranked)
+
+Generate **3–5 ranked, falsifiable hypotheses** before testing any.
+
+Format: "If X is the cause, then changing Y will make the bug disappear / changing Z will make it worse."
+
+If you cannot state the prediction, sharpen or discard the hypothesis.
+
+Show the ranked list to the user when available (domain knowledge re-ranks cheaply). Do not block forever if they are AFK  -  proceed with your ranking.
+
+Do not start with a single pet theory.
+
+## Phase 4  -  Instrument
+
+Each probe maps to a specific prediction. **Change one variable at a time.**
+
+Preference order:
+
+1. Debugger / REPL if available
+2. Targeted logs at boundaries that distinguish hypotheses
+3. Never "log everything and grep"
+
+Tag every temporary log with a unique prefix, e.g. \`[DEBUG-a4f2]\`, so cleanup is one grep.
+
+**Perf branch:** establish a baseline measurement first (timing, profiler, query plan), then bisect. Measure before "fixing."
+
+## Phase 5  -  Fix and regression test
+
+Write the regression test **before** the permanent fix when a **correct seam** exists (see \`$revealui-tdd\`).
+
+A correct seam exercises the **real bug pattern** as it occurs at the call site. A shallow unit that cannot reproduce the chain gives false confidence.
+
+If no correct seam exists, that is a finding: note it for architecture follow-up after the fix.
+
+When a seam exists:
+
+1. Turn the minimised repro into a failing test
+2. Watch it fail
+3. Apply the minimal fix
+4. Watch it pass
+5. Re-run the Phase 1 loop against the original (un-minimised) scenario
+
+## Phase 6  -  Cleanup and post-mortem
+
+Required before done:
+
+- [ ] Phase 1 loop is green on the original scenario
+- [ ] Regression test passes (or missing seam is documented)
+- [ ] All \`[DEBUG-...]\` instrumentation removed (\`grep\` the prefix)
+- [ ] Throwaway harnesses deleted or clearly marked temporary
+- [ ] Correct hypothesis stated in commit / PR message
+
+Then ask: **what would have prevented this?** If the answer is architectural (no good seam, tangled callers), file a follow-up  -  after the fix is in.
 
 ## Anti-Patterns
 
+- Hypothesising before a red-capable loop
 - Changing multiple things at once ("shotgun debugging")
 - Fixing symptoms instead of root causes
-- Adding try/catch blocks to silence errors
-- Increasing timeouts to hide race conditions
-- Reverting to "known good" without understanding what broke
-- Asking "does this fix it?" without a hypothesis
+- Adding try/catch to silence errors
+- Increasing timeouts to hide races
+- Reverting to "known good" without understanding the break
+- Asking "does this fix it?" without a prediction
+- Leaving untagged debug logs or secret values in logs
 
 ## Common RevealUI Debugging Paths
 
@@ -70,5 +148,14 @@ When something breaks, follow this process. Do not skip steps.
 | Type error across packages | \`pnpm typecheck:all\`  -  check \`workspace:*\` versions |
 | Test passes alone, fails in gate | Concurrency pressure  -  see \`$revealui-testing\` |
 | Supabase error in unexpected path | Import boundary violation  -  see \`$revealui-db\` |
-| Biome error after edit | Run \`npx biome check --write <file>\` |`,
+| Biome error after edit | Run \`npx biome check --write <file>\` |
+| Agent tool denied / unexpected auth | Tool governance / permission path in \`@revealui/ai\` |
+| "Docs say X, runtime does Y" | Trust **code** (primary source); fix the doc after |
+
+## Commit
+
+- One commit for the fix when possible
+- Format: \`fix(scope): description of what was broken\`
+- Name the winning hypothesis in the body when non-obvious
+`,
 };

--- a/packages/harnesses/src/content/definitions/skills/revealui-tdd.ts
+++ b/packages/harnesses/src/content/definitions/skills/revealui-tdd.ts
@@ -5,7 +5,7 @@ export const revealuiTddSkill: Skill = {
   tier: 'pro',
   name: 'RevealUI TDD',
   description:
-    'Test-driven development workflow for RevealUI. Use when implementing any feature,\nfixing bugs, adding functionality, or writing new code. Enforces write-test-first,\nred-green-refactor cycle. Works with Vitest and React Testing Library.',
+    'Test-driven development for RevealUI: agree seams first, then red-green vertical slices with Vitest. Use when implementing features, fixing bugs, or writing tests.',
   disableModelInvocation: false,
   skipFrontmatter: false,
   filePatterns: [],
@@ -15,14 +15,38 @@ export const revealuiTddSkill: Skill = {
 
 Follow this cycle for every code change. No exceptions.
 
-## The Cycle
+## What a good test is
 
-1. **Write a failing test**  -  describe the expected behavior
-2. **Run it**  -  confirm it fails for the right reason
-3. **Write minimal implementation**  -  just enough to pass
+Tests verify **behavior through public interfaces**, not implementation details. Code can change entirely; tests should survive. A good test reads like a specification ("user can checkout with a valid cart") and fails only when behavior changes.
+
+Expected values must come from an **independent source of truth** (spec, known-good literal, worked example). Do not recompute the expected value the same way the production code does.
+
+## Seams (agree before writing tests)
+
+A **seam** is the public boundary you test at: the interface where you observe behavior without reaching inside. Tests live at seams, never against private internals.
+
+**Before writing any test**, list the seams under test and confirm them (with the user when available):
+
+- Prefer existing public package exports (\`@revealui/*\` entry points) over new seams.
+- Prefer the highest seam that still catches the bug or feature (integration over pure unit when the bug needs the call chain).
+- Prefer fewer seams. Do not add a seam "just for testability" if the real interface can express the behavior.
+
+Ask: "What is the public interface, and which seams should we test?"
+
+For module shape questions (depth, interface size, locality), keep tests at the agreed seam and escalate design redesigns rather than testing past the interface.
+
+## The red-green cycle (vertical slices)
+
+Work in **vertical slices**, not horizontal bulk:
+
+1. **Write one failing test** at a confirmed seam  -  one behavior, one assertion focus
+2. **Run it**  -  confirm it fails for the **right** reason (not import/setup noise)
+3. **Write minimal implementation**  -  just enough to pass; no speculative features
 4. **Run it**  -  confirm it passes
-5. **Refactor**  -  clean up, then run tests again
-6. **Commit**  -  one commit per cycle
+5. **Tiny cleanup only**  -  rename for clarity, extract only what this slice needs. Broad redesign belongs in review, not in the red-green loop
+6. **Commit**  -  one commit per slice when the change is ready to land
+
+**Tracer bullet:** each slice is a thin complete path that teaches the next slice. Do not write all tests first, then all implementation (horizontal slicing).
 
 ## Commands
 
@@ -46,8 +70,8 @@ pnpm --filter @revealui/<package> test -- --coverage
 ## What to Test
 
 - Public API surface of each module
-- Error paths and edge cases
-- Integration points between packages
+- Error paths and edge cases at the agreed seams
+- Integration points between packages when the seam is inter-package
 
 ## What NOT to Test
 
@@ -61,9 +85,12 @@ For concurrency tuning, flaky test triage, and Pro/OSS test boundaries, see the 
 
 ## Anti-Patterns
 
-- Writing implementation before the test
-- Writing tests that pass immediately (test must fail first)
-- Testing implementation details instead of behavior
-- Skipping the refactor step
-- Large commits with multiple features`,
+- **Implementation before red**  -  writing code before a failing test
+- **Green on arrival**  -  tests that pass immediately (never proved red)
+- **Implementation-coupled**  -  mocking internal collaborators, testing private methods, or asserting via side channels (raw DB) instead of the public interface. Tell: test breaks on refactor with no behavior change
+- **Tautological**  -  expected value recomputed the same way as the code (\`expect(add(a,b)).toBe(a+b)\`). Cannot disagree with the code
+- **Horizontal slicing**  -  all tests first, then all implementation; tests lock imagined shape instead of learned behavior
+- **Testing past the seam**  -  reaching into internals because the module is the wrong shape; fix the seam or file a design follow-up
+- **Large multi-feature commits**  -  many slices in one commit without a green checkpoint
+`,
 };


### PR DESCRIPTION
## Summary

Extends control-layer skills (not greenfield forks of Matt Pocock's pack):

- **`revealui-tdd`**: agree seams before tests; vertical red-green slices; anti-patterns (implementation-coupled, tautological, horizontal slicing)
- **`revealui-debugging`**: build a red-capable feedback loop first; minimise; multi-hypothesis; tagged instrumentation; regression at a correct seam; cleanup/post-mortem
- Refresh `content-snapshots/claude-code.json`, materialize `.revealui/content` skills, patch changeset

Companion private note (glossary + AX checklist): https://github.com/RevealUIStudio/revealui-jv/pull/1206

## Test plan

- [x] `pnpm content:snapshot:write` + `content:snapshot:check`
- [x] content schemas/snapshot vitest
- [x] pre-push phase 1 gate PASS
- [ ] CI green on PR

## Notes

- Proposal-shaped only; no merge disposition requested
- Skills keep existing IDs so adapters and materialization stay stable