### PR TITLE
fix(marketing): de-dupe landing + hybrid true concise copy

### DIFF
--- a/apps/marketing/app/components/__tests__/Problem.test.tsx
+++ b/apps/marketing/app/components/__tests__/Problem.test.tsx
@@ -19,12 +19,15 @@ describe('Problem capability stack', () => {
     }
   });
 
-  it('keeps path blurbs and every row claim', () => {
+  it('renders the matrix only (no path-blurb list above it)', () => {
     render(<Problem />);
-    expect(screen.getByText(HOME_PROBLEM.highlightedLabel)).toBeTruthy();
-    expect(screen.getByText(HOME_PROBLEM.pathBlurbs.sprawl)).toBeTruthy();
-    expect(screen.getByText(HOME_PROBLEM.pathBlurbs.agentOnly)).toBeTruthy();
-    expect(screen.getByText(HOME_PROBLEM.pathBlurbs.revealui)).toBeTruthy();
+    // Body already states the three paths; do not restate one-liners.
+    expect(
+      screen.queryByText('Rent a product for each slice. Glue them together yourself.'),
+    ).toBeNull();
+    expect(
+      screen.queryByText('Agents first. Rebuild sign-in, content, and billing underneath.'),
+    ).toBeNull();
 
     for (const row of HOME_PROBLEM.rows) {
       expect(screen.getByText(row.sprawl)).toBeTruthy();

--- a/apps/marketing/app/components/__tests__/ProductFrame.test.tsx
+++ b/apps/marketing/app/components/__tests__/ProductFrame.test.tsx
@@ -3,23 +3,25 @@ import { describe, expect, it } from 'vitest';
 import { ProductFrame } from '../landing/ProductFrame';
 
 describe('ProductFrame', () => {
-  it('renders live presentation primitives inside admin chrome', () => {
+  it('renders agents-as-users chrome without replaying the hero refund receipt', () => {
     render(
       <ProductFrame
         caption={{
-          prefix: 'Local screenshot from a fresh',
-          code: 'npx create-revealui',
-          suffix: '. The three beats below describe the steps.',
+          prefix: 'Live admin chrome composed from',
+          code: '@revealui/presentation',
+          suffix: 'components. The three beats are the local install path.',
         }}
       />,
     );
 
-    // figure (not role=img): interactive descendants make role=img invalid for axe
     expect(screen.getByRole('figure', { name: /RevealUI admin shell/i })).toBeTruthy();
-    expect(screen.getByText(/support-agent · refund flow/i)).toBeTruthy();
-    expect(screen.getByLabelText(/Agent online/i)).toBeTruthy();
+    expect(screen.getByText(/Agents on the same roles and policies as people/i)).toBeTruthy();
+    expect(screen.getByText('support-agent')).toBeTruthy();
+    expect(screen.getByText('billing-agent')).toBeTruthy();
+    expect(screen.queryByText(/refund flow/i)).toBeNull();
+    expect(screen.queryByText(/Live audit trail/i)).toBeNull();
     expect(screen.getByLabelText(/Approved/i)).toBeTruthy();
-    expect(screen.getByText(/npx create-revealui/)).toBeTruthy();
+    expect(screen.getByText(/@revealui\/presentation/)).toBeTruthy();
     expect(screen.getByText(/Live presentation components/i)).toBeTruthy();
   });
 

--- a/apps/marketing/app/components/landing/Primitives.tsx
+++ b/apps/marketing/app/components/landing/Primitives.tsx
@@ -12,23 +12,13 @@ import {
   SectionHeader,
 } from '@revealui/presentation';
 import type { ComponentType } from 'react';
-import { HOME_PRIMITIVES, HOME_PRIMITIVES_SECTION } from '../../content/primitives';
+import { HOME_PRIMITIVES_SECTION } from '../../content/primitives';
 import { PRIMITIVES_FALLBACK_DATA, type PrimitivesData } from '../../lib/page-blocks';
 
-// Accent chips must be surface-relative so they adapt under the token-based
-// theme (dark-first; light via system pref OR a manual [data-theme] override).
-// We deliberately do NOT use Tailwind `dark:` variants: those are media-based
-// and would desync from a manual [data-theme] toggle. brand rides the adaptive
-// primary token; the other four keep distinct accent hues at /10–/20 opacity.
-const accentBg: Record<string, string> = {
-  brand: 'bg-primary/10 text-primary ring-primary/20',
-  // legacy alias if CMS still has emerald
-  emerald: 'bg-primary/10 text-primary ring-primary/20',
-  blue: 'bg-blue-500/10 text-blue-500 ring-blue-500/20',
-  amber: 'bg-amber-500/10 text-amber-500 ring-amber-500/20',
-  cyan: 'bg-cyan-500/10 text-cyan-500 ring-cyan-500/20',
-  violet: 'bg-violet-500/10 text-violet-500 ring-violet-500/20',
-};
+// Cobalt-only chips (landing de-dupe / brand residual). Multi-hue rainbow chips
+// competed with the receipt identity and with Phase B Cobalt-only craft.
+// Adaptive primary token tracks dark/light; no media-only `dark:` variants.
+const PRIMITIVE_CHIP = 'bg-primary/10 text-primary ring-primary/20';
 
 // Icons ship from @revealui/presentation (Gate 5 move-and-import). Order matches
 // HOME_PRIMITIVES / block stream — keyed by index so CMS label renames keep icons.
@@ -39,8 +29,6 @@ const PRIMITIVE_ICONS: readonly ComponentType<IconProps>[] = [
   IconPrimitivePayments,
   IconPrimitiveAgents,
 ];
-
-const primitiveStyles = HOME_PRIMITIVES.map((p) => ({ color: p.color }));
 
 export interface PrimitivesProps {
   /** Rich section data; defaults to the static content modules (byte-identical). */
@@ -71,7 +59,6 @@ export function Primitives({
       <div className="mx-auto mt-12 max-w-3xl divide-y divide-border border-y border-border sm:mt-14">
         {data.items.map((item, index) => {
           const flipped = index % 2 === 1;
-          const style = primitiveStyles[index];
           return (
             <div
               key={item.label}
@@ -80,7 +67,7 @@ export function Primitives({
               }`}
             >
               <div
-                className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-xl ring-1 ${style ? accentBg[style.color] : ''}`}
+                className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-xl ring-1 ${PRIMITIVE_CHIP}`}
               >
                 {(() => {
                   const Icon = PRIMITIVE_ICONS[index];

--- a/apps/marketing/app/components/landing/Problem.tsx
+++ b/apps/marketing/app/components/landing/Problem.tsx
@@ -4,20 +4,12 @@ import { HOME_PROBLEM } from '../../content/home';
 /**
  * Capability stack (craft pass 2026-08, Linear redesign principles).
  *
- * Replaces:
- * - desktop spreadsheet table
- * - mobile per-capability cards that restated the matrix
- * - three marketing "path" cards (still too much chrome)
+ * One comparison device: capability rows with three aligned answers.
+ * Path one-liners were removed (GAP-480 de-dupe) — body + matrix already
+ * state the three paths; a second list restated them.
  *
- * One layout at every breakpoint: capability rows with three aligned answers.
- * Hierarchy comes from type weight and spacing, not rings, fills, or boxes.
+ * Hierarchy from type weight and spacing, not rings or cards.
  * Claims stay in HOME_PROBLEM.rows so claims-evidence export paths hold.
- *
- * Linear lessons applied:
- * - reduce visual noise
- * - maintain visual alignment (label column + answer column)
- * - increase hierarchy via density, not decoration
- * - limit brand chrome; neutral surfaces
  */
 
 interface Answer {
@@ -61,51 +53,6 @@ export function Problem() {
         description={HOME_PROBLEM.body}
         align="center"
       />
-
-      {/* Path blurbs: three quiet lines under the intro, not three cards. */}
-      <ul
-        className="mx-auto mt-12 flex max-w-3xl flex-col gap-3 text-left sm:mt-14"
-        aria-label="Three paths"
-      >
-        {(
-          [
-            ['sprawl', HOME_PROBLEM.columns.sprawl, HOME_PROBLEM.pathBlurbs.sprawl, false],
-            ['agentOnly', HOME_PROBLEM.columns.agentOnly, HOME_PROBLEM.pathBlurbs.agentOnly, false],
-            ['revealui', HOME_PROBLEM.columns.revealui, HOME_PROBLEM.pathBlurbs.revealui, true],
-          ] as const
-        ).map(([id, name, blurb, emphasis]) => (
-          <li
-            key={id}
-            className="grid grid-cols-1 gap-1 sm:grid-cols-[11rem_1fr] sm:gap-6 sm:items-baseline"
-          >
-            <span
-              className={
-                emphasis
-                  ? 'text-sm font-semibold text-foreground'
-                  : 'text-sm font-medium text-muted-foreground'
-              }
-            >
-              {emphasis ? (
-                <>
-                  <span className="mr-2 text-[11px] font-semibold uppercase tracking-widest text-primary">
-                    {HOME_PROBLEM.highlightedLabel}
-                  </span>
-                  <span className="block sm:inline">{name}</span>
-                </>
-              ) : (
-                name
-              )}
-            </span>
-            <span
-              className={
-                emphasis ? 'text-sm leading-6 text-foreground' : 'text-sm leading-6 text-body'
-              }
-            >
-              {blurb}
-            </span>
-          </li>
-        ))}
-      </ul>
 
       <ul
         className="mx-auto mt-12 max-w-3xl list-none border-t border-border p-0 sm:mt-14"

--- a/apps/marketing/app/components/landing/ProductFrame.tsx
+++ b/apps/marketing/app/components/landing/ProductFrame.tsx
@@ -1,15 +1,17 @@
-import { type AuditEvent, AuditLine, StatusDot, VerdictChip } from '@revealui/presentation';
+import { StatusDot, VerdictChip } from '@revealui/presentation';
 
 /**
  * Live product-chrome frame for the homepage Demo section.
  *
- * Honest product-as-proof: composed from real `@revealui/presentation`
- * primitives (StatusDot, VerdictChip, AuditLine), not a stale screenshot.
- * Mirrors the receipt motif and the admin shell shape without claiming a
- * pixel-perfect capture of a specific build.
+ * Honest product-as-proof: real `@revealui/presentation` primitives
+ * (StatusDot, VerdictChip), not a screenshot. Admin shell shape only.
  *
- * Linear craft lesson (linear.app redesign): the product is the proof.
- * Hierarchy + density over decorative chrome.
+ * GAP-480 de-dupe: does NOT re-stage the hero refund receipt / AuditLine
+ * trail. Hero owns the receipt motif; this frame shows agents as governed
+ * users (roster + policy verdicts) so the page tells two complementary
+ * product stories once each.
+ *
+ * Linear craft: hierarchy + density over decorative chrome.
  */
 
 const SIDEBAR_NAV = [
@@ -20,32 +22,39 @@ const SIDEBAR_NAV = [
   { label: 'Agents', active: true },
 ] as const;
 
-const FRAME_EVENTS: readonly AuditEvent[] = [
+interface AgentRow {
+  readonly name: string;
+  readonly role: string;
+  readonly status: 'ok' | 'warn' | 'idle';
+  readonly statusLabel: string;
+  readonly verdict: 'approve' | 'request-changes' | 'hold' | 'pending';
+  readonly asOf: string;
+}
+
+const AGENT_ROWS: readonly AgentRow[] = [
   {
-    ts: '09:41:07',
-    actor: 'support-agent',
-    action: 'signed in as',
-    object: 'agents@demo.revealui.com',
+    name: 'support-agent',
+    role: 'Customer refunds · $100 cap',
+    status: 'ok',
+    statusLabel: 'Online',
+    verdict: 'approve',
+    asOf: '09:41',
   },
   {
-    ts: '09:41:09',
-    actor: 'support-agent',
-    action: 'refunded',
-    object: 'order #4189',
+    name: 'billing-agent',
+    role: 'Subscription changes',
+    status: 'ok',
+    statusLabel: 'Online',
+    verdict: 'hold',
+    asOf: '09:38',
   },
   {
-    ts: '09:41:09',
-    actor: 'policy',
-    action: 'allowed',
-    object: 'refunds under $100',
-  },
-  {
-    ts: '09:41:10',
-    actor: 'audit-log',
-    action: 'recorded',
-    // No refId: CopyRef is interactive; this frame is a static product demo
-    // (axe nested-interactive fails if buttons sit inside role=img chrome).
-    object: 'the receipt',
+    name: 'ops-agent',
+    role: 'Deploy gates',
+    status: 'idle',
+    statusLabel: 'Idle',
+    verdict: 'request-changes',
+    asOf: '09:12',
   },
 ] as const;
 
@@ -66,13 +75,10 @@ export function ProductFrame({
 }: ProductFrameProps) {
   return (
     <figure className="mx-auto w-full max-w-5xl" aria-label={label}>
-      {/* Product mat: dark outer frame (design system demo pattern), quiet chrome.
-          Linear: hierarchy via surface elevation, not brand-colored decoration.
-          Do NOT put role=img on this mat: it may contain focusable controls
-          (AuditLine CopyRef) and nested-interactive fails axe WCAG 4.1.2. */}
+      {/* Product mat: elevation over brand decoration.
+          No nested interactive controls (axe WCAG 4.1.2). */}
       <div className="overflow-hidden rounded-2xl bg-foreground p-1 shadow-lg shadow-foreground/10 sm:p-1.5">
         <div className="overflow-hidden rounded-xl bg-background">
-          {/* Window chrome — inverted-L: title bar only; density over ornament */}
           <div className="flex h-9 items-center gap-3 border-b border-border px-3 sm:h-10 sm:px-4">
             <div className="flex items-center gap-1.5" aria-hidden="true">
               <span className="size-2 rounded-full bg-muted-foreground/25" />
@@ -88,7 +94,6 @@ export function ProductFrame({
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-[10.5rem_1fr]">
-            {/* Sidebar — fixed label column alignment (Linear sidebar lesson) */}
             <aside
               className="hidden border-r border-border bg-secondary/30 p-2 sm:block"
               aria-hidden="true"
@@ -123,46 +128,39 @@ export function ProductFrame({
               </ul>
             </aside>
 
-            {/* Main pane */}
             <div className="min-w-0 p-3 sm:p-4">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
-                    Agent activity
-                  </p>
-                  <h3 className="mt-0.5 font-display text-sm font-semibold tracking-tight text-foreground sm:text-base">
-                    support-agent · refund flow
-                  </h3>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="inline-flex h-7 items-center gap-1.5 rounded-md bg-secondary px-2 text-xs text-muted-foreground">
-                    <StatusDot status="ok" label="Agent online" pulse />
-                    Online
-                  </span>
-                  <VerdictChip verdict="approve" actor="policy" asOf="09:41" />
-                </div>
+              <div className="min-w-0">
+                <p className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
+                  Governed users
+                </p>
+                <h3 className="mt-0.5 font-display text-sm font-semibold tracking-tight text-foreground sm:text-base">
+                  Agents on the same roles and policies as people
+                </h3>
               </div>
 
-              <div className="mt-4 overflow-hidden rounded-lg border border-border/80">
-                <div className="flex h-8 items-center border-b border-border/80 px-3">
-                  <p className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
-                    Live audit trail
-                  </p>
-                </div>
-                <ul className="divide-y divide-border/80">
-                  {FRAME_EVENTS.map((event) => (
-                    <li
-                      key={`${event.ts}-${event.action}-${event.object}`}
-                      className="px-3 py-2 sm:px-3.5"
-                    >
-                      <AuditLine event={event} dense />
-                    </li>
-                  ))}
-                </ul>
-              </div>
+              <ul className="mt-4 divide-y divide-border/80 overflow-hidden rounded-lg border border-border/80">
+                {AGENT_ROWS.map((agent) => (
+                  <li
+                    key={agent.name}
+                    className="flex flex-wrap items-center justify-between gap-3 px-3 py-2.5 sm:px-3.5"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-mono text-xs font-medium text-foreground">{agent.name}</p>
+                      <p className="mt-0.5 text-xs leading-5 text-body">{agent.role}</p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="inline-flex h-7 items-center gap-1.5 rounded-md bg-secondary px-2 text-xs text-muted-foreground">
+                        <StatusDot status={agent.status} label={agent.statusLabel} />
+                        {agent.statusLabel}
+                      </span>
+                      <VerdictChip verdict={agent.verdict} actor="policy" asOf={agent.asOf} />
+                    </div>
+                  </li>
+                ))}
+              </ul>
 
               <p className="mt-3 text-xs leading-5 text-muted-foreground">
-                Live presentation components. Same receipt story as the hero, inside an admin shell.
+                Live presentation components. Agents are users with policy, not a separate stack.
               </p>
             </div>
           </div>

--- a/apps/marketing/app/content/claims-evidence/claims-part-1.ts
+++ b/apps/marketing/app/content/claims-evidence/claims-part-1.ts
@@ -192,42 +192,11 @@ export const claimsPart1: readonly ClaimEntry[] = [
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.body',
     proofGrade: 'outcome',
-    text: 'Most teams stitch sign-in, content, billing, and agents from different vendors. Or they pick an agent framework and rebuild the rest underneath it. RevealUI is the third path: one self-hosted runtime for the business and the agents that run it.',
+    text: 'Teams either stitch a vendor for each slice, or start with agents and rebuild the rest. RevealUI is one self-hosted runtime for the business and the agents that run it.',
     evidence: [AUTH_SESSIONS, COLLECTIONS, BILLING, LICENSE_MIT],
   },
-  {
-    file: 'home.ts',
-    exportPath: 'HOME_PROBLEM.pathBlurbs.sprawl',
-    proofGrade: 'path',
-    text: 'Rent a product for each slice. Glue them together yourself.',
-    evidence: [
-      {
-        kind: 'url',
-        ref: 'https://revealui.com/pricing',
-        note: 'competitor-path framing; cost detail lives on the pricing page',
-      },
-    ],
-  },
-  {
-    file: 'home.ts',
-    exportPath: 'HOME_PROBLEM.pathBlurbs.agentOnly',
-    proofGrade: 'path',
-    text: 'Agents first. Rebuild sign-in, content, and billing underneath.',
-    evidence: [
-      {
-        kind: 'url',
-        ref: 'https://revealui.com/pricing',
-        note: 'competitor-path framing; cost detail lives on the pricing page',
-      },
-    ],
-  },
-  {
-    file: 'home.ts',
-    exportPath: 'HOME_PROBLEM.pathBlurbs.revealui',
-    proofGrade: 'outcome',
-    text: 'One self-hosted runtime for the business and the agents that run it.',
-    evidence: [AUTH_SESSIONS, COLLECTIONS, BILLING, LICENSE_MIT],
-  },
+  // pathBlurbs claims retired (GAP-480 landing de-dupe): blurbs removed from
+  // the Problem band; body + matrix remain the single comparison device.
   {
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.rows[0].sprawl',
@@ -286,7 +255,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
     file: 'home.ts',
     exportPath: 'HOME_PROBLEM.footnote',
     proofGrade: 'behavior',
-    text: 'Capability comparison only; a monthly cost estimate lives on the pricing page. (interpolated: Pro price from pricing-fallbacks)',
+    text: 'Capability only. Pricing is on the pricing page (interpolated: Pro price from pricing-fallbacks). Vercel, Cloudflare, and Fly are deploy targets, not competitors.',
     match: 'path',
     evidence: [PRICING_FALLBACKS, DEPLOY_TARGETS],
   },
@@ -301,28 +270,34 @@ export const claimsPart1: readonly ClaimEntry[] = [
     file: 'home.ts',
     exportPath: 'HOME_DEMO.body',
     proofGrade: 'outcome',
-    text: 'Install on your machine. Take a test payment. Connect an agent to the same data your admin UI already uses.',
+    text: 'Install on your machine. Take a test payment. Connect an agent to the same data your admin already uses.',
     evidence: [CLI_CREATE, BILLING, MCP_CONTENT],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.mockupCaption.prefix',
     proofGrade: 'path',
-    text: 'Local screenshot from a fresh',
-    evidence: [CLI_CREATE],
+    text: 'Live admin chrome composed from',
+    evidence: [
+      {
+        kind: 'code',
+        ref: 'apps/marketing/app/components/landing/ProductFrame.tsx',
+        note: 'composed from StatusDot/VerdictChip, not a screenshot',
+      },
+    ],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.mockupCaption.suffix',
     proofGrade: 'path',
-    text: '. The three beats below describe the steps.',
+    text: 'components. The three beats are the local install path.',
     evidence: [CLI_CREATE],
   },
   {
     file: 'home.ts',
     exportPath: 'HOME_DEMO.beats[0].body',
     proofGrade: 'behavior',
-    text: 'One command. Sign-in, content, admin UI, billing hooks, and agent tooling run locally in about a minute.',
+    text: 'One command. Sign-in, content, admin, billing, and agent tooling run locally.',
     evidence: [CLI_CREATE, AUTH_SESSIONS, WEBHOOKS, MCP_CONTENT],
   },
   {
@@ -336,7 +311,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
     file: 'home.ts',
     exportPath: 'HOME_DEMO.beats[1].body',
     proofGrade: 'behavior',
-    text: 'A user signs up, picks a plan, and test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
+    text: 'A user signs up, picks a plan, and test-mode checkout completes. Switch to live mode when you take real money.',
     evidence: [
       AUTH_SESSIONS,
       BILLING,
@@ -351,7 +326,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
     file: 'home.ts',
     exportPath: 'HOME_DEMO.beats[2].body',
     proofGrade: 'behavior',
-    text: 'Connect a model. Agents read and write the same content your team does, under the same sign-in and plan rules.',
+    text: 'Connect a model. Agents use the same content, sign-in, and plan rules as your team.',
     evidence: [PROVIDERS, MCP_CONTENT, TIER_GATES],
   },
   {
@@ -631,7 +606,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
     file: 'proof.ts',
     exportPath: 'PROOF_DEPLOYERS.body',
     proofGrade: 'outcome',
-    text: 'Some buyers install RevealUI themselves. Some hire us, or their own forward-deployed engineer, to stamp and hand over a fleet. Either way the outcome is the same: a self-hosted runtime where the business and its agents live under one roof, on infrastructure the customer owns.',
+    text: 'Install yourself, hire Studio, or bring your own forward-deployed engineer. The outcome is the same: a self-hosted runtime on infrastructure you own.',
     evidence: [
       REPO,
       {
@@ -642,7 +617,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
       {
         kind: 'url',
         ref: 'https://revealui.com',
-        note: 'self-install product path; canonical ownership sentence',
+        note: 'self-install product path',
       },
     ],
   },
@@ -650,7 +625,7 @@ export const claimsPart1: readonly ClaimEntry[] = [
     file: 'proof.ts',
     exportPath: 'PROOF_DEPLOYERS.foil',
     proofGrade: 'outcome',
-    text: 'Cloud agent platforms rent you an outcome. A forward-deployed engagement leaves a runtime the customer runs.',
+    text: 'Cloud platforms rent you an outcome. A handoff leaves a runtime you run.',
     evidence: [
       REPO,
       {

--- a/apps/marketing/app/content/home.ts
+++ b/apps/marketing/app/content/home.ts
@@ -92,21 +92,16 @@ export interface ProblemRow {
 export const HOME_PROBLEM = {
   eyebrow: 'The problem',
   heading: 'Stop buying a separate product for each slice of the stack.',
-  body: 'Most teams stitch sign-in, content, billing, and agents from different vendors. Or they pick an agent framework and rebuild the rest underneath it. RevealUI is the third path: one self-hosted runtime for the business and the agents that run it.',
+  // Hybrid: body states the fork once; matrix carries capability detail.
+  // pathBlurbs removed (de-dupe) so we do not restate the three paths twice.
+  body: 'Teams either stitch a vendor for each slice, or start with agents and rebuild the rest. RevealUI is one self-hosted runtime for the business and the agents that run it.',
   /** Accessible name for the three-path comparison region. */
   tableAriaLabel: 'Vendor sprawl vs agent-framework vs RevealUI comparison',
-  /** Label on the winning path only. */
-  highlightedLabel: 'The third path',
   columns: {
     capability: 'Capability',
     sprawl: 'Vendor sprawl',
     agentOnly: 'Agent framework only',
     revealui: 'RevealUI',
-  },
-  pathBlurbs: {
-    sprawl: 'Rent a product for each slice. Glue them together yourself.',
-    agentOnly: 'Agents first. Rebuild sign-in, content, and billing underneath.',
-    revealui: 'One self-hosted runtime for the business and the agents that run it.',
   },
   rows: [
     {
@@ -134,7 +129,7 @@ export const HOME_PROBLEM = {
       revealui: 'Agents use the same data and gates as your team',
     },
   ] as readonly ProblemRow[],
-  footnote: `Capability comparison only; a monthly cost estimate lives on the pricing page. RevealUI Pro is ${SUBSCRIPTION_PRICE_FALLBACKS.pro.price}/mo + your own infrastructure. Vercel, Cloudflare, and Fly are deploy targets, not competitors. RevealUI runs on all three.`,
+  footnote: `Capability only. Pricing is on the pricing page (Pro ${SUBSCRIPTION_PRICE_FALLBACKS.pro.price}/mo + your infrastructure). Vercel, Cloudflare, and Fly are deploy targets, not competitors.`,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -150,27 +145,30 @@ export interface DemoBeat {
 export const HOME_DEMO = {
   eyebrow: 'Watch it work',
   heading: 'From one command to a running stack in about a minute.',
-  body: 'Install on your machine. Take a test payment. Connect an agent to the same data your admin UI already uses.',
+  body: 'Install on your machine. Take a test payment. Connect an agent to the same data your admin already uses.',
+  // Honest: ProductFrame is live presentation components, not a screenshot.
+  // Install path stays in the three beats (create-revealui).
   mockupCaption: {
-    prefix: 'Local screenshot from a fresh',
-    code: 'npx create-revealui',
-    suffix: '. The three beats below describe the steps.',
+    // ≥26-char prose units so claims-evidence indexes them (floor in gate).
+    prefix: 'Live admin chrome composed from',
+    code: '@revealui/presentation',
+    suffix: 'components. The three beats are the local install path.',
   },
   beats: [
     {
       n: '01',
       title: 'Spin up a stack.',
-      body: 'One command. Sign-in, content, admin UI, billing hooks, and agent tooling run locally in about a minute.',
+      body: 'One command. Sign-in, content, admin, billing, and agent tooling run locally.',
     },
     {
       n: '02',
       title: 'Customer flow, end to end.',
-      body: 'A user signs up, picks a plan, and test-mode checkout completes. The admin UI shows the new account. Switch to live mode when you are ready to take real money.',
+      body: 'A user signs up, picks a plan, and test-mode checkout completes. Switch to live mode when you take real money.',
     },
     {
       n: '03',
       title: 'Agents on your data.',
-      body: 'Connect a model. Agents read and write the same content your team does, under the same sign-in and plan rules.',
+      body: 'Connect a model. Agents use the same content, sign-in, and plan rules as your team.',
     },
   ] as readonly DemoBeat[],
 } as const;

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -49,8 +49,8 @@ export const PROOF_TRUST = {
 export const PROOF_DEPLOYERS = {
   eyebrow: 'For deployers',
   heading: 'Built for people who deploy, not only demo.',
-  body: 'Some buyers install RevealUI themselves. Some hire us, or their own forward-deployed engineer, to stamp and hand over a fleet. Either way the outcome is the same: a self-hosted runtime where the business and its agents live under one roof, on infrastructure the customer owns.',
-  foil: 'Cloud agent platforms rent you an outcome. A forward-deployed engagement leaves a runtime the customer runs.',
+  body: 'Install yourself, hire Studio, or bring your own forward-deployed engineer. The outcome is the same: a self-hosted runtime on infrastructure you own.',
+  foil: 'Cloud platforms rent you an outcome. A handoff leaves a runtime you run.',
   cta: {
     label: 'Work with Studio',
     href: SITE.urls.agency,


### PR DESCRIPTION
## Summary

Landing craft pass: **best UI + best true copy hybrid**, not a redesign.

### De-dupe (UI)
- **Problem:** drop path blurb list; body + capability matrix is the only comparison device
- **ProductFrame:** no second refund receipt / audit trail; agents-as-governed-users roster instead (hero keeps the receipt motif alone)
- **Primitives:** Cobalt-only chips (no multi-hue rainbow)

### Copy (true, shorter)
- Tighter Problem body and footnote
- Demo body/beats shortened; caption **honest** (live presentation chrome, not a fake screenshot)
- Proof deployers body + foil shortened without losing self-install / hire / FDE meaning
- Hero positioning strings **unchanged** (locked)

### Gates
- `validate:claims-evidence` green (1427 claims)
- `validate:claims` green
- Problem + ProductFrame unit tests green
- Pre-push phase-1 PASS

## Test plan
- [x] Unit: Problem + ProductFrame
- [x] Claims evidence + claim drift
- [ ] Visual: home scroll — one receipt story, one agent roster, one comparison matrix
- [ ] CI green

Refs: GAP-480 residual / frontend-excellence landing craft