### PR TITLE
fix(marketing): hero contrast hierarchy and body type ladder

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -28,13 +28,13 @@ export function GetStarted({
             {data.heading}
           </h2>
           <p
-            className="mt-5 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-body"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}
           </p>
           <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
-            <Button asChild size="lg" variant="brand">
+            <Button asChild size="lg" variant="brand" glow>
               <a href={data.cta.primary.href}>{data.cta.primary.label}</a>
             </Button>
             <Button asChild appearance="outline" variant="neutral" size="lg">

--- a/apps/marketing/app/components/__tests__/Hero.test.tsx
+++ b/apps/marketing/app/components/__tests__/Hero.test.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom/vitest';
+import { Router, RouterProvider } from '@revealui/router';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HOME_HERO } from '../../content/home';
+import { Hero } from '../landing/Hero';
+
+afterEach(cleanup);
+
+function renderHero(search = '') {
+  const router = new Router();
+  // Seed location so selectAudience / selectHomeHero see the same search string.
+  if (search) {
+    window.history.replaceState({}, '', `/${search.startsWith('?') ? search : `?${search}`}`);
+  } else {
+    window.history.replaceState({}, '', '/');
+  }
+  return render(
+    <RouterProvider router={router}>
+      <Hero />
+    </RouterProvider>,
+  );
+}
+
+describe('Hero (marketing craft hierarchy)', () => {
+  it('renders the L1 H1 with ink (text-foreground), not muted', () => {
+    renderHero();
+    const h1 = screen.getByRole('heading', { level: 1, name: HOME_HERO.h1 });
+    expect(h1.className).toContain('text-foreground');
+    expect(h1.className).not.toContain('text-muted-foreground');
+  });
+
+  it('uses body text for the subtitle (readable ladder), not muted', () => {
+    renderHero();
+    const subtitle = screen.getByText(HOME_HERO.subtitle.sentence1, { exact: false });
+    expect(subtitle.className).toContain('text-body');
+    expect(subtitle.className).not.toContain('text-muted-foreground');
+  });
+
+  it('renders primary CTA as a solid brand control with glow emphasis', () => {
+    renderHero();
+    const primary = screen.getByRole('link', {
+      name: new RegExp(HOME_HERO.cta.primary.label, 'i'),
+    });
+    // glowClasses from presentation uses the brand glow token shadow.
+    expect(primary.className).toMatch(
+      /shadow-\[var\(--rvui-shadow-glow\)\]|shadow-\[var\(--rvui-shadow-glow/,
+    );
+  });
+
+  it('lists trust signals without brand-dot chrome', () => {
+    renderHero();
+    expect(screen.getByText('Open source')).toBeInTheDocument();
+    expect(screen.getByText('Self-hostable')).toBeInTheDocument();
+    expect(screen.getByText('Local-first AI')).toBeInTheDocument();
+    // No decorative primary dots in the trust strip (craft: separators only).
+    const list = screen.getByText('Open source').closest('ul');
+    expect(list).toBeTruthy();
+    expect(list?.querySelectorAll('.bg-primary').length ?? 0).toBe(0);
+  });
+
+  it('exposes the audience toggle as navigation', () => {
+    renderHero();
+    expect(screen.getByRole('navigation', { name: 'Choose your view' })).toBeInTheDocument();
+  });
+});

--- a/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
@@ -30,15 +30,12 @@ export function ClosingCta({
         >
           {data.heading}
         </h2>
-        <p
-          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground"
-          {...field('body')}
-        >
+        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-body" {...field('body')}>
           {data.body}
         </p>
 
         <div className="mt-10 flex justify-center">
-          <Button asChild size="lg">
+          <Button asChild size="lg" glow>
             <a
               href={data.primaryCta.href}
               {...(data.primaryCta.external

--- a/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
@@ -46,14 +46,14 @@ export function Hero({
         </h1>
 
         <p
-          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-body sm:text-xl"
           {...field('subtitle')}
         >
           {data.subtitle}
         </p>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-          <Button asChild size="lg" className="w-full sm:w-auto">
+          <Button asChild size="lg" glow className="w-full sm:w-auto">
             <a
               href={data.primaryCta.href}
               {...(data.primaryCta.external

--- a/apps/marketing/app/components/for-operators-managed/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Hero.tsx
@@ -42,7 +42,7 @@ export function Hero({ data, path, annotation }: FoManagedHeroProps = {}) {
         </h1>
 
         <p
-          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-body sm:text-xl"
           {...(base ? fieldAttrs(ann, `${base}.subtitle`) : {})}
         >
           {content.subtitle}

--- a/apps/marketing/app/components/for-operators/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators/ClosingCta.tsx
@@ -28,14 +28,14 @@ export function ClosingCta({ data, path, annotation }: ClosingCtaProps = {}) {
           {content.heading}
         </h2>
         <p
-          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground"
+          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-body"
           {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
         >
           {content.body}
         </p>
 
         <div className="mt-10 flex justify-center">
-          <Button asChild size="lg">
+          <Button asChild size="lg" glow>
             <a
               href={content.primaryCta.href}
               {...(content.primaryCta.external

--- a/apps/marketing/app/components/for-operators/EngagementPricing.tsx
+++ b/apps/marketing/app/components/for-operators/EngagementPricing.tsx
@@ -39,7 +39,7 @@ export function EngagementPricing({ data, path, annotation }: EngagementPricingP
             {intro.heading}
           </h2>
           <p
-            className="mt-6 text-lg leading-8 text-muted-foreground"
+            className="mt-6 text-lg leading-8 text-body"
             {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
           >
             {intro.body}

--- a/apps/marketing/app/components/for-operators/Hero.tsx
+++ b/apps/marketing/app/components/for-operators/Hero.tsx
@@ -45,14 +45,14 @@ export function Hero({ data, path, annotation }: ServicesHeroProps = {}) {
         </h1>
 
         <p
-          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-body sm:text-xl"
           {...(base ? fieldAttrs(ann, `${base}.subtitle`) : {})}
         >
           {content.subtitle}
         </p>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-          <Button asChild size="lg" className="w-full sm:w-auto">
+          <Button asChild size="lg" glow className="w-full sm:w-auto">
             <a
               href={content.primaryCta.href}
               {...(content.primaryCta.external

--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -36,7 +36,7 @@ export function WhatYouGet({ data, path, annotation }: WhatYouGetProps = {}) {
             {content.heading}
           </h2>
           <p
-            className="mt-6 text-lg leading-8 text-muted-foreground"
+            className="mt-6 text-lg leading-8 text-body"
             {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
           >
             {content.body}

--- a/apps/marketing/app/components/landing/CostCalculator.tsx
+++ b/apps/marketing/app/components/landing/CostCalculator.tsx
@@ -67,7 +67,7 @@ export function CostCalculator() {
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {C.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{C.body}</p>
+          <p className="mt-6 text-lg leading-8 text-body">{C.body}</p>
         </div>
 
         <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -30,7 +30,7 @@ export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {}
             {data.heading}
           </h2>
           <p
-            className="mt-5 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-body"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -12,9 +12,8 @@ import { selectHomeHero } from '../../lib/hero-variant';
 import { AudienceToggle } from './AudienceToggle';
 
 // Shared trust strip (the signals the retired eyebrow pill used to carry).
-// Rendered above BOTH hero H1 variants and for both audiences, so the
-// "Local-first AI" chip lands without forking the ?hero=foundation A/B or
-// adding a third hero variant (positioning decision d).
+// Rendered for both audiences. Separators (not brand dots) keep chrome quiet —
+// Linear craft: limit decoration; hierarchy from type weight and spacing.
 const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as const;
 
 /**
@@ -24,16 +23,29 @@ const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as cons
  * to `--color-primary` rather than a literal color. Lives inside an
  * overflow-hidden box so the off-canvas offset never creates a scrollbar.
  * Reads in both light and dark.
- *
- * Craft pass 2026-08: lower opacity, smaller glow. Linear redesign lesson:
- * reduce chrome noise; let type and the receipt carry hierarchy.
  */
 function HeroBackground() {
   return (
     <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.03] via-background to-background" />
-      <div className="absolute -top-32 left-1/2 h-[520px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--color-primary),transparent_70%)] opacity-[0.07] blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.04] via-background to-background" />
+      <div className="absolute -top-32 left-1/2 h-[520px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--color-primary),transparent_70%)] opacity-[0.12] blur-3xl" />
     </div>
+  );
+}
+
+/** Trust strip: vertical rules between labels, no brand-dot decoration. */
+function TrustStrip() {
+  return (
+    <ul className="mt-8 flex flex-wrap items-center justify-center gap-y-2 text-sm text-body list-none p-0">
+      {TRUST_SIGNALS.map((signal, index) => (
+        <li key={signal} className="flex items-center">
+          {index > 0 ? (
+            <span aria-hidden="true" className="mx-3 h-3 w-px bg-border-strong sm:mx-4" />
+          ) : null}
+          <span>{signal}</span>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -41,16 +53,23 @@ function HeroBackground() {
 function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
   return (
     <>
-      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
+      {/*
+        Type ladder (P0 craft):
+        - H1 = text-foreground (ink, max contrast)
+        - subtitle = text-body (rvui-text-1) for long reading, not muted
+        - trust / captions = muted only when meta
+        SwipePages/SaaS LPs fail when body is grey-on-paper; text-body clears AA.
+      */}
+      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground text-balance sm:text-6xl lg:text-7xl">
         {hero.h1}
       </h1>
 
-      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:mt-8 sm:text-xl sm:leading-8">
+      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-body sm:mt-8 sm:text-xl">
         {hero.subtitle.sentence1} {hero.subtitle.sentence2} {hero.subtitle.support}
       </p>
 
-      <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
-        <Button asChild size="lg" className="w-full sm:w-auto gap-2">
+      <div className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3 sm:mt-10 sm:gap-4">
+        <Button asChild size="lg" glow className="w-full sm:w-auto gap-2">
           <a href={hero.cta.primary.href}>
             {hero.cta.primary.label}
             <IconArrowRight size="sm" />
@@ -70,15 +89,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         </Button>
       </div>
 
-      {/* Trust strip: quiet separators, not competing brand dots. */}
-      <ul className="mt-8 flex flex-wrap items-center justify-center gap-x-0 gap-y-2 text-sm text-muted-foreground list-none p-0">
-        {TRUST_SIGNALS.map((signal, index) => (
-          <li key={signal} className="flex items-center">
-            {index > 0 && <span aria-hidden="true" className="mx-3 h-3 w-px bg-border sm:mx-4" />}
-            <span>{signal}</span>
-          </li>
-        ))}
-      </ul>
+      <TrustStrip />
     </>
   );
 }
@@ -92,7 +103,7 @@ function NonTechnicalHero() {
   const hero = FOR_OPERATORS_HERO;
   return (
     <>
-      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
+      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground text-balance sm:text-6xl lg:text-7xl">
         {hero.h1Lines.map((line) => (
           <span key={line} className="block">
             {line}
@@ -100,12 +111,12 @@ function NonTechnicalHero() {
         ))}
       </h1>
 
-      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:mt-8 sm:text-xl sm:leading-8">
+      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-body sm:mt-8 sm:text-xl">
         {hero.subtitle}
       </p>
 
       <div className="mt-9 flex justify-center sm:mt-10">
-        <Button asChild size="lg" className="w-full sm:w-auto gap-2">
+        <Button asChild size="lg" glow className="w-full sm:w-auto gap-2">
           <a href={hero.primaryCta.href} target="_blank" rel="noopener noreferrer">
             {hero.primaryCta.label}
             <IconArrowRight size="sm" />
@@ -113,14 +124,7 @@ function NonTechnicalHero() {
         </Button>
       </div>
 
-      <ul className="mt-8 flex flex-wrap items-center justify-center gap-x-0 gap-y-2 text-sm text-muted-foreground list-none p-0">
-        {TRUST_SIGNALS.map((signal, index) => (
-          <li key={signal} className="flex items-center">
-            {index > 0 && <span aria-hidden="true" className="mx-3 h-3 w-px bg-border sm:mx-4" />}
-            <span>{signal}</span>
-          </li>
-        ))}
-      </ul>
+      <TrustStrip />
     </>
   );
 }
@@ -145,8 +149,7 @@ export function Hero() {
         </div>
 
         {/* Receipt-motif moment (frontend-excellence Phase 5): one orchestrated
-            print entrance. Signature creative element only (Linear craft: one
-            moment, not competing chrome). */}
+            print entrance, shared verbatim by both audience variants. */}
         <div className="mt-12 w-full max-w-md min-w-0 mx-auto text-left sm:mt-14 sm:max-w-lg">
           <ReceiptCard
             title={RECEIPT_HERO_TITLE}
@@ -154,11 +157,11 @@ export function Hero() {
             integrity={RECEIPT_HERO_INTEGRITY}
             animate="print"
           />
-          <p className="mt-4 text-center text-sm text-muted-foreground">
+          <p className="mt-4 text-center text-sm text-body">
             {RECEIPT_HERO_CAPTION.text}{' '}
             <Link
               to={RECEIPT_HERO_CAPTION.link.href}
-              className="text-foreground underline underline-offset-4 hover:text-primary"
+              className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
             >
               {RECEIPT_HERO_CAPTION.link.label}
             </Link>

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -55,9 +55,7 @@ export function PricingTeaser() {
           <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PRICING_TEASER_SECTION.heading}
           </h2>
-          <p className="mt-5 text-lg leading-8 text-muted-foreground">
-            {PRICING_TEASER_SECTION.body}
-          </p>
+          <p className="mt-5 text-lg leading-8 text-body">{PRICING_TEASER_SECTION.body}</p>
         </div>
 
         <div className="mx-auto mt-14 grid max-w-3xl grid-cols-1 gap-5 sm:mt-16 sm:grid-cols-2 sm:gap-6">

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -71,7 +71,7 @@ export function Primitives({
             {data.heading}
           </h2>
           <p
-            className="mt-5 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-body"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -56,7 +56,7 @@ export function Problem() {
           <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {HOME_PROBLEM.heading}
           </h2>
-          <p className="mt-5 text-lg leading-8 text-muted-foreground">{HOME_PROBLEM.body}</p>
+          <p className="mt-5 text-lg leading-8 text-body">{HOME_PROBLEM.body}</p>
         </div>
 
         {/* Path blurbs: three quiet lines under the intro, not three cards. */}

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -14,7 +14,7 @@ export function Proof() {
           <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PROOF_SECTION.heading}
           </h2>
-          <p className="mt-5 text-lg leading-8 text-muted-foreground">{PROOF_SECTION.body}</p>
+          <p className="mt-5 text-lg leading-8 text-body">{PROOF_SECTION.body}</p>
 
           <div className="mt-6 flex justify-center">
             <a
@@ -66,8 +66,8 @@ export function Proof() {
           <h3 className="mt-3 font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
             {PROOF_DEPLOYERS.heading}
           </h3>
-          <p className="mt-4 text-base leading-7 text-muted-foreground">{PROOF_DEPLOYERS.body}</p>
-          <p className="mt-4 text-sm leading-6 text-muted-foreground">{PROOF_DEPLOYERS.foil}</p>
+          <p className="mt-4 text-base leading-7 text-body">{PROOF_DEPLOYERS.body}</p>
+          <p className="mt-4 text-sm leading-6 text-body">{PROOF_DEPLOYERS.foil}</p>
           <div className="mt-8">
             <Button asChild size="default" className="items-center justify-center">
               <a href={PROOF_DEPLOYERS.cta.href} target="_blank" rel="noopener noreferrer">

--- a/apps/marketing/app/components/products/ProductsCta.tsx
+++ b/apps/marketing/app/components/products/ProductsCta.tsx
@@ -25,10 +25,7 @@ export function ProductsCta({
         >
           {data.heading}
         </h2>
-        <p
-          className="mt-6 text-lg leading-8 text-muted-foreground"
-          {...fieldAttrs(annotation, `${path}.body`)}
-        >
+        <p className="mt-6 text-lg leading-8 text-body" {...fieldAttrs(annotation, `${path}.body`)}>
           {data.body}
         </p>
         <div

--- a/apps/marketing/app/components/products/ProductsHero.tsx
+++ b/apps/marketing/app/components/products/ProductsHero.tsx
@@ -32,7 +32,7 @@ export function ProductsHero({
           {data.h1}
         </h1>
         <p
-          className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl"
           {...fieldAttrs(annotation, `${path}.subtitle`)}
         >
           {data.subtitle}

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -86,7 +86,7 @@ export function BlogIndexPage() {
           <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             Blog
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
             Updates, guides, and insights from the RevealUI team.
           </p>
         </div>

--- a/apps/marketing/app/routes/ContactPage.tsx
+++ b/apps/marketing/app/routes/ContactPage.tsx
@@ -11,7 +11,7 @@ export function ContactPage() {
             <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
               {CONTACT_HERO.title}
             </h1>
-            <p className="mt-6 text-lg leading-8 text-muted-foreground">{CONTACT_HERO.subtitle}</p>
+            <p className="mt-6 text-lg leading-8 text-body">{CONTACT_HERO.subtitle}</p>
           </div>
 
           <ContactForm />

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -381,10 +381,7 @@ function FairSourceCta({ data, path, annotation }: CtaProps) {
         >
           {data.heading}
         </h2>
-        <p
-          className="mt-6 text-lg leading-8 text-muted-foreground"
-          {...fieldAttrs(annotation, `${path}.body`)}
-        >
+        <p className="mt-6 text-lg leading-8 text-body" {...fieldAttrs(annotation, `${path}.body`)}>
           {data.body}
         </p>
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -451,7 +448,7 @@ export function FairSourcePage() {
             {FAIR_SOURCE_HERO.headline}
             <span className="block text-primary">{FAIR_SOURCE_HERO.headlineHighlight}</span>
           </h1>
-          <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-muted-foreground sm:text-2xl">
+          <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-body sm:text-2xl">
             {FAIR_SOURCE_HERO.subhead}
           </p>
           <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -45,7 +45,7 @@ function LocalAiHero({ data, path, annotation }: LocalAiHeroProps) {
           {data.h1}
         </h1>
         <p
-          className="mt-6 text-lg leading-8 text-muted-foreground"
+          className="mt-6 text-lg leading-8 text-body"
           {...fieldAttrs(annotation, `${path}.subtitle`)}
         >
           {data.lead}

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -74,7 +74,7 @@ function PhilosophyBody({ data, path, annotation }: PhilosophyBodyProps) {
           return (
             <p
               key={`body-${index}`}
-              className="text-lg leading-8 text-muted-foreground"
+              className="text-lg leading-8 text-body"
               {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
             >
               {section.body}

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -111,7 +111,7 @@ export function PricingPage() {
               RevealUI
             </span>
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
             {PRICING_HERO.subtitle}
           </p>
           <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
@@ -650,9 +650,7 @@ export function PricingPage() {
           <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PRICING_FINAL_CTA.title}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">
-            {PRICING_FINAL_CTA.subtitle}
-          </p>
+          <p className="mt-6 text-lg leading-8 text-body">{PRICING_FINAL_CTA.subtitle}</p>
           <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Button asChild size="lg" className="w-full sm:w-auto">
               <a

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -63,7 +63,7 @@ export function RoadmapPage() {
               Roadmap
             </span>
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
             {ROADMAP_HERO.subtitle} See our{' '}
             <a
               href={ROADMAP_HERO_LINK.href}


### PR DESCRIPTION
## Summary

Raises marketing homepage reading contrast without changing locked copy (L1 H1 + positioning subtitle).

- Hero subtitle and section intros use `text-body` (`--rvui-text-1`) instead of `text-muted-foreground` for long-form reading
- H1 stays `text-foreground` (ink)
- Primary CTAs use brand `glow` for emphasis
- Trust strip uses quiet separators (no primary dots)
- Receipt caption link is stronger (`font-medium text-foreground`)

Grounded in SaaS LP craft research (SwipePages, Linear, Stripe/Shopify patterns): hierarchy via type weight and contrast, not decoration.

## Test plan

- [x] `vitest` Hero + Problem + hero-variant (17 tests)
- [x] `pnpm gate --phase=1 --changed` green
- [x] `turbo build --filter=marketing...` green
- [ ] Visual check on light + dark OS: hero H1 ink, subtitle readable, CTA glow
- [ ] Confirm trust strip separators render cleanly

## Notes

Copy is unchanged. Design-code Loop A re-push still pending after merge for Claude Design kits.