### PR TITLE
fix(presentation): AA contrast on VerdictChip (unblock promote e2e)

### DIFF
--- a/packages/presentation/src/__tests__/components/verdict-chip.test.tsx
+++ b/packages/presentation/src/__tests__/components/verdict-chip.test.tsx
@@ -19,10 +19,10 @@ describe('VerdictChip', () => {
 
   it('maps each verdict to its semantic --rvui-* token classes', () => {
     const cases: Array<[Parameters<typeof VerdictChip>[0]['verdict'], string]> = [
-      ['approve', 'text-[var(--rvui-success)]'],
-      ['request-changes', 'text-[var(--rvui-error)]'],
-      ['hold', 'text-[var(--rvui-warning)]'],
-      ['pending', 'text-[var(--rvui-text-2)]'],
+      ['approve', 'text-[var(--rvui-success-text)]'],
+      ['request-changes', 'text-[var(--rvui-error-text)]'],
+      ['hold', 'text-[var(--rvui-warning-text)]'],
+      ['pending', 'text-[var(--rvui-text-1)]'],
     ];
     for (const [verdict, token] of cases) {
       const { unmount } = render(<VerdictChip verdict={verdict} />);

--- a/packages/presentation/src/components/verdict-chip.tsx
+++ b/packages/presentation/src/components/verdict-chip.tsx
@@ -10,22 +10,24 @@ interface VerdictMeta {
   classes: string;
 }
 
+// Text tokens are AA-safe on the matching subtle fills (fill tokens alone
+// fail small-text contrast — see Button solid/outline warning path).
 const verdictMeta: Record<Verdict, VerdictMeta> = {
   approve: {
     word: 'Approved',
-    classes: 'bg-[var(--rvui-success-subtle)] text-[var(--rvui-success)]',
+    classes: 'bg-[var(--rvui-success-subtle)] text-[var(--rvui-success-text)]',
   },
   'request-changes': {
     word: 'Changes requested',
-    classes: 'bg-[var(--rvui-error-subtle)] text-[var(--rvui-error)]',
+    classes: 'bg-[var(--rvui-error-subtle)] text-[var(--rvui-error-text)]',
   },
   hold: {
     word: 'On hold',
-    classes: 'bg-[var(--rvui-warning-subtle)] text-[var(--rvui-warning)]',
+    classes: 'bg-[var(--rvui-warning-subtle)] text-[var(--rvui-warning-text)]',
   },
   pending: {
     word: 'Pending',
-    classes: 'bg-[var(--rvui-surface-2)] text-[var(--rvui-text-2)]',
+    classes: 'bg-[var(--rvui-surface-2)] text-[var(--rvui-text-1)]',
   },
 };
 


### PR DESCRIPTION
## Summary

Promote PR #2607 failed E2E a11y on marketing homepage:

- VerdictChip `hold` used `text-[var(--rvui-warning)]` on `warning-subtle` → **2.83:1** (need 4.5:1)

Fix: use `--rvui-*-text` tokens for all verdicts (same as Button). Pending uses `text-1`.

Unblocks test→main promote after this lands on `test` (head of #2607 auto-updates).

## Test plan
- [x] Unit test class expectations updated
- [x] pre-push phase-1
- [ ] CI green; re-check #2607 E2E after merge to test