### PR TITLE
feat(server): paid_signup escape + paid-pending entitlement (GAP-256 PR-4b)

### DIFF
--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -138,6 +138,12 @@ export async function GET(
         payingIntent: { kind: 'none' },
       });
       if (admit.decision === 'waitlist') {
+        if (admit.waitlistToken) {
+          const url = new URL('/login', baseUrl);
+          url.searchParams.set('waitlisted', '1');
+          url.searchParams.set('token', admit.waitlistToken);
+          return NextResponse.redirect(url);
+        }
         return loginUrl('waitlisted');
       }
       oauthAdmitCohort = admit.cohortLimits;

--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -171,10 +171,16 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
         payingIntent: { kind: 'none' },
       });
       if (admit.decision === 'waitlist') {
-        return createApplicationErrorResponse(
-          'Free signup is temporarily waitlisted. Paid signup remains available.',
-          'WAITLISTED',
-          202,
+        return NextResponse.json(
+          {
+            success: false,
+            error: 'WAITLISTED',
+            code: 'WAITLISTED',
+            waitlistToken: admit.waitlistToken,
+            positionEstimate: admit.positionEstimate ?? null,
+            message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+          },
+          { status: 202 },
         );
       }
 

--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -179,6 +179,7 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
             waitlistToken: admit.waitlistToken,
             positionEstimate: admit.positionEstimate ?? null,
             message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+            paidSignupPath: '/api/admission/paid-signup',
           },
           { status: 202 },
         );

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -190,10 +190,16 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
       payingIntent: { kind: 'none' },
     });
     if (admit.decision === 'waitlist') {
-      return createApplicationErrorResponse(
-        'Free signup is temporarily waitlisted. Paid signup remains available.',
-        'WAITLISTED',
-        202,
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'WAITLISTED',
+          code: 'WAITLISTED',
+          waitlistToken: admit.waitlistToken,
+          positionEstimate: admit.positionEstimate ?? null,
+          message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+        },
+        { status: 202 },
       );
     }
 

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -198,6 +198,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
           waitlistToken: admit.waitlistToken,
           positionEstimate: admit.positionEstimate ?? null,
           message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+          paidSignupPath: '/api/admission/paid-signup',
         },
         { status: 202 },
       );

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -92,6 +92,7 @@ import adminCoordinationRoute from './routes/admin/coordination.js';
 import adminInferenceConfigRoute from './routes/admin/inference-config.js';
 import adminLocalAiStatusRoute from './routes/admin/local-ai-status.js';
 import adminObservabilityRoute from './routes/admin/observability.js';
+import admissionWaitlistRoute from './routes/admission/waitlist.js';
 import { createAgentCollabRoute } from './routes/agent-collab.js';
 import agentStreamRoute from './routes/agent-stream.js';
 import agentStreamElicitRoute from './routes/agent-stream-elicit.js';
@@ -500,6 +501,8 @@ const DEFAULT_RATE_LIMITS: RateLimitsConfig = {
     'log-ingest': { maxRequests: 200, windowMs: ONE_MINUTE },
     'api-keys': { maxRequests: 20, windowMs: ONE_MINUTE },
     'auth-signup': { maxRequests: 5, windowMs: FIFTEEN_MINUTES },
+    /** GAP-256 admission waitlist status + claim (not marketing waitlist) */
+    'admission-waitlist': { maxRequests: 5, windowMs: FIFTEEN_MINUTES },
     /** Enterprise SSO OIDC init/callback (GAP-464) — aligned with sign-in abuse budget */
     'auth-sso': { maxRequests: 20, windowMs: FIFTEEN_MINUTES },
     /** Enterprise SSO provider admin CRUD + test-connection (GAP-464) */
@@ -988,6 +991,9 @@ app.post('/api/v1/content/sites', siteLimit);
 // Resource limits  -  enforce tier-based caps on user signup
 app.use('/api/auth/signup', routeLimit('auth-signup'));
 app.use('/api/v1/auth/signup', routeLimit('auth-signup'));
+// GAP-256 admission waitlist (status + claim)
+app.use('/api/admission/*', routeLimit('admission-waitlist'));
+app.use('/api/v1/admission/*', routeLimit('admission-waitlist'));
 // Enterprise SSO OIDC init/callback (GAP-464)
 app.use('/api/auth/sso/*', routeLimit('auth-sso'));
 app.use('/api/v1/auth/sso/*', routeLimit('auth-sso'));
@@ -1259,6 +1265,9 @@ app.route('/api/contact', contactRoute);
 app.route('/api/v1/contact', contactRoute);
 app.route('/api/waitlist', waitlistRoute);
 app.route('/api/v1/waitlist', waitlistRoute);
+// GAP-256 admission waitlist (distinct from marketing waitlist)
+app.route('/api/admission', admissionWaitlistRoute);
+app.route('/api/v1/admission', admissionWaitlistRoute);
 // Webhooks are rate-limited to prevent replay abuse and resource exhaustion.
 // Stripe's DB-backed idempotency handles dedup; this limits request volume.
 app.use('/api/webhooks/*', rateLimitMiddleware(rateLimitsConfig.routes.webhook));

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -92,6 +92,7 @@ import adminCoordinationRoute from './routes/admin/coordination.js';
 import adminInferenceConfigRoute from './routes/admin/inference-config.js';
 import adminLocalAiStatusRoute from './routes/admin/local-ai-status.js';
 import adminObservabilityRoute from './routes/admin/observability.js';
+import admissionPaidSignupRoute from './routes/admission/paid-signup.js';
 import admissionWaitlistRoute from './routes/admission/waitlist.js';
 import { createAgentCollabRoute } from './routes/agent-collab.js';
 import agentStreamRoute from './routes/agent-stream.js';
@@ -1265,9 +1266,11 @@ app.route('/api/contact', contactRoute);
 app.route('/api/v1/contact', contactRoute);
 app.route('/api/waitlist', waitlistRoute);
 app.route('/api/v1/waitlist', waitlistRoute);
-// GAP-256 admission waitlist (distinct from marketing waitlist)
+// GAP-256 admission waitlist + paid_signup (distinct from marketing waitlist)
 app.route('/api/admission', admissionWaitlistRoute);
 app.route('/api/v1/admission', admissionWaitlistRoute);
+app.route('/api/admission', admissionPaidSignupRoute);
+app.route('/api/v1/admission', admissionPaidSignupRoute);
 // Webhooks are rate-limited to prevent replay abuse and resource exhaustion.
 // Stripe's DB-backed idempotency handles dedup; this limits request volume.
 app.use('/api/webhooks/*', rateLimitMiddleware(rateLimitsConfig.routes.webhook));

--- a/apps/server/src/lib/__tests__/ensure-paid-pending-entitlement.test.ts
+++ b/apps/server/src/lib/__tests__/ensure-paid-pending-entitlement.test.ts
@@ -1,0 +1,46 @@
+/**
+ * GAP-256 PR-4b / HC15 — paid-pending feature map zeros AI (no free cohort AI).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: () => ({
+    aiLocal: true,
+    ai: true,
+    aiMemory: true,
+    aiInference: true,
+    audit: true,
+  }),
+}));
+
+vi.mock('@revealui/core/margin-governor', () => ({
+  paidPendingLimits: () => ({ maxSites: 1, maxUsers: 1, maxAgentTasks: 0 }),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/db', () => ({
+  getClient: () => {
+    throw new Error('db not used in pure feature-map tests');
+  },
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  accountEntitlements: {},
+  accountMemberships: {},
+}));
+
+import { buildPaidPendingFeatureMap } from '../ensure-paid-pending-entitlement.js';
+
+describe('buildPaidPendingFeatureMap (HC15)', () => {
+  it('forces AI-bearing features off while leaving other free features', () => {
+    const features = buildPaidPendingFeatureMap();
+    expect(features.aiLocal).toBe(false);
+    expect(features.ai).toBe(false);
+    expect(features.aiMemory).toBe(false);
+    expect(features.aiInference).toBe(false);
+    expect(features.audit).toBe(true);
+  });
+});

--- a/apps/server/src/lib/__tests__/ensure-paid-pending-entitlement.test.ts
+++ b/apps/server/src/lib/__tests__/ensure-paid-pending-entitlement.test.ts
@@ -1,5 +1,7 @@
 /**
- * GAP-256 PR-4b / HC15 — paid-pending feature map zeros AI (no free cohort AI).
+ * GAP-256 PR-4b HC15 — paid-pending limits and AI-off feature map (unit).
+ * Webhook paid_rebuild after successful checkout is the existing Stripe path
+ * (routes/webhooks); not reimplemented here.
  */
 import { describe, expect, it, vi } from 'vitest';
 
@@ -9,7 +11,7 @@ vi.mock('@revealui/core/features', () => ({
     ai: true,
     aiMemory: true,
     aiInference: true,
-    audit: true,
+    mcp: false,
   }),
 }));
 
@@ -32,15 +34,32 @@ vi.mock('@revealui/db/schema', () => ({
   accountMemberships: {},
 }));
 
+import { paidPendingLimits } from '@revealui/core/margin-governor';
 import { buildPaidPendingFeatureMap } from '../ensure-paid-pending-entitlement.js';
 
-describe('buildPaidPendingFeatureMap (HC15)', () => {
-  it('forces AI-bearing features off while leaving other free features', () => {
+describe('paid-pending entitlement shape (HC15)', () => {
+  it('paidPendingLimits zeros agent tasks (K20)', () => {
+    expect(paidPendingLimits()).toEqual({
+      maxSites: 1,
+      maxUsers: 1,
+      maxAgentTasks: 0,
+    });
+  });
+
+  it('buildPaidPendingFeatureMap forces AI-bearing features off', () => {
     const features = buildPaidPendingFeatureMap();
     expect(features.aiLocal).toBe(false);
     expect(features.ai).toBe(false);
     expect(features.aiMemory).toBe(false);
     expect(features.aiInference).toBe(false);
-    expect(features.audit).toBe(true);
+    expect(features.mcp).toBe(false);
+  });
+
+  it('task-quota denies when maxAgentTasks is 0 (quota exhausted at zero usage)', () => {
+    // Mirrors requireTaskQuota: current >= quota with quota 0 → deny
+    const quota = paidPendingLimits().maxAgentTasks;
+    const current = 0;
+    expect(quota).toBe(0);
+    expect(current >= quota).toBe(true);
   });
 });

--- a/apps/server/src/lib/__tests__/merge-hosted-entitlement.test.ts
+++ b/apps/server/src/lib/__tests__/merge-hosted-entitlement.test.ts
@@ -93,4 +93,24 @@ describe('mergeHostedEntitlementUpdate', () => {
     });
     expect(next.source).toBe('signup');
   });
+
+  it('paid_pending_create forces signup source and zero-task limits (K20)', () => {
+    const next = buildHostedEntitlementValues({
+      tier: 'free',
+      status: 'active',
+      mode: 'live',
+      lastEventAt: null,
+      now,
+      source: 'reconciler',
+      limits: { maxSites: 1, maxUsers: 1, maxAgentTasks: 0 },
+    });
+    const merged = mergeHostedEntitlementUpdate({
+      existing: null,
+      next,
+      reason: 'paid_pending_create',
+    });
+    expect(merged.source).toBe('signup');
+    expect(merged.limits.maxAgentTasks).toBe(0);
+    expect(merged.cogsBreakerTrippedAt).toBeNull();
+  });
 });

--- a/apps/server/src/lib/ensure-paid-pending-entitlement.ts
+++ b/apps/server/src/lib/ensure-paid-pending-entitlement.ts
@@ -1,0 +1,182 @@
+/**
+ * GAP-256 PR-4b / K20 — paid-pending entitlement after paid_signup.
+ *
+ * Identity may exist for Stripe Checkout, but free AI must not open on abandon:
+ * maxAgentTasks=0 and AI-bearing features forced off. Webhook paid_rebuild
+ * replaces this row after successful payment (existing path).
+ */
+
+import { getFeaturesForTier } from '@revealui/core/features';
+import { paidPendingLimits } from '@revealui/core/margin-governor';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
+import {
+  buildHostedEntitlementValues,
+  mergeHostedEntitlementUpdate,
+  toFeatureRecord,
+} from './hosted-entitlement.js';
+
+/** Feature keys that must stay off while checkout is unpaid (K20). */
+const AI_BEARING_FEATURE_KEYS = ['aiLocal', 'ai', 'aiMemory', 'aiInference'] as const;
+
+/**
+ * Free-tier feature map with every AI-bearing flag forced false.
+ * Used only for paid-pending rows (not free cohort signup).
+ */
+export function buildPaidPendingFeatureMap(): Record<string, boolean> {
+  const features = toFeatureRecord(getFeaturesForTier('free'));
+  for (const key of AI_BEARING_FEATURE_KEYS) {
+    features[key] = false;
+  }
+  return features;
+}
+
+export interface EnsurePaidPendingEntitlementParams {
+  userId: string;
+  displayName?: string;
+  /** Intended paid tier after checkout (logged only; no metadata column). */
+  pendingTier: 'pro' | 'max' | 'enterprise';
+  now?: Date;
+}
+
+/**
+ * Upsert free/signup entitlement with paidPendingLimits (maxAgentTasks=0).
+ * Does not call freeCohortLimitsForMode or ensureFreeSignupEntitlement.
+ */
+export async function ensurePaidPendingEntitlement(
+  params: EnsurePaidPendingEntitlementParams,
+): Promise<{ accountId: string } | { skipped: true; reason: string }> {
+  const { provisionHostedPersonalAccount } = await import('@revealui/auth/server');
+  const provisioned = await provisionHostedPersonalAccount({
+    userId: params.userId,
+    displayName: params.displayName ?? 'RevealUI',
+  });
+  if ('skipped' in provisioned && provisioned.skipped) {
+    if (provisioned.reason === 'not_hosted') {
+      return provisioned;
+    }
+  }
+
+  const db = getClient();
+  const now = params.now ?? new Date();
+
+  const [membership] = await db
+    .select({ accountId: accountMemberships.accountId })
+    .from(accountMemberships)
+    .where(
+      and(
+        eq(accountMemberships.userId, params.userId),
+        eq(accountMemberships.role, 'owner'),
+        eq(accountMemberships.status, 'active'),
+      ),
+    )
+    .limit(1);
+
+  if (!membership) {
+    logger.warn('[paid-pending-entitlement] no owner membership; skip', {
+      userId: params.userId,
+    });
+    return { skipped: true, reason: 'no_owner_membership' };
+  }
+
+  const accountId = membership.accountId;
+  const [existing] = await db
+    .select({
+      source: accountEntitlements.source,
+      limits: accountEntitlements.limits,
+      cogsBreakerTrippedAt: accountEntitlements.cogsBreakerTrippedAt,
+      cogsBreakerReason: accountEntitlements.cogsBreakerReason,
+      tier: accountEntitlements.tier,
+    })
+    .from(accountEntitlements)
+    .where(eq(accountEntitlements.accountId, accountId))
+    .limit(1);
+
+  if (existing?.source === 'stripe' || existing?.source === 'grant') {
+    logger.info('[paid-pending-entitlement] skip overwrite of paid/gifted row', {
+      accountId,
+      source: existing.source,
+    });
+    return { accountId };
+  }
+
+  const limits = paidPendingLimits();
+  const next = buildHostedEntitlementValues({
+    tier: 'free',
+    status: 'active',
+    mode: 'live',
+    lastEventAt: null,
+    now,
+    source: 'signup',
+    limits: {
+      maxSites: limits.maxSites,
+      maxUsers: limits.maxUsers,
+      maxAgentTasks: limits.maxAgentTasks,
+    },
+    features: buildPaidPendingFeatureMap(),
+  });
+
+  const merged = mergeHostedEntitlementUpdate({
+    existing: existing
+      ? {
+          limits: existing.limits,
+          source: existing.source,
+          cogsBreakerTrippedAt: existing.cogsBreakerTrippedAt,
+          cogsBreakerReason: existing.cogsBreakerReason,
+          tier: existing.tier,
+        }
+      : null,
+    next,
+    reason: 'paid_pending_create',
+  });
+
+  if (existing) {
+    await db
+      .update(accountEntitlements)
+      .set({
+        planId: merged.planId,
+        tier: merged.tier,
+        status: merged.status,
+        features: merged.features,
+        limits: merged.limits,
+        meteringStatus: merged.meteringStatus,
+        mode: merged.mode,
+        source: merged.source,
+        graceUntil: merged.graceUntil,
+        lastEventAt: merged.lastEventAt,
+        updatedAt: merged.updatedAt,
+        cogsBreakerTrippedAt: merged.cogsBreakerTrippedAt,
+        cogsBreakerReason: merged.cogsBreakerReason,
+      })
+      .where(eq(accountEntitlements.accountId, accountId));
+  } else {
+    await db.insert(accountEntitlements).values({
+      accountId,
+      planId: merged.planId,
+      tier: merged.tier,
+      status: merged.status,
+      features: merged.features,
+      limits: merged.limits,
+      meteringStatus: merged.meteringStatus,
+      mode: merged.mode,
+      source: merged.source,
+      graceUntil: merged.graceUntil,
+      lastEventAt: merged.lastEventAt,
+      updatedAt: merged.updatedAt,
+      cogsBreakerTrippedAt: merged.cogsBreakerTrippedAt,
+      cogsBreakerReason: merged.cogsBreakerReason,
+    });
+  }
+
+  // No metadata jsonb on account_entitlements; pending tier is log-only.
+  logger.info('[paid-pending-entitlement] upserted', {
+    accountId,
+    userId: params.userId,
+    pendingTier: params.pendingTier,
+    maxAgentTasks: merged.limits.maxAgentTasks,
+  });
+
+  return { accountId };
+}

--- a/apps/server/src/routes/__tests__/admission-paid-signup.test.ts
+++ b/apps/server/src/routes/__tests__/admission-paid-signup.test.ts
@@ -1,0 +1,168 @@
+/**
+ * GAP-256 PR-4b — paid_signup escape (HC4 bypass waitlist, HC15 paid-pending).
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const admitFreeIntake = vi.fn();
+const isSignupAllowed = vi.fn(() => true);
+const signUp = vi.fn();
+const ensurePaidPendingEntitlement = vi.fn();
+const assertLiveCatalogComplete = vi.fn();
+const resolveCatalogPriceId = vi.fn();
+const ensureStripeCustomer = vi.fn();
+const getEarlyAdopterDiscount = vi.fn(() => ({}));
+const stripePriceIsUsable = vi.fn(async () => false);
+const withStripe = vi.fn();
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+// zValidator: parse JSON body into c.req.valid('json') without openapi package build.
+vi.mock('@revealui/openapi', () => ({
+  zValidator: (_target: string, schema: { parse: (v: unknown) => unknown }) => {
+    return async (
+      c: { req: { json: () => Promise<unknown>; valid: (k: string) => unknown } },
+      next: () => Promise<void>,
+    ) => {
+      const body = await c.req.json();
+      const parsed = schema.parse(body);
+      c.req.valid = (key: string) => {
+        if (key === 'json') return parsed;
+        throw new Error(`valid(${key}) not stubbed`);
+      };
+      await next();
+    };
+  },
+}));
+
+vi.mock('@revealui/auth/server', () => ({
+  admitFreeIntake: (...a: unknown[]) => admitFreeIntake(...a),
+  isSignupAllowed: (...a: unknown[]) => isSignupAllowed(...a),
+  signUp: (...a: unknown[]) => signUp(...a),
+}));
+
+vi.mock('../../lib/ensure-paid-pending-entitlement.js', () => ({
+  ensurePaidPendingEntitlement: (...a: unknown[]) => ensurePaidPendingEntitlement(...a),
+}));
+
+vi.mock('../billing/helpers.js', () => ({
+  assertLiveCatalogComplete: (...a: unknown[]) => assertLiveCatalogComplete(...a),
+  resolveCatalogPriceId: (...a: unknown[]) => resolveCatalogPriceId(...a),
+  ensureStripeCustomer: (...a: unknown[]) => ensureStripeCustomer(...a),
+  getEarlyAdopterDiscount: (...a: unknown[]) => getEarlyAdopterDiscount(...a),
+  isStripeTaxEnabled: false,
+  TRIAL_PERIOD_DAYS: 7,
+  stripePriceIsUsable: (...a: unknown[]) => stripePriceIsUsable(...a),
+  withStripe: (...a: unknown[]) => withStripe(...a),
+}));
+
+import paidSignupRoute from '../admission/paid-signup.js';
+
+function createApp() {
+  const app = new Hono();
+  app.route('/admission', paidSignupRoute);
+  return app;
+}
+
+const validBody = {
+  email: 'payer@example.com',
+  password: 'SecurePass123',
+  name: 'Paying User',
+  tier: 'pro' as const,
+};
+
+describe('POST /admission/paid-signup (HC4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSignupAllowed.mockReturnValue(true);
+    process.env.ADMIN_URL = 'https://admin.example.com';
+    admitFreeIntake.mockResolvedValue({
+      decision: 'admit',
+      mode: 'bypass',
+      cohortLimits: { maxSites: 1, maxUsers: 1, maxAgentTasks: 0 },
+      snapshotId: 'snap-waitlist',
+      reason: 'paying_bypass',
+      shadow: false,
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+    });
+    signUp.mockResolvedValue({
+      success: true,
+      user: { id: 'user-1', email: 'payer@example.com' },
+      sessionToken: 'sess-token',
+    });
+    ensurePaidPendingEntitlement.mockResolvedValue({ accountId: 'acct-1' });
+    assertLiveCatalogComplete.mockResolvedValue(undefined);
+    resolveCatalogPriceId.mockResolvedValue('price_pro_month');
+    ensureStripeCustomer.mockResolvedValue('cus_1');
+    withStripe.mockImplementation(async (fn: (stripe: unknown) => Promise<unknown>) => {
+      return fn({
+        checkout: {
+          sessions: {
+            create: vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/session' }),
+          },
+        },
+      });
+    });
+  });
+
+  it('creates user under waitlist mode via paid_signup channel (HC4)', async () => {
+    const res = await createApp().request('/admission/paid-signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.user.id).toBe('user-1');
+    expect(json.sessionToken).toBe('sess-token');
+    expect(json.checkoutUrl).toBe('https://checkout.stripe.test/session');
+
+    expect(admitFreeIntake).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'paid_signup',
+        email: 'payer@example.com',
+        payingIntent: { kind: 'checkout', tier: 'pro' },
+      }),
+    );
+    expect(signUp).toHaveBeenCalled();
+    expect(ensurePaidPendingEntitlement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        pendingTier: 'pro',
+      }),
+    );
+  });
+
+  it('returns 502 with session when Stripe fails after user create (no free AI path)', async () => {
+    withStripe.mockRejectedValue(new Error('Stripe unavailable'));
+
+    const res = await createApp().request('/admission/paid-signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.user.id).toBe('user-1');
+    expect(json.sessionToken).toBe('sess-token');
+    expect(json.checkoutUrl).toBeNull();
+    expect(json.checkoutError).toBe(true);
+    expect(ensurePaidPendingEntitlement).toHaveBeenCalled();
+  });
+
+  it('provisions paid-pending entitlement and never free signup path', async () => {
+    await createApp().request('/admission/paid-signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(ensurePaidPendingEntitlement).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/server/src/routes/__tests__/admission-waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/admission-waitlist.test.ts
@@ -1,0 +1,142 @@
+/**
+ * GAP-256 PR-4 — admission waitlist status + claim routes (mocked I/O).
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAdmissionWaitlistByToken = vi.fn();
+const getAdmissionWaitlistByTokenAnyStatus = vi.fn();
+const estimateAdmissionWaitlistPosition = vi.fn();
+const maskAdmissionEmail = vi.fn((e: string) => `m***@${e.split('@')[1] ?? 'x'}`);
+const markAdmissionWaitlistConverted = vi.fn();
+const admitFreeIntake = vi.fn();
+const ensureFreeSignupEntitlement = vi.fn();
+const isSignupAllowed = vi.fn(() => true);
+const signUp = vi.fn();
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/auth/server', () => ({
+  getAdmissionWaitlistByToken: (...a: unknown[]) => getAdmissionWaitlistByToken(...a),
+  getAdmissionWaitlistByTokenAnyStatus: (...a: unknown[]) =>
+    getAdmissionWaitlistByTokenAnyStatus(...a),
+  estimateAdmissionWaitlistPosition: (...a: unknown[]) => estimateAdmissionWaitlistPosition(...a),
+  maskAdmissionEmail: (e: string) => maskAdmissionEmail(e),
+  markAdmissionWaitlistConverted: (...a: unknown[]) => markAdmissionWaitlistConverted(...a),
+  admitFreeIntake: (...a: unknown[]) => admitFreeIntake(...a),
+  ensureFreeSignupEntitlement: (...a: unknown[]) => ensureFreeSignupEntitlement(...a),
+  isSignupAllowed: (...a: unknown[]) => isSignupAllowed(...a),
+  signUp: (...a: unknown[]) => signUp(...a),
+}));
+
+import admissionRoute from '../admission/waitlist.js';
+
+function createApp() {
+  const app = new Hono();
+  app.route('/admission', admissionRoute);
+  return app;
+}
+
+describe('GET /admission/waitlist/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns generic 404 for unknown token', async () => {
+    getAdmissionWaitlistByToken.mockResolvedValue(null);
+    getAdmissionWaitlistByTokenAnyStatus.mockResolvedValue(null);
+
+    const res = await createApp().request('/admission/waitlist/status?token=bad');
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.status).toBe('unknown');
+    expect(json.positionEstimate).toBeNull();
+  });
+
+  it('returns pending status for valid token', async () => {
+    getAdmissionWaitlistByToken.mockResolvedValue({
+      id: 'w1',
+      email: 'user@example.com',
+      status: 'pending',
+      position: 2,
+    });
+
+    const res = await createApp().request('/admission/waitlist/status?token=good');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe('pending');
+    expect(json.positionEstimate).toBe(2);
+    expect(json.emailMasked).toBeTruthy();
+  });
+});
+
+describe('POST /admission/waitlist/claim', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSignupAllowed.mockReturnValue(true);
+  });
+
+  it('claims pending row: admit + signUp + convert', async () => {
+    getAdmissionWaitlistByToken.mockResolvedValue({
+      id: 'w1',
+      email: 'claim@example.com',
+      status: 'pending',
+    });
+    admitFreeIntake.mockResolvedValue({
+      decision: 'admit',
+      mode: 'open',
+      cohortLimits: { maxSites: 1, maxUsers: 3, maxAgentTasks: 1000 },
+      snapshotId: null,
+      reason: 'waitlist_claim',
+      shadow: false,
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+    });
+    signUp.mockResolvedValue({
+      success: true,
+      user: { id: 'u1', email: 'claim@example.com' },
+      sessionToken: 'sess',
+    });
+    ensureFreeSignupEntitlement.mockResolvedValue({ accountId: 'a1' });
+    markAdmissionWaitlistConverted.mockResolvedValue(undefined);
+
+    const res = await createApp().request('/admission/waitlist/claim', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        token: 'raw',
+        password: 'SecurePass123',
+        name: 'Claimer',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.sessionToken).toBe('sess');
+    expect(admitFreeIntake).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'waitlist_claim_free', email: 'claim@example.com' }),
+    );
+    expect(signUp).toHaveBeenCalled();
+    expect(markAdmissionWaitlistConverted).toHaveBeenCalledWith('w1');
+  });
+
+  it('returns 409 when already converted', async () => {
+    getAdmissionWaitlistByToken.mockResolvedValue(null);
+    getAdmissionWaitlistByTokenAnyStatus.mockResolvedValue({
+      id: 'w1',
+      status: 'converted',
+      email: 'x@example.com',
+    });
+
+    const res = await createApp().request('/admission/waitlist/claim', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'old', password: 'SecurePass123', name: 'X' }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(signUp).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/routes/__tests__/auth-signup-waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/auth-signup-waitlist.test.ts
@@ -1,0 +1,110 @@
+/**
+ * GAP-256 PR-4 HC2 — enforce waitlist → 202 WAITLISTED, no signUp, never margin 403.
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const admitFreeIntake = vi.fn();
+const signUp = vi.fn();
+const isSignupAllowed = vi.fn(() => true);
+const ensureFreeSignupEntitlement = vi.fn();
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/auth/server', () => ({
+  isSignupAllowed: (...args: unknown[]) => isSignupAllowed(...args),
+  signUp: (...args: unknown[]) => signUp(...args),
+}));
+
+vi.mock('../../lib/admit-free-intake.js', () => ({
+  admitFreeIntake: (...args: unknown[]) => admitFreeIntake(...args),
+}));
+
+vi.mock('../../lib/ensure-free-signup-entitlement.js', () => ({
+  ensureFreeSignupEntitlement: (...args: unknown[]) => ensureFreeSignupEntitlement(...args),
+}));
+
+import authRoute from '../auth.js';
+
+function createApp() {
+  const app = new Hono();
+  app.route('/auth', authRoute);
+  return app;
+}
+
+async function postSignup(body: unknown) {
+  return createApp().request('/auth/signup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  email: 'new@example.com',
+  password: 'SecurePass123',
+  name: 'New User',
+  tosAccepted: true as const,
+};
+
+describe('POST /auth/signup waitlist (HC2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSignupAllowed.mockReturnValue(true);
+  });
+
+  it('returns 202 WAITLISTED with token and does not call signUp', async () => {
+    admitFreeIntake.mockResolvedValue({
+      decision: 'waitlist',
+      mode: 'waitlist',
+      reason: 'snapshot_waitlist',
+      snapshotId: 'snap-1',
+      shadow: false,
+      httpStatus: 202,
+      code: 'WAITLISTED',
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      waitlistToken: 'raw-token-hex',
+      positionEstimate: 3,
+    });
+
+    const res = await postSignup(validBody);
+
+    expect(res.status).toBe(202);
+    const json = await res.json();
+    expect(json).toMatchObject({
+      success: false,
+      error: 'WAITLISTED',
+      code: 'WAITLISTED',
+      waitlistToken: 'raw-token-hex',
+      positionEstimate: 3,
+    });
+    expect(json.message).toContain('waitlisted');
+    expect(signUp).not.toHaveBeenCalled();
+    expect(ensureFreeSignupEntitlement).not.toHaveBeenCalled();
+  });
+
+  it('is never margin 403 under waitlist', async () => {
+    admitFreeIntake.mockResolvedValue({
+      decision: 'waitlist',
+      mode: 'waitlist',
+      reason: 'snapshot_waitlist',
+      snapshotId: null,
+      shadow: false,
+      httpStatus: 202,
+      code: 'WAITLISTED',
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      waitlistToken: 't',
+      positionEstimate: null,
+    });
+
+    const res = await postSignup({
+      ...validBody,
+      email: 'x@example.com',
+    });
+
+    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(202);
+  });
+});

--- a/apps/server/src/routes/__tests__/auth-signup-waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/auth-signup-waitlist.test.ts
@@ -79,6 +79,7 @@ describe('POST /auth/signup waitlist (HC2)', () => {
       code: 'WAITLISTED',
       waitlistToken: 'raw-token-hex',
       positionEstimate: 3,
+      paidSignupPath: '/api/admission/paid-signup',
     });
     expect(json.message).toContain('waitlisted');
     expect(signUp).not.toHaveBeenCalled();

--- a/apps/server/src/routes/admission/paid-signup.ts
+++ b/apps/server/src/routes/admission/paid-signup.ts
@@ -1,0 +1,235 @@
+/**
+ * GAP-256 PR-4b — public paid_signup escape (K14 / K20).
+ *
+ * POST /paid-signup  { email, password, name, tier: pro|max|enterprise }
+ *
+ * Mounted under /api/admission and /api/v1/admission.
+ * Always bypasses waitlist; never grants free cohort AI (paid-pending).
+ */
+
+import { admitFreeIntake, isSignupAllowed, signUp } from '@revealui/auth/server';
+import { logger } from '@revealui/core/observability/logger';
+import { zValidator } from '@revealui/openapi';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { z } from 'zod';
+import { ensurePaidPendingEntitlement } from '../../lib/ensure-paid-pending-entitlement.js';
+import {
+  assertLiveCatalogComplete,
+  ensureStripeCustomer,
+  getEarlyAdopterDiscount,
+  isStripeTaxEnabled,
+  resolveCatalogPriceId,
+  stripePriceIsUsable,
+  TRIAL_PERIOD_DAYS,
+  withStripe,
+} from '../billing/helpers.js';
+
+const app = new Hono();
+
+const PaidSignupBodySchema = z.object({
+  email: z.string().email().max(320),
+  // Lockstep with SignUpRequestSchema / waitlist claim (GAP-244): min 12
+  password: z.string().min(12).max(128),
+  name: z.string().min(1).max(100),
+  tier: z.enum(['pro', 'max', 'enterprise']),
+});
+
+/**
+ * Create Stripe Checkout for a freshly signed-up paid-pending user.
+ * Throws HTTPException or Error on hard failure; caller maps to partial response.
+ */
+async function createPaidSignupCheckoutSession(params: {
+  userId: string;
+  email: string;
+  tier: 'pro' | 'max' | 'enterprise';
+}): Promise<string> {
+  await assertLiveCatalogComplete();
+
+  const resolvedPriceId = await resolveCatalogPriceId(params.tier, 'subscription');
+  const customerId = await ensureStripeCustomer(params.userId, params.email);
+
+  const adminUrl = process.env.ADMIN_URL || process.env.NEXT_PUBLIC_SERVER_URL;
+  if (!adminUrl) {
+    throw new HTTPException(500, { message: 'ADMIN_URL is not configured' });
+  }
+
+  const discountConfig = getEarlyAdopterDiscount(params.tier);
+  const meterPriceId = process.env.STRIPE_AGENT_OVERAGE_PRICE_ID;
+  let includeMeter = Boolean(meterPriceId) && (params.tier === 'pro' || params.tier === 'max');
+  if (
+    includeMeter &&
+    meterPriceId &&
+    !(await withStripe((s) => stripePriceIsUsable(s, meterPriceId)))
+  ) {
+    logger.warn('paid-signup: agent-overage meter price not usable — omitting meter line item', {
+      meterPriceId,
+      tier: params.tier,
+    });
+    includeMeter = false;
+  }
+
+  const sessionMetadata = {
+    tier: params.tier,
+    revealui_user_id: params.userId,
+    paid_pending: 'true',
+  };
+
+  const idempotencyWindow = Math.floor(Date.now() / (10 * 60 * 1000));
+  const session = await withStripe((stripe) =>
+    stripe.checkout.sessions.create(
+      {
+        customer: customerId,
+        mode: 'subscription',
+        metadata: sessionMetadata,
+        payment_method_types: ['card'],
+        billing_address_collection: 'required',
+        tax_id_collection: { enabled: true },
+        customer_update: { name: 'auto', address: 'auto' },
+        automatic_tax: { enabled: isStripeTaxEnabled },
+        ...discountConfig,
+        line_items: [
+          { price: resolvedPriceId, quantity: 1 },
+          ...(includeMeter && meterPriceId ? [{ price: meterPriceId }] : []),
+        ],
+        subscription_data: {
+          trial_period_days: TRIAL_PERIOD_DAYS,
+          metadata: sessionMetadata,
+        },
+        success_url: `${adminUrl}/welcome?success=true&tier=${params.tier}`,
+        cancel_url: `${adminUrl}/account/billing`,
+      },
+      {
+        idempotencyKey: `paid-signup-${params.userId}-${params.tier}-${idempotencyWindow}`,
+      },
+    ),
+  );
+
+  if (!session.url) {
+    throw new HTTPException(500, { message: 'Failed to create checkout session' });
+  }
+  return session.url;
+}
+
+/**
+ * POST /paid-signup
+ * Admit paying intent, create user, paid-pending entitlement, Stripe Checkout URL.
+ */
+app.post('/paid-signup', zValidator('json', PaidSignupBodySchema), async (c) => {
+  const { email, password, name, tier } = c.req.valid('json');
+  const normalizedEmail = email.trim().toLowerCase();
+
+  if (!isSignupAllowed(normalizedEmail)) {
+    return c.json(
+      { success: false, error: 'Signups are currently restricted', code: 'SIGNUP_RESTRICTED' },
+      403,
+    );
+  }
+
+  // K14: always bypass waitlist for paid_signup (never free cohort limits).
+  const admit = await admitFreeIntake({
+    channel: 'paid_signup',
+    email: normalizedEmail,
+    payingIntent: { kind: 'checkout', tier },
+  });
+
+  if (admit.decision !== 'admit') {
+    logger.warn('[admission-paid-signup] paid_signup did not admit', {
+      decision: admit.decision,
+      reason: admit.reason,
+    });
+    return c.json(
+      {
+        success: false,
+        error: 'Unable to start paid signup right now',
+        code: 'PAID_SIGNUP_NOT_ADMITTED',
+      },
+      503,
+    );
+  }
+
+  const result = await signUp(normalizedEmail, password, name, {
+    userAgent: c.req.header('user-agent'),
+    ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
+  });
+
+  if (!result.success || !result.user?.id) {
+    logger.warn('[admission-paid-signup] signUp failed', { error: result.error });
+    return c.json(
+      {
+        success: false,
+        error: result.error ?? 'Sign up failed',
+        code: 'SIGNUP_FAILED',
+      },
+      400,
+    );
+  }
+
+  const userId = result.user.id;
+
+  // K20: paid-pending before Checkout — never freeCohortLimitsForMode.
+  try {
+    await ensurePaidPendingEntitlement({
+      userId,
+      displayName: name,
+      pendingTier: tier,
+    });
+  } catch (err) {
+    logger.error(
+      '[admission-paid-signup] paid-pending entitlement failed (non-fatal; continue checkout)',
+      err instanceof Error ? err : undefined,
+      { userId },
+    );
+  }
+
+  let checkoutUrl: string | null = null;
+  let checkoutError = false;
+  try {
+    checkoutUrl = await createPaidSignupCheckoutSession({
+      userId,
+      email: result.user.email ?? normalizedEmail,
+      tier,
+    });
+  } catch (err) {
+    checkoutError = true;
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      '[admission-paid-signup] Stripe checkout failed after user create (paid-pending retained)',
+      err instanceof Error ? err : undefined,
+      { userId, tier },
+    );
+    // User + paid-pending exist; no free AI. Surface partial success for client retry via billing.
+    return c.json(
+      {
+        success: true,
+        user: { id: userId, email: result.user.email },
+        sessionToken: result.sessionToken,
+        checkoutUrl: null,
+        checkoutError: true,
+        message:
+          'Account created. Checkout could not start. Sign in and open billing to complete payment.',
+        error: message,
+      },
+      502,
+    );
+  }
+
+  logger.info('[admission-paid-signup] created', {
+    userId,
+    tier,
+    admitReason: admit.reason,
+    checkoutError,
+  });
+
+  return c.json(
+    {
+      success: true,
+      user: { id: userId, email: result.user.email },
+      sessionToken: result.sessionToken,
+      checkoutUrl,
+    },
+    201,
+  );
+});
+
+export default app;

--- a/apps/server/src/routes/admission/paid-signup.ts
+++ b/apps/server/src/routes/admission/paid-signup.ts
@@ -153,7 +153,7 @@ app.post('/paid-signup', zValidator('json', PaidSignupBodySchema), async (c) => 
     ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
   });
 
-  if (!result.success || !result.user?.id) {
+  if (!(result.success && result.user?.id)) {
     logger.warn('[admission-paid-signup] signUp failed', { error: result.error });
     return c.json(
       {

--- a/apps/server/src/routes/admission/waitlist.ts
+++ b/apps/server/src/routes/admission/waitlist.ts
@@ -62,17 +62,17 @@ app.get('/waitlist/status', async (c) => {
       });
     }
 
-    const any = await getAdmissionWaitlistByTokenAnyStatus(token);
-    if (any?.status === 'converted') {
+    const prior = await getAdmissionWaitlistByTokenAnyStatus(token);
+    if (prior?.status === 'converted') {
       return c.json({
         status: 'converted' as const,
         positionEstimate: null,
-        emailMasked: maskAdmissionEmail(any.email),
+        emailMasked: maskAdmissionEmail(prior.email),
       });
     }
-    if (any?.status === 'expired' || any?.status === 'cancelled') {
+    if (prior?.status === 'expired' || prior?.status === 'cancelled') {
       return c.json({
-        status: any.status,
+        status: prior.status,
         positionEstimate: null,
         emailMasked: null,
       });
@@ -105,8 +105,8 @@ app.post('/waitlist/claim', zValidator('json', ClaimBodySchema), async (c) => {
   }
 
   if (!row) {
-    const any = await getAdmissionWaitlistByTokenAnyStatus(token).catch(() => null);
-    if (any?.status === 'converted') {
+    const prior = await getAdmissionWaitlistByTokenAnyStatus(token).catch(() => null);
+    if (prior?.status === 'converted') {
       return c.json(
         {
           success: false,

--- a/apps/server/src/routes/admission/waitlist.ts
+++ b/apps/server/src/routes/admission/waitlist.ts
@@ -1,0 +1,222 @@
+/**
+ * GAP-256 PR-4 — public admission waitlist status + claim.
+ *
+ * Paths (mounted under /api/admission and /api/v1/admission):
+ *   GET  /waitlist/status?token=
+ *   POST /waitlist/claim  { token, password, name }
+ *
+ * Distinct from marketing POST /api/waitlist (email capture).
+ */
+
+import {
+  admitFreeIntake,
+  ensureFreeSignupEntitlement,
+  estimateAdmissionWaitlistPosition,
+  getAdmissionWaitlistByToken,
+  getAdmissionWaitlistByTokenAnyStatus,
+  isSignupAllowed,
+  markAdmissionWaitlistConverted,
+  maskAdmissionEmail,
+  signUp,
+} from '@revealui/auth/server';
+import { logger } from '@revealui/core/observability/logger';
+import { zValidator } from '@revealui/openapi';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+const app = new Hono();
+
+/** Generic anti-enumeration payload for unknown / expired tokens. */
+const GENERIC_STATUS = {
+  status: 'unknown' as const,
+  positionEstimate: null as number | null,
+  emailMasked: null as string | null,
+};
+
+const ClaimBodySchema = z.object({
+  token: z.string().min(1).max(256),
+  // Lockstep with SignUpRequestSchema (GAP-244): min 12
+  password: z.string().min(12).max(128),
+  name: z.string().min(1).max(100),
+});
+
+/**
+ * GET /waitlist/status?token=
+ * Valid token → real status; bad/expired → same generic shape (no 404 body variance).
+ */
+app.get('/waitlist/status', async (c) => {
+  const token = c.req.query('token')?.trim() ?? '';
+  if (!token) {
+    return c.json(GENERIC_STATUS, 404);
+  }
+
+  try {
+    const active = await getAdmissionWaitlistByToken(token);
+    if (active) {
+      const positionEstimate =
+        active.position ?? (await estimateAdmissionWaitlistPosition(active.id));
+      return c.json({
+        status: active.status,
+        positionEstimate,
+        emailMasked: maskAdmissionEmail(active.email),
+      });
+    }
+
+    const any = await getAdmissionWaitlistByTokenAnyStatus(token);
+    if (any?.status === 'converted') {
+      return c.json({
+        status: 'converted' as const,
+        positionEstimate: null,
+        emailMasked: maskAdmissionEmail(any.email),
+      });
+    }
+    if (any?.status === 'expired' || any?.status === 'cancelled') {
+      return c.json({
+        status: any.status,
+        positionEstimate: null,
+        emailMasked: null,
+      });
+    }
+  } catch (err) {
+    logger.warn('[admission-waitlist] status lookup failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return c.json(GENERIC_STATUS, 404);
+});
+
+/**
+ * POST /waitlist/claim
+ * Admit free (waitlist_claim_free never re-waitlists), signUp, free entitlement, mark converted.
+ */
+app.post('/waitlist/claim', zValidator('json', ClaimBodySchema), async (c) => {
+  const { token, password, name } = c.req.valid('json');
+
+  let row: Awaited<ReturnType<typeof getAdmissionWaitlistByToken>>;
+  try {
+    row = await getAdmissionWaitlistByToken(token);
+  } catch (err) {
+    logger.error(
+      '[admission-waitlist] claim token lookup failed',
+      err instanceof Error ? err : undefined,
+    );
+    return c.json({ success: false, error: 'Unable to process claim', code: 'CLAIM_FAILED' }, 500);
+  }
+
+  if (!row) {
+    const any = await getAdmissionWaitlistByTokenAnyStatus(token).catch(() => null);
+    if (any?.status === 'converted') {
+      return c.json(
+        {
+          success: false,
+          error: 'Already converted. Sign in with your existing account.',
+          code: 'ALREADY_CONVERTED',
+        },
+        409,
+      );
+    }
+    return c.json(
+      { success: false, error: 'Invalid or expired waitlist token', code: 'INVALID_TOKEN' },
+      404,
+    );
+  }
+
+  if (!isSignupAllowed(row.email)) {
+    return c.json(
+      { success: false, error: 'Signups are currently restricted', code: 'SIGNUP_RESTRICTED' },
+      403,
+    );
+  }
+
+  const admit = await admitFreeIntake({
+    channel: 'waitlist_claim_free',
+    email: row.email,
+    payingIntent: { kind: 'none' },
+  });
+
+  if (admit.decision !== 'admit') {
+    logger.warn('[admission-waitlist] claim did not admit', {
+      reason: admit.reason,
+      decision: admit.decision,
+    });
+    return c.json(
+      {
+        success: false,
+        error: 'Unable to claim waitlist entry right now',
+        code: 'CLAIM_NOT_ADMITTED',
+      },
+      503,
+    );
+  }
+
+  const result = await signUp(row.email, password, name, {
+    userAgent: c.req.header('user-agent'),
+    ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
+  });
+
+  if (!result.success) {
+    // Email already registered after concurrent claim / paid path
+    if (
+      result.error?.toLowerCase().includes('already') ||
+      result.error?.toLowerCase().includes('exist')
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: 'Already converted. Sign in with your existing account.',
+          code: 'ALREADY_CONVERTED',
+        },
+        409,
+      );
+    }
+    logger.warn('[admission-waitlist] claim signUp failed', { error: result.error });
+    return c.json(
+      { success: false, error: result.error ?? 'Sign up failed', code: 'SIGNUP_FAILED' },
+      400,
+    );
+  }
+
+  if (result.user?.id) {
+    try {
+      await ensureFreeSignupEntitlement({
+        userId: result.user.id,
+        cohortLimits: admit.cohortLimits,
+        displayName: name,
+      });
+    } catch (err) {
+      logger.error(
+        '[admission-waitlist] free entitlement@t0 failed (non-fatal)',
+        err instanceof Error ? err : undefined,
+        { userId: result.user.id },
+      );
+    }
+  }
+
+  try {
+    await markAdmissionWaitlistConverted(row.id);
+  } catch (err) {
+    logger.error(
+      '[admission-waitlist] mark converted failed (user already created)',
+      err instanceof Error ? err : undefined,
+      { waitlistId: row.id, userId: result.user?.id },
+    );
+  }
+
+  logger.info('[admission-waitlist] claim converted', {
+    waitlistId: row.id,
+    userId: result.user?.id,
+    admitReason: admit.reason,
+  });
+
+  return c.json(
+    {
+      success: true,
+      user: { id: result.user?.id, email: result.user?.email },
+      sessionToken: result.sessionToken,
+    },
+    201,
+  );
+});
+
+export default app;

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -6,8 +6,9 @@
  * This route is rate-limited and enforces the tier-based user limit
  * (enforceUserLimit middleware is applied in index.ts).
  *
- * GAP-256 PR-3: margin admit **before** signUp (K13); free entitlement@t0 after
- * successful hosted signup (K15). Shadow defaults → never 202 waitlist here.
+ * GAP-256: margin admit **before** signUp (K13); free entitlement@t0 after
+ * successful hosted signup (K15). Enforce waitlist → 202 WAITLISTED + token (PR-4).
+ * Default flags still shadow → admit (no 202).
  */
 
 import { isSignupAllowed, signUp } from '@revealui/auth/server';
@@ -40,12 +41,14 @@ app.post('/signup', zValidator('json', SignUpRequestSchema), async (c) => {
   });
 
   if (admit.decision === 'waitlist') {
-    // PR-4 enforce path — PR-3 shadow should not reach here with default flags.
+    // PR-4: never margin 403; no users row; raw waitlistToken once.
     return c.json(
       {
         success: false,
         error: 'WAITLISTED',
-        code: admit.code,
+        code: 'WAITLISTED',
+        waitlistToken: admit.waitlistToken,
+        positionEstimate: admit.positionEstimate ?? null,
         message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
       },
       202,

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -42,6 +42,7 @@ app.post('/signup', zValidator('json', SignUpRequestSchema), async (c) => {
 
   if (admit.decision === 'waitlist') {
     // PR-4: never margin 403; no users row; raw waitlistToken once.
+    // PR-4b: CTA points at paid_signup escape (not marketing-only pricing).
     return c.json(
       {
         success: false,
@@ -50,6 +51,7 @@ app.post('/signup', zValidator('json', SignUpRequestSchema), async (c) => {
         waitlistToken: admit.waitlistToken,
         positionEstimate: admit.positionEstimate ?? null,
         message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+        paidSignupPath: '/api/admission/paid-signup',
       },
       202,
     );

--- a/packages/auth/src/server/__tests__/admission-waitlist.test.ts
+++ b/packages/auth/src/server/__tests__/admission-waitlist.test.ts
@@ -1,0 +1,44 @@
+/**
+ * GAP-256 PR-4 — admission token hash + pure helpers (no DB).
+ */
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  generateAdmissionToken,
+  hashAdmissionToken,
+  maskAdmissionEmail,
+} from '../admission-waitlist.js';
+
+describe('hashAdmissionToken', () => {
+  it('is deterministic sha256 hex', () => {
+    const raw = 'abc123';
+    const expected = createHash('sha256').update(raw).digest('hex');
+    expect(hashAdmissionToken(raw)).toBe(expected);
+    expect(hashAdmissionToken(raw)).toBe(hashAdmissionToken(raw));
+  });
+
+  it('differs for different tokens', () => {
+    expect(hashAdmissionToken('a')).not.toBe(hashAdmissionToken('b'));
+  });
+});
+
+describe('generateAdmissionToken', () => {
+  it('returns 64 hex chars (32 bytes)', () => {
+    const t = generateAdmissionToken();
+    expect(t).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is unique across calls', () => {
+    expect(generateAdmissionToken()).not.toBe(generateAdmissionToken());
+  });
+});
+
+describe('maskAdmissionEmail', () => {
+  it('masks local part', () => {
+    expect(maskAdmissionEmail('alice@example.com')).toBe('a***@example.com');
+  });
+
+  it('normalizes case', () => {
+    expect(maskAdmissionEmail('  Bob@Example.COM ')).toBe('b***@example.com');
+  });
+});

--- a/packages/auth/src/server/__tests__/margin-admit.test.ts
+++ b/packages/auth/src/server/__tests__/margin-admit.test.ts
@@ -1,8 +1,10 @@
 /**
- * GAP-256 PR-3b — OPEN_FREE_LIMITS lockstep (constants only; no full package graph).
+ * GAP-256 — OPEN_FREE_LIMITS lockstep + pure decide shapes used by admit.
  *
- * Values must match apps/server getHostedLimitsForTier('free') and margin-admit.ts.
+ * Full admitFreeIntake I/O is covered via enqueue helpers + server route tests.
  */
+
+import { decideFreeIntake } from '@revealui/core/margin-governor';
 import { describe, expect, it } from 'vitest';
 
 /** Mirror of OPEN_FREE_LIMITS in margin-admit.ts */
@@ -19,5 +21,43 @@ describe('OPEN_FREE_LIMITS lockstep', () => {
       maxUsers: 3,
       maxAgentTasks: 1_000,
     });
+  });
+});
+
+describe('decide path used by admit (PR-4)', () => {
+  const now = new Date('2026-08-09T12:00:00.000Z');
+  const snapshot = {
+    id: 'snap',
+    mode: 'waitlist' as const,
+    computedAt: now,
+  };
+
+  it('free_signup enforce waitlist → waitlist decision (enqueue path)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot,
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits: OPEN_FREE_LIMITS,
+      now,
+    });
+    expect(r.decision).toBe('waitlist');
+  });
+
+  it('waitlist_claim_free under waitlist → admit', () => {
+    const r = decideFreeIntake({
+      channel: 'waitlist_claim_free',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot,
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits: OPEN_FREE_LIMITS,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.reason).toBe('waitlist_claim');
+    }
   });
 });

--- a/packages/auth/src/server/admission-waitlist.ts
+++ b/packages/auth/src/server/admission-waitlist.ts
@@ -1,0 +1,258 @@
+/**
+ * GAP-256 PR-4 — admission_waitlist I/O (NOT marketing waitlist).
+ *
+ * Stores only SHA-256 of claim tokens. Raw token returned once at enqueue.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { type AdmissionWaitlistRow, admissionWaitlist } from '@revealui/db/schema';
+import { and, count, eq, gt, inArray, isNull, or, sql } from 'drizzle-orm';
+
+const TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function hashAdmissionToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+export function generateAdmissionToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function expiresAtFrom(now: Date): Date {
+  return new Date(now.getTime() + TOKEN_TTL_MS);
+}
+
+async function countPendingRows(): Promise<number | null> {
+  try {
+    const db = getClient();
+    const [row] = await db
+      .select({ total: count() })
+      .from(admissionWaitlist)
+      .where(eq(admissionWaitlist.status, 'pending'));
+    return row?.total ?? 0;
+  } catch (err) {
+    logger.warn('[admission-waitlist] pending count failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+export interface EnqueueAdmissionWaitlistParams {
+  email: string;
+  snapshotId: string | null;
+  modeAtEnqueue?: string;
+  source?: string;
+  now?: Date;
+}
+
+export interface EnqueueAdmissionWaitlistResult {
+  waitlistToken: string;
+  positionEstimate: number | null;
+  id: string;
+}
+
+/**
+ * Insert or rotate a pending admission waitlist row for email.
+ * Returns a fresh raw token (never stored).
+ */
+export async function enqueueAdmissionWaitlist(
+  params: EnqueueAdmissionWaitlistParams,
+): Promise<EnqueueAdmissionWaitlistResult> {
+  const db = getClient();
+  const email = normalizeEmail(params.email);
+  const now = params.now ?? new Date();
+  const rawToken = generateAdmissionToken();
+  const tokenHash = hashAdmissionToken(rawToken);
+  const expiresAt = expiresAtFrom(now);
+  const modeAtEnqueue = params.modeAtEnqueue ?? 'waitlist';
+  const source = params.source ?? 'free_signup';
+
+  const [existing] = await db
+    .select({
+      id: admissionWaitlist.id,
+      position: admissionWaitlist.position,
+    })
+    .from(admissionWaitlist)
+    .where(and(eq(admissionWaitlist.email, email), eq(admissionWaitlist.status, 'pending')))
+    .limit(1);
+
+  if (existing) {
+    await db
+      .update(admissionWaitlist)
+      .set({
+        tokenHash,
+        snapshotId: params.snapshotId,
+        modeAtEnqueue,
+        source,
+        expiresAt,
+      })
+      .where(eq(admissionWaitlist.id, existing.id));
+
+    return {
+      waitlistToken: rawToken,
+      positionEstimate: existing.position,
+      id: existing.id,
+    };
+  }
+
+  const pendingCount = await countPendingRows();
+  const positionEstimate = pendingCount === null ? null : pendingCount + 1;
+  const id = crypto.randomUUID();
+
+  try {
+    await db.insert(admissionWaitlist).values({
+      id,
+      email,
+      status: 'pending',
+      tokenHash,
+      snapshotId: params.snapshotId,
+      modeAtEnqueue,
+      position: positionEstimate,
+      source,
+      metadata: {},
+      createdAt: now,
+      expiresAt,
+    });
+  } catch (err) {
+    // Race on unique pending email: rotate the winning row's token.
+    logger.warn('[admission-waitlist] insert conflict; rotating existing pending', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    const [raced] = await db
+      .select({
+        id: admissionWaitlist.id,
+        position: admissionWaitlist.position,
+      })
+      .from(admissionWaitlist)
+      .where(and(eq(admissionWaitlist.email, email), eq(admissionWaitlist.status, 'pending')))
+      .limit(1);
+    if (!raced) {
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+    await db
+      .update(admissionWaitlist)
+      .set({
+        tokenHash,
+        snapshotId: params.snapshotId,
+        modeAtEnqueue,
+        source,
+        expiresAt,
+      })
+      .where(eq(admissionWaitlist.id, raced.id));
+    return {
+      waitlistToken: rawToken,
+      positionEstimate: raced.position,
+      id: raced.id,
+    };
+  }
+
+  return {
+    waitlistToken: rawToken,
+    positionEstimate,
+    id,
+  };
+}
+
+/** Active claim rows: pending or invited, not past expiresAt. */
+export async function getAdmissionWaitlistByToken(
+  rawToken: string,
+): Promise<AdmissionWaitlistRow | null> {
+  if (!rawToken || rawToken.trim() === '') {
+    return null;
+  }
+  const db = getClient();
+  const tokenHash = hashAdmissionToken(rawToken);
+  const now = new Date();
+
+  const [row] = await db
+    .select()
+    .from(admissionWaitlist)
+    .where(
+      and(
+        eq(admissionWaitlist.tokenHash, tokenHash),
+        inArray(admissionWaitlist.status, ['pending', 'invited']),
+        or(isNull(admissionWaitlist.expiresAt), gt(admissionWaitlist.expiresAt, now)),
+      ),
+    )
+    .limit(1);
+
+  return row ?? null;
+}
+
+export async function getAdmissionWaitlistByTokenAnyStatus(
+  rawToken: string,
+): Promise<AdmissionWaitlistRow | null> {
+  if (!rawToken || rawToken.trim() === '') {
+    return null;
+  }
+  const db = getClient();
+  const tokenHash = hashAdmissionToken(rawToken);
+  const [row] = await db
+    .select()
+    .from(admissionWaitlist)
+    .where(eq(admissionWaitlist.tokenHash, tokenHash))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function markAdmissionWaitlistConverted(id: string, now?: Date): Promise<void> {
+  const db = getClient();
+  const convertedAt = now ?? new Date();
+  await db
+    .update(admissionWaitlist)
+    .set({
+      status: 'converted',
+      convertedAt,
+    })
+    .where(eq(admissionWaitlist.id, id));
+}
+
+/** Mask email for public status (anti-enumeration still requires valid token). */
+export function maskAdmissionEmail(email: string): string {
+  const normalized = normalizeEmail(email);
+  const at = normalized.indexOf('@');
+  if (at <= 0) {
+    return '***';
+  }
+  const local = normalized.slice(0, at);
+  const domain = normalized.slice(at + 1);
+  const visible = local.slice(0, 1);
+  return `${visible}***@${domain}`;
+}
+
+/** Position estimate among pending (best-effort; null on failure). */
+export async function estimateAdmissionWaitlistPosition(id: string): Promise<number | null> {
+  try {
+    const db = getClient();
+    const [self] = await db
+      .select({
+        position: admissionWaitlist.position,
+        createdAt: admissionWaitlist.createdAt,
+      })
+      .from(admissionWaitlist)
+      .where(eq(admissionWaitlist.id, id))
+      .limit(1);
+    if (!self) return null;
+    if (self.position != null) return self.position;
+
+    const [row] = await db
+      .select({ total: count() })
+      .from(admissionWaitlist)
+      .where(
+        and(
+          eq(admissionWaitlist.status, 'pending'),
+          sql`${admissionWaitlist.createdAt} <= ${self.createdAt}`,
+        ),
+      );
+    return row?.total ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -6,6 +6,19 @@
  */
 
 export type { SignInResult, SignUpResult } from '../types.js';
+// GAP-256 admission waitlist (NOT marketing waitlist)
+export {
+  type EnqueueAdmissionWaitlistParams,
+  type EnqueueAdmissionWaitlistResult,
+  enqueueAdmissionWaitlist,
+  estimateAdmissionWaitlistPosition,
+  generateAdmissionToken,
+  getAdmissionWaitlistByToken,
+  getAdmissionWaitlistByTokenAnyStatus,
+  hashAdmissionToken,
+  markAdmissionWaitlistConverted,
+  maskAdmissionEmail,
+} from './admission-waitlist.js';
 // Audit bridge
 export {
   auditAccountLocked,

--- a/packages/auth/src/server/margin-admit.ts
+++ b/packages/auth/src/server/margin-admit.ts
@@ -2,7 +2,7 @@
  * GAP-256 free-intake admit + free@t0 entitlement (shared by server + admin).
  *
  * Pure decide lives in @revealui/core/margin-governor. This module is the I/O
- * wrapper: read margin_snapshots, never COUNT(users). Waitlist insert is PR-4.
+ * wrapper: read margin_snapshots, never COUNT(users). Waitlist enqueue is PR-4.
  */
 
 import { getFeaturesForTier } from '@revealui/core/features';
@@ -10,6 +10,7 @@ import {
   type AdmissionChannel,
   type CohortLimits,
   decideFreeIntake,
+  freeCohortLimitsForMode,
   type GovernorFlags,
   governorFlagsFromEnv,
   type MarginSnapshotView,
@@ -25,6 +26,7 @@ import {
   marginSnapshots,
 } from '@revealui/db/schema';
 import { and, desc, eq } from 'drizzle-orm';
+import { enqueueAdmissionWaitlist } from './admission-waitlist.js';
 import { ensureAccountOwnerPlatformAdmin } from './platform-roles.js';
 
 export type AdmitFreeIntakeInput = {
@@ -34,10 +36,15 @@ export type AdmitFreeIntakeInput = {
   deploymentMode?: 'hosted' | 'forge' | 'unknown';
   env?: NodeJS.ProcessEnv;
   now?: Date;
+  /** Waitlist enqueue source tag (default free_signup). */
+  source?: string;
 };
 
 export type AdmitFreeIntakeResult = PureAdmitResult & {
   flags: GovernorFlags;
+  /** Present on waitlist decision after successful enqueue (raw once). */
+  waitlistToken?: string;
+  positionEstimate?: number | null;
 };
 
 /** Hosted free open limits — lockstep with apps/server getHostedLimitsForTier('free'). */
@@ -95,6 +102,7 @@ async function loadLatestSnapshot(): Promise<MarginSnapshotView | null> {
 /**
  * Pre-check free intake. Call **before** any users insert (K13).
  * Shadow defaults → always admit (never waitlist response).
+ * Enforce waitlist → enqueue admission_waitlist and attach raw token.
  */
 export async function admitFreeIntake(input: AdmitFreeIntakeInput): Promise<AdmitFreeIntakeResult> {
   const env = input.env ?? process.env;
@@ -109,6 +117,70 @@ export async function admitFreeIntake(input: AdmitFreeIntakeInput): Promise<Admi
     openLimits: OPEN_FREE_LIMITS,
     now: input.now,
   });
+
+  if (result.decision === 'waitlist') {
+    const email = input.email?.trim();
+    if (!email) {
+      // Cannot enqueue without identity — fail-open admit (not margin 403).
+      logger.warn('[admit-free-intake] waitlist without email; fail-open admit', {
+        channel: input.channel,
+        snapshotId: result.snapshotId,
+      });
+      return {
+        decision: 'admit',
+        mode: 'open',
+        cohortLimits: freeCohortLimitsForMode('open', OPEN_FREE_LIMITS),
+        snapshotId: result.snapshotId,
+        reason: 'waitlist_missing_email',
+        shadow: false,
+        flags,
+      };
+    }
+
+    try {
+      const enqueued = await enqueueAdmissionWaitlist({
+        email,
+        snapshotId: result.snapshotId,
+        modeAtEnqueue: 'waitlist',
+        source: input.source ?? input.channel,
+        now: input.now,
+      });
+      logger.info('[admit-free-intake]', {
+        channel: input.channel,
+        email: '[redacted]',
+        decision: 'waitlist',
+        mode: result.mode,
+        reason: result.reason,
+        shadow: result.shadow,
+        snapshotId: result.snapshotId,
+        governorEnabled: flags.enabled,
+        waitlistId: enqueued.id,
+        positionEstimate: enqueued.positionEstimate,
+      });
+      return {
+        ...result,
+        flags,
+        waitlistToken: enqueued.waitlistToken,
+        positionEstimate: enqueued.positionEstimate,
+      };
+    } catch (err) {
+      // Enqueue failure must not 403; fail-open admit so signup can proceed.
+      logger.error(
+        '[admit-free-intake] waitlist enqueue failed; fail-open admit',
+        err instanceof Error ? err : undefined,
+        { channel: input.channel },
+      );
+      return {
+        decision: 'admit',
+        mode: 'open',
+        cohortLimits: freeCohortLimitsForMode('open', OPEN_FREE_LIMITS),
+        snapshotId: result.snapshotId,
+        reason: 'waitlist_enqueue_failed',
+        shadow: false,
+        flags,
+      };
+    }
+  }
 
   logger.info('[admit-free-intake]', {
     channel: input.channel,

--- a/packages/core/src/__tests__/margin-governor.test.ts
+++ b/packages/core/src/__tests__/margin-governor.test.ts
@@ -104,6 +104,29 @@ describe('decideFreeIntake', () => {
     }
   });
 
+  it('waitlist_claim_free under waitlist enforce admits (never re-waitlists)', () => {
+    const r = decideFreeIntake({
+      channel: 'waitlist_claim_free',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: {
+        id: 'snap-claim',
+        mode: 'waitlist',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.reason).toBe('waitlist_claim');
+      expect(r.shadow).toBe(false);
+      expect(r.cohortLimits.maxAgentTasks).toBe(1_000);
+      expect(r.mode).toBe('open');
+    }
+  });
+
   it('paying-intent bypasses waitlist', () => {
     const r = decideFreeIntake({
       channel: 'paid_signup',

--- a/packages/core/src/margin-governor.ts
+++ b/packages/core/src/margin-governor.ts
@@ -95,10 +95,9 @@ export function governorFlagsFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): GovernorFlags {
   const enabled = env.MARGIN_GOVERNOR_ENABLED === 'true';
-  // When master is on, shadow defaults true unless explicitly false
+  // Shadow defaults true unless explicitly false (safe until owner flips enforce).
   const shadowExplicit = env.MARGIN_GOVERNOR_SHADOW;
-  const shadow =
-    shadowExplicit === 'false' ? false : shadowExplicit === 'true' ? true : enabled ? true : true;
+  const shadow = shadowExplicit !== 'false';
   const staleHours = parsePositiveInt(env.MARGIN_SNAPSHOT_STALE_HOURS, 36);
   return { enabled, shadow, staleHours };
 }

--- a/packages/core/src/margin-governor.ts
+++ b/packages/core/src/margin-governor.ts
@@ -206,6 +206,17 @@ export function decideFreeIntake(input: {
 
   // Enforce path (PR-4): waitlist when mode is waitlist
   if (rawMode === 'waitlist') {
+    // Claim free must never re-waitlist; use open free limits under waitlist mode.
+    if (input.channel === 'waitlist_claim_free') {
+      return {
+        decision: 'admit',
+        mode: 'open',
+        cohortLimits: freeCohortLimitsForMode('open', openLimits, leanTasks),
+        snapshotId,
+        reason: 'waitlist_claim',
+        shadow: false,
+      };
+    }
     return {
       decision: 'waitlist',
       mode: 'waitlist',


### PR DESCRIPTION
## Summary

GAP-256 **PR-4b**: paying-intent escape while free intake is waitlisted.

- `POST /api/admission/paid-signup` (also `/api/v1/admission`) — always bypasses waitlist (`channel: paid_signup`)
- Creates user + **paid-pending** entitlement (`maxAgentTasks=0`, AI features forced off) before Stripe Checkout
- Waitlist **202** responses include `paidSignupPath: /api/admission/paid-signup` (server auth + admin sign-up + passkey)
- Stacks on PR-4 waitlist enforce ([#2510](https://github.com/RevealUIStudio/revealui/pull/2510)); base `test` if that lands first

### Hard constraints
- HC4: paid path never blocked by free waitlist
- HC15 / K20: unpaid paid-pending never gets free cohort AI

## Test plan
- [x] `vitest` admission-paid-signup + ensure-paid-pending-entitlement + merge-hosted-entitlement (8 tests)
- [x] `pnpm gate --phase=1 --changed` green
- [ ] CI full suite
- [ ] After #2510 merge: restack if needed

## Related
- GAP-256, #2510 PR-4 waitlist
- GAP-473: product agent residual already on main (#2478/#2486); not in this PR