### PR TITLE
feat(rsc-poc): compose remaining hosts on presentation (GAP-479)

### DIFF
--- a/.changeset/gap-479-rsc-poc-hosts.md
+++ b/.changeset/gap-479-rsc-poc-hosts.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': patch
+---
+
+Allow presentation Input type="hidden" so form posts do not hand-roll a host tag.

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.11",
     "@revealui/core": "workspace:*",
+    "@revealui/presentation": "workspace:*",
     "@revealui/router": "workspace:*",
     "@revealui/security": "workspace:*",
     "@revealui/utils": "workspace:*",

--- a/apps/rsc-poc/src/pages/action-form.tsx
+++ b/apps/rsc-poc/src/pages/action-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button, Input } from '@revealui/presentation';
 import { useState } from 'react';
 
 interface ActionFormProps {
@@ -29,15 +30,10 @@ export function ActionForm({ action }: ActionFormProps): React.ReactNode {
   return (
     <div>
       <form action={formAction} style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
-        <input
-          type="text"
-          name="message"
-          placeholder="Type a message"
-          style={{ padding: '6px 10px', border: '1px solid #d1d5db', borderRadius: '4px' }}
-        />
-        <button type="submit" disabled={pending}>
+        <Input type="text" name="message" placeholder="Type a message" />
+        <Button type="submit" disabled={pending} isLoading={pending} size="sm">
           {pending ? 'Sending…' : 'Send to server'}
-        </button>
+        </Button>
       </form>
       {result !== null && (
         <div

--- a/apps/rsc-poc/src/pages/counter.tsx
+++ b/apps/rsc-poc/src/pages/counter.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@revealui/presentation';
 import { useState } from 'react';
 
 export function Counter(): React.ReactNode {
@@ -15,13 +16,13 @@ export function Counter(): React.ReactNode {
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-      <button type="button" onClick={decrement}>
+      <Button type="button" variant="neutral" appearance="outline" size="sm" onClick={decrement}>
         -
-      </button>
+      </Button>
       <span>Count: {count}</span>
-      <button type="button" onClick={increment}>
+      <Button type="button" variant="neutral" appearance="outline" size="sm" onClick={increment}>
         +
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/rsc-poc/src/pages/errors-client.tsx
+++ b/apps/rsc-poc/src/pages/errors-client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@revealui/presentation';
 import { useState } from 'react';
 
 function Bomb(): React.ReactNode {
@@ -12,9 +13,16 @@ export function ErrorsClient(): React.ReactNode {
   return (
     <section style={{ marginTop: 24 }}>
       <h2>Client render throw</h2>
-      <button type="button" onClick={() => setExplode(true)} data-errors-client-boom="">
+      <Button
+        type="button"
+        variant="danger"
+        appearance="outline"
+        size="sm"
+        onClick={() => setExplode(true)}
+        data-errors-client-boom=""
+      >
         Throw in client tree
-      </button>
+      </Button>
       {explode ? <Bomb /> : null}
     </section>
   );

--- a/apps/rsc-poc/src/pages/session-client.tsx
+++ b/apps/rsc-poc/src/pages/session-client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@revealui/presentation';
 import { useState, useTransition } from 'react';
 import { secretPing, whoami } from './session.server.ts';
 
@@ -9,9 +10,11 @@ export function WhoamiButton(): React.ReactNode {
 
   return (
     <div>
-      <button
+      <Button
         type="button"
         disabled={pending}
+        isLoading={pending}
+        size="sm"
         onClick={() => {
           start(async () => {
             setText(await whoami());
@@ -19,7 +22,7 @@ export function WhoamiButton(): React.ReactNode {
         }}
       >
         {pending ? '…' : 'whoami()'}
-      </button>
+      </Button>
       {text !== null && (
         <pre data-whoami="" style={{ marginTop: 8 }}>
           {text}
@@ -36,9 +39,11 @@ export function SecretPingForm(): React.ReactNode {
 
   return (
     <div>
-      <button
+      <Button
         type="button"
         disabled={pending}
+        isLoading={pending}
+        size="sm"
         onClick={() => {
           start(async () => {
             setError(null);
@@ -52,7 +57,7 @@ export function SecretPingForm(): React.ReactNode {
         }}
       >
         {pending ? '…' : 'secretPing()'}
-      </button>
+      </Button>
       {text !== null && (
         <pre data-secret-ok="" style={{ marginTop: 8, color: '#166534' }}>
           {text}

--- a/apps/rsc-poc/src/pages/session.tsx
+++ b/apps/rsc-poc/src/pages/session.tsx
@@ -1,3 +1,4 @@
+import { Button, Input } from '@revealui/presentation';
 import { getSession } from '../auth/session-server.ts';
 import { SecretPingForm, WhoamiButton } from './session-client.tsx';
 
@@ -22,11 +23,15 @@ export async function SessionPage(): Promise<React.ReactNode> {
           action="/api/session/login"
           style={{ display: 'flex', gap: 8, marginBottom: 12 }}
         >
-          <input type="hidden" name="sub" value="demo" />
-          <button type="submit">Sign in as demo</button>
+          <Input type="hidden" name="sub" value="demo" />
+          <Button type="submit" size="sm">
+            Sign in as demo
+          </Button>
         </form>
         <form method="POST" action="/api/session/logout">
-          <button type="submit">Sign out</button>
+          <Button type="submit" variant="neutral" appearance="outline" size="sm">
+            Sign out
+          </Button>
         </form>
       </section>
 

--- a/packages/presentation/src/__tests__/components/Input.test.tsx
+++ b/packages/presentation/src/__tests__/components/Input.test.tsx
@@ -386,6 +386,18 @@ describe('Input', () => {
     });
   });
 
+  describe('Hidden Input', () => {
+    it('renders a native hidden input without chrome', () => {
+      const { container } = render(<Input type="hidden" name="sub" value="demo" />);
+
+      const input = container.querySelector('input[type="hidden"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'sub');
+      expect(input).toHaveAttribute('value', 'demo');
+      expect(container.querySelector('[data-slot=control]')).not.toBeInTheDocument();
+    });
+  });
+
   describe('File Input', () => {
     it('should render file input', () => {
       render(<Input type="file" />);

--- a/packages/presentation/src/components/input-headless.tsx
+++ b/packages/presentation/src/components/input-headless.tsx
@@ -25,7 +25,17 @@ type DateType = (typeof dateTypes)[number];
 
 type InputProps = {
   className?: string;
-  type?: 'email' | 'file' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url' | DateType;
+  type?:
+    | 'email'
+    | 'file'
+    | 'hidden'
+    | 'number'
+    | 'password'
+    | 'search'
+    | 'tel'
+    | 'text'
+    | 'url'
+    | DateType;
   disabled?: boolean;
   invalid?: boolean;
   ref?: React.Ref<HTMLInputElement>;
@@ -34,6 +44,10 @@ type InputProps = {
 export function Input({ className, disabled, invalid, ref, ...props }: InputProps) {
   const interactiveProps = useDataInteractive({ disabled });
   const fieldProps = useFieldControlProps();
+
+  if (props.type === 'hidden') {
+    return <input ref={ref} disabled={disabled} className={className} {...props} />;
+  }
 
   return (
     <span

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,6 +692,9 @@ importers:
       '@revealui/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@revealui/presentation':
+        specifier: workspace:*
+        version: link:../../packages/presentation
       '@revealui/router':
         specifier: workspace:*
         version: link:../../packages/router

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -27,41 +27,6 @@
       "reason": "content-driven product icon path data; no Icon* match (GAP-398 residual)"
     },
     {
-      "path": "apps/rsc-poc/src/pages/action-form.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/action-form.tsx",
-      "tag": "input",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/counter.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/errors-client.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/session-client.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/session.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/session.tsx",
-      "tag": "input",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
       "path": "packages/editor/src/canvas/EditSessionCanvas.tsx",
       "tag": "button",
       "reason": "GAP-479 later slice: visual-edit canvas chrome; use presentation Button/Input/Textarea"


### PR DESCRIPTION
## Summary

Burn the rsc-poc GAP-479 allowlist. All `apps/rsc-poc` button/input hosts now come from `@revealui/presentation`.

- Add workspace dep `@revealui/presentation`
- Counter, errors, action form, and session pages use `Button` / `Input`
- Presentation `Input` accepts `type=\"hidden\"` (no chrome wrapper) so the session login form does not hand-roll a host tag
- Drop all `apps/rsc-poc/**` allowlist rows

Remaining allowlist: admin chart/letterform SVGs, marketing ProductsPage SVG, editor canvas chrome.

## Test plan

- [x] `pnpm --filter @revealui/presentation exec vitest run src/__tests__/components/Input.test.tsx` (45 passed)
- [x] `pnpm --filter @rsc-poc/app test` (8 passed)
- [x] `pnpm validate:tier1-presentation -- --hard-fail` (0 violations)
- [x] phase-1 pre-push gate