### PR TITLE
fix(admin,server): audit trail load for owner role and API limit

### DIFF
--- a/apps/admin/src/app/(backend)/audit/page.tsx
+++ b/apps/admin/src/app/(backend)/audit/page.tsx
@@ -108,10 +108,31 @@ function AuditDashboard() {
     ? searchParams.get('severity')
     : undefined;
   const filterAgent = searchParams.get('agent') || undefined;
-  const limit = Math.min(Number(searchParams.get('limit')) || 200, 1000);
+  // Must stay within PaginationQuery max (100) on /api/admin/audit — higher
+  // values produce a validation error and a blank trail UI.
+  const limit = Math.min(Math.max(Number(searchParams.get('limit')) || 100, 1), 100);
 
   useEffect(() => {
     let cancelled = false;
+
+    function formatApiError(body: unknown, status: number): string {
+      if (body && typeof body === 'object') {
+        const err = (body as { error?: unknown }).error;
+        if (typeof err === 'string' && err.trim()) return err;
+        if (err && typeof err === 'object') {
+          try {
+            return JSON.stringify(err);
+          } catch {
+            // fall through
+          }
+        }
+        const code = (body as { code?: unknown }).code;
+        if (typeof code === 'string' && code.trim()) {
+          return `Request failed (${status}, ${code})`;
+        }
+      }
+      return `Failed to load audit log (${status})`;
+    }
 
     async function fetchAudit() {
       dispatch({ type: 'FETCH_START' });
@@ -126,8 +147,8 @@ function AuditDashboard() {
           credentials: 'include',
         });
         if (!res.ok) {
-          const body = (await res.json().catch(() => null)) as { error?: string } | null;
-          throw new Error(body?.error ?? `Failed to load audit log (${res.status})`);
+          const body: unknown = await res.json().catch(() => null);
+          throw new Error(formatApiError(body, res.status));
         }
         const data = (await res.json()) as PaginatedResponse;
         if (!cancelled) {

--- a/apps/server/src/routes/admin/__tests__/observability-jobs.test.ts
+++ b/apps/server/src/routes/admin/__tests__/observability-jobs.test.ts
@@ -113,6 +113,46 @@ describe('GET /admin/jobs', () => {
   });
 });
 
+describe('GET /admin/audit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 for non-admin roles', async () => {
+    const { app } = createApp({ id: 'u1', role: 'editor' });
+    const res = await app.fetch(new Request('http://localhost/audit?limit=20&offset=0'));
+    expect(res.status).toBe(403);
+  });
+
+  it('grants access to the canonical owner role (bootstrap / founder)', async () => {
+    const row = {
+      id: 'a1',
+      timestamp: new Date('2026-08-12T00:00:00Z'),
+      eventType: 'auth.login',
+      severity: 'low',
+      agentId: 'user-1',
+      taskId: null,
+      sessionId: null,
+      payload: {},
+      policyViolations: [],
+    };
+    const { app } = createApp({ id: 'u1', role: 'owner' }, [[row], [{ total: 1 }]]);
+    const res = await app.fetch(new Request('http://localhost/audit?limit=20&offset=0'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; total: number; data: unknown[] };
+    expect(body.success).toBe(true);
+    expect(body.total).toBe(1);
+    expect(body.data).toHaveLength(1);
+  });
+
+  it('rejects limit above PaginationQuery max (100)', async () => {
+    const { app } = createApp({ id: 'u1', role: 'admin' });
+    // Admin UI previously sent limit=200 and showed a broken [object Object] error.
+    const res = await app.fetch(new Request('http://localhost/audit?limit=200&offset=0'));
+    expect(res.status).toBe(400);
+  });
+});
+
 describe('GET /admin/jobs/summary', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/server/src/routes/admin/observability.ts
+++ b/apps/server/src/routes/admin/observability.ts
@@ -30,13 +30,13 @@ import {
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, count, desc, eq, gte, lte, type SQL, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { isAdminRole } from '../../lib/access.js';
 import { recordUsageMeter } from '../../lib/metering.js';
 import {
   AUDIT_EXPORT_METER_NAME,
   AUDIT_VIEW_METER_NAME,
   recordMilestoneMeterFirstSafe,
 } from '../../lib/nudges/milestone-meters.js';
-import { isAdminRole } from '../../lib/access.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString } from '../_helpers/serialize.js';
 

--- a/apps/server/src/routes/admin/observability.ts
+++ b/apps/server/src/routes/admin/observability.ts
@@ -36,6 +36,7 @@ import {
   AUDIT_VIEW_METER_NAME,
   recordMilestoneMeterFirstSafe,
 } from '../../lib/nudges/milestone-meters.js';
+import { isAdminRole } from '../../lib/access.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString } from '../_helpers/serialize.js';
 
@@ -48,11 +49,12 @@ type AdminVariables = {
 // Shared
 // =============================================================================
 
-const ADMIN_ROLES = new Set(['admin', 'super-admin', 'admin', 'super-admin']);
-
 function requireAdmin(user: { id: string; role: string } | undefined): void {
   if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-  if (!ADMIN_ROLES.has(user.role)) {
+  // Match CMS shell isAdminRole (owner | admin | super-admin) — the prior
+  // local set omitted `owner`, so bootstrap/founder sessions could open
+  // /audit but the API returned 403.
+  if (!isAdminRole(user.role)) {
     throw new HTTPException(403, { message: 'Admin access required' });
   }
 }


### PR DESCRIPTION
## Summary
Founder dogfood on admin.revealui.com **/audit** showed `Failed to load audit log: [object Object]`.

### Root causes
1. **UI asked for `limit=200`** (default) while `/api/admin/audit` `PaginationQuery` max is **100** → validation error → object-shaped body rendered as `[object Object]`.
2. **Observability `requireAdmin` omitted `owner`** (unlike `isAdminRole` used by margin/coordination). Bootstrap/founder `users.role = owner` can open the CMS shell but get 403 on the audit API.

### Fixes
- Cap admin audit page limit at 1–100; default 100
- Format API errors as readable strings
- Use shared `isAdminRole` on admin observability routes
- Tests: owner can list audit; limit=200 rejected with 400

## Test plan
- [x] `observability-jobs.test.ts` 10/10
- [x] phase-1 changed gate
- [ ] After merge+deploy: founder opens https://admin.revealui.com/audit and sees the trail (or empty list without error)