### PR TITLE
feat(marketing): rewire section chrome onto MarketingSection

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -1,4 +1,11 @@
-import { type BlockAnnotation, Button, fieldAttrs, IconArrowRight } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  Button,
+  fieldAttrs,
+  IconArrowRight,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { HOME_GET_STARTED } from '../content/home';
 import type { GetStartedData } from '../lib/page-blocks';
 import { NewsletterSignup } from './NewsletterSignup';
@@ -18,71 +25,66 @@ export function GetStarted({
   annotation = {},
 }: GetStartedProps) {
   return (
-    <section className="border-t border-border bg-background py-20 sm:py-28">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <h2
-            className="font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-          <p
-            className="mt-5 text-lg leading-8 text-body"
-            {...fieldAttrs(annotation, `${path}.body`)}
-          >
-            {data.body}
-          </p>
-          <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
-            <Button asChild size="lg" variant="brand" glow>
-              <a href={data.cta.primary.href}>{data.cta.primary.label}</a>
-            </Button>
-            <Button asChild appearance="outline" variant="neutral" size="lg">
-              <a href={data.cta.secondary.href}>
-                {data.cta.secondary.label}
-                <IconArrowRight size="sm" className="ml-1.5" />
-              </a>
-            </Button>
-          </div>
+    <MarketingSection
+      tone="background"
+      density="default"
+      width="default"
+      className="border-t border-border"
+    >
+      <SectionHeader
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
+        align="center"
+      />
 
-          {/* CLI quick-start, moved here from the hero (frontend-excellence
-              Phase 1 hero declutter). */}
-          <div
-            className="mt-8 inline-flex items-center gap-3 rounded-xl bg-foreground px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-background/10"
-            {...fieldAttrs(annotation, `${path}.snippet.lines`)}
-          >
-            <span className="select-none text-background/50">$</span>
-            {data.cli.command.map((token, index) => (
-              <span
-                // biome-ignore lint/suspicious/noArrayIndexKey: static, order-fixed command tokens
-                key={index}
-                className={
-                  index === 0
-                    ? 'text-emerald-400' // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
-                    : index === data.cli.command.length - 1
-                      ? 'text-blue-300'
-                      : 'text-background'
-                }
-              >
-                {token}
-              </span>
-            ))}
-          </div>
-          <p
-            className="mt-4 text-sm text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.snippet.caption`)}
-          >
-            {data.cli.caption}
-          </p>
+      <div className="mx-auto max-w-2xl text-center">
+        <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
+          <Button asChild size="lg" variant="brand" glow>
+            <a href={data.cta.primary.href}>{data.cta.primary.label}</a>
+          </Button>
+          <Button asChild appearance="outline" variant="neutral" size="lg">
+            <a href={data.cta.secondary.href}>
+              {data.cta.secondary.label}
+              <IconArrowRight size="sm" className="ml-1.5" />
+            </a>
+          </Button>
+        </div>
 
-          <div className="mt-14 border-t border-border pt-10">
-            <p className="mb-4 text-sm font-medium text-muted-foreground">
-              {data.newsletter.label}
-            </p>
-            <NewsletterSignup variant="stacked" />
-          </div>
+        {/* CLI quick-start, moved here from the hero (frontend-excellence
+            Phase 1 hero declutter). */}
+        <div
+          className="mt-8 inline-flex items-center gap-3 rounded-xl bg-foreground px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-background/10"
+          {...fieldAttrs(annotation, `${path}.snippet.lines`)}
+        >
+          <span className="select-none text-background/50">$</span>
+          {data.cli.command.map((token, index) => (
+            <span
+              // biome-ignore lint/suspicious/noArrayIndexKey: static, order-fixed command tokens
+              key={index}
+              className={
+                index === 0
+                  ? 'text-emerald-400' // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
+                  : index === data.cli.command.length - 1
+                    ? 'text-blue-300'
+                    : 'text-background'
+              }
+            >
+              {token}
+            </span>
+          ))}
+        </div>
+        <p
+          className="mt-4 text-sm text-muted-foreground"
+          {...fieldAttrs(annotation, `${path}.snippet.caption`)}
+        >
+          {data.cli.caption}
+        </p>
+
+        <div className="mt-14 border-t border-border pt-10">
+          <p className="mb-4 text-sm font-medium text-muted-foreground">{data.newsletter.label}</p>
+          <NewsletterSignup variant="stacked" />
         </div>
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
@@ -1,4 +1,10 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  Button,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_HIW_CLOSING } from '../../content/for-operators-how-it-works';
 import type { FoHiwCtaData } from '../../lib/page-blocks';
 
@@ -22,42 +28,34 @@ export function ClosingCta({
     annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
 
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-        <h2
-          className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...field('heading')}
-        >
-          {data.heading}
-        </h2>
-        <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-body" {...field('body')}>
-          {data.body}
-        </p>
+    <MarketingSection tone="background" density="default" width="narrow">
+      <SectionHeader
+        title={<span {...field('heading')}>{data.heading}</span>}
+        description={<span {...field('body')}>{data.body}</span>}
+        align="center"
+      />
 
-        <div className="mt-10 flex justify-center">
-          <Button asChild size="lg" glow>
-            <a
-              href={data.primaryCta.href}
-              {...(data.primaryCta.external
-                ? { target: '_blank', rel: 'noopener noreferrer' }
-                : {})}
-              {...field('links.0.label')}
-            >
-              {data.primaryCta.label}
-            </a>
-          </Button>
-        </div>
-
-        <p className="mt-6 text-sm text-muted-foreground">
+      <div className="mt-10 flex justify-center">
+        <Button asChild size="lg" glow>
           <a
-            href={data.backLink.href}
-            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
-            {...field('links.1.label')}
+            href={data.primaryCta.href}
+            {...(data.primaryCta.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+            {...field('links.0.label')}
           >
-            {data.backLink.label}
+            {data.primaryCta.label}
           </a>
-        </p>
+        </Button>
       </div>
-    </section>
+
+      <p className="mt-6 text-center text-sm text-muted-foreground">
+        <a
+          href={data.backLink.href}
+          className="underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground"
+          {...field('links.1.label')}
+        >
+          {data.backLink.label}
+        </a>
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_HIW_STEPS } from '../../content/for-operators-how-it-works';
 import type { FoHiwStepsData } from '../../lib/page-blocks';
 
@@ -13,53 +18,43 @@ export function EngagementSteps({ data = FO_HIW_STEPS, path, annotation }: Engag
     annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
 
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-5xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...field('eyebrow')}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...field('heading')}
-          >
-            {data.heading}
-          </h2>
-        </div>
+    <MarketingSection tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={<span {...field('eyebrow')}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...field('heading')}>{data.heading}</span>}
+        align="center"
+      />
 
-        <ol className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-6 list-none p-0">
-          {data.steps.map((step, index) => (
-            <li
-              key={step.number}
-              className="grid grid-cols-[auto_1fr] gap-6 rounded-2xl border border-border bg-card p-6 shadow-sm"
+      <ol className="mx-auto mt-16 grid max-w-4xl list-none grid-cols-1 gap-6 p-0">
+        {data.steps.map((step, index) => (
+          <li
+            key={step.number}
+            className="grid grid-cols-[auto_1fr] gap-6 rounded-2xl border border-border bg-card p-6 shadow-sm"
+          >
+            <div
+              className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 font-mono text-base font-semibold text-primary"
+              {...field(`items.${index}.label`)}
             >
-              <div
-                className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 font-mono text-base font-semibold text-primary"
-                {...field(`items.${index}.label`)}
+              {step.number}
+            </div>
+            <div>
+              <h3
+                className="text-lg font-semibold leading-7 text-foreground"
+                {...field(`items.${index}.title`)}
               >
-                {step.number}
-              </div>
-              <div>
-                <h3
-                  className="text-lg font-semibold leading-7 text-foreground"
-                  {...field(`items.${index}.title`)}
-                >
-                  {step.title}
-                </h3>
-                <p
-                  className="mt-2 text-base leading-7 text-muted-foreground"
-                  {...field(`items.${index}.body`)}
-                >
-                  {step.body}
-                </p>
-              </div>
-            </li>
-          ))}
-        </ol>
-      </div>
-    </section>
+                {step.title}
+              </h3>
+              <p
+                className="mt-2 text-base leading-7 text-muted-foreground"
+                {...field(`items.${index}.body`)}
+              >
+                {step.body}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_HIW_FEAR } from '../../content/for-operators-how-it-works';
 import type { FoHiwFearData } from '../../lib/page-blocks';
 
@@ -17,57 +22,46 @@ export function FearRemoval({ data = FO_HIW_FEAR, path, annotation }: FearRemova
   const closingIndex = optionStart + data.options.length;
 
   return (
-    <section className="bg-muted py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...field('eyebrow')}
-        >
-          {data.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...field('heading')}
-        >
-          {data.heading}
-        </h2>
+    <MarketingSection tone="secondary" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={<span {...field('eyebrow')}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...field('heading')}>{data.heading}</span>}
+        align="start"
+      />
 
-        <p className="mt-8 text-base leading-7 text-muted-foreground" {...field('body')}>
-          {data.paragraph1}
-        </p>
-        <p className="mt-4 text-base leading-7 text-muted-foreground" {...field('items.0.body')}>
-          {data.paragraph2}
-        </p>
+      <p className="mt-8 text-base leading-7 text-body" {...field('body')}>
+        {data.paragraph1}
+      </p>
+      <p className="mt-4 text-base leading-7 text-body" {...field('items.0.body')}>
+        {data.paragraph2}
+      </p>
 
-        <ul className="mt-6 space-y-4 list-none p-0">
-          {data.options.map((option, index) => (
-            <li
-              key={option.title}
-              className="rounded-2xl border border-border bg-card p-5 shadow-sm"
+      <ul className="mt-6 list-none space-y-4 p-0">
+        {data.options.map((option, index) => (
+          <li key={option.title} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+            <h3
+              className="text-base font-semibold leading-7 text-foreground"
+              {...field(`items.${optionStart + index}.title`)}
             >
-              <h3
-                className="text-base font-semibold leading-7 text-foreground"
-                {...field(`items.${optionStart + index}.title`)}
-              >
-                {option.title}
-              </h3>
-              <p
-                className="mt-1 text-base leading-7 text-muted-foreground"
-                {...field(`items.${optionStart + index}.body`)}
-              >
-                {option.body}
-              </p>
-            </li>
-          ))}
-        </ul>
+              {option.title}
+            </h3>
+            <p
+              className="mt-1 text-base leading-7 text-muted-foreground"
+              {...field(`items.${optionStart + index}.body`)}
+            >
+              {option.body}
+            </p>
+          </li>
+        ))}
+      </ul>
 
-        <p
-          className="mt-8 text-base leading-7 text-foreground font-medium"
-          {...field(`items.${closingIndex}.body`)}
-        >
-          {data.closing}
-        </p>
-      </div>
-    </section>
+      <p
+        className="mt-8 text-base font-medium leading-7 text-foreground"
+        {...field(`items.${closingIndex}.body`)}
+      >
+        {data.closing}
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Hero.tsx
@@ -1,4 +1,4 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs, MarketingSection } from '@revealui/presentation';
 import { FO_HIW_HERO } from '../../content/for-operators-how-it-works';
 import type { FoHiwHeroData } from '../../lib/page-blocks';
 
@@ -23,12 +23,17 @@ export function Hero({
     annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
 
   return (
-    <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
+    <MarketingSection
+      tone="background"
+      density="spacious"
+      width="narrow"
+      className="relative isolate overflow-hidden"
+    >
       <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
 
-      <div className="relative mx-auto max-w-3xl text-center">
+      <div className="relative text-center">
         <p
-          className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6"
+          className="mb-6 text-sm font-semibold uppercase tracking-[0.2em] text-primary"
           {...field('eyebrow')}
         >
           {data.eyebrow}
@@ -52,7 +57,7 @@ export function Hero({
           {data.subtitle}
         </p>
 
-        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Button asChild size="lg" glow className="w-full sm:w-auto">
             <a
               href={data.primaryCta.href}
@@ -69,13 +74,13 @@ export function Hero({
         <p className="mt-8 text-sm text-muted-foreground">
           <a
             href={data.backLink.href}
-            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground"
             {...field('links.1.label')}
           >
             {data.backLink.label}
           </a>
         </p>
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_HIW_OWNERSHIP } from '../../content/for-operators-how-it-works';
 import type { FoHiwOwnershipData } from '../../lib/page-blocks';
 
@@ -15,54 +20,43 @@ export function Ownership({ data = FO_HIW_OWNERSHIP, path, annotation }: Ownersh
   const diffIndex = data.claims.length;
 
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...field('eyebrow')}
-        >
-          {data.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...field('heading')}
-        >
-          {data.heading}
-        </h2>
+    <MarketingSection tone="background" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={<span {...field('eyebrow')}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...field('heading')}>{data.heading}</span>}
+        align="start"
+      />
 
-        <p className="mt-6 text-base leading-7 text-muted-foreground" {...field('body')}>
-          {data.intro}
-        </p>
+      <p className="mt-6 text-base leading-7 text-body" {...field('body')}>
+        {data.intro}
+      </p>
 
-        <ul className="mt-6 space-y-4 list-none p-0">
-          {data.claims.map((claim, index) => (
-            <li
-              key={claim.title}
-              className="rounded-2xl border border-border bg-card p-5 shadow-sm"
+      <ul className="mt-6 list-none space-y-4 p-0">
+        {data.claims.map((claim, index) => (
+          <li key={claim.title} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+            <h3
+              className="text-base font-semibold leading-7 text-foreground"
+              {...field(`items.${index}.title`)}
             >
-              <h3
-                className="text-base font-semibold leading-7 text-foreground"
-                {...field(`items.${index}.title`)}
-              >
-                {claim.title}
-              </h3>
-              <p
-                className="mt-1 text-base leading-7 text-muted-foreground"
-                {...field(`items.${index}.body`)}
-              >
-                {claim.body}
-              </p>
-            </li>
-          ))}
-        </ul>
+              {claim.title}
+            </h3>
+            <p
+              className="mt-1 text-base leading-7 text-muted-foreground"
+              {...field(`items.${index}.body`)}
+            >
+              {claim.body}
+            </p>
+          </li>
+        ))}
+      </ul>
 
-        <p
-          className="mt-8 text-base leading-7 text-foreground font-medium"
-          {...field(`items.${diffIndex}.body`)}
-        >
-          {data.differentiator}
-        </p>
-      </div>
-    </section>
+      <p
+        className="mt-8 text-base font-medium leading-7 text-foreground"
+        {...field(`items.${diffIndex}.body`)}
+      >
+        {data.differentiator}
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_HIW_TIMELINE } from '../../content/for-operators-how-it-works';
 import type { FoHiwTimelineData } from '../../lib/page-blocks';
 
@@ -13,28 +18,20 @@ export function Timeline({ data = FO_HIW_TIMELINE, path, annotation }: TimelineP
     annotation && path ? fieldAttrs(annotation, `${path}.${suffix}`) : {};
 
   return (
-    <section className="bg-muted py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...field('eyebrow')}
-        >
-          {data.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...field('heading')}
-        >
-          {data.heading}
-        </h2>
+    <MarketingSection tone="secondary" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={<span {...field('eyebrow')}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...field('heading')}>{data.heading}</span>}
+        align="start"
+      />
 
-        <p className="mt-6 text-base leading-7 text-muted-foreground" {...field('body')}>
-          {data.paragraph1}
-        </p>
-        <p className="mt-4 text-base leading-7 text-muted-foreground" {...field('items.0.body')}>
-          {data.paragraph2}
-        </p>
-      </div>
-    </section>
+      <p className="mt-6 text-base leading-7 text-body" {...field('body')}>
+        {data.paragraph1}
+      </p>
+      <p className="mt-4 text-base leading-7 text-body" {...field('items.0.body')}>
+        {data.paragraph2}
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-managed/Hero.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Hero.tsx
@@ -1,4 +1,4 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import { type BlockAnnotation, fieldAttrs, MarketingSection } from '@revealui/presentation';
 import { FO_MANAGED_HERO } from '../../content/for-operators-managed';
 import type { FoManagedHeroData } from '../../lib/page-blocks';
 
@@ -19,12 +19,17 @@ export function Hero({ data, path, annotation }: FoManagedHeroProps = {}) {
   const base = path ?? '';
 
   return (
-    <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
+    <MarketingSection
+      tone="background"
+      density="spacious"
+      width="narrow"
+      className="relative isolate overflow-hidden"
+    >
       <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
 
-      <div className="relative mx-auto max-w-3xl text-center">
+      <div className="relative text-center">
         <p
-          className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6"
+          className="mb-6 text-sm font-semibold uppercase tracking-[0.2em] text-primary"
           {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
         >
           {content.eyebrow}
@@ -51,13 +56,13 @@ export function Hero({ data, path, annotation }: FoManagedHeroProps = {}) {
         <p className="mt-10 text-sm text-muted-foreground">
           <a
             href={content.backLink.href}
-            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground"
             {...(base ? fieldAttrs(ann, `${base}.links.0.label`) : {})}
           >
             {content.backLink.label}
           </a>
         </p>
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_MANAGED_PREREQS } from '../../content/for-operators-managed';
 import type { FoManagedPrereqsData } from '../../lib/page-blocks';
 
@@ -24,57 +29,54 @@ export function Prerequisites({ data, path, annotation }: FoManagedPrereqsProps 
   const closingIndex = content.prerequisites.length;
 
   return (
-    <section className="bg-muted py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-        >
-          {content.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-        >
-          {content.heading}
-        </h2>
+    <MarketingSection tone="secondary" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{content.eyebrow}</span>
+          ) : (
+            content.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        description={
+          base ? <span {...fieldAttrs(ann, `${base}.body`)}>{content.intro}</span> : content.intro
+        }
+        align="start"
+      />
 
-        <p
-          className="mt-6 text-base leading-7 text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
-        >
-          {content.intro}
-        </p>
-
-        <ul className="mt-6 space-y-4 list-none p-0">
-          {content.prerequisites.map((prereq, index) => (
-            <li
-              key={prereq.title}
-              className="rounded-2xl border border-border bg-card p-5 shadow-sm"
+      <ul className="mt-6 list-none space-y-4 p-0">
+        {content.prerequisites.map((prereq, index) => (
+          <li key={prereq.title} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+            <h3
+              className="text-base font-semibold leading-7 text-foreground"
+              {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
             >
-              <h3
-                className="text-base font-semibold leading-7 text-foreground"
-                {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
-              >
-                {prereq.title}
-              </h3>
-              <p
-                className="mt-2 text-base leading-7 text-muted-foreground"
-                {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
-              >
-                {prereq.body}
-              </p>
-            </li>
-          ))}
-        </ul>
+              {prereq.title}
+            </h3>
+            <p
+              className="mt-2 text-base leading-7 text-muted-foreground"
+              {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
+            >
+              {prereq.body}
+            </p>
+          </li>
+        ))}
+      </ul>
 
-        <p
-          className="mt-8 text-base leading-7 text-foreground font-medium"
-          {...(base ? fieldAttrs(ann, `${base}.items.${closingIndex}.body`) : {})}
-        >
-          {content.closing}
-        </p>
-      </div>
-    </section>
+      <p
+        className="mt-8 text-base font-medium leading-7 text-foreground"
+        {...(base ? fieldAttrs(ann, `${base}.items.${closingIndex}.body`) : {})}
+      >
+        {content.closing}
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-managed/Status.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Status.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_MANAGED_STATUS } from '../../content/for-operators-managed';
 import type { FoManagedStatusData } from '../../lib/page-blocks';
 
@@ -20,27 +25,31 @@ export function Status({ data, path, annotation }: FoManagedStatusProps = {}) {
   const base = path ?? '';
 
   return (
-    <section className="bg-muted py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-        >
-          {content.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-        >
-          {content.heading}
-        </h2>
+    <MarketingSection tone="secondary" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{content.eyebrow}</span>
+          ) : (
+            content.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        align="start"
+      />
 
-        <div className="mt-8 space-y-6 text-base leading-7 text-muted-foreground">
-          <p {...(base ? fieldAttrs(ann, `${base}.body`) : {})}>{content.paragraph1}</p>
-          <p {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>{content.paragraph2}</p>
-          <p {...(base ? fieldAttrs(ann, `${base}.items.1.body`) : {})}>{content.paragraph3}</p>
-        </div>
+      <div className="mt-8 space-y-6 text-base leading-7 text-body">
+        <p {...(base ? fieldAttrs(ann, `${base}.body`) : {})}>{content.paragraph1}</p>
+        <p {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>{content.paragraph2}</p>
+        <p {...(base ? fieldAttrs(ann, `${base}.items.1.body`) : {})}>{content.paragraph3}</p>
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-managed/Today.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Today.tsx
@@ -1,4 +1,10 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  Button,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_MANAGED_TODAY } from '../../content/for-operators-managed';
 import type { FoManagedTodayData } from '../../lib/page-blocks';
 
@@ -20,51 +26,51 @@ export function Today({ data, path, annotation }: FoManagedTodayProps = {}) {
   const base = path ?? '';
 
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-        >
-          {content.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-        >
-          {content.heading}
-        </h2>
+    <MarketingSection tone="background" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{content.eyebrow}</span>
+          ) : (
+            content.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        description={
+          base ? <span {...fieldAttrs(ann, `${base}.body`)}>{content.body}</span> : content.body
+        }
+        align="center"
+      />
 
-        <p
-          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
-        >
-          {content.body}
+      <div className="mt-10 flex flex-col items-center gap-4">
+        <Button asChild size="lg">
+          <a
+            href={content.primaryCta.href}
+            {...(content.primaryCta.external
+              ? { target: '_blank', rel: 'noopener noreferrer' }
+              : {})}
+            {...(base ? fieldAttrs(ann, `${base}.items.0.label`) : {})}
+          >
+            {content.primaryCta.label}
+          </a>
+        </Button>
+        <p className="text-sm">
+          <a
+            href={content.detailLink.href}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            {...(base ? fieldAttrs(ann, `${base}.items.1.label`) : {})}
+          >
+            {content.detailLink.label}
+          </a>
         </p>
-
-        <div className="mt-10 flex flex-col items-center gap-4">
-          <Button asChild size="lg">
-            <a
-              href={content.primaryCta.href}
-              {...(content.primaryCta.external
-                ? { target: '_blank', rel: 'noopener noreferrer' }
-                : {})}
-              {...(base ? fieldAttrs(ann, `${base}.items.0.label`) : {})}
-            >
-              {content.primaryCta.label}
-            </a>
-          </Button>
-          <p className="text-sm">
-            <a
-              href={content.detailLink.href}
-              className="font-medium text-primary hover:underline underline-offset-4"
-              {...(base ? fieldAttrs(ann, `${base}.items.1.label`) : {})}
-            >
-              {content.detailLink.label}
-            </a>
-          </p>
-        </div>
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
@@ -1,4 +1,11 @@
-import { type BlockAnnotation, Button, fieldAttrs, Input } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  Button,
+  fieldAttrs,
+  Input,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
 import { FO_MANAGED_WAITLIST } from '../../content/for-operators-managed';
@@ -49,73 +56,73 @@ export function Waitlist({ data, path, annotation }: FoManagedWaitlistProps = {}
   }
 
   return (
-    <section className="bg-muted py-24 sm:py-32">
-      <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-        >
-          {content.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-        >
-          {content.heading}
-        </h2>
+    <MarketingSection tone="secondary" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{content.eyebrow}</span>
+          ) : (
+            content.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        description={
+          base ? <span {...fieldAttrs(ann, `${base}.body`)}>{content.body}</span> : content.body
+        }
+        align="center"
+      />
 
+      {status === 'success' ? (
         <p
-          className="mx-auto mt-6 max-w-xl text-base leading-7 text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
+          className="mt-10 animate-[fade-in_300ms_ease-out] text-center text-base font-medium text-primary"
+          {...(base ? fieldAttrs(ann, `${base}.items.3.body`) : {})}
         >
-          {content.body}
+          {message}
         </p>
-
-        {status === 'success' ? (
-          <p
-            className="mt-10 animate-[fade-in_300ms_ease-out] text-base font-medium text-primary"
-            {...(base ? fieldAttrs(ann, `${base}.items.3.body`) : {})}
+      ) : (
+        <form onSubmit={handleSubmit} className="mx-auto mt-10 flex max-w-sm flex-col gap-3">
+          <label htmlFor="waitlist-email" className="sr-only">
+            Email address
+          </label>
+          <Input
+            id="waitlist-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder={content.inputPlaceholder}
+            required
+          />
+          {/* Labels ride CMS for seed/fallback parity; form controls stay unannotated. */}
+          <span className="sr-only" {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>
+            {content.inputPlaceholder}
+          </span>
+          <Button
+            type="submit"
+            variant="brand"
+            isLoading={status === 'loading'}
+            disabled={status === 'loading'}
           >
-            {message}
-          </p>
-        ) : (
-          <form onSubmit={handleSubmit} className="mx-auto mt-10 flex max-w-sm flex-col gap-3">
-            <label htmlFor="waitlist-email" className="sr-only">
-              Email address
-            </label>
-            <Input
-              id="waitlist-email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder={content.inputPlaceholder}
-              required
-            />
-            {/* Labels ride CMS for seed/fallback parity; form controls stay unannotated. */}
-            <span className="sr-only" {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>
-              {content.inputPlaceholder}
-            </span>
-            <Button
-              type="submit"
-              variant="brand"
-              isLoading={status === 'loading'}
-              disabled={status === 'loading'}
+            <span
+              {...(base
+                ? fieldAttrs(
+                    ann,
+                    status === 'loading' ? `${base}.items.2.body` : `${base}.items.1.body`,
+                  )
+                : {})}
             >
-              <span
-                {...(base
-                  ? fieldAttrs(
-                      ann,
-                      status === 'loading' ? `${base}.items.2.body` : `${base}.items.1.body`,
-                    )
-                  : {})}
-              >
-                {status === 'loading' ? content.buttonLabelLoading : content.buttonLabel}
-              </span>
-            </Button>
-            {status === 'error' && <p className="text-xs text-destructive">{message}</p>}
-          </form>
-        )}
-      </div>
-    </section>
+              {status === 'loading' ? content.buttonLabelLoading : content.buttonLabel}
+            </span>
+          </Button>
+          {status === 'error' && <p className="text-xs text-destructive">{message}</p>}
+        </form>
+      )}
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
+++ b/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FO_MANAGED_WOULD_BE } from '../../content/for-operators-managed';
 import type { FoManagedWouldBeData } from '../../lib/page-blocks';
 
@@ -23,52 +28,54 @@ export function WouldBe({ data, path, annotation }: FoManagedWouldBeProps = {}) 
   const closingIndex = content.capabilities.length;
 
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-5xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-          >
-            {content.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-          >
-            {content.heading}
-          </h2>
-        </div>
+    <MarketingSection tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{content.eyebrow}</span>
+          ) : (
+            content.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        align="center"
+      />
 
-        <ul className="mx-auto mt-16 grid max-w-4xl grid-cols-1 gap-6 list-none p-0">
-          {content.capabilities.map((capability, index) => (
-            <li
-              key={capability.title}
-              className="rounded-2xl border border-border bg-card p-6 shadow-sm"
+      <ul className="mx-auto mt-16 grid max-w-4xl list-none grid-cols-1 gap-6 p-0">
+        {content.capabilities.map((capability, index) => (
+          <li
+            key={capability.title}
+            className="rounded-2xl border border-border bg-card p-6 shadow-sm"
+          >
+            <h3
+              className="text-lg font-semibold leading-7 text-foreground"
+              {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
             >
-              <h3
-                className="text-lg font-semibold leading-7 text-foreground"
-                {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
-              >
-                {capability.title}
-              </h3>
-              <p
-                className="mt-2 text-base leading-7 text-muted-foreground"
-                {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
-              >
-                {capability.body}
-              </p>
-            </li>
-          ))}
-        </ul>
+              {capability.title}
+            </h3>
+            <p
+              className="mt-2 text-base leading-7 text-muted-foreground"
+              {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
+            >
+              {capability.body}
+            </p>
+          </li>
+        ))}
+      </ul>
 
-        <p
-          className="mx-auto mt-12 max-w-2xl text-center text-base leading-7 text-foreground font-medium"
-          {...(base ? fieldAttrs(ann, `${base}.items.${closingIndex}.body`) : {})}
-        >
-          {content.closing}
-        </p>
-      </div>
-    </section>
+      <p
+        className="mx-auto mt-12 max-w-2xl text-center text-base font-medium leading-7 text-foreground"
+        {...(base ? fieldAttrs(ann, `${base}.items.${closingIndex}.body`) : {})}
+      >
+        {content.closing}
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators/ClosingCta.tsx
@@ -1,4 +1,10 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  Button,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FOR_OPERATORS_CLOSING } from '../../content/for-operators';
 import type { ServicesCtaData } from '../../lib/page-blocks';
 
@@ -19,51 +25,50 @@ export function ClosingCta({ data, path, annotation }: ClosingCtaProps = {}) {
   const base = path ?? '';
 
   return (
-    <section className="bg-muted py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-        <h2
-          className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-        >
-          {content.heading}
-        </h2>
-        <p
-          className="mx-auto mt-6 max-w-2xl text-base leading-7 text-body"
-          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
-        >
-          {content.body}
-        </p>
+    <MarketingSection tone="secondary" density="default" width="narrow">
+      <SectionHeader
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        description={
+          base ? <span {...fieldAttrs(ann, `${base}.body`)}>{content.body}</span> : content.body
+        }
+        align="center"
+      />
 
-        <div className="mt-10 flex justify-center">
-          <Button asChild size="lg" glow>
-            <a
-              href={content.primaryCta.href}
-              {...(content.primaryCta.external
-                ? { target: '_blank', rel: 'noopener noreferrer' }
-                : {})}
-              {...(base ? fieldAttrs(ann, `${base}.links.0.label`) : {})}
-            >
-              {content.primaryCta.label}
-            </a>
-          </Button>
-        </div>
-
-        <p className="mt-6 text-sm text-muted-foreground">
-          <span {...(base ? fieldAttrs(ann, `${base}.snippet.lines.0`) : {})}>
-            {content.emailFallback.prefix}
-          </span>
+      <div className="mt-10 flex justify-center">
+        <Button asChild size="lg" glow>
           <a
-            href={`mailto:${content.emailFallback.address}`}
-            className="font-medium text-primary hover:underline underline-offset-4"
-            {...(base ? fieldAttrs(ann, `${base}.snippet.lines.1`) : {})}
+            href={content.primaryCta.href}
+            {...(content.primaryCta.external
+              ? { target: '_blank', rel: 'noopener noreferrer' }
+              : {})}
+            {...(base ? fieldAttrs(ann, `${base}.links.0.label`) : {})}
           >
-            {content.emailFallback.address}
+            {content.primaryCta.label}
           </a>
-          <span {...(base ? fieldAttrs(ann, `${base}.snippet.lines.2`) : {})}>
-            {content.emailFallback.suffix}
-          </span>
-        </p>
+        </Button>
       </div>
-    </section>
+
+      <p className="mt-6 text-center text-sm text-muted-foreground">
+        <span {...(base ? fieldAttrs(ann, `${base}.snippet.lines.0`) : {})}>
+          {content.emailFallback.prefix}
+        </span>
+        <a
+          href={`mailto:${content.emailFallback.address}`}
+          className="font-medium text-primary underline-offset-4 hover:underline"
+          {...(base ? fieldAttrs(ann, `${base}.snippet.lines.1`) : {})}
+        >
+          {content.emailFallback.address}
+        </a>
+        <span {...(base ? fieldAttrs(ann, `${base}.snippet.lines.2`) : {})}>
+          {content.emailFallback.suffix}
+        </span>
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators/DiscoveryScopeShip.tsx
+++ b/apps/marketing/app/components/for-operators/DiscoveryScopeShip.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FOR_OPERATORS_DISCOVERY } from '../../content/for-operators';
 import type { ServicesDiscoveryData } from '../../lib/page-blocks';
 
@@ -19,36 +24,37 @@ export function DiscoveryScopeShip({ data, path, annotation }: DiscoveryScopeShi
   const base = path ?? '';
 
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 text-center lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
+    <MarketingSection tone="background" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{content.eyebrow}</span>
+          ) : (
+            content.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        description={
+          base ? <span {...fieldAttrs(ann, `${base}.body`)}>{content.body}</span> : content.body
+        }
+        align="center"
+      />
+      <p className="mt-8 text-center">
+        <a
+          href={content.link.href}
+          className="font-medium text-primary underline-offset-4 hover:underline"
+          {...(base ? fieldAttrs(ann, `${base}.items.0.label`) : {})}
         >
-          {content.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-        >
-          {content.heading}
-        </h2>
-        <p
-          className="mt-6 text-base leading-7 text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
-        >
-          {content.body}
-        </p>
-        <p className="mt-8">
-          <a
-            href={content.link.href}
-            className="font-medium text-primary hover:underline underline-offset-4"
-            {...(base ? fieldAttrs(ann, `${base}.items.0.label`) : {})}
-          >
-            {content.link.label}
-          </a>
-        </p>
-      </div>
-    </section>
+          {content.link.label}
+        </a>
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators/EngagementPricing.tsx
+++ b/apps/marketing/app/components/for-operators/EngagementPricing.tsx
@@ -1,4 +1,10 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  Button,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FOR_OPERATORS_PRICING } from '../../content/for-operators';
 import type { ServicesPricingIntroData } from '../../lib/page-blocks';
 
@@ -23,52 +29,51 @@ export function EngagementPricing({ data, path, annotation }: EngagementPricingP
   const base = path ?? '';
 
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-          >
-            {intro.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-          >
-            {intro.heading}
-          </h2>
-          <p
-            className="mt-6 text-lg leading-8 text-body"
-            {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
-          >
-            {intro.body}
-          </p>
-        </div>
+    <MarketingSection tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{intro.eyebrow}</span>
+          ) : (
+            intro.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{intro.heading}</span>
+          ) : (
+            intro.heading
+          )
+        }
+        description={
+          base ? <span {...fieldAttrs(ann, `${base}.body`)}>{intro.body}</span> : intro.body
+        }
+        align="center"
+      />
 
-        <ul className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3 list-none p-0">
-          {rungs.map((rung) => (
-            <li
-              key={rung.title}
-              className="flex flex-col rounded-2xl border border-border bg-card p-8 shadow-sm"
-            >
-              <h3 className="text-lg font-semibold leading-7 text-foreground">{rung.title}</h3>
-              <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{rung.price}</p>
-              <p className="mt-4 flex-1 text-base leading-7 text-muted-foreground">{rung.body}</p>
-              <div className="mt-8">
-                <Button asChild appearance="outline" variant="neutral" className="w-full">
-                  <a
-                    href={rung.cta.href}
-                    {...(rung.cta.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                  >
-                    {rung.cta.label}
-                  </a>
-                </Button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </section>
+      <ul className="mx-auto mt-16 grid max-w-5xl list-none grid-cols-1 gap-6 p-0 lg:grid-cols-3">
+        {rungs.map((rung) => (
+          <li
+            key={rung.title}
+            className="flex flex-col rounded-2xl border border-border bg-card p-8 shadow-sm"
+          >
+            <h3 className="text-lg font-semibold leading-7 text-foreground">{rung.title}</h3>
+            <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{rung.price}</p>
+            <p className="mt-4 flex-1 text-base leading-7 text-muted-foreground">{rung.body}</p>
+            <div className="mt-8">
+              <Button asChild appearance="outline" variant="neutral" className="w-full">
+                <a
+                  href={rung.cta.href}
+                  {...(rung.cta.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                >
+                  {rung.cta.label}
+                </a>
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators/Faq.tsx
+++ b/apps/marketing/app/components/for-operators/Faq.tsx
@@ -1,4 +1,4 @@
-import { IconPlus } from '@revealui/presentation';
+import { IconPlus, MarketingSection, SectionHeader } from '@revealui/presentation';
 import { FOR_OPERATORS_FAQ } from '../../content/for-operators';
 
 /**
@@ -7,33 +7,27 @@ import { FOR_OPERATORS_FAQ } from '../../content/for-operators';
  */
 export function Faq() {
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            {FOR_OPERATORS_FAQ.eyebrow}
-          </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {FOR_OPERATORS_FAQ.heading}
-          </h2>
-        </div>
+    <MarketingSection tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={FOR_OPERATORS_FAQ.eyebrow}
+        eyebrowTone="muted"
+        title={FOR_OPERATORS_FAQ.heading}
+        align="center"
+      />
 
-        <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
-          {FOR_OPERATORS_FAQ.items.map((item) => (
-            <details key={item.question} className="group py-6">
-              <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                <h3 className="text-lg font-semibold leading-7 text-foreground">{item.question}</h3>
-                <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
-                  <IconPlus size="sm" label="Toggle" />
-                </span>
-              </summary>
-              <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">
-                {item.answer}
-              </div>
-            </details>
-          ))}
-        </div>
+      <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
+        {FOR_OPERATORS_FAQ.items.map((item) => (
+          <details key={item.question} className="group py-6">
+            <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
+              <h3 className="text-lg font-semibold leading-7 text-foreground">{item.question}</h3>
+              <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
+                <IconPlus size="sm" label="Toggle" />
+              </span>
+            </summary>
+            <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">{item.answer}</div>
+          </details>
+        ))}
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators/Hero.tsx
+++ b/apps/marketing/app/components/for-operators/Hero.tsx
@@ -1,4 +1,4 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs, MarketingSection } from '@revealui/presentation';
 import { FOR_OPERATORS_HERO } from '../../content/for-operators';
 import type { ServicesHeroData } from '../../lib/page-blocks';
 
@@ -22,12 +22,17 @@ export function Hero({ data, path, annotation }: ServicesHeroProps = {}) {
   const base = path ?? '';
 
   return (
-    <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-20 sm:px-6 sm:pt-28 sm:pb-28 lg:px-8">
+    <MarketingSection
+      tone="background"
+      density="spacious"
+      width="narrow"
+      className="relative isolate overflow-hidden"
+    >
       <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background" />
 
-      <div className="relative mx-auto max-w-3xl text-center">
+      <div className="relative text-center">
         <p
-          className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6"
+          className="mb-6 text-sm font-semibold uppercase tracking-[0.2em] text-primary"
           {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
         >
           {content.eyebrow}
@@ -51,7 +56,7 @@ export function Hero({ data, path, annotation }: ServicesHeroProps = {}) {
           {content.subtitle}
         </p>
 
-        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Button asChild size="lg" glow className="w-full sm:w-auto">
             <a
               href={content.primaryCta.href}
@@ -68,13 +73,13 @@ export function Hero({ data, path, annotation }: ServicesHeroProps = {}) {
         <p className="mt-8 text-sm text-muted-foreground">
           <a
             href={content.reverseLink.href}
-            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
+            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground"
             {...(base ? fieldAttrs(ann, `${base}.links.1.label`) : {})}
           >
             {content.reverseLink.label}
           </a>
         </p>
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators/HowWeDeliver.tsx
+++ b/apps/marketing/app/components/for-operators/HowWeDeliver.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FOR_OPERATORS_HOW_WE_DELIVER } from '../../content/for-operators';
 import type { ServicesHowWeDeliverData } from '../../lib/page-blocks';
 
@@ -21,41 +26,31 @@ export function HowWeDeliver({ data, path, annotation }: HowWeDeliverProps = {})
   const { eyebrow, heading, paragraph1, paragraph2, paragraph3 } = content;
 
   return (
-    <section className="bg-muted py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-        >
-          {eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-        >
-          {heading}
-        </h2>
+    <MarketingSection tone="secondary" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={base ? <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{eyebrow}</span> : eyebrow}
+        eyebrowTone="muted"
+        title={base ? <span {...fieldAttrs(ann, `${base}.heading`)}>{heading}</span> : heading}
+        align="start"
+      />
 
-        <div className="mt-8 space-y-6 text-base leading-7 text-muted-foreground">
-          <p {...(base ? fieldAttrs(ann, `${base}.body`) : {})}>{paragraph1}</p>
-          <p>
-            <span {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>
-              {paragraph2.before}
-            </span>
-            <a
-              href={paragraph2.linkHref}
-              className="font-medium text-primary hover:underline underline-offset-4"
-              {...(base ? fieldAttrs(ann, `${base}.items.1.body`) : {})}
-            >
-              {paragraph2.linkLabel}
-            </a>
-            <span {...(base ? fieldAttrs(ann, `${base}.items.2.body`) : {})}>
-              {paragraph2.after}
-            </span>
-          </p>
-          <p {...(base ? fieldAttrs(ann, `${base}.items.3.body`) : {})}>{paragraph3}</p>
-        </div>
+      <div className="mt-8 space-y-6 text-base leading-7 text-body">
+        <p {...(base ? fieldAttrs(ann, `${base}.body`) : {})}>{paragraph1}</p>
+        <p>
+          <span {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>
+            {paragraph2.before}
+          </span>
+          <a
+            href={paragraph2.linkHref}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            {...(base ? fieldAttrs(ann, `${base}.items.1.body`) : {})}
+          >
+            {paragraph2.linkLabel}
+          </a>
+          <span {...(base ? fieldAttrs(ann, `${base}.items.2.body`) : {})}>{paragraph2.after}</span>
+        </p>
+        <p {...(base ? fieldAttrs(ann, `${base}.items.3.body`) : {})}>{paragraph3}</p>
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators/Proof.tsx
+++ b/apps/marketing/app/components/for-operators/Proof.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FOR_OPERATORS_PROOF } from '../../content/for-operators';
 import type { ServicesProofData } from '../../lib/page-blocks';
 
@@ -25,60 +30,60 @@ export function Proof({ data, path, annotation }: ProofProps = {}) {
   const firstLinkIndex = firstBulletIndex + content.bullets.length;
 
   return (
-    <section className="bg-muted py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl px-6 lg:px-8">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-        >
-          {content.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-        >
-          {content.heading}
-        </h2>
+    <MarketingSection tone="secondary" density="default" width="narrow">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{content.eyebrow}</span>
+          ) : (
+            content.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        description={
+          base ? <span {...fieldAttrs(ann, `${base}.body`)}>{content.body}</span> : content.body
+        }
+        align="start"
+      />
 
-        <p
-          className="mt-6 text-base leading-7 text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
-        >
-          {content.body}
-        </p>
+      <p
+        className="mt-6 text-base leading-7 text-body"
+        {...(base ? fieldAttrs(ann, `${base}.items.${introItemIndex}.body`) : {})}
+      >
+        {content.bulletIntro}
+      </p>
 
-        <p
-          className="mt-6 text-base leading-7 text-muted-foreground"
-          {...(base ? fieldAttrs(ann, `${base}.items.${introItemIndex}.body`) : {})}
-        >
-          {content.bulletIntro}
-        </p>
+      <ul className="mt-4 list-disc space-y-3 pl-6 text-base leading-7 text-body marker:text-primary">
+        {content.bullets.map((bullet, index) => (
+          <li
+            key={bullet}
+            {...(base ? fieldAttrs(ann, `${base}.items.${firstBulletIndex + index}.body`) : {})}
+          >
+            {bullet}
+          </li>
+        ))}
+      </ul>
 
-        <ul className="mt-4 space-y-3 list-disc pl-6 text-base leading-7 text-muted-foreground marker:text-primary">
-          {content.bullets.map((bullet, index) => (
-            <li
-              key={bullet}
-              {...(base ? fieldAttrs(ann, `${base}.items.${firstBulletIndex + index}.body`) : {})}
-            >
-              {bullet}
-            </li>
-          ))}
-        </ul>
-
-        <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-sm">
-          {content.links.map((link, index) => (
-            <a
-              key={link.href}
-              href={link.href}
-              {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-              className="font-medium text-primary hover:underline underline-offset-4"
-              {...(base ? fieldAttrs(ann, `${base}.items.${firstLinkIndex + index}.label`) : {})}
-            >
-              {link.label}
-            </a>
-          ))}
-        </div>
+      <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+        {content.links.map((link, index) => (
+          <a
+            key={link.href}
+            href={link.href}
+            {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            {...(base ? fieldAttrs(ann, `${base}.items.${firstLinkIndex + index}.label`) : {})}
+          >
+            {link.label}
+          </a>
+        ))}
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { FOR_OPERATORS_WHAT_YOU_GET } from '../../content/for-operators';
 import type { ServicesWhatYouGetData } from '../../lib/page-blocks';
 import { CenteredCardGrid } from '../CenteredCardGrid';
@@ -20,51 +25,50 @@ export function WhatYouGet({ data, path, annotation }: WhatYouGetProps = {}) {
   const base = path ?? '';
 
   return (
-    <section className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...(base ? fieldAttrs(ann, `${base}.eyebrow`) : {})}
-          >
-            {content.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...(base ? fieldAttrs(ann, `${base}.heading`) : {})}
-          >
-            {content.heading}
-          </h2>
-          <p
-            className="mt-6 text-lg leading-8 text-body"
-            {...(base ? fieldAttrs(ann, `${base}.body`) : {})}
-          >
-            {content.body}
-          </p>
-        </div>
+    <MarketingSection tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.eyebrow`)}>{content.eyebrow}</span>
+          ) : (
+            content.eyebrow
+          )
+        }
+        eyebrowTone="muted"
+        title={
+          base ? (
+            <span {...fieldAttrs(ann, `${base}.heading`)}>{content.heading}</span>
+          ) : (
+            content.heading
+          )
+        }
+        description={
+          base ? <span {...fieldAttrs(ann, `${base}.body`)}>{content.body}</span> : content.body
+        }
+        align="center"
+      />
 
-        <CenteredCardGrid className="mx-auto mt-16 max-w-5xl">
-          {content.cards.map((card, index) => (
-            <div
-              key={card.title}
-              className="w-full rounded-2xl border border-border bg-card p-6 shadow-sm sm:w-[calc(50%-0.75rem)] lg:w-[calc(33.333%-1rem)]"
+      <CenteredCardGrid className="mx-auto mt-16 max-w-5xl">
+        {content.cards.map((card, index) => (
+          <div
+            key={card.title}
+            className="w-full rounded-2xl border border-border bg-card p-6 shadow-sm sm:w-[calc(50%-0.75rem)] lg:w-[calc(33.333%-1rem)]"
+          >
+            <h3
+              className="text-lg font-semibold leading-7 text-foreground"
+              {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
             >
-              <h3
-                className="text-lg font-semibold leading-7 text-foreground"
-                {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}
-              >
-                {card.title}
-              </h3>
-              <p
-                className="mt-3 text-base leading-7 text-muted-foreground"
-                {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
-              >
-                {card.body}
-              </p>
-            </div>
-          ))}
-        </CenteredCardGrid>
-      </div>
-    </section>
+              {card.title}
+            </h3>
+            <p
+              className="mt-3 text-base leading-7 text-muted-foreground"
+              {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
+            >
+              {card.body}
+            </p>
+          </div>
+        ))}
+      </CenteredCardGrid>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/landing/CostCalculator.tsx
+++ b/apps/marketing/app/components/landing/CostCalculator.tsx
@@ -1,4 +1,4 @@
-import { Slider } from '@revealui/presentation';
+import { MarketingSection, SectionHeader, Slider } from '@revealui/presentation';
 import { useState } from 'react';
 import { PRICING_COST_CALCULATOR as C } from '../../content/pricing';
 
@@ -58,77 +58,73 @@ export function CostCalculator() {
   const tier = pickTier(products, vendors, mrr);
 
   return (
-    <section className="bg-background pb-24 sm:pb-32">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-widest text-primary">
-            {C.eyebrow}
-          </p>
-          <h2 className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {C.heading}
-          </h2>
-          <p className="mt-6 text-lg leading-8 text-body">{C.body}</p>
+    <MarketingSection tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={C.eyebrow}
+        eyebrowTone="primary"
+        title={C.heading}
+        description={C.body}
+        align="center"
+      />
+
+      <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="space-y-6 rounded-2xl bg-card p-8 ring-1 ring-border">
+          <LabeledSlider
+            label={C.inputs.products.label}
+            min={C.inputs.products.min}
+            max={C.inputs.products.max}
+            step={C.inputs.products.step}
+            value={products}
+            display={products >= C.inputs.products.max ? `${products}+` : String(products)}
+            onChange={setProducts}
+          />
+          <LabeledSlider
+            label={C.inputs.vendors.label}
+            min={C.inputs.vendors.min}
+            max={C.inputs.vendors.max}
+            step={C.inputs.vendors.step}
+            value={vendors}
+            display={String(vendors)}
+            onChange={setVendors}
+          />
+          <LabeledSlider
+            label={C.inputs.mrr.label}
+            min={C.inputs.mrr.min}
+            max={C.inputs.mrr.max}
+            step={C.inputs.mrr.step}
+            value={mrr}
+            display={
+              mrr >= C.inputs.mrr.max
+                ? `$${(mrr / 1000).toFixed(0)}k+`
+                : `$${(mrr / 1000).toFixed(0)}k`
+            }
+            onChange={setMrr}
+          />
         </div>
 
-        <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
-          <div className="space-y-6 rounded-2xl bg-card p-8 ring-1 ring-border">
-            <LabeledSlider
-              label={C.inputs.products.label}
-              min={C.inputs.products.min}
-              max={C.inputs.products.max}
-              step={C.inputs.products.step}
-              value={products}
-              display={products >= C.inputs.products.max ? `${products}+` : String(products)}
-              onChange={setProducts}
-            />
-            <LabeledSlider
-              label={C.inputs.vendors.label}
-              min={C.inputs.vendors.min}
-              max={C.inputs.vendors.max}
-              step={C.inputs.vendors.step}
-              value={vendors}
-              display={String(vendors)}
-              onChange={setVendors}
-            />
-            <LabeledSlider
-              label={C.inputs.mrr.label}
-              min={C.inputs.mrr.min}
-              max={C.inputs.mrr.max}
-              step={C.inputs.mrr.step}
-              value={mrr}
-              display={
-                mrr >= C.inputs.mrr.max
-                  ? `$${(mrr / 1000).toFixed(0)}k+`
-                  : `$${(mrr / 1000).toFixed(0)}k`
-              }
-              onChange={setMrr}
-            />
+        <div className="flex flex-col justify-center gap-6 rounded-2xl bg-secondary p-8 ring-1 ring-border">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+              {C.rentedLabel}
+            </p>
+            <p className="mt-1 text-3xl font-bold tracking-tight text-foreground">{tier.range}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{tier.note}</p>
           </div>
-
-          <div className="flex flex-col justify-center gap-6 rounded-2xl bg-secondary p-8 ring-1 ring-border">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                {C.rentedLabel}
-              </p>
-              <p className="mt-1 text-3xl font-bold tracking-tight text-foreground">{tier.range}</p>
-              <p className="mt-1 text-sm text-muted-foreground">{tier.note}</p>
-            </div>
-            <div className="border-t border-border pt-6">
-              <p className="text-xs font-semibold uppercase tracking-widest text-primary">
-                {C.revealui.label}
-              </p>
-              <p className="mt-1 text-3xl font-bold tracking-tight text-primary">
-                {C.revealui.value}
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground">{C.revealui.sub}</p>
-            </div>
+          <div className="border-t border-border pt-6">
+            <p className="text-xs font-semibold uppercase tracking-widest text-primary">
+              {C.revealui.label}
+            </p>
+            <p className="mt-1 text-3xl font-bold tracking-tight text-primary">
+              {C.revealui.value}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">{C.revealui.sub}</p>
           </div>
         </div>
-
-        <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-muted-foreground">
-          {C.footnote}
-        </p>
       </div>
-    </section>
+
+      <p className="mx-auto mt-6 max-w-3xl text-center text-xs text-muted-foreground">
+        {C.footnote}
+      </p>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { HOME_DEMO } from '../../content/home';
 import type { DemoData } from '../../lib/page-blocks';
 import { ProductFrame } from './ProductFrame';
@@ -14,61 +19,52 @@ export interface DemoProps {
 
 export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {} }: DemoProps) {
   return (
-    <section id="demo" className="relative bg-secondary py-20 sm:py-28">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-xs font-semibold uppercase tracking-widest text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.eyebrow`)}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-          <p
-            className="mt-5 text-lg leading-8 text-body"
-            {...fieldAttrs(annotation, `${path}.body`)}
-          >
-            {data.body}
-          </p>
-        </div>
+    <MarketingSection
+      id="demo"
+      tone="secondary"
+      density="default"
+      width="default"
+      className="relative"
+    >
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
+        align="center"
+      />
 
-        {/* Product-as-proof: live component frame (Linear craft pattern).
-            Content mockupCaption was previously unwired; honesty line stays. */}
-        <div className="mt-14 sm:mt-16">
-          <ProductFrame caption={HOME_DEMO.mockupCaption} />
-        </div>
-
-        {/* Beats as aligned stack, not three bordered cards (Linear: density over chrome). */}
-        <ol className="mx-auto mt-14 grid max-w-5xl list-none grid-cols-1 gap-0 divide-y divide-border border-y border-border p-0 sm:mt-16 lg:grid-cols-3 lg:gap-0 lg:divide-x lg:divide-y-0">
-          {data.beats.map((b, index) => (
-            <li key={b.n} className="relative px-0 py-7 lg:px-8 lg:py-8 first:lg:pl-0 last:lg:pr-0">
-              <div
-                className="font-mono text-[11px] font-medium tabular-nums tracking-widest text-muted-foreground"
-                {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
-              >
-                {b.n}
-              </div>
-              <h3
-                className="mt-3 font-display text-lg font-semibold tracking-tight text-foreground"
-                {...fieldAttrs(annotation, `${path}.items.${index}.title`)}
-              >
-                {b.title}
-              </h3>
-              <p
-                className="mt-2 text-sm leading-6 text-muted-foreground"
-                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
-              >
-                {b.body}
-              </p>
-            </li>
-          ))}
-        </ol>
+      {/* Product-as-proof: live component frame (Linear craft pattern).
+          Content mockupCaption was previously unwired; honesty line stays. */}
+      <div className="mt-14 sm:mt-16">
+        <ProductFrame caption={HOME_DEMO.mockupCaption} />
       </div>
-    </section>
+
+      {/* Beats as aligned stack, not three bordered cards (Linear: density over chrome). */}
+      <ol className="mx-auto mt-14 grid max-w-5xl list-none grid-cols-1 gap-0 divide-y divide-border border-y border-border p-0 sm:mt-16 lg:grid-cols-3 lg:gap-0 lg:divide-x lg:divide-y-0">
+        {data.beats.map((b, index) => (
+          <li key={b.n} className="relative px-0 py-7 lg:px-8 lg:py-8 first:lg:pl-0 last:lg:pr-0">
+            <div
+              className="font-mono text-[11px] font-medium tabular-nums tracking-widest text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+            >
+              {b.n}
+            </div>
+            <h3
+              className="mt-3 font-display text-lg font-semibold tracking-tight text-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.title`)}
+            >
+              {b.title}
+            </h3>
+            <p
+              className="mt-2 text-sm leading-6 text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+            >
+              {b.body}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -1,4 +1,10 @@
-import { type BlockAnnotation, fieldAttrs, IconPlus } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  IconPlus,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { HOME_FAQ } from '../../content/home';
 import type { FaqData } from '../../lib/page-blocks';
 
@@ -13,48 +19,38 @@ export interface FaqProps {
 
 export function Faq({ data = HOME_FAQ, path = 'blocks.1.data', annotation = {} }: FaqProps) {
   return (
-    <section id="faq" className="bg-background py-24 sm:py-32">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.eyebrow`)}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-        </div>
+    <MarketingSection id="faq" tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        align="center"
+      />
 
-        <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
-          {data.items.map((item, index) => (
-            <details key={item.question} className="group py-6">
-              <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                <h3
-                  className="text-lg font-semibold leading-7 text-foreground"
-                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
-                >
-                  {item.question}
-                </h3>
-
-                <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
-                  <IconPlus size="sm" label="Toggle" />
-                </span>
-              </summary>
-              <div
-                className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
-                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+      <div className="mx-auto mt-16 max-w-3xl divide-y divide-border">
+        {data.items.map((item, index) => (
+          <details key={item.question} className="group py-6">
+            <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
+              <h3
+                className="text-lg font-semibold leading-7 text-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
               >
-                {item.answer}
-              </div>
-            </details>
-          ))}
-        </div>
+                {item.question}
+              </h3>
+
+              <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
+                <IconPlus size="sm" label="Toggle" />
+              </span>
+            </summary>
+            <div
+              className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+            >
+              {item.answer}
+            </div>
+          </details>
+        ))}
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -1,5 +1,5 @@
 import type { PricingResponse } from '@revealui/contracts/pricing';
-import { Button, IconCheckCircle } from '@revealui/presentation';
+import { Button, IconCheckCircle, MarketingSection, SectionHeader } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import {
   PRICING_TEASER_FOOTER,
@@ -46,103 +46,95 @@ export function PricingTeaser() {
   }, []);
 
   return (
-    <section className="bg-secondary py-20 sm:py-28">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-            {PRICING_TEASER_SECTION.eyebrow}
-          </p>
-          <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {PRICING_TEASER_SECTION.heading}
-          </h2>
-          <p className="mt-5 text-lg leading-8 text-body">{PRICING_TEASER_SECTION.body}</p>
-        </div>
+    <MarketingSection tone="secondary" density="default" width="default">
+      <SectionHeader
+        eyebrow={PRICING_TEASER_SECTION.eyebrow}
+        eyebrowTone="muted"
+        title={PRICING_TEASER_SECTION.heading}
+        description={PRICING_TEASER_SECTION.body}
+        align="center"
+      />
 
-        <div className="mx-auto mt-14 grid max-w-3xl grid-cols-1 gap-5 sm:mt-16 sm:grid-cols-2 sm:gap-6">
-          {PRICING_TEASER_TIERS.map((t) => {
-            const { price, period } = prices[t.id];
-            return (
-              <div
-                key={t.id}
-                className={`relative flex flex-col rounded-2xl bg-card p-7 ring-1 ring-border/80 transition sm:p-8 ${
-                  t.highlight ? 'shadow-md shadow-foreground/5' : ''
-                }`}
-              >
-                {t.highlight && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-secondary px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-foreground ring-1 ring-border">
-                    Recommended
-                  </div>
-                )}
-                <h3 className="font-display text-lg font-semibold text-foreground">{t.name}</h3>
-                <div className="mt-4 flex items-baseline gap-2">
-                  <span className="font-display text-4xl font-bold tracking-tight text-foreground tabular-nums">
-                    {price}
-                  </span>
-                  {period && <span className="text-sm text-muted-foreground">{period}</span>}
-                </div>
-                <p className="mt-4 text-sm leading-6 text-muted-foreground">{t.description}</p>
-
-                <ul className="mt-6 flex-1 space-y-3">
-                  {t.features.map((f) => (
-                    <li key={f} className="flex items-start gap-2 text-sm text-foreground">
-                      <IconCheckCircle size="sm" className="mt-0.5 flex-shrink-0 text-primary" />
-                      {f}
-                    </li>
-                  ))}
-                </ul>
-
-                <div className="mt-8">
-                  {t.highlight ? (
-                    <Button asChild size="default" className="w-full">
-                      <a href={t.href}>{t.cta}</a>
-                    </Button>
-                  ) : (
-                    <Button
-                      asChild
-                      size="default"
-                      appearance="outline"
-                      variant="neutral"
-                      className="w-full"
-                    >
-                      <a href={t.href}>{t.cta}</a>
-                    </Button>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="mx-auto mt-8 flex max-w-3xl flex-col items-center justify-center gap-2 text-sm sm:flex-row sm:gap-6">
-          {PRICING_TEASER_LINKS.map((tier) => (
-            <a
-              key={tier.id}
-              href={tier.href}
-              className="text-muted-foreground hover:text-foreground"
+      <div className="mx-auto mt-14 grid max-w-3xl grid-cols-1 gap-5 sm:mt-16 sm:grid-cols-2 sm:gap-6">
+        {PRICING_TEASER_TIERS.map((t) => {
+          const { price, period } = prices[t.id];
+          return (
+            <div
+              key={t.id}
+              className={`relative flex flex-col rounded-2xl bg-card p-7 ring-1 ring-border/80 transition sm:p-8 ${
+                t.highlight ? 'shadow-md shadow-foreground/5' : ''
+              }`}
             >
-              <span className="font-medium text-foreground">{tier.name}</span> {tier.description}
-            </a>
-          ))}
-        </div>
+              {t.highlight && (
+                <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-secondary px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-foreground ring-1 ring-border">
+                  Recommended
+                </div>
+              )}
+              <h3 className="font-display text-lg font-semibold text-foreground">{t.name}</h3>
+              <div className="mt-4 flex items-baseline gap-2">
+                <span className="font-display text-4xl font-bold tracking-tight text-foreground tabular-nums">
+                  {price}
+                </span>
+                {period && <span className="text-sm text-muted-foreground">{period}</span>}
+              </div>
+              <p className="mt-4 text-sm leading-6 text-muted-foreground">{t.description}</p>
 
-        <div className="mt-10 text-center">
-          <Button
-            asChild
-            appearance="link"
-            size="default"
-            className="items-center justify-center text-sm font-medium"
-          >
-            <a href={PRICING_TEASER_FOOTER.moreHref}>{PRICING_TEASER_FOOTER.moreLabel}</a>
-          </Button>
-          <p className="mt-5 text-xs leading-5 text-muted-foreground">
-            {PRICING_TEASER_FOOTER.caption.prefix}{' '}
-            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
-              {PRICING_TEASER_FOOTER.caption.code}
-            </code>{' '}
-            {PRICING_TEASER_FOOTER.caption.suffix}
-          </p>
-        </div>
+              <ul className="mt-6 flex-1 space-y-3">
+                {t.features.map((f) => (
+                  <li key={f} className="flex items-start gap-2 text-sm text-foreground">
+                    <IconCheckCircle size="sm" className="mt-0.5 flex-shrink-0 text-primary" />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+
+              <div className="mt-8">
+                {t.highlight ? (
+                  <Button asChild size="default" className="w-full">
+                    <a href={t.href}>{t.cta}</a>
+                  </Button>
+                ) : (
+                  <Button
+                    asChild
+                    size="default"
+                    appearance="outline"
+                    variant="neutral"
+                    className="w-full"
+                  >
+                    <a href={t.href}>{t.cta}</a>
+                  </Button>
+                )}
+              </div>
+            </div>
+          );
+        })}
       </div>
-    </section>
+
+      <div className="mx-auto mt-8 flex max-w-3xl flex-col items-center justify-center gap-2 text-sm sm:flex-row sm:gap-6">
+        {PRICING_TEASER_LINKS.map((tier) => (
+          <a key={tier.id} href={tier.href} className="text-muted-foreground hover:text-foreground">
+            <span className="font-medium text-foreground">{tier.name}</span> {tier.description}
+          </a>
+        ))}
+      </div>
+
+      <div className="mt-10 text-center">
+        <Button
+          asChild
+          appearance="link"
+          size="default"
+          className="items-center justify-center text-sm font-medium"
+        >
+          <a href={PRICING_TEASER_FOOTER.moreHref}>{PRICING_TEASER_FOOTER.moreLabel}</a>
+        </Button>
+        <p className="mt-5 text-xs leading-5 text-muted-foreground">
+          {PRICING_TEASER_FOOTER.caption.prefix}{' '}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
+            {PRICING_TEASER_FOOTER.caption.code}
+          </code>{' '}
+          {PRICING_TEASER_FOOTER.caption.suffix}
+        </p>
+      </div>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -8,6 +8,8 @@ import {
   IconPrimitivePayments,
   IconPrimitivePeople,
   type IconProps,
+  MarketingSection,
+  SectionHeader,
 } from '@revealui/presentation';
 import type { ComponentType } from 'react';
 import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../../content/primitives';
@@ -55,82 +57,67 @@ export function Primitives({
   annotation = {},
 }: PrimitivesProps) {
   return (
-    <section className="bg-background py-20 sm:py-28">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-xs font-semibold uppercase tracking-widest text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.eyebrow`)}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-          <p
-            className="mt-5 text-lg leading-8 text-body"
-            {...fieldAttrs(annotation, `${path}.body`)}
-          >
-            {data.body}
-          </p>
-        </div>
+    <MarketingSection tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
+        align="center"
+      />
 
-        {/* Quiet stacked rows (not a card grid). Linear craft: density + alignment
-            over decorative cards. Alternating icon side still gives rhythm. */}
-        <div className="mx-auto mt-14 max-w-3xl divide-y divide-border border-y border-border sm:mt-16">
-          {data.items.map((item, index) => {
-            const flipped = index % 2 === 1;
-            const style = primitiveStyles[index];
-            return (
+      {/* Quiet stacked rows (not a card grid). Linear craft: density + alignment
+          over decorative cards. Alternating icon side still gives rhythm. */}
+      <div className="mx-auto mt-14 max-w-3xl divide-y divide-border border-y border-border sm:mt-16">
+        {data.items.map((item, index) => {
+          const flipped = index % 2 === 1;
+          const style = primitiveStyles[index];
+          return (
+            <div
+              key={item.label}
+              className={`flex flex-col gap-4 py-8 sm:items-center sm:gap-8 sm:py-10 ${
+                flipped ? 'sm:flex-row-reverse' : 'sm:flex-row'
+              }`}
+            >
               <div
-                key={item.label}
-                className={`flex flex-col gap-4 py-8 sm:items-center sm:gap-8 sm:py-10 ${
-                  flipped ? 'sm:flex-row-reverse' : 'sm:flex-row'
-                }`}
+                className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-xl ring-1 ${style ? accentBg[style.color] : ''}`}
               >
-                <div
-                  className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-xl ring-1 ${style ? accentBg[style.color] : ''}`}
-                >
-                  {(() => {
-                    const Icon = PRIMITIVE_ICONS[index];
-                    return Icon ? <Icon className="h-7 w-7" size="lg" label={item.label} /> : null;
-                  })()}
-                </div>
-                <div className={`flex-1 min-w-0 ${flipped ? 'sm:text-right' : ''}`}>
-                  <h3
-                    className="font-display text-lg font-semibold tracking-tight text-foreground"
-                    {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
-                  >
-                    {item.label}
-                  </h3>
-                  <p
-                    className="mt-1.5 text-base leading-7 text-muted-foreground"
-                    {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
-                  >
-                    {item.body}
-                  </p>
-                </div>
+                {(() => {
+                  const Icon = PRIMITIVE_ICONS[index];
+                  return Icon ? <Icon className="h-7 w-7" size="lg" label={item.label} /> : null;
+                })()}
               </div>
-            );
-          })}
-        </div>
-
-        <div className="mt-10 text-center">
-          <Button
-            asChild
-            appearance="link"
-            size="default"
-            className="items-center justify-center text-sm font-medium"
-          >
-            <a href={HOME_PRIMITIVES_SECTION.docsLink.href}>
-              {HOME_PRIMITIVES_SECTION.docsLink.label}
-            </a>
-          </Button>
-        </div>
+              <div className={`flex-1 min-w-0 ${flipped ? 'sm:text-right' : ''}`}>
+                <h3
+                  className="font-display text-lg font-semibold tracking-tight text-foreground"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+                >
+                  {item.label}
+                </h3>
+                <p
+                  className="mt-1.5 text-base leading-7 text-muted-foreground"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+                >
+                  {item.body}
+                </p>
+              </div>
+            </div>
+          );
+        })}
       </div>
-    </section>
+
+      <div className="mt-10 text-center">
+        <Button
+          asChild
+          appearance="link"
+          size="default"
+          className="items-center justify-center text-sm font-medium"
+        >
+          <a href={HOME_PRIMITIVES_SECTION.docsLink.href}>
+            {HOME_PRIMITIVES_SECTION.docsLink.label}
+          </a>
+        </Button>
+      </div>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -1,82 +1,78 @@
-import { Button, GitHubIcon } from '@revealui/presentation';
+import { Button, GitHubIcon, MarketingSection, SectionHeader } from '@revealui/presentation';
 import { PROOF_DEPLOYERS, PROOF_SECTION, PROOF_TRUST } from '../../content/proof';
 import { SITE } from '../../content/site';
 import { LiveMetricsBadge } from './LiveMetricsBadge';
 
 export function Proof() {
   return (
-    <section className="bg-background py-20 sm:py-28">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-            {PROOF_SECTION.eyebrow}
-          </p>
-          <h2 className="mt-3 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {PROOF_SECTION.heading}
-          </h2>
-          <p className="mt-5 text-lg leading-8 text-body">{PROOF_SECTION.body}</p>
+    <MarketingSection tone="background" density="default" width="default">
+      <SectionHeader
+        eyebrow={PROOF_SECTION.eyebrow}
+        eyebrowTone="muted"
+        title={PROOF_SECTION.heading}
+        description={PROOF_SECTION.body}
+        align="center"
+      />
 
-          <div className="mt-6 flex justify-center">
-            <a
-              href={SITE.urls.repo}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-full bg-secondary px-4 py-1.5 text-sm font-medium text-foreground ring-1 ring-border transition hover:ring-border/80"
-            >
-              <GitHubIcon className="size-4" />
-              {PROOF_SECTION.repoLinkLabel}
-            </a>
-          </div>
-        </div>
+      <div className="mt-6 flex justify-center">
+        <a
+          href={SITE.urls.repo}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-full bg-secondary px-4 py-1.5 text-sm font-medium text-foreground ring-1 ring-border transition hover:ring-border/80"
+        >
+          <GitHubIcon className="size-4" />
+          {PROOF_SECTION.repoLinkLabel}
+        </a>
+      </div>
 
-        <div className="mt-14 sm:mt-16">
-          <LiveMetricsBadge />
-        </div>
+      <div className="mt-14 sm:mt-16">
+        <LiveMetricsBadge />
+      </div>
 
-        <div className="mx-auto mt-12 max-w-2xl text-center">
-          <p className="text-base leading-7 text-muted-foreground">
-            {PROOF_TRUST.body}{' '}
-            <a
-              href={PROOF_TRUST.linkHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
-            >
-              {PROOF_TRUST.linkLabel}
-            </a>
-          </p>
-        </div>
-
-        <div className="mt-8 text-center">
-          <Button
-            asChild
-            appearance="link"
-            size="default"
-            className="items-center justify-center text-sm font-medium"
+      <div className="mx-auto mt-12 max-w-2xl text-center">
+        <p className="text-base leading-7 text-muted-foreground">
+          {PROOF_TRUST.body}{' '}
+          <a
+            href={PROOF_TRUST.linkHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
           >
-            <a href={PROOF_TRUST.changelogCta.href}>{PROOF_TRUST.changelogCta.label}</a>
+            {PROOF_TRUST.linkLabel}
+          </a>
+        </p>
+      </div>
+
+      <div className="mt-8 text-center">
+        <Button
+          asChild
+          appearance="link"
+          size="default"
+          className="items-center justify-center text-sm font-medium"
+        >
+          <a href={PROOF_TRUST.changelogCta.href}>{PROOF_TRUST.changelogCta.label}</a>
+        </Button>
+      </div>
+
+      {/* Secondary FDE layer — same homepage section (≤7 rule), not a new section */}
+      <div className="mx-auto mt-16 max-w-2xl border-t border-border pt-14 text-center">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          {PROOF_DEPLOYERS.eyebrow}
+        </p>
+        <h3 className="mt-3 font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+          {PROOF_DEPLOYERS.heading}
+        </h3>
+        <p className="mt-4 text-base leading-7 text-body">{PROOF_DEPLOYERS.body}</p>
+        <p className="mt-4 text-sm leading-6 text-body">{PROOF_DEPLOYERS.foil}</p>
+        <div className="mt-8">
+          <Button asChild size="default" className="items-center justify-center">
+            <a href={PROOF_DEPLOYERS.cta.href} target="_blank" rel="noopener noreferrer">
+              {PROOF_DEPLOYERS.cta.label}
+            </a>
           </Button>
         </div>
-
-        {/* Secondary FDE layer — same homepage section (≤7 rule), not a new section */}
-        <div className="mx-auto mt-16 max-w-2xl border-t border-border pt-14 text-center">
-          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-            {PROOF_DEPLOYERS.eyebrow}
-          </p>
-          <h3 className="mt-3 font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-            {PROOF_DEPLOYERS.heading}
-          </h3>
-          <p className="mt-4 text-base leading-7 text-body">{PROOF_DEPLOYERS.body}</p>
-          <p className="mt-4 text-sm leading-6 text-body">{PROOF_DEPLOYERS.foil}</p>
-          <div className="mt-8">
-            <Button asChild size="default" className="items-center justify-center">
-              <a href={PROOF_DEPLOYERS.cta.href} target="_blank" rel="noopener noreferrer">
-                {PROOF_DEPLOYERS.cta.label}
-              </a>
-            </Button>
-          </div>
-        </div>
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/products/ProductsCta.tsx
+++ b/apps/marketing/app/components/products/ProductsCta.tsx
@@ -1,4 +1,9 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { PRODUCTS_CTA_SECTION } from '../../content/products';
 import type { ProductsCtaData } from '../../lib/page-blocks';
 
@@ -17,38 +22,32 @@ export function ProductsCta({
   annotation = {},
 }: ProductsCtaProps) {
   return (
-    <section className="py-24 sm:py-32">
-      <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
-        <h2
-          className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...fieldAttrs(annotation, `${path}.heading`)}
-        >
-          {data.heading}
-        </h2>
-        <p className="mt-6 text-lg leading-8 text-body" {...fieldAttrs(annotation, `${path}.body`)}>
-          {data.body}
-        </p>
-        <div
-          className="mt-8 rounded-lg bg-foreground px-6 py-4 text-left font-mono text-sm text-background"
-          {...fieldAttrs(annotation, `${path}.snippet.lines`)}
-        >
-          <span className="text-background/50">$</span> {data.cliSnippet}
-        </div>
-        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-          <a
-            href={data.cta.docs.href}
-            className="rounded-md bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
-          >
-            {data.cta.docs.label}
-          </a>
-          <a
-            href={data.cta.pricing.href}
-            className="rounded-md bg-secondary px-8 py-4 text-base font-semibold text-foreground hover:bg-muted transition-colors"
-          >
-            {data.cta.pricing.label}
-          </a>
-        </div>
+    <MarketingSection tone="background" density="default" width="narrow">
+      <SectionHeader
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
+        align="center"
+      />
+      <div
+        className="mt-8 rounded-lg bg-foreground px-6 py-4 text-left font-mono text-sm text-background"
+        {...fieldAttrs(annotation, `${path}.snippet.lines`)}
+      >
+        <span className="text-background/50">$</span> {data.cliSnippet}
       </div>
-    </section>
+      <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <a
+          href={data.cta.docs.href}
+          className="rounded-md bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+        >
+          {data.cta.docs.label}
+        </a>
+        <a
+          href={data.cta.pricing.href}
+          className="rounded-md bg-secondary px-8 py-4 text-base font-semibold text-foreground transition-colors hover:bg-muted"
+        >
+          {data.cta.pricing.label}
+        </a>
+      </div>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/components/products/ProductsHero.tsx
+++ b/apps/marketing/app/components/products/ProductsHero.tsx
@@ -1,4 +1,4 @@
-import { type BlockAnnotation, fieldAttrs } from '@revealui/presentation';
+import { type BlockAnnotation, fieldAttrs, MarketingSection } from '@revealui/presentation';
 import { PRODUCTS_FLAGSHIP, PRODUCTS_PAGE_HERO, PRODUCTS_SISTERS } from '../../content/products';
 import type { ProductsHeroData } from '../../lib/page-blocks';
 
@@ -23,32 +23,40 @@ export function ProductsHero({
   annotation = {},
 }: ProductsHeroProps) {
   return (
-    <section className="relative overflow-hidden bg-gradient-to-br from-primary/5 via-background to-blue-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-      <div className="mx-auto max-w-4xl text-center">
-        <h1
-          className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
-          {...fieldAttrs(annotation, `${path}.title`)}
-        >
-          {data.h1}
-        </h1>
-        <p
-          className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl"
-          {...fieldAttrs(annotation, `${path}.subtitle`)}
-        >
-          {data.subtitle}
-        </p>
-        <div className="mt-10 flex flex-wrap justify-center gap-2 text-sm font-medium">
-          {ALL_PRODUCT_ANCHORS.map((anchor) => (
-            <a
-              key={anchor.slug}
-              href={`#${anchor.slug}`}
-              className="rounded-full bg-card px-4 py-1.5 text-muted-foreground ring-1 ring-border transition-colors hover:bg-primary/10 hover:text-primary hover:ring-primary/30"
-            >
-              {anchor.name}
-            </a>
-          ))}
-        </div>
+    <MarketingSection
+      tone="background"
+      density="spacious"
+      width="default"
+      className="relative overflow-hidden"
+      innerClassName="max-w-4xl text-center"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/5 via-background to-blue-500/10"
+      />
+      <h1
+        className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+        {...fieldAttrs(annotation, `${path}.title`)}
+      >
+        {data.h1}
+      </h1>
+      <p
+        className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl"
+        {...fieldAttrs(annotation, `${path}.subtitle`)}
+      >
+        {data.subtitle}
+      </p>
+      <div className="mt-10 flex flex-wrap justify-center gap-2 text-sm font-medium">
+        {ALL_PRODUCT_ANCHORS.map((anchor) => (
+          <a
+            key={anchor.slug}
+            href={`#${anchor.slug}`}
+            className="rounded-full bg-card px-4 py-1.5 text-muted-foreground ring-1 ring-border transition-colors hover:bg-primary/10 hover:text-primary hover:ring-primary/30"
+          >
+            {anchor.name}
+          </a>
+        ))}
       </div>
-    </section>
+    </MarketingSection>
   );
 }

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -1,3 +1,4 @@
+import { MarketingSection, SectionHeader } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { Footer } from '../components/Footer';
 import { NewsletterSignup } from '../components/NewsletterSignup';
@@ -80,69 +81,74 @@ export function BlogIndexPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-blue-500/10 via-background to-indigo-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-            Blog
-          </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
-            Updates, guides, and insights from the RevealUI team.
-          </p>
-        </div>
-      </section>
+      <MarketingSection
+        tone="background"
+        density="spacious"
+        width="default"
+        className="relative overflow-hidden"
+        innerClassName="max-w-4xl text-center"
+      >
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-blue-500/10 via-background to-indigo-500/10"
+        />
+        <SectionHeader
+          title="Blog"
+          description="Updates, guides, and insights from the RevealUI team."
+          titleAs="h1"
+          align="center"
+          titleClassName="text-4xl sm:text-5xl lg:text-6xl"
+          descriptionClassName="sm:text-xl"
+        />
+      </MarketingSection>
 
-      {/* Posts */}
-      <section className="py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          {posts.length === 0 ? (
-            <div className="mx-auto max-w-2xl text-center">
-              <p className="text-lg text-muted-foreground">
-                No posts yet. Check back soon for updates from the RevealUI team.
-              </p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
-              {posts.map((post) => (
-                <article
-                  key={post.id}
-                  className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border hover:ring-primary/40 transition-all"
-                >
-                  <div className="flex items-center gap-x-4 text-xs text-muted-foreground">
-                    <time dateTime={post.publishedAt ?? post.createdAt}>
-                      {formatDate(post.publishedAt ?? post.createdAt)}
-                    </time>
-                    {post.author && <span>{post.author}</span>}
-                  </div>
-                  <h3 className="mt-3 text-xl font-bold tracking-tight text-foreground">
-                    <a href={`/blog/${post.slug}`} className="hover:text-primary transition-colors">
-                      {post.title}
-                    </a>
-                  </h3>
-                  <p className="mt-4 text-sm leading-6 text-muted-foreground">
-                    {post.excerpt ?? getExcerpt(post.content)}
-                  </p>
-                  <a
-                    href={`/blog/${post.slug}`}
-                    className="mt-4 inline-block text-sm font-semibold text-primary hover:text-primary/80 transition-colors"
-                  >
-                    Read more &rarr;
-                  </a>
-                </article>
-              ))}
-            </div>
-          )}
-
-          {/* Newsletter capture */}
-          <div className="mx-auto mt-16 max-w-2xl rounded-2xl bg-secondary p-8 text-center ring-1 ring-border">
-            <h3 className="text-lg font-semibold text-foreground">Get notified when we publish</h3>
-            <p className="mt-2 text-sm text-muted-foreground mb-6">
-              Engineering insights, product updates, and launch announcements. No spam.
+      <MarketingSection tone="background" density="default" width="default">
+        {posts.length === 0 ? (
+          <div className="mx-auto max-w-2xl text-center">
+            <p className="text-lg text-muted-foreground">
+              No posts yet. Check back soon for updates from the RevealUI team.
             </p>
-            <NewsletterSignup variant="stacked" />
           </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+            {posts.map((post) => (
+              <article
+                key={post.id}
+                className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border transition-all hover:ring-primary/40"
+              >
+                <div className="flex items-center gap-x-4 text-xs text-muted-foreground">
+                  <time dateTime={post.publishedAt ?? post.createdAt}>
+                    {formatDate(post.publishedAt ?? post.createdAt)}
+                  </time>
+                  {post.author && <span>{post.author}</span>}
+                </div>
+                <h3 className="mt-3 text-xl font-bold tracking-tight text-foreground">
+                  <a href={`/blog/${post.slug}`} className="transition-colors hover:text-primary">
+                    {post.title}
+                  </a>
+                </h3>
+                <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                  {post.excerpt ?? getExcerpt(post.content)}
+                </p>
+                <a
+                  href={`/blog/${post.slug}`}
+                  className="mt-4 inline-block text-sm font-semibold text-primary transition-colors hover:text-primary/80"
+                >
+                  Read more &rarr;
+                </a>
+              </article>
+            ))}
+          </div>
+        )}
+
+        <div className="mx-auto mt-16 max-w-2xl rounded-2xl bg-secondary p-8 text-center ring-1 ring-border">
+          <h3 className="text-lg font-semibold text-foreground">Get notified when we publish</h3>
+          <p className="mb-6 mt-2 text-sm text-muted-foreground">
+            Engineering insights, product updates, and launch announcements. No spam.
+          </p>
+          <NewsletterSignup variant="stacked" />
         </div>
-      </section>
+      </MarketingSection>
 
       <Footer />
     </div>

--- a/apps/marketing/app/routes/ClaimsPage.tsx
+++ b/apps/marketing/app/routes/ClaimsPage.tsx
@@ -1,4 +1,4 @@
-import { Badge, Callout, CodeBlock, Divider } from '@revealui/presentation';
+import { Badge, Callout, CodeBlock, Divider, MarketingSection } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import {
   CLAIMS_COUNTS_LABELS,
@@ -200,8 +200,13 @@ export function ClaimsPage() {
         </div>
       </header>
 
-      <section className="border-b border-border px-6 py-8 lg:px-8">
-        <div className="mx-auto max-w-3xl space-y-4">
+      <MarketingSection
+        tone="background"
+        density="compact"
+        width="narrow"
+        className="border-b border-border"
+      >
+        <div className="space-y-4">
           <Callout variant="info" title={CLAIMS_SIGNED_LEDGER_NOTE.heading}>
             <p>{CLAIMS_SIGNED_LEDGER_NOTE.body}</p>
           </Callout>
@@ -209,22 +214,25 @@ export function ClaimsPage() {
             <p>{CLAIMS_RECEIPT_HOLD_NOTE.body}</p>
           </Callout>
         </div>
-      </section>
+      </MarketingSection>
 
-      <section className="border-b border-border bg-muted/40 px-6 py-8 lg:px-8">
-        <div className="mx-auto max-w-3xl">
-          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {CLAIMS_KIND_LEGEND.map((entry) => (
-              <div key={entry.kind} className="flex items-start gap-3">
-                <Badge color={KIND_BADGE_COLOR} className="mt-0.5 shrink-0">
-                  {entry.label}
-                </Badge>
-                <dd className="text-sm text-muted-foreground">{entry.description}</dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-      </section>
+      <MarketingSection
+        tone="secondary"
+        density="compact"
+        width="narrow"
+        className="border-b border-border"
+      >
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {CLAIMS_KIND_LEGEND.map((entry) => (
+            <div key={entry.kind} className="flex items-start gap-3">
+              <Badge color={KIND_BADGE_COLOR} className="mt-0.5 shrink-0">
+                {entry.label}
+              </Badge>
+              <dd className="text-sm text-muted-foreground">{entry.description}</dd>
+            </div>
+          ))}
+        </dl>
+      </MarketingSection>
 
       <nav aria-label="Sections" className="border-b border-border px-6 py-6 lg:px-8">
         <div className="mx-auto max-w-3xl">
@@ -292,8 +300,13 @@ export function ClaimsPage() {
         </div>
       </div>
 
-      <section className="border-t border-border bg-muted/40 px-6 py-16 lg:px-8">
-        <div className="mx-auto max-w-3xl space-y-4">
+      <MarketingSection
+        tone="secondary"
+        density="compact"
+        width="narrow"
+        className="border-t border-border"
+      >
+        <div className="space-y-4">
           <Callout variant="info" title={CLAIMS_HONESTY_RAILS_SECTION.heading}>
             <p>{CLAIMS_HONESTY_RAILS_SECTION.intro}</p>
             <ul className="mt-2 list-disc space-y-1 pl-5">
@@ -313,7 +326,7 @@ export function ClaimsPage() {
             </div>
           </div>
         </div>
-      </section>
+      </MarketingSection>
 
       <Footer />
     </div>

--- a/apps/marketing/app/routes/ContactPage.tsx
+++ b/apps/marketing/app/routes/ContactPage.tsx
@@ -1,3 +1,4 @@
+import { MarketingSection, SectionHeader } from '@revealui/presentation';
 import { ContactForm } from '../components/ContactForm';
 import { Footer } from '../components/Footer';
 import { CONTACT_HERO, CONTACT_METHODS } from '../content/contact';
@@ -5,37 +6,46 @@ import { CONTACT_HERO, CONTACT_METHODS } from '../content/contact';
 export function ContactPage() {
   return (
     <div className="min-h-screen bg-background">
-      <section className="relative overflow-hidden bg-gradient-to-br from-secondary via-background to-secondary px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <div className="mx-auto max-w-2xl">
-          <div className="text-center mb-12">
-            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-              {CONTACT_HERO.title}
-            </h1>
-            <p className="mt-6 text-lg leading-8 text-body">{CONTACT_HERO.subtitle}</p>
-          </div>
+      <MarketingSection
+        tone="background"
+        density="spacious"
+        width="narrow"
+        className="relative overflow-hidden"
+      >
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-secondary via-background to-secondary"
+        />
+        <SectionHeader
+          title={CONTACT_HERO.title}
+          description={CONTACT_HERO.subtitle}
+          titleAs="h1"
+          align="center"
+          titleClassName="text-4xl sm:text-5xl"
+          className="mb-12"
+        />
 
-          <ContactForm />
+        <ContactForm />
 
-          <div className="mt-16 grid grid-cols-1 gap-8 sm:grid-cols-3 text-center">
-            {CONTACT_METHODS.map((method) => (
-              <div key={method.title}>
-                <h3 className="text-sm font-semibold text-foreground">{method.title}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {method.body ? <>{method.body} </> : null}
-                  <a
-                    href={method.href}
-                    target={method.external ? '_blank' : undefined}
-                    rel={method.external ? 'noopener noreferrer' : undefined}
-                    className="text-primary hover:text-primary/80 underline"
-                  >
-                    {method.linkLabel}
-                  </a>
-                </p>
-              </div>
-            ))}
-          </div>
+        <div className="mt-16 grid grid-cols-1 gap-8 text-center sm:grid-cols-3">
+          {CONTACT_METHODS.map((method) => (
+            <div key={method.title}>
+              <h3 className="text-sm font-semibold text-foreground">{method.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {method.body ? <>{method.body} </> : null}
+                <a
+                  href={method.href}
+                  target={method.external ? '_blank' : undefined}
+                  rel={method.external ? 'noopener noreferrer' : undefined}
+                  className="text-primary underline hover:text-primary/80"
+                >
+                  {method.linkLabel}
+                </a>
+              </p>
+            </div>
+          ))}
         </div>
-      </section>
+      </MarketingSection>
       <Footer />
     </div>
   );

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -5,6 +5,8 @@ import {
   IconCheckCircle,
   IconPlus,
   IconXCircle,
+  MarketingSection,
+  SectionHeader,
 } from '@revealui/presentation';
 import { useEffect } from 'react';
 import { Footer } from '../components/Footer';
@@ -42,62 +44,52 @@ interface ContractProps extends AnnotatedSectionProps {
 
 function FairSourceContract({ data, path, annotation }: ContractProps) {
   return (
-    <section className="bg-background py-16 sm:py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.eyebrow`)}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-        </div>
+    <MarketingSection tone="background" density="compact" width="default">
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        align="center"
+      />
 
-        <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2">
-          {data.cards.map((c, index) => (
-            <div
-              key={c.title}
-              className={`rounded-2xl p-6 ring-1 transition ${
-                c.kind === 'yes'
-                  ? 'bg-primary/10 ring-primary/20'
-                  : 'bg-amber-500/15 ring-amber-500/30'
-              }`}
-            >
-              <div className="flex items-start gap-3">
-                {c.kind === 'yes' ? (
-                  <IconCheckCircle size="md" className="mt-0.5 flex-shrink-0 text-primary" />
-                ) : (
-                  <IconXCircle
-                    size="md"
-                    className="mt-0.5 flex-shrink-0 text-amber-800 dark:text-amber-200"
-                  />
-                )}
-                <div>
-                  <h3
-                    className="text-lg font-semibold text-foreground"
-                    {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
-                  >
-                    {c.title}
-                  </h3>
-                  <p
-                    className="mt-2 text-sm leading-6 text-muted-foreground"
-                    {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
-                  >
-                    {c.body}
-                  </p>
-                </div>
+      <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2">
+        {data.cards.map((c, index) => (
+          <div
+            key={c.title}
+            className={`rounded-2xl p-6 ring-1 transition ${
+              c.kind === 'yes'
+                ? 'bg-primary/10 ring-primary/20'
+                : 'bg-amber-500/15 ring-amber-500/30'
+            }`}
+          >
+            <div className="flex items-start gap-3">
+              {c.kind === 'yes' ? (
+                <IconCheckCircle size="md" className="mt-0.5 flex-shrink-0 text-primary" />
+              ) : (
+                <IconXCircle
+                  size="md"
+                  className="mt-0.5 flex-shrink-0 text-amber-800 dark:text-amber-200"
+                />
+              )}
+              <div>
+                <h3
+                  className="text-lg font-semibold text-foreground"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+                >
+                  {c.title}
+                </h3>
+                <p
+                  className="mt-2 text-sm leading-6 text-muted-foreground"
+                  {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+                >
+                  {c.body}
+                </p>
               </div>
             </div>
-          ))}
-        </div>
+          </div>
+        ))}
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -110,95 +102,78 @@ function FairSourcePackagesIntro({ data, path, annotation }: PackagesIntroProps)
   // section header + footer prose are CMS-driven so metric/package inventory
   // claims never leave the claim-covered content modules + static table.
   return (
-    <section className="bg-secondary py-16 sm:py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.eyebrow`)}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-          <p
-            className="mt-6 text-base leading-7 text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.body`)}
-          >
-            {data.body}
-          </p>
-        </div>
+    <MarketingSection tone="secondary" density="compact" width="default">
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
+        align="center"
+      />
 
-        <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-card ring-1 ring-border">
-          <table className="w-full text-left text-sm">
-            <thead className="bg-muted text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-              <tr>
-                <th className="px-6 py-3">Package</th>
-                <th className="px-6 py-3">Purpose</th>
-                <th className="px-6 py-3">License</th>
-                <th className="px-6 py-3">Source</th>
+      <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-card ring-1 ring-border">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-muted text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            <tr>
+              <th className="px-6 py-3">Package</th>
+              <th className="px-6 py-3">Purpose</th>
+              <th className="px-6 py-3">License</th>
+              <th className="px-6 py-3">Source</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {FAIR_SOURCE_PACKAGES.map((p) => (
+              <tr key={p.name}>
+                <td className="px-6 py-4 font-mono text-sm font-semibold text-foreground">
+                  {p.name}
+                </td>
+                <td className="px-6 py-4 text-muted-foreground">{p.purpose}</td>
+                <td className="px-6 py-4">
+                  <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
+                    {p.license}
+                  </span>
+                </td>
+                <td className="px-6 py-4 text-sm">
+                  <a
+                    href={p.repo}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:text-primary/80"
+                  >
+                    GitHub
+                  </a>
+                  <span className="px-2 text-muted-foreground/40">·</span>
+                  <a
+                    href={p.npm}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:text-primary/80"
+                  >
+                    npm
+                  </a>
+                </td>
               </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {FAIR_SOURCE_PACKAGES.map((p) => (
-                <tr key={p.name}>
-                  <td className="px-6 py-4 font-mono text-sm font-semibold text-foreground">
-                    {p.name}
-                  </td>
-                  <td className="px-6 py-4 text-muted-foreground">{p.purpose}</td>
-                  <td className="px-6 py-4">
-                    <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
-                      {p.license}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-sm">
-                    <a
-                      href={p.repo}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary hover:text-primary/80"
-                    >
-                      GitHub
-                    </a>
-                    <span className="px-2 text-muted-foreground/40">·</span>
-                    <a
-                      href={p.npm}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary hover:text-primary/80"
-                    >
-                      npm
-                    </a>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        <p
-          className="mx-auto mt-6 max-w-2xl text-center text-sm text-muted-foreground"
-          {...fieldAttrs(annotation, `${path}.items.0.body`)}
-        >
-          {data.footer.includes(data.footerCommand) ? (
-            <>
-              {data.footer.slice(0, data.footer.indexOf(data.footerCommand))}
-              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-                {data.footerCommand}
-              </code>
-              {data.footer.slice(
-                data.footer.indexOf(data.footerCommand) + data.footerCommand.length,
-              )}
-            </>
-          ) : (
-            data.footer
-          )}
-        </p>
+            ))}
+          </tbody>
+        </table>
       </div>
-    </section>
+      <p
+        className="mx-auto mt-6 max-w-2xl text-center text-sm text-muted-foreground"
+        {...fieldAttrs(annotation, `${path}.items.0.body`)}
+      >
+        {data.footer.includes(data.footerCommand) ? (
+          <>
+            {data.footer.slice(0, data.footer.indexOf(data.footerCommand))}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+              {data.footerCommand}
+            </code>
+            {data.footer.slice(data.footer.indexOf(data.footerCommand) + data.footerCommand.length)}
+          </>
+        ) : (
+          data.footer
+        )}
+      </p>
+    </MarketingSection>
   );
 }
 
@@ -208,58 +183,43 @@ interface ClockProps extends AnnotatedSectionProps {
 
 function FairSourceClock({ data, path, annotation }: ClockProps) {
   return (
-    <section className="bg-background py-16 sm:py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.eyebrow`)}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-          <p
-            className="mt-6 text-base leading-7 text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.body`)}
-          >
-            {data.body}
-          </p>
-        </div>
+    <MarketingSection tone="background" density="compact" width="default">
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
+        align="center"
+      />
 
-        <div className="mx-auto mt-12 max-w-3xl">
-          <ol className="relative border-l-2 border-primary/20 pl-8">
-            {data.steps.map((step, index) => (
-              <li key={step.title} className="mb-8 last:mb-0">
-                <span
-                  className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-background ${
-                    step.color === 'emerald' ? 'bg-primary' : 'bg-amber-600'
-                  }`}
-                >
-                  <span className="h-1.5 w-1.5 rounded-full bg-white" />
-                </span>
-                <h3
-                  className="font-semibold text-foreground"
-                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
-                >
-                  {step.title}
-                </h3>
-                <p
-                  className="mt-1 text-sm text-muted-foreground"
-                  {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
-                >
-                  {step.body}
-                </p>
-              </li>
-            ))}
-          </ol>
-        </div>
+      <div className="mx-auto mt-12 max-w-3xl">
+        <ol className="relative border-l-2 border-primary/20 pl-8">
+          {data.steps.map((step, index) => (
+            <li key={step.title} className="mb-8 last:mb-0">
+              <span
+                className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-background ${
+                  step.color === 'emerald' ? 'bg-primary' : 'bg-amber-600'
+                }`}
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-white" />
+              </span>
+              <h3
+                className="font-semibold text-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
+              >
+                {step.title}
+              </h3>
+              <p
+                className="mt-1 text-sm text-muted-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+              >
+                {step.body}
+              </p>
+            </li>
+          ))}
+        </ol>
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -269,50 +229,40 @@ interface PeersProps extends AnnotatedSectionProps {
 
 function FairSourcePeers({ data, path, annotation }: PeersProps) {
   return (
-    <section className="bg-secondary py-16 sm:py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.eyebrow`)}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-        </div>
+    <MarketingSection tone="secondary" density="compact" width="default">
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        align="center"
+      />
 
-        <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
-          {data.peers.map((p, index) => (
-            <a
-              key={p.name}
-              href={p.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-2xl bg-card p-6 ring-1 ring-border no-underline transition hover:ring-border/60"
+      <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
+        {data.peers.map((p, index) => (
+          <a
+            key={p.name}
+            href={p.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-2xl bg-card p-6 ring-1 ring-border no-underline transition hover:ring-border/60"
+          >
+            <h3
+              className="text-lg font-semibold text-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
             >
-              <h3
-                className="text-lg font-semibold text-foreground"
-                {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
-              >
-                {p.name}
-              </h3>
-              <p
-                className="mt-2 text-sm leading-6 text-muted-foreground"
-                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
-              >
-                {p.note}
-              </p>
-              <p className="mt-3 text-xs font-medium text-primary">Read their post &rarr;</p>
-            </a>
-          ))}
-        </div>
+              {p.name}
+            </h3>
+            <p
+              className="mt-2 text-sm leading-6 text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+            >
+              {p.note}
+            </p>
+            <p className="mt-3 text-xs font-medium text-primary">Read their post &rarr;</p>
+          </a>
+        ))}
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -322,48 +272,38 @@ interface FaqProps extends AnnotatedSectionProps {
 
 function FairSourceFaq({ data, path, annotation }: FaqProps) {
   return (
-    <section className="bg-background py-16 sm:py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto max-w-2xl text-center">
-          <p
-            className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
-            {...fieldAttrs(annotation, `${path}.eyebrow`)}
-          >
-            {data.eyebrow}
-          </p>
-          <h2
-            className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-            {...fieldAttrs(annotation, `${path}.heading`)}
-          >
-            {data.heading}
-          </h2>
-        </div>
+    <MarketingSection tone="background" density="compact" width="default">
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="muted"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        align="center"
+      />
 
-        <div className="mx-auto mt-12 max-w-3xl divide-y divide-border">
-          {data.items.map((f, index) => (
-            <details key={f.question} className="group py-6">
-              <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
-                <h3
-                  className="text-lg font-semibold leading-7 text-foreground"
-                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
-                >
-                  {f.question}
-                </h3>
-                <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
-                  <IconPlus size="sm" label="Toggle" />
-                </span>
-              </summary>
-              <div
-                className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
-                {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+      <div className="mx-auto mt-12 max-w-3xl divide-y divide-border">
+        {data.items.map((f, index) => (
+          <details key={f.question} className="group py-6">
+            <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
+              <h3
+                className="text-lg font-semibold leading-7 text-foreground"
+                {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
               >
-                {f.answer}
-              </div>
-            </details>
-          ))}
-        </div>
+                {f.question}
+              </h3>
+              <span className="ml-2 mt-1 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-open:rotate-45 group-open:bg-primary/10 group-open:text-primary">
+                <IconPlus size="sm" label="Toggle" />
+              </span>
+            </summary>
+            <div
+              className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
+            >
+              {f.answer}
+            </div>
+          </details>
+        ))}
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -373,31 +313,25 @@ interface CtaProps extends AnnotatedSectionProps {
 
 function FairSourceCta({ data, path, annotation }: CtaProps) {
   return (
-    <section className="bg-card py-16 sm:py-24">
-      <div className="mx-auto max-w-2xl px-6 lg:px-8 text-center">
-        <h2
-          className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
-          {...fieldAttrs(annotation, `${path}.heading`)}
-        >
-          {data.heading}
-        </h2>
-        <p className="mt-6 text-lg leading-8 text-body" {...fieldAttrs(annotation, `${path}.body`)}>
-          {data.body}
-        </p>
-        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-          <Button asChild size="lg" variant="brand">
-            <a href={data.primary.href} {...fieldAttrs(annotation, `${path}.links.0.label`)}>
-              {data.primary.label}
-            </a>
-          </Button>
-          <Button asChild appearance="outline" variant="neutral" size="lg">
-            <a href={data.secondary.href} {...fieldAttrs(annotation, `${path}.links.1.label`)}>
-              {data.secondary.label}
-            </a>
-          </Button>
-        </div>
+    <MarketingSection tone="card" density="compact" width="narrow">
+      <SectionHeader
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
+        align="center"
+      />
+      <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <Button asChild size="lg" variant="brand">
+          <a href={data.primary.href} {...fieldAttrs(annotation, `${path}.links.0.label`)}>
+            {data.primary.label}
+          </a>
+        </Button>
+        <Button asChild appearance="outline" variant="neutral" size="lg">
+          <a href={data.secondary.href} {...fieldAttrs(annotation, `${path}.links.1.label`)}>
+            {data.secondary.label}
+          </a>
+        </Button>
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -429,7 +363,12 @@ export function FairSourcePage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Hero — static: headline/subhead/body interpolate METRICS counts */}
-      <section className="relative isolate overflow-hidden bg-background px-6 pt-20 pb-16 sm:pt-28 sm:pb-20 lg:px-8">
+      <MarketingSection
+        tone="background"
+        density="spacious"
+        width="narrow"
+        className="relative isolate overflow-hidden"
+      >
         <div
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background"
@@ -439,9 +378,9 @@ export function FairSourcePage() {
           className="pointer-events-none absolute -top-40 left-1/2 -z-10 h-[600px] w-[1000px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--rvui-brand-glow),transparent_70%)] blur-2xl"
         />
 
-        <div className="relative mx-auto max-w-3xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary mb-6">
-            <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary align-middle mr-2" />
+        <div className="relative text-center">
+          <p className="mb-6 text-sm font-semibold uppercase tracking-[0.2em] text-primary">
+            <span className="mr-2 inline-block h-1.5 w-1.5 rounded-full bg-primary align-middle" />
             {FAIR_SOURCE_HERO.eyebrow}
           </p>
           <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
@@ -463,7 +402,7 @@ export function FairSourcePage() {
             {FAIR_SOURCE_HERO.body.suffix}
           </p>
         </div>
-      </section>
+      </MarketingSection>
 
       <FairSourceContract data={contract.data} path={contract.path} annotation={annotation} />
       <FairSourcePackagesIntro

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -1,4 +1,10 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import {
+  type BlockAnnotation,
+  Button,
+  fieldAttrs,
+  MarketingSection,
+  SectionHeader,
+} from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import { FrontierPathway } from '../components/landing/FrontierPathway';
 import { ProviderSwitch } from '../components/landing/ProviderSwitch';
@@ -30,28 +36,35 @@ interface LocalAiHeroProps {
 
 function LocalAiHero({ data, path, annotation }: LocalAiHeroProps) {
   return (
-    <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-violet-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-      <div className="mx-auto max-w-3xl">
-        <p
-          className="text-sm font-semibold uppercase tracking-wide text-primary"
-          {...fieldAttrs(annotation, `${path}.eyebrow`)}
-        >
-          {data.eyebrow}
-        </p>
-        <h1
-          className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
-          {...fieldAttrs(annotation, `${path}.title`)}
-        >
-          {data.h1}
-        </h1>
-        <p
-          className="mt-6 text-lg leading-8 text-body"
-          {...fieldAttrs(annotation, `${path}.subtitle`)}
-        >
-          {data.lead}
-        </p>
-      </div>
-    </section>
+    <MarketingSection
+      tone="background"
+      density="spacious"
+      width="narrow"
+      className="relative overflow-hidden"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-violet-500/10"
+      />
+      <p
+        className="text-sm font-semibold uppercase tracking-wide text-primary"
+        {...fieldAttrs(annotation, `${path}.eyebrow`)}
+      >
+        {data.eyebrow}
+      </p>
+      <h1
+        className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+        {...fieldAttrs(annotation, `${path}.title`)}
+      >
+        {data.h1}
+      </h1>
+      <p
+        className="mt-6 text-lg leading-8 text-body"
+        {...fieldAttrs(annotation, `${path}.subtitle`)}
+      >
+        {data.lead}
+      </p>
+    </MarketingSection>
   );
 }
 
@@ -63,7 +76,7 @@ interface LocalAiPillarsProps {
 
 function LocalAiPillars({ data, path, annotation }: LocalAiPillarsProps) {
   return (
-    <section className="px-6 py-16 sm:py-20 lg:px-8">
+    <MarketingSection tone="background" density="compact" width="default">
       <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
         {data.pillars.map((pillar, index) => (
           <div key={`pillar-${index}`} className="rounded-2xl bg-card p-6 ring-1 ring-border">
@@ -82,7 +95,7 @@ function LocalAiPillars({ data, path, annotation }: LocalAiPillarsProps) {
           </div>
         ))}
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -94,26 +107,24 @@ interface LocalAiSnippetProps {
 
 function LocalAiSnippet({ caption, captionPath, annotation }: LocalAiSnippetProps) {
   return (
-    <section className="px-6 pb-8 lg:px-8">
-      <div className="mx-auto max-w-3xl">
-        <div className="rounded-2xl bg-foreground p-6 ring-1 ring-background/10">
-          <ul className="space-y-2 font-mono text-sm list-none p-0">
-            {LOCAL_AI_SECTION.snippet.lines.map((line) => (
-              <li
-                key={line.code}
-                className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3"
-              >
-                <code className={SNIPPET_CODE_CLASS_NAME}>{line.code}</code>
-                <span className="text-background/60"># {line.note}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <p className="mt-3 text-sm text-muted-foreground" {...fieldAttrs(annotation, captionPath)}>
-          {caption}
-        </p>
+    <MarketingSection tone="background" density="compact" width="narrow">
+      <div className="rounded-2xl bg-foreground p-6 ring-1 ring-background/10">
+        <ul className="list-none space-y-2 p-0 font-mono text-sm">
+          {LOCAL_AI_SECTION.snippet.lines.map((line) => (
+            <li
+              key={line.code}
+              className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3"
+            >
+              <code className={SNIPPET_CODE_CLASS_NAME}>{line.code}</code>
+              <span className="text-background/60"># {line.note}</span>
+            </li>
+          ))}
+        </ul>
       </div>
-    </section>
+      <p className="mt-3 text-sm text-muted-foreground" {...fieldAttrs(annotation, captionPath)}>
+        {caption}
+      </p>
+    </MarketingSection>
   );
 }
 
@@ -125,57 +136,45 @@ interface LocalAiMarketProofProps {
 
 function LocalAiMarketProof({ data, path, annotation }: LocalAiMarketProofProps) {
   return (
-    <section className="px-6 py-16 sm:py-20 lg:px-8">
-      <div className="mx-auto max-w-3xl">
-        <p
-          className="text-sm font-semibold uppercase tracking-widest text-primary"
-          {...fieldAttrs(annotation, `${path}.eyebrow`)}
-        >
-          {data.eyebrow}
-        </p>
-        <h2
-          className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
-          {...fieldAttrs(annotation, `${path}.heading`)}
-        >
-          {data.heading}
-        </h2>
-        <p
-          className="mt-4 text-base leading-7 text-muted-foreground"
-          {...fieldAttrs(annotation, `${path}.body`)}
-        >
-          {data.body}
-        </p>
-        <ul className="mt-8 space-y-4 list-none p-0">
-          {data.adopters.map((adopter, index) => (
-            <li key={`adopter-${index}`} className="rounded-xl bg-secondary p-5 ring-1 ring-border">
-              <p className="text-base text-foreground">
-                <span
-                  className="font-semibold"
-                  {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
-                >
-                  {adopter.name}
-                </span>{' '}
-                <span {...fieldAttrs(annotation, `${path}.items.${index}.body`)}>
-                  {adopter.detail}
-                </span>
-              </p>
-              <p
-                className="mt-1 text-xs text-muted-foreground"
-                {...fieldAttrs(annotation, `${path}.items.${index}.title`)}
+    <MarketingSection tone="background" density="compact" width="narrow">
+      <SectionHeader
+        eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
+        eyebrowTone="primary"
+        title={<span {...fieldAttrs(annotation, `${path}.heading`)}>{data.heading}</span>}
+        description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
+        align="start"
+        titleClassName="text-2xl sm:text-3xl"
+      />
+      <ul className="mt-8 list-none space-y-4 p-0">
+        {data.adopters.map((adopter, index) => (
+          <li key={`adopter-${index}`} className="rounded-xl bg-secondary p-5 ring-1 ring-border">
+            <p className="text-base text-foreground">
+              <span
+                className="font-semibold"
+                {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
               >
-                {adopter.source}
-              </p>
-            </li>
-          ))}
-        </ul>
-        <p
-          className="mt-6 text-sm italic leading-6 text-muted-foreground"
-          {...fieldAttrs(annotation, `${path}.items.${data.adopters.length}.body`)}
-        >
-          {data.disclaimer}
-        </p>
-      </div>
-    </section>
+                {adopter.name}
+              </span>{' '}
+              <span {...fieldAttrs(annotation, `${path}.items.${index}.body`)}>
+                {adopter.detail}
+              </span>
+            </p>
+            <p
+              className="mt-1 text-xs text-muted-foreground"
+              {...fieldAttrs(annotation, `${path}.items.${index}.title`)}
+            >
+              {adopter.source}
+            </p>
+          </li>
+        ))}
+      </ul>
+      <p
+        className="mt-6 text-sm italic leading-6 text-muted-foreground"
+        {...fieldAttrs(annotation, `${path}.items.${data.adopters.length}.body`)}
+      >
+        {data.disclaimer}
+      </p>
+    </MarketingSection>
   );
 }
 
@@ -188,10 +187,10 @@ interface LocalAiNotesProps {
 function LocalAiNotes({ data, path, annotation }: LocalAiNotesProps) {
   // Item indices match localAiNotesBlock order: dogfood, honesty, roadmap, snippet-caption.
   return (
-    <section className="px-6 pb-16 lg:px-8">
-      <div className="mx-auto max-w-3xl space-y-6">
+    <MarketingSection tone="background" density="compact" width="narrow">
+      <div className="space-y-6">
         <p
-          className="text-base leading-7 text-muted-foreground"
+          className="text-base leading-7 text-body"
           {...fieldAttrs(annotation, `${path}.items.0.body`)}
         >
           {data.dogfood}
@@ -218,7 +217,7 @@ function LocalAiNotes({ data, path, annotation }: LocalAiNotesProps) {
           {data.honesty}
         </p>
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -230,8 +229,8 @@ interface LocalAiCtaProps {
 
 function LocalAiCta({ data, path, annotation }: LocalAiCtaProps) {
   return (
-    <section className="px-6 pb-24 sm:pb-32 lg:px-8">
-      <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
+    <MarketingSection tone="background" density="default" width="narrow">
+      <div className="flex flex-col items-start gap-4 sm:flex-row">
         <Button asChild size="lg" variant="brand">
           <a href={data.primary.href} {...fieldAttrs(annotation, `${path}.links.0.label`)}>
             {data.primary.label}
@@ -248,7 +247,7 @@ function LocalAiCta({ data, path, annotation }: LocalAiCtaProps) {
           </a>
         </Button>
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -274,10 +273,10 @@ export function LocalAiPage() {
         captionPath={`${notes.path}.items.3.body`}
         annotation={annotation}
       />
-      <section className="px-6 pb-8 lg:px-8">
+      <MarketingSection tone="background" density="compact" width="default">
         <ProviderSwitch />
         <FrontierPathway />
-      </section>
+      </MarketingSection>
       <LocalAiMarketProof data={marketProof.data} path={marketProof.path} annotation={annotation} />
       <LocalAiNotes data={notes.data} path={notes.path} annotation={annotation} />
       <LocalAiCta data={cta.data} path={cta.path} annotation={annotation} />

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -1,4 +1,4 @@
-import { type BlockAnnotation, Button, fieldAttrs } from '@revealui/presentation';
+import { type BlockAnnotation, Button, fieldAttrs, MarketingSection } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import {
   PHILOSOPHY_FALLBACK_BLOCKS,
@@ -19,22 +19,29 @@ interface PhilosophyHeroProps {
 
 function PhilosophyHero({ data, path, annotation }: PhilosophyHeroProps) {
   return (
-    <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-background to-violet-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-      <div className="mx-auto max-w-3xl">
-        <p
-          className="text-sm font-semibold uppercase tracking-wide text-primary"
-          {...fieldAttrs(annotation, `${path}.eyebrow`)}
-        >
-          {data.eyebrow}
-        </p>
-        <h1
-          className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
-          {...fieldAttrs(annotation, `${path}.title`)}
-        >
-          {data.h1}
-        </h1>
-      </div>
-    </section>
+    <MarketingSection
+      tone="background"
+      density="spacious"
+      width="narrow"
+      className="relative overflow-hidden"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-violet-500/10"
+      />
+      <p
+        className="text-sm font-semibold uppercase tracking-wide text-primary"
+        {...fieldAttrs(annotation, `${path}.eyebrow`)}
+      >
+        {data.eyebrow}
+      </p>
+      <h1
+        className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+        {...fieldAttrs(annotation, `${path}.title`)}
+      >
+        {data.h1}
+      </h1>
+    </MarketingSection>
   );
 }
 
@@ -46,8 +53,8 @@ interface PhilosophyBodyProps {
 
 function PhilosophyBody({ data, path, annotation }: PhilosophyBodyProps) {
   return (
-    <section className="px-6 py-16 sm:py-24 lg:px-8">
-      <div className="mx-auto max-w-3xl space-y-8">
+    <MarketingSection tone="background" density="default" width="narrow">
+      <div className="space-y-8">
         {data.sections.map((section, index) => {
           if (section.role === 'lead') {
             return (
@@ -82,7 +89,7 @@ function PhilosophyBody({ data, path, annotation }: PhilosophyBodyProps) {
           );
         })}
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 
@@ -94,8 +101,8 @@ interface PhilosophyCtaProps {
 
 function PhilosophyCta({ data, path, annotation }: PhilosophyCtaProps) {
   return (
-    <section className="px-6 pb-24 sm:pb-32 lg:px-8">
-      <div className="mx-auto flex max-w-3xl flex-col items-start gap-4 sm:flex-row">
+    <MarketingSection tone="background" density="default" width="narrow">
+      <div className="flex flex-col items-start gap-4 sm:flex-row">
         <Button asChild size="lg" variant="brand">
           <a
             href={data.primary.href}
@@ -117,7 +124,7 @@ function PhilosophyCta({ data, path, annotation }: PhilosophyCtaProps) {
           </a>
         </Button>
       </div>
-    </section>
+    </MarketingSection>
   );
 }
 

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -4,6 +4,8 @@ import {
   IconCode,
   IconSearch,
   IconTerminal,
+  MarketingSection,
+  SectionHeader,
 } from '@revealui/presentation';
 import { useEffect, useState } from 'react';
 import { CenteredCardGrid } from '../components/CenteredCardGrid';
@@ -103,176 +105,179 @@ export function PricingPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Hero */}
-      <section className="relative overflow-hidden bg-gradient-to-b from-primary/5 via-background to-background px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-            Two ways to use{' '}
-            <span className="block bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
-              RevealUI
-            </span>
-          </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
-            {PRICING_HERO.subtitle}
-          </p>
-          <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
-            {PRICING_HERO_SUBTEXT.prefix}{' '}
+      <MarketingSection
+        tone="background"
+        density="spacious"
+        width="default"
+        className="relative overflow-hidden"
+        innerClassName="max-w-4xl text-center"
+      >
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background"
+        />
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+          Two ways to use{' '}
+          <span className="block bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
+            RevealUI
+          </span>
+        </h1>
+        <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
+          {PRICING_HERO.subtitle}
+        </p>
+        <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
+          {PRICING_HERO_SUBTEXT.prefix}{' '}
+          <a
+            href={PRICING_HERO_SUBTEXT.linkHref}
+            className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+          >
+            {PRICING_HERO_SUBTEXT.linkLabel}
+          </a>{' '}
+          {PRICING_HERO_SUBTEXT.suffix}
+        </p>
+        <div className="mt-8 flex flex-wrap justify-center gap-3 text-sm font-medium">
+          {PRICING_HERO_NAV_ANCHORS.map((anchor) => (
             <a
-              href={PRICING_HERO_SUBTEXT.linkHref}
-              className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+              key={anchor.href}
+              href={anchor.href}
+              className="rounded-full bg-primary/10 px-4 py-1.5 text-primary ring-1 ring-primary/20 transition-colors hover:bg-primary/15"
             >
-              {PRICING_HERO_SUBTEXT.linkLabel}
-            </a>{' '}
-            {PRICING_HERO_SUBTEXT.suffix}
-          </p>
-          <div className="mt-8 flex flex-wrap justify-center gap-3 text-sm font-medium">
-            {PRICING_HERO_NAV_ANCHORS.map((anchor) => (
-              <a
-                key={anchor.href}
-                href={anchor.href}
-                className="rounded-full bg-primary/10 px-4 py-1.5 text-primary ring-1 ring-primary/20 transition-colors hover:bg-primary/15"
-              >
-                {anchor.label}
-              </a>
-            ))}
-          </div>
+              {anchor.label}
+            </a>
+          ))}
         </div>
-      </section>
+      </MarketingSection>
 
       {/* Subscriptions */}
-      <section id="subscriptions" className="py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mb-12 text-center">
-            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
-              {PRICING_TRACK_A_SECTION.eyebrow}
-            </span>
-            <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {PRICING_TRACK_A_SECTION.heading}
-            </h2>
-            <p className="mt-4 text-lg text-muted-foreground">{PRICING_TRACK_A_SECTION.body}</p>
-          </div>
+      <MarketingSection id="subscriptions" tone="background" density="default" width="default">
+        <SectionHeader
+          eyebrow={PRICING_TRACK_A_SECTION.eyebrow}
+          eyebrowTone="primary"
+          title={PRICING_TRACK_A_SECTION.heading}
+          description={PRICING_TRACK_A_SECTION.body}
+          align="center"
+          className="mb-12"
+        />
 
-          {/* Value band: you own the runtime (no competitor prices) */}
-          <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-8 ring-1 ring-primary/15">
-            <h3 className="text-2xl font-bold tracking-tight text-foreground">
-              {PRICING_VALUE_BAND.heading}
-            </h3>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">
-              {PRICING_VALUE_BAND.body}
-            </p>
-            <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {PRICING_VALUE_BAND.points.map((point) => (
-                <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                  <span>{point}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {showAnnualToggle && (
-            <div className="mb-8 flex justify-center">
-              <div className="inline-flex items-center gap-1 rounded-full bg-muted p-1 text-sm font-medium ring-1 ring-border">
-                <Button
-                  type="button"
-                  size="sm"
-                  appearance={billingInterval === 'month' ? 'solid' : 'ghost'}
-                  variant={billingInterval === 'month' ? 'neutral' : 'neutral'}
-                  onClick={() => setBillingInterval('month')}
-                  className="rounded-full"
-                >
-                  Monthly
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  appearance={billingInterval === 'year' ? 'solid' : 'ghost'}
-                  variant={billingInterval === 'year' ? 'neutral' : 'neutral'}
-                  onClick={() => setBillingInterval('year')}
-                  className="rounded-full"
-                >
-                  Annually
-                  <span className="ml-1.5 rounded-full bg-green-500/15 px-1.5 py-0.5 text-xs font-semibold text-green-800 dark:text-green-400">
-                    Save 20%
-                  </span>
-                </Button>
-              </div>
-            </div>
-          )}
-
-          <CenteredCardGrid>
-            {tiers.map((tier, index) => (
-              <div
-                key={tier.id}
-                className={`relative flex w-full flex-col rounded-2xl bg-card p-8 shadow-lg sm:w-[calc(50%-0.75rem)] ${
-                  index === tiers.length - 1 && tiers.length % 3 === 1
-                    ? 'lg:w-2/3'
-                    : 'lg:w-[calc(33.333%-1rem)]'
-                } ${tier.highlighted ? 'ring-2 ring-primary' : 'ring-1 ring-border'}`}
-              >
-                {tier.highlighted && (
-                  <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-primary px-3 py-1.5 text-center text-sm font-semibold text-primary-foreground shadow-lg">
-                    {PRICING_HIGHLIGHTED_BADGE}
-                  </div>
-                )}
-                <div className="mb-8">
-                  <h3 className="text-xl font-bold tracking-tight text-foreground">{tier.name}</h3>
-                  <p className="mt-2 text-sm text-muted-foreground">{tier.description}</p>
-                  <p className="mt-6 flex items-baseline gap-x-1">
-                    <span className="text-4xl font-bold tracking-tight text-foreground">
-                      {tier.price ?? 'Contact us'}
-                    </span>
-                    {tier.period && (
-                      <span className="text-sm text-muted-foreground">{tier.period}</span>
-                    )}
-                  </p>
-                  {tier.savings && (
-                    <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
-                      {tier.savings}
-                    </p>
-                  )}
-                </div>
-                <ul className="mb-8 flex-1 space-y-3">
-                  {tier.features.map((feature) => (
-                    <li key={feature} className="flex items-start gap-x-3">
-                      <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                      <span className="text-sm text-muted-foreground">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-                {tier.highlighted ? (
-                  <Button asChild size="default" className="w-full">
-                    <a
-                      href={tier.ctaHref}
-                      target={tier.id === 'free' ? '_blank' : undefined}
-                      rel={tier.id === 'free' ? 'noopener noreferrer' : undefined}
-                    >
-                      {tier.cta}
-                    </a>
-                  </Button>
-                ) : (
-                  <Button
-                    asChild
-                    appearance="outline"
-                    variant="neutral"
-                    size="default"
-                    className="w-full"
-                  >
-                    <a
-                      href={tier.ctaHref}
-                      target={tier.id === 'free' ? '_blank' : undefined}
-                      rel={tier.id === 'free' ? 'noopener noreferrer' : undefined}
-                    >
-                      {tier.cta}
-                    </a>
-                  </Button>
-                )}
-              </div>
+        {/* Value band: you own the runtime (no competitor prices) */}
+        <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-8 ring-1 ring-primary/15">
+          <h3 className="text-2xl font-bold tracking-tight text-foreground">
+            {PRICING_VALUE_BAND.heading}
+          </h3>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">{PRICING_VALUE_BAND.body}</p>
+          <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {PRICING_VALUE_BAND.points.map((point) => (
+              <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
+                <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
+                <span>{point}</span>
+              </li>
             ))}
-          </CenteredCardGrid>
-
-          <p className="mt-8 text-center text-sm text-muted-foreground">{PRICING_TRIAL_NOTE}</p>
+          </ul>
         </div>
-      </section>
+
+        {showAnnualToggle && (
+          <div className="mb-8 flex justify-center">
+            <div className="inline-flex items-center gap-1 rounded-full bg-muted p-1 text-sm font-medium ring-1 ring-border">
+              <Button
+                type="button"
+                size="sm"
+                appearance={billingInterval === 'month' ? 'solid' : 'ghost'}
+                variant={billingInterval === 'month' ? 'neutral' : 'neutral'}
+                onClick={() => setBillingInterval('month')}
+                className="rounded-full"
+              >
+                Monthly
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                appearance={billingInterval === 'year' ? 'solid' : 'ghost'}
+                variant={billingInterval === 'year' ? 'neutral' : 'neutral'}
+                onClick={() => setBillingInterval('year')}
+                className="rounded-full"
+              >
+                Annually
+                <span className="ml-1.5 rounded-full bg-green-500/15 px-1.5 py-0.5 text-xs font-semibold text-green-800 dark:text-green-400">
+                  Save 20%
+                </span>
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <CenteredCardGrid>
+          {tiers.map((tier, index) => (
+            <div
+              key={tier.id}
+              className={`relative flex w-full flex-col rounded-2xl bg-card p-8 shadow-lg sm:w-[calc(50%-0.75rem)] ${
+                index === tiers.length - 1 && tiers.length % 3 === 1
+                  ? 'lg:w-2/3'
+                  : 'lg:w-[calc(33.333%-1rem)]'
+              } ${tier.highlighted ? 'ring-2 ring-primary' : 'ring-1 ring-border'}`}
+            >
+              {tier.highlighted && (
+                <div className="absolute -top-4 left-0 right-0 mx-auto w-32 rounded-full bg-primary px-3 py-1.5 text-center text-sm font-semibold text-primary-foreground shadow-lg">
+                  {PRICING_HIGHLIGHTED_BADGE}
+                </div>
+              )}
+              <div className="mb-8">
+                <h3 className="text-xl font-bold tracking-tight text-foreground">{tier.name}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{tier.description}</p>
+                <p className="mt-6 flex items-baseline gap-x-1">
+                  <span className="text-4xl font-bold tracking-tight text-foreground">
+                    {tier.price ?? 'Contact us'}
+                  </span>
+                  {tier.period && (
+                    <span className="text-sm text-muted-foreground">{tier.period}</span>
+                  )}
+                </p>
+                {tier.savings && (
+                  <p className="mt-1 text-xs font-medium text-green-700 dark:text-green-400">
+                    {tier.savings}
+                  </p>
+                )}
+              </div>
+              <ul className="mb-8 flex-1 space-y-3">
+                {tier.features.map((feature) => (
+                  <li key={feature} className="flex items-start gap-x-3">
+                    <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
+                    <span className="text-sm text-muted-foreground">{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              {tier.highlighted ? (
+                <Button asChild size="default" className="w-full">
+                  <a
+                    href={tier.ctaHref}
+                    target={tier.id === 'free' ? '_blank' : undefined}
+                    rel={tier.id === 'free' ? 'noopener noreferrer' : undefined}
+                  >
+                    {tier.cta}
+                  </a>
+                </Button>
+              ) : (
+                <Button
+                  asChild
+                  appearance="outline"
+                  variant="neutral"
+                  size="default"
+                  className="w-full"
+                >
+                  <a
+                    href={tier.ctaHref}
+                    target={tier.id === 'free' ? '_blank' : undefined}
+                    rel={tier.id === 'free' ? 'noopener noreferrer' : undefined}
+                  >
+                    {tier.cta}
+                  </a>
+                </Button>
+              )}
+            </div>
+          ))}
+        </CenteredCardGrid>
+
+        <p className="mt-8 text-center text-sm text-muted-foreground">{PRICING_TRIAL_NOTE}</p>
+      </MarketingSection>
 
       {/* Cost calculator: moved here from the homepage (internal marketing
           funnel audit, 2026-07-09), right after the value band above so the
@@ -281,408 +286,387 @@ export function PricingPage() {
       <CostCalculator />
 
       {/* Perpetual licenses */}
-      <section id="perpetual" className="bg-secondary py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mb-12 text-center">
-            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
-              {PRICING_TRACK_C_SECTION.eyebrow}
-            </span>
-            <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {PRICING_TRACK_C_SECTION.heading}
-            </h2>
-            <p className="mt-4 text-lg text-muted-foreground">{PRICING_TRACK_C_SECTION.body}</p>
-          </div>
+      <MarketingSection id="perpetual" tone="secondary" density="default" width="default">
+        <SectionHeader
+          eyebrow={PRICING_TRACK_C_SECTION.eyebrow}
+          eyebrowTone="primary"
+          title={PRICING_TRACK_C_SECTION.heading}
+          description={PRICING_TRACK_C_SECTION.body}
+          align="center"
+          className="mb-12"
+        />
 
-          {/* Studio / agency reseller value band: the multi-client P&L */}
-          <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-8 ring-1 ring-primary/15">
-            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
-              {PRICING_AGENCY_VALUE_BAND.eyebrow}
-            </span>
-            <h3 className="mt-2 text-2xl font-bold tracking-tight text-foreground">
-              {PRICING_AGENCY_VALUE_BAND.heading}
-            </h3>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">
-              {PRICING_AGENCY_VALUE_BAND.body}
-            </p>
-            <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {PRICING_AGENCY_VALUE_BAND.points.map((point) => (
-                <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                  <span>{point}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
-            {perpetualTiers.map((tier) => (
-              <div
-                key={tier.name}
-                className="relative flex flex-col rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border"
-              >
-                {tier.comingSoon && (
-                  <div className="absolute right-4 top-4">
-                    <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
-                      Coming soon
-                    </span>
-                  </div>
-                )}
-                <h3 className="text-lg font-bold text-foreground">{tier.name}</h3>
-                <p className="mt-1 text-sm text-muted-foreground">{tier.description}</p>
-                {tier.price ? (
-                  <p className="mt-4 flex items-baseline gap-x-1">
-                    <span className="text-4xl font-bold text-foreground">{tier.price}</span>
-                    {tier.priceNote && (
-                      <span className="text-sm text-muted-foreground">{tier.priceNote}</span>
-                    )}
-                  </p>
-                ) : (
-                  <p className="mt-4 text-base font-semibold text-foreground">
-                    Contact for pricing
-                  </p>
-                )}
-                {tier.renewal && (
-                  <p className="mt-1 text-xs text-muted-foreground">{tier.renewal}</p>
-                )}
-                <ul className="mb-8 mt-6 flex-1 space-y-3">
-                  {tier.features.map((feature) => (
-                    <li key={feature} className="flex items-start gap-x-3">
-                      <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                      <span className="text-sm text-muted-foreground">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-                <Button
-                  asChild
-                  appearance="outline"
-                  variant="neutral"
-                  size="default"
-                  className="w-full"
-                >
-                  <a href={tier.ctaHref}>{tier.cta}</a>
-                </Button>
-              </div>
+        {/* Studio / agency reseller value band: the multi-client P&L */}
+        <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-8 ring-1 ring-primary/15">
+          <span className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {PRICING_AGENCY_VALUE_BAND.eyebrow}
+          </span>
+          <h3 className="mt-2 text-2xl font-bold tracking-tight text-foreground">
+            {PRICING_AGENCY_VALUE_BAND.heading}
+          </h3>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            {PRICING_AGENCY_VALUE_BAND.body}
+          </p>
+          <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {PRICING_AGENCY_VALUE_BAND.points.map((point) => (
+              <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
+                <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
+                <span>{point}</span>
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
-      </section>
+
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
+          {perpetualTiers.map((tier) => (
+            <div
+              key={tier.name}
+              className="relative flex flex-col rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border"
+            >
+              {tier.comingSoon && (
+                <div className="absolute right-4 top-4">
+                  <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
+                    Coming soon
+                  </span>
+                </div>
+              )}
+              <h3 className="text-lg font-bold text-foreground">{tier.name}</h3>
+              <p className="mt-1 text-sm text-muted-foreground">{tier.description}</p>
+              {tier.price ? (
+                <p className="mt-4 flex items-baseline gap-x-1">
+                  <span className="text-4xl font-bold text-foreground">{tier.price}</span>
+                  {tier.priceNote && (
+                    <span className="text-sm text-muted-foreground">{tier.priceNote}</span>
+                  )}
+                </p>
+              ) : (
+                <p className="mt-4 text-base font-semibold text-foreground">Contact for pricing</p>
+              )}
+              {tier.renewal && <p className="mt-1 text-xs text-muted-foreground">{tier.renewal}</p>}
+              <ul className="mb-8 mt-6 flex-1 space-y-3">
+                {tier.features.map((feature) => (
+                  <li key={feature} className="flex items-start gap-x-3">
+                    <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
+                    <span className="text-sm text-muted-foreground">{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <Button
+                asChild
+                appearance="outline"
+                variant="neutral"
+                size="default"
+                className="w-full"
+              >
+                <a href={tier.ctaHref}>{tier.cta}</a>
+              </Button>
+            </div>
+          ))}
+        </div>
+      </MarketingSection>
 
       {/* For AI Agents */}
-      <section id="for-agents" className="bg-secondary py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-4xl">
-            <div className="mb-12 text-center">
-              <span className="text-sm font-semibold uppercase tracking-widest text-primary">
-                {PRICING_AGENTS_SECTION.eyebrow}
-              </span>
-              <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-                {PRICING_AGENTS_SECTION.heading}
-              </h2>
-              <p className="mt-4 text-lg text-muted-foreground">{PRICING_AGENTS_SECTION.subhead}</p>
-              <span className="mt-3 inline-block rounded-full bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-800 dark:text-amber-200 ring-1 ring-amber-500/30">
-                {PRICING_AGENTS_SECTION.badge}
-              </span>
-            </div>
+      <MarketingSection id="for-agents" tone="secondary" density="default" width="default">
+        <div className="mx-auto max-w-4xl">
+          <div className="mb-12 text-center">
+            <SectionHeader
+              eyebrow={PRICING_AGENTS_SECTION.eyebrow}
+              eyebrowTone="primary"
+              title={PRICING_AGENTS_SECTION.heading}
+              description={PRICING_AGENTS_SECTION.subhead}
+              align="center"
+            />
+            <span className="mt-3 inline-block rounded-full bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-800 dark:text-amber-200 ring-1 ring-amber-500/30">
+              {PRICING_AGENTS_SECTION.badge}
+            </span>
+          </div>
 
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-              <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
-                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
-                  <IconSearch size="md" className="text-primary" />
-                </div>
-                <h3 className="text-base font-semibold text-foreground">
-                  {PRICING_AGENT_A2A.heading}
-                </h3>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {PRICING_AGENT_A2A.body.prefix}{' '}
-                  <a
-                    href={PRICING_AGENT_A2A.body.linkHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="break-all text-primary underline hover:text-primary/80"
-                  >
-                    {PRICING_AGENT_A2A.body.linkLabel}
-                  </a>
-                  {PRICING_AGENT_A2A.body.suffix}
-                </p>
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+            <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+                <IconSearch size="md" className="text-primary" />
               </div>
-
-              <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
-                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 ring-1 ring-blue-500/20">
-                  <IconCode size="md" className="text-blue-600" />
-                </div>
-                <h3 className="text-base font-semibold text-foreground">
-                  {PRICING_AGENT_X402.heading}
-                </h3>
-                <p className="mt-2 text-sm text-muted-foreground">{PRICING_AGENT_X402.body}</p>
-              </div>
-
-              <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
-                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-violet-500/10 ring-1 ring-violet-500/20">
-                  <IconTerminal size="md" className="text-violet-600" />
-                </div>
-                <h3 className="text-base font-semibold text-foreground">
-                  {PRICING_AGENT_MCP.heading}
-                </h3>
-                <p className="mt-2 text-sm text-muted-foreground">{PRICING_AGENT_MCP.body}</p>
+              <h3 className="text-base font-semibold text-foreground">
+                {PRICING_AGENT_A2A.heading}
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {PRICING_AGENT_A2A.body.prefix}{' '}
                 <a
-                  href={PRICING_AGENT_MCP.docsLink.href}
-                  className="mt-3 inline-block text-xs font-semibold text-violet-600 hover:text-violet-700"
+                  href={PRICING_AGENT_A2A.body.linkHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="break-all text-primary underline hover:text-primary/80"
                 >
-                  {PRICING_AGENT_MCP.docsLink.label}
+                  {PRICING_AGENT_A2A.body.linkLabel}
                 </a>
-              </div>
+                {PRICING_AGENT_A2A.body.suffix}
+              </p>
             </div>
 
-            <div className="mt-10 text-center">
+            <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 ring-1 ring-blue-500/20">
+                <IconCode size="md" className="text-blue-600" />
+              </div>
+              <h3 className="text-base font-semibold text-foreground">
+                {PRICING_AGENT_X402.heading}
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">{PRICING_AGENT_X402.body}</p>
+            </div>
+
+            <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-violet-500/10 ring-1 ring-violet-500/20">
+                <IconTerminal size="md" className="text-violet-600" />
+              </div>
+              <h3 className="text-base font-semibold text-foreground">
+                {PRICING_AGENT_MCP.heading}
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">{PRICING_AGENT_MCP.body}</p>
               <a
-                href={PRICING_AGENT_CTA_LINKS.openapi.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-lg bg-card px-4 py-2 text-sm font-medium text-muted-foreground ring-1 ring-border transition-colors hover:bg-muted"
+                href={PRICING_AGENT_MCP.docsLink.href}
+                className="mt-3 inline-block text-xs font-semibold text-violet-600 hover:text-violet-700"
               >
-                <IconCode size="sm" />
-                {PRICING_AGENT_CTA_LINKS.openapi.label}
-              </a>
-              <a
-                href={PRICING_AGENT_CTA_LINKS.apiDocs.href}
-                className="ml-4 inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-              >
-                {PRICING_AGENT_CTA_LINKS.apiDocs.label}
+                {PRICING_AGENT_MCP.docsLink.label}
               </a>
             </div>
           </div>
+
+          <div className="mt-10 text-center">
+            <a
+              href={PRICING_AGENT_CTA_LINKS.openapi.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-card px-4 py-2 text-sm font-medium text-muted-foreground ring-1 ring-border transition-colors hover:bg-muted"
+            >
+              <IconCode size="sm" />
+              {PRICING_AGENT_CTA_LINKS.openapi.label}
+            </a>
+            <a
+              href={PRICING_AGENT_CTA_LINKS.apiDocs.href}
+              className="ml-4 inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              {PRICING_AGENT_CTA_LINKS.apiDocs.label}
+            </a>
+          </div>
         </div>
-      </section>
+      </MarketingSection>
 
       {/* GAP-434 Starter Kit — one-time content product (Stripe Payment Link) */}
-      <section id="starter-kit" className="py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-3xl rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border sm:p-10">
-            <div className="flex flex-wrap items-center gap-3">
-              <span className="text-sm font-semibold uppercase tracking-widest text-primary">
-                {PRICING_STARTER_KIT.eyebrow}
+      <MarketingSection id="starter-kit" tone="background" density="default" width="default">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border sm:p-10">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
+              {PRICING_STARTER_KIT.eyebrow}
+            </span>
+            {PRICING_STARTER_KIT.badge ? (
+              <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
+                {PRICING_STARTER_KIT.badge}
               </span>
-              {PRICING_STARTER_KIT.badge ? (
-                <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
-                  {PRICING_STARTER_KIT.badge}
-                </span>
-              ) : null}
-            </div>
-            <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {PRICING_STARTER_KIT.heading}
-            </h2>
-            <p className="mt-4 flex items-baseline gap-x-2">
-              <span className="text-4xl font-bold text-foreground">
-                {PRICING_STARTER_KIT.price}
-              </span>
-              <span className="text-sm text-muted-foreground">{PRICING_STARTER_KIT.priceNote}</span>
-            </p>
-            <p className="mt-4 text-lg text-muted-foreground">{PRICING_STARTER_KIT.body}</p>
-            <ul className="mt-6 space-y-3">
-              {PRICING_STARTER_KIT.points.map((point) => (
-                <li key={point} className="flex items-start gap-x-3">
-                  <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                  <span className="text-sm text-muted-foreground">{point}</span>
-                </li>
-              ))}
-            </ul>
-            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-              <Button asChild size="lg" className="w-full sm:w-auto">
-                <a
-                  href={PRICING_STARTER_KIT.primaryCta.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {PRICING_STARTER_KIT.primaryCta.label}
-                </a>
-              </Button>
-              <Button
-                asChild
-                appearance="outline"
-                variant="neutral"
-                size="lg"
-                className="w-full sm:w-auto"
+            ) : null}
+          </div>
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {PRICING_STARTER_KIT.heading}
+          </h2>
+          <p className="mt-4 flex items-baseline gap-x-2">
+            <span className="text-4xl font-bold text-foreground">{PRICING_STARTER_KIT.price}</span>
+            <span className="text-sm text-muted-foreground">{PRICING_STARTER_KIT.priceNote}</span>
+          </p>
+          <p className="mt-4 text-lg text-muted-foreground">{PRICING_STARTER_KIT.body}</p>
+          <ul className="mt-6 space-y-3">
+            {PRICING_STARTER_KIT.points.map((point) => (
+              <li key={point} className="flex items-start gap-x-3">
+                <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
+                <span className="text-sm text-muted-foreground">{point}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button asChild size="lg" className="w-full sm:w-auto">
+              <a
+                href={PRICING_STARTER_KIT.primaryCta.href}
+                target="_blank"
+                rel="noopener noreferrer"
               >
-                <a
-                  href={PRICING_STARTER_KIT.secondaryCta.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {PRICING_STARTER_KIT.secondaryCta.label}
-                </a>
-              </Button>
-            </div>
+                {PRICING_STARTER_KIT.primaryCta.label}
+              </a>
+            </Button>
+            <Button
+              asChild
+              appearance="outline"
+              variant="neutral"
+              size="lg"
+              className="w-full sm:w-auto"
+            >
+              <a
+                href={PRICING_STARTER_KIT.secondaryCta.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {PRICING_STARTER_KIT.secondaryCta.label}
+              </a>
+            </Button>
           </div>
         </div>
-      </section>
+      </MarketingSection>
 
       {/* GAP-448 Agency Founding Kit — Agency Perpetual self-serve path */}
-      <section id="agency-founding-kit" className="bg-muted/30 py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-3xl rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border sm:p-10">
-            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
-              {PRICING_AGENCY_FOUNDING_KIT.eyebrow}
+      <MarketingSection id="agency-founding-kit" tone="secondary" density="default" width="default">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border sm:p-10">
+          <span className="text-sm font-semibold uppercase tracking-widest text-primary">
+            {PRICING_AGENCY_FOUNDING_KIT.eyebrow}
+          </span>
+          <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {PRICING_AGENCY_FOUNDING_KIT.heading}
+          </h2>
+          <p className="mt-4 flex items-baseline gap-x-2">
+            <span className="text-4xl font-bold text-foreground">
+              {PRICING_AGENCY_FOUNDING_KIT.price}
             </span>
-            <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {PRICING_AGENCY_FOUNDING_KIT.heading}
-            </h2>
-            <p className="mt-4 flex items-baseline gap-x-2">
-              <span className="text-4xl font-bold text-foreground">
-                {PRICING_AGENCY_FOUNDING_KIT.price}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                {PRICING_AGENCY_FOUNDING_KIT.priceNote}
-              </span>
-            </p>
-            <p className="mt-4 text-lg text-muted-foreground">{PRICING_AGENCY_FOUNDING_KIT.body}</p>
-            <ul className="mt-6 space-y-3">
-              {PRICING_AGENCY_FOUNDING_KIT.points.map((point) => (
-                <li key={point} className="flex items-start gap-x-3">
-                  <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                  <span className="text-sm text-muted-foreground">{point}</span>
-                </li>
-              ))}
-            </ul>
-            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-              <Button asChild size="lg" className="w-full sm:w-auto">
-                <a
-                  href={PRICING_AGENCY_FOUNDING_KIT.primaryCta.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {PRICING_AGENCY_FOUNDING_KIT.primaryCta.label}
-                </a>
-              </Button>
-              <Button
-                asChild
-                appearance="outline"
-                variant="neutral"
-                size="lg"
-                className="w-full sm:w-auto"
+            <span className="text-sm text-muted-foreground">
+              {PRICING_AGENCY_FOUNDING_KIT.priceNote}
+            </span>
+          </p>
+          <p className="mt-4 text-lg text-muted-foreground">{PRICING_AGENCY_FOUNDING_KIT.body}</p>
+          <ul className="mt-6 space-y-3">
+            {PRICING_AGENCY_FOUNDING_KIT.points.map((point) => (
+              <li key={point} className="flex items-start gap-x-3">
+                <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
+                <span className="text-sm text-muted-foreground">{point}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button asChild size="lg" className="w-full sm:w-auto">
+              <a
+                href={PRICING_AGENCY_FOUNDING_KIT.primaryCta.href}
+                target="_blank"
+                rel="noopener noreferrer"
               >
-                <a href={PRICING_AGENCY_FOUNDING_KIT.secondaryCta.href}>
-                  {PRICING_AGENCY_FOUNDING_KIT.secondaryCta.label}
-                </a>
-              </Button>
-            </div>
+                {PRICING_AGENCY_FOUNDING_KIT.primaryCta.label}
+              </a>
+            </Button>
+            <Button
+              asChild
+              appearance="outline"
+              variant="neutral"
+              size="lg"
+              className="w-full sm:w-auto"
+            >
+              <a href={PRICING_AGENCY_FOUNDING_KIT.secondaryCta.href}>
+                {PRICING_AGENCY_FOUNDING_KIT.secondaryCta.label}
+              </a>
+            </Button>
           </div>
         </div>
-      </section>
+      </MarketingSection>
 
       {/* Done-for-you rung: services ladder + discovery-call capture */}
-      <section id="done-for-you" className="bg-primary/5 py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mb-12 text-center">
-            <span className="text-sm font-semibold uppercase tracking-widest text-primary">
-              {PRICING_DONE_FOR_YOU.eyebrow}
-            </span>
-            <h2 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {PRICING_DONE_FOR_YOU.heading}
-            </h2>
-            <p className="mx-auto mt-4 max-w-2xl text-lg text-muted-foreground">
-              {PRICING_DONE_FOR_YOU.body}
-            </p>
-          </div>
+      <MarketingSection
+        id="done-for-you"
+        tone="background"
+        density="default"
+        width="default"
+        className="bg-primary/5"
+      >
+        <SectionHeader
+          eyebrow={PRICING_DONE_FOR_YOU.eyebrow}
+          eyebrowTone="primary"
+          title={PRICING_DONE_FOR_YOU.heading}
+          description={PRICING_DONE_FOR_YOU.body}
+          align="center"
+          className="mb-12"
+        />
 
-          <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
-            {PRICING_DONE_FOR_YOU.rungs.map((rung) => (
-              <div key={rung.name} className="rounded-2xl bg-card p-6 ring-1 ring-border">
-                <h3 className="text-base font-semibold text-foreground">{rung.name}</h3>
-                <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">
-                  {rung.price}
-                </p>
-                <p className="mt-3 text-sm text-muted-foreground">{rung.note}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <Button asChild size="lg" className="w-full sm:w-auto">
-              <a
-                href={PRICING_DONE_FOR_YOU.primaryCta.href}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {PRICING_DONE_FOR_YOU.primaryCta.label}
-              </a>
-            </Button>
-            <Button
-              asChild
-              appearance="outline"
-              variant="neutral"
-              size="lg"
-              className="w-full sm:w-auto"
-            >
-              <a
-                href={PRICING_DONE_FOR_YOU.secondaryCta.href}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {PRICING_DONE_FOR_YOU.secondaryCta.label}
-              </a>
-            </Button>
-          </div>
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
+          {PRICING_DONE_FOR_YOU.rungs.map((rung) => (
+            <div key={rung.name} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+              <h3 className="text-base font-semibold text-foreground">{rung.name}</h3>
+              <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{rung.price}</p>
+              <p className="mt-3 text-sm text-muted-foreground">{rung.note}</p>
+            </div>
+          ))}
         </div>
-      </section>
+
+        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Button asChild size="lg" className="w-full sm:w-auto">
+            <a
+              href={PRICING_DONE_FOR_YOU.primaryCta.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {PRICING_DONE_FOR_YOU.primaryCta.label}
+            </a>
+          </Button>
+          <Button
+            asChild
+            appearance="outline"
+            variant="neutral"
+            size="lg"
+            className="w-full sm:w-auto"
+          >
+            <a
+              href={PRICING_DONE_FOR_YOU.secondaryCta.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {PRICING_DONE_FOR_YOU.secondaryCta.label}
+            </a>
+          </Button>
+        </div>
+      </MarketingSection>
 
       {/* FAQ Section */}
-      <section className="bg-background py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-4xl">
-            <h2 className="mb-12 text-center text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {PRICING_FAQ_SECTION.heading}
-            </h2>
-            <dl className="space-y-8">
-              {PRICING_FAQS.map((faq) => (
-                <div key={faq.question} className="rounded-lg bg-secondary p-6 ring-1 ring-border">
-                  <dt className="mb-2 text-lg font-semibold text-foreground">{faq.question}</dt>
-                  <dd className="text-base text-muted-foreground">{faq.answer}</dd>
-                </div>
-              ))}
-            </dl>
-          </div>
+      <MarketingSection tone="background" density="default" width="default">
+        <div className="mx-auto max-w-4xl">
+          <SectionHeader title={PRICING_FAQ_SECTION.heading} align="center" className="mb-12" />
+          <dl className="space-y-8">
+            {PRICING_FAQS.map((faq) => (
+              <div key={faq.question} className="rounded-lg bg-secondary p-6 ring-1 ring-border">
+                <dt className="mb-2 text-lg font-semibold text-foreground">{faq.question}</dt>
+                <dd className="text-base text-muted-foreground">{faq.answer}</dd>
+              </div>
+            ))}
+          </dl>
         </div>
-      </section>
+      </MarketingSection>
 
       {/* Final CTA */}
-      <section className="bg-secondary py-24 sm:py-32">
-        <div className="mx-auto max-w-2xl px-6 text-center lg:px-8">
-          <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            {PRICING_FINAL_CTA.title}
-          </h2>
-          <p className="mt-6 text-lg leading-8 text-body">{PRICING_FINAL_CTA.subtitle}</p>
-          <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <Button asChild size="lg" className="w-full sm:w-auto">
-              <a
-                href={
-                  PRICING_FINAL_CTA_LINKS.getStarted.href.startsWith('/')
-                    ? `${ADMIN_URL}${PRICING_FINAL_CTA_LINKS.getStarted.href}`
-                    : PRICING_FINAL_CTA_LINKS.getStarted.href
-                }
-              >
-                {PRICING_FINAL_CTA_LINKS.getStarted.label}
-              </a>
-            </Button>
-            <Button
-              asChild
-              appearance="outline"
-              variant="neutral"
-              size="lg"
-              className="w-full sm:w-auto"
+      <MarketingSection tone="secondary" density="default" width="narrow">
+        <SectionHeader
+          title={PRICING_FINAL_CTA.title}
+          description={PRICING_FINAL_CTA.subtitle}
+          align="center"
+        />
+        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Button asChild size="lg" className="w-full sm:w-auto">
+            <a
+              href={
+                PRICING_FINAL_CTA_LINKS.getStarted.href.startsWith('/')
+                  ? `${ADMIN_URL}${PRICING_FINAL_CTA_LINKS.getStarted.href}`
+                  : PRICING_FINAL_CTA_LINKS.getStarted.href
+              }
             >
-              <a href={PRICING_FINAL_CTA_LINKS.contactSales.href}>
-                {PRICING_FINAL_CTA_LINKS.contactSales.label}
-              </a>
-            </Button>
-          </div>
-          <div className="mt-16 border-t border-border pt-10">
-            <p className="mb-4 text-sm font-medium text-muted-foreground">
-              {PRICING_NEWSLETTER_LABEL}
-            </p>
-            <NewsletterSignup variant="stacked" />
-          </div>
+              {PRICING_FINAL_CTA_LINKS.getStarted.label}
+            </a>
+          </Button>
+          <Button
+            asChild
+            appearance="outline"
+            variant="neutral"
+            size="lg"
+            className="w-full sm:w-auto"
+          >
+            <a href={PRICING_FINAL_CTA_LINKS.contactSales.href}>
+              {PRICING_FINAL_CTA_LINKS.contactSales.label}
+            </a>
+          </Button>
         </div>
-      </section>
+        <div className="mt-16 border-t border-border pt-10 text-center">
+          <p className="mb-4 text-sm font-medium text-muted-foreground">
+            {PRICING_NEWSLETTER_LABEL}
+          </p>
+          <NewsletterSignup variant="stacked" />
+        </div>
+      </MarketingSection>
 
       <Footer />
     </div>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -1,4 +1,4 @@
-import { Button, IconCheckCircle } from '@revealui/presentation';
+import { Button, IconCheckCircle, MarketingSection, SectionHeader } from '@revealui/presentation';
 import { useState } from 'react';
 import { Footer } from '../components/Footer';
 import { Faq } from '../components/landing/Faq';
@@ -46,245 +46,240 @@ export function ProductsPage() {
       <ProductsHero data={hero.data} path={hero.path} annotation={annotation} />
 
       {/* Flagship — RevealUI featured card */}
-      <section id={PRODUCTS_FLAGSHIP.slug} className="py-20 sm:py-24">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-primary/90 to-primary/70 p-10 shadow-2xl ring-1 ring-primary/20 sm:p-14">
-            <div className="absolute -right-16 -top-16 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
-            <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-blue-500/15 blur-3xl" />
-            <div className="relative">
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                <div className="flex items-center gap-4">
-                  <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary-foreground/15 ring-1 ring-primary-foreground/30 backdrop-blur">
-                    <svg
-                      className="h-7 w-7 text-primary-foreground"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth={1.75}
-                      stroke="currentColor"
-                    >
-                      <title>{PRODUCTS_FLAGSHIP.name}</title>
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d={PRODUCTS_FLAGSHIP.iconPath}
-                      />
-                    </svg>
-                  </div>
-                  <div>
-                    <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary-foreground/90">
-                      {PRODUCTS_FLAGSHIP.eyebrow}
-                    </p>
-                    <h2 className="mt-1 text-3xl font-bold tracking-tight text-primary-foreground sm:text-4xl">
-                      {PRODUCTS_FLAGSHIP.name}
-                    </h2>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2 text-xs font-semibold">
-                  <span className="rounded-full bg-primary-foreground/15 px-3 py-1 text-primary-foreground ring-1 ring-primary-foreground/30 backdrop-blur">
-                    {PRODUCTS_FLAGSHIP.status}
-                  </span>
-                  <span className="rounded-full bg-primary-foreground/10 px-3 py-1 font-mono text-primary-foreground/90 ring-1 ring-primary-foreground/20">
-                    {PRODUCTS_FLAGSHIP.version}
-                  </span>
-                </div>
-              </div>
-
-              <p className="mt-6 max-w-3xl text-xl font-medium leading-8 text-primary-foreground">
-                {PRODUCTS_FLAGSHIP.tagline}
-              </p>
-              <p className="mt-3 max-w-3xl text-base leading-7 text-primary-foreground/90">
-                {PRODUCTS_FLAGSHIP.body}
-              </p>
-
-              <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
-                {PRODUCTS_FLAGSHIP.facts.map((fact) => (
-                  <div
-                    key={fact.label}
-                    className="rounded-xl bg-primary-foreground/10 px-4 py-3 ring-1 ring-primary-foreground/20 backdrop-blur"
+      <MarketingSection
+        id={PRODUCTS_FLAGSHIP.slug}
+        tone="background"
+        density="default"
+        width="default"
+      >
+        <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-primary/90 to-primary/70 p-10 shadow-2xl ring-1 ring-primary/20 sm:p-14">
+          <div className="absolute -right-16 -top-16 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
+          <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-blue-500/15 blur-3xl" />
+          <div className="relative">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex items-center gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary-foreground/15 ring-1 ring-primary-foreground/30 backdrop-blur">
+                  <svg
+                    className="h-7 w-7 text-primary-foreground"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.75}
+                    stroke="currentColor"
                   >
-                    <dt className="text-xs uppercase tracking-wide text-primary-foreground/80">
-                      {fact.label}
-                    </dt>
-                    <dd className="mt-1 text-2xl font-bold tracking-tight text-primary-foreground">
-                      {fact.stat}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-
-              <p className="mt-8 inline-flex items-center gap-2 rounded-full bg-primary-foreground/15 px-4 py-1.5 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/30 backdrop-blur">
-                <IconCheckCircle className="h-4 w-4" size="sm" label="Pricing" />
-                {PRODUCTS_FLAGSHIP.priceLabel}
-              </p>
-
-              <div className="mt-10 flex flex-col gap-3 sm:flex-row">
-                <a
-                  href={PRODUCTS_FLAGSHIP.ctas.docs.href}
-                  className="rounded-md bg-primary-foreground px-6 py-3 text-sm font-semibold text-primary shadow-sm transition-colors hover:bg-primary-foreground/90"
-                >
-                  {PRODUCTS_FLAGSHIP.ctas.docs.label}
-                </a>
-                <a
-                  href={PRODUCTS_FLAGSHIP.ctas.pricing.href}
-                  className="rounded-md bg-primary-foreground/15 px-6 py-3 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/30 transition-colors hover:bg-primary-foreground/25"
-                >
-                  {PRODUCTS_FLAGSHIP.ctas.pricing.label}
-                </a>
-                <a
-                  href={PRODUCTS_FLAGSHIP.ctas.repo.href}
-                  className="rounded-md px-6 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/10"
-                  {...(PRODUCTS_FLAGSHIP.ctas.repo.external
-                    ? { target: '_blank', rel: 'noreferrer' }
-                    : {})}
-                >
-                  {PRODUCTS_FLAGSHIP.ctas.repo.label}
-                </a>
+                    <title>{PRODUCTS_FLAGSHIP.name}</title>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d={PRODUCTS_FLAGSHIP.iconPath}
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary-foreground/90">
+                    {PRODUCTS_FLAGSHIP.eyebrow}
+                  </p>
+                  <h2 className="mt-1 text-3xl font-bold tracking-tight text-primary-foreground sm:text-4xl">
+                    {PRODUCTS_FLAGSHIP.name}
+                  </h2>
+                </div>
               </div>
+              <div className="flex items-center gap-2 text-xs font-semibold">
+                <span className="rounded-full bg-primary-foreground/15 px-3 py-1 text-primary-foreground ring-1 ring-primary-foreground/30 backdrop-blur">
+                  {PRODUCTS_FLAGSHIP.status}
+                </span>
+                <span className="rounded-full bg-primary-foreground/10 px-3 py-1 font-mono text-primary-foreground/90 ring-1 ring-primary-foreground/20">
+                  {PRODUCTS_FLAGSHIP.version}
+                </span>
+              </div>
+            </div>
+
+            <p className="mt-6 max-w-3xl text-xl font-medium leading-8 text-primary-foreground">
+              {PRODUCTS_FLAGSHIP.tagline}
+            </p>
+            <p className="mt-3 max-w-3xl text-base leading-7 text-primary-foreground/90">
+              {PRODUCTS_FLAGSHIP.body}
+            </p>
+
+            <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
+              {PRODUCTS_FLAGSHIP.facts.map((fact) => (
+                <div
+                  key={fact.label}
+                  className="rounded-xl bg-primary-foreground/10 px-4 py-3 ring-1 ring-primary-foreground/20 backdrop-blur"
+                >
+                  <dt className="text-xs uppercase tracking-wide text-primary-foreground/80">
+                    {fact.label}
+                  </dt>
+                  <dd className="mt-1 text-2xl font-bold tracking-tight text-primary-foreground">
+                    {fact.stat}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+
+            <p className="mt-8 inline-flex items-center gap-2 rounded-full bg-primary-foreground/15 px-4 py-1.5 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/30 backdrop-blur">
+              <IconCheckCircle className="h-4 w-4" size="sm" label="Pricing" />
+              {PRODUCTS_FLAGSHIP.priceLabel}
+            </p>
+
+            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+              <a
+                href={PRODUCTS_FLAGSHIP.ctas.docs.href}
+                className="rounded-md bg-primary-foreground px-6 py-3 text-sm font-semibold text-primary shadow-sm transition-colors hover:bg-primary-foreground/90"
+              >
+                {PRODUCTS_FLAGSHIP.ctas.docs.label}
+              </a>
+              <a
+                href={PRODUCTS_FLAGSHIP.ctas.pricing.href}
+                className="rounded-md bg-primary-foreground/15 px-6 py-3 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/30 transition-colors hover:bg-primary-foreground/25"
+              >
+                {PRODUCTS_FLAGSHIP.ctas.pricing.label}
+              </a>
+              <a
+                href={PRODUCTS_FLAGSHIP.ctas.repo.href}
+                className="rounded-md px-6 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/10"
+                {...(PRODUCTS_FLAGSHIP.ctas.repo.external
+                  ? { target: '_blank', rel: 'noreferrer' }
+                  : {})}
+              >
+                {PRODUCTS_FLAGSHIP.ctas.repo.label}
+              </a>
             </div>
           </div>
         </div>
-      </section>
+      </MarketingSection>
 
       {/* Sister products — uniform card grid */}
-      <section className="bg-secondary py-20 sm:py-24">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-2xl text-center">
-            <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              And the rest of the fleet
-            </h2>
-            <p className="mt-4 text-lg leading-7 text-muted-foreground">
-              Sister products that extend the runtime: secrets, dev tooling, white-labeling, skills,
-              and the agent tool catalog.
-            </p>
-          </div>
+      <MarketingSection tone="secondary" density="default" width="default">
+        <SectionHeader
+          title="And the rest of the fleet"
+          description="Sister products that extend the runtime: secrets, dev tooling, white-labeling, skills, and the agent tool catalog."
+          align="center"
+        />
 
-          {/* Status filter chips (Phase D, interactive). */}
-          <div
-            className="mt-10 flex flex-wrap items-center justify-center gap-2"
-            role="tablist"
-            aria-label="Filter products by status"
-          >
-            {STATUS_FILTERS.map((f) => {
-              const selected = filter === f;
-              return (
-                <Button
-                  key={f}
-                  type="button"
-                  role="tab"
-                  aria-selected={selected}
-                  size="sm"
-                  appearance={selected ? 'solid' : 'outline'}
-                  variant={selected ? 'brand' : 'neutral'}
-                  onClick={() => setFilter(f)}
-                  className="rounded-full"
-                >
-                  {f}
-                  <span className="text-xs text-muted-foreground">{countFor(f)}</span>
-                </Button>
-              );
-            })}
-          </div>
-
-          <ul className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
-            {visibleSisters.map((product) => {
-              const status = PRODUCT_STATUS_STYLES[product.status];
-              return (
-                <li
-                  key={product.slug}
-                  id={product.slug}
-                  className="group relative flex flex-col rounded-2xl bg-card p-8 shadow-sm ring-1 ring-border transition-shadow hover:shadow-lg"
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="flex items-center gap-4">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-secondary ring-1 ring-border">
-                        <svg
-                          className="h-6 w-6 text-muted-foreground"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          strokeWidth={1.5}
-                          stroke="currentColor"
-                        >
-                          <title>{product.name}</title>
-                          <path strokeLinecap="round" strokeLinejoin="round" d={product.iconPath} />
-                        </svg>
-                      </div>
-                      <div>
-                        <h3 className="text-xl font-bold tracking-tight text-foreground">
-                          {product.name}
-                        </h3>
-                        <p className="mt-0.5 text-sm font-medium text-muted-foreground">
-                          {product.tagline}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="flex flex-col items-end gap-1.5 text-xs font-semibold">
-                      <span
-                        className={`rounded-full px-2.5 py-1 ring-1 ${status.bg} ${status.text} ${status.ring}`}
-                      >
-                        {product.status}
-                      </span>
-                      {product.version ? (
-                        <span className="font-mono text-[0.7rem] text-muted-foreground">
-                          {product.version}
-                        </span>
-                      ) : null}
-                    </div>
-                  </div>
-
-                  <ul className="mt-5 grow space-y-2.5">
-                    {product.highlights.map((highlight) => (
-                      <li
-                        key={highlight}
-                        className="flex items-start gap-2.5 text-sm leading-6 text-muted-foreground"
-                      >
-                        <IconCheckCircle size="sm" className="mt-1 flex-shrink-0 text-primary" />
-                        {highlight}
-                      </li>
-                    ))}
-                  </ul>
-
-                  <div className="mt-6 flex items-center justify-between gap-3 border-t border-border pt-4">
-                    <span className="text-xs font-semibold text-foreground/70">
-                      {product.priceLabel}
-                    </span>
-                    <a
-                      href={product.primaryCta.href}
-                      className="inline-flex min-h-11 items-center text-sm font-semibold text-primary transition-colors hover:text-primary/80"
-                      {...(product.primaryCta.external
-                        ? { target: '_blank', rel: 'noreferrer' }
-                        : {})}
-                    >
-                      {product.primaryCta.label}
-                    </a>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
+        {/* Status filter chips (Phase D, interactive). */}
+        <div
+          className="mt-10 flex flex-wrap items-center justify-center gap-2"
+          role="tablist"
+          aria-label="Filter products by status"
+        >
+          {STATUS_FILTERS.map((f) => {
+            const selected = filter === f;
+            return (
+              <Button
+                key={f}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                size="sm"
+                appearance={selected ? 'solid' : 'outline'}
+                variant={selected ? 'brand' : 'neutral'}
+                onClick={() => setFilter(f)}
+                className="rounded-full"
+              >
+                {f}
+                <span className="text-xs text-muted-foreground">{countFor(f)}</span>
+              </Button>
+            );
+          })}
         </div>
-      </section>
+
+        <ul className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
+          {visibleSisters.map((product) => {
+            const status = PRODUCT_STATUS_STYLES[product.status];
+            return (
+              <li
+                key={product.slug}
+                id={product.slug}
+                className="group relative flex flex-col rounded-2xl bg-card p-8 shadow-sm ring-1 ring-border transition-shadow hover:shadow-lg"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-center gap-4">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-secondary ring-1 ring-border">
+                      <svg
+                        className="h-6 w-6 text-muted-foreground"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        strokeWidth={1.5}
+                        stroke="currentColor"
+                      >
+                        <title>{product.name}</title>
+                        <path strokeLinecap="round" strokeLinejoin="round" d={product.iconPath} />
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 className="text-xl font-bold tracking-tight text-foreground">
+                        {product.name}
+                      </h3>
+                      <p className="mt-0.5 text-sm font-medium text-muted-foreground">
+                        {product.tagline}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-1.5 text-xs font-semibold">
+                    <span
+                      className={`rounded-full px-2.5 py-1 ring-1 ${status.bg} ${status.text} ${status.ring}`}
+                    >
+                      {product.status}
+                    </span>
+                    {product.version ? (
+                      <span className="font-mono text-[0.7rem] text-muted-foreground">
+                        {product.version}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+
+                <ul className="mt-5 grow space-y-2.5">
+                  {product.highlights.map((highlight) => (
+                    <li
+                      key={highlight}
+                      className="flex items-start gap-2.5 text-sm leading-6 text-muted-foreground"
+                    >
+                      <IconCheckCircle size="sm" className="mt-1 flex-shrink-0 text-primary" />
+                      {highlight}
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="mt-6 flex items-center justify-between gap-3 border-t border-border pt-4">
+                  <span className="text-xs font-semibold text-foreground/70">
+                    {product.priceLabel}
+                  </span>
+                  <a
+                    href={product.primaryCta.href}
+                    className="inline-flex min-h-11 items-center text-sm font-semibold text-primary transition-colors hover:text-primary/80"
+                    {...(product.primaryCta.external
+                      ? { target: '_blank', rel: 'noreferrer' }
+                      : {})}
+                  >
+                    {product.primaryCta.label}
+                  </a>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </MarketingSection>
 
       {/* Stats — production credibility */}
-      <section className="bg-card py-24 sm:py-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              {PRODUCTS_STATS_SECTION.heading}
-            </h2>
-            <p className="mt-4 text-lg text-muted-foreground">{PRODUCTS_STATS_SECTION.body}</p>
-          </div>
-          <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
-            {PRODUCTS_STATS_SECTION.items.map((item) => (
-              <div key={item.label} className="text-center">
-                <p className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-                  {item.stat}
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">{item.label}</p>
-              </div>
-            ))}
-          </div>
+      <MarketingSection tone="card" density="default" width="default">
+        <SectionHeader
+          title={PRODUCTS_STATS_SECTION.heading}
+          description={PRODUCTS_STATS_SECTION.body}
+          align="center"
+          className="mb-16"
+        />
+        <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
+          {PRODUCTS_STATS_SECTION.items.map((item) => (
+            <div key={item.label} className="text-center">
+              <p className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+                {item.stat}
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">{item.label}</p>
+            </div>
+          ))}
         </div>
-      </section>
+      </MarketingSection>
 
       {/* Proof — social proof, repo signals, and trust cards */}
       <Proof />

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@revealui/presentation';
+import { Button, MarketingSection, SectionHeader } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 import {
   ROADMAP_CTA,
@@ -33,14 +33,14 @@ function statusBadgeClass(status: string): string {
 function FeatureCard({ feature }: { feature: RoadmapItem }) {
   return (
     <div className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border">
-      <div className="flex items-center gap-3 mb-4">
+      <div className="mb-4 flex items-center gap-3">
         <span
-          className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${categoryColors[feature.category.toLowerCase()] ?? 'bg-muted text-muted-foreground'}`}
+          className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${categoryColors[feature.category.toLowerCase()] ?? 'bg-muted text-muted-foreground'}`}
         >
           {feature.category}
         </span>
         <span
-          className={`text-xs font-medium px-2.5 py-0.5 rounded-full ring-1 ${statusBadgeClass(feature.status)}`}
+          className={`rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${statusBadgeClass(feature.status)}`}
         >
           {feature.status}
         </span>
@@ -54,96 +54,107 @@ function FeatureCard({ feature }: { feature: RoadmapItem }) {
 export function RoadmapPage() {
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-amber-500/10 via-background to-orange-500/10 px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
-        <div className="mx-auto max-w-4xl text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-            Product
-            <span className="block bg-gradient-to-r from-amber-600 to-orange-600 bg-clip-text text-transparent">
-              Roadmap
-            </span>
-          </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
-            {ROADMAP_HERO.subtitle} See our{' '}
+      <MarketingSection
+        tone="background"
+        density="spacious"
+        width="default"
+        className="relative overflow-hidden"
+        innerClassName="max-w-4xl text-center"
+      >
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-amber-500/10 via-background to-orange-500/10"
+        />
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+          Product
+          <span className="block bg-gradient-to-r from-amber-600 to-orange-600 bg-clip-text text-transparent">
+            Roadmap
+          </span>
+        </h1>
+        <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
+          {ROADMAP_HERO.subtitle} See our{' '}
+          <a
+            href={ROADMAP_HERO_LINK.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-amber-700 underline hover:text-amber-600"
+          >
+            {ROADMAP_HERO_LINK.label}
+          </a>{' '}
+          for the full timeline.
+        </p>
+      </MarketingSection>
+
+      <MarketingSection tone="secondary" density="compact" width="default">
+        <SectionHeader
+          title={ROADMAP_SHIPPED_SECTION.title}
+          align="start"
+          titleClassName="text-2xl sm:text-3xl"
+          className="mb-8 max-w-none"
+        />
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {ROADMAP_SHIPPED.map((feature) => (
+            <FeatureCard key={feature.name} feature={feature} />
+          ))}
+        </div>
+      </MarketingSection>
+
+      <MarketingSection tone="background" density="compact" width="default">
+        <SectionHeader
+          title={ROADMAP_UPCOMING_SECTION.title}
+          align="start"
+          titleClassName="text-2xl sm:text-3xl"
+          className="mb-8 max-w-none"
+        />
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {ROADMAP_UPCOMING.map((feature) => (
+            <FeatureCard key={feature.name} feature={feature} />
+          ))}
+        </div>
+      </MarketingSection>
+
+      <MarketingSection
+        tone="secondary"
+        density="compact"
+        width="default"
+        innerClassName="max-w-4xl text-center"
+      >
+        <SectionHeader
+          title={ROADMAP_CTA.title}
+          description={ROADMAP_CTA.subtitle}
+          align="center"
+          titleClassName="text-2xl sm:text-3xl"
+        />
+        <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Button asChild size="lg" variant="brand">
             <a
-              href={ROADMAP_HERO_LINK.href}
+              href={ROADMAP_CTA_LINKS.requestFeature.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-amber-700 underline hover:text-amber-600"
             >
-              {ROADMAP_HERO_LINK.label}
-            </a>{' '}
-            for the full timeline.
-          </p>
-        </div>
-      </section>
-
-      {/* Recently Shipped */}
-      <section className="py-16 sm:py-20 bg-secondary">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl mb-8">
-            {ROADMAP_SHIPPED_SECTION.title}
-          </h2>
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {ROADMAP_SHIPPED.map((feature) => (
-              <FeatureCard key={feature.name} feature={feature} />
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Coming Next */}
-      <section className="py-16 sm:py-20">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl mb-8">
-            {ROADMAP_UPCOMING_SECTION.title}
-          </h2>
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {ROADMAP_UPCOMING.map((feature) => (
-              <FeatureCard key={feature.name} feature={feature} />
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="bg-secondary py-16">
-        <div className="mx-auto max-w-4xl px-6 text-center lg:px-8">
-          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-            {ROADMAP_CTA.title}
-          </h2>
-          <p className="mt-4 text-lg text-muted-foreground">{ROADMAP_CTA.subtitle}</p>
-          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Button asChild size="lg" variant="brand">
-              <a
-                href={ROADMAP_CTA_LINKS.requestFeature.href}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {ROADMAP_CTA_LINKS.requestFeature.label}
-              </a>
-            </Button>
-            <Button asChild size="lg" appearance="outline" variant="neutral">
-              <a
-                href={ROADMAP_CTA_LINKS.joinDiscussion.href}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {ROADMAP_CTA_LINKS.joinDiscussion.label}
-              </a>
-            </Button>
-          </div>
-          <p className="mt-8 text-sm text-muted-foreground">
-            See what's shipped today &rarr;{' '}
-            <a
-              href={ROADMAP_CTA_PRODUCTS_LINK.href}
-              className="font-medium text-foreground hover:text-foreground/80 transition-colors"
-            >
-              {ROADMAP_CTA_PRODUCTS_LINK.label}
+              {ROADMAP_CTA_LINKS.requestFeature.label}
             </a>
-          </p>
+          </Button>
+          <Button asChild size="lg" appearance="outline" variant="neutral">
+            <a
+              href={ROADMAP_CTA_LINKS.joinDiscussion.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {ROADMAP_CTA_LINKS.joinDiscussion.label}
+            </a>
+          </Button>
         </div>
-      </section>
+        <p className="mt-8 text-sm text-muted-foreground">
+          See what&apos;s shipped today &rarr;{' '}
+          <a
+            href={ROADMAP_CTA_PRODUCTS_LINK.href}
+            className="font-medium text-foreground transition-colors hover:text-foreground/80"
+          >
+            {ROADMAP_CTA_PRODUCTS_LINK.label}
+          </a>
+        </p>
+      </MarketingSection>
 
       <Footer />
     </div>

--- a/packages/presentation/docs/marketing-section-system.md
+++ b/packages/presentation/docs/marketing-section-system.md
@@ -46,6 +46,13 @@ Eyebrow tones: `primary` (default brand signal) or `muted` (quiet sections).
 3. CMS `SectionBlock` body copy must use the body rung (aligned with this ladder).
 4. Route craft only after consumers adopt shells (frontend-excellence sequence).
 
-## Pilot
+## Pilot + Phase 2 rewire
 
-Home `Hero` + `Problem` rewired first. Expand route-by-route after type burn-down.
+Home `Hero` + `Problem` were the pilot. Phase 2 rewired remaining marketing
+section components and major routes onto `MarketingSection` / `SectionHeader`
+(landing, for-operators*, products, pricing, claims, blog index, etc.).
+
+Still intentional non-shell pages: thin document shells (404, some legal),
+nested widgets (ProviderSwitch, FrontierPathway), NavBar/Footer.
+
+Next: type burn-down (body vs muted), PricingTable/FaqList, then route craft.


### PR DESCRIPTION
## Summary

Phase 2 of the marketing section system (follows #2564 shells):

- Rewire landing, for-operators*, products, and major routes onto `MarketingSection` / `SectionHeader`
- Drop nested `max-w-7xl px-6` double padding (shell owns rails)
- Keep CMS `fieldAttrs`, pricing API, and audience/business logic intact
- Update shell contract doc for Phase 2 adoption

## Coverage

| Area | Status |
|------|--------|
| landing (Demo, Primitives, Proof, PricingTeaser, Faq, CostCalculator, GetStarted) | Rewired |
| for-operators / how-it-works / managed | Rewired |
| products Heroes + CTA | Rewired |
| Pricing, Products, LocalAi, Philosophy, FairSource, Claims, Contact, Roadmap, Blog index | Rewired |
| Hero + Problem | Already piloted (#2564) |

**Skipped (intentional):** NavBar/Footer, nested widgets (ProviderSwitch, FrontierPathway), thin 404/legal/status document shells.

## Test plan

- [x] `pnpm --filter marketing test` — 154 passed
- [x] Marketing app build
- [x] Local phase-1 gate PASS
- [ ] CI green
- [ ] Spot-check home / pricing / services in light+dark after merge

## Follow-ups

- Type burn-down (long copy still on muted in many card bodies)
- PricingTable / Accordion FAQ
- Route craft only after that