### PR TITLE
promote: test → main (marketing craft)

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -18,22 +18,22 @@ export function GetStarted({
   annotation = {},
 }: GetStartedProps) {
   return (
-    <section className="py-24 bg-card sm:py-32">
+    <section className="border-t border-border bg-background py-20 sm:py-28">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <h2
-            className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            className="font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
             {...fieldAttrs(annotation, `${path}.heading`)}
           >
             {data.heading}
           </h2>
           <p
-            className="mt-6 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-muted-foreground"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}
           </p>
-          <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
             <Button asChild size="lg" variant="brand">
               <a href={data.cta.primary.href}>{data.cta.primary.label}</a>
             </Button>
@@ -75,9 +75,8 @@ export function GetStarted({
             {data.cli.caption}
           </p>
 
-          {/* Newsletter */}
-          <div className="mt-16 pt-10 border-t border-border">
-            <p className="text-sm font-medium text-muted-foreground mb-4">
+          <div className="mt-14 border-t border-border pt-10">
+            <p className="mb-4 text-sm font-medium text-muted-foreground">
               {data.newsletter.label}
             </p>
             <NewsletterSignup variant="stacked" />

--- a/apps/marketing/app/components/__tests__/Problem.test.tsx
+++ b/apps/marketing/app/components/__tests__/Problem.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { HOME_PROBLEM } from '../../content/home';
+import { Problem } from '../landing/Problem';
+
+describe('Problem capability stack', () => {
+  it('renders no table and no path cards', () => {
+    const { container } = render(<Problem />);
+    expect(container.querySelector('table')).toBeNull();
+    // Stacked list of capabilities, not a card matrix.
+    expect(screen.getByRole('list', { name: HOME_PROBLEM.tableAriaLabel })).toBeTruthy();
+    expect(container.querySelectorAll('[class*="rounded-2xl"]').length).toBe(0);
+  });
+
+  it('lists every capability once as a heading', () => {
+    render(<Problem />);
+    for (const row of HOME_PROBLEM.rows) {
+      expect(screen.getByRole('heading', { level: 3, name: row.capability })).toBeTruthy();
+    }
+  });
+
+  it('keeps path blurbs and every row claim', () => {
+    render(<Problem />);
+    expect(screen.getByText(HOME_PROBLEM.highlightedLabel)).toBeTruthy();
+    expect(screen.getByText(HOME_PROBLEM.pathBlurbs.sprawl)).toBeTruthy();
+    expect(screen.getByText(HOME_PROBLEM.pathBlurbs.agentOnly)).toBeTruthy();
+    expect(screen.getByText(HOME_PROBLEM.pathBlurbs.revealui)).toBeTruthy();
+
+    for (const row of HOME_PROBLEM.rows) {
+      expect(screen.getByText(row.sprawl)).toBeTruthy();
+      expect(screen.getByText(row.revealui)).toBeTruthy();
+    }
+    expect(screen.getAllByText('Bring your own').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('aligns answers under each capability (definition list)', () => {
+    const { container } = render(<Problem />);
+    const dls = container.querySelectorAll('dl');
+    expect(dls.length).toBe(HOME_PROBLEM.rows.length);
+    // Each capability has three answers (sprawl / agentOnly / revealui).
+    for (const dl of dls) {
+      expect(dl.querySelectorAll('dt').length).toBe(3);
+      expect(dl.querySelectorAll('dd').length).toBe(3);
+    }
+  });
+});

--- a/apps/marketing/app/components/__tests__/ProductFrame.test.tsx
+++ b/apps/marketing/app/components/__tests__/ProductFrame.test.tsx
@@ -14,7 +14,8 @@ describe('ProductFrame', () => {
       />,
     );
 
-    expect(screen.getByRole('img', { name: /RevealUI admin shell/i })).toBeTruthy();
+    // figure (not role=img): interactive descendants make role=img invalid for axe
+    expect(screen.getByRole('figure', { name: /RevealUI admin shell/i })).toBeTruthy();
     expect(screen.getByText(/support-agent · refund flow/i)).toBeTruthy();
     expect(screen.getByLabelText(/Agent online/i)).toBeTruthy();
     expect(screen.getByLabelText(/Approved/i)).toBeTruthy();

--- a/apps/marketing/app/components/__tests__/ProductFrame.test.tsx
+++ b/apps/marketing/app/components/__tests__/ProductFrame.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProductFrame } from '../landing/ProductFrame';
+
+describe('ProductFrame', () => {
+  it('renders live presentation primitives inside admin chrome', () => {
+    render(
+      <ProductFrame
+        caption={{
+          prefix: 'Local screenshot from a fresh',
+          code: 'npx create-revealui',
+          suffix: '. The three beats below describe the steps.',
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: /RevealUI admin shell/i })).toBeTruthy();
+    expect(screen.getByText(/support-agent · refund flow/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Agent online/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Approved/i)).toBeTruthy();
+    expect(screen.getByText(/npx create-revealui/)).toBeTruthy();
+    expect(screen.getByText(/Live presentation components/i)).toBeTruthy();
+  });
+
+  it('lists the five primitives in the sidebar chrome', () => {
+    const { container } = render(<ProductFrame />);
+    for (const label of ['People', 'Content', 'Offers', 'Payments', 'Agents']) {
+      expect(container.textContent).toContain(label);
+    }
+  });
+});

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -1,6 +1,7 @@
 import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
 import { HOME_DEMO } from '../../content/home';
 import type { DemoData } from '../../lib/page-blocks';
+import { ProductFrame } from './ProductFrame';
 
 export interface DemoProps {
   /** Rich section data; defaults to the static content module (byte-identical). */
@@ -13,53 +14,60 @@ export interface DemoProps {
 
 export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {} }: DemoProps) {
   return (
-    <section id="demo" className="bg-secondary py-24 sm:py-32">
+    <section id="demo" className="relative bg-secondary py-20 sm:py-28">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            className="text-xs font-semibold uppercase tracking-widest text-muted-foreground"
             {...fieldAttrs(annotation, `${path}.eyebrow`)}
           >
             {data.eyebrow}
           </p>
           <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
             {...fieldAttrs(annotation, `${path}.heading`)}
           >
             {data.heading}
           </h2>
           <p
-            className="mt-6 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-muted-foreground"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}
           </p>
         </div>
 
-        <div className="mx-auto mt-20 grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-3">
+        {/* Product-as-proof: live component frame (Linear craft pattern).
+            Content mockupCaption was previously unwired; honesty line stays. */}
+        <div className="mt-14 sm:mt-16">
+          <ProductFrame caption={HOME_DEMO.mockupCaption} />
+        </div>
+
+        {/* Beats as aligned stack, not three bordered cards (Linear: density over chrome). */}
+        <ol className="mx-auto mt-14 grid max-w-5xl list-none grid-cols-1 gap-0 divide-y divide-border border-y border-border p-0 sm:mt-16 lg:grid-cols-3 lg:gap-0 lg:divide-x lg:divide-y-0">
           {data.beats.map((b, index) => (
-            <div key={b.n} className="rounded-2xl bg-card p-8 ring-1 ring-border">
+            <li key={b.n} className="relative px-0 py-7 lg:px-8 lg:py-8 first:lg:pl-0 last:lg:pr-0">
               <div
-                className="font-mono text-xs font-semibold uppercase tracking-widest text-primary"
+                className="font-mono text-[11px] font-medium tabular-nums tracking-widest text-muted-foreground"
                 {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
               >
                 {b.n}
               </div>
               <h3
-                className="mt-3 text-lg font-semibold text-foreground"
+                className="mt-3 font-display text-lg font-semibold tracking-tight text-foreground"
                 {...fieldAttrs(annotation, `${path}.items.${index}.title`)}
               >
                 {b.title}
               </h3>
               <p
-                className="mt-3 text-sm leading-6 text-muted-foreground"
+                className="mt-2 text-sm leading-6 text-muted-foreground"
                 {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
               >
                 {b.body}
               </p>
-            </div>
+            </li>
           ))}
-        </div>
+        </ol>
       </div>
     </section>
   );

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -145,8 +145,8 @@ export function Hero() {
         </div>
 
         {/* Receipt-motif moment (frontend-excellence Phase 5): one orchestrated
-            print entrance. Signature creative element only — Linear: one moment,
-            not competing chrome. */}
+            print entrance. Signature creative element only (Linear craft: one
+            moment, not competing chrome). */}
         <div className="mt-12 w-full max-w-md min-w-0 mx-auto text-left sm:mt-14 sm:max-w-lg">
           <ReceiptCard
             title={RECEIPT_HERO_TITLE}

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -24,12 +24,15 @@ const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as cons
  * to `--color-primary` rather than a literal color. Lives inside an
  * overflow-hidden box so the off-canvas offset never creates a scrollbar.
  * Reads in both light and dark.
+ *
+ * Craft pass 2026-08: lower opacity, smaller glow. Linear redesign lesson:
+ * reduce chrome noise; let type and the receipt carry hierarchy.
  */
 function HeroBackground() {
   return (
     <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-primary/5 via-background to-background" />
-      <div className="absolute -top-40 left-1/2 h-[700px] w-[1100px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--color-primary),transparent_70%)] opacity-10 blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.03] via-background to-background" />
+      <div className="absolute -top-32 left-1/2 h-[520px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--color-primary),transparent_70%)] opacity-[0.07] blur-3xl" />
     </div>
   );
 }
@@ -38,15 +41,15 @@ function HeroBackground() {
 function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
   return (
     <>
-      <h1 className="font-display text-5xl font-extrabold tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
+      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
         {hero.h1}
       </h1>
 
-      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:mt-8 sm:text-xl sm:leading-8">
         {hero.subtitle.sentence1} {hero.subtitle.sentence2} {hero.subtitle.support}
       </p>
 
-      <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+      <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
         <Button asChild size="lg" className="w-full sm:w-auto gap-2">
           <a href={hero.cta.primary.href}>
             {hero.cta.primary.label}
@@ -67,12 +70,12 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         </Button>
       </div>
 
-      {/* Trust strip: the signals the retired eyebrow pill used to carry. */}
-      <ul className="mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm text-muted-foreground list-none p-0">
-        {TRUST_SIGNALS.map((signal) => (
-          <li key={signal} className="flex items-center gap-2">
-            <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
-            {signal}
+      {/* Trust strip: quiet separators, not competing brand dots. */}
+      <ul className="mt-8 flex flex-wrap items-center justify-center gap-x-0 gap-y-2 text-sm text-muted-foreground list-none p-0">
+        {TRUST_SIGNALS.map((signal, index) => (
+          <li key={signal} className="flex items-center">
+            {index > 0 && <span aria-hidden="true" className="mx-3 h-3 w-px bg-border sm:mx-4" />}
+            <span>{signal}</span>
           </li>
         ))}
       </ul>
@@ -89,7 +92,7 @@ function NonTechnicalHero() {
   const hero = FOR_OPERATORS_HERO;
   return (
     <>
-      <h1 className="font-display text-5xl font-extrabold tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
+      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
         {hero.h1Lines.map((line) => (
           <span key={line} className="block">
             {line}
@@ -97,11 +100,11 @@ function NonTechnicalHero() {
         ))}
       </h1>
 
-      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:mt-8 sm:text-xl sm:leading-8">
         {hero.subtitle}
       </p>
 
-      <div className="mt-10 flex justify-center">
+      <div className="mt-9 flex justify-center sm:mt-10">
         <Button asChild size="lg" className="w-full sm:w-auto gap-2">
           <a href={hero.primaryCta.href} target="_blank" rel="noopener noreferrer">
             {hero.primaryCta.label}
@@ -110,12 +113,11 @@ function NonTechnicalHero() {
         </Button>
       </div>
 
-      {/* Trust strip: mirror of TechnicalHero; same signals for the operator view. */}
-      <ul className="mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm text-muted-foreground list-none p-0">
-        {TRUST_SIGNALS.map((signal) => (
-          <li key={signal} className="flex items-center gap-2">
-            <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
-            {signal}
+      <ul className="mt-8 flex flex-wrap items-center justify-center gap-x-0 gap-y-2 text-sm text-muted-foreground list-none p-0">
+        {TRUST_SIGNALS.map((signal, index) => (
+          <li key={signal} className="flex items-center">
+            {index > 0 && <span aria-hidden="true" className="mx-3 h-3 w-px bg-border sm:mx-4" />}
+            <span>{signal}</span>
           </li>
         ))}
       </ul>
@@ -129,13 +131,13 @@ export function Hero() {
   const hero = selectHomeHero(search);
 
   return (
-    <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
+    <section className="relative isolate overflow-hidden bg-background px-6 pt-16 pb-16 sm:px-6 sm:pt-24 sm:pb-20 lg:px-8">
       <HeroBackground />
 
       <div className="relative mx-auto max-w-7xl">
         <div className="mx-auto max-w-3xl text-center">
           {/* Audience switch: replaces the former eyebrow pill. */}
-          <div className="mb-8 flex justify-center">
+          <div className="mb-7 flex justify-center sm:mb-8">
             <AudienceToggle current={audience} />
           </div>
 
@@ -143,8 +145,9 @@ export function Hero() {
         </div>
 
         {/* Receipt-motif moment (frontend-excellence Phase 5): one orchestrated
-            print entrance, shared verbatim by both audience variants. */}
-        <div className="mt-12 w-full max-w-md min-w-0 mx-auto text-left">
+            print entrance. Signature creative element only — Linear: one moment,
+            not competing chrome. */}
+        <div className="mt-12 w-full max-w-md min-w-0 mx-auto text-left sm:mt-14 sm:max-w-lg">
           <ReceiptCard
             title={RECEIPT_HERO_TITLE}
             lines={[...RECEIPT_HERO_LINES]}

--- a/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
+++ b/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
@@ -1,20 +1,24 @@
 import { LIVE_METRICS as M } from '../../content/proof';
 
 /**
- * Live-metrics snapshot badge. Renders the gate-pinned site.ts METRICS as a
+ * Live-metrics snapshot. Renders the gate-pinned site.ts METRICS as a dense
  * "live from the repo" strip and links to the claim-drift validator that
  * enforces them. Static (the numbers are build-time constants pinned by CI).
+ *
+ * Craft pass: less card-in-card chrome; tabular density (Linear-like stats).
  */
 export function LiveMetricsBadge() {
   return (
-    <div className="mx-auto mb-16 max-w-5xl rounded-2xl bg-secondary p-8 ring-1 ring-border">
+    <div className="mx-auto max-w-4xl">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-primary">
-            <span aria-hidden="true" className="h-2 w-2 animate-pulse rounded-full bg-primary" />
+          <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
             {M.eyebrow}
           </p>
-          <h3 className="mt-2 text-xl font-semibold text-foreground">{M.heading}</h3>
+          <h3 className="mt-2 font-display text-lg font-semibold tracking-tight text-foreground sm:text-xl">
+            {M.heading}
+          </h3>
         </div>
         <a
           href={M.validatorHref}
@@ -26,16 +30,20 @@ export function LiveMetricsBadge() {
         </a>
       </div>
 
-      <dl className="mt-6 grid grid-cols-3 gap-4 sm:grid-cols-6">
+      <dl className="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border ring-1 ring-border sm:grid-cols-3 lg:grid-cols-6">
         {M.metrics.map((m) => (
-          <div key={m.label} className="text-center">
-            <dd className="text-3xl font-bold tracking-tight text-foreground">{m.value}</dd>
-            <dt className="mt-1 text-xs text-muted-foreground">{m.label}</dt>
+          <div key={m.label} className="bg-card px-3 py-5 text-center sm:px-4 sm:py-6">
+            <dd className="font-display text-2xl font-bold tracking-tight text-foreground tabular-nums sm:text-3xl">
+              {m.value}
+            </dd>
+            <dt className="mt-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+              {m.label}
+            </dt>
           </div>
         ))}
       </dl>
 
-      <p className="mt-6 text-sm leading-6 text-muted-foreground">{M.body}</p>
+      <p className="mt-5 text-sm leading-6 text-muted-foreground">{M.body}</p>
     </div>
   );
 }

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -13,6 +13,10 @@ const API_URL =
   import.meta.env.VITE_API_URL ??
   (import.meta.env.PROD ? 'https://api.revealui.com' : 'http://localhost:3004');
 
+/**
+ * Craft pass: drop the inverted (black) Pro card. Highlight with primary ring
+ * and a quiet badge so the section stays calm on both light and dark themes.
+ */
 export function PricingTeaser() {
   const [prices, setPrices] = useState(SUBSCRIPTION_PRICE_FALLBACKS);
 
@@ -42,70 +46,48 @@ export function PricingTeaser() {
   }, []);
 
   return (
-    <section className="bg-secondary py-24 sm:py-32">
+    <section className="bg-secondary py-20 sm:py-28">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
             {PRICING_TEASER_SECTION.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PRICING_TEASER_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+          <p className="mt-5 text-lg leading-8 text-muted-foreground">
             {PRICING_TEASER_SECTION.body}
           </p>
         </div>
 
-        <div className="mx-auto mt-16 grid max-w-3xl grid-cols-1 gap-6 sm:grid-cols-2">
+        <div className="mx-auto mt-14 grid max-w-3xl grid-cols-1 gap-5 sm:mt-16 sm:grid-cols-2 sm:gap-6">
           {PRICING_TEASER_TIERS.map((t) => {
             const { price, period } = prices[t.id];
             return (
               <div
                 key={t.id}
-                className={`relative flex flex-col rounded-2xl p-8 ring-1 transition ${
-                  t.highlight
-                    ? 'bg-foreground text-background ring-foreground shadow-xl'
-                    : 'bg-card text-foreground ring-border hover:ring-border/80'
+                className={`relative flex flex-col rounded-2xl bg-card p-7 ring-1 ring-border/80 transition sm:p-8 ${
+                  t.highlight ? 'shadow-md shadow-foreground/5' : ''
                 }`}
               >
                 {t.highlight && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs font-semibold uppercase tracking-widest text-primary-foreground">
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-secondary px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-foreground ring-1 ring-border">
                     Recommended
                   </div>
                 )}
-                <h3 className="text-lg font-semibold">{t.name}</h3>
+                <h3 className="font-display text-lg font-semibold text-foreground">{t.name}</h3>
                 <div className="mt-4 flex items-baseline gap-2">
-                  <span className="text-4xl font-bold tracking-tight">{price}</span>
-                  {period && (
-                    <span
-                      className={`text-sm ${t.highlight ? 'text-background/60' : 'text-muted-foreground'}`}
-                    >
-                      {period}
-                    </span>
-                  )}
+                  <span className="font-display text-4xl font-bold tracking-tight text-foreground tabular-nums">
+                    {price}
+                  </span>
+                  {period && <span className="text-sm text-muted-foreground">{period}</span>}
                 </div>
-                <p
-                  className={`mt-4 text-sm leading-6 ${
-                    t.highlight ? 'text-background/70' : 'text-muted-foreground'
-                  }`}
-                >
-                  {t.description}
-                </p>
+                <p className="mt-4 text-sm leading-6 text-muted-foreground">{t.description}</p>
 
                 <ul className="mt-6 flex-1 space-y-3">
                   {t.features.map((f) => (
-                    <li
-                      key={f}
-                      className={`flex items-start gap-2 text-sm ${
-                        t.highlight ? 'text-background/80' : 'text-foreground'
-                      }`}
-                    >
-                      <IconCheckCircle
-                        size="sm"
-                        className={`mt-0.5 flex-shrink-0 ${
-                          t.highlight ? 'text-primary' : 'text-primary'
-                        }`}
-                      />
+                    <li key={f} className="flex items-start gap-2 text-sm text-foreground">
+                      <IconCheckCircle size="sm" className="mt-0.5 flex-shrink-0 text-primary" />
                       {f}
                     </li>
                   ))}
@@ -113,11 +95,7 @@ export function PricingTeaser() {
 
                 <div className="mt-8">
                   {t.highlight ? (
-                    <Button
-                      asChild
-                      size="default"
-                      className="w-full bg-background text-foreground hover:bg-secondary"
-                    >
+                    <Button asChild size="default" className="w-full">
                       <a href={t.href}>{t.cta}</a>
                     </Button>
                   ) : (
@@ -137,7 +115,6 @@ export function PricingTeaser() {
           })}
         </div>
 
-        {/* Max and Enterprise collapse to single-line links; full pricing on /pricing. */}
         <div className="mx-auto mt-8 flex max-w-3xl flex-col items-center justify-center gap-2 text-sm sm:flex-row sm:gap-6">
           {PRICING_TEASER_LINKS.map((tier) => (
             <a
@@ -150,7 +127,7 @@ export function PricingTeaser() {
           ))}
         </div>
 
-        <div className="mt-12 text-center">
+        <div className="mt-10 text-center">
           <Button
             asChild
             appearance="link"
@@ -159,7 +136,7 @@ export function PricingTeaser() {
           >
             <a href={PRICING_TEASER_FOOTER.moreHref}>{PRICING_TEASER_FOOTER.moreLabel}</a>
           </Button>
-          <p className="mt-6 text-xs leading-5 text-muted-foreground">
+          <p className="mt-5 text-xs leading-5 text-muted-foreground">
             {PRICING_TEASER_FOOTER.caption.prefix}{' '}
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
               {PRICING_TEASER_FOOTER.caption.code}

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -55,62 +55,59 @@ export function Primitives({
   annotation = {},
 }: PrimitivesProps) {
   return (
-    <section className="bg-background py-24 sm:py-32">
+    <section className="bg-background py-20 sm:py-28">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
+            className="text-xs font-semibold uppercase tracking-widest text-muted-foreground"
             {...fieldAttrs(annotation, `${path}.eyebrow`)}
           >
             {data.eyebrow}
           </p>
           <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+            className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
             {...fieldAttrs(annotation, `${path}.heading`)}
           >
             {data.heading}
           </h2>
           <p
-            className="mt-6 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-muted-foreground"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}
           </p>
         </div>
 
-        {/* Alternating feature rows (a zigzag), not a card grid — gives the page
-            rhythm. Each primitive is a generous row with a large accent icon that
-            alternates sides; the copy hugs toward it. */}
-        <div className="mx-auto mt-16 max-w-4xl space-y-10 sm:space-y-14">
+        {/* Quiet stacked rows (not a card grid). Linear craft: density + alignment
+            over decorative cards. Alternating icon side still gives rhythm. */}
+        <div className="mx-auto mt-14 max-w-3xl divide-y divide-border border-y border-border sm:mt-16">
           {data.items.map((item, index) => {
             const flipped = index % 2 === 1;
             const style = primitiveStyles[index];
             return (
               <div
                 key={item.label}
-                className={`flex flex-col gap-5 sm:items-center sm:gap-10 ${
+                className={`flex flex-col gap-4 py-8 sm:items-center sm:gap-8 sm:py-10 ${
                   flipped ? 'sm:flex-row-reverse' : 'sm:flex-row'
                 }`}
               >
                 <div
-                  className={`flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl ring-1 ${style ? accentBg[style.color] : ''}`}
+                  className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-xl ring-1 ${style ? accentBg[style.color] : ''}`}
                 >
                   {(() => {
                     const Icon = PRIMITIVE_ICONS[index];
-                    return Icon ? (
-                      <Icon className="h-10 w-10" size="xl" label={item.label} />
-                    ) : null;
+                    return Icon ? <Icon className="h-7 w-7" size="lg" label={item.label} /> : null;
                   })()}
                 </div>
-                <div className={`flex-1 ${flipped ? 'sm:text-right' : ''}`}>
+                <div className={`flex-1 min-w-0 ${flipped ? 'sm:text-right' : ''}`}>
                   <h3
-                    className="text-xl font-semibold text-foreground"
+                    className="font-display text-lg font-semibold tracking-tight text-foreground"
                     {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
                   >
                     {item.label}
                   </h3>
                   <p
-                    className="mt-2 text-base leading-7 text-muted-foreground"
+                    className="mt-1.5 text-base leading-7 text-muted-foreground"
                     {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
                   >
                     {item.body}
@@ -121,7 +118,7 @@ export function Primitives({
           })}
         </div>
 
-        <div className="mt-12 text-center">
+        <div className="mt-10 text-center">
           <Button
             asChild
             appearance="link"

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -1,91 +1,162 @@
 import { HOME_PROBLEM } from '../../content/home';
 
+/**
+ * Capability stack (craft pass 2026-08, Linear redesign principles).
+ *
+ * Replaces:
+ * - desktop spreadsheet table
+ * - mobile per-capability cards that restated the matrix
+ * - three marketing "path" cards (still too much chrome)
+ *
+ * One layout at every breakpoint: capability rows with three aligned answers.
+ * Hierarchy comes from type weight and spacing, not rings, fills, or boxes.
+ * Claims stay in HOME_PROBLEM.rows so claims-evidence export paths hold.
+ *
+ * Linear lessons applied:
+ * - reduce visual noise
+ * - maintain visual alignment (label column + answer column)
+ * - increase hierarchy via density, not decoration
+ * - limit brand chrome; neutral surfaces
+ */
+
+interface Answer {
+  readonly label: string;
+  readonly value: string;
+  readonly emphasis: boolean;
+}
+
+function answersFor(row: (typeof HOME_PROBLEM.rows)[number]): readonly Answer[] {
+  return [
+    {
+      label: HOME_PROBLEM.columns.sprawl,
+      value: row.sprawl,
+      emphasis: false,
+    },
+    {
+      label: HOME_PROBLEM.columns.agentOnly,
+      value: row.agentOnly,
+      emphasis: false,
+    },
+    {
+      label: HOME_PROBLEM.columns.revealui,
+      value: row.revealui,
+      emphasis: true,
+    },
+  ];
+}
+
 export function Problem() {
   return (
-    <section className="bg-background py-24 sm:py-32">
+    <section className="bg-background py-20 sm:py-28">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
             {HOME_PROBLEM.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {HOME_PROBLEM.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{HOME_PROBLEM.body}</p>
+          <p className="mt-5 text-lg leading-8 text-muted-foreground">{HOME_PROBLEM.body}</p>
         </div>
 
-        {/* Mobile (<md): each capability becomes a card so the RevealUI column is
-            never hidden behind a horizontal scrollbar. No sidescroll. */}
-        <div className="mt-16 space-y-4 md:hidden">
-          <h3 className="sr-only">{HOME_PROBLEM.tableAriaLabel}</h3>
-          {HOME_PROBLEM.rows.map((r) => (
-            <div
-              key={r.capability}
-              className="overflow-hidden rounded-2xl bg-card ring-1 ring-border shadow-sm"
+        {/* Path blurbs: three quiet lines under the intro, not three cards. */}
+        <ul
+          className="mx-auto mt-10 flex max-w-3xl flex-col gap-3 text-left sm:mt-12"
+          aria-label="Three paths"
+        >
+          {(
+            [
+              ['sprawl', HOME_PROBLEM.columns.sprawl, HOME_PROBLEM.pathBlurbs.sprawl, false],
+              [
+                'agentOnly',
+                HOME_PROBLEM.columns.agentOnly,
+                HOME_PROBLEM.pathBlurbs.agentOnly,
+                false,
+              ],
+              ['revealui', HOME_PROBLEM.columns.revealui, HOME_PROBLEM.pathBlurbs.revealui, true],
+            ] as const
+          ).map(([id, name, blurb, emphasis]) => (
+            <li
+              key={id}
+              className="grid grid-cols-1 gap-1 sm:grid-cols-[11rem_1fr] sm:gap-6 sm:items-baseline"
             >
-              <p className="bg-secondary px-4 py-3 text-sm font-semibold text-foreground">
-                {r.capability}
-              </p>
-              <dl className="divide-y divide-border">
-                <div className="flex items-start justify-between gap-4 px-4 py-3">
-                  <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    {HOME_PROBLEM.columns.sprawl}
-                  </dt>
-                  <dd className="text-right text-sm text-muted-foreground">{r.sprawl}</dd>
-                </div>
-                <div className="flex items-start justify-between gap-4 px-4 py-3">
-                  <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    {HOME_PROBLEM.columns.agentOnly}
-                  </dt>
-                  <dd className="text-right text-sm text-muted-foreground">{r.agentOnly}</dd>
-                </div>
-                <div className="flex items-start justify-between gap-4 bg-primary/5 px-4 py-3">
-                  <dt className="text-xs font-semibold uppercase tracking-wide text-primary">
-                    {HOME_PROBLEM.columns.revealui}
-                  </dt>
-                  <dd className="text-right text-sm font-medium text-primary">{r.revealui}</dd>
-                </div>
+              <span
+                className={
+                  emphasis
+                    ? 'text-sm font-semibold text-foreground'
+                    : 'text-sm font-medium text-muted-foreground'
+                }
+              >
+                {emphasis ? (
+                  <>
+                    <span className="mr-2 text-[11px] font-semibold uppercase tracking-widest text-primary">
+                      {HOME_PROBLEM.highlightedLabel}
+                    </span>
+                    <span className="block sm:inline">{name}</span>
+                  </>
+                ) : (
+                  name
+                )}
+              </span>
+              <span
+                className={
+                  emphasis
+                    ? 'text-sm leading-6 text-foreground'
+                    : 'text-sm leading-6 text-muted-foreground'
+                }
+              >
+                {blurb}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <div
+          className="mx-auto mt-14 max-w-3xl border-t border-border sm:mt-16"
+          role="list"
+          aria-label={HOME_PROBLEM.tableAriaLabel}
+        >
+          {HOME_PROBLEM.rows.map((row) => (
+            <div
+              key={row.capability}
+              role="listitem"
+              className="border-b border-border py-8 first:pt-10 last:pb-2"
+            >
+              <h3 className="font-display text-base font-semibold tracking-tight text-foreground sm:text-lg">
+                {row.capability}
+              </h3>
+              <dl className="mt-4 space-y-3">
+                {answersFor(row).map((answer) => (
+                  <div
+                    key={answer.label}
+                    className="grid grid-cols-1 gap-0.5 sm:grid-cols-[11rem_1fr] sm:items-baseline sm:gap-6"
+                  >
+                    <dt
+                      className={
+                        answer.emphasis
+                          ? 'text-sm font-semibold text-foreground'
+                          : 'text-sm text-muted-foreground'
+                      }
+                    >
+                      {answer.label}
+                    </dt>
+                    <dd
+                      className={
+                        answer.emphasis
+                          ? 'text-sm leading-6 font-medium text-foreground'
+                          : 'text-sm leading-6 text-muted-foreground'
+                      }
+                    >
+                      {answer.value}
+                    </dd>
+                  </div>
+                ))}
               </dl>
             </div>
           ))}
         </div>
 
-        {/* Tablet/desktop (>=md): full comparison table. Four short columns fit
-            within the container at md+, so no horizontal scroll is needed. */}
-        <div className="mx-auto mt-16 hidden max-w-6xl overflow-hidden rounded-2xl ring-1 ring-border shadow-sm md:block">
-          <table className="w-full text-left text-sm" aria-label={HOME_PROBLEM.tableAriaLabel}>
-            <thead>
-              <tr className="bg-secondary text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
-                  {HOME_PROBLEM.columns.capability}
-                </th>
-                <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
-                  {HOME_PROBLEM.columns.sprawl}
-                </th>
-                <th scope="col" className="px-4 py-3 sm:px-6 sm:py-4">
-                  {HOME_PROBLEM.columns.agentOnly}
-                </th>
-                <th scope="col" className="bg-primary/10 px-4 py-3 text-primary sm:px-6 sm:py-4">
-                  {HOME_PROBLEM.columns.revealui}
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border bg-card">
-              {HOME_PROBLEM.rows.map((r) => (
-                <tr key={r.capability} className="hover:bg-secondary/60 transition">
-                  <td className="px-4 py-4 font-medium text-foreground sm:px-6">{r.capability}</td>
-                  <td className="px-4 py-4 text-muted-foreground sm:px-6">{r.sprawl}</td>
-                  <td className="px-4 py-4 text-muted-foreground sm:px-6">{r.agentOnly}</td>
-                  <td className="bg-primary/5 px-4 py-4 font-medium text-primary sm:px-6">
-                    {r.revealui}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-muted-foreground">
+        <p className="mx-auto mt-8 max-w-3xl text-center text-xs leading-5 text-muted-foreground">
           {HOME_PROBLEM.footnote}
         </p>
       </div>

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -111,17 +111,12 @@ export function Problem() {
           ))}
         </ul>
 
-        <div
-          className="mx-auto mt-14 max-w-3xl border-t border-border sm:mt-16"
-          role="list"
+        <ul
+          className="mx-auto mt-14 max-w-3xl list-none border-t border-border p-0 sm:mt-16"
           aria-label={HOME_PROBLEM.tableAriaLabel}
         >
           {HOME_PROBLEM.rows.map((row) => (
-            <div
-              key={row.capability}
-              role="listitem"
-              className="border-b border-border py-8 first:pt-10 last:pb-2"
-            >
+            <li key={row.capability} className="border-b border-border py-8 first:pt-10 last:pb-2">
               <h3 className="font-display text-base font-semibold tracking-tight text-foreground sm:text-lg">
                 {row.capability}
               </h3>
@@ -152,9 +147,9 @@ export function Problem() {
                   </div>
                 ))}
               </dl>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
 
         <p className="mx-auto mt-8 max-w-3xl text-center text-xs leading-5 text-muted-foreground">
           {HOME_PROBLEM.footnote}

--- a/apps/marketing/app/components/landing/ProductFrame.tsx
+++ b/apps/marketing/app/components/landing/ProductFrame.tsx
@@ -1,0 +1,184 @@
+import { type AuditEvent, AuditLine, StatusDot, VerdictChip } from '@revealui/presentation';
+
+/**
+ * Live product-chrome frame for the homepage Demo section.
+ *
+ * Honest product-as-proof: composed from real `@revealui/presentation`
+ * primitives (StatusDot, VerdictChip, AuditLine), not a stale screenshot.
+ * Mirrors the receipt motif and the admin shell shape without claiming a
+ * pixel-perfect capture of a specific build.
+ *
+ * Linear craft lesson (linear.app redesign): the product is the proof.
+ * Hierarchy + density over decorative chrome.
+ */
+
+const SIDEBAR_NAV = [
+  { label: 'People', active: false },
+  { label: 'Content', active: false },
+  { label: 'Offers', active: false },
+  { label: 'Payments', active: false },
+  { label: 'Agents', active: true },
+] as const;
+
+const FRAME_EVENTS: readonly AuditEvent[] = [
+  {
+    ts: '09:41:07',
+    actor: 'support-agent',
+    action: 'signed in as',
+    object: 'agents@demo.revealui.com',
+  },
+  {
+    ts: '09:41:09',
+    actor: 'support-agent',
+    action: 'refunded',
+    object: 'order #4189',
+  },
+  {
+    ts: '09:41:09',
+    actor: 'policy',
+    action: 'allowed',
+    object: 'refunds under $100',
+  },
+  {
+    ts: '09:41:10',
+    actor: 'audit-log',
+    action: 'recorded',
+    object: 'the receipt',
+    refId: 'rcpt_8f3ka91',
+  },
+] as const;
+
+export interface ProductFrameProps {
+  /** Accessible name for the frame landmark. */
+  readonly label?: string;
+  /** Caption under the frame (mockup honesty line). */
+  readonly caption?: {
+    readonly prefix: string;
+    readonly code: string;
+    readonly suffix: string;
+  };
+}
+
+export function ProductFrame({
+  label = 'RevealUI admin shell, live component demo',
+  caption,
+}: ProductFrameProps) {
+  return (
+    <figure className="mx-auto w-full max-w-5xl">
+      {/* Product mat: dark outer frame (design system demo pattern), quiet chrome.
+          Linear: hierarchy via surface elevation, not brand-colored decoration. */}
+      <div
+        role="img"
+        aria-label={label}
+        className="overflow-hidden rounded-2xl bg-foreground p-1.5 shadow-2xl shadow-foreground/10 sm:p-2"
+      >
+        <div className="overflow-hidden rounded-xl bg-background">
+          {/* Window chrome — inverted-L: title bar only; density over ornament */}
+          <div className="flex h-10 items-center gap-3 border-b border-border px-3 sm:px-4">
+            <div className="flex items-center gap-1.5" aria-hidden="true">
+              <span className="size-2 rounded-full bg-muted-foreground/25" />
+              <span className="size-2 rounded-full bg-muted-foreground/25" />
+              <span className="size-2 rounded-full bg-muted-foreground/25" />
+            </div>
+            <div className="flex flex-1 items-center justify-center">
+              <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                admin.local · Agents
+              </span>
+            </div>
+            <div className="w-8" aria-hidden="true" />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-[10.5rem_1fr]">
+            {/* Sidebar — fixed label column alignment (Linear sidebar lesson) */}
+            <aside
+              className="hidden border-r border-border bg-secondary/30 p-2 sm:block"
+              aria-hidden="true"
+            >
+              <div className="mb-3 flex h-8 items-center gap-2 px-2">
+                <span className="flex size-5 items-center justify-center rounded-[5px] bg-primary font-display text-[9px] font-bold text-primary-foreground">
+                  R
+                </span>
+                <span className="text-xs font-medium text-foreground">RevealUI</span>
+              </div>
+              <ul className="space-y-0.5">
+                {SIDEBAR_NAV.map((item) => (
+                  <li key={item.label}>
+                    <span
+                      className={
+                        item.active
+                          ? 'flex h-8 items-center gap-2 rounded-md bg-foreground/[0.06] px-2 text-xs font-medium text-foreground'
+                          : 'flex h-8 items-center gap-2 rounded-md px-2 text-xs text-muted-foreground'
+                      }
+                    >
+                      <span
+                        className={
+                          item.active
+                            ? 'size-1 rounded-full bg-foreground'
+                            : 'size-1 rounded-full bg-muted-foreground/40'
+                        }
+                      />
+                      {item.label}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </aside>
+
+            {/* Main pane */}
+            <div className="min-w-0 p-4 sm:p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+                    Agent activity
+                  </p>
+                  <h3 className="mt-1 font-display text-base font-semibold tracking-tight text-foreground">
+                    support-agent · refund flow
+                  </h3>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="inline-flex h-7 items-center gap-1.5 rounded-md bg-secondary px-2 text-xs text-muted-foreground">
+                    <StatusDot status="ok" label="Agent online" pulse />
+                    Online
+                  </span>
+                  <VerdictChip verdict="approve" actor="policy" asOf="09:41" />
+                </div>
+              </div>
+
+              <div className="mt-4 overflow-hidden rounded-lg border border-border/80">
+                <div className="flex h-8 items-center border-b border-border/80 px-3">
+                  <p className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+                    Live audit trail
+                  </p>
+                </div>
+                <ul className="divide-y divide-border/80">
+                  {FRAME_EVENTS.map((event) => (
+                    <li
+                      key={`${event.ts}-${event.action}-${event.object}`}
+                      className="px-3 py-2 sm:px-3.5"
+                    >
+                      <AuditLine event={event} dense />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <p className="mt-3 text-xs leading-5 text-muted-foreground">
+                Live presentation components. Same receipt story as the hero, inside an admin shell.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {caption && (
+        <figcaption className="mt-4 text-center text-sm text-muted-foreground">
+          {caption.prefix}{' '}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
+            {caption.code}
+          </code>{' '}
+          {caption.suffix}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/apps/marketing/app/components/landing/ProductFrame.tsx
+++ b/apps/marketing/app/components/landing/ProductFrame.tsx
@@ -43,8 +43,9 @@ const FRAME_EVENTS: readonly AuditEvent[] = [
     ts: '09:41:10',
     actor: 'audit-log',
     action: 'recorded',
+    // No refId: CopyRef is interactive; this frame is a static product demo
+    // (axe nested-interactive fails if buttons sit inside role=img chrome).
     object: 'the receipt',
-    refId: 'rcpt_8f3ka91',
   },
 ] as const;
 
@@ -64,14 +65,12 @@ export function ProductFrame({
   caption,
 }: ProductFrameProps) {
   return (
-    <figure className="mx-auto w-full max-w-5xl">
+    <figure className="mx-auto w-full max-w-5xl" aria-label={label}>
       {/* Product mat: dark outer frame (design system demo pattern), quiet chrome.
-          Linear: hierarchy via surface elevation, not brand-colored decoration. */}
-      <div
-        role="img"
-        aria-label={label}
-        className="overflow-hidden rounded-2xl bg-foreground p-1.5 shadow-2xl shadow-foreground/10 sm:p-2"
-      >
+          Linear: hierarchy via surface elevation, not brand-colored decoration.
+          Do NOT put role=img on this mat: it may contain focusable controls
+          (AuditLine CopyRef) and nested-interactive fails axe WCAG 4.1.2. */}
+      <div className="overflow-hidden rounded-2xl bg-foreground p-1.5 shadow-2xl shadow-foreground/10 sm:p-2">
         <div className="overflow-hidden rounded-xl bg-background">
           {/* Window chrome — inverted-L: title bar only; density over ornament */}
           <div className="flex h-10 items-center gap-3 border-b border-border px-3 sm:px-4">

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -5,23 +5,23 @@ import { LiveMetricsBadge } from './LiveMetricsBadge';
 
 export function Proof() {
   return (
-    <section className="bg-background py-24 sm:py-32">
+    <section className="bg-background py-20 sm:py-28">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
             {PROOF_SECTION.eyebrow}
           </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PROOF_SECTION.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{PROOF_SECTION.body}</p>
+          <p className="mt-5 text-lg leading-8 text-muted-foreground">{PROOF_SECTION.body}</p>
 
           <div className="mt-6 flex justify-center">
             <a
               href={SITE.urls.repo}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-md bg-card px-3 py-1.5 text-sm font-medium text-foreground ring-1 ring-border hover:ring-border/80 transition"
+              className="inline-flex items-center gap-2 rounded-full bg-secondary px-4 py-1.5 text-sm font-medium text-foreground ring-1 ring-border transition hover:ring-border/80"
             >
               <GitHubIcon className="size-4" />
               {PROOF_SECTION.repoLinkLabel}
@@ -29,11 +29,11 @@ export function Proof() {
           </div>
         </div>
 
-        <div className="mt-16">
+        <div className="mt-14 sm:mt-16">
           <LiveMetricsBadge />
         </div>
 
-        <div className="mx-auto mt-16 max-w-2xl text-center">
+        <div className="mx-auto mt-12 max-w-2xl text-center">
           <p className="text-base leading-7 text-muted-foreground">
             {PROOF_TRUST.body}{' '}
             <a
@@ -47,7 +47,7 @@ export function Proof() {
           </p>
         </div>
 
-        <div className="mt-12 text-center">
+        <div className="mt-8 text-center">
           <Button
             asChild
             appearance="link"
@@ -59,11 +59,11 @@ export function Proof() {
         </div>
 
         {/* Secondary FDE layer — same homepage section (≤7 rule), not a new section */}
-        <div className="mx-auto mt-20 max-w-2xl rounded-2xl border border-border bg-card px-6 py-10 text-center sm:px-10">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+        <div className="mx-auto mt-16 max-w-2xl border-t border-border pt-14 text-center">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
             {PROOF_DEPLOYERS.eyebrow}
           </p>
-          <h3 className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+          <h3 className="mt-3 font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
             {PROOF_DEPLOYERS.heading}
           </h3>
           <p className="mt-4 text-base leading-7 text-muted-foreground">{PROOF_DEPLOYERS.body}</p>

--- a/apps/marketing/app/content/claims-evidence/claims-part-1.ts
+++ b/apps/marketing/app/content/claims-evidence/claims-part-1.ts
@@ -184,7 +184,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
       {
         kind: 'code',
         ref: 'packages',
-        note: 'framing sentence; the table below carries the claims',
+        note: 'framing sentence; the three-path comparison below carries the claims',
       },
     ],
   },
@@ -193,6 +193,39 @@ export const claimsPart1: readonly ClaimEntry[] = [
     exportPath: 'HOME_PROBLEM.body',
     proofGrade: 'outcome',
     text: 'Most teams stitch sign-in, content, billing, and agents from different vendors. Or they pick an agent framework and rebuild the rest underneath it. RevealUI is the third path: one self-hosted runtime for the business and the agents that run it.',
+    evidence: [AUTH_SESSIONS, COLLECTIONS, BILLING, LICENSE_MIT],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.pathBlurbs.sprawl',
+    proofGrade: 'path',
+    text: 'Rent a product for each slice. Glue them together yourself.',
+    evidence: [
+      {
+        kind: 'url',
+        ref: 'https://revealui.com/pricing',
+        note: 'competitor-path framing; cost detail lives on the pricing page',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.pathBlurbs.agentOnly',
+    proofGrade: 'path',
+    text: 'Agents first. Rebuild sign-in, content, and billing underneath.',
+    evidence: [
+      {
+        kind: 'url',
+        ref: 'https://revealui.com/pricing',
+        note: 'competitor-path framing; cost detail lives on the pricing page',
+      },
+    ],
+  },
+  {
+    file: 'home.ts',
+    exportPath: 'HOME_PROBLEM.pathBlurbs.revealui',
+    proofGrade: 'outcome',
+    text: 'One self-hosted runtime for the business and the agents that run it.',
     evidence: [AUTH_SESSIONS, COLLECTIONS, BILLING, LICENSE_MIT],
   },
   {

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -77,7 +77,9 @@ export const HOME_HERO_L2 = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Problem (comparison table)
+// Problem (three-path comparison — not a table)
+// Craft pass 2026-08: desktop spreadsheet + mobile capability cards replaced
+// with three equal paths. Row claims stay for claims-evidence export paths.
 // ---------------------------------------------------------------------------
 
 export interface ProblemRow {
@@ -91,12 +93,20 @@ export const HOME_PROBLEM = {
   eyebrow: 'The problem',
   heading: 'Stop buying a separate product for each slice of the stack.',
   body: 'Most teams stitch sign-in, content, billing, and agents from different vendors. Or they pick an agent framework and rebuild the rest underneath it. RevealUI is the third path: one self-hosted runtime for the business and the agents that run it.',
+  /** Accessible name for the three-path comparison region. */
   tableAriaLabel: 'Vendor sprawl vs agent-framework vs RevealUI comparison',
+  /** Label on the winning path only. */
+  highlightedLabel: 'The third path',
   columns: {
     capability: 'Capability',
     sprawl: 'Vendor sprawl',
     agentOnly: 'Agent framework only',
     revealui: 'RevealUI',
+  },
+  pathBlurbs: {
+    sprawl: 'Rent a product for each slice. Glue them together yourself.',
+    agentOnly: 'Agents first. Rebuild sign-in, content, and billing underneath.',
+    revealui: 'One self-hosted runtime for the business and the agents that run it.',
   },
   rows: [
     {

--- a/docs/distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md
+++ b/docs/distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md
@@ -1,14 +1,16 @@
-# Owner publish checklist — Railway marketplace template (GAP-430)
+# Owner publish checklist — customer marketplace sales channel (GAP-430)
 
-**Filename is historical.** Studio production hosting stays on **Vercel + Neon + Fly**.
-This template is a **customer sales channel** only (`deployment/railway/*`).
+**Filename is historical** (`RAILWAY-MARKETPLACE-…`). Studio production hosting is
+**Vercel + Neon + Fly** only. This template is a **customer self-host sales channel**
+under `deployment/railway/*` — not Studio production.
 
 Agent config-as-code is **done** on `main`. Closure is **owner dashboard publish** +
 clean-account deploy walk.
 
-Full service/env/first-boot detail lives in:
+Full service/env/first-boot detail:
 
 [`deployment/railway/README.md`](../../deployment/railway/README.md)
+(customer marketplace path; Studio prod stays off that stack.)
 
 ## 0. Product decision (before public list)
 
@@ -19,10 +21,10 @@ Pick one and put it in the listing description:
 
 Do not ship a public Deploy button that dead-ends at a license prompt for most visitors.
 
-## 1. Account
+## 1. Account (customer marketplace dashboard)
 
-1. Railway Hobby (paid) account signed in.
-2. Partner / Template Queue / payout enrollment ready (`station.railway.com/my-template-queue`).
+1. Hobby (paid) account signed in on the customer marketplace host.
+2. Partner / Template Queue / payout enrollment ready (Template Queue URL in the platform docs).
 
 ## 2. Clean-account compose (acceptance walk)
 
@@ -46,7 +48,7 @@ Generate secrets with `openssl` (see README env tables). Set Free flag **or** re
 3. Log in with `REVEALUI_ADMIN_EMAIL` / `REVEALUI_ADMIN_PASSWORD`.
 4. Rotate admin password immediately.
 
-## 4. Marketplace publish
+## 4. Marketplace publish (sales channel only)
 
 1. Project → Generate Template (or current dashboard equivalent).
 2. Listing name, description, icon, category (state Free vs licensed audience).
@@ -62,6 +64,6 @@ Generate secrets with `openssl` (see README env tables). Set Free flag **or** re
 ## Do not
 
 - Re-scaffold `deployment/railway/api.json` / `admin.json` without a new residual.
-- Present Railway as Studio production hosting.
+- Present the customer marketplace host as Studio production (Studio = Vercel + Neon + Fly).
 - Use vanilla `postgres` image (vector extension fails).
 - Leave migrate Restart Policy on ALWAYS/ON_FAILURE (crash loop).

--- a/docs/distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md
+++ b/docs/distribution/RAILWAY-MARKETPLACE-OWNER-PUBLISH.md
@@ -1,57 +1,67 @@
-# Owner publish checklist — customer Railway marketplace template (GAP-430)
+# Owner publish checklist — Railway marketplace template (GAP-430)
 
-Agent work for template definition, first-boot docs, and monorepo cross-links is
-**done** (`deployment/railway/*` on `test`). Closure is **owner dashboard publish**
-only. Studio production hosting stays Vercel + Neon + Fly; this listing is a
-customer self-host **sales channel** (marketplace template), not Studio infra.
+**Filename is historical.** Studio production hosting stays on **Vercel + Neon + Fly**.
+This template is a **customer sales channel** only (`deployment/railway/*`).
+
+Agent config-as-code is **done** on `main`. Closure is **owner dashboard publish** +
+clean-account deploy walk.
+
+Full service/env/first-boot detail lives in:
+
+[`deployment/railway/README.md`](../../deployment/railway/README.md)
+
+## 0. Product decision (before public list)
+
+Pick one and put it in the listing description:
+
+1. **Licensed Fleet customers only** — visitor already has `REVEALUI_LICENSE_KEY` + public key from Studio; or
+2. **Free (OSS) try path** — set `REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true` on **both** `api` and `admin`, omit license keys.
+
+Do not ship a public Deploy button that dead-ends at a license prompt for most visitors.
 
 ## 1. Account
 
-1. Sign in to the RevealUI author account on the customer marketplace platform
-   (Hobby paid account already used for early sales-channel work 2026-07-27).
-2. Confirm billing is active (marketplace author kickback requires a paid plan
-   context as the marketplace vendor documents it).
-3. Optional: enable support-bonus queue / author program settings if offered.
+1. Railway Hobby (paid) account signed in.
+2. Partner / Template Queue / payout enrollment ready (`station.railway.com/my-template-queue`).
 
-## 2. Template source
+## 2. Clean-account compose (acceptance walk)
 
-- Config-as-code: `deployment/railway/README.md`, `api.json`, `admin.json`
-- Images: `apps/server/Dockerfile`, `apps/admin/Dockerfile`, migrate image
-  `ghcr.io/revealuistudio/revealui-migrate`, Postgres `pgvector/pgvector:pg16`
-- Docs already cross-link from README and `docs/guides/deployment.md`
+Create a **new** project (not Studio prod). Order:
 
-Do **not** re-author a parallel compose path. Extend `deployment/railway/` only.
+| # | Service | Source | Config path / notes |
+|---|---------|--------|---------------------|
+| 1 | `postgres` | Docker `pgvector/pgvector:pg16` | **Not** plain Postgres; set `POSTGRES_*` |
+| 2 | `migrate` | `ghcr.io/revealuistudio/revealui-migrate` (`latest` from `main`, or `sha-…`) | Restart policy **NEVER**; run once after postgres healthy |
+| 3 | `api` | This GitHub repo, root context | Config File Path `/deployment/railway/api.json`; public domain |
+| 4 | `admin` | This GitHub repo, root context | Config File Path `/deployment/railway/admin.json`; public domain |
 
-## 3. Publish (dashboard)
+Generate secrets with `openssl` (see README env tables). Set Free flag **or** real license keys on **api and admin**.
 
-1. Create or update a marketplace **Template** from this monorepo, pointing
-   services at the config in `deployment/railway/`.
-2. Ensure template services match the README architecture table (postgres,
-   migrate, api, admin).
-3. Document required env vars in the template UI (no secrets baked in).
-4. Set Free-tier path: `REVEALUI_ALLOW_UNLICENSED_SELF_HOST=true` on **both**
-   api and admin when no license key is supplied (see README).
-5. Publish to the marketplace; opt into author kickback / support bonus if
-   separate toggles exist.
-6. Wire payout (Stripe Connect or the marketplace vendor payout path) for the
-   $100 threshold on this sales channel.
+**Build order:** generate `api` public domain **before** first `admin` build (`NEXT_PUBLIC_API_URL` is build-time). Redeploy admin if api domain was late.
 
-## 4. Clean-account acceptance walk (close GAP-430)
+## 3. First-boot
 
-From a **second** buyer account on the marketplace (or reset project):
+1. `migrate` exits 0 once.
+2. `api` `/health` and `admin` `/api/health` healthy.
+3. Log in with `REVEALUI_ADMIN_EMAIL` / `REVEALUI_ADMIN_PASSWORD`.
+4. Rotate admin password immediately.
 
-1. Deploy template one-click.
-2. Wait migrate success; api + admin healthy.
-3. Open admin; seeded login works with documented defaults / env.
-4. Record: marketplace listing URL, deploy project id, screenshot or log note
-   of healthy services, kickback/payout status.
+## 4. Marketplace publish
 
-## 5. Record on GAP-430
+1. Project → Generate Template (or current dashboard equivalent).
+2. Listing name, description, icon, category (state Free vs licensed audience).
+3. Submit Template Queue for review.
+4. Confirm partner kickback / payout settings.
 
-Paste listing URL + smoke date into `docs/gaps/GAP-430.yml` progress, then close
-when acceptance is met.
+## 5. Acceptance (close GAP-430)
 
-## Peers
+1. Clean-account walk green (login works).
+2. Public marketplace listing URL recorded on GAP-430 progress.
+3. Payout enrollment confirmed (or explicitly deferred with reason).
 
-Do not re-scaffold `deployment/railway/api.json` or `admin.json` without a new
-proven residual. Owner publish is the remaining door.
+## Do not
+
+- Re-scaffold `deployment/railway/api.json` / `admin.json` without a new residual.
+- Present Railway as Studio production hosting.
+- Use vanilla `postgres` image (vector extension fails).
+- Leave migrate Restart Policy on ALWAYS/ON_FAILURE (crash loop).

--- a/packages/presentation/src/components/verdict-chip.tsx
+++ b/packages/presentation/src/components/verdict-chip.tsx
@@ -105,7 +105,10 @@ export function VerdictChip({
       </span>
       <span aria-hidden="true">{meta.word}</span>
       {actor && (
-        <span aria-hidden="true" className="opacity-70">
+        // Full-opacity secondary label (not opacity-70): success/error chip
+        // surfaces fail WCAG AA when the actor string is alpha-faded (axe
+        // color-contrast ~2.9 on approve). Actor stays in aria-label above.
+        <span aria-hidden="true" className="font-normal">
           · {actor}
         </span>
       )}


### PR DESCRIPTION
## Promote

Merge-commit promote of `test` → `main` so production marketing picks up the Linear-craft homepage (capability stack Problem, product frame Demo, calm pricing, receipt hero craft).

Includes [revealui#2546](https://github.com/RevealUIStudio/revealui/pull/2546) and other `test` commits not yet on `main`.

## Deploy lockstep (GAP-466)

After merge (merge commit only):
1. Confirm `deploy.yml` on `main` green for marketing
2. Spot-check production SPA bundle for craft strings (not shell HTML alone)

## Checklist

- [ ] Owner merges with **Create a merge commit** (not squash/rebase)
- [ ] Deploy marketing job green
- [ ] `https://revealui.com` shows capability stack (no comparison table)