### PR TITLE
feat(db,admin,server): yjs document owner_id Electric ACL (GAP-477)

### DIFF
--- a/apps/admin/src/app/api/shapes/__tests__/yjs-documents.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/yjs-documents.test.ts
@@ -11,6 +11,15 @@ vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
+const mockLimit = vi.fn();
+const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+const mockFrom = vi.fn(() => ({ where: mockWhere }));
+const mockSelect = vi.fn(() => ({ from: mockFrom }));
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(() => ({ select: mockSelect })),
+}));
+
 vi.mock('@/lib/api/electric-proxy', () => ({
   prepareElectricUrl: vi.fn((_url: string) => {
     const electricUrl = new URL('http://localhost:5133/v1/shape');
@@ -88,8 +97,9 @@ describe('GET /api/shapes/yjs-documents', () => {
     expect(data.error).toBe('UNAUTHORIZED');
   });
 
-  it('should return 403 for non-admin', async () => {
+  it('should return 403 for non-admin without document ownership', async () => {
     mockGetSession.mockResolvedValue(makeSession('viewer') as never);
+    mockLimit.mockResolvedValue([{ ownerId: 'other-user' }]);
 
     const request = new NextRequest(
       `http://localhost:3000/api/shapes/yjs-documents?document_id=${VALID_DOC_ID}`,
@@ -99,6 +109,24 @@ describe('GET /api/shapes/yjs-documents', () => {
 
     expect(response.status).toBe(403);
     expect(data.error).toBe('FORBIDDEN');
+  });
+
+  it('should proxy for document owner (non-admin) with owner_id where clause', async () => {
+    mockGetSession.mockResolvedValue(makeSession('viewer') as never);
+    mockLimit.mockResolvedValue([{ ownerId: '123e4567-e89b-12d3-a456-426614174001' }]);
+
+    const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/shapes/yjs-documents?document_id=${VALID_DOC_ID}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(prepareElectricUrl).toHaveBeenCalled();
+    expect(proxyElectricRequest).toHaveBeenCalled();
+    const originUrl = vi.mocked(proxyElectricRequest).mock.calls[0]?.[0] as URL;
+    expect(originUrl.searchParams.get('where')).toContain('owner_id =');
   });
 
   it('should return 400 when document_id is missing', async () => {
@@ -127,6 +155,7 @@ describe('GET /api/shapes/yjs-documents', () => {
 
   it('should proxy request when admin with valid UUID', async () => {
     mockGetSession.mockResolvedValue(makeSession('admin') as never);
+    mockLimit.mockResolvedValue([]);
 
     const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
 

--- a/apps/admin/src/app/api/shapes/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/shapes/yjs-document-patches/route.ts
@@ -4,15 +4,15 @@
  * GET /api/shapes/yjs-document-patches?document_id=<document_id>
  *
  * Authenticated proxy for ElectricSQL yjs_document_patches shape.
- * GAP-476: fail-closed to isAdminRole — no document ACL join.
- * Residual Phase C: document-level ACL when ownership model lands.
+ * GAP-477: same document ACL as yjs-documents (owner or platform admin).
  */
 
 import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
-import { requireAdminRole } from '@/lib/api/shape-authz';
+import { userCanAccessYjsDocument } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
@@ -35,10 +35,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
 
-    if (!requireAdminRole(session.user.role)) {
-      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
-    }
-
     const documentId = new URL(request.url).searchParams.get('document_id');
     if (!documentId || documentId.trim().length === 0) {
       return createValidationErrorResponse(
@@ -55,6 +51,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         'document_id',
         documentId,
       );
+    }
+
+    const db = getClient();
+    const allowed = await userCanAccessYjsDocument(
+      db,
+      session.user.id,
+      documentId,
+      session.user.role,
+    );
+    if (!allowed) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
     }
 
     const originUrl = prepareElectricUrl(request.url);

--- a/apps/admin/src/app/api/shapes/yjs-documents/route.ts
+++ b/apps/admin/src/app/api/shapes/yjs-documents/route.ts
@@ -4,17 +4,18 @@
  * GET /api/shapes/yjs-documents?document_id=<uuid>
  *
  * Authenticated proxy for ElectricSQL yjs_documents shape.
- * GAP-476: fail-closed to isAdminRole — table has no user_id / ACL column.
- * Residual Phase C: document-level ACL when ownership model lands.
- * UUID-only document_id still required for the Electric where clause.
+ * GAP-477: acl_resource — platform admin may read any UUID doc; non-admin
+ * only when owner_id matches session user (legacy null owner = admin-only).
  */
 
 import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
-import { isUuid, requireAdminRole } from '@/lib/api/shape-authz';
+import { isUuid, requireAdminRole, userCanAccessYjsDocument } from '@/lib/api/shape-authz';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 export const dynamic = 'force-dynamic';
@@ -28,10 +29,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
 
-    if (!requireAdminRole(session.user.role)) {
-      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
-    }
-
     const url = new URL(request.url);
     const documentId = url.searchParams.get('document_id');
 
@@ -43,9 +40,32 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
     }
 
+    const db = getClient();
+    const allowed = await userCanAccessYjsDocument(
+      db,
+      session.user.id,
+      documentId,
+      session.user.role,
+    );
+    if (!allowed) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
+
     const originUrl = prepareElectricUrl(request.url);
     originUrl.searchParams.set('table', 'yjs_documents');
-    originUrl.searchParams.set('where', `id = '${documentId}'`);
+
+    // Admin: document id only. Owner: id + owner_id match (defense in depth with the gate above).
+    if (requireAdminRole(session.user.role)) {
+      originUrl.searchParams.set('where', `id = '${documentId}'`);
+    } else {
+      if (!isSyncIdentifier(session.user.id)) {
+        return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+      }
+      originUrl.searchParams.set(
+        'where',
+        `id = '${documentId}' AND owner_id = '${session.user.id}'`,
+      );
+    }
 
     return proxyElectricRequest(originUrl);
   } catch (error) {

--- a/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
@@ -13,7 +13,7 @@ import { getClient } from '@revealui/db';
 import { yjsDocumentPatches, yjsDocuments } from '@revealui/db/schema';
 import { applyPatches } from '@revealui/sync/collab/server';
 import { logger } from '@revealui/utils/logger';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
@@ -128,11 +128,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         .update(yjsDocuments)
         .set({ state, stateVector, updatedAt: new Date() })
         .where(eq(yjsDocuments.id, body.document_id));
+      // Durable heal: stamp creator once for legacy null-owner rows.
+      await db
+        .update(yjsDocuments)
+        .set({ ownerId: session.user.id })
+        .where(and(eq(yjsDocuments.id, body.document_id), isNull(yjsDocuments.ownerId)));
     } else {
       await db.insert(yjsDocuments).values({
         id: body.document_id,
         state,
         stateVector,
+        ownerId: session.user.id,
       });
     }
 

--- a/apps/admin/src/lib/api/shape-authz-registry.ts
+++ b/apps/admin/src/lib/api/shape-authz-registry.ts
@@ -64,13 +64,13 @@ export const SHAPE_AUTHZ_REGISTRY: Readonly<Record<string, ShapeAuthzEntry>> = {
   },
   'yjs-documents': {
     table: 'yjs_documents',
-    scope: 'admin_platform',
-    enforcement: 'isAdminRole until owner_id ACL migrates (Phase C residual)',
+    scope: 'acl_resource',
+    enforcement: 'admin: id where; owner: id AND owner_id = session user; null owner = admin-only',
   },
   'yjs-document-patches': {
     table: 'yjs_document_patches',
-    scope: 'admin_platform',
-    enforcement: 'isAdminRole until document ACL migrates',
+    scope: 'acl_resource',
+    enforcement: 'userCanAccessYjsDocument on parent document_id, then document_id where',
   },
   'kg-nodes': {
     table: 'kg_nodes',

--- a/apps/admin/src/lib/api/shape-authz.ts
+++ b/apps/admin/src/lib/api/shape-authz.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Database } from '@revealui/db/client';
-import { siteCollaborators, sites } from '@revealui/db/schema';
+import { siteCollaborators, sites, yjsDocuments } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
 import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { isSyncIdentifier, isUuid } from '@/lib/utils/identifier-validation';
@@ -13,6 +13,29 @@ export { isUuid };
 /** True when role is owner/admin/super-admin (CMS shell admin plane). */
 export function requireAdminRole(role: string | null | undefined): boolean {
   return isAdminRole(role);
+}
+
+/**
+ * Whether `userId` may Electric-sync a yjs document (GAP-477 acl_resource).
+ * Platform admins always may. Non-admins require a row whose owner_id matches.
+ * Legacy null owner_id stays admin-only (fail-closed until stamped on write).
+ */
+export async function userCanAccessYjsDocument(
+  db: Database,
+  userId: string,
+  documentId: string,
+  role: string | null | undefined,
+): Promise<boolean> {
+  if (requireAdminRole(role)) return true;
+
+  const [row] = await db
+    .select({ ownerId: yjsDocuments.ownerId })
+    .from(yjsDocuments)
+    .where(eq(yjsDocuments.id, documentId))
+    .limit(1);
+
+  if (!row) return false;
+  return row.ownerId != null && row.ownerId === userId;
 }
 
 /**

--- a/apps/server/src/collab/persistence.ts
+++ b/apps/server/src/collab/persistence.ts
@@ -1,5 +1,5 @@
 import { yjsDocuments } from '@revealui/db/schema/yjs-documents';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import * as Y from 'yjs';
 
 interface DrizzleDb {
@@ -20,9 +20,14 @@ interface DrizzleDb {
   };
 }
 
+export type SaveDocumentOptions = {
+  /** Creating user when known (GAP-477). Set on insert; never cleared on update. */
+  ownerId?: string | null;
+};
+
 export interface YjsPersistence {
   loadDocument(id: string, doc: Y.Doc): Promise<void>;
-  saveDocument(id: string, doc: Y.Doc): Promise<void>;
+  saveDocument(id: string, doc: Y.Doc, options?: SaveDocumentOptions): Promise<void>;
   updateClientCount(id: string, count: number): Promise<void>;
 }
 
@@ -40,10 +45,11 @@ export function createYjsPersistence(db: DrizzleDb): YjsPersistence {
       }
     },
 
-    async saveDocument(id: string, doc: Y.Doc): Promise<void> {
+    async saveDocument(id: string, doc: Y.Doc, options?: SaveDocumentOptions): Promise<void> {
       const state = Buffer.from(Y.encodeStateAsUpdate(doc));
       const stateVector = Buffer.from(Y.encodeStateVector(doc));
       const now = new Date();
+      const ownerId = options?.ownerId?.trim() || null;
 
       await db
         .insert(yjsDocuments)
@@ -51,6 +57,7 @@ export function createYjsPersistence(db: DrizzleDb): YjsPersistence {
           id,
           state,
           stateVector,
+          ownerId,
           connectedClients: 0,
           createdAt: now,
           updatedAt: now,
@@ -63,6 +70,14 @@ export function createYjsPersistence(db: DrizzleDb): YjsPersistence {
             updatedAt: now,
           },
         });
+
+      // Durable heal for legacy rows: stamp owner once, never reassign.
+      if (ownerId) {
+        await db
+          .update(yjsDocuments)
+          .set({ ownerId })
+          .where(and(eq(yjsDocuments.id, id), isNull(yjsDocuments.ownerId)));
+      }
     },
 
     async updateClientCount(id: string, count: number): Promise<void> {

--- a/apps/server/src/routes/__tests__/collab.test.ts
+++ b/apps/server/src/routes/__tests__/collab.test.ts
@@ -211,7 +211,9 @@ describe('collab routes', () => {
       });
 
       expect(mockLoadDocument).toHaveBeenCalledWith(docId, expect.any(Object));
-      expect(mockSaveDocument).toHaveBeenCalledWith(docId, expect.any(Object));
+      expect(mockSaveDocument).toHaveBeenCalledWith(docId, expect.any(Object), {
+        ownerId: testUser.id,
+      });
     });
   });
 

--- a/apps/server/src/routes/collab.ts
+++ b/apps/server/src/routes/collab.ts
@@ -114,7 +114,7 @@ export function createCollabRoute(): OpenAPIHono<{ Variables: Variables }> {
       const doc = new Y.Doc();
       await persistence.loadDocument(documentId, doc);
       Y.applyUpdate(doc, updateBytes);
-      await persistence.saveDocument(documentId, doc);
+      await persistence.saveDocument(documentId, doc, { ownerId: user.id });
       doc.destroy();
       return c.json({ success: true as const });
     } catch (err) {

--- a/packages/db/migrations/0040_gap477_yjs_owner_id.sql
+++ b/packages/db/migrations/0040_gap477_yjs_owner_id.sql
@@ -1,0 +1,7 @@
+-- GAP-477 residual: yjs_documents.owner_id for Electric shape ACL (creator stamp).
+-- Nullable for backfill of legacy rows; shapes treat null owner as admin-only.
+-- Companion Drizzle: packages/db/src/schema/yjs-documents.ts
+
+ALTER TABLE "yjs_documents" ADD COLUMN IF NOT EXISTS "owner_id" text;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "yjs_documents_owner_id_idx"
+  ON "yjs_documents" USING btree ("owner_id");

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -146,6 +146,12 @@
       "rationale": "GAP-256 PR-1: CREATE TABLE margin_snapshots, account_margin_daily, admission_waitlist; ADD COGS breaker columns on account_entitlements; widen source CHECK to include signup. Hand-written IF NOT EXISTS / DO $$ for idempotency and partial unique index WHERE status='pending' (not fully expressible via plain drizzle-kit without snapshot debt). Companion Drizzle schemas: packages/db/src/schema/margin-admission.ts + accounts.ts cogsBreaker* + source check.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as peer hand-written migrations; Drizzle schemas are the type contract for PR-2+."
+    },
+    {
+      "tag": "0040_gap477_yjs_owner_id",
+      "rationale": "GAP-477 residual: ADD COLUMN yjs_documents.owner_id (nullable text) + btree index for Electric shape ACL (creator stamp). Hand-written ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS for idempotency, following the 0011/0031/0036 column-addition precedent. Companion Drizzle schema at packages/db/src/schema/yjs-documents.ts models ownerId; write paths stamp session user on insert and never clear owner on update.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as peer hand-written migrations; Drizzle schema is the type contract."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1786272000000,
       "tag": "0039_gap256_margin_admission",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1786548000000,
+      "tag": "0040_gap477_yjs_owner_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/yjs-owner-schema.test.ts
+++ b/packages/db/src/__tests__/yjs-owner-schema.test.ts
@@ -1,0 +1,12 @@
+/**
+ * GAP-477 residual — yjs_documents.owner_id column is modeled for ACL stamps.
+ */
+import { describe, expect, it } from 'vitest';
+import { yjsDocuments } from '../schema/yjs-documents.js';
+
+describe('yjs_documents owner_id schema', () => {
+  it('exports owner_id for Electric shape ACL stamps', () => {
+    expect(yjsDocuments.ownerId.name).toBe('owner_id');
+    expect(yjsDocuments.id.name).toBe('id');
+  });
+});

--- a/packages/db/src/schema/yjs-documents.ts
+++ b/packages/db/src/schema/yjs-documents.ts
@@ -1,4 +1,4 @@
-import { customType, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { customType, index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 const bytea = customType<{ data: Buffer; driverData: Buffer }>({
   dataType() {
@@ -6,17 +6,29 @@ const bytea = customType<{ data: Buffer; driverData: Buffer }>({
   },
 });
 
-export const yjsDocuments = pgTable('yjs_documents', {
-  id: text('id').primaryKey(),
-  state: bytea('state').notNull(),
-  stateVector: bytea('state_vector'),
-  connectedClients: integer('connected_clients').notNull().default(0),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .$onUpdateFn(() => new Date())
-    .defaultNow()
-    .notNull(),
-});
+/**
+ * Collaborative Yjs document blobs.
+ *
+ * `owner_id` (GAP-477 residual): creating user for Electric shape ACL.
+ * Null rows are legacy (pre-migration) and remain admin_platform-only on shapes.
+ */
+export const yjsDocuments = pgTable(
+  'yjs_documents',
+  {
+    id: text('id').primaryKey(),
+    state: bytea('state').notNull(),
+    stateVector: bytea('state_vector'),
+    /** Creating user id when known; null = legacy / unstamped (admin-only shapes). */
+    ownerId: text('owner_id'),
+    connectedClients: integer('connected_clients').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .$onUpdateFn(() => new Date())
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [index('yjs_documents_owner_id_idx').on(table.ownerId)],
+);
 
 export type YjsDocument = typeof yjsDocuments.$inferSelect;
 export type NewYjsDocument = typeof yjsDocuments.$inferInsert;


### PR DESCRIPTION
## Summary
Durable residual for GAP-477: `yjs_documents.owner_id` creator ownership for Electric shape AuthZ.

- Migration `0040_gap477_yjs_owner_id` + Drizzle `ownerId` (nullable for legacy rows)
- Write paths stamp creator on insert; never reassign; heal null once on update
- Shape routes: platform admin any doc; owner only when `owner_id` matches; null owner remains admin-only (fail-closed)
- Registry scope `acl_resource` for yjs-documents and yjs-document-patches
- Tests for owner vs non-owner vs admin

No temporary dual-path bypass. Multi-user collab still goes through authenticated collab/update (stamps owner).

## Related
- GAP-477 Phase C: #2554 (merged)
- jv closeout/progress: RevealUIStudio/revealui-jv#1260

## Test plan
- [x] `migration-journal` pass
- [x] admin vitest yjs-documents + shape-authz-registry
- [x] phase-1 changed gate pass
- [ ] CI green