### PR TITLE
fix(marketing): AA contrast on GetStarted CLI tokens

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -62,10 +62,12 @@ export function GetStarted({
               // biome-ignore lint/suspicious/noArrayIndexKey: static, order-fixed command tokens
               key={index}
               className={
+                // Dark pill (bg-foreground): light text only. Never text-primary
+                // (paper brand blue fails AA on midnight at 14px).
                 index === 0
-                  ? 'text-emerald-400' // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
+                  ? 'text-primary-foreground'
                   : index === data.cli.command.length - 1
-                    ? 'text-primary'
+                    ? 'text-background/80'
                     : 'text-background'
               }
             >

--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -65,7 +65,7 @@ export function GetStarted({
                 index === 0
                   ? 'text-emerald-400' // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
                   : index === data.cli.command.length - 1
-                    ? 'text-blue-300'
+                    ? 'text-primary'
                     : 'text-background'
               }
             >

--- a/apps/marketing/app/components/products/ProductsHero.tsx
+++ b/apps/marketing/app/components/products/ProductsHero.tsx
@@ -32,7 +32,7 @@ export function ProductsHero({
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/5 via-background to-blue-500/10"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/5 via-background to-background"
       />
       <h1
         className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl"

--- a/apps/marketing/app/content/products.ts
+++ b/apps/marketing/app/content/products.ts
@@ -71,24 +71,24 @@ export interface ProductStatusStyle {
 
 export const PRODUCT_STATUS_STYLES: Readonly<Record<ProductStatus, ProductStatusStyle>> = {
   Beta: {
-    bg: 'bg-emerald-500/10', // adherence-ignore: emerald-utility - apps/marketing/app/index.css:80-92 remaps emerald-* to cobalt oklch values (Cobalt v5 palette remap); renders cobalt today, zero visual change
-    text: 'text-emerald-700', // adherence-ignore: emerald-utility - see index.css:80-92 emerald->cobalt remap; renders cobalt today, zero visual change
-    ring: 'ring-emerald-500/30', // adherence-ignore: emerald-utility - see index.css:80-92 emerald->cobalt remap; renders cobalt today, zero visual change
+    bg: 'bg-primary/10',
+    text: 'text-primary',
+    ring: 'ring-primary/30',
   },
   Alpha: {
-    bg: 'bg-amber-500/10',
-    text: 'text-amber-700',
-    ring: 'ring-amber-500/30',
+    bg: 'bg-secondary',
+    text: 'text-foreground',
+    ring: 'ring-border',
   },
   'Active (MIT)': {
-    bg: 'bg-blue-500/10',
-    text: 'text-blue-700',
-    ring: 'ring-blue-500/30',
+    bg: 'bg-primary/10',
+    text: 'text-primary',
+    ring: 'ring-primary/30',
   },
   Planned: {
-    bg: 'bg-slate-500/10',
-    text: 'text-slate-700',
-    ring: 'ring-slate-500/30',
+    bg: 'bg-muted',
+    text: 'text-muted-foreground',
+    ring: 'ring-border',
   },
 } as const;
 

--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -90,7 +90,7 @@ export function BlogIndexPage() {
       >
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-blue-500/10 via-background to-indigo-500/10"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
         />
         <SectionHeader
           title="Blog"

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -110,7 +110,7 @@ export function BlogPostPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      <article className="py-24 sm:py-32">
+      <article className="py-16 sm:py-24 lg:py-28">
         <div className="mx-auto max-w-3xl px-6 lg:px-8">
           {/* Back link */}
           <a

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -57,19 +57,14 @@ function FairSourceContract({ data, path, annotation }: ContractProps) {
           <div
             key={c.title}
             className={`rounded-2xl p-6 ring-1 transition sm:p-8 ${
-              c.kind === 'yes'
-                ? 'bg-primary/10 ring-primary/20'
-                : 'bg-amber-500/15 ring-amber-500/30'
+              c.kind === 'yes' ? 'bg-primary/10 ring-primary/20' : 'bg-muted ring-border'
             }`}
           >
             <div className="flex items-start gap-3">
               {c.kind === 'yes' ? (
                 <IconCheckCircle size="md" className="mt-0.5 flex-shrink-0 text-primary" />
               ) : (
-                <IconXCircle
-                  size="md"
-                  className="mt-0.5 flex-shrink-0 text-amber-800 dark:text-amber-200"
-                />
+                <IconXCircle size="md" className="mt-0.5 flex-shrink-0 text-muted-foreground" />
               )}
               <div>
                 <h3
@@ -129,7 +124,7 @@ function FairSourcePackagesIntro({ data, path, annotation }: PackagesIntroProps)
                 </td>
                 <td className="px-6 py-4 text-muted-foreground">{p.purpose}</td>
                 <td className="px-6 py-4">
-                  <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
+                  <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary ring-1 ring-primary/20">
                     {p.license}
                   </span>
                 </td>
@@ -198,7 +193,7 @@ function FairSourceClock({ data, path, annotation }: ClockProps) {
             <li key={step.title} className="mb-7 last:mb-0 sm:mb-8">
               <span
                 className={`absolute -left-2.5 mt-1.5 flex h-5 w-5 items-center justify-center rounded-full ring-4 ring-background ${
-                  step.color === 'emerald' ? 'bg-primary' : 'bg-amber-600'
+                  step.color === 'emerald' ? 'bg-primary' : 'bg-muted-foreground'
                 }`}
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-white" />

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -44,7 +44,7 @@ function LocalAiHero({ data, path, annotation }: LocalAiHeroProps) {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-violet-500/10"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
       />
       <p
         className="text-sm font-semibold uppercase tracking-wide text-primary"

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -27,7 +27,7 @@ function PhilosophyHero({ data, path, annotation }: PhilosophyHeroProps) {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-violet-500/10"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
       />
       <p
         className="text-sm font-semibold uppercase tracking-wide text-primary"

--- a/apps/marketing/app/routes/PricingPage.tsx
+++ b/apps/marketing/app/routes/PricingPage.tsx
@@ -273,7 +273,7 @@ export function PricingPage() {
             >
               {tier.comingSoon && (
                 <div className="absolute right-4 top-4">
-                  <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground ring-1 ring-border">
                     Coming soon
                   </span>
                 </div>
@@ -324,7 +324,7 @@ export function PricingPage() {
               description={PRICING_AGENTS_SECTION.subhead}
               align="center"
             />
-            <span className="mt-3 inline-block rounded-full bg-amber-500/15 px-3 py-1 text-xs font-semibold text-amber-800 dark:text-amber-200 ring-1 ring-amber-500/30">
+            <span className="mt-3 inline-block rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary ring-1 ring-primary/30">
               {PRICING_AGENTS_SECTION.badge}
             </span>
           </div>
@@ -352,8 +352,8 @@ export function PricingPage() {
             </div>
 
             <div className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
-              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 ring-1 ring-blue-500/20">
-                <IconCode size="md" className="text-blue-600" />
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+                <IconCode size="md" className="text-primary" />
               </div>
               <h3 className="text-base font-semibold text-foreground">
                 {PRICING_AGENT_X402.heading}
@@ -362,8 +362,8 @@ export function PricingPage() {
             </div>
 
             <div className="rounded-2xl bg-card p-6 ring-1 ring-border sm:p-8">
-              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-violet-500/10 ring-1 ring-violet-500/20">
-                <IconTerminal size="md" className="text-violet-600" />
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+                <IconTerminal size="md" className="text-primary" />
               </div>
               <h3 className="text-base font-semibold text-foreground">
                 {PRICING_AGENT_MCP.heading}
@@ -371,7 +371,7 @@ export function PricingPage() {
               <p className="mt-2 text-sm text-body">{PRICING_AGENT_MCP.body}</p>
               <a
                 href={PRICING_AGENT_MCP.docsLink.href}
-                className="mt-3 inline-block text-xs font-semibold text-violet-600 hover:text-violet-700"
+                className="mt-3 inline-block text-xs font-semibold text-primary hover:text-primary/80"
               >
                 {PRICING_AGENT_MCP.docsLink.label}
               </a>
@@ -406,7 +406,7 @@ export function PricingPage() {
               {PRICING_STARTER_KIT.eyebrow}
             </span>
             {PRICING_STARTER_KIT.badge ? (
-              <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:text-amber-200">
+              <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground ring-1 ring-border">
                 {PRICING_STARTER_KIT.badge}
               </span>
             ) : null}

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -54,7 +54,7 @@ export function ProductsPage() {
       >
         <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-primary/90 to-primary/70 p-10 shadow-2xl ring-1 ring-primary/20 sm:p-14">
           <div className="absolute -right-16 -top-16 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
-          <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-blue-500/15 blur-3xl" />
+          <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
           <div className="relative">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
Promote a11y failed: `text-primary` (#003d94) on GetStarted dark CLI pill (`bg-foreground` / midnight) = **1.93:1**.

Use light-on-dark tokens (`text-primary-foreground` / `text-background`) for command tokens.

## Test plan
- [ ] CI Accessibility E2E + smoke on marketing home
- [ ] Promote #2594 re-check after this lands on test