### PR TITLE
test(validate): extend tier-1 presentation gate (GAP-479)

### DIFF
--- a/scripts/validate/README.md
+++ b/scripts/validate/README.md
@@ -38,6 +38,7 @@ tsx scripts/validate/boundary.ts
 | `structure.ts`       | `pnpm validate:structure`| Enforce project structure                      |
 | `build-artifacts.ts` | `pnpm validate:artifacts`| Validate build artifacts                       |
 | `react-rsc-floor.ts` | `pnpm validate:react-floor` | Enforce the React Server Component floor    |
+| `tier1-presentation.ts` | `pnpm validate:tier1-presentation` | Tier-1 JSX hosts must come from `@revealui/presentation` (GAP-398 / GAP-479). `--repo-root` / `--root` for sibling repos. |
 | `validate-code.ts`   | run via `tsx`          | Validate code files against RevealUI standards   |
 | `validate-root-markdown.ts` | run via `tsx`   | Enforce which `.md` files may live in the repo root |
 

--- a/scripts/validate/__tests__/tier1-presentation.test.ts
+++ b/scripts/validate/__tests__/tier1-presentation.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SCAN_ROOTS,
+  isAllowlisted,
+  parseCliArgs,
+  partitionHits,
+  scanFile,
+} from '../tier1-presentation';
+
+describe('parseCliArgs', () => {
+  it('defaults to the monorepo GAP-479 scan window', () => {
+    const opts = parseCliArgs([], '/repo');
+    expect(opts.hardFail).toBe(false);
+    expect(opts.scanRoots).toEqual([...DEFAULT_SCAN_ROOTS]);
+    expect(opts.scanRoots).toContain('packages/core');
+    expect(opts.scanRoots).toContain('packages/cli/templates');
+    expect(opts.scanRoots).toContain('apps/rsc-poc');
+  });
+
+  it('accepts --repo-root, --root, --hard-fail, and --allowlist', () => {
+    const opts = parseCliArgs(
+      [
+        '--repo-root',
+        '/demo',
+        '--root',
+        'app',
+        '--root',
+        'src',
+        '--hard-fail',
+        '--allowlist',
+        '/demo/allow.json',
+      ],
+      '/repo',
+    );
+    expect(opts.repoRoot).toBe('/demo');
+    expect(opts.scanRoots).toEqual(['app', 'src']);
+    expect(opts.hardFail).toBe(true);
+    expect(opts.allowlistPath).toBe('/demo/allow.json');
+  });
+});
+
+describe('scanFile + allowlist', () => {
+  it('flags Tier-1 host tags and ignores composed components', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'tier1-'));
+    const file = join(dir, 'Page.tsx');
+    writeFileSync(
+      file,
+      `export function Page() {
+  return (
+    <section>
+      <Button>ok</Button>
+      <input type="text" />
+      <button type="button">raw</button>
+    </section>
+  );
+}
+`,
+      'utf8',
+    );
+    const hits = scanFile(file, dir);
+    expect(hits.map((h) => h.tag).sort()).toEqual(['button', 'input']);
+  });
+
+  it('requires a non-empty reason to allowlist', () => {
+    expect(isAllowlisted('a.tsx', 'button', [{ path: 'a.tsx', tag: 'button', reason: '' }])).toBe(
+      false,
+    );
+    expect(
+      isAllowlisted('a.tsx', 'button', [
+        { path: 'a.tsx', tag: 'button', reason: 'chart primitive' },
+      ]),
+    ).toBe(true);
+  });
+
+  it('partitions allowlisted hits from violations', () => {
+    const { violations, allowlisted } = partitionHits(
+      [
+        { path: 'a.tsx', tag: 'button', line: 1, col: 1 },
+        { path: 'b.tsx', tag: 'svg', line: 2, col: 1 },
+      ],
+      [{ path: 'b.tsx', tag: 'svg', reason: 'data-driven chart' }],
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.path).toBe('a.tsx');
+    expect(allowlisted).toHaveLength(1);
+  });
+});

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -1,5 +1,5 @@
 {
-  "description": "Allowlisted Tier-1 JSX intrinsics in apps/* (GAP-398 residual floor). Hard-fail gate: pnpm validate:tier1-presentation -- --hard-fail. Each entry needs a non-empty reason. Intentional floor classes: data charts, Lexical letterform toolbar icons, CMS/content-driven path icons. ADR 2026-05-16 amendment 2026-07-21. Do not empty without new presentation primitives.",
+  "description": "Allowlisted Tier-1 JSX intrinsics until burned to @revealui/presentation (GAP-398 residual floor + GAP-479 extra roots). Each entry needs a non-empty reason. Hard-fail: pnpm validate:tier1-presentation -- --hard-fail.",
   "entries": [
     {
       "path": "apps/admin/src/components/revealui/sections/stats-with-graph.tsx",
@@ -22,14 +22,204 @@
       "reason": "Lexical toolbar letterform icon (custom Aa glyph); no Icon* match (GAP-398 residual)"
     },
     {
-      "path": "apps/marketing/app/components/landing/Primitives.tsx",
-      "tag": "svg",
-      "reason": "CMS/static content-driven icon path data per primitive; no Icon* match (GAP-398 residual)"
-    },
-    {
       "path": "apps/marketing/app/routes/ProductsPage.tsx",
       "tag": "svg",
       "reason": "content-driven product icon path data; no Icon* match (GAP-398 residual)"
+    },
+    {
+      "path": "apps/rsc-poc/src/pages/action-form.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
+    },
+    {
+      "path": "apps/rsc-poc/src/pages/action-form.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
+    },
+    {
+      "path": "apps/rsc-poc/src/pages/counter.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
+    },
+    {
+      "path": "apps/rsc-poc/src/pages/errors-client.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
+    },
+    {
+      "path": "apps/rsc-poc/src/pages/session-client.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
+    },
+    {
+      "path": "apps/rsc-poc/src/pages/session.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
+    },
+    {
+      "path": "apps/rsc-poc/src/pages/session.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/AdminDashboard.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/AdminDashboard.tsx",
+      "tag": "svg",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/CollectionList.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/CollectionList.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/CollectionList.tsx",
+      "tag": "svg",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/DocumentForm.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/DocumentForm.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/DocumentForm.tsx",
+      "tag": "select",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/DocumentForm.tsx",
+      "tag": "textarea",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/GlobalForm.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/GlobalForm.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/GlobalForm.tsx",
+      "tag": "select",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/components/GlobalForm.tsx",
+      "tag": "textarea",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/admin/page.tsx",
+      "tag": "svg",
+      "reason": "GAP-479 later slice: core admin forms; replace with presentation Button/Input/Select/Textarea"
+    },
+    {
+      "path": "packages/core/src/client/richtext/components/ImageNodeComponent.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: Lexical editor chrome in @revealui/core; compose presentation after toolbar rewrite"
+    },
+    {
+      "path": "packages/core/src/client/richtext/components/ImageNodeComponent.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: Lexical editor chrome in @revealui/core; compose presentation after toolbar rewrite"
+    },
+    {
+      "path": "packages/core/src/client/richtext/components/ImageUploadButton.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: Lexical editor chrome in @revealui/core; compose presentation after toolbar rewrite"
+    },
+    {
+      "path": "packages/core/src/client/richtext/components/ImageUploadButton.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: Lexical editor chrome in @revealui/core; compose presentation after toolbar rewrite"
+    },
+    {
+      "path": "packages/core/src/client/richtext/plugins/FloatingToolbarPlugin.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: Lexical editor chrome in @revealui/core; compose presentation after toolbar rewrite"
+    },
+    {
+      "path": "packages/core/src/client/richtext/plugins/FloatingToolbarPlugin.tsx",
+      "tag": "select",
+      "reason": "GAP-479 later slice: Lexical editor chrome in @revealui/core; compose presentation after toolbar rewrite"
+    },
+    {
+      "path": "packages/core/src/client/richtext/plugins/ToolbarPlugin.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: Lexical editor chrome in @revealui/core; compose presentation after toolbar rewrite"
+    },
+    {
+      "path": "packages/core/src/client/richtext/plugins/ToolbarPlugin.tsx",
+      "tag": "select",
+      "reason": "GAP-479 later slice: Lexical editor chrome in @revealui/core; compose presentation after toolbar rewrite"
+    },
+    {
+      "path": "packages/core/src/client/ui/index.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: core TextInput/select/textarea duplicate presentation; delete after callers migrate"
+    },
+    {
+      "path": "packages/core/src/client/ui/index.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: core TextInput/select/textarea duplicate presentation; delete after callers migrate"
+    },
+    {
+      "path": "packages/core/src/client/ui/index.tsx",
+      "tag": "select",
+      "reason": "GAP-479 later slice: core TextInput/select/textarea duplicate presentation; delete after callers migrate"
+    },
+    {
+      "path": "packages/core/src/client/ui/index.tsx",
+      "tag": "textarea",
+      "reason": "GAP-479 later slice: core TextInput/select/textarea duplicate presentation; delete after callers migrate"
+    },
+    {
+      "path": "packages/core/src/error-handling/error-boundary.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: core error fallback actions; use presentation Button"
+    },
+    {
+      "path": "packages/core/src/error-handling/fallback-components.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: core error fallback actions; use presentation Button"
+    },
+    {
+      "path": "packages/core/src/utils/block-conversion.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: CMS block conversion control; use presentation Input"
+    },
+    {
+      "path": "packages/editor/src/canvas/EditSessionCanvas.tsx",
+      "tag": "button",
+      "reason": "GAP-479 later slice: visual-edit canvas chrome; use presentation Button/Input/Textarea"
+    },
+    {
+      "path": "packages/editor/src/canvas/EditSessionCanvas.tsx",
+      "tag": "input",
+      "reason": "GAP-479 later slice: visual-edit canvas chrome; use presentation Button/Input/Textarea"
+    },
+    {
+      "path": "packages/editor/src/canvas/EditSessionCanvas.tsx",
+      "tag": "textarea",
+      "reason": "GAP-479 later slice: visual-edit canvas chrome; use presentation Button/Input/Textarea"
     }
   ]
 }

--- a/scripts/validate/tier1-presentation.ts
+++ b/scripts/validate/tier1-presentation.ts
@@ -1,6 +1,6 @@
 // console-allowed
 /**
- * Tier-1 presentation intrinsic gate (GAP-398).
+ * Tier-1 presentation intrinsic gate (GAP-398, fleet window GAP-479).
  *
  * Flags JSX host elements that must come from @revealui/presentation:
  *   button | input | select | textarea | svg
@@ -14,21 +14,31 @@
  * Usage:
  *   pnpm validate:tier1-presentation
  *   pnpm validate:tier1-presentation -- --hard-fail
+ *   pnpm validate:tier1-presentation -- --repo-root /path/to/demo --root app --hard-fail
  */
 
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { extname, join, relative, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import ts from '@revealui/ts-strada';
 
 function out(line: string): void {
   process.stdout.write(`${line}\n`);
 }
 
-const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
-const ALLOWLIST_PATH = join(REPO_ROOT, 'scripts/validate/tier1-presentation-allowlist.json');
+const DEFAULT_REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
 
-const SCAN_ROOTS = ['apps/marketing', 'apps/docs', 'apps/admin'];
+/** Default scan window inside the revealui monorepo. presentation itself is the primitive home. */
+export const DEFAULT_SCAN_ROOTS = [
+  'apps/marketing',
+  'apps/docs',
+  'apps/admin',
+  'apps/rsc-poc',
+  'packages/core',
+  'packages/cli/templates',
+  'packages/editor',
+] as const;
+
 const SOURCE_EXTS = new Set(['.tsx', '.jsx']);
 const SKIP_DIRS = new Set([
   'node_modules',
@@ -43,22 +53,79 @@ const SKIP_DIRS = new Set([
   '__mocks__',
 ]);
 
-const TIER1_TAGS = new Set(['button', 'input', 'select', 'textarea', 'svg']);
+export const TIER1_TAGS = new Set(['button', 'input', 'select', 'textarea', 'svg']);
 
-interface AllowEntry {
+export interface AllowEntry {
   path: string;
   tag: string;
   reason: string;
 }
 
-interface Hit {
+export interface Hit {
   path: string;
   tag: string;
   line: number;
   col: number;
 }
 
-function walk(dir: string, outFiles: string[] = []): string[] {
+export interface CliOptions {
+  hardFail: boolean;
+  writeAllowlist: boolean;
+  repoRoot: string;
+  allowlistPath: string;
+  scanRoots: string[];
+}
+
+export function parseCliArgs(argv: string[], defaultRepoRoot = DEFAULT_REPO_ROOT): CliOptions {
+  let repoRoot = defaultRepoRoot;
+  let allowlistPath = join(defaultRepoRoot, 'scripts/validate/tier1-presentation-allowlist.json');
+  const roots: string[] = [];
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--repo-root') {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        repoRoot = resolve(next);
+        i += 1;
+      }
+      continue;
+    }
+    if (arg === '--allowlist') {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        allowlistPath = resolve(next);
+        i += 1;
+      }
+      continue;
+    }
+    if (arg === '--root') {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        roots.push(next);
+        i += 1;
+      }
+    }
+  }
+
+  if (
+    repoRoot !== defaultRepoRoot &&
+    allowlistPath === join(defaultRepoRoot, 'scripts/validate/tier1-presentation-allowlist.json')
+  ) {
+    const sibling = join(repoRoot, 'scripts/validate/tier1-presentation-allowlist.json');
+    if (existsSync(sibling)) allowlistPath = sibling;
+  }
+
+  return {
+    hardFail: argv.includes('--hard-fail'),
+    writeAllowlist: argv.includes('--write-allowlist'),
+    repoRoot,
+    allowlistPath,
+    scanRoots: roots.length > 0 ? roots : [...DEFAULT_SCAN_ROOTS],
+  };
+}
+
+export function walk(dir: string, outFiles: string[] = []): string[] {
   if (!existsSync(dir)) return outFiles;
   for (const ent of readdirSync(dir, { withFileTypes: true })) {
     if (SKIP_DIRS.has(ent.name)) continue;
@@ -75,21 +142,21 @@ function walk(dir: string, outFiles: string[] = []): string[] {
   return outFiles;
 }
 
-function loadAllowlist(): AllowEntry[] {
-  if (!existsSync(ALLOWLIST_PATH)) return [];
-  const raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8')) as { entries?: AllowEntry[] };
+export function loadAllowlist(allowlistPath: string): AllowEntry[] {
+  if (!existsSync(allowlistPath)) return [];
+  const raw = JSON.parse(readFileSync(allowlistPath, 'utf8')) as { entries?: AllowEntry[] };
   return raw.entries ?? [];
 }
 
-function isAllowlisted(pathRel: string, tag: string, entries: AllowEntry[]): boolean {
+export function isAllowlisted(pathRel: string, tag: string, entries: AllowEntry[]): boolean {
   return entries.some((e) => e.path === pathRel && e.tag === tag && e.reason.trim().length > 0);
 }
 
-function scanFile(absPath: string): Hit[] {
+export function scanFile(absPath: string, repoRoot: string): Hit[] {
   const text = readFileSync(absPath, 'utf8');
   const sf = ts.createSourceFile(absPath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
   const hits: Hit[] = [];
-  const pathRel = relative(REPO_ROOT, absPath).replaceAll('\\', '/');
+  const pathRel = relative(repoRoot, absPath).replaceAll('\\', '/');
 
   const visit = (node: ts.Node): void => {
     if (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) {
@@ -108,62 +175,79 @@ function scanFile(absPath: string): Hit[] {
   return hits;
 }
 
-function main(): void {
-  const hardFail = process.argv.includes('--hard-fail');
-  const writeAllowlist = process.argv.includes('--write-allowlist');
-  const entries = loadAllowlist();
-  const files: string[] = [];
-  for (const root of SCAN_ROOTS) {
-    walk(resolve(REPO_ROOT, root), files);
-  }
-
-  const allHits: Hit[] = [];
-  for (const f of files) {
-    allHits.push(...scanFile(f));
-  }
-
-  if (writeAllowlist) {
-    // Group by path+tag for compact allowlist entries (one reason per pair).
-    const key = new Map<string, AllowEntry>();
-    for (const h of allHits) {
-      const k = `${h.path}::${h.tag}`;
-      if (!key.has(k)) {
-        key.set(k, {
-          path: h.path,
-          tag: h.tag,
-          reason: 'GAP-398 residual burn-down (pre-existing Tier-1 handroll)',
-        });
-      }
-    }
-    const payload = {
-      description:
-        'Allowlisted Tier-1 JSX intrinsics in apps/* until burned to presentation components (GAP-398). Each entry needs a non-empty reason.',
-      entries: [...key.values()].sort((a, b) =>
-        a.path === b.path ? a.tag.localeCompare(b.tag) : a.path.localeCompare(b.path),
-      ),
-    };
-    writeFileSync(ALLOWLIST_PATH, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-    out(
-      `Wrote ${payload.entries.length} allowlist entries → ${relative(REPO_ROOT, ALLOWLIST_PATH)}`,
-    );
-    process.exit(0);
-  }
-
+export function partitionHits(
+  hits: Hit[],
+  entries: AllowEntry[],
+): { violations: Hit[]; allowlisted: Hit[] } {
   const violations: Hit[] = [];
   const allowlisted: Hit[] = [];
-  for (const h of allHits) {
+  for (const h of hits) {
     if (isAllowlisted(h.path, h.tag, entries)) allowlisted.push(h);
     else violations.push(h);
   }
+  return { violations, allowlisted };
+}
+
+function collectHits(opts: CliOptions): { files: string[]; hits: Hit[] } {
+  const files: string[] = [];
+  for (const root of opts.scanRoots) {
+    walk(resolve(opts.repoRoot, root), files);
+  }
+  const hits: Hit[] = [];
+  for (const f of files) {
+    hits.push(...scanFile(f, opts.repoRoot));
+  }
+  return { files, hits };
+}
+
+function writeAllowlistFile(opts: CliOptions, hits: Hit[], existing: AllowEntry[]): void {
+  const prior = new Map(existing.map((e) => [`${e.path}::${e.tag}`, e]));
+  const key = new Map<string, AllowEntry>();
+  for (const h of hits) {
+    const k = `${h.path}::${h.tag}`;
+    if (key.has(k)) continue;
+    const kept = prior.get(k);
+    key.set(
+      k,
+      kept ?? {
+        path: h.path,
+        tag: h.tag,
+        reason: 'GAP-479 grandfather: migrate this host to @revealui/presentation',
+      },
+    );
+  }
+  const payload = {
+    description:
+      'Allowlisted Tier-1 JSX intrinsics until burned to @revealui/presentation (GAP-398 residual floor + GAP-479 extra roots). Each entry needs a non-empty reason. Hard-fail: pnpm validate:tier1-presentation -- --hard-fail.',
+    entries: [...key.values()].sort((a, b) =>
+      a.path === b.path ? a.tag.localeCompare(b.tag) : a.path.localeCompare(b.path),
+    ),
+  };
+  writeFileSync(opts.allowlistPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  out(
+    `Wrote ${payload.entries.length} allowlist entries → ${relative(opts.repoRoot, opts.allowlistPath)}`,
+  );
+}
+
+export function runGate(argv: string[] = process.argv.slice(2)): number {
+  const opts = parseCliArgs(argv);
+  const existing = loadAllowlist(opts.allowlistPath);
+  const { files, hits } = collectHits(opts);
+
+  if (opts.writeAllowlist) {
+    writeAllowlistFile(opts, hits, existing);
+    return 0;
+  }
+
+  const { violations, allowlisted } = partitionHits(hits, existing);
 
   out('================================================================');
-  out('Tier-1 presentation intrinsic gate (GAP-398)');
+  out('Tier-1 presentation intrinsic gate (GAP-398 / GAP-479)');
   out('================================================================');
-  out(`Scanned ${files.length} files under ${SCAN_ROOTS.join(', ')}`);
-  out(
-    `Hits: ${allHits.length}  allowlisted: ${allowlisted.length}  violations: ${violations.length}`,
-  );
-  out(`Mode: ${hardFail ? 'HARD FAIL' : 'WARN (exit 0)'}`);
+  out(`Repo: ${opts.repoRoot}`);
+  out(`Scanned ${files.length} files under ${opts.scanRoots.join(', ')}`);
+  out(`Hits: ${hits.length}  allowlisted: ${allowlisted.length}  violations: ${violations.length}`);
+  out(`Mode: ${opts.hardFail ? 'HARD FAIL' : 'WARN (exit 0)'}`);
   out('');
 
   if (violations.length > 0) {
@@ -175,15 +259,21 @@ function main(): void {
     out(
       'Fix: replace with Button / Input / Slider / Switch / Tabs / Icon* from @revealui/presentation,',
     );
-    out('or add a reasoned entry to scripts/validate/tier1-presentation-allowlist.json.');
+    out(`or add a reasoned entry to ${opts.allowlistPath}.`);
   } else {
     out('✓ No non-allowlisted Tier-1 intrinsics.');
   }
 
-  if (hardFail && violations.length > 0) {
-    process.exit(1);
-  }
-  process.exit(0);
+  if (opts.hardFail && violations.length > 0) return 1;
+  return 0;
 }
 
-main();
+function isDirectRun(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(resolve(entry)).href;
+}
+
+if (isDirectRun()) {
+  process.exit(runGate());
+}


### PR DESCRIPTION
## Summary
Extends the GAP-398 AST gate so Tier-1 host tags (`button`, `input`, `select`, `textarea`, `svg`) are also scanned in `apps/rsc-poc`, `packages/core`, `packages/cli/templates`, and `packages/editor`. Adds `--repo-root` and repeatable `--root` so sibling product repos can invoke the same script.

Existing marketing/docs/admin residual floor is unchanged. New roots are grandfathered with reasoned allowlist rows for later burn slices.

## Test plan
- [x] `pnpm exec vitest run scripts/validate/__tests__/tier1-presentation.test.ts`
- [x] `pnpm validate:tier1-presentation -- --hard-fail`
- [x] pre-push phase-1 gate PASS