### PR TITLE
fix(admin): emit auth.login audit receipts on all session mint paths

### DIFF
--- a/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
@@ -42,6 +42,8 @@ vi.mock('@revealui/auth/server', () => ({
   upsertOAuthUser: (...args: unknown[]) => mockUpsertOAuthUser(...args),
   createSession: (...args: unknown[]) => mockCreateSession(...args),
   rotateSession: (...args: unknown[]) => mockCreateSession(...args),
+  // Login receipt after OAuth session mint (GAP-338 dogfood residual)
+  auditLoginSuccess: vi.fn().mockResolvedValue(undefined),
   // Default: signup allowed. Specific tests can override via
   // mockIsSignupAllowed.mockReturnValueOnce(false) to exercise the
   // revealui#833 closed-signup gate.

--- a/apps/admin/src/app/api/auth/__tests__/integration.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/integration.test.ts
@@ -25,6 +25,8 @@ vi.mock('@revealui/auth/server', () => ({
   getSession: vi.fn(),
   createSession: vi.fn(),
   rotateSession: vi.fn(),
+  // Login receipt after session mint on MFA / passkey / recovery paths
+  auditLoginSuccess: vi.fn().mockResolvedValue(undefined),
   deleteAllUserSessions: vi.fn(),
   verifyCookiePayload: vi.fn(),
   signCookiePayload: vi.fn(),

--- a/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
@@ -38,6 +38,8 @@ vi.mock('@revealui/auth/server', () => ({
   upsertOAuthUser: (...args: unknown[]) => mockUpsertOAuthUser(...args),
   createSession: (...args: unknown[]) => mockCreateSession(...args),
   rotateSession: (...args: unknown[]) => mockCreateSession(...args),
+  // Login receipt after OAuth session mint (GAP-338 dogfood residual)
+  auditLoginSuccess: vi.fn().mockResolvedValue(undefined),
   // Default: signup allowed. Tests can override via
   // mockIsSignupAllowed.mockReturnValueOnce(false) to exercise the
   // revealui#833 closed-signup gate.

--- a/apps/admin/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/admin/src/app/api/auth/callback/[provider]/route.ts
@@ -11,6 +11,7 @@
 
 import {
   admitFreeIntake,
+  auditLoginSuccess,
   ensureFreeSignupEntitlement,
   exchangeCode,
   fetchProviderUser,
@@ -179,6 +180,9 @@ export async function GET(
       undefined;
 
     const { token } = await rotateSession(user.id, { userAgent, ipAddress, persistent: true });
+
+    // Login receipt (GAP-338 dogfood): password signIn already emits; OAuth did not.
+    await auditLoginSuccess(user.id, ipAddress ?? 'unknown', userAgent ?? 'unknown');
 
     // Resolve redirectTo: reject cross-origin URLs to prevent open redirect.
     // startsWith('/') is insufficient  -  paths like /..//..//attacker.com pass.

--- a/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/mfa/__tests__/routes.test.ts
@@ -27,6 +27,7 @@ vi.mock('@revealui/auth/server', () => ({
   isMFAEnabled: vi.fn(),
   createSession: vi.fn(),
   rotateSession: vi.fn(),
+  auditLoginSuccess: vi.fn().mockResolvedValue(undefined),
   verifyCookiePayload: vi.fn(),
   verifyAuthentication: vi.fn(),
   checkRateLimit: vi.fn(),

--- a/apps/admin/src/app/api/auth/mfa/backup/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/backup/route.ts
@@ -9,7 +9,12 @@
  * On success, creates a full session and sets `revealui-session` + `revealui-role`.
  */
 
-import { rotateSession, verifyBackupCode, verifyCookiePayload } from '@revealui/auth/server';
+import {
+  auditLoginSuccess,
+  rotateSession,
+  verifyBackupCode,
+  verifyCookiePayload,
+} from '@revealui/auth/server';
 import config from '@revealui/config';
 import { MFABackupCodeRequestContract } from '@revealui/contracts';
 import { getClient } from '@revealui/db';
@@ -102,6 +107,9 @@ async function backupHandler(request: NextRequest): Promise<NextResponse> {
       ipAddress,
       metadata: { mfaVerified: true },
     });
+
+    // Same as MFA TOTP verify: full session is established only after step-up.
+    await auditLoginSuccess(payload.userId, ipAddress ?? 'unknown', userAgent ?? 'unknown');
 
     const user = await getUserById(getClient(), payload.userId);
 

--- a/apps/admin/src/app/api/auth/mfa/verify/route.ts
+++ b/apps/admin/src/app/api/auth/mfa/verify/route.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  auditLoginSuccess,
   readUsersRole,
   rotateSession,
   verifyCookiePayload,
@@ -107,6 +108,10 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       // Marks this session as MFA step-up complete for requireMfa (C11).
       metadata: { mfaVerified: true },
     });
+
+    // Password signIn returns requiresMfa before minting a session, so the
+    // login receipt is written here when the full session is established.
+    await auditLoginSuccess(payload.userId, ipAddress ?? 'unknown', userAgent ?? 'unknown');
 
     // Role for proxy gate after createSession shell repair (GAP-473).
     // sign-in skips setting the cookie when MFA is required.

--- a/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
@@ -31,6 +31,7 @@ vi.mock('@revealui/auth/server', () => ({
   verifyCookiePayload: vi.fn(),
   createSession: vi.fn(),
   rotateSession: vi.fn(),
+  auditLoginSuccess: vi.fn().mockResolvedValue(undefined),
   initiateMFASetup: vi.fn(),
   verifyMFASetup: vi.fn(),
   checkRateLimit: vi.fn(),
@@ -850,6 +851,11 @@ describe('POST /api/auth/passkey/authenticate-verify', () => {
       expect.objectContaining({
         metadata: { mfaVerified: true, mfaMethod: 'passkey' },
       }),
+    );
+    expect(vi.mocked(authServer.auditLoginSuccess)).toHaveBeenCalledWith(
+      'user-123',
+      expect.any(String),
+      expect.any(String),
     );
 
     // Session cookie should be set

--- a/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
+++ b/apps/admin/src/app/api/auth/passkey/authenticate-verify/route.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  auditLoginSuccess,
   readUsersRole,
   rotateSession,
   verifyAuthentication,
@@ -141,6 +142,9 @@ async function authenticateVerifyHandler(request: NextRequest): Promise<NextResp
       ipAddress,
       metadata: { mfaVerified: true, mfaMethod: 'passkey' },
     });
+
+    // Full session minted (passkeys are phishing-resistant MFA). Land login receipt.
+    await auditLoginSuccess(storedPasskey.userId, ipAddress ?? 'unknown', userAgent ?? 'unknown');
 
     // After createSession shell repair (GAP-473), cookie + JSON must match DB.
     let userRole = user.role ?? 'viewer';

--- a/apps/admin/src/app/api/auth/recovery/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/recovery/__tests__/routes.test.ts
@@ -16,6 +16,7 @@ vi.mock('@revealui/auth/server', () => ({
   verifyMagicLink: vi.fn(),
   createSession: vi.fn(),
   deleteAllUserSessions: vi.fn(),
+  auditLoginSuccess: vi.fn().mockResolvedValue(undefined),
   checkRateLimit: vi.fn(),
 }));
 

--- a/apps/admin/src/app/api/auth/recovery/verify/route.ts
+++ b/apps/admin/src/app/api/auth/recovery/verify/route.ts
@@ -7,7 +7,12 @@
  * The session has a 30-minute expiry and metadata marking it as a recovery session.
  */
 
-import { createSession, deleteAllUserSessions, verifyMagicLink } from '@revealui/auth/server';
+import {
+  auditLoginSuccess,
+  createSession,
+  deleteAllUserSessions,
+  verifyMagicLink,
+} from '@revealui/auth/server';
 import { RecoveryVerifyRequestSchema } from '@revealui/contracts';
 import { getClient } from '@revealui/db';
 import { getUserById } from '@revealui/db/queries/users';
@@ -82,6 +87,9 @@ async function verifyHandler(request: NextRequest): Promise<NextResponse> {
       userAgent,
       ipAddress,
     });
+
+    // Recovery magic-link establishes a session; record a login receipt.
+    await auditLoginSuccess(verified.userId, ipAddress ?? 'unknown', userAgent ?? 'unknown');
 
     const user = await getUserById(getClient(), verified.userId);
 


### PR DESCRIPTION
## Summary
Founder dogfood on **Audit Trail**: page loads after #2561, but **no login row** after sign-in.

### Cause
`auditLoginSuccess` only ran on **password `signIn`** and **email verify**. These paths mint a session without a receipt:

- OAuth callback (`rotateSession`)
- Passkey authenticate-verify
- MFA TOTP verify / backup (password path returns `requiresMfa` *before* receipt)
- Recovery magic-link verify

### Fix
Call the same best-effort `auditLoginSuccess` after successful session mint on each path. Event type remains `auth.login`.

### Tests
- Passkey / MFA / recovery suites green (72) with mocks + passkey assertion

## Test plan
- [x] passkey + mfa + recovery route tests
- [x] phase-1 changed gate
- [ ] After merge → main + deploy: sign in (OAuth/passkey/password as used) → `/audit` shows fresh `auth.login`