### PR TITLE
fix(admin): hide enterprise upsell chrome on upgrade surfaces

### DIFF
--- a/apps/admin/src/app/(backend)/upgrade/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(backend)/upgrade/__tests__/page.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseLicense = vi.fn();
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+vi.mock('@/components/TestModeBanner', () => ({
+  TestModeBanner: () => <div data-testid="test-mode-banner" />,
+}));
+
+vi.mock('@revealui/presentation/client', () => ({
+  PricingTable: ({ currentTier }: { currentTier?: string | null }) => (
+    <div data-testid="pricing-table" data-current={currentTier ?? ''} />
+  ),
+}));
+
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/safe-stripe-redirect', () => ({
+  safeStripeRedirect: vi.fn(),
+}));
+
+import UpgradePage from '../page';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('UpgradePage', () => {
+  it('shows plan chooser when a higher commercial tier exists', () => {
+    mockUseLicense.mockReturnValue({ tier: 'pro' });
+    render(<UpgradePage />);
+    expect(screen.getByRole('heading', { name: 'Choose Your Plan' })).toBeInTheDocument();
+    expect(screen.getByTestId('pricing-table')).toBeInTheDocument();
+    expect(screen.getByText(/Upgrade to unlock more features/)).toBeInTheDocument();
+  });
+
+  it('does not upsell when the account is already on enterprise', () => {
+    mockUseLicense.mockReturnValue({ tier: 'enterprise' });
+    render(<UpgradePage />);
+    expect(screen.getByRole('heading', { name: 'Your Plan' })).toBeInTheDocument();
+    expect(screen.queryByTestId('pricing-table')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/There is no higher commercial plan to upgrade into/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'account billing' })).toHaveAttribute(
+      'href',
+      '/account/billing',
+    );
+  });
+});

--- a/apps/admin/src/app/(backend)/upgrade/page.tsx
+++ b/apps/admin/src/app/(backend)/upgrade/page.tsx
@@ -1,10 +1,18 @@
 'use client';
 
-import { FEATURE_LABELS, SUBSCRIPTION_TIERS, TIER_LIMITS } from '@revealui/contracts/pricing';
+import {
+  FEATURE_LABELS,
+  getTiersFromCurrent,
+  type LicenseTierId,
+  SUBSCRIPTION_TIERS,
+  TIER_LABELS,
+  TIER_LIMITS,
+} from '@revealui/contracts/pricing';
 import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
 import { PricingTable } from '@revealui/presentation/client';
 import { useState } from 'react';
 import { TestModeBanner } from '@/components/TestModeBanner';
+import { hasCommercialUpgradePath } from '@/lib/components/should-show-upgrade-nav';
 import { useLicense } from '@/lib/providers/LicenseProvider';
 import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
@@ -12,8 +20,11 @@ import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 export default function UpgradePage() {
   const { tier: currentTier } = useLicense();
   const [error, setError] = useState<string | null>(null);
+  const tierId = (currentTier ?? 'free') as LicenseTierId;
+  const canUpgrade = hasCommercialUpgradePath(tierId);
+  const selectableTiers = canUpgrade ? getTiersFromCurrent(tierId) : [];
 
-  const handleSelectTier = async (tierId: string) => {
+  const handleSelectTier = async (nextTierId: string) => {
     setError(null);
     try {
       const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim();
@@ -30,14 +41,14 @@ export default function UpgradePage() {
         max: process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID,
         enterprise: process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID,
       };
-      const priceId = priceIdMap[tierId];
+      const priceId = priceIdMap[nextTierId];
       const res = await apiFetch(`${apiUrl}/api/billing/checkout`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({
           ...(priceId && { priceId }),
-          tier: tierId,
+          tier: nextTierId,
         }),
       });
 
@@ -53,7 +64,7 @@ export default function UpgradePage() {
         setError(data.error || 'Failed to start checkout. Please try again.');
       }
     } catch {
-      window.location.href = `/account/billing?upgrade=${tierId}`;
+      window.location.href = `/account/billing?upgrade=${nextTierId}`;
     }
   };
 
@@ -61,10 +72,12 @@ export default function UpgradePage() {
     <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8">
       <div className="text-center mb-12">
         <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
-          Choose Your Plan
+          {canUpgrade ? 'Choose Your Plan' : 'Your Plan'}
         </h1>
         <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
-          Upgrade to unlock more features, higher limits, and priority support.
+          {canUpgrade
+            ? 'Upgrade to unlock more features, higher limits, and priority support.'
+            : `You are on ${TIER_LABELS[tierId]}. There is no higher commercial plan to upgrade into.`}
         </p>
       </div>
 
@@ -78,11 +91,21 @@ export default function UpgradePage() {
         </div>
       )}
 
-      <PricingTable
-        tiers={SUBSCRIPTION_TIERS}
-        currentTier={currentTier}
-        onSelectTier={(id: string) => void handleSelectTier(id)}
-      />
+      {canUpgrade ? (
+        <PricingTable
+          tiers={selectableTiers.length > 0 ? selectableTiers : SUBSCRIPTION_TIERS}
+          currentTier={currentTier}
+          onSelectTier={(id: string) => void handleSelectTier(id)}
+        />
+      ) : (
+        <div className="mx-auto max-w-2xl rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          Manage invoices and payment methods from{' '}
+          <a href="/account/billing" className="font-medium text-primary hover:underline">
+            account billing
+          </a>
+          .
+        </div>
+      )}
 
       {/* Feature comparison matrix */}
       <div className="mt-16">

--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -20,6 +20,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import { TestModeBanner } from '@/components/TestModeBanner';
+import { hasCommercialUpgradePath } from '@/lib/components/should-show-upgrade-nav';
 import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
@@ -472,9 +473,12 @@ function BillingContent() {
           )}
 
           <div className="flex flex-col gap-2 border-t pt-4">
-            <Button asChild appearance="outline" variant="neutral" className="w-full">
-              <Link href="/upgrade">Change plan →</Link>
-            </Button>
+            {/* Top commercial tier (enterprise): no higher plan — hide upsell. */}
+            {hasCommercialUpgradePath(tier) && (
+              <Button asChild appearance="outline" variant="neutral" className="w-full">
+                <Link href="/upgrade">Change plan →</Link>
+              </Button>
+            )}
             {tier !== 'free' && (
               <Button
                 onClick={handleManageBilling}

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -24,6 +24,7 @@ import {
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { hasCommercialUpgradePath } from '@/lib/components/should-show-upgrade-nav';
 import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
@@ -186,7 +187,8 @@ export default function LicensePage() {
   const tier = subscription?.tier ?? 'free';
   const limits = TIER_LIMITS[tier];
   const tierFeatures = features?.[tier];
-  const canUpgrade = tier === 'free' || tier === 'pro';
+  // free / pro / max can climb; enterprise is the commercial top (GAP-473).
+  const canUpgrade = hasCommercialUpgradePath(tier);
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 py-12">
@@ -252,7 +254,11 @@ export default function LicensePage() {
                 href="/account/billing"
                 className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
               >
-                {tier === 'free' ? 'Upgrade to Pro →' : 'Upgrade to Enterprise →'}
+                {tier === 'free'
+                  ? 'Upgrade to Pro →'
+                  : tier === 'pro'
+                    ? 'Upgrade to Max →'
+                    : 'Upgrade to Enterprise →'}
               </Link>
             </div>
           )}

--- a/apps/admin/src/lib/components/UpgradeDialog.tsx
+++ b/apps/admin/src/lib/components/UpgradeDialog.tsx
@@ -72,32 +72,40 @@ export function UpgradeDialog() {
   }, []);
 
   const upgradeTiers = getTiersFromCurrent(tier);
+  // Enterprise / top grant: no higher commercial plan — do not upsell empty tables.
+  const atTopTier = upgradeTiers.length === 0;
 
   return (
     <Dialog open={open} onClose={handleClose} size="2xl">
-      <DialogTitle>Upgrade Your Plan</DialogTitle>
+      <DialogTitle>{atTopTier ? 'You are on the top plan' : 'Upgrade Your Plan'}</DialogTitle>
       <DialogDescription>
-        {featureName
-          ? `"${featureName}" requires a higher tier. Choose a plan to unlock it.`
-          : 'Unlock more features by upgrading your plan.'}
+        {atTopTier
+          ? 'Your account already has the highest commercial tier. No further upgrade is available.'
+          : featureName
+            ? `"${featureName}" requires a higher tier. Choose a plan to unlock it.`
+            : 'Unlock more features by upgrading your plan.'}
       </DialogDescription>
       <DialogBody>
         {error && <div className="mb-4 rounded-md bg-error/10 p-3 text-sm text-error">{error}</div>}
-        <PricingTable
-          tiers={upgradeTiers}
-          currentTier={tier ?? 'free'}
-          compact
-          onSelectTier={(id) => void handleSelectTier(id)}
-        />
+        {!atTopTier && (
+          <PricingTable
+            tiers={upgradeTiers}
+            currentTier={tier ?? 'free'}
+            compact
+            onSelectTier={(id) => void handleSelectTier(id)}
+          />
+        )}
       </DialogBody>
       <DialogActions>
-        <Link
-          href="/upgrade"
-          className="text-sm font-medium text-primary hover:underline"
-          onClick={handleClose}
-        >
-          View full pricing
-        </Link>
+        {!atTopTier && (
+          <Link
+            href="/upgrade"
+            className="text-sm font-medium text-primary hover:underline"
+            onClick={handleClose}
+          >
+            View full pricing
+          </Link>
+        )}
         <Button
           type="button"
           appearance="ghost"
@@ -105,7 +113,7 @@ export function UpgradeDialog() {
           onClick={handleClose}
           className="text-muted-foreground hover:text-foreground"
         >
-          Maybe later
+          {atTopTier ? 'Close' : 'Maybe later'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
@@ -7,13 +7,15 @@ vi.mock('@/lib/providers/LicenseProvider', () => ({
   useLicense: () => mockUseLicense(),
 }));
 
-// Mock @revealui/contracts/pricing
-const mockGetTiersFromCurrent = vi.fn(() => [
-  { id: 'pro', name: 'Pro', price: '$49/mo' },
-  { id: 'max', name: 'Max', price: '$299/mo' },
-]);
+// Mock @revealui/contracts/pricing (hoisted so factory can close over the mock).
+const { mockGetTiersFromCurrent } = vi.hoisted(() => ({
+  mockGetTiersFromCurrent: vi.fn(() => [
+    { id: 'pro', name: 'Pro', price: '$49/mo' },
+    { id: 'max', name: 'Max', price: '$299/mo' },
+  ]),
+}));
 vi.mock('@revealui/contracts/pricing', () => ({
-  getTiersFromCurrent: (...args: unknown[]) => mockGetTiersFromCurrent(...args),
+  getTiersFromCurrent: mockGetTiersFromCurrent,
 }));
 
 // Mock presentation components

--- a/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
@@ -8,11 +8,12 @@ vi.mock('@/lib/providers/LicenseProvider', () => ({
 }));
 
 // Mock @revealui/contracts/pricing
+const mockGetTiersFromCurrent = vi.fn(() => [
+  { id: 'pro', name: 'Pro', price: '$49/mo' },
+  { id: 'max', name: 'Max', price: '$299/mo' },
+]);
 vi.mock('@revealui/contracts/pricing', () => ({
-  getTiersFromCurrent: vi.fn(() => [
-    { id: 'pro', name: 'Pro', price: '$49/mo' },
-    { id: 'max', name: 'Max', price: '$299/mo' },
-  ]),
+  getTiersFromCurrent: (...args: unknown[]) => mockGetTiersFromCurrent(...args),
 }));
 
 // Mock presentation components
@@ -110,6 +111,10 @@ afterEach(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseLicense.mockReturnValue({ tier: 'free' });
+  mockGetTiersFromCurrent.mockReturnValue([
+    { id: 'pro', name: 'Pro', price: '$49/mo' },
+    { id: 'max', name: 'Max', price: '$299/mo' },
+  ]);
 });
 
 describe('UpgradeDialog', () => {
@@ -193,6 +198,19 @@ describe('UpgradeDialog', () => {
       const link = screen.getByText('View full pricing');
       expect(link).toHaveAttribute('href', '/upgrade');
     });
+  });
+
+  it('does not upsell when already on the top commercial tier', async () => {
+    mockUseLicense.mockReturnValue({ tier: 'enterprise' });
+    mockGetTiersFromCurrent.mockReturnValue([]);
+    render(<UpgradeDialog />);
+    await dispatchUpgradeRequired();
+    await waitFor(() => {
+      expect(screen.getByText('You are on the top plan')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('pricing-table')).not.toBeInTheDocument();
+    expect(screen.queryByText('View full pricing')).not.toBeInTheDocument();
+    expect(screen.getByText('Close')).toBeInTheDocument();
   });
 
   it('calls fetch with checkout endpoint when tier is selected', async () => {

--- a/apps/admin/src/lib/components/__tests__/shouldShowUpgradeNavItem.test.ts
+++ b/apps/admin/src/lib/components/__tests__/shouldShowUpgradeNavItem.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { shouldShowUpgradeNavItem } from '../should-show-upgrade-nav';
+import { hasCommercialUpgradePath, shouldShowUpgradeNavItem } from '../should-show-upgrade-nav';
+
+describe('hasCommercialUpgradePath', () => {
+  it('is true below enterprise', () => {
+    expect(hasCommercialUpgradePath('free')).toBe(true);
+    expect(hasCommercialUpgradePath('pro')).toBe(true);
+    expect(hasCommercialUpgradePath('max')).toBe(true);
+  });
+
+  it('is false for enterprise, unknown, empty', () => {
+    expect(hasCommercialUpgradePath('enterprise')).toBe(false);
+    expect(hasCommercialUpgradePath('')).toBe(false);
+    expect(hasCommercialUpgradePath(null)).toBe(false);
+    expect(hasCommercialUpgradePath(undefined)).toBe(false);
+    expect(hasCommercialUpgradePath('unknown')).toBe(false);
+  });
+});
 
 describe('shouldShowUpgradeNavItem', () => {
   const base = { isFleetMode: false, isLoading: false, resolveError: null };

--- a/apps/admin/src/lib/components/should-show-upgrade-nav.ts
+++ b/apps/admin/src/lib/components/should-show-upgrade-nav.ts
@@ -1,11 +1,11 @@
 /**
- * Whether the sidebar "Upgrade" item should show.
+ * Whether commercial upgrade chrome may show for a tier.
  *
  * Mirrors commercial ladder free < pro < max < enterprise (see
  * `@revealui/contracts/pricing` TIER_RANK / getTiersFromCurrent). Enterprise
- * is the top grant (founder / operator) — no higher plan, no Upgrade nav.
- * Fleet kits never show Stripe upgrade. While tier is loading or resolution
- * failed, hide upsell (GAP-454: do not invent free/upsell on unknown).
+ * is the top grant (founder / operator) — no higher plan, no Upgrade nav /
+ * upsell CTAs. Fleet kits never show Stripe upgrade. While tier is loading or
+ * resolution failed, hide upsell (GAP-454: do not invent free/upsell on unknown).
  */
 
 const TIER_RANK = {
@@ -18,6 +18,16 @@ const TIER_RANK = {
 /** Enterprise is the commercial top; no higher plan to upsell into. */
 const TOP_RANK: number = TIER_RANK.enterprise;
 
+/**
+ * True when a higher commercial plan exists above `tier`.
+ * False for enterprise, unknown tier strings, and empty tier.
+ */
+export function hasCommercialUpgradePath(tier: string | null | undefined): boolean {
+  if (!(tier && tier in TIER_RANK)) return false;
+  const rank = TIER_RANK[tier as keyof typeof TIER_RANK];
+  return rank < TOP_RANK;
+}
+
 export function shouldShowUpgradeNavItem(
   tier: string,
   options: {
@@ -28,7 +38,5 @@ export function shouldShowUpgradeNavItem(
 ): boolean {
   if (options.isFleetMode) return false;
   if (options.isLoading || options.resolveError) return false;
-  if (!(tier in TIER_RANK)) return false;
-  const rank = TIER_RANK[tier as keyof typeof TIER_RANK];
-  return rank < TOP_RANK;
+  return hasCommercialUpgradePath(tier);
 }


### PR DESCRIPTION
## Summary

Enterprise (and other top-tier grants) already hide the left-nav **Upgrade** item. Direct upgrade surfaces still sold a higher plan.

This residual hardens the remaining commercial upsell chrome:

- Shared `hasCommercialUpgradePath` helper (enterprise / unknown / empty fail closed)
- **Upgrade dialog** — top-tier honesty, no empty pricing table
- **`/upgrade` page** — no checkout chooser when already at the top
- **Billing** — hide **Change plan** when no higher commercial tier exists
- **License** — upgrade CTA for free/pro/**max** (was free/pro only); hidden for enterprise

## Test plan

- [x] Unit: `hasCommercialUpgradePath` / `shouldShowUpgradeNavItem`
- [x] Unit: UpgradeDialog enterprise top-tier path
- [x] Unit: Upgrade page enterprise vs pro
- [ ] Owner dogfood on admin: enterprise session has no Upgrade nav, no free banner, no Change plan upsell; re-login after account-owner shell repair if needed
- [ ] Visual: dashboard / agents / settings no document x-scroll at 1280–1920

## Notes

Builds on earlier founder shell work already on `test`/`main` (upgrade nav gate, SidebarLayout overflow, session mint shell-admin repair).