### PR TITLE
chore: promote test → main (harnesses 0.15.1)

### DIFF
--- a/.changeset/harnesses-acp-optional-ai.md
+++ b/.changeset/harnesses-acp-optional-ai.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Declare `@revealui/ai` as an optionalDependency so ACP headless prompts resolve the agent runtime in monorepo and install graphs (no hand symlinks / NODE_PATH).

--- a/.changeset/harnesses-ai-mechanics-pointer.md
+++ b/.changeset/harnesses-ai-mechanics-pointer.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Add always-on `ai-mechanics` rule (model/harness/context/smart zone/primary source diagnosis) with progressive disclosure to the fleet glossary.

--- a/.changeset/harnesses-review-standards-spec.md
+++ b/.changeset/harnesses-review-standards-spec.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Harden revealui-review skill: Standards ‖ Spec parallel review axes + deep-module checks.

--- a/.changeset/harnesses-tdd-debug-skills.md
+++ b/.changeset/harnesses-tdd-debug-skills.md
@@ -1,5 +1,0 @@
----
-"@revealui/harnesses": patch
----
-
-Harden control-layer `revealui-tdd` (seams, vertical slices, test anti-patterns) and `revealui-debugging` (red-capable feedback loop first, multi-hypothesis, instrument/cleanup).

--- a/packages/harnesses/CHANGELOG.md
+++ b/packages/harnesses/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @revealui/harnesses
 
+## 0.15.1
+
+### Patch Changes
+
+- 8e53beb: Declare `@revealui/ai` as an optionalDependency so ACP headless prompts resolve the agent runtime in monorepo and install graphs (no hand symlinks / NODE_PATH).
+- 158381f: Add always-on `ai-mechanics` rule (model/harness/context/smart zone/primary source diagnosis) with progressive disclosure to the fleet glossary.
+- a7e172c: Harden revealui-review skill: Standards ‖ Spec parallel review axes + deep-module checks.
+- ffd40ba: Harden control-layer `revealui-tdd` (seams, vertical slices, test anti-patterns) and `revealui-debugging` (red-capable feedback loop first, multi-hypothesis, instrument/cleanup).
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/harnesses",
-  "version": "0.15.0",
-  "description": "AI harness integration \u2014 CLI, content definitions, and CI gates; the coordination daemon lives in RevDev.",
+  "version": "0.15.1",
+  "description": "AI harness integration — CLI, content definitions, and CI gates; the coordination daemon lives in RevDev.",
   "repository": {
     "type": "git",
     "url": "https://github.com/RevealUIStudio/revealui.git",


### PR DESCRIPTION
## Summary
Promote `test` → `main` so **@revealui/harnesses@0.15.1** version commit can land on main for `release.yml` (OIDC publish).

Depends on **#2521** (version PR) merging to `test` first.

## Merge policy
**Create a merge commit** only (promotion-gate requires head = `test`).

```bash
gh pr merge <n> -R RevealUIStudio/revealui --merge
```

## After promote
```bash
gh workflow run release.yml -R RevealUIStudio/revealui --ref main
```
