### PR TITLE
docs(marketing): wire Skool profile URL (invite-only)

### DIFF
--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -101,14 +101,13 @@ export const SITE = {
 } as const;
 
 /**
- * Community defaults (owner 2026-08-10). Full map:
+ * Community defaults (owner 2026-08-10; Skool URL 2026-08-11). Full map:
  * fleet private `business/community-map-2026-08-10.md` + offerings-canonical Track E.
  *
- * URLs: OWNER_FILL later. Do not invent live hrefs. Consumers must not render a
- * nav/footer link when `url` is null (same pattern as omitted X handle).
+ * Consumers must not render a nav/footer link when `url` is null, and must not
+ * treat Skool as a public join CTA while `skool.access === 'invite-only'`.
  *
- * Defaults until owner updates:
- * - Skool: invite-only after purchase (no public join CTA)
+ * - Skool: invite-only after purchase (profile URL is for owner fulfillment / invites)
  * - Substack: public subscribe when URL set; broadcast list, not paid support home
  * - Discussions / Projects: public (urls live under SITE.urls)
  */
@@ -123,12 +122,12 @@ export const COMMUNITY = {
   },
   /**
    * Paid buyer home. Invite after Starter Kit / SaaS / AR close.
-   * Set `url` only when intentionally publishing a join link; default stays null.
+   * Profile URL set 2026-08-11 (owner). Still invite-only: do not put a free
+   * "Join Skool" CTA on marketing while access is invite-only.
    */
   skool: {
     access: 'invite-only' as const,
-    /** OWNER_FILL later — e.g. https://www.skool.com/… */
-    url: null as string | null,
+    url: 'https://www.skool.com/@joshua-vaughn-3634',
   },
   /**
    * Broadcast + free list. Not the paid support desk.

--- a/examples/starter-kit/OWNER-LAUNCH.md
+++ b/examples/starter-kit/OWNER-LAUNCH.md
@@ -15,7 +15,7 @@ the same Payment Link / Checkout surface.
 | **Stripe price** | **live** `price_1U01D1Jz64n6uEibtamJHxkU` ($299 one-time) |
 | **Payment Link** | **live** `https://buy.stripe.com/dRmeVegcH1AM2mmdbsa3u03` (`plink_1U01D2Jz64n6uEibnSK45nuS`) |
 | `SITE.urls.starterKitCheckout` | **wired** on marketing (`SITE.urls.starterKitCheckout`) |
-| Fulfillment | **manual**: GitHub invite + Skool buyer invite (launch volume). Substack = broadcast list only (URL OWNER_FILL later). |
+| Fulfillment | **manual**: GitHub invite + Skool buyer invite (launch volume). Skool profile: https://www.skool.com/@joshua-vaughn-3634 (invite-only; not a marketing CTA). Substack URL still OWNER_FILL. |
 | First-month Pro coupon | **seed script ready** (§4); run once on live key |
 | Stripe Tax | confirm `STRIPE_TAX_ENABLED=true` on prod api if selling broadly |
 | Managed Payments (D) | enable in Dashboard when eligible |
@@ -78,8 +78,8 @@ stripe promotion_codes create \
 2. Buyer email from receipt.
 3. GitHub: invite buyer as **read** collaborator on
    `RevealUIStudio/revealui-starter-kit`.
-4. Skool: invite buyer to the paid classroom (invite-only; no public join link
-   until owner publishes one). Substack is not the support home.
+4. Skool: invite buyer via https://www.skool.com/@joshua-vaughn-3634 (invite-only;
+   no public marketing join CTA). Substack is not the support home.
 5. Reply with invite notes + optional `STARTERKITPRO1` (when created).
 
 Target: within **one business day** (matches Payment Link confirmation copy).


### PR DESCRIPTION
## Summary

- Set `COMMUNITY.skool.url` to https://www.skool.com/@joshua-vaughn-3634
- Keep `access: invite-only` (not a free marketing join CTA)
- OWNER-LAUNCH fulfillment points at this profile for manual invites
- Substack remains OWNER_FILL / null

## Test plan

- [ ] Confirm Skool profile is the right invite surface (or replace with classroom URL later)
- [ ] No footer/nav exposes Skool while invite-only