### PR TITLE
chore(release): version knowledge-graph 0.1.9 + mcp 0.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "changeset": "node --require ./scripts/polyfill-yaml-safeload.cjs ./node_modules/@changesets/cli/bin.js",
     "changeset:publish": "node --require ./scripts/polyfill-yaml-safeload.cjs ./node_modules/@changesets/cli/bin.js publish",
     "changeset:status": "node --require ./scripts/polyfill-yaml-safeload.cjs ./node_modules/@changesets/cli/bin.js status",
-    "changeset:version": "changeset version && node scripts/sync-mcp-server-json.mjs && pnpm install --no-frozen-lockfile && git add pnpm-lock.yaml packages/mcp/server.json",
+    "changeset:version": "node --require ./scripts/polyfill-yaml-safeload.cjs ./node_modules/@changesets/cli/bin.js version && node scripts/sync-mcp-server-json.mjs && pnpm install --no-frozen-lockfile && git add pnpm-lock.yaml packages/mcp/server.json",
     "clean": "rm -rf node_modules packages/*/node_modules apps/*/node_modules packages/*/dist apps/*/dist packages/*/.next apps/*/.next packages/*/.turbo apps/*/.turbo packages/*/tsconfig.tsbuildinfo apps/*/tsconfig.tsbuildinfo .next .turbo",
     "clean:install": "pnpm clean && pnpm install:clean",
     "admin:bootstrap": "tsx scripts/admin/bootstrap.ts",

--- a/packages/knowledge-graph/CHANGELOG.md
+++ b/packages/knowledge-graph/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @revealui/knowledge-graph
 
+## 0.1.9
+
+### Patch Changes
+
+- Add revkg decommission for retired repository edges (GAP-349 residual).
+
 ## 0.1.8
 
 ## 0.1.7

--- a/packages/knowledge-graph/package.json
+++ b/packages/knowledge-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@revealui/knowledge-graph",
-  "version": "0.1.8",
-  "description": "Fleet knowledge graph \u2014 bi-temporal, content-addressed graph (ontology, deterministic IDs, deterministic ingestion, hybrid search) over Neon + pgvector. GAP-340.",
+  "version": "0.1.9",
+  "description": "Fleet knowledge graph — bi-temporal, content-addressed graph (ontology, deterministic IDs, deterministic ingestion, hybrid search) over Neon + pgvector. GAP-340.",
   "keywords": [
     "knowledge-graph",
     "temporal",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @revealui/mcp
 
+## 0.8.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @revealui/knowledge-graph@0.1.9
+
 ## 0.8.6
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revealui/mcp",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Model Context Protocol framework — first-party server launchers, adapter pattern, tool discovery, and an incubating multi-server hypervisor (not app-mounted by default; ADR-007).",
   "repository": {
     "type": "git",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/RevealUIStudio/revealui",
     "source": "github"
   },
-  "version": "0.8.6",
+  "version": "0.8.7",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "@revealui/mcp",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Production release prep for the current `test` tip:

| Package | Version | Why |
|---------|---------|-----|
| `@revealui/knowledge-graph` | **0.1.8 → 0.1.9** | `revkg decommission` for retired repo edges (GAP-349 residual, #2539) |
| `@revealui/mcp` | **0.8.6 → 0.8.7** | Internal dep bump (`updateInternalDependencies: patch`) |

Also hardens `pnpm changeset:version` to use the js-yaml `safeLoad` polyfill (same class as #2524).

Apps (server honesty #2533, marketing PLG, SENTRY_DSN #2541) are not npm-published; they ship via Vercel on **test → main** promote.

## After merge to `test`

1. Open promote PR: head `test` → base `main` (gate requires head = `test`).
2. Merge with **Create a merge commit** only.
3. `gh workflow run release.yml --ref main` (npm publish + tags).
4. Confirm deploy.yml smoke on api/admin/marketing.

## Test plan

- [x] Changeset version via polyfilled CLI
- [x] CHANGELOG for 0.1.9 / 0.8.7
- [x] `packages/mcp/server.json` synced to 0.8.7
- [ ] CI green
- [ ] Promote + release.yml after land
