### PR TITLE
feat(ai): default Inference Snap is gemma3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ No assembly required. Define your data once. Humans manage it through the dashbo
 The Agents primitive ships with open-model defaults. No proprietary API keys required, no API bill that scales with usage.
 
 - **Ollama** — local model runner; the standard developer-machine path.
-- **Ubuntu Inference Snaps** — US-origin model runtimes for production. `sudo snap install nemotron-3-nano` (or `gemma4`, `gemma3`, `nemotron-3-nano-omni`). Non-US catalog snaps are rejected in product code.
+- **Ubuntu Inference Snaps** — US-origin model runtimes for production. `sudo snap install gemma3` (or `gemma4`, `nemotron-3-nano`, `nemotron-3-nano-omni`). Non-US catalog snaps are rejected in product code.
 - **Pluggable provider adapters** — Claude, OpenAI, and others available as opt-in adapters. The fleet runtime never imports any provider SDK by default; you wire whichever model you want.
 
 Verifiable: `git grep -l "@anthropic-ai/sdk" packages/` returns nothing inside `@revealui/*` packages. The runtime is provider-agnostic by contract.
@@ -127,7 +127,7 @@ The [Pro tier](https://revealui.com/pro) adds AI agents and automation that work
 
 - **AI agent system** _(beta — works in staging, production usage is early)_: build and deploy purpose-built agents for your workflows
 - **MCP framework:** hypervisor, adapter framework, and tool discovery for connecting agents to external services
-- **Open-model inference:** Ubuntu Inference Snaps (canonical default — Studio lifecycle pending), Ollama, and open source models via the RevealUI harness. `sudo snap install nemotron-3-nano` for US-origin local AI (or `gemma4` / `nemotron-3-nano-omni`). No proprietary APIs, no vendor lock-in, zero API bills
+- **Open-model inference:** Ubuntu Inference Snaps (canonical default — Studio lifecycle pending), Ollama, and open source models via the RevealUI harness. `sudo snap install gemma3` for US-origin local AI (or `gemma4` / `nemotron-3-nano`). No proprietary APIs, no vendor lock-in, zero API bills
 - **Task history:** every agent action logged, auditable, and visible in the dashboard
 - **Editor config sync:** generate and sync settings for Zed, VS Code, Cursor, and Antigravity
 

--- a/apps/docs/public/docs-pro/ai/index.md
+++ b/apps/docs/public/docs-pro/ai/index.md
@@ -34,7 +34,7 @@ ollama pull qwen2.5:3b
 ollama pull nomic-embed-text
 
 # OR planned path (run + manage the snap yourself for now)
-sudo snap install nemotron-3-nano
+sudo snap install gemma3
 ```
 
 ```typescript

--- a/apps/docs/public/docs-pro/inference/index.md
+++ b/apps/docs/public/docs-pro/inference/index.md
@@ -12,13 +12,13 @@ RevealUI AI defaults to open-model inference (Snaps, Ollama). Groq, Anthropic, O
 
 ```bash
 # Install the default model (US-origin allowlist)
-sudo snap install nemotron-3-nano
+sudo snap install gemma3
 
 # Check status and endpoint
-nemotron-3-nano status
+gemma3 status
 
-# Optional: change the HTTP port (default 9090)
-nemotron-3-nano set http.port=9090
+# Product port (Canonical OpenAI-compat default)
+gemma3 set http.port=9090 --assume-yes
 ```
 
 The snap serves an OpenAI-compatible API at `http://localhost:<port>/v1`  -  the RevealUI AI provider uses this directly with zero additional configuration.
@@ -31,10 +31,10 @@ operator sets `REVEALUI_ALLOW_NON_US_MODELS=1` (never seed this).
 
 | Snap | Origin | Type | Use Case |
 |------|--------|------|----------|
-| `nemotron-3-nano` | NVIDIA (US) | General + tools | **Default** |
+| `gemma3` | Google (US) | General + vision | **Default** (270m fits 4GB WSL) |
+| `gemma4` | Google (US) | General + vision + tools | Larger Gemma |
+| `nemotron-3-nano` | NVIDIA (US) | General + tools | Heavy / capable hosts |
 | `nemotron-3-nano-omni` | NVIDIA (US) | Multimodal | Text/image/video/audio in |
-| `gemma4` | Google (US) | General + vision + tools | Strong general alternative |
-| `gemma3` | Google (US) | General + vision | Legacy allowlisted snap |
 
 ### Configuration
 

--- a/apps/marketing/app/content/claims-evidence/claims-part-3.ts
+++ b/apps/marketing/app/content/claims-evidence/claims-part-3.ts
@@ -493,7 +493,7 @@ export const claimsPart3: readonly ClaimEntry[] = [
     file: 'local-ai.ts',
     exportPath: 'LOCAL_AI_SECTION.snippet.lines[0].note',
     proofGrade: 'behavior',
-    text: 'nemotron-3-nano on your box, port 9090 (default runner)',
+    text: 'gemma3 on your box, port 9090 (default runner)',
     evidence: [LLM_CLIENT],
   },
   {
@@ -619,7 +619,7 @@ export const claimsPart3: readonly ClaimEntry[] = [
     file: 'local-ai.ts',
     exportPath: 'PROVIDER_SWITCH.modes.local.model',
     proofGrade: 'behavior',
-    text: 'nemotron-3-nano, open-weight (US-origin)',
+    text: 'gemma3, open-weight (US-origin)',
     evidence: [LLM_CLIENT, OPEN_WEIGHT],
   },
   {

--- a/apps/marketing/app/content/claims-evidence/shared-refs.ts
+++ b/apps/marketing/app/content/claims-evidence/shared-refs.ts
@@ -371,7 +371,7 @@ export const SERVICES_STRIPE: EvidenceRef = {
 export const LLM_CLIENT: EvidenceRef = {
   kind: 'code',
   ref: 'packages/ai/src/llm/client.ts',
-  note: 'createLLMClientFromEnv default provider inference-snaps, defaultModel nemotron-3-nano, port 9090; US-origin allowlist; LLMProviderType union groq/ollama/huggingface/inference-snaps',
+  note: 'createLLMClientFromEnv default provider inference-snaps, defaultModel gemma3, port 9090; US-origin allowlist; LLMProviderType union groq/ollama/huggingface/inference-snaps',
 };
 export const OLLAMA: EvidenceRef = {
   kind: 'code',

--- a/apps/marketing/app/content/local-ai.ts
+++ b/apps/marketing/app/content/local-ai.ts
@@ -17,7 +17,7 @@
 // cost + sovereignty + good-enough-for-most-work economics, NEVER on parity,
 // "free", "turnkey", or "faster". Frontier stays the opt-in escalation. The
 // provider snippet is grep-accurate to packages/ai/src/llm/client.ts
-// (LLM_PROVIDER; inference-snaps default nemotron-3-nano :9090, ollama qwen2.5:3b :11434).
+// (LLM_PROVIDER; inference-snaps default gemma3 :9090, ollama qwen2.5:3b :11434).
 // Positioning guardrail (Phase C): ownership stays the lead; local AI is its proof.
 //
 // claims-ratchet 2026-07-12: frontier-mode provider naming scoped to the shipped
@@ -57,7 +57,7 @@ export const LOCAL_AI_SECTION = {
     lines: [
       {
         code: 'LLM_PROVIDER=inference-snaps',
-        note: 'nemotron-3-nano on your box, port 9090 (default runner)',
+        note: 'gemma3 on your box, port 9090 (default runner)',
       },
       { code: 'LLM_PROVIDER=ollama', note: 'qwen2.5:3b on your box, port 11434' },
     ],
@@ -140,7 +140,7 @@ export const PROVIDER_SWITCH = {
     local: {
       label: 'Local',
       badge: 'default',
-      model: 'nemotron-3-nano, open-weight (US-origin)',
+      model: 'gemma3, open-weight (US-origin)',
       locus: 'Runs on your own box',
       cost: 'Your inference cost, no per-token fee',
       config: 'LLM_PROVIDER=inference-snaps',

--- a/apps/server/src/routes/__tests__/agent-stream-success.test.ts
+++ b/apps/server/src/routes/__tests__/agent-stream-success.test.ts
@@ -72,8 +72,8 @@ vi.mock('@revealui/ai', () => {
     createToolsFromMcpClient: vi.fn().mockResolvedValue([]),
     // US-origin Inference Snaps hardline (agent-stream sampling allowlist)
     US_ORIGIN_INFERENCE_SNAP_IDS: ['nemotron-3-nano', 'nemotron-3-nano-omni', 'gemma3', 'gemma4'],
-    DEFAULT_US_ORIGIN_INFERENCE_SNAP: 'nemotron-3-nano',
-    createSamplingHandler: vi.fn().mockReturnValue(async () => ({ model: 'nemotron-3-nano' })),
+    DEFAULT_US_ORIGIN_INFERENCE_SNAP: 'gemma3',
+    createSamplingHandler: vi.fn().mockReturnValue(async () => ({ model: 'gemma3' })),
   };
 });
 

--- a/docs/AI.md
+++ b/docs/AI.md
@@ -33,9 +33,9 @@ pnpm add @revealui/ai
 Install a model via Ubuntu Inference Snaps (canonical default — install + run yourself today; Studio lifecycle pending):
 
 ```bash
-sudo snap install nemotron-3-nano    # default — NVIDIA US-origin general + tools
+sudo snap install gemma3             # default — Google US-origin; 270m fits 4GB WSL
 # or: sudo snap install gemma4                 # Google US-origin general + vision + tools
-# or: sudo snap install gemma3                 # Google US-origin (allowlisted)
+# or: sudo snap install nemotron-3-nano        # NVIDIA US-origin heavy / capable hosts
 # or: sudo snap install nemotron-3-nano-omni   # NVIDIA multimodal
 ```
 
@@ -105,10 +105,10 @@ const memory = {
 
 | Snap | Type | Use Case |
 | ---- | ---- | -------- |
-| `nemotron-3-nano` | General + tools (NVIDIA, US) | **Default** product snap |
+| `gemma3` | General + vision (Google, US) | **Default** product snap (270m fits 4GB WSL) |
+| `gemma4` | General + vision + tools (Google, US) | Larger Gemma |
+| `nemotron-3-nano` | General + tools (NVIDIA, US) | Heavy / capable hosts |
 | `nemotron-3-nano-omni` | Multimodal (NVIDIA, US) | Text/image/video/audio in |
-| `gemma4` | General + vision + tools (Google, US) | Strong general alternative |
-| `gemma3` | General + vision (Google, US) | Allowlisted legacy snap |
 
 Non-US snaps in Canonical's catalog (DeepSeek, Qwen, GLM) are rejected in product code unless `REVEALUI_ALLOW_NON_US_MODELS=1`.
 
@@ -151,7 +151,7 @@ For the planned recommended path (when you're ready to install + run a Canonical
 
 ```bash
 # Install your first model (default)
-sudo snap install nemotron-3-nano
+sudo snap install gemma3
 
 # Check status
 gemma3 status

--- a/docs/LOCAL_FIRST.md
+++ b/docs/LOCAL_FIRST.md
@@ -60,9 +60,9 @@ The Nix flake activates: Node 24, pnpm 10, Biome, and all build dependencies are
 Inference snaps are the canonical local-AI path for RevealUI. Canonical's snap-packaged model serving provides hardware-aware engine selection, signed packages, and zero configuration. Today, you install + run the snap yourself; Studio lifecycle management (start / stop / health / model discovery) is on the roadmap.
 
 ```bash
-sudo snap install nemotron-3-nano    # default — NVIDIA US-origin general + tools
+sudo snap install gemma3             # default — Google US-origin; 270m fits 4GB WSL
 # or: sudo snap install gemma4                 # Google US-origin general + vision + tools
-# or: sudo snap install gemma3                 # Google US-origin (allowlisted)
+# or: sudo snap install nemotron-3-nano        # NVIDIA US-origin heavy / capable hosts
 # or: sudo snap install nemotron-3-nano-omni   # NVIDIA multimodal
 ```
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -50,7 +50,7 @@ A coordination layer that lets multiple AI coding tools (Claude Code, Cursor, Ai
 
 ## Inference Snaps
 
-Canonical's silicon-optimized snap-packaged LLMs running on Ubuntu. The **canonical default** open-model inference path for RevealUI per memory `project_canonical_inference_snap_stack`. Today the snap *provider* in `@revealui/ai` works (point `INFERENCE_SNAPS_BASE_URL` at a running snap and route LLM calls); Studio lifecycle management (auto-install, start/stop, health, model discovery) is **not yet shipped** — install + run snaps yourself. Product US-origin allowlist (2026-07): `nemotron-3-nano` (default), `nemotron-3-nano-omni`, `gemma3`, `gemma4`. Non-US catalog snaps are fail-closed. See [`./AI`](./AI.md).
+Canonical's silicon-optimized snap-packaged LLMs running on Ubuntu. The **canonical default** open-model inference path for RevealUI per memory `project_canonical_inference_snap_stack`. Today the snap *provider* in `@revealui/ai` works (point `INFERENCE_SNAPS_BASE_URL` at a running snap and route LLM calls); Studio lifecycle management (auto-install, start/stop, health, model discovery) is **not yet shipped** — install + run snaps yourself. Product US-origin allowlist (2026-08): `gemma3` (default), `gemma4`, `nemotron-3-nano`, `nemotron-3-nano-omni`. Non-US catalog snaps are fail-closed. See [`./AI`](./AI.md).
 
 ## JWT
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -54,9 +54,9 @@ rejected at provider construction. Operator escape (never seed):
 Quick setup:
 
 ```bash
-sudo snap install nemotron-3-nano      # default; or gemma4 / nemotron-3-nano-omni
-nemotron-3-nano set http.port=9090
-nemotron-3-nano status                 # confirms base URL
+sudo snap install gemma3               # default; or gemma4 / nemotron-3-nano
+gemma3 set http.port=9090 --assume-yes
+gemma3 status                          # confirms base URL
 ```
 
 ```typescript
@@ -66,7 +66,7 @@ const client = new LLMClient({
   provider: 'inference-snaps',
   apiKey: 'inference-snaps',
   baseURL: 'http://localhost:9090/v1',
-  model: 'nemotron-3-nano', // default when omitted
+  model: 'gemma3', // default when omitted
 })
 
 // Or the provider alone:
@@ -201,7 +201,7 @@ import { InferenceSnapsProvider, createSamplingHandler } from '@revealui/ai'
 
 const llm = new InferenceSnapsProvider({
   baseURL: 'http://localhost:9090/v1',
-  model: 'nemotron-3-nano',
+  model: 'gemma3',
 })
 
 const client = new McpClient({
@@ -209,9 +209,9 @@ const client = new McpClient({
   transport: { kind: 'streamable-http', url: 'https://example.com/mcp' },
   samplingHandler: createSamplingHandler({
     llm,
-    defaultModel: 'nemotron-3-nano',
+    defaultModel: 'gemma3',
     // Keep sampling hints on the US-origin allowlist (provider also enforces).
-    allowedModels: ['nemotron-3-nano', 'gemma4', 'gemma3'],
+    allowedModels: ['gemma3', 'gemma4', 'nemotron-3-nano'],
     onSamplingRequest: (info) => {
       // metering / audit trail
       metrics.incr('mcp.sampling', { model: info.model })

--- a/packages/ai/src/llm/client.ts
+++ b/packages/ai/src/llm/client.ts
@@ -644,11 +644,11 @@ export class LLMClient {
  *
  * Canonical Inference Snaps is the reference local provider on Ubuntu — offline,
  * silicon-optimized, no API key required. Product usage is **US-origin snaps
- * only** (nemotron-3-nano default; gemma3/4 also allowlisted). See
+ * only** (gemma3 default; gemma4 and nemotron also allowlisted). See
  * `providers/us-origin-snaps.ts` and `providers/inference-snaps.ts`.
  *
  * Provider defaults:
- *   inference-snaps → nemotron-3-nano   (base URL defaults to http://localhost:9090/v1)
+ *   inference-snaps → gemma3   (base URL defaults to http://localhost:9090/v1)
  *   groq            → llama-3.3-70b-versatile
  *   ollama          → DEFAULT_DAILY_OLLAMA_MODEL (qwen2.5:3b; base URL http://localhost:11434)
  *   anthropic       → claude-sonnet-4-6 (base URL defaults to https://api.anthropic.com/v1)

--- a/packages/ai/src/llm/local-ai-profile.ts
+++ b/packages/ai/src/llm/local-ai-profile.ts
@@ -14,7 +14,6 @@ import { dirname, join } from 'node:path';
 import {
   DEFAULT_DAILY_OLLAMA_MODEL,
   DEFAULT_LOW_RAM_INFERENCE_SNAP,
-  DEFAULT_US_ORIGIN_INFERENCE_SNAP,
 } from './providers/us-origin-snaps.js';
 
 export type LocalAiTier = 'idle' | 'daily' | 'snaps' | 'heavy';
@@ -186,7 +185,7 @@ export function profileDefaultsForTier(
     case 'heavy':
       return {
         provider: 'inference-snaps',
-        model: DEFAULT_US_ORIGIN_INFERENCE_SNAP,
+        model: 'nemotron-3-nano',
         baseURL: null,
         keepAlive: null,
         note: 'Heavy snap — needs substantial RAM; avoid concurrent IDE load on 4GB WSL',

--- a/packages/ai/src/llm/providers/__tests__/us-origin-snaps.test.ts
+++ b/packages/ai/src/llm/providers/__tests__/us-origin-snaps.test.ts
@@ -60,7 +60,8 @@ describe('isUsOriginInferenceSnap', () => {
 });
 
 describe('assertUsOriginInferenceSnap', () => {
-  it('defaults to nemotron-3-nano when model is omitted', () => {
+  it('defaults to gemma3 when model is omitted', () => {
+    expect(DEFAULT_US_ORIGIN_INFERENCE_SNAP).toBe('gemma3');
     expect(assertUsOriginInferenceSnap(undefined)).toBe(DEFAULT_US_ORIGIN_INFERENCE_SNAP);
     expect(assertUsOriginInferenceSnap('')).toBe(DEFAULT_US_ORIGIN_INFERENCE_SNAP);
   });

--- a/packages/ai/src/llm/providers/inference-snaps.ts
+++ b/packages/ai/src/llm/providers/inference-snaps.ts
@@ -6,17 +6,18 @@
  *
  * Product hardline: US-origin snap models only (see us-origin-snaps.ts).
  * Allowlisted snaps (install these):
- *   nemotron-3-nano        -  NVIDIA general + tools (default)
+ *   gemma3                 -  Google general + vision (default; WSL-supported)
+ *   gemma4                 -  Google general + vision + tools
+ *   nemotron-3-nano        -  NVIDIA general + tools (heavy / capable hosts)
  *   nemotron-3-nano-omni   -  NVIDIA multimodal
- *   gemma3 / gemma4        -  Google general + vision + tools
  *
  * Canonical also publishes non-US snaps (deepseek-r1, qwen-*, glm-*). Those
  * are rejected at construction unless REVEALUI_ALLOW_NON_US_MODELS=1.
  *
  * Install a model:
- *   sudo snap install nemotron-3-nano
- *   nemotron-3-nano set http.port=9090   # optional: change port
- *   nemotron-3-nano status              # shows base URL and available models
+ *   sudo snap install gemma3
+ *   gemma3 set http.port=9090 --assume-yes
+ *   gemma3 status              # shows base URL and available models
  *
  * Set env vars:
  *   INFERENCE_SNAPS_BASE_URL=http://localhost:9090/v1

--- a/packages/ai/src/llm/providers/us-origin-snaps.ts
+++ b/packages/ai/src/llm/providers/us-origin-snaps.ts
@@ -7,7 +7,7 @@
  * Definition: open weights published by an organization whose ultimate parent
  * is incorporated in the United States. Packaging (Canonical snaps) is not origin.
  *
- * Allowlist today (Canonical catalog, 2026-07):
+ * Allowlist today (Canonical catalog, 2026-08):
  *   - nemotron-3-nano / nemotron-3-nano-omni — NVIDIA
  *   - gemma3 / gemma4 — Google (Alphabet)
  *
@@ -20,24 +20,26 @@
 /**
  * Product install/list catalog (snap name + operator-facing description).
  * SSOT for harnesses InferenceService + Studio install UIs.
- * Order: product default first (nemotron for capable hosts; gemma preferred on low-RAM via profile daily).
+ * Order: product default first. Canonical marks only gemma3 as WSL-supported
+ * (https://documentation.ubuntu.com/inference-snaps/reference/snaps/).
+ * Nemotron stays allowlisted for capable hosts.
  */
 export const PRODUCT_INFERENCE_SNAP_CATALOG = [
   {
-    id: 'nemotron-3-nano',
-    description: 'NVIDIA (US) — general + tools; product default on capable hosts',
-  },
-  {
-    id: 'nemotron-3-nano-omni',
-    description: 'NVIDIA (US) — multimodal (text/image/video/audio in)',
+    id: 'gemma3',
+    description: 'Google (US) — product default; 270m fits 4GB WSL',
   },
   {
     id: 'gemma4',
     description: 'Google (US) — general + vision + tools',
   },
   {
-    id: 'gemma3',
-    description: 'Google (US) — general + vision; prefer 270m on low-RAM hosts',
+    id: 'nemotron-3-nano',
+    description: 'NVIDIA (US) — heavy / capable hosts (set LLM_MODEL=nemotron-3-nano)',
+  },
+  {
+    id: 'nemotron-3-nano-omni',
+    description: 'NVIDIA (US) — multimodal (text/image/video/audio in)',
   },
 ] as const;
 
@@ -48,7 +50,7 @@ export const US_ORIGIN_INFERENCE_SNAP_IDS: readonly UsOriginInferenceSnapId[] =
   PRODUCT_INFERENCE_SNAP_CATALOG.map((entry) => entry.id);
 
 /** Default chat/embed model when none is specified (env factory / provider). */
-export const DEFAULT_US_ORIGIN_INFERENCE_SNAP: UsOriginInferenceSnapId = 'nemotron-3-nano';
+export const DEFAULT_US_ORIGIN_INFERENCE_SNAP: UsOriginInferenceSnapId = 'gemma3';
 
 /** Preferred snap on constrained hosts (profile `snaps` tier). */
 export const DEFAULT_LOW_RAM_INFERENCE_SNAP: UsOriginInferenceSnapId = 'gemma3';

--- a/packages/ai/src/tools/mcp-sampling.ts
+++ b/packages/ai/src/tools/mcp-sampling.ts
@@ -21,7 +21,7 @@
  *
  * const llm = new InferenceSnapsProvider({
  *   baseURL: 'http://localhost:9090/v1',
- *   model: 'nemotron-3-nano',
+ *   model: 'gemma3',
  * });
  *
  * const client = new McpClient({
@@ -29,8 +29,8 @@
  *   transport: { kind: 'streamable-http', url: 'https://example.com/mcp' },
  *   samplingHandler: createSamplingHandler({
  *     llm,
- *     defaultModel: 'nemotron-3-nano',
- *     allowedModels: ['nemotron-3-nano', 'gemma4', 'gemma3'],
+ *     defaultModel: 'gemma3',
+ *     allowedModels: ['gemma3', 'gemma4', 'nemotron-3-nano'],
  *   }),
  * });
  * await client.connect();

--- a/packages/ai/test-response-cache.ts
+++ b/packages/ai/test-response-cache.ts
@@ -19,7 +19,7 @@ async function testResponseCaching() {
   const client = new LLMClient({
     provider: 'inference-snaps',
     apiKey: 'inference-snaps',
-    model: process.env.LLM_MODEL || 'nemotron-3-nano',
+    model: process.env.LLM_MODEL || 'gemma3',
     baseURL: process.env.INFERENCE_SNAPS_BASE_URL,
     enableResponseCache: true,
     responseCacheOptions: {

--- a/packages/ai/test-semantic-cache.ts
+++ b/packages/ai/test-semantic-cache.ts
@@ -18,7 +18,7 @@ async function testSemanticCaching() {
   const client = new LLMClient({
     provider: 'inference-snaps',
     apiKey: 'inference-snaps',
-    model: process.env.LLM_MODEL || 'nemotron-3-nano',
+    model: process.env.LLM_MODEL || 'gemma3',
     baseURL: process.env.INFERENCE_SNAPS_BASE_URL,
     enableSemanticCache: true,
     semanticCacheOptions: {

--- a/packages/harnesses/src/__tests__/inference-service-snaps.test.ts
+++ b/packages/harnesses/src/__tests__/inference-service-snaps.test.ts
@@ -26,8 +26,8 @@ describe('PRODUCT_INFERENCE_SNAPS', () => {
     }
   });
 
-  it('defaults product id remains nemotron-3-nano first', () => {
-    expect(PRODUCT_INFERENCE_SNAPS[0]?.[0]).toBe('nemotron-3-nano');
+  it('defaults product id remains gemma3 first', () => {
+    expect(PRODUCT_INFERENCE_SNAPS[0]?.[0]).toBe('gemma3');
   });
 
   it('lockstep with @revealui/ai PRODUCT_INFERENCE_SNAP_CATALOG ids', () => {

--- a/packages/harnesses/src/__tests__/skill-invoke.test.ts
+++ b/packages/harnesses/src/__tests__/skill-invoke.test.ts
@@ -51,7 +51,7 @@ describe('skill invoke (GAP-293 Phase C)', () => {
     expect('error' in result).toBe(false);
     if ('error' in result) return;
     expect(result.model).toBe(PHASE_C_INFERENCE_SNAP);
-    expect(result.model).toBe('nemotron-3-nano');
+    expect(result.model).toBe('gemma3');
     expect(result.system).toContain('# revealui-doctor body');
     expect(result.user).toContain('cannot execute tools');
   });

--- a/packages/harnesses/src/content/skill-invoke.ts
+++ b/packages/harnesses/src/content/skill-invoke.ts
@@ -1,7 +1,7 @@
 /**
  * GAP-293 Phase C — bind native workflow skills to the product default snap.
  *
- * Snap is not invented: `nemotron-3-nano` is DEFAULT_US_ORIGIN_INFERENCE_SNAP
+ * Snap is not invented: `gemma3` is DEFAULT_US_ORIGIN_INFERENCE_SNAP
  * in `@revealui/ai` (`providers/us-origin-snaps.ts`). This module only
  * prepares the invoke; it does not run tools or commit.
  */
@@ -18,7 +18,7 @@ export const NATIVE_WORKFLOW_SKILL_IDS = [
 export type NativeWorkflowSkillId = (typeof NATIVE_WORKFLOW_SKILL_IDS)[number];
 
 /** Product default Inference Snap (US-origin catalog). */
-export const PHASE_C_INFERENCE_SNAP = 'nemotron-3-nano';
+export const PHASE_C_INFERENCE_SNAP = 'gemma3';
 
 const ALIASES: Record<string, NativeWorkflowSkillId> = {
   doctor: 'revealui-doctor',
@@ -86,7 +86,7 @@ export function buildSkillInvokeRequest(
 }
 
 /**
- * OpenAI-compat completion text. US-origin snaps (nemotron-3-nano) put
+ * OpenAI-compat completion text. Some snaps (e.g. nemotron-3-nano) put
  * tokens in `reasoning_content` and leave `content` empty.
  */
 export function extractSkillInvokeText(payload: unknown): string {

--- a/packages/harnesses/src/server/inference-service.ts
+++ b/packages/harnesses/src/server/inference-service.ts
@@ -76,10 +76,10 @@ export interface LocalAiProfileView extends LocalAiProfile {
  * Lockstep with packages/ai PRODUCT_INFERENCE_SNAP_CATALOG.
  */
 export const PRODUCT_INFERENCE_SNAPS: ReadonlyArray<readonly [string, string]> = [
-  ['nemotron-3-nano', 'NVIDIA (US) — general + tools; product default on capable hosts'],
-  ['nemotron-3-nano-omni', 'NVIDIA (US) — multimodal (text/image/video/audio in)'],
+  ['gemma3', 'Google (US) — product default; 270m fits 4GB WSL'],
   ['gemma4', 'Google (US) — general + vision + tools'],
-  ['gemma3', 'Google (US) — general + vision; prefer 270m on low-RAM hosts'],
+  ['nemotron-3-nano', 'NVIDIA (US) — heavy / capable hosts (set LLM_MODEL=nemotron-3-nano)'],
+  ['nemotron-3-nano-omni', 'NVIDIA (US) — multimodal (text/image/video/audio in)'],
 ] as const;
 
 const KNOWN_SNAPS = PRODUCT_INFERENCE_SNAPS;


### PR DESCRIPTION
## Summary

Product default Inference Snap is now `gemma3`. Canonical's catalog marks **only Gemma 3** as supported on WSL 2 ([Available snaps](https://documentation.ubuntu.com/inference-snaps/reference/snaps/)). This 4GB WSL host cannot run 31B Nemotron.

Nemotron stays on the US-origin allowlist for the heavy profile (`LLM_MODEL=nemotron-3-nano`). Do not treat this as a silent workaround: it is the named product-default flip (owner option 2).

Did **not** add `nemotron-3.5-lightning` or `nomic-embed-text-v1-5`. Packaging is not origin; allowlist stays US-origin weights only.

SSOT: `DEFAULT_US_ORIGIN_INFERENCE_SNAP = 'gemma3'` in `@revealui/ai`. Catalog order puts gemma3 first. `PHASE_C_INFERENCE_SNAP` and harnesses `InferenceService` follow. Heavy profile remains `nemotron-3-nano`.

Companions:
- revdev#399 (daemon `skills.invoke` bind)
- jv#1321 (ADR Q2)

## After merge (operator)

Two snaps cannot share `:9090`. Point the product default at gemma3:

```
sudo snap set gemma3 http.port=9090 --assume-yes
```

Then live doctor / Phase C generate.

## Review

Touches `@revealui/harnesses` skill invoke + inference catalog. Treat as harnesses/security-classed: **do not merge until a non-author guardrail-2 verdict lands** (`sec-review:approved`).

## Test plan

- [x] `pnpm validate:claims-evidence` (1427 claims matched)
- [x] `pnpm validate:claims` (0 mismatches)
- [x] Phase 1 CI gate on push (PASS)
- [ ] CI on this PR
- [ ] After land: gemma3 on :9090 + live `skills.invoke` doctor

GAP-293. Does not close GAP-300 / 360 / 260 / 479.