### PR TITLE
style(marketing): second-pass route craft

### DIFF
--- a/apps/marketing/app/routes/ContactPage.tsx
+++ b/apps/marketing/app/routes/ContactPage.tsx
@@ -27,17 +27,20 @@ export function ContactPage() {
 
         <ContactForm />
 
-        <div className="mt-16 grid grid-cols-1 gap-8 text-center sm:grid-cols-3">
+        <div className="mt-16 grid grid-cols-1 gap-4 text-center sm:grid-cols-3 sm:gap-6">
           {CONTACT_METHODS.map((method) => (
-            <div key={method.title}>
+            <div
+              key={method.title}
+              className="rounded-2xl bg-card px-4 py-6 ring-1 ring-border sm:px-5"
+            >
               <h3 className="text-sm font-semibold text-foreground">{method.title}</h3>
-              <p className="mt-2 text-sm text-body">
+              <p className="mt-2 text-sm leading-6 text-body">
                 {method.body ? <>{method.body} </> : null}
                 <a
                   href={method.href}
                   target={method.external ? '_blank' : undefined}
                   rel={method.external ? 'noopener noreferrer' : undefined}
-                  className="text-primary underline hover:text-primary/80"
+                  className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
                 >
                   {method.linkLabel}
                 </a>

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -53,7 +53,7 @@ function LocalAiHero({ data, path, annotation }: LocalAiHeroProps) {
         {data.eyebrow}
       </p>
       <h1
-        className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+        className="mt-4 font-display text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
         {...fieldAttrs(annotation, `${path}.title`)}
       >
         {data.h1}
@@ -84,7 +84,7 @@ function LocalAiPillars({ data, path, annotation }: LocalAiPillarsProps) {
             className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8"
           >
             <h2
-              className="text-lg font-semibold text-foreground"
+              className="font-display text-lg font-semibold tracking-tight text-foreground"
               {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
             >
               {pillar.title}
@@ -151,9 +151,9 @@ function LocalAiMarketProof({ data, path, annotation }: LocalAiMarketProofProps)
       <ul className="mt-12 list-none space-y-4 p-0 sm:mt-14">
         {data.adopters.map((adopter, index) => (
           <li key={`adopter-${index}`} className="rounded-2xl bg-card p-6 ring-1 ring-border">
-            <p className="text-base text-foreground">
+            <p className="text-base leading-7 text-body">
               <span
-                className="font-semibold"
+                className="font-semibold text-foreground"
                 {...fieldAttrs(annotation, `${path}.items.${index}.label`)}
               >
                 {adopter.name}

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -36,7 +36,7 @@ function PhilosophyHero({ data, path, annotation }: PhilosophyHeroProps) {
         {data.eyebrow}
       </p>
       <h1
-        className="mt-4 text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+        className="mt-4 font-display text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"
         {...fieldAttrs(annotation, `${path}.title`)}
       >
         {data.h1}
@@ -71,7 +71,7 @@ function PhilosophyBody({ data, path, annotation }: PhilosophyBodyProps) {
             return (
               <p
                 key={`footer-${index}`}
-                className="mt-12 border-t border-border pt-8 text-base font-medium text-muted-foreground"
+                className="mt-12 border-t border-border pt-8 text-base font-medium leading-7 text-body"
                 {...fieldAttrs(annotation, `${path}.items.${index}.body`)}
               >
                 {section.body}

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -177,7 +177,15 @@ export function ProductsPage() {
                 className="rounded-full"
               >
                 {f}
-                <span className="text-xs text-muted-foreground">{countFor(f)}</span>
+                <span
+                  className={
+                    selected
+                      ? 'text-xs text-primary-foreground/80'
+                      : 'text-xs text-muted-foreground'
+                  }
+                >
+                  {countFor(f)}
+                </span>
               </Button>
             );
           })}
@@ -207,7 +215,7 @@ export function ProductsPage() {
                       </svg>
                     </div>
                     <div>
-                      <h3 className="text-xl font-bold tracking-tight text-foreground">
+                      <h3 className="font-display text-xl font-semibold tracking-tight text-foreground">
                         {product.name}
                       </h3>
                       <p className="mt-0.5 text-sm font-medium text-body">{product.tagline}</p>
@@ -270,7 +278,7 @@ export function ProductsPage() {
         <div className="grid grid-cols-2 gap-6 sm:grid-cols-4 sm:gap-8">
           {PRODUCTS_STATS_SECTION.items.map((item) => (
             <div key={item.label} className="text-center">
-              <p className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+              <p className="font-display text-4xl font-bold tracking-tight text-foreground tabular-nums sm:text-5xl">
                 {item.stat}
               </p>
               <p className="mt-2 text-sm text-muted-foreground">{item.label}</p>

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -13,30 +13,19 @@ import {
   type RoadmapItem,
 } from '../content/roadmap';
 
-const categoryColors: Record<string, string> = {
-  payments: 'bg-amber-100 text-amber-700',
-  billing: 'bg-purple-100 text-purple-700',
-  ai: 'bg-violet-100 text-violet-700',
-  infrastructure: 'bg-blue-100 text-blue-700',
-  docs: 'bg-primary/10 text-primary',
-  product: 'bg-pink-100 text-pink-700',
-  enterprise: 'bg-muted text-muted-foreground',
-};
-
+/** Quiet token-only chips (no off-palette rainbow). Category is label meta. */
 function statusBadgeClass(status: string): string {
   if (status === 'Shipped' || status === 'Available') {
     return 'text-primary bg-primary/10 ring-primary/20';
   }
-  return 'text-amber-700 bg-amber-50 ring-amber-200';
+  return 'text-muted-foreground bg-muted ring-border';
 }
 
 function FeatureCard({ feature }: { feature: RoadmapItem }) {
   return (
-    <div className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border">
-      <div className="mb-4 flex items-center gap-3">
-        <span
-          className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${categoryColors[feature.category.toLowerCase()] ?? 'bg-muted text-muted-foreground'}`}
-        >
+    <div className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <span className="rounded-full bg-secondary px-2.5 py-0.5 text-xs font-semibold text-muted-foreground ring-1 ring-border">
           {feature.category}
         </span>
         <span
@@ -45,7 +34,9 @@ function FeatureCard({ feature }: { feature: RoadmapItem }) {
           {feature.status}
         </span>
       </div>
-      <h3 className="text-lg font-bold tracking-tight text-foreground">{feature.name}</h3>
+      <h3 className="font-display text-lg font-semibold tracking-tight text-foreground">
+        {feature.name}
+      </h3>
       <p className="mt-3 text-sm leading-6 text-body">{feature.description}</p>
     </div>
   );
@@ -63,13 +54,10 @@ export function RoadmapPage() {
       >
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-amber-500/10 via-background to-orange-500/10"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-primary/5"
         />
-        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-          Product
-          <span className="block bg-gradient-to-r from-amber-600 to-orange-600 bg-clip-text text-transparent">
-            Roadmap
-          </span>
+        <h1 className="font-display text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+          Product <span className="text-primary">Roadmap</span>
         </h1>
         <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
           {ROADMAP_HERO.subtitle} See our{' '}
@@ -77,7 +65,7 @@ export function RoadmapPage() {
             href={ROADMAP_HERO_LINK.href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-amber-700 underline hover:text-amber-600"
+            className="font-medium text-primary underline decoration-primary/40 underline-offset-4 hover:text-primary/80"
           >
             {ROADMAP_HERO_LINK.label}
           </a>{' '}


### PR DESCRIPTION
## Summary
Phase 3 of the marketing residual craft train (after chrome #2579 and widgets #2581).

- **Roadmap:** Cobalt-only hero and chips (removed amber/orange/rainbow category colors); quieter cards; display type titles
- **Local AI / Philosophy:** display type heroes; body-rung prose where it was muted
- **Products:** display type on sister names and stats; filter chip count contrast when selected
- **Contact:** method tiles as calm card chrome

No copy changes.

## Test plan
- [ ] CI green
- [ ] Spot-check `/roadmap`, `/products`, `/local-ai`, `/philosophy`, `/contact` on preview

Merge order: chrome → widgets → this (independent commits; any order OK).