### PR TITLE
docs(marketing): Skool buyer community defaults (Substack URL later)

### DIFF
--- a/apps/marketing/app/content/claims-evidence/claims-part-2.ts
+++ b/apps/marketing/app/content/claims-evidence/claims-part-2.ts
@@ -102,7 +102,7 @@ export const claimsPart2: readonly ClaimEntry[] = [
   {
     file: 'pricing.ts',
     exportPath: 'PRICING_STARTER_KIT.points[3]',
-    text: 'Checkout on Stripe; private GitHub repo access and Substack invite are manual at launch volume',
+    text: 'Checkout on Stripe; private GitHub repo access and Skool buyer invite are manual at launch volume',
     evidence: [STARTER_KIT],
   },
   {
@@ -564,7 +564,7 @@ export const claimsPart2: readonly ClaimEntry[] = [
   {
     file: 'pricing-faq.ts',
     exportPath: 'PRICING_FAQS[4].answer',
-    text: 'The Starter Kit is a $299 one-time, content-only product. It packages create-revealui onboarding, Postgres bootstrap, and governed agent recipes that demonstrate signed receipts you can verify offline. It does not include a Pro subscription entitlement or a full RevealUI Fleet stamp. Checkout is on Stripe. After purchase we invite you to the private kit repo and Substack section within one business day.',
+    text: 'The Starter Kit is a $299 one-time, content-only product. It packages create-revealui onboarding, Postgres bootstrap, and governed agent recipes that demonstrate signed receipts you can verify offline. It does not include a Pro subscription entitlement or a full RevealUI Fleet stamp. Checkout is on Stripe. After purchase we invite you to the private kit repo and Skool buyer community within one business day.',
     evidence: [STARTER_KIT, STARTER_KIT_GETTING_STARTED, CLI_CREATE, STARTER_KIT_RECEIPT_TEST],
   },
   {

--- a/apps/marketing/app/content/pricing-faq.ts
+++ b/apps/marketing/app/content/pricing-faq.ts
@@ -34,7 +34,7 @@ export const PRICING_FAQS: readonly FaqItem[] = [
   {
     question: 'What is the RevealUI Starter Kit?',
     answer:
-      'The Starter Kit is a $299 one-time, content-only product. It packages create-revealui onboarding, Postgres bootstrap, and governed agent recipes that demonstrate signed receipts you can verify offline. It does not include a Pro subscription entitlement or a full RevealUI Fleet stamp. Checkout is on Stripe. After purchase we invite you to the private kit repo and Substack section within one business day.',
+      'The Starter Kit is a $299 one-time, content-only product. It packages create-revealui onboarding, Postgres bootstrap, and governed agent recipes that demonstrate signed receipts you can verify offline. It does not include a Pro subscription entitlement or a full RevealUI Fleet stamp. Checkout is on Stripe. After purchase we invite you to the private kit repo and Skool buyer community within one business day.',
   },
   {
     question: 'What is the RevealUI Agency Founding Kit?',

--- a/apps/marketing/app/content/pricing.ts
+++ b/apps/marketing/app/content/pricing.ts
@@ -68,7 +68,7 @@ export const PRICING_STARTER_KIT = {
     'npm create-revealui path plus Postgres-only bootstrap scripts',
     'Governed agent recipes that write a receipt you can verify offline',
     'Ships as content and scripts, not a Pro license key or runtime upgrade',
-    'Checkout on Stripe; private GitHub repo access and Substack invite are manual at launch volume',
+    'Checkout on Stripe; private GitHub repo access and Skool buyer invite are manual at launch volume',
   ],
   badge: null,
   primaryCta: {

--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -84,6 +84,11 @@ export const SITE = {
      * Stripe product prod_V01FoZi9YbgZw9 / price_1U01D1Jz64n6uEibtamJHxkU.
      */
     starterKitCheckout: 'https://buy.stripe.com/dRmeVegcH1AM2mmdbsa3u03',
+    /**
+     * Public shipping board (Projects tab). Prefer a concrete Projects v2 URL when
+     * one is pinned; until then the org/repo projects index is the honest link.
+     */
+    repoProjects: 'https://github.com/RevealUIStudio/revealui/projects',
   },
   emails: {
     support: 'support@revealui.com',
@@ -95,4 +100,46 @@ export const SITE = {
   },
 } as const;
 
+/**
+ * Community defaults (owner 2026-08-10). Full map:
+ * fleet private `business/community-map-2026-08-10.md` + offerings-canonical Track E.
+ *
+ * URLs: OWNER_FILL later. Do not invent live hrefs. Consumers must not render a
+ * nav/footer link when `url` is null (same pattern as omitted X handle).
+ *
+ * Defaults until owner updates:
+ * - Skool: invite-only after purchase (no public join CTA)
+ * - Substack: public subscribe when URL set; broadcast list, not paid support home
+ * - Discussions / Projects: public (urls live under SITE.urls)
+ */
+export const COMMUNITY = {
+  discussions: {
+    access: 'public' as const,
+    url: SITE.urls.repoDiscussions,
+  },
+  projects: {
+    access: 'public-view' as const,
+    url: SITE.urls.repoProjects,
+  },
+  /**
+   * Paid buyer home. Invite after Starter Kit / SaaS / AR close.
+   * Set `url` only when intentionally publishing a join link; default stays null.
+   */
+  skool: {
+    access: 'invite-only' as const,
+    /** OWNER_FILL later — e.g. https://www.skool.com/… */
+    url: null as string | null,
+  },
+  /**
+   * Broadcast + free list. Not the paid support desk.
+   * Set `url` when the publication is ready for public subscribe CTAs.
+   */
+  substack: {
+    access: 'public-subscribe' as const,
+    /** OWNER_FILL later — e.g. https://….substack.com */
+    url: null as string | null,
+  },
+} as const;
+
 export type SiteConfig = typeof SITE;
+export type CommunityConfig = typeof COMMUNITY;

--- a/examples/starter-kit/GETTING-STARTED.md
+++ b/examples/starter-kit/GETTING-STARTED.md
@@ -22,8 +22,9 @@ packages) stays free. What this kit adds:
 4. **Three governed-agent recipes**, each producing a cryptographically
    signed, offline-verifiable receipt of every action — the pattern the
    fleet's own Apify actor uses, generalized for use in your own app.
-5. Access to the private RevealUI Substack section and lifetime kit updates
-   (see your purchase confirmation for the invite).
+5. Invite to the **Skool buyer community** and lifetime kit updates
+   (see your purchase confirmation for the invite). Public product questions
+   stay on [GitHub Discussions](https://github.com/RevealUIStudio/revealui/discussions).
 
 ## What "governed agent" and "receipt" mean here
 
@@ -119,5 +120,7 @@ checkout when you're ready to upgrade at revealui.com/pricing.
 
 ## Support
 
-Questions and requests go in the private RevealUI Substack section (invite
-in your purchase confirmation). Kit updates ship there too.
+Questions and requests go in the **Skool buyer community** (invite in your
+purchase confirmation). Kit updates ship via the private repo and community
+notes. Public product discussion:
+https://github.com/RevealUIStudio/revealui/discussions

--- a/examples/starter-kit/OWNER-LAUNCH.md
+++ b/examples/starter-kit/OWNER-LAUNCH.md
@@ -15,7 +15,7 @@ the same Payment Link / Checkout surface.
 | **Stripe price** | **live** `price_1U01D1Jz64n6uEibtamJHxkU` ($299 one-time) |
 | **Payment Link** | **live** `https://buy.stripe.com/dRmeVegcH1AM2mmdbsa3u03` (`plink_1U01D2Jz64n6uEibnSK45nuS`) |
 | `SITE.urls.starterKitCheckout` | **wired** on marketing (`SITE.urls.starterKitCheckout`) |
-| Fulfillment | **manual**: GitHub invite + Substack (launch volume) |
+| Fulfillment | **manual**: GitHub invite + Skool buyer invite (launch volume). Substack = broadcast list only (URL OWNER_FILL later). |
 | First-month Pro coupon | **seed script ready** (§4); run once on live key |
 | Stripe Tax | confirm `STRIPE_TAX_ENABLED=true` on prod api if selling broadly |
 | Managed Payments (D) | enable in Dashboard when eligible |
@@ -78,7 +78,8 @@ stripe promotion_codes create \
 2. Buyer email from receipt.
 3. GitHub: invite buyer as **read** collaborator on
    `RevealUIStudio/revealui-starter-kit`.
-4. Substack: private section invite.
+4. Skool: invite buyer to the paid classroom (invite-only; no public join link
+   until owner publishes one). Substack is not the support home.
 5. Reply with invite notes + optional `STARTERKITPRO1` (when created).
 
 Target: within **one business day** (matches Payment Link confirmation copy).
@@ -88,7 +89,7 @@ Target: within **one business day** (matches Payment Link confirmation copy).
 One link: `https://buy.stripe.com/dRmeVegcH1AM2mmdbsa3u03`
 
 - `/pricing#starter-kit` (after merge/deploy)
-- X / LinkedIn / Substack
+- LinkedIn / Substack (when URL set) / optional X when the handle is live
 - Product Hunt / Show HN / Indie Hackers
 - Technical post (receipt recipes) with soft CTA
 - GitHub monorepo docs pointer to pricing section
@@ -98,7 +99,7 @@ Do not dual-list Polar or Lemon Squeezy storefronts.
 ## 7. Acceptance
 
 1. Smoke purchase (owner card OK; refund after).
-2. Manual GitHub + Substack invite works.
+2. Manual GitHub + Skool invite works.
 3. `pnpm install && pnpm test && pnpm recipe:action` on private clone.
 4. Pricing CTA hits Payment Link (not mailto).
 5. Record on GAP-434; close when coupon + first external sale accepted.


### PR DESCRIPTION
## Summary

- Lock Stage-1 community defaults: **Skool** = invite-only buyer home; **Substack** = broadcast list when URL is set (no public href while null).
- Update Starter Kit pricing FAQ/points + claims-evidence lockstep (no more “Substack section” as support home).
- Add `COMMUNITY` + `SITE.urls.repoProjects` in marketing `site.ts`.
- Starter kit GETTING-STARTED / OWNER-LAUNCH fulfillment: GitHub + Skool invite.

Canonical fleet notes live in revealui-jv (`business/community-map-2026-08-10.md`, offerings-canonical Track E, GAP-434). Owner will paste live Skool/Substack URLs later.

## Test plan

- [x] pricing.ts ↔ claims-part-2 text lockstep
- [x] `tsc --noEmit -p apps/marketing`
- [ ] CI green on PR
- [ ] After owner URLs: set `COMMUNITY.substack.url` / optional skool public join only if intentional