### PR TITLE
fix(marketing): homepage axe a11y for promote CI

### DIFF
--- a/apps/marketing/app/components/__tests__/ProductFrame.test.tsx
+++ b/apps/marketing/app/components/__tests__/ProductFrame.test.tsx
@@ -14,7 +14,8 @@ describe('ProductFrame', () => {
       />,
     );
 
-    expect(screen.getByRole('img', { name: /RevealUI admin shell/i })).toBeTruthy();
+    // figure (not role=img): interactive descendants make role=img invalid for axe
+    expect(screen.getByRole('figure', { name: /RevealUI admin shell/i })).toBeTruthy();
     expect(screen.getByText(/support-agent · refund flow/i)).toBeTruthy();
     expect(screen.getByLabelText(/Agent online/i)).toBeTruthy();
     expect(screen.getByLabelText(/Approved/i)).toBeTruthy();

--- a/apps/marketing/app/components/landing/ProductFrame.tsx
+++ b/apps/marketing/app/components/landing/ProductFrame.tsx
@@ -43,8 +43,9 @@ const FRAME_EVENTS: readonly AuditEvent[] = [
     ts: '09:41:10',
     actor: 'audit-log',
     action: 'recorded',
+    // No refId: CopyRef is interactive; this frame is a static product demo
+    // (axe nested-interactive fails if buttons sit inside role=img chrome).
     object: 'the receipt',
-    refId: 'rcpt_8f3ka91',
   },
 ] as const;
 
@@ -64,14 +65,12 @@ export function ProductFrame({
   caption,
 }: ProductFrameProps) {
   return (
-    <figure className="mx-auto w-full max-w-5xl">
+    <figure className="mx-auto w-full max-w-5xl" aria-label={label}>
       {/* Product mat: dark outer frame (design system demo pattern), quiet chrome.
-          Linear: hierarchy via surface elevation, not brand-colored decoration. */}
-      <div
-        role="img"
-        aria-label={label}
-        className="overflow-hidden rounded-2xl bg-foreground p-1.5 shadow-2xl shadow-foreground/10 sm:p-2"
-      >
+          Linear: hierarchy via surface elevation, not brand-colored decoration.
+          Do NOT put role=img on this mat: it may contain focusable controls
+          (AuditLine CopyRef) and nested-interactive fails axe WCAG 4.1.2. */}
+      <div className="overflow-hidden rounded-2xl bg-foreground p-1.5 shadow-2xl shadow-foreground/10 sm:p-2">
         <div className="overflow-hidden rounded-xl bg-background">
           {/* Window chrome — inverted-L: title bar only; density over ornament */}
           <div className="flex h-10 items-center gap-3 border-b border-border px-3 sm:px-4">

--- a/packages/presentation/src/components/verdict-chip.tsx
+++ b/packages/presentation/src/components/verdict-chip.tsx
@@ -105,7 +105,10 @@ export function VerdictChip({
       </span>
       <span aria-hidden="true">{meta.word}</span>
       {actor && (
-        <span aria-hidden="true" className="opacity-70">
+        // Full-opacity secondary label (not opacity-70): success/error chip
+        // surfaces fail WCAG AA when the actor string is alpha-faded (axe
+        // color-contrast ~2.9 on approve). Actor stays in aria-label above.
+        <span aria-hidden="true" className="font-normal">
           · {actor}
         </span>
       )}


### PR DESCRIPTION
## Summary

Fixes E2E Smoke + Accessibility failures blocking [revealui#2547](https://github.com/RevealUIStudio/revealui/pull/2547) (test → main promote).

### Root cause (homepage craft ProductFrame)
1. **nested-interactive** — product mat used `role=\"img\"` with `p-1.5` while AuditLine `CopyRef` buttons were focusable descendants
2. **color-contrast** — VerdictChip actor used `opacity-70` on success-subtle (~2.9:1 vs 4.5:1 AA)

### Fix
- ProductFrame: figure label only (no role=img); demo events omit `refId`
- VerdictChip: full-opacity actor label (still in accessible name)

## Test plan
- [x] ProductFrame + VerdictChip unit tests
- [x] pre-push phase-1 gate
- [ ] CI E2E Smoke / Accessibility green on this PR
- [ ] Merge to test updates #2547 head; recheck promote CI