### PR TITLE
fix(server): stop AI module misses from claiming Free plan

### DIFF
--- a/apps/server/src/lib/__tests__/ai-module-loader.test.ts
+++ b/apps/server/src/lib/__tests__/ai-module-loader.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AI_MODULE_UNAVAILABLE_CODE,
+  AI_RESOLVE_FAILED_CODE,
+  aiModuleUnavailableBody,
+  aiResolveFailedBody,
+} from '../ai-module-loader.js';
+
+describe('ai-module-loader honest error bodies', () => {
+  it('aiModuleUnavailableBody never claims Free or Pro upgrade', () => {
+    const body = aiModuleUnavailableBody();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe(AI_MODULE_UNAVAILABLE_CODE);
+    expect(body.error).not.toMatch(/Free plan|requires a Pro or Enterprise license/i);
+    expect(body.error).toMatch(/not available in this deployment/i);
+  });
+
+  it('aiResolveFailedBody never claims Free or Pro upgrade', () => {
+    const body = aiResolveFailedBody();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe(AI_RESOLVE_FAILED_CODE);
+    expect(body.error).not.toMatch(/Free plan|requires a Pro or Enterprise license/i);
+    expect(body.error).toMatch(/API keys/i);
+  });
+
+  it('optional detail is appended without changing the code', () => {
+    const body = aiModuleUnavailableBody('dispatcher unavailable');
+    expect(body.code).toBe(AI_MODULE_UNAVAILABLE_CODE);
+    expect(body.error).toContain('dispatcher unavailable');
+  });
+});

--- a/apps/server/src/lib/ai-module-loader.ts
+++ b/apps/server/src/lib/ai-module-loader.ts
@@ -12,9 +12,24 @@
  */
 
 import { logger } from '@revealui/core/observability/logger';
+import { z } from '@revealui/openapi';
 
 export const AI_MODULE_UNAVAILABLE_CODE = 'AI_MODULE_UNAVAILABLE' as const;
 export const AI_RESOLVE_FAILED_CODE = 'AI_RESOLVE_FAILED' as const;
+
+/** OpenAPI / Zod body for 503 AI_MODULE_UNAVAILABLE responses. */
+export const AiModuleUnavailableBodySchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+  code: z.literal(AI_MODULE_UNAVAILABLE_CODE),
+});
+
+/** OpenAPI / Zod body for 500 AI_RESOLVE_FAILED responses. */
+export const AiResolveFailedBodySchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+  code: z.literal(AI_RESOLVE_FAILED_CODE),
+});
 
 export const AI_MODULE_UNAVAILABLE_MESSAGE =
   'The AI runtime is not available in this deployment. This is a server configuration problem, not a Free-plan limit. Contact support if you are on Pro or Enterprise.';
@@ -100,7 +115,7 @@ export async function loadAgentStreamAiModules(): Promise<{
   // Empty mock modules (vitest `() => ({})`) and partial deploys must not pass.
   // Use `in` + try/catch: Vitest auto-mocks throw on missing named exports.
   const hasFn = (mod: object | null, name: string): boolean => {
-    if (!mod || !(name in mod)) return false;
+    if (!(mod && name in mod)) return false;
     try {
       return typeof (mod as Record<string, unknown>)[name] === 'function';
     } catch {

--- a/apps/server/src/lib/ai-module-loader.ts
+++ b/apps/server/src/lib/ai-module-loader.ts
@@ -1,0 +1,132 @@
+/**
+ * Lazy loaders for optional `@revealui/ai` (Pro peer).
+ *
+ * OSS / thin deploys omit the package; dynamic import must not crash cold start.
+ * When the module is missing, responses must NOT claim the caller is on Free /
+ * needs a Pro license — that message is reserved for real entitlement denial
+ * (`requireFeature` / `requireAIAccess`). Import failure is a deployment fault
+ * (503 AI_MODULE_UNAVAILABLE). Resolve failure after the module loads is a
+ * 500 AI_RESOLVE_FAILED (or 409 LLM_NOT_CONFIGURED when typed that way).
+ *
+ * Same optional-peer pattern as `services-loader.ts`.
+ */
+
+import { logger } from '@revealui/core/observability/logger';
+
+export const AI_MODULE_UNAVAILABLE_CODE = 'AI_MODULE_UNAVAILABLE' as const;
+export const AI_RESOLVE_FAILED_CODE = 'AI_RESOLVE_FAILED' as const;
+
+export const AI_MODULE_UNAVAILABLE_MESSAGE =
+  'The AI runtime is not available in this deployment. This is a server configuration problem, not a Free-plan limit. Contact support if you are on Pro or Enterprise.';
+
+export const AI_RESOLVE_FAILED_MESSAGE =
+  'Could not start AI for this account. Check Settings → API keys, then try again. This is not a Free-plan limit.';
+
+/** Machine-readable body when `@revealui/ai` failed to load. */
+export interface AiModuleUnavailableBody {
+  success: false;
+  error: string;
+  code: typeof AI_MODULE_UNAVAILABLE_CODE;
+}
+
+/** Machine-readable body when BYOK / client resolve failed (non-config). */
+export interface AiResolveFailedBody {
+  success: false;
+  error: string;
+  code: typeof AI_RESOLVE_FAILED_CODE;
+}
+
+export function aiModuleUnavailableBody(detail?: string): AiModuleUnavailableBody {
+  return {
+    success: false,
+    error: detail?.trim()
+      ? `${AI_MODULE_UNAVAILABLE_MESSAGE} (${detail})`
+      : AI_MODULE_UNAVAILABLE_MESSAGE,
+    code: AI_MODULE_UNAVAILABLE_CODE,
+  };
+}
+
+export function aiResolveFailedBody(detail?: string): AiResolveFailedBody {
+  return {
+    success: false,
+    error: detail?.trim() ? `${AI_RESOLVE_FAILED_MESSAGE} (${detail})` : AI_RESOLVE_FAILED_MESSAGE,
+    code: AI_RESOLVE_FAILED_CODE,
+  };
+}
+
+type AiRoot = typeof import('@revealui/ai');
+type AiLlmClient = typeof import('@revealui/ai/llm/client');
+type AiStreamingRuntime = typeof import('@revealui/ai/orchestration/streaming-runtime');
+
+let aiRootPromise: Promise<AiRoot | null> | null = null;
+
+/**
+ * Cached root import of `@revealui/ai`. Logs once on failure (not per request).
+ */
+export function getAiModule(): Promise<AiRoot | null> {
+  if (!aiRootPromise) {
+    aiRootPromise = import('@revealui/ai').catch((err: unknown) => {
+      logger.error('[ai-module-loader] @revealui/ai import failed', {
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    });
+  }
+  return aiRootPromise;
+}
+
+/** Load the three modules agent-stream needs. Any miss → null + logged. */
+export async function loadAgentStreamAiModules(): Promise<{
+  ai: AiRoot;
+  llmClient: AiLlmClient;
+  streamingRuntime: AiStreamingRuntime;
+} | null> {
+  const [ai, llmClient, streamingRuntime] = await Promise.all([
+    getAiModule(),
+    import('@revealui/ai/llm/client').catch((err: unknown) => {
+      logger.error('[ai-module-loader] @revealui/ai/llm/client import failed', {
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }),
+    import('@revealui/ai/orchestration/streaming-runtime').catch((err: unknown) => {
+      logger.error('[ai-module-loader] streaming-runtime import failed', {
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }),
+  ]);
+
+  // Empty mock modules (vitest `() => ({})`) and partial deploys must not pass.
+  // Use `in` + try/catch: Vitest auto-mocks throw on missing named exports.
+  const hasFn = (mod: object | null, name: string): boolean => {
+    if (!mod || !(name in mod)) return false;
+    try {
+      return typeof (mod as Record<string, unknown>)[name] === 'function';
+    } catch {
+      return false;
+    }
+  };
+  if (
+    !(
+      hasFn(ai, 'resolveLLMClientForRequest') &&
+      hasFn(llmClient, 'LLMClient') &&
+      hasFn(streamingRuntime, 'StreamingAgentRuntime')
+    )
+  ) {
+    if (ai || llmClient || streamingRuntime) {
+      logger.error('[ai-module-loader] agent-stream modules loaded but missing required exports');
+    }
+    return null;
+  }
+  return {
+    ai: ai as AiRoot,
+    llmClient: llmClient as AiLlmClient,
+    streamingRuntime: streamingRuntime as AiStreamingRuntime,
+  };
+}
+
+/** Test-only: reset cached import promise between cases. */
+export function resetAiModuleLoaderForTests(): void {
+  aiRootPromise = null;
+}

--- a/apps/server/src/routes/__tests__/agent-stream.test.ts
+++ b/apps/server/src/routes/__tests__/agent-stream.test.ts
@@ -62,19 +62,22 @@ describe('agent-stream route', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 403 when AI package is not available', async () => {
+  it('returns 503 AI_MODULE_UNAVAILABLE when AI package is not available (not Free-plan)', async () => {
     const app = createApp();
 
     const res = await jsonPost(app, '/agent-stream', {
       instruction: 'Hello',
     });
 
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(503);
     const body = await parseBody(res);
-    expect(body.error).toContain('requires a Pro or Enterprise license');
+    expect(body.code).toBe('AI_MODULE_UNAVAILABLE');
+    expect(body.error).not.toMatch(/requires a Pro or Enterprise license/i);
+    expect(body.error).toMatch(/not available in this deployment/i);
+    expect(body.error).toMatch(/not a Free-plan limit/i);
   });
 
-  it('returns 403 with empty instruction string (AI not configured)', async () => {
+  it('returns 503 with empty instruction string when AI module missing', async () => {
     const app = createApp();
 
     const res = await jsonPost(app, '/agent-stream', {
@@ -82,7 +85,9 @@ describe('agent-stream route', () => {
     });
 
     // Schema accepts empty string  -  handler proceeds but AI module not available
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(503);
+    const body = await parseBody(res);
+    expect(body.code).toBe('AI_MODULE_UNAVAILABLE');
   });
 });
 
@@ -102,8 +107,8 @@ describe('agent-stream route  -  mode parameter', () => {
       mode: 'admin',
     });
 
-    // AI modules not available → 403 (schema validation passed)
-    expect(res.status).toBe(403);
+    // AI modules not available → 503 deployment fault (schema validation passed)
+    expect(res.status).toBe(503);
   });
 
   it('accepts mode: "coding" without error', async () => {
@@ -114,8 +119,8 @@ describe('agent-stream route  -  mode parameter', () => {
       mode: 'coding',
     });
 
-    // AI modules not available → 403 (schema validation passed)
-    expect(res.status).toBe(403);
+    // AI modules not available → 503 deployment fault (schema validation passed)
+    expect(res.status).toBe(503);
   });
 
   it('defaults to admin mode when mode is omitted', async () => {
@@ -125,8 +130,8 @@ describe('agent-stream route  -  mode parameter', () => {
       instruction: 'Hello',
     });
 
-    // Schema defaults mode to 'admin'; AI not available → 403
-    expect(res.status).toBe(403);
+    // Schema defaults mode to 'admin'; AI not available → 503
+    expect(res.status).toBe(503);
   });
 
   it('rejects invalid mode values', async () => {
@@ -154,7 +159,7 @@ describe('agent-stream route  -  mode parameter', () => {
       mode: 'coding',
     });
 
-    // Schema accepts all fields; AI not available → 403
-    expect(res.status).toBe(403);
+    // Schema accepts all fields; AI not available → 503
+    expect(res.status).toBe(503);
   });
 });

--- a/apps/server/src/routes/__tests__/agent-tasks.test.ts
+++ b/apps/server/src/routes/__tests__/agent-tasks.test.ts
@@ -246,10 +246,11 @@ describe('POST /  -  submit agent task', () => {
       '/',
       post({ instruction: 'Publish blog post', boardId: 'board-1' }),
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(503);
     const body = await parseBody(res);
     expect(body.success).toBe(false);
-    expect(body.error).toContain('requires a Pro or Enterprise license');
+    expect(body.code).toBe('AI_MODULE_UNAVAILABLE');
+    expect(body.error).not.toMatch(/requires a Pro or Enterprise license/i);
   });
 
   it('returns 200 with agent output on success', async () => {
@@ -348,18 +349,19 @@ describe('POST /:ticketId/dispatch  -  dispatch existing ticket', () => {
     expect(body.error).toBe('Ticket not found');
   });
 
-  it('returns 403 when no LLM key is configured', async () => {
-    // Simulate missing API key: createLLMClientFromEnv throws
+  it('returns 503 when dispatcher cannot start (module/resolve miss, not Free-plan)', async () => {
+    // Simulate missing API key: createLLMClientFromEnv throws → dispatcher null
     mockCreateLLMClient.mockImplementationOnce(() => {
       throw new Error('API key not found');
     });
     mt.getTicketById.mockResolvedValue(makeTicket() as never);
     const app = createApp();
     const res = await app.request('/ticket-1/dispatch', post({}));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(503);
     const body = await parseBody(res);
     expect(body.success).toBe(false);
-    expect(body.error).toContain('requires a Pro or Enterprise license');
+    expect(body.code).toBe('AI_MODULE_UNAVAILABLE');
+    expect(body.error).not.toMatch(/requires a Pro or Enterprise license/i);
   });
 
   it('returns 200 with agent output on success', async () => {

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -98,6 +98,10 @@ app.openapi(
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
       },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
+      },
     },
   }),
   async (c) => {
@@ -145,6 +149,10 @@ app.openapi(
       403: {
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
+      },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
       },
     },
   }),
@@ -399,6 +407,10 @@ a2a.openapi(
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
       },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
+      },
     },
   }),
   async (c) => {
@@ -440,6 +452,10 @@ a2a.openapi(
       403: {
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
+      },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
       },
     },
   }),
@@ -493,6 +509,10 @@ a2a.openapi(
       403: {
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
+      },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
       },
     },
   }),
@@ -652,6 +672,10 @@ a2a.openapi(
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
       },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
+      },
     },
   }),
   async (c) => {
@@ -753,6 +777,10 @@ a2a.openapi(
         content: { 'application/json': { schema: z.unknown() } },
         description: 'Agent not found',
       },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
+      },
     },
   }),
   async (c) => {
@@ -829,6 +857,10 @@ a2a.openapi(
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
       },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
+      },
       409: {
         content: { 'application/json': { schema: z.unknown() } },
         description: 'Agent already registered',
@@ -904,6 +936,10 @@ a2a.openapi(
       403: {
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
+      },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
       },
     },
   }),
@@ -995,6 +1031,10 @@ a2a.openapi(
       403: {
         content: { 'application/json': { schema: z.unknown() } },
         description: 'AI feature requires Pro or Enterprise license',
+      },
+      503: {
+        content: { 'application/json': { schema: z.unknown() } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
       },
       409: {
         content: { 'application/json': { schema: z.unknown() } },

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -26,6 +26,7 @@ import { getClient } from '@revealui/db';
 import { agentActions, marketplaceServers, registeredAgents } from '@revealui/db/schema';
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { desc, eq } from 'drizzle-orm';
+import { aiModuleUnavailableBody, getAiModule } from '../lib/ai-module-loader.js';
 import { createAuditStore } from '../lib/audit-signer.js';
 import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
 import { buildMcpManifest } from '../lib/mcp-manifest.js';
@@ -43,16 +44,6 @@ import {
 
 // JSON-RPC error codes (inlined  -  avoids static import of @revealui/ai)
 const RPC_INVALID_REQUEST = -32600;
-
-// Lazy-loaded @revealui/ai module  -  cached after first successful import
-let aiModulePromise: Promise<typeof import('@revealui/ai') | null> | null = null;
-
-function getAiModule(): Promise<typeof import('@revealui/ai') | null> {
-  if (!aiModulePromise) {
-    aiModulePromise = import('@revealui/ai').catch(() => null);
-  }
-  return aiModulePromise;
-}
 
 interface UserContext {
   id: string;
@@ -112,13 +103,7 @@ app.openapi(
   async (c) => {
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
     const baseUrl = getBaseUrl(c.req.raw);
     const card = aiMod.agentCardRegistry.getCard('revealui-creator', baseUrl);
@@ -166,13 +151,7 @@ app.openapi(
   async (c) => {
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
     const { id: agentId } = c.req.valid('param');
     if (!isValidAgentId(agentId)) {
@@ -425,13 +404,7 @@ a2a.openapi(
   async (c) => {
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
     const baseUrl = getBaseUrl(c.req.raw);
     const cards = aiMod.agentCardRegistry.listCards(baseUrl);
@@ -473,13 +446,7 @@ a2a.openapi(
   async (c) => {
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
     const { id: agentId } = c.req.valid('param');
     if (!isValidAgentId(agentId)) {
@@ -532,13 +499,7 @@ a2a.openapi(
   async (c) => {
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
     const { id: agentId } = c.req.valid('param');
     if (!isValidAgentId(agentId)) {
@@ -696,13 +657,7 @@ a2a.openapi(
   async (c) => {
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
     const { id: agentId } = c.req.valid('param');
     if (!isValidAgentId(agentId)) {
@@ -813,13 +768,7 @@ a2a.openapi(
 
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
 
     const removed = aiMod.agentCardRegistry.unregister(agentId);
@@ -896,13 +845,7 @@ a2a.openapi(
 
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
 
     const def = parsed.data;
@@ -967,13 +910,7 @@ a2a.openapi(
   async (c) => {
     const aiMod = await getAiModule();
     if (!aiMod) {
-      return c.json(
-        {
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      return c.json(aiModuleUnavailableBody(), 503);
     }
     const { taskId } = c.req.valid('param');
 
@@ -1076,11 +1013,11 @@ a2a.openapi(
           id: null,
           error: {
             code: -32003,
-            message:
-              "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
+            message: aiModuleUnavailableBody().error,
+            data: { code: 'AI_MODULE_UNAVAILABLE' },
           },
         },
-        403,
+        503,
       );
     }
 
@@ -1109,13 +1046,15 @@ a2a.openapi(
         | undefined;
       const aiEnabled = entitlements?.features?.ai ?? false;
       if (!aiEnabled) {
+        // Real entitlement denial (Free / feature off) — not a module load miss.
         return c.json(
           {
             jsonrpc: '2.0',
             id: req.id,
             error: {
               code: -32003,
-              message: "Feature 'ai' requires a Pro or Enterprise license.",
+              message:
+                "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
             },
           },
           403,

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -122,24 +122,15 @@ app.openapi(agentStreamRoute, async (c) => {
 
   const body = c.req.valid('json');
 
-  // Dynamically load @revealui/ai modules
-  const [aiMod, llmClientMod, streamingRuntimeMod] = await Promise.all([
-    import('@revealui/ai').catch(() => null),
-    import('@revealui/ai/llm/client').catch(() => null),
-    import('@revealui/ai/orchestration/streaming-runtime').catch(() => null),
-  ]);
-
-  if (!(aiMod && llmClientMod && streamingRuntimeMod)) {
-    return c.json(
-      {
-        success: false,
-        error:
-          "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        code: 'HTTP_403',
-      },
-      403,
-    );
+  // Dynamically load optional Pro package @revealui/ai (must not claim Free on miss).
+  const { loadAgentStreamAiModules, aiModuleUnavailableBody, aiResolveFailedBody } = await import(
+    '../lib/ai-module-loader.js'
+  );
+  const aiMods = await loadAgentStreamAiModules();
+  if (!aiMods) {
+    return c.json(aiModuleUnavailableBody(), 503);
   }
+  const { ai: aiMod, llmClient: llmClientMod, streamingRuntime: streamingRuntimeMod } = aiMods;
 
   // Free tier: local inference only (Ollama or inference snaps)
   const aiAccessMode = c.get('aiAccessMode');
@@ -160,16 +151,11 @@ app.openapi(agentStreamRoute, async (c) => {
         // Lockstep packages/ai DEFAULT_DAILY_OLLAMA_MODEL when ollama
         model: process.env.LLM_MODEL ?? 'qwen2.5:3b',
       });
-    } catch {
-      return c.json(
-        {
-          success: false,
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-          code: 'HTTP_403',
-        },
-        403,
-      );
+    } catch (err) {
+      logger.error('[agent-stream] local LLM client construct failed', {
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return c.json(aiResolveFailedBody('local inference client'), 500);
     }
   } else {
     // Paid path: resolve per-account BYOK on hosted, env on self-hosted. userId
@@ -186,15 +172,10 @@ app.openapi(agentStreamRoute, async (c) => {
       if (notConfigured) {
         return c.json(notConfigured, 409);
       }
-      return c.json(
-        {
-          success: false,
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-          code: 'HTTP_403',
-        },
-        403,
-      );
+      logger.error('[agent-stream] resolveLLMClientForRequest failed', {
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return c.json(aiResolveFailedBody(), 500);
     }
   }
 

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -30,6 +30,10 @@ import {
 } from '../lib/agent-run-sessions.js';
 import { recordAgentMcpToolAudit } from '../lib/agent-tool-audit.js';
 import { applyAgentToolGovernance } from '../lib/agent-tool-governance.js';
+import {
+  AiModuleUnavailableBodySchema,
+  AiResolveFailedBodySchema,
+} from '../lib/ai-module-loader.js';
 import { createAgentEventLoggerIfEnabled } from '../lib/ai-observability-wire.js';
 import { createSkillProviderIfEnabled } from '../lib/ai-skills-wire.js';
 import { createAuditStore } from '../lib/audit-signer.js';
@@ -97,6 +101,22 @@ const agentStreamRoute = createRoute({
         },
       },
       description: 'AI feature requires Pro or Enterprise license',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: AiResolveFailedBodySchema,
+        },
+      },
+      description: 'AI client resolve failed (not a Free-plan limit)',
+    },
+    503: {
+      content: {
+        'application/json': {
+          schema: AiModuleUnavailableBodySchema,
+        },
+      },
+      description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
     },
     409: {
       content: {

--- a/apps/server/src/routes/agent-tasks.ts
+++ b/apps/server/src/routes/agent-tasks.ts
@@ -38,6 +38,7 @@ import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { HTTPException } from 'hono/http-exception';
 import type { AgentDispatchOutput, AgentDispatchPayload } from '../jobs/agent-dispatch.js';
 import { buildDispatcher, type Dispatcher } from '../lib/agent-dispatcher.js';
+import { AiModuleUnavailableBodySchema } from '../lib/ai-module-loader.js';
 import { asLLMNotConfigured } from '../lib/llm-not-configured.js';
 import { detectDeploymentMode, type EnvMap } from '../lib/validate-startup.js';
 import { getEntitlementsFromContext } from '../middleware/entitlements.js';
@@ -183,6 +184,10 @@ app.openapi(
         content: { 'application/json': { schema: LLMNotConfiguredSchema } },
         description:
           'Hosted account has no LLM provider configured (set one at /settings/api-keys)',
+      },
+      503: {
+        content: { 'application/json': { schema: AiModuleUnavailableBodySchema } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
       },
     },
   }),
@@ -332,6 +337,10 @@ app.openapi(
         content: { 'application/json': { schema: LLMNotConfiguredSchema } },
         description:
           'Hosted account has no LLM provider configured (set one at /settings/api-keys)',
+      },
+      503: {
+        content: { 'application/json': { schema: AiModuleUnavailableBodySchema } },
+        description: 'AI runtime package not available in this deployment (not a Free-plan limit)',
       },
     },
   }),

--- a/apps/server/src/routes/agent-tasks.ts
+++ b/apps/server/src/routes/agent-tasks.ts
@@ -272,14 +272,9 @@ app.openapi(
     const dispatcher = built.dispatcher;
     if (!dispatcher) {
       await ticketQueries.updateTicket(db, ticket.id, { status: 'open' });
-      return c.json(
-        {
-          success: false as const,
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      // Null dispatcher = optional @revealui/ai missing or resolve failed — not Free.
+      const { aiModuleUnavailableBody } = await import('../lib/ai-module-loader.js');
+      return c.json(aiModuleUnavailableBody('dispatcher unavailable'), 503);
     }
 
     const dispatchResult = await dispatchWithTimeout(db, dispatcher, ticket);
@@ -405,14 +400,8 @@ app.openapi(
     }
     const dispatcher = built.dispatcher;
     if (!dispatcher) {
-      return c.json(
-        {
-          success: false as const,
-          error:
-            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
-        },
-        403,
-      );
+      const { aiModuleUnavailableBody } = await import('../lib/ai-module-loader.js');
+      return c.json(aiModuleUnavailableBody('dispatcher unavailable'), 503);
     }
 
     await ticketQueries.updateTicket(db, ticketId, { status: 'in_progress' });

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -6,7 +6,7 @@
     "api/**": {
       "memory": 512,
       "maxDuration": 30,
-      "includeFiles": "{dist/index_bg.wasm,dist/assets/fonts/**}",
+      "includeFiles": "{dist/index_bg.wasm,dist/assets/fonts/**,../../packages/ai/dist/**,../../packages/services/dist/**,../../node_modules/@revealui/ai/**,../../node_modules/@revealui/services/**}",
       "excludeFiles": "{**/*.ts,**/*.tsx,apps/admin/**,apps/marketing/**,apps/docs/**,packages/**/src/**,packages/**/templates/**,**/coverage/**,**/.next/**,**/.turbo/**,**/__tests__/**}"
     }
   },


### PR DESCRIPTION
## Summary

Enterprise / Pro accounts were seeing Free-plan / upgrade messaging when agent
execution failed because `@revealui/ai` was missing or resolve failed. That
string is reserved for real entitlement denial; import/resolve faults are
deployment or config problems.

- Add `ai-module-loader` with `AI_MODULE_UNAVAILABLE` (503) and
  `AI_RESOLVE_FAILED` (500) bodies that never claim Free.
- Wire agent-stream, a2a (module miss), and agent-tasks null-dispatcher paths.
- Expand Vercel `includeFiles` so Pro package dist is in the function payload.
- Tests updated for honest status codes.

## Founder account (ops, already applied in prod)

- `founder@revealui.com` is enterprise active with perpetual license key.
- Revvault Postgres URL re-synced from Fly; `grant-entitlement --dry-run` works.
- Neon API key in revvault still 401 (owner rotation needed).

## Test plan

- [x] vitest agent-stream, agent-tasks, ai-module-loader (38 tests)
- [x] local pre-push CI gate PASS
- [ ] After merge/deploy: entitled POST `/api/agent-stream` must not return
  Free-upgrade copy when AI package is present; if package missing, expect
  503 `AI_MODULE_UNAVAILABLE`.