### PR TITLE
style(marketing): secondary route residual craft

### DIFF
--- a/apps/marketing/app/routes/BlogIndexPage.tsx
+++ b/apps/marketing/app/routes/BlogIndexPage.tsx
@@ -90,19 +90,19 @@ export function BlogIndexPage() {
       >
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background"
         />
         <SectionHeader
           title="Blog"
           description="Updates, guides, and insights from the RevealUI team."
           titleAs="h1"
           align="center"
-          titleClassName="text-4xl sm:text-5xl lg:text-6xl"
+          titleClassName="font-display text-4xl sm:text-5xl lg:text-6xl"
           descriptionClassName="sm:text-xl"
         />
       </MarketingSection>
 
-      <MarketingSection tone="background" density="default" width="default">
+      <MarketingSection tone="secondary" density="default" width="default">
         {posts.length === 0 ? (
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-lg text-body">
@@ -110,11 +110,11 @@ export function BlogIndexPage() {
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 sm:gap-8">
             {posts.map((post) => (
               <article
                 key={post.id}
-                className="rounded-2xl bg-card p-8 shadow-lg ring-1 ring-border transition-all hover:ring-primary/40"
+                className="rounded-2xl bg-card p-6 ring-1 ring-border transition-colors hover:ring-primary/30 sm:p-8"
               >
                 <div className="flex items-center gap-x-4 text-xs text-muted-foreground">
                   <time dateTime={post.publishedAt ?? post.createdAt}>

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -80,7 +80,12 @@ export function BlogPostPage() {
   if (loading && !post) {
     return (
       <div className="min-h-screen bg-background">
-        <MarketingSection tone="background" density="spacious" width="narrow" className="text-center">
+        <MarketingSection
+          tone="background"
+          density="spacious"
+          width="narrow"
+          className="text-center"
+        >
           <p className="text-muted-foreground">Loading…</p>
         </MarketingSection>
         <Footer />
@@ -91,7 +96,12 @@ export function BlogPostPage() {
   if (!post) {
     return (
       <div className="min-h-screen bg-background">
-        <MarketingSection tone="background" density="spacious" width="narrow" className="text-center">
+        <MarketingSection
+          tone="background"
+          density="spacious"
+          width="narrow"
+          className="text-center"
+        >
           <p className="text-sm font-semibold uppercase tracking-widest text-primary">404</p>
           <h1 className="mt-2 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             Post not found

--- a/apps/marketing/app/routes/BlogPostPage.tsx
+++ b/apps/marketing/app/routes/BlogPostPage.tsx
@@ -1,5 +1,5 @@
 import { RichTextContent, type SerializedEditorState } from '@revealui/core/richtext/rsc';
-import { Button } from '@revealui/presentation';
+import { Button, MarketingSection } from '@revealui/presentation';
 import { useParams } from '@revealui/router';
 import { useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
@@ -80,9 +80,9 @@ export function BlogPostPage() {
   if (loading && !post) {
     return (
       <div className="min-h-screen bg-background">
-        <div className="mx-auto max-w-3xl px-6 py-32 text-center text-muted-foreground">
-          Loading…
-        </div>
+        <MarketingSection tone="background" density="spacious" width="narrow" className="text-center">
+          <p className="text-muted-foreground">Loading…</p>
+        </MarketingSection>
         <Footer />
       </div>
     );
@@ -91,18 +91,18 @@ export function BlogPostPage() {
   if (!post) {
     return (
       <div className="min-h-screen bg-background">
-        <section className="flex flex-col items-center justify-center px-6 py-32 text-center">
+        <MarketingSection tone="background" density="spacious" width="narrow" className="text-center">
           <p className="text-sm font-semibold uppercase tracking-widest text-primary">404</p>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          <h1 className="mt-2 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
             Post not found
           </h1>
-          <p className="mt-4 max-w-md text-base text-body">
+          <p className="mx-auto mt-4 max-w-md text-base text-body">
             That blog post does not exist or has been removed.
           </p>
           <Button asChild variant="brand" className="mt-8">
             <a href="/blog">Back to Blog</a>
           </Button>
-        </section>
+        </MarketingSection>
         <Footer />
       </div>
     );
@@ -110,30 +110,27 @@ export function BlogPostPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      <article className="py-16 sm:py-24 lg:py-28">
-        <div className="mx-auto max-w-3xl px-6 lg:px-8">
-          {/* Back link */}
+      <MarketingSection tone="background" density="default" width="narrow">
+        <article>
           <a
             href="/blog"
-            className="inline-flex items-center gap-x-1 text-sm font-semibold text-primary hover:text-primary/80 transition-colors mb-8"
+            className="mb-8 inline-flex items-center gap-x-1 text-sm font-semibold text-primary transition-colors hover:text-primary/80"
           >
             &larr; Back to Blog
           </a>
 
-          {/* Header */}
-          <header className="mb-12">
+          <header className="mb-10 sm:mb-12">
             <div className="flex items-center gap-x-4 text-sm text-muted-foreground">
               <time dateTime={post.publishedAt ?? post.createdAt}>
                 {formatDate(post.publishedAt ?? post.createdAt)}
               </time>
               {post.author && <span>{post.author}</span>}
             </div>
-            <h1 className="mt-2 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+            <h1 className="mt-2 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl lg:text-5xl">
               {post.title}
             </h1>
           </header>
 
-          {/* Content */}
           <div className="prose prose-gray prose-lg max-w-none">
             {isLexicalState(post.content) ? (
               <RichTextContent data={post.content} />
@@ -145,27 +142,25 @@ export function BlogPostPage() {
               <p className="text-body">{post.excerpt}</p>
             )}
           </div>
-        </div>
-      </article>
+        </article>
+      </MarketingSection>
 
-      <section className="border-t border-border bg-secondary py-16 sm:py-20">
-        <div className="mx-auto max-w-3xl px-6 lg:px-8 text-center">
-          <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
-            Ready to build?
-          </h2>
-          <p className="mt-4 text-base leading-7 text-body">
-            People, Content, Offers, Payments, and Agents, pre-wired. Start locally in minutes.
-          </p>
-          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Button asChild size="lg" variant="brand">
-              <a href="https://admin.revealui.com/signup">Start free</a>
-            </Button>
-            <Button asChild size="lg" appearance="outline" variant="neutral">
-              <a href="https://docs.revealui.com">Read the docs</a>
-            </Button>
-          </div>
+      <MarketingSection tone="secondary" density="compact" width="narrow" className="text-center">
+        <h2 className="font-display text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+          Ready to build?
+        </h2>
+        <p className="mx-auto mt-4 max-w-xl text-base leading-7 text-body">
+          People, Content, Offers, Payments, and Agents, pre-wired. Start locally in minutes.
+        </p>
+        <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Button asChild size="lg" variant="brand">
+            <a href="https://admin.revealui.com/signup">Start free</a>
+          </Button>
+          <Button asChild size="lg" appearance="outline" variant="neutral">
+            <a href="https://docs.revealui.com">Read the docs</a>
+          </Button>
         </div>
-      </section>
+      </MarketingSection>
 
       <Footer />
     </div>

--- a/apps/marketing/app/routes/FairSourcePage.tsx
+++ b/apps/marketing/app/routes/FairSourcePage.tsx
@@ -358,6 +358,7 @@ export function FairSourcePage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Hero — static: headline/subhead/body interpolate METRICS counts */}
+      {/* One quiet wash only (no radial blob + brand-dot chrome). */}
       <MarketingSection
         tone="background"
         density="spacious"
@@ -368,24 +369,19 @@ export function FairSourcePage() {
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background"
         />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -top-40 left-1/2 -z-10 h-[600px] w-[1000px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,var(--rvui-brand-glow),transparent_70%)] blur-2xl"
-        />
 
         <div className="relative text-center">
           <p className="mb-6 text-sm font-semibold uppercase tracking-[0.2em] text-primary">
-            <span className="mr-2 inline-block h-1.5 w-1.5 rounded-full bg-primary align-middle" />
             {FAIR_SOURCE_HERO.eyebrow}
           </p>
-          <h1 className="text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+          <h1 className="font-display text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
             {FAIR_SOURCE_HERO.headline}
             <span className="block text-primary">{FAIR_SOURCE_HERO.headlineHighlight}</span>
           </h1>
-          <p className="mx-auto mt-8 max-w-2xl text-xl leading-8 text-body sm:text-2xl">
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-8 text-body sm:text-xl">
             {FAIR_SOURCE_HERO.subhead}
           </p>
-          <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-body">
+          <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-body">
             {/* COUNT: packages-fsl = 5, packages-mit = 21 (of 26 total — see /packages/ in repo) */}
             {FAIR_SOURCE_HERO.body.prefix}{' '}
             <a

--- a/apps/marketing/app/routes/LocalAiPage.tsx
+++ b/apps/marketing/app/routes/LocalAiPage.tsx
@@ -44,7 +44,7 @@ function LocalAiHero({ data, path, annotation }: LocalAiHeroProps) {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background"
       />
       <p
         className="text-sm font-semibold uppercase tracking-wide text-primary"

--- a/apps/marketing/app/routes/NotFoundPage.tsx
+++ b/apps/marketing/app/routes/NotFoundPage.tsx
@@ -1,15 +1,15 @@
-import { Button } from '@revealui/presentation';
+import { Button, MarketingSection } from '@revealui/presentation';
 import { Footer } from '../components/Footer';
 
 export function NotFoundPage() {
   return (
     <div className="min-h-screen bg-background">
-      <section className="flex flex-col items-center justify-center px-6 py-32 text-center">
+      <MarketingSection tone="background" density="spacious" width="narrow" className="text-center">
         <p className="text-sm font-semibold uppercase tracking-widest text-primary">404</p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        <h1 className="mt-2 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           Page not found
         </h1>
-        <p className="mt-4 max-w-md text-base text-body">
+        <p className="mx-auto mt-4 max-w-md text-base text-body">
           The page you're looking for doesn't exist or has moved.
         </p>
         <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
@@ -20,7 +20,7 @@ export function NotFoundPage() {
             <a href="/products">View products</a>
           </Button>
         </div>
-      </section>
+      </MarketingSection>
       <Footer />
     </div>
   );

--- a/apps/marketing/app/routes/PhilosophyPage.tsx
+++ b/apps/marketing/app/routes/PhilosophyPage.tsx
@@ -27,7 +27,7 @@ function PhilosophyHero({ data, path, annotation }: PhilosophyHeroProps) {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-background"
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background"
       />
       <p
         className="text-sm font-semibold uppercase tracking-wide text-primary"

--- a/apps/marketing/app/routes/ProductsPage.tsx
+++ b/apps/marketing/app/routes/ProductsPage.tsx
@@ -52,98 +52,95 @@ export function ProductsPage() {
         density="default"
         width="default"
       >
-        <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-primary/90 to-primary/70 p-10 shadow-2xl ring-1 ring-primary/20 sm:p-14">
-          <div className="absolute -right-16 -top-16 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
-          <div className="absolute -bottom-20 -left-20 h-72 w-72 rounded-full bg-primary-foreground/10 blur-3xl" />
-          <div className="relative">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex items-center gap-4">
-                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary-foreground/15 ring-1 ring-primary-foreground/30 backdrop-blur">
-                  <svg
-                    className="h-7 w-7 text-primary-foreground"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.75}
-                    stroke="currentColor"
-                  >
-                    <title>{PRODUCTS_FLAGSHIP.name}</title>
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d={PRODUCTS_FLAGSHIP.iconPath}
-                    />
-                  </svg>
-                </div>
-                <div>
-                  <p className="text-xs font-bold uppercase tracking-[0.2em] text-primary-foreground/90">
-                    {PRODUCTS_FLAGSHIP.eyebrow}
-                  </p>
-                  <h2 className="mt-1 text-3xl font-bold tracking-tight text-primary-foreground sm:text-4xl">
-                    {PRODUCTS_FLAGSHIP.name}
-                  </h2>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 text-xs font-semibold">
-                <span className="rounded-full bg-primary-foreground/15 px-3 py-1 text-primary-foreground ring-1 ring-primary-foreground/30 backdrop-blur">
-                  {PRODUCTS_FLAGSHIP.status}
-                </span>
-                <span className="rounded-full bg-primary-foreground/10 px-3 py-1 font-mono text-primary-foreground/90 ring-1 ring-primary-foreground/20">
-                  {PRODUCTS_FLAGSHIP.version}
-                </span>
-              </div>
-            </div>
-
-            <p className="mt-6 max-w-3xl text-xl font-medium leading-8 text-primary-foreground">
-              {PRODUCTS_FLAGSHIP.tagline}
-            </p>
-            <p className="mt-3 max-w-3xl text-base leading-7 text-primary-foreground/90">
-              {PRODUCTS_FLAGSHIP.body}
-            </p>
-
-            <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
-              {PRODUCTS_FLAGSHIP.facts.map((fact) => (
-                <div
-                  key={fact.label}
-                  className="rounded-xl bg-primary-foreground/10 px-4 py-3 ring-1 ring-primary-foreground/20 backdrop-blur"
+        {/* Quiet flagship panel: solid primary, no multi-blob chrome (GAP-480 residual). */}
+        <div className="relative overflow-hidden rounded-2xl bg-primary p-8 ring-1 ring-primary/20 sm:p-12">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-center gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary-foreground/15 ring-1 ring-primary-foreground/25">
+                <svg
+                  className="h-6 w-6 text-primary-foreground"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.75}
+                  stroke="currentColor"
                 >
-                  <dt className="text-xs uppercase tracking-wide text-primary-foreground/80">
-                    {fact.label}
-                  </dt>
-                  <dd className="mt-1 text-2xl font-bold tracking-tight text-primary-foreground">
-                    {fact.stat}
-                  </dd>
-                </div>
-              ))}
-            </dl>
-
-            <p className="mt-8 inline-flex items-center gap-2 rounded-full bg-primary-foreground/15 px-4 py-1.5 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/30 backdrop-blur">
-              <IconCheckCircle className="h-4 w-4" size="sm" label="Pricing" />
-              {PRODUCTS_FLAGSHIP.priceLabel}
-            </p>
-
-            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
-              <a
-                href={PRODUCTS_FLAGSHIP.ctas.docs.href}
-                className="rounded-md bg-primary-foreground px-6 py-3 text-sm font-semibold text-primary shadow-sm transition-colors hover:bg-primary-foreground/90"
-              >
-                {PRODUCTS_FLAGSHIP.ctas.docs.label}
-              </a>
-              <a
-                href={PRODUCTS_FLAGSHIP.ctas.pricing.href}
-                className="rounded-md bg-primary-foreground/15 px-6 py-3 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/30 transition-colors hover:bg-primary-foreground/25"
-              >
-                {PRODUCTS_FLAGSHIP.ctas.pricing.label}
-              </a>
-              <a
-                href={PRODUCTS_FLAGSHIP.ctas.repo.href}
-                className="rounded-md px-6 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/10"
-                {...(PRODUCTS_FLAGSHIP.ctas.repo.external
-                  ? { target: '_blank', rel: 'noreferrer' }
-                  : {})}
-              >
-                {PRODUCTS_FLAGSHIP.ctas.repo.label}
-              </a>
+                  <title>{PRODUCTS_FLAGSHIP.name}</title>
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d={PRODUCTS_FLAGSHIP.iconPath}
+                  />
+                </svg>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary-foreground/85">
+                  {PRODUCTS_FLAGSHIP.eyebrow}
+                </p>
+                <h2 className="mt-1 font-display text-2xl font-bold tracking-tight text-primary-foreground sm:text-3xl">
+                  {PRODUCTS_FLAGSHIP.name}
+                </h2>
+              </div>
             </div>
+            <div className="flex items-center gap-2 text-xs font-semibold">
+              <span className="rounded-full bg-primary-foreground/15 px-3 py-1 text-primary-foreground ring-1 ring-primary-foreground/25">
+                {PRODUCTS_FLAGSHIP.status}
+              </span>
+              <span className="rounded-full bg-primary-foreground/10 px-3 py-1 font-mono text-primary-foreground/90 ring-1 ring-primary-foreground/20">
+                {PRODUCTS_FLAGSHIP.version}
+              </span>
+            </div>
+          </div>
+
+          <p className="mt-6 max-w-3xl text-lg font-medium leading-8 text-primary-foreground sm:text-xl">
+            {PRODUCTS_FLAGSHIP.tagline}
+          </p>
+          <p className="mt-3 max-w-3xl text-base leading-7 text-primary-foreground/90">
+            {PRODUCTS_FLAGSHIP.body}
+          </p>
+
+          <dl className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-4">
+            {PRODUCTS_FLAGSHIP.facts.map((fact) => (
+              <div
+                key={fact.label}
+                className="rounded-xl bg-primary-foreground/10 px-4 py-3 ring-1 ring-primary-foreground/20"
+              >
+                <dt className="text-xs uppercase tracking-wide text-primary-foreground/80">
+                  {fact.label}
+                </dt>
+                <dd className="mt-1 text-xl font-bold tracking-tight text-primary-foreground sm:text-2xl">
+                  {fact.stat}
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          <p className="mt-6 inline-flex items-center gap-2 rounded-full bg-primary-foreground/15 px-4 py-1.5 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/25">
+            <IconCheckCircle className="h-4 w-4" size="sm" label="Pricing" />
+            {PRODUCTS_FLAGSHIP.priceLabel}
+          </p>
+
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a
+              href={PRODUCTS_FLAGSHIP.ctas.docs.href}
+              className="rounded-md bg-primary-foreground px-6 py-3 text-sm font-semibold text-primary shadow-sm transition-colors hover:bg-primary-foreground/90"
+            >
+              {PRODUCTS_FLAGSHIP.ctas.docs.label}
+            </a>
+            <a
+              href={PRODUCTS_FLAGSHIP.ctas.pricing.href}
+              className="rounded-md bg-primary-foreground/15 px-6 py-3 text-sm font-semibold text-primary-foreground ring-1 ring-primary-foreground/25 transition-colors hover:bg-primary-foreground/25"
+            >
+              {PRODUCTS_FLAGSHIP.ctas.pricing.label}
+            </a>
+            <a
+              href={PRODUCTS_FLAGSHIP.ctas.repo.href}
+              className="rounded-md px-6 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/10"
+              {...(PRODUCTS_FLAGSHIP.ctas.repo.external
+                ? { target: '_blank', rel: 'noreferrer' }
+                : {})}
+            >
+              {PRODUCTS_FLAGSHIP.ctas.repo.label}
+            </a>
           </div>
         </div>
       </MarketingSection>

--- a/apps/marketing/app/routes/RoadmapPage.tsx
+++ b/apps/marketing/app/routes/RoadmapPage.tsx
@@ -54,7 +54,7 @@ export function RoadmapPage() {
       >
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-primary/10 via-background to-primary/5"
+          className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-background to-background"
         />
         <h1 className="font-display text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
           Product <span className="text-primary">Roadmap</span>

--- a/apps/marketing/app/routes/StatusPage.tsx
+++ b/apps/marketing/app/routes/StatusPage.tsx
@@ -54,8 +54,8 @@ function badgeFor(
 ) {
   if (state.kind === 'self') {
     return (
-      <span className="inline-flex items-center gap-2 rounded-full bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-700 ring-1 ring-green-200 dark:bg-green-950/30 dark:text-green-400 dark:ring-green-800">
-        <span aria-hidden="true" className="size-1.5 rounded-full bg-green-500" />
+      <span className="inline-flex items-center gap-2 rounded-full bg-success-subtle px-2.5 py-0.5 text-xs font-medium text-success-text ring-1 ring-success/30">
+        <span aria-hidden="true" className="size-1.5 rounded-full bg-success" />
         Operational (you are here)
       </span>
     );
@@ -82,15 +82,15 @@ function badgeFor(
   }
   if (r.status === 'up') {
     return (
-      <span className="inline-flex items-center gap-2 rounded-full bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-700 ring-1 ring-green-200 dark:bg-green-950/30 dark:text-green-400 dark:ring-green-800">
-        <span aria-hidden="true" className="size-1.5 rounded-full bg-green-500" />
+      <span className="inline-flex items-center gap-2 rounded-full bg-success-subtle px-2.5 py-0.5 text-xs font-medium text-success-text ring-1 ring-success/30">
+        <span aria-hidden="true" className="size-1.5 rounded-full bg-success" />
         Operational · {r.latencyMs}ms
       </span>
     );
   }
   return (
-    <span className="inline-flex items-center gap-2 rounded-full bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-700 ring-1 ring-red-200 dark:bg-red-950/30 dark:text-red-400 dark:ring-red-800">
-      <span aria-hidden="true" className="size-1.5 rounded-full bg-red-500" />
+    <span className="inline-flex items-center gap-2 rounded-full bg-destructive/10 px-2.5 py-0.5 text-xs font-medium text-destructive ring-1 ring-destructive/30">
+      <span aria-hidden="true" className="size-1.5 rounded-full bg-destructive" />
       Unreachable
     </span>
   );


### PR DESCRIPTION
## Summary

GAP-480 secondary-route residual (not redesign). Align non-home pages with landing craft bar.

| Route | Change |
|-------|--------|
| **Products** | Flagship panel: solid Cobalt, no dual blur blobs / shadow-2xl |
| **FairSource** | One hero wash; drop radial blob + brand-dot eyebrow |
| **Blog index** | Quiet wash; secondary band; lighter cards |
| **Blog post** | MarketingSection shells for load/404/article/CTA (no py-32) |
| **NotFound** | MarketingSection spacious narrow |
| **Roadmap / Philosophy / Local AI** | Single `from-primary/5` wash |
| **Status** | success/destructive tokens (no raw green/red palette) |

## Test plan
- [x] Pre-push phase-1 gate PASS
- [ ] Visual: /products flagship, /fair-source, /blog, /status
- [ ] CI green

Pairs landing residuals #2603; promote still GAP-466.