### PR TITLE
fix(marketing): GAP-480 landing residuals (viewport, proof, close)

### DIFF
--- a/apps/marketing/app/components/GetStarted.tsx
+++ b/apps/marketing/app/components/GetStarted.tsx
@@ -38,7 +38,7 @@ export function GetStarted({
       />
 
       <div className="mx-auto max-w-2xl text-center">
-        <div className="mt-12 flex flex-col items-center justify-center gap-3 sm:mt-14 sm:flex-row sm:gap-4">
+        <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:mt-12 sm:flex-row sm:gap-4">
           <Button asChild size="lg" variant="brand" glow>
             <a href={data.cta.primary.href}>{data.cta.primary.label}</a>
           </Button>
@@ -51,7 +51,7 @@ export function GetStarted({
         </div>
 
         {/* CLI quick-start, moved here from the hero (frontend-excellence
-            Phase 1 hero declutter). */}
+            Phase 1 hero declutter). Primary close = CTA + command. */}
         <div
           className="mt-8 inline-flex items-center gap-3 rounded-xl bg-foreground px-5 py-3 font-mono text-sm shadow-lg ring-1 ring-background/10"
           {...fieldAttrs(annotation, `${path}.snippet.lines`)}
@@ -76,14 +76,15 @@ export function GetStarted({
           ))}
         </div>
         <p
-          className="mt-4 text-sm text-muted-foreground"
+          className="mt-3 text-sm text-muted-foreground"
           {...fieldAttrs(annotation, `${path}.snippet.caption`)}
         >
           {data.cli.caption}
         </p>
 
-        <div className="mt-12 border-t border-border pt-10 sm:mt-14">
-          <p className="mb-4 text-sm font-medium text-muted-foreground">{data.newsletter.label}</p>
+        {/* Newsletter demoted: optional, not a second close. */}
+        <div className="mt-8 max-w-md mx-auto sm:mt-10">
+          <p className="mb-3 text-xs font-medium text-muted-foreground">{data.newsletter.label}</p>
           <NewsletterSignup variant="stacked" />
         </div>
       </div>

--- a/apps/marketing/app/components/__tests__/Hero.test.tsx
+++ b/apps/marketing/app/components/__tests__/Hero.test.tsx
@@ -48,14 +48,17 @@ describe('Hero (marketing craft hierarchy)', () => {
     );
   });
 
-  it('lists trust signals without brand-dot chrome', () => {
+  it('lists trust signals without brand-dot chrome (sm+; hidden on phone)', () => {
     renderHero();
-    expect(screen.getByText('Open source')).toBeInTheDocument();
+    // Present in DOM for a11y/desktop; `hidden sm:flex` demotes phone chrome.
+    const openSource = screen.getByText('Open source');
+    expect(openSource).toBeInTheDocument();
     expect(screen.getByText('Self-hostable')).toBeInTheDocument();
     expect(screen.getByText('Local-first AI')).toBeInTheDocument();
-    // No decorative primary dots in the trust strip (craft: separators only).
-    const list = screen.getByText('Open source').closest('ul');
+    const list = openSource.closest('ul');
     expect(list).toBeTruthy();
+    expect(list?.className).toMatch(/hidden/);
+    expect(list?.className).toMatch(/sm:flex/);
     expect(list?.querySelectorAll('.bg-primary').length ?? 0).toBe(0);
   });
 

--- a/apps/marketing/app/components/landing/Hero.tsx
+++ b/apps/marketing/app/components/landing/Hero.tsx
@@ -18,8 +18,8 @@ import { selectHomeHero } from '../../lib/hero-variant';
 import { AudienceToggle } from './AudienceToggle';
 
 // Shared trust strip (the signals the retired eyebrow pill used to carry).
-// Rendered for both audiences. Separators (not brand dots) keep chrome quiet —
-// Linear craft: limit decoration; hierarchy from type weight and spacing.
+// Separators (not brand dots). Hidden on small viewports so first screen is
+// H1 + CTA + receipt (GAP-480 residual viewport discipline).
 const TRUST_SIGNALS = ['Open source', 'Self-hostable', 'Local-first AI'] as const;
 
 /**
@@ -38,9 +38,7 @@ function HeroBackground() {
       aria-hidden="true"
       className="pointer-events-none absolute inset-0 -z-10 overflow-hidden"
     >
-      {/* Edge-to-edge wash across the whole stage */}
       <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.07] via-background to-background" />
-      {/* Viewport-relative radial — soft top center, not a content-sized blob */}
       <div
         className={[
           'absolute left-1/2 top-0 -translate-x-1/2 -translate-y-[15%]',
@@ -54,10 +52,10 @@ function HeroBackground() {
   );
 }
 
-/** Trust strip: vertical rules between labels, no brand-dot decoration. */
+/** Trust strip: sm+ only so phone first viewport owns H1 → CTA → receipt. */
 function TrustStrip() {
   return (
-    <ul className="mt-8 flex list-none flex-wrap items-center justify-center gap-y-2 p-0 text-sm text-body">
+    <ul className="mt-5 hidden list-none flex-wrap items-center justify-center gap-y-2 p-0 text-sm text-body sm:mt-7 sm:flex">
       {TRUST_SIGNALS.map((signal, index) => (
         <li key={signal} className="flex items-center">
           {index > 0 ? (
@@ -80,15 +78,15 @@ function TechnicalHero({ hero }: { hero: ReturnType<typeof selectHomeHero> }) {
         - subtitle = text-body (rvui-text-1) for long reading, not muted
         - trust / captions = muted only when meta
       */}
-      <h1 className="text-balance font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
+      <h1 className="text-balance font-display text-[2.5rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
         {hero.h1}
       </h1>
 
-      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-body sm:mt-8 sm:text-xl">
+      <p className="mx-auto mt-4 max-w-2xl text-base leading-7 text-body sm:mt-7 sm:text-xl sm:leading-8">
         {hero.subtitle.sentence1} {hero.subtitle.sentence2} {hero.subtitle.support}
       </p>
 
-      <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
+      <div className="mt-6 flex flex-col items-center justify-center gap-3 sm:mt-9 sm:flex-row sm:gap-4">
         <Button asChild size="lg" glow className="w-full gap-2 sm:w-auto">
           <a href={hero.cta.primary.href}>
             {hero.cta.primary.label}
@@ -123,7 +121,7 @@ function NonTechnicalHero() {
   const hero = FOR_OPERATORS_HERO;
   return (
     <>
-      <h1 className="text-balance font-display text-[2.75rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
+      <h1 className="text-balance font-display text-[2.5rem] font-extrabold leading-[1.05] tracking-tighter text-foreground sm:text-6xl lg:text-7xl">
         {hero.h1Lines.map((line) => (
           <span key={line} className="block">
             {line}
@@ -131,11 +129,11 @@ function NonTechnicalHero() {
         ))}
       </h1>
 
-      <p className="mx-auto mt-7 max-w-2xl text-lg leading-8 text-body sm:mt-8 sm:text-xl">
+      <p className="mx-auto mt-4 max-w-2xl text-base leading-7 text-body sm:mt-7 sm:text-xl sm:leading-8">
         {hero.subtitle}
       </p>
 
-      <div className="mt-9 flex justify-center sm:mt-10">
+      <div className="mt-6 flex justify-center sm:mt-9">
         <Button asChild size="lg" glow className="w-full gap-2 sm:w-auto">
           <a href={hero.primaryCta.href} target="_blank" rel="noopener noreferrer">
             {hero.primaryCta.label}
@@ -168,8 +166,7 @@ export function Hero() {
       ].join(' ')}
     >
       <div className="mx-auto max-w-3xl text-center">
-        {/* Audience switch: replaces the former eyebrow pill. */}
-        <div className="mb-7 flex justify-center sm:mb-8">
+        <div className="mb-4 flex justify-center sm:mb-7">
           <AudienceToggle current={audience} />
         </div>
 
@@ -178,14 +175,14 @@ export function Hero() {
 
       {/* Receipt-motif moment (frontend-excellence Phase 5): one orchestrated
           print entrance, shared verbatim by both audience variants. */}
-      <div className="mx-auto mt-12 w-full min-w-0 max-w-md text-left sm:mt-14 sm:max-w-lg">
+      <div className="mx-auto mt-8 w-full min-w-0 max-w-md text-left sm:mt-12 sm:max-w-lg">
         <ReceiptCard
           title={RECEIPT_HERO_TITLE}
           lines={[...RECEIPT_HERO_LINES]}
           integrity={RECEIPT_HERO_INTEGRITY}
           animate="print"
         />
-        <p className="mt-4 text-center text-sm text-body">
+        <p className="mt-3 text-center text-sm text-body sm:mt-4">
           {RECEIPT_HERO_CAPTION.text}{' '}
           <Link
             to={RECEIPT_HERO_CAPTION.link.href}

--- a/apps/marketing/app/components/landing/Proof.tsx
+++ b/apps/marketing/app/components/landing/Proof.tsx
@@ -4,8 +4,8 @@ import { SITE } from '../../content/site';
 import { LiveMetricsBadge } from './LiveMetricsBadge';
 
 /**
- * Homepage proof band (GAP-480 Phase C rhythm).
- * Metrics first; deployers as a quiet sub-band (border only, no card chrome).
+ * Homepage proof band: one story (inspectable open source + live metrics).
+ * FDE / Studio handoff is a single quiet footer line (not a second section).
  */
 export function Proof() {
   return (
@@ -18,7 +18,7 @@ export function Proof() {
         align="center"
       />
 
-      <div className="mt-10 flex justify-center sm:mt-12">
+      <div className="mt-8 flex justify-center sm:mt-10">
         <a
           href={SITE.urls.repo}
           target="_blank"
@@ -46,7 +46,7 @@ export function Proof() {
             {PROOF_TRUST.linkLabel}
           </a>
         </p>
-        <div className="mt-5">
+        <div className="mt-4">
           <Button
             asChild
             appearance="link"
@@ -58,26 +58,18 @@ export function Proof() {
         </div>
       </div>
 
-      {/* FDE sub-band: border-only (≤7 sections rule). Demoted chrome. */}
-      <div className="mx-auto mt-10 max-w-2xl border-t border-border pt-8 text-center sm:mt-12 sm:pt-10">
-        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-          {PROOF_DEPLOYERS.eyebrow}
-        </p>
-        <h3 className="mt-2 font-display text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
-          {PROOF_DEPLOYERS.heading}
-        </h3>
-        <p className="mt-3 text-sm leading-6 text-body sm:text-base sm:leading-7">
-          {PROOF_DEPLOYERS.body}
-        </p>
-        <p className="mt-2 text-sm leading-6 text-muted-foreground">{PROOF_DEPLOYERS.foil}</p>
-        <div className="mt-6">
-          <Button asChild appearance="outline" variant="neutral" size="default">
-            <a href={PROOF_DEPLOYERS.cta.href} target="_blank" rel="noopener noreferrer">
-              {PROOF_DEPLOYERS.cta.label}
-            </a>
-          </Button>
-        </div>
-      </div>
+      {/* Single-line handoff (keeps ≤7 sections; no second H3 narrative). */}
+      <p className="mx-auto mt-8 max-w-2xl border-t border-border pt-6 text-center text-sm leading-6 text-muted-foreground sm:mt-10">
+        {PROOF_DEPLOYERS.body}{' '}
+        <a
+          href={PROOF_DEPLOYERS.cta.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+        >
+          {PROOF_DEPLOYERS.cta.label}
+        </a>
+      </p>
     </MarketingSection>
   );
 }

--- a/apps/marketing/app/content/proof.ts
+++ b/apps/marketing/app/content/proof.ts
@@ -43,9 +43,11 @@ export const PROOF_TRUST = {
   },
 } as const;
 
-// Secondary FDE / deployers band (ADR 2026-07-21 accepted). Nested under Proof
-// so the homepage stays within the ≤7 section hard rule (ADR 2026-07-10).
+// Secondary FDE / deployers line (ADR 2026-07-21 accepted). Nested under Proof
+// as a single footer sentence (GAP-480 residual: not a second H3 band).
 // Never a H1 or primary ICP. Copy pack §3 (scenario first, runtime noun).
+// eyebrow/heading/foil remain in the content module for claims-evidence; the
+// live UI renders body + CTA only.
 export const PROOF_DEPLOYERS = {
   eyebrow: 'For deployers',
   heading: 'Built for people who deploy, not only demo.',


### PR DESCRIPTION
## Summary

Final GAP-480 craft residuals (not redesign):

1. **Hero viewport** — tighter mobile spacing; trust strip `hidden sm:flex` so first screen is H1 + CTA + receipt
2. **Proof single story** — open-source metrics/trust only; FDE is one footer line + Studio link (no second H3 band)
3. **GetStarted** — demote newsletter under primary CTA + CLI close

claims-evidence green. Hero unit tests updated.

## Test plan
- [x] Hero tests
- [x] proof-deployers content tests
- [x] claims-evidence
- [x] pre-push phase-1
- [ ] Visual: phone first viewport; Proof no second narrative block
- [ ] CI green

Closes craft half of GAP-480; **promote still GAP-466 / owner**.