### PR TITLE
style(marketing): NavBar and Footer chrome craft

### DIFF
--- a/apps/marketing/app/components/Footer.tsx
+++ b/apps/marketing/app/components/Footer.tsx
@@ -14,35 +14,38 @@ import { NewsletterSignup } from './NewsletterSignup';
 export function Footer() {
   const currentYear = new Date().getFullYear();
   return (
-    <footer className="bg-muted border-t border-border py-12">
+    <footer className="border-t border-border bg-muted py-16 lg:py-20">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-5">
-          <div className="lg:col-span-2">
-            <div className="flex items-center gap-2.5 font-display text-2xl font-bold tracking-tight text-foreground mb-4">
-              <img src="/icon-mark.svg" alt="" aria-hidden="true" className="h-7 w-7" />
-              {SITE.brand}
+        <div className="grid grid-cols-1 gap-12 lg:grid-cols-12 lg:gap-10">
+          {/* Brand + secondary pathways */}
+          <div className="space-y-6 lg:col-span-5">
+            <div className="space-y-3">
+              <div className="flex items-center gap-2.5 font-display text-2xl font-bold tracking-tight text-foreground">
+                <img src="/icon-mark.svg" alt="" aria-hidden="true" className="h-7 w-7" />
+                {SITE.brand}
+              </div>
+              <p className="max-w-sm text-sm font-medium leading-6 text-foreground">
+                {SITE.brandTagline}
+              </p>
+              {/* Type ladder: multi-sentence product line is body, not meta. */}
+              <p className="max-w-sm text-sm leading-6 text-body">{FOOTER_TAGLINE}</p>
             </div>
-            <p className="text-foreground text-sm font-medium leading-6 max-w-sm">
-              {SITE.brandTagline}
-            </p>
-            <p className="text-muted-foreground text-sm leading-6 max-w-sm mt-2">
-              {FOOTER_TAGLINE}
-            </p>
-            <p className="text-muted-foreground text-xs leading-6 max-w-sm mt-3">
-              {FOOTER_SOLO_OPERATOR_NOTE}
-            </p>
-            <p className="text-muted-foreground text-xs leading-6 max-w-sm mt-3">
-              {FOOTER_CLAIMS_LEDGER_NOTE.prefix}{' '}
-              <a
-                href={FOOTER_CLAIMS_LEDGER_NOTE.href}
-                className="font-medium text-primary hover:underline"
-              >
-                {FOOTER_CLAIMS_LEDGER_NOTE.linkLabel}
-              </a>
-            </p>
-            <div className="mt-3 space-y-1">
+
+            <div className="space-y-2">
+              <p className="max-w-sm text-xs leading-6 text-muted-foreground">
+                {FOOTER_SOLO_OPERATOR_NOTE}
+              </p>
+              <p className="max-w-sm text-xs leading-6 text-muted-foreground">
+                {FOOTER_CLAIMS_LEDGER_NOTE.prefix}{' '}
+                <a
+                  href={FOOTER_CLAIMS_LEDGER_NOTE.href}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {FOOTER_CLAIMS_LEDGER_NOTE.linkLabel}
+                </a>
+              </p>
               {FOOTER_SERVICE_LINKS.map((item) => (
-                <p key={item.label} className="text-muted-foreground text-xs leading-6">
+                <p key={item.label} className="max-w-sm text-xs leading-6 text-muted-foreground">
                   {item.prefix}{' '}
                   <a href={item.href} className="font-medium text-primary hover:underline">
                     {item.label}
@@ -50,8 +53,9 @@ export function Footer() {
                 </p>
               ))}
             </div>
-            <div className="mt-6">
-              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+
+            <div>
+              <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                 Stay in the loop
               </p>
               <NewsletterSignup />
@@ -59,17 +63,18 @@ export function Footer() {
                 Product updates and engineering insights. No spam.
               </p>
             </div>
-            <div className="mt-6 flex flex-wrap items-center gap-4">
+
+            <div className="flex flex-wrap items-center gap-4">
               <a
                 href={SITE.urls.repo}
-                className="text-muted-foreground hover:text-foreground transition-colors"
+                className="text-muted-foreground transition-colors hover:text-foreground"
                 aria-label="GitHub"
               >
                 <GitHubIcon className="size-5" />
               </a>
               <a
                 href={SITE.urls.linkedin}
-                className="text-muted-foreground hover:text-foreground transition-colors"
+                className="text-muted-foreground transition-colors hover:text-foreground"
                 aria-label="RevealUI on LinkedIn"
               >
                 <LinkedInIcon className="size-5" />
@@ -79,35 +84,40 @@ export function Footer() {
                   href={COMMUNITY.substack.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+                  className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
                 >
                   Substack
                 </a>
               ) : null}
             </div>
           </div>
-          {FOOTER_COLUMNS.map((col) => (
-            <div key={col.heading}>
-              <h3 className="text-sm font-semibold uppercase tracking-widest text-muted-foreground mb-4">
-                {col.heading}
-              </h3>
-              <ul className="space-y-3 text-sm text-muted-foreground">
-                {col.links.map(({ label, href, external }) => (
-                  <li key={label}>
-                    <a
-                      href={href}
-                      {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                      className="hover:text-foreground transition-colors"
-                    >
-                      {label}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+
+          {/* Link columns */}
+          <div className="grid grid-cols-2 gap-10 sm:grid-cols-3 lg:col-span-7 lg:gap-8">
+            {FOOTER_COLUMNS.map((col) => (
+              <div key={col.heading}>
+                <h3 className="mb-4 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                  {col.heading}
+                </h3>
+                <ul className="space-y-3 text-sm text-muted-foreground">
+                  {col.links.map(({ label, href, external }) => (
+                    <li key={label}>
+                      <a
+                        href={href}
+                        {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                        className="transition-colors hover:text-foreground"
+                      >
+                        {label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="mt-12 pt-8 border-t border-border flex flex-col sm:flex-row items-center justify-between gap-4 text-muted-foreground text-sm">
+
+        <div className="mt-14 flex flex-col items-center justify-between gap-4 border-t border-border pt-8 text-sm text-muted-foreground sm:flex-row">
           <div className="flex flex-wrap items-center justify-center gap-4 sm:justify-start">
             <p>
               &copy; {currentYear} RevealUI is operated by{' '}
@@ -115,7 +125,7 @@ export function Footer() {
                 href={FOOTER_LEGAL.operatorHref}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="hover:text-foreground transition-colors underline-offset-4 hover:underline"
+                className="underline-offset-4 transition-colors hover:text-foreground hover:underline"
               >
                 {FOOTER_LEGAL.operator}
               </a>{' '}
@@ -125,7 +135,7 @@ export function Footer() {
           </div>
           <div className="flex flex-wrap justify-center gap-x-6 gap-y-2">
             {FOOTER_LEGAL_LINKS.map(({ label, href }) => (
-              <a key={label} href={href} className="hover:text-foreground transition-colors">
+              <a key={label} href={href} className="transition-colors hover:text-foreground">
                 {label}
               </a>
             ))}

--- a/apps/marketing/app/components/NavBar.tsx
+++ b/apps/marketing/app/components/NavBar.tsx
@@ -25,25 +25,52 @@ function NavLink({
   className,
   onClick,
   children,
+  'aria-current': ariaCurrent,
 }: {
   href: string;
   className?: string;
   onClick?: () => void;
   children: ReactNode;
+  'aria-current'?: 'page' | undefined;
 }) {
   if (href.startsWith('/')) {
     return (
-      <Link to={href} className={className} onClick={onClick}>
+      <Link to={href} className={className} onClick={onClick} aria-current={ariaCurrent}>
         {children}
       </Link>
     );
   }
   return (
-    <a href={href} className={className} onClick={onClick}>
+    <a href={href} className={className} onClick={onClick} aria-current={ariaCurrent}>
       {children}
     </a>
   );
 }
+
+/** True when this chrome link is the current marketing route (internal paths only). */
+function isNavActive(pathname: string, href: string): boolean {
+  if (!href.startsWith('/')) {
+    return false;
+  }
+  if (href === '/') {
+    return pathname === '/';
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+const desktopLinkClass = (active: boolean): string =>
+  [
+    'text-sm font-medium transition-colors',
+    active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+  ].join(' ');
+
+const mobileLinkClass = (active: boolean): string =>
+  [
+    'rounded-md px-3 py-3 text-sm font-medium transition-colors',
+    active
+      ? 'bg-muted text-foreground'
+      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+  ].join(' ');
 
 export function NavBar() {
   const [open, setOpen] = useState(false);
@@ -74,28 +101,40 @@ export function NavBar() {
   }, [pathname]);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border bg-background backdrop-blur-md supports-[backdrop-filter]:bg-background/80">
-      <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6 lg:px-8">
+    <header className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur-md supports-[backdrop-filter]:bg-background/80">
+      <nav
+        className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-4 px-6 lg:px-8"
+        aria-label="Primary"
+      >
         <NavLink
           href="/"
-          className="flex items-center gap-2 font-display text-xl font-bold tracking-tight text-foreground"
+          className="flex shrink-0 items-center gap-2 font-display text-xl font-bold tracking-tight text-foreground"
+          aria-current={pathname === '/' ? 'page' : undefined}
         >
           <img src="/icon-mark.svg" alt="" aria-hidden="true" className="h-[22px] w-[22px]" />
           RevealUI
         </NavLink>
 
         {/* Desktop links */}
-        <div className="hidden items-center gap-8 text-sm font-medium text-muted-foreground lg:flex">
-          {NAV_LINKS.map(({ label, href }) => (
-            <NavLink key={label} href={href} className="transition-colors hover:text-foreground">
-              {label}
-            </NavLink>
-          ))}
+        <div className="hidden items-center gap-7 lg:flex">
+          {NAV_LINKS.map(({ label, href }) => {
+            const active = isNavActive(pathname, href);
+            return (
+              <NavLink
+                key={label}
+                href={href}
+                className={desktopLinkClass(active)}
+                aria-current={active ? 'page' : undefined}
+              >
+                {label}
+              </NavLink>
+            );
+          })}
           <a
             href="https://github.com/RevealUIStudio/revealui"
             target="_blank"
             rel="noopener noreferrer"
-            className="transition-colors hover:text-foreground"
+            className="text-muted-foreground transition-colors hover:text-foreground"
             aria-label="GitHub"
           >
             <span className="sr-only">GitHub</span>
@@ -103,7 +142,7 @@ export function NavBar() {
           </a>
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex shrink-0 items-center gap-2 sm:gap-3">
           <NavLink
             href={NAV_AUTH.login.href}
             className="hidden text-sm font-medium text-muted-foreground transition-colors hover:text-foreground lg:inline-flex"
@@ -141,35 +180,35 @@ export function NavBar() {
         <div
           id={MOBILE_MENU_ID}
           ref={menuRef}
-          className="relative z-50 border-t border-border bg-background px-6 py-4 lg:hidden"
+          className="relative z-50 border-t border-border bg-background px-6 py-5 lg:hidden"
         >
-          <div className="flex flex-col gap-1">
-            {NAV_LINKS.map(({ label, href }) => (
-              <NavLink
-                key={label}
-                href={href}
-                className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                onClick={close}
-              >
-                {label}
-              </NavLink>
-            ))}
+          <div className="flex flex-col gap-0.5">
+            {NAV_LINKS.map(({ label, href }) => {
+              const active = isNavActive(pathname, href);
+              return (
+                <NavLink
+                  key={label}
+                  href={href}
+                  className={mobileLinkClass(active)}
+                  aria-current={active ? 'page' : undefined}
+                  onClick={close}
+                >
+                  {label}
+                </NavLink>
+              );
+            })}
             <a
               href="https://github.com/RevealUIStudio/revealui"
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className={mobileLinkClass(false)}
               onClick={close}
             >
               GitHub
             </a>
           </div>
-          <div className="mt-4 flex flex-col gap-2 border-t border-border pt-4">
-            <NavLink
-              href={NAV_AUTH.login.href}
-              className="rounded-md px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              onClick={close}
-            >
+          <div className="mt-5 flex flex-col gap-2 border-t border-border pt-5">
+            <NavLink href={NAV_AUTH.login.href} className={mobileLinkClass(false)} onClick={close}>
               {NAV_AUTH.login.label}
             </NavLink>
             <LinkButton href={NAV_AUTH.signup.href} onClick={close} className="w-full">

--- a/apps/marketing/app/components/__tests__/NavBar.test.tsx
+++ b/apps/marketing/app/components/__tests__/NavBar.test.tsx
@@ -109,4 +109,24 @@ describe('NavBar (marketing)', () => {
     const docs = screen.getByRole('link', { name: 'Docs' });
     expect(docs).toHaveAttribute('href', 'https://docs.revealui.com');
   });
+
+  it('marks the home brand link as the current page on /', () => {
+    window.history.pushState({}, '', '/');
+    renderNavBar();
+    const home = screen.getByRole('link', { name: 'RevealUI' });
+    expect(home).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('marks the active desktop route with aria-current=page', () => {
+    window.history.pushState({}, '', '/pricing');
+    renderNavBar();
+    const pricing = screen.getByRole('link', { name: 'Pricing' });
+    expect(pricing).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Products' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('exposes primary navigation landmark', () => {
+    renderNavBar();
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
Phase 1 of the marketing residual craft train (chrome before nested widgets / second-pass routes).

- **NavBar:** `aria-current="page"` on active primary links (desktop + mobile), primary nav landmark, calmer mobile drawer spacing, header/backdrop polish.
- **Footer:** type ladder (`FOOTER_TAGLINE` → `text-body`), clearer brand vs meta stacks, 12-col grid with roomier columns, denser quiet spacing.
- **Tests:** active-route + landmark coverage on NavBar.

No copy changes. No new shell primitives.

## Test plan
- [x] `pnpm exec vitest run app/components/__tests__/NavBar.test.tsx` (11 pass)
- [ ] CI quality + marketing voice
- [ ] Spot-check sticky nav + mobile menu + footer density on preview

Part of residual train after marketing system promote: chrome → widgets → route craft.