### PR TITLE
chore(deploy): lock Vercel dashboard to apps vercel.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Boundary validation (hard fail)
         run: pnpm validate:boundary
 
+      - name: Vercel project settings lockstep (files)
+        run: pnpm validate:vercel-settings
+
       - name: Incubate posture (ADR-007, hard fail)
         run: pnpm validate:incubate-posture
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,11 @@ jobs:
       - name: Install Vercel CLI
         run: pnpm add -g vercel@56.3.1
 
+      - name: Vercel project settings lockstep (live)
+        run: pnpm validate:vercel-settings -- --live
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
       - name: Resolve api project id from .github/vercel-projects.json
         run: echo "API_PROJECT_ID=$(jq -r '.api' .github/vercel-projects.json)" >> "$GITHUB_ENV"
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -93,15 +93,15 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 
 ### Build Configuration
 
-The admin app uses Next.js standalone output mode. Vercel detects the framework automatically. No custom build settings are needed beyond environment variables.
+Each official app has a `vercel.json` next to it (`apps/marketing`, `apps/docs`, `apps/admin`, `apps/server`). That file is the source of truth for Framework, Build Command, Output Directory, and Install Command. The Vercel dashboard must match it. Check or apply:
 
-The API app uses Hono and builds with tsup. Set the Vercel project framework to "Other" and configure:
+```bash
+pnpm validate:vercel-settings           # files only
+pnpm validate:vercel-settings -- --live # compare dashboard
+pnpm validate:vercel-settings -- --sync # write dashboard from vercel.json
+```
 
-| Setting | Value |
-|---------|-------|
-| Build Command | `pnpm build:api` |
-| Output Directory | `apps/server/dist` |
-| Install Command | `pnpm install` |
+Project ids live in `.github/vercel-projects.json`. Root Directory is `apps/<app>` (`apps/server` for api). Git Integration stays disconnected. The repo-root `vercel.json` only turns off Git auto-deploys if someone reconnects a root project.
 
 ### CI/CD Pipeline
 

--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
     "validate:kek-rotation": "vitest run scripts/security/__tests__/rotate-kek.test.ts",
     "validate:migrations": "tsx scripts/validate/migration-journal.ts",
     "validate:prod-env": "tsx scripts/validate/prod-env.ts",
+    "validate:vercel-settings": "tsx scripts/validate/vercel-project-settings.ts",
     "validate:raw-sql": "tsx scripts/validate/raw-sql.ts",
     "validate:seed-wiring": "tsx scripts/validate/seed-script-wiring.ts",
     "validate:stripe-client": "tsx scripts/validate/stripe-client.ts",

--- a/scripts/gates/ci-gate.ts
+++ b/scripts/gates/ci-gate.ts
@@ -295,6 +295,11 @@ async function gate(): Promise<void> {
         args: ['validate:boundary'],
       },
       {
+        name: 'Vercel project settings lockstep (files)',
+        command: 'pnpm',
+        args: ['validate:vercel-settings'],
+      },
+      {
         name: 'Version policy',
         command: 'pnpm',
         args: ['validate:versions'],

--- a/scripts/validate/__tests__/vercel-project-settings.test.ts
+++ b/scripts/validate/__tests__/vercel-project-settings.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertRootVercelJsonGuard,
+  diffProjectSettings,
+  expectedSettingsForApp,
+  liveFromApiBody,
+  loadExpectedSettings,
+  loadProjectIdMap,
+  OFFICIAL_APPS,
+  parseAppVercelJson,
+  patchBodyFromExpected,
+  REPO_ROOT,
+} from '../vercel-project-settings';
+
+describe('loadProjectIdMap', () => {
+  it('requires prj_ ids for the four official apps', () => {
+    const ids = loadProjectIdMap(
+      JSON.stringify({
+        api: 'prj_api',
+        admin: 'prj_admin',
+        marketing: 'prj_mkt',
+        docs: 'prj_docs',
+      }),
+    );
+    expect(ids.marketing).toBe('prj_mkt');
+  });
+
+  it('rejects a missing app', () => {
+    let message = '';
+    try {
+      loadProjectIdMap(JSON.stringify({ api: 'prj_api' }));
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message.includes('.github/vercel-projects.json')).toBe(true);
+  });
+});
+
+describe('parseAppVercelJson / expectedSettingsForApp', () => {
+  it('maps marketing vercel.json to dashboard fields', () => {
+    const spec = OFFICIAL_APPS.find((a) => a.app === 'marketing');
+    if (!spec) throw new Error('missing marketing spec');
+    const expected = expectedSettingsForApp(
+      spec,
+      {
+        api: 'prj_api',
+        admin: 'prj_admin',
+        marketing: 'prj_mkt',
+        docs: 'prj_docs',
+      },
+      JSON.stringify({
+        framework: 'vite',
+        buildCommand: 'cd ../.. && pnpm --filter marketing run vercel-build',
+        outputDirectory: 'dist',
+        installCommand: '',
+      }),
+    );
+    expect(expected.framework).toBe('vite');
+    expect(expected.rootDirectory).toBe('apps/marketing');
+    expect(expected.outputDirectory).toBe('dist');
+    expect(expected.installCommand).toBe('');
+    expect(expected.commandForIgnoringBuildStep).toBe('exit 1');
+    expect(expected.sourceFilesOutsideRootDirectory).toBe(true);
+  });
+
+  it('keeps framework null for Other (api)', () => {
+    const parsed = parseAppVercelJson(
+      JSON.stringify({
+        framework: null,
+        buildCommand: 'cd ../.. && pnpm --filter server run vercel-build',
+      }),
+    );
+    expect(parsed.framework).toBeNull();
+  });
+
+  it('requires buildCommand', () => {
+    const spec = OFFICIAL_APPS[0];
+    expect(() =>
+      expectedSettingsForApp(
+        spec,
+        { api: 'prj_a', admin: 'prj_b', marketing: 'prj_c', docs: 'prj_d' },
+        JSON.stringify({ framework: 'vite' }),
+      ),
+    ).toThrow(/buildCommand/);
+  });
+});
+
+describe('assertRootVercelJsonGuard', () => {
+  it('accepts git.deploymentEnabled false only', () => {
+    expect(
+      assertRootVercelJsonGuard(
+        JSON.stringify({
+          $schema: 'https://openapi.vercel.sh/vercel.json',
+          git: { deploymentEnabled: false },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects a root framework/build that would look like an app', () => {
+    const errors = assertRootVercelJsonGuard(
+      JSON.stringify({
+        git: { deploymentEnabled: false },
+        framework: 'vite',
+        buildCommand: 'pnpm turbo build --filter=marketing',
+        outputDirectory: 'apps/marketing/dist',
+      }),
+    );
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('diffProjectSettings', () => {
+  const expected = expectedSettingsForApp(
+    OFFICIAL_APPS[0],
+    { api: 'prj_a', admin: 'prj_b', marketing: 'prj_c', docs: 'prj_d' },
+    JSON.stringify({
+      framework: 'vite',
+      buildCommand: 'cd ../.. && pnpm --filter marketing run vercel-build',
+      outputDirectory: 'dist',
+      installCommand: '',
+    }),
+  );
+
+  it('is empty when live matches', () => {
+    const live = liveFromApiBody({
+      id: 'prj_c',
+      name: 'revealui-marketing',
+      framework: 'vite',
+      rootDirectory: 'apps/marketing',
+      buildCommand: 'cd ../.. && pnpm --filter marketing run vercel-build',
+      outputDirectory: 'dist',
+      installCommand: '',
+      commandForIgnoringBuildStep: 'exit 1',
+      sourceFilesOutsideRootDirectory: true,
+    });
+    expect(diffProjectSettings(expected, live)).toEqual([]);
+  });
+
+  it('reports the dashboard buildCommand mismatch', () => {
+    const live = liveFromApiBody({
+      id: 'prj_c',
+      name: 'revealui-marketing',
+      framework: 'vite',
+      rootDirectory: 'apps/marketing',
+      buildCommand: 'cd ../.. && pnpm turbo build --filter=marketing',
+      outputDirectory: null,
+      installCommand: 'cd ../.. && pnpm install --no-frozen-lockfile',
+      commandForIgnoringBuildStep: 'exit 1',
+      sourceFilesOutsideRootDirectory: true,
+    });
+    const fields = diffProjectSettings(expected, live).map((d) => d.field);
+    expect(fields).toContain('buildCommand');
+    expect(fields).toContain('outputDirectory');
+    expect(fields).toContain('installCommand');
+  });
+
+  it('fails closed when Git is connected', () => {
+    const live = liveFromApiBody({
+      id: 'prj_c',
+      framework: 'vite',
+      rootDirectory: 'apps/marketing',
+      buildCommand: expected.buildCommand,
+      outputDirectory: 'dist',
+      installCommand: '',
+      commandForIgnoringBuildStep: 'exit 1',
+      sourceFilesOutsideRootDirectory: true,
+      link: { type: 'github', repo: 'revealui' },
+    });
+    expect(diffProjectSettings(expected, live).some((d) => d.field === 'git')).toBe(true);
+  });
+});
+
+describe('loadExpectedSettings (repo files)', () => {
+  it('loads all four official apps from the checkout', () => {
+    const all = loadExpectedSettings(REPO_ROOT);
+    expect(all.map((a) => a.app).sort()).toEqual(['admin', 'api', 'docs', 'marketing']);
+    const marketing = all.find((a) => a.app === 'marketing');
+    expect(marketing?.framework).toBe('vite');
+    expect(marketing?.buildCommand).toContain('pnpm --filter marketing run vercel-build');
+    expect(marketing?.outputDirectory).toBe('dist');
+    const api = all.find((a) => a.app === 'api');
+    expect(api?.framework).toBeNull();
+    expect(api?.rootDirectory).toBe('apps/server');
+  });
+});
+
+describe('patchBodyFromExpected', () => {
+  it('sends framework null for Other', () => {
+    const api = loadExpectedSettings(REPO_ROOT).find((a) => a.app === 'api');
+    if (!api) throw new Error('missing api');
+    expect(patchBodyFromExpected(api).framework).toBeNull();
+  });
+});

--- a/scripts/validate/vercel-project-settings.ts
+++ b/scripts/validate/vercel-project-settings.ts
@@ -1,0 +1,393 @@
+#!/usr/bin/env tsx
+/**
+ * Official Vercel project settings must match each app vercel.json.
+ *
+ * SSOT is the per-app vercel.json (plus the project-id map). The dashboard
+ * is a mirror. `check` compares live Project Settings; `sync` PATCHes them.
+ *
+ * GitHub Actions is the only official deploy path. Git Integration must stay
+ * disconnected on these four projects.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+export const PROJECT_ID_MAP_PATH = join(REPO_ROOT, '.github', 'vercel-projects.json');
+export const ROOT_VERCEL_JSON = join(REPO_ROOT, 'vercel.json');
+
+export type OfficialApp = 'marketing' | 'docs' | 'admin' | 'api';
+
+export interface OfficialAppSpec {
+  app: OfficialApp;
+  rootDirectory: string;
+  vercelJsonPath: string;
+}
+
+export const OFFICIAL_APPS: readonly OfficialAppSpec[] = [
+  {
+    app: 'marketing',
+    rootDirectory: 'apps/marketing',
+    vercelJsonPath: 'apps/marketing/vercel.json',
+  },
+  { app: 'docs', rootDirectory: 'apps/docs', vercelJsonPath: 'apps/docs/vercel.json' },
+  { app: 'admin', rootDirectory: 'apps/admin', vercelJsonPath: 'apps/admin/vercel.json' },
+  { app: 'api', rootDirectory: 'apps/server', vercelJsonPath: 'apps/server/vercel.json' },
+];
+
+export interface AppVercelJson {
+  framework?: string | null;
+  buildCommand?: string | null;
+  outputDirectory?: string | null;
+  installCommand?: string | null;
+}
+
+export interface ExpectedProjectSettings {
+  app: OfficialApp;
+  projectId: string;
+  rootDirectory: string;
+  framework: string | null;
+  buildCommand: string | null;
+  outputDirectory: string | null;
+  installCommand: string | null;
+  commandForIgnoringBuildStep: string;
+  sourceFilesOutsideRootDirectory: true;
+}
+
+export interface LiveProjectSettings {
+  id: string;
+  name: string;
+  framework: string | null;
+  rootDirectory: string | null;
+  buildCommand: string | null;
+  outputDirectory: string | null;
+  installCommand: string | null;
+  commandForIgnoringBuildStep: string | null;
+  sourceFilesOutsideRootDirectory: boolean | null;
+  gitLinked: boolean;
+}
+
+export interface FieldDrift {
+  field: string;
+  expected: string;
+  actual: string;
+}
+
+export interface ProjectIdMap {
+  api: string;
+  admin: string;
+  marketing: string;
+  docs: string;
+}
+
+export function loadProjectIdMap(
+  raw: string = readFileSync(PROJECT_ID_MAP_PATH, 'utf8'),
+): ProjectIdMap {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('.github/vercel-projects.json must be an object');
+  }
+  const rec = parsed as Record<string, unknown>;
+  const required: Array<keyof ProjectIdMap> = ['api', 'admin', 'marketing', 'docs'];
+  const out: Partial<ProjectIdMap> = {};
+  for (const key of required) {
+    const value = rec[key];
+    if (typeof value !== 'string' || !value.startsWith('prj_')) {
+      throw new Error(`.github/vercel-projects.json.${key} must be a prj_ id`);
+    }
+    out[key] = value;
+  }
+  return out as ProjectIdMap;
+}
+
+export function parseAppVercelJson(raw: string): AppVercelJson {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('vercel.json must be an object');
+  }
+  const rec = parsed as Record<string, unknown>;
+  return {
+    framework: rec.framework === undefined ? undefined : (rec.framework as string | null),
+    buildCommand: rec.buildCommand === undefined ? undefined : (rec.buildCommand as string | null),
+    outputDirectory:
+      rec.outputDirectory === undefined ? undefined : (rec.outputDirectory as string | null),
+    installCommand:
+      rec.installCommand === undefined ? undefined : (rec.installCommand as string | null),
+  };
+}
+
+export function expectedSettingsForApp(
+  spec: OfficialAppSpec,
+  ids: ProjectIdMap,
+  vercelJsonRaw: string,
+): ExpectedProjectSettings {
+  const cfg = parseAppVercelJson(vercelJsonRaw);
+  if (cfg.buildCommand === undefined || cfg.buildCommand === null || cfg.buildCommand === '') {
+    throw new Error(`${spec.vercelJsonPath} must set buildCommand`);
+  }
+  if (cfg.framework === undefined) {
+    throw new Error(`${spec.vercelJsonPath} must set framework (use null for Other)`);
+  }
+  return {
+    app: spec.app,
+    projectId: ids[spec.app],
+    rootDirectory: spec.rootDirectory,
+    framework: cfg.framework,
+    buildCommand: cfg.buildCommand,
+    outputDirectory: cfg.outputDirectory ?? null,
+    installCommand: cfg.installCommand ?? null,
+    commandForIgnoringBuildStep: 'exit 1',
+    sourceFilesOutsideRootDirectory: true,
+  };
+}
+
+export function loadExpectedSettings(repoRoot: string = REPO_ROOT): ExpectedProjectSettings[] {
+  const ids = loadProjectIdMap(
+    readFileSync(join(repoRoot, '.github', 'vercel-projects.json'), 'utf8'),
+  );
+  return OFFICIAL_APPS.map((spec) =>
+    expectedSettingsForApp(spec, ids, readFileSync(join(repoRoot, spec.vercelJsonPath), 'utf8')),
+  );
+}
+
+export function assertRootVercelJsonGuard(raw: string): string[] {
+  const errors: string[] = [];
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return ['root vercel.json must be an object'];
+  }
+  const rec = parsed as Record<string, unknown>;
+  const git = rec.git;
+  if (!git || typeof git !== 'object' || Array.isArray(git)) {
+    errors.push('root vercel.json must set git.deploymentEnabled to false');
+    return errors;
+  }
+  const enabled = (git as Record<string, unknown>).deploymentEnabled;
+  if (enabled !== false) {
+    errors.push('root vercel.json git.deploymentEnabled must be false');
+  }
+  if (
+    rec.framework !== undefined ||
+    rec.buildCommand !== undefined ||
+    rec.outputDirectory !== undefined
+  ) {
+    errors.push(
+      'root vercel.json must not set framework/buildCommand/outputDirectory (official apps live under apps/*)',
+    );
+  }
+  return errors;
+}
+
+function display(value: string | null | undefined | boolean): string {
+  if (value === undefined || value === null) return '(unset)';
+  if (value === '') return '(empty)';
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  return value;
+}
+
+export function diffProjectSettings(
+  expected: ExpectedProjectSettings,
+  live: LiveProjectSettings,
+): FieldDrift[] {
+  const drifts: FieldDrift[] = [];
+  const pairs: Array<[string, string | null | boolean, string | null | boolean | undefined]> = [
+    ['framework', expected.framework, live.framework],
+    ['rootDirectory', expected.rootDirectory, live.rootDirectory],
+    ['buildCommand', expected.buildCommand, live.buildCommand],
+    ['outputDirectory', expected.outputDirectory, live.outputDirectory],
+    ['installCommand', expected.installCommand, live.installCommand],
+    [
+      'commandForIgnoringBuildStep',
+      expected.commandForIgnoringBuildStep,
+      live.commandForIgnoringBuildStep,
+    ],
+    [
+      'sourceFilesOutsideRootDirectory',
+      expected.sourceFilesOutsideRootDirectory,
+      live.sourceFilesOutsideRootDirectory,
+    ],
+  ];
+  for (const [field, exp, act] of pairs) {
+    const expS = display(exp);
+    const actS = display(act);
+    if (expS !== actS) {
+      drifts.push({ field, expected: expS, actual: actS });
+    }
+  }
+  if (live.gitLinked) {
+    drifts.push({
+      field: 'git',
+      expected: 'disconnected',
+      actual: 'connected',
+    });
+  }
+  return drifts;
+}
+
+export function liveFromApiBody(body: Record<string, unknown>): LiveProjectSettings {
+  const link = body.link;
+  const gitLinked = Boolean(
+    link && typeof link === 'object' && !Array.isArray(link) && 'type' in link,
+  );
+  return {
+    id: typeof body.id === 'string' ? body.id : '',
+    name: typeof body.name === 'string' ? body.name : '',
+    framework: (body.framework as string | null | undefined) ?? null,
+    rootDirectory: (body.rootDirectory as string | null | undefined) ?? null,
+    buildCommand: (body.buildCommand as string | null | undefined) ?? null,
+    outputDirectory: (body.outputDirectory as string | null | undefined) ?? null,
+    installCommand: (body.installCommand as string | null | undefined) ?? null,
+    commandForIgnoringBuildStep:
+      (body.commandForIgnoringBuildStep as string | null | undefined) ?? null,
+    sourceFilesOutsideRootDirectory:
+      typeof body.sourceFilesOutsideRootDirectory === 'boolean'
+        ? body.sourceFilesOutsideRootDirectory
+        : null,
+    gitLinked,
+  };
+}
+
+export function patchBodyFromExpected(expected: ExpectedProjectSettings): Record<string, unknown> {
+  return {
+    framework: expected.framework,
+    rootDirectory: expected.rootDirectory,
+    buildCommand: expected.buildCommand,
+    outputDirectory: expected.outputDirectory,
+    installCommand: expected.installCommand,
+    commandForIgnoringBuildStep: expected.commandForIgnoringBuildStep,
+    sourceFilesOutsideRootDirectory: expected.sourceFilesOutsideRootDirectory,
+  };
+}
+
+function runVercelApi(path: string, method: 'GET' | 'PATCH', body?: unknown): unknown {
+  const args = ['api', path, '--method', method];
+  const token = process.env.VERCEL_TOKEN;
+  if (token && token.length > 0) {
+    args.push('--token', token);
+  }
+  if (body !== undefined) {
+    args.push('--input', '-');
+  }
+  const result = spawnSync('vercel', args, {
+    encoding: 'utf8',
+    input: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `vercel api ${method} ${path} failed: ${(result.stderr || result.stdout || '').trim()}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+export async function fetchLiveProject(projectId: string): Promise<LiveProjectSettings> {
+  const body = runVercelApi(`/v9/projects/${projectId}`, 'GET');
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new Error(`unexpected GET /v9/projects/${projectId} body`);
+  }
+  return liveFromApiBody(body as Record<string, unknown>);
+}
+
+export async function syncLiveProject(expected: ExpectedProjectSettings): Promise<void> {
+  runVercelApi(`/v9/projects/${expected.projectId}`, 'PATCH', patchBodyFromExpected(expected));
+}
+
+export async function strayRevealuiProjectExists(): Promise<boolean> {
+  const args = ['api', '/v9/projects/revealui'];
+  const token = process.env.VERCEL_TOKEN;
+  if (token && token.length > 0) args.push('--token', token);
+  const result = spawnSync('vercel', args, { encoding: 'utf8' });
+  if (result.status !== 0) return false;
+  try {
+    const body: unknown = JSON.parse(result.stdout);
+    return Boolean(body && typeof body === 'object' && !Array.isArray(body) && 'id' in body);
+  } catch {
+    return false;
+  }
+}
+
+function printDrifts(app: string, drifts: FieldDrift[]): void {
+  for (const d of drifts) {
+    console.error(`  ${app}.${d.field}: expected ${d.expected}  actual ${d.actual}`);
+  }
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const sync = argv.includes('--sync');
+  const live = argv.includes('--live') || sync;
+
+  const fileErrors: string[] = [];
+  try {
+    fileErrors.push(
+      ...assertRootVercelJsonGuard(readFileSync(join(REPO_ROOT, 'vercel.json'), 'utf8')),
+    );
+  } catch (err) {
+    fileErrors.push(`root vercel.json: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  let expected: ExpectedProjectSettings[] = [];
+  try {
+    expected = loadExpectedSettings(REPO_ROOT);
+  } catch (err) {
+    fileErrors.push(err instanceof Error ? err.message : String(err));
+  }
+
+  if (fileErrors.length > 0) {
+    for (const e of fileErrors) console.error(e);
+    return 1;
+  }
+
+  if (!live) {
+    console.log(
+      `vercel.json lockstep: ${expected.length} official apps ok (pass --live to compare dashboard)`,
+    );
+    return 0;
+  }
+
+  let failed = 0;
+  if (await strayRevealuiProjectExists()) {
+    console.error(
+      'stray Vercel project "revealui" exists; official apps are revealui-{marketing,docs,admin,api}',
+    );
+    failed += 1;
+  }
+
+  for (const exp of expected) {
+    const current = await fetchLiveProject(exp.projectId);
+    if (sync) {
+      const before = diffProjectSettings(exp, current);
+      if (before.length === 0) {
+        console.log(`${exp.app} (${exp.projectId}): already matches`);
+        continue;
+      }
+      console.log(`${exp.app}: syncing ${before.map((d) => d.field).join(', ')}`);
+      await syncLiveProject(exp);
+      const after = diffProjectSettings(exp, await fetchLiveProject(exp.projectId));
+      if (after.length > 0) {
+        printDrifts(exp.app, after);
+        failed += 1;
+      }
+      continue;
+    }
+    const drifts = diffProjectSettings(exp, current);
+    if (drifts.length === 0) {
+      console.log(`${exp.app}: matches apps/${exp.app === 'api' ? 'server' : exp.app}/vercel.json`);
+      continue;
+    }
+    printDrifts(exp.app, drifts);
+    failed += 1;
+  }
+
+  if (failed > 0 && !sync) {
+    console.error('Fix: pnpm validate:vercel-settings -- --sync');
+  }
+  return failed > 0 ? 1 : 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => {
+    process.exit(code);
+  });
+}


### PR DESCRIPTION
## Summary

Official Vercel Project Settings must match each app `vercel.json`. That file is the source of truth. The dashboard is a mirror.

- `pnpm validate:vercel-settings` checks the files (CI + local gate)
- `--live` compares the four official projects
- `--sync` writes the dashboard from those files
- Deploy workflow runs `--live` so a drifted UI cannot ship unnoticed
- Root `vercel.json` stays a Git-off guard only

This session already ran `--sync`. Marketing, docs, admin, and api dashboards now match.

## Test plan

- [x] Unit tests for mapping + drift
- [x] File-level check
- [x] Live sync + recheck (all four match)
- [ ] CI Quality on this PR