### PR TITLE
fix(marketing,presentation): full-bleed viewport-stage hero backdrop

### DIFF
--- a/apps/marketing/app/components/__tests__/Hero.test.tsx
+++ b/apps/marketing/app/components/__tests__/Hero.test.tsx
@@ -63,4 +63,17 @@ describe('Hero (marketing craft hierarchy)', () => {
     renderHero();
     expect(screen.getByRole('navigation', { name: 'Choose your view' })).toBeInTheDocument();
   });
+
+  it('uses a viewport-stage shell with full-bleed backdrop (not content-boxed paint)', () => {
+    const { container } = renderHero();
+    const section = container.querySelector('[data-slot="marketing-section"]');
+    expect(section).toBeTruthy();
+    expect(section).toHaveAttribute('data-has-backdrop', 'true');
+    // min-height fills remaining viewport under sticky nav.
+    expect(section?.className).toMatch(/min-h-\[calc\(100svh-var\(--marketing-nav-h/);
+    const backdrop = container.querySelector('[data-slot="hero-background"]');
+    expect(backdrop).toBeTruthy();
+    // Backdrop is a direct child of the outer section (full bleed), not the max-w rail.
+    expect(backdrop?.parentElement).toBe(section);
+  });
 });

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -23,18 +23,33 @@ import { AudienceToggle } from './AudienceToggle';
 const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as const;
 
 /**
- * Hero background: one quiet signature background (frontend-excellence Phase 1;
- * ADR 2026-07-10-frontend-design-direction hard rule "kill the 5-blob gradient
- * stack"). A top-down token wash plus a single subtle radial glow, both keyed
- * to `--color-primary` rather than a literal color. Lives inside an
- * overflow-hidden box so the off-canvas offset never creates a scrollbar.
- * Reads in both light and dark.
+ * Full-bleed hero stage paint (viewport-stage, not content-boxed).
+ *
+ * Frontend-excellence Phase 1 + ADR 2026-07-10: one quiet signature wash.
+ * Painted via MarketingSection `backdrop` so absolute inset-0 is relative to
+ * the outer section (full width), not the max-w-7xl content rail.
+ *
+ * Glow uses svh/vw so it scales phone → ultrawide (no fixed 900×520 halo).
  */
 function HeroBackground() {
   return (
-    <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.04] via-background to-background" />
-      <div className="absolute -top-32 left-1/2 h-[520px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--color-primary),transparent_70%)] opacity-[0.12] blur-3xl" />
+    <div
+      data-slot="hero-background"
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 -z-10 overflow-hidden"
+    >
+      {/* Edge-to-edge wash across the whole stage */}
+      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.07] via-background to-background" />
+      {/* Viewport-relative radial — soft top center, not a content-sized blob */}
+      <div
+        className={[
+          'absolute left-1/2 top-0 -translate-x-1/2 -translate-y-[15%]',
+          'h-[min(75svh,42rem)] w-[min(140vw,90rem)]',
+          'rounded-full',
+          'bg-[radial-gradient(closest-side,var(--color-primary),transparent_72%)]',
+          'opacity-[0.14] blur-3xl',
+        ].join(' ')}
+      />
     </div>
   );
 }
@@ -42,7 +57,7 @@ function HeroBackground() {
 /** Trust strip: vertical rules between labels, no brand-dot decoration. */
 function TrustStrip() {
   return (
-    <ul className="mt-8 flex flex-wrap items-center justify-center gap-y-2 text-sm text-body list-none p-0">
+    <ul className="mt-8 flex list-none flex-wrap items-center justify-center gap-y-2 p-0 text-sm text-body">
       {TRUST_SIGNALS.map((signal, index) => (
         <li key={signal} className="flex items-center">
           {index > 0 ? (
@@ -64,9 +79,8 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         - H1 = text-foreground (ink, max contrast)
         - subtitle = text-body (rvui-text-1) for long reading, not muted
         - trust / captions = muted only when meta
-        SwipePages/SaaS LPs fail when body is grey-on-paper; text-body clears AA.
       */}
-      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground text-balance sm:text-6xl lg:text-7xl">
+      <h1 className="text-balance font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
         {hero.h1}
       </h1>
 
@@ -74,8 +88,8 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         {hero.subtitle.sentence1} {hero.subtitle.sentence2} {hero.subtitle.support}
       </p>
 
-      <div className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3 sm:mt-10 sm:gap-4">
-        <Button asChild size="lg" glow className="w-full sm:w-auto gap-2">
+      <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
+        <Button asChild size="lg" glow className="w-full gap-2 sm:w-auto">
           <a href={hero.cta.primary.href}>
             {hero.cta.primary.label}
             <IconArrowRight size="sm" />
@@ -86,7 +100,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
           appearance="outline"
           variant="neutral"
           size="lg"
-          className="w-full sm:w-auto gap-2"
+          className="w-full gap-2 sm:w-auto"
         >
           <a href={hero.cta.secondary.href} target="_blank" rel="noopener noreferrer">
             <GitHubIcon className="size-4" />
@@ -109,7 +123,7 @@ function NonTechnicalHero() {
   const hero = FOR_OPERATORS_HERO;
   return (
     <>
-      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground text-balance sm:text-6xl lg:text-7xl">
+      <h1 className="text-balance font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
         {hero.h1Lines.map((line) => (
           <span key={line} className="block">
             {line}
@@ -122,7 +136,7 @@ function NonTechnicalHero() {
       </p>
 
       <div className="mt-9 flex justify-center sm:mt-10">
-        <Button asChild size="lg" glow className="w-full sm:w-auto gap-2">
+        <Button asChild size="lg" glow className="w-full gap-2 sm:w-auto">
           <a href={hero.primaryCta.href} target="_blank" rel="noopener noreferrer">
             {hero.primaryCta.label}
             <IconArrowRight size="sm" />
@@ -145,10 +159,14 @@ export function Hero() {
       tone="background"
       density="spacious"
       width="default"
-      className="relative isolate overflow-hidden"
+      backdrop={<HeroBackground />}
+      className={[
+        // Viewport stage under sticky nav (see --marketing-nav-h on :root).
+        'min-h-[calc(100svh-var(--marketing-nav-h,4rem))]',
+        // Center the stack on tall screens; grows past min-h when content is taller.
+        'flex flex-col justify-center overflow-hidden',
+      ].join(' ')}
     >
-      <HeroBackground />
-
       <div className="mx-auto max-w-3xl text-center">
         {/* Audience switch: replaces the former eyebrow pill. */}
         <div className="mb-7 flex justify-center sm:mb-8">
@@ -160,7 +178,7 @@ export function Hero() {
 
       {/* Receipt-motif moment (frontend-excellence Phase 5): one orchestrated
           print entrance, shared verbatim by both audience variants. */}
-      <div className="mt-12 w-full max-w-md min-w-0 mx-auto text-left sm:mt-14 sm:max-w-lg">
+      <div className="mx-auto mt-12 w-full min-w-0 max-w-md text-left sm:mt-14 sm:max-w-lg">
         <ReceiptCard
           title={RECEIPT_HERO_TITLE}
           lines={[...RECEIPT_HERO_LINES]}

--- a/apps/marketing/app/index.css
+++ b/apps/marketing/app/index.css
@@ -35,6 +35,8 @@
   --rvui-font-sans: 'Inter Variable', 'Inter', system-ui, sans-serif;
   --rvui-font-display: 'Inter Tight Variable', 'Inter Tight', 'Inter', system-ui, sans-serif;
   --rvui-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+  /* Sticky marketing NavBar row height (h-16). Hero stage min-height uses this. */
+  --marketing-nav-h: 4rem;
 }
 
 /* Tailwind v4 does not scan node_modules by default. Without this, the utility

--- a/packages/presentation/docs/marketing-section-system.md
+++ b/packages/presentation/docs/marketing-section-system.md
@@ -34,17 +34,21 @@ Rules:
 | `width` | `narrow` \| `default` \| `wide` \| `full` | Content max-width |
 | `density` | `compact` \| `default` \| `spacious` | Vertical padding |
 | `bleed` | boolean | Skip outer horizontal pad (rare) |
+| `backdrop` | `ReactNode` | Full-bleed layer on the **outer** section (not the max-w rail). Hero washes/glows. |
 
 `SectionHeader` owns intro stack: optional eyebrow, title, optional description (`text-body`).
 
 Eyebrow tones: `primary` (default brand signal) or `muted` (quiet sections).
 
+**Viewport-stage heroes:** put decoration in `backdrop` (absolute inset-0), put min-height on the section (`min-h-[calc(100svh-var(--marketing-nav-h))]`), never nest absolute paint inside the max-width children.
+
 ## Consumer rules
 
 1. Prefer shells over raw `py-24` / `max-w-7xl` / `px-6` duplication.
 2. Keep page-specific content (matrices, calculators) as **children** of the shell.
-3. CMS `SectionBlock` body copy must use the body rung (aligned with this ladder).
-4. Route craft only after consumers adopt shells (frontend-excellence sequence).
+3. Full-bleed washes go in `backdrop`, not as absolute children of the content rail.
+4. CMS `SectionBlock` body copy must use the body rung (aligned with this ladder).
+5. Route craft only after consumers adopt shells (frontend-excellence sequence).
 
 ## Pilot + Phase 2 rewire
 

--- a/packages/presentation/src/__tests__/components/marketing-section.test.tsx
+++ b/packages/presentation/src/__tests__/components/marketing-section.test.tsx
@@ -57,6 +57,28 @@ describe('MarketingSection', () => {
     expect(section).toHaveClass('isolate');
     expect(section).toHaveClass('overflow-hidden');
   });
+
+  it('paints backdrop on the outer section, not the max-width rail', () => {
+    render(
+      <MarketingSection
+        width="narrow"
+        backdrop={
+          <div data-testid="full-bleed-backdrop" className="absolute inset-0" aria-hidden="true" />
+        }
+      >
+        <span>Content</span>
+      </MarketingSection>,
+    );
+    const section = screen.getByText('Content').closest('section');
+    expect(section).toHaveAttribute('data-has-backdrop', 'true');
+    expect(section).toHaveClass('relative');
+    const backdrop = screen.getByTestId('full-bleed-backdrop');
+    // Backdrop is a direct child of the section (full bleed), not inside max-w rail.
+    expect(backdrop.parentElement).toBe(section);
+    const rail = screen.getByText('Content').parentElement;
+    expect(rail).toHaveClass('max-w-3xl');
+    expect(rail?.contains(backdrop)).toBe(false);
+  });
 });
 
 describe('SectionHeader', () => {

--- a/packages/presentation/src/components/marketing-section.tsx
+++ b/packages/presentation/src/components/marketing-section.tsx
@@ -25,6 +25,12 @@ export interface MarketingSectionProps extends React.ComponentPropsWithoutRef<'s
    * Prefer false unless embedding full-bleed media.
    */
   bleed?: boolean;
+  /**
+   * Full-bleed layer painted on the outer section (not the max-width rail).
+   * Use for hero washes/glows so decoration is viewport-wide, not content-boxed.
+   * Caller should use absolute inset-0 (or similar) and aria-hidden as needed.
+   */
+  backdrop?: React.ReactNode;
   /** Classes for the inner max-width container. */
   innerClassName?: string;
 }
@@ -61,6 +67,7 @@ export function MarketingSection({
   width = 'default',
   density = 'default',
   bleed = false,
+  backdrop,
   className,
   innerClassName,
   children,
@@ -72,10 +79,19 @@ export function MarketingSection({
       data-tone={tone}
       data-density={density}
       data-width={width}
-      className={cn(toneClass[tone], densityClass[density], !bleed && 'px-6 lg:px-8', className)}
+      data-has-backdrop={backdrop != null ? 'true' : undefined}
+      className={cn(
+        toneClass[tone],
+        densityClass[density],
+        !bleed && 'px-6 lg:px-8',
+        // Backdrop is position:absolute relative to this outer section (full bleed).
+        backdrop != null && 'relative isolate',
+        className,
+      )}
       {...props}
     >
-      <div className={cn('relative mx-auto w-full', widthClass[width], innerClassName)}>
+      {backdrop}
+      <div className={cn('relative z-0 mx-auto w-full', widthClass[width], innerClassName)}>
         {children}
       </div>
     </section>


### PR DESCRIPTION
## Summary
Home hero background was painted **inside** `MarketingSection`'s max-width content rail (`absolute inset-0` relative to that rail), so the wash/glow only surrounded the type/receipt stack instead of filling the first screen.

### Fix
1. **`MarketingSection.backdrop`** — full-bleed layer on the **outer** section (not the max-w rail).
2. **Hero stage height** — `min-h-[calc(100svh-var(--marketing-nav-h))]` with `--marketing-nav-h: 4rem` (matches sticky `h-16` nav).
3. **Responsive glow** — `min(75svh)` / `min(140vw)` instead of fixed 520×900 blob.
4. **Layout** — `flex flex-col justify-center` so the stack sits calmly on tall viewports; section still grows when content exceeds min-height.

### Tests
- presentation: marketing-section backdrop placement
- marketing: Hero viewport-stage + backdrop is section direct child

## Test plan
- [x] `marketing-section.test.tsx` (8)
- [x] `Hero.test.tsx` (6)
- [ ] CI green
- [ ] Spot-check `/` on phone + laptop + ultrawide: wash edge-to-edge under nav; no content-boxed halo