### PR TITLE
fix(sync): drop license private key from admin manifests

### DIFF
--- a/apps/admin/src/__tests__/utils/session-cookies.test.ts
+++ b/apps/admin/src/__tests__/utils/session-cookies.test.ts
@@ -92,6 +92,15 @@ describe('requireSessionCookieDomain', () => {
     );
   });
 
+  it('throws in production when MODE=hosted even if the signing private key is absent (GAP-260 P4-4)', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_COOKIE_DOMAIN', '');
+    vi.stubEnv('REVEALUI_DEPLOYMENT_MODE', 'hosted');
+    expect(() => requireSessionCookieDomain()).toThrow(
+      'SESSION_COOKIE_DOMAIN env var is required in production for cross-subdomain auth on a RevealUI Studio hosted deployment',
+    );
+  });
+
   it('falls back to host-only under REVEALUI_FLEET_MODE instead of throwing', () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('SESSION_COOKIE_DOMAIN', '');

--- a/apps/admin/src/lib/utils/__tests__/env-validation.test.ts
+++ b/apps/admin/src/lib/utils/__tests__/env-validation.test.ts
@@ -129,6 +129,17 @@ describe('validateRequiredEnvVars', () => {
       expect(result.valid).toBe(true);
       expect(result.missing).toEqual([]);
     });
+
+    it('treats MODE=hosted without a signing private key as hosted SaaS (GAP-260 P4-4)', () => {
+      setCriticalRequiredVars();
+      process.env.REVEALUI_DEPLOYMENT_MODE = 'hosted';
+      delete process.env.REVEALUI_LICENSE_PRIVATE_KEY;
+
+      const result = validateRequiredEnvVars({ environment: 'production' });
+
+      expect(result.valid).toBe(false);
+      expect(result.missing).toEqual(expect.arrayContaining(['SESSION_COOKIE_DOMAIN']));
+    });
   });
 
   describe('non-production environments', () => {

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -102,7 +102,7 @@ value is never UI/API-revealable after write (credentials + private signing keys
 
 | Path | Kind | Sensitive | Consumers | Notes |
 | --- | --- | --- | --- | --- |
-| `revdev/license-signing-private-key` | signing-private | yes | vercel:api, vercel:admin, fly:worker, with-secrets:license-signing | → migrating to `revealui/prod/license/private-key` (since 2026-06-28); Ed25519 license-signing key - the fleet crown jewel; only api mints |
+| `revdev/license-signing-private-key` | signing-private | yes | vercel:api, fly:worker, with-secrets:license-signing | → migrating to `revealui/prod/license/private-key` (since 2026-06-28); Ed25519 license-signing key - the fleet crown jewel; api (+ worker until Fly drop) mints. Admin dropped P4-4 (verify-only). |
 | `revdev/license-signing-public-key` | signing-public | no | vercel:api, vercel:admin, fly:worker, with-secrets:license | → migrating to `revealui/prod/license/public-key` (since 2026-06-28); Ed25519 verification key - rotating invalidates all issued customer licenses |
 | `revealui/prod/admin/api-key` | credential | yes | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/admin/email` | public-config | no | vercel:admin |  |
@@ -174,7 +174,7 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/staging/cron-secret` | credential | yes | vercel:api-staging, vercel:admin-staging |  |
 | `revealui/staging/db/postgres-url` | credential | yes | vercel:api-staging, vercel:admin-staging | Phase 1 (owner-run empty Neon branch + full migrate) fills this |
 | `revealui/staging/kek` | credential | yes | vercel:api-staging, vercel:admin-staging | fresh staging value (scripts/setup/gen-staging-secrets.ts) |
-| `revealui/staging/license/private-key` | signing-private | yes | vercel:api-staging, vercel:admin-staging | fresh Ed25519 pair, isolated from revdev/license-signing-* (GAP-343 decision 1) |
+| `revealui/staging/license/private-key` | signing-private | yes | vercel:api-staging | fresh Ed25519 pair, isolated from revdev/license-signing-* (GAP-343 decision 1). Admin-staging dropped P4-4 (verify-only). |
 | `revealui/staging/license/public-key` | signing-public | no | vercel:api-staging, vercel:admin-staging |  |
 | `revealui/staging/passkey/origin` | public-config | no | vercel:api-staging, vercel:admin-staging | the admin app origin, https://admin.staging.revealui.com |
 | `revealui/staging/passkey/rp-id` | public-config | no | vercel:api-staging, vercel:admin-staging |  |
@@ -341,7 +341,13 @@ requires `REVEALUI_LICENSE_PRIVATE_KEY` + `REVEALUI_SIGNER_INVOKE_SECRET` at boo
 `POST /api/license/generate`) call `@revealui/core/license/mint-client`. Default remains
 local private-key mint. Set `REVEALUI_LICENSE_SIGN_VIA_SIGNER=1` plus
 `REVEALUI_LICENSE_SIGNER_URL` and `REVEALUI_SIGNER_INVOKE_SECRET` on api (and worker if
-it mints) to route mints to the signer. Private-key drop from admin/Fly is P4-4.
+it mints) to route mints to the signer.
+
+**P4-4 admin drop:** prod and staging admin manifests no longer sync
+`REVEALUI_LICENSE_PRIVATE_KEY`. Set `REVEALUI_DEPLOYMENT_MODE=hosted` on admin
+preview, prove boot GREEN, then owner-apply `revvault sync vercel` so the
+private key is not re-pushed. Fly worker still lists the private key until
+executor-off is proven live. Do not apply this train without that MODE set.
 
 ### LLM / AI providers
 

--- a/scripts/sync/__tests__/secret-paths-lockstep.test.ts
+++ b/scripts/sync/__tests__/secret-paths-lockstep.test.ts
@@ -100,6 +100,24 @@ describe('manifest ↔ spec lockstep', () => {
     expect(pub?.sensitive).toBe(false);
   });
 
+  it('admin (prod + staging) does not sync the license private key (GAP-260 P4-4)', () => {
+    const adminPriv = vercelVars.filter(
+      (v) =>
+        v.name === 'REVEALUI_LICENSE_PRIVATE_KEY' &&
+        (v.source === 'vercel:revealui-admin' || v.source === 'vercel:revealui-admin-staging'),
+    );
+    const stagingAdminPriv = stagingVars.filter(
+      (v) =>
+        v.name === 'REVEALUI_LICENSE_PRIVATE_KEY' && v.source === 'vercel:revealui-admin-staging',
+    );
+    expect(adminPriv).toEqual([]);
+    expect(stagingAdminPriv).toEqual([]);
+    const apiPriv = vercelVars.find(
+      (v) => v.name === 'REVEALUI_LICENSE_PRIVATE_KEY' && v.source === 'vercel:revealui-api',
+    );
+    expect(apiPriv?.path).toBe('revdev/license-signing-private-key');
+  });
+
   it('the staging license private key is sensitive and the public key is bare', () => {
     const priv = stagingVars.find((v) => v.name === 'REVEALUI_LICENSE_PRIVATE_KEY');
     const pub = stagingVars.find((v) => v.name === 'REVEALUI_LICENSE_PUBLIC_KEY');

--- a/scripts/sync/revvault-fly.toml
+++ b/scripts/sync/revvault-fly.toml
@@ -62,6 +62,9 @@ DATABASE_URL = "revealui/prod/db/postgres-url"
 # Core signing / session + license + audit + encryption
 REVEALUI_SECRET              = "revealui/prod/secret"
 REVEALUI_KEK                 = "revealui/prod/kek"
+# GAP-260 P4-4: Fly is LAST. Do not drop private here until a flyctl digest
+# proves the worker is not the Stripe executor path (REVMARKET_EXECUTOR_ENABLED
+# default-off verified live). Admin Vercel drop is the first surface.
 REVEALUI_LICENSE_PRIVATE_KEY = "revdev/license-signing-private-key"
 REVEALUI_LICENSE_PUBLIC_KEY  = "revdev/license-signing-public-key"
 REVEALUI_AUDIT_SIGNING_KEY   = "revealui/prod/audit/signing-private-key"

--- a/scripts/sync/revvault-vercel-staging.toml
+++ b/scripts/sync/revvault-vercel-staging.toml
@@ -164,6 +164,8 @@ git_branch = "staging"
 skip = [
   "NODE_ENV",
   "NEXT_TELEMETRY_DISABLED",
+  # GAP-260 P4-4: owner sets hosted on preview before dropping private (not vaulted).
+  "REVEALUI_DEPLOYMENT_MODE",
 ]
 
 [projects.revealui-admin-staging.vars]
@@ -197,7 +199,7 @@ POSTGRES_URL = { path = "revealui/staging/db/postgres-url", sensitive = true }
 
 # Encryption + signing (parity with api — same staging KEK/license/secret)
 REVEALUI_KEK                 = { path = "revealui/staging/kek", sensitive = true }
-REVEALUI_LICENSE_PRIVATE_KEY = { path = "revealui/staging/license/private-key", sensitive = true }
+# GAP-260 P4-4: admin-staging is verify-only (preview analog). Private stays on api-staging.
 REVEALUI_LICENSE_PUBLIC_KEY  = "revealui/staging/license/public-key"
 REVEALUI_SECRET              = { path = "revealui/staging/secret", sensitive = true }
 

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -179,6 +179,11 @@ skip = [
   # NEXT_PUBLIC_IS_LIVE. Keeping in skip means existing Vercel value is
   # not tracked by sync and will surface as an Orphan until removed.
   "REVEALUI_PUBLIC_STRIPE_IS_TEST_KEY",
+  # GAP-260 P4-4: plain hosted|forge flag, not vaulted. Owner sets
+  # REVEALUI_DEPLOYMENT_MODE=hosted on admin (preview then prod) BEFORE
+  # applying a sync that drops the private key. Skip so apply does not
+  # orphan or delete the owner-set value.
+  "REVEALUI_DEPLOYMENT_MODE",
 ]
 
 [projects.revealui-admin.vars]
@@ -214,7 +219,9 @@ NEON_API_KEY  = { path = "revealui/prod/db/neon-api-key", sensitive = true }
 # admin's production instrumentation hard-requires it (apps/admin/src/lib/utils/env-validation.ts);
 # leaving it untracked here is what let it go missing when the prod env was rebuilt (regression #928).
 REVEALUI_KEK                 = { path = "revealui/prod/kek", sensitive = true }
-REVEALUI_LICENSE_PRIVATE_KEY = { path = "revdev/license-signing-private-key", sensitive = true }
+# GAP-260 P4-4: admin is verify-only. Do not sync the signing private key here.
+# Mint stays on api (local fallback) until SIGN_VIA_SIGNER is the sole path,
+# then apps/license-signer. Public key remains so admin can verify JWTs.
 REVEALUI_LICENSE_PUBLIC_KEY  = "revdev/license-signing-public-key"
 REVEALUI_AUDIT_SIGNING_KEY   = { path = "revealui/prod/audit/signing-private-key", sensitive = true }
 REVEALUI_AUDIT_PUBLIC_KEY    = "revealui/prod/audit/signing-public-key"

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -258,10 +258,10 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'signing-private',
     sensitive: true,
     tier: 'prod',
-    consumers: ['vercel:api', 'vercel:admin', 'fly:worker', 'with-secrets:license-signing'],
+    consumers: ['vercel:api', 'fly:worker', 'with-secrets:license-signing'],
     migratingTo: 'revealui/prod/license/private-key',
     migratingSince: '2026-06-28',
-    note: 'Ed25519 license-signing key - the fleet crown jewel; only api mints',
+    note: 'Ed25519 license-signing key - the fleet crown jewel; api (+ worker until Fly drop) mints. Admin dropped P4-4 (verify-only).',
   },
   {
     path: 'revdev/license-signing-public-key',
@@ -673,8 +673,8 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'signing-private',
     sensitive: true,
     tier: 'staging',
-    consumers: ['vercel:api-staging', 'vercel:admin-staging'],
-    note: 'fresh Ed25519 pair, isolated from revdev/license-signing-* (GAP-343 decision 1)',
+    consumers: ['vercel:api-staging'],
+    note: 'fresh Ed25519 pair, isolated from revdev/license-signing-* (GAP-343 decision 1). Admin-staging dropped P4-4 (verify-only).',
   },
   {
     path: 'revealui/staging/license/public-key',


### PR DESCRIPTION
## Summary

GAP-260 P4-4 (owner-named this session): admin is verify-only.

- Remove `REVEALUI_LICENSE_PRIVATE_KEY` from prod + staging **admin** sync manifests
- Keep public key on admin
- Keep private on **api** (local mint fallback) and **Fly worker** (Fly is last; executor-off not proven live)
- Skip `REVEALUI_DEPLOYMENT_MODE` on admin so owner-set `hosted` is not orphaned
- Lockstep + admin tests: `MODE=hosted` without private is hosted SaaS

## Do not apply yet

Owner must set `REVEALUI_DEPLOYMENT_MODE=hosted` on admin **preview**, prove boot GREEN with private absent, then `revvault sync vercel --apply`. This PR does not apply, unset Fly secrets, or flip `SIGN_VIA_SIGNER`.

## Security

License signing / env sync. Guardrail-2 review required. **Not merge-ready until that verdict is recorded.**

## Residual (not this PR)

- Deploy license-signer + `SIGN_VIA_SIGNER` on api
- Drop private from Fly after live executor-off digest
- Later: drop private from api when signer is the sole mint path