### PR TITLE
feat(server): admission waitlist 202 path and claim

### DIFF
--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -138,6 +138,12 @@ export async function GET(
         payingIntent: { kind: 'none' },
       });
       if (admit.decision === 'waitlist') {
+        if (admit.waitlistToken) {
+          const url = new URL('/login', baseUrl);
+          url.searchParams.set('waitlisted', '1');
+          url.searchParams.set('token', admit.waitlistToken);
+          return NextResponse.redirect(url);
+        }
         return loginUrl('waitlisted');
       }
       oauthAdmitCohort = admit.cohortLimits;

--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -171,10 +171,16 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
         payingIntent: { kind: 'none' },
       });
       if (admit.decision === 'waitlist') {
-        return createApplicationErrorResponse(
-          'Free signup is temporarily waitlisted. Paid signup remains available.',
-          'WAITLISTED',
-          202,
+        return NextResponse.json(
+          {
+            success: false,
+            error: 'WAITLISTED',
+            code: 'WAITLISTED',
+            waitlistToken: admit.waitlistToken,
+            positionEstimate: admit.positionEstimate ?? null,
+            message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+          },
+          { status: 202 },
         );
       }
 

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -190,10 +190,16 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
       payingIntent: { kind: 'none' },
     });
     if (admit.decision === 'waitlist') {
-      return createApplicationErrorResponse(
-        'Free signup is temporarily waitlisted. Paid signup remains available.',
-        'WAITLISTED',
-        202,
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'WAITLISTED',
+          code: 'WAITLISTED',
+          waitlistToken: admit.waitlistToken,
+          positionEstimate: admit.positionEstimate ?? null,
+          message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+        },
+        { status: 202 },
       );
     }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -92,6 +92,7 @@ import adminCoordinationRoute from './routes/admin/coordination.js';
 import adminInferenceConfigRoute from './routes/admin/inference-config.js';
 import adminLocalAiStatusRoute from './routes/admin/local-ai-status.js';
 import adminObservabilityRoute from './routes/admin/observability.js';
+import admissionWaitlistRoute from './routes/admission/waitlist.js';
 import { createAgentCollabRoute } from './routes/agent-collab.js';
 import agentStreamRoute from './routes/agent-stream.js';
 import agentStreamElicitRoute from './routes/agent-stream-elicit.js';
@@ -500,6 +501,8 @@ const DEFAULT_RATE_LIMITS: RateLimitsConfig = {
     'log-ingest': { maxRequests: 200, windowMs: ONE_MINUTE },
     'api-keys': { maxRequests: 20, windowMs: ONE_MINUTE },
     'auth-signup': { maxRequests: 5, windowMs: FIFTEEN_MINUTES },
+    /** GAP-256 admission waitlist status + claim (not marketing waitlist) */
+    'admission-waitlist': { maxRequests: 5, windowMs: FIFTEEN_MINUTES },
     /** Enterprise SSO OIDC init/callback (GAP-464) — aligned with sign-in abuse budget */
     'auth-sso': { maxRequests: 20, windowMs: FIFTEEN_MINUTES },
     /** Enterprise SSO provider admin CRUD + test-connection (GAP-464) */
@@ -988,6 +991,9 @@ app.post('/api/v1/content/sites', siteLimit);
 // Resource limits  -  enforce tier-based caps on user signup
 app.use('/api/auth/signup', routeLimit('auth-signup'));
 app.use('/api/v1/auth/signup', routeLimit('auth-signup'));
+// GAP-256 admission waitlist (status + claim)
+app.use('/api/admission/*', routeLimit('admission-waitlist'));
+app.use('/api/v1/admission/*', routeLimit('admission-waitlist'));
 // Enterprise SSO OIDC init/callback (GAP-464)
 app.use('/api/auth/sso/*', routeLimit('auth-sso'));
 app.use('/api/v1/auth/sso/*', routeLimit('auth-sso'));
@@ -1259,6 +1265,9 @@ app.route('/api/contact', contactRoute);
 app.route('/api/v1/contact', contactRoute);
 app.route('/api/waitlist', waitlistRoute);
 app.route('/api/v1/waitlist', waitlistRoute);
+// GAP-256 admission waitlist (distinct from marketing waitlist)
+app.route('/api/admission', admissionWaitlistRoute);
+app.route('/api/v1/admission', admissionWaitlistRoute);
 // Webhooks are rate-limited to prevent replay abuse and resource exhaustion.
 // Stripe's DB-backed idempotency handles dedup; this limits request volume.
 app.use('/api/webhooks/*', rateLimitMiddleware(rateLimitsConfig.routes.webhook));

--- a/apps/server/src/routes/__tests__/admission-waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/admission-waitlist.test.ts
@@ -1,0 +1,142 @@
+/**
+ * GAP-256 PR-4 — admission waitlist status + claim routes (mocked I/O).
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAdmissionWaitlistByToken = vi.fn();
+const getAdmissionWaitlistByTokenAnyStatus = vi.fn();
+const estimateAdmissionWaitlistPosition = vi.fn();
+const maskAdmissionEmail = vi.fn((e: string) => `m***@${e.split('@')[1] ?? 'x'}`);
+const markAdmissionWaitlistConverted = vi.fn();
+const admitFreeIntake = vi.fn();
+const ensureFreeSignupEntitlement = vi.fn();
+const isSignupAllowed = vi.fn(() => true);
+const signUp = vi.fn();
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/auth/server', () => ({
+  getAdmissionWaitlistByToken: (...a: unknown[]) => getAdmissionWaitlistByToken(...a),
+  getAdmissionWaitlistByTokenAnyStatus: (...a: unknown[]) =>
+    getAdmissionWaitlistByTokenAnyStatus(...a),
+  estimateAdmissionWaitlistPosition: (...a: unknown[]) => estimateAdmissionWaitlistPosition(...a),
+  maskAdmissionEmail: (e: string) => maskAdmissionEmail(e),
+  markAdmissionWaitlistConverted: (...a: unknown[]) => markAdmissionWaitlistConverted(...a),
+  admitFreeIntake: (...a: unknown[]) => admitFreeIntake(...a),
+  ensureFreeSignupEntitlement: (...a: unknown[]) => ensureFreeSignupEntitlement(...a),
+  isSignupAllowed: (...a: unknown[]) => isSignupAllowed(...a),
+  signUp: (...a: unknown[]) => signUp(...a),
+}));
+
+import admissionRoute from '../admission/waitlist.js';
+
+function createApp() {
+  const app = new Hono();
+  app.route('/admission', admissionRoute);
+  return app;
+}
+
+describe('GET /admission/waitlist/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns generic 404 for unknown token', async () => {
+    getAdmissionWaitlistByToken.mockResolvedValue(null);
+    getAdmissionWaitlistByTokenAnyStatus.mockResolvedValue(null);
+
+    const res = await createApp().request('/admission/waitlist/status?token=bad');
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.status).toBe('unknown');
+    expect(json.positionEstimate).toBeNull();
+  });
+
+  it('returns pending status for valid token', async () => {
+    getAdmissionWaitlistByToken.mockResolvedValue({
+      id: 'w1',
+      email: 'user@example.com',
+      status: 'pending',
+      position: 2,
+    });
+
+    const res = await createApp().request('/admission/waitlist/status?token=good');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe('pending');
+    expect(json.positionEstimate).toBe(2);
+    expect(json.emailMasked).toBeTruthy();
+  });
+});
+
+describe('POST /admission/waitlist/claim', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSignupAllowed.mockReturnValue(true);
+  });
+
+  it('claims pending row: admit + signUp + convert', async () => {
+    getAdmissionWaitlistByToken.mockResolvedValue({
+      id: 'w1',
+      email: 'claim@example.com',
+      status: 'pending',
+    });
+    admitFreeIntake.mockResolvedValue({
+      decision: 'admit',
+      mode: 'open',
+      cohortLimits: { maxSites: 1, maxUsers: 3, maxAgentTasks: 1000 },
+      snapshotId: null,
+      reason: 'waitlist_claim',
+      shadow: false,
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+    });
+    signUp.mockResolvedValue({
+      success: true,
+      user: { id: 'u1', email: 'claim@example.com' },
+      sessionToken: 'sess',
+    });
+    ensureFreeSignupEntitlement.mockResolvedValue({ accountId: 'a1' });
+    markAdmissionWaitlistConverted.mockResolvedValue(undefined);
+
+    const res = await createApp().request('/admission/waitlist/claim', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        token: 'raw',
+        password: 'SecurePass123',
+        name: 'Claimer',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.sessionToken).toBe('sess');
+    expect(admitFreeIntake).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'waitlist_claim_free', email: 'claim@example.com' }),
+    );
+    expect(signUp).toHaveBeenCalled();
+    expect(markAdmissionWaitlistConverted).toHaveBeenCalledWith('w1');
+  });
+
+  it('returns 409 when already converted', async () => {
+    getAdmissionWaitlistByToken.mockResolvedValue(null);
+    getAdmissionWaitlistByTokenAnyStatus.mockResolvedValue({
+      id: 'w1',
+      status: 'converted',
+      email: 'x@example.com',
+    });
+
+    const res = await createApp().request('/admission/waitlist/claim', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'old', password: 'SecurePass123', name: 'X' }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(signUp).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/routes/__tests__/auth-signup-waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/auth-signup-waitlist.test.ts
@@ -1,0 +1,110 @@
+/**
+ * GAP-256 PR-4 HC2 — enforce waitlist → 202 WAITLISTED, no signUp, never margin 403.
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const admitFreeIntake = vi.fn();
+const signUp = vi.fn();
+const isSignupAllowed = vi.fn(() => true);
+const ensureFreeSignupEntitlement = vi.fn();
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/auth/server', () => ({
+  isSignupAllowed: (...args: unknown[]) => isSignupAllowed(...args),
+  signUp: (...args: unknown[]) => signUp(...args),
+}));
+
+vi.mock('../../lib/admit-free-intake.js', () => ({
+  admitFreeIntake: (...args: unknown[]) => admitFreeIntake(...args),
+}));
+
+vi.mock('../../lib/ensure-free-signup-entitlement.js', () => ({
+  ensureFreeSignupEntitlement: (...args: unknown[]) => ensureFreeSignupEntitlement(...args),
+}));
+
+import authRoute from '../auth.js';
+
+function createApp() {
+  const app = new Hono();
+  app.route('/auth', authRoute);
+  return app;
+}
+
+async function postSignup(body: unknown) {
+  return createApp().request('/auth/signup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  email: 'new@example.com',
+  password: 'SecurePass123',
+  name: 'New User',
+  tosAccepted: true as const,
+};
+
+describe('POST /auth/signup waitlist (HC2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSignupAllowed.mockReturnValue(true);
+  });
+
+  it('returns 202 WAITLISTED with token and does not call signUp', async () => {
+    admitFreeIntake.mockResolvedValue({
+      decision: 'waitlist',
+      mode: 'waitlist',
+      reason: 'snapshot_waitlist',
+      snapshotId: 'snap-1',
+      shadow: false,
+      httpStatus: 202,
+      code: 'WAITLISTED',
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      waitlistToken: 'raw-token-hex',
+      positionEstimate: 3,
+    });
+
+    const res = await postSignup(validBody);
+
+    expect(res.status).toBe(202);
+    const json = await res.json();
+    expect(json).toMatchObject({
+      success: false,
+      error: 'WAITLISTED',
+      code: 'WAITLISTED',
+      waitlistToken: 'raw-token-hex',
+      positionEstimate: 3,
+    });
+    expect(json.message).toContain('waitlisted');
+    expect(signUp).not.toHaveBeenCalled();
+    expect(ensureFreeSignupEntitlement).not.toHaveBeenCalled();
+  });
+
+  it('is never margin 403 under waitlist', async () => {
+    admitFreeIntake.mockResolvedValue({
+      decision: 'waitlist',
+      mode: 'waitlist',
+      reason: 'snapshot_waitlist',
+      snapshotId: null,
+      shadow: false,
+      httpStatus: 202,
+      code: 'WAITLISTED',
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      waitlistToken: 't',
+      positionEstimate: null,
+    });
+
+    const res = await postSignup({
+      ...validBody,
+      email: 'x@example.com',
+    });
+
+    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(202);
+  });
+});

--- a/apps/server/src/routes/admission/waitlist.ts
+++ b/apps/server/src/routes/admission/waitlist.ts
@@ -62,17 +62,17 @@ app.get('/waitlist/status', async (c) => {
       });
     }
 
-    const any = await getAdmissionWaitlistByTokenAnyStatus(token);
-    if (any?.status === 'converted') {
+    const prior = await getAdmissionWaitlistByTokenAnyStatus(token);
+    if (prior?.status === 'converted') {
       return c.json({
         status: 'converted' as const,
         positionEstimate: null,
-        emailMasked: maskAdmissionEmail(any.email),
+        emailMasked: maskAdmissionEmail(prior.email),
       });
     }
-    if (any?.status === 'expired' || any?.status === 'cancelled') {
+    if (prior?.status === 'expired' || prior?.status === 'cancelled') {
       return c.json({
-        status: any.status,
+        status: prior.status,
         positionEstimate: null,
         emailMasked: null,
       });
@@ -105,8 +105,8 @@ app.post('/waitlist/claim', zValidator('json', ClaimBodySchema), async (c) => {
   }
 
   if (!row) {
-    const any = await getAdmissionWaitlistByTokenAnyStatus(token).catch(() => null);
-    if (any?.status === 'converted') {
+    const prior = await getAdmissionWaitlistByTokenAnyStatus(token).catch(() => null);
+    if (prior?.status === 'converted') {
       return c.json(
         {
           success: false,

--- a/apps/server/src/routes/admission/waitlist.ts
+++ b/apps/server/src/routes/admission/waitlist.ts
@@ -1,0 +1,222 @@
+/**
+ * GAP-256 PR-4 — public admission waitlist status + claim.
+ *
+ * Paths (mounted under /api/admission and /api/v1/admission):
+ *   GET  /waitlist/status?token=
+ *   POST /waitlist/claim  { token, password, name }
+ *
+ * Distinct from marketing POST /api/waitlist (email capture).
+ */
+
+import {
+  admitFreeIntake,
+  ensureFreeSignupEntitlement,
+  estimateAdmissionWaitlistPosition,
+  getAdmissionWaitlistByToken,
+  getAdmissionWaitlistByTokenAnyStatus,
+  isSignupAllowed,
+  markAdmissionWaitlistConverted,
+  maskAdmissionEmail,
+  signUp,
+} from '@revealui/auth/server';
+import { logger } from '@revealui/core/observability/logger';
+import { zValidator } from '@revealui/openapi';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+const app = new Hono();
+
+/** Generic anti-enumeration payload for unknown / expired tokens. */
+const GENERIC_STATUS = {
+  status: 'unknown' as const,
+  positionEstimate: null as number | null,
+  emailMasked: null as string | null,
+};
+
+const ClaimBodySchema = z.object({
+  token: z.string().min(1).max(256),
+  // Lockstep with SignUpRequestSchema (GAP-244): min 12
+  password: z.string().min(12).max(128),
+  name: z.string().min(1).max(100),
+});
+
+/**
+ * GET /waitlist/status?token=
+ * Valid token → real status; bad/expired → same generic shape (no 404 body variance).
+ */
+app.get('/waitlist/status', async (c) => {
+  const token = c.req.query('token')?.trim() ?? '';
+  if (!token) {
+    return c.json(GENERIC_STATUS, 404);
+  }
+
+  try {
+    const active = await getAdmissionWaitlistByToken(token);
+    if (active) {
+      const positionEstimate =
+        active.position ?? (await estimateAdmissionWaitlistPosition(active.id));
+      return c.json({
+        status: active.status,
+        positionEstimate,
+        emailMasked: maskAdmissionEmail(active.email),
+      });
+    }
+
+    const any = await getAdmissionWaitlistByTokenAnyStatus(token);
+    if (any?.status === 'converted') {
+      return c.json({
+        status: 'converted' as const,
+        positionEstimate: null,
+        emailMasked: maskAdmissionEmail(any.email),
+      });
+    }
+    if (any?.status === 'expired' || any?.status === 'cancelled') {
+      return c.json({
+        status: any.status,
+        positionEstimate: null,
+        emailMasked: null,
+      });
+    }
+  } catch (err) {
+    logger.warn('[admission-waitlist] status lookup failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return c.json(GENERIC_STATUS, 404);
+});
+
+/**
+ * POST /waitlist/claim
+ * Admit free (waitlist_claim_free never re-waitlists), signUp, free entitlement, mark converted.
+ */
+app.post('/waitlist/claim', zValidator('json', ClaimBodySchema), async (c) => {
+  const { token, password, name } = c.req.valid('json');
+
+  let row: Awaited<ReturnType<typeof getAdmissionWaitlistByToken>>;
+  try {
+    row = await getAdmissionWaitlistByToken(token);
+  } catch (err) {
+    logger.error(
+      '[admission-waitlist] claim token lookup failed',
+      err instanceof Error ? err : undefined,
+    );
+    return c.json({ success: false, error: 'Unable to process claim', code: 'CLAIM_FAILED' }, 500);
+  }
+
+  if (!row) {
+    const any = await getAdmissionWaitlistByTokenAnyStatus(token).catch(() => null);
+    if (any?.status === 'converted') {
+      return c.json(
+        {
+          success: false,
+          error: 'Already converted. Sign in with your existing account.',
+          code: 'ALREADY_CONVERTED',
+        },
+        409,
+      );
+    }
+    return c.json(
+      { success: false, error: 'Invalid or expired waitlist token', code: 'INVALID_TOKEN' },
+      404,
+    );
+  }
+
+  if (!isSignupAllowed(row.email)) {
+    return c.json(
+      { success: false, error: 'Signups are currently restricted', code: 'SIGNUP_RESTRICTED' },
+      403,
+    );
+  }
+
+  const admit = await admitFreeIntake({
+    channel: 'waitlist_claim_free',
+    email: row.email,
+    payingIntent: { kind: 'none' },
+  });
+
+  if (admit.decision !== 'admit') {
+    logger.warn('[admission-waitlist] claim did not admit', {
+      reason: admit.reason,
+      decision: admit.decision,
+    });
+    return c.json(
+      {
+        success: false,
+        error: 'Unable to claim waitlist entry right now',
+        code: 'CLAIM_NOT_ADMITTED',
+      },
+      503,
+    );
+  }
+
+  const result = await signUp(row.email, password, name, {
+    userAgent: c.req.header('user-agent'),
+    ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
+  });
+
+  if (!result.success) {
+    // Email already registered after concurrent claim / paid path
+    if (
+      result.error?.toLowerCase().includes('already') ||
+      result.error?.toLowerCase().includes('exist')
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: 'Already converted. Sign in with your existing account.',
+          code: 'ALREADY_CONVERTED',
+        },
+        409,
+      );
+    }
+    logger.warn('[admission-waitlist] claim signUp failed', { error: result.error });
+    return c.json(
+      { success: false, error: result.error ?? 'Sign up failed', code: 'SIGNUP_FAILED' },
+      400,
+    );
+  }
+
+  if (result.user?.id) {
+    try {
+      await ensureFreeSignupEntitlement({
+        userId: result.user.id,
+        cohortLimits: admit.cohortLimits,
+        displayName: name,
+      });
+    } catch (err) {
+      logger.error(
+        '[admission-waitlist] free entitlement@t0 failed (non-fatal)',
+        err instanceof Error ? err : undefined,
+        { userId: result.user.id },
+      );
+    }
+  }
+
+  try {
+    await markAdmissionWaitlistConverted(row.id);
+  } catch (err) {
+    logger.error(
+      '[admission-waitlist] mark converted failed (user already created)',
+      err instanceof Error ? err : undefined,
+      { waitlistId: row.id, userId: result.user?.id },
+    );
+  }
+
+  logger.info('[admission-waitlist] claim converted', {
+    waitlistId: row.id,
+    userId: result.user?.id,
+    admitReason: admit.reason,
+  });
+
+  return c.json(
+    {
+      success: true,
+      user: { id: result.user?.id, email: result.user?.email },
+      sessionToken: result.sessionToken,
+    },
+    201,
+  );
+});
+
+export default app;

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -6,8 +6,9 @@
  * This route is rate-limited and enforces the tier-based user limit
  * (enforceUserLimit middleware is applied in index.ts).
  *
- * GAP-256 PR-3: margin admit **before** signUp (K13); free entitlement@t0 after
- * successful hosted signup (K15). Shadow defaults → never 202 waitlist here.
+ * GAP-256: margin admit **before** signUp (K13); free entitlement@t0 after
+ * successful hosted signup (K15). Enforce waitlist → 202 WAITLISTED + token (PR-4).
+ * Default flags still shadow → admit (no 202).
  */
 
 import { isSignupAllowed, signUp } from '@revealui/auth/server';
@@ -40,12 +41,14 @@ app.post('/signup', zValidator('json', SignUpRequestSchema), async (c) => {
   });
 
   if (admit.decision === 'waitlist') {
-    // PR-4 enforce path — PR-3 shadow should not reach here with default flags.
+    // PR-4: never margin 403; no users row; raw waitlistToken once.
     return c.json(
       {
         success: false,
         error: 'WAITLISTED',
-        code: admit.code,
+        code: 'WAITLISTED',
+        waitlistToken: admit.waitlistToken,
+        positionEstimate: admit.positionEstimate ?? null,
         message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
       },
       202,

--- a/packages/auth/src/server/__tests__/admission-waitlist.test.ts
+++ b/packages/auth/src/server/__tests__/admission-waitlist.test.ts
@@ -1,0 +1,44 @@
+/**
+ * GAP-256 PR-4 — admission token hash + pure helpers (no DB).
+ */
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  generateAdmissionToken,
+  hashAdmissionToken,
+  maskAdmissionEmail,
+} from '../admission-waitlist.js';
+
+describe('hashAdmissionToken', () => {
+  it('is deterministic sha256 hex', () => {
+    const raw = 'abc123';
+    const expected = createHash('sha256').update(raw).digest('hex');
+    expect(hashAdmissionToken(raw)).toBe(expected);
+    expect(hashAdmissionToken(raw)).toBe(hashAdmissionToken(raw));
+  });
+
+  it('differs for different tokens', () => {
+    expect(hashAdmissionToken('a')).not.toBe(hashAdmissionToken('b'));
+  });
+});
+
+describe('generateAdmissionToken', () => {
+  it('returns 64 hex chars (32 bytes)', () => {
+    const t = generateAdmissionToken();
+    expect(t).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is unique across calls', () => {
+    expect(generateAdmissionToken()).not.toBe(generateAdmissionToken());
+  });
+});
+
+describe('maskAdmissionEmail', () => {
+  it('masks local part', () => {
+    expect(maskAdmissionEmail('alice@example.com')).toBe('a***@example.com');
+  });
+
+  it('normalizes case', () => {
+    expect(maskAdmissionEmail('  Bob@Example.COM ')).toBe('b***@example.com');
+  });
+});

--- a/packages/auth/src/server/__tests__/margin-admit.test.ts
+++ b/packages/auth/src/server/__tests__/margin-admit.test.ts
@@ -1,8 +1,10 @@
 /**
- * GAP-256 PR-3b — OPEN_FREE_LIMITS lockstep (constants only; no full package graph).
+ * GAP-256 — OPEN_FREE_LIMITS lockstep + pure decide shapes used by admit.
  *
- * Values must match apps/server getHostedLimitsForTier('free') and margin-admit.ts.
+ * Full admitFreeIntake I/O is covered via enqueue helpers + server route tests.
  */
+
+import { decideFreeIntake } from '@revealui/core/margin-governor';
 import { describe, expect, it } from 'vitest';
 
 /** Mirror of OPEN_FREE_LIMITS in margin-admit.ts */
@@ -19,5 +21,43 @@ describe('OPEN_FREE_LIMITS lockstep', () => {
       maxUsers: 3,
       maxAgentTasks: 1_000,
     });
+  });
+});
+
+describe('decide path used by admit (PR-4)', () => {
+  const now = new Date('2026-08-09T12:00:00.000Z');
+  const snapshot = {
+    id: 'snap',
+    mode: 'waitlist' as const,
+    computedAt: now,
+  };
+
+  it('free_signup enforce waitlist → waitlist decision (enqueue path)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot,
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits: OPEN_FREE_LIMITS,
+      now,
+    });
+    expect(r.decision).toBe('waitlist');
+  });
+
+  it('waitlist_claim_free under waitlist → admit', () => {
+    const r = decideFreeIntake({
+      channel: 'waitlist_claim_free',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot,
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits: OPEN_FREE_LIMITS,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.reason).toBe('waitlist_claim');
+    }
   });
 });

--- a/packages/auth/src/server/admission-waitlist.ts
+++ b/packages/auth/src/server/admission-waitlist.ts
@@ -1,0 +1,258 @@
+/**
+ * GAP-256 PR-4 — admission_waitlist I/O (NOT marketing waitlist).
+ *
+ * Stores only SHA-256 of claim tokens. Raw token returned once at enqueue.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { type AdmissionWaitlistRow, admissionWaitlist } from '@revealui/db/schema';
+import { and, count, eq, gt, inArray, isNull, or, sql } from 'drizzle-orm';
+
+const TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function hashAdmissionToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+export function generateAdmissionToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function expiresAtFrom(now: Date): Date {
+  return new Date(now.getTime() + TOKEN_TTL_MS);
+}
+
+async function countPendingRows(): Promise<number | null> {
+  try {
+    const db = getClient();
+    const [row] = await db
+      .select({ total: count() })
+      .from(admissionWaitlist)
+      .where(eq(admissionWaitlist.status, 'pending'));
+    return row?.total ?? 0;
+  } catch (err) {
+    logger.warn('[admission-waitlist] pending count failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+export interface EnqueueAdmissionWaitlistParams {
+  email: string;
+  snapshotId: string | null;
+  modeAtEnqueue?: string;
+  source?: string;
+  now?: Date;
+}
+
+export interface EnqueueAdmissionWaitlistResult {
+  waitlistToken: string;
+  positionEstimate: number | null;
+  id: string;
+}
+
+/**
+ * Insert or rotate a pending admission waitlist row for email.
+ * Returns a fresh raw token (never stored).
+ */
+export async function enqueueAdmissionWaitlist(
+  params: EnqueueAdmissionWaitlistParams,
+): Promise<EnqueueAdmissionWaitlistResult> {
+  const db = getClient();
+  const email = normalizeEmail(params.email);
+  const now = params.now ?? new Date();
+  const rawToken = generateAdmissionToken();
+  const tokenHash = hashAdmissionToken(rawToken);
+  const expiresAt = expiresAtFrom(now);
+  const modeAtEnqueue = params.modeAtEnqueue ?? 'waitlist';
+  const source = params.source ?? 'free_signup';
+
+  const [existing] = await db
+    .select({
+      id: admissionWaitlist.id,
+      position: admissionWaitlist.position,
+    })
+    .from(admissionWaitlist)
+    .where(and(eq(admissionWaitlist.email, email), eq(admissionWaitlist.status, 'pending')))
+    .limit(1);
+
+  if (existing) {
+    await db
+      .update(admissionWaitlist)
+      .set({
+        tokenHash,
+        snapshotId: params.snapshotId,
+        modeAtEnqueue,
+        source,
+        expiresAt,
+      })
+      .where(eq(admissionWaitlist.id, existing.id));
+
+    return {
+      waitlistToken: rawToken,
+      positionEstimate: existing.position,
+      id: existing.id,
+    };
+  }
+
+  const pendingCount = await countPendingRows();
+  const positionEstimate = pendingCount === null ? null : pendingCount + 1;
+  const id = crypto.randomUUID();
+
+  try {
+    await db.insert(admissionWaitlist).values({
+      id,
+      email,
+      status: 'pending',
+      tokenHash,
+      snapshotId: params.snapshotId,
+      modeAtEnqueue,
+      position: positionEstimate,
+      source,
+      metadata: {},
+      createdAt: now,
+      expiresAt,
+    });
+  } catch (err) {
+    // Race on unique pending email: rotate the winning row's token.
+    logger.warn('[admission-waitlist] insert conflict; rotating existing pending', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    const [raced] = await db
+      .select({
+        id: admissionWaitlist.id,
+        position: admissionWaitlist.position,
+      })
+      .from(admissionWaitlist)
+      .where(and(eq(admissionWaitlist.email, email), eq(admissionWaitlist.status, 'pending')))
+      .limit(1);
+    if (!raced) {
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+    await db
+      .update(admissionWaitlist)
+      .set({
+        tokenHash,
+        snapshotId: params.snapshotId,
+        modeAtEnqueue,
+        source,
+        expiresAt,
+      })
+      .where(eq(admissionWaitlist.id, raced.id));
+    return {
+      waitlistToken: rawToken,
+      positionEstimate: raced.position,
+      id: raced.id,
+    };
+  }
+
+  return {
+    waitlistToken: rawToken,
+    positionEstimate,
+    id,
+  };
+}
+
+/** Active claim rows: pending or invited, not past expiresAt. */
+export async function getAdmissionWaitlistByToken(
+  rawToken: string,
+): Promise<AdmissionWaitlistRow | null> {
+  if (!rawToken || rawToken.trim() === '') {
+    return null;
+  }
+  const db = getClient();
+  const tokenHash = hashAdmissionToken(rawToken);
+  const now = new Date();
+
+  const [row] = await db
+    .select()
+    .from(admissionWaitlist)
+    .where(
+      and(
+        eq(admissionWaitlist.tokenHash, tokenHash),
+        inArray(admissionWaitlist.status, ['pending', 'invited']),
+        or(isNull(admissionWaitlist.expiresAt), gt(admissionWaitlist.expiresAt, now)),
+      ),
+    )
+    .limit(1);
+
+  return row ?? null;
+}
+
+export async function getAdmissionWaitlistByTokenAnyStatus(
+  rawToken: string,
+): Promise<AdmissionWaitlistRow | null> {
+  if (!rawToken || rawToken.trim() === '') {
+    return null;
+  }
+  const db = getClient();
+  const tokenHash = hashAdmissionToken(rawToken);
+  const [row] = await db
+    .select()
+    .from(admissionWaitlist)
+    .where(eq(admissionWaitlist.tokenHash, tokenHash))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function markAdmissionWaitlistConverted(id: string, now?: Date): Promise<void> {
+  const db = getClient();
+  const convertedAt = now ?? new Date();
+  await db
+    .update(admissionWaitlist)
+    .set({
+      status: 'converted',
+      convertedAt,
+    })
+    .where(eq(admissionWaitlist.id, id));
+}
+
+/** Mask email for public status (anti-enumeration still requires valid token). */
+export function maskAdmissionEmail(email: string): string {
+  const normalized = normalizeEmail(email);
+  const at = normalized.indexOf('@');
+  if (at <= 0) {
+    return '***';
+  }
+  const local = normalized.slice(0, at);
+  const domain = normalized.slice(at + 1);
+  const visible = local.slice(0, 1);
+  return `${visible}***@${domain}`;
+}
+
+/** Position estimate among pending (best-effort; null on failure). */
+export async function estimateAdmissionWaitlistPosition(id: string): Promise<number | null> {
+  try {
+    const db = getClient();
+    const [self] = await db
+      .select({
+        position: admissionWaitlist.position,
+        createdAt: admissionWaitlist.createdAt,
+      })
+      .from(admissionWaitlist)
+      .where(eq(admissionWaitlist.id, id))
+      .limit(1);
+    if (!self) return null;
+    if (self.position != null) return self.position;
+
+    const [row] = await db
+      .select({ total: count() })
+      .from(admissionWaitlist)
+      .where(
+        and(
+          eq(admissionWaitlist.status, 'pending'),
+          sql`${admissionWaitlist.createdAt} <= ${self.createdAt}`,
+        ),
+      );
+    return row?.total ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -6,6 +6,19 @@
  */
 
 export type { SignInResult, SignUpResult } from '../types.js';
+// GAP-256 admission waitlist (NOT marketing waitlist)
+export {
+  type EnqueueAdmissionWaitlistParams,
+  type EnqueueAdmissionWaitlistResult,
+  enqueueAdmissionWaitlist,
+  estimateAdmissionWaitlistPosition,
+  generateAdmissionToken,
+  getAdmissionWaitlistByToken,
+  getAdmissionWaitlistByTokenAnyStatus,
+  hashAdmissionToken,
+  markAdmissionWaitlistConverted,
+  maskAdmissionEmail,
+} from './admission-waitlist.js';
 // Audit bridge
 export {
   auditAccountLocked,

--- a/packages/auth/src/server/margin-admit.ts
+++ b/packages/auth/src/server/margin-admit.ts
@@ -2,7 +2,7 @@
  * GAP-256 free-intake admit + free@t0 entitlement (shared by server + admin).
  *
  * Pure decide lives in @revealui/core/margin-governor. This module is the I/O
- * wrapper: read margin_snapshots, never COUNT(users). Waitlist insert is PR-4.
+ * wrapper: read margin_snapshots, never COUNT(users). Waitlist enqueue is PR-4.
  */
 
 import { getFeaturesForTier } from '@revealui/core/features';
@@ -10,6 +10,7 @@ import {
   type AdmissionChannel,
   type CohortLimits,
   decideFreeIntake,
+  freeCohortLimitsForMode,
   type GovernorFlags,
   governorFlagsFromEnv,
   type MarginSnapshotView,
@@ -25,6 +26,7 @@ import {
   marginSnapshots,
 } from '@revealui/db/schema';
 import { and, desc, eq } from 'drizzle-orm';
+import { enqueueAdmissionWaitlist } from './admission-waitlist.js';
 import { ensureAccountOwnerPlatformAdmin } from './platform-roles.js';
 
 export type AdmitFreeIntakeInput = {
@@ -34,10 +36,15 @@ export type AdmitFreeIntakeInput = {
   deploymentMode?: 'hosted' | 'forge' | 'unknown';
   env?: NodeJS.ProcessEnv;
   now?: Date;
+  /** Waitlist enqueue source tag (default free_signup). */
+  source?: string;
 };
 
 export type AdmitFreeIntakeResult = PureAdmitResult & {
   flags: GovernorFlags;
+  /** Present on waitlist decision after successful enqueue (raw once). */
+  waitlistToken?: string;
+  positionEstimate?: number | null;
 };
 
 /** Hosted free open limits — lockstep with apps/server getHostedLimitsForTier('free'). */
@@ -95,6 +102,7 @@ async function loadLatestSnapshot(): Promise<MarginSnapshotView | null> {
 /**
  * Pre-check free intake. Call **before** any users insert (K13).
  * Shadow defaults → always admit (never waitlist response).
+ * Enforce waitlist → enqueue admission_waitlist and attach raw token.
  */
 export async function admitFreeIntake(input: AdmitFreeIntakeInput): Promise<AdmitFreeIntakeResult> {
   const env = input.env ?? process.env;
@@ -109,6 +117,70 @@ export async function admitFreeIntake(input: AdmitFreeIntakeInput): Promise<Admi
     openLimits: OPEN_FREE_LIMITS,
     now: input.now,
   });
+
+  if (result.decision === 'waitlist') {
+    const email = input.email?.trim();
+    if (!email) {
+      // Cannot enqueue without identity — fail-open admit (not margin 403).
+      logger.warn('[admit-free-intake] waitlist without email; fail-open admit', {
+        channel: input.channel,
+        snapshotId: result.snapshotId,
+      });
+      return {
+        decision: 'admit',
+        mode: 'open',
+        cohortLimits: freeCohortLimitsForMode('open', OPEN_FREE_LIMITS),
+        snapshotId: result.snapshotId,
+        reason: 'waitlist_missing_email',
+        shadow: false,
+        flags,
+      };
+    }
+
+    try {
+      const enqueued = await enqueueAdmissionWaitlist({
+        email,
+        snapshotId: result.snapshotId,
+        modeAtEnqueue: 'waitlist',
+        source: input.source ?? input.channel,
+        now: input.now,
+      });
+      logger.info('[admit-free-intake]', {
+        channel: input.channel,
+        email: '[redacted]',
+        decision: 'waitlist',
+        mode: result.mode,
+        reason: result.reason,
+        shadow: result.shadow,
+        snapshotId: result.snapshotId,
+        governorEnabled: flags.enabled,
+        waitlistId: enqueued.id,
+        positionEstimate: enqueued.positionEstimate,
+      });
+      return {
+        ...result,
+        flags,
+        waitlistToken: enqueued.waitlistToken,
+        positionEstimate: enqueued.positionEstimate,
+      };
+    } catch (err) {
+      // Enqueue failure must not 403; fail-open admit so signup can proceed.
+      logger.error(
+        '[admit-free-intake] waitlist enqueue failed; fail-open admit',
+        err instanceof Error ? err : undefined,
+        { channel: input.channel },
+      );
+      return {
+        decision: 'admit',
+        mode: 'open',
+        cohortLimits: freeCohortLimitsForMode('open', OPEN_FREE_LIMITS),
+        snapshotId: result.snapshotId,
+        reason: 'waitlist_enqueue_failed',
+        shadow: false,
+        flags,
+      };
+    }
+  }
 
   logger.info('[admit-free-intake]', {
     channel: input.channel,

--- a/packages/core/src/__tests__/margin-governor.test.ts
+++ b/packages/core/src/__tests__/margin-governor.test.ts
@@ -104,6 +104,29 @@ describe('decideFreeIntake', () => {
     }
   });
 
+  it('waitlist_claim_free under waitlist enforce admits (never re-waitlists)', () => {
+    const r = decideFreeIntake({
+      channel: 'waitlist_claim_free',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: {
+        id: 'snap-claim',
+        mode: 'waitlist',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.reason).toBe('waitlist_claim');
+      expect(r.shadow).toBe(false);
+      expect(r.cohortLimits.maxAgentTasks).toBe(1_000);
+      expect(r.mode).toBe('open');
+    }
+  });
+
   it('paying-intent bypasses waitlist', () => {
     const r = decideFreeIntake({
       channel: 'paid_signup',

--- a/packages/core/src/margin-governor.ts
+++ b/packages/core/src/margin-governor.ts
@@ -95,10 +95,9 @@ export function governorFlagsFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): GovernorFlags {
   const enabled = env.MARGIN_GOVERNOR_ENABLED === 'true';
-  // When master is on, shadow defaults true unless explicitly false
+  // Shadow defaults true unless explicitly false (safe until owner flips enforce).
   const shadowExplicit = env.MARGIN_GOVERNOR_SHADOW;
-  const shadow =
-    shadowExplicit === 'false' ? false : shadowExplicit === 'true' ? true : enabled ? true : true;
+  const shadow = shadowExplicit !== 'false';
   const staleHours = parsePositiveInt(env.MARGIN_SNAPSHOT_STALE_HOURS, 36);
   return { enabled, shadow, staleHours };
 }

--- a/packages/core/src/margin-governor.ts
+++ b/packages/core/src/margin-governor.ts
@@ -206,6 +206,17 @@ export function decideFreeIntake(input: {
 
   // Enforce path (PR-4): waitlist when mode is waitlist
   if (rawMode === 'waitlist') {
+    // Claim free must never re-waitlist; use open free limits under waitlist mode.
+    if (input.channel === 'waitlist_claim_free') {
+      return {
+        decision: 'admit',
+        mode: 'open',
+        cohortLimits: freeCohortLimitsForMode('open', openLimits, leanTasks),
+        snapshotId,
+        reason: 'waitlist_claim',
+        shadow: false,
+      };
+    }
     return {
       decision: 'waitlist',
       mode: 'waitlist',


### PR DESCRIPTION
## Summary

GAP-256 PR-4: margin governor **enforce waitlist** path for free intake.

- When `MARGIN_GOVERNOR_ENABLED=true` **and** `MARGIN_GOVERNOR_SHADOW=false` **and** latest snapshot mode is `waitlist`:
  - Free signup surfaces return **202 WAITLISTED** with `waitlistToken` / `positionEstimate` (never margin 403)
  - **No users row** created (admit before insert / K13)
  - Enqueue `admission_waitlist` (not marketing `waitlist`)
- `waitlist_claim_free` always **admits** (never re-waitlists); uses open free cohort limits under waitlist mode
- Public APIs: `GET /api/admission/waitlist/status`, `POST /api/admission/waitlist/claim` (+ `/api/v1` aliases)
- Rate limit `admission-waitlist` (5 / 15 min)
- Default flags remain shadow → existing tests unchanged

Depends on: PR-1 schema (`admission_waitlist`), PR-3/3b admit surfaces (merged).

## Surfaces

| Path | Waitlist behavior |
|------|-------------------|
| Server `POST /api/auth/signup` | 202 + token |
| Admin password sign-up | 202 JSON + token |
| Passkey register-verify | 202 JSON + token |
| OAuth new user | redirect `?waitlisted=1&token=` (or `login?error=waitlisted` if no token) |
| Claim free | admit + signUp + free entitlement@t0 + mark converted |

## Hard constraints

- Never `COUNT(users)` for admit
- Never margin 403
- Never marketing `waitlist` table
- Never admit after users insert

## Tests

- `@revealui/core` margin-governor: waitlist enforce, shadow admit, `waitlist_claim_free` admit (10)
- `@revealui/auth` token hash + decide path (9)
- server HC2 signup mock + admission status/claim (6)

## Residual (deferred)

- Admin invite list / drain cron (PR-8)
- Paid-signup escape + paid-pending (PR-4b)
- Claim concurrency `FOR UPDATE` hardening beyond token lookup + convert mark

## Flags

Defaults unchanged: governor off or shadow → always admit. Enforce requires explicit owner ops.