### PR TITLE
fix(deploy): stop repo-root Vercel looking for public/

### DIFF
--- a/.claude/skills/revealui-deploy/SKILL.md
+++ b/.claude/skills/revealui-deploy/SKILL.md
@@ -147,6 +147,14 @@ Non-production deploys need the `vercel alias` step. Check that:
 - `--scope` uses the correct org ID
 - The domain is configured in the Vercel project's domain settings
 
+### "No Output Directory named public"
+
+A Vercel Git Integration project is pointed at the **repo root** (dashboard Output Directory still `public`). Official apps live under `apps/*/vercel.json` and emit `dist` (or Next.js output). Production deploys are GitHub Actions only.
+
+The repo-root `vercel.json` sets `github.enabled: false` so that stray project does not deploy, and `outputDirectory` to `apps/marketing/dist` if it still builds.
+
+Also disconnect Git on the extra project: Vercel → Project → Settings → Git → Disconnect. The four production projects must keep Root Directory `apps/marketing`, `apps/docs`, `apps/admin`, or `apps/server`.
+
 ## Manual Deploy (emergency)
 
 ```bash
@@ -167,7 +175,8 @@ VERCEL_PROJECT_ID=prj_XXX vercel deploy --prebuilt --prod --token='TOKEN'
 
 - `.github/workflows/deploy.yml` — deploy workflow
 - `.github/workflows/ci.yml` — CI checks (must pass before deploy)
-- `apps/*/vercel.json` — per-app Vercel configuration (if any)
+- `apps/*/vercel.json` — per-app Vercel configuration
+- `vercel.json` — repo-root guard: disable Git Integration on a root-linked project; marketing `dist` if one still builds
 
 ## Rules
 

--- a/.claude/skills/revealui-deploy/SKILL.md
+++ b/.claude/skills/revealui-deploy/SKILL.md
@@ -147,14 +147,6 @@ Non-production deploys need the `vercel alias` step. Check that:
 - `--scope` uses the correct org ID
 - The domain is configured in the Vercel project's domain settings
 
-### "No Output Directory named public"
-
-A Vercel Git Integration project is pointed at the **repo root** (dashboard Output Directory still `public`). Official apps live under `apps/*/vercel.json` and emit `dist` (or Next.js output). Production deploys are GitHub Actions only.
-
-The repo-root `vercel.json` sets `github.enabled: false` so that stray project does not deploy, and `outputDirectory` to `apps/marketing/dist` if it still builds.
-
-Also disconnect Git on the extra project: Vercel → Project → Settings → Git → Disconnect. The four production projects must keep Root Directory `apps/marketing`, `apps/docs`, `apps/admin`, or `apps/server`.
-
 ## Manual Deploy (emergency)
 
 ```bash
@@ -175,8 +167,7 @@ VERCEL_PROJECT_ID=prj_XXX vercel deploy --prebuilt --prod --token='TOKEN'
 
 - `.github/workflows/deploy.yml` — deploy workflow
 - `.github/workflows/ci.yml` — CI checks (must pass before deploy)
-- `apps/*/vercel.json` — per-app Vercel configuration
-- `vercel.json` — repo-root guard: disable Git Integration on a root-linked project; marketing `dist` if one still builds
+- `apps/*/vercel.json` — per-app Vercel configuration (if any)
 
 ## Rules
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "github": {
+    "enabled": false,
+    "silent": true
+  },
+  "framework": "vite",
+  "buildCommand": "pnpm turbo build --filter=marketing",
+  "outputDirectory": "apps/marketing/dist"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
-  "github": {
-    "enabled": false,
-    "silent": true
-  },
-  "framework": "vite",
-  "buildCommand": "pnpm turbo build --filter=marketing",
-  "outputDirectory": "apps/marketing/dist"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
 }


### PR DESCRIPTION
## Summary

A stray Hobby Git Integration project named `revealui` is linked to this repo at the **root**. Official production deploys are GitHub Actions into four other projects (`revealui-marketing`, `revealui-docs`, `revealui-admin`, `revealui-api`) with Root Directory `apps/*`.

Repo-root `vercel.json` now uses the current Vercel setting:

```json
{
  "git": {
    "deploymentEnabled": false
  }
}
```

That is the official replacement for deprecated `github.enabled: false` ([Git configuration](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled)). A root `vercel.json` also stops the documented default: package.json + no `api/` + no vercel.json expects a `public/` output ([Error list: Missing public directory](https://vercel.com/docs/errors/error-list)).

Per-app `apps/*/vercel.json` is unchanged.

## Live dashboard (2026-08-13)

- Stray `revealui`: Git connected to `RevealUIStudio/revealui`, Root `.`, Framework Other, Ignored Build Step `exit 0` (last 50 deploys CANCELED), PR comments still on.
- Official four: Git **not** connected. Root Directory already `apps/marketing`, `apps/docs`, `apps/admin`, `apps/server`.

## Owner (dashboard)

Disconnect Git on the extra project: Vercel → project `revealui` → Settings → Git → Disconnect. Official docs: [Disconnect your Git repository](https://vercel.com/docs/project-configuration/git-settings#disconnect-your-git-repository).

Leave the four production projects Git-disconnected.

## Test plan

- [x] Root vercel.json uses `git.deploymentEnabled: false` (current docs)
- [x] Per-app vercel.json unchanged
- [ ] Quality (rules-lockstep) green after dropping the skill edit
- [ ] After merge, stray Git Integration should not create a real build

Not a GAP-293 change.