### PR TITLE
fix(ci): vercel deploy --archive=tgz for admin/api prebuilts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,7 +71,7 @@ Deploys all 4 apps (api, admin, marketing, docs) in parallel via matrix strategy
 - `main` → production (`*.revealui.com`)
 - `test` → test (`test.*.revealui.com`)
 
-Each app: `vercel pull` → `vercel build` → `vercel deploy --prebuilt` → alias to stable domain.
+Each app: `vercel pull` → `vercel build` → `vercel deploy --prebuilt --archive=tgz` → alias to stable domain.
 Smoke tests (health checks) run on production and test deploys.
 
 ## Disabled / Removed Workflows

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Deploy (preview — not production)
         id: deploy
         run: |
-          URL=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          URL=$(vercel deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "::notice::${{ matrix.app }} preview: $URL"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -414,8 +414,10 @@ jobs:
 
       - name: Deploy
         id: deploy
+        # --archive=tgz: single tarball upload avoids Vercel free-tier
+        # api-upload-free (5000 file) rate limit on monorepo prebuilts.
         run: |
-          URL=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          URL=$(vercel deploy --prebuilt --prod --archive=tgz --token="$VERCEL_TOKEN")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "::notice::${{ matrix.app }} deployed to $URL"
         env:


### PR DESCRIPTION
## Summary
Deploy admin/api failed on main after promote:

```
Error: Too many requests - try again in 24 hours (more than 5000, code: "api-upload-free").
Try using \`--archive=tgz\` to limit the amount of files you upload.
```

Add \`--archive=tgz\` to production and preview prebuilt deploys (deploy.yml + deploy-test.yml).

## Note
Deploy log targeted \`joshuas-projects-c07004e7\` (personal free). If limits persist after this, move \`VERCEL_TOKEN\` / \`VERCEL_ORG_ID\` to the **RevealUI Studio** team Pro scope for CI.

## After merge
Promote \`test\`→\`main\` and re-run deploy (or re-run failed workflow on main once this is on main).