### PR TITLE
feat(docs): GAP-480 Phase D static landing receipt motif

### DIFF
--- a/apps/docs/__tests__/routes/docs-index-receipt.test.tsx
+++ b/apps/docs/__tests__/routes/docs-index-receipt.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Docs landing static receipt motif (GAP-480 Phase D / frontend-excellence Phase 5).
+ */
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DocsIndexPage } from '../../app/routes/DocsIndexPage';
+
+vi.mock('../../app/lib/head', () => ({
+  applyDocHead: vi.fn(),
+}));
+
+vi.mock('../../app/utils/markdown', () => ({
+  renderMarkdown: vi.fn((md: string) => <div data-testid="markdown">{md.slice(0, 40)}</div>),
+}));
+
+vi.mock('@revealui/router', () => ({
+  Link: ({
+    to,
+    children,
+    className,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('DocsIndexPage receipt motif', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a static receipt header with audit-receipts link (no print animation)', () => {
+    const { container } = render(<DocsIndexPage />);
+
+    expect(screen.getByRole('region', { name: 'Governed action, on record' })).toBeInTheDocument();
+    expect(screen.getByText(/If an agent did it, there's a receipt\./)).toBeInTheDocument();
+
+    const docsLink = screen.getByRole('link', { name: 'Audit receipts docs →' });
+    expect(docsLink).toHaveAttribute('href', '/security/audit-receipts');
+
+    // Static only: print animation injects a <style> tag when animate="print".
+    expect(container.querySelector('style')).toBeNull();
+    expect(screen.getByTestId('markdown')).toBeInTheDocument();
+  });
+});

--- a/apps/docs/app/content/receipt.ts
+++ b/apps/docs/app/content/receipt.ts
@@ -1,0 +1,40 @@
+// Docs landing receipt motif (frontend-excellence Phase 5 rollout echo,
+// GAP-480 Phase D). Static only: no animate="print". Demonstration content,
+// not live production data. Timestamps are static strings.
+// Links to /security/audit-receipts for the real product docs.
+
+import type { AuditEvent } from '@revealui/presentation';
+
+export const DOCS_RECEIPT_TITLE = 'Governed action, on record' as const;
+
+export const DOCS_RECEIPT_LINES: readonly AuditEvent[] = [
+  {
+    ts: '10:14:02',
+    actor: 'ops-agent',
+    action: 'signed in as',
+    object: 'agents@demo.revealui.com',
+  },
+  {
+    ts: '10:14:05',
+    actor: 'ops-agent',
+    action: 'ran',
+    object: 'policy check on deploy #318',
+  },
+  {
+    ts: '10:14:06',
+    actor: 'audit-log',
+    action: 'recorded',
+    object: 'the receipt',
+    refId: 'rcpt_docs01',
+  },
+] as const;
+
+export const DOCS_RECEIPT_INTEGRITY = {
+  kind: 'sha256',
+  value: 'c3d1…7a90',
+} as const;
+
+export const DOCS_RECEIPT_CAPTION = {
+  text: "If an agent did it, there's a receipt.",
+  link: { label: 'Audit receipts docs →', href: '/security/audit-receipts' },
+} as const;

--- a/apps/docs/app/routes/DocsIndexPage.tsx
+++ b/apps/docs/app/routes/DocsIndexPage.tsx
@@ -1,4 +1,12 @@
+import { ReceiptCard } from '@revealui/presentation';
+import { Link } from '@revealui/router';
 import { useEffect } from 'react';
+import {
+  DOCS_RECEIPT_CAPTION,
+  DOCS_RECEIPT_INTEGRITY,
+  DOCS_RECEIPT_LINES,
+  DOCS_RECEIPT_TITLE,
+} from '../content/receipt';
 import { applyDocHead } from '../lib/head';
 import { renderMarkdown } from '../utils/markdown';
 
@@ -35,5 +43,29 @@ Open [http://localhost:4000/admin](http://localhost:4000/admin) to see the admin
 Everything else lives in the sidebar. Found a gap in these docs? See the [Contributing Guide](https://github.com/RevealUIStudio/revealui/blob/main/CONTRIBUTING.md).
 `;
 
-  return <div>{renderMarkdown(content)}</div>;
+  return (
+    <div>
+      {/*
+        Static receipt header artifact (frontend-excellence Phase 5 / GAP-480 Phase D).
+        No animate: docs stay the calmest surface. Links to audit-receipts docs.
+      */}
+      <div className="mb-10 w-full max-w-md min-w-0">
+        <ReceiptCard
+          title={DOCS_RECEIPT_TITLE}
+          lines={[...DOCS_RECEIPT_LINES]}
+          integrity={DOCS_RECEIPT_INTEGRITY}
+        />
+        <p className="mt-3 text-sm text-muted-foreground">
+          {DOCS_RECEIPT_CAPTION.text}{' '}
+          <Link
+            to={DOCS_RECEIPT_CAPTION.link.href}
+            className="font-semibold text-foreground underline-offset-4 hover:underline"
+          >
+            {DOCS_RECEIPT_CAPTION.link.label}
+          </Link>
+        </p>
+      </div>
+      {renderMarkdown(content)}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

GAP-480 Phase D / frontend-excellence Phase 5 **docs** rollout echo.

- Static `ReceiptCard` on docs landing (`DocsIndexPage`) as header artifact
- **No** `animate="print"` (docs stay the calmest surface)
- Caption links to `/security/audit-receipts`
- Does not rebuild showcase; product page only

## Test plan

- [x] Unit: `apps/docs/__tests__/routes/docs-index-receipt.test.tsx`
- [x] `tsc --noEmit` in apps/docs
- [x] Local pre-push phase-1 gate PASS
- [ ] CI green on PR
- [ ] Visual: docs home shows completed receipt above markdown; link hits audit receipts

Refs: GAP-480, frontend-excellence Phase 5 residual, concept §Rollout echoes (docs).