### PR TITLE
fix(admin): same-origin /a2a so session unlocks AI (not free false)

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -195,6 +195,10 @@ const nextConfig = {
       )
       return []
     }
+    // Same-origin /a2a proxy: admin UI used to call api.revealui.com cross-origin
+    // with credentials. Host-only session cookies (or any Domain mismatch) never
+    // reach the API, so requireFeature('ai') saw tier free and blocked create/
+    // task routes. Browser → admin /a2a → rewrite → API forwards Cookie.
     return [
       {
         source: '/api/agent-stream',
@@ -203,6 +207,14 @@ const nextConfig = {
       {
         source: '/api/agent-stream/:path*',
         destination: `${apiUrl}/api/agent-stream/:path*`,
+      },
+      {
+        source: '/a2a',
+        destination: `${apiUrl}/a2a`,
+      },
+      {
+        source: '/a2a/:path*',
+        destination: `${apiUrl}/a2a/:path*`,
       },
     ]
   },

--- a/apps/admin/src/app/(backend)/agent-tasks/page.tsx
+++ b/apps/admin/src/app/(backend)/agent-tasks/page.tsx
@@ -95,31 +95,29 @@ function AgentTasksDashboard() {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { tasks, loading, error, statusFilter, dateFilter, expandedId } = state;
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
   useEffect(() => {
     let cancelled = false;
     dispatch({ type: 'FETCH_START' });
 
     (async () => {
       try {
-        // Fetch tasks from all registered agents
-        const agentsRes = await fetch(`${apiUrl}/a2a/agents`, { credentials: 'include' });
+        // Fetch tasks from all registered agents (same-origin /a2a rewrite).
+        const agentsRes = await fetch('/a2a/agents', { credentials: 'include' });
         if (!agentsRes.ok) throw new Error('Failed to load agents');
 
-        const agentsData = (await agentsRes.json()) as { agents: Array<{ name: string }> };
-        const agentNames = (agentsData.agents ?? []).map((a) =>
-          a.name
-            .toLowerCase()
-            .replace(/\s+/g, '-')
-            .replace(/[^a-z0-9-]/g, ''),
-        );
+        const agentsData = (await agentsRes.json()) as {
+          agents: Array<{ id?: string; name: string }>;
+        };
+        // Registry id from API only — do not slugify display names.
+        const agentIds = (agentsData.agents ?? [])
+          .map((a) => (typeof a.id === 'string' && a.id.length > 0 ? a.id : null))
+          .filter((id): id is string => id !== null);
 
         // Fetch tasks from each agent in parallel
         const allTasks: AgentTask[] = [];
         const results = await Promise.allSettled(
-          agentNames.map(async (agentId) => {
-            const res = await fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}/tasks`, {
+          agentIds.map(async (agentId) => {
+            const res = await fetch(`/a2a/agents/${encodeURIComponent(agentId)}/tasks`, {
               credentials: 'include',
             });
             if (!res.ok) return [];
@@ -152,7 +150,7 @@ function AgentTasksDashboard() {
     return () => {
       cancelled = true;
     };
-  }, [apiUrl]);
+  }, []);
 
   const dateThreshold: Date | null = (() => {
     if (dateFilter === 'all') return null;

--- a/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
@@ -57,9 +57,11 @@ export default function AgentDetailPage({ params }: PageProps) {
   const [retireError, setRetireError] = useState<string | null>(null);
 
   const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
+  // Same-origin /a2a rewrite → API (session cookie authenticates feature gates).
+  const a2aBase = '/a2a';
 
   useEffect(() => {
-    fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, { credentials: 'include' })
+    fetch(`${a2aBase}/agents/${encodeURIComponent(agentId)}`, { credentials: 'include' })
       .then((r) => {
         if (!r.ok) throw new Error(`Agent '${agentId}' not found`);
         return r.json();
@@ -72,13 +74,13 @@ export default function AgentDetailPage({ params }: PageProps) {
         );
       })
       .finally(() => setLoading(false));
-  }, [agentId, apiUrl]);
+  }, [agentId]);
 
   async function handleEditStart() {
     setLoadingDef(true);
     setSaveError(null);
     try {
-      const res = await fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}/def`, {
+      const res = await fetch(`${a2aBase}/agents/${encodeURIComponent(agentId)}/def`, {
         credentials: 'include',
       });
       if (!res.ok) throw new Error('Unable to load agent definition');
@@ -106,7 +108,7 @@ export default function AgentDetailPage({ params }: PageProps) {
     setRetiring(true);
     setRetireError(null);
     try {
-      const res = await apiFetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, {
+      const res = await apiFetch(`${a2aBase}/agents/${encodeURIComponent(agentId)}`, {
         method: 'DELETE',
         credentials: 'include',
       });
@@ -130,7 +132,7 @@ export default function AgentDetailPage({ params }: PageProps) {
     setSaving(true);
     setSaveError(null);
     try {
-      const res = await apiFetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, {
+      const res = await apiFetch(`${a2aBase}/agents/${encodeURIComponent(agentId)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/app/(backend)/agents/agents-client.tsx
+++ b/apps/admin/src/app/(backend)/agents/agents-client.tsx
@@ -77,19 +77,20 @@ function AgentCardsPanel() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
   useEffect(() => {
-    fetch(`${apiUrl}/a2a/agents`, { credentials: 'include' })
+    // Same-origin /a2a (admin rewrite → API) so the session cookie authenticates.
+    fetch('/a2a/agents', { credentials: 'include' })
       .then((r) => r.json())
-      .then((data: { agents: A2AAgentCard[] }) => {
-        const withIds: AgentWithId[] = (data.agents ?? []).map((card) => ({
-          card,
-          agentId: card.name
-            .toLowerCase()
-            .replace(/\s+/g, '-')
-            .replace(/[^a-z0-9-]/g, ''),
-        }));
+      .then((data: { agents: Array<A2AAgentCard & { id?: string }> }) => {
+        // Prefer registry id from the API. Never invent ids from display names
+        // ("Ticket Agent" must not become "ticket-agent").
+        const withIds: AgentWithId[] = (data.agents ?? [])
+          .map((row) => {
+            if (typeof row.id !== 'string' || row.id.length === 0) return null;
+            const { id, ...cardFields } = row;
+            return { card: cardFields as A2AAgentCard, agentId: id };
+          })
+          .filter((row): row is AgentWithId => row !== null);
         setAgents(withIds);
       })
       .catch((e: unknown) => {
@@ -99,7 +100,7 @@ function AgentCardsPanel() {
         );
       })
       .finally(() => setLoading(false));
-  }, [apiUrl]);
+  }, []);
 
   if (loading) {
     return (

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -157,7 +157,6 @@ function formReducer(state: FormState, action: FormAction): FormState {
 
 export default function NewAgentPage() {
   const router = useRouter();
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
 
   const [state, dispatch] = useReducer(formReducer, initialState);
   const { selectedTemplate, name, description, systemPrompt, submitting, error } = state;
@@ -238,7 +237,8 @@ export default function NewAgentPage() {
     };
 
     try {
-      const res = await apiFetch(`${apiUrl}/a2a/agents`, {
+      // Same-origin /a2a rewrite so admin session cookie reaches the API feature gate.
+      const res = await apiFetch('/a2a/agents', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/lib/components/agents/task-history.tsx
+++ b/apps/admin/src/lib/components/agents/task-history.tsx
@@ -35,15 +35,13 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
   const [rows, setRows] = useState<AgentActionRow[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
   // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is an intentional re-fetch trigger passed from parent
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     (async () => {
       try {
-        const r = await fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}/tasks`, {
+        const r = await fetch(`/a2a/agents/${encodeURIComponent(agentId)}/tasks`, {
           credentials: 'include',
         });
         if (!r.ok) {
@@ -68,7 +66,7 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
     return () => {
       cancelled = true;
     };
-  }, [agentId, apiUrl, refreshKey]);
+  }, [agentId, refreshKey]);
 
   if (loading) {
     return (

--- a/apps/admin/src/lib/components/agents/task-tester.tsx
+++ b/apps/admin/src/lib/components/agents/task-tester.tsx
@@ -44,8 +44,6 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
   const [task, setTask] = useState<A2ATask | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
   async function submit() {
     if (!instruction.trim()) return;
     setState('submitting');
@@ -58,7 +56,8 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
     };
 
     try {
-      const res = await apiFetch(`${apiUrl}/a2a`, {
+      // Same-origin /a2a rewrite so the admin session authenticates AI feature gates.
+      const res = await apiFetch('/a2a', {
         method: 'POST',
         headers,
         credentials: 'include',

--- a/apps/server/src/routes/__tests__/a2a.test.ts
+++ b/apps/server/src/routes/__tests__/a2a.test.ts
@@ -23,6 +23,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockGetCard,
   mockListCards,
+  mockListDefs,
   mockHas,
   mockGetDef,
   mockRegister,
@@ -37,6 +38,7 @@ const {
 } = vi.hoisted(() => ({
   mockGetCard: vi.fn(),
   mockListCards: vi.fn(),
+  mockListDefs: vi.fn(),
   mockHas: vi.fn(),
   mockGetDef: vi.fn(),
   mockRegister: vi.fn(),
@@ -59,6 +61,7 @@ vi.mock('@revealui/ai', () => ({
   agentCardRegistry: {
     getCard: mockGetCard,
     listCards: mockListCards,
+    listDefs: mockListDefs,
     has: mockHas,
     getDef: mockGetDef,
     register: mockRegister,
@@ -239,6 +242,7 @@ function resetMocks() {
 
   mockGetCard.mockReturnValue(MOCK_CARD);
   mockListCards.mockReturnValue([MOCK_CARD]);
+  mockListDefs.mockReturnValue([MOCK_DEF]);
   mockHas.mockReturnValue(false);
   mockGetDef.mockReturnValue(MOCK_DEF);
   mockRegister.mockImplementation(() => undefined);
@@ -412,12 +416,31 @@ describe('GET /agents', () => {
   });
 
   it('returns empty agents array when registry is empty', async () => {
+    mockListDefs.mockReturnValue([]);
     mockListCards.mockReturnValue([]);
     const app = makeA2AApp();
     const res = await app.request(get('/agents'));
     expect(res.status).toBe(200);
     const body = (await res.json()) as { agents: unknown[] };
     expect(body.agents).toHaveLength(0);
+  });
+
+  it('includes registry id so list UIs do not invent ids from display names', async () => {
+    mockListDefs.mockReturnValue([
+      { ...MOCK_DEF, id: 'revealui-ticket-agent', name: 'Ticket Agent' },
+    ]);
+    mockGetCard.mockReturnValue({
+      ...MOCK_CARD,
+      id: undefined,
+      name: 'Ticket Agent',
+    });
+    const app = makeA2AApp();
+    const res = await app.request(get('/agents'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { agents: Array<{ id: string; name: string }> };
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0]?.id).toBe('revealui-ticket-agent');
+    expect(body.agents[0]?.name).toBe('Ticket Agent');
   });
 });
 

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -422,10 +422,16 @@ a2a.openapi(
     // Include registry id on each card. Display name alone is not a stable id
     // (e.g. "Ticket Agent" ≠ "revealui-ticket-agent") — admin list UIs must not
     // invent ids by slugifying the name.
-    const agents = aiMod.agentCardRegistry.listDefs().map((def) => ({
-      id: def.id,
-      ...aiMod.agentCardRegistry.getCard(def.id, baseUrl),
-    }));
+    // Registry id must be applied AFTER the card spread so a missing/undefined
+    // id field on the A2A card shape cannot overwrite the real agent id.
+    const agents = aiMod.agentCardRegistry
+      .listDefs()
+      .map((def) => {
+        const card = aiMod.agentCardRegistry.getCard(def.id, baseUrl);
+        if (!card) return null;
+        return { ...card, id: def.id };
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null);
     return c.json({ agents });
   },
 );

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -419,8 +419,14 @@ a2a.openapi(
       return c.json(aiModuleUnavailableBody(), 503);
     }
     const baseUrl = getBaseUrl(c.req.raw);
-    const cards = aiMod.agentCardRegistry.listCards(baseUrl);
-    return c.json({ agents: cards });
+    // Include registry id on each card. Display name alone is not a stable id
+    // (e.g. "Ticket Agent" ≠ "revealui-ticket-agent") — admin list UIs must not
+    // invent ids by slugifying the name.
+    const agents = aiMod.agentCardRegistry.listDefs().map((def) => ({
+      id: def.id,
+      ...aiMod.agentCardRegistry.getCard(def.id, baseUrl),
+    }));
+    return c.json({ agents });
   },
 );
 


### PR DESCRIPTION
## Summary

**Symptom (GAP-360 walk):** Create agent / AI routes return  
`Feature 'ai' requires a pro license. Current tier: free`  
even when `founder@` has **enterprise** + `features.ai: true` in `account_entitlements`.

**Root cause:** Admin browser called `https://api.revealui.com/a2a/*` cross-origin.  
If the session cookie is host-only on `admin.revealui.com` (or Domain does not reach the API), the API sees no user → entitlements middleware attaches free → `requireFeature('ai')` 403.

API keys still worked because they use same-origin `/api/user/api-keys` on admin.

**Fix:**
1. Next rewrite: `/a2a` → API (same pattern as `/api/agent-stream`)
2. Admin agent UI uses relative `/a2a/...` so the session cookie authenticates
3. `GET /a2a/agents` returns registry `id`; list UI no longer slugifies display names (`Ticket Agent` ≠ `ticket-agent`)

## Test plan
- [ ] CI green
- [ ] After deploy to test/prod: sign in as founder@ → create agent succeeds
- [ ] Agents list Test Agent opens `/agents/revealui-ticket-agent` (not `ticket-agent`)
- [ ] Task Tester send works with Groq key

## Notes
- founder enterprise grant on mode=live re-confirmed in DB
- Durable fix is request path, not re-granting entitlements each walk
