### PR TITLE
fix(marketing): burn down body copy onto text-body type rung

### DIFF
--- a/apps/marketing/app/components/ErrorBoundary.tsx
+++ b/apps/marketing/app/components/ErrorBoundary.tsx
@@ -39,7 +39,7 @@ function DefaultErrorFallback() {
       <h1 className="mt-2 text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
         Something went wrong
       </h1>
-      <p className="mt-4 max-w-md text-sm text-muted-foreground">
+      <p className="mt-4 max-w-md text-sm text-body">
         An unexpected error occurred while rendering this page. Our team has been notified.
       </p>
       <Button asChild variant="brand" className="mt-6">

--- a/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
@@ -45,10 +45,7 @@ export function EngagementSteps({ data = FO_HIW_STEPS, path, annotation }: Engag
               >
                 {step.title}
               </h3>
-              <p
-                className="mt-2 text-base leading-7 text-muted-foreground"
-                {...field(`items.${index}.body`)}
-              >
+              <p className="mt-2 text-base leading-7 text-body" {...field(`items.${index}.body`)}>
                 {step.body}
               </p>
             </div>

--- a/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
@@ -47,7 +47,7 @@ export function FearRemoval({ data = FO_HIW_FEAR, path, annotation }: FearRemova
               {option.title}
             </h3>
             <p
-              className="mt-1 text-base leading-7 text-muted-foreground"
+              className="mt-1 text-base leading-7 text-body"
               {...field(`items.${optionStart + index}.body`)}
             >
               {option.body}

--- a/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
@@ -41,10 +41,7 @@ export function Ownership({ data = FO_HIW_OWNERSHIP, path, annotation }: Ownersh
             >
               {claim.title}
             </h3>
-            <p
-              className="mt-1 text-base leading-7 text-muted-foreground"
-              {...field(`items.${index}.body`)}
-            >
+            <p className="mt-1 text-base leading-7 text-body" {...field(`items.${index}.body`)}>
               {claim.body}
             </p>
           </li>

--- a/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
@@ -62,7 +62,7 @@ export function Prerequisites({ data, path, annotation }: FoManagedPrereqsProps 
               {prereq.title}
             </h3>
             <p
-              className="mt-2 text-base leading-7 text-muted-foreground"
+              className="mt-2 text-base leading-7 text-body"
               {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
             >
               {prereq.body}

--- a/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
+++ b/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
@@ -61,7 +61,7 @@ export function WouldBe({ data, path, annotation }: FoManagedWouldBeProps = {}) 
               {capability.title}
             </h3>
             <p
-              className="mt-2 text-base leading-7 text-muted-foreground"
+              className="mt-2 text-base leading-7 text-body"
               {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
             >
               {capability.body}

--- a/apps/marketing/app/components/for-operators/EngagementPricing.tsx
+++ b/apps/marketing/app/components/for-operators/EngagementPricing.tsx
@@ -60,7 +60,7 @@ export function EngagementPricing({ data, path, annotation }: EngagementPricingP
           >
             <h3 className="text-lg font-semibold leading-7 text-foreground">{rung.title}</h3>
             <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{rung.price}</p>
-            <p className="mt-4 flex-1 text-base leading-7 text-muted-foreground">{rung.body}</p>
+            <p className="mt-4 flex-1 text-base leading-7 text-body">{rung.body}</p>
             <div className="mt-8">
               <Button asChild appearance="outline" variant="neutral" className="w-full">
                 <a

--- a/apps/marketing/app/components/for-operators/Faq.tsx
+++ b/apps/marketing/app/components/for-operators/Faq.tsx
@@ -24,7 +24,7 @@ export function Faq() {
                 <IconPlus size="sm" label="Toggle" />
               </span>
             </summary>
-            <div className="mt-4 pr-9 text-base leading-7 text-muted-foreground">{item.answer}</div>
+            <div className="mt-4 pr-9 text-base leading-7 text-body">{item.answer}</div>
           </details>
         ))}
       </div>

--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -61,7 +61,7 @@ export function WhatYouGet({ data, path, annotation }: WhatYouGetProps = {}) {
               {card.title}
             </h3>
             <p
-              className="mt-3 text-base leading-7 text-muted-foreground"
+              className="mt-3 text-base leading-7 text-body"
               {...(base ? fieldAttrs(ann, `${base}.items.${index}.body`) : {})}
             >
               {card.body}

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -57,7 +57,7 @@ export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {}
               {b.title}
             </h3>
             <p
-              className="mt-2 text-sm leading-6 text-muted-foreground"
+              className="mt-2 text-sm leading-6 text-body"
               {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
             >
               {b.body}

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -43,7 +43,7 @@ export function Faq({ data = HOME_FAQ, path = 'blocks.1.data', annotation = {} }
               </span>
             </summary>
             <div
-              className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
+              className="mt-4 pr-9 text-base leading-7 text-body"
               {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
             >
               {item.answer}

--- a/apps/marketing/app/components/landing/FrontierPathway.tsx
+++ b/apps/marketing/app/components/landing/FrontierPathway.tsx
@@ -20,7 +20,7 @@ export function FrontierPathway() {
               {step.n}
             </span>
             <h4 className="mt-4 text-base font-semibold text-foreground">{step.title}</h4>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">{step.body}</p>
+            <p className="mt-2 text-sm leading-6 text-body">{step.body}</p>
           </li>
         ))}
       </ol>

--- a/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
+++ b/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
@@ -43,7 +43,7 @@ export function LiveMetricsBadge() {
         ))}
       </dl>
 
-      <p className="mt-5 text-sm leading-6 text-muted-foreground">{M.body}</p>
+      <p className="mt-5 text-sm leading-6 text-body">{M.body}</p>
     </div>
   );
 }

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -77,7 +77,7 @@ export function PricingTeaser() {
                 </span>
                 {period && <span className="text-sm text-muted-foreground">{period}</span>}
               </div>
-              <p className="mt-4 text-sm leading-6 text-muted-foreground">{t.description}</p>
+              <p className="mt-4 text-sm leading-6 text-body">{t.description}</p>
 
               <ul className="mt-6 flex-1 space-y-3">
                 {t.features.map((f) => (

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -95,7 +95,7 @@ export function Primitives({
                   {item.label}
                 </h3>
                 <p
-                  className="mt-1.5 text-base leading-7 text-muted-foreground"
+                  className="mt-1.5 text-base leading-7 text-body"
                   {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
                 >
                   {item.body}

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -93,9 +93,7 @@ export function Problem() {
             </span>
             <span
               className={
-                emphasis
-                  ? 'text-sm leading-6 text-foreground'
-                  : 'text-sm leading-6 text-muted-foreground'
+                emphasis ? 'text-sm leading-6 text-foreground' : 'text-sm leading-6 text-body'
               }
             >
               {blurb}
@@ -132,7 +130,7 @@ export function Problem() {
                     className={
                       answer.emphasis
                         ? 'text-sm leading-6 font-medium text-foreground'
-                        : 'text-sm leading-6 text-muted-foreground'
+                        : 'text-sm leading-6 text-body'
                     }
                   >
                     {answer.value}

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -31,7 +31,7 @@ export function Proof() {
       </div>
 
       <div className="mx-auto mt-12 max-w-2xl text-center">
-        <p className="text-base leading-7 text-muted-foreground">
+        <p className="text-base leading-7 text-body">
           {PROOF_TRUST.body}{' '}
           <a
             href={PROOF_TRUST.linkHref}

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -105,7 +105,7 @@ export function BlogIndexPage() {
       <MarketingSection tone="background" density="default" width="default">
         {posts.length === 0 ? (
           <div className="mx-auto max-w-2xl text-center">
-            <p className="text-lg text-muted-foreground">
+            <p className="text-lg text-body">
               No posts yet. Check back soon for updates from the RevealUI team.
             </p>
           </div>
@@ -127,7 +127,7 @@ export function BlogIndexPage() {
                     {post.title}
                   </a>
                 </h3>
-                <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                <p className="mt-4 text-sm leading-6 text-body">
                   {post.excerpt ?? getExcerpt(post.content)}
                 </p>
                 <a
@@ -143,7 +143,7 @@ export function BlogIndexPage() {
 
         <div className="mx-auto mt-16 max-w-2xl rounded-2xl bg-secondary p-8 text-center ring-1 ring-border">
           <h3 className="text-lg font-semibold text-foreground">Get notified when we publish</h3>
-          <p className="mb-6 mt-2 text-sm text-muted-foreground">
+          <p className="mb-6 mt-2 text-sm text-body">
             Engineering insights, product updates, and launch announcements. No spam.
           </p>
           <NewsletterSignup variant="stacked" />

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -96,7 +96,7 @@ export function BlogPostPage() {
           <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             Post not found
           </h1>
-          <p className="mt-4 max-w-md text-base text-muted-foreground">
+          <p className="mt-4 max-w-md text-base text-body">
             That blog post does not exist or has been removed.
           </p>
           <Button asChild variant="brand" className="mt-8">
@@ -142,7 +142,7 @@ export function BlogPostPage() {
             ) : (
               // Content shape unrecognized (neither Lexical nor markdown string):
               // render the real excerpt instead of placeholder copy (GAP-423).
-              <p className="text-muted-foreground">{post.excerpt}</p>
+              <p className="text-body">{post.excerpt}</p>
             )}
           </div>
         </div>
@@ -153,7 +153,7 @@ export function BlogPostPage() {
           <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
             Ready to build?
           </h2>
-          <p className="mt-4 text-base leading-7 text-muted-foreground">
+          <p className="mt-4 text-base leading-7 text-body">
             People, Content, Offers, Payments, and Agents, pre-wired. Start locally in minutes.
           </p>
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/apps/marketing/app/routes/ClaimsPage.tsx
+++ b/apps/marketing/app/routes/ClaimsPage.tsx
@@ -184,9 +184,7 @@ export function ClaimsPage() {
           <h1 className="mt-3 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
             {CLAIMS_HERO.h1}
           </h1>
-          <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
-            {CLAIMS_HERO.subtitle}
-          </p>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-body">{CLAIMS_HERO.subtitle}</p>
           <div className="mt-6 flex flex-wrap gap-x-8 gap-y-2 font-mono text-sm tabular-nums text-foreground">
             <span>
               <strong className="font-semibold">{CLAIMS.length}</strong>{' '}
@@ -228,7 +226,7 @@ export function ClaimsPage() {
               <Badge color={KIND_BADGE_COLOR} className="mt-0.5 shrink-0">
                 {entry.label}
               </Badge>
-              <dd className="text-sm text-muted-foreground">{entry.description}</dd>
+              <dd className="text-sm text-body">{entry.description}</dd>
             </div>
           ))}
         </dl>
@@ -236,7 +234,7 @@ export function ClaimsPage() {
 
       <nav aria-label="Sections" className="border-b border-border px-6 py-6 lg:px-8">
         <div className="mx-auto max-w-3xl">
-          <p className="mb-3 text-sm leading-6 text-muted-foreground">{CLAIMS_LEDGER_INTRO}</p>
+          <p className="mb-3 text-sm leading-6 text-body">{CLAIMS_LEDGER_INTRO}</p>
           <ul className="flex flex-wrap gap-x-4 gap-y-2 font-mono text-xs">
             {FILE_SECTIONS.map((section) => (
               <li key={section.file}>
@@ -279,9 +277,7 @@ export function ClaimsPage() {
                 </code>
               </p>
               {section.claims.length === 0 ? (
-                <p className="mt-4 text-sm text-muted-foreground">
-                  No indexed claims yet for this file.
-                </p>
+                <p className="mt-4 text-sm text-body">No indexed claims yet for this file.</p>
               ) : (
                 <ol className="mt-4 divide-y divide-border">
                   {section.claims.map((claim) => (
@@ -319,7 +315,7 @@ export function ClaimsPage() {
             <p className="text-sm font-semibold text-foreground">
               {CLAIMS_HONESTY_RAILS_SECTION.notCheckedHeading}
             </p>
-            <div className="mt-1 space-y-1 text-sm text-muted-foreground">
+            <div className="mt-1 space-y-1 text-sm text-body">
               {CLAIMS_HONESTY_RAILS_SECTION.doesNotCheck.map((sentence) => (
                 <p key={sentence}>{sentence}</p>
               ))}

--- a/apps/marketing/app/routes/ContactPage.tsx
+++ b/apps/marketing/app/routes/ContactPage.tsx
@@ -31,7 +31,7 @@ export function ContactPage() {
           {CONTACT_METHODS.map((method) => (
             <div key={method.title}>
               <h3 className="text-sm font-semibold text-foreground">{method.title}</h3>
-              <p className="mt-2 text-sm text-muted-foreground">
+              <p className="mt-2 text-sm text-body">
                 {method.body ? <>{method.body} </> : null}
                 <a
                   href={method.href}

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -79,7 +79,7 @@ function FairSourceContract({ data, path, annotation }: ContractProps) {
                   {c.title}
                 </h3>
                 <p
-                  className="mt-2 text-sm leading-6 text-muted-foreground"
+                  className="mt-2 text-sm leading-6 text-body"
                   {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
                 >
                   {c.body}
@@ -158,7 +158,7 @@ function FairSourcePackagesIntro({ data, path, annotation }: PackagesIntroProps)
         </table>
       </div>
       <p
-        className="mx-auto mt-6 max-w-2xl text-center text-sm text-muted-foreground"
+        className="mx-auto mt-6 max-w-2xl text-center text-sm text-body"
         {...fieldAttrs(annotation, `${path}.items.0.body`)}
       >
         {data.footer.includes(data.footerCommand) ? (
@@ -210,7 +210,7 @@ function FairSourceClock({ data, path, annotation }: ClockProps) {
                 {step.title}
               </h3>
               <p
-                className="mt-1 text-sm text-muted-foreground"
+                className="mt-1 text-sm text-body"
                 {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
               >
                 {step.body}
@@ -253,7 +253,7 @@ function FairSourcePeers({ data, path, annotation }: PeersProps) {
               {p.name}
             </h3>
             <p
-              className="mt-2 text-sm leading-6 text-muted-foreground"
+              className="mt-2 text-sm leading-6 text-body"
               {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
             >
               {p.note}
@@ -295,7 +295,7 @@ function FairSourceFaq({ data, path, annotation }: FaqProps) {
               </span>
             </summary>
             <div
-              className="mt-4 pr-9 text-base leading-7 text-muted-foreground"
+              className="mt-4 pr-9 text-base leading-7 text-body"
               {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
             >
               {f.answer}
@@ -390,7 +390,7 @@ export function FairSourcePage() {
           <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-body sm:text-2xl">
             {FAIR_SOURCE_HERO.subhead}
           </p>
-          <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-muted-foreground">
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-body">
             {/* COUNT: packages-fsl = 5, packages-mit = 21 (of 26 total — see /packages/ in repo) */}
             {FAIR_SOURCE_HERO.body.prefix}{' '}
             <a

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -87,7 +87,7 @@ function LocalAiPillars({ data, path, annotation }: LocalAiPillarsProps) {
               {pillar.title}
             </h2>
             <p
-              className="mt-3 text-sm leading-6 text-muted-foreground"
+              className="mt-3 text-sm leading-6 text-body"
               {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
             >
               {pillar.body}
@@ -169,7 +169,7 @@ function LocalAiMarketProof({ data, path, annotation }: LocalAiMarketProofProps)
         ))}
       </ul>
       <p
-        className="mt-6 text-sm italic leading-6 text-muted-foreground"
+        className="mt-6 text-sm italic leading-6 text-body"
         {...fieldAttrs(annotation, `${path}.items.${data.adopters.length}.body`)}
       >
         {data.disclaimer}
@@ -202,7 +202,7 @@ function LocalAiNotes({ data, path, annotation }: LocalAiNotesProps) {
           >
             {data.roadmapHeading}
           </p>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          <p className="mt-2 text-sm leading-6 text-body">
             <span {...fieldAttrs(annotation, `${path}.items.2.body`)}>{data.roadmapBody}</span>{' '}
             <a href={data.roadmapHref} className="font-medium text-primary hover:underline">
               See the roadmap
@@ -211,7 +211,7 @@ function LocalAiNotes({ data, path, annotation }: LocalAiNotesProps) {
           </p>
         </div>
         <p
-          className="border-t border-border pt-6 text-sm leading-6 text-muted-foreground"
+          className="border-t border-border pt-6 text-sm leading-6 text-body"
           {...fieldAttrs(annotation, `${path}.items.1.body`)}
         >
           {data.honesty}

--- a/apps/marketing/app/routes/NotFoundPage.tsx
+++ b/apps/marketing/app/routes/NotFoundPage.tsx
@@ -9,7 +9,7 @@ export function NotFoundPage() {
         <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           Page not found
         </h1>
-        <p className="mt-4 max-w-md text-base text-muted-foreground">
+        <p className="mt-4 max-w-md text-base text-body">
           The page you're looking for doesn't exist or has moved.
         </p>
         <div className="mt-8 flex flex-wrap items-center justify-center gap-3">

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -125,7 +125,7 @@ export function PricingPage() {
         <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
           {PRICING_HERO.subtitle}
         </p>
-        <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
+        <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-body">
           {PRICING_HERO_SUBTEXT.prefix}{' '}
           <a
             href={PRICING_HERO_SUBTEXT.linkHref}
@@ -164,10 +164,10 @@ export function PricingPage() {
           <h3 className="text-2xl font-bold tracking-tight text-foreground">
             {PRICING_VALUE_BAND.heading}
           </h3>
-          <p className="mt-3 text-sm leading-6 text-muted-foreground">{PRICING_VALUE_BAND.body}</p>
+          <p className="mt-3 text-sm leading-6 text-body">{PRICING_VALUE_BAND.body}</p>
           <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
             {PRICING_VALUE_BAND.points.map((point) => (
-              <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
+              <li key={point} className="flex items-start gap-2 text-sm text-body">
                 <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
                 <span>{point}</span>
               </li>
@@ -222,7 +222,7 @@ export function PricingPage() {
               )}
               <div className="mb-8">
                 <h3 className="text-xl font-bold tracking-tight text-foreground">{tier.name}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">{tier.description}</p>
+                <p className="mt-2 text-sm text-body">{tier.description}</p>
                 <p className="mt-6 flex items-baseline gap-x-1">
                   <span className="text-4xl font-bold tracking-tight text-foreground">
                     {tier.price ?? 'Contact us'}
@@ -241,7 +241,7 @@ export function PricingPage() {
                 {tier.features.map((feature) => (
                   <li key={feature} className="flex items-start gap-x-3">
                     <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                    <span className="text-sm text-muted-foreground">{feature}</span>
+                    <span className="text-sm text-body">{feature}</span>
                   </li>
                 ))}
               </ul>
@@ -304,12 +304,10 @@ export function PricingPage() {
           <h3 className="mt-2 text-2xl font-bold tracking-tight text-foreground">
             {PRICING_AGENCY_VALUE_BAND.heading}
           </h3>
-          <p className="mt-3 text-sm leading-6 text-muted-foreground">
-            {PRICING_AGENCY_VALUE_BAND.body}
-          </p>
+          <p className="mt-3 text-sm leading-6 text-body">{PRICING_AGENCY_VALUE_BAND.body}</p>
           <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
             {PRICING_AGENCY_VALUE_BAND.points.map((point) => (
-              <li key={point} className="flex items-start gap-2 text-sm text-muted-foreground">
+              <li key={point} className="flex items-start gap-2 text-sm text-body">
                 <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
                 <span>{point}</span>
               </li>
@@ -331,7 +329,7 @@ export function PricingPage() {
                 </div>
               )}
               <h3 className="text-lg font-bold text-foreground">{tier.name}</h3>
-              <p className="mt-1 text-sm text-muted-foreground">{tier.description}</p>
+              <p className="mt-1 text-sm text-body">{tier.description}</p>
               {tier.price ? (
                 <p className="mt-4 flex items-baseline gap-x-1">
                   <span className="text-4xl font-bold text-foreground">{tier.price}</span>
@@ -347,7 +345,7 @@ export function PricingPage() {
                 {tier.features.map((feature) => (
                   <li key={feature} className="flex items-start gap-x-3">
                     <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                    <span className="text-sm text-muted-foreground">{feature}</span>
+                    <span className="text-sm text-body">{feature}</span>
                   </li>
                 ))}
               </ul>
@@ -389,7 +387,7 @@ export function PricingPage() {
               <h3 className="text-base font-semibold text-foreground">
                 {PRICING_AGENT_A2A.heading}
               </h3>
-              <p className="mt-2 text-sm text-muted-foreground">
+              <p className="mt-2 text-sm text-body">
                 {PRICING_AGENT_A2A.body.prefix}{' '}
                 <a
                   href={PRICING_AGENT_A2A.body.linkHref}
@@ -410,7 +408,7 @@ export function PricingPage() {
               <h3 className="text-base font-semibold text-foreground">
                 {PRICING_AGENT_X402.heading}
               </h3>
-              <p className="mt-2 text-sm text-muted-foreground">{PRICING_AGENT_X402.body}</p>
+              <p className="mt-2 text-sm text-body">{PRICING_AGENT_X402.body}</p>
             </div>
 
             <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
@@ -420,7 +418,7 @@ export function PricingPage() {
               <h3 className="text-base font-semibold text-foreground">
                 {PRICING_AGENT_MCP.heading}
               </h3>
-              <p className="mt-2 text-sm text-muted-foreground">{PRICING_AGENT_MCP.body}</p>
+              <p className="mt-2 text-sm text-body">{PRICING_AGENT_MCP.body}</p>
               <a
                 href={PRICING_AGENT_MCP.docsLink.href}
                 className="mt-3 inline-block text-xs font-semibold text-violet-600 hover:text-violet-700"
@@ -470,12 +468,12 @@ export function PricingPage() {
             <span className="text-4xl font-bold text-foreground">{PRICING_STARTER_KIT.price}</span>
             <span className="text-sm text-muted-foreground">{PRICING_STARTER_KIT.priceNote}</span>
           </p>
-          <p className="mt-4 text-lg text-muted-foreground">{PRICING_STARTER_KIT.body}</p>
+          <p className="mt-4 text-lg text-body">{PRICING_STARTER_KIT.body}</p>
           <ul className="mt-6 space-y-3">
             {PRICING_STARTER_KIT.points.map((point) => (
               <li key={point} className="flex items-start gap-x-3">
                 <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                <span className="text-sm text-muted-foreground">{point}</span>
+                <span className="text-sm text-body">{point}</span>
               </li>
             ))}
           </ul>
@@ -525,12 +523,12 @@ export function PricingPage() {
               {PRICING_AGENCY_FOUNDING_KIT.priceNote}
             </span>
           </p>
-          <p className="mt-4 text-lg text-muted-foreground">{PRICING_AGENCY_FOUNDING_KIT.body}</p>
+          <p className="mt-4 text-lg text-body">{PRICING_AGENCY_FOUNDING_KIT.body}</p>
           <ul className="mt-6 space-y-3">
             {PRICING_AGENCY_FOUNDING_KIT.points.map((point) => (
               <li key={point} className="flex items-start gap-x-3">
                 <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
-                <span className="text-sm text-muted-foreground">{point}</span>
+                <span className="text-sm text-body">{point}</span>
               </li>
             ))}
           </ul>
@@ -581,7 +579,7 @@ export function PricingPage() {
             <div key={rung.name} className="rounded-2xl bg-card p-6 ring-1 ring-border">
               <h3 className="text-base font-semibold text-foreground">{rung.name}</h3>
               <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{rung.price}</p>
-              <p className="mt-3 text-sm text-muted-foreground">{rung.note}</p>
+              <p className="mt-3 text-sm text-body">{rung.note}</p>
             </div>
           ))}
         </div>
@@ -622,7 +620,7 @@ export function PricingPage() {
             {PRICING_FAQS.map((faq) => (
               <div key={faq.question} className="rounded-lg bg-secondary p-6 ring-1 ring-border">
                 <dt className="mb-2 text-lg font-semibold text-foreground">{faq.question}</dt>
-                <dd className="text-base text-muted-foreground">{faq.answer}</dd>
+                <dd className="text-base text-body">{faq.answer}</dd>
               </div>
             ))}
           </dl>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -210,9 +210,7 @@ export function ProductsPage() {
                       <h3 className="text-xl font-bold tracking-tight text-foreground">
                         {product.name}
                       </h3>
-                      <p className="mt-0.5 text-sm font-medium text-muted-foreground">
-                        {product.tagline}
-                      </p>
+                      <p className="mt-0.5 text-sm font-medium text-body">{product.tagline}</p>
                     </div>
                   </div>
                   <div className="flex flex-col items-end gap-1.5 text-xs font-semibold">
@@ -233,7 +231,7 @@ export function ProductsPage() {
                   {product.highlights.map((highlight) => (
                     <li
                       key={highlight}
-                      className="flex items-start gap-2.5 text-sm leading-6 text-muted-foreground"
+                      className="flex items-start gap-2.5 text-sm leading-6 text-body"
                     >
                       <IconCheckCircle size="sm" className="mt-1 flex-shrink-0 text-primary" />
                       {highlight}

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -46,7 +46,7 @@ function FeatureCard({ feature }: { feature: RoadmapItem }) {
         </span>
       </div>
       <h3 className="text-lg font-bold tracking-tight text-foreground">{feature.name}</h3>
-      <p className="mt-3 text-sm leading-6 text-muted-foreground">{feature.description}</p>
+      <p className="mt-3 text-sm leading-6 text-body">{feature.description}</p>
     </div>
   );
 }

--- a/packages/presentation/docs/marketing-section-system.md
+++ b/packages/presentation/docs/marketing-section-system.md
@@ -55,4 +55,6 @@ section components and major routes onto `MarketingSection` / `SectionHeader`
 Still intentional non-shell pages: thin document shells (404, some legal),
 nested widgets (ProviderSwitch, FrontierPathway), NavBar/Footer.
 
-Next: type burn-down (body vs muted), PricingTable/FaqList, then route craft.
+Phase 3 type burn-down: marketing app reading prose moved to `text-body`;
+meta/chrome stays on `text-muted-foreground`. Next: PricingTable/FaqList, then
+route craft.


### PR DESCRIPTION
## Summary

Phase 3 of the marketing UI system program (after #2564 shells + #2567 rewire):

- Long reading copy, card descriptions, FAQ answers, and list prose → **`text-body`** (`rvui-text-1`)
- Footnotes, captions, secondary labels, price periods, mono chrome → stay **`text-muted-foreground`**

Rough counts in `apps/marketing/app/**/*.tsx`: body **28 → 90**, muted **165 → 103**.

## Why

After shared section shells, body hierarchy was still washed: multi-sentence prose often used muted (rung 2). The ladder needs the middle rung for AA reading and craft.

## Test plan

- [x] Marketing unit tests 154 passed
- [x] Marketing production build
- [x] Local phase-1 gate PASS
- [ ] CI green
- [ ] Spot-check home / pricing / services contrast light+dark after merge

## Follow-ups

- PricingTable extension + Accordion FAQ
- Route craft (visual hierarchy polish only; type + shells already shared)