### PR TITLE
feat(marketing): contact/newsletter Substack + PLG docs index

### DIFF
--- a/apps/marketing/app/components/NewsletterSignup.tsx
+++ b/apps/marketing/app/components/NewsletterSignup.tsx
@@ -1,6 +1,7 @@
 import { Button, Input } from '@revealui/presentation';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
+import { COMMUNITY } from '../content/site';
 import { submitNewsletter } from '../lib/api';
 
 export function NewsletterSignup({ variant = 'inline' }: { variant?: 'inline' | 'stacked' }) {
@@ -66,6 +67,21 @@ export function NewsletterSignup({ variant = 'inline' }: { variant?: 'inline' | 
         )}
         <p className="text-xs text-muted-foreground">
           Product updates and engineering insights. No spam.
+          {COMMUNITY.substack.url ? (
+            <>
+              {' '}
+              Or read on{' '}
+              <a
+                href={COMMUNITY.substack.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-primary hover:underline"
+              >
+                Substack
+              </a>
+              .
+            </>
+          ) : null}
         </p>
       </form>
     );
@@ -102,6 +118,19 @@ export function NewsletterSignup({ variant = 'inline' }: { variant?: 'inline' | 
           {message}
         </p>
       )}
+      {COMMUNITY.substack.url ? (
+        <p className="text-xs text-muted-foreground">
+          Prefer essays?{' '}
+          <a
+            href={COMMUNITY.substack.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-primary hover:underline"
+          >
+            Substack
+          </a>
+        </p>
+      ) : null}
     </form>
   );
 }

--- a/apps/marketing/app/content/contact.ts
+++ b/apps/marketing/app/content/contact.ts
@@ -29,7 +29,7 @@ export const CONTACT_METHODS: readonly ContactMethod[] = [
     ? [
         {
           title: 'Essays',
-          body: 'Product notes and long-form posts on',
+          body: '',
           linkLabel: 'Substack',
           href: COMMUNITY.substack.url,
           external: true,
@@ -38,14 +38,14 @@ export const CONTACT_METHODS: readonly ContactMethod[] = [
     : []),
   {
     title: 'Support',
-    body: 'Billing, licenses, and private account issues:',
+    body: '',
     linkLabel: SITE.emails.support,
     href: `mailto:${SITE.emails.support}`,
     isEmail: true,
   },
   {
     title: 'Help channels',
-    body: 'Full channel map (docs, email SLA, paid-buyer community):',
+    body: '',
     linkLabel: 'Support page',
     href: '/support',
   },

--- a/apps/marketing/app/content/contact.ts
+++ b/apps/marketing/app/content/contact.ts
@@ -1,6 +1,6 @@
 // Sourced from: app/routes/ContactPage.tsx (Phase 1, no copy changes). Per the internal marketing-overhaul plan §4.4.
 
-import { SITE } from './site';
+import { COMMUNITY, SITE } from './site';
 
 export interface ContactMethod {
   readonly title: string;
@@ -25,12 +25,29 @@ export const CONTACT_METHODS: readonly ContactMethod[] = [
     href: SITE.urls.repoDiscussions,
     external: true,
   },
+  ...(COMMUNITY.substack.url
+    ? [
+        {
+          title: 'Essays',
+          body: 'Product notes and long-form posts on',
+          linkLabel: 'Substack',
+          href: COMMUNITY.substack.url,
+          external: true,
+        } satisfies ContactMethod,
+      ]
+    : []),
   {
     title: 'Support',
-    body: '',
+    body: 'Billing, licenses, and private account issues:',
     linkLabel: SITE.emails.support,
     href: `mailto:${SITE.emails.support}`,
     isEmail: true,
+  },
+  {
+    title: 'Help channels',
+    body: 'Full channel map (docs, email SLA, paid-buyer community):',
+    linkLabel: 'Support page',
+    href: '/support',
   },
   {
     title: 'Bug Reports',

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,9 +35,6 @@ Six **[design principles](./JOSHUA.md)** govern every architectural decision: Ju
 - [Marketplace](./MARKETPLACE.md): Agent-commerce monetization direction and marketplace economics
 - [HTTP 402 Payments](./blog/02-http-402-payments.md): Paid API and machine-to-machine payment model
 - [Pro](./PRO.md): Commercial packaging for AI, MCP, trust, and governance features
-- [PLG channels status](./distribution/PLG-CHANNELS-STATUS.md): Starter Kit, Apify governed run, customer Railway marketplace template (owner publish residuals)
-- [Apify owner publish](./distribution/APIFY-GOVERNED-RUN-OWNER-PUBLISH.md): Store publish checklist for GAP-431
-- [Railway marketplace owner publish](./distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md): Customer sales-channel template publish checklist for GAP-430
 
 ## Development
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,6 +35,9 @@ Six **[design principles](./JOSHUA.md)** govern every architectural decision: Ju
 - [Marketplace](./MARKETPLACE.md): Agent-commerce monetization direction and marketplace economics
 - [HTTP 402 Payments](./blog/02-http-402-payments.md): Paid API and machine-to-machine payment model
 - [Pro](./PRO.md): Commercial packaging for AI, MCP, trust, and governance features
+- [PLG channels status](./distribution/PLG-CHANNELS-STATUS.md): Starter Kit, Apify governed run, customer Railway marketplace template (owner publish residuals)
+- [Apify owner publish](./distribution/APIFY-GOVERNED-RUN-OWNER-PUBLISH.md): Store publish checklist for GAP-431
+- [Railway marketplace owner publish](./distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md): Customer sales-channel template publish checklist for GAP-430
 
 ## Development
 


### PR DESCRIPTION
## Summary

Remaining optional Stage-1 polish:

- Contact: Substack essays + Support page channel map
- Newsletter: dual path to Substack
- Docs INDEX: PLG channel status + Apify/Railway owner publish checklists

## Test plan

- [ ] /contact shows Substack + Support page
- [ ] Footer newsletter mentions Substack
- [ ] docs INDEX links resolve
- [ ] CI green