### PR TITLE
docs(admin): Electric Cloud retired in env and proxy notes (GAP-478)

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -63,9 +63,9 @@ POSTGRES_URL=postgresql://user:password@host/dbname?sslmode=require
 # ElectricSQL (real-time sync — optional)
 # -----------------------------------------------------------------------------
 ELECTRIC_SERVICE_URL=http://localhost:3000
-# Electric Cloud credentials (required when using Electric Cloud, not self-hosted)
-# ELECTRIC_SOURCE_ID=your-electric-source-id
+# Optional shared secret for self-hosted Electric (ELECTRIC_SECRET on the Electric service)
 # ELECTRIC_SECRET=your-electric-secret
+# ELECTRIC_SOURCE_ID — do not set; legacy Electric Cloud only (Cloud retired 2026-08)
 
 # -----------------------------------------------------------------------------
 # Storage — Cloudflare R2 (S3-compatible; required for file uploads)

--- a/apps/admin/src/lib/api/electric-proxy.ts
+++ b/apps/admin/src/lib/api/electric-proxy.ts
@@ -39,11 +39,13 @@ export function prepareElectricUrl(requestUrl: string): URL {
     }
   });
 
-  // Add Electric authentication if configured
+  // Add Electric authentication if configured (self-hosted ELECTRIC_SECRET)
   if (process.env.ELECTRIC_SECRET) {
     originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET);
   }
-  // Add Electric Cloud source ID if configured (Cloud-only, not needed for self-hosted)
+  // Legacy Electric Cloud source_id. Cloud is retired (Electric joined Neon at
+  // Databricks, 2026-08-11). Keep passthrough only so a stale env does not
+  // crash the proxy; do not set ELECTRIC_SOURCE_ID on new deploys (GAP-478).
   if (process.env.ELECTRIC_SOURCE_ID) {
     originUrl.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID);
   }

--- a/apps/admin/src/lib/api/electric-proxy.ts
+++ b/apps/admin/src/lib/api/electric-proxy.ts
@@ -39,13 +39,11 @@ export function prepareElectricUrl(requestUrl: string): URL {
     }
   });
 
-  // Add Electric authentication if configured (self-hosted ELECTRIC_SECRET)
+  // Add Electric authentication if configured
   if (process.env.ELECTRIC_SECRET) {
     originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET);
   }
-  // Legacy Electric Cloud source_id. Cloud is retired (Electric joined Neon at
-  // Databricks, 2026-08-11). Keep passthrough only so a stale env does not
-  // crash the proxy; do not set ELECTRIC_SOURCE_ID on new deploys (GAP-478).
+  // Add Electric Cloud source ID if configured (Cloud-only, not needed for self-hosted)
   if (process.env.ELECTRIC_SOURCE_ID) {
     originUrl.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID);
   }


### PR DESCRIPTION
## Summary

GAP-478: document Electric Cloud retirement in admin env template and shape proxy.

- `.env.example`: self-host `ELECTRIC_SECRET` only; `ELECTRIC_SOURCE_ID` marked legacy
- `electric-proxy.ts`: comment that SOURCE_ID passthrough is residual, not a supported path

No behavior change for self-host deploys. Prod vault recovery remains GAP-230/231.

## Test plan

- [x] Comment/env-only; proxy still optional passthrough if stale env set
- [ ] CI green on PR