### PR TITLE
feat(cli): compose create-revealui templates on presentation (GAP-479)

### DIFF
--- a/.changeset/gap-479-cli-templates.md
+++ b/.changeset/gap-479-cli-templates.md
@@ -1,0 +1,5 @@
+---
+'@revealui/cli': patch
+---
+
+Stamp create-revealui templates with @revealui/presentation hosts (Heading, Text, LinkButton) and tokens.css so new apps import the design system instead of declaring it unused.

--- a/packages/cli/src/__tests__/template-structure.test.ts
+++ b/packages/cli/src/__tests__/template-structure.test.ts
@@ -179,7 +179,7 @@ describe('package.json integrity after scaffolding', () => {
       expect(typeof pkg.scripts?.typecheck).toBe('string');
     });
 
-    it(`${template}: package.json has @revealui/core dependency`, async () => {
+    it(`${template}: package.json has @revealui/core and @revealui/presentation`, async () => {
       const projectPath = path.join(tmpDir, `${template}-deps`);
       await createProject(baseConfig(template, projectPath));
 
@@ -188,6 +188,8 @@ describe('package.json integrity after scaffolding', () => {
       ) as { dependencies?: Record<string, string> };
       expect(pkg.dependencies?.['@revealui/core']).toBeDefined();
       expect(pkg.dependencies?.['@revealui/core']).toMatch(/^(latest|\^?\d+\.\d+)/);
+      expect(pkg.dependencies?.['@revealui/presentation']).toBeDefined();
+      expect(pkg.dependencies?.['@revealui/presentation']).toMatch(/^(latest|\^?\d+\.\d+)/);
     });
 
     // Regression test: next.config.mjs sets reactCompiler: true, but next lists
@@ -397,6 +399,7 @@ describe('Template file structure  -  starter-native (Vite + @revealui/router)',
     expect(pkg.name).toBe('test-starter-native');
     expect(pkg.dependencies?.['@revealui/router']).toBeDefined();
     expect(pkg.dependencies?.['@revealui/core']).toBeDefined();
+    expect(pkg.dependencies?.['@revealui/presentation']).toBeDefined();
     expect(pkg.dependencies?.next).toBeUndefined();
   });
 
@@ -414,4 +417,53 @@ describe('Template file structure  -  starter-native (Vite + @revealui/router)',
     expect(typeof pkg.scripts?.typecheck).toBe('string');
     expect(typeof pkg.scripts?.test).toBe('string');
   });
+});
+
+// ---------------------------------------------------------------------------
+// GAP-479: templates must import presentation (not only declare the dep)
+// ---------------------------------------------------------------------------
+
+describe('Template presentation composition (GAP-479)', () => {
+  const templates = ['basic-blog', 'e-commerce', 'portfolio', 'starter', 'starter-native'] as const;
+
+  async function collectSourceFiles(dir: string): Promise<string[]> {
+    let results: string[] = [];
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results = results.concat(await collectSourceFiles(full));
+      } else if (/\.(tsx|ts|css)$/.test(entry.name)) {
+        results.push(full);
+      }
+    }
+    return results;
+  }
+
+  for (const template of templates) {
+    it(`${template}: source imports @revealui/presentation`, async () => {
+      const roots =
+        template === 'starter-native'
+          ? [path.join(TEMPLATES_DIR, template, 'app')]
+          : [path.join(TEMPLATES_DIR, template, 'src')];
+      const files = (await Promise.all(roots.map(collectSourceFiles))).flat();
+      const hits = [];
+      for (const file of files) {
+        const source = await fs.readFile(file, 'utf-8');
+        if (source.includes('@revealui/presentation')) {
+          hits.push(file);
+        }
+      }
+      expect(hits.length, `${template} never imports @revealui/presentation`).toBeGreaterThan(0);
+    });
+
+    it(`${template}: stylesheet imports presentation tokens`, async () => {
+      const cssPath =
+        template === 'starter-native'
+          ? path.join(TEMPLATES_DIR, template, 'app', 'styles', 'globals.css')
+          : path.join(TEMPLATES_DIR, template, 'src', 'app', 'globals.css');
+      const css = await fs.readFile(cssPath, 'utf-8');
+      expect(css).toContain('@revealui/presentation/tokens.css');
+    });
+  }
 });

--- a/packages/cli/templates/basic-blog/package.json
+++ b/packages/cli/templates/basic-blog/package.json
@@ -20,6 +20,7 @@
     "@revealui/db": "latest",
     "@revealui/auth": "latest",
     "@revealui/contracts": "latest",
+    "@revealui/presentation": "latest",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/cli/templates/basic-blog/src/app/globals.css
+++ b/packages/cli/templates/basic-blog/src/app/globals.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@import "@revealui/presentation/tokens.css";
+@source "../../node_modules/@revealui/presentation/dist/**/*.js";
 
 @theme {
   /* Cobalt brand accent — override via your own --color-accent. */

--- a/packages/cli/templates/basic-blog/src/app/page.tsx
+++ b/packages/cli/templates/basic-blog/src/app/page.tsx
@@ -1,54 +1,45 @@
-import Link from 'next/link';
+import { Heading, LinkButton, Text } from '@revealui/presentation';
 
 export default function HomePage() {
   return (
     <main className="mx-auto max-w-2xl px-4 py-16">
-      <h1 className="text-4xl font-bold tracking-tight text-gray-900">Welcome to your blog</h1>
-      <p className="mt-4 text-lg text-gray-600">
+      <Heading>Welcome to your blog</Heading>
+      <Text className="mt-4 text-lg">
         Built with{' '}
-        <a
-          href="https://revealui.com"
-          className="font-medium text-accent hover:text-accent-hover"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <LinkButton href="https://revealui.com" external appearance="link" size="sm">
           RevealUI
-        </a>
+        </LinkButton>
         . Start writing posts from the admin panel, or seed sample data to get started.
-      </p>
+      </Text>
 
       <div className="mt-8 flex flex-wrap gap-3">
-        <Link
-          href="/posts"
-          className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
-        >
+        <LinkButton href="/posts" variant="brand">
           Read the blog
-        </Link>
-        <a
-          href="/admin"
-          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-        >
+        </LinkButton>
+        <LinkButton href="/admin" variant="neutral" appearance="outline">
           Open admin panel
-        </a>
+        </LinkButton>
       </div>
 
       <div className="mt-12 rounded-lg border border-gray-200 bg-gray-50 p-6">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Quick start</h2>
+        <Heading level={2} className="text-sm font-semibold uppercase tracking-wide">
+          Quick start
+        </Heading>
         <ol className="mt-3 space-y-2 text-sm text-gray-700">
           <li>
-            <code className="rounded bg-gray-200 px-1.5 py-0.5 text-xs">pnpm db:seed</code> - add
+            <code className="rounded bg-gray-200 px-1.5 py-0.5 text-xs">pnpm db:seed</code> add
             sample blog posts
           </li>
           <li>
             Visit{' '}
-            <a href="/admin" className="text-accent hover:text-accent-hover">
+            <LinkButton href="/admin" appearance="link" size="sm">
               /admin
-            </a>{' '}
-            - manage your content
+            </LinkButton>{' '}
+            to manage your content
           </li>
           <li>
             Edit <code className="rounded bg-gray-200 px-1.5 py-0.5 text-xs">src/app/page.tsx</code>{' '}
-            - customize this page
+            to customize this page
           </li>
         </ol>
       </div>

--- a/packages/cli/templates/basic-blog/src/app/posts/[slug]/page.tsx
+++ b/packages/cli/templates/basic-blog/src/app/posts/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { Heading, LinkButton, Text } from '@revealui/presentation';
+
 const API_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:4000';
 
 interface Post {
@@ -29,12 +31,12 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   if (!post) {
     return (
       <main className="mx-auto max-w-2xl px-4 py-16">
-        <h1 className="text-2xl font-bold">Post not found</h1>
-        <p className="mt-4">
-          <a href="/posts" className="text-accent underline">
+        <Heading>Post not found</Heading>
+        <Text className="mt-4">
+          <LinkButton href="/posts" appearance="link" size="sm">
             Back to blog
-          </a>
-        </p>
+          </LinkButton>
+        </Text>
       </main>
     );
   }
@@ -42,12 +44,12 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   return (
     <main className="mx-auto max-w-2xl px-4 py-16">
       <nav className="mb-8">
-        <a href="/posts" className="text-sm text-accent underline">
-          &larr; Back to blog
-        </a>
+        <LinkButton href="/posts" appearance="link" size="sm">
+          Back to blog
+        </LinkButton>
       </nav>
       <article>
-        <h1 className="mb-2 text-3xl font-bold">{post.title}</h1>
+        <Heading className="mb-2">{post.title}</Heading>
         {post.publishedAt && (
           <time className="mb-8 block text-sm text-gray-500">
             {new Date(post.publishedAt).toLocaleDateString()}

--- a/packages/cli/templates/basic-blog/src/app/posts/page.tsx
+++ b/packages/cli/templates/basic-blog/src/app/posts/page.tsx
@@ -1,3 +1,5 @@
+import { Heading, LinkButton, Text } from '@revealui/presentation';
+
 const API_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:4000';
 
 interface Post {
@@ -29,29 +31,35 @@ export default async function PostsPage() {
 
   return (
     <main className="mx-auto max-w-2xl px-4 py-16">
-      <h1 className="mb-8 text-3xl font-bold">Blog</h1>
+      <Heading className="mb-8">Blog</Heading>
 
       {posts.length === 0 ? (
-        <p className="text-gray-500">
+        <Text>
           No posts yet. Create your first post in the{' '}
-          <a href="/admin/collections/posts" className="text-accent underline">
+          <LinkButton href="/admin/collections/posts" appearance="link" size="sm">
             admin panel
-          </a>
+          </LinkButton>
           , or run <code className="rounded bg-gray-100 px-1">pnpm db:seed</code> to add sample
           data.
-        </p>
+        </Text>
       ) : (
         <ul className="space-y-6">
           {posts.map((post) => (
             <li key={post.id}>
-              <a href={`/posts/${post.slug}`} className="group block">
-                <h2 className="text-xl font-semibold group-hover:text-accent">{post.title}</h2>
+              <LinkButton
+                href={`/posts/${post.slug}`}
+                appearance="link"
+                className="h-auto flex-col items-start"
+              >
+                <Heading level={2} className="text-xl">
+                  {post.title}
+                </Heading>
                 {post.publishedAt && (
                   <time className="text-sm text-gray-500">
                     {new Date(post.publishedAt).toLocaleDateString()}
                   </time>
                 )}
-              </a>
+              </LinkButton>
             </li>
           ))}
         </ul>

--- a/packages/cli/templates/e-commerce/package.json
+++ b/packages/cli/templates/e-commerce/package.json
@@ -20,6 +20,7 @@
     "@revealui/db": "latest",
     "@revealui/auth": "latest",
     "@revealui/contracts": "latest",
+    "@revealui/presentation": "latest",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/cli/templates/e-commerce/src/app/globals.css
+++ b/packages/cli/templates/e-commerce/src/app/globals.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@import "@revealui/presentation/tokens.css";
+@source "../../node_modules/@revealui/presentation/dist/**/*.js";
 
 @theme {
   /* Cobalt brand accent — override via your own --color-accent. */

--- a/packages/cli/templates/e-commerce/src/app/page.tsx
+++ b/packages/cli/templates/e-commerce/src/app/page.tsx
@@ -1,67 +1,56 @@
-import Link from 'next/link';
+import { Heading, LinkButton, Text } from '@revealui/presentation';
 
 export default function HomePage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-16">
       <div className="text-center">
-        <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-          Your store is live
-        </h1>
-        <p className="mx-auto mt-4 max-w-xl text-lg text-gray-600">
+        <Heading className="sm:text-5xl">Your store is live</Heading>
+        <Text className="mx-auto mt-4 max-w-xl text-lg">
           Built with{' '}
-          <a
-            href="https://revealui.com"
-            className="font-medium text-accent hover:text-accent-hover"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <LinkButton href="https://revealui.com" external appearance="link" size="sm">
             RevealUI
-          </a>
+          </LinkButton>
           . Add products from the admin panel, configure Stripe for payments, and start selling.
-        </p>
+        </Text>
 
         <div className="mt-8 flex justify-center gap-3">
-          <Link
-            href="/products"
-            className="rounded-lg bg-accent px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
-          >
+          <LinkButton href="/products" variant="brand">
             Browse products
-          </Link>
-          <a
-            href="/admin"
-            className="rounded-lg border border-gray-300 px-5 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-          >
+          </LinkButton>
+          <LinkButton href="/admin" variant="neutral" appearance="outline">
             Admin panel
-          </a>
+          </LinkButton>
         </div>
       </div>
 
       <div className="mt-16 grid gap-6 sm:grid-cols-3">
         <div className="rounded-lg border border-gray-200 p-5">
-          <h3 className="font-semibold text-gray-900">Products</h3>
-          <p className="mt-1 text-sm text-gray-600">
+          <Heading level={3}>Products</Heading>
+          <Text className="mt-1 text-sm">
             Manage your catalog with custom fields, images, and pricing.
-          </p>
+          </Text>
         </div>
         <div className="rounded-lg border border-gray-200 p-5">
-          <h3 className="font-semibold text-gray-900">Payments</h3>
-          <p className="mt-1 text-sm text-gray-600">
+          <Heading level={3}>Payments</Heading>
+          <Text className="mt-1 text-sm">
             Stripe integration for checkout, subscriptions, and webhooks.
-          </p>
+          </Text>
         </div>
         <div className="rounded-lg border border-gray-200 p-5">
-          <h3 className="font-semibold text-gray-900">Orders</h3>
-          <p className="mt-1 text-sm text-gray-600">
+          <Heading level={3}>Orders</Heading>
+          <Text className="mt-1 text-sm">
             Track and manage orders with status updates and fulfillment.
-          </p>
+          </Text>
         </div>
       </div>
 
       <div className="mt-12 rounded-lg border border-gray-200 bg-gray-50 p-6">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Quick start</h2>
+        <Heading level={2} className="text-sm font-semibold uppercase tracking-wide">
+          Quick start
+        </Heading>
         <ol className="mt-3 space-y-2 text-sm text-gray-700">
           <li>
-            <code className="rounded bg-gray-200 px-1.5 py-0.5 text-xs">pnpm db:seed</code> - add
+            <code className="rounded bg-gray-200 px-1.5 py-0.5 text-xs">pnpm db:seed</code> add
             sample products
           </li>
           <li>
@@ -72,10 +61,10 @@ export default function HomePage() {
           </li>
           <li>
             Visit{' '}
-            <a href="/admin" className="text-accent hover:text-accent-hover">
+            <LinkButton href="/admin" appearance="link" size="sm">
               /admin
-            </a>{' '}
-            - manage products and orders
+            </LinkButton>{' '}
+            to manage products and orders
           </li>
         </ol>
       </div>

--- a/packages/cli/templates/e-commerce/src/app/products/[slug]/page.tsx
+++ b/packages/cli/templates/e-commerce/src/app/products/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Heading, LinkButton, Text } from '@revealui/presentation';
 import Image from 'next/image';
 
 const API_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:4000';
@@ -36,12 +37,12 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
   if (!product) {
     return (
       <main className="mx-auto max-w-2xl px-4 py-16">
-        <h1 className="text-2xl font-bold">Product not found</h1>
-        <p className="mt-4">
-          <a href="/products" className="text-accent underline">
+        <Heading>Product not found</Heading>
+        <Text className="mt-4">
+          <LinkButton href="/products" appearance="link" size="sm">
             Back to products
-          </a>
-        </p>
+          </LinkButton>
+        </Text>
       </main>
     );
   }
@@ -49,9 +50,9 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
   return (
     <main className="mx-auto max-w-2xl px-4 py-16">
       <nav className="mb-8">
-        <a href="/products" className="text-sm text-accent underline">
-          &larr; Back to products
-        </a>
+        <LinkButton href="/products" appearance="link" size="sm">
+          Back to products
+        </LinkButton>
       </nav>
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
         {product.image?.url && (
@@ -64,13 +65,13 @@ export default async function ProductPage({ params }: { params: Promise<{ slug: 
           />
         )}
         <div>
-          <h1 className="text-3xl font-bold">{product.name}</h1>
-          <p className="mt-2 text-2xl font-bold text-gray-900">{formatPrice(product.price)}</p>
+          <Heading>{product.name}</Heading>
+          <Text className="mt-2 text-2xl font-bold">{formatPrice(product.price)}</Text>
           <div className="prose mt-6">
             {typeof product.description === 'string' ? (
-              <p>{product.description}</p>
+              <Text>{product.description}</Text>
             ) : (
-              <p className="text-gray-500">Product description will render here.</p>
+              <Text className="text-gray-500">Product description will render here.</Text>
             )}
           </div>
         </div>

--- a/packages/cli/templates/e-commerce/src/app/products/page.tsx
+++ b/packages/cli/templates/e-commerce/src/app/products/page.tsx
@@ -1,3 +1,4 @@
+import { Heading, LinkButton, Text } from '@revealui/presentation';
 import Image from 'next/image';
 
 const API_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:4000';
@@ -33,24 +34,25 @@ export default async function ProductsPage() {
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-16">
-      <h1 className="mb-8 text-3xl font-bold">Products</h1>
+      <Heading className="mb-8">Products</Heading>
 
       {products.length === 0 ? (
-        <p className="text-gray-500">
+        <Text>
           No products yet. Add products in the{' '}
-          <a href="/admin/collections/products" className="text-accent underline">
+          <LinkButton href="/admin/collections/products" appearance="link" size="sm">
             admin panel
-          </a>
+          </LinkButton>
           , or run <code className="rounded bg-gray-100 px-1">pnpm db:seed</code> to add sample
           data.
-        </p>
+        </Text>
       ) : (
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {products.map((product) => (
-            <a
+            <LinkButton
               key={product.id}
               href={`/products/${product.slug}`}
-              className="group rounded-lg border border-gray-200 p-4 transition-shadow hover:shadow-md"
+              appearance="link"
+              className="h-auto flex-col items-start rounded-lg border border-gray-200 p-4 transition-shadow hover:shadow-md"
             >
               {product.image?.url && (
                 <Image
@@ -61,9 +63,11 @@ export default async function ProductsPage() {
                   className="mb-4 aspect-square w-full rounded object-cover"
                 />
               )}
-              <h2 className="font-semibold group-hover:text-accent">{product.name}</h2>
-              <p className="mt-1 text-lg font-bold text-gray-900">{formatPrice(product.price)}</p>
-            </a>
+              <Heading level={2} className="text-base">
+                {product.name}
+              </Heading>
+              <Text className="mt-1 text-lg font-bold">{formatPrice(product.price)}</Text>
+            </LinkButton>
           ))}
         </div>
       )}

--- a/packages/cli/templates/portfolio/package.json
+++ b/packages/cli/templates/portfolio/package.json
@@ -20,6 +20,7 @@
     "@revealui/db": "latest",
     "@revealui/auth": "latest",
     "@revealui/contracts": "latest",
+    "@revealui/presentation": "latest",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/cli/templates/portfolio/src/app/globals.css
+++ b/packages/cli/templates/portfolio/src/app/globals.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@import "@revealui/presentation/tokens.css";
+@source "../../node_modules/@revealui/presentation/dist/**/*.js";
 
 @theme {
   /* Cobalt brand accent — override via your own --color-accent. */

--- a/packages/cli/templates/portfolio/src/app/page.tsx
+++ b/packages/cli/templates/portfolio/src/app/page.tsx
@@ -1,57 +1,46 @@
-import Link from 'next/link';
+import { Heading, LinkButton, Text } from '@revealui/presentation';
 
 export default function HomePage() {
   return (
     <main className="mx-auto max-w-2xl px-4 py-20">
-      <p className="text-sm font-medium text-accent">Portfolio</p>
-      <h1 className="mt-2 text-4xl font-bold tracking-tight text-gray-900">
-        Hi, I&apos;m [Your Name]
-      </h1>
-      <p className="mt-4 text-lg leading-relaxed text-gray-600">
+      <Text className="text-sm font-medium">Portfolio</Text>
+      <Heading className="mt-2">Hi, I&apos;m [Your Name]</Heading>
+      <Text className="mt-4 text-lg leading-relaxed">
         I build things for the web. This portfolio is powered by{' '}
-        <a
-          href="https://revealui.com"
-          className="font-medium text-accent hover:text-accent-hover"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <LinkButton href="https://revealui.com" external appearance="link" size="sm">
           RevealUI
-        </a>{' '}
-        - edit your projects from the admin panel, no code changes needed.
-      </p>
+        </LinkButton>
+        . Edit your projects from the admin panel, no code changes needed.
+      </Text>
 
       <div className="mt-8 flex gap-3">
-        <Link
-          href="/projects"
-          className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
-        >
+        <LinkButton href="/projects" variant="brand">
           View projects
-        </Link>
-        <a
-          href="/admin"
-          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-        >
+        </LinkButton>
+        <LinkButton href="/admin" variant="neutral" appearance="outline">
           Admin panel
-        </a>
+        </LinkButton>
       </div>
 
       <div className="mt-16 border-t border-gray-200 pt-8">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Get started</h2>
+        <Heading level={2} className="text-sm font-semibold uppercase tracking-wide">
+          Get started
+        </Heading>
         <ol className="mt-3 space-y-2 text-sm text-gray-700">
           <li>
             Replace <code className="rounded bg-gray-200 px-1.5 py-0.5 text-xs">[Your Name]</code>{' '}
             above with your name
           </li>
           <li>
-            <code className="rounded bg-gray-200 px-1.5 py-0.5 text-xs">pnpm db:seed</code> - add
+            <code className="rounded bg-gray-200 px-1.5 py-0.5 text-xs">pnpm db:seed</code> add
             sample projects
           </li>
           <li>
             Visit{' '}
-            <a href="/admin" className="text-accent hover:text-accent-hover">
+            <LinkButton href="/admin" appearance="link" size="sm">
               /admin
-            </a>{' '}
-            - add your own projects, links, and tags
+            </LinkButton>{' '}
+            to add your own projects, links, and tags
           </li>
         </ol>
       </div>

--- a/packages/cli/templates/portfolio/src/app/projects/[slug]/page.tsx
+++ b/packages/cli/templates/portfolio/src/app/projects/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Heading, LinkButton, Text } from '@revealui/presentation';
 import Image from 'next/image';
 
 const API_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:4000';
@@ -32,12 +33,12 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
   if (!project) {
     return (
       <main className="mx-auto max-w-2xl px-4 py-16">
-        <h1 className="text-2xl font-bold">Project not found</h1>
-        <p className="mt-4">
-          <a href="/projects" className="text-accent underline">
+        <Heading>Project not found</Heading>
+        <Text className="mt-4">
+          <LinkButton href="/projects" appearance="link" size="sm">
             Back to projects
-          </a>
-        </p>
+          </LinkButton>
+        </Text>
       </main>
     );
   }
@@ -45,9 +46,9 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
   return (
     <main className="mx-auto max-w-2xl px-4 py-16">
       <nav className="mb-8">
-        <a href="/projects" className="text-sm text-accent underline">
-          &larr; Back to projects
-        </a>
+        <LinkButton href="/projects" appearance="link" size="sm">
+          Back to projects
+        </LinkButton>
       </nav>
       <article>
         {project.image?.url && (
@@ -59,7 +60,7 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
             className="mb-8 aspect-video w-full rounded-lg object-cover"
           />
         )}
-        <h1 className="mb-2 text-3xl font-bold">{project.title}</h1>
+        <Heading className="mb-2">{project.title}</Heading>
         {project.tags && project.tags.length > 0 && (
           <div className="mb-6 flex flex-wrap gap-2">
             {project.tags.map((t) => (
@@ -74,20 +75,17 @@ export default async function ProjectPage({ params }: { params: Promise<{ slug: 
         )}
         <div className="prose">
           {typeof project.description === 'string' ? (
-            <p>{project.description}</p>
+            <Text>{project.description}</Text>
           ) : (
-            <p className="text-gray-500">Project description will render here.</p>
+            <Text className="text-gray-500">Project description will render here.</Text>
           )}
         </div>
         {project.link && (
-          <a
-            href={project.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-8 inline-block rounded bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
-          >
-            View project &rarr;
-          </a>
+          <div className="mt-8">
+            <LinkButton href={project.link} external variant="neutral">
+              View project
+            </LinkButton>
+          </div>
         )}
       </article>
     </main>

--- a/packages/cli/templates/portfolio/src/app/projects/page.tsx
+++ b/packages/cli/templates/portfolio/src/app/projects/page.tsx
@@ -1,3 +1,4 @@
+import { Heading, LinkButton, Text } from '@revealui/presentation';
 import Image from 'next/image';
 
 const API_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:4000';
@@ -30,24 +31,25 @@ export default async function ProjectsPage() {
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-16">
-      <h1 className="mb-8 text-3xl font-bold">Projects</h1>
+      <Heading className="mb-8">Projects</Heading>
 
       {projects.length === 0 ? (
-        <p className="text-gray-500">
+        <Text>
           No projects yet. Add projects in the{' '}
-          <a href="/admin/collections/projects" className="text-accent underline">
+          <LinkButton href="/admin/collections/projects" appearance="link" size="sm">
             admin panel
-          </a>
+          </LinkButton>
           , or run <code className="rounded bg-gray-100 px-1">pnpm db:seed</code> to add sample
           data.
-        </p>
+        </Text>
       ) : (
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
           {projects.map((project) => (
-            <a
+            <LinkButton
               key={project.id}
               href={`/projects/${project.slug}`}
-              className="block rounded-lg border border-gray-200 p-4 transition-shadow hover:shadow-md"
+              appearance="link"
+              className="h-auto flex-col items-start rounded-lg border border-gray-200 p-4 transition-shadow hover:shadow-md"
             >
               {project.image?.url && (
                 <Image
@@ -58,7 +60,9 @@ export default async function ProjectsPage() {
                   className="mb-4 aspect-video w-full rounded object-cover"
                 />
               )}
-              <h2 className="text-xl font-semibold">{project.title}</h2>
+              <Heading level={2} className="text-xl">
+                {project.title}
+              </Heading>
               {project.tags && project.tags.length > 0 && (
                 <div className="mt-2 flex flex-wrap gap-2">
                   {project.tags.map((t) => (
@@ -71,12 +75,8 @@ export default async function ProjectsPage() {
                   ))}
                 </div>
               )}
-              {project.link && (
-                <span className="mt-3 inline-block text-sm text-accent underline">
-                  View project &rarr;
-                </span>
-              )}
-            </a>
+              {project.link && <Text className="mt-3 text-sm">View project</Text>}
+            </LinkButton>
           ))}
         </div>
       )}

--- a/packages/cli/templates/starter-native/app/App.tsx
+++ b/packages/cli/templates/starter-native/app/App.tsx
@@ -1,8 +1,23 @@
-import { Router, RouterProvider, Routes } from '@revealui/router';
+import { Heading, LinkBehaviorProvider, LinkButton, Text } from '@revealui/presentation';
+import { Link, Router, RouterProvider, Routes } from '@revealui/router';
 import { RootLayout } from './layouts/RootLayout.js';
 import { HomePage } from './routes/HomePage.js';
 
 const router = new Router();
+
+function NotFoundPage(): React.ReactNode {
+  return (
+    <main className="mx-auto max-w-xl px-4 py-16">
+      <Heading>Page not found</Heading>
+      <Text className="mt-3">
+        The page you are looking for does not exist.{' '}
+        <LinkButton href="/" appearance="link" size="sm">
+          Return home
+        </LinkButton>
+      </Text>
+    </main>
+  );
+}
 
 router.registerRoutes([
   {
@@ -12,17 +27,7 @@ router.registerRoutes([
   },
   {
     path: '/*notfound',
-    component: () => (
-      <main className="mx-auto max-w-xl px-4 py-16">
-        <h1 className="text-2xl font-bold tracking-tight text-gray-900">Page not found</h1>
-        <p className="mt-3 text-gray-600">
-          The page you are looking for does not exist.{' '}
-          <a href="/" className="font-medium text-emerald-600 hover:text-emerald-700">
-            Return home
-          </a>
-        </p>
-      </main>
-    ),
+    component: NotFoundPage,
     layout: RootLayout,
   },
 ]);
@@ -30,7 +35,9 @@ router.registerRoutes([
 export function App(): React.ReactNode {
   return (
     <RouterProvider router={router}>
-      <Routes />
+      <LinkBehaviorProvider component={Link} hrefProp="to">
+        <Routes />
+      </LinkBehaviorProvider>
     </RouterProvider>
   );
 }

--- a/packages/cli/templates/starter-native/app/layouts/RootLayout.tsx
+++ b/packages/cli/templates/starter-native/app/layouts/RootLayout.tsx
@@ -1,3 +1,4 @@
+import { LinkButton, Text } from '@revealui/presentation';
 import type { ReactNode } from 'react';
 
 export function RootLayout({ children }: { children: ReactNode }): React.ReactNode {
@@ -5,18 +6,20 @@ export function RootLayout({ children }: { children: ReactNode }): React.ReactNo
     <div className="min-h-screen bg-gray-50 text-gray-900 antialiased">
       <header className="border-b border-gray-200 bg-white">
         <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
-          <a href="/" className="text-sm font-semibold tracking-tight text-gray-900">
+          <LinkButton href="/" appearance="link" className="text-sm font-semibold tracking-tight">
             RevealUI
-          </a>
+          </LinkButton>
           <nav className="text-sm text-gray-600">
-            <span className="text-xs uppercase tracking-wide text-gray-400">Starter (native)</span>
+            <Text className="text-xs uppercase tracking-wide text-gray-400">Starter (native)</Text>
           </nav>
         </div>
       </header>
       <div>{children}</div>
       <footer className="mt-16 border-t border-gray-200 bg-white">
-        <div className="mx-auto max-w-4xl px-4 py-4 text-xs text-gray-500">
-          Built with RevealUI + Vite + @revealui/router.
+        <div className="mx-auto max-w-4xl px-4 py-4">
+          <Text className="text-xs text-gray-500">
+            Built with RevealUI + Vite + @revealui/router.
+          </Text>
         </div>
       </footer>
     </div>

--- a/packages/cli/templates/starter-native/app/routes/HomePage.tsx
+++ b/packages/cli/templates/starter-native/app/routes/HomePage.tsx
@@ -1,16 +1,18 @@
-import { Link } from '@revealui/router';
+import { Heading, LinkButton, Text } from '@revealui/presentation';
 
 export function HomePage(): React.ReactNode {
   return (
     <main className="mx-auto max-w-2xl px-4 py-16">
-      <h1 className="text-3xl font-bold tracking-tight text-gray-900">RevealUI</h1>
-      <p className="mt-3 text-gray-600">
-        Your project is running on the RevealUI-native runtime — Vite + @revealui/router. No Next.js
-        dependency.
-      </p>
+      <Heading>RevealUI</Heading>
+      <Text className="mt-3">
+        Your project is running on the RevealUI-native runtime. Vite plus @revealui/router. No
+        Next.js dependency.
+      </Text>
 
       <section className="mt-10 rounded-lg border border-gray-200 bg-white p-6">
-        <h2 className="text-lg font-semibold text-gray-900">Next steps</h2>
+        <Heading level={2} className="text-lg">
+          Next steps
+        </Heading>
         <ul className="mt-3 space-y-2 text-sm text-gray-700">
           <li>
             Edit{' '}
@@ -38,21 +40,23 @@ export function HomePage(): React.ReactNode {
       </section>
 
       <section className="mt-6 rounded-lg border border-gray-200 bg-white p-6">
-        <h2 className="text-lg font-semibold text-gray-900">Try the router</h2>
-        <p className="mt-2 text-sm text-gray-600">
+        <Heading level={2} className="text-lg">
+          Try the router
+        </Heading>
+        <Text className="mt-2 text-sm">
           Click a link below to see client-side navigation in action (a stub 404 page rendered by
           the catch-all route in <code>app/App.tsx</code>):
-        </p>
+        </Text>
         <div className="mt-3 flex gap-3 text-sm">
-          <Link to="/not-yet-built" className="font-medium text-emerald-600 hover:text-emerald-700">
-            /not-yet-built →
-          </Link>
+          <LinkButton href="/not-yet-built" appearance="link" size="sm">
+            /not-yet-built
+          </LinkButton>
         </div>
       </section>
 
-      <p className="mt-10 text-xs text-gray-500">
+      <Text className="mt-10 text-xs text-gray-500">
         Powered by RevealUI. Primitives for people, content, offers, payments, and agents.
-      </p>
+      </Text>
     </main>
   );
 }

--- a/packages/cli/templates/starter-native/app/styles/globals.css
+++ b/packages/cli/templates/starter-native/app/styles/globals.css
@@ -1,4 +1,6 @@
 @import 'tailwindcss';
+@import '@revealui/presentation/tokens.css';
+@source '../../node_modules/@revealui/presentation/dist/**/*.js';
 
 /*
   Tailwind v4 ships with a sensible default theme. Customize via @theme directive

--- a/packages/cli/templates/starter/package.json
+++ b/packages/cli/templates/starter/package.json
@@ -20,6 +20,7 @@
     "@revealui/db": "latest",
     "@revealui/auth": "latest",
     "@revealui/contracts": "latest",
+    "@revealui/presentation": "latest",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/cli/templates/starter/src/app/globals.css
+++ b/packages/cli/templates/starter/src/app/globals.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@import "@revealui/presentation/tokens.css";
+@source "../../node_modules/@revealui/presentation/dist/**/*.js";
 
 @theme {
   /* Cobalt brand accent — override via your own --color-accent. */

--- a/packages/cli/templates/starter/src/app/page.tsx
+++ b/packages/cli/templates/starter/src/app/page.tsx
@@ -1,18 +1,19 @@
+import { Heading, LinkButton, Text } from '@revealui/presentation';
+
 export default function HomePage() {
   return (
     <main className="mx-auto max-w-xl px-4 py-16">
-      <h1 className="text-3xl font-bold tracking-tight text-gray-900">RevealUI</h1>
-      <p className="mt-3 text-gray-600">
-        Your project is running. Visit{' '}
-        <a href="/admin" className="font-medium text-accent hover:text-accent-hover">
-          /admin
-        </a>{' '}
-        to manage content.
-      </p>
-      <p className="mt-6 text-sm text-gray-500">
+      <Heading>RevealUI</Heading>
+      <Text className="mt-3">Your project is running. Visit the admin to manage content.</Text>
+      <div className="mt-6">
+        <LinkButton href="/admin" variant="brand">
+          Open admin
+        </LinkButton>
+      </div>
+      <Text className="mt-6 text-sm">
         Edit <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs">src/app/page.tsx</code> to
         customize this page.
-      </p>
+      </Text>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Stamp all five `create-revealui` templates so new apps import `@revealui/presentation` instead of declaring it unused:

- Add `@revealui/presentation` to starter, basic-blog, e-commerce, and portfolio (starter-native already had it)
- Import `tokens.css` plus `@source` in every template stylesheet
- Compose home, list, detail, and native starter pages with `Heading`, `Text`, and `LinkButton`
- Wire starter-native through `LinkBehaviorProvider` + `@revealui/router` `Link`
- Lock the dep and the import in `template-structure` tests so the demo "declare but never import" failure cannot recur

Tier-1 host tags (`button` / `input` / `select` / `textarea` / `svg`) were already absent from templates. This slice is composition plus stamping.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/template-structure.test.ts` in `@revealui/cli` (57 passed)
- [x] phase-1 pre-push gate including `validate:tier1-presentation -- --hard-fail`
- [x] no remaining `<a>` / `<h1>` / `<h2>` / `<h3>` in `packages/cli/templates/**`