### PR TITLE
promote: test → main

### DIFF
--- a/.github/workflows/ds.yml
+++ b/.github/workflows/ds.yml
@@ -51,6 +51,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Runner flake seen on promote PRs: git fetch fails with
+      # "server certificate verification failed. CAfile: none". Ensure the
+      # system CA bundle is present and exported before checkout (checkout
+      # already retries, but retries without CAs still fail).
+      - name: Ensure git SSL CA bundle
+        run: |
+          set -euo pipefail
+          CA=/etc/ssl/certs/ca-certificates.crt
+          if [ ! -s "$CA" ]; then
+            sudo apt-get update -qq
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates
+            sudo update-ca-certificates
+          fi
+          test -s "$CA"
+          {
+            echo "SSL_CERT_FILE=$CA"
+            echo "GIT_SSL_CAINFO=$CA"
+            echo "CURL_CA_BUNDLE=$CA"
+            echo "REQUESTS_CA_BUNDLE=$CA"
+          } >> "$GITHUB_ENV"
+          git config --global http.sslCAInfo "$CA"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -76,6 +97,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Runner flake seen on promote PRs: git fetch fails with
+      # "server certificate verification failed. CAfile: none". Ensure the
+      # system CA bundle is present and exported before checkout (checkout
+      # already retries, but retries without CAs still fail).
+      - name: Ensure git SSL CA bundle
+        run: |
+          set -euo pipefail
+          CA=/etc/ssl/certs/ca-certificates.crt
+          if [ ! -s "$CA" ]; then
+            sudo apt-get update -qq
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates
+            sudo update-ca-certificates
+          fi
+          test -s "$CA"
+          {
+            echo "SSL_CERT_FILE=$CA"
+            echo "GIT_SSL_CAINFO=$CA"
+            echo "CURL_CA_BUNDLE=$CA"
+            echo "REQUESTS_CA_BUNDLE=$CA"
+          } >> "$GITHUB_ENV"
+          git config --global http.sslCAInfo "$CA"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -102,6 +144,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # Runner flake seen on promote PRs: git fetch fails with
+      # "server certificate verification failed. CAfile: none". Ensure the
+      # system CA bundle is present and exported before checkout (checkout
+      # already retries, but retries without CAs still fail).
+      - name: Ensure git SSL CA bundle
+        run: |
+          set -euo pipefail
+          CA=/etc/ssl/certs/ca-certificates.crt
+          if [ ! -s "$CA" ]; then
+            sudo apt-get update -qq
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates
+            sudo update-ca-certificates
+          fi
+          test -s "$CA"
+          {
+            echo "SSL_CERT_FILE=$CA"
+            echo "GIT_SSL_CAINFO=$CA"
+            echo "CURL_CA_BUNDLE=$CA"
+            echo "REQUESTS_CA_BUNDLE=$CA"
+          } >> "$GITHUB_ENV"
+          git config --global http.sslCAInfo "$CA"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -129,6 +192,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Runner flake seen on promote PRs: git fetch fails with
+      # "server certificate verification failed. CAfile: none". Ensure the
+      # system CA bundle is present and exported before checkout (checkout
+      # already retries, but retries without CAs still fail).
+      - name: Ensure git SSL CA bundle
+        run: |
+          set -euo pipefail
+          CA=/etc/ssl/certs/ca-certificates.crt
+          if [ ! -s "$CA" ]; then
+            sudo apt-get update -qq
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates
+            sudo update-ca-certificates
+          fi
+          test -s "$CA"
+          {
+            echo "SSL_CERT_FILE=$CA"
+            echo "GIT_SSL_CAINFO=$CA"
+            echo "CURL_CA_BUNDLE=$CA"
+            echo "REQUESTS_CA_BUNDLE=$CA"
+          } >> "$GITHUB_ENV"
+          git config --global http.sslCAInfo "$CA"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -184,6 +268,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Runner flake seen on promote PRs: git fetch fails with
+      # "server certificate verification failed. CAfile: none". Ensure the
+      # system CA bundle is present and exported before checkout (checkout
+      # already retries, but retries without CAs still fail).
+      - name: Ensure git SSL CA bundle
+        run: |
+          set -euo pipefail
+          CA=/etc/ssl/certs/ca-certificates.crt
+          if [ ! -s "$CA" ]; then
+            sudo apt-get update -qq
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates
+            sudo update-ca-certificates
+          fi
+          test -s "$CA"
+          {
+            echo "SSL_CERT_FILE=$CA"
+            echo "GIT_SSL_CAINFO=$CA"
+            echo "CURL_CA_BUNDLE=$CA"
+            echo "REQUESTS_CA_BUNDLE=$CA"
+          } >> "$GITHUB_ENV"
+          git config --global http.sslCAInfo "$CA"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -63,9 +63,9 @@ POSTGRES_URL=postgresql://user:password@host/dbname?sslmode=require
 # ElectricSQL (real-time sync — optional)
 # -----------------------------------------------------------------------------
 ELECTRIC_SERVICE_URL=http://localhost:3000
-# Electric Cloud credentials (required when using Electric Cloud, not self-hosted)
-# ELECTRIC_SOURCE_ID=your-electric-source-id
+# Optional shared secret for self-hosted Electric (ELECTRIC_SECRET on the Electric service)
 # ELECTRIC_SECRET=your-electric-secret
+# ELECTRIC_SOURCE_ID — do not set; legacy Electric Cloud only (Cloud retired 2026-08)
 
 # -----------------------------------------------------------------------------
 # Storage — Cloudflare R2 (S3-compatible; required for file uploads)

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -195,6 +195,10 @@ const nextConfig = {
       )
       return []
     }
+    // Same-origin /a2a proxy: admin UI used to call api.revealui.com cross-origin
+    // with credentials. Host-only session cookies (or any Domain mismatch) never
+    // reach the API, so requireFeature('ai') saw tier free and blocked create/
+    // task routes. Browser → admin /a2a → rewrite → API forwards Cookie.
     return [
       {
         source: '/api/agent-stream',
@@ -203,6 +207,14 @@ const nextConfig = {
       {
         source: '/api/agent-stream/:path*',
         destination: `${apiUrl}/api/agent-stream/:path*`,
+      },
+      {
+        source: '/a2a',
+        destination: `${apiUrl}/a2a`,
+      },
+      {
+        source: '/a2a/:path*',
+        destination: `${apiUrl}/a2a/:path*`,
       },
     ]
   },

--- a/apps/admin/src/__tests__/api/memory-search.test.ts
+++ b/apps/admin/src/__tests__/api/memory-search.test.ts
@@ -26,6 +26,20 @@ vi.mock('@revealui/core/features', () => ({
   isFeatureEnabled: vi.fn().mockReturnValue(true),
 }));
 
+vi.mock('@revealui/db/client', () => ({
+  getClient: vi.fn(() => {
+    throw new Error('no database in unit test');
+  }),
+}));
+
+vi.mock('@/lib/access/account-feature', () => ({
+  accountHasFeature: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('@revealui/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
 vi.mock('@revealui/core/observability/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));

--- a/apps/admin/src/__tests__/api/sync-routes.test.ts
+++ b/apps/admin/src/__tests__/api/sync-routes.test.ts
@@ -126,7 +126,7 @@ describe('POST /api/sync/agent-memories', () => {
 
   it('returns 403 when AI feature gate is active', async () => {
     mockGetSession.mockResolvedValue(makeSession());
-    mockCheckAIFeatureGate.mockReturnValue(
+    mockCheckAIFeatureGate.mockResolvedValue(
       new Response(JSON.stringify({ error: 'AI features require a Pro license' }), { status: 403 }),
     );
     const req = makeRequest('http://localhost/api/sync/agent-memories', 'POST', {});
@@ -135,7 +135,7 @@ describe('POST /api/sync/agent-memories', () => {
   });
 
   it('returns 401 when not authenticated', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(null);
     const req = makeRequest('http://localhost/api/sync/agent-memories', 'POST', {});
     const res = await memoriesPost(req);
@@ -143,7 +143,7 @@ describe('POST /api/sync/agent-memories', () => {
   });
 
   it('returns 400 for invalid agent_id', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const req = makeRequest('http://localhost/api/sync/agent-memories', 'POST', {
       agent_id: 'bad agent!',
@@ -157,7 +157,7 @@ describe('POST /api/sync/agent-memories', () => {
   });
 
   it('returns 400 for invalid memory type', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const req = makeRequest('http://localhost/api/sync/agent-memories', 'POST', {
       agent_id: 'agent-1',
@@ -171,7 +171,7 @@ describe('POST /api/sync/agent-memories', () => {
   });
 
   it('returns 400 when source is not an object', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const req = makeRequest('http://localhost/api/sync/agent-memories', 'POST', {
       agent_id: 'agent-1',
@@ -185,7 +185,7 @@ describe('POST /api/sync/agent-memories', () => {
   });
 
   it('returns 201 with created memory on success', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const created = { id: VALID_UUID, agentId: 'agent-1', content: 'text', type: 'fact' };
     // selectRows: ownership check returns a site owned by user-1
@@ -214,7 +214,7 @@ describe('PATCH /api/sync/agent-memories/:id', () => {
 
   it('returns 403 when AI gate is active', async () => {
     mockGetSession.mockResolvedValue(makeSession());
-    mockCheckAIFeatureGate.mockReturnValue(
+    mockCheckAIFeatureGate.mockResolvedValue(
       new Response(JSON.stringify({ error: 'AI features require a Pro license' }), { status: 403 }),
     );
     const req = makeRequest(`http://localhost/api/sync/agent-memories/${VALID_UUID}`, 'PATCH', {});
@@ -223,7 +223,7 @@ describe('PATCH /api/sync/agent-memories/:id', () => {
   });
 
   it('returns 401 when not authenticated', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(null);
     const req = makeRequest(`http://localhost/api/sync/agent-memories/${VALID_UUID}`, 'PATCH', {});
     const res = await memoriesPatch(req, { params: Promise.resolve({ id: VALID_UUID }) });
@@ -231,7 +231,7 @@ describe('PATCH /api/sync/agent-memories/:id', () => {
   });
 
   it('returns 400 for invalid UUID', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const req = makeRequest('http://localhost/api/sync/agent-memories/not-a-uuid', 'PATCH', {
       content: 'updated',
@@ -241,7 +241,7 @@ describe('PATCH /api/sync/agent-memories/:id', () => {
   });
 
   it('returns 400 when no fields to update', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const chain = makeDbChain([]);
     mockGetClient.mockReturnValue(chain);
@@ -255,7 +255,7 @@ describe('PATCH /api/sync/agent-memories/:id', () => {
   });
 
   it('returns 404 when memory not found', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const chain = makeDbChain([]); // empty → no rows returned
     mockGetClient.mockReturnValue(chain);
@@ -267,7 +267,7 @@ describe('PATCH /api/sync/agent-memories/:id', () => {
   });
 
   it('returns 200 on success', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const updated = { id: VALID_UUID, content: 'updated' };
     const chain = makeDbChain([updated]);
@@ -288,7 +288,7 @@ describe('DELETE /api/sync/agent-memories/:id', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 401 when not authenticated', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(null);
     const req = new NextRequest(`http://localhost/api/sync/agent-memories/${VALID_UUID}`, {
       method: 'DELETE',
@@ -298,7 +298,7 @@ describe('DELETE /api/sync/agent-memories/:id', () => {
   });
 
   it('returns 404 when memory not found', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const chain = makeDbChain([]);
     mockGetClient.mockReturnValue(chain);
@@ -310,7 +310,7 @@ describe('DELETE /api/sync/agent-memories/:id', () => {
   });
 
   it('returns 200 on success', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const chain = makeDbChain([{ id: VALID_UUID }]);
     mockGetClient.mockReturnValue(chain);
@@ -333,7 +333,7 @@ describe('POST /api/sync/agent-contexts', () => {
 
   it('returns 403 when AI gate is active', async () => {
     mockGetSession.mockResolvedValue(makeSession());
-    mockCheckAIFeatureGate.mockReturnValue(
+    mockCheckAIFeatureGate.mockResolvedValue(
       new Response(JSON.stringify({ error: 'AI features require a Pro license' }), { status: 403 }),
     );
     const req = makeRequest('http://localhost/api/sync/agent-contexts', 'POST', {});
@@ -342,7 +342,7 @@ describe('POST /api/sync/agent-contexts', () => {
   });
 
   it('returns 400 for priority out of range', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const req = makeRequest('http://localhost/api/sync/agent-contexts', 'POST', {
       agent_id: 'agent-1',
@@ -353,7 +353,7 @@ describe('POST /api/sync/agent-contexts', () => {
   });
 
   it('returns 201 on successful upsert', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const created = { id: 'sess-1:agent-1', sessionId: 'sess-1', agentId: 'agent-1' };
     const chain = makeDbChain([created]);
@@ -376,7 +376,7 @@ describe('PATCH /api/sync/agent-contexts/:id', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 401 when not authenticated', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(null);
     const req = makeRequest('http://localhost/api/sync/agent-contexts/ctx-1', 'PATCH', {});
     const res = await contextsPatch(req, { params: Promise.resolve({ id: 'ctx-1' }) });
@@ -384,7 +384,7 @@ describe('PATCH /api/sync/agent-contexts/:id', () => {
   });
 
   it('returns 400 for priority out of range', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const req = makeRequest('http://localhost/api/sync/agent-contexts/ctx-1', 'PATCH', {
       priority: -0.1,
@@ -394,7 +394,7 @@ describe('PATCH /api/sync/agent-contexts/:id', () => {
   });
 
   it('returns 404 when context not found for this session', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const chain = makeDbChain([]);
     mockGetClient.mockReturnValue(chain);
@@ -406,7 +406,7 @@ describe('PATCH /api/sync/agent-contexts/:id', () => {
   });
 
   it('returns 200 on success', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const chain = makeDbChain([{ id: 'ctx-1' }]);
     mockGetClient.mockReturnValue(chain);
@@ -426,7 +426,7 @@ describe('DELETE /api/sync/agent-contexts/:id', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 404 when context not found for this session', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const chain = makeDbChain([]);
     mockGetClient.mockReturnValue(chain);
@@ -438,7 +438,7 @@ describe('DELETE /api/sync/agent-contexts/:id', () => {
   });
 
   it('returns 200 on success', async () => {
-    mockCheckAIFeatureGate.mockReturnValue(null);
+    mockCheckAIFeatureGate.mockResolvedValue(null);
     mockGetSession.mockResolvedValue(makeSession());
     const chain = makeDbChain([{ id: 'ctx-1' }]);
     mockGetClient.mockReturnValue(chain);

--- a/apps/admin/src/__tests__/api/sync-routes.test.ts
+++ b/apps/admin/src/__tests__/api/sync-routes.test.ts
@@ -125,6 +125,7 @@ describe('POST /api/sync/agent-memories', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 403 when AI feature gate is active', async () => {
+    mockGetSession.mockResolvedValue(makeSession());
     mockCheckAIFeatureGate.mockReturnValue(
       new Response(JSON.stringify({ error: 'AI features require a Pro license' }), { status: 403 }),
     );
@@ -212,6 +213,7 @@ describe('PATCH /api/sync/agent-memories/:id', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 403 when AI gate is active', async () => {
+    mockGetSession.mockResolvedValue(makeSession());
     mockCheckAIFeatureGate.mockReturnValue(
       new Response(JSON.stringify({ error: 'AI features require a Pro license' }), { status: 403 }),
     );
@@ -330,6 +332,7 @@ describe('POST /api/sync/agent-contexts', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 403 when AI gate is active', async () => {
+    mockGetSession.mockResolvedValue(makeSession());
     mockCheckAIFeatureGate.mockReturnValue(
       new Response(JSON.stringify({ error: 'AI features require a Pro license' }), { status: 403 }),
     );

--- a/apps/admin/src/__tests__/integration/api/chat.test.ts
+++ b/apps/admin/src/__tests__/integration/api/chat.test.ts
@@ -47,7 +47,7 @@ vi.mock('@revealui/auth/server', () => ({
 }));
 
 vi.mock('@/lib/middleware/ai-feature-gate', () => ({
-  checkAIFeatureGate: vi.fn().mockReturnValue(null),
+  checkAIFeatureGate: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@revealui/db', () => ({

--- a/apps/admin/src/app/(backend)/agent-tasks/page.tsx
+++ b/apps/admin/src/app/(backend)/agent-tasks/page.tsx
@@ -95,31 +95,29 @@ function AgentTasksDashboard() {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { tasks, loading, error, statusFilter, dateFilter, expandedId } = state;
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
   useEffect(() => {
     let cancelled = false;
     dispatch({ type: 'FETCH_START' });
 
     (async () => {
       try {
-        // Fetch tasks from all registered agents
-        const agentsRes = await fetch(`${apiUrl}/a2a/agents`, { credentials: 'include' });
+        // Fetch tasks from all registered agents (same-origin /a2a rewrite).
+        const agentsRes = await fetch('/a2a/agents', { credentials: 'include' });
         if (!agentsRes.ok) throw new Error('Failed to load agents');
 
-        const agentsData = (await agentsRes.json()) as { agents: Array<{ name: string }> };
-        const agentNames = (agentsData.agents ?? []).map((a) =>
-          a.name
-            .toLowerCase()
-            .replace(/\s+/g, '-')
-            .replace(/[^a-z0-9-]/g, ''),
-        );
+        const agentsData = (await agentsRes.json()) as {
+          agents: Array<{ id?: string; name: string }>;
+        };
+        // Registry id from API only — do not slugify display names.
+        const agentIds = (agentsData.agents ?? [])
+          .map((a) => (typeof a.id === 'string' && a.id.length > 0 ? a.id : null))
+          .filter((id): id is string => id !== null);
 
         // Fetch tasks from each agent in parallel
         const allTasks: AgentTask[] = [];
         const results = await Promise.allSettled(
-          agentNames.map(async (agentId) => {
-            const res = await fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}/tasks`, {
+          agentIds.map(async (agentId) => {
+            const res = await fetch(`/a2a/agents/${encodeURIComponent(agentId)}/tasks`, {
               credentials: 'include',
             });
             if (!res.ok) return [];
@@ -152,7 +150,7 @@ function AgentTasksDashboard() {
     return () => {
       cancelled = true;
     };
-  }, [apiUrl]);
+  }, []);
 
   const dateThreshold: Date | null = (() => {
     if (dateFilter === 'all') return null;

--- a/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
@@ -57,9 +57,11 @@ export default function AgentDetailPage({ params }: PageProps) {
   const [retireError, setRetireError] = useState<string | null>(null);
 
   const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
+  // Same-origin /a2a rewrite → API (session cookie authenticates feature gates).
+  const a2aBase = '/a2a';
 
   useEffect(() => {
-    fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, { credentials: 'include' })
+    fetch(`${a2aBase}/agents/${encodeURIComponent(agentId)}`, { credentials: 'include' })
       .then((r) => {
         if (!r.ok) throw new Error(`Agent '${agentId}' not found`);
         return r.json();
@@ -72,13 +74,13 @@ export default function AgentDetailPage({ params }: PageProps) {
         );
       })
       .finally(() => setLoading(false));
-  }, [agentId, apiUrl]);
+  }, [agentId]);
 
   async function handleEditStart() {
     setLoadingDef(true);
     setSaveError(null);
     try {
-      const res = await fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}/def`, {
+      const res = await fetch(`${a2aBase}/agents/${encodeURIComponent(agentId)}/def`, {
         credentials: 'include',
       });
       if (!res.ok) throw new Error('Unable to load agent definition');
@@ -106,7 +108,7 @@ export default function AgentDetailPage({ params }: PageProps) {
     setRetiring(true);
     setRetireError(null);
     try {
-      const res = await apiFetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, {
+      const res = await apiFetch(`${a2aBase}/agents/${encodeURIComponent(agentId)}`, {
         method: 'DELETE',
         credentials: 'include',
       });
@@ -130,7 +132,7 @@ export default function AgentDetailPage({ params }: PageProps) {
     setSaving(true);
     setSaveError(null);
     try {
-      const res = await apiFetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}`, {
+      const res = await apiFetch(`${a2aBase}/agents/${encodeURIComponent(agentId)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/app/(backend)/agents/agents-client.tsx
+++ b/apps/admin/src/app/(backend)/agents/agents-client.tsx
@@ -77,19 +77,20 @@ function AgentCardsPanel() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
   useEffect(() => {
-    fetch(`${apiUrl}/a2a/agents`, { credentials: 'include' })
+    // Same-origin /a2a (admin rewrite → API) so the session cookie authenticates.
+    fetch('/a2a/agents', { credentials: 'include' })
       .then((r) => r.json())
-      .then((data: { agents: A2AAgentCard[] }) => {
-        const withIds: AgentWithId[] = (data.agents ?? []).map((card) => ({
-          card,
-          agentId: card.name
-            .toLowerCase()
-            .replace(/\s+/g, '-')
-            .replace(/[^a-z0-9-]/g, ''),
-        }));
+      .then((data: { agents: Array<A2AAgentCard & { id?: string }> }) => {
+        // Prefer registry id from the API. Never invent ids from display names
+        // ("Ticket Agent" must not become "ticket-agent").
+        const withIds: AgentWithId[] = (data.agents ?? [])
+          .map((row) => {
+            if (typeof row.id !== 'string' || row.id.length === 0) return null;
+            const { id, ...cardFields } = row;
+            return { card: cardFields as A2AAgentCard, agentId: id };
+          })
+          .filter((row): row is AgentWithId => row !== null);
         setAgents(withIds);
       })
       .catch((e: unknown) => {
@@ -99,7 +100,7 @@ function AgentCardsPanel() {
         );
       })
       .finally(() => setLoading(false));
-  }, [apiUrl]);
+  }, []);
 
   if (loading) {
     return (

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -157,7 +157,6 @@ function formReducer(state: FormState, action: FormAction): FormState {
 
 export default function NewAgentPage() {
   const router = useRouter();
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
 
   const [state, dispatch] = useReducer(formReducer, initialState);
   const { selectedTemplate, name, description, systemPrompt, submitting, error } = state;
@@ -238,7 +237,8 @@ export default function NewAgentPage() {
     };
 
     try {
-      const res = await apiFetch(`${apiUrl}/a2a/agents`, {
+      // Same-origin /a2a rewrite so admin session cookie reaches the API feature gate.
+      const res = await apiFetch('/a2a/agents', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/apps/admin/src/app/api/chat/route.ts
+++ b/apps/admin/src/app/api/chat/route.ts
@@ -187,7 +187,7 @@ export async function POST(request: NextRequest) {
       headers: { 'Content-Type': 'application/json' },
     });
   }
-  const aiGate = checkAIFeatureGate();
+  const aiGate = await checkAIFeatureGate(authSession.user.id);
   if (aiGate) return aiGate;
 
   try {

--- a/apps/admin/src/app/api/conversations/[id]/messages/route.ts
+++ b/apps/admin/src/app/api/conversations/[id]/messages/route.ts
@@ -22,7 +22,7 @@ interface RouteParams {
 export async function GET(request: NextRequest, { params }: RouteParams) {
   const session = await getSession(request.headers, extractRequestContext(request));
   if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
-  const aiGate = checkAIFeatureGate();
+  const aiGate = await checkAIFeatureGate(session.user.id);
   if (aiGate) return aiGate;
 
   const { id } = await params;
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 export async function POST(request: NextRequest, { params }: RouteParams) {
   const session = await getSession(request.headers, extractRequestContext(request));
   if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
-  const aiGate = checkAIFeatureGate();
+  const aiGate = await checkAIFeatureGate(session.user.id);
   if (aiGate) return aiGate;
 
   const { id } = await params;

--- a/apps/admin/src/app/api/conversations/[id]/route.ts
+++ b/apps/admin/src/app/api/conversations/[id]/route.ts
@@ -27,7 +27,7 @@ interface RouteParams {
 export async function GET(request: NextRequest, { params }: RouteParams) {
   const session = await getSession(request.headers, extractRequestContext(request));
   if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
-  const aiGate = checkAIFeatureGate();
+  const aiGate = await checkAIFeatureGate(session.user.id);
   if (aiGate) return aiGate;
 
   const { id } = await params;
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 export async function PATCH(request: NextRequest, { params }: RouteParams) {
   const session = await getSession(request.headers, extractRequestContext(request));
   if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
-  const aiGate = checkAIFeatureGate();
+  const aiGate = await checkAIFeatureGate(session.user.id);
   if (aiGate) return aiGate;
 
   const { id } = await params;
@@ -58,7 +58,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   const session = await getSession(request.headers, extractRequestContext(request));
   if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 });
-  const aiGate = checkAIFeatureGate();
+  const aiGate = await checkAIFeatureGate(session.user.id);
   if (aiGate) return aiGate;
 
   const { id } = await params;

--- a/apps/admin/src/app/api/conversations/__tests__/conversation-routes.test.ts
+++ b/apps/admin/src/app/api/conversations/__tests__/conversation-routes.test.ts
@@ -9,7 +9,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetSession = vi.fn();
 const mockIsFeatureEnabled = vi.fn();
-const mockGetClient = vi.fn();
+const mockGetClient = vi.fn(() => ({}));
+const mockAccountHasFeature = vi.fn();
 const mockGetConversations = vi.fn();
 const mockCreateConversation = vi.fn();
 const mockGetConversationById = vi.fn();
@@ -26,8 +27,17 @@ vi.mock('@revealui/core/features', () => ({
   isFeatureEnabled: (...args: unknown[]) => mockIsFeatureEnabled(...args),
 }));
 
+// Gate imports getClient from @revealui/db/client (not @revealui/db).
+vi.mock('@revealui/db/client', () => ({
+  getClient: () => mockGetClient(),
+}));
+
 vi.mock('@revealui/db', () => ({
   getClient: () => mockGetClient(),
+}));
+
+vi.mock('@/lib/access/account-feature', () => ({
+  accountHasFeature: (...args: unknown[]) => mockAccountHasFeature(...args),
 }));
 
 vi.mock('@revealui/db/queries/conversations', () => ({
@@ -62,6 +72,8 @@ function makeRequest(opts: { searchParams?: Record<string, string>; body?: unkno
 describe('GET /api/conversations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockGetClient.mockReturnValue({});
   });
 
   async function loadRoute() {
@@ -80,6 +92,7 @@ describe('GET /api/conversations', () => {
 
   it('returns 403 when AI features disabled', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockAccountHasFeature.mockResolvedValue(false);
     mockIsFeatureEnabled.mockReturnValue(false);
     const GET = await loadRoute();
     const res = await GET(makeRequest());
@@ -89,7 +102,6 @@ describe('GET /api/conversations', () => {
   it('returns paginated conversations', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'u1' } });
     mockIsFeatureEnabled.mockReturnValue(true);
-    mockGetClient.mockReturnValue({});
     mockGetConversations.mockResolvedValue([{ id: 'c1', title: 'Test' }]);
 
     const GET = await loadRoute();
@@ -125,6 +137,8 @@ describe('GET /api/conversations', () => {
 describe('POST /api/conversations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockGetClient.mockReturnValue({});
   });
 
   async function loadRoute() {
@@ -142,7 +156,6 @@ describe('POST /api/conversations', () => {
   it('creates conversation and returns 201', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'u1' } });
     mockIsFeatureEnabled.mockReturnValue(true);
-    mockGetClient.mockReturnValue({});
     mockCreateConversation.mockResolvedValue({ id: 'c-new', title: 'New Chat' });
 
     const POST = await loadRoute();
@@ -159,6 +172,8 @@ describe('POST /api/conversations', () => {
 describe('GET /api/conversations/:id', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockGetClient.mockReturnValue({});
   });
 
   async function loadRoute() {
@@ -195,6 +210,8 @@ describe('GET /api/conversations/:id', () => {
 describe('PATCH /api/conversations/:id', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockGetClient.mockReturnValue({});
   });
 
   async function loadRoute() {
@@ -231,6 +248,8 @@ describe('PATCH /api/conversations/:id', () => {
 describe('DELETE /api/conversations/:id', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockGetClient.mockReturnValue({});
   });
 
   async function loadRoute() {
@@ -269,6 +288,8 @@ describe('DELETE /api/conversations/:id', () => {
 describe('GET /api/conversations/:id/messages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockGetClient.mockReturnValue({});
   });
 
   async function loadRoute() {
@@ -306,6 +327,8 @@ describe('GET /api/conversations/:id/messages', () => {
 describe('POST /api/conversations/:id/messages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockGetClient.mockReturnValue({});
   });
 
   async function loadRoute() {

--- a/apps/admin/src/app/api/conversations/route.ts
+++ b/apps/admin/src/app/api/conversations/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest) {
   if (!session) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const aiGate = checkAIFeatureGate();
+  const aiGate = await checkAIFeatureGate(session.user.id);
   if (aiGate) return aiGate;
 
   const db = getClient();
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
   if (!session) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const aiGate = checkAIFeatureGate();
+  const aiGate = await checkAIFeatureGate(session.user.id);
   if (aiGate) return aiGate;
 
   const body = (await request.json()) as { title?: string };

--- a/apps/admin/src/app/api/kg/repos/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/kg/repos/__tests__/route.test.ts
@@ -10,8 +10,8 @@ vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock('@revealui/core/features', () => ({
-  isFeatureEnabled: vi.fn().mockReturnValue(true),
+vi.mock('@/lib/middleware/ai-feature-gate', () => ({
+  checkAIFeatureGate: vi.fn().mockResolvedValue(null),
 }));
 
 const mockOrderBy = vi.fn();

--- a/apps/admin/src/app/api/kg/repos/route.ts
+++ b/apps/admin/src/app/api/kg/repos/route.ts
@@ -27,14 +27,14 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const db = getClient();
     const rows = await db

--- a/apps/admin/src/app/api/memory/__tests__/memory-search-routes.test.ts
+++ b/apps/admin/src/app/api/memory/__tests__/memory-search-routes.test.ts
@@ -77,7 +77,8 @@ function makeRequest(body?: unknown) {
 describe('POST /api/memory/search', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCheckAIMemoryFeatureGate.mockReturnValue(null);
+    // Gate is async (GAP-477); resolve so await in the route works.
+    mockCheckAIMemoryFeatureGate.mockResolvedValue(null);
     mockCheckRateLimit.mockResolvedValue({
       allowed: true,
       remaining: 29,
@@ -93,7 +94,8 @@ describe('POST /api/memory/search', () => {
 
   it('returns feature gate response when AI is disabled', async () => {
     const { NextResponse } = require('next/server');
-    mockCheckAIMemoryFeatureGate.mockReturnValue(
+    mockGetSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockCheckAIMemoryFeatureGate.mockResolvedValue(
       NextResponse.json({ error: 'AI disabled' }, { status: 403 }),
     );
 
@@ -163,7 +165,7 @@ describe('POST /api/memory/search', () => {
 describe('POST /api/memory/search-text', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCheckAIMemoryFeatureGate.mockReturnValue(null);
+    mockCheckAIMemoryFeatureGate.mockResolvedValue(null);
   });
 
   async function loadRoute() {
@@ -173,7 +175,8 @@ describe('POST /api/memory/search-text', () => {
 
   it('returns feature gate response when AI is disabled', async () => {
     const { NextResponse } = require('next/server');
-    mockCheckAIMemoryFeatureGate.mockReturnValue(
+    mockGetSession.mockResolvedValue({ user: { id: 'u1' } });
+    mockCheckAIMemoryFeatureGate.mockResolvedValue(
       NextResponse.json({ error: 'AI disabled' }, { status: 403 }),
     );
 

--- a/apps/admin/src/app/api/memory/context/[sessionId]/[agentId]/route.ts
+++ b/apps/admin/src/app/api/memory/context/[sessionId]/[agentId]/route.ts
@@ -44,9 +44,6 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ sessionId: string; agentId: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   let sessionId: string | undefined;
   let agentId: string | undefined;
 
@@ -55,6 +52,9 @@ export async function GET(
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     sessionId = paramsResolved.sessionId;
@@ -133,9 +133,6 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ sessionId: string; agentId: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   let sessionId: string | undefined;
   let agentId: string | undefined;
 
@@ -144,6 +141,9 @@ export async function POST(
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     sessionId = paramsResolved.sessionId;
@@ -274,8 +274,8 @@ export async function DELETE(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const memoryGate = checkAIMemoryFeatureGate();
-    if (memoryGate) return memoryGate;
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     sessionId = paramsResolved.sessionId;

--- a/apps/admin/src/app/api/memory/episodic/[userId]/[memoryId]/route.ts
+++ b/apps/admin/src/app/api/memory/episodic/[userId]/[memoryId]/route.ts
@@ -59,8 +59,8 @@ export async function PUT(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const memoryGate = checkAIMemoryFeatureGate();
-    if (memoryGate) return memoryGate;
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     userId = paramsResolved.userId;
@@ -202,9 +202,6 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ userId: string; memoryId: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   let userId: string | undefined;
   let memoryId: string | undefined;
 
@@ -213,6 +210,9 @@ export async function DELETE(
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     userId = paramsResolved.userId;

--- a/apps/admin/src/app/api/memory/episodic/[userId]/route.ts
+++ b/apps/admin/src/app/api/memory/episodic/[userId]/route.ts
@@ -43,9 +43,6 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ userId: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   let userId: string | undefined;
 
   try {
@@ -53,6 +50,9 @@ export async function GET(
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     userId = paramsResolved.userId;
@@ -111,9 +111,6 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ userId: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   let userId: string | undefined;
 
   try {
@@ -121,6 +118,9 @@ export async function POST(
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     userId = paramsResolved.userId;

--- a/apps/admin/src/app/api/memory/search-text/route.ts
+++ b/apps/admin/src/app/api/memory/search-text/route.ts
@@ -45,14 +45,14 @@ interface SearchTextBody {
  * }
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const authSession = await getSession(request.headers, extractRequestContext(request));
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     let body: SearchTextBody;
     try {

--- a/apps/admin/src/app/api/memory/search/route.ts
+++ b/apps/admin/src/app/api/memory/search/route.ts
@@ -40,14 +40,14 @@ export const runtime = 'nodejs';
  * }
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const authSession = await getSession(request.headers, extractRequestContext(request));
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     // Rate limit per user
     const rateLimit = await checkRateLimit(

--- a/apps/admin/src/app/api/memory/working/[sessionId]/route.ts
+++ b/apps/admin/src/app/api/memory/working/[sessionId]/route.ts
@@ -43,9 +43,6 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ sessionId: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   let sessionId: string | undefined;
 
   try {
@@ -53,6 +50,9 @@ export async function GET(
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     sessionId = paramsResolved.sessionId;
@@ -121,9 +121,6 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ sessionId: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIMemoryFeatureGate();
-  if (aiGate) return aiGate;
-
   let sessionId: string | undefined;
 
   try {
@@ -131,6 +128,9 @@ export async function POST(
     if (!authSession) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const aiGate = await checkAIMemoryFeatureGate(authSession.user.id);
+    if (aiGate) return aiGate;
 
     const paramsResolved = await params;
     sessionId = paramsResolved.sessionId;

--- a/apps/admin/src/app/api/shapes/__tests__/agent-contexts.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/agent-contexts.test.ts
@@ -1,24 +1,23 @@
 /**
  * Agent Contexts Shape Proxy Route Tests
- *
- * Tests the authenticated proxy route for ElectricSQL agent_contexts shape.
  */
 
 import * as authServer from '@revealui/auth/server';
 import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { GET } from '../agent-contexts/route';
 
-// Mock the auth server
+const { mockCheckAIFeatureGate } = vi.hoisted(() => ({
+  mockCheckAIFeatureGate: vi.fn(),
+}));
+
 vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock('@revealui/core/features', () => ({
-  isFeatureEnabled: vi.fn().mockReturnValue(true),
+vi.mock('@/lib/middleware/ai-feature-gate', () => ({
+  checkAIFeatureGate: mockCheckAIFeatureGate,
 }));
 
-// Mock the electric proxy utilities
 vi.mock('@/lib/api/electric-proxy', () => ({
   prepareElectricUrl: vi.fn((_url: string) => {
     const electricUrl = new URL('http://localhost:5133/v1/shape');
@@ -32,6 +31,8 @@ vi.mock('@/lib/api/electric-proxy', () => ({
     });
   }),
 }));
+
+import { GET } from '../agent-contexts/route';
 
 const mockSession = {
   session: {
@@ -77,6 +78,7 @@ describe('GET /api/shapes/agent-contexts', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheckAIFeatureGate.mockResolvedValue(null);
   });
 
   it('should return 401 when session is missing', async () => {
@@ -91,7 +93,7 @@ describe('GET /api/shapes/agent-contexts', () => {
   });
 
   it('should proxy request filtered by session_id when authenticated', async () => {
-    mockGetSession.mockResolvedValue(mockSession);
+    mockGetSession.mockResolvedValue(mockSession as never);
 
     const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
 
@@ -101,8 +103,8 @@ describe('GET /api/shapes/agent-contexts', () => {
     expect(response.status).toBe(200);
     expect(prepareElectricUrl).toHaveBeenCalled();
     expect(proxyElectricRequest).toHaveBeenCalled();
+    expect(mockCheckAIFeatureGate).toHaveBeenCalledWith(mockSession.user.id);
 
-    // Verify the prepared URL included the request URL
     const callArgs = vi.mocked(prepareElectricUrl).mock.calls[0];
     expect(callArgs?.[0]).toContain('/api/shapes/agent-contexts');
   });

--- a/apps/admin/src/app/api/shapes/__tests__/agent-memories.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/agent-memories.test.ts
@@ -1,24 +1,38 @@
 /**
- * Agent Memories Shape Proxy Route Tests
- *
- * Tests the authenticated proxy route for ElectricSQL agent_memories shape.
+ * Agent Memories Shape Proxy Route Tests (GAP-476)
  */
 
 import * as authServer from '@revealui/auth/server';
 import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { GET } from '../agent-memories/route';
 
-// Mock the auth server
+const { mockGetClient, mockCheckAIFeatureGate, mockUserCanAccessSite } = vi.hoisted(() => ({
+  mockGetClient: vi.fn(),
+  mockCheckAIFeatureGate: vi.fn(),
+  mockUserCanAccessSite: vi.fn(),
+}));
+
 vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock('@revealui/core/features', () => ({
-  isFeatureEnabled: vi.fn().mockReturnValue(true),
+vi.mock('@revealui/db/client', () => ({
+  getClient: mockGetClient,
 }));
 
-// Mock the electric proxy utilities
+vi.mock('@/lib/middleware/ai-feature-gate', () => ({
+  checkAIFeatureGate: mockCheckAIFeatureGate,
+}));
+
+vi.mock('@/lib/api/shape-authz', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/api/shape-authz')>('@/lib/api/shape-authz');
+  return {
+    ...actual,
+    userCanAccessSite: mockUserCanAccessSite,
+  };
+});
+
 vi.mock('@/lib/api/electric-proxy', () => ({
   prepareElectricUrl: vi.fn((_url: string) => {
     const electricUrl = new URL('http://localhost:5133/v1/shape');
@@ -33,50 +47,59 @@ vi.mock('@/lib/api/electric-proxy', () => ({
   }),
 }));
 
-const mockSession = {
-  session: {
-    id: 'session-abc-123',
-    userId: '123e4567-e89b-12d3-a456-426614174000',
-    schemaVersion: '1',
-    tokenHash: 'token-hash',
-    expiresAt: new Date(Date.now() + 86400000),
-    userAgent: 'test-agent',
-    ipAddress: '127.0.0.1',
-    persistent: false,
-    lastActivityAt: new Date(),
-    createdAt: new Date(),
-    metadata: null,
-  },
-  user: {
-    id: '123e4567-e89b-12d3-a456-426614174000',
-    schemaVersion: '1',
-    type: 'human',
-    name: 'Test User',
-    email: 'test@example.com',
-    avatarUrl: null,
-    password: null,
-    role: 'viewer',
-    status: 'active',
-    emailVerified: false,
-    emailVerificationToken: null,
-    emailVerifiedAt: null,
-    mfaEnabled: false,
-    mfaVerifiedAt: null,
-    agentModel: null,
-    agentCapabilities: null,
-    agentConfig: null,
-    preferences: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    lastActiveAt: null,
-  },
-};
+import { GET } from '../agent-memories/route';
+
+function makeSession(role: string, userId = '123e4567-e89b-12d3-a456-426614174000') {
+  return {
+    session: {
+      id: 'session-abc-123',
+      userId,
+      schemaVersion: '1',
+      tokenHash: 'token-hash',
+      expiresAt: new Date(Date.now() + 86400000),
+      userAgent: 'test-agent',
+      ipAddress: '127.0.0.1',
+      persistent: false,
+      lastActivityAt: new Date(),
+      createdAt: new Date(),
+      metadata: null,
+    },
+    user: {
+      id: userId,
+      schemaVersion: '1',
+      type: 'human',
+      name: 'Test User',
+      email: 'test@example.com',
+      avatarUrl: null,
+      password: null,
+      role,
+      status: 'active',
+      emailVerified: false,
+      emailVerificationToken: null,
+      emailVerifiedAt: null,
+      mfaEnabled: false,
+      mfaVerifiedAt: null,
+      agentModel: null,
+      agentCapabilities: null,
+      agentConfig: null,
+      preferences: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActiveAt: null,
+    },
+  };
+}
+
+const SITE_ID = 'site-owned-1';
 
 describe('GET /api/shapes/agent-memories', () => {
   const mockGetSession = vi.mocked(authServer.getSession);
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheckAIFeatureGate.mockResolvedValue(null);
+    mockGetClient.mockReturnValue({});
+    mockUserCanAccessSite.mockResolvedValue(false);
   });
 
   it('should return 401 when session is missing', async () => {
@@ -93,7 +116,7 @@ describe('GET /api/shapes/agent-memories', () => {
   });
 
   it('should return 400 when agent_id query param is missing', async () => {
-    mockGetSession.mockResolvedValue(mockSession);
+    mockGetSession.mockResolvedValue(makeSession('viewer') as never);
 
     const request = new NextRequest('http://localhost:3000/api/shapes/agent-memories');
     const response = await GET(request);
@@ -103,10 +126,57 @@ describe('GET /api/shapes/agent-memories', () => {
     expect(data.error).toBe('VALIDATION_ERROR');
   });
 
-  it('should proxy request filtered by agent_id when authenticated', async () => {
-    mockGetSession.mockResolvedValue(mockSession);
+  it('should return 403 for non-admin without site_id', async () => {
+    mockGetSession.mockResolvedValue(makeSession('viewer') as never);
 
-    const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+    const request = new NextRequest(
+      'http://localhost:3000/api/shapes/agent-memories?agent_id=assistant',
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe('FORBIDDEN');
+  });
+
+  it('should return 403 when non-admin lacks site access', async () => {
+    mockGetSession.mockResolvedValue(makeSession('viewer') as never);
+    mockUserCanAccessSite.mockResolvedValue(false);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/shapes/agent-memories?agent_id=assistant&site_id=${SITE_ID}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe('FORBIDDEN');
+    expect(mockUserCanAccessSite).toHaveBeenCalled();
+  });
+
+  it('should proxy with agent_id and site_id when non-admin owns site', async () => {
+    mockGetSession.mockResolvedValue(makeSession('viewer') as never);
+    mockUserCanAccessSite.mockResolvedValue(true);
+
+    const { proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/shapes/agent-memories?agent_id=assistant&site_id=${SITE_ID}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(proxyElectricRequest).toHaveBeenCalled();
+    const originUrl = vi.mocked(proxyElectricRequest).mock.calls[0]?.[0] as URL;
+    expect(originUrl.searchParams.get('where')).toBe(
+      `agent_id = 'assistant' AND site_id = '${SITE_ID}'`,
+    );
+  });
+
+  it('should proxy agent_id only for admin without site_id', async () => {
+    mockGetSession.mockResolvedValue(makeSession('admin') as never);
+
+    const { proxyElectricRequest } = await import('@/lib/api/electric-proxy');
 
     const request = new NextRequest(
       'http://localhost:3000/api/shapes/agent-memories?agent_id=assistant',
@@ -114,11 +184,9 @@ describe('GET /api/shapes/agent-memories', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
-    expect(prepareElectricUrl).toHaveBeenCalled();
-    expect(proxyElectricRequest).toHaveBeenCalled();
-
-    const callArgs = vi.mocked(prepareElectricUrl).mock.calls[0];
-    expect(callArgs?.[0]).toContain('/api/shapes/agent-memories');
+    const originUrl = vi.mocked(proxyElectricRequest).mock.calls[0]?.[0] as URL;
+    expect(originUrl.searchParams.get('where')).toBe(`agent_id = 'assistant'`);
+    expect(mockUserCanAccessSite).not.toHaveBeenCalled();
   });
 
   it('should handle errors gracefully', async () => {

--- a/apps/admin/src/app/api/shapes/__tests__/coordination-sessions.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/coordination-sessions.test.ts
@@ -1,5 +1,5 @@
 /**
- * Coordination Sessions Shape Proxy Route Tests
+ * Coordination Sessions Shape Proxy Route Tests (GAP-476)
  */
 
 import * as authServer from '@revealui/auth/server';
@@ -25,44 +25,46 @@ vi.mock('@/lib/api/electric-proxy', () => ({
   }),
 }));
 
-const VALID_SESSION = {
-  session: {
-    id: 'session-id',
-    userId: '123e4567-e89b-12d3-a456-426614174000',
-    schemaVersion: '1',
-    tokenHash: 'token-hash',
-    expiresAt: new Date(Date.now() + 86400000),
-    userAgent: 'test-agent',
-    ipAddress: '127.0.0.1',
-    persistent: false,
-    lastActivityAt: new Date(),
-    createdAt: new Date(),
-    metadata: null,
-  },
-  user: {
-    id: '123e4567-e89b-12d3-a456-426614174000',
-    schemaVersion: '1',
-    type: 'human',
-    name: 'Test User',
-    email: 'test@example.com',
-    avatarUrl: null,
-    password: null,
-    role: 'viewer',
-    status: 'active',
-    emailVerified: false,
-    emailVerificationToken: null,
-    emailVerifiedAt: null,
-    mfaEnabled: false,
-    mfaVerifiedAt: null,
-    agentModel: null,
-    agentCapabilities: null,
-    agentConfig: null,
-    preferences: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    lastActiveAt: null,
-  },
-};
+function makeSession(role: string) {
+  return {
+    session: {
+      id: 'session-id',
+      userId: '123e4567-e89b-12d3-a456-426614174000',
+      schemaVersion: '1',
+      tokenHash: 'token-hash',
+      expiresAt: new Date(Date.now() + 86400000),
+      userAgent: 'test-agent',
+      ipAddress: '127.0.0.1',
+      persistent: false,
+      lastActivityAt: new Date(),
+      createdAt: new Date(),
+      metadata: null,
+    },
+    user: {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      schemaVersion: '1',
+      type: 'human',
+      name: 'Test User',
+      email: 'test@example.com',
+      avatarUrl: null,
+      password: null,
+      role,
+      status: 'active',
+      emailVerified: false,
+      emailVerificationToken: null,
+      emailVerifiedAt: null,
+      mfaEnabled: false,
+      mfaVerifiedAt: null,
+      agentModel: null,
+      agentCapabilities: null,
+      agentConfig: null,
+      preferences: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActiveAt: null,
+    },
+  };
+}
 
 describe('GET /api/shapes/coordination-sessions', () => {
   const mockGetSession = vi.mocked(authServer.getSession);
@@ -82,8 +84,19 @@ describe('GET /api/shapes/coordination-sessions', () => {
     expect(data.error).toBe('UNAUTHORIZED');
   });
 
-  it('should proxy request without row-level filtering when authenticated', async () => {
-    mockGetSession.mockResolvedValue(VALID_SESSION);
+  it('should return 403 for viewer role', async () => {
+    mockGetSession.mockResolvedValue(makeSession('viewer') as never);
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/coordination-sessions');
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe('FORBIDDEN');
+  });
+
+  it('should proxy for admin role', async () => {
+    mockGetSession.mockResolvedValue(makeSession('admin') as never);
 
     const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
 
@@ -96,7 +109,7 @@ describe('GET /api/shapes/coordination-sessions', () => {
   });
 
   it('should set table param to coordination_sessions', async () => {
-    mockGetSession.mockResolvedValue(VALID_SESSION);
+    mockGetSession.mockResolvedValue(makeSession('owner') as never);
 
     const { prepareElectricUrl } = await import('@/lib/api/electric-proxy');
     const mockUrl = new URL('http://localhost:5133/v1/shape');

--- a/apps/admin/src/app/api/shapes/__tests__/kg-edge-episodes.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-edge-episodes.test.ts
@@ -47,7 +47,7 @@ const mockSession = {
     email: 'test@example.com',
     avatarUrl: null,
     password: null,
-    role: 'viewer',
+    role: 'admin',
     status: 'active',
     emailVerified: false,
     emailVerificationToken: null,

--- a/apps/admin/src/app/api/shapes/__tests__/kg-edge-episodes.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-edge-episodes.test.ts
@@ -11,8 +11,8 @@ vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock('@revealui/core/features', () => ({
-  isFeatureEnabled: vi.fn().mockReturnValue(true),
+vi.mock('@/lib/middleware/ai-feature-gate', () => ({
+  checkAIFeatureGate: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/lib/api/electric-proxy', () => ({

--- a/apps/admin/src/app/api/shapes/__tests__/kg-edges.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-edges.test.ts
@@ -47,7 +47,7 @@ const mockSession = {
     email: 'test@example.com',
     avatarUrl: null,
     password: null,
-    role: 'viewer',
+    role: 'admin',
     status: 'active',
     emailVerified: false,
     emailVerificationToken: null,

--- a/apps/admin/src/app/api/shapes/__tests__/kg-edges.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-edges.test.ts
@@ -11,8 +11,8 @@ vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock('@revealui/core/features', () => ({
-  isFeatureEnabled: vi.fn().mockReturnValue(true),
+vi.mock('@/lib/middleware/ai-feature-gate', () => ({
+  checkAIFeatureGate: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/lib/api/electric-proxy', () => ({

--- a/apps/admin/src/app/api/shapes/__tests__/kg-nodes.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-nodes.test.ts
@@ -50,7 +50,7 @@ const mockSession = {
     email: 'test@example.com',
     avatarUrl: null,
     password: null,
-    role: 'viewer',
+    role: 'admin',
     status: 'active',
     emailVerified: false,
     emailVerificationToken: null,
@@ -83,6 +83,17 @@ describe('GET /api/shapes/kg-nodes', () => {
 
     expect(response.status).toBe(401);
     expect(data.error).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 403 when non-admin (GAP-477)', async () => {
+    mockGetSession.mockResolvedValue({
+      ...mockSession,
+      user: { ...mockSession.user, role: 'viewer' },
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/shapes/kg-nodes');
+    const response = await GET(request);
+    expect(response.status).toBe(403);
   });
 
   it('proxies with no where clause when repo is omitted', async () => {

--- a/apps/admin/src/app/api/shapes/__tests__/kg-nodes.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-nodes.test.ts
@@ -11,8 +11,8 @@ vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock('@revealui/core/features', () => ({
-  isFeatureEnabled: vi.fn().mockReturnValue(true),
+vi.mock('@/lib/middleware/ai-feature-gate', () => ({
+  checkAIFeatureGate: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/lib/api/electric-proxy', () => ({

--- a/apps/admin/src/app/api/shapes/__tests__/kg-views.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-views.test.ts
@@ -47,7 +47,7 @@ const mockSession = {
     email: 'test@example.com',
     avatarUrl: null,
     password: null,
-    role: 'viewer',
+    role: 'admin',
     status: 'active',
     emailVerified: false,
     emailVerificationToken: null,

--- a/apps/admin/src/app/api/shapes/__tests__/kg-views.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/kg-views.test.ts
@@ -11,8 +11,8 @@ vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock('@revealui/core/features', () => ({
-  isFeatureEnabled: vi.fn().mockReturnValue(true),
+vi.mock('@/lib/middleware/ai-feature-gate', () => ({
+  checkAIFeatureGate: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/lib/api/electric-proxy', () => ({

--- a/apps/admin/src/app/api/shapes/__tests__/yjs-documents.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/yjs-documents.test.ts
@@ -1,7 +1,5 @@
 /**
- * Yjs Documents Shape Proxy Route Tests
- *
- * Tests the authenticated proxy route for ElectricSQL yjs_documents shape.
+ * Yjs Documents Shape Proxy Route Tests (GAP-476 admin-scoped)
  */
 
 import * as authServer from '@revealui/auth/server';
@@ -9,12 +7,10 @@ import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GET } from '../yjs-documents/route';
 
-// Mock the auth server
 vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
-// Mock the electric proxy utilities
 vi.mock('@/lib/api/electric-proxy', () => ({
   prepareElectricUrl: vi.fn((_url: string) => {
     const electricUrl = new URL('http://localhost:5133/v1/shape');
@@ -29,44 +25,46 @@ vi.mock('@/lib/api/electric-proxy', () => ({
   }),
 }));
 
-const VALID_SESSION = {
-  session: {
-    id: '123e4567-e89b-12d3-a456-426614174000',
-    userId: '123e4567-e89b-12d3-a456-426614174001',
-    schemaVersion: '1',
-    tokenHash: 'token-hash',
-    expiresAt: new Date(Date.now() + 86400000),
-    userAgent: 'test-agent',
-    ipAddress: '127.0.0.1',
-    persistent: false,
-    lastActivityAt: new Date(),
-    createdAt: new Date(),
-    metadata: null,
-  },
-  user: {
-    id: '123e4567-e89b-12d3-a456-426614174001',
-    schemaVersion: '1',
-    type: 'human',
-    name: 'Test User',
-    email: 'test@example.com',
-    avatarUrl: null,
-    password: null,
-    role: 'viewer',
-    status: 'active',
-    emailVerified: false,
-    emailVerificationToken: null,
-    emailVerifiedAt: null,
-    mfaEnabled: false,
-    mfaVerifiedAt: null,
-    agentModel: null,
-    agentCapabilities: null,
-    agentConfig: null,
-    preferences: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    lastActiveAt: null,
-  },
-};
+function makeSession(role: string) {
+  return {
+    session: {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      userId: '123e4567-e89b-12d3-a456-426614174001',
+      schemaVersion: '1',
+      tokenHash: 'token-hash',
+      expiresAt: new Date(Date.now() + 86400000),
+      userAgent: 'test-agent',
+      ipAddress: '127.0.0.1',
+      persistent: false,
+      lastActivityAt: new Date(),
+      createdAt: new Date(),
+      metadata: null,
+    },
+    user: {
+      id: '123e4567-e89b-12d3-a456-426614174001',
+      schemaVersion: '1',
+      type: 'human',
+      name: 'Test User',
+      email: 'test@example.com',
+      avatarUrl: null,
+      password: null,
+      role,
+      status: 'active',
+      emailVerified: false,
+      emailVerificationToken: null,
+      emailVerifiedAt: null,
+      mfaEnabled: false,
+      mfaVerifiedAt: null,
+      agentModel: null,
+      agentCapabilities: null,
+      agentConfig: null,
+      preferences: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastActiveAt: null,
+    },
+  };
+}
 
 const VALID_DOC_ID = 'aaaabbbb-cccc-dddd-eeee-ffff00001111';
 
@@ -90,8 +88,21 @@ describe('GET /api/shapes/yjs-documents', () => {
     expect(data.error).toBe('UNAUTHORIZED');
   });
 
+  it('should return 403 for non-admin', async () => {
+    mockGetSession.mockResolvedValue(makeSession('viewer') as never);
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/shapes/yjs-documents?document_id=${VALID_DOC_ID}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe('FORBIDDEN');
+  });
+
   it('should return 400 when document_id is missing', async () => {
-    mockGetSession.mockResolvedValue(VALID_SESSION);
+    mockGetSession.mockResolvedValue(makeSession('admin') as never);
 
     const request = new NextRequest('http://localhost:3000/api/shapes/yjs-documents');
     const response = await GET(request);
@@ -102,7 +113,7 @@ describe('GET /api/shapes/yjs-documents', () => {
   });
 
   it('should return 400 when document_id is not a UUID', async () => {
-    mockGetSession.mockResolvedValue(VALID_SESSION);
+    mockGetSession.mockResolvedValue(makeSession('admin') as never);
 
     const request = new NextRequest(
       'http://localhost:3000/api/shapes/yjs-documents?document_id=not-a-valid-uuid',
@@ -114,8 +125,8 @@ describe('GET /api/shapes/yjs-documents', () => {
     expect(data.error).toBe('VALIDATION_ERROR');
   });
 
-  it('should proxy request when authenticated with valid UUID', async () => {
-    mockGetSession.mockResolvedValue(VALID_SESSION);
+  it('should proxy request when admin with valid UUID', async () => {
+    mockGetSession.mockResolvedValue(makeSession('admin') as never);
 
     const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
 

--- a/apps/admin/src/app/api/shapes/agent-contexts/route.ts
+++ b/apps/admin/src/app/api/shapes/agent-contexts/route.ts
@@ -4,13 +4,15 @@
  * GET /api/shapes/agent-contexts
  *
  * Authenticated proxy for ElectricSQL agent_contexts shape.
- * Filters by session_id (agent_contexts.session_id belongs to the auth session).
+ * Row-level filtered to the caller's auth session id (write path keys
+ * agent_contexts by session.session.id). That is user-self scoping.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { isUuid } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
@@ -19,24 +21,20 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
-    // Validate session using RevealUI auth
     const session = await getSession(request.headers, extractRequestContext(request));
 
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
 
-    // Build the ElectricSQL URL with row-level filtering
-    // Filter by session_id  -  agent_contexts are scoped to the auth session
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
+
     const originUrl = prepareElectricUrl(request.url);
     originUrl.searchParams.set('table', 'agent_contexts');
-    // Validate session ID format before inlining
     const sessionId = session.session.id;
-    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)) {
+    if (!isUuid(sessionId)) {
       return createApplicationErrorResponse('Invalid session ID format', 'VALIDATION_ERROR', 400);
     }
     originUrl.searchParams.set('where', `session_id = '${sessionId}'`);

--- a/apps/admin/src/app/api/shapes/agent-memories/route.ts
+++ b/apps/admin/src/app/api/shapes/agent-memories/route.ts
@@ -1,55 +1,57 @@
 /**
  * Agent Memories Shape Proxy Route
  *
- * GET /api/shapes/agent-memories?agent_id=<agent_id>
+ * GET /api/shapes/agent-memories?agent_id=<agent_id>[&site_id=<site_id>]
  *
- * Authenticated proxy for ElectricSQL agent_memories shape.
- * Caller must supply `agent_id` as a query param. Auth gate ensures only
- * authenticated users can subscribe to any agent's memories.
+ * Authenticated proxy for ElectricSQL agent_memories shape (GAP-476).
+ * - Admins: agent_id filter only (ops full-agent view)
+ * - Non-admins: require site_id and prove owner/collaborator access;
+ *   Electric where: agent_id AND site_id
  */
 
 import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db/client';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { isSafeSiteId, requireAdminRole, userCanAccessSite } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
-    // Validate session using RevealUI auth
     const session = await getSession(request.headers, extractRequestContext(request));
 
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
 
-    // Caller supplies the agent_id to scope memories to a specific agent
-    const agentId = new URL(request.url).searchParams.get('agent_id');
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
+
+    const url = new URL(request.url);
+    const agentId = url.searchParams.get('agent_id');
     if (!agentId || agentId.trim().length === 0) {
       return createValidationErrorResponse(
         'agent_id query parameter is required',
         'agent_id',
         agentId,
         {
-          example: '/api/shapes/agent-memories?agent_id=assistant',
+          example: '/api/shapes/agent-memories?agent_id=assistant&site_id=<site-id>',
         },
       );
     }
 
-    // Validate agent_id is safe to inline (alphanumeric, hyphens, underscores only)
-    if (!/^[a-zA-Z0-9_-]+$/.test(agentId)) {
+    if (!isSyncIdentifier(agentId)) {
       return createValidationErrorResponse(
         'agent_id must contain only alphanumeric characters, hyphens, and underscores',
         'agent_id',
@@ -57,10 +59,42 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Build the ElectricSQL URL with row-level filtering
     const originUrl = prepareElectricUrl(request.url);
     originUrl.searchParams.set('table', 'agent_memories');
-    originUrl.searchParams.set('where', `agent_id = '${agentId}'`);
+
+    if (requireAdminRole(session.user.role)) {
+      originUrl.searchParams.set('where', `agent_id = '${agentId}'`);
+      return proxyElectricRequest(originUrl);
+    }
+
+    const siteId = url.searchParams.get('site_id');
+    if (!siteId || siteId.trim().length === 0) {
+      return createApplicationErrorResponse(
+        'site_id query parameter is required for non-admin access',
+        'FORBIDDEN',
+        403,
+      );
+    }
+
+    if (!isSafeSiteId(siteId)) {
+      return createValidationErrorResponse(
+        'site_id must contain only alphanumeric characters, hyphens, and underscores',
+        'site_id',
+        siteId,
+      );
+    }
+
+    const db = getClient();
+    const allowed = await userCanAccessSite(db, session.user.id, siteId, session.user.role);
+    if (!allowed) {
+      return createApplicationErrorResponse(
+        'Access denied: you do not own or collaborate on this site',
+        'FORBIDDEN',
+        403,
+      );
+    }
+
+    originUrl.searchParams.set('where', `agent_id = '${agentId}' AND site_id = '${siteId}'`);
 
     return proxyElectricRequest(originUrl);
   } catch (error) {

--- a/apps/admin/src/app/api/shapes/coordination-sessions/route.ts
+++ b/apps/admin/src/app/api/shapes/coordination-sessions/route.ts
@@ -4,14 +4,15 @@
  * GET /api/shapes/coordination-sessions
  *
  * Authenticated proxy for ElectricSQL coordination_sessions shape.
- * Admin-scoped: any authenticated user can observe all coordination sessions
- * (this endpoint backs the Active Agents dashboard, not a per-user view).
+ * Admin-scoped (GAP-476): full-table Electric for isAdminRole only.
+ * Backs the Active Agents dashboard, not a per-user view.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
@@ -24,6 +25,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
     }
 
     const originUrl = prepareElectricUrl(request.url);

--- a/apps/admin/src/app/api/shapes/coordination-work-items/route.ts
+++ b/apps/admin/src/app/api/shapes/coordination-work-items/route.ts
@@ -4,14 +4,15 @@
  * GET /api/shapes/coordination-work-items
  *
  * Authenticated proxy for ElectricSQL coordination_work_items shape.
- * Admin-scoped: any authenticated user can observe all coordination work
- * items (this endpoint backs the coordination dashboard, not a per-user view).
+ * Admin-scoped (GAP-476): full-table Electric for isAdminRole only.
+ * Backs the coordination dashboard, not a per-user view.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
@@ -24,6 +25,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
     }
 
     const originUrl = prepareElectricUrl(request.url);

--- a/apps/admin/src/app/api/shapes/kg-edge-episodes/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-edge-episodes/route.ts
@@ -30,14 +30,14 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const originUrl = prepareElectricUrl(request.url);
     originUrl.searchParams.set('table', 'kg_edge_episodes');

--- a/apps/admin/src/app/api/shapes/kg-edge-episodes/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-edge-episodes/route.ts
@@ -22,6 +22,7 @@ import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
@@ -38,6 +39,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
+
+    // GAP-477: full provenance join is fleet-operator data only.
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
 
     const originUrl = prepareElectricUrl(request.url);
     originUrl.searchParams.set('table', 'kg_edge_episodes');

--- a/apps/admin/src/app/api/shapes/kg-edges/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-edges/route.ts
@@ -25,14 +25,14 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const repo = new URL(request.url).searchParams.get('repo');
     if (repo !== null && !isRepoIdentifier(repo)) {

--- a/apps/admin/src/app/api/shapes/kg-edges/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-edges/route.ts
@@ -3,15 +3,14 @@
  *
  * GET /api/shapes/kg-edges[?repo=<repo>]
  *
- * Authenticated, read-only proxy for the ElectricSQL `kg_edges` shape
- * (GAP-349 P4, design spec §8.2/§9). Same repo-partition and validation
- * contract as `kg-nodes` — see that route's header comment.
+ * Same AuthZ as kg-nodes (GAP-477 Phase C): admin_platform + AI gate.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
@@ -33,6 +32,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
 
     const repo = new URL(request.url).searchParams.get('repo');
     if (repo !== null && !isRepoIdentifier(repo)) {

--- a/apps/admin/src/app/api/shapes/kg-nodes/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-nodes/route.ts
@@ -33,14 +33,14 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const repo = new URL(request.url).searchParams.get('repo');
     if (repo !== null && !isRepoIdentifier(repo)) {

--- a/apps/admin/src/app/api/shapes/kg-nodes/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-nodes/route.ts
@@ -3,23 +3,18 @@
  *
  * GET /api/shapes/kg-nodes[?repo=<repo>]
  *
- * Authenticated, read-only proxy for the ElectricSQL `kg_nodes` shape
- * (GAP-349 P4, design spec §8.2/§9). Partitioned by the denormalized `repo`
- * column: an omitted `repo` param syncs the whole fleet graph; a supplied
- * one is validated against {@link isRepoIdentifier} (character-set only, no
- * authored regex) before being inlined into the Electric `where` clause —
- * Electric's shape API takes `where` as a literal SQL predicate string, so
- * an unvalidated value here would be a SQL injection surface.
+ * Fleet knowledge graph (GAP-349). GAP-477 Phase C: admin_platform only —
+ * any authenticated user previously could sync the whole graph. Optional
+ * `repo` still scopes the Electric where for admins who pass it.
  *
- * Electric sync is read-only by design: this route (and its kg-edges /
- * kg-edge-episodes siblings) never accepts a write. The only write path into
- * `kg_*` tables is `POST /api/sync/kg-episodes` (additive `ingestEpisode`).
+ * Electric sync is read-only. Writes go through POST /api/sync/kg-episodes.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
@@ -41,6 +36,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
 
     const repo = new URL(request.url).searchParams.get('repo');
     if (repo !== null && !isRepoIdentifier(repo)) {

--- a/apps/admin/src/app/api/shapes/kg-views/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-views/route.ts
@@ -33,14 +33,14 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const documentId = new URL(request.url).searchParams.get('document_id');
     if (!(documentId && isKgViewDocumentId(documentId))) {

--- a/apps/admin/src/app/api/shapes/kg-views/route.ts
+++ b/apps/admin/src/app/api/shapes/kg-views/route.ts
@@ -25,6 +25,7 @@ import { isKgViewDocumentId } from '@revealui/sync/collab/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
@@ -41,6 +42,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
 
     const documentId = new URL(request.url).searchParams.get('document_id');
     if (!(documentId && isKgViewDocumentId(documentId))) {

--- a/apps/admin/src/app/api/shapes/shared-facts/route.ts
+++ b/apps/admin/src/app/api/shapes/shared-facts/route.ts
@@ -4,35 +4,39 @@
  * GET /api/shapes/shared-facts?session_id=<session_id>
  *
  * Authenticated proxy for ElectricSQL shared_facts shape.
- * Scoped by coordination session ID so only agents in the same
- * session receive each other's discoveries.
+ * GAP-476: admin-scoped until ACL — schema has no user_id ownership join;
+ * non-admins receive 403. Coordination session_id still scopes the Electric where.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
-
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
     }
 
     const sessionId = new URL(request.url).searchParams.get('session_id');
@@ -45,7 +49,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    if (!SESSION_ID_RE.test(sessionId)) {
+    if (!isSyncIdentifier(sessionId)) {
       return createValidationErrorResponse(
         'session_id must contain only alphanumeric characters, hyphens, and underscores',
         'session_id',

--- a/apps/admin/src/app/api/shapes/shared-memories/route.ts
+++ b/apps/admin/src/app/api/shapes/shared-memories/route.ts
@@ -5,33 +5,38 @@
  *
  * Authenticated proxy for ElectricSQL agent_memories shape,
  * filtered to shared and reconciled memories within a coordination session.
+ * GAP-476: admin-scoped until ACL — no user ownership join on session_scope.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-const SESSION_SCOPE_RE = /^[a-zA-Z0-9_-]+$/;
-
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
     }
 
     const sessionScope = new URL(request.url).searchParams.get('session_scope');
@@ -44,7 +49,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    if (!SESSION_SCOPE_RE.test(sessionScope)) {
+    if (!isSyncIdentifier(sessionScope)) {
       return createValidationErrorResponse(
         'session_scope must contain only alphanumeric characters, hyphens, and underscores',
         'session_scope',

--- a/apps/admin/src/app/api/shapes/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/shapes/yjs-document-patches/route.ts
@@ -4,34 +4,39 @@
  * GET /api/shapes/yjs-document-patches?document_id=<document_id>
  *
  * Authenticated proxy for ElectricSQL yjs_document_patches shape.
- * Scoped by document ID so subscribers see patches for their scratchpad.
+ * GAP-476: fail-closed to isAdminRole — no document ACL join.
+ * Residual Phase C: document-level ACL when ownership model lands.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { requireAdminRole } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
   createErrorResponse,
   createValidationErrorResponse,
 } from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-const DOCUMENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
-
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
+
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
     }
 
     const documentId = new URL(request.url).searchParams.get('document_id');
@@ -44,7 +49,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    if (!DOCUMENT_ID_RE.test(documentId)) {
+    if (!isSyncIdentifier(documentId)) {
       return createValidationErrorResponse(
         'document_id must contain only alphanumeric characters, hyphens, and underscores',
         'document_id',

--- a/apps/admin/src/app/api/shapes/yjs-documents/route.ts
+++ b/apps/admin/src/app/api/shapes/yjs-documents/route.ts
@@ -1,24 +1,24 @@
 /**
  * Yjs Documents Shape Proxy Route
  *
- * GET /api/shapes/yjs-documents
+ * GET /api/shapes/yjs-documents?document_id=<uuid>
  *
  * Authenticated proxy for ElectricSQL yjs_documents shape.
- * Access control: authenticated session + valid document UUID.
- * yjs_documents has no user_id column  -  documents are collaborative (shared by UUID).
+ * GAP-476: fail-closed to isAdminRole — table has no user_id / ACL column.
+ * Residual Phase C: document-level ACL when ownership model lands.
+ * UUID-only document_id still required for the Electric where clause.
  */
 
 import { getSession } from '@revealui/auth/server';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
+import { isUuid, requireAdminRole } from '@/lib/api/shape-authz';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
@@ -28,10 +28,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
 
+    if (!requireAdminRole(session.user.role)) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
+
     const url = new URL(request.url);
     const documentId = url.searchParams.get('document_id');
 
-    if (!(documentId && UUID_RE.test(documentId))) {
+    if (!(documentId && isUuid(documentId))) {
       return createApplicationErrorResponse(
         'Missing or invalid document_id: must be a UUID',
         'VALIDATION_ERROR',
@@ -41,7 +45,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const originUrl = prepareElectricUrl(request.url);
     originUrl.searchParams.set('table', 'yjs_documents');
-    // Inline the validated UUID in the where clause (safe  -  UUID format verified above)
     originUrl.searchParams.set('where', `id = '${documentId}'`);
 
     return proxyElectricRequest(originUrl);

--- a/apps/admin/src/app/api/sync/agent-contexts/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/agent-contexts/[id]/route.ts
@@ -28,14 +28,14 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     const body = (await request.json()) as {
@@ -82,14 +82,14 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     const db = getClient();

--- a/apps/admin/src/app/api/sync/agent-contexts/route.ts
+++ b/apps/admin/src/app/api/sync/agent-contexts/route.ts
@@ -26,14 +26,14 @@ export const runtime = 'nodejs';
 const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const body = (await request.json()) as {
       agent_id?: string;

--- a/apps/admin/src/app/api/sync/agent-memories/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/agent-memories/[id]/route.ts
@@ -30,14 +30,14 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     if (!UUID_RE.test(id)) {
@@ -88,14 +88,14 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     if (!UUID_RE.test(id)) {

--- a/apps/admin/src/app/api/sync/agent-memories/route.ts
+++ b/apps/admin/src/app/api/sync/agent-memories/route.ts
@@ -37,14 +37,14 @@ const VALID_MEMORY_TYPES = new Set([
 ]);
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const body = (await request.json()) as {
       agent_id?: string;

--- a/apps/admin/src/app/api/sync/conversations/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/conversations/[id]/route.ts
@@ -45,14 +45,14 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     if (!isValidUUID(id)) {
@@ -95,14 +95,14 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     if (!isValidUUID(id)) {

--- a/apps/admin/src/app/api/sync/conversations/route.ts
+++ b/apps/admin/src/app/api/sync/conversations/route.ts
@@ -38,14 +38,14 @@ function isValidAgentId(id: string): boolean {
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const body = (await request.json()) as {
       agent_id?: string;

--- a/apps/admin/src/app/api/sync/kg-episodes/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/sync/kg-episodes/__tests__/route.test.ts
@@ -19,6 +19,20 @@ vi.mock('@revealui/core/features', () => ({
   isFeatureEnabled: vi.fn().mockReturnValue(true),
 }));
 
+vi.mock('@revealui/db/client', () => ({
+  getClient: vi.fn(() => {
+    throw new Error('no database in unit test');
+  }),
+}));
+
+vi.mock('@/lib/access/account-feature', () => ({
+  accountHasFeature: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('@revealui/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
 vi.mock('@revealui/db/pool', () => ({
   getPool: vi.fn(() => ({})),
 }));

--- a/apps/admin/src/app/api/sync/kg-episodes/route.ts
+++ b/apps/admin/src/app/api/sync/kg-episodes/route.ts
@@ -74,14 +74,14 @@ async function loadEmbedder(): Promise<((text: string) => Promise<number[]>) | u
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const body: unknown = await request.json();
     const parsed = KgFlushArgsSchema.safeParse(body);

--- a/apps/admin/src/app/api/sync/reconcile/route.ts
+++ b/apps/admin/src/app/api/sync/reconcile/route.ts
@@ -84,14 +84,14 @@ function reconcileFacts(
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const body = (await request.json()) as {
       session_id?: string;

--- a/apps/admin/src/app/api/sync/shared-facts/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/shared-facts/[id]/route.ts
@@ -30,14 +30,14 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     if (!UUID_RE.test(id)) {
@@ -102,14 +102,14 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     if (!UUID_RE.test(id)) {

--- a/apps/admin/src/app/api/sync/shared-facts/route.ts
+++ b/apps/admin/src/app/api/sync/shared-facts/route.ts
@@ -30,13 +30,15 @@ const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const VALID_FACT_TYPES = new Set(['discovery', 'bug', 'decision', 'warning', 'question', 'answer']);
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
+
     const sessionId = request.nextUrl.searchParams.get('session_id');
     if (!(sessionId && SESSION_ID_RE.test(sessionId))) {
       return createValidationErrorResponse(
@@ -70,14 +72,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const body = (await request.json()) as {
       session_id?: string;

--- a/apps/admin/src/app/api/sync/shared-memories/[id]/route.ts
+++ b/apps/admin/src/app/api/sync/shared-memories/[id]/route.ts
@@ -51,14 +51,14 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     if (!isUuid(id)) {
@@ -139,14 +139,14 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const { id } = await params;
     if (!isUuid(id)) {

--- a/apps/admin/src/app/api/sync/shared-memories/route.ts
+++ b/apps/admin/src/app/api/sync/shared-memories/route.ts
@@ -29,13 +29,15 @@ const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const SESSION_SCOPE_RE = /^[a-zA-Z0-9_-]+$/;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
+
     const sessionScope = request.nextUrl.searchParams.get('session_scope');
     if (!(sessionScope && SESSION_SCOPE_RE.test(sessionScope))) {
       return createValidationErrorResponse(
@@ -81,14 +83,14 @@ const VALID_MEMORY_TYPES = new Set([
 ]);
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const body = (await request.json()) as {
       agent_id?: string;

--- a/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
@@ -31,14 +31,14 @@ const AGENT_ID_RE = /^[a-zA-Z0-9_-]+$/;
 const VALID_PATCH_TYPES = new Set(['append_section', 'append_item', 'replace_section', 'set_key']);
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const aiGate = checkAIFeatureGate();
-  if (aiGate) return aiGate;
-
   try {
     const session = await getSession(request.headers, extractRequestContext(request));
     if (!session) {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
+
+    const aiGate = await checkAIFeatureGate(session.user.id);
+    if (aiGate) return aiGate;
 
     const body = (await request.json()) as {
       document_id?: string;

--- a/apps/admin/src/lib/access/__tests__/account-feature.test.ts
+++ b/apps/admin/src/lib/access/__tests__/account-feature.test.ts
@@ -1,0 +1,116 @@
+/**
+ * accountHasFeature unit tests (GAP-476)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetConfiguredStripeMode = vi.fn(() => 'test' as const);
+const mockGetFeaturesForTier = vi.fn();
+
+vi.mock('@revealui/config/stripe-mode', () => ({
+  getConfiguredStripeMode: () => mockGetConfiguredStripeMode(),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: (...args: unknown[]) => mockGetFeaturesForTier(...args),
+}));
+
+vi.mock('@revealui/db/schema', () => ({
+  accountMemberships: {
+    accountId: 'account_memberships.account_id',
+    userId: 'account_memberships.user_id',
+    status: 'account_memberships.status',
+  },
+  accountEntitlements: {
+    accountId: 'account_entitlements.account_id',
+    mode: 'account_entitlements.mode',
+    tier: 'account_entitlements.tier',
+    status: 'account_entitlements.status',
+    graceUntil: 'account_entitlements.grace_until',
+    features: 'account_entitlements.features',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => args,
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+}));
+
+import { accountHasFeature } from '../account-feature';
+
+function makeDb(membershipRows: unknown[], entitlementRows: unknown[]) {
+  let selectCall = 0;
+  const limit = vi.fn(async () => {
+    selectCall += 1;
+    return selectCall === 1 ? membershipRows : entitlementRows;
+  });
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return { select, from, where, limit };
+}
+
+describe('accountHasFeature', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFeaturesForTier.mockReturnValue({ ai: true, aiMemory: false });
+  });
+
+  it('returns false for null userId', async () => {
+    const db = makeDb([], []);
+    await expect(accountHasFeature(db as never, null, 'ai')).resolves.toBe(false);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns false when no membership', async () => {
+    const db = makeDb([], []);
+    await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(false);
+  });
+
+  it('returns false when grace expired', async () => {
+    const db = makeDb(
+      [{ accountId: 'acct-1' }],
+      [
+        {
+          tier: 'pro',
+          status: 'past_due',
+          graceUntil: new Date(Date.now() - 60_000),
+          features: { ai: true },
+        },
+      ],
+    );
+    await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(false);
+  });
+
+  it('returns true from entitlement features map', async () => {
+    const db = makeDb(
+      [{ accountId: 'acct-1' }],
+      [
+        {
+          tier: 'pro',
+          status: 'active',
+          graceUntil: null,
+          features: { ai: true },
+        },
+      ],
+    );
+    await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(true);
+  });
+
+  it('falls back to getFeaturesForTier when features empty', async () => {
+    mockGetFeaturesForTier.mockReturnValue({ ai: true });
+    const db = makeDb(
+      [{ accountId: 'acct-1' }],
+      [
+        {
+          tier: 'pro',
+          status: 'active',
+          graceUntil: null,
+          features: {},
+        },
+      ],
+    );
+    await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(true);
+    expect(mockGetFeaturesForTier).toHaveBeenCalledWith('pro');
+  });
+});

--- a/apps/admin/src/lib/access/__tests__/account-feature.test.ts
+++ b/apps/admin/src/lib/access/__tests__/account-feature.test.ts
@@ -1,5 +1,5 @@
 /**
- * accountHasFeature unit tests (GAP-476)
+ * accountHasFeature unit tests (GAP-476 / GAP-477 membership resolve)
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -18,8 +18,14 @@ vi.mock('@revealui/core/features', () => ({
 vi.mock('@revealui/db/schema', () => ({
   accountMemberships: {
     accountId: 'account_memberships.account_id',
+    role: 'account_memberships.role',
     userId: 'account_memberships.user_id',
     status: 'account_memberships.status',
+    createdAt: 'account_memberships.created_at',
+  },
+  accounts: {
+    id: 'accounts.id',
+    slug: 'accounts.slug',
   },
   accountEntitlements: {
     accountId: 'account_entitlements.account_id',
@@ -33,21 +39,33 @@ vi.mock('@revealui/db/schema', () => ({
 
 vi.mock('drizzle-orm', () => ({
   and: (...args: unknown[]) => args,
+  asc: (x: unknown) => x,
   eq: (a: unknown, b: unknown) => ({ a, b }),
+  or: (...args: unknown[]) => args,
 }));
 
 import { accountHasFeature } from '../account-feature';
 
-function makeDb(membershipRows: unknown[], entitlementRows: unknown[]) {
-  let selectCall = 0;
-  const limit = vi.fn(async () => {
-    selectCall += 1;
-    return selectCall === 1 ? membershipRows : entitlementRows;
-  });
-  const where = vi.fn(() => ({ limit }));
-  const from = vi.fn(() => ({ where }));
-  const select = vi.fn(() => ({ from }));
-  return { select, from, where, limit };
+/**
+ * Fluent select chain for resolveActiveMembership + entitlement lookup.
+ * Each terminal `.limit()` pops the next result queue entry.
+ */
+function makeDb(limitResults: unknown[][]) {
+  const queue = [...limitResults];
+  const limit = vi.fn(async () => queue.shift() ?? []);
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit,
+  };
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.orderBy.mockReturnValue(chain);
+  const select = vi.fn(() => chain);
+  return { select, chain, limit };
 }
 
 describe('accountHasFeature', () => {
@@ -57,19 +75,20 @@ describe('accountHasFeature', () => {
   });
 
   it('returns false for null userId', async () => {
-    const db = makeDb([], []);
+    const db = makeDb([]);
     await expect(accountHasFeature(db as never, null, 'ai')).resolves.toBe(false);
     expect(db.select).not.toHaveBeenCalled();
   });
 
   it('returns false when no membership', async () => {
-    const db = makeDb([], []);
+    // resolveActiveMembership: empty rows
+    const db = makeDb([[]]);
     await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(false);
   });
 
   it('returns false when grace expired', async () => {
-    const db = makeDb(
-      [{ accountId: 'acct-1' }],
+    const db = makeDb([
+      [{ accountId: 'acct-1', role: 'owner' }],
       [
         {
           tier: 'pro',
@@ -78,13 +97,13 @@ describe('accountHasFeature', () => {
           features: { ai: true },
         },
       ],
-    );
+    ]);
     await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(false);
   });
 
   it('returns true from entitlement features map', async () => {
-    const db = makeDb(
-      [{ accountId: 'acct-1' }],
+    const db = makeDb([
+      [{ accountId: 'acct-1', role: 'owner' }],
       [
         {
           tier: 'pro',
@@ -93,14 +112,14 @@ describe('accountHasFeature', () => {
           features: { ai: true },
         },
       ],
-    );
+    ]);
     await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(true);
   });
 
   it('falls back to getFeaturesForTier when features empty', async () => {
     mockGetFeaturesForTier.mockReturnValue({ ai: true });
-    const db = makeDb(
-      [{ accountId: 'acct-1' }],
+    const db = makeDb([
+      [{ accountId: 'acct-1', role: 'member' }],
       [
         {
           tier: 'pro',
@@ -109,8 +128,26 @@ describe('accountHasFeature', () => {
           features: {},
         },
       ],
-    );
+    ]);
     await expect(accountHasFeature(db as never, 'user-1', 'ai')).resolves.toBe(true);
     expect(mockGetFeaturesForTier).toHaveBeenCalledWith('pro');
+  });
+
+  it('uses preferred account membership when provided', async () => {
+    const db = makeDb([
+      [{ accountId: 'acct-preferred', role: 'owner' }],
+      [
+        {
+          tier: 'pro',
+          status: 'active',
+          graceUntil: null,
+          features: { ai: true },
+        },
+      ],
+    ]);
+    await expect(accountHasFeature(db as never, 'user-1', 'ai', 'acct-preferred')).resolves.toBe(
+      true,
+    );
+    expect(db.chain.innerJoin).toHaveBeenCalled();
   });
 });

--- a/apps/admin/src/lib/access/account-feature.ts
+++ b/apps/admin/src/lib/access/account-feature.ts
@@ -13,7 +13,7 @@ import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
 import type { Database } from '@revealui/db/client';
 import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
-import { resolveActiveMembership } from './resolve-membership.js';
+import { resolveActiveMembership } from './resolve-membership';
 
 function isHealthyStatus(status: string | null): boolean {
   return status === 'active' || status === 'trialing';

--- a/apps/admin/src/lib/access/account-feature.ts
+++ b/apps/admin/src/lib/access/account-feature.ts
@@ -1,0 +1,83 @@
+/**
+ * Account-scoped feature entitlement lookup for admin routes (GAP-476).
+ *
+ * Mirrors apps/server/src/lib/account-entitlement.ts accountHasAiFeature:
+ * membership → account_entitlements (stripe mode) → grace-expired fail-closed →
+ * features from row or getFeaturesForTier(tier).
+ *
+ * Do not import from apps/server; keep this admin-local mirror in sync with
+ * the server helper when entitlement rules change.
+ */
+
+import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
+import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
+import type { Database } from '@revealui/db/client';
+import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+function isHealthyStatus(status: string | null): boolean {
+  return status === 'active' || status === 'trialing';
+}
+
+function featureRecord(features: object | null | undefined): Record<string, boolean> {
+  if (!features) return {};
+  return Object.fromEntries(
+    Object.entries(features).filter(
+      (entry): entry is [string, boolean] => typeof entry[1] === 'boolean',
+    ),
+  );
+}
+
+/**
+ * Whether the account owning `userId` currently has `featureKey`.
+ *
+ * Fail-closed: null userId, no active membership, no entitlement row, or a
+ * grace-expired subscription all resolve to false.
+ */
+export async function accountHasFeature(
+  db: Database,
+  userId: string | null | undefined,
+  featureKey: keyof FeatureFlags,
+): Promise<boolean> {
+  if (!userId) return false;
+
+  const [membership] = await db
+    .select({ accountId: accountMemberships.accountId })
+    .from(accountMemberships)
+    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
+    .limit(1);
+
+  if (!membership?.accountId) return false;
+
+  const [entitlement] = await db
+    .select({
+      tier: accountEntitlements.tier,
+      status: accountEntitlements.status,
+      graceUntil: accountEntitlements.graceUntil,
+      features: accountEntitlements.features,
+    })
+    .from(accountEntitlements)
+    .where(
+      and(
+        eq(accountEntitlements.accountId, membership.accountId),
+        eq(accountEntitlements.mode, getConfiguredStripeMode()),
+      ),
+    )
+    .limit(1);
+
+  if (!entitlement) return false;
+
+  const status = entitlement.status ?? null;
+  const graceUntil = entitlement.graceUntil ?? null;
+  const graceActive = graceUntil != null && graceUntil.getTime() > Date.now();
+  const graceExpired = status !== null && !isHealthyStatus(status) && !graceActive;
+  if (graceExpired) return false;
+
+  const tier = (entitlement.tier as 'free' | 'pro' | 'max' | 'enterprise' | undefined) ?? 'free';
+  const features =
+    entitlement.features && Object.keys(entitlement.features).length > 0
+      ? featureRecord(entitlement.features)
+      : featureRecord(getFeaturesForTier(tier));
+
+  return features[featureKey] === true;
+}

--- a/apps/admin/src/lib/access/account-feature.ts
+++ b/apps/admin/src/lib/access/account-feature.ts
@@ -1,19 +1,19 @@
 /**
- * Account-scoped feature entitlement lookup for admin routes (GAP-476).
+ * Account-scoped feature entitlement lookup for admin routes (GAP-477).
  *
- * Mirrors apps/server/src/lib/account-entitlement.ts accountHasAiFeature:
- * membership → account_entitlements (stripe mode) → grace-expired fail-closed →
- * features from row or getFeaturesForTier(tier).
+ * Mirrors apps/server/src/lib/account-entitlement.ts:
+ * resolve membership (preferred + deterministic oldest) → account_entitlements
+ * (stripe mode) → grace-expired fail-closed → features from row or tier map.
  *
- * Do not import from apps/server; keep this admin-local mirror in sync with
- * the server helper when entitlement rules change.
+ * Do not import from apps/server; keep this admin-local mirror in sync.
  */
 
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
 import type { Database } from '@revealui/db/client';
-import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
+import { resolveActiveMembership } from './resolve-membership.js';
 
 function isHealthyStatus(status: string | null): boolean {
   return status === 'active' || status === 'trialing';
@@ -31,22 +31,17 @@ function featureRecord(features: object | null | undefined): Record<string, bool
 /**
  * Whether the account owning `userId` currently has `featureKey`.
  *
- * Fail-closed: null userId, no active membership, no entitlement row, or a
- * grace-expired subscription all resolve to false.
+ * @param preferredAccountId - Optional account id/slug (X-Tenant-ID / workspace).
  */
 export async function accountHasFeature(
   db: Database,
   userId: string | null | undefined,
   featureKey: keyof FeatureFlags,
+  preferredAccountId?: string | null,
 ): Promise<boolean> {
   if (!userId) return false;
 
-  const [membership] = await db
-    .select({ accountId: accountMemberships.accountId })
-    .from(accountMemberships)
-    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
-    .limit(1);
-
+  const membership = await resolveActiveMembership(db, userId, preferredAccountId);
   if (!membership?.accountId) return false;
 
   const [entitlement] = await db

--- a/apps/admin/src/lib/access/resolve-membership.ts
+++ b/apps/admin/src/lib/access/resolve-membership.ts
@@ -1,0 +1,57 @@
+/**
+ * Active account membership resolution for admin (GAP-477 Phase C).
+ *
+ * Mirror of apps/server/src/lib/resolve-membership.ts — keep lockstep when
+ * preference rules change. Admin cannot import apps/server.
+ */
+
+import type { Database } from '@revealui/db/client';
+import { accountMemberships, accounts } from '@revealui/db/schema';
+import { and, asc, eq, or } from 'drizzle-orm';
+
+export interface ActiveMembership {
+  accountId: string;
+  role: string;
+}
+
+export async function resolveActiveMembership(
+  db: Database,
+  userId: string,
+  preferredAccountId?: string | null,
+): Promise<ActiveMembership | null> {
+  const preferred = preferredAccountId?.trim() || null;
+
+  if (preferred) {
+    const [preferredRow] = await db
+      .select({
+        accountId: accountMemberships.accountId,
+        role: accountMemberships.role,
+      })
+      .from(accountMemberships)
+      .innerJoin(accounts, eq(accounts.id, accountMemberships.accountId))
+      .where(
+        and(
+          eq(accountMemberships.userId, userId),
+          eq(accountMemberships.status, 'active'),
+          or(eq(accounts.id, preferred), eq(accounts.slug, preferred)),
+        ),
+      )
+      .limit(1);
+
+    if (preferredRow) {
+      return preferredRow;
+    }
+  }
+
+  const rows = await db
+    .select({
+      accountId: accountMemberships.accountId,
+      role: accountMemberships.role,
+    })
+    .from(accountMemberships)
+    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
+    .orderBy(asc(accountMemberships.createdAt))
+    .limit(1);
+
+  return rows[0] ?? null;
+}

--- a/apps/admin/src/lib/api/__tests__/shape-authz-registry.test.ts
+++ b/apps/admin/src/lib/api/__tests__/shape-authz-registry.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Shape AuthZ registry completeness (GAP-477 Phase C).
+ */
+
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SHAPE_AUTHZ_REGISTRY } from '../shape-authz-registry.js';
+
+const SHAPES_DIR = join(__dirname, '../../../app/api/shapes');
+
+function listShapeRouteDirs(): string[] {
+  return readdirSync(SHAPES_DIR).filter((name) => {
+    if (name === '__tests__') return false;
+    const full = join(SHAPES_DIR, name);
+    try {
+      return statSync(full).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+}
+
+describe('SHAPE_AUTHZ_REGISTRY', () => {
+  it('registers every shapes/* route directory', () => {
+    const dirs = listShapeRouteDirs().sort();
+    const registered = Object.keys(SHAPE_AUTHZ_REGISTRY).sort();
+    expect(registered).toEqual(dirs);
+  });
+
+  it('assigns a known scope kind to every entry', () => {
+    const allowed = new Set(['user_self', 'site_member', 'admin_platform', 'acl_resource']);
+    for (const [name, entry] of Object.entries(SHAPE_AUTHZ_REGISTRY)) {
+      expect(allowed.has(entry.scope), `${name} has invalid scope ${entry.scope}`).toBe(true);
+      expect(entry.table.length).toBeGreaterThan(0);
+      expect(entry.enforcement.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/admin/src/lib/api/electric-proxy.ts
+++ b/apps/admin/src/lib/api/electric-proxy.ts
@@ -39,11 +39,13 @@ export function prepareElectricUrl(requestUrl: string): URL {
     }
   });
 
-  // Add Electric authentication if configured
+  // Add Electric authentication if configured (self-hosted ELECTRIC_SECRET)
   if (process.env.ELECTRIC_SECRET) {
     originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET);
   }
-  // Add Electric Cloud source ID if configured (Cloud-only, not needed for self-hosted)
+  // Legacy Electric Cloud source_id. Cloud is retired (Electric joined Neon at
+  // Databricks, 2026-08-11). Keep passthrough only so a stale env does not
+  // crash the proxy; do not set ELECTRIC_SOURCE_ID on new deploys (GAP-478).
   if (process.env.ELECTRIC_SOURCE_ID) {
     originUrl.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID);
   }

--- a/apps/admin/src/lib/api/electric-proxy.ts
+++ b/apps/admin/src/lib/api/electric-proxy.ts
@@ -39,13 +39,11 @@ export function prepareElectricUrl(requestUrl: string): URL {
     }
   });
 
-  // Add Electric authentication if configured (self-hosted ELECTRIC_SECRET)
+  // Add Electric authentication if configured
   if (process.env.ELECTRIC_SECRET) {
     originUrl.searchParams.set('secret', process.env.ELECTRIC_SECRET);
   }
-  // Legacy Electric Cloud source_id. Cloud is retired (Electric joined Neon at
-  // Databricks, 2026-08-11). Keep passthrough only so a stale env does not
-  // crash the proxy; do not set ELECTRIC_SOURCE_ID on new deploys (GAP-478).
+  // Add Electric Cloud source ID if configured (Cloud-only, not needed for self-hosted)
   if (process.env.ELECTRIC_SOURCE_ID) {
     originUrl.searchParams.set('source_id', process.env.ELECTRIC_SOURCE_ID);
   }

--- a/apps/admin/src/lib/api/shape-authz-registry.ts
+++ b/apps/admin/src/lib/api/shape-authz-registry.ts
@@ -1,0 +1,97 @@
+/**
+ * Electric shape AuthZ registry (GAP-477 Phase C).
+ *
+ * Every apps/admin/src/app/api/shapes/<name>/route.ts must appear here with an
+ * explicit scope kind. Tests fail closed if a route directory is unregistered
+ * so new shapes cannot ship as auth-only proxies.
+ */
+
+export type ShapeAuthzScope = 'user_self' | 'site_member' | 'admin_platform' | 'acl_resource';
+
+export interface ShapeAuthzEntry {
+  /** Electric table (or primary table) this proxy reads. */
+  table: string;
+  /** How ownership / admin is enforced on the route. */
+  scope: ShapeAuthzScope;
+  /** One-line how the where / gate is applied. */
+  enforcement: string;
+}
+
+/**
+ * Canonical map: shape route directory name → AuthZ contract.
+ * Keep in lockstep with route files under apps/admin/src/app/api/shapes/.
+ */
+export const SHAPE_AUTHZ_REGISTRY: Readonly<Record<string, ShapeAuthzEntry>> = {
+  conversations: {
+    table: 'conversations',
+    scope: 'user_self',
+    enforcement: 'where user_id = session.user.id',
+  },
+  'task-submissions': {
+    table: 'task_submissions',
+    scope: 'user_self',
+    enforcement: 'where submitter_id = session.user.id',
+  },
+  'agent-contexts': {
+    table: 'agent_contexts',
+    scope: 'user_self',
+    enforcement: 'where session_id = auth session id (write path key)',
+  },
+  'agent-memories': {
+    table: 'agent_memories',
+    scope: 'site_member',
+    enforcement: 'admin: agent_id; non-admin: site access + agent_id AND site_id',
+  },
+  'coordination-sessions': {
+    table: 'coordination_sessions',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole full-table',
+  },
+  'coordination-work-items': {
+    table: 'coordination_work_items',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole full-table',
+  },
+  'shared-facts': {
+    table: 'shared_facts',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + session_id where (no user ACL column)',
+  },
+  'shared-memories': {
+    table: 'agent_memories',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + scope filter (no user ACL join)',
+  },
+  'yjs-documents': {
+    table: 'yjs_documents',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole until owner_id ACL migrates (Phase C residual)',
+  },
+  'yjs-document-patches': {
+    table: 'yjs_document_patches',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole until document ACL migrates',
+  },
+  'kg-nodes': {
+    table: 'kg_nodes',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + optional repo where (fleet graph)',
+  },
+  'kg-edges': {
+    table: 'kg_edges',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + optional repo where (fleet graph)',
+  },
+  'kg-edge-episodes': {
+    table: 'kg_edge_episodes',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole (join table; no ownership column)',
+  },
+  'kg-views': {
+    table: 'yjs_documents',
+    scope: 'admin_platform',
+    enforcement: 'isAdminRole + document id where (kg-view ids)',
+  },
+} as const;
+
+export const SHAPE_AUTHZ_ROUTE_NAMES: readonly string[] = Object.keys(SHAPE_AUTHZ_REGISTRY);

--- a/apps/admin/src/lib/api/shape-authz.ts
+++ b/apps/admin/src/lib/api/shape-authz.ts
@@ -1,5 +1,5 @@
 /**
- * Shared AuthZ helpers for Electric shape proxy routes (GAP-476).
+ * Shared AuthZ helpers for Electric shape proxy routes (GAP-477).
  */
 
 import type { Database } from '@revealui/db/client';

--- a/apps/admin/src/lib/api/shape-authz.ts
+++ b/apps/admin/src/lib/api/shape-authz.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared AuthZ helpers for Electric shape proxy routes (GAP-476).
+ */
+
+import type { Database } from '@revealui/db/client';
+import { siteCollaborators, sites } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { isAdminRole } from '@/lib/access/roles/isAdminRole';
+import { isSyncIdentifier, isUuid } from '@/lib/utils/identifier-validation';
+
+export { isUuid };
+
+/** True when role is owner/admin/super-admin (CMS shell admin plane). */
+export function requireAdminRole(role: string | null | undefined): boolean {
+  return isAdminRole(role);
+}
+
+/**
+ * Site id safe to inline into an Electric `where` clause (sync identifier charset).
+ */
+export function isSafeSiteId(value: string): boolean {
+  return isSyncIdentifier(value);
+}
+
+/**
+ * Whether `userId` may access agent/site-scoped data for `siteId`.
+ * Admins always may. Otherwise owner or site_collaborators row.
+ */
+export async function userCanAccessSite(
+  db: Database,
+  userId: string,
+  siteId: string,
+  role: string | null | undefined,
+): Promise<boolean> {
+  if (requireAdminRole(role)) return true;
+
+  const [site] = await db
+    .select({ ownerId: sites.ownerId })
+    .from(sites)
+    .where(eq(sites.id, siteId))
+    .limit(1);
+
+  if (!site) return false;
+  if (site.ownerId === userId) return true;
+
+  const [collaborator] = await db
+    .select({ id: siteCollaborators.id })
+    .from(siteCollaborators)
+    .where(and(eq(siteCollaborators.siteId, siteId), eq(siteCollaborators.userId, userId)))
+    .limit(1);
+
+  return collaborator != null;
+}

--- a/apps/admin/src/lib/components/agents/task-history.tsx
+++ b/apps/admin/src/lib/components/agents/task-history.tsx
@@ -35,15 +35,13 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
   const [rows, setRows] = useState<AgentActionRow[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
   // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is an intentional re-fetch trigger passed from parent
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     (async () => {
       try {
-        const r = await fetch(`${apiUrl}/a2a/agents/${encodeURIComponent(agentId)}/tasks`, {
+        const r = await fetch(`/a2a/agents/${encodeURIComponent(agentId)}/tasks`, {
           credentials: 'include',
         });
         if (!r.ok) {
@@ -68,7 +66,7 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
     return () => {
       cancelled = true;
     };
-  }, [agentId, apiUrl, refreshKey]);
+  }, [agentId, refreshKey]);
 
   if (loading) {
     return (

--- a/apps/admin/src/lib/components/agents/task-tester.tsx
+++ b/apps/admin/src/lib/components/agents/task-tester.tsx
@@ -44,8 +44,6 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
   const [task, setTask] = useState<A2ATask | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-  const apiUrl = (process.env.NEXT_PUBLIC_API_URL ?? 'https://api.revealui.com').trim();
-
   async function submit() {
     if (!instruction.trim()) return;
     setState('submitting');
@@ -58,7 +56,8 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
     };
 
     try {
-      const res = await apiFetch(`${apiUrl}/a2a`, {
+      // Same-origin /a2a rewrite so the admin session authenticates AI feature gates.
+      const res = await apiFetch('/a2a', {
         method: 'POST',
         headers,
         credentials: 'include',

--- a/apps/admin/src/lib/middleware/__tests__/ai-feature-gate.test.ts
+++ b/apps/admin/src/lib/middleware/__tests__/ai-feature-gate.test.ts
@@ -1,5 +1,5 @@
 /**
- * AI Feature Gate Middleware Tests (GAP-476)
+ * AI Feature Gate Middleware Tests (GAP-477)
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +14,10 @@ vi.mock('@revealui/core/features', () => ({
 
 vi.mock('@revealui/db/client', () => ({
   getClient: () => mockGetClient(),
+}));
+
+vi.mock('@revealui/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 vi.mock('@/lib/access/account-feature', () => ({
@@ -111,5 +115,18 @@ describe('checkAIFeatureGate', () => {
     const result = await checkAIFeatureGate('user-1');
     expect(result).not.toBeNull();
     expect((result as { status: number }).status).toBe(403);
+  });
+
+  it('falls back to process license when getClient throws (no DB in unit tests)', async () => {
+    mockGetClient.mockImplementation(() => {
+      throw new Error('Database connection string not provided');
+    });
+    mockIsFeatureEnabled.mockReturnValue(true);
+    const checkAIFeatureGate = await loadFn();
+
+    const result = await checkAIFeatureGate('user-1');
+    expect(result).toBeNull();
+    expect(mockIsFeatureEnabled).toHaveBeenCalledWith('ai');
+    expect(mockAccountHasFeature).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin/src/lib/middleware/__tests__/ai-feature-gate.test.ts
+++ b/apps/admin/src/lib/middleware/__tests__/ai-feature-gate.test.ts
@@ -1,15 +1,23 @@
 /**
- * AI Feature Gate Middleware Tests
- *
- * Tests for checkAIFeatureGate() which gates Pro AI features behind a license check.
+ * AI Feature Gate Middleware Tests (GAP-476)
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockIsFeatureEnabled = vi.fn();
+const mockAccountHasFeature = vi.fn();
+const mockGetClient = vi.fn(() => ({}));
 
 vi.mock('@revealui/core/features', () => ({
   isFeatureEnabled: (...args: unknown[]) => mockIsFeatureEnabled(...args),
+}));
+
+vi.mock('@revealui/db/client', () => ({
+  getClient: () => mockGetClient(),
+}));
+
+vi.mock('@/lib/access/account-feature', () => ({
+  accountHasFeature: (...args: unknown[]) => mockAccountHasFeature(...args),
 }));
 
 vi.mock('next/server', () => {
@@ -33,31 +41,75 @@ vi.mock('next/server', () => {
 describe('checkAIFeatureGate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockIsFeatureEnabled.mockReturnValue(false);
   });
 
   async function loadFn() {
+    vi.resetModules();
     const mod = await import('../ai-feature-gate.js');
     return mod.checkAIFeatureGate;
   }
 
-  it('returns null when AI features are enabled', async () => {
+  it('returns 401 when userId is missing', async () => {
+    const checkAIFeatureGate = await loadFn();
+    const result = await checkAIFeatureGate(null);
+    expect(result).not.toBeNull();
+    expect((result as { status: number }).status).toBe(401);
+  });
+
+  it('returns null when account entitlements grant ai', async () => {
+    mockAccountHasFeature.mockResolvedValue(true);
+    const checkAIFeatureGate = await loadFn();
+
+    const result = await checkAIFeatureGate('user-1');
+    expect(result).toBeNull();
+    expect(mockAccountHasFeature).toHaveBeenCalled();
+    expect(mockIsFeatureEnabled).not.toHaveBeenCalled();
+  });
+
+  it('falls back to process isFeatureEnabled when account lacks feature', async () => {
+    mockAccountHasFeature.mockResolvedValue(false);
     mockIsFeatureEnabled.mockReturnValue(true);
     const checkAIFeatureGate = await loadFn();
 
-    const result = checkAIFeatureGate();
+    const result = await checkAIFeatureGate('user-1');
     expect(result).toBeNull();
     expect(mockIsFeatureEnabled).toHaveBeenCalledWith('ai');
   });
 
-  it('returns 403 response when AI features are not enabled', async () => {
+  it('returns 403 when neither account nor process license grants ai', async () => {
+    mockAccountHasFeature.mockResolvedValue(false);
     mockIsFeatureEnabled.mockReturnValue(false);
     const checkAIFeatureGate = await loadFn();
 
-    const result = checkAIFeatureGate();
+    const result = await checkAIFeatureGate('user-1');
     expect(result).not.toBeNull();
     expect((result as { status: number }).status).toBe(403);
     expect((result as unknown as { body: { error: string } }).body).toEqual({
       error: 'AI features require a Pro license',
     });
+  });
+
+  it('allows when REVEALUI_ALLOW_DEV_FEATURE_BYPASS=1', async () => {
+    vi.stubEnv('REVEALUI_ALLOW_DEV_FEATURE_BYPASS', '1');
+    const checkAIFeatureGate = await loadFn();
+
+    const result = await checkAIFeatureGate('user-1');
+    expect(result).toBeNull();
+    expect(mockAccountHasFeature).not.toHaveBeenCalled();
+  });
+
+  it('does not bypass on NODE_ENV=development alone', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('REVEALUI_ALLOW_DEV_FEATURE_BYPASS', '');
+    mockAccountHasFeature.mockResolvedValue(false);
+    mockIsFeatureEnabled.mockReturnValue(false);
+    const checkAIFeatureGate = await loadFn();
+
+    const result = await checkAIFeatureGate('user-1');
+    expect(result).not.toBeNull();
+    expect((result as { status: number }).status).toBe(403);
   });
 });

--- a/apps/admin/src/lib/middleware/ai-feature-gate.ts
+++ b/apps/admin/src/lib/middleware/ai-feature-gate.ts
@@ -5,15 +5,18 @@
  * - `checkAIFeatureGate(userId)` checks the `ai` feature (Pro tier, $49/mo)
  * - `checkAIMemoryFeatureGate(userId)` checks the `aiMemory` feature (Max tier, $299/mo)
  *
- * Resolution (GAP-476):
+ * Resolution (GAP-477):
  * 1. Fail closed if no userId
  * 2. Account entitlements via membership + account_entitlements
  * 3. Fallback to process-level isFeatureEnabled (fleet/self-host JWT license)
- * 4. Dev bypass only when REVEALUI_ALLOW_DEV_FEATURE_BYPASS=1 (not NODE_ENV)
+ * 4. If account lookup cannot run (no DB URL, pool error), fall through to (3)
+ *    so fleet kits and unit tests that only mock process license still work
+ * 5. Dev bypass only when REVEALUI_ALLOW_DEV_FEATURE_BYPASS=1 (not NODE_ENV)
  */
 
 import { type FeatureFlags, isFeatureEnabled } from '@revealui/core/features';
 import { getClient } from '@revealui/db/client';
+import { logger } from '@revealui/utils/logger';
 import { NextResponse } from 'next/server';
 import { accountHasFeature } from '@/lib/access/account-feature';
 
@@ -28,8 +31,18 @@ async function userHasFeature(
   if (!userId) return false;
   if (allowDevFeatureBypass()) return true;
 
-  const db = getClient();
-  if (await accountHasFeature(db, userId, featureKey)) return true;
+  try {
+    const db = getClient();
+    if (await accountHasFeature(db, userId, featureKey)) return true;
+  } catch (error) {
+    // No DATABASE_URL in unit tests, or transient DB outage: do not 500 the
+    // request. Hosted production still fails closed when process license is free
+    // and the account row was never readable as true.
+    logger.warn('account feature lookup failed; falling back to process license', {
+      featureKey,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   // Fleet / single-tenant self-host: process license JWT
   return isFeatureEnabled(featureKey);

--- a/apps/admin/src/lib/middleware/ai-feature-gate.ts
+++ b/apps/admin/src/lib/middleware/ai-feature-gate.ts
@@ -2,45 +2,65 @@
  * AI Feature Gate Middleware
  *
  * Provides gate functions for AI-related API routes.
- * - `checkAIFeatureGate()` checks the `ai` feature (Pro tier, $49/mo)
- * - `checkAIMemoryFeatureGate()` checks the `aiMemory` feature (Max tier, $299/mo)
+ * - `checkAIFeatureGate(userId)` checks the `ai` feature (Pro tier, $49/mo)
+ * - `checkAIMemoryFeatureGate(userId)` checks the `aiMemory` feature (Max tier, $299/mo)
+ *
+ * Resolution (GAP-476):
+ * 1. Fail closed if no userId
+ * 2. Account entitlements via membership + account_entitlements
+ * 3. Fallback to process-level isFeatureEnabled (fleet/self-host JWT license)
+ * 4. Dev bypass only when REVEALUI_ALLOW_DEV_FEATURE_BYPASS=1 (not NODE_ENV)
  */
 
-import { isFeatureEnabled } from '@revealui/core/features';
+import { type FeatureFlags, isFeatureEnabled } from '@revealui/core/features';
+import { getClient } from '@revealui/db/client';
 import { NextResponse } from 'next/server';
+import { accountHasFeature } from '@/lib/access/account-feature';
 
-/**
- * In development mode, all feature gates are open so developers can test
- * AI routes without a license key. Production always enforces licensing.
- */
-const isDev = process.env.NODE_ENV === 'development';
+function allowDevFeatureBypass(): boolean {
+  return process.env.REVEALUI_ALLOW_DEV_FEATURE_BYPASS === '1';
+}
 
-/**
- * Returns a 403 NextResponse if AI features are not enabled (no Pro license).
- * Returns null if the request should proceed.
- * Bypassed in development mode.
- */
-export function checkAIFeatureGate(): NextResponse | null {
-  if (isDev) return null;
-  if (!isFeatureEnabled('ai')) {
-    return NextResponse.json({ error: 'AI features require a Pro license' }, { status: 403 });
-  }
-  return null;
+async function userHasFeature(
+  userId: string | null | undefined,
+  featureKey: keyof FeatureFlags,
+): Promise<boolean> {
+  if (!userId) return false;
+  if (allowDevFeatureBypass()) return true;
+
+  const db = getClient();
+  if (await accountHasFeature(db, userId, featureKey)) return true;
+
+  // Fleet / single-tenant self-host: process license JWT
+  return isFeatureEnabled(featureKey);
 }
 
 /**
- * Returns a 403 NextResponse if AI Memory features are not enabled (no Max license).
- * AI Memory routes (episodic, working, context, vector search) require Max ($299/mo),
- * not Pro ($49/mo).
- * Bypassed in development mode.
+ * Returns a 403 NextResponse if AI features are not enabled for this user.
+ * Returns null if the request should proceed.
+ * Call only after AuthN with session.user.id.
  */
-export function checkAIMemoryFeatureGate(): NextResponse | null {
-  if (isDev) return null;
-  if (!isFeatureEnabled('aiMemory')) {
-    return NextResponse.json(
-      { error: 'AI Memory features require a Max license' },
-      { status: 403 },
-    );
+export async function checkAIFeatureGate(
+  userId: string | null | undefined,
+): Promise<NextResponse | null> {
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  return null;
+  if (await userHasFeature(userId, 'ai')) return null;
+  return NextResponse.json({ error: 'AI features require a Pro license' }, { status: 403 });
+}
+
+/**
+ * Returns a 403 NextResponse if AI Memory features are not enabled for this user.
+ * AI Memory routes (episodic, working, context, vector search) require Max ($299/mo).
+ * Call only after AuthN with session.user.id.
+ */
+export async function checkAIMemoryFeatureGate(
+  userId: string | null | undefined,
+): Promise<NextResponse | null> {
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (await userHasFeature(userId, 'aiMemory')) return null;
+  return NextResponse.json({ error: 'AI Memory features require a Max license' }, { status: 403 });
 }

--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -28,13 +28,13 @@ export function GetStarted({
             {data.heading}
           </h2>
           <p
-            className="mt-5 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-body"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}
           </p>
           <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
-            <Button asChild size="lg" variant="brand">
+            <Button asChild size="lg" variant="brand" glow>
               <a href={data.cta.primary.href}>{data.cta.primary.label}</a>
             </Button>
             <Button asChild appearance="outline" variant="neutral" size="lg">

--- a/apps/marketing/app/components/__tests__/Hero.test.tsx
+++ b/apps/marketing/app/components/__tests__/Hero.test.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom/vitest';
+import { Router, RouterProvider } from '@revealui/router';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HOME_HERO } from '../../content/home';
+import { Hero } from '../landing/Hero';
+
+afterEach(cleanup);
+
+function renderHero(search = '') {
+  const router = new Router();
+  // Seed location so selectAudience / selectHomeHero see the same search string.
+  if (search) {
+    window.history.replaceState({}, '', `/${search.startsWith('?') ? search : `?${search}`}`);
+  } else {
+    window.history.replaceState({}, '', '/');
+  }
+  return render(
+    <RouterProvider router={router}>
+      <Hero />
+    </RouterProvider>,
+  );
+}
+
+describe('Hero (marketing craft hierarchy)', () => {
+  it('renders the L1 H1 with ink (text-foreground), not muted', () => {
+    renderHero();
+    const h1 = screen.getByRole('heading', { level: 1, name: HOME_HERO.h1 });
+    expect(h1.className).toContain('text-foreground');
+    expect(h1.className).not.toContain('text-muted-foreground');
+  });
+
+  it('uses body text for the subtitle (readable ladder), not muted', () => {
+    renderHero();
+    const subtitle = screen.getByText(HOME_HERO.subtitle.sentence1, { exact: false });
+    expect(subtitle.className).toContain('text-body');
+    expect(subtitle.className).not.toContain('text-muted-foreground');
+  });
+
+  it('renders primary CTA as a solid brand control with glow emphasis', () => {
+    renderHero();
+    const primary = screen.getByRole('link', {
+      name: new RegExp(HOME_HERO.cta.primary.label, 'i'),
+    });
+    // glowClasses from presentation uses the brand glow token shadow.
+    expect(primary.className).toMatch(
+      /shadow-\[var\(--rvui-shadow-glow\)\]|shadow-\[var\(--rvui-shadow-glow/,
+    );
+  });
+
+  it('lists trust signals without brand-dot chrome', () => {
+    renderHero();
+    expect(screen.getByText('Open source')).toBeInTheDocument();
+    expect(screen.getByText('Self-hostable')).toBeInTheDocument();
+    expect(screen.getByText('Local-first AI')).toBeInTheDocument();
+    // No decorative primary dots in the trust strip (craft: separators only).
+    const list = screen.getByText('Open source').closest('ul');
+    expect(list).toBeTruthy();
+    expect(list?.querySelectorAll('.bg-primary').length ?? 0).toBe(0);
+  });
+
+  it('exposes the audience toggle as navigation', () => {
+    renderHero();
+    expect(screen.getByRole('navigation', { name: 'Choose your view' })).toBeInTheDocument();
+  });
+});

--- a/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
@@ -30,15 +30,12 @@ export function ClosingCta({
         >
           {data.heading}
         </h2>
-        <p
-          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground"
-          {...field('body')}
-        >
+        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-body" {...field('body')}>
           {data.body}
         </p>
 
         <div className="mt-10 flex justify-center">
-          <Button asChild size="lg">
+          <Button asChild size="lg" glow>
             <a
               href={data.primaryCta.href}
               {...(data.primaryCta.external

--- a/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
@@ -46,14 +46,14 @@ export function Hero({
         </h1>
 
         <p
-          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-body sm:text-xl"
           {...field('subtitle')}
         >
           {data.subtitle}
         </p>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-          <Button asChild size="lg" className="w-full sm:w-auto">
+          <Button asChild size="lg" glow className="w-full sm:w-auto">
             <a
               href={data.primaryCta.href}
               {...(data.primaryCta.external

--- a/apps/marketing/app/components/for-operators-managed/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Hero.tsx
@@ -42,7 +42,7 @@ export function Hero({ data, path, annotation }: FoManagedHeroProps = {}) {
         </h1>
 
         <p
-          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-body sm:text-xl"
           {...(base ? fieldAttrs(ann, `${base}.subtitle`) : {})}
         >
           {content.subtitle}

--- a/apps/marketing/app/components/for-operators/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators/ClosingCta.tsx
@@ -28,14 +28,14 @@ export function ClosingCta({ data, path, annotation }: ClosingCtaProps = {}) {
           {content.heading}
         </h2>
         <p
-          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground"
+          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-body"
           {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
         >
           {content.body}
         </p>
 
         <div className="mt-10 flex justify-center">
-          <Button asChild size="lg">
+          <Button asChild size="lg" glow>
             <a
               href={content.primaryCta.href}
               {...(content.primaryCta.external

--- a/apps/marketing/app/components/for-operators/EngagementPricing.tsx
+++ b/apps/marketing/app/components/for-operators/EngagementPricing.tsx
@@ -39,7 +39,7 @@ export function EngagementPricing({ data, path, annotation }: EngagementPricingP
             {intro.heading}
           </h2>
           <p
-            className="mt-6 text-lg leading-8 text-muted-foreground"
+            className="mt-6 text-lg leading-8 text-body"
             {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
           >
             {intro.body}

--- a/apps/marketing/app/components/for-operators/Hero.tsx
+++ b/apps/marketing/app/components/for-operators/Hero.tsx
@@ -45,14 +45,14 @@ export function Hero({ data, path, annotation }: ServicesHeroProps = {}) {
         </h1>
 
         <p
-          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-body sm:text-xl"
           {...(base ? fieldAttrs(ann, `${base}.subtitle`) : {})}
         >
           {content.subtitle}
         </p>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-          <Button asChild size="lg" className="w-full sm:w-auto">
+          <Button asChild size="lg" glow className="w-full sm:w-auto">
             <a
               href={content.primaryCta.href}
               {...(content.primaryCta.external

--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -36,7 +36,7 @@ export function WhatYouGet({ data, path, annotation }: WhatYouGetProps = {}) {
             {content.heading}
           </h2>
           <p
-            className="mt-6 text-lg leading-8 text-muted-foreground"
+            className="mt-6 text-lg leading-8 text-body"
             {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
           >
             {content.body}

--- a/apps/marketing/app/components/landing/CostCalculator.tsx
+++ b/apps/marketing/app/components/landing/CostCalculator.tsx
@@ -67,7 +67,7 @@ export function CostCalculator() {
           <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {C.heading}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">{C.body}</p>
+          <p className="mt-6 text-lg leading-8 text-body">{C.body}</p>
         </div>
 
         <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -30,7 +30,7 @@ export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {}
             {data.heading}
           </h2>
           <p
-            className="mt-5 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-body"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -12,9 +12,8 @@ import { selectHomeHero } from '../../lib/hero-variant';
 import { AudienceToggle } from './AudienceToggle';
 
 // Shared trust strip (the signals the retired eyebrow pill used to carry).
-// Rendered above BOTH hero H1 variants and for both audiences, so the
-// "Local-first AI" chip lands without forking the ?hero=foundation A/B or
-// adding a third hero variant (positioning decision d).
+// Rendered for both audiences. Separators (not brand dots) keep chrome quiet —
+// Linear craft: limit decoration; hierarchy from type weight and spacing.
 const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as const;
 
 /**
@@ -24,16 +23,29 @@ const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as cons
  * to `--color-primary` rather than a literal color. Lives inside an
  * overflow-hidden box so the off-canvas offset never creates a scrollbar.
  * Reads in both light and dark.
- *
- * Craft pass 2026-08: lower opacity, smaller glow. Linear redesign lesson:
- * reduce chrome noise; let type and the receipt carry hierarchy.
  */
 function HeroBackground() {
   return (
     <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.03] via-background to-background" />
-      <div className="absolute -top-32 left-1/2 h-[520px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--color-primary),transparent_70%)] opacity-[0.07] blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.04] via-background to-background" />
+      <div className="absolute -top-32 left-1/2 h-[520px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--color-primary),transparent_70%)] opacity-[0.12] blur-3xl" />
     </div>
+  );
+}
+
+/** Trust strip: vertical rules between labels, no brand-dot decoration. */
+function TrustStrip() {
+  return (
+    <ul className="mt-8 flex flex-wrap items-center justify-center gap-y-2 text-sm text-body list-none p-0">
+      {TRUST_SIGNALS.map((signal, index) => (
+        <li key={signal} className="flex items-center">
+          {index > 0 ? (
+            <span aria-hidden="true" className="mx-3 h-3 w-px bg-border-strong sm:mx-4" />
+          ) : null}
+          <span>{signal}</span>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -41,16 +53,23 @@ function HeroBackground() {
 function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
   return (
     <>
-      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
+      {/*
+        Type ladder (P0 craft):
+        - H1 = text-foreground (ink, max contrast)
+        - subtitle = text-body (rvui-text-1) for long reading, not muted
+        - trust / captions = muted only when meta
+        SwipePages/SaaS LPs fail when body is grey-on-paper; text-body clears AA.
+      */}
+      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground text-balance sm:text-6xl lg:text-7xl">
         {hero.h1}
       </h1>
 
-      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:mt-8 sm:text-xl sm:leading-8">
+      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-body sm:mt-8 sm:text-xl">
         {hero.subtitle.sentence1} {hero.subtitle.sentence2} {hero.subtitle.support}
       </p>
 
-      <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
-        <Button asChild size="lg" className="w-full sm:w-auto gap-2">
+      <div className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3 sm:mt-10 sm:gap-4">
+        <Button asChild size="lg" glow className="w-full sm:w-auto gap-2">
           <a href={hero.cta.primary.href}>
             {hero.cta.primary.label}
             <IconArrowRight size="sm" />
@@ -70,15 +89,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         </Button>
       </div>
 
-      {/* Trust strip: quiet separators, not competing brand dots. */}
-      <ul className="mt-8 flex flex-wrap items-center justify-center gap-x-0 gap-y-2 text-sm text-muted-foreground list-none p-0">
-        {TRUST_SIGNALS.map((signal, index) => (
-          <li key={signal} className="flex items-center">
-            {index > 0 && <span aria-hidden="true" className="mx-3 h-3 w-px bg-border sm:mx-4" />}
-            <span>{signal}</span>
-          </li>
-        ))}
-      </ul>
+      <TrustStrip />
     </>
   );
 }
@@ -92,7 +103,7 @@ function NonTechnicalHero() {
   const hero = FOR_OPERATORS_HERO;
   return (
     <>
-      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
+      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground text-balance sm:text-6xl lg:text-7xl">
         {hero.h1Lines.map((line) => (
           <span key={line} className="block">
             {line}
@@ -100,12 +111,12 @@ function NonTechnicalHero() {
         ))}
       </h1>
 
-      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-muted-foreground sm:mt-8 sm:text-xl sm:leading-8">
+      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-body sm:mt-8 sm:text-xl">
         {hero.subtitle}
       </p>
 
       <div className="mt-9 flex justify-center sm:mt-10">
-        <Button asChild size="lg" className="w-full sm:w-auto gap-2">
+        <Button asChild size="lg" glow className="w-full sm:w-auto gap-2">
           <a href={hero.primaryCta.href} target="_blank" rel="noopener noreferrer">
             {hero.primaryCta.label}
             <IconArrowRight size="sm" />
@@ -113,14 +124,7 @@ function NonTechnicalHero() {
         </Button>
       </div>
 
-      <ul className="mt-8 flex flex-wrap items-center justify-center gap-x-0 gap-y-2 text-sm text-muted-foreground list-none p-0">
-        {TRUST_SIGNALS.map((signal, index) => (
-          <li key={signal} className="flex items-center">
-            {index > 0 && <span aria-hidden="true" className="mx-3 h-3 w-px bg-border sm:mx-4" />}
-            <span>{signal}</span>
-          </li>
-        ))}
-      </ul>
+      <TrustStrip />
     </>
   );
 }
@@ -145,8 +149,7 @@ export function Hero() {
         </div>
 
         {/* Receipt-motif moment (frontend-excellence Phase 5): one orchestrated
-            print entrance. Signature creative element only (Linear craft: one
-            moment, not competing chrome). */}
+            print entrance, shared verbatim by both audience variants. */}
         <div className="mt-12 w-full max-w-md min-w-0 mx-auto text-left sm:mt-14 sm:max-w-lg">
           <ReceiptCard
             title={RECEIPT_HERO_TITLE}
@@ -154,11 +157,11 @@ export function Hero() {
             integrity={RECEIPT_HERO_INTEGRITY}
             animate="print"
           />
-          <p className="mt-4 text-center text-sm text-muted-foreground">
+          <p className="mt-4 text-center text-sm text-body">
             {RECEIPT_HERO_CAPTION.text}{' '}
             <Link
               to={RECEIPT_HERO_CAPTION.link.href}
-              className="text-foreground underline underline-offset-4 hover:text-primary"
+              className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
             >
               {RECEIPT_HERO_CAPTION.link.label}
             </Link>

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -55,9 +55,7 @@ export function PricingTeaser() {
           <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PRICING_TEASER_SECTION.heading}
           </h2>
-          <p className="mt-5 text-lg leading-8 text-muted-foreground">
-            {PRICING_TEASER_SECTION.body}
-          </p>
+          <p className="mt-5 text-lg leading-8 text-body">{PRICING_TEASER_SECTION.body}</p>
         </div>
 
         <div className="mx-auto mt-14 grid max-w-3xl grid-cols-1 gap-5 sm:mt-16 sm:grid-cols-2 sm:gap-6">

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -71,7 +71,7 @@ export function Primitives({
             {data.heading}
           </h2>
           <p
-            className="mt-5 text-lg leading-8 text-muted-foreground"
+            className="mt-5 text-lg leading-8 text-body"
             {...fieldAttrs(annotation, `${path}.body`)}
           >
             {data.body}

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -56,7 +56,7 @@ export function Problem() {
           <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {HOME_PROBLEM.heading}
           </h2>
-          <p className="mt-5 text-lg leading-8 text-muted-foreground">{HOME_PROBLEM.body}</p>
+          <p className="mt-5 text-lg leading-8 text-body">{HOME_PROBLEM.body}</p>
         </div>
 
         {/* Path blurbs: three quiet lines under the intro, not three cards. */}

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -14,7 +14,7 @@ export function Proof() {
           <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PROOF_SECTION.heading}
           </h2>
-          <p className="mt-5 text-lg leading-8 text-muted-foreground">{PROOF_SECTION.body}</p>
+          <p className="mt-5 text-lg leading-8 text-body">{PROOF_SECTION.body}</p>
 
           <div className="mt-6 flex justify-center">
             <a
@@ -66,8 +66,8 @@ export function Proof() {
           <h3 className="mt-3 font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
             {PROOF_DEPLOYERS.heading}
           </h3>
-          <p className="mt-4 text-base leading-7 text-muted-foreground">{PROOF_DEPLOYERS.body}</p>
-          <p className="mt-4 text-sm leading-6 text-muted-foreground">{PROOF_DEPLOYERS.foil}</p>
+          <p className="mt-4 text-base leading-7 text-body">{PROOF_DEPLOYERS.body}</p>
+          <p className="mt-4 text-sm leading-6 text-body">{PROOF_DEPLOYERS.foil}</p>
           <div className="mt-8">
             <Button asChild size="default" className="items-center justify-center">
               <a href={PROOF_DEPLOYERS.cta.href} target="_blank" rel="noopener noreferrer">

--- a/apps/marketing/app/components/products/ProductsCta.tsx
+++ b/apps/marketing/app/components/products/ProductsCta.tsx
@@ -25,10 +25,7 @@ export function ProductsCta({
         >
           {data.heading}
         </h2>
-        <p
-          className="mt-6 text-lg leading-8 text-muted-foreground"
-          {...fieldAttrs(annotation, `${path}.body`)}
-        >
+        <p className="mt-6 text-lg leading-8 text-body" {...fieldAttrs(annotation, `${path}.body`)}>
           {data.body}
         </p>
         <div

--- a/apps/marketing/app/components/products/ProductsHero.tsx
+++ b/apps/marketing/app/components/products/ProductsHero.tsx
@@ -32,7 +32,7 @@ export function ProductsHero({
           {data.h1}
         </h1>
         <p
-          className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl"
+          className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl"
           {...fieldAttrs(annotation, `${path}.subtitle`)}
         >
           {data.subtitle}

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -86,7 +86,7 @@ export function BlogIndexPage() {
           <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             Blog
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
             Updates, guides, and insights from the RevealUI team.
           </p>
         </div>

--- a/apps/marketing/app/routes/ContactPage.tsx
+++ b/apps/marketing/app/routes/ContactPage.tsx
@@ -11,7 +11,7 @@ export function ContactPage() {
             <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
               {CONTACT_HERO.title}
             </h1>
-            <p className="mt-6 text-lg leading-8 text-muted-foreground">{CONTACT_HERO.subtitle}</p>
+            <p className="mt-6 text-lg leading-8 text-body">{CONTACT_HERO.subtitle}</p>
           </div>
 
           <ContactForm />

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -381,10 +381,7 @@ function FairSourceCta({ data, path, annotation }: CtaProps) {
         >
           {data.heading}
         </h2>
-        <p
-          className="mt-6 text-lg leading-8 text-muted-foreground"
-          {...fieldAttrs(annotation, `${path}.body`)}
-        >
+        <p className="mt-6 text-lg leading-8 text-body" {...fieldAttrs(annotation, `${path}.body`)}>
           {data.body}
         </p>
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -451,7 +448,7 @@ export function FairSourcePage() {
             {FAIR_SOURCE_HERO.headline}
             <span className="block text-primary">{FAIR_SOURCE_HERO.headlineHighlight}</span>
           </h1>
-          <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-muted-foreground sm:text-2xl">
+          <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-body sm:text-2xl">
             {FAIR_SOURCE_HERO.subhead}
           </p>
           <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -45,7 +45,7 @@ function LocalAiHero({ data, path, annotation }: LocalAiHeroProps) {
           {data.h1}
         </h1>
         <p
-          className="mt-6 text-lg leading-8 text-muted-foreground"
+          className="mt-6 text-lg leading-8 text-body"
           {...fieldAttrs(annotation, `${path}.subtitle`)}
         >
           {data.lead}

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -74,7 +74,7 @@ function PhilosophyBody({ data, path, annotation }: PhilosophyBodyProps) {
           return (
             <p
               key={`body-${index}`}
-              className="text-lg leading-8 text-muted-foreground"
+              className="text-lg leading-8 text-body"
               {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
             >
               {section.body}

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -111,7 +111,7 @@ export function PricingPage() {
               RevealUI
             </span>
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
             {PRICING_HERO.subtitle}
           </p>
           <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
@@ -650,9 +650,7 @@ export function PricingPage() {
           <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             {PRICING_FINAL_CTA.title}
           </h2>
-          <p className="mt-6 text-lg leading-8 text-muted-foreground">
-            {PRICING_FINAL_CTA.subtitle}
-          </p>
+          <p className="mt-6 text-lg leading-8 text-body">{PRICING_FINAL_CTA.subtitle}</p>
           <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Button asChild size="lg" className="w-full sm:w-auto">
               <a

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -63,7 +63,7 @@ export function RoadmapPage() {
               Roadmap
             </span>
           </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground sm:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
             {ROADMAP_HERO.subtitle} See our{' '}
             <a
               href={ROADMAP_HERO_LINK.href}

--- a/apps/server/src/lib/__tests__/resolve-membership.test.ts
+++ b/apps/server/src/lib/__tests__/resolve-membership.test.ts
@@ -1,0 +1,88 @@
+/**
+ * resolveActiveMembership (GAP-477 Phase C)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@revealui/db/schema', () => ({
+  accountMemberships: {
+    accountId: 'accountId',
+    role: 'role',
+    userId: 'userId',
+    status: 'status',
+    createdAt: 'createdAt',
+  },
+  accounts: {
+    id: 'id',
+    slug: 'slug',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => args,
+  asc: (x: unknown) => x,
+  eq: (...args: unknown[]) => args,
+  or: (...args: unknown[]) => args,
+}));
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockInnerJoin = vi.fn();
+const mockWhere = vi.fn();
+const mockOrderBy = vi.fn();
+const mockLimit = vi.fn();
+
+function chain() {
+  const c = {
+    select: mockSelect,
+    from: mockFrom,
+    innerJoin: mockInnerJoin,
+    where: mockWhere,
+    orderBy: mockOrderBy,
+    limit: mockLimit,
+  };
+  mockSelect.mockReturnValue(c);
+  mockFrom.mockReturnValue(c);
+  mockInnerJoin.mockReturnValue(c);
+  mockWhere.mockReturnValue(c);
+  mockOrderBy.mockReturnValue(c);
+  return c;
+}
+
+describe('resolveActiveMembership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chain();
+  });
+
+  it('returns preferred membership when user is a member', async () => {
+    mockLimit.mockResolvedValueOnce([{ accountId: 'acct-preferred', role: 'owner' }]);
+    const { resolveActiveMembership } = await import('../resolve-membership.js');
+    const db = { select: mockSelect } as never;
+
+    const result = await resolveActiveMembership(db, 'user-1', 'acct-preferred');
+    expect(result).toEqual({ accountId: 'acct-preferred', role: 'owner' });
+    expect(mockInnerJoin).toHaveBeenCalled();
+  });
+
+  it('falls back to oldest active membership when preferred misses', async () => {
+    mockLimit
+      .mockResolvedValueOnce([]) // preferred miss
+      .mockResolvedValueOnce([{ accountId: 'acct-old', role: 'member' }]);
+    const { resolveActiveMembership } = await import('../resolve-membership.js');
+    const db = { select: mockSelect } as never;
+
+    const result = await resolveActiveMembership(db, 'user-1', 'missing-slug');
+    expect(result).toEqual({ accountId: 'acct-old', role: 'member' });
+    expect(mockOrderBy).toHaveBeenCalled();
+  });
+
+  it('returns null when user has no active membership', async () => {
+    mockLimit.mockResolvedValueOnce([]);
+    const { resolveActiveMembership } = await import('../resolve-membership.js');
+    const db = { select: mockSelect } as never;
+
+    const result = await resolveActiveMembership(db, 'user-1', null);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/server/src/lib/account-entitlement.ts
+++ b/apps/server/src/lib/account-entitlement.ts
@@ -12,8 +12,9 @@
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import type { Database } from '@revealui/db/client';
-import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
+import { resolveActiveMembership } from './resolve-membership.js';
 
 /** A subscription status that still confers the paid tier (mirrors the middleware). */
 function isHealthyStatus(status: string | null): boolean {
@@ -38,23 +39,18 @@ function featureRecord(features: object | null | undefined): Record<string, bool
  * the authenticated dispatcher captured server-side at enqueue time for the
  * durable worker (`AgentDispatchPayload.userId`) — never a client-writable
  * value such as a ticket row's `reporterId` (§6.1).
+ *
+ * Membership pick: {@link resolveActiveMembership} (preferred account, else
+ * oldest active — GAP-477 Phase C; no more unordered `.limit(1)`).
  */
-export async function accountHasAiFeature(db: Database, userId: string | null): Promise<boolean> {
+export async function accountHasAiFeature(
+  db: Database,
+  userId: string | null,
+  preferredAccountId?: string | null,
+): Promise<boolean> {
   if (!userId) return false;
 
-  // TODO(GAP-360 follow-up): `.limit(1)` picks an arbitrary active membership
-  // for a user who belongs to multiple accounts. `entitlementMiddleware` has
-  // the same shape (entitlements.ts `entitlementMiddleware`), so this mirrors
-  // existing behavior rather than introducing new ambiguity, but multi-account
-  // BYOK resolution deserves its own design pass (which membership "wins" for
-  // both entitlement and key lookup should be the same account, and today
-  // that's just "whichever active row postgres returns first").
-  const [membership] = await db
-    .select({ accountId: accountMemberships.accountId })
-    .from(accountMemberships)
-    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
-    .limit(1);
-
+  const membership = await resolveActiveMembership(db, userId, preferredAccountId);
   if (!membership?.accountId) return false;
 
   const [entitlement] = await db

--- a/apps/server/src/lib/resolve-membership.ts
+++ b/apps/server/src/lib/resolve-membership.ts
@@ -1,0 +1,70 @@
+/**
+ * Active account membership resolution (GAP-477 Phase C).
+ *
+ * Replaces nondeterministic `.limit(1)` without ORDER BY on multi-account users.
+ *
+ * Priority:
+ * 1. Preferred account id/slug (X-Tenant-ID / tenant middleware) when the user
+ *    has an active membership on that account
+ * 2. Exactly one active membership → that row
+ * 3. Multiple memberships without preference → oldest by created_at (stable)
+ *
+ * Fail-closed: no active membership → null.
+ */
+
+import type { Database } from '@revealui/db/client';
+import { accountMemberships, accounts } from '@revealui/db/schema';
+import { and, asc, eq, or } from 'drizzle-orm';
+
+export interface ActiveMembership {
+  accountId: string;
+  role: string;
+}
+
+/**
+ * Resolve which billing/workspace account a user is acting as for entitlements.
+ *
+ * @param preferredAccountId - Optional account id or slug (e.g. X-Tenant-ID).
+ *   Only wins when the user has an active membership on that account.
+ */
+export async function resolveActiveMembership(
+  db: Database,
+  userId: string,
+  preferredAccountId?: string | null,
+): Promise<ActiveMembership | null> {
+  const preferred = preferredAccountId?.trim() || null;
+
+  if (preferred) {
+    const [preferredRow] = await db
+      .select({
+        accountId: accountMemberships.accountId,
+        role: accountMemberships.role,
+      })
+      .from(accountMemberships)
+      .innerJoin(accounts, eq(accounts.id, accountMemberships.accountId))
+      .where(
+        and(
+          eq(accountMemberships.userId, userId),
+          eq(accountMemberships.status, 'active'),
+          or(eq(accounts.id, preferred), eq(accounts.slug, preferred)),
+        ),
+      )
+      .limit(1);
+
+    if (preferredRow) {
+      return preferredRow;
+    }
+  }
+
+  const rows = await db
+    .select({
+      accountId: accountMemberships.accountId,
+      role: accountMemberships.role,
+    })
+    .from(accountMemberships)
+    .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
+    .orderBy(asc(accountMemberships.createdAt))
+    .limit(1);
+
+  return rows[0] ?? null;
+}

--- a/apps/server/src/middleware/__tests__/entitlements.test.ts
+++ b/apps/server/src/middleware/__tests__/entitlements.test.ts
@@ -1,9 +1,12 @@
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+/** Fluent select chain for resolveActiveMembership + entitlement lookup. */
 const mockDbSelectChain = {
   from: vi.fn(),
+  innerJoin: vi.fn(),
   where: vi.fn(),
+  orderBy: vi.fn(),
   limit: vi.fn(),
 };
 
@@ -21,19 +24,29 @@ vi.mock('@revealui/db/schema', () => ({
     userId: 'account_memberships.userId',
     role: 'account_memberships.role',
     status: 'account_memberships.status',
+    createdAt: 'account_memberships.createdAt',
+  },
+  accounts: {
+    id: 'accounts.id',
+    slug: 'accounts.slug',
   },
   accountEntitlements: {
     accountId: 'account_entitlements.accountId',
+    mode: 'account_entitlements.mode',
     tier: 'account_entitlements.tier',
     status: 'account_entitlements.status',
+    graceUntil: 'account_entitlements.graceUntil',
     features: 'account_entitlements.features',
     limits: 'account_entitlements.limits',
+    cogsBreakerTrippedAt: 'account_entitlements.cogsBreakerTrippedAt',
   },
 }));
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
+  asc: vi.fn((_col: unknown) => `asc(${String(_col)})`),
   eq: vi.fn((_col: unknown, _val: unknown) => `eq(${String(_col)},${String(_val)})`),
+  or: vi.fn((...args: unknown[]) => `or(${args.join(',')})`),
 }));
 
 import { entitlementMiddleware, getEntitlementsFromContext } from '../entitlements.js';
@@ -57,7 +70,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   selectResults = [];
   mockDbSelectChain.from.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.innerJoin.mockReturnValue(mockDbSelectChain);
   mockDbSelectChain.where.mockReturnValue(mockDbSelectChain);
+  mockDbSelectChain.orderBy.mockReturnValue(mockDbSelectChain);
   mockDbSelectChain.limit.mockImplementation(() => Promise.resolve(selectResults.shift() ?? []));
   mockDb.select.mockReturnValue(mockDbSelectChain);
 });

--- a/apps/server/src/middleware/entitlements.ts
+++ b/apps/server/src/middleware/entitlements.ts
@@ -9,9 +9,10 @@
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import { getClient } from '@revealui/db';
-import { accountEntitlements, accountMemberships } from '@revealui/db/schema';
+import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
 import type { MiddlewareHandler } from 'hono';
+import { resolveActiveMembership } from '../lib/resolve-membership.js';
 
 export interface EntitlementContext {
   userId: string | null;
@@ -81,14 +82,16 @@ export const entitlementMiddleware = (): MiddlewareHandler => {
     }
 
     const db = getClient();
-    const [membership] = await db
-      .select({
-        accountId: accountMemberships.accountId,
-        role: accountMemberships.role,
-      })
-      .from(accountMemberships)
-      .where(and(eq(accountMemberships.userId, userId), eq(accountMemberships.status, 'active')))
-      .limit(1);
+    // Preferred workspace: tenant middleware context, then X-Tenant-ID / X-Account-ID.
+    // resolveActiveMembership only admits accounts the user actually belongs to.
+    const tenant = c.get('tenant') as { id?: string } | undefined;
+    const preferredAccountId =
+      tenant?.id?.trim() ||
+      c.req.header('X-Tenant-ID')?.trim() ||
+      c.req.header('X-Account-ID')?.trim() ||
+      null;
+
+    const membership = await resolveActiveMembership(db, userId, preferredAccountId);
 
     if (!membership?.accountId) {
       c.set('entitlements', createFreeEntitlements(userId));

--- a/apps/server/src/routes/__tests__/a2a.test.ts
+++ b/apps/server/src/routes/__tests__/a2a.test.ts
@@ -23,6 +23,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockGetCard,
   mockListCards,
+  mockListDefs,
   mockHas,
   mockGetDef,
   mockRegister,
@@ -37,6 +38,7 @@ const {
 } = vi.hoisted(() => ({
   mockGetCard: vi.fn(),
   mockListCards: vi.fn(),
+  mockListDefs: vi.fn(),
   mockHas: vi.fn(),
   mockGetDef: vi.fn(),
   mockRegister: vi.fn(),
@@ -59,6 +61,7 @@ vi.mock('@revealui/ai', () => ({
   agentCardRegistry: {
     getCard: mockGetCard,
     listCards: mockListCards,
+    listDefs: mockListDefs,
     has: mockHas,
     getDef: mockGetDef,
     register: mockRegister,
@@ -239,6 +242,7 @@ function resetMocks() {
 
   mockGetCard.mockReturnValue(MOCK_CARD);
   mockListCards.mockReturnValue([MOCK_CARD]);
+  mockListDefs.mockReturnValue([MOCK_DEF]);
   mockHas.mockReturnValue(false);
   mockGetDef.mockReturnValue(MOCK_DEF);
   mockRegister.mockImplementation(() => undefined);
@@ -412,12 +416,31 @@ describe('GET /agents', () => {
   });
 
   it('returns empty agents array when registry is empty', async () => {
+    mockListDefs.mockReturnValue([]);
     mockListCards.mockReturnValue([]);
     const app = makeA2AApp();
     const res = await app.request(get('/agents'));
     expect(res.status).toBe(200);
     const body = (await res.json()) as { agents: unknown[] };
     expect(body.agents).toHaveLength(0);
+  });
+
+  it('includes registry id so list UIs do not invent ids from display names', async () => {
+    mockListDefs.mockReturnValue([
+      { ...MOCK_DEF, id: 'revealui-ticket-agent', name: 'Ticket Agent' },
+    ]);
+    mockGetCard.mockReturnValue({
+      ...MOCK_CARD,
+      id: undefined,
+      name: 'Ticket Agent',
+    });
+    const app = makeA2AApp();
+    const res = await app.request(get('/agents'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { agents: Array<{ id: string; name: string }> };
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0]?.id).toBe('revealui-ticket-agent');
+    expect(body.agents[0]?.name).toBe('Ticket Agent');
   });
 });
 

--- a/apps/server/src/routes/__tests__/entitlement-mode-scope.test.ts
+++ b/apps/server/src/routes/__tests__/entitlement-mode-scope.test.ts
@@ -24,12 +24,25 @@ vi.mock('@revealui/core/features', () => ({
 }));
 
 const mockDbLimitFn = vi.fn().mockResolvedValue([]);
+
+/** Fluent select chain: membership uses orderBy/innerJoin; entitlement uses where.limit. */
+function makeSelectChain() {
+  const chain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit: mockDbLimitFn,
+  };
+  chain.from.mockReturnValue(chain);
+  chain.innerJoin.mockReturnValue(chain);
+  chain.where.mockReturnValue(chain);
+  chain.orderBy.mockReturnValue(chain);
+  return chain;
+}
+
 const mockDb = {
-  select: vi.fn().mockReturnValue({
-    from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({ limit: mockDbLimitFn }),
-    }),
-  }),
+  select: vi.fn().mockImplementation(() => makeSelectChain()),
 };
 
 vi.mock('@revealui/db', () => ({
@@ -42,6 +55,11 @@ vi.mock('@revealui/db/schema', () => ({
     status: 'am.status',
     accountId: 'am.accountId',
     role: 'am.role',
+    createdAt: 'am.createdAt',
+  },
+  accounts: {
+    id: 'accounts.id',
+    slug: 'accounts.slug',
   },
   accountEntitlements: {
     accountId: 'ae.accountId',
@@ -51,12 +69,15 @@ vi.mock('@revealui/db/schema', () => ({
     graceUntil: 'ae.graceUntil',
     features: 'ae.features',
     limits: 'ae.limits',
+    cogsBreakerTrippedAt: 'ae.cogsBreakerTrippedAt',
   },
 }));
 
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn((_c: unknown, _v: unknown) => 'eq'),
   and: vi.fn((...args: unknown[]) => `and(${args.join(',')})`),
+  asc: vi.fn((_c: unknown) => 'asc'),
+  or: vi.fn((...args: unknown[]) => `or(${args.join(',')})`),
 }));
 
 import { accountEntitlements } from '@revealui/db/schema';
@@ -83,11 +104,7 @@ describe('Entitlement middleware — mode-scoped reader (GAP-266 Track B)', () =
     vi.clearAllMocks();
     mockGetConfiguredStripeMode.mockReturnValue('live');
     mockDbLimitFn.mockReset().mockResolvedValue([]);
-    vi.mocked(mockDb.select).mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({ limit: mockDbLimitFn }),
-      }),
-    });
+    vi.mocked(mockDb.select).mockImplementation(() => makeSelectChain());
   });
 
   afterEach(() => {

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -422,10 +422,16 @@ a2a.openapi(
     // Include registry id on each card. Display name alone is not a stable id
     // (e.g. "Ticket Agent" ≠ "revealui-ticket-agent") — admin list UIs must not
     // invent ids by slugifying the name.
-    const agents = aiMod.agentCardRegistry.listDefs().map((def) => ({
-      id: def.id,
-      ...aiMod.agentCardRegistry.getCard(def.id, baseUrl),
-    }));
+    // Registry id must be applied AFTER the card spread so a missing/undefined
+    // id field on the A2A card shape cannot overwrite the real agent id.
+    const agents = aiMod.agentCardRegistry
+      .listDefs()
+      .map((def) => {
+        const card = aiMod.agentCardRegistry.getCard(def.id, baseUrl);
+        if (!card) return null;
+        return { ...card, id: def.id };
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null);
     return c.json({ agents });
   },
 );

--- a/apps/server/src/routes/a2a.ts
+++ b/apps/server/src/routes/a2a.ts
@@ -419,8 +419,14 @@ a2a.openapi(
       return c.json(aiModuleUnavailableBody(), 503);
     }
     const baseUrl = getBaseUrl(c.req.raw);
-    const cards = aiMod.agentCardRegistry.listCards(baseUrl);
-    return c.json({ agents: cards });
+    // Include registry id on each card. Display name alone is not a stable id
+    // (e.g. "Ticket Agent" ≠ "revealui-ticket-agent") — admin list UIs must not
+    // invent ids by slugifying the name.
+    const agents = aiMod.agentCardRegistry.listDefs().map((def) => ({
+      id: def.id,
+      ...aiMod.agentCardRegistry.getCard(def.id, baseUrl),
+    }));
+    return c.json({ agents });
   },
 );
 

--- a/deployment/fly/electric/README.md
+++ b/deployment/fly/electric/README.md
@@ -1,0 +1,84 @@
+# Fly — revealui-electric (ElectricSQL)
+
+Phase 5 of `drop-railway-migrate-to-fly`. Closes **GAP-230** / **GAP-231** when vault + Vercel admin pick up this host.
+
+## What it is
+
+| | |
+|--|--|
+| Fly app | `revealui-electric` |
+| Image | `electricsql/electric:1.0.17` (pin; bump deliberately) |
+| Region | `iad` (Neon prod us-east-1) |
+| Volume | `electric_data` → `/var/lib/electric/persistent` |
+| Public URL | `https://revealui-electric.fly.dev` |
+
+Admin shape proxies (`apps/admin`) call this URL via `ELECTRIC_SERVICE_URL`. The worker does not serve shapes; it only carries a mirrored env for parity.
+
+## One-time create
+
+```bash
+flyctl apps create revealui-electric --org personal
+flyctl volumes create electric_data --app revealui-electric --region iad --size 1 --yes
+```
+
+## Secrets + vault (stream-safe)
+
+Generate a secret once, force-set vault, then mirror to Fly:
+
+```bash
+# 1) secret → revvault (stdin; no TTY print)
+openssl rand -hex 32 | revvault set revealui/prod/electric/secret --force
+
+# 2) service URL after DNS/hostname known (public-config)
+printf '%s' 'https://revealui-electric.fly.dev' | revvault set revealui/prod/electric/service-url --force
+
+# 3) Fly secrets — expand vars INSIDE bash (outer shell empties them)
+revvault run \
+  --env DATABASE_URL=revealui/prod/db/postgres-url \
+  --env ELECTRIC_SECRET=revealui/prod/electric/secret -- \
+  bash -c '
+    DB="$DATABASE_URL"
+    case "$DB" in postgresql://*) DB="postgres://${DB#postgresql://}" ;; esac
+    flyctl secrets set --app revealui-electric \
+      DATABASE_URL="$DB" ELECTRIC_SECRET="$ELECTRIC_SECRET"
+  '
+```
+
+Neon must have **logical replication** enabled. `revealui/prod/db/postgres-url`
+must be the **direct** endpoint (not `-pooler`). Electric 1.0.17 parses
+`postgres://`; rewrite `postgresql://` if the vault stores that form.
+
+**Do not** run `flyctl secrets set DATABASE_URL="$DATABASE_URL"` as the direct
+child of `revvault run` — the outer shell expands the empty var before inject.
+
+## Deploy
+
+```bash
+cd ~/revfleet/revealui   # or worktree
+flyctl deploy --config deployment/fly/electric/fly.toml --remote-only
+flyctl status --app revealui-electric
+curl -sS "https://revealui-electric.fly.dev/v1/health"
+```
+
+## Vercel admin (not unscoped full sync)
+
+Prefer dry-run then apply, or single-key push after vault is clean. Full `vercel:sync:apply` can rewrite every sensitive var (GAP-339). After vault is good:
+
+```bash
+revvault run --env VERCEL_TOKEN=revealui/prod/api-keys/vercel-token -- \
+  revvault sync vercel --manifest scripts/sync/revvault-vercel.toml
+# inspect electric rows only, then:
+revvault run --env VERCEL_TOKEN=revealui/prod/api-keys/vercel-token -- \
+  revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply
+```
+
+Redeploy **revealui-admin** so runtime picks up env. Probe:
+
+```bash
+curl -sS https://admin.revealui.com/api/health/electric
+# expect {"ok":true,...}
+```
+
+## Teardown note
+
+Do not delete the Fly volume without first dropping Neon replication slots Electric created (`electric_slot_*`), or WAL can grow unbounded.

--- a/deployment/fly/electric/fly.toml
+++ b/deployment/fly/electric/fly.toml
@@ -1,0 +1,65 @@
+# deployment/fly/electric/fly.toml
+#
+# Fly.io configuration for the ElectricSQL sync service (Phase 5 of
+# drop-railway-migrate-to-fly / GAP-230 / GAP-231).
+#
+# Replicates from Neon prod Postgres (logical replication) and serves
+# shape HTTP to apps/admin shape proxies via ELECTRIC_SERVICE_URL.
+#
+# Separate app from revealui-worker (512 MB Node-only today). ADR 2026-05-18
+# preferred co-location; isolation keeps worker memory headroom and lets
+# Electric scale/restart independently. Same region as Neon (iad / us-east-1).
+#
+# Deploy (from monorepo root or this directory):
+#   flyctl deploy --config deployment/fly/electric/fly.toml --remote-only
+#
+# Secrets (stream-safe):
+#   revvault run --env DATABASE_URL=revealui/prod/db/postgres-url \
+#     --env ELECTRIC_SECRET=revealui/prod/electric/secret -- \
+#     flyctl secrets set -a revealui-electric \
+#       DATABASE_URL="$DATABASE_URL" ELECTRIC_SECRET="$ELECTRIC_SECRET"
+#
+# Public URL after first deploy: https://revealui-electric.fly.dev
+# Pin image deliberately (not :latest) — matches monorepo compose 1.0.17.
+
+app = 'revealui-electric'
+primary_region = 'iad'
+
+[build]
+  image = 'electricsql/electric:1.0.17'
+
+[env]
+  ELECTRIC_USAGE_REPORTING = 'false'
+  ELECTRIC_STORAGE_DIR = '/var/lib/electric/persistent'
+  ELECTRIC_LISTEN_ON_IPV6 = 'false'
+  # HTTP port Electric binds (image default 3000)
+  ELECTRIC_HTTP_PORT = '3000'
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = 'off'
+  auto_start_machines = false
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = 'connections'
+    hard_limit = 200
+    soft_limit = 150
+
+  # Electric health (v1); longer grace for first WAL catch-up / slot create
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '120s'
+    method = 'GET'
+    path = '/v1/health'
+
+[[vm]]
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 512
+
+[mounts]
+  source = 'electric_data'
+  destination = '/var/lib/electric/persistent'

--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -159,9 +159,17 @@ unhealthy. Investigate via `flyctl logs --app revealui-worker`.
 
 ## Electric (Phase 5)
 
-ElectricSQL Fly setup lives in a separate `fly.electric.toml`
-(landing in Phase 5 of the infra-consolidation lane). Same region
-(iad), same Fly account. Connects to the same Neon `POSTGRES_URL`
-the worker uses. The cutover from the retired Railway-hosted Electric
-(dropped per ADR 2026-05-18) to Fly-hosted Electric is the load-bearing
-piece of Phase 5 — see the lane plan for sequencing.
+Config: [`deployment/fly/electric/fly.toml`](../../deployment/fly/electric/fly.toml)
++ runbook [`deployment/fly/electric/README.md`](../../deployment/fly/electric/README.md).
+
+| | |
+|--|--|
+| App | `revealui-electric` |
+| Image | `electricsql/electric:1.0.17` |
+| Region | `iad` (same Neon us-east-1) |
+| URL | `https://revealui-electric.fly.dev` |
+
+Connects to Neon via `revealui/prod/db/postgres-url` (direct, non-pooler).
+Vault paths after cutover: `revealui/prod/electric/service-url` +
+`revealui/prod/electric/secret` (GAP-230 / GAP-231). Electric Cloud is
+**retired** (2026-08-11); self-host only.


### PR DESCRIPTION
## Summary

Promote `test` → `main` (24 commits, main fully contained in test).

Notable landings on `test` since last promote:

- **Marketing craft** — #2556 hero contrast + site-wide body type ladder + operator CTA glow
- **Admin entitlements / shapes** — #2554 shape registry, knowledge-graph admin, membership resolve (+ follow-up test mocks)
- **Electric on Fly** — #2555 Phase 5 cutover
- **Electric shape authz / A2A** — #2552, #2550 and related admin/server fixes
- **Electric Cloud retired** — #2553 env and proxy docs notes
- Prior test train already included marketing Linear craft (#2546–#2548) and related work on this tip

## Merge method (required)

Use **Create a merge commit** only (not squash/rebase):

```bash
gh pr merge 2557 -R RevealUIStudio/revealui --merge
```

## Test plan

- [x] `main` is ancestor of `test` (behind_by=0)
- [ ] CI green on this PR
- [ ] After merge: confirm marketing deploy + smoke homepage contrast/CTA
- [ ] After merge: admin and Electric paths if owner-attended smoke needed

## Owner residuals (not blocking promote)

- DesignSync re-push after prod craft lands (Claude session)
- Any owner-only prod walks still outstanding