### PR TITLE
feat(server): paid_signup escape with paid-pending zero-task entitlement

### DIFF
--- a/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/register-verify/route.ts
@@ -179,6 +179,7 @@ async function registerVerifyHandler(request: NextRequest): Promise<NextResponse
             waitlistToken: admit.waitlistToken,
             positionEstimate: admit.positionEstimate ?? null,
             message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+            paidSignupPath: '/api/admission/paid-signup',
           },
           { status: 202 },
         );

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -198,6 +198,7 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
           waitlistToken: admit.waitlistToken,
           positionEstimate: admit.positionEstimate ?? null,
           message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+          paidSignupPath: '/api/admission/paid-signup',
         },
         { status: 202 },
       );

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -92,6 +92,7 @@ import adminCoordinationRoute from './routes/admin/coordination.js';
 import adminInferenceConfigRoute from './routes/admin/inference-config.js';
 import adminLocalAiStatusRoute from './routes/admin/local-ai-status.js';
 import adminObservabilityRoute from './routes/admin/observability.js';
+import admissionPaidSignupRoute from './routes/admission/paid-signup.js';
 import admissionWaitlistRoute from './routes/admission/waitlist.js';
 import { createAgentCollabRoute } from './routes/agent-collab.js';
 import agentStreamRoute from './routes/agent-stream.js';
@@ -1265,9 +1266,11 @@ app.route('/api/contact', contactRoute);
 app.route('/api/v1/contact', contactRoute);
 app.route('/api/waitlist', waitlistRoute);
 app.route('/api/v1/waitlist', waitlistRoute);
-// GAP-256 admission waitlist (distinct from marketing waitlist)
+// GAP-256 admission waitlist + paid_signup (distinct from marketing waitlist)
 app.route('/api/admission', admissionWaitlistRoute);
 app.route('/api/v1/admission', admissionWaitlistRoute);
+app.route('/api/admission', admissionPaidSignupRoute);
+app.route('/api/v1/admission', admissionPaidSignupRoute);
 // Webhooks are rate-limited to prevent replay abuse and resource exhaustion.
 // Stripe's DB-backed idempotency handles dedup; this limits request volume.
 app.use('/api/webhooks/*', rateLimitMiddleware(rateLimitsConfig.routes.webhook));

--- a/apps/server/src/lib/__tests__/ensure-paid-pending-entitlement.test.ts
+++ b/apps/server/src/lib/__tests__/ensure-paid-pending-entitlement.test.ts
@@ -1,0 +1,46 @@
+/**
+ * GAP-256 PR-4b / HC15 — paid-pending feature map zeros AI (no free cohort AI).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: () => ({
+    aiLocal: true,
+    ai: true,
+    aiMemory: true,
+    aiInference: true,
+    audit: true,
+  }),
+}));
+
+vi.mock('@revealui/core/margin-governor', () => ({
+  paidPendingLimits: () => ({ maxSites: 1, maxUsers: 1, maxAgentTasks: 0 }),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@revealui/db', () => ({
+  getClient: () => {
+    throw new Error('db not used in pure feature-map tests');
+  },
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  accountEntitlements: {},
+  accountMemberships: {},
+}));
+
+import { buildPaidPendingFeatureMap } from '../ensure-paid-pending-entitlement.js';
+
+describe('buildPaidPendingFeatureMap (HC15)', () => {
+  it('forces AI-bearing features off while leaving other free features', () => {
+    const features = buildPaidPendingFeatureMap();
+    expect(features.aiLocal).toBe(false);
+    expect(features.ai).toBe(false);
+    expect(features.aiMemory).toBe(false);
+    expect(features.aiInference).toBe(false);
+    expect(features.audit).toBe(true);
+  });
+});

--- a/apps/server/src/lib/__tests__/ensure-paid-pending-entitlement.test.ts
+++ b/apps/server/src/lib/__tests__/ensure-paid-pending-entitlement.test.ts
@@ -1,5 +1,7 @@
 /**
- * GAP-256 PR-4b / HC15 — paid-pending feature map zeros AI (no free cohort AI).
+ * GAP-256 PR-4b HC15 — paid-pending limits and AI-off feature map (unit).
+ * Webhook paid_rebuild after successful checkout is the existing Stripe path
+ * (routes/webhooks); not reimplemented here.
  */
 import { describe, expect, it, vi } from 'vitest';
 
@@ -9,7 +11,7 @@ vi.mock('@revealui/core/features', () => ({
     ai: true,
     aiMemory: true,
     aiInference: true,
-    audit: true,
+    mcp: false,
   }),
 }));
 
@@ -32,15 +34,32 @@ vi.mock('@revealui/db/schema', () => ({
   accountMemberships: {},
 }));
 
+import { paidPendingLimits } from '@revealui/core/margin-governor';
 import { buildPaidPendingFeatureMap } from '../ensure-paid-pending-entitlement.js';
 
-describe('buildPaidPendingFeatureMap (HC15)', () => {
-  it('forces AI-bearing features off while leaving other free features', () => {
+describe('paid-pending entitlement shape (HC15)', () => {
+  it('paidPendingLimits zeros agent tasks (K20)', () => {
+    expect(paidPendingLimits()).toEqual({
+      maxSites: 1,
+      maxUsers: 1,
+      maxAgentTasks: 0,
+    });
+  });
+
+  it('buildPaidPendingFeatureMap forces AI-bearing features off', () => {
     const features = buildPaidPendingFeatureMap();
     expect(features.aiLocal).toBe(false);
     expect(features.ai).toBe(false);
     expect(features.aiMemory).toBe(false);
     expect(features.aiInference).toBe(false);
-    expect(features.audit).toBe(true);
+    expect(features.mcp).toBe(false);
+  });
+
+  it('task-quota denies when maxAgentTasks is 0 (quota exhausted at zero usage)', () => {
+    // Mirrors requireTaskQuota: current >= quota with quota 0 → deny
+    const quota = paidPendingLimits().maxAgentTasks;
+    const current = 0;
+    expect(quota).toBe(0);
+    expect(current >= quota).toBe(true);
   });
 });

--- a/apps/server/src/lib/__tests__/merge-hosted-entitlement.test.ts
+++ b/apps/server/src/lib/__tests__/merge-hosted-entitlement.test.ts
@@ -93,4 +93,24 @@ describe('mergeHostedEntitlementUpdate', () => {
     });
     expect(next.source).toBe('signup');
   });
+
+  it('paid_pending_create forces signup source and zero-task limits (K20)', () => {
+    const next = buildHostedEntitlementValues({
+      tier: 'free',
+      status: 'active',
+      mode: 'live',
+      lastEventAt: null,
+      now,
+      source: 'reconciler',
+      limits: { maxSites: 1, maxUsers: 1, maxAgentTasks: 0 },
+    });
+    const merged = mergeHostedEntitlementUpdate({
+      existing: null,
+      next,
+      reason: 'paid_pending_create',
+    });
+    expect(merged.source).toBe('signup');
+    expect(merged.limits.maxAgentTasks).toBe(0);
+    expect(merged.cogsBreakerTrippedAt).toBeNull();
+  });
 });

--- a/apps/server/src/lib/ensure-paid-pending-entitlement.ts
+++ b/apps/server/src/lib/ensure-paid-pending-entitlement.ts
@@ -1,0 +1,182 @@
+/**
+ * GAP-256 PR-4b / K20 — paid-pending entitlement after paid_signup.
+ *
+ * Identity may exist for Stripe Checkout, but free AI must not open on abandon:
+ * maxAgentTasks=0 and AI-bearing features forced off. Webhook paid_rebuild
+ * replaces this row after successful payment (existing path).
+ */
+
+import { getFeaturesForTier } from '@revealui/core/features';
+import { paidPendingLimits } from '@revealui/core/margin-governor';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
+import {
+  buildHostedEntitlementValues,
+  mergeHostedEntitlementUpdate,
+  toFeatureRecord,
+} from './hosted-entitlement.js';
+
+/** Feature keys that must stay off while checkout is unpaid (K20). */
+const AI_BEARING_FEATURE_KEYS = ['aiLocal', 'ai', 'aiMemory', 'aiInference'] as const;
+
+/**
+ * Free-tier feature map with every AI-bearing flag forced false.
+ * Used only for paid-pending rows (not free cohort signup).
+ */
+export function buildPaidPendingFeatureMap(): Record<string, boolean> {
+  const features = toFeatureRecord(getFeaturesForTier('free'));
+  for (const key of AI_BEARING_FEATURE_KEYS) {
+    features[key] = false;
+  }
+  return features;
+}
+
+export interface EnsurePaidPendingEntitlementParams {
+  userId: string;
+  displayName?: string;
+  /** Intended paid tier after checkout (logged only; no metadata column). */
+  pendingTier: 'pro' | 'max' | 'enterprise';
+  now?: Date;
+}
+
+/**
+ * Upsert free/signup entitlement with paidPendingLimits (maxAgentTasks=0).
+ * Does not call freeCohortLimitsForMode or ensureFreeSignupEntitlement.
+ */
+export async function ensurePaidPendingEntitlement(
+  params: EnsurePaidPendingEntitlementParams,
+): Promise<{ accountId: string } | { skipped: true; reason: string }> {
+  const { provisionHostedPersonalAccount } = await import('@revealui/auth/server');
+  const provisioned = await provisionHostedPersonalAccount({
+    userId: params.userId,
+    displayName: params.displayName ?? 'RevealUI',
+  });
+  if ('skipped' in provisioned && provisioned.skipped) {
+    if (provisioned.reason === 'not_hosted') {
+      return provisioned;
+    }
+  }
+
+  const db = getClient();
+  const now = params.now ?? new Date();
+
+  const [membership] = await db
+    .select({ accountId: accountMemberships.accountId })
+    .from(accountMemberships)
+    .where(
+      and(
+        eq(accountMemberships.userId, params.userId),
+        eq(accountMemberships.role, 'owner'),
+        eq(accountMemberships.status, 'active'),
+      ),
+    )
+    .limit(1);
+
+  if (!membership) {
+    logger.warn('[paid-pending-entitlement] no owner membership; skip', {
+      userId: params.userId,
+    });
+    return { skipped: true, reason: 'no_owner_membership' };
+  }
+
+  const accountId = membership.accountId;
+  const [existing] = await db
+    .select({
+      source: accountEntitlements.source,
+      limits: accountEntitlements.limits,
+      cogsBreakerTrippedAt: accountEntitlements.cogsBreakerTrippedAt,
+      cogsBreakerReason: accountEntitlements.cogsBreakerReason,
+      tier: accountEntitlements.tier,
+    })
+    .from(accountEntitlements)
+    .where(eq(accountEntitlements.accountId, accountId))
+    .limit(1);
+
+  if (existing?.source === 'stripe' || existing?.source === 'grant') {
+    logger.info('[paid-pending-entitlement] skip overwrite of paid/gifted row', {
+      accountId,
+      source: existing.source,
+    });
+    return { accountId };
+  }
+
+  const limits = paidPendingLimits();
+  const next = buildHostedEntitlementValues({
+    tier: 'free',
+    status: 'active',
+    mode: 'live',
+    lastEventAt: null,
+    now,
+    source: 'signup',
+    limits: {
+      maxSites: limits.maxSites,
+      maxUsers: limits.maxUsers,
+      maxAgentTasks: limits.maxAgentTasks,
+    },
+    features: buildPaidPendingFeatureMap(),
+  });
+
+  const merged = mergeHostedEntitlementUpdate({
+    existing: existing
+      ? {
+          limits: existing.limits,
+          source: existing.source,
+          cogsBreakerTrippedAt: existing.cogsBreakerTrippedAt,
+          cogsBreakerReason: existing.cogsBreakerReason,
+          tier: existing.tier,
+        }
+      : null,
+    next,
+    reason: 'paid_pending_create',
+  });
+
+  if (existing) {
+    await db
+      .update(accountEntitlements)
+      .set({
+        planId: merged.planId,
+        tier: merged.tier,
+        status: merged.status,
+        features: merged.features,
+        limits: merged.limits,
+        meteringStatus: merged.meteringStatus,
+        mode: merged.mode,
+        source: merged.source,
+        graceUntil: merged.graceUntil,
+        lastEventAt: merged.lastEventAt,
+        updatedAt: merged.updatedAt,
+        cogsBreakerTrippedAt: merged.cogsBreakerTrippedAt,
+        cogsBreakerReason: merged.cogsBreakerReason,
+      })
+      .where(eq(accountEntitlements.accountId, accountId));
+  } else {
+    await db.insert(accountEntitlements).values({
+      accountId,
+      planId: merged.planId,
+      tier: merged.tier,
+      status: merged.status,
+      features: merged.features,
+      limits: merged.limits,
+      meteringStatus: merged.meteringStatus,
+      mode: merged.mode,
+      source: merged.source,
+      graceUntil: merged.graceUntil,
+      lastEventAt: merged.lastEventAt,
+      updatedAt: merged.updatedAt,
+      cogsBreakerTrippedAt: merged.cogsBreakerTrippedAt,
+      cogsBreakerReason: merged.cogsBreakerReason,
+    });
+  }
+
+  // No metadata jsonb on account_entitlements; pending tier is log-only.
+  logger.info('[paid-pending-entitlement] upserted', {
+    accountId,
+    userId: params.userId,
+    pendingTier: params.pendingTier,
+    maxAgentTasks: merged.limits.maxAgentTasks,
+  });
+
+  return { accountId };
+}

--- a/apps/server/src/routes/__tests__/admission-paid-signup.test.ts
+++ b/apps/server/src/routes/__tests__/admission-paid-signup.test.ts
@@ -1,0 +1,168 @@
+/**
+ * GAP-256 PR-4b — paid_signup escape (HC4 bypass waitlist, HC15 paid-pending).
+ */
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const admitFreeIntake = vi.fn();
+const isSignupAllowed = vi.fn(() => true);
+const signUp = vi.fn();
+const ensurePaidPendingEntitlement = vi.fn();
+const assertLiveCatalogComplete = vi.fn();
+const resolveCatalogPriceId = vi.fn();
+const ensureStripeCustomer = vi.fn();
+const getEarlyAdopterDiscount = vi.fn(() => ({}));
+const stripePriceIsUsable = vi.fn(async () => false);
+const withStripe = vi.fn();
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+// zValidator: parse JSON body into c.req.valid('json') without openapi package build.
+vi.mock('@revealui/openapi', () => ({
+  zValidator: (_target: string, schema: { parse: (v: unknown) => unknown }) => {
+    return async (
+      c: { req: { json: () => Promise<unknown>; valid: (k: string) => unknown } },
+      next: () => Promise<void>,
+    ) => {
+      const body = await c.req.json();
+      const parsed = schema.parse(body);
+      c.req.valid = (key: string) => {
+        if (key === 'json') return parsed;
+        throw new Error(`valid(${key}) not stubbed`);
+      };
+      await next();
+    };
+  },
+}));
+
+vi.mock('@revealui/auth/server', () => ({
+  admitFreeIntake: (...a: unknown[]) => admitFreeIntake(...a),
+  isSignupAllowed: (...a: unknown[]) => isSignupAllowed(...a),
+  signUp: (...a: unknown[]) => signUp(...a),
+}));
+
+vi.mock('../../lib/ensure-paid-pending-entitlement.js', () => ({
+  ensurePaidPendingEntitlement: (...a: unknown[]) => ensurePaidPendingEntitlement(...a),
+}));
+
+vi.mock('../billing/helpers.js', () => ({
+  assertLiveCatalogComplete: (...a: unknown[]) => assertLiveCatalogComplete(...a),
+  resolveCatalogPriceId: (...a: unknown[]) => resolveCatalogPriceId(...a),
+  ensureStripeCustomer: (...a: unknown[]) => ensureStripeCustomer(...a),
+  getEarlyAdopterDiscount: (...a: unknown[]) => getEarlyAdopterDiscount(...a),
+  isStripeTaxEnabled: false,
+  TRIAL_PERIOD_DAYS: 7,
+  stripePriceIsUsable: (...a: unknown[]) => stripePriceIsUsable(...a),
+  withStripe: (...a: unknown[]) => withStripe(...a),
+}));
+
+import paidSignupRoute from '../admission/paid-signup.js';
+
+function createApp() {
+  const app = new Hono();
+  app.route('/admission', paidSignupRoute);
+  return app;
+}
+
+const validBody = {
+  email: 'payer@example.com',
+  password: 'SecurePass123',
+  name: 'Paying User',
+  tier: 'pro' as const,
+};
+
+describe('POST /admission/paid-signup (HC4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSignupAllowed.mockReturnValue(true);
+    process.env.ADMIN_URL = 'https://admin.example.com';
+    admitFreeIntake.mockResolvedValue({
+      decision: 'admit',
+      mode: 'bypass',
+      cohortLimits: { maxSites: 1, maxUsers: 1, maxAgentTasks: 0 },
+      snapshotId: 'snap-waitlist',
+      reason: 'paying_bypass',
+      shadow: false,
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+    });
+    signUp.mockResolvedValue({
+      success: true,
+      user: { id: 'user-1', email: 'payer@example.com' },
+      sessionToken: 'sess-token',
+    });
+    ensurePaidPendingEntitlement.mockResolvedValue({ accountId: 'acct-1' });
+    assertLiveCatalogComplete.mockResolvedValue(undefined);
+    resolveCatalogPriceId.mockResolvedValue('price_pro_month');
+    ensureStripeCustomer.mockResolvedValue('cus_1');
+    withStripe.mockImplementation(async (fn: (stripe: unknown) => Promise<unknown>) => {
+      return fn({
+        checkout: {
+          sessions: {
+            create: vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/session' }),
+          },
+        },
+      });
+    });
+  });
+
+  it('creates user under waitlist mode via paid_signup channel (HC4)', async () => {
+    const res = await createApp().request('/admission/paid-signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.user.id).toBe('user-1');
+    expect(json.sessionToken).toBe('sess-token');
+    expect(json.checkoutUrl).toBe('https://checkout.stripe.test/session');
+
+    expect(admitFreeIntake).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'paid_signup',
+        email: 'payer@example.com',
+        payingIntent: { kind: 'checkout', tier: 'pro' },
+      }),
+    );
+    expect(signUp).toHaveBeenCalled();
+    expect(ensurePaidPendingEntitlement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        pendingTier: 'pro',
+      }),
+    );
+  });
+
+  it('returns 502 with session when Stripe fails after user create (no free AI path)', async () => {
+    withStripe.mockRejectedValue(new Error('Stripe unavailable'));
+
+    const res = await createApp().request('/admission/paid-signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.user.id).toBe('user-1');
+    expect(json.sessionToken).toBe('sess-token');
+    expect(json.checkoutUrl).toBeNull();
+    expect(json.checkoutError).toBe(true);
+    expect(ensurePaidPendingEntitlement).toHaveBeenCalled();
+  });
+
+  it('provisions paid-pending entitlement and never free signup path', async () => {
+    await createApp().request('/admission/paid-signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(ensurePaidPendingEntitlement).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/server/src/routes/__tests__/auth-signup-waitlist.test.ts
+++ b/apps/server/src/routes/__tests__/auth-signup-waitlist.test.ts
@@ -79,6 +79,7 @@ describe('POST /auth/signup waitlist (HC2)', () => {
       code: 'WAITLISTED',
       waitlistToken: 'raw-token-hex',
       positionEstimate: 3,
+      paidSignupPath: '/api/admission/paid-signup',
     });
     expect(json.message).toContain('waitlisted');
     expect(signUp).not.toHaveBeenCalled();

--- a/apps/server/src/routes/admission/paid-signup.ts
+++ b/apps/server/src/routes/admission/paid-signup.ts
@@ -1,0 +1,235 @@
+/**
+ * GAP-256 PR-4b — public paid_signup escape (K14 / K20).
+ *
+ * POST /paid-signup  { email, password, name, tier: pro|max|enterprise }
+ *
+ * Mounted under /api/admission and /api/v1/admission.
+ * Always bypasses waitlist; never grants free cohort AI (paid-pending).
+ */
+
+import { admitFreeIntake, isSignupAllowed, signUp } from '@revealui/auth/server';
+import { logger } from '@revealui/core/observability/logger';
+import { zValidator } from '@revealui/openapi';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { z } from 'zod';
+import { ensurePaidPendingEntitlement } from '../../lib/ensure-paid-pending-entitlement.js';
+import {
+  assertLiveCatalogComplete,
+  ensureStripeCustomer,
+  getEarlyAdopterDiscount,
+  isStripeTaxEnabled,
+  resolveCatalogPriceId,
+  stripePriceIsUsable,
+  TRIAL_PERIOD_DAYS,
+  withStripe,
+} from '../billing/helpers.js';
+
+const app = new Hono();
+
+const PaidSignupBodySchema = z.object({
+  email: z.string().email().max(320),
+  // Lockstep with SignUpRequestSchema / waitlist claim (GAP-244): min 12
+  password: z.string().min(12).max(128),
+  name: z.string().min(1).max(100),
+  tier: z.enum(['pro', 'max', 'enterprise']),
+});
+
+/**
+ * Create Stripe Checkout for a freshly signed-up paid-pending user.
+ * Throws HTTPException or Error on hard failure; caller maps to partial response.
+ */
+async function createPaidSignupCheckoutSession(params: {
+  userId: string;
+  email: string;
+  tier: 'pro' | 'max' | 'enterprise';
+}): Promise<string> {
+  await assertLiveCatalogComplete();
+
+  const resolvedPriceId = await resolveCatalogPriceId(params.tier, 'subscription');
+  const customerId = await ensureStripeCustomer(params.userId, params.email);
+
+  const adminUrl = process.env.ADMIN_URL || process.env.NEXT_PUBLIC_SERVER_URL;
+  if (!adminUrl) {
+    throw new HTTPException(500, { message: 'ADMIN_URL is not configured' });
+  }
+
+  const discountConfig = getEarlyAdopterDiscount(params.tier);
+  const meterPriceId = process.env.STRIPE_AGENT_OVERAGE_PRICE_ID;
+  let includeMeter = Boolean(meterPriceId) && (params.tier === 'pro' || params.tier === 'max');
+  if (
+    includeMeter &&
+    meterPriceId &&
+    !(await withStripe((s) => stripePriceIsUsable(s, meterPriceId)))
+  ) {
+    logger.warn('paid-signup: agent-overage meter price not usable — omitting meter line item', {
+      meterPriceId,
+      tier: params.tier,
+    });
+    includeMeter = false;
+  }
+
+  const sessionMetadata = {
+    tier: params.tier,
+    revealui_user_id: params.userId,
+    paid_pending: 'true',
+  };
+
+  const idempotencyWindow = Math.floor(Date.now() / (10 * 60 * 1000));
+  const session = await withStripe((stripe) =>
+    stripe.checkout.sessions.create(
+      {
+        customer: customerId,
+        mode: 'subscription',
+        metadata: sessionMetadata,
+        payment_method_types: ['card'],
+        billing_address_collection: 'required',
+        tax_id_collection: { enabled: true },
+        customer_update: { name: 'auto', address: 'auto' },
+        automatic_tax: { enabled: isStripeTaxEnabled },
+        ...discountConfig,
+        line_items: [
+          { price: resolvedPriceId, quantity: 1 },
+          ...(includeMeter && meterPriceId ? [{ price: meterPriceId }] : []),
+        ],
+        subscription_data: {
+          trial_period_days: TRIAL_PERIOD_DAYS,
+          metadata: sessionMetadata,
+        },
+        success_url: `${adminUrl}/welcome?success=true&tier=${params.tier}`,
+        cancel_url: `${adminUrl}/account/billing`,
+      },
+      {
+        idempotencyKey: `paid-signup-${params.userId}-${params.tier}-${idempotencyWindow}`,
+      },
+    ),
+  );
+
+  if (!session.url) {
+    throw new HTTPException(500, { message: 'Failed to create checkout session' });
+  }
+  return session.url;
+}
+
+/**
+ * POST /paid-signup
+ * Admit paying intent, create user, paid-pending entitlement, Stripe Checkout URL.
+ */
+app.post('/paid-signup', zValidator('json', PaidSignupBodySchema), async (c) => {
+  const { email, password, name, tier } = c.req.valid('json');
+  const normalizedEmail = email.trim().toLowerCase();
+
+  if (!isSignupAllowed(normalizedEmail)) {
+    return c.json(
+      { success: false, error: 'Signups are currently restricted', code: 'SIGNUP_RESTRICTED' },
+      403,
+    );
+  }
+
+  // K14: always bypass waitlist for paid_signup (never free cohort limits).
+  const admit = await admitFreeIntake({
+    channel: 'paid_signup',
+    email: normalizedEmail,
+    payingIntent: { kind: 'checkout', tier },
+  });
+
+  if (admit.decision !== 'admit') {
+    logger.warn('[admission-paid-signup] paid_signup did not admit', {
+      decision: admit.decision,
+      reason: admit.reason,
+    });
+    return c.json(
+      {
+        success: false,
+        error: 'Unable to start paid signup right now',
+        code: 'PAID_SIGNUP_NOT_ADMITTED',
+      },
+      503,
+    );
+  }
+
+  const result = await signUp(normalizedEmail, password, name, {
+    userAgent: c.req.header('user-agent'),
+    ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
+  });
+
+  if (!result.success || !result.user?.id) {
+    logger.warn('[admission-paid-signup] signUp failed', { error: result.error });
+    return c.json(
+      {
+        success: false,
+        error: result.error ?? 'Sign up failed',
+        code: 'SIGNUP_FAILED',
+      },
+      400,
+    );
+  }
+
+  const userId = result.user.id;
+
+  // K20: paid-pending before Checkout — never freeCohortLimitsForMode.
+  try {
+    await ensurePaidPendingEntitlement({
+      userId,
+      displayName: name,
+      pendingTier: tier,
+    });
+  } catch (err) {
+    logger.error(
+      '[admission-paid-signup] paid-pending entitlement failed (non-fatal; continue checkout)',
+      err instanceof Error ? err : undefined,
+      { userId },
+    );
+  }
+
+  let checkoutUrl: string | null = null;
+  let checkoutError = false;
+  try {
+    checkoutUrl = await createPaidSignupCheckoutSession({
+      userId,
+      email: result.user.email ?? normalizedEmail,
+      tier,
+    });
+  } catch (err) {
+    checkoutError = true;
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      '[admission-paid-signup] Stripe checkout failed after user create (paid-pending retained)',
+      err instanceof Error ? err : undefined,
+      { userId, tier },
+    );
+    // User + paid-pending exist; no free AI. Surface partial success for client retry via billing.
+    return c.json(
+      {
+        success: true,
+        user: { id: userId, email: result.user.email },
+        sessionToken: result.sessionToken,
+        checkoutUrl: null,
+        checkoutError: true,
+        message:
+          'Account created. Checkout could not start. Sign in and open billing to complete payment.',
+        error: message,
+      },
+      502,
+    );
+  }
+
+  logger.info('[admission-paid-signup] created', {
+    userId,
+    tier,
+    admitReason: admit.reason,
+    checkoutError,
+  });
+
+  return c.json(
+    {
+      success: true,
+      user: { id: userId, email: result.user.email },
+      sessionToken: result.sessionToken,
+      checkoutUrl,
+    },
+    201,
+  );
+});
+
+export default app;

--- a/apps/server/src/routes/admission/paid-signup.ts
+++ b/apps/server/src/routes/admission/paid-signup.ts
@@ -153,7 +153,7 @@ app.post('/paid-signup', zValidator('json', PaidSignupBodySchema), async (c) => 
     ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
   });
 
-  if (!result.success || !result.user?.id) {
+  if (!(result.success && result.user?.id)) {
     logger.warn('[admission-paid-signup] signUp failed', { error: result.error });
     return c.json(
       {

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -42,6 +42,7 @@ app.post('/signup', zValidator('json', SignUpRequestSchema), async (c) => {
 
   if (admit.decision === 'waitlist') {
     // PR-4: never margin 403; no users row; raw waitlistToken once.
+    // PR-4b: CTA points at paid_signup escape (not marketing-only pricing).
     return c.json(
       {
         success: false,
@@ -50,6 +51,7 @@ app.post('/signup', zValidator('json', SignUpRequestSchema), async (c) => {
         waitlistToken: admit.waitlistToken,
         positionEstimate: admit.positionEstimate ?? null,
         message: 'Free signup is temporarily waitlisted. Paid signup remains available.',
+        paidSignupPath: '/api/admission/paid-signup',
       },
       202,
     );


### PR DESCRIPTION
## Summary

GAP-256 **PR-4b** (K14/K20, HC4/HC15): paid signup escape that bypasses waitlist without granting free AI on Checkout abandon.

- `POST /api/admission/paid-signup` (+ `/api/v1/admission` alias): `{ email, password, name, tier: pro|max|enterprise }`
- `admitFreeIntake({ channel: 'paid_signup', payingIntent: { kind: 'checkout', tier } })` always bypasses waitlist
- `signUp` + **paid-pending** entitlement via `buildHostedEntitlementValues` + `mergeHostedEntitlementUpdate({ reason: 'paid_pending_create' })`
  - `tier: free`, `source: signup`, `paidPendingLimits()` → **maxAgentTasks: 0**
  - AI-bearing features forced false (`aiLocal`, `ai`, `aiMemory`, `aiInference`)
- Stripe Checkout session (billing helpers); metadata includes `paid_pending: 'true'`
- On Stripe failure after user create: **502** with user + sessionToken + `checkoutUrl: null` + `checkoutError` (no free AI)
- Waitlist **202** bodies include `paidSignupPath: '/api/admission/paid-signup'` (server auth, admin sign-up, passkey register)

Depends on **#2510** (PR-4 waitlist enforce, merged to `test`). Branch rebased onto `origin/test` after #2510 squash-merge.

## Hard constraints

- No `COUNT(users)` for admit
- No free cohort on this path (`freeCohortLimitsForMode` / `ensureFreeSignupEntitlement` not used)
- No free AI on abandon (maxAgentTasks=0 + AI features off)
- Existing Stripe webhook `paid_rebuild` path remains the post-payment unlock (not reimplemented)

## Tests

- HC4: `admission-paid-signup.test.ts` (paid_signup channel + user create)
- HC15: `ensure-paid-pending-entitlement.test.ts` (zero tasks + AI off + quota deny shape)
- Waitlist CTA: `auth-signup-waitlist.test.ts` asserts `paidSignupPath`
- Merge helper: `paid_pending_create` case

## Residuals

- Optional `admission-paid-pending-expire` cron (48h reclaim) → **PR-8**
- Admin OAuth waitlist redirect CTA (JSON paths co-shipped; OAuth is redirect-shaped)

## Test plan

- [x] Unit: paid-signup HC4 + HC15 + waitlist CTA
- [ ] CI green on `test`
- [ ] After merge: enforce waitlist + paid_signup E2E smoke with Stripe test mode