### PR TITLE
feat(marketing): Substack footer, support channels, PLG checklists

### DIFF
--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -8,7 +8,7 @@ import {
   FOOTER_SOLO_OPERATOR_NOTE,
   FOOTER_TAGLINE,
 } from '../content/nav';
-import { SITE } from '../content/site';
+import { COMMUNITY, SITE } from '../content/site';
 import { NewsletterSignup } from './NewsletterSignup';
 
 export function Footer() {
@@ -59,7 +59,7 @@ export function Footer() {
                 Product updates and engineering insights. No spam.
               </p>
             </div>
-            <div className="mt-6 flex gap-4">
+            <div className="mt-6 flex flex-wrap items-center gap-4">
               <a
                 href={SITE.urls.repo}
                 className="text-muted-foreground hover:text-foreground transition-colors"
@@ -74,6 +74,16 @@ export function Footer() {
               >
                 <LinkedInIcon className="size-5" />
               </a>
+              {COMMUNITY.substack.url ? (
+                <a
+                  href={COMMUNITY.substack.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Substack
+                </a>
+              ) : null}
             </div>
           </div>
           {FOOTER_COLUMNS.map((col) => (

--- a/apps/marketing/app/content/claims-evidence/claims-part-5.ts
+++ b/apps/marketing/app/content/claims-evidence/claims-part-5.ts
@@ -451,6 +451,18 @@ export const claimsPart5: readonly ClaimEntry[] = [
   },
   {
     file: 'legal/support.ts',
+    exportPath: 'SUPPORT_SECTIONS[0].listItems[4]',
+    text: '**Paid product buyers (Starter Kit, Pro, Max, and services):** after purchase we invite you to the private Skool buyer community for onboarding and product questions. That invite is manual at launch volume and is not a public join link. Billing and license issues still go to email.',
+    evidence: [LEGAL_SUPPORT_CONTENT],
+  },
+  {
+    file: 'legal/support.ts',
+    exportPath: 'SUPPORT_SECTIONS[0].listItems[5]',
+    text: '**Essays and product notes:** https://substack.com/@revealuistudio is the public broadcast list. It is not a support desk.',
+    evidence: [LEGAL_SUPPORT_CONTENT],
+  },
+  {
+    file: 'legal/support.ts',
     exportPath: 'SUPPORT_SECTIONS[1].paragraphs[0]',
     text: '(interpolated: SITE email / domain embedded at runtime)',
     match: 'path',

--- a/apps/marketing/app/content/legal/support.ts
+++ b/apps/marketing/app/content/legal/support.ts
@@ -6,7 +6,7 @@ import type { LegalSection } from './privacy';
 
 export const SUPPORT_META = {
   title: 'Support',
-  lastUpdated: 'May 28, 2026',
+  lastUpdated: 'August 11, 2026',
   intro:
     'RevealUI Studio is a solo-operator company. We want to help you succeed with RevealUI, and we want to be honest about what kind of help we can offer, on what timeline, and through which channels. This page covers all three.',
 } as const;
@@ -20,6 +20,8 @@ export const SUPPORT_SECTIONS: readonly LegalSection[] = [
       `**GitHub Discussions** at https://github.com/RevealUIStudio/revealui/discussions: community-friendly format for design questions, "is there a better way to do X", and ideas. Other users and the maintainer both watch this. Best for questions where a public answer benefits more than just you.`,
       `**GitHub Issues** at https://github.com/RevealUIStudio/revealui/issues: for confirmed bugs and feature requests. Include reproduction steps. See §5 below for "bug vs support" guidance.`,
       `**Email** at ${SITE.emails.support}: for account-specific issues (billing, license keys, your data), security concerns, and questions you cannot ask in public.`,
+      '**Paid product buyers (Starter Kit, Pro, Max, and services):** after purchase we invite you to the private Skool buyer community for onboarding and product questions. That invite is manual at launch volume and is not a public join link. Billing and license issues still go to email.',
+      '**Essays and product notes:** https://substack.com/@revealuistudio is the public broadcast list. It is not a support desk.',
     ],
   },
   {

--- a/apps/marketing/app/content/nav.ts
+++ b/apps/marketing/app/content/nav.ts
@@ -1,7 +1,7 @@
 // Sourced from: app/components/NavBar.tsx, app/components/Footer.tsx (Phase 1c, no copy changes).
 // Per the internal marketing-overhaul plan §4.4.
 
-import { SITE } from './site';
+import { COMMUNITY, SITE } from './site';
 import type { NavLink } from './types';
 
 export const NAV_LINKS: readonly NavLink[] = [
@@ -22,6 +22,16 @@ export interface FooterColumn {
   readonly links: readonly NavLink[];
 }
 
+const communityLinks: readonly NavLink[] = [
+  { label: 'GitHub', href: SITE.urls.repo, external: true },
+  { label: 'Discussions', href: SITE.urls.repoDiscussions, external: true },
+  ...(COMMUNITY.substack.url
+    ? ([{ label: 'Substack', href: COMMUNITY.substack.url, external: true }] as const)
+    : []),
+  { label: 'RevealUI Studio (agency) →', href: SITE.urls.agency, external: true },
+  { label: 'Contact', href: '/contact' },
+];
+
 export const FOOTER_COLUMNS: readonly FooterColumn[] = [
   {
     heading: 'Product',
@@ -38,12 +48,8 @@ export const FOOTER_COLUMNS: readonly FooterColumn[] = [
   },
   {
     heading: 'Community',
-    links: [
-      { label: 'GitHub', href: SITE.urls.repo, external: true },
-      { label: 'Discussions', href: SITE.urls.repoDiscussions, external: true },
-      { label: 'RevealUI Studio (agency) →', href: SITE.urls.agency, external: true },
-      { label: 'Contact', href: '/contact' },
-    ],
+    // Broadcast list (Substack) only; Skool stays invite-only and off the public footer.
+    links: communityLinks,
   },
   {
     heading: 'Trust',

--- a/docs/distribution/PLG-CHANNELS-STATUS.md
+++ b/docs/distribution/PLG-CHANNELS-STATUS.md
@@ -1,0 +1,21 @@
+# Product-led channels — status (Stage 1)
+
+Owner strategy: `business/strategy-product-led-online-revenue-2026-07-26.md`
+(in revealui-jv). Stage 1 go pack: `business/stage-1-go-pack-2026-08-11.md`.
+
+| Channel | Gap | Agent code | Remaining |
+|---------|-----|------------|-----------|
+| Starter Kit $299 | GAP-434 | Done (Payment Link, listing, coupon `STARTERKITPRO1`) | Owner smoke purchase + GitHub + Skool invite; then close |
+| Apify Governed Agent Run | GAP-431 | Done (`packages/apify-actor-governed-run`, tests green when deps installed) | Owner Store publish + PPE prices + smoke — [APIFY-GOVERNED-RUN-OWNER-PUBLISH.md](./APIFY-GOVERNED-RUN-OWNER-PUBLISH.md) |
+| Railway marketplace template | GAP-430 | Done (`deployment/railway/*` + docs links) | Owner dashboard publish + clean-account walk — [RAILWAY-MARKETPLACE-OWNER-PUBLISH.md](./RAILWAY-MARKETPLACE-OWNER-PUBLISH.md) |
+
+Pick **one** channel to push to first stranger money; do not fan out all three
+before Stage 1 graduation.
+
+### Community (not a fourth SKU)
+
+| Surface | URL | Role |
+|---------|-----|------|
+| Skool | https://www.skool.com/@joshua-vaughn-3634 | Invite-only after pay |
+| Substack | https://substack.com/@revealuistudio | Public broadcast |
+| Discussions | https://github.com/RevealUIStudio/revealui/discussions | Free product community |

--- a/docs/distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md
+++ b/docs/distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md
@@ -1,16 +1,16 @@
-# Owner publish checklist — Railway marketplace (GAP-430)
+# Owner publish checklist — customer Railway marketplace template (GAP-430)
 
 Agent work for template definition, first-boot docs, and monorepo cross-links is
 **done** (`deployment/railway/*` on `test`). Closure is **owner dashboard publish**
 only. Studio production hosting stays Vercel + Neon + Fly; this listing is a
-customer self-host sales channel.
+customer self-host **sales channel** (marketplace template), not Studio infra.
 
 ## 1. Account
 
-1. Sign in to the RevealUI Railway account (Hobby paid account already used for
-   early work 2026-07-27).
+1. Sign in to the RevealUI author account on the customer marketplace platform
+   (Hobby paid account already used for early sales-channel work 2026-07-27).
 2. Confirm billing is active (marketplace author kickback requires a paid plan
-   context as Railway documents it).
+   context as the marketplace vendor documents it).
 3. Optional: enable support-bonus queue / author program settings if offered.
 
 ## 2. Template source
@@ -24,8 +24,8 @@ Do **not** re-author a parallel compose path. Extend `deployment/railway/` only.
 
 ## 3. Publish (dashboard)
 
-1. Create or update a Railway **Template** from this monorepo, pointing services
-   at the config in `deployment/railway/`.
+1. Create or update a marketplace **Template** from this monorepo, pointing
+   services at the config in `deployment/railway/`.
 2. Ensure template services match the README architecture table (postgres,
    migrate, api, admin).
 3. Document required env vars in the template UI (no secrets baked in).
@@ -33,11 +33,12 @@ Do **not** re-author a parallel compose path. Extend `deployment/railway/` only.
    api and admin when no license key is supplied (see README).
 5. Publish to the marketplace; opt into author kickback / support bonus if
    separate toggles exist.
-6. Wire payout (Stripe Connect or Railway payout path) for the $100 threshold.
+6. Wire payout (Stripe Connect or the marketplace vendor payout path) for the
+   $100 threshold on this sales channel.
 
 ## 4. Clean-account acceptance walk (close GAP-430)
 
-From a **second** Railway account (or reset project):
+From a **second** buyer account on the marketplace (or reset project):
 
 1. Deploy template one-click.
 2. Wait migrate success; api + admin healthy.

--- a/docs/distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md
+++ b/docs/distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md
@@ -1,0 +1,56 @@
+# Owner publish checklist — Railway marketplace (GAP-430)
+
+Agent work for template definition, first-boot docs, and monorepo cross-links is
+**done** (`deployment/railway/*` on `test`). Closure is **owner dashboard publish**
+only. Studio production hosting stays Vercel + Neon + Fly; this listing is a
+customer self-host sales channel.
+
+## 1. Account
+
+1. Sign in to the RevealUI Railway account (Hobby paid account already used for
+   early work 2026-07-27).
+2. Confirm billing is active (marketplace author kickback requires a paid plan
+   context as Railway documents it).
+3. Optional: enable support-bonus queue / author program settings if offered.
+
+## 2. Template source
+
+- Config-as-code: `deployment/railway/README.md`, `api.json`, `admin.json`
+- Images: `apps/server/Dockerfile`, `apps/admin/Dockerfile`, migrate image
+  `ghcr.io/revealuistudio/revealui-migrate`, Postgres `pgvector/pgvector:pg16`
+- Docs already cross-link from README and `docs/guides/deployment.md`
+
+Do **not** re-author a parallel compose path. Extend `deployment/railway/` only.
+
+## 3. Publish (dashboard)
+
+1. Create or update a Railway **Template** from this monorepo, pointing services
+   at the config in `deployment/railway/`.
+2. Ensure template services match the README architecture table (postgres,
+   migrate, api, admin).
+3. Document required env vars in the template UI (no secrets baked in).
+4. Set Free-tier path: `REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true` on **both**
+   api and admin when no license key is supplied (see README).
+5. Publish to the marketplace; opt into author kickback / support bonus if
+   separate toggles exist.
+6. Wire payout (Stripe Connect or Railway payout path) for the $100 threshold.
+
+## 4. Clean-account acceptance walk (close GAP-430)
+
+From a **second** Railway account (or reset project):
+
+1. Deploy template one-click.
+2. Wait migrate success; api + admin healthy.
+3. Open admin; seeded login works with documented defaults / env.
+4. Record: marketplace listing URL, deploy project id, screenshot or log note
+   of healthy services, kickback/payout status.
+
+## 5. Record on GAP-430
+
+Paste listing URL + smoke date into `docs/gaps/GAP-430.yml` progress, then close
+when acceptance is met.
+
+## Peers
+
+Do not re-scaffold `deployment/railway/api.json` or `admin.json` without a new
+proven residual. Owner publish is the remaining door.


### PR DESCRIPTION
## Summary

Optional Stage-1 polish:

1. **Substack** in footer community column + social row (`COMMUNITY.substack`)
2. **Support** honesty: Skool invite-only for paid buyers; Substack = broadcast only
3. **PLG:** Railway owner publish checklist + status matrix (Apify already had OWNER-PUBLISH; code exhausted pending owner)

Trust URLs already return 200 on prod (`/security`, `/support`, `/status`, `/.well-known/security.txt`).

## Test plan

- [ ] Footer shows Substack; no public Skool join
- [ ] `/support` lists new channels
- [ ] Claims evidence lockstep green
- [ ] CI green