### PR TITLE
feat(harnesses): read-only skill catalog for RevDev

### DIFF
--- a/packages/harnesses/src/__tests__/skill-catalog.test.ts
+++ b/packages/harnesses/src/__tests__/skill-catalog.test.ts
@@ -1,0 +1,86 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { listSkillCatalog, skimSkillFrontmatter } from '../content/skill-catalog.js';
+
+describe('skill catalog (GAP-293 Phase B)', () => {
+  it('skims YAML frontmatter without executing the body', () => {
+    const fields = skimSkillFrontmatter(`---
+name: Demo skill
+description: "A read-only listing fixture"
+---
+
+# Demo
+run something dangerous
+`);
+    expect(fields.name).toBe('Demo skill');
+    expect(fields.description).toBe('A read-only listing fixture');
+  });
+
+  it('lists package definitions when no disk trees are passed', () => {
+    const list = listSkillCatalog({ includeDefinitions: true });
+    expect(list.length).toBeGreaterThan(0);
+    expect(list.every((s) => s.source === 'definitions')).toBe(true);
+    expect(list.every((s) => s.id.length > 0 && s.name.length > 0)).toBe(true);
+    const ids = list.map((s) => s.id);
+    expect(ids).toEqual([...ids].sort());
+  });
+
+  it('project content wins over definitions for the same id', () => {
+    const root = mkdtempSync(join(tmpdir(), 'skill-cat-'));
+    const skillDir = join(root, '.revealui/content/skills/preflight');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: Preflight (disk)
+description: Materialized override
+---
+`,
+    );
+    const list = listSkillCatalog({ projectRoot: root, includeDefinitions: true });
+    const hit = list.find((s) => s.id === 'preflight');
+    expect(hit?.source).toBe('content');
+    expect(hit?.name).toBe('Preflight (disk)');
+    expect(hit?.description).toBe('Materialized override');
+  });
+
+  it('reads a revskills tree and does not require definitions', () => {
+    const root = mkdtempSync(join(tmpdir(), 'revskills-cat-'));
+    const skillDir = join(root, 'skills/example-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: Example
+description: From revskills
+---
+body
+`,
+    );
+    const list = listSkillCatalog({
+      revskillsRoot: root,
+      includeDefinitions: false,
+    });
+    expect(list).toEqual([
+      {
+        id: 'example-skill',
+        name: 'Example',
+        description: 'From revskills',
+        path: join(skillDir, 'SKILL.md'),
+        source: 'revskills',
+      },
+    ]);
+  });
+
+  it('skips directories without SKILL.md', () => {
+    const root = mkdtempSync(join(tmpdir(), 'skill-empty-'));
+    mkdirSync(join(root, '.revealui/content/skills/orphan'), { recursive: true });
+    const list = listSkillCatalog({
+      projectRoot: root,
+      includeDefinitions: false,
+    });
+    expect(list).toEqual([]);
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -14,6 +14,7 @@
  *   coordinate [--project <path>]    Print current workboard state
  *   hook <cursor|claude-code|vscode|grok> Normalize a hook payload from stdin, evaluate policy, spool the receipt
  *   acp                              Run RevealUI as an ACP agent on stdio (GAP-381 Phase D; Zed/JetBrains)
+ *   skills list [--json]             Read-only skill catalog (GAP-293 Phase B)
  *   session register|end|peers|reap  Soft-optional RevDev session boundary + peer panel + reaper (GAP-459)
  *
  * License: FSL-1.1-MIT
@@ -33,6 +34,7 @@ import {
   generateContent,
   listContent,
   listGenerators,
+  listSkillCatalog,
   loadContentSnapshot,
   MANAGER_CONTENT_OUTPUT,
   MANAGER_MATERIALIZE_GENERATORS,
@@ -568,6 +570,36 @@ async function main() {
     }
     process.stderr.write('Usage: revealui-harnesses inference <status|apply> [tier]\n');
     process.exit(1);
+  }
+
+  if (command === 'skills') {
+    const [subcommand] = args;
+    const projectIdx = args.indexOf('--project');
+    const revskillsIdx = args.indexOf('--revskills');
+    const asJson = args.includes('--json');
+    const projectRoot =
+      projectIdx >= 0 ? (args[projectIdx + 1] ?? DEFAULT_PROJECT) : DEFAULT_PROJECT;
+    const revskillsRoot = revskillsIdx >= 0 ? args[revskillsIdx + 1] : undefined;
+    if (subcommand !== 'list') {
+      process.stderr.write(
+        'Usage: revealui-harnesses skills list [--json] [--project <dir>] [--revskills <dir>]\n',
+      );
+      process.exit(1);
+    }
+    const catalog = listSkillCatalog({
+      projectRoot,
+      revskillsRoot,
+      includeDefinitions: true,
+    });
+    if (asJson) {
+      process.stdout.write(`${JSON.stringify(catalog, null, 2)}\n`);
+      return;
+    }
+    process.stdout.write(`${catalog.length} skills\n`);
+    for (const skill of catalog) {
+      process.stdout.write(`${skill.id}\t${skill.source}\t${skill.name}\t${skill.description}\n`);
+    }
+    return;
   }
 
   if (command === 'manager') {

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -68,6 +68,8 @@ export {
   RuleSchema,
   SkillSchema,
 } from './schemas/index.js';
+export type { SkillCatalogEntry, SkillCatalogSource } from './skill-catalog.js';
+export { listSkillCatalog, skimSkillFrontmatter } from './skill-catalog.js';
 export type {
   ContentSnapshot,
   ContentSnapshotFile,

--- a/packages/harnesses/src/content/skill-catalog.ts
+++ b/packages/harnesses/src/content/skill-catalog.ts
@@ -1,0 +1,142 @@
+/**
+ * GAP-293 Phase B — read-only skill catalog.
+ *
+ * Lists skills a Claude user already sees: package definitions, materialized
+ * `.revealui/content/skills`, and an optional revskills tree. Never executes
+ * SKILL.md. RevDev consumes this list; it does not own a second pack.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildManifest } from './definitions/index.js';
+import { MANAGER_CONTENT_OUTPUT } from './generators/types.js';
+
+export type SkillCatalogSource = 'content' | 'revskills' | 'definitions';
+
+export interface SkillCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  source: SkillCatalogSource;
+}
+
+export interface ListSkillCatalogOptions {
+  projectRoot?: string;
+  revskillsRoot?: string;
+  includeDefinitions?: boolean;
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'ENOENT'
+  );
+}
+
+function unquote(raw: string): string {
+  if (raw.length >= 2) {
+    const a = raw[0];
+    const b = raw[raw.length - 1];
+    if ((a === '"' && b === '"') || (a === "'" && b === "'")) {
+      return raw.slice(1, -1);
+    }
+  }
+  return raw;
+}
+
+/** Line-oriented YAML frontmatter skim. No authored regex. */
+export function skimSkillFrontmatter(text: string): { name: string; description: string } {
+  const lines = text.split('\n');
+  let inFm = false;
+  let name = '';
+  let description = '';
+  for (const line of lines) {
+    if (line === '---') {
+      if (!inFm) {
+        inFm = true;
+        continue;
+      }
+      break;
+    }
+    if (!inFm) break;
+    if (line.startsWith('name:')) name = unquote(line.slice(5).trim());
+    else if (line.startsWith('description:')) description = unquote(line.slice(12).trim());
+  }
+  return { name, description };
+}
+
+function readSkillFile(filePath: string): string | null {
+  try {
+    return readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    if (isEnoent(err)) return null;
+    throw err;
+  }
+}
+
+function listSkillDir(skillsDir: string, source: SkillCatalogSource): SkillCatalogEntry[] {
+  let names: string[];
+  try {
+    names = readdirSync(skillsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch (err) {
+    if (isEnoent(err)) return [];
+    throw err;
+  }
+  const out: SkillCatalogEntry[] = [];
+  for (const id of names) {
+    const path = join(skillsDir, id, 'SKILL.md');
+    const text = readSkillFile(path);
+    if (text === null) continue;
+    const fields = skimSkillFrontmatter(text);
+    out.push({
+      id,
+      name: fields.name || id,
+      description: fields.description,
+      path,
+      source,
+    });
+  }
+  return out;
+}
+
+/**
+ * Union catalog. Disk content wins over revskills over definitions for the
+ * same id so a materialized project tree is what RevDev reports first.
+ */
+export function listSkillCatalog(options: ListSkillCatalogOptions = {}): SkillCatalogEntry[] {
+  const includeDefinitions = options.includeDefinitions !== false;
+  const byId = new Map<string, SkillCatalogEntry>();
+
+  if (includeDefinitions) {
+    for (const skill of buildManifest().skills) {
+      byId.set(skill.id, {
+        id: skill.id,
+        name: skill.name,
+        description: skill.description,
+        path: `${MANAGER_CONTENT_OUTPUT}/skills/${skill.id}/SKILL.md`,
+        source: 'definitions',
+      });
+    }
+  }
+
+  if (options.revskillsRoot) {
+    for (const entry of listSkillDir(join(options.revskillsRoot, 'skills'), 'revskills')) {
+      byId.set(entry.id, entry);
+    }
+  }
+
+  if (options.projectRoot) {
+    const contentDir = join(options.projectRoot, MANAGER_CONTENT_OUTPUT, 'skills');
+    for (const entry of listSkillDir(contentDir, 'content')) {
+      byId.set(entry.id, entry);
+    }
+  }
+
+  return [...byId.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}


### PR DESCRIPTION
## Summary

GAP-293 Phase B (control layer). \`listSkillCatalog\` unions package definitions, \`.revealui/content/skills\`, and an optional revskills tree. \`revealui-harnesses skills list [--json]\`. Never executes SKILL.md.

Companion daemon RPC: RevealUIStudio/revdev#394 (\`skills.list\`).

## Test plan

- [x] \`vitest run src/__tests__/skill-catalog.test.ts\`
- [x] biome check on touched files
- [x] content diff check (38 files up to date)