### PR TITLE
feat(harnesses): bind native workflow skills to default snap

### DIFF
--- a/packages/harnesses/src/__tests__/skill-invoke.test.ts
+++ b/packages/harnesses/src/__tests__/skill-invoke.test.ts
@@ -1,0 +1,51 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { SkillCatalogEntry } from '../content/skill-catalog.js';
+import {
+  buildSkillInvokeRequest,
+  PHASE_C_INFERENCE_SNAP,
+  resolveNativeWorkflowSkillId,
+} from '../content/skill-invoke.js';
+
+function entry(id: string, dir: string): SkillCatalogEntry {
+  const path = join(dir, 'SKILL.md');
+  writeFileSync(
+    path,
+    `---
+name: ${id}
+description: fixture
+---
+# ${id} body
+`,
+  );
+  return { id, name: id, description: 'fixture', path, source: 'revskills' };
+}
+
+describe('skill invoke (GAP-293 Phase C)', () => {
+  it('resolves aliases to native workflow ids', () => {
+    expect(resolveNativeWorkflowSkillId('doctor')).toBe('revealui-doctor');
+    expect(resolveNativeWorkflowSkillId('revealui-checkpoint')).toBe('revealui-checkpoint');
+    expect(resolveNativeWorkflowSkillId('lint')).toBeNull();
+  });
+
+  it('rejects skills outside the native allowlist', () => {
+    const result = buildSkillInvokeRequest('preflight', []);
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('allowlist');
+  });
+
+  it('binds the product default snap and does not claim execution', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'skill-inv-'));
+    mkdirSync(dir, { recursive: true });
+    const catalog = [entry('revealui-doctor', dir)];
+    const result = buildSkillInvokeRequest('doctor', catalog);
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.model).toBe(PHASE_C_INFERENCE_SNAP);
+    expect(result.model).toBe('nemotron-3-nano');
+    expect(result.system).toContain('# revealui-doctor body');
+    expect(result.user).toContain('cannot execute tools');
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -580,9 +580,31 @@ async function main() {
     const projectRoot =
       projectIdx >= 0 ? (args[projectIdx + 1] ?? DEFAULT_PROJECT) : DEFAULT_PROJECT;
     const revskillsRoot = revskillsIdx >= 0 ? args[revskillsIdx + 1] : undefined;
+    if (subcommand === 'invoke') {
+      const skillId = args[1];
+      if (!skillId) {
+        process.stderr.write(
+          'Usage: revealui-harnesses skills invoke <doctor|recover|checkpoint> [--dry-run] [--project <dir>] [--revskills <dir>]\n',
+        );
+        process.exit(1);
+      }
+      const { buildSkillInvokeRequest } = await import('./content/skill-invoke.js');
+      const catalog = listSkillCatalog({
+        projectRoot,
+        revskillsRoot,
+        includeDefinitions: true,
+      });
+      const prepared = buildSkillInvokeRequest(skillId, catalog);
+      if ('error' in prepared) {
+        process.stderr.write(`${prepared.error}\n`);
+        process.exit(1);
+      }
+      process.stdout.write(`${JSON.stringify({ ...prepared, dryRun: true }, null, 2)}\n`);
+      return;
+    }
     if (subcommand !== 'list') {
       process.stderr.write(
-        'Usage: revealui-harnesses skills list [--json] [--project <dir>] [--revskills <dir>]\n',
+        'Usage: revealui-harnesses skills <list|invoke> [--json] [--project <dir>] [--revskills <dir>]\n',
       );
       process.exit(1);
     }

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -70,6 +70,14 @@ export {
 } from './schemas/index.js';
 export type { SkillCatalogEntry, SkillCatalogSource } from './skill-catalog.js';
 export { listSkillCatalog, skimSkillFrontmatter } from './skill-catalog.js';
+export type { NativeWorkflowSkillId, SkillInvokeRequest } from './skill-invoke.js';
+export {
+  buildSkillInvokeRequest,
+  isNativeWorkflowSkillId,
+  NATIVE_WORKFLOW_SKILL_IDS,
+  PHASE_C_INFERENCE_SNAP,
+  resolveNativeWorkflowSkillId,
+} from './skill-invoke.js';
 export type {
   ContentSnapshot,
   ContentSnapshotFile,

--- a/packages/harnesses/src/content/skill-invoke.ts
+++ b/packages/harnesses/src/content/skill-invoke.ts
@@ -1,0 +1,86 @@
+/**
+ * GAP-293 Phase C — bind native workflow skills to the product default snap.
+ *
+ * Snap is not invented: `nemotron-3-nano` is DEFAULT_US_ORIGIN_INFERENCE_SNAP
+ * in `@revealui/ai` (`providers/us-origin-snaps.ts`). This module only
+ * prepares the invoke; it does not run tools or commit.
+ */
+
+import { readFileSync } from 'node:fs';
+import type { SkillCatalogEntry } from './skill-catalog.js';
+
+export const NATIVE_WORKFLOW_SKILL_IDS = [
+  'revealui-doctor',
+  'revealui-recover',
+  'revealui-checkpoint',
+] as const;
+
+export type NativeWorkflowSkillId = (typeof NATIVE_WORKFLOW_SKILL_IDS)[number];
+
+/** Product default Inference Snap (US-origin catalog). */
+export const PHASE_C_INFERENCE_SNAP = 'nemotron-3-nano';
+
+const ALIASES: Record<string, NativeWorkflowSkillId> = {
+  doctor: 'revealui-doctor',
+  recover: 'revealui-recover',
+  checkpoint: 'revealui-checkpoint',
+};
+
+export function resolveNativeWorkflowSkillId(raw: string): NativeWorkflowSkillId | null {
+  const key = raw.trim();
+  if (key in ALIASES) return ALIASES[key] ?? null;
+  for (const id of NATIVE_WORKFLOW_SKILL_IDS) {
+    if (id === key) return id;
+  }
+  return null;
+}
+
+export function isNativeWorkflowSkillId(id: string): id is NativeWorkflowSkillId {
+  return resolveNativeWorkflowSkillId(id) !== null;
+}
+
+export interface SkillInvokeRequest {
+  skillId: NativeWorkflowSkillId;
+  model: typeof PHASE_C_INFERENCE_SNAP;
+  path: string;
+  system: string;
+  user: string;
+}
+
+export function buildSkillInvokeRequest(
+  skillId: string,
+  catalog: SkillCatalogEntry[],
+): SkillInvokeRequest | { error: string } {
+  const resolved = resolveNativeWorkflowSkillId(skillId);
+  if (!resolved) {
+    return {
+      error: `skills.invoke allowlist is ${NATIVE_WORKFLOW_SKILL_IDS.join(', ')} (or doctor/recover/checkpoint). Got: ${skillId}`,
+    };
+  }
+  const entry = catalog.find((s) => s.id === resolved);
+  if (!entry) {
+    return {
+      error: `skill ${resolved} is not in the catalog (materialize content or set revskills root)`,
+    };
+  }
+  let body: string;
+  try {
+    body = readFileSync(entry.path, 'utf-8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: `cannot read ${entry.path}: ${msg}` };
+  }
+  return {
+    skillId: resolved,
+    model: PHASE_C_INFERENCE_SNAP,
+    path: entry.path,
+    system: body,
+    user: [
+      `Run the ${resolved} workflow as a RevDev-native pass.`,
+      `Local model is the product default Inference Snap: ${PHASE_C_INFERENCE_SNAP}.`,
+      'You cannot execute tools or git commits from this invoke.',
+      'Produce the structured report the skill specifies (traffic-light / diagnostic / checkpoint report).',
+      'Name any command you would have run; do not claim you ran it.',
+    ].join(' '),
+  };
+}


### PR DESCRIPTION
## Summary

GAP-293 Phase C first slice: bind the three native workflow skills (`revealui-doctor`, `revealui-recover`, `revealui-checkpoint`) to the product default Inference Snap (`nemotron-3-nano` from `@revealui/ai` US-origin catalog). Generate-only. No tools, no commits.

- `packages/harnesses/src/content/skill-invoke.ts` — allowlist + `buildSkillInvokeRequest`
- CLI: `revealui-harnesses skills invoke <doctor|recover|checkpoint>` prints dry-run JSON (`dryRun: true`, `toolsExecuted` implied false)
- Snap is not invented: `DEFAULT_US_ORIGIN_INFERENCE_SNAP`

Companion PRs:
- RevealUIStudio/revdev#395 (`skills.invoke` daemon RPC)
- RevealUIStudio/revealui-jv#1301 (spec + gap progress)

## Residual (not this slice)

Full tool-using AgentRuntime loop + GAP-294 permission modes.

## Test plan

- [x] `pnpm --filter @revealui/harnesses test` — `skill-invoke.test.ts` (3) + `skill-catalog.test.ts` (5) pass
- [ ] CI Quality / harnesses tests on this PR