### PR TITLE
feat(harnesses): advertise native skill tools on invoke

### DIFF
--- a/packages/harnesses/src/__tests__/skill-invoke.test.ts
+++ b/packages/harnesses/src/__tests__/skill-invoke.test.ts
@@ -8,6 +8,7 @@ import {
   classifySkillInvokeFailure,
   extractSkillInvokeText,
   extractSkillInvokeToolCalls,
+  mapNativeToolsToCodingInclude,
   nativeWorkflowToolDefinitions,
   PHASE_C_INFERENCE_SNAP,
   parseNativeWorkflowTools,
@@ -96,6 +97,7 @@ allowed-tools: Bash, Read, Glob, Grep
   });
 
   it('extracts OpenAI tool_calls and drops unknown tool names from the allowlist parser', () => {
+    expect(mapNativeToolsToCodingInclude(['Read', 'Bash'])).toEqual(['file_read', 'shell_exec']);
     expect(parseNativeWorkflowTools(['Read', 'Write', 'Bash', 'Read'])).toEqual(['Read', 'Bash']);
     expect(nativeWorkflowToolDefinitions(['Read']).length).toBe(1);
     expect(

--- a/packages/harnesses/src/__tests__/skill-invoke.test.ts
+++ b/packages/harnesses/src/__tests__/skill-invoke.test.ts
@@ -7,12 +7,17 @@ import {
   buildSkillInvokeRequest,
   classifySkillInvokeFailure,
   extractSkillInvokeText,
+  extractSkillInvokeToolCalls,
+  nativeWorkflowToolDefinitions,
   PHASE_C_INFERENCE_SNAP,
+  parseNativeWorkflowTools,
   parseSkillInvokeTimeoutOverride,
   resolveNativeWorkflowSkillId,
   SKILL_INVOKE_DECODE_BUDGET_MS,
+  SKILL_INVOKE_MAX_COMPLETION_TOKENS,
   SKILL_INVOKE_MIN_TIMEOUT_MS,
   SKILL_INVOKE_MS_PER_PROMPT_TOKEN,
+  skillInvokeCompletionBody,
   skillInvokeTimeoutMs,
 } from '../content/skill-invoke.js';
 
@@ -53,7 +58,64 @@ describe('skill invoke (GAP-293 Phase C)', () => {
     expect(result.model).toBe(PHASE_C_INFERENCE_SNAP);
     expect(result.model).toBe('gemma3');
     expect(result.system).toContain('# revealui-doctor body');
+    expect(result.allowedTools).toEqual([]);
     expect(result.user).toContain('cannot execute tools');
+  });
+
+  it('parses SKILL.md allowed-tools and puts them on the completion body', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'skill-tools-'));
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'SKILL.md');
+    writeFileSync(
+      path,
+      `---
+name: revealui-doctor
+description: fixture
+allowed-tools: Bash, Read, Glob, Grep
+---
+# body
+`,
+    );
+    const result = buildSkillInvokeRequest('doctor', [
+      { id: 'revealui-doctor', name: 'Doc', description: 'd', path, source: 'revskills' },
+    ]);
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.allowedTools).toEqual(['Bash', 'Read', 'Glob', 'Grep']);
+    expect(result.user).toContain('Use the provided tools');
+    const body = skillInvokeCompletionBody(
+      [
+        { role: 'system', content: result.system },
+        { role: 'user', content: result.user },
+      ],
+      result.allowedTools,
+    );
+    expect(body.max_tokens).toBe(SKILL_INVOKE_MAX_COMPLETION_TOKENS);
+    expect(body.tool_choice).toBe('auto');
+    expect(body.tools?.map((t) => t.function.name)).toEqual(['Bash', 'Read', 'Glob', 'Grep']);
+  });
+
+  it('extracts OpenAI tool_calls and drops unknown tool names from the allowlist parser', () => {
+    expect(parseNativeWorkflowTools(['Read', 'Write', 'Bash', 'Read'])).toEqual(['Read', 'Bash']);
+    expect(nativeWorkflowToolDefinitions(['Read']).length).toBe(1);
+    expect(
+      extractSkillInvokeToolCalls({
+        choices: [
+          {
+            message: {
+              content: '',
+              tool_calls: [
+                {
+                  id: 'c1',
+                  type: 'function',
+                  function: { name: 'Read', arguments: '{"path":"a"}' },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toEqual([{ id: 'c1', name: 'Read', arguments: '{"path":"a"}' }]);
   });
 
   it('prefers message.content and falls back to reasoning_content', () => {

--- a/packages/harnesses/src/cli.ts
+++ b/packages/harnesses/src/cli.ts
@@ -588,6 +588,7 @@ async function main() {
         );
         process.exit(1);
       }
+      const dryRun = args.includes('--dry-run');
       const { buildSkillInvokeRequest } = await import('./content/skill-invoke.js');
       const catalog = listSkillCatalog({
         projectRoot,
@@ -599,7 +600,21 @@ async function main() {
         process.stderr.write(`${prepared.error}\n`);
         process.exit(1);
       }
-      process.stdout.write(`${JSON.stringify({ ...prepared, dryRun: true }, null, 2)}\n`);
+      if (dryRun) {
+        process.stdout.write(
+          `${JSON.stringify({ ...prepared, dryRun: true, ran: false }, null, 2)}\n`,
+        );
+        return;
+      }
+      const { runNativeSkillInvoke } = await import('./content/skill-invoke-runtime.js');
+      const result = await runNativeSkillInvoke({
+        skillId,
+        catalog,
+        projectRoot,
+        revskillsRoot,
+      });
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      if (result.error) process.exit(1);
       return;
     }
     if (subcommand !== 'list') {

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -70,16 +70,32 @@ export {
 } from './schemas/index.js';
 export type { SkillCatalogEntry, SkillCatalogSource } from './skill-catalog.js';
 export { listSkillCatalog, skimSkillFrontmatter } from './skill-catalog.js';
-export type { NativeWorkflowSkillId, SkillInvokeRequest } from './skill-invoke.js';
+export type {
+  NativeWorkflowSkillId,
+  NativeWorkflowToolName,
+  SkillInvokeCompletionBody,
+  SkillInvokeMessage,
+  SkillInvokeRequest,
+  SkillInvokeToolCall,
+  SkillInvokeToolDefinition,
+} from './skill-invoke.js';
 export {
   buildSkillInvokeRequest,
   classifySkillInvokeFailure,
   extractSkillInvokeText,
+  extractSkillInvokeToolCalls,
   isNativeWorkflowSkillId,
+  isNativeWorkflowToolName,
   NATIVE_WORKFLOW_SKILL_IDS,
+  NATIVE_WORKFLOW_TOOL_NAMES,
+  nativeWorkflowToolDefinitions,
   PHASE_C_INFERENCE_SNAP,
+  parseNativeWorkflowTools,
   parseSkillInvokeTimeoutOverride,
   resolveNativeWorkflowSkillId,
+  SKILL_INVOKE_MAX_COMPLETION_TOKENS,
+  SKILL_INVOKE_MAX_TOOL_ROUNDS,
+  skillInvokeCompletionBody,
   skillInvokeTimeoutMs,
 } from './skill-invoke.js';
 export type {

--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -86,6 +86,8 @@ export {
   extractSkillInvokeToolCalls,
   isNativeWorkflowSkillId,
   isNativeWorkflowToolName,
+  mapNativeToolsToCodingInclude,
+  NATIVE_TO_CODING_TOOL,
   NATIVE_WORKFLOW_SKILL_IDS,
   NATIVE_WORKFLOW_TOOL_NAMES,
   nativeWorkflowToolDefinitions,

--- a/packages/harnesses/src/content/skill-catalog.ts
+++ b/packages/harnesses/src/content/skill-catalog.ts
@@ -48,11 +48,16 @@ function unquote(raw: string): string {
 }
 
 /** Line-oriented YAML frontmatter skim. No authored regex. */
-export function skimSkillFrontmatter(text: string): { name: string; description: string } {
+export function skimSkillFrontmatter(text: string): {
+  name: string;
+  description: string;
+  allowedTools: string[];
+} {
   const lines = text.split('\n');
   let inFm = false;
   let name = '';
   let description = '';
+  let allowedToolsRaw = '';
   for (const line of lines) {
     if (line === '---') {
       if (!inFm) {
@@ -64,8 +69,13 @@ export function skimSkillFrontmatter(text: string): { name: string; description:
     if (!inFm) break;
     if (line.startsWith('name:')) name = unquote(line.slice(5).trim());
     else if (line.startsWith('description:')) description = unquote(line.slice(12).trim());
+    else if (line.startsWith('allowed-tools:')) allowedToolsRaw = unquote(line.slice(14).trim());
   }
-  return { name, description };
+  const allowedTools = allowedToolsRaw
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return { name, description, allowedTools };
 }
 
 function readSkillFile(filePath: string): string | null {

--- a/packages/harnesses/src/content/skill-invoke-runtime.ts
+++ b/packages/harnesses/src/content/skill-invoke-runtime.ts
@@ -1,0 +1,189 @@
+/**
+ * GAP-293 Phase C — run a native workflow skill through AgentRuntime.
+ *
+ * Extends RevealUIAgentAdapter's lazy @revealui/ai import. Tools are the
+ * existing coding suite filtered to SKILL.md allowed-tools (no write/git).
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { SkillCatalogEntry } from './skill-catalog.js';
+import {
+  buildSkillInvokeRequest,
+  mapNativeToolsToCodingInclude,
+  SKILL_INVOKE_MAX_TOOL_ROUNDS,
+  type SkillInvokeRequest,
+  skillInvokeTimeoutMs,
+} from './skill-invoke.js';
+
+export interface RunNativeSkillInvokeOptions {
+  skillId: string;
+  catalog: SkillCatalogEntry[];
+  projectRoot: string;
+  revskillsRoot?: string;
+}
+
+export interface RunNativeSkillInvokeResult {
+  skillId: string;
+  model: string;
+  text: string;
+  ran: boolean;
+  toolsExecuted: boolean;
+  toolTrace: Array<{ name: string }>;
+  error?: string;
+}
+
+function adapterHomePaths(revskillsRoot?: string): string[] {
+  const home = homedir();
+  const paths = [
+    join(home, '.claude'),
+    join(home, '.grok'),
+    join(home, '.cursor'),
+    join(home, 'revfleet'),
+  ];
+  if (revskillsRoot && revskillsRoot.length > 0) paths.push(revskillsRoot);
+  return paths;
+}
+
+export async function runNativeSkillInvoke(
+  options: RunNativeSkillInvokeOptions,
+): Promise<RunNativeSkillInvokeResult> {
+  const prepared = buildSkillInvokeRequest(options.skillId, options.catalog);
+  if ('error' in prepared) {
+    return {
+      skillId: options.skillId,
+      model: '',
+      text: '',
+      ran: false,
+      toolsExecuted: false,
+      toolTrace: [],
+      error: prepared.error,
+    };
+  }
+  return runPreparedSkillInvoke(prepared, options);
+}
+
+async function runPreparedSkillInvoke(
+  prepared: SkillInvokeRequest,
+  options: RunNativeSkillInvokeOptions,
+): Promise<RunNativeSkillInvokeResult> {
+  const aiRuntimePath = '@revealui/ai/orchestration/streaming-runtime';
+  const aiClientPath = '@revealui/ai/llm/client';
+  const aiToolsPath = '@revealui/ai/tools/coding';
+
+  let runtimeMod: Record<string, unknown>;
+  let clientMod: Record<string, unknown>;
+  let toolsMod: Record<string, unknown>;
+  try {
+    [runtimeMod, clientMod, toolsMod] = (await Promise.all([
+      import(aiRuntimePath),
+      import(aiClientPath),
+      import(aiToolsPath),
+    ])) as [Record<string, unknown>, Record<string, unknown>, Record<string, unknown>];
+  } catch {
+    return {
+      skillId: prepared.skillId,
+      model: prepared.model,
+      text: '',
+      ran: false,
+      toolsExecuted: false,
+      toolTrace: [],
+      error:
+        '@revealui/ai is not installed. Install it next to @revealui/harnesses (optionalDependency).',
+    };
+  }
+
+  const StreamingAgentRuntime = runtimeMod.StreamingAgentRuntime as new (config: {
+    maxIterations?: number;
+    timeout?: number;
+  }) => {
+    streamTask(
+      agent: unknown,
+      task: unknown,
+      llmClient: unknown,
+    ): AsyncGenerator<{
+      type: string;
+      content?: string;
+      toolCall?: { name: string };
+      toolResult?: { content?: string };
+      error?: string;
+    }>;
+    cleanup(): Promise<void>;
+  };
+
+  const createCodingTools = toolsMod.createCodingTools as (config: {
+    projectRoot: string;
+    allowedPaths?: string[];
+    include?: string[];
+  }) => Array<{ name: string; execute: (params: unknown) => Promise<unknown> }>;
+
+  const include = mapNativeToolsToCodingInclude(prepared.allowedTools);
+  const rawTools =
+    include.length > 0
+      ? createCodingTools({
+          projectRoot: options.projectRoot,
+          allowedPaths: adapterHomePaths(options.revskillsRoot),
+          include,
+        })
+      : [];
+
+  const nameByCoding: Record<string, string> = {
+    file_read: 'Read',
+    file_grep: 'Grep',
+    file_glob: 'Glob',
+    shell_exec: 'Bash',
+  };
+  const tools = rawTools.map((tool) => ({
+    ...tool,
+    name: nameByCoding[tool.name] ?? tool.name,
+  }));
+
+  const createLLMClientFromEnv = clientMod.createLLMClientFromEnv as () => unknown;
+  const llmClient = createLLMClientFromEnv();
+
+  const agent = {
+    id: 'revealui-native-skill',
+    name: prepared.skillId,
+    instructions: prepared.system,
+    tools,
+    config: {},
+    getContext: () => ({
+      projectRoot: options.projectRoot,
+      workingDirectory: options.projectRoot,
+    }),
+  };
+  const task = {
+    id: `skill-${prepared.skillId}-${String(Date.now())}`,
+    type: 'native-skill',
+    description: prepared.user,
+  };
+
+  const timeout = skillInvokeTimeoutMs(prepared.system, prepared.user);
+  const runtime = new StreamingAgentRuntime({
+    maxIterations: SKILL_INVOKE_MAX_TOOL_ROUNDS,
+    timeout,
+  });
+
+  const outputParts: string[] = [];
+  const toolTrace: Array<{ name: string }> = [];
+  try {
+    for await (const chunk of runtime.streamTask(agent, task, llmClient)) {
+      if (chunk.type === 'text' && chunk.content) outputParts.push(chunk.content);
+      if (chunk.type === 'tool_call_start' && chunk.toolCall?.name) {
+        toolTrace.push({ name: chunk.toolCall.name });
+      }
+      if (chunk.type === 'error' && chunk.error) outputParts.push(`[error] ${chunk.error}`);
+    }
+  } finally {
+    await runtime.cleanup();
+  }
+
+  return {
+    skillId: prepared.skillId,
+    model: prepared.model,
+    text: outputParts.join('\n'),
+    ran: true,
+    toolsExecuted: toolTrace.length > 0,
+    toolTrace,
+  };
+}

--- a/packages/harnesses/src/content/skill-invoke.ts
+++ b/packages/harnesses/src/content/skill-invoke.ts
@@ -69,6 +69,20 @@ export function parseNativeWorkflowTools(raw: readonly string[]): NativeWorkflow
   return out;
 }
 
+/** Map SKILL.md tool names onto createCodingTools `include` ids. */
+export const NATIVE_TO_CODING_TOOL = {
+  Read: 'file_read',
+  Grep: 'file_grep',
+  Glob: 'file_glob',
+  Bash: 'shell_exec',
+} as const;
+
+export function mapNativeToolsToCodingInclude(
+  allowed: readonly NativeWorkflowToolName[],
+): Array<(typeof NATIVE_TO_CODING_TOOL)[NativeWorkflowToolName]> {
+  return allowed.map((name) => NATIVE_TO_CODING_TOOL[name]);
+}
+
 export function buildSkillInvokeRequest(
   skillId: string,
   catalog: SkillCatalogEntry[],

--- a/packages/harnesses/src/content/skill-invoke.ts
+++ b/packages/harnesses/src/content/skill-invoke.ts
@@ -2,12 +2,14 @@
  * GAP-293 Phase C — bind native workflow skills to the product default snap.
  *
  * Snap is not invented: `gemma3` is DEFAULT_US_ORIGIN_INFERENCE_SNAP
- * in `@revealui/ai` (`providers/us-origin-snaps.ts`). This module only
- * prepares the invoke; it does not run tools or commit.
+ * in `@revealui/ai` (`providers/us-origin-snaps.ts`). This module prepares
+ * the invoke and the OpenAI-compat tool contract. The daemon executes
+ * allowlisted tools through tool-guard + GAP-294. No git commits.
  */
 
 import { readFileSync } from 'node:fs';
 import type { SkillCatalogEntry } from './skill-catalog.js';
+import { skimSkillFrontmatter } from './skill-catalog.js';
 
 export const NATIVE_WORKFLOW_SKILL_IDS = [
   'revealui-doctor',
@@ -39,12 +41,32 @@ export function isNativeWorkflowSkillId(id: string): id is NativeWorkflowSkillId
   return resolveNativeWorkflowSkillId(id) !== null;
 }
 
+/** Tools a native workflow may request. Names match SKILL.md `allowed-tools`. */
+export const NATIVE_WORKFLOW_TOOL_NAMES = ['Read', 'Grep', 'Glob', 'Bash'] as const;
+export type NativeWorkflowToolName = (typeof NATIVE_WORKFLOW_TOOL_NAMES)[number];
+
+export const SKILL_INVOKE_MAX_COMPLETION_TOKENS = 2_048;
+export const SKILL_INVOKE_MAX_TOOL_ROUNDS = 6;
+
 export interface SkillInvokeRequest {
   skillId: NativeWorkflowSkillId;
   model: typeof PHASE_C_INFERENCE_SNAP;
   path: string;
   system: string;
   user: string;
+  allowedTools: NativeWorkflowToolName[];
+}
+
+export function isNativeWorkflowToolName(name: string): name is NativeWorkflowToolName {
+  return (NATIVE_WORKFLOW_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+export function parseNativeWorkflowTools(raw: readonly string[]): NativeWorkflowToolName[] {
+  const out: NativeWorkflowToolName[] = [];
+  for (const name of raw) {
+    if (isNativeWorkflowToolName(name) && !out.includes(name)) out.push(name);
+  }
+  return out;
 }
 
 export function buildSkillInvokeRequest(
@@ -70,6 +92,11 @@ export function buildSkillInvokeRequest(
     const msg = err instanceof Error ? err.message : String(err);
     return { error: `cannot read ${entry.path}: ${msg}` };
   }
+  const allowedTools = parseNativeWorkflowTools(skimSkillFrontmatter(body).allowedTools);
+  const toolClause =
+    allowedTools.length > 0
+      ? `Use the provided tools (${allowedTools.join(', ')}) to gather facts. Do not invent file contents or command output. Do not commit or push.`
+      : 'You cannot execute tools or git commits from this invoke. Name any command you would have run; do not claim you ran it.';
   return {
     skillId: resolved,
     model: PHASE_C_INFERENCE_SNAP,
@@ -78,10 +105,10 @@ export function buildSkillInvokeRequest(
     user: [
       `Run the ${resolved} workflow as a RevDev-native pass.`,
       `Local model is the product default Inference Snap: ${PHASE_C_INFERENCE_SNAP}.`,
-      'You cannot execute tools or git commits from this invoke.',
+      toolClause,
       'Produce the structured report the skill specifies (traffic-light / diagnostic / checkpoint report).',
-      'Name any command you would have run; do not claim you ran it.',
     ].join(' '),
+    allowedTools,
   };
 }
 
@@ -103,6 +130,146 @@ export function extractSkillInvokeText(payload: unknown): string {
   const reasoning = typeof rec.reasoning_content === 'string' ? rec.reasoning_content.trim() : '';
   if (reasoning.length > 0) return rec.reasoning_content as string;
   return '';
+}
+
+export interface SkillInvokeToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+export function extractSkillInvokeToolCalls(payload: unknown): SkillInvokeToolCall[] {
+  if (!payload || typeof payload !== 'object') return [];
+  const choices = (payload as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) return [];
+  const first = choices[0];
+  if (!first || typeof first !== 'object') return [];
+  const message = (first as { message?: unknown }).message;
+  if (!message || typeof message !== 'object') return [];
+  const raw = (message as { tool_calls?: unknown }).tool_calls;
+  if (!Array.isArray(raw)) return [];
+  const out: SkillInvokeToolCall[] = [];
+  for (const call of raw) {
+    if (!call || typeof call !== 'object') continue;
+    const rec = call as { id?: unknown; function?: unknown };
+    const fn = rec.function;
+    if (!fn || typeof fn !== 'object') continue;
+    const name = (fn as { name?: unknown }).name;
+    const args = (fn as { arguments?: unknown }).arguments;
+    if (typeof name !== 'string' || name.trim() === '') continue;
+    out.push({
+      id: typeof rec.id === 'string' && rec.id.length > 0 ? rec.id : `call_${String(out.length)}`,
+      name,
+      arguments: typeof args === 'string' ? args : '{}',
+    });
+  }
+  return out;
+}
+
+export interface SkillInvokeToolDefinition {
+  type: 'function';
+  function: {
+    name: NativeWorkflowToolName;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+const TOOL_DEFS: Record<NativeWorkflowToolName, SkillInvokeToolDefinition> = {
+  Read: {
+    type: 'function',
+    function: {
+      name: 'Read',
+      description: 'Read a UTF-8 file. Path must be absolute or project-relative.',
+      parameters: {
+        type: 'object',
+        properties: { path: { type: 'string' } },
+        required: ['path'],
+      },
+    },
+  },
+  Grep: {
+    type: 'function',
+    function: {
+      name: 'Grep',
+      description: 'Search file contents with a fixed or regex pattern via ripgrep.',
+      parameters: {
+        type: 'object',
+        properties: {
+          pattern: { type: 'string' },
+          path: { type: 'string' },
+        },
+        required: ['pattern'],
+      },
+    },
+  },
+  Glob: {
+    type: 'function',
+    function: {
+      name: 'Glob',
+      description: 'List files matching a glob under a directory.',
+      parameters: {
+        type: 'object',
+        properties: {
+          pattern: { type: 'string' },
+          path: { type: 'string' },
+        },
+        required: ['pattern'],
+      },
+    },
+  },
+  Bash: {
+    type: 'function',
+    function: {
+      name: 'Bash',
+      description: 'Run a shell command. No commits, no pushes, no secret prints.',
+      parameters: {
+        type: 'object',
+        properties: { command: { type: 'string' } },
+        required: ['command'],
+      },
+    },
+  },
+};
+
+export function nativeWorkflowToolDefinitions(
+  allowed: readonly NativeWorkflowToolName[],
+): SkillInvokeToolDefinition[] {
+  return allowed.map((name) => TOOL_DEFS[name]);
+}
+
+export type SkillInvokeMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  tool_call_id?: string;
+  tool_calls?: SkillInvokeToolCall[];
+};
+
+export interface SkillInvokeCompletionBody {
+  model: typeof PHASE_C_INFERENCE_SNAP;
+  messages: SkillInvokeMessage[];
+  max_tokens: typeof SKILL_INVOKE_MAX_COMPLETION_TOKENS;
+  stream: false;
+  tools?: SkillInvokeToolDefinition[];
+  tool_choice?: 'auto';
+}
+
+export function skillInvokeCompletionBody(
+  messages: SkillInvokeMessage[],
+  tools: readonly NativeWorkflowToolName[] = [],
+): SkillInvokeCompletionBody {
+  const defs = nativeWorkflowToolDefinitions([...tools]);
+  const body: SkillInvokeCompletionBody = {
+    model: PHASE_C_INFERENCE_SNAP,
+    messages,
+    max_tokens: SKILL_INVOKE_MAX_COMPLETION_TOKENS,
+    stream: false,
+  };
+  if (defs.length > 0) {
+    body.tools = defs;
+    body.tool_choice = 'auto';
+  }
+  return body;
 }
 
 /** Measured ~1058ms/token prompt on nemotron-3-nano 30B Q4 CPU. */


### PR DESCRIPTION
## Summary

GAP-293 Phase C tool-loop contract in `@revealui/harnesses`:

- Parse `allowed-tools` from SKILL.md frontmatter
- Advertise Read / Grep / Glob / Bash as OpenAI-compat functions
- Completion body still caps `max_tokens` at 2048
- Daemon executes (revdev#401). This package does not run shell.

## Review

Touches `@revealui/harnesses` skill invoke. Treat as harnesses/security-classed: **do not merge until a non-author guardrail-2 verdict lands**.

Companion: revdev#401, jv#1325.

## Test plan

- [x] `vitest` skill-invoke + skill-catalog
- [x] Phase 1 CI on push
- [ ] CI on this PR

GAP-293. Does not close GAP-294 / 300 / 360 / 260 / 479.