### PR TITLE
fix(admin,core): mount GAP-300 onboarding on CMS Overview home

### DIFF
--- a/apps/admin/src/app/(backend)/[[...segments]]/page.tsx
+++ b/apps/admin/src/app/(backend)/[[...segments]]/page.tsx
@@ -3,6 +3,7 @@ import { serializeConfig } from '@revealui/core/admin/utils/serializeConfig';
 import type { RevealConfig } from '@revealui/core/types/core';
 import { IconSettings } from '@revealui/presentation/server';
 import Link from 'next/link';
+import HomeOnboarding from '@/lib/components/BeforeDashboard/HomeOnboarding';
 import config from '../../../../revealui.config';
 
 // Force dynamic rendering to prevent build-time initialization
@@ -37,7 +38,11 @@ export default async function Page({ params: _params, searchParams: _searchParam
       >
         <IconSettings className="h-5 w-5" aria-hidden="true" />
       </Link>
-      <AdminDashboard config={serializedConfig} siteName={siteName} />
+      <AdminDashboard
+        config={serializedConfig}
+        siteName={siteName}
+        overviewLead={<HomeOnboarding />}
+      />
     </div>
   );
 }

--- a/apps/admin/src/app/(backend)/dashboard/page.tsx
+++ b/apps/admin/src/app/(backend)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { serializeConfig } from '@revealui/core/admin/utils/serializeConfig';
 import type { RevealConfig } from '@revealui/core/types/core';
 import { IconSettings } from '@revealui/presentation';
 import Link from 'next/link';
+import HomeOnboarding from '@/lib/components/BeforeDashboard/HomeOnboarding';
 import config from '../../../../revealui.config';
 
 // Static route for /dashboard — wins over (frontend)/[slug] dynamic route.
@@ -30,7 +31,11 @@ export default async function Page() {
       >
         <IconSettings size="md" />
       </Link>
-      <AdminDashboard config={serializedConfig} siteName={siteName} />
+      <AdminDashboard
+        config={serializedConfig}
+        siteName={siteName}
+        overviewLead={<HomeOnboarding />}
+      />
     </div>
   );
 }

--- a/apps/admin/src/lib/components/BeforeDashboard/HomeOnboarding.tsx
+++ b/apps/admin/src/lib/components/BeforeDashboard/HomeOnboarding.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+/**
+ * Onboarding lead for the CMS Overview home (GAP-300).
+ *
+ * BeforeDashboard used to own checklist + nudge, but home routes render
+ * AdminDashboard Overview — that slot was never mounted. This thin stack is
+ * passed as AdminDashboard `overviewLead` so first-session surfaces land on
+ * the page founders actually open (/).
+ */
+
+import OnboardingChecklist from './OnboardingChecklist';
+import OnboardingNudge from './OnboardingNudge';
+
+export default function HomeOnboarding() {
+  return (
+    <div className="flex flex-col gap-4">
+      <OnboardingNudge />
+      <OnboardingChecklist />
+    </div>
+  );
+}

--- a/apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx
+++ b/apps/admin/src/lib/components/BeforeDashboard/OnboardingChecklist.tsx
@@ -128,11 +128,11 @@ export default function OnboardingChecklist() {
   };
 
   return (
-    <div className="mb-6 rounded-lg border border-zinc-700 bg-zinc-800/50 p-6">
-      <div className="mb-4 flex items-center justify-between">
+    <div className="rounded-lg border border-border bg-card p-6 shadow-sm">
+      <div className="mb-4 flex items-center justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-white">Getting Started</h2>
-          <p className="mt-0.5 text-sm text-zinc-400">
+          <h2 className="text-lg font-semibold text-foreground">Getting Started</h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
             Welcome to {SITE_NAME}. Here are a few things to get you going.
           </p>
         </div>
@@ -142,7 +142,7 @@ export default function OnboardingChecklist() {
           variant="neutral"
           size="sm"
           onClick={handleDismiss}
-          className="shrink-0 text-xs text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+          className="shrink-0 text-xs text-muted-foreground"
         >
           Dismiss
         </Button>
@@ -156,20 +156,20 @@ export default function OnboardingChecklist() {
             <Link
               key={item.href}
               href={item.href}
-              className="flex items-start gap-3 rounded-lg border border-zinc-700/50 bg-zinc-800 p-3 transition-colors hover:border-zinc-500 hover:bg-zinc-750"
+              className="flex items-start gap-3 rounded-lg border border-border bg-background p-3 transition-colors hover:border-primary/40 hover:bg-muted/40"
             >
               <span
                 className={`mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border text-xs ${
                   checked
                     ? 'border-success bg-success/20 text-success'
-                    : 'border-zinc-600 text-zinc-500'
+                    : 'border-border text-muted-foreground'
                 }`}
               >
                 {checked ? <span aria-hidden="true">&#10003;</span> : index + 1}
               </span>
               <div>
-                <p className="text-sm font-medium text-white">{item.label}</p>
-                <p className="mt-0.5 text-xs text-zinc-400">{item.description}</p>
+                <p className="text-sm font-medium text-foreground">{item.label}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{item.description}</p>
               </div>
             </Link>
           );

--- a/apps/admin/src/lib/components/BeforeDashboard/OnboardingNudge.tsx
+++ b/apps/admin/src/lib/components/BeforeDashboard/OnboardingNudge.tsx
@@ -30,10 +30,9 @@ async function fetchCurrentNudge(apiUrl: string): Promise<CurrentNudge | null> {
 }
 
 /**
- * One-at-a-time onboarding nudge (GAP-300 §7). Sits next to
- * OnboardingChecklist in the BeforeDashboard slot. Dismissal is a
- * server-tracked snooze, not a localStorage kill switch — see
- * `packages/db/src/schema/nudges.ts`.
+ * One-at-a-time onboarding nudge (GAP-300 §7). Mounted via HomeOnboarding as
+ * AdminDashboard overviewLead (not the legacy beforeNavLinks slot). Dismissal
+ * is a server-tracked snooze — see packages/db/src/schema/nudges.ts.
  */
 export default function OnboardingNudge() {
   const [nudge, setNudge] = useState<CurrentNudge | null>(null);
@@ -65,11 +64,11 @@ export default function OnboardingNudge() {
   };
 
   return (
-    <div className="mb-6 rounded-lg border border-primary/30 bg-primary/5 p-6">
+    <div className="rounded-lg border border-primary/30 bg-primary/5 p-6 shadow-sm">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-lg font-semibold text-white">{nudge.headline}</h2>
-          <p className="mt-1 text-sm text-zinc-300">{nudge.body}</p>
+          <h2 className="text-lg font-semibold text-foreground">{nudge.headline}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{nudge.body}</p>
           <Link
             href={nudge.ctaHref}
             className="mt-3 inline-block rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
@@ -83,7 +82,7 @@ export default function OnboardingNudge() {
           variant="neutral"
           size="sm"
           onClick={handleDismiss}
-          className="shrink-0 text-xs text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
+          className="shrink-0 text-xs text-muted-foreground"
         >
           Dismiss
         </Button>

--- a/packages/core/src/client/admin/components/AdminDashboard.tsx
+++ b/packages/core/src/client/admin/components/AdminDashboard.tsx
@@ -27,6 +27,12 @@ interface AdminDashboardProps {
    * files cannot read those env vars at runtime (build-time inlining).
    */
   siteName?: string;
+  /**
+   * Optional lead content above the Overview stats (GAP-300 onboarding
+   * checklist/nudge). Only shown on the home Overview view, not collection
+   * or document editors.
+   */
+  overviewLead?: ReactNode;
 }
 
 type ViewType = 'dashboard' | 'collection' | 'edit' | 'global';
@@ -460,6 +466,7 @@ function DashboardHome({
   degraded,
   onCollectionClick,
   onGlobalClick,
+  overviewLead,
 }: {
   siteName: string;
   collections: RevealCollectionConfig[];
@@ -467,6 +474,7 @@ function DashboardHome({
   degraded: boolean;
   onCollectionClick: (c: RevealCollectionConfig) => void;
   onGlobalClick: (g: RevealGlobalConfig) => void;
+  overviewLead?: ReactNode;
 }) {
   const grouped = groupCollectionsByTaxonomy(collections);
 
@@ -498,6 +506,8 @@ function DashboardHome({
             Collections, globals, and system status for {siteName}.
           </p>
         </div>
+
+        {overviewLead ? <div className="mb-6">{overviewLead}</div> : null}
 
         <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
           <StatTile label="Collections" value={collections.length} icon={collectionsIcon} />
@@ -556,7 +566,11 @@ function logApiError(err: unknown, context: string): void {
 // Main component
 // =============================================================================
 
-export function AdminDashboard({ config, siteName = 'RevealUI' }: AdminDashboardProps) {
+export function AdminDashboard({
+  config,
+  siteName = 'RevealUI',
+  overviewLead,
+}: AdminDashboardProps) {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const collections = config.collections || [];
@@ -894,6 +908,7 @@ export function AdminDashboard({ config, siteName = 'RevealUI' }: AdminDashboard
       degraded={Boolean(state.error)}
       onCollectionClick={(c) => void handleCollectionClick(c)}
       onGlobalClick={(g) => void handleGlobalClick(g)}
+      overviewLead={overviewLead}
     />
   );
 }


### PR DESCRIPTION
## Summary
GAP-300 walk step 2 failed on prod: home shows CMS **Overview** only. The **Getting Started** checklist and nudge lived under `BeforeDashboard`, wired only via legacy `beforeNavLinks` that `AdminDashboard` never renders.

### Fix
- Add `overviewLead` to `@revealui/core` `AdminDashboard` (Overview only)
- Pass `HomeOnboarding` (nudge + checklist) from `/` and `/dashboard`
- Semantic tokens so the card is readable on the light Overview shell

### Test
- [x] OnboardingChecklist + OnboardingNudge unit tests (10)
- [x] Local phase-1 gate
- Owner: after merge → promote → hard refresh `https://admin.revealui.com/` → see **Getting Started** with **Run your first agent**

## GAP
GAP-300 residual (surface unwired on real home).