### PR TITLE
feat(deploy): ElectricSQL on Fly (Phase 5 cutover)

### DIFF
--- a/deployment/fly/electric/README.md
+++ b/deployment/fly/electric/README.md
@@ -1,0 +1,84 @@
+# Fly — revealui-electric (ElectricSQL)
+
+Phase 5 of `drop-railway-migrate-to-fly`. Closes **GAP-230** / **GAP-231** when vault + Vercel admin pick up this host.
+
+## What it is
+
+| | |
+|--|--|
+| Fly app | `revealui-electric` |
+| Image | `electricsql/electric:1.0.17` (pin; bump deliberately) |
+| Region | `iad` (Neon prod us-east-1) |
+| Volume | `electric_data` → `/var/lib/electric/persistent` |
+| Public URL | `https://revealui-electric.fly.dev` |
+
+Admin shape proxies (`apps/admin`) call this URL via `ELECTRIC_SERVICE_URL`. The worker does not serve shapes; it only carries a mirrored env for parity.
+
+## One-time create
+
+```bash
+flyctl apps create revealui-electric --org personal
+flyctl volumes create electric_data --app revealui-electric --region iad --size 1 --yes
+```
+
+## Secrets + vault (stream-safe)
+
+Generate a secret once, force-set vault, then mirror to Fly:
+
+```bash
+# 1) secret → revvault (stdin; no TTY print)
+openssl rand -hex 32 | revvault set revealui/prod/electric/secret --force
+
+# 2) service URL after DNS/hostname known (public-config)
+printf '%s' 'https://revealui-electric.fly.dev' | revvault set revealui/prod/electric/service-url --force
+
+# 3) Fly secrets — expand vars INSIDE bash (outer shell empties them)
+revvault run \
+  --env DATABASE_URL=revealui/prod/db/postgres-url \
+  --env ELECTRIC_SECRET=revealui/prod/electric/secret -- \
+  bash -c '
+    DB="$DATABASE_URL"
+    case "$DB" in postgresql://*) DB="postgres://${DB#postgresql://}" ;; esac
+    flyctl secrets set --app revealui-electric \
+      DATABASE_URL="$DB" ELECTRIC_SECRET="$ELECTRIC_SECRET"
+  '
+```
+
+Neon must have **logical replication** enabled. `revealui/prod/db/postgres-url`
+must be the **direct** endpoint (not `-pooler`). Electric 1.0.17 parses
+`postgres://`; rewrite `postgresql://` if the vault stores that form.
+
+**Do not** run `flyctl secrets set DATABASE_URL="$DATABASE_URL"` as the direct
+child of `revvault run` — the outer shell expands the empty var before inject.
+
+## Deploy
+
+```bash
+cd ~/revfleet/revealui   # or worktree
+flyctl deploy --config deployment/fly/electric/fly.toml --remote-only
+flyctl status --app revealui-electric
+curl -sS "https://revealui-electric.fly.dev/v1/health"
+```
+
+## Vercel admin (not unscoped full sync)
+
+Prefer dry-run then apply, or single-key push after vault is clean. Full `vercel:sync:apply` can rewrite every sensitive var (GAP-339). After vault is good:
+
+```bash
+revvault run --env VERCEL_TOKEN=revealui/prod/api-keys/vercel-token -- \
+  revvault sync vercel --manifest scripts/sync/revvault-vercel.toml
+# inspect electric rows only, then:
+revvault run --env VERCEL_TOKEN=revealui/prod/api-keys/vercel-token -- \
+  revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply
+```
+
+Redeploy **revealui-admin** so runtime picks up env. Probe:
+
+```bash
+curl -sS https://admin.revealui.com/api/health/electric
+# expect {"ok":true,...}
+```
+
+## Teardown note
+
+Do not delete the Fly volume without first dropping Neon replication slots Electric created (`electric_slot_*`), or WAL can grow unbounded.

--- a/deployment/fly/electric/fly.toml
+++ b/deployment/fly/electric/fly.toml
@@ -1,0 +1,65 @@
+# deployment/fly/electric/fly.toml
+#
+# Fly.io configuration for the ElectricSQL sync service (Phase 5 of
+# drop-railway-migrate-to-fly / GAP-230 / GAP-231).
+#
+# Replicates from Neon prod Postgres (logical replication) and serves
+# shape HTTP to apps/admin shape proxies via ELECTRIC_SERVICE_URL.
+#
+# Separate app from revealui-worker (512 MB Node-only today). ADR 2026-05-18
+# preferred co-location; isolation keeps worker memory headroom and lets
+# Electric scale/restart independently. Same region as Neon (iad / us-east-1).
+#
+# Deploy (from monorepo root or this directory):
+#   flyctl deploy --config deployment/fly/electric/fly.toml --remote-only
+#
+# Secrets (stream-safe):
+#   revvault run --env DATABASE_URL=revealui/prod/db/postgres-url \
+#     --env ELECTRIC_SECRET=revealui/prod/electric/secret -- \
+#     flyctl secrets set -a revealui-electric \
+#       DATABASE_URL="$DATABASE_URL" ELECTRIC_SECRET="$ELECTRIC_SECRET"
+#
+# Public URL after first deploy: https://revealui-electric.fly.dev
+# Pin image deliberately (not :latest) — matches monorepo compose 1.0.17.
+
+app = 'revealui-electric'
+primary_region = 'iad'
+
+[build]
+  image = 'electricsql/electric:1.0.17'
+
+[env]
+  ELECTRIC_USAGE_REPORTING = 'false'
+  ELECTRIC_STORAGE_DIR = '/var/lib/electric/persistent'
+  ELECTRIC_LISTEN_ON_IPV6 = 'false'
+  # HTTP port Electric binds (image default 3000)
+  ELECTRIC_HTTP_PORT = '3000'
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = 'off'
+  auto_start_machines = false
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = 'connections'
+    hard_limit = 200
+    soft_limit = 150
+
+  # Electric health (v1); longer grace for first WAL catch-up / slot create
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '120s'
+    method = 'GET'
+    path = '/v1/health'
+
+[[vm]]
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 512
+
+[mounts]
+  source = 'electric_data'
+  destination = '/var/lib/electric/persistent'

--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -159,9 +159,17 @@ unhealthy. Investigate via `flyctl logs --app revealui-worker`.
 
 ## Electric (Phase 5)
 
-ElectricSQL Fly setup lives in a separate `fly.electric.toml`
-(landing in Phase 5 of the infra-consolidation lane). Same region
-(iad), same Fly account. Connects to the same Neon `POSTGRES_URL`
-the worker uses. The cutover from the retired Railway-hosted Electric
-(dropped per ADR 2026-05-18) to Fly-hosted Electric is the load-bearing
-piece of Phase 5 — see the lane plan for sequencing.
+Config: [`deployment/fly/electric/fly.toml`](../../deployment/fly/electric/fly.toml)
++ runbook [`deployment/fly/electric/README.md`](../../deployment/fly/electric/README.md).
+
+| | |
+|--|--|
+| App | `revealui-electric` |
+| Image | `electricsql/electric:1.0.17` |
+| Region | `iad` (same Neon us-east-1) |
+| URL | `https://revealui-electric.fly.dev` |
+
+Connects to Neon via `revealui/prod/db/postgres-url` (direct, non-pooler).
+Vault paths after cutover: `revealui/prod/electric/service-url` +
+`revealui/prod/electric/secret` (GAP-230 / GAP-231). Electric Cloud is
+**retired** (2026-08-11); self-host only.


### PR DESCRIPTION
## Summary

Phase 5 of drop-railway: document and pin the production ElectricSQL Fly app.

- `deployment/fly/electric/fly.toml` — image `electricsql/electric:1.0.17`, volume, health `/v1/health`
- Runbook with stream-safe secret injection (outer-shell expansion pitfall documented)
- `docs/deployment/fly.md` Electric section updated

**Ops already applied this session** (not in this PR): app create, vault SET, secrets, deploy, Vercel env patch, admin redeploy. Closes GAP-230/231 via companion jv PR.

## Test plan
- [x] `https://revealui-electric.fly.dev/v1/health` → 200 active
- [x] `https://admin.revealui.com/api/health/electric` → 200 ok
- [ ] CI green on docs-only deploy config