### PR TITLE
promote: test → main (audit trail load + recent test train)

### DIFF
--- a/apps/admin/src/app/(backend)/audit/page.tsx
+++ b/apps/admin/src/app/(backend)/audit/page.tsx
@@ -108,10 +108,31 @@ function AuditDashboard() {
     ? searchParams.get('severity')
     : undefined;
   const filterAgent = searchParams.get('agent') || undefined;
-  const limit = Math.min(Number(searchParams.get('limit')) || 200, 1000);
+  // Must stay within PaginationQuery max (100) on /api/admin/audit — higher
+  // values produce a validation error and a blank trail UI.
+  const limit = Math.min(Math.max(Number(searchParams.get('limit')) || 100, 1), 100);
 
   useEffect(() => {
     let cancelled = false;
+
+    function formatApiError(body: unknown, status: number): string {
+      if (body && typeof body === 'object') {
+        const err = (body as { error?: unknown }).error;
+        if (typeof err === 'string' && err.trim()) return err;
+        if (err && typeof err === 'object') {
+          try {
+            return JSON.stringify(err);
+          } catch {
+            // fall through
+          }
+        }
+        const code = (body as { code?: unknown }).code;
+        if (typeof code === 'string' && code.trim()) {
+          return `Request failed (${status}, ${code})`;
+        }
+      }
+      return `Failed to load audit log (${status})`;
+    }
 
     async function fetchAudit() {
       dispatch({ type: 'FETCH_START' });
@@ -126,8 +147,8 @@ function AuditDashboard() {
           credentials: 'include',
         });
         if (!res.ok) {
-          const body = (await res.json().catch(() => null)) as { error?: string } | null;
-          throw new Error(body?.error ?? `Failed to load audit log (${res.status})`);
+          const body: unknown = await res.json().catch(() => null);
+          throw new Error(formatApiError(body, res.status));
         }
         const data = (await res.json()) as PaginatedResponse;
         if (!cancelled) {

--- a/apps/admin/src/app/(backend)/upgrade/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(backend)/upgrade/__tests__/page.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseLicense = vi.fn();
+vi.mock('@/lib/providers/LicenseProvider', () => ({
+  useLicense: () => mockUseLicense(),
+}));
+
+vi.mock('@/components/TestModeBanner', () => ({
+  TestModeBanner: () => <div data-testid="test-mode-banner" />,
+}));
+
+vi.mock('@revealui/presentation/client', () => ({
+  PricingTable: ({ currentTier }: { currentTier?: string | null }) => (
+    <div data-testid="pricing-table" data-current={currentTier ?? ''} />
+  ),
+}));
+
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/safe-stripe-redirect', () => ({
+  safeStripeRedirect: vi.fn(),
+}));
+
+import UpgradePage from '../page';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('UpgradePage', () => {
+  it('shows plan chooser when a higher commercial tier exists', () => {
+    mockUseLicense.mockReturnValue({ tier: 'pro' });
+    render(<UpgradePage />);
+    expect(screen.getByRole('heading', { name: 'Choose Your Plan' })).toBeInTheDocument();
+    expect(screen.getByTestId('pricing-table')).toBeInTheDocument();
+    expect(screen.getByText(/Upgrade to unlock more features/)).toBeInTheDocument();
+  });
+
+  it('does not upsell when the account is already on enterprise', () => {
+    mockUseLicense.mockReturnValue({ tier: 'enterprise' });
+    render(<UpgradePage />);
+    expect(screen.getByRole('heading', { name: 'Your Plan' })).toBeInTheDocument();
+    expect(screen.queryByTestId('pricing-table')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/There is no higher commercial plan to upgrade into/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'account billing' })).toHaveAttribute(
+      'href',
+      '/account/billing',
+    );
+  });
+});

--- a/apps/admin/src/app/(backend)/upgrade/page.tsx
+++ b/apps/admin/src/app/(backend)/upgrade/page.tsx
@@ -1,10 +1,18 @@
 'use client';
 
-import { FEATURE_LABELS, SUBSCRIPTION_TIERS, TIER_LIMITS } from '@revealui/contracts/pricing';
+import {
+  FEATURE_LABELS,
+  getTiersFromCurrent,
+  type LicenseTierId,
+  SUBSCRIPTION_TIERS,
+  TIER_LABELS,
+  TIER_LIMITS,
+} from '@revealui/contracts/pricing';
 import { type FeatureFlags, getFeaturesForTier } from '@revealui/core/features';
 import { PricingTable } from '@revealui/presentation/client';
 import { useState } from 'react';
 import { TestModeBanner } from '@/components/TestModeBanner';
+import { hasCommercialUpgradePath } from '@/lib/components/should-show-upgrade-nav';
 import { useLicense } from '@/lib/providers/LicenseProvider';
 import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
@@ -12,8 +20,11 @@ import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 export default function UpgradePage() {
   const { tier: currentTier } = useLicense();
   const [error, setError] = useState<string | null>(null);
+  const tierId = (currentTier ?? 'free') as LicenseTierId;
+  const canUpgrade = hasCommercialUpgradePath(tierId);
+  const selectableTiers = canUpgrade ? getTiersFromCurrent(tierId) : [];
 
-  const handleSelectTier = async (tierId: string) => {
+  const handleSelectTier = async (nextTierId: string) => {
     setError(null);
     try {
       const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://api.revealui.com').trim();
@@ -30,14 +41,14 @@ export default function UpgradePage() {
         max: process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID,
         enterprise: process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID,
       };
-      const priceId = priceIdMap[tierId];
+      const priceId = priceIdMap[nextTierId];
       const res = await apiFetch(`${apiUrl}/api/billing/checkout`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({
           ...(priceId && { priceId }),
-          tier: tierId,
+          tier: nextTierId,
         }),
       });
 
@@ -53,7 +64,7 @@ export default function UpgradePage() {
         setError(data.error || 'Failed to start checkout. Please try again.');
       }
     } catch {
-      window.location.href = `/account/billing?upgrade=${tierId}`;
+      window.location.href = `/account/billing?upgrade=${nextTierId}`;
     }
   };
 
@@ -61,10 +72,12 @@ export default function UpgradePage() {
     <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8">
       <div className="text-center mb-12">
         <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-white sm:text-4xl">
-          Choose Your Plan
+          {canUpgrade ? 'Choose Your Plan' : 'Your Plan'}
         </h1>
         <p className="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
-          Upgrade to unlock more features, higher limits, and priority support.
+          {canUpgrade
+            ? 'Upgrade to unlock more features, higher limits, and priority support.'
+            : `You are on ${TIER_LABELS[tierId]}. There is no higher commercial plan to upgrade into.`}
         </p>
       </div>
 
@@ -78,11 +91,21 @@ export default function UpgradePage() {
         </div>
       )}
 
-      <PricingTable
-        tiers={SUBSCRIPTION_TIERS}
-        currentTier={currentTier}
-        onSelectTier={(id: string) => void handleSelectTier(id)}
-      />
+      {canUpgrade ? (
+        <PricingTable
+          tiers={selectableTiers.length > 0 ? selectableTiers : SUBSCRIPTION_TIERS}
+          currentTier={currentTier}
+          onSelectTier={(id: string) => void handleSelectTier(id)}
+        />
+      ) : (
+        <div className="mx-auto max-w-2xl rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          Manage invoices and payment methods from{' '}
+          <a href="/account/billing" className="font-medium text-primary hover:underline">
+            account billing
+          </a>
+          .
+        </div>
+      )}
 
       {/* Feature comparison matrix */}
       <div className="mt-16">

--- a/apps/admin/src/app/(frontend)/account/billing/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/billing/page.tsx
@@ -20,6 +20,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import { TestModeBanner } from '@/components/TestModeBanner';
+import { hasCommercialUpgradePath } from '@/lib/components/should-show-upgrade-nav';
 import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
@@ -472,9 +473,12 @@ function BillingContent() {
           )}
 
           <div className="flex flex-col gap-2 border-t pt-4">
-            <Button asChild appearance="outline" variant="neutral" className="w-full">
-              <Link href="/upgrade">Change plan →</Link>
-            </Button>
+            {/* Top commercial tier (enterprise): no higher plan — hide upsell. */}
+            {hasCommercialUpgradePath(tier) && (
+              <Button asChild appearance="outline" variant="neutral" className="w-full">
+                <Link href="/upgrade">Change plan →</Link>
+              </Button>
+            )}
             {tier !== 'free' && (
               <Button
                 onClick={handleManageBilling}

--- a/apps/admin/src/app/(frontend)/account/license/page.tsx
+++ b/apps/admin/src/app/(frontend)/account/license/page.tsx
@@ -24,6 +24,7 @@ import {
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { hasCommercialUpgradePath } from '@/lib/components/should-show-upgrade-nav';
 import { apiFetch } from '@/lib/utils/csrf';
 import { safeStripeRedirect } from '@/lib/utils/safe-stripe-redirect';
 
@@ -186,7 +187,8 @@ export default function LicensePage() {
   const tier = subscription?.tier ?? 'free';
   const limits = TIER_LIMITS[tier];
   const tierFeatures = features?.[tier];
-  const canUpgrade = tier === 'free' || tier === 'pro';
+  // free / pro / max can climb; enterprise is the commercial top (GAP-473).
+  const canUpgrade = hasCommercialUpgradePath(tier);
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 py-12">
@@ -252,7 +254,11 @@ export default function LicensePage() {
                 href="/account/billing"
                 className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
               >
-                {tier === 'free' ? 'Upgrade to Pro →' : 'Upgrade to Enterprise →'}
+                {tier === 'free'
+                  ? 'Upgrade to Pro →'
+                  : tier === 'pro'
+                    ? 'Upgrade to Max →'
+                    : 'Upgrade to Enterprise →'}
               </Link>
             </div>
           )}

--- a/apps/admin/src/app/api/shapes/__tests__/yjs-documents.test.ts
+++ b/apps/admin/src/app/api/shapes/__tests__/yjs-documents.test.ts
@@ -11,6 +11,15 @@ vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
 }));
 
+const mockLimit = vi.fn();
+const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+const mockFrom = vi.fn(() => ({ where: mockWhere }));
+const mockSelect = vi.fn(() => ({ from: mockFrom }));
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(() => ({ select: mockSelect })),
+}));
+
 vi.mock('@/lib/api/electric-proxy', () => ({
   prepareElectricUrl: vi.fn((_url: string) => {
     const electricUrl = new URL('http://localhost:5133/v1/shape');
@@ -88,8 +97,9 @@ describe('GET /api/shapes/yjs-documents', () => {
     expect(data.error).toBe('UNAUTHORIZED');
   });
 
-  it('should return 403 for non-admin', async () => {
+  it('should return 403 for non-admin without document ownership', async () => {
     mockGetSession.mockResolvedValue(makeSession('viewer') as never);
+    mockLimit.mockResolvedValue([{ ownerId: 'other-user' }]);
 
     const request = new NextRequest(
       `http://localhost:3000/api/shapes/yjs-documents?document_id=${VALID_DOC_ID}`,
@@ -99,6 +109,24 @@ describe('GET /api/shapes/yjs-documents', () => {
 
     expect(response.status).toBe(403);
     expect(data.error).toBe('FORBIDDEN');
+  });
+
+  it('should proxy for document owner (non-admin) with owner_id where clause', async () => {
+    mockGetSession.mockResolvedValue(makeSession('viewer') as never);
+    mockLimit.mockResolvedValue([{ ownerId: '123e4567-e89b-12d3-a456-426614174001' }]);
+
+    const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/shapes/yjs-documents?document_id=${VALID_DOC_ID}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(prepareElectricUrl).toHaveBeenCalled();
+    expect(proxyElectricRequest).toHaveBeenCalled();
+    const originUrl = vi.mocked(proxyElectricRequest).mock.calls[0]?.[0] as URL;
+    expect(originUrl.searchParams.get('where')).toContain('owner_id =');
   });
 
   it('should return 400 when document_id is missing', async () => {
@@ -127,6 +155,7 @@ describe('GET /api/shapes/yjs-documents', () => {
 
   it('should proxy request when admin with valid UUID', async () => {
     mockGetSession.mockResolvedValue(makeSession('admin') as never);
+    mockLimit.mockResolvedValue([]);
 
     const { prepareElectricUrl, proxyElectricRequest } = await import('@/lib/api/electric-proxy');
 

--- a/apps/admin/src/app/api/shapes/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/shapes/yjs-document-patches/route.ts
@@ -4,15 +4,15 @@
  * GET /api/shapes/yjs-document-patches?document_id=<document_id>
  *
  * Authenticated proxy for ElectricSQL yjs_document_patches shape.
- * GAP-476: fail-closed to isAdminRole — no document ACL join.
- * Residual Phase C: document-level ACL when ownership model lands.
+ * GAP-477: same document ACL as yjs-documents (owner or platform admin).
  */
 
 import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
-import { requireAdminRole } from '@/lib/api/shape-authz';
+import { userCanAccessYjsDocument } from '@/lib/api/shape-authz';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
   createApplicationErrorResponse,
@@ -35,10 +35,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const aiGate = await checkAIFeatureGate(session.user.id);
     if (aiGate) return aiGate;
 
-    if (!requireAdminRole(session.user.role)) {
-      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
-    }
-
     const documentId = new URL(request.url).searchParams.get('document_id');
     if (!documentId || documentId.trim().length === 0) {
       return createValidationErrorResponse(
@@ -55,6 +51,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         'document_id',
         documentId,
       );
+    }
+
+    const db = getClient();
+    const allowed = await userCanAccessYjsDocument(
+      db,
+      session.user.id,
+      documentId,
+      session.user.role,
+    );
+    if (!allowed) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
     }
 
     const originUrl = prepareElectricUrl(request.url);

--- a/apps/admin/src/app/api/shapes/yjs-documents/route.ts
+++ b/apps/admin/src/app/api/shapes/yjs-documents/route.ts
@@ -4,17 +4,18 @@
  * GET /api/shapes/yjs-documents?document_id=<uuid>
  *
  * Authenticated proxy for ElectricSQL yjs_documents shape.
- * GAP-476: fail-closed to isAdminRole — table has no user_id / ACL column.
- * Residual Phase C: document-level ACL when ownership model lands.
- * UUID-only document_id still required for the Electric where clause.
+ * GAP-477: acl_resource — platform admin may read any UUID doc; non-admin
+ * only when owner_id matches session user (legacy null owner = admin-only).
  */
 
 import { getSession } from '@revealui/auth/server';
+import { getClient } from '@revealui/db';
 import { logger } from '@revealui/utils/logger';
 import type { NextRequest, NextResponse } from 'next/server';
 import { prepareElectricUrl, proxyElectricRequest } from '@/lib/api/electric-proxy';
-import { isUuid, requireAdminRole } from '@/lib/api/shape-authz';
+import { isUuid, requireAdminRole, userCanAccessYjsDocument } from '@/lib/api/shape-authz';
 import { createApplicationErrorResponse, createErrorResponse } from '@/lib/utils/error-response';
+import { isSyncIdentifier } from '@/lib/utils/identifier-validation';
 import { extractRequestContext } from '@/lib/utils/request-context';
 
 export const dynamic = 'force-dynamic';
@@ -28,10 +29,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return createApplicationErrorResponse('Unauthorized', 'UNAUTHORIZED', 401);
     }
 
-    if (!requireAdminRole(session.user.role)) {
-      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
-    }
-
     const url = new URL(request.url);
     const documentId = url.searchParams.get('document_id');
 
@@ -43,9 +40,32 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
     }
 
+    const db = getClient();
+    const allowed = await userCanAccessYjsDocument(
+      db,
+      session.user.id,
+      documentId,
+      session.user.role,
+    );
+    if (!allowed) {
+      return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+    }
+
     const originUrl = prepareElectricUrl(request.url);
     originUrl.searchParams.set('table', 'yjs_documents');
-    originUrl.searchParams.set('where', `id = '${documentId}'`);
+
+    // Admin: document id only. Owner: id + owner_id match (defense in depth with the gate above).
+    if (requireAdminRole(session.user.role)) {
+      originUrl.searchParams.set('where', `id = '${documentId}'`);
+    } else {
+      if (!isSyncIdentifier(session.user.id)) {
+        return createApplicationErrorResponse('Forbidden', 'FORBIDDEN', 403);
+      }
+      originUrl.searchParams.set(
+        'where',
+        `id = '${documentId}' AND owner_id = '${session.user.id}'`,
+      );
+    }
 
     return proxyElectricRequest(originUrl);
   } catch (error) {

--- a/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
+++ b/apps/admin/src/app/api/sync/yjs-document-patches/route.ts
@@ -13,7 +13,7 @@ import { getClient } from '@revealui/db';
 import { yjsDocumentPatches, yjsDocuments } from '@revealui/db/schema';
 import { applyPatches } from '@revealui/sync/collab/server';
 import { logger } from '@revealui/utils/logger';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
 import { checkAIFeatureGate } from '@/lib/middleware/ai-feature-gate';
 import {
@@ -128,11 +128,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         .update(yjsDocuments)
         .set({ state, stateVector, updatedAt: new Date() })
         .where(eq(yjsDocuments.id, body.document_id));
+      // Durable heal: stamp creator once for legacy null-owner rows.
+      await db
+        .update(yjsDocuments)
+        .set({ ownerId: session.user.id })
+        .where(and(eq(yjsDocuments.id, body.document_id), isNull(yjsDocuments.ownerId)));
     } else {
       await db.insert(yjsDocuments).values({
         id: body.document_id,
         state,
         stateVector,
+        ownerId: session.user.id,
       });
     }
 

--- a/apps/admin/src/lib/api/shape-authz-registry.ts
+++ b/apps/admin/src/lib/api/shape-authz-registry.ts
@@ -64,13 +64,13 @@ export const SHAPE_AUTHZ_REGISTRY: Readonly<Record<string, ShapeAuthzEntry>> = {
   },
   'yjs-documents': {
     table: 'yjs_documents',
-    scope: 'admin_platform',
-    enforcement: 'isAdminRole until owner_id ACL migrates (Phase C residual)',
+    scope: 'acl_resource',
+    enforcement: 'admin: id where; owner: id AND owner_id = session user; null owner = admin-only',
   },
   'yjs-document-patches': {
     table: 'yjs_document_patches',
-    scope: 'admin_platform',
-    enforcement: 'isAdminRole until document ACL migrates',
+    scope: 'acl_resource',
+    enforcement: 'userCanAccessYjsDocument on parent document_id, then document_id where',
   },
   'kg-nodes': {
     table: 'kg_nodes',

--- a/apps/admin/src/lib/api/shape-authz.ts
+++ b/apps/admin/src/lib/api/shape-authz.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Database } from '@revealui/db/client';
-import { siteCollaborators, sites } from '@revealui/db/schema';
+import { siteCollaborators, sites, yjsDocuments } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
 import { isAdminRole } from '@/lib/access/roles/isAdminRole';
 import { isSyncIdentifier, isUuid } from '@/lib/utils/identifier-validation';
@@ -13,6 +13,29 @@ export { isUuid };
 /** True when role is owner/admin/super-admin (CMS shell admin plane). */
 export function requireAdminRole(role: string | null | undefined): boolean {
   return isAdminRole(role);
+}
+
+/**
+ * Whether `userId` may Electric-sync a yjs document (GAP-477 acl_resource).
+ * Platform admins always may. Non-admins require a row whose owner_id matches.
+ * Legacy null owner_id stays admin-only (fail-closed until stamped on write).
+ */
+export async function userCanAccessYjsDocument(
+  db: Database,
+  userId: string,
+  documentId: string,
+  role: string | null | undefined,
+): Promise<boolean> {
+  if (requireAdminRole(role)) return true;
+
+  const [row] = await db
+    .select({ ownerId: yjsDocuments.ownerId })
+    .from(yjsDocuments)
+    .where(eq(yjsDocuments.id, documentId))
+    .limit(1);
+
+  if (!row) return false;
+  return row.ownerId != null && row.ownerId === userId;
 }
 
 /**

--- a/apps/admin/src/lib/components/UpgradeDialog.tsx
+++ b/apps/admin/src/lib/components/UpgradeDialog.tsx
@@ -72,32 +72,40 @@ export function UpgradeDialog() {
   }, []);
 
   const upgradeTiers = getTiersFromCurrent(tier);
+  // Enterprise / top grant: no higher commercial plan — do not upsell empty tables.
+  const atTopTier = upgradeTiers.length === 0;
 
   return (
     <Dialog open={open} onClose={handleClose} size="2xl">
-      <DialogTitle>Upgrade Your Plan</DialogTitle>
+      <DialogTitle>{atTopTier ? 'You are on the top plan' : 'Upgrade Your Plan'}</DialogTitle>
       <DialogDescription>
-        {featureName
-          ? `"${featureName}" requires a higher tier. Choose a plan to unlock it.`
-          : 'Unlock more features by upgrading your plan.'}
+        {atTopTier
+          ? 'Your account already has the highest commercial tier. No further upgrade is available.'
+          : featureName
+            ? `"${featureName}" requires a higher tier. Choose a plan to unlock it.`
+            : 'Unlock more features by upgrading your plan.'}
       </DialogDescription>
       <DialogBody>
         {error && <div className="mb-4 rounded-md bg-error/10 p-3 text-sm text-error">{error}</div>}
-        <PricingTable
-          tiers={upgradeTiers}
-          currentTier={tier ?? 'free'}
-          compact
-          onSelectTier={(id) => void handleSelectTier(id)}
-        />
+        {!atTopTier && (
+          <PricingTable
+            tiers={upgradeTiers}
+            currentTier={tier ?? 'free'}
+            compact
+            onSelectTier={(id) => void handleSelectTier(id)}
+          />
+        )}
       </DialogBody>
       <DialogActions>
-        <Link
-          href="/upgrade"
-          className="text-sm font-medium text-primary hover:underline"
-          onClick={handleClose}
-        >
-          View full pricing
-        </Link>
+        {!atTopTier && (
+          <Link
+            href="/upgrade"
+            className="text-sm font-medium text-primary hover:underline"
+            onClick={handleClose}
+          >
+            View full pricing
+          </Link>
+        )}
         <Button
           type="button"
           appearance="ghost"
@@ -105,7 +113,7 @@ export function UpgradeDialog() {
           onClick={handleClose}
           className="text-muted-foreground hover:text-foreground"
         >
-          Maybe later
+          {atTopTier ? 'Close' : 'Maybe later'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
@@ -7,13 +7,15 @@ vi.mock('@/lib/providers/LicenseProvider', () => ({
   useLicense: () => mockUseLicense(),
 }));
 
-// Mock @revealui/contracts/pricing
-const mockGetTiersFromCurrent = vi.fn(() => [
-  { id: 'pro', name: 'Pro', price: '$49/mo' },
-  { id: 'max', name: 'Max', price: '$299/mo' },
-]);
+// Mock @revealui/contracts/pricing (hoisted so factory can close over the mock).
+const { mockGetTiersFromCurrent } = vi.hoisted(() => ({
+  mockGetTiersFromCurrent: vi.fn(() => [
+    { id: 'pro', name: 'Pro', price: '$49/mo' },
+    { id: 'max', name: 'Max', price: '$299/mo' },
+  ]),
+}));
 vi.mock('@revealui/contracts/pricing', () => ({
-  getTiersFromCurrent: (...args: unknown[]) => mockGetTiersFromCurrent(...args),
+  getTiersFromCurrent: mockGetTiersFromCurrent,
 }));
 
 // Mock presentation components

--- a/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
+++ b/apps/admin/src/lib/components/__tests__/UpgradeDialog.test.tsx
@@ -8,11 +8,12 @@ vi.mock('@/lib/providers/LicenseProvider', () => ({
 }));
 
 // Mock @revealui/contracts/pricing
+const mockGetTiersFromCurrent = vi.fn(() => [
+  { id: 'pro', name: 'Pro', price: '$49/mo' },
+  { id: 'max', name: 'Max', price: '$299/mo' },
+]);
 vi.mock('@revealui/contracts/pricing', () => ({
-  getTiersFromCurrent: vi.fn(() => [
-    { id: 'pro', name: 'Pro', price: '$49/mo' },
-    { id: 'max', name: 'Max', price: '$299/mo' },
-  ]),
+  getTiersFromCurrent: (...args: unknown[]) => mockGetTiersFromCurrent(...args),
 }));
 
 // Mock presentation components
@@ -110,6 +111,10 @@ afterEach(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseLicense.mockReturnValue({ tier: 'free' });
+  mockGetTiersFromCurrent.mockReturnValue([
+    { id: 'pro', name: 'Pro', price: '$49/mo' },
+    { id: 'max', name: 'Max', price: '$299/mo' },
+  ]);
 });
 
 describe('UpgradeDialog', () => {
@@ -193,6 +198,19 @@ describe('UpgradeDialog', () => {
       const link = screen.getByText('View full pricing');
       expect(link).toHaveAttribute('href', '/upgrade');
     });
+  });
+
+  it('does not upsell when already on the top commercial tier', async () => {
+    mockUseLicense.mockReturnValue({ tier: 'enterprise' });
+    mockGetTiersFromCurrent.mockReturnValue([]);
+    render(<UpgradeDialog />);
+    await dispatchUpgradeRequired();
+    await waitFor(() => {
+      expect(screen.getByText('You are on the top plan')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('pricing-table')).not.toBeInTheDocument();
+    expect(screen.queryByText('View full pricing')).not.toBeInTheDocument();
+    expect(screen.getByText('Close')).toBeInTheDocument();
   });
 
   it('calls fetch with checkout endpoint when tier is selected', async () => {

--- a/apps/admin/src/lib/components/__tests__/shouldShowUpgradeNavItem.test.ts
+++ b/apps/admin/src/lib/components/__tests__/shouldShowUpgradeNavItem.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { shouldShowUpgradeNavItem } from '../should-show-upgrade-nav';
+import { hasCommercialUpgradePath, shouldShowUpgradeNavItem } from '../should-show-upgrade-nav';
+
+describe('hasCommercialUpgradePath', () => {
+  it('is true below enterprise', () => {
+    expect(hasCommercialUpgradePath('free')).toBe(true);
+    expect(hasCommercialUpgradePath('pro')).toBe(true);
+    expect(hasCommercialUpgradePath('max')).toBe(true);
+  });
+
+  it('is false for enterprise, unknown, empty', () => {
+    expect(hasCommercialUpgradePath('enterprise')).toBe(false);
+    expect(hasCommercialUpgradePath('')).toBe(false);
+    expect(hasCommercialUpgradePath(null)).toBe(false);
+    expect(hasCommercialUpgradePath(undefined)).toBe(false);
+    expect(hasCommercialUpgradePath('unknown')).toBe(false);
+  });
+});
 
 describe('shouldShowUpgradeNavItem', () => {
   const base = { isFleetMode: false, isLoading: false, resolveError: null };

--- a/apps/admin/src/lib/components/should-show-upgrade-nav.ts
+++ b/apps/admin/src/lib/components/should-show-upgrade-nav.ts
@@ -1,11 +1,11 @@
 /**
- * Whether the sidebar "Upgrade" item should show.
+ * Whether commercial upgrade chrome may show for a tier.
  *
  * Mirrors commercial ladder free < pro < max < enterprise (see
  * `@revealui/contracts/pricing` TIER_RANK / getTiersFromCurrent). Enterprise
- * is the top grant (founder / operator) — no higher plan, no Upgrade nav.
- * Fleet kits never show Stripe upgrade. While tier is loading or resolution
- * failed, hide upsell (GAP-454: do not invent free/upsell on unknown).
+ * is the top grant (founder / operator) — no higher plan, no Upgrade nav /
+ * upsell CTAs. Fleet kits never show Stripe upgrade. While tier is loading or
+ * resolution failed, hide upsell (GAP-454: do not invent free/upsell on unknown).
  */
 
 const TIER_RANK = {
@@ -18,6 +18,16 @@ const TIER_RANK = {
 /** Enterprise is the commercial top; no higher plan to upsell into. */
 const TOP_RANK: number = TIER_RANK.enterprise;
 
+/**
+ * True when a higher commercial plan exists above `tier`.
+ * False for enterprise, unknown tier strings, and empty tier.
+ */
+export function hasCommercialUpgradePath(tier: string | null | undefined): boolean {
+  if (!(tier && tier in TIER_RANK)) return false;
+  const rank = TIER_RANK[tier as keyof typeof TIER_RANK];
+  return rank < TOP_RANK;
+}
+
 export function shouldShowUpgradeNavItem(
   tier: string,
   options: {
@@ -28,7 +38,5 @@ export function shouldShowUpgradeNavItem(
 ): boolean {
   if (options.isFleetMode) return false;
   if (options.isLoading || options.resolveError) return false;
-  if (!(tier in TIER_RANK)) return false;
-  const rank = TIER_RANK[tier as keyof typeof TIER_RANK];
-  return rank < TOP_RANK;
+  return hasCommercialUpgradePath(tier);
 }

--- a/apps/server/src/collab/persistence.ts
+++ b/apps/server/src/collab/persistence.ts
@@ -1,5 +1,5 @@
 import { yjsDocuments } from '@revealui/db/schema/yjs-documents';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import * as Y from 'yjs';
 
 interface DrizzleDb {
@@ -20,9 +20,14 @@ interface DrizzleDb {
   };
 }
 
+export type SaveDocumentOptions = {
+  /** Creating user when known (GAP-477). Set on insert; never cleared on update. */
+  ownerId?: string | null;
+};
+
 export interface YjsPersistence {
   loadDocument(id: string, doc: Y.Doc): Promise<void>;
-  saveDocument(id: string, doc: Y.Doc): Promise<void>;
+  saveDocument(id: string, doc: Y.Doc, options?: SaveDocumentOptions): Promise<void>;
   updateClientCount(id: string, count: number): Promise<void>;
 }
 
@@ -40,10 +45,11 @@ export function createYjsPersistence(db: DrizzleDb): YjsPersistence {
       }
     },
 
-    async saveDocument(id: string, doc: Y.Doc): Promise<void> {
+    async saveDocument(id: string, doc: Y.Doc, options?: SaveDocumentOptions): Promise<void> {
       const state = Buffer.from(Y.encodeStateAsUpdate(doc));
       const stateVector = Buffer.from(Y.encodeStateVector(doc));
       const now = new Date();
+      const ownerId = options?.ownerId?.trim() || null;
 
       await db
         .insert(yjsDocuments)
@@ -51,6 +57,7 @@ export function createYjsPersistence(db: DrizzleDb): YjsPersistence {
           id,
           state,
           stateVector,
+          ownerId,
           connectedClients: 0,
           createdAt: now,
           updatedAt: now,
@@ -63,6 +70,14 @@ export function createYjsPersistence(db: DrizzleDb): YjsPersistence {
             updatedAt: now,
           },
         });
+
+      // Durable heal for legacy rows: stamp owner once, never reassign.
+      if (ownerId) {
+        await db
+          .update(yjsDocuments)
+          .set({ ownerId })
+          .where(and(eq(yjsDocuments.id, id), isNull(yjsDocuments.ownerId)));
+      }
     },
 
     async updateClientCount(id: string, count: number): Promise<void> {

--- a/apps/server/src/routes/__tests__/collab.test.ts
+++ b/apps/server/src/routes/__tests__/collab.test.ts
@@ -211,7 +211,9 @@ describe('collab routes', () => {
       });
 
       expect(mockLoadDocument).toHaveBeenCalledWith(docId, expect.any(Object));
-      expect(mockSaveDocument).toHaveBeenCalledWith(docId, expect.any(Object));
+      expect(mockSaveDocument).toHaveBeenCalledWith(docId, expect.any(Object), {
+        ownerId: testUser.id,
+      });
     });
   });
 

--- a/apps/server/src/routes/admin/__tests__/observability-jobs.test.ts
+++ b/apps/server/src/routes/admin/__tests__/observability-jobs.test.ts
@@ -113,6 +113,46 @@ describe('GET /admin/jobs', () => {
   });
 });
 
+describe('GET /admin/audit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 for non-admin roles', async () => {
+    const { app } = createApp({ id: 'u1', role: 'editor' });
+    const res = await app.fetch(new Request('http://localhost/audit?limit=20&offset=0'));
+    expect(res.status).toBe(403);
+  });
+
+  it('grants access to the canonical owner role (bootstrap / founder)', async () => {
+    const row = {
+      id: 'a1',
+      timestamp: new Date('2026-08-12T00:00:00Z'),
+      eventType: 'auth.login',
+      severity: 'low',
+      agentId: 'user-1',
+      taskId: null,
+      sessionId: null,
+      payload: {},
+      policyViolations: [],
+    };
+    const { app } = createApp({ id: 'u1', role: 'owner' }, [[row], [{ total: 1 }]]);
+    const res = await app.fetch(new Request('http://localhost/audit?limit=20&offset=0'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; total: number; data: unknown[] };
+    expect(body.success).toBe(true);
+    expect(body.total).toBe(1);
+    expect(body.data).toHaveLength(1);
+  });
+
+  it('rejects limit above PaginationQuery max (100)', async () => {
+    const { app } = createApp({ id: 'u1', role: 'admin' });
+    // Admin UI previously sent limit=200 and showed a broken [object Object] error.
+    const res = await app.fetch(new Request('http://localhost/audit?limit=200&offset=0'));
+    expect(res.status).toBe(400);
+  });
+});
+
 describe('GET /admin/jobs/summary', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/server/src/routes/admin/observability.ts
+++ b/apps/server/src/routes/admin/observability.ts
@@ -30,13 +30,13 @@ import {
 import { createRoute, OpenAPIHono, z } from '@revealui/openapi';
 import { and, count, desc, eq, gte, lte, type SQL, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
+import { isAdminRole } from '../../lib/access.js';
 import { recordUsageMeter } from '../../lib/metering.js';
 import {
   AUDIT_EXPORT_METER_NAME,
   AUDIT_VIEW_METER_NAME,
   recordMilestoneMeterFirstSafe,
 } from '../../lib/nudges/milestone-meters.js';
-import { isAdminRole } from '../../lib/access.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString } from '../_helpers/serialize.js';
 

--- a/apps/server/src/routes/admin/observability.ts
+++ b/apps/server/src/routes/admin/observability.ts
@@ -36,6 +36,7 @@ import {
   AUDIT_VIEW_METER_NAME,
   recordMilestoneMeterFirstSafe,
 } from '../../lib/nudges/milestone-meters.js';
+import { isAdminRole } from '../../lib/access.js';
 import { PaginationQuery } from '../_helpers/pagination.js';
 import { dateToString } from '../_helpers/serialize.js';
 
@@ -48,11 +49,12 @@ type AdminVariables = {
 // Shared
 // =============================================================================
 
-const ADMIN_ROLES = new Set(['admin', 'super-admin', 'admin', 'super-admin']);
-
 function requireAdmin(user: { id: string; role: string } | undefined): void {
   if (!user) throw new HTTPException(401, { message: 'Authentication required' });
-  if (!ADMIN_ROLES.has(user.role)) {
+  // Match CMS shell isAdminRole (owner | admin | super-admin) — the prior
+  // local set omitted `owner`, so bootstrap/founder sessions could open
+  // /audit but the API returned 403.
+  if (!isAdminRole(user.role)) {
     throw new HTTPException(403, { message: 'Admin access required' });
   }
 }

--- a/apps/server/src/routes/collab.ts
+++ b/apps/server/src/routes/collab.ts
@@ -114,7 +114,7 @@ export function createCollabRoute(): OpenAPIHono<{ Variables: Variables }> {
       const doc = new Y.Doc();
       await persistence.loadDocument(documentId, doc);
       Y.applyUpdate(doc, updateBytes);
-      await persistence.saveDocument(documentId, doc);
+      await persistence.saveDocument(documentId, doc, { ownerId: user.id });
       doc.destroy();
       return c.json({ success: true as const });
     } catch (err) {

--- a/packages/db/migrations/0040_gap477_yjs_owner_id.sql
+++ b/packages/db/migrations/0040_gap477_yjs_owner_id.sql
@@ -1,0 +1,7 @@
+-- GAP-477 residual: yjs_documents.owner_id for Electric shape ACL (creator stamp).
+-- Nullable for backfill of legacy rows; shapes treat null owner as admin-only.
+-- Companion Drizzle: packages/db/src/schema/yjs-documents.ts
+
+ALTER TABLE "yjs_documents" ADD COLUMN IF NOT EXISTS "owner_id" text;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "yjs_documents_owner_id_idx"
+  ON "yjs_documents" USING btree ("owner_id");

--- a/packages/db/migrations/meta/_custom.json
+++ b/packages/db/migrations/meta/_custom.json
@@ -146,6 +146,12 @@
       "rationale": "GAP-256 PR-1: CREATE TABLE margin_snapshots, account_margin_daily, admission_waitlist; ADD COGS breaker columns on account_entitlements; widen source CHECK to include signup. Hand-written IF NOT EXISTS / DO $$ for idempotency and partial unique index WHERE status='pending' (not fully expressible via plain drizzle-kit without snapshot debt). Companion Drizzle schemas: packages/db/src/schema/margin-admission.ts + accounts.ts cogsBreaker* + source check.",
       "missingSnapshot": true,
       "snapshotDebtNote": "Same regen path as peer hand-written migrations; Drizzle schemas are the type contract for PR-2+."
+    },
+    {
+      "tag": "0040_gap477_yjs_owner_id",
+      "rationale": "GAP-477 residual: ADD COLUMN yjs_documents.owner_id (nullable text) + btree index for Electric shape ACL (creator stamp). Hand-written ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS for idempotency, following the 0011/0031/0036 column-addition precedent. Companion Drizzle schema at packages/db/src/schema/yjs-documents.ts models ownerId; write paths stamp session user on insert and never clear owner on update.",
+      "missingSnapshot": true,
+      "snapshotDebtNote": "Same regen path as peer hand-written migrations; Drizzle schema is the type contract."
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1786272000000,
       "tag": "0039_gap256_margin_admission",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1786548000000,
+      "tag": "0040_gap477_yjs_owner_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/yjs-owner-schema.test.ts
+++ b/packages/db/src/__tests__/yjs-owner-schema.test.ts
@@ -1,0 +1,12 @@
+/**
+ * GAP-477 residual — yjs_documents.owner_id column is modeled for ACL stamps.
+ */
+import { describe, expect, it } from 'vitest';
+import { yjsDocuments } from '../schema/yjs-documents.js';
+
+describe('yjs_documents owner_id schema', () => {
+  it('exports owner_id for Electric shape ACL stamps', () => {
+    expect(yjsDocuments.ownerId.name).toBe('owner_id');
+    expect(yjsDocuments.id.name).toBe('id');
+  });
+});

--- a/packages/db/src/schema/yjs-documents.ts
+++ b/packages/db/src/schema/yjs-documents.ts
@@ -1,4 +1,4 @@
-import { customType, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { customType, index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 const bytea = customType<{ data: Buffer; driverData: Buffer }>({
   dataType() {
@@ -6,17 +6,29 @@ const bytea = customType<{ data: Buffer; driverData: Buffer }>({
   },
 });
 
-export const yjsDocuments = pgTable('yjs_documents', {
-  id: text('id').primaryKey(),
-  state: bytea('state').notNull(),
-  stateVector: bytea('state_vector'),
-  connectedClients: integer('connected_clients').notNull().default(0),
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .$onUpdateFn(() => new Date())
-    .defaultNow()
-    .notNull(),
-});
+/**
+ * Collaborative Yjs document blobs.
+ *
+ * `owner_id` (GAP-477 residual): creating user for Electric shape ACL.
+ * Null rows are legacy (pre-migration) and remain admin_platform-only on shapes.
+ */
+export const yjsDocuments = pgTable(
+  'yjs_documents',
+  {
+    id: text('id').primaryKey(),
+    state: bytea('state').notNull(),
+    stateVector: bytea('state_vector'),
+    /** Creating user id when known; null = legacy / unstamped (admin-only shapes). */
+    ownerId: text('owner_id'),
+    connectedClients: integer('connected_clients').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .$onUpdateFn(() => new Date())
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [index('yjs_documents_owner_id_idx').on(table.ownerId)],
+);
 
 export type YjsDocument = typeof yjsDocuments.$inferSelect;
 export type NewYjsDocument = typeof yjsDocuments.$inferInsert;


### PR DESCRIPTION
## Summary
Promote `test` → `main` so production admin/api pick up:

- **#2561** — audit trail load fix (limit≤100 + owner role on `/api/admin/audit`) — required for founder GAP-338 dogfood on admin.revealui.com
- **#2560** — admin shell honesty follow-ups (if not already on main)
- **#2558** — yjs owner_id ACL
- other test merges since last promote #2557

## Deploy
Production Vercel/Railway deploy from **main** only. Merged-to-test is not live on admin.revealui.com until this promote + deploy.yml succeed.

## Owner
Merge with **Create a merge commit** (not squash):

```bash
gh pr edit <N> -R RevealUIStudio/revealui --add-label merge:merge-commit
gh pr merge <N> -R RevealUIStudio/revealui --merge
```

Then wait for deploy.yml on main; hard-refresh https://admin.revealui.com/audit