### PR TITLE
feat(marketing): route craft visual hierarchy polish

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -38,7 +38,7 @@ export function GetStarted({
       />
 
       <div className="mx-auto max-w-2xl text-center">
-        <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
+        <div className="mt-12 flex flex-col items-center justify-center gap-3 sm:mt-14 sm:flex-row sm:gap-4">
           <Button asChild size="lg" variant="brand" glow>
             <a href={data.cta.primary.href}>{data.cta.primary.label}</a>
           </Button>
@@ -80,7 +80,7 @@ export function GetStarted({
           {data.cli.caption}
         </p>
 
-        <div className="mt-14 border-t border-border pt-10">
+        <div className="mt-12 border-t border-border pt-10 sm:mt-14">
           <p className="mb-4 text-sm font-medium text-muted-foreground">{data.newsletter.label}</p>
           <NewsletterSignup variant="stacked" />
         </div>

--- a/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/ClosingCta.tsx
@@ -35,7 +35,7 @@ export function ClosingCta({
         align="center"
       />
 
-      <div className="mt-10 flex justify-center">
+      <div className="mt-12 flex justify-center sm:mt-14">
         <Button asChild size="lg" glow>
           <a
             href={data.primaryCta.href}

--- a/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/EngagementSteps.tsx
@@ -26,11 +26,11 @@ export function EngagementSteps({ data = FO_HIW_STEPS, path, annotation }: Engag
         align="center"
       />
 
-      <ol className="mx-auto mt-16 grid max-w-4xl list-none grid-cols-1 gap-6 p-0">
+      <ol className="mx-auto mt-12 grid max-w-4xl list-none grid-cols-1 gap-6 p-0 sm:mt-14">
         {data.steps.map((step, index) => (
           <li
             key={step.number}
-            className="grid grid-cols-[auto_1fr] gap-6 rounded-2xl border border-border bg-card p-6 shadow-sm"
+            className="grid grid-cols-[auto_1fr] gap-6 rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8"
           >
             <div
               className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 font-mono text-base font-semibold text-primary"

--- a/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/FearRemoval.tsx
@@ -30,7 +30,7 @@ export function FearRemoval({ data = FO_HIW_FEAR, path, annotation }: FearRemova
         align="start"
       />
 
-      <p className="mt-8 text-base leading-7 text-body" {...field('body')}>
+      <p className="mt-12 text-base leading-7 text-body sm:mt-14" {...field('body')}>
         {data.paragraph1}
       </p>
       <p className="mt-4 text-base leading-7 text-body" {...field('items.0.body')}>
@@ -39,7 +39,7 @@ export function FearRemoval({ data = FO_HIW_FEAR, path, annotation }: FearRemova
 
       <ul className="mt-6 list-none space-y-4 p-0">
         {data.options.map((option, index) => (
-          <li key={option.title} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+          <li key={option.title} className="rounded-2xl bg-card p-6 ring-1 ring-border">
             <h3
               className="text-base font-semibold leading-7 text-foreground"
               {...field(`items.${optionStart + index}.title`)}

--- a/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Ownership.tsx
@@ -28,13 +28,13 @@ export function Ownership({ data = FO_HIW_OWNERSHIP, path, annotation }: Ownersh
         align="start"
       />
 
-      <p className="mt-6 text-base leading-7 text-body" {...field('body')}>
+      <p className="mt-12 text-base leading-7 text-body sm:mt-14" {...field('body')}>
         {data.intro}
       </p>
 
       <ul className="mt-6 list-none space-y-4 p-0">
         {data.claims.map((claim, index) => (
-          <li key={claim.title} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+          <li key={claim.title} className="rounded-2xl bg-card p-6 ring-1 ring-border">
             <h3
               className="text-base font-semibold leading-7 text-foreground"
               {...field(`items.${index}.title`)}

--- a/apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx
+++ b/apps/marketing/app/components/for-operators-how-it-works/Timeline.tsx
@@ -26,7 +26,7 @@ export function Timeline({ data = FO_HIW_TIMELINE, path, annotation }: TimelineP
         align="start"
       />
 
-      <p className="mt-6 text-base leading-7 text-body" {...field('body')}>
+      <p className="mt-12 text-base leading-7 text-body sm:mt-14" {...field('body')}>
         {data.paragraph1}
       </p>
       <p className="mt-4 text-base leading-7 text-body" {...field('items.0.body')}>

--- a/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Prerequisites.tsx
@@ -52,9 +52,9 @@ export function Prerequisites({ data, path, annotation }: FoManagedPrereqsProps 
         align="start"
       />
 
-      <ul className="mt-6 list-none space-y-4 p-0">
+      <ul className="mt-12 list-none space-y-4 p-0 sm:mt-14">
         {content.prerequisites.map((prereq, index) => (
-          <li key={prereq.title} className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+          <li key={prereq.title} className="rounded-2xl bg-card p-6 ring-1 ring-border">
             <h3
               className="text-base font-semibold leading-7 text-foreground"
               {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}

--- a/apps/marketing/app/components/for-operators-managed/Status.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Status.tsx
@@ -45,7 +45,7 @@ export function Status({ data, path, annotation }: FoManagedStatusProps = {}) {
         align="start"
       />
 
-      <div className="mt-8 space-y-6 text-base leading-7 text-body">
+      <div className="mt-12 space-y-6 text-base leading-7 text-body sm:mt-14">
         <p {...(base ? fieldAttrs(ann, `${base}.body`) : {})}>{content.paragraph1}</p>
         <p {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>{content.paragraph2}</p>
         <p {...(base ? fieldAttrs(ann, `${base}.items.1.body`) : {})}>{content.paragraph3}</p>

--- a/apps/marketing/app/components/for-operators-managed/Today.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Today.tsx
@@ -49,7 +49,7 @@ export function Today({ data, path, annotation }: FoManagedTodayProps = {}) {
         align="center"
       />
 
-      <div className="mt-10 flex flex-col items-center gap-4">
+      <div className="mt-12 flex flex-col items-center gap-4 sm:mt-14">
         <Button asChild size="lg">
           <a
             href={content.primaryCta.href}

--- a/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
+++ b/apps/marketing/app/components/for-operators-managed/Waitlist.tsx
@@ -81,13 +81,16 @@ export function Waitlist({ data, path, annotation }: FoManagedWaitlistProps = {}
 
       {status === 'success' ? (
         <p
-          className="mt-10 animate-[fade-in_300ms_ease-out] text-center text-base font-medium text-primary"
+          className="mt-12 animate-[fade-in_300ms_ease-out] text-center text-base font-medium text-primary sm:mt-14"
           {...(base ? fieldAttrs(ann, `${base}.items.3.body`) : {})}
         >
           {message}
         </p>
       ) : (
-        <form onSubmit={handleSubmit} className="mx-auto mt-10 flex max-w-sm flex-col gap-3">
+        <form
+          onSubmit={handleSubmit}
+          className="mx-auto mt-12 flex max-w-sm flex-col gap-3 sm:mt-14"
+        >
           <label htmlFor="waitlist-email" className="sr-only">
             Email address
           </label>

--- a/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
+++ b/apps/marketing/app/components/for-operators-managed/WouldBe.tsx
@@ -48,12 +48,9 @@ export function WouldBe({ data, path, annotation }: FoManagedWouldBeProps = {}) 
         align="center"
       />
 
-      <ul className="mx-auto mt-16 grid max-w-4xl list-none grid-cols-1 gap-6 p-0">
+      <ul className="mx-auto mt-12 grid max-w-4xl list-none grid-cols-1 gap-6 p-0 sm:mt-14">
         {content.capabilities.map((capability, index) => (
-          <li
-            key={capability.title}
-            className="rounded-2xl border border-border bg-card p-6 shadow-sm"
-          >
+          <li key={capability.title} className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
             <h3
               className="text-lg font-semibold leading-7 text-foreground"
               {...(base ? fieldAttrs(ann, `${base}.items.${index}.label`) : {})}

--- a/apps/marketing/app/components/for-operators/ClosingCta.tsx
+++ b/apps/marketing/app/components/for-operators/ClosingCta.tsx
@@ -40,7 +40,7 @@ export function ClosingCta({ data, path, annotation }: ClosingCtaProps = {}) {
         align="center"
       />
 
-      <div className="mt-10 flex justify-center">
+      <div className="mt-12 flex justify-center sm:mt-14">
         <Button asChild size="lg" glow>
           <a
             href={content.primaryCta.href}

--- a/apps/marketing/app/components/for-operators/DiscoveryScopeShip.tsx
+++ b/apps/marketing/app/components/for-operators/DiscoveryScopeShip.tsx
@@ -46,7 +46,7 @@ export function DiscoveryScopeShip({ data, path, annotation }: DiscoveryScopeShi
         }
         align="center"
       />
-      <p className="mt-8 text-center">
+      <p className="mt-12 text-center sm:mt-14">
         <a
           href={content.link.href}
           className="font-medium text-primary underline-offset-4 hover:underline"

--- a/apps/marketing/app/components/for-operators/EngagementPricing.tsx
+++ b/apps/marketing/app/components/for-operators/EngagementPricing.tsx
@@ -52,11 +52,11 @@ export function EngagementPricing({ data, path, annotation }: EngagementPricingP
         align="center"
       />
 
-      <ul className="mx-auto mt-16 grid max-w-5xl list-none grid-cols-1 gap-6 p-0 lg:grid-cols-3">
+      <ul className="mx-auto mt-12 grid max-w-5xl list-none grid-cols-1 gap-6 p-0 sm:mt-14 lg:grid-cols-3">
         {rungs.map((rung) => (
           <li
             key={rung.title}
-            className="flex flex-col rounded-2xl border border-border bg-card p-8 shadow-sm"
+            className="flex flex-col rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8"
           >
             <h3 className="text-lg font-semibold leading-7 text-foreground">{rung.title}</h3>
             <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{rung.price}</p>

--- a/apps/marketing/app/components/for-operators/Faq.tsx
+++ b/apps/marketing/app/components/for-operators/Faq.tsx
@@ -15,7 +15,7 @@ export function Faq() {
         align="center"
       />
 
-      <Accordion className="mx-auto mt-16 max-w-3xl border-t border-border">
+      <Accordion className="mx-auto mt-12 max-w-3xl border-t border-border sm:mt-14">
         {FOR_OPERATORS_FAQ.items.map((item) => (
           <AccordionItem
             key={item.question}

--- a/apps/marketing/app/components/for-operators/HowWeDeliver.tsx
+++ b/apps/marketing/app/components/for-operators/HowWeDeliver.tsx
@@ -34,7 +34,7 @@ export function HowWeDeliver({ data, path, annotation }: HowWeDeliverProps = {})
         align="start"
       />
 
-      <div className="mt-8 space-y-6 text-base leading-7 text-body">
+      <div className="mt-12 space-y-6 text-base leading-7 text-body sm:mt-14">
         <p {...(base ? fieldAttrs(ann, `${base}.body`) : {})}>{paragraph1}</p>
         <p>
           <span {...(base ? fieldAttrs(ann, `${base}.items.0.body`) : {})}>

--- a/apps/marketing/app/components/for-operators/Proof.tsx
+++ b/apps/marketing/app/components/for-operators/Proof.tsx
@@ -54,7 +54,7 @@ export function Proof({ data, path, annotation }: ProofProps = {}) {
       />
 
       <p
-        className="mt-6 text-base leading-7 text-body"
+        className="mt-12 text-base leading-7 text-body sm:mt-14"
         {...(base ? fieldAttrs(ann, `${base}.items.${introItemIndex}.body`) : {})}
       >
         {content.bulletIntro}

--- a/apps/marketing/app/components/for-operators/WhatYouGet.tsx
+++ b/apps/marketing/app/components/for-operators/WhatYouGet.tsx
@@ -48,11 +48,11 @@ export function WhatYouGet({ data, path, annotation }: WhatYouGetProps = {}) {
         align="center"
       />
 
-      <CenteredCardGrid className="mx-auto mt-16 max-w-5xl">
+      <CenteredCardGrid className="mx-auto mt-12 max-w-5xl sm:mt-14">
         {content.cards.map((card, index) => (
           <div
             key={card.title}
-            className="w-full rounded-2xl border border-border bg-card p-6 shadow-sm sm:w-[calc(50%-0.75rem)] lg:w-[calc(33.333%-1rem)]"
+            className="w-full rounded-2xl bg-card p-6 ring-1 ring-border sm:w-[calc(50%-0.75rem)] sm:p-8 lg:w-[calc(33.333%-1rem)]"
           >
             <h3
               className="text-lg font-semibold leading-7 text-foreground"

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -36,14 +36,14 @@ export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {}
 
       {/* Product-as-proof: live component frame (Linear craft pattern).
           Content mockupCaption was previously unwired; honesty line stays. */}
-      <div className="mt-14 sm:mt-16">
+      <div className="mt-12 sm:mt-14">
         <ProductFrame caption={HOME_DEMO.mockupCaption} />
       </div>
 
       {/* Beats as aligned stack, not three bordered cards (Linear: density over chrome). */}
-      <ol className="mx-auto mt-14 grid max-w-5xl list-none grid-cols-1 gap-0 divide-y divide-border border-y border-border p-0 sm:mt-16 lg:grid-cols-3 lg:gap-0 lg:divide-x lg:divide-y-0">
+      <ol className="mx-auto mt-12 grid max-w-5xl list-none grid-cols-1 gap-0 divide-y divide-border border-y border-border p-0 sm:mt-14 lg:grid-cols-3 lg:gap-0 lg:divide-x lg:divide-y-0">
         {data.beats.map((b, index) => (
-          <li key={b.n} className="relative px-0 py-7 lg:px-8 lg:py-8 first:lg:pl-0 last:lg:pr-0">
+          <li key={b.n} className="relative px-0 py-6 lg:px-8 lg:py-7 first:lg:pl-0 last:lg:pr-0">
             <div
               className="font-mono text-[11px] font-medium tabular-nums tracking-widest text-muted-foreground"
               {...fieldAttrs(annotation, `${path}.items.${index}.label`)}

--- a/apps/marketing/app/components/landing/Faq.tsx
+++ b/apps/marketing/app/components/landing/Faq.tsx
@@ -28,7 +28,7 @@ export function Faq({ data = HOME_FAQ, path = 'blocks.1.data', annotation = {} }
         align="center"
       />
 
-      <Accordion className="mx-auto mt-16 max-w-3xl border-t border-border">
+      <Accordion className="mx-auto mt-12 max-w-3xl border-t border-border sm:mt-14">
         {data.items.map((item, index) => (
           <AccordionItem
             key={item.question}

--- a/apps/marketing/app/components/landing/PricingTeaser.tsx
+++ b/apps/marketing/app/components/landing/PricingTeaser.tsx
@@ -80,7 +80,7 @@ export function PricingTeaser() {
         align="center"
       />
 
-      <div className="mx-auto mt-14 max-w-3xl sm:mt-16">
+      <div className="mx-auto mt-12 max-w-3xl sm:mt-14">
         <PricingTable tiers={tiers} highlightedLabel="Recommended" />
       </div>
 

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -68,14 +68,14 @@ export function Primitives({
 
       {/* Quiet stacked rows (not a card grid). Linear craft: density + alignment
           over decorative cards. Alternating icon side still gives rhythm. */}
-      <div className="mx-auto mt-14 max-w-3xl divide-y divide-border border-y border-border sm:mt-16">
+      <div className="mx-auto mt-12 max-w-3xl divide-y divide-border border-y border-border sm:mt-14">
         {data.items.map((item, index) => {
           const flipped = index % 2 === 1;
           const style = primitiveStyles[index];
           return (
             <div
               key={item.label}
-              className={`flex flex-col gap-4 py-8 sm:items-center sm:gap-8 sm:py-10 ${
+              className={`flex flex-col gap-4 py-7 sm:items-center sm:gap-8 sm:py-8 ${
                 flipped ? 'sm:flex-row-reverse' : 'sm:flex-row'
               }`}
             >

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -59,7 +59,7 @@ export function Problem() {
 
       {/* Path blurbs: three quiet lines under the intro, not three cards. */}
       <ul
-        className="mx-auto mt-10 flex max-w-3xl flex-col gap-3 text-left sm:mt-12"
+        className="mx-auto mt-12 flex max-w-3xl flex-col gap-3 text-left sm:mt-14"
         aria-label="Three paths"
       >
         {(
@@ -103,11 +103,14 @@ export function Problem() {
       </ul>
 
       <ul
-        className="mx-auto mt-14 max-w-3xl list-none border-t border-border p-0 sm:mt-16"
+        className="mx-auto mt-12 max-w-3xl list-none border-t border-border p-0 sm:mt-14"
         aria-label={HOME_PROBLEM.tableAriaLabel}
       >
         {HOME_PROBLEM.rows.map((row) => (
-          <li key={row.capability} className="border-b border-border py-8 first:pt-10 last:pb-2">
+          <li
+            key={row.capability}
+            className="border-b border-border py-6 first:pt-8 last:pb-2 sm:py-7 sm:first:pt-9"
+          >
             <h3 className="font-display text-base font-semibold tracking-tight text-foreground sm:text-lg">
               {row.capability}
             </h3>

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -14,7 +14,7 @@ export function Proof() {
         align="center"
       />
 
-      <div className="mt-6 flex justify-center">
+      <div className="mt-12 flex justify-center sm:mt-14">
         <a
           href={SITE.urls.repo}
           target="_blank"
@@ -26,11 +26,11 @@ export function Proof() {
         </a>
       </div>
 
-      <div className="mt-14 sm:mt-16">
+      <div className="mt-10 sm:mt-12">
         <LiveMetricsBadge />
       </div>
 
-      <div className="mx-auto mt-12 max-w-2xl text-center">
+      <div className="mx-auto mt-10 max-w-2xl text-center sm:mt-12">
         <p className="text-base leading-7 text-body">
           {PROOF_TRUST.body}{' '}
           <a
@@ -56,7 +56,7 @@ export function Proof() {
       </div>
 
       {/* Secondary FDE layer — same homepage section (≤7 rule), not a new section */}
-      <div className="mx-auto mt-16 max-w-2xl border-t border-border pt-14 text-center">
+      <div className="mx-auto mt-12 max-w-2xl border-t border-border pt-12 text-center sm:mt-14 sm:pt-14">
         <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
           {PROOF_DEPLOYERS.eyebrow}
         </p>

--- a/apps/marketing/app/components/products/ProductsCta.tsx
+++ b/apps/marketing/app/components/products/ProductsCta.tsx
@@ -29,7 +29,7 @@ export function ProductsCta({
         align="center"
       />
       <div
-        className="mt-8 rounded-lg bg-foreground px-6 py-4 text-left font-mono text-sm text-background"
+        className="mt-12 rounded-2xl bg-foreground px-6 py-4 text-left font-mono text-sm text-background sm:mt-14"
         {...fieldAttrs(annotation, `${path}.snippet.lines`)}
       >
         <span className="text-background/50">$</span> {data.cliSnippet}
@@ -37,7 +37,7 @@ export function ProductsCta({
       <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
         <a
           href={data.cta.docs.href}
-          className="rounded-md bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+          className="rounded-md bg-primary px-8 py-4 text-base font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
         >
           {data.cta.docs.label}
         </a>

--- a/apps/marketing/app/routes/ClaimsPage.tsx
+++ b/apps/marketing/app/routes/ClaimsPage.tsx
@@ -154,16 +154,16 @@ function ClaimRow({
   route: string;
 }) {
   return (
-    <li className="py-6" data-testid="claim-row">
+    <li className="py-5 sm:py-6" data-testid="claim-row">
       <p className="text-sm leading-6 text-foreground">{claim.text}</p>
-      <p className="mt-1 font-mono text-xs text-muted-foreground">
+      <p className="mt-1.5 font-mono text-xs text-muted-foreground">
         Proves{' '}
         <a href={route} className="text-primary hover:text-primary/80">
           {pageTitle}
         </a>{' '}
         &middot; {claim.exportPath}
       </p>
-      <ul className="mt-2">
+      <ul className="mt-2.5">
         {claim.evidence.map((ev, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: evidence refs carry no stable id of their own
           <EvidenceRow key={`${claim.exportPath}-${i}`} evidence={ev} />
@@ -176,7 +176,7 @@ function ClaimRow({
 export function ClaimsPage() {
   return (
     <div className="min-h-screen bg-background">
-      <header className="border-b border-border px-6 pt-24 pb-12 lg:px-8">
+      <header className="border-b border-border px-6 pt-24 pb-10 sm:pb-12 lg:px-8">
         <div className="mx-auto max-w-3xl">
           <p className="text-sm font-semibold uppercase tracking-widest text-primary">
             {CLAIMS_HERO.eyebrow}
@@ -259,15 +259,15 @@ export function ClaimsPage() {
               key={section.file}
               id={anchorId(section.file)}
               aria-labelledby={`${anchorId(section.file)}-heading`}
-              className="py-8"
+              className="py-7 sm:py-8"
             >
               <h2
                 id={`${anchorId(section.file)}-heading`}
-                className="text-xl font-semibold text-foreground"
+                className="text-xl font-semibold tracking-tight text-foreground"
               >
                 {section.pageTitle}
               </h2>
-              <p className="mt-1 font-mono text-xs text-muted-foreground">
+              <p className="mt-1.5 font-mono text-xs text-muted-foreground">
                 <a href={section.route} className="text-primary hover:text-primary/80">
                   {section.route}
                 </a>{' '}
@@ -279,7 +279,7 @@ export function ClaimsPage() {
               {section.claims.length === 0 ? (
                 <p className="mt-4 text-sm text-body">No indexed claims yet for this file.</p>
               ) : (
-                <ol className="mt-4 divide-y divide-border">
+                <ol className="mt-5 divide-y divide-border">
                   {section.claims.map((claim) => (
                     <ClaimRow
                       key={claim.exportPath}
@@ -290,7 +290,7 @@ export function ClaimsPage() {
                   ))}
                 </ol>
               )}
-              {i < FILE_SECTIONS.length - 1 && <Divider soft className="mt-8" />}
+              {i < FILE_SECTIONS.length - 1 && <Divider soft className="mt-6 sm:mt-8" />}
             </section>
           ))}
         </div>
@@ -311,7 +311,7 @@ export function ClaimsPage() {
               ))}
             </ul>
           </Callout>
-          <div className="rounded-xl bg-muted p-4 ring-1 ring-border">
+          <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
             <p className="text-sm font-semibold text-foreground">
               {CLAIMS_HONESTY_RAILS_SECTION.notCheckedHeading}
             </p>

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -52,11 +52,11 @@ function FairSourceContract({ data, path, annotation }: ContractProps) {
         align="center"
       />
 
-      <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:mt-14 sm:grid-cols-2">
         {data.cards.map((c, index) => (
           <div
             key={c.title}
-            className={`rounded-2xl p-6 ring-1 transition ${
+            className={`rounded-2xl p-6 ring-1 transition sm:p-8 ${
               c.kind === 'yes'
                 ? 'bg-primary/10 ring-primary/20'
                 : 'bg-amber-500/15 ring-amber-500/30'
@@ -111,7 +111,7 @@ function FairSourcePackagesIntro({ data, path, annotation }: PackagesIntroProps)
         align="center"
       />
 
-      <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-card ring-1 ring-border">
+      <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-2xl bg-card ring-1 ring-border sm:mt-14">
         <table className="w-full text-left text-sm">
           <thead className="bg-muted text-xs font-semibold uppercase tracking-widest text-muted-foreground">
             <tr>
@@ -192,10 +192,10 @@ function FairSourceClock({ data, path, annotation }: ClockProps) {
         align="center"
       />
 
-      <div className="mx-auto mt-12 max-w-3xl">
+      <div className="mx-auto mt-12 max-w-3xl sm:mt-14">
         <ol className="relative border-l-2 border-primary/20 pl-8">
           {data.steps.map((step, index) => (
-            <li key={step.title} className="mb-8 last:mb-0">
+            <li key={step.title} className="mb-7 last:mb-0 sm:mb-8">
               <span
                 className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-background ${
                   step.color === 'emerald' ? 'bg-primary' : 'bg-amber-600'
@@ -237,14 +237,14 @@ function FairSourcePeers({ data, path, annotation }: PeersProps) {
         align="center"
       />
 
-      <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:mt-14 sm:grid-cols-3">
         {data.peers.map((p, index) => (
           <a
             key={p.name}
             href={p.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="rounded-2xl bg-card p-6 ring-1 ring-border no-underline transition hover:ring-border/60"
+            className="rounded-2xl bg-card p-6 ring-1 ring-border no-underline transition hover:ring-border/60 sm:p-8"
           >
             <h3
               className="text-lg font-semibold text-foreground"
@@ -280,9 +280,9 @@ function FairSourceFaq({ data, path, annotation }: FaqProps) {
         align="center"
       />
 
-      <div className="mx-auto mt-12 max-w-3xl divide-y divide-border">
+      <div className="mx-auto mt-12 max-w-3xl divide-y divide-border sm:mt-14">
         {data.items.map((f, index) => (
-          <details key={f.question} className="group py-6">
+          <details key={f.question} className="group py-5 sm:py-6">
             <summary className="flex cursor-pointer list-none items-start justify-between gap-6 text-left">
               <h3
                 className="text-lg font-semibold leading-7 text-foreground"
@@ -319,7 +319,7 @@ function FairSourceCta({ data, path, annotation }: CtaProps) {
         description={<span {...fieldAttrs(annotation, `${path}.body`)}>{data.body}</span>}
         align="center"
       />
-      <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+      <div className="mt-12 flex flex-col items-center justify-center gap-4 sm:mt-14 sm:flex-row">
         <Button asChild size="lg" variant="brand">
           <a href={data.primary.href} {...fieldAttrs(annotation, `${path}.links.0.label`)}>
             {data.primary.label}

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -79,7 +79,10 @@ function LocalAiPillars({ data, path, annotation }: LocalAiPillarsProps) {
     <MarketingSection tone="background" density="compact" width="default">
       <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
         {data.pillars.map((pillar, index) => (
-          <div key={`pillar-${index}`} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+          <div
+            key={`pillar-${index}`}
+            className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8"
+          >
             <h2
               className="text-lg font-semibold text-foreground"
               {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
@@ -145,9 +148,9 @@ function LocalAiMarketProof({ data, path, annotation }: LocalAiMarketProofProps)
         align="start"
         titleClassName="text-2xl sm:text-3xl"
       />
-      <ul className="mt-8 list-none space-y-4 p-0">
+      <ul className="mt-12 list-none space-y-4 p-0 sm:mt-14">
         {data.adopters.map((adopter, index) => (
-          <li key={`adopter-${index}`} className="rounded-xl bg-secondary p-5 ring-1 ring-border">
+          <li key={`adopter-${index}`} className="rounded-2xl bg-card p-6 ring-1 ring-border">
             <p className="text-base text-foreground">
               <span
                 className="font-semibold"
@@ -195,7 +198,7 @@ function LocalAiNotes({ data, path, annotation }: LocalAiNotesProps) {
         >
           {data.dogfood}
         </p>
-        <div className="rounded-xl border border-border bg-card p-5">
+        <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
           <p
             className="text-sm font-semibold uppercase tracking-widest text-muted-foreground"
             {...fieldAttrs(annotation, `${path}.items.2.title`)}

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -159,16 +159,16 @@ export function PricingPage() {
           title={PRICING_TRACK_A_SECTION.heading}
           description={PRICING_TRACK_A_SECTION.body}
           align="center"
-          className="mb-12"
+          className="mb-10 sm:mb-12"
         />
 
         {/* Value band: you own the runtime (no competitor prices) */}
-        <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-8 ring-1 ring-primary/15">
+        <div className="mx-auto mb-10 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-6 ring-1 ring-primary/15 sm:mb-12 sm:p-8">
           <h3 className="text-2xl font-bold tracking-tight text-foreground">
             {PRICING_VALUE_BAND.heading}
           </h3>
           <p className="mt-3 text-sm leading-6 text-body">{PRICING_VALUE_BAND.body}</p>
-          <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <ul className="mt-5 grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:gap-3">
             {PRICING_VALUE_BAND.points.map((point) => (
               <li key={point} className="flex items-start gap-2 text-sm text-body">
                 <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
@@ -200,7 +200,7 @@ export function PricingPage() {
                 className="rounded-full"
               >
                 Annually
-                <span className="ml-1.5 rounded-full bg-green-500/15 px-1.5 py-0.5 text-xs font-semibold text-green-800 dark:text-green-400">
+                <span className="ml-1.5 rounded-full bg-success/15 px-1.5 py-0.5 text-xs font-semibold text-success">
                   Save 20%
                 </span>
               </Button>
@@ -243,11 +243,11 @@ export function PricingPage() {
           title={PRICING_TRACK_C_SECTION.heading}
           description={PRICING_TRACK_C_SECTION.body}
           align="center"
-          className="mb-12"
+          className="mb-10 sm:mb-12"
         />
 
         {/* Studio / agency reseller value band: the multi-client P&L */}
-        <div className="mx-auto mb-16 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-8 ring-1 ring-primary/15">
+        <div className="mx-auto mb-10 max-w-4xl rounded-2xl bg-gradient-to-br from-primary/5 to-card p-6 ring-1 ring-primary/15 sm:mb-12 sm:p-8">
           <span className="text-sm font-semibold uppercase tracking-widest text-primary">
             {PRICING_AGENCY_VALUE_BAND.eyebrow}
           </span>
@@ -255,7 +255,7 @@ export function PricingPage() {
             {PRICING_AGENCY_VALUE_BAND.heading}
           </h3>
           <p className="mt-3 text-sm leading-6 text-body">{PRICING_AGENCY_VALUE_BAND.body}</p>
-          <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <ul className="mt-5 grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:gap-3">
             {PRICING_AGENCY_VALUE_BAND.points.map((point) => (
               <li key={point} className="flex items-start gap-2 text-sm text-body">
                 <IconCheckCircle className="mt-0.5 shrink-0 text-primary" size="md" />
@@ -269,7 +269,7 @@ export function PricingPage() {
           {perpetualTiers.map((tier) => (
             <div
               key={tier.name}
-              className="relative flex flex-col rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border"
+              className="relative flex flex-col rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8"
             >
               {tier.comingSoon && (
                 <div className="absolute right-4 top-4">
@@ -316,7 +316,7 @@ export function PricingPage() {
       {/* For AI Agents */}
       <MarketingSection id="for-agents" tone="secondary" density="default" width="default">
         <div className="mx-auto max-w-4xl">
-          <div className="mb-12 text-center">
+          <div className="mb-10 text-center sm:mb-12">
             <SectionHeader
               eyebrow={PRICING_AGENTS_SECTION.eyebrow}
               eyebrowTone="primary"
@@ -330,7 +330,7 @@ export function PricingPage() {
           </div>
 
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-            <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
+            <div className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
               <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
                 <IconSearch size="md" className="text-primary" />
               </div>
@@ -351,7 +351,7 @@ export function PricingPage() {
               </p>
             </div>
 
-            <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
+            <div className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
               <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 ring-1 ring-blue-500/20">
                 <IconCode size="md" className="text-blue-600" />
               </div>
@@ -361,7 +361,7 @@ export function PricingPage() {
               <p className="mt-2 text-sm text-body">{PRICING_AGENT_X402.body}</p>
             </div>
 
-            <div className="rounded-2xl bg-card p-6 ring-1 ring-border">
+            <div className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
               <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-violet-500/10 ring-1 ring-violet-500/20">
                 <IconTerminal size="md" className="text-violet-600" />
               </div>
@@ -400,7 +400,7 @@ export function PricingPage() {
 
       {/* GAP-434 Starter Kit — one-time content product (Stripe Payment Link) */}
       <MarketingSection id="starter-kit" tone="background" density="default" width="default">
-        <div className="mx-auto max-w-3xl rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border sm:p-10">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
           <div className="flex flex-wrap items-center gap-3">
             <span className="text-sm font-semibold uppercase tracking-widest text-primary">
               {PRICING_STARTER_KIT.eyebrow}
@@ -458,7 +458,7 @@ export function PricingPage() {
 
       {/* GAP-448 Agency Founding Kit — Agency Perpetual self-serve path */}
       <MarketingSection id="agency-founding-kit" tone="secondary" density="default" width="default">
-        <div className="mx-auto max-w-3xl rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border sm:p-10">
+        <div className="mx-auto max-w-3xl rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
           <span className="text-sm font-semibold uppercase tracking-widest text-primary">
             {PRICING_AGENCY_FOUNDING_KIT.eyebrow}
           </span>
@@ -521,12 +521,12 @@ export function PricingPage() {
           title={PRICING_DONE_FOR_YOU.heading}
           description={PRICING_DONE_FOR_YOU.body}
           align="center"
-          className="mb-12"
+          className="mb-10 sm:mb-12"
         />
 
         <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-3">
           {PRICING_DONE_FOR_YOU.rungs.map((rung) => (
-            <div key={rung.name} className="rounded-2xl bg-card p-6 ring-1 ring-border">
+            <div key={rung.name} className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
               <h3 className="text-base font-semibold text-foreground">{rung.name}</h3>
               <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{rung.price}</p>
               <p className="mt-3 text-sm text-body">{rung.note}</p>
@@ -565,8 +565,12 @@ export function PricingPage() {
       {/* FAQ Section */}
       <MarketingSection tone="background" density="default" width="default">
         <div className="mx-auto max-w-4xl">
-          <SectionHeader title={PRICING_FAQ_SECTION.heading} align="center" className="mb-12" />
-          <Accordion className="rounded-lg border border-border bg-card px-4 sm:px-6">
+          <SectionHeader
+            title={PRICING_FAQ_SECTION.heading}
+            align="center"
+            className="mb-10 sm:mb-12"
+          />
+          <Accordion className="rounded-2xl bg-card px-4 ring-1 ring-border sm:px-6">
             {PRICING_FAQS.map((faq) => (
               <AccordionItem
                 key={faq.question}
@@ -589,8 +593,9 @@ export function PricingPage() {
           title={PRICING_FINAL_CTA.title}
           description={PRICING_FINAL_CTA.subtitle}
           align="center"
+          className="mb-10 sm:mb-12"
         />
-        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Button asChild size="lg" className="w-full sm:w-auto">
             <a
               href={
@@ -614,7 +619,7 @@ export function PricingPage() {
             </a>
           </Button>
         </div>
-        <div className="mt-16 border-t border-border pt-10 text-center">
+        <div className="mt-12 border-t border-border pt-10 text-center sm:mt-14">
           <p className="mb-4 text-sm font-medium text-muted-foreground">
             {PRICING_NEWSLETTER_LABEL}
           </p>

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -158,7 +158,7 @@ export function ProductsPage() {
 
         {/* Status filter chips (Phase D, interactive). */}
         <div
-          className="mt-10 flex flex-wrap items-center justify-center gap-2"
+          className="mt-12 flex flex-wrap items-center justify-center gap-2 sm:mt-14"
           role="tablist"
           aria-label="Filter products by status"
         >
@@ -183,14 +183,14 @@ export function ProductsPage() {
           })}
         </div>
 
-        <ul className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
+        <ul className="mt-10 grid grid-cols-1 gap-6 sm:mt-12 md:grid-cols-2">
           {visibleSisters.map((product) => {
             const status = PRODUCT_STATUS_STYLES[product.status];
             return (
               <li
                 key={product.slug}
                 id={product.slug}
-                className="group relative flex flex-col rounded-2xl bg-card p-8 shadow-sm ring-1 ring-border transition-shadow hover:shadow-lg"
+                className="group relative flex flex-col rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex items-center gap-4">
@@ -265,9 +265,9 @@ export function ProductsPage() {
           title={PRODUCTS_STATS_SECTION.heading}
           description={PRODUCTS_STATS_SECTION.body}
           align="center"
-          className="mb-16"
+          className="mb-10 sm:mb-12"
         />
-        <div className="grid grid-cols-2 gap-8 sm:grid-cols-4">
+        <div className="grid grid-cols-2 gap-6 sm:grid-cols-4 sm:gap-8">
           {PRODUCTS_STATS_SECTION.items.map((item) => (
             <div key={item.label} className="text-center">
               <p className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">


### PR DESCRIPTION
## Summary

Final free-agent slice of the marketing UI system program (after shells #2564, rewire #2567, type-burn #2569, PricingTable/FAQ #2571):

- Standardize **post-SectionHeader density** (`mt-12 sm:mt-14` / `mb-10 sm:mb-12`)
- Quiet content **cards** (`rounded-2xl bg-card ring-1 ring-border`, less mixed shadow)
- Pricing annual savings chip: **semantic success tokens** (not raw green palette)
- Touches home, pricing, for-operators*, products, local-ai, claims, fair-source

**Claim copy unchanged.** No new design primitives.

## Test plan

- [x] marketing tests 154 passed
- [x] marketing production build
- [x] local phase-1 gate PASS
- [ ] CI green
- [ ] Spot-check `/`, `/pricing`, `/services` light+dark after merge

## Program complete (on merge)

| Step | PR |
|------|-----|
| Section shells | #2564 |
| Section rewire | #2567 |
| Type burn-down | #2569 |
| PricingTable + Accordion | #2571 |
| Route craft | this PR |

Next: promote `test` → `main` when you want prod; optional DesignSync Loop A.