### PR TITLE
fix(admin,server): GAP-477 Phase C shape registry, KG admin, membership resolve

### DIFF
--- a/apps/admin/src/app/api/shapes/__tests__/kg-edge-episodes.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-edge-episodes.test.ts
@@ -47,7 +47,7 @@ const mockSession = {
     email: 'test@example.com',
     avatarUrl: null,
     password: null,
-    role: 'viewer',
+    role: 'admin',
     status: 'active',
     emailVerified: false,
     emailVerificationToken: null,

--- a/apps/admin/src/app/api/shapes/__tests__/kg-edges.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-edges.test.ts
@@ -47,7 +47,7 @@ const mockSession = {
     email: 'test@example.com',
     avatarUrl: null,
     password: null,
-    role: 'viewer',
+    role: 'admin',
     status: 'active',
     emailVerified: false,
     emailVerificationToken: null,

--- a/apps/admin/src/app/api/shapes/__tests__/kg-nodes.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-nodes.test.ts
@@ -50,7 +50,7 @@ const mockSession = {
     email: 'test@example.com',
     avatarUrl: null,
     password: null,
-    role: 'viewer',
+    role: 'admin',
     status: 'active',
     emailVerified: false,
     emailVerificationToken: null,
@@ -83,6 +83,17 @@ describe('GET /api/shapes/kg-nodes', () => {
 
     expect(response.status).toBe(401);
     expect(data.error).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 403 when non-admin (GAP-477)', async () => {
+    mockGetSession.mockResolvedValue({
+      ...mockSession,
+      user: { ...mockSession.user, role: 'viewer' },
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-nodes');
+    const response = await GET(request);
+    expect(response.status).toBe(403);
   });
 
   it('proxies with no where clause when repo is omitted', async () => {

--- a/apps/admin/src/app/api/shapes/__tests__/kg-views.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-views.test.ts
@@ -47,7 +47,7 @@ const mockSession = {
     email: 'test@example.com',
     avatarUrl: null,
     password: null,
-    role: 'viewer',
+    role: 'admin',
     status: 'active',
     emailVerified: false,
     emailVerificationToken: null,

--- a/apps/admin/src/app/api/shapes/kg-edge-episodes/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-edge-episodes/route.ts
@@ -22,6 +22,7 @@ import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
@@ -38,6 +39,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
+
+    // GAP-477: full provenance join is fleet-operator data only.
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
 
     const originUrl = prepareElectricUrl(request.url);
     originUrl.searchParams.set('table', 'kg_edge_episodes');

--- a/apps/admin/src/app/api/shapes/kg-edges/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-edges/route.ts
@@ -3,15 +3,14 @@
  *
  * GET /api/shapes/kg-edges[?repo=<repo>]
  *
- * Authenticated, read-only proxy for the ElectricSQL `kg_edges` shape
- * (GAP-349 P4, design spec §8.2/§9). Same repo-partition and validation
- * contract as `kg-nodes` — see that route's header comment.
+ * Same AuthZ as kg-nodes (GAP-477 Phase C): admin_platform + AI gate.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
@@ -33,6 +32,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
 
     const repo = new URL(request.url).searchParams.get('repo');
     if (repo !== null && !isRepoIdentifier(repo)) {

--- a/apps/admin/src/app/api/shapes/kg-nodes/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-nodes/route.ts
@@ -3,23 +3,18 @@
  *
  * GET /api/shapes/kg-nodes[?repo=<repo>]
  *
- * Authenticated, read-only proxy for the ElectricSQL `kg_nodes` shape
- * (GAP-349 P4, design spec §8.2/§9). Partitioned by the denormalized `repo`
- * column: an omitted `repo` param syncs the whole fleet graph; a supplied
- * one is validated against {@link isRepoIdentifier} (character-set only, no
- * authored regex) before being inlined into the Electric `where` clause —
- * Electric's shape API takes `where` as a literal SQL predicate string, so
- * an unvalidated value here would be a SQL injection surface.
+ * Fleet knowledge graph (GAP-349). GAP-477 Phase C: admin_platform only —
+ * any authenticated user previously could sync the whole graph. Optional
+ * `repo` still scopes the Electric where for admins who pass it.
  *
- * Electric sync is read-only by design: this route (and its kg-edges /
- * kg-edge-episodes siblings) never accepts a write. The only write path into
- * `kg_*` tables is `POST /api/sync/kg-episodes` (additive `ingestEpisode`).
+ * Electric sync is read-only. Writes go through POST /api/sync/kg-episodes.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
@@ -41,6 +36,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
 
     const repo = new URL(request.url).searchParams.get('repo');
     if (repo !== null && !isRepoIdentifier(repo)) {

--- a/apps/admin/src/app/api/shapes/kg-views/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-views/route.ts
@@ -25,6 +25,7 @@ import { isKgViewDocumentId } from '@revealui/sync/collab/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
@@ -41,6 +42,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
 
     const documentId = new URL(request.url).searchParams.get('document_id');
     if (!(documentId && isKgViewDocumentId(documentId))) {

--- a/apps/admin/src/lib/access/__tests__/account-feature.test.ts
+++ b/apps/admin/src/lib/access/__tests__/account-feature.test.ts
@@ -1,5 +1,5 @@
 /**
- * accountHasFeature unit tests (GAP-476)
+ * accountHasFeature unit tests (GAP-476 / GAP-477 membership resolve)
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -18,8 +18,14 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/db/schema', () => ({
   accountMemberships: {
     accountId: 'account_memberships.account_id',
+    role: 'account_memberships.role',
     userId: 'account_memberships.user_id',
     status: 'account_memberships.status',
+    createdAt: 'account_memberships.created_at',
+  },
+  accounts: {
+    id: 'accounts.id',
+    slug: 'accounts.slug',
   },
   accountEntitlements: {
     accountId: 'account_entitlements.account_id',
@@ -33,21 +39,33 @@ vi.mock('@revealui/db/schema', () => ({
 
 vi.mock('drizzle-orm', () => ({
   and: (...args: unknown[]) => args,
+  asc: (x: unknown) => x,
   eq: (a: unknown, b: unknown) => ({ a, b }),
+  or: (...args: unknown[]) => args,
 }));
 
 import { accountHasFeature } from '../account-feature';
 
-function makeDb(membershipRows: unknown[], entitlementRows: unknown[]) {
-  let selectCall = 0;
-  const limit = vi.fn(async () => {
-    selectCall += 1;
-    return selectCall === 1 ? membershipRows : entitlementRows;
-  });
-  const where = vi.fn(() => ({ limit }));
-  const from = vi.fn(() => ({ where }));
-  const select = vi.fn(() => ({ from }));
-  return { select, from, where, limit };
+/**
+ * Fluent select chain for resolveActiveMembership + entitlement lookup.
+ * Each terminal `.limit()` pops the next result queue entry.
+ */
+function makeDb(limitResults: unknown[][]) {
+  const queue = [...limitResults];
+  const limit = vi.fn(async () => queue.shift() ?? []);
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit,
+  };
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.orderBy.mockReturnValue(chain);
+  const select = vi.fn(() => chain);
+  return { select, chain, limit };
 }
 
 describe('accountHasFeature', () => {
@@ -57,19 +75,20 @@ describe('accountHasFeature', () => {
   });
 
   it('returns false for null userId', async () => {
-    const db = makeDb([], []);
+    const db = makeDb([]);
     await expect(accountHasFeature(db as never, null, 'ai')).resolves.toBe(false);
     expect(db.select).not.toHaveBeenCalled();
   });
 
   it('returns false when no membership', async () => {
-    const db = makeDb([], []);
+    // resolveActiveMembership: empty rows
+    const db = makeDb([[]]);
     await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(false);
   });
 
   it('returns false when grace expired', async () => {
-    const db = makeDb(
-      [{ accountId: 'acct-1' }],
+    const db = makeDb([
+      [{ accountId: 'acct-1', role: 'owner' }],
       [
         {
           tier: 'pro',
@@ -78,13 +97,13 @@ describe('accountHasFeature', () => {
           features: { ai: true },
         },
       ],
-    );
+    ]);
     await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(false);
   });
 
   it('returns true from entitlement features map', async () => {
-    const db = makeDb(
-      [{ accountId: 'acct-1' }],
+    const db = makeDb([
+      [{ accountId: 'acct-1', role: 'owner' }],
       [
         {
           tier: 'pro',
@@ -93,14 +112,14 @@ describe('accountHasFeature', () => {
           features: { ai: true },
         },
       ],
-    );
+    ]);
     await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(true);
   });
 
   it('falls back to getFeaturesForTier when features empty', async () => {
     mockGetFeaturesForTier.mockReturnValue({ ai: true });
-    const db = makeDb(
-      [{ accountId: 'acct-1' }],
+    const db = makeDb([
+      [{ accountId: 'acct-1', role: 'member' }],
       [
         {
           tier: 'pro',
@@ -109,8 +128,26 @@ describe('accountHasFeature', () => {
           features: {},
         },
       ],
-    );
+    ]);
     await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(true);
     expect(mockGetFeaturesForTier).toHaveBeenCalledWith('pro');
+  });
+
+  it('uses preferred account membership when provided', async () => {
+    const db = makeDb([
+      [{ accountId: 'acct-preferred', role: 'owner' }],
+      [
+        {
+          tier: 'pro',
+          status: 'active',
+          graceUntil: null,
+          features: { ai: true },
+        },
+      ],
+    ]);
+    await expect(accountHasFeature(db as never, 'user-1', 'ai', 'acct-preferred')).resolves.toBe(
+      true,
+    );
+    expect(db.chain.innerJoin).toHaveBeenCalled();
   });
 });

--- a/apps/admin/src/lib/access/account-feature.ts
+++ b/apps/admin/src/lib/access/account-feature.ts
@@ -13,7 +13,7 @@ import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
 import type { Database } from '@revealui/db/client';
 import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
-import { resolveActiveMembership } from './resolve-membership.js';
+import { resolveActiveMembership } from './resolve-membership';
 
 function isHealthyStatus(status: string | null): boolean {
   return status === 'active' || status === 'trialing';

--- a/apps/admin/src/lib/access/account-feature.ts
+++ b/apps/admin/src/lib/access/account-feature.ts
@@ -1,19 +1,19 @@
 /**
- * Account-scoped feature entitlement lookup for admin routes (GAP-476).
+ * Account-scoped feature entitlement lookup for admin routes (GAP-477).
  *
- * Mirrors apps/server/src/lib/account-entitlement.ts accountHasAiFeature:
- * membership → account_entitlements (stripe mode) → grace-expired fail-closed →
- * features from row or getFeaturesForTier(tier).
+ * Mirrors apps/server/src/lib/account-entitlement.ts:
+ * resolve membership (preferred + deterministic oldest) → account_entitlements
+ * (stripe mode) → grace-expired fail-closed → features from row or tier map.
  *
- * Do not import from apps/server; keep this admin-local mirror in sync with
- * the server helper when entitlement rules change.
+ * Do not import from apps/server; keep this admin-local mirror in sync.
  */
 
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
 import type { Database } from '@revealui/db/client';
-import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
+import { resolveActiveMembership } from './resolve-membership.js';
 
 function isHealthyStatus(status: string | null): boolean {
   return status === 'active' || status === 'trialing';
@@ -31,22 +31,17 @@ function featureRecord(features: object | null | undefined): Record<string, bool
 /**
  * Whether the account owning `userId` currently has `featureKey`.
  *
- * Fail-closed: null userId, no active membership, no entitlement row, or a
- * grace-expired subscription all resolve to false.
+ * @param preferredAccountId - Optional account id/slug (X-Tenant-ID / workspace).
  */
 export async function accountHasFeature(
   db: Database,
   userId: string | null | undefined,
   featureKey: keyof FeatureFlags,
+  preferredAccountId?: string | null,
 ): Promise<boolean> {
   if (!userId) return false;
 
-  const [membership] = await db
-    .select({ accountId: accountMemberships.accountId })
-    .from(accountMemberships)
-    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
-    .limit(1);
-
+  const membership = await resolveActiveMembership(db, userId, preferredAccountId);
   if (!membership?.accountId) return false;
 
   const [entitlement] = await db

--- a/apps/admin/src/lib/access/resolve-membership.ts
+++ b/apps/admin/src/lib/access/resolve-membership.ts
@@ -1,0 +1,57 @@
+/**
+ * Active account membership resolution for admin (GAP-477 Phase C).
+ *
+ * Mirror of apps/server/src/lib/resolve-membership.ts — keep lockstep when
+ * preference rules change. Admin cannot import apps/server.
+ */
+
+import type { Database } from '@revealui/db/client';
+import { accountMemberships, accounts } from '@revealui/db/schema';
+import { and, asc, eq, or } from 'drizzle-orm';
+
+export interface ActiveMembership {
+  accountId: string;
+  role: string;
+}
+
+export async function resolveActiveMembership(
+  db: Database,
+  userId: string,
+  preferredAccountId?: string | null,
+): Promise<ActiveMembership | null> {
+  const preferred = preferredAccountId?.trim() || null;
+
+  if (preferred) {
+    const [preferredRow] = await db
+      .select({
+        accountId: accountMemberships.accountId,
+        role: accountMemberships.role,
+      })
+      .from(accountMemberships)
+      .innerJoin(accounts, eq(accounts.id, accountMemberships.accountId))
+      .where(
+        and(
+          eq(accountMemberships.userId, userId),
+          eq(accountMemberships.status, 'active'),
+          or(eq(accounts.id, preferred), eq(accounts.slug, preferred)),
+        ),
+      )
+      .limit(1);
+
+    if (preferredRow) {
+      return preferredRow;
+    }
+  }
+
+  const rows = await db
+    .select({
+      accountId: accountMemberships.accountId,
+      role: accountMemberships.role,
+    })
+    .from(accountMemberships)
+    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
+    .orderBy(asc(accountMemberships.createdAt))
+    .limit(1);
+
+  return rows[0] ?? null;
+}

--- a/apps/admin/src/lib/api/__tests__/shape-authz-registry.test.ts
+++ b/apps/admin/src/lib/api/__tests__/shape-authz-registry.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Shape AuthZ registry completeness (GAP-477 Phase C).
+ */
+
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SHAPE_AUTHZ_REGISTRY } from '../shape-authz-registry.js';
+
+const SHAPES_DIR = join(__dirname, '../../../app/api/shapes');
+
+function listShapeRouteDirs(): string[] {
+  return readdirSync(SHAPES_DIR).filter((name) => {
+    if (name === '__tests__') return false;
+    const full = join(SHAPES_DIR, name);
+    try {
+      return statSync(full).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+}
+
+describe('SHAPE_AUTHZ_REGISTRY', () => {
+  it('registers every shapes/* route directory', () => {
+    const dirs = listShapeRouteDirs().sort();
+    const registered = Object.keys(SHAPE_AUTHZ_REGISTRY).sort();
+    expect(registered).toEqual(dirs);
+  });
+
+  it('assigns a known scope kind to every entry', () => {
+    const allowed = new Set(['user_self', 'site_member', 'admin_platform', 'acl_resource']);
+    for (const [name, entry] of Object.entries(SHAPE_AUTHZ_REGISTRY)) {
+      expect(allowed.has(entry.scope), `${name} has invalid scope ${entry.scope}`).toBe(true);
+      expect(entry.table.length).toBeGreaterThan(0);
+      expect(entry.enforcement.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/admin/src/lib/api/shape-authz-registry.ts
+++ b/apps/admin/src/lib/api/shape-authz-registry.ts
@@ -1,0 +1,97 @@
+/**
+ * Electric shape AuthZ registry (GAP-477 Phase C).
+ *
+ * Every apps/admin/src/app/api/shapes/<name>/route.ts must appear here with an
+ * explicit scope kind. Tests fail closed if a route directory is unregistered
+ * so new shapes cannot ship as auth-only proxies.
+ */
+
+export type ShapeAuthzScope = 'user_self' | 'site_member' | 'admin_platform' | 'acl_resource';
+
+export interface ShapeAuthzEntry {
+  /** Electric table (or primary table) this proxy reads. */
+  table: string;
+  /** How ownership / admin is enforced on the route. */
+  scope: ShapeAuthzScope;
+  /** One-line how the where / gate is applied. */
+  enforcement: string;
+}
+
+/**
+ * Canonical map: shape route directory name → AuthZ contract.
+ * Keep in lockstep with route files under apps/admin/src/app/api/shapes/.
+ */
+export const SHAPE_AUTHZ_REGISTRY: Readonly<Record<string, ShapeAuthzEntry>> = {
+  conversations: {
+    table: 'conversations',
+    scope: 'user_self',
+    enforcement: 'where user_id = session.user.id',
+  },
+  'task-submissions': {
+    table: 'task_submissions',
+    scope: 'user_self',
+    enforcement: 'where submitter_id = session.user.id',
+  },
+  'agent-contexts': {
+    table: 'agent_contexts',
+    scope: 'user_self',
+    enforcement: 'where session_id = auth session id (write path key)',
+  },
+  'agent-memories': {
+    table: 'agent_memories',
+    scope: 'site_member',
+    enforcement: 'admin: agent_id; non-admin: site access + agent_id AND site_id',
+  },
+  'coordination-sessions': {
+    table: 'coordination_sessions',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole full-table',
+  },
+  'coordination-work-items': {
+    table: 'coordination_work_items',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole full-table',
+  },
+  'shared-facts': {
+    table: 'shared_facts',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + session_id where (no user ACL column)',
+  },
+  'shared-memories': {
+    table: 'agent_memories',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + scope filter (no user ACL join)',
+  },
+  'yjs-documents': {
+    table: 'yjs_documents',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole until owner_id ACL migrates (Phase C residual)',
+  },
+  'yjs-document-patches': {
+    table: 'yjs_document_patches',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole until document ACL migrates',
+  },
+  'kg-nodes': {
+    table: 'kg_nodes',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + optional repo where (fleet graph)',
+  },
+  'kg-edges': {
+    table: 'kg_edges',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + optional repo where (fleet graph)',
+  },
+  'kg-edge-episodes': {
+    table: 'kg_edge_episodes',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole (join table; no ownership column)',
+  },
+  'kg-views': {
+    table: 'yjs_documents',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + document id where (kg-view ids)',
+  },
+} as const;
+
+export const SHAPE_AUTHZ_ROUTE_NAMES: readonly string[] = Object.keys(SHAPE_AUTHZ_REGISTRY);

--- a/apps/admin/src/lib/api/shape-authz.ts
+++ b/apps/admin/src/lib/api/shape-authz.ts
@@ -1,5 +1,5 @@
 /**
- * Shared AuthZ helpers for Electric shape proxy routes (GAP-476).
+ * Shared AuthZ helpers for Electric shape proxy routes (GAP-477).
  */
 
 import type { Database } from '@revealui/db/client';

--- a/apps/server/src/lib/__tests__/resolve-membership.test.ts
+++ b/apps/server/src/lib/__tests__/resolve-membership.test.ts
@@ -1,0 +1,88 @@
+/**
+ * resolveActiveMembership (GAP-477 Phase C)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/db/schema', () => ({
+  accountMemberships: {
+    accountId: 'accountId',
+    role: 'role',
+    userId: 'userId',
+    status: 'status',
+    createdAt: 'createdAt',
+  },
+  accounts: {
+    id: 'id',
+    slug: 'slug',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => args,
+  asc: (x: unknown) => x,
+  eq: (...args: unknown[]) => args,
+  or: (...args: unknown[]) => args,
+}));
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockInnerJoin = vi.fn();
+const mockWhere = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLimit = vi.fn();
+
+function chain() {
+  const c = {
+    select: mockSelect,
+    from: mockFrom,
+    innerJoin: mockInnerJoin,
+    where: mockWhere,
+    orderBy: mockOrderBy,
+    limit: mockLimit,
+  };
+  mockSelect.mockReturnValue(c);
+  mockFrom.mockReturnValue(c);
+  mockInnerJoin.mockReturnValue(c);
+  mockWhere.mockReturnValue(c);
+  mockOrderBy.mockReturnValue(c);
+  return c;
+}
+
+describe('resolveActiveMembership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chain();
+  });
+
+  it('returns preferred membership when user is a member', async () => {
+    mockLimit.mockResolvedValueOnce([{ accountId: 'acct-preferred', role: 'owner' }]);
+    const { resolveActiveMembership } = await import('../resolve-membership.js');
+    const db = { select: mockSelect } as never;
+
+    const result = await resolveActiveMembership(db, 'user-1', 'acct-preferred');
+    expect(result).toEqual({ accountId: 'acct-preferred', role: 'owner' });
+    expect(mockInnerJoin).toHaveBeenCalled();
+  });
+
+  it('falls back to oldest active membership when preferred misses', async () => {
+    mockLimit
+      .mockResolvedValueOnce([]) // preferred miss
+      .mockResolvedValueOnce([{ accountId: 'acct-old', role: 'member' }]);
+    const { resolveActiveMembership } = await import('../resolve-membership.js');
+    const db = { select: mockSelect } as never;
+
+    const result = await resolveActiveMembership(db, 'user-1', 'missing-slug');
+    expect(result).toEqual({ accountId: 'acct-old', role: 'member' });
+    expect(mockOrderBy).toHaveBeenCalled();
+  });
+
+  it('returns null when user has no active membership', async () => {
+    mockLimit.mockResolvedValueOnce([]);
+    const { resolveActiveMembership } = await import('../resolve-membership.js');
+    const db = { select: mockSelect } as never;
+
+    const result = await resolveActiveMembership(db, 'user-1', null);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/server/src/lib/account-entitlement.ts
+++ b/apps/server/src/lib/account-entitlement.ts
@@ -12,8 +12,9 @@
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import type { Database } from '@revealui/db/client';
-import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
+import { resolveActiveMembership } from './resolve-membership.js';
 
 /** A subscription status that still confers the paid tier (mirrors the middleware). */
 function isHealthyStatus(status: string | null): boolean {
@@ -38,23 +39,18 @@ function featureRecord(features: object | null | undefined): Record<string, bool
  * the authenticated dispatcher captured server-side at enqueue time for the
  * durable worker (`AgentDispatchPayload.userId`) — never a client-writable
  * value such as a ticket row's `reporterId` (§6.1).
+ *
+ * Membership pick: {@link resolveActiveMembership} (preferred account, else
+ * oldest active — GAP-477 Phase C; no more unordered `.limit(1)`).
  */
-export async function accountHasAiFeature(db: Database, userId: string | null): Promise<boolean> {
+export async function accountHasAiFeature(
+  db: Database,
+  userId: string | null,
+  preferredAccountId?: string | null,
+): Promise<boolean> {
   if (!userId) return false;
 
-  // TODO(GAP-360 follow-up): `.limit(1)` picks an arbitrary active membership
-  // for a user who belongs to multiple accounts. `entitlementMiddleware` has
-  // the same shape (entitlements.ts `entitlementMiddleware`), so this mirrors
-  // existing behavior rather than introducing new ambiguity, but multi-account
-  // BYOK resolution deserves its own design pass (which membership "wins" for
-  // both entitlement and key lookup should be the same account, and today
-  // that's just "whichever active row postgres returns first").
-  const [membership] = await db
-    .select({ accountId: accountMemberships.accountId })
-    .from(accountMemberships)
-    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
-    .limit(1);
-
+  const membership = await resolveActiveMembership(db, userId, preferredAccountId);
   if (!membership?.accountId) return false;
 
   const [entitlement] = await db

--- a/apps/server/src/lib/resolve-membership.ts
+++ b/apps/server/src/lib/resolve-membership.ts
@@ -1,0 +1,70 @@
+/**
+ * Active account membership resolution (GAP-477 Phase C).
+ *
+ * Replaces nondeterministic `.limit(1)` without ORDER BY on multi-account users.
+ *
+ * Priority:
+ * 1. Preferred account id/slug (X-Tenant-ID / tenant middleware) when the user
+ *    has an active membership on that account
+ * 2. Exactly one active membership → that row
+ * 3. Multiple memberships without preference → oldest by created_at (stable)
+ *
+ * Fail-closed: no active membership → null.
+ */
+
+import type { Database } from '@revealui/db/client';
+import { accountMemberships, accounts } from '@revealui/db/schema';
+import { and, asc, eq, or } from 'drizzle-orm';
+
+export interface ActiveMembership {
+  accountId: string;
+  role: string;
+}
+
+/**
+ * Resolve which billing/workspace account a user is acting as for entitlements.
+ *
+ * @param preferredAccountId - Optional account id or slug (e.g. X-Tenant-ID).
+ *   Only wins when the user has an active membership on that account.
+ */
+export async function resolveActiveMembership(
+  db: Database,
+  userId: string,
+  preferredAccountId?: string | null,
+): Promise<ActiveMembership | null> {
+  const preferred = preferredAccountId?.trim() || null;
+
+  if (preferred) {
+    const [preferredRow] = await db
+      .select({
+        accountId: accountMemberships.accountId,
+        role: accountMemberships.role,
+      })
+      .from(accountMemberships)
+      .innerJoin(accounts, eq(accounts.id, accountMemberships.accountId))
+      .where(
+        and(
+          eq(accountMemberships.userId, userId),
+          eq(accountMemberships.status, 'active'),
+          or(eq(accounts.id, preferred), eq(accounts.slug, preferred)),
+        ),
+      )
+      .limit(1);
+
+    if (preferredRow) {
+      return preferredRow;
+    }
+  }
+
+  const rows = await db
+    .select({
+      accountId: accountMemberships.accountId,
+      role: accountMemberships.role,
+    })
+    .from(accountMemberships)
+    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
+    .orderBy(asc(accountMemberships.createdAt))
+    .limit(1);
+
+  return rows[0] ?? null;
+}

--- a/apps/server/src/middleware/__tests__/entitlements.test.ts
+++ b/apps/server/src/middleware/__tests__/entitlements.test.ts
@@ -1,9 +1,12 @@
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+/** Fluent select chain for resolveActiveMembership + entitlement lookup. */
 const mockDbSelectChain = {
   from: vi.fn(),
+  innerJoin: vi.fn(),
   where: vi.fn(),
+  orderBy: vi.fn(),
   limit: vi.fn(),
 };
 
@@ -21,19 +24,29 @@ vi.mock('@revealui/db/schema', () => ({
     userId: 'account_memberships.userId',
     role: 'account_memberships.role',
     status: 'account_memberships.status',
+    createdAt: 'account_memberships.createdAt',
+  },
+  accounts: {
+    id: 'accounts.id',
+    slug: 'accounts.slug',
   },
   accountEntitlements: {
     accountId: 'account_entitlements.accountId',
+    mode: 'account_entitlements.mode',
     tier: 'account_entitlements.tier',
     status: 'account_entitlements.status',
+    graceUntil: 'account_entitlements.graceUntil',
     features: 'account_entitlements.features',
     limits: 'account_entitlements.limits',
+    cogsBreakerTrippedAt: 'account_entitlements.cogsBreakerTrippedAt',
   },
 }));
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
+  asc: vi.fn((_col: unknown) => `asc(${String(_col)})`),
   eq: vi.fn((_col: unknown, _val: unknown) => `eq(${String(_col)},${String(_val)})`),
+  or: vi.fn((...args: unknown[]) => `or(${args.join(',')})`),
 }));
 
 import { entitlementMiddleware, getEntitlementsFromContext } from '../entitlements.js';
@@ -57,7 +70,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   selectResults = [];
   mockDbSelectChain.from.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.innerJoin.mockReturnValue(mockDbSelectChain);
   mockDbSelectChain.where.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.orderBy.mockReturnValue(mockDbSelectChain);
   mockDbSelectChain.limit.mockImplementation(() => Promise.resolve(selectResults.shift() ?? []));
   mockDb.select.mockReturnValue(mockDbSelectChain);
 });

--- a/apps/server/src/middleware/entitlements.ts
+++ b/apps/server/src/middleware/entitlements.ts
@@ -9,9 +9,10 @@
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import { getClient } from '@revealui/db';
-import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
 import type { MiddlewareHandler } from 'hono';
+import { resolveActiveMembership } from '../lib/resolve-membership.js';
 
 export interface EntitlementContext {
   userId: string | null;
@@ -81,14 +82,16 @@ export const entitlementMiddleware = (): MiddlewareHandler => {
     }
 
     const db = getClient();
-    const [membership] = await db
-      .select({
-        accountId: accountMemberships.accountId,
-        role: accountMemberships.role,
-      })
-      .from(accountMemberships)
-      .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
-      .limit(1);
+    // Preferred workspace: tenant middleware context, then X-Tenant-ID / X-Account-ID.
+    // resolveActiveMembership only admits accounts the user actually belongs to.
+    const tenant = c.get('tenant') as { id?: string } | undefined;
+    const preferredAccountId =
+      tenant?.id?.trim() ||
+      c.req.header('X-Tenant-ID')?.trim() ||
+      c.req.header('X-Account-ID')?.trim() ||
+      null;
+
+    const membership = await resolveActiveMembership(db, userId, preferredAccountId);
 
     if (!membership?.accountId) {
       c.set('entitlements', createFreeEntitlements(userId));

--- a/apps/server/src/routes/__tests__/entitlement-mode-scope.test.ts
+++ b/apps/server/src/routes/__tests__/entitlement-mode-scope.test.ts
@@ -24,12 +24,25 @@ vi.mock('@revealui/core/features', () => ({
 }));
 
 const mockDbLimitFn = vi.fn().mockResolvedValue([]);
+
+/** Fluent select chain: membership uses orderBy/innerJoin; entitlement uses where.limit. */
+function makeSelectChain() {
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit: mockDbLimitFn,
+  };
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.orderBy.mockReturnValue(chain);
+  return chain;
+}
+
 const mockDb = {
-  select: vi.fn().mockReturnValue({
-    from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({ limit: mockDbLimitFn }),
-    }),
-  }),
+  select: vi.fn().mockImplementation(() => makeSelectChain()),
 };
 
 vi.mock('@revealui/db', () => ({
@@ -42,6 +55,11 @@ vi.mock('@revealui/db/schema', () => ({
     status: 'am.status',
     accountId: 'am.accountId',
     role: 'am.role',
+    createdAt: 'am.createdAt',
+  },
+  accounts: {
+    id: 'accounts.id',
+    slug: 'accounts.slug',
   },
   accountEntitlements: {
     accountId: 'ae.accountId',
@@ -51,12 +69,15 @@ vi.mock('@revealui/db/schema', () => ({
     graceUntil: 'ae.graceUntil',
     features: 'ae.features',
     limits: 'ae.limits',
+    cogsBreakerTrippedAt: 'ae.cogsBreakerTrippedAt',
   },
 }));
 
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((_c: unknown, _v: unknown) => 'eq'),
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
+  asc: vi.fn((_c: unknown) => 'asc'),
+  or: vi.fn((...args: unknown[]) => `or(${args.join(',')})`),
 }));
 
 import { accountEntitlements } from '@revealui/db/schema';
@@ -83,11 +104,7 @@ describe('Entitlement middleware — mode-scoped reader (GAP-266 Track B)', () =
     vi.clearAllMocks();
     mockGetConfiguredStripeMode.mockReturnValue('live');
     mockDbLimitFn.mockReset().mockResolvedValue([]);
-    vi.mocked(mockDb.select).mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({ limit: mockDbLimitFn }),
-      }),
-    });
+    vi.mocked(mockDb.select).mockImplementation(() => makeSelectChain());
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

GAP-477 Phase C hardening (after A/B on #2552):

1. **Shape AuthZ registry** (`shape-authz-registry.ts`) — every `shapes/*` route declares `user_self | site_member | admin_platform | acl_resource`; test fails if a route dir is unregistered.
2. **KG shapes** — `kg-nodes`, `kg-edges`, `kg-edge-episodes`, `kg-views` require `isAdminRole` (fleet graph is operator data).
3. **Deterministic membership** — `resolveActiveMembership`: preferred `X-Tenant-ID` / `X-Account-ID` / tenant context, else oldest active membership by `created_at`. Wired into `entitlementMiddleware`, `accountHasAiFeature`, and admin `accountHasFeature`.

## Residual (still open on GAP-477)

- `yjs_documents.owner_id` ACL migration + write-path stamp (currently admin_platform fail-closed)
- Optional extract of feature lookup into `@revealui/db` to drop admin/server mirrors

## Test plan

- [x] `resolve-membership` unit tests (server)
- [x] Pre-push phase-1 gate green
- [ ] CI unit tests on PR
- [ ] Guardrail-2 / sec-review if required (authz surface)