### PR TITLE
docs(marketing): Skool + Substack community URLs

### DIFF
--- a/apps/marketing/app/content/site.ts
+++ b/apps/marketing/app/content/site.ts
@@ -101,15 +101,14 @@ export const SITE = {
 } as const;
 
 /**
- * Community defaults (owner 2026-08-10). Full map:
+ * Community defaults (owner 2026-08-10; Skool URL 2026-08-11). Full map:
  * fleet private `business/community-map-2026-08-10.md` + offerings-canonical Track E.
  *
- * URLs: OWNER_FILL later. Do not invent live hrefs. Consumers must not render a
- * nav/footer link when `url` is null (same pattern as omitted X handle).
+ * Consumers must not render a nav/footer link when `url` is null, and must not
+ * treat Skool as a public join CTA while `skool.access === 'invite-only'`.
  *
- * Defaults until owner updates:
- * - Skool: invite-only after purchase (no public join CTA)
- * - Substack: public subscribe when URL set; broadcast list, not paid support home
+ * - Skool: invite-only after purchase (profile URL is for owner fulfillment / invites)
+ * - Substack: public subscribe (https://substack.com/@revealuistudio); broadcast list, not paid support home
  * - Discussions / Projects: public (urls live under SITE.urls)
  */
 export const COMMUNITY = {
@@ -123,21 +122,20 @@ export const COMMUNITY = {
   },
   /**
    * Paid buyer home. Invite after Starter Kit / SaaS / AR close.
-   * Set `url` only when intentionally publishing a join link; default stays null.
+   * Profile URL set 2026-08-11 (owner). Still invite-only: do not put a free
+   * "Join Skool" CTA on marketing while access is invite-only.
    */
   skool: {
     access: 'invite-only' as const,
-    /** OWNER_FILL later — e.g. https://www.skool.com/… */
-    url: null as string | null,
+    url: 'https://www.skool.com/@joshua-vaughn-3634',
   },
   /**
    * Broadcast + free list. Not the paid support desk.
-   * Set `url` when the publication is ready for public subscribe CTAs.
+   * Public subscribe URL set 2026-08-11 (owner). Safe for footer/nav when non-null.
    */
   substack: {
     access: 'public-subscribe' as const,
-    /** OWNER_FILL later — e.g. https://….substack.com */
-    url: null as string | null,
+    url: 'https://substack.com/@revealuistudio',
   },
 } as const;
 

--- a/examples/starter-kit/OWNER-LAUNCH.md
+++ b/examples/starter-kit/OWNER-LAUNCH.md
@@ -15,8 +15,8 @@ the same Payment Link / Checkout surface.
 | **Stripe price** | **live** `price_1U01D1Jz64n6uEibtamJHxkU` ($299 one-time) |
 | **Payment Link** | **live** `https://buy.stripe.com/dRmeVegcH1AM2mmdbsa3u03` (`plink_1U01D2Jz64n6uEibnSK45nuS`) |
 | `SITE.urls.starterKitCheckout` | **wired** on marketing (`SITE.urls.starterKitCheckout`) |
-| Fulfillment | **manual**: GitHub invite + Skool buyer invite (launch volume). Substack = broadcast list only (URL OWNER_FILL later). |
-| First-month Pro coupon | **LIVE** `STARTERKITPRO1` (check OK 2026-08-11) |
+| Fulfillment | **manual**: GitHub invite + Skool buyer invite (launch volume). Skool: https://www.skool.com/@joshua-vaughn-3634 (invite-only). Substack broadcast: https://substack.com/@revealuistudio (not support home). |
+| First-month Pro coupon | **seed script ready** (§4); run once on live key |
 | Stripe Tax | confirm `STRIPE_TAX_ENABLED=true` on prod api if selling broadly |
 | Managed Payments (D) | enable in Dashboard when eligible |
 
@@ -78,8 +78,8 @@ stripe promotion_codes create \
 2. Buyer email from receipt.
 3. GitHub: invite buyer as **read** collaborator on
    `RevealUIStudio/revealui-starter-kit`.
-4. Skool: invite buyer to the paid classroom (invite-only; no public join link
-   until owner publishes one). Substack is not the support home.
+4. Skool: invite buyer via https://www.skool.com/@joshua-vaughn-3634 (invite-only;
+   no public marketing join CTA). Substack is not the support home.
 5. Reply with invite notes + optional `STARTERKITPRO1` (when created).
 
 Target: within **one business day** (matches Payment Link confirmation copy).
@@ -89,7 +89,7 @@ Target: within **one business day** (matches Payment Link confirmation copy).
 One link: `https://buy.stripe.com/dRmeVegcH1AM2mmdbsa3u03`
 
 - `/pricing#starter-kit` (after merge/deploy)
-- LinkedIn / Substack (when URL set) / optional X when the handle is live
+- LinkedIn / Substack (https://substack.com/@revealuistudio) / optional X when the handle is live
 - Product Hunt / Show HN / Indie Hackers
 - Technical post (receipt recipes) with soft CTA
 - GitHub monorepo docs pointer to pricing section


### PR DESCRIPTION
## Summary

Replaces conflicted #2536 / #2535. Sets:

- `COMMUNITY.skool.url` = https://www.skool.com/@joshua-vaughn-3634 (invite-only)
- `COMMUNITY.substack.url` = https://substack.com/@revealuistudio (public broadcast)
- OWNER-LAUNCH fulfillment notes

## Test plan

- [ ] CI green
- [ ] No public Skool join CTA while invite-only