### PR TITLE
promote: test → main (marketing craft + hero stage)

### DIFF
--- a/.changeset/gap-479-rsc-poc-hosts.md
+++ b/.changeset/gap-479-rsc-poc-hosts.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': patch
+---
+
+Allow presentation Input type="hidden" so form posts do not hand-roll a host tag.

--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -62,10 +62,12 @@ export function GetStarted({
               // biome-ignore lint/suspicious/noArrayIndexKey: static, order-fixed command tokens
               key={index}
               className={
+                // Dark pill (bg-foreground): light text only. Never text-primary
+                // (paper brand blue fails AA on midnight at 14px).
                 index === 0
-                  ? 'text-emerald-400' // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
+                  ? 'text-primary-foreground'
                   : index === data.cli.command.length - 1
-                    ? 'text-primary'
+                    ? 'text-background/80'
                     : 'text-background'
               }
             >

--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -65,7 +65,7 @@ export function GetStarted({
                 index === 0
                   ? 'text-emerald-400' // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
                   : index === data.cli.command.length - 1
-                    ? 'text-blue-300'
+                    ? 'text-primary'
                     : 'text-background'
               }
             >

--- a/apps/marketing/app/components/__tests__/Hero.test.tsx
+++ b/apps/marketing/app/components/__tests__/Hero.test.tsx
@@ -63,4 +63,17 @@ describe('Hero (marketing craft hierarchy)', () => {
     renderHero();
     expect(screen.getByRole('navigation', { name: 'Choose your view' })).toBeInTheDocument();
   });
+
+  it('uses a viewport-stage shell with full-bleed backdrop (not content-boxed paint)', () => {
+    const { container } = renderHero();
+    const section = container.querySelector('[data-slot="marketing-section"]');
+    expect(section).toBeTruthy();
+    expect(section).toHaveAttribute('data-has-backdrop', 'true');
+    // min-height fills remaining viewport under sticky nav.
+    expect(section?.className).toMatch(/min-h-\[calc\(100svh-var\(--marketing-nav-h/);
+    const backdrop = container.querySelector('[data-slot="hero-background"]');
+    expect(backdrop).toBeTruthy();
+    // Backdrop is a direct child of the outer section (full bleed), not the max-w rail.
+    expect(backdrop?.parentElement).toBe(section);
+  });
 });

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -23,18 +23,33 @@ import { AudienceToggle } from './AudienceToggle';
 const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as const;
 
 /**
- * Hero background: one quiet signature background (frontend-excellence Phase 1;
- * ADR 2026-07-10-frontend-design-direction hard rule "kill the 5-blob gradient
- * stack"). A top-down token wash plus a single subtle radial glow, both keyed
- * to `--color-primary` rather than a literal color. Lives inside an
- * overflow-hidden box so the off-canvas offset never creates a scrollbar.
- * Reads in both light and dark.
+ * Full-bleed hero stage paint (viewport-stage, not content-boxed).
+ *
+ * Frontend-excellence Phase 1 + ADR 2026-07-10: one quiet signature wash.
+ * Painted via MarketingSection `backdrop` so absolute inset-0 is relative to
+ * the outer section (full width), not the max-w-7xl content rail.
+ *
+ * Glow uses svh/vw so it scales phone → ultrawide (no fixed 900×520 halo).
  */
 function HeroBackground() {
   return (
-    <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.04] via-background to-background" />
-      <div className="absolute -top-32 left-1/2 h-[520px] w-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--color-primary),transparent_70%)] opacity-[0.12] blur-3xl" />
+    <div
+      data-slot="hero-background"
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 -z-10 overflow-hidden"
+    >
+      {/* Edge-to-edge wash across the whole stage */}
+      <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.07] via-background to-background" />
+      {/* Viewport-relative radial — soft top center, not a content-sized blob */}
+      <div
+        className={[
+          'absolute left-1/2 top-0 -translate-x-1/2 -translate-y-[15%]',
+          'h-[min(75svh,42rem)] w-[min(140vw,90rem)]',
+          'rounded-full',
+          'bg-[radial-gradient(closest-side,var(--color-primary),transparent_72%)]',
+          'opacity-[0.14] blur-3xl',
+        ].join(' ')}
+      />
     </div>
   );
 }
@@ -42,7 +57,7 @@ function HeroBackground() {
 /** Trust strip: vertical rules between labels, no brand-dot decoration. */
 function TrustStrip() {
   return (
-    <ul className="mt-8 flex flex-wrap items-center justify-center gap-y-2 text-sm text-body list-none p-0">
+    <ul className="mt-8 flex list-none flex-wrap items-center justify-center gap-y-2 p-0 text-sm text-body">
       {TRUST_SIGNALS.map((signal, index) => (
         <li key={signal} className="flex items-center">
           {index > 0 ? (
@@ -64,9 +79,8 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         - H1 = text-foreground (ink, max contrast)
         - subtitle = text-body (rvui-text-1) for long reading, not muted
         - trust / captions = muted only when meta
-        SwipePages/SaaS LPs fail when body is grey-on-paper; text-body clears AA.
       */}
-      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground text-balance sm:text-6xl lg:text-7xl">
+      <h1 className="text-balance font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
         {hero.h1}
       </h1>
 
@@ -74,8 +88,8 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         {hero.subtitle.sentence1} {hero.subtitle.sentence2} {hero.subtitle.support}
       </p>
 
-      <div className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3 sm:mt-10 sm:gap-4">
-        <Button asChild size="lg" glow className="w-full sm:w-auto gap-2">
+      <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
+        <Button asChild size="lg" glow className="w-full gap-2 sm:w-auto">
           <a href={hero.cta.primary.href}>
             {hero.cta.primary.label}
             <IconArrowRight size="sm" />
@@ -86,7 +100,7 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
           appearance="outline"
           variant="neutral"
           size="lg"
-          className="w-full sm:w-auto gap-2"
+          className="w-full gap-2 sm:w-auto"
         >
           <a href={hero.cta.secondary.href} target="_blank" rel="noopener noreferrer">
             <GitHubIcon className="size-4" />
@@ -109,7 +123,7 @@ function NonTechnicalHero() {
   const hero = FOR_OPERATORS_HERO;
   return (
     <>
-      <h1 className="font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground text-balance sm:text-6xl lg:text-7xl">
+      <h1 className="text-balance font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
         {hero.h1Lines.map((line) => (
           <span key={line} className="block">
             {line}
@@ -122,7 +136,7 @@ function NonTechnicalHero() {
       </p>
 
       <div className="mt-9 flex justify-center sm:mt-10">
-        <Button asChild size="lg" glow className="w-full sm:w-auto gap-2">
+        <Button asChild size="lg" glow className="w-full gap-2 sm:w-auto">
           <a href={hero.primaryCta.href} target="_blank" rel="noopener noreferrer">
             {hero.primaryCta.label}
             <IconArrowRight size="sm" />
@@ -145,10 +159,14 @@ export function Hero() {
       tone="background"
       density="spacious"
       width="default"
-      className="relative isolate overflow-hidden"
+      backdrop={<HeroBackground />}
+      className={[
+        // Viewport stage under sticky nav (see --marketing-nav-h on :root).
+        'min-h-[calc(100svh-var(--marketing-nav-h,4rem))]',
+        // Center the stack on tall screens; grows past min-h when content is taller.
+        'flex flex-col justify-center overflow-hidden',
+      ].join(' ')}
     >
-      <HeroBackground />
-
       <div className="mx-auto max-w-3xl text-center">
         {/* Audience switch: replaces the former eyebrow pill. */}
         <div className="mb-7 flex justify-center sm:mb-8">
@@ -160,7 +178,7 @@ export function Hero() {
 
       {/* Receipt-motif moment (frontend-excellence Phase 5): one orchestrated
           print entrance, shared verbatim by both audience variants. */}
-      <div className="mt-12 w-full max-w-md min-w-0 mx-auto text-left sm:mt-14 sm:max-w-lg">
+      <div className="mx-auto mt-12 w-full min-w-0 max-w-md text-left sm:mt-14 sm:max-w-lg">
         <ReceiptCard
           title={RECEIPT_HERO_TITLE}
           lines={[...RECEIPT_HERO_LINES]}

--- a/apps/marketing/app/components/products/ProductsHero.tsx
+++ b/apps/marketing/app/components/products/ProductsHero.tsx
@@ -32,7 +32,7 @@ export function ProductsHero({
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/5 via-background to-blue-500/10"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/5 via-background to-background"
       />
       <h1
         className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -71,24 +71,24 @@ export interface ProductStatusStyle {
 
 export const PRODUCT_STATUS_STYLES: Readonly<Record<ProductStatus, ProductStatusStyle>> = {
   Beta: {
-    bg: 'bg-emerald-500/10', // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
-    text: 'text-emerald-700', // adherence-ignore: emerald-utility - see index.css:80-92 emerald->cobalt remap; renders cobalt today, zero visual change
-    ring: 'ring-emerald-500/30', // adherence-ignore: emerald-utility - see index.css:80-92 emerald->cobalt remap; renders cobalt today, zero visual change
+    bg: 'bg-primary/10',
+    text: 'text-primary',
+    ring: 'ring-primary/30',
   },
   Alpha: {
-    bg: 'bg-amber-500/10',
-    text: 'text-amber-700',
-    ring: 'ring-amber-500/30',
+    bg: 'bg-secondary',
+    text: 'text-foreground',
+    ring: 'ring-border',
   },
   'Active (MIT)': {
-    bg: 'bg-blue-500/10',
-    text: 'text-blue-700',
-    ring: 'ring-blue-500/30',
+    bg: 'bg-primary/10',
+    text: 'text-primary',
+    ring: 'ring-primary/30',
   },
   Planned: {
-    bg: 'bg-slate-500/10',
-    text: 'text-slate-700',
-    ring: 'ring-slate-500/30',
+    bg: 'bg-muted',
+    text: 'text-muted-foreground',
+    ring: 'ring-border',
   },
 } as const;
 

--- a/apps/marketing/app/index.css
+++ b/apps/marketing/app/index.css
@@ -35,6 +35,8 @@
   --rvui-font-sans: 'Inter Variable', 'Inter', system-ui, sans-serif;
   --rvui-font-display: 'Inter Tight Variable', 'Inter Tight', 'Inter', system-ui, sans-serif;
   --rvui-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+  /* Sticky marketing NavBar row height (h-16). Hero stage min-height uses this. */
+  --marketing-nav-h: 4rem;
 }
 
 /* Tailwind v4 does not scan node_modules by default. Without this, the utility

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -90,7 +90,7 @@ export function BlogIndexPage() {
       >
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-blue-500/10 via-background to-indigo-500/10"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
         />
         <SectionHeader
           title="Blog"

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -110,7 +110,7 @@ export function BlogPostPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      <article className="py-24 sm:py-32">
+      <article className="py-16 sm:py-24 lg:py-28">
         <div className="mx-auto max-w-3xl px-6 lg:px-8">
           {/* Back link */}
           <a

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -57,19 +57,14 @@ function FairSourceContract({ data, path, annotation }: ContractProps) {
           <div
             key={c.title}
             className={`rounded-2xl p-6 ring-1 transition sm:p-8 ${
-              c.kind === 'yes'
-                ? 'bg-primary/10 ring-primary/20'
-                : 'bg-amber-500/15 ring-amber-500/30'
+              c.kind === 'yes' ? 'bg-primary/10 ring-primary/20' : 'bg-muted ring-border'
             }`}
           >
             <div className="flex items-start gap-3">
               {c.kind === 'yes' ? (
                 <IconCheckCircle size="md" className="mt-0.5 flex-shrink-0 text-primary" />
               ) : (
-                <IconXCircle
-                  size="md"
-                  className="mt-0.5 flex-shrink-0 text-amber-800 dark:text-amber-200"
-                />
+                <IconXCircle size="md" className="mt-0.5 flex-shrink-0 text-muted-foreground" />
               )}
               <div>
                 <h3
@@ -129,7 +124,7 @@ function FairSourcePackagesIntro({ data, path, annotation }: PackagesIntroProps)
                 </td>
                 <td className="px-6 py-4 text-muted-foreground">{p.purpose}</td>
                 <td className="px-6 py-4">
-                  <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
+                  <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary ring-1 ring-primary/20">
                     {p.license}
                   </span>
                 </td>
@@ -198,7 +193,7 @@ function FairSourceClock({ data, path, annotation }: ClockProps) {
             <li key={step.title} className="mb-7 last:mb-0 sm:mb-8">
               <span
                 className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-background ${
-                  step.color === 'emerald' ? 'bg-primary' : 'bg-amber-600'
+                  step.color === 'emerald' ? 'bg-primary' : 'bg-muted-foreground'
                 }`}
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-white" />

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -44,7 +44,7 @@ function LocalAiHero({ data, path, annotation }: LocalAiHeroProps) {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-violet-500/10"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
       />
       <p
         className="text-sm font-semibold uppercase tracking-wide text-primary"

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -27,7 +27,7 @@ function PhilosophyHero({ data, path, annotation }: PhilosophyHeroProps) {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-violet-500/10"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
       />
       <p
         className="text-sm font-semibold uppercase tracking-wide text-primary"

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -273,7 +273,7 @@ export function PricingPage() {
             >
               {tier.comingSoon && (
                 <div className="absolute right-4 top-4">
-                  <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground ring-1 ring-border">
                     Coming soon
                   </span>
                 </div>
@@ -324,7 +324,7 @@ export function PricingPage() {
               description={PRICING_AGENTS_SECTION.subhead}
               align="center"
             />
-            <span className="mt-3 inline-block rounded-full bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-800 dark:text-amber-200 ring-1 ring-amber-500/30">
+            <span className="mt-3 inline-block rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary ring-1 ring-primary/30">
               {PRICING_AGENTS_SECTION.badge}
             </span>
           </div>
@@ -352,8 +352,8 @@ export function PricingPage() {
             </div>
 
             <div className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
-              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 ring-1 ring-blue-500/20">
-                <IconCode size="md" className="text-blue-600" />
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+                <IconCode size="md" className="text-primary" />
               </div>
               <h3 className="text-base font-semibold text-foreground">
                 {PRICING_AGENT_X402.heading}
@@ -362,8 +362,8 @@ export function PricingPage() {
             </div>
 
             <div className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
-              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-violet-500/10 ring-1 ring-violet-500/20">
-                <IconTerminal size="md" className="text-violet-600" />
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+                <IconTerminal size="md" className="text-primary" />
               </div>
               <h3 className="text-base font-semibold text-foreground">
                 {PRICING_AGENT_MCP.heading}
@@ -371,7 +371,7 @@ export function PricingPage() {
               <p className="mt-2 text-sm text-body">{PRICING_AGENT_MCP.body}</p>
               <a
                 href={PRICING_AGENT_MCP.docsLink.href}
-                className="mt-3 inline-block text-xs font-semibold text-violet-600 hover:text-violet-700"
+                className="mt-3 inline-block text-xs font-semibold text-primary hover:text-primary/80"
               >
                 {PRICING_AGENT_MCP.docsLink.label}
               </a>
@@ -406,7 +406,7 @@ export function PricingPage() {
               {PRICING_STARTER_KIT.eyebrow}
             </span>
             {PRICING_STARTER_KIT.badge ? (
-              <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
+              <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground ring-1 ring-border">
                 {PRICING_STARTER_KIT.badge}
               </span>
             ) : null}

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -54,7 +54,7 @@ export function ProductsPage() {
       >
         <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-primary/90 to-primary/70 p-10 shadow-2xl ring-1 ring-primary/20 sm:p-14">
           <div className="absolute -right-16 -top-16 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
-          <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-blue-500/15 blur-3xl" />
+          <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
           <div className="relative">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex items-center gap-4">

--- a/apps/rsc-poc/package.json
+++ b/apps/rsc-poc/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.11",
     "@revealui/core": "workspace:*",
+    "@revealui/presentation": "workspace:*",
     "@revealui/router": "workspace:*",
     "@revealui/security": "workspace:*",
     "@revealui/utils": "workspace:*",

--- a/apps/rsc-poc/src/pages/action-form.tsx
+++ b/apps/rsc-poc/src/pages/action-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button, Input } from '@revealui/presentation';
 import { useState } from 'react';
 
 interface ActionFormProps {
@@ -29,15 +30,10 @@ export function ActionForm({ action }: ActionFormProps): React.ReactNode {
   return (
     <div>
       <form action={formAction} style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
-        <input
-          type="text"
-          name="message"
-          placeholder="Type a message"
-          style={{ padding: '6px 10px', border: '1px solid #d1d5db', borderRadius: '4px' }}
-        />
-        <button type="submit" disabled={pending}>
+        <Input type="text" name="message" placeholder="Type a message" />
+        <Button type="submit" disabled={pending} isLoading={pending} size="sm">
           {pending ? 'Sending…' : 'Send to server'}
-        </button>
+        </Button>
       </form>
       {result !== null && (
         <div

--- a/apps/rsc-poc/src/pages/counter.tsx
+++ b/apps/rsc-poc/src/pages/counter.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@revealui/presentation';
 import { useState } from 'react';
 
 export function Counter(): React.ReactNode {
@@ -15,13 +16,13 @@ export function Counter(): React.ReactNode {
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-      <button type="button" onClick={decrement}>
+      <Button type="button" variant="neutral" appearance="outline" size="sm" onClick={decrement}>
         -
-      </button>
+      </Button>
       <span>Count: {count}</span>
-      <button type="button" onClick={increment}>
+      <Button type="button" variant="neutral" appearance="outline" size="sm" onClick={increment}>
         +
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/rsc-poc/src/pages/errors-client.tsx
+++ b/apps/rsc-poc/src/pages/errors-client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@revealui/presentation';
 import { useState } from 'react';
 
 function Bomb(): React.ReactNode {
@@ -12,9 +13,16 @@ export function ErrorsClient(): React.ReactNode {
   return (
     <section style={{ marginTop: 24 }}>
       <h2>Client render throw</h2>
-      <button type="button" onClick={() => setExplode(true)} data-errors-client-boom="">
+      <Button
+        type="button"
+        variant="danger"
+        appearance="outline"
+        size="sm"
+        onClick={() => setExplode(true)}
+        data-errors-client-boom=""
+      >
         Throw in client tree
-      </button>
+      </Button>
       {explode ? <Bomb /> : null}
     </section>
   );

--- a/apps/rsc-poc/src/pages/session-client.tsx
+++ b/apps/rsc-poc/src/pages/session-client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@revealui/presentation';
 import { useState, useTransition } from 'react';
 import { secretPing, whoami } from './session.server.ts';
 
@@ -9,9 +10,11 @@ export function WhoamiButton(): React.ReactNode {
 
   return (
     <div>
-      <button
+      <Button
         type="button"
         disabled={pending}
+        isLoading={pending}
+        size="sm"
         onClick={() => {
           start(async () => {
             setText(await whoami());
@@ -19,7 +22,7 @@ export function WhoamiButton(): React.ReactNode {
         }}
       >
         {pending ? '…' : 'whoami()'}
-      </button>
+      </Button>
       {text !== null && (
         <pre data-whoami="" style={{ marginTop: 8 }}>
           {text}
@@ -36,9 +39,11 @@ export function SecretPingForm(): React.ReactNode {
 
   return (
     <div>
-      <button
+      <Button
         type="button"
         disabled={pending}
+        isLoading={pending}
+        size="sm"
         onClick={() => {
           start(async () => {
             setError(null);
@@ -52,7 +57,7 @@ export function SecretPingForm(): React.ReactNode {
         }}
       >
         {pending ? '…' : 'secretPing()'}
-      </button>
+      </Button>
       {text !== null && (
         <pre data-secret-ok="" style={{ marginTop: 8, color: '#166534' }}>
           {text}

--- a/apps/rsc-poc/src/pages/session.tsx
+++ b/apps/rsc-poc/src/pages/session.tsx
@@ -1,3 +1,4 @@
+import { Button, Input } from '@revealui/presentation';
 import { getSession } from '../auth/session-server.ts';
 import { SecretPingForm, WhoamiButton } from './session-client.tsx';
 
@@ -22,11 +23,15 @@ export async function SessionPage(): Promise<React.ReactNode> {
           action="/api/session/login"
           style={{ display: 'flex', gap: 8, marginBottom: 12 }}
         >
-          <input type="hidden" name="sub" value="demo" />
-          <button type="submit">Sign in as demo</button>
+          <Input type="hidden" name="sub" value="demo" />
+          <Button type="submit" size="sm">
+            Sign in as demo
+          </Button>
         </form>
         <form method="POST" action="/api/session/logout">
-          <button type="submit">Sign out</button>
+          <Button type="submit" variant="neutral" appearance="outline" size="sm">
+            Sign out
+          </Button>
         </form>
       </section>
 

--- a/packages/harnesses/src/__tests__/skill-invoke.test.ts
+++ b/packages/harnesses/src/__tests__/skill-invoke.test.ts
@@ -1,0 +1,51 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { SkillCatalogEntry } from '../content/skill-catalog.js';
+import {
+  buildSkillInvokeRequest,
+  PHASE_C_INFERENCE_SNAP,
+  resolveNativeWorkflowSkillId,
+} from '../content/skill-invoke.js';
+
+function entry(id: string, dir: string): SkillCatalogEntry {
+  const path = join(dir, 'SKILL.md');
+  writeFileSync(
+    path,
+    `---
+name: ${id}
+description: fixture
+---
+# ${id} body
+`,
+  );
+  return { id, name: id, description: 'fixture', path, source: 'revskills' };
+}
+
+describe('skill invoke (GAP-293 Phase C)', () => {
+  it('resolves aliases to native workflow ids', () => {
+    expect(resolveNativeWorkflowSkillId('doctor')).toBe('revealui-doctor');
+    expect(resolveNativeWorkflowSkillId('revealui-checkpoint')).toBe('revealui-checkpoint');
+    expect(resolveNativeWorkflowSkillId('lint')).toBeNull();
+  });
+
+  it('rejects skills outside the native allowlist', () => {
+    const result = buildSkillInvokeRequest('preflight', []);
+    expect('error' in result).toBe(true);
+    if ('error' in result) expect(result.error).toContain('allowlist');
+  });
+
+  it('binds the product default snap and does not claim execution', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'skill-inv-'));
+    mkdirSync(dir, { recursive: true });
+    const catalog = [entry('revealui-doctor', dir)];
+    const result = buildSkillInvokeRequest('doctor', catalog);
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.model).toBe(PHASE_C_INFERENCE_SNAP);
+    expect(result.model).toBe('nemotron-3-nano');
+    expect(result.system).toContain('# revealui-doctor body');
+    expect(result.user).toContain('cannot execute tools');
+  });
+});

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -580,9 +580,31 @@ async function main() {
     const projectRoot =
       projectIdx >= 0 ? (args[projectIdx + 1] ?? DEFAULT_PROJECT) : DEFAULT_PROJECT;
     const revskillsRoot = revskillsIdx >= 0 ? args[revskillsIdx + 1] : undefined;
+    if (subcommand === 'invoke') {
+      const skillId = args[1];
+      if (!skillId) {
+        process.stderr.write(
+          'Usage: revealui-harnesses skills invoke <doctor|recover|checkpoint> [--dry-run] [--project <dir>] [--revskills <dir>]\n',
+        );
+        process.exit(1);
+      }
+      const { buildSkillInvokeRequest } = await import('./content/skill-invoke.js');
+      const catalog = listSkillCatalog({
+        projectRoot,
+        revskillsRoot,
+        includeDefinitions: true,
+      });
+      const prepared = buildSkillInvokeRequest(skillId, catalog);
+      if ('error' in prepared) {
+        process.stderr.write(`${prepared.error}\n`);
+        process.exit(1);
+      }
+      process.stdout.write(`${JSON.stringify({ ...prepared, dryRun: true }, null, 2)}\n`);
+      return;
+    }
     if (subcommand !== 'list') {
       process.stderr.write(
-        'Usage: revealui-harnesses skills list [--json] [--project <dir>] [--revskills <dir>]\n',
+        'Usage: revealui-harnesses skills <list|invoke> [--json] [--project <dir>] [--revskills <dir>]\n',
       );
       process.exit(1);
     }

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -70,6 +70,14 @@ export {
 } from './schemas/index.js';
 export type { SkillCatalogEntry, SkillCatalogSource } from './skill-catalog.js';
 export { listSkillCatalog, skimSkillFrontmatter } from './skill-catalog.js';
+export type { NativeWorkflowSkillId, SkillInvokeRequest } from './skill-invoke.js';
+export {
+  buildSkillInvokeRequest,
+  isNativeWorkflowSkillId,
+  NATIVE_WORKFLOW_SKILL_IDS,
+  PHASE_C_INFERENCE_SNAP,
+  resolveNativeWorkflowSkillId,
+} from './skill-invoke.js';
 export type {
   ContentSnapshot,
   ContentSnapshotFile,

--- a/packages/harnesses/src/content/skill-invoke.ts
+++ b/packages/harnesses/src/content/skill-invoke.ts
@@ -1,0 +1,86 @@
+/**
+ * GAP-293 Phase C — bind native workflow skills to the product default snap.
+ *
+ * Snap is not invented: `nemotron-3-nano` is DEFAULT_US_ORIGIN_INFERENCE_SNAP
+ * in `@revealui/ai` (`providers/us-origin-snaps.ts`). This module only
+ * prepares the invoke; it does not run tools or commit.
+ */
+
+import { readFileSync } from 'node:fs';
+import type { SkillCatalogEntry } from './skill-catalog.js';
+
+export const NATIVE_WORKFLOW_SKILL_IDS = [
+  'revealui-doctor',
+  'revealui-recover',
+  'revealui-checkpoint',
+] as const;
+
+export type NativeWorkflowSkillId = (typeof NATIVE_WORKFLOW_SKILL_IDS)[number];
+
+/** Product default Inference Snap (US-origin catalog). */
+export const PHASE_C_INFERENCE_SNAP = 'nemotron-3-nano';
+
+const ALIASES: Record<string, NativeWorkflowSkillId> = {
+  doctor: 'revealui-doctor',
+  recover: 'revealui-recover',
+  checkpoint: 'revealui-checkpoint',
+};
+
+export function resolveNativeWorkflowSkillId(raw: string): NativeWorkflowSkillId | null {
+  const key = raw.trim();
+  if (key in ALIASES) return ALIASES[key] ?? null;
+  for (const id of NATIVE_WORKFLOW_SKILL_IDS) {
+    if (id === key) return id;
+  }
+  return null;
+}
+
+export function isNativeWorkflowSkillId(id: string): id is NativeWorkflowSkillId {
+  return resolveNativeWorkflowSkillId(id) !== null;
+}
+
+export interface SkillInvokeRequest {
+  skillId: NativeWorkflowSkillId;
+  model: typeof PHASE_C_INFERENCE_SNAP;
+  path: string;
+  system: string;
+  user: string;
+}
+
+export function buildSkillInvokeRequest(
+  skillId: string,
+  catalog: SkillCatalogEntry[],
+): SkillInvokeRequest | { error: string } {
+  const resolved = resolveNativeWorkflowSkillId(skillId);
+  if (!resolved) {
+    return {
+      error: `skills.invoke allowlist is ${NATIVE_WORKFLOW_SKILL_IDS.join(', ')} (or doctor/recover/checkpoint). Got: ${skillId}`,
+    };
+  }
+  const entry = catalog.find((s) => s.id === resolved);
+  if (!entry) {
+    return {
+      error: `skill ${resolved} is not in the catalog (materialize content or set revskills root)`,
+    };
+  }
+  let body: string;
+  try {
+    body = readFileSync(entry.path, 'utf-8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: `cannot read ${entry.path}: ${msg}` };
+  }
+  return {
+    skillId: resolved,
+    model: PHASE_C_INFERENCE_SNAP,
+    path: entry.path,
+    system: body,
+    user: [
+      `Run the ${resolved} workflow as a RevDev-native pass.`,
+      `Local model is the product default Inference Snap: ${PHASE_C_INFERENCE_SNAP}.`,
+      'You cannot execute tools or git commits from this invoke.',
+      'Produce the structured report the skill specifies (traffic-light / diagnostic / checkpoint report).',
+      'Name any command you would have run; do not claim you ran it.',
+    ].join(' '),
+  };
+}

--- a/packages/presentation/docs/marketing-section-system.md
+++ b/packages/presentation/docs/marketing-section-system.md
@@ -34,17 +34,21 @@ Rules:
 | `width` | `narrow` \| `default` \| `wide` \| `full` | Content max-width |
 | `density` | `compact` \| `default` \| `spacious` | Vertical padding |
 | `bleed` | boolean | Skip outer horizontal pad (rare) |
+| `backdrop` | `ReactNode` | Full-bleed layer on the **outer** section (not the max-w rail). Hero washes/glows. |
 
 `SectionHeader` owns intro stack: optional eyebrow, title, optional description (`text-body`).
 
 Eyebrow tones: `primary` (default brand signal) or `muted` (quiet sections).
 
+**Viewport-stage heroes:** put decoration in `backdrop` (absolute inset-0), put min-height on the section (`min-h-[calc(100svh-var(--marketing-nav-h))]`), never nest absolute paint inside the max-width children.
+
 ## Consumer rules
 
 1. Prefer shells over raw `py-24` / `max-w-7xl` / `px-6` duplication.
 2. Keep page-specific content (matrices, calculators) as **children** of the shell.
-3. CMS `SectionBlock` body copy must use the body rung (aligned with this ladder).
-4. Route craft only after consumers adopt shells (frontend-excellence sequence).
+3. Full-bleed washes go in `backdrop`, not as absolute children of the content rail.
+4. CMS `SectionBlock` body copy must use the body rung (aligned with this ladder).
+5. Route craft only after consumers adopt shells (frontend-excellence sequence).
 
 ## Pilot + Phase 2 rewire
 

--- a/packages/presentation/src/__tests__/components/Input.test.tsx
+++ b/packages/presentation/src/__tests__/components/Input.test.tsx
@@ -386,6 +386,18 @@ describe('Input', () => {
     });
   });
 
+  describe('Hidden Input', () => {
+    it('renders a native hidden input without chrome', () => {
+      const { container } = render(<Input type="hidden" name="sub" value="demo" />);
+
+      const input = container.querySelector('input[type="hidden"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('name', 'sub');
+      expect(input).toHaveAttribute('value', 'demo');
+      expect(container.querySelector('[data-slot=control]')).not.toBeInTheDocument();
+    });
+  });
+
   describe('File Input', () => {
     it('should render file input', () => {
       render(<Input type="file" />);

--- a/packages/presentation/src/__tests__/components/marketing-section.test.tsx
+++ b/packages/presentation/src/__tests__/components/marketing-section.test.tsx
@@ -57,6 +57,28 @@ describe('MarketingSection', () => {
     expect(section).toHaveClass('isolate');
     expect(section).toHaveClass('overflow-hidden');
   });
+
+  it('paints backdrop on the outer section, not the max-width rail', () => {
+    render(
+      <MarketingSection
+        width="narrow"
+        backdrop={
+          <div data-testid="full-bleed-backdrop" className="absolute inset-0" aria-hidden="true" />
+        }
+      >
+        <span>Content</span>
+      </MarketingSection>,
+    );
+    const section = screen.getByText('Content').closest('section');
+    expect(section).toHaveAttribute('data-has-backdrop', 'true');
+    expect(section).toHaveClass('relative');
+    const backdrop = screen.getByTestId('full-bleed-backdrop');
+    // Backdrop is a direct child of the section (full bleed), not inside max-w rail.
+    expect(backdrop.parentElement).toBe(section);
+    const rail = screen.getByText('Content').parentElement;
+    expect(rail).toHaveClass('max-w-3xl');
+    expect(rail?.contains(backdrop)).toBe(false);
+  });
 });
 
 describe('SectionHeader', () => {

--- a/packages/presentation/src/components/input-headless.tsx
+++ b/packages/presentation/src/components/input-headless.tsx
@@ -25,7 +25,17 @@ type DateType = (typeof dateTypes)[number];
 
 type InputProps = {
   className?: string;
-  type?: 'email' | 'file' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url' | DateType;
+  type?:
+    | 'email'
+    | 'file'
+    | 'hidden'
+    | 'number'
+    | 'password'
+    | 'search'
+    | 'tel'
+    | 'text'
+    | 'url'
+    | DateType;
   disabled?: boolean;
   invalid?: boolean;
   ref?: React.Ref<HTMLInputElement>;
@@ -34,6 +44,10 @@ type InputProps = {
 export function Input({ className, disabled, invalid, ref, ...props }: InputProps) {
   const interactiveProps = useDataInteractive({ disabled });
   const fieldProps = useFieldControlProps();
+
+  if (props.type === 'hidden') {
+    return <input ref={ref} disabled={disabled} className={className} {...props} />;
+  }
 
   return (
     <span

--- a/packages/presentation/src/components/marketing-section.tsx
+++ b/packages/presentation/src/components/marketing-section.tsx
@@ -25,6 +25,12 @@ export interface MarketingSectionProps extends React.ComponentPropsWithoutRef<'s
    * Prefer false unless embedding full-bleed media.
    */
   bleed?: boolean;
+  /**
+   * Full-bleed layer painted on the outer section (not the max-width rail).
+   * Use for hero washes/glows so decoration is viewport-wide, not content-boxed.
+   * Caller should use absolute inset-0 (or similar) and aria-hidden as needed.
+   */
+  backdrop?: React.ReactNode;
   /** Classes for the inner max-width container. */
   innerClassName?: string;
 }
@@ -61,6 +67,7 @@ export function MarketingSection({
   width = 'default',
   density = 'default',
   bleed = false,
+  backdrop,
   className,
   innerClassName,
   children,
@@ -72,10 +79,19 @@ export function MarketingSection({
       data-tone={tone}
       data-density={density}
       data-width={width}
-      className={cn(toneClass[tone], densityClass[density], !bleed && 'px-6 lg:px-8', className)}
+      data-has-backdrop={backdrop != null ? 'true' : undefined}
+      className={cn(
+        toneClass[tone],
+        densityClass[density],
+        !bleed && 'px-6 lg:px-8',
+        // Backdrop is position:absolute relative to this outer section (full bleed).
+        backdrop != null && 'relative isolate',
+        className,
+      )}
       {...props}
     >
-      <div className={cn('relative mx-auto w-full', widthClass[width], innerClassName)}>
+      {backdrop}
+      <div className={cn('relative z-0 mx-auto w-full', widthClass[width], innerClassName)}>
         {children}
       </div>
     </section>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,6 +692,9 @@ importers:
       '@revealui/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@revealui/presentation':
+        specifier: workspace:*
+        version: link:../../packages/presentation
       '@revealui/router':
         specifier: workspace:*
         version: link:../../packages/router

--- a/scripts/validate/tier1-presentation-allowlist.json
+++ b/scripts/validate/tier1-presentation-allowlist.json
@@ -27,41 +27,6 @@
       "reason": "content-driven product icon path data; no Icon* match (GAP-398 residual)"
     },
     {
-      "path": "apps/rsc-poc/src/pages/action-form.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/action-form.tsx",
-      "tag": "input",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/counter.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/errors-client.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/session-client.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/session.tsx",
-      "tag": "button",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
-      "path": "apps/rsc-poc/src/pages/session.tsx",
-      "tag": "input",
-      "reason": "GAP-479 later slice: rsc-poc research harness; migrate hosts to presentation"
-    },
-    {
       "path": "packages/editor/src/canvas/EditSessionCanvas.tsx",
       "tag": "button",
       "reason": "GAP-479 later slice: visual-edit canvas chrome; use presentation Button/Input/Textarea"


### PR DESCRIPTION
## Summary
Promote integration tip to production.

Includes (among other test landings):
- Marketing craft trains (shells, type, PricingTable, route craft, chrome/widgets)
- **#2588** hero full-bleed viewport stage
- Harnesses snap skills (#2589)
- Will pick up **#2593** Cobalt residual when it merges to test before this merge

## Merge method
**Create a merge commit only** (not squash).

## Test plan
- [ ] CI green on this PR (incl. a11y where path-required)
- [ ] After merge: deploy.yml success for marketing; spot-check /