### PR TITLE
fix(marketing): AA contrast on pricing annual Save chip

### DIFF
--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -200,7 +200,7 @@ export function PricingPage() {
                 className="rounded-full"
               >
                 Annually
-                <span className="ml-1.5 rounded-full bg-success/15 px-1.5 py-0.5 text-xs font-semibold text-success">
+                <span className="ml-1.5 rounded-full bg-success-strong px-1.5 py-0.5 text-xs font-semibold text-success-foreground">
                   Save 20%
                 </span>
               </Button>


### PR DESCRIPTION
## Summary

Fixes Accessibility E2E on the promote path: pricing page WCAG 2.1 AA color-contrast failure on the annual **Save 20%** chip.

**Before:** `bg-success/15` + `text-success` → ~4.27:1 at 12px (needs 4.5:1).  
**After:** `bg-success-strong` + `text-success-foreground` (solid fill + on-fill ink).

## Test plan

- [x] Local phase-1 gate PASS
- [ ] CI green including Accessibility (E2E) on pricing
- [ ] Re-run promote `test` → `main` after this lands on test