### PR TITLE
feat(server): lean new-cohort free maxAgentTasks

### DIFF
--- a/apps/server/src/lib/__tests__/merge-hosted-entitlement.test.ts
+++ b/apps/server/src/lib/__tests__/merge-hosted-entitlement.test.ts
@@ -23,6 +23,7 @@ vi.mock('../tier-limits.js', () => ({
 import {
   buildHostedEntitlementValues,
   mergeHostedEntitlementUpdate,
+  reconcileHealMergeReason,
 } from '../hosted-entitlement.js';
 
 describe('mergeHostedEntitlementUpdate', () => {
@@ -112,5 +113,70 @@ describe('mergeHostedEntitlementUpdate', () => {
     expect(merged.source).toBe('signup');
     expect(merged.limits.maxAgentTasks).toBe(0);
     expect(merged.cogsBreakerTrippedAt).toBeNull();
+  });
+});
+
+describe('reconcileHealMergeReason (PR-5 / HC11 / HC12)', () => {
+  const now = new Date('2026-08-09T00:00:00.000Z');
+
+  it('paid expected tiers → paid_rebuild', () => {
+    expect(reconcileHealMergeReason('pro')).toBe('paid_rebuild');
+    expect(reconcileHealMergeReason('max')).toBe('paid_rebuild');
+    expect(reconcileHealMergeReason('enterprise')).toBe('paid_rebuild');
+  });
+
+  it('free expected → free_preserve', () => {
+    expect(reconcileHealMergeReason('free')).toBe('free_preserve');
+  });
+
+  it('reconciler free→free path keeps lean signup maxAgentTasks (HC11)', () => {
+    const next = buildHostedEntitlementValues({
+      tier: 'free',
+      status: 'active',
+      mode: 'live',
+      lastEventAt: null,
+      now,
+      source: 'reconciler',
+      limits: { maxSites: 1, maxUsers: 3, maxAgentTasks: 1_000 },
+    });
+    const merged = mergeHostedEntitlementUpdate({
+      existing: {
+        limits: { maxSites: 1, maxUsers: 3, maxAgentTasks: 250 },
+        source: 'signup',
+        cogsBreakerTrippedAt: null,
+        cogsBreakerReason: null,
+        tier: 'free',
+      },
+      next,
+      reason: reconcileHealMergeReason('free'),
+    });
+    expect(merged.limits.maxAgentTasks).toBe(250);
+    expect(merged.source).toBe('signup');
+  });
+
+  it('reconciler paid heal rebuilds and clears breaker (HC12)', () => {
+    const next = buildHostedEntitlementValues({
+      tier: 'pro',
+      status: 'active',
+      mode: 'live',
+      lastEventAt: null,
+      now,
+      source: 'reconciler',
+    });
+    const merged = mergeHostedEntitlementUpdate({
+      existing: {
+        limits: { maxSites: 1, maxUsers: 3, maxAgentTasks: 250 },
+        source: 'signup',
+        cogsBreakerTrippedAt: now,
+        cogsBreakerReason: 'daily',
+        tier: 'free',
+      },
+      next,
+      reason: reconcileHealMergeReason('pro'),
+    });
+    expect(merged.tier).toBe('pro');
+    expect(merged.cogsBreakerTrippedAt).toBeNull();
+    expect(merged.cogsBreakerReason).toBeNull();
+    expect(merged.source).toBe('reconciler');
   });
 });

--- a/apps/server/src/lib/hosted-entitlement.ts
+++ b/apps/server/src/lib/hosted-entitlement.ts
@@ -205,3 +205,15 @@ export function mergeHostedEntitlementUpdate(params: {
     cogsBreakerReason: null,
   };
 }
+
+/**
+ * GAP-256 PR-5 / HC11 — reconciler heal reason from expected tier.
+ * Paid expected → full rebuild + clear breaker. Free expected → free_preserve
+ * so an existing lean signup maxAgentTasks is never clobbered free→free.
+ */
+export function reconcileHealMergeReason(expectedTier: HostedTier): MergeHostedEntitlementReason {
+  if (expectedTier === 'pro' || expectedTier === 'max' || expectedTier === 'enterprise') {
+    return 'paid_rebuild';
+  }
+  return 'free_preserve';
+}

--- a/apps/server/src/routes/cron/reconcile-entitlements.ts
+++ b/apps/server/src/routes/cron/reconcile-entitlements.ts
@@ -79,6 +79,8 @@ import {
   buildHostedEntitlementValues,
   coerceHostedTier,
   type HostedTier,
+  mergeHostedEntitlementUpdate,
+  reconcileHealMergeReason,
 } from '../../lib/hosted-entitlement.js';
 
 const app = new Hono();
@@ -149,6 +151,10 @@ app.post('/reconcile-entitlements', async (c) => {
       entAccountId: accountEntitlements.accountId,
       entTier: accountEntitlements.tier,
       entLastEventAt: accountEntitlements.lastEventAt,
+      entLimits: accountEntitlements.limits,
+      entSource: accountEntitlements.source,
+      entCogsBreakerTrippedAt: accountEntitlements.cogsBreakerTrippedAt,
+      entCogsBreakerReason: accountEntitlements.cogsBreakerReason,
       hasActiveLicense: sql<boolean>`EXISTS (
         SELECT 1 FROM ${licenses} l
         JOIN ${accountMemberships} m2 ON m2.user_id = l.user_id
@@ -252,7 +258,8 @@ app.post('/reconcile-entitlements', async (c) => {
       continue;
     }
 
-    const values = buildHostedEntitlementValues({
+    // K21 / HC12: never raw `.set(values)` — paid rebuild vs free_preserve.
+    const next = buildHostedEntitlementValues({
       tier: expectedTier,
       status: row.subStatus ?? 'active',
       mode,
@@ -264,16 +271,61 @@ app.post('/reconcile-entitlements', async (c) => {
       now,
       source: 'reconciler',
     });
+    const existing = missing
+      ? null
+      : {
+          limits: (row.entLimits ?? {}) as Record<string, unknown>,
+          source: row.entSource ?? 'reconciler',
+          cogsBreakerTrippedAt: row.entCogsBreakerTrippedAt ?? null,
+          cogsBreakerReason: row.entCogsBreakerReason ?? null,
+          tier: row.entTier ?? undefined,
+        };
+    // HC11: paid_rebuild only for paid expected; free→free uses free_preserve
+    // so lean signup maxAgentTasks is never clobbered.
+    const merged = mergeHostedEntitlementUpdate({
+      existing,
+      next,
+      reason: reconcileHealMergeReason(expectedTier),
+    });
 
     if (missing) {
       await db
         .insert(accountEntitlements)
-        .values({ accountId, ...values })
+        .values({
+          accountId,
+          planId: merged.planId,
+          tier: merged.tier,
+          status: merged.status,
+          features: merged.features,
+          limits: merged.limits,
+          meteringStatus: merged.meteringStatus,
+          mode: merged.mode,
+          source: merged.source,
+          graceUntil: merged.graceUntil,
+          lastEventAt: merged.lastEventAt,
+          updatedAt: merged.updatedAt,
+          cogsBreakerTrippedAt: merged.cogsBreakerTrippedAt,
+          cogsBreakerReason: merged.cogsBreakerReason,
+        })
         .onConflictDoNothing();
     } else {
       await db
         .update(accountEntitlements)
-        .set(values)
+        .set({
+          planId: merged.planId,
+          tier: merged.tier,
+          status: merged.status,
+          features: merged.features,
+          limits: merged.limits,
+          meteringStatus: merged.meteringStatus,
+          mode: merged.mode,
+          source: merged.source,
+          graceUntil: merged.graceUntil,
+          lastEventAt: merged.lastEventAt,
+          updatedAt: merged.updatedAt,
+          cogsBreakerTrippedAt: merged.cogsBreakerTrippedAt,
+          cogsBreakerReason: merged.cogsBreakerReason,
+        })
         .where(
           and(eq(accountEntitlements.accountId, accountId), eq(accountEntitlements.mode, mode)),
         );

--- a/packages/auth/src/server/__tests__/margin-admit.test.ts
+++ b/packages/auth/src/server/__tests__/margin-admit.test.ts
@@ -60,4 +60,22 @@ describe('decide path used by admit (PR-4)', () => {
       expect(r.reason).toBe('waitlist_claim');
     }
   });
+
+  it('shadow never applies lean cohort limits (PR-5 / HC11)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: { id: 'snap', mode: 'lean', computedAt: now },
+      flags: { enabled: true, shadow: true, staleHours: 36 },
+      openLimits: OPEN_FREE_LIMITS,
+      leanMaxAgentTasks: 250,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.cohortLimits.maxAgentTasks).toBe(1_000);
+      expect(r.reason).toBe('shadow_would_lean');
+    }
+  });
 });

--- a/packages/auth/src/server/margin-admit.ts
+++ b/packages/auth/src/server/margin-admit.ts
@@ -104,6 +104,13 @@ async function loadLatestSnapshot(): Promise<MarginSnapshotView | null> {
  * Shadow defaults → always admit (never waitlist response).
  * Enforce waitlist → enqueue admission_waitlist and attach raw token.
  */
+function leanMaxAgentTasksFromEnv(env: NodeJS.ProcessEnv): number {
+  const raw = env.LEAN_FREE_MAX_AGENT_TASKS;
+  if (raw === undefined || raw.trim() === '') return 250;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 250;
+}
+
 export async function admitFreeIntake(input: AdmitFreeIntakeInput): Promise<AdmitFreeIntakeResult> {
   const env = input.env ?? process.env;
   const flags = governorFlagsFromEnv(env);
@@ -115,6 +122,7 @@ export async function admitFreeIntake(input: AdmitFreeIntakeInput): Promise<Admi
     snapshot,
     flags,
     openLimits: OPEN_FREE_LIMITS,
+    leanMaxAgentTasks: leanMaxAgentTasksFromEnv(env),
     now: input.now,
   });
 

--- a/packages/core/src/__tests__/margin-governor.test.ts
+++ b/packages/core/src/__tests__/margin-governor.test.ts
@@ -147,6 +147,99 @@ describe('decideFreeIntake', () => {
     }
   });
 
+  it('enforce + lean → new cohort maxAgentTasks 250 (HC11)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: {
+        id: 'snap-lean',
+        mode: 'lean',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.mode).toBe('lean');
+      expect(r.cohortLimits).toEqual({
+        maxSites: 1,
+        maxUsers: 3,
+        maxAgentTasks: 250,
+      });
+      expect(r.reason).toBe('snapshot_lean');
+    }
+  });
+
+  it('enforce + open → maxAgentTasks 1000 (HC11)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: {
+        id: 'snap-open',
+        mode: 'open',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.mode).toBe('open');
+      expect(r.cohortLimits.maxAgentTasks).toBe(1_000);
+    }
+  });
+
+  it('shadow + lean snapshot → still open 1000 (never lean under shadow) (HC11)', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: {
+        id: 'snap-shadow-lean',
+        mode: 'lean',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: true, staleHours: 36 },
+      openLimits,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.mode).toBe('shadow');
+      expect(r.shadow).toBe(true);
+      expect(r.reason).toBe('shadow_would_lean');
+      expect(r.cohortLimits.maxAgentTasks).toBe(1_000);
+      expect(r.cohortLimits.maxSites).toBe(1);
+      expect(r.cohortLimits.maxUsers).toBe(3);
+    }
+  });
+
+  it('enforce lean respects leanMaxAgentTasks override', () => {
+    const r = decideFreeIntake({
+      channel: 'free_signup',
+      deploymentMode: 'hosted',
+      payingIntent: { kind: 'none' },
+      snapshot: {
+        id: 'snap-lean-override',
+        mode: 'lean',
+        computedAt: now,
+      },
+      flags: { enabled: true, shadow: false, staleHours: 36 },
+      openLimits,
+      leanMaxAgentTasks: 100,
+      now,
+    });
+    expect(r.decision).toBe('admit');
+    if (r.decision === 'admit') {
+      expect(r.cohortLimits.maxAgentTasks).toBe(100);
+    }
+  });
+
   it('does not reference user COUNT (HC6 — pure API surface)', () => {
     // Module has no users import; smoke the API only.
     expect(typeof decideFreeIntake).toBe('function');

--- a/packages/core/src/margin-governor.ts
+++ b/packages/core/src/margin-governor.ts
@@ -190,13 +190,13 @@ export function decideFreeIntake(input: {
   const rawMode: SnapshotMode = stale ? 'open' : (input.snapshot?.mode ?? 'open');
   const snapshotId = input.snapshot?.id ?? null;
 
-  // Shadow: always admit; attach would-be mode for logs
+  // Shadow: always admit with open limits (never waitlist / never lean-enforce).
+  // Reason still records would-be mode for logs (MARGIN_GOVERNOR_SHADOW table).
   if (input.flags.shadow) {
-    const cohortMode = rawMode === 'lean' ? 'lean' : 'open';
     return {
       decision: 'admit',
       mode: 'shadow',
-      cohortLimits: freeCohortLimitsForMode(cohortMode, openLimits, leanTasks),
+      cohortLimits: freeCohortLimitsForMode('open', openLimits, leanTasks),
       snapshotId,
       reason: stale ? `shadow_stale_would_${rawMode}` : `shadow_would_${rawMode}`,
       shadow: true,


### PR DESCRIPTION
## Summary

**GAP-256 PR-5** after PR-1…4b on `test`.

### Changes
- **Shadow never lean-enforces** — admit with open free limits; reason still records `shadow_would_*` (design: never waitlist/lean under shadow)
- **Enforce lean** — `maxAgentTasks` 250 (override via `LEAN_FREE_MAX_AGENT_TASKS`); seats/sites unchanged
- **Reconciler** — all heal writes go through `mergeHostedEntitlementUpdate` via `reconcileHealMergeReason` (`paid_rebuild` vs `free_preserve`) so free→free does not clobber lean signup limits (HC11/HC12)

### Tests
- core margin-governor HC11 (14 tests)
- auth margin-admit shadow/lean (4)
- merge-hosted-entitlement + reconcile reason (8)

### Peer note
Does **not** touch `gap256-admin-margin` COGS/admin UI WIP (PR-6/7).

## Test plan
- [x] local targeted vitest green
- [ ] CI Quality / Unit Tests
- [ ] security review if labeled

Depends on: #2500–#2503, #2510, #2513 (already on test)