### PR TITLE
style(marketing): homepage section rhythm (GAP-480 Phase C)

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -27,7 +27,7 @@ export function GetStarted({
   return (
     <MarketingSection
       tone="background"
-      density="default"
+      density="compact"
       width="default"
       className="border-t border-border"
     >

--- a/apps/marketing/app/components/landing/Demo.tsx
+++ b/apps/marketing/app/components/landing/Demo.tsx
@@ -21,7 +21,7 @@ export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {}
   return (
     <MarketingSection
       id="demo"
-      tone="secondary"
+      tone="background"
       density="default"
       width="default"
       className="relative"
@@ -36,12 +36,12 @@ export function Demo({ data = HOME_DEMO, path = 'blocks.0.data', annotation = {}
 
       {/* Product-as-proof: live component frame (Linear craft pattern).
           Content mockupCaption was previously unwired; honesty line stays. */}
-      <div className="mt-12 sm:mt-14">
+      <div className="mt-10 sm:mt-12">
         <ProductFrame caption={HOME_DEMO.mockupCaption} />
       </div>
 
       {/* Beats as aligned stack, not three bordered cards (Linear: density over chrome). */}
-      <ol className="mx-auto mt-12 grid max-w-5xl list-none grid-cols-1 gap-0 divide-y divide-border border-y border-border p-0 sm:mt-14 lg:grid-cols-3 lg:gap-0 lg:divide-x lg:divide-y-0">
+      <ol className="mx-auto mt-10 grid max-w-5xl list-none grid-cols-1 gap-0 divide-y divide-border border-y border-border p-0 sm:mt-12 lg:grid-cols-3 lg:gap-0 lg:divide-x lg:divide-y-0">
         {data.beats.map((b, index) => (
           <li key={b.n} className="relative px-0 py-6 lg:px-8 lg:py-7 first:lg:pl-0 last:lg:pr-0">
             <div

--- a/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
+++ b/apps/marketing/app/components/landing/LiveMetricsBadge.tsx
@@ -30,20 +30,20 @@ export function LiveMetricsBadge() {
         </a>
       </div>
 
-      <dl className="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border ring-1 ring-border sm:grid-cols-3 lg:grid-cols-6">
+      <dl className="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border ring-1 ring-border sm:grid-cols-3 lg:grid-cols-6">
         {M.metrics.map((m) => (
-          <div key={m.label} className="bg-card px-3 py-5 text-center sm:px-4 sm:py-6">
-            <dd className="font-display text-2xl font-bold tabular-nums tracking-tight text-foreground sm:text-3xl">
+          <div key={m.label} className="bg-card px-3 py-4 text-center sm:px-4 sm:py-5">
+            <dd className="font-display text-xl font-bold tabular-nums tracking-tight text-foreground sm:text-2xl">
               {m.value}
             </dd>
-            <dt className="mt-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+            <dt className="mt-1 text-[11px] uppercase tracking-wide text-muted-foreground">
               {m.label}
             </dt>
           </div>
         ))}
       </dl>
 
-      <p className="mt-5 text-sm leading-6 text-body">{M.body}</p>
+      <p className="mt-4 text-sm leading-6 text-body">{M.body}</p>
     </div>
   );
 }

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -57,7 +57,7 @@ export function Primitives({
   annotation = {},
 }: PrimitivesProps) {
   return (
-    <MarketingSection tone="background" density="default" width="default">
+    <MarketingSection tone="secondary" density="compact" width="default">
       <SectionHeader
         eyebrow={<span {...fieldAttrs(annotation, `${path}.eyebrow`)}>{data.eyebrow}</span>}
         eyebrowTone="muted"

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -48,7 +48,12 @@ function answersFor(row: (typeof HOME_PROBLEM.rows)[number]): readonly Answer[] 
 
 export function Problem() {
   return (
-    <MarketingSection tone="background" density="default" width="default">
+    <MarketingSection
+      // Secondary band after hero stage — homepage rhythm (GAP-480 Phase C).
+      tone="secondary"
+      density="default"
+      width="default"
+    >
       <SectionHeader
         eyebrow={HOME_PROBLEM.eyebrow}
         eyebrowTone="muted"

--- a/apps/marketing/app/components/landing/ProductFrame.tsx
+++ b/apps/marketing/app/components/landing/ProductFrame.tsx
@@ -70,10 +70,10 @@ export function ProductFrame({
           Linear: hierarchy via surface elevation, not brand-colored decoration.
           Do NOT put role=img on this mat: it may contain focusable controls
           (AuditLine CopyRef) and nested-interactive fails axe WCAG 4.1.2. */}
-      <div className="overflow-hidden rounded-2xl bg-foreground p-1.5 shadow-2xl shadow-foreground/10 sm:p-2">
+      <div className="overflow-hidden rounded-2xl bg-foreground p-1 shadow-lg shadow-foreground/10 sm:p-1.5">
         <div className="overflow-hidden rounded-xl bg-background">
           {/* Window chrome — inverted-L: title bar only; density over ornament */}
-          <div className="flex h-10 items-center gap-3 border-b border-border px-3 sm:px-4">
+          <div className="flex h-9 items-center gap-3 border-b border-border px-3 sm:h-10 sm:px-4">
             <div className="flex items-center gap-1.5" aria-hidden="true">
               <span className="size-2 rounded-full bg-muted-foreground/25" />
               <span className="size-2 rounded-full bg-muted-foreground/25" />
@@ -124,13 +124,13 @@ export function ProductFrame({
             </aside>
 
             {/* Main pane */}
-            <div className="min-w-0 p-4 sm:p-5">
+            <div className="min-w-0 p-3 sm:p-4">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="min-w-0">
                   <p className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
                     Agent activity
                   </p>
-                  <h3 className="mt-1 font-display text-base font-semibold tracking-tight text-foreground">
+                  <h3 className="mt-0.5 font-display text-sm font-semibold tracking-tight text-foreground sm:text-base">
                     support-agent · refund flow
                   </h3>
                 </div>

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -3,9 +3,13 @@ import { PROOF_DEPLOYERS, PROOF_SECTION, PROOF_TRUST } from '../../content/proof
 import { SITE } from '../../content/site';
 import { LiveMetricsBadge } from './LiveMetricsBadge';
 
+/**
+ * Homepage proof band (GAP-480 Phase C rhythm).
+ * Metrics first; deployers as a quiet sub-band (border only, no card chrome).
+ */
 export function Proof() {
   return (
-    <MarketingSection tone="background" density="default" width="default">
+    <MarketingSection tone="background" density="compact" width="default">
       <SectionHeader
         eyebrow={PROOF_SECTION.eyebrow}
         eyebrowTone="muted"
@@ -14,7 +18,7 @@ export function Proof() {
         align="center"
       />
 
-      <div className="mt-12 flex justify-center sm:mt-14">
+      <div className="mt-10 flex justify-center sm:mt-12">
         <a
           href={SITE.urls.repo}
           target="_blank"
@@ -26,11 +30,11 @@ export function Proof() {
         </a>
       </div>
 
-      <div className="mt-10 sm:mt-12">
+      <div className="mt-8 sm:mt-10">
         <LiveMetricsBadge />
       </div>
 
-      <div className="mx-auto mt-10 max-w-2xl text-center sm:mt-12">
+      <div className="mx-auto mt-8 max-w-2xl text-center sm:mt-10">
         <p className="text-base leading-7 text-body">
           {PROOF_TRUST.body}{' '}
           <a
@@ -42,31 +46,32 @@ export function Proof() {
             {PROOF_TRUST.linkLabel}
           </a>
         </p>
+        <div className="mt-5">
+          <Button
+            asChild
+            appearance="link"
+            size="default"
+            className="items-center justify-center text-sm font-medium"
+          >
+            <a href={PROOF_TRUST.changelogCta.href}>{PROOF_TRUST.changelogCta.label}</a>
+          </Button>
+        </div>
       </div>
 
-      <div className="mt-8 text-center">
-        <Button
-          asChild
-          appearance="link"
-          size="default"
-          className="items-center justify-center text-sm font-medium"
-        >
-          <a href={PROOF_TRUST.changelogCta.href}>{PROOF_TRUST.changelogCta.label}</a>
-        </Button>
-      </div>
-
-      {/* Secondary FDE layer — same homepage section (≤7 rule), not a new section */}
-      <div className="mx-auto mt-12 max-w-2xl border-t border-border pt-12 text-center sm:mt-14 sm:pt-14">
+      {/* FDE sub-band: border-only (≤7 sections rule). Demoted chrome. */}
+      <div className="mx-auto mt-10 max-w-2xl border-t border-border pt-8 text-center sm:mt-12 sm:pt-10">
         <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
           {PROOF_DEPLOYERS.eyebrow}
         </p>
-        <h3 className="mt-3 font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+        <h3 className="mt-2 font-display text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
           {PROOF_DEPLOYERS.heading}
         </h3>
-        <p className="mt-4 text-base leading-7 text-body">{PROOF_DEPLOYERS.body}</p>
-        <p className="mt-4 text-sm leading-6 text-body">{PROOF_DEPLOYERS.foil}</p>
-        <div className="mt-8">
-          <Button asChild size="default" className="items-center justify-center">
+        <p className="mt-3 text-sm leading-6 text-body sm:text-base sm:leading-7">
+          {PROOF_DEPLOYERS.body}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">{PROOF_DEPLOYERS.foil}</p>
+        <div className="mt-6">
+          <Button asChild appearance="outline" variant="neutral" size="default">
             <a href={PROOF_DEPLOYERS.cta.href} target="_blank" rel="noopener noreferrer">
               {PROOF_DEPLOYERS.cta.label}
             </a>


### PR DESCRIPTION
## Summary
GAP-480 Phase C: homepage rhythm only (no new sections, no redesign).

### Tone / density (Hero → GetStarted)
| Section | Tone | Density |
|---------|------|---------|
| Hero | background (stage) | spacious |
| Problem | **secondary** | default |
| Demo | **background** | default |
| Primitives | **secondary** | **compact** |
| Proof | background | **compact** |
| PricingTeaser | secondary | default |
| GetStarted | background | **compact** |

### Density / chrome
- **Proof** deployers: smaller type, outline CTA, foil muted, tighter gaps
- **LiveMetrics**: denser cells
- **ProductFrame**: lighter shadow/padding
- **Demo**: tighter frame/beats spacing

## Test plan
- [x] Local phase-1 gate
- [ ] CI green
- [ ] Spot-check home scroll rhythm on phone + desktop