### PR TITLE
feat(harnesses): Standards ‖ Spec axes on revealui-review skill

### DIFF
--- a/.changeset/harnesses-review-standards-spec.md
+++ b/.changeset/harnesses-review-standards-spec.md
@@ -1,0 +1,5 @@
+---
+"@revealui/harnesses": patch
+---
+
+Harden revealui-review skill: Standards ‖ Spec parallel review axes + deep-module checks.

--- a/.revealui/content/skills/revealui-review/SKILL.md
+++ b/.revealui/content/skills/revealui-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: RevealUI Code Review
 description: "Code review for RevealUI: run Standards and Spec axes in parallel before merge or \"done\". Use when reviewing code, completing a feature, checking quality, or before committing. Invoke with $revealui-review."
+disable-model-invocation: true
 ---
 
 # RevealUI Code Review
@@ -116,4 +117,3 @@ If copy/claims touched: `pnpm validate:claims`. If harness content touched: cont
 - `$revealui-debugging`  -  red-capable loop before hypothesising
 - `$revealui-testing`  -  flaky/concurrency triage
 - `$revealui-conventions`  -  house TypeScript/Tailwind/monorepo rules
-

--- a/.revealui/content/skills/revealui-review/SKILL.md
+++ b/.revealui/content/skills/revealui-review/SKILL.md
@@ -1,60 +1,119 @@
 ---
 name: RevealUI Code Review
-description: "Code review checklist for RevealUI. Use when reviewing code, completing a feature,\nchecking quality, or before committing. Invoke explicitly with $revealui-review."
-disable-model-invocation: true
+description: "Code review for RevealUI: run Standards and Spec axes in parallel before merge or \"done\". Use when reviewing code, completing a feature, checking quality, or before committing. Invoke with $revealui-review."
 ---
 
 # RevealUI Code Review
 
-Run this checklist before committing or claiming work is complete.
+Run **both axes in parallel** before claiming done or approving a PR. Do not finish on Standards alone (pretty code that fails the job) or Spec alone (works once, unmaintainable).
 
-## Automated Checks
+| Axis | Question | Verdict |
+|------|----------|---------|
+| **Standards** | Does this match fleet hardlines, package boundaries, and house style? | PASS / FAIL with file:line |
+| **Spec** | Does this deliver the agreed behavior at the right seams? | PASS / FAIL with acceptance map |
 
-Run each command and confirm clean output:
+Ship only when **both** are PASS (or FAIL items are filed as durable follow-ups with owner disposition, not silent skips).
+
+## 0. Automated Checks (both axes feed on these)
+
+Run and record clean/red:
 
 ```bash
-# 1. Biome lint + format
 pnpm lint
-
-# 2. TypeScript  -  all packages
 pnpm typecheck:all
-
-# 3. Tests  -  affected packages
 pnpm --filter <package> test
-
-# 4. Quick gate (lint + typecheck + structure)
 pnpm gate:quick
 ```
 
-## Manual Checks
+If copy/claims touched: `pnpm validate:claims`. If harness content touched: content snapshot / freshness checks.
 
-### Type Safety
-- [ ] No `any` types (use `unknown` + type guards)
-- [ ] No `as` casts where `satisfies` works
+---
+
+## Axis A  -  Standards (how we build)
+
+### A1. Type safety
+- [ ] No `any` (use `unknown` + guards)
+- [ ] Prefer `satisfies` over casual `as`
 - [ ] Exported functions have explicit return types
-- [ ] `import type` used for type-only imports
+- [ ] `import type` for type-only imports
+- [ ] No underscore-silenced unused params (`_foo`) when the honest fix is implement/remove
 
-### Code Quality
-- [ ] No `console.*` in production code (use `@revealui/utils` logger)
-- [ ] No hardcoded config values (use parameterization pattern)
-- [ ] No unused variables/imports (follow decision tree if flagged)
-- [ ] Single responsibility  -  each file does one thing
+### A2. Code quality
+- [ ] No `console.*` in product paths (use observability logger)
+- [ ] No hardcoded env/config that belongs in parameterization or revvault paths
+- [ ] Single responsibility per module; no drive-by unrelated rewrites
+- [ ] Biome-clean; no format debt left for CI
 
-### Architecture
-- [ ] No Supabase imports outside permitted paths
-- [ ] No cross-package relative imports (use `@revealui/<name>`)
-- [ ] Internal deps use `workspace:*`
-- [ ] OSS packages don't import from Pro packages
+### A3. Architecture and boundaries
+- [ ] No forbidden Supabase / dual-DB imports
+- [ ] Cross-package via `@revealui/<name>`, not relative into other packages
+- [ ] Internal deps `workspace:*`; OSS packages do not import Pro packages
+- [ ] **Deep modules:** prefer deep interfaces (small public surface, rich implementation) over shallow "pass-through" layers that leak internals
+- [ ] **Locality:** change cost stays near the owning package; avoid shotgun edits across unrelated packages without a named reason
 
-### Tailwind v4
-- [ ] `bg-(--var)` not `bg-[--var]` for CSS variables
-- [ ] `bg-red-500!` not `!bg-red-500` for important
+### A4. Tailwind v4 (UI)
+- [ ] `bg-(--var)` not `bg-[--var]`
+- [ ] `bg-red-500!` not `!bg-red-500`
 - [ ] `@import "tailwindcss"` not `@tailwind`
 - [ ] `@utility` not `@layer utilities`
-- [ ] `gap` preferred over `space-*`
+- [ ] Prefer `gap` over `space-*`
 
-### Git
+### A5. Git and secrets
 - [ ] Conventional commit: `type(scope): description`
-- [ ] Subject under 72 characters, imperative mood
-- [ ] Identity: RevealUI Studio <founder@revealui.com>
-- [ ] No secrets in committed files
+- [ ] Subject under 72 chars, imperative
+- [ ] Identity: `RevealUI Studio <43050008+joshua-v-dev@users.noreply.github.com>` (never `founder@revealui.com` on signed fleet commits)
+- [ ] No secrets in tree; revvault paths only in docs/chat
+
+### A6. Process hardlines (when applicable)
+- [ ] Durable fix in owning primitive (no unregistered hotfix / workaround recipe)
+- [ ] Proposal-shaped only unless owner named a disposition
+- [ ] Security surfaces: recorded review before "ready to merge" language
+
+---
+
+## Axis B  -  Spec (what we agreed to build)
+
+### B1. Seams and acceptance
+- [ ] Behavior is specified at **public seams** (package exports, HTTP routes, CLI), not private helpers
+- [ ] Acceptance criteria from gap/PR/spec map 1:1 to observable outcomes
+- [ ] User-visible copy matches `copy-voice` / no em dashes on public surfaces
+
+### B2. Correctness and proof
+- [ ] Happy path and material failure paths covered
+- [ ] Tests (or gate commands) prove red→green for the change class; no tautological expects
+- [ ] code-over-docs: if prose and code disagree, code is truth and docs are fixed or filed
+
+### B3. Regression and safety
+- [ ] Adjacent behavior not broken (call sites, consumers, materialize consumers for harness content)
+- [ ] Feature gates / entitlements / authz still fail closed
+- [ ] No new poll loops or token-economy violations (prefer completion events / `events.wait`)
+
+### B4. Depth check (design smell)
+- [ ] New API is not a shallow wrapper that forces callers to know internals
+- [ ] If the module is hard to test without mocking private collaborators, fix the seam (or file design follow-up) rather than shipping implementation-coupled tests
+
+---
+
+## Parallel workflow (how to run the review)
+
+1. **List** the change set (PR files or `git diff origin/test...HEAD`).
+2. **Standards pass**  -  walk Axis A; write FAIL as `path:line  -  rule  -  fix`.
+3. **Spec pass**  -  walk Axis B; write FAIL as `criterion  -  evidence missing/broken  -  fix`.
+4. **Cross-check**  -  a Standards-only green with Spec FAIL is **not** shippable; same in reverse.
+5. **Verdict**  -  APPROVE only if both axes PASS (or residual is owner-dispositioned and tracked).
+
+## Anti-patterns
+
+- **Style theater**  -  formatting clean, wrong product behavior
+- **Demo-only green**  -  works in one happy curl, no failure paths
+- **Shallow module**  -  many small files that re-export each other without a real boundary
+- **Testing past the seam**  -  private access to force coverage
+- **Doc cosplay**  -  updating handoffs instead of code (or the reverse without reconciling)
+
+## Related skills
+
+- `$revealui-tdd`  -  seams, vertical slices, anti-patterns for new work
+- `$revealui-debugging`  -  red-capable loop before hypothesising
+- `$revealui-testing`  -  flaky/concurrency triage
+- `$revealui-conventions`  -  house TypeScript/Tailwind/monorepo rules
+

--- a/packages/harnesses/content-snapshots/claude-code.json
+++ b/packages/harnesses/content-snapshots/claude-code.json
@@ -136,7 +136,7 @@
     },
     {
       "relativePath": ".revealui/content/skills/revealui-review/SKILL.md",
-      "sha256": "9e7d85e7b028e9668c36a31723abc8ede637dcfac65236aa8b0c135c91fdc895"
+      "sha256": "420a65c8f5b28d5bc36294305d619a9f02cb45bac1762a1025921aa1eb323f73"
     },
     {
       "relativePath": ".revealui/content/skills/revealui-safety/SKILL.md",

--- a/packages/harnesses/src/content/definitions/skills/revealui-review.ts
+++ b/packages/harnesses/src/content/definitions/skills/revealui-review.ts
@@ -5,7 +5,7 @@ export const revealuiReviewSkill: Skill = {
   tier: 'pro',
   name: 'RevealUI Code Review',
   description:
-    'Code review checklist for RevealUI. Use when reviewing code, completing a feature,\nchecking quality, or before committing. Invoke explicitly with $revealui-review.',
+    'Code review for RevealUI: run Standards and Spec axes in parallel before merge or "done". Use when reviewing code, completing a feature, checking quality, or before committing. Invoke with $revealui-review.',
   disableModelInvocation: true,
   skipFrontmatter: false,
   filePatterns: [],
@@ -13,56 +13,116 @@ export const revealuiReviewSkill: Skill = {
   references: {},
   content: `# RevealUI Code Review
 
-Run this checklist before committing or claiming work is complete.
+Run **both axes in parallel** before claiming done or approving a PR. Do not finish on Standards alone (pretty code that fails the job) or Spec alone (works once, unmaintainable).
 
-## Automated Checks
+| Axis | Question | Verdict |
+|------|----------|---------|
+| **Standards** | Does this match fleet hardlines, package boundaries, and house style? | PASS / FAIL with file:line |
+| **Spec** | Does this deliver the agreed behavior at the right seams? | PASS / FAIL with acceptance map |
 
-Run each command and confirm clean output:
+Ship only when **both** are PASS (or FAIL items are filed as durable follow-ups with owner disposition, not silent skips).
+
+## 0. Automated Checks (both axes feed on these)
+
+Run and record clean/red:
 
 \`\`\`bash
-# 1. Biome lint + format
 pnpm lint
-
-# 2. TypeScript  -  all packages
 pnpm typecheck:all
-
-# 3. Tests  -  affected packages
 pnpm --filter <package> test
-
-# 4. Quick gate (lint + typecheck + structure)
 pnpm gate:quick
 \`\`\`
 
-## Manual Checks
+If copy/claims touched: \`pnpm validate:claims\`. If harness content touched: content snapshot / freshness checks.
 
-### Type Safety
-- [ ] No \`any\` types (use \`unknown\` + type guards)
-- [ ] No \`as\` casts where \`satisfies\` works
+---
+
+## Axis A  -  Standards (how we build)
+
+### A1. Type safety
+- [ ] No \`any\` (use \`unknown\` + guards)
+- [ ] Prefer \`satisfies\` over casual \`as\`
 - [ ] Exported functions have explicit return types
-- [ ] \`import type\` used for type-only imports
+- [ ] \`import type\` for type-only imports
+- [ ] No underscore-silenced unused params (\`_foo\`) when the honest fix is implement/remove
 
-### Code Quality
-- [ ] No \`console.*\` in production code (use \`@revealui/utils\` logger)
-- [ ] No hardcoded config values (use parameterization pattern)
-- [ ] No unused variables/imports (follow decision tree if flagged)
-- [ ] Single responsibility  -  each file does one thing
+### A2. Code quality
+- [ ] No \`console.*\` in product paths (use observability logger)
+- [ ] No hardcoded env/config that belongs in parameterization or revvault paths
+- [ ] Single responsibility per module; no drive-by unrelated rewrites
+- [ ] Biome-clean; no format debt left for CI
 
-### Architecture
-- [ ] No Supabase imports outside permitted paths
-- [ ] No cross-package relative imports (use \`@revealui/<name>\`)
-- [ ] Internal deps use \`workspace:*\`
-- [ ] OSS packages don't import from Pro packages
+### A3. Architecture and boundaries
+- [ ] No forbidden Supabase / dual-DB imports
+- [ ] Cross-package via \`@revealui/<name>\`, not relative into other packages
+- [ ] Internal deps \`workspace:*\`; OSS packages do not import Pro packages
+- [ ] **Deep modules:** prefer deep interfaces (small public surface, rich implementation) over shallow "pass-through" layers that leak internals
+- [ ] **Locality:** change cost stays near the owning package; avoid shotgun edits across unrelated packages without a named reason
 
-### Tailwind v4
-- [ ] \`bg-(--var)\` not \`bg-[--var]\` for CSS variables
-- [ ] \`bg-red-500!\` not \`!bg-red-500\` for important
+### A4. Tailwind v4 (UI)
+- [ ] \`bg-(--var)\` not \`bg-[--var]\`
+- [ ] \`bg-red-500!\` not \`!bg-red-500\`
 - [ ] \`@import "tailwindcss"\` not \`@tailwind\`
 - [ ] \`@utility\` not \`@layer utilities\`
-- [ ] \`gap\` preferred over \`space-*\`
+- [ ] Prefer \`gap\` over \`space-*\`
 
-### Git
+### A5. Git and secrets
 - [ ] Conventional commit: \`type(scope): description\`
-- [ ] Subject under 72 characters, imperative mood
-- [ ] Identity: RevealUI Studio <founder@revealui.com>
-- [ ] No secrets in committed files`,
+- [ ] Subject under 72 chars, imperative
+- [ ] Identity: \`RevealUI Studio <43050008+joshua-v-dev@users.noreply.github.com>\` (never \`founder@revealui.com\` on signed fleet commits)
+- [ ] No secrets in tree; revvault paths only in docs/chat
+
+### A6. Process hardlines (when applicable)
+- [ ] Durable fix in owning primitive (no unregistered hotfix / workaround recipe)
+- [ ] Proposal-shaped only unless owner named a disposition
+- [ ] Security surfaces: recorded review before "ready to merge" language
+
+---
+
+## Axis B  -  Spec (what we agreed to build)
+
+### B1. Seams and acceptance
+- [ ] Behavior is specified at **public seams** (package exports, HTTP routes, CLI), not private helpers
+- [ ] Acceptance criteria from gap/PR/spec map 1:1 to observable outcomes
+- [ ] User-visible copy matches \`copy-voice\` / no em dashes on public surfaces
+
+### B2. Correctness and proof
+- [ ] Happy path and material failure paths covered
+- [ ] Tests (or gate commands) prove red→green for the change class; no tautological expects
+- [ ] code-over-docs: if prose and code disagree, code is truth and docs are fixed or filed
+
+### B3. Regression and safety
+- [ ] Adjacent behavior not broken (call sites, consumers, materialize consumers for harness content)
+- [ ] Feature gates / entitlements / authz still fail closed
+- [ ] No new poll loops or token-economy violations (prefer completion events / \`events.wait\`)
+
+### B4. Depth check (design smell)
+- [ ] New API is not a shallow wrapper that forces callers to know internals
+- [ ] If the module is hard to test without mocking private collaborators, fix the seam (or file design follow-up) rather than shipping implementation-coupled tests
+
+---
+
+## Parallel workflow (how to run the review)
+
+1. **List** the change set (PR files or \`git diff origin/test...HEAD\`).
+2. **Standards pass**  -  walk Axis A; write FAIL as \`path:line  -  rule  -  fix\`.
+3. **Spec pass**  -  walk Axis B; write FAIL as \`criterion  -  evidence missing/broken  -  fix\`.
+4. **Cross-check**  -  a Standards-only green with Spec FAIL is **not** shippable; same in reverse.
+5. **Verdict**  -  APPROVE only if both axes PASS (or residual is owner-dispositioned and tracked).
+
+## Anti-patterns
+
+- **Style theater**  -  formatting clean, wrong product behavior
+- **Demo-only green**  -  works in one happy curl, no failure paths
+- **Shallow module**  -  many small files that re-export each other without a real boundary
+- **Testing past the seam**  -  private access to force coverage
+- **Doc cosplay**  -  updating handoffs instead of code (or the reverse without reconciling)
+
+## Related skills
+
+- \`$revealui-tdd\`  -  seams, vertical slices, anti-patterns for new work
+- \`$revealui-debugging\`  -  red-capable loop before hypothesising
+- \`$revealui-testing\`  -  flaky/concurrency triage
+- \`$revealui-conventions\`  -  house TypeScript/Tailwind/monorepo rules
+`,
 };


### PR DESCRIPTION
## Summary
Harden `$revealui-review` control-layer skill with **Standards ‖ Spec** parallel axes (AI-mechanics research follow-up #2).

- **Standards:** type safety, boundaries, deep-module/locality, Tailwind v4, git identity (noreply), durable/disposition hardlines
- **Spec:** seams, acceptance, proof, regression/token-economy, depth smell
- Materialized `.revealui/content` + content snapshots; changeset patch for `@revealui/harnesses`

## Test plan
- [x] content snapshot tests green
- [x] content tree freshness green
- [x] phase-1 gate PASS locally

## Merge
Target `test`. Not security-sensitive content skill PR (no gate labels needed beyond normal CI).
