### PR TITLE
chore(release): version @revealui/harnesses 0.15.1

### DIFF
--- a/.changeset/harnesses-acp-optional-ai.md
+++ b/.changeset/harnesses-acp-optional-ai.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Declare `@revealui/ai` as an optionalDependency so ACP headless prompts resolve the agent runtime in monorepo and install graphs (no hand symlinks / NODE_PATH).

--- a/.changeset/harnesses-ai-mechanics-pointer.md
+++ b/.changeset/harnesses-ai-mechanics-pointer.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Add always-on `ai-mechanics` rule (model/harness/context/smart zone/primary source diagnosis) with progressive disclosure to the fleet glossary.

--- a/.changeset/harnesses-review-standards-spec.md
+++ b/.changeset/harnesses-review-standards-spec.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Harden revealui-review skill: Standards ‖ Spec parallel review axes + deep-module checks.

--- a/.changeset/harnesses-tdd-debug-skills.md
+++ b/.changeset/harnesses-tdd-debug-skills.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Harden control-layer `revealui-tdd` (seams, vertical slices, test anti-patterns) and `revealui-debugging` (red-capable feedback loop first, multi-hypothesis, instrument/cleanup).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "revealui",
   "version": "0.4.0",
   "private": true,
-  "description": "Agentic business runtime. Users, content, products, payments, and AI — pre-wired, open source, and ready to deploy.",
+  "description": "Agentic business runtime. Users, content, products, payments, and AI \u2014 pre-wired, open source, and ready to deploy.",
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@biomejs/biome": "catalog:",
@@ -127,7 +127,8 @@
       "hono": "4.12.34",
       "fast-uri@4": ">=4.1.2",
       "fast-uri@3": ">=3.1.5",
-      "brace-expansion": ">=5.0.9"
+      "brace-expansion": ">=5.0.9",
+      "read-yaml-file>js-yaml": "3.14.2"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @revealui/harnesses
 
+## 0.15.1
+
+### Patch Changes
+
+- 8e53beb: Declare `@revealui/ai` as an optionalDependency so ACP headless prompts resolve the agent runtime in monorepo and install graphs (no hand symlinks / NODE_PATH).
+- 158381f: Add always-on `ai-mechanics` rule (model/harness/context/smart zone/primary source diagnosis) with progressive disclosure to the fleet glossary.
+- a7e172c: Harden revealui-review skill: Standards ‖ Spec parallel review axes + deep-module checks.
+- ffd40ba: Harden control-layer `revealui-tdd` (seams, vertical slices, test anti-patterns) and `revealui-debugging` (red-capable feedback loop first, multi-hypothesis, instrument/cleanup).
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.15.0",
-  "description": "AI harness integration \u2014 CLI, content definitions, and CI gates; the coordination daemon lives in RevDev.",
+  "version": "0.15.1",
+  "description": "AI harness integration — CLI, content definitions, and CI gates; the coordination daemon lives in RevDev.",
   "repository": {
     "type": "git",
     "url": "https://github.com/RevealUIStudio/revealui.git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,7 @@ overrides:
   fast-uri@4: '>=4.1.2'
   fast-uri@3: '>=3.1.5'
   brace-expansion: '>=5.0.9'
+  read-yaml-file>js-yaml: 3.14.2
 
 importers:
 
@@ -6880,6 +6881,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@5.2.2:
     resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
@@ -12971,7 +12976,6 @@ snapshots:
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
-    optional: true
 
   argparse@2.0.1: {}
 
@@ -14377,6 +14381,11 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
@@ -15766,7 +15775,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 5.2.2
+      js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -16212,8 +16221,7 @@ snapshots:
     dependencies:
       through: 2.3.8
 
-  sprintf-js@1.0.3:
-    optional: true
+  sprintf-js@1.0.3: {}
 
   srvx@0.11.22: {}
 


### PR DESCRIPTION
## Summary
Version **@revealui/harnesses** `0.15.0` → **`0.15.1`** by applying pending changesets on `main`:

- ACP optionalDependency on `@revealui/ai`
- always-on `ai-mechanics` rule
- `revealui-review` Standards ‖ Spec axes
- `revealui-tdd` / `revealui-debugging` harden

Also durable fix: pin `read-yaml-file>js-yaml@3.14.2` so `@changesets/cli` works under the fleet `js-yaml@5` security override (`safeLoad` removed in 5.x).

## After merge to main
Canonical publish (OIDC):

```bash
gh workflow run release.yml -R RevealUIStudio/revealui --ref main
# optional dry-run first:
gh workflow run release.yml -R RevealUIStudio/revealui --ref main -f dry-run=true
```

## Test plan
- [x] `pnpm changeset status` shows harnesses 0.15.1
- [x] phase-1 gate PASS locally
- [ ] CI green on this PR
