### PR TITLE
style(marketing): nested landing widgets craft

### DIFF
--- a/apps/marketing/app/components/landing/AudienceToggle.tsx
+++ b/apps/marketing/app/components/landing/AudienceToggle.tsx
@@ -29,8 +29,8 @@ export function AudienceToggle({ current }: { current: Audience }) {
             aria-current={active ? 'true' : undefined}
             className={
               active
-                ? 'rounded-full bg-primary px-4 py-1.5 text-sm font-semibold text-primary-foreground'
-                : 'rounded-full px-4 py-1.5 text-sm font-medium text-muted-foreground transition hover:text-foreground'
+                ? 'inline-flex min-h-9 items-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground'
+                : 'inline-flex min-h-9 items-center rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground'
             }
           >
             {option.label}

--- a/apps/marketing/app/components/landing/FrontierPathway.tsx
+++ b/apps/marketing/app/components/landing/FrontierPathway.tsx
@@ -10,16 +10,20 @@ export function FrontierPathway() {
     <div className="mx-auto mt-12 max-w-4xl">
       <div className="text-center">
         <p className="text-xs font-semibold uppercase tracking-widest text-primary">{F.eyebrow}</p>
-        <h3 className="mt-2 text-xl font-semibold text-foreground">{F.heading}</h3>
+        <h3 className="mt-2 font-display text-xl font-semibold tracking-tight text-foreground">
+          {F.heading}
+        </h3>
       </div>
 
-      <ol className="mt-8 grid grid-cols-1 gap-4 list-none p-0 sm:grid-cols-2">
+      <ol className="mt-8 grid list-none grid-cols-1 gap-4 p-0 sm:grid-cols-2">
         {F.steps.map((step) => (
           <li key={step.n} className="rounded-2xl bg-card p-6 ring-1 ring-border">
             <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 font-mono text-sm font-semibold text-primary">
               {step.n}
             </span>
-            <h4 className="mt-4 text-base font-semibold text-foreground">{step.title}</h4>
+            <h4 className="mt-4 text-base font-semibold tracking-tight text-foreground">
+              {step.title}
+            </h4>
             <p className="mt-2 text-sm leading-6 text-body">{step.body}</p>
           </li>
         ))}

--- a/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
+++ b/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
@@ -10,10 +10,10 @@ import { LIVE_METRICS as M } from '../../content/proof';
 export function LiveMetricsBadge() {
   return (
     <div className="mx-auto max-w-4xl">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0">
           <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-            <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-primary" />
+            <span aria-hidden="true" className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
             {M.eyebrow}
           </p>
           <h3 className="mt-2 font-display text-lg font-semibold tracking-tight text-foreground sm:text-xl">
@@ -24,7 +24,7 @@ export function LiveMetricsBadge() {
           href={M.validatorHref}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
+          className="shrink-0 text-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 transition-colors hover:text-primary/80"
         >
           {M.validatorLabel}
         </a>
@@ -33,10 +33,10 @@ export function LiveMetricsBadge() {
       <dl className="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border ring-1 ring-border sm:grid-cols-3 lg:grid-cols-6">
         {M.metrics.map((m) => (
           <div key={m.label} className="bg-card px-3 py-5 text-center sm:px-4 sm:py-6">
-            <dd className="font-display text-2xl font-bold tracking-tight text-foreground tabular-nums sm:text-3xl">
+            <dd className="font-display text-2xl font-bold tabular-nums tracking-tight text-foreground sm:text-3xl">
               {m.value}
             </dd>
-            <dt className="mt-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+            <dt className="mt-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
               {m.label}
             </dt>
           </div>

--- a/apps/marketing/app/components/landing/ProductFrame.tsx
+++ b/apps/marketing/app/components/landing/ProductFrame.tsx
@@ -105,7 +105,7 @@ export function ProductFrame({
                     <span
                       className={
                         item.active
-                          ? 'flex h-8 items-center gap-2 rounded-md bg-foreground/[0.06] px-2 text-xs font-medium text-foreground'
+                          ? 'flex h-8 items-center gap-2 rounded-md bg-muted px-2 text-xs font-medium text-foreground'
                           : 'flex h-8 items-center gap-2 rounded-md px-2 text-xs text-muted-foreground'
                       }
                     >
@@ -170,7 +170,7 @@ export function ProductFrame({
       </div>
 
       {caption && (
-        <figcaption className="mt-4 text-center text-sm text-muted-foreground">
+        <figcaption className="mt-4 text-center text-sm leading-6 text-body">
           {caption.prefix}{' '}
           <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
             {caption.code}

--- a/apps/marketing/app/components/landing/ProviderSwitch.tsx
+++ b/apps/marketing/app/components/landing/ProviderSwitch.tsx
@@ -19,7 +19,9 @@ export function ProviderSwitch() {
     <div className="mx-auto mt-12 max-w-3xl rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
       <div className="text-center">
         <p className="text-xs font-semibold uppercase tracking-widest text-primary">{P.eyebrow}</p>
-        <h3 className="mt-2 text-xl font-semibold text-foreground">{P.heading}</h3>
+        <h3 className="mt-2 font-display text-xl font-semibold tracking-tight text-foreground">
+          {P.heading}
+        </h3>
       </div>
 
       <div
@@ -39,12 +41,16 @@ export function ProviderSwitch() {
               variant={selected ? 'brand' : 'neutral'}
               size="sm"
               onClick={() => setMode(m)}
-              className={`w-full justify-center gap-2 rounded-lg ${
-                selected ? 'shadow-sm ring-1 ring-border' : ''
-              }`}
+              className={`w-full justify-center gap-2 rounded-lg ${selected ? 'shadow-sm' : ''}`}
             >
               {P.modes[m].label}
-              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[0.65rem] font-semibold uppercase text-primary">
+              <span
+                className={
+                  selected
+                    ? 'rounded-full bg-primary-foreground/15 px-2 py-0.5 text-[0.65rem] font-semibold uppercase text-primary-foreground'
+                    : 'rounded-full bg-primary/10 px-2 py-0.5 text-[0.65rem] font-semibold uppercase text-primary'
+                }
+              >
                 {P.modes[m].badge}
               </span>
             </Button>
@@ -65,13 +71,13 @@ export function ProviderSwitch() {
         ))}
       </dl>
 
-      <div className="mt-4 rounded-xl bg-primary/5 p-4 ring-1 ring-primary/20">
-        <p className="text-xs font-semibold uppercase tracking-widest text-primary">
+      <div className="mt-5 rounded-xl bg-secondary/60 p-4 ring-1 ring-border">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
           {P.constant.label}
         </p>
-        <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 list-none p-0">
+        <ul className="mt-2 flex list-none flex-wrap gap-x-4 gap-y-1 p-0">
           {P.constant.items.map((item) => (
-            <li key={item} className="text-sm text-foreground">
+            <li key={item} className="text-sm leading-6 text-body">
               {item}
             </li>
           ))}


### PR DESCRIPTION
## Summary
Phase 2 of the marketing residual craft train (nested widgets after chrome #2579).

- **AudienceToggle:** min-h-9 touch targets
- **ProviderSwitch:** display type heading, selected badge contrast, quieter constant panel (`text-body`)
- **FrontierPathway:** display type + tracking alignment
- **LiveMetricsBadge:** layout polish (gap, shrink)
- **ProductFrame:** active nav uses `bg-muted`; figcaption on `text-body` rung

No copy changes.

## Test plan
- [x] ProductFrame unit tests
- [ ] CI green
- [ ] Spot-check home Demo frame + Local AI switcher on preview

Depends on sequencing only (independent of #2579). Residual train: chrome → widgets → route craft.