### PR TITLE
feat(harnesses): export runNativeSkillInvoke from content

### DIFF
--- a/packages/harnesses/src/content/index.ts
+++ b/packages/harnesses/src/content/index.ts
@@ -101,6 +101,11 @@ export {
   skillInvokeTimeoutMs,
 } from './skill-invoke.js';
 export type {
+  RunNativeSkillInvokeOptions,
+  RunNativeSkillInvokeResult,
+} from './skill-invoke-runtime.js';
+export { runNativeSkillInvoke } from './skill-invoke-runtime.js';
+export type {
   ContentSnapshot,
   ContentSnapshotFile,
   SnapshotCheckResult,


### PR DESCRIPTION
## Summary

Export `runNativeSkillInvoke` from `@revealui/harnesses/content` so the AgentRuntime native-skill loop is a public SSOT. Companion revdev#402 switches the daemon RPC onto that loop class.

## Review

Harnesses export. Treat as review-pending with revdev#402.

GAP-293.