### PR TITLE
feat(harnesses): RevDev manager adapter consumes content SSOT

### DIFF
--- a/.revealui/adapters/revdev.md
+++ b/.revealui/adapters/revdev.md
@@ -1,0 +1,23 @@
+> **RevealUI manager.** Policy and skills are owned by `.revealui/`.
+> This vendor tree is an **adapter stub only** (equal rank with every other vendor).
+> Do not fork hardlines here. Edit package definitions → generate into `.revealui/content/`.
+> **Quality over speed:** correctness and proof outrank throughput in every session.
+
+# RevealUI manager (RevDev adapter)
+
+RevDev Studio, Console, and the daemon are an **equal adapter**. They **read**
+the project manager and generated content. They do not own a second rules tree.
+
+When cwd is this project:
+
+1. Read **`.revealui/manager.json`**
+2. Read **`.revealui/content/`** for shared policy (SSOT after `manager materialize`)
+3. Open `tracker.path` from the manager (fleet TRACKER)
+4. Product I/O: RevealUI MCP (`rfg`) — not a vendor side channel
+5. Local inference stays on snaps / Ollama via the daemon. No Anthropic SDK.
+
+Do not create `~/.revdev/rules/` hardline copies. Do not emit a parallel
+generator that duplicates `.revealui/content/`. Skills index RPC and
+AgentRuntime cockpit loops are later GAP-293 phases.
+
+See `.revealui/README.md` and `.jv/docs/gap-specs/GAP-293-revdev-harness-parity-design.md`.

--- a/.revealui/manager.json
+++ b/.revealui/manager.json
@@ -36,6 +36,11 @@
       "id": "revealui-agent",
       "projectTree": null,
       "rank": "equal"
+    },
+    {
+      "id": "revdev",
+      "projectTree": null,
+      "rank": "equal"
     }
   ],
   "mcp": {

--- a/packages/harnesses/src/__tests__/manager.test.ts
+++ b/packages/harnesses/src/__tests__/manager.test.ts
@@ -32,6 +32,7 @@ describe('project manager (.revealui)', () => {
     expect(cfg.version).toBe(1);
     expect(cfg.contentRoot).toBe('content');
     expect(cfg.adapters.some((a) => a.id === 'claude-code' && a.rank === 'equal')).toBe(true);
+    expect(cfg.adapters.some((a) => a.id === 'revdev' && a.projectTree === null)).toBe(true);
     expect(cfg.adapters.every((a) => a.rank === 'equal')).toBe(true);
   });
 
@@ -51,6 +52,10 @@ describe('project manager (.revealui)', () => {
     const opencodeStub = readFileSync(join(root, '.opencode/revealui-manager.md'), 'utf-8');
     expect(opencodeStub).toContain('.revealui/manager.json');
     expect(opencodeStub).toContain('equal');
+    const revdevStub = readFileSync(join(root, '.revealui/adapters/revdev.md'), 'utf-8');
+    expect(revdevStub).toContain('.revealui/content/');
+    expect(revdevStub).toContain('Do not create');
+    expect(revdevStub).toContain('equal adapter');
   });
 
   it('materialize emits Grok peer SessionStart/SessionEnd control-layer hooks', () => {
@@ -160,6 +165,7 @@ describe('project manager (.revealui)', () => {
         { id: 'vscode', projectTree: null, rank: 'equal' },
         { id: 'grok', projectTree: null, rank: 'equal' },
         { id: 'revealui-agent', projectTree: null, rank: 'equal' },
+        { id: 'revdev', projectTree: null, rank: 'equal' },
       ],
       mcp: { configPath: 'mcp.json' },
       contentPackage: '@revealui/harnesses',
@@ -184,6 +190,17 @@ describe('project manager (.revealui)', () => {
     writeManagerAdapterContent(root);
     const after = checkManager(root);
     expect(after.ok).toBe(true);
+  });
+
+  it('checkManager warns when the RevDev consume-content stub is missing', () => {
+    const root = tempProject();
+    materializeManager(root, {
+      adapters: ['claude-code', 'cursor', 'opencode', 'grok'],
+    });
+    writeManagerAdapterContent(root);
+    const checked = checkManager(root);
+    expect(checked.ok).toBe(true);
+    expect(checked.warnings.some((w) => w.includes('revdev.md'))).toBe(true);
   });
 
   it('check fails when content tree is missing after manager.json exists', () => {

--- a/packages/harnesses/src/manager/index.ts
+++ b/packages/harnesses/src/manager/index.ts
@@ -15,6 +15,7 @@ export {
   materializeGrokPointer,
   materializeManager,
   materializeOpenCodeStub,
+  materializeRevDevPointer,
   writeManager,
   writeManagerPreserving,
 } from './materialize.js';

--- a/packages/harnesses/src/manager/materialize.ts
+++ b/packages/harnesses/src/manager/materialize.ts
@@ -223,6 +223,41 @@ Rebuild \`@revealui/harnesses\` so \`dist/cli.js session\` / \`hook grok\` are a
   return rel;
 }
 
+/**
+ * GAP-293 Phase A: RevDev consumes `.revealui/content` as SSOT.
+ * No second emit tree (would twin the claude-code generator).
+ */
+export function materializeRevDevPointer(projectRoot: string): string {
+  const rel = join(MANAGER_DIR, 'adapters', 'revdev.md');
+  const abs = join(projectRoot, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(
+    abs,
+    `${STUB_HEADER}
+# RevealUI manager (RevDev adapter)
+
+RevDev Studio, Console, and the daemon are an **equal adapter**. They **read**
+the project manager and generated content. They do not own a second rules tree.
+
+When cwd is this project:
+
+1. Read **\`.revealui/manager.json\`**
+2. Read **\`.revealui/content/\`** for shared policy (SSOT after \`manager materialize\`)
+3. Open \`tracker.path\` from the manager (fleet TRACKER)
+4. Product I/O: RevealUI MCP (\`rfg\`) — not a vendor side channel
+5. Local inference stays on snaps / Ollama via the daemon. No Anthropic SDK.
+
+Do not create \`~/.revdev/rules/\` hardline copies. Do not emit a parallel
+generator that duplicates \`.revealui/content/\`. Skills index RPC and
+AgentRuntime cockpit loops are later GAP-293 phases.
+
+See \`.revealui/README.md\` and \`.jv/docs/gap-specs/GAP-293-revdev-harness-parity-design.md\`.
+`,
+    'utf-8',
+  );
+  return rel;
+}
+
 export interface MaterializeResult {
   managerPath: string;
   stubs: string[];
@@ -233,17 +268,18 @@ export function materializeManager(
   projectRoot: string,
   options?: {
     config?: ManagerConfig;
-    adapters?: Array<'claude-code' | 'cursor' | 'opencode' | 'grok'>;
+    adapters?: Array<'claude-code' | 'cursor' | 'opencode' | 'grok' | 'revdev'>;
   },
 ): MaterializeResult {
   const managerFile = writeManagerPreserving(projectRoot, options?.config);
-  const adapters = options?.adapters ?? ['claude-code', 'cursor', 'opencode', 'grok'];
+  const adapters = options?.adapters ?? ['claude-code', 'cursor', 'opencode', 'grok', 'revdev'];
   const stubs: string[] = [];
   for (const id of adapters) {
     if (id === 'claude-code') stubs.push(materializeClaudeStub(projectRoot));
     else if (id === 'cursor') stubs.push(materializeCursorStub(projectRoot));
     else if (id === 'opencode') stubs.push(materializeOpenCodeStub(projectRoot));
     else if (id === 'grok') stubs.push(materializeGrokPointer(projectRoot));
+    else if (id === 'revdev') stubs.push(materializeRevDevPointer(projectRoot));
   }
   return { managerPath: managerFile, stubs };
 }
@@ -348,6 +384,10 @@ export function checkManager(projectRoot: string): ManagerCheckResult {
   const opencodeStub = join(projectRoot, '.opencode', 'revealui-manager.md');
   if (readFileOrNull(opencodeStub) === null) {
     warnings.push('missing .opencode/revealui-manager.md stub (materialize opencode)');
+  }
+  const revdevStub = join(projectRoot, MANAGER_DIR, 'adapters', 'revdev.md');
+  if (readFileOrNull(revdevStub) === null) {
+    warnings.push('missing .revealui/adapters/revdev.md stub (materialize revdev)');
   }
   const readme = join(projectRoot, MANAGER_DIR, 'README.md');
   if (readFileOrNull(readme) === null) {

--- a/packages/harnesses/src/manager/schema.ts
+++ b/packages/harnesses/src/manager/schema.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 /**
  * Project manager manifest (`.revealui/manager.json`).
  *
- * Equal vendor authority: Claude, Grok, Cursor, OpenCode, VSCode all
- * *reference* this tree; none is the policy SSOT (GAP-406).
+ * Equal vendor authority: Claude, Grok, Cursor, OpenCode, VSCode, RevDev all
+ * *reference* this tree; none is the policy SSOT (GAP-406 / GAP-293).
  */
 export const ManagerSchema = z.object({
   version: z.literal(1).default(1),
@@ -23,8 +23,16 @@ export const ManagerSchema = z.object({
   adapters: z
     .array(
       z.object({
-        id: z.enum(['claude-code', 'cursor', 'opencode', 'vscode', 'grok', 'revealui-agent']),
-        /** Vendor tree relative to project root (null = machine-home only) */
+        id: z.enum([
+          'claude-code',
+          'cursor',
+          'opencode',
+          'vscode',
+          'grok',
+          'revealui-agent',
+          'revdev',
+        ]),
+        /** Vendor tree relative to project root (null = consume .revealui/content) */
         projectTree: z.string().nullable().default(null),
         /** Equal rank — no adapter is more authoritative than another */
         rank: z.literal('equal').default('equal'),
@@ -37,6 +45,7 @@ export const ManagerSchema = z.object({
       { id: 'vscode', projectTree: null, rank: 'equal' },
       { id: 'grok', projectTree: null, rank: 'equal' },
       { id: 'revealui-agent', projectTree: null, rank: 'equal' },
+      { id: 'revdev', projectTree: null, rank: 'equal' },
     ]),
   mcp: z
     .object({


### PR DESCRIPTION
## Summary

GAP-293 Phase A. Owner accepted the spec in-session (stub-and-consume \`.revealui/content\`; Phase B later).

- Manager adapter id \`revdev\` (equal rank, no project tree)
- \`materializeRevDevPointer\` writes \`.revealui/adapters/revdev.md\`
- Monorepo \`manager.json\` + committed stub
- No second content generator (would twin \`.revealui/content\`)
- No skills-index RPC (Phase B)

Spec: RevealUIStudio/revealui-jv#1291

## Test plan

- [x] \`vitest run src/__tests__/manager.test.ts\` 10/10
- [x] biome on touched files
- [x] local phase-1 gate PASS