### PR TITLE
fix(auth): grant enterprise to instance super-admin

### DIFF
--- a/.changeset/operator-enterprise-entitlement.md
+++ b/.changeset/operator-enterprise-entitlement.md
@@ -1,0 +1,5 @@
+---
+'@revealui/auth': patch
+---
+
+Grant a real Enterprise entitlement row for the instance super-admin instead of leaving the operator on free signup limits.

--- a/apps/admin/src/__tests__/auth/auth-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/auth-routes.test.ts
@@ -55,6 +55,9 @@ vi.mock('@revealui/auth/server', () => ({
     flags: { enabled: true, shadow: true, staleHours: 48 },
   }),
   ensureFreeSignupEntitlement: vi.fn().mockResolvedValue({ accountId: 'acct-test' }),
+  ensurePlatformOperatorEntitlement: vi
+    .fn()
+    .mockResolvedValue({ accountId: 'acct-test', wrote: true }),
 }));
 
 vi.mock('@revealui/utils/logger', () => ({

--- a/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
+++ b/apps/admin/src/__tests__/auth/oauth-provider-routes.test.ts
@@ -61,6 +61,10 @@ vi.mock('@revealui/auth/server', () => ({
     flags: { enabled: true, shadow: true, staleHours: 48 },
   }),
   ensureFreeSignupEntitlement: vi.fn().mockResolvedValue({ accountId: 'acct-test' }),
+  ensurePlatformOperatorEntitlement: vi.fn().mockResolvedValue({
+    accountId: 'acct-test',
+    wrote: true,
+  }),
 }));
 
 vi.mock('@revealui/core/utils/logger', () => ({

--- a/apps/admin/src/app/api/auth/__tests__/integration.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/integration.test.ts
@@ -62,6 +62,10 @@ vi.mock('@revealui/auth/server', () => ({
     flags: { enabled: true, shadow: true, staleHours: 48 },
   }),
   ensureFreeSignupEntitlement: vi.fn().mockResolvedValue({ accountId: 'acct-test' }),
+  ensurePlatformOperatorEntitlement: vi.fn().mockResolvedValue({
+    accountId: 'acct-test',
+    wrote: true,
+  }),
 }));
 
 vi.mock('@revealui/core/utils/logger', () => ({

--- a/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
+++ b/apps/admin/src/app/api/auth/__tests__/oauth-routes.test.ts
@@ -58,6 +58,10 @@ vi.mock('@revealui/auth/server', () => ({
     flags: { enabled: true, shadow: true, staleHours: 48 },
   }),
   ensureFreeSignupEntitlement: vi.fn().mockResolvedValue({ accountId: 'acct-test' }),
+  ensurePlatformOperatorEntitlement: vi.fn().mockResolvedValue({
+    accountId: 'acct-test',
+    wrote: true,
+  }),
 }));
 
 vi.mock('@revealui/db/queries/oauth-accounts', () => ({

--- a/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
+++ b/apps/admin/src/app/api/auth/passkey/__tests__/routes.test.ts
@@ -48,6 +48,10 @@ vi.mock('@revealui/auth/server', () => ({
     flags: { enabled: true, shadow: true, staleHours: 48 },
   }),
   ensureFreeSignupEntitlement: vi.fn().mockResolvedValue({ accountId: 'acct-test' }),
+  ensurePlatformOperatorEntitlement: vi.fn().mockResolvedValue({
+    accountId: 'acct-test',
+    wrote: true,
+  }),
 }));
 
 // Mock the logger

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -9,6 +9,7 @@
 import {
   admitFreeIntake,
   ensureFreeSignupEntitlement,
+  ensurePlatformOperatorEntitlement,
   isSignupAllowed,
   signUp,
 } from '@revealui/auth/server';
@@ -255,6 +256,14 @@ async function signUpHandler(request: NextRequest): Promise<NextResponse> {
         // `_json`, so the grant must be a typed update afterward. Canonical
         // owner shape per #1219 / GAP-244: DB role owner + _json.roles=['super-admin'].
         await grantSuperAdminRoleById(db, result.user.id);
+        try {
+          await ensurePlatformOperatorEntitlement({ userId: result.user.id });
+        } catch (entErr) {
+          logger.error('Failed enterprise grant after first-user promotion (non-fatal)', {
+            userId: result.user.id,
+            error: entErr instanceof Error ? entErr.message : String(entErr),
+          });
+        }
         if (updatedUser) {
           resolvedUser = {
             ...updatedUser,

--- a/apps/admin/src/app/api/auth/sign-up/route.ts
+++ b/apps/admin/src/app/api/auth/sign-up/route.ts
@@ -6,10 +6,10 @@
  * Creates a new user account.
  */
 
+import { ensurePlatformOperatorEntitlement } from '@revealui/auth/platform-operator';
 import {
   admitFreeIntake,
   ensureFreeSignupEntitlement,
-  ensurePlatformOperatorEntitlement,
   isSignupAllowed,
   signUp,
 } from '@revealui/auth/server';

--- a/apps/server/src/lib/__tests__/platform-operator-limits-lockstep.test.ts
+++ b/apps/server/src/lib/__tests__/platform-operator-limits-lockstep.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { getHostedLimitsForTier } from '../tier-limits.js';
+
+/** Must stay equal to PLATFORM_OPERATOR_LIMITS in @revealui/auth platform-operator. */
+describe('platform operator limits lockstep', () => {
+  it('enterprise hosted limits stay unlimited tasks', () => {
+    expect(getHostedLimitsForTier('enterprise')).toEqual({
+      maxAgentTasks: Number.MAX_SAFE_INTEGER,
+    });
+  });
+});

--- a/apps/server/src/middleware/__tests__/entitlements.test.ts
+++ b/apps/server/src/middleware/__tests__/entitlements.test.ts
@@ -14,6 +14,11 @@ const mockDb = {
   select: vi.fn(),
 };
 
+vi.mock('@revealui/auth/server', () => ({
+  isPlatformOperatorUser: vi.fn(() => false),
+  ensurePlatformOperatorEntitlement: vi.fn(),
+}));
+
 vi.mock('@revealui/db', () => ({
   getClient: vi.fn(() => mockDb),
 }));
@@ -49,6 +54,7 @@ vi.mock('drizzle-orm', () => ({
   or: vi.fn((...args: unknown[]) => `or(${args.join(',')})`),
 }));
 
+import { ensurePlatformOperatorEntitlement, isPlatformOperatorUser } from '@revealui/auth/server';
 import { entitlementMiddleware, getEntitlementsFromContext } from '../entitlements.js';
 import { errorHandler } from '../error.js';
 
@@ -68,6 +74,7 @@ function createApp(user?: { id: string }) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(isPlatformOperatorUser).mockReturnValue(false);
   selectResults = [];
   mockDbSelectChain.from.mockReturnValue(mockDbSelectChain);
   mockDbSelectChain.innerJoin.mockReturnValue(mockDbSelectChain);
@@ -143,5 +150,36 @@ describe('entitlementMiddleware', () => {
     expect(body.tier).toBe('free');
     expect(body.membershipRole).toBe('member');
     expect(body.subscriptionStatus).toBeNull();
+  });
+
+  it('heals a platform operator onto an enterprise grant before attaching', async () => {
+    vi.mocked(isPlatformOperatorUser).mockReturnValue(true);
+    vi.mocked(ensurePlatformOperatorEntitlement).mockResolvedValue({
+      accountId: 'acct_1',
+      wrote: true,
+    });
+    selectResults = [
+      [{ accountId: 'acct_1', role: 'owner' }],
+      [
+        {
+          tier: 'enterprise',
+          status: 'active',
+          features: { ai: true },
+          limits: { maxAgentTasks: Number.MAX_SAFE_INTEGER },
+        },
+      ],
+    ];
+
+    const app = createApp({ id: 'user-1' });
+    const res = await app.request('/test');
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(ensurePlatformOperatorEntitlement).toHaveBeenCalledWith({
+      userId: 'user-1',
+      accountId: 'acct_1',
+    });
+    expect(body.tier).toBe('enterprise');
+    expect(body.features).toEqual({ ai: true });
   });
 });

--- a/apps/server/src/middleware/__tests__/entitlements.test.ts
+++ b/apps/server/src/middleware/__tests__/entitlements.test.ts
@@ -14,7 +14,7 @@ const mockDb = {
   select: vi.fn(),
 };
 
-vi.mock('@revealui/auth/server', () => ({
+vi.mock('@revealui/auth/platform-operator', () => ({
   isPlatformOperatorUser: vi.fn(() => false),
   ensurePlatformOperatorEntitlement: vi.fn(),
 }));
@@ -54,7 +54,10 @@ vi.mock('drizzle-orm', () => ({
   or: vi.fn((...args: unknown[]) => `or(${args.join(',')})`),
 }));
 
-import { ensurePlatformOperatorEntitlement, isPlatformOperatorUser } from '@revealui/auth/server';
+import {
+  ensurePlatformOperatorEntitlement,
+  isPlatformOperatorUser,
+} from '@revealui/auth/platform-operator';
 import { entitlementMiddleware, getEntitlementsFromContext } from '../entitlements.js';
 import { errorHandler } from '../error.js';
 

--- a/apps/server/src/middleware/__tests__/entitlements.test.ts
+++ b/apps/server/src/middleware/__tests__/entitlements.test.ts
@@ -180,9 +180,31 @@ describe('entitlementMiddleware', () => {
     expect(res.status).toBe(200);
     expect(ensurePlatformOperatorEntitlement).toHaveBeenCalledWith({
       userId: 'user-1',
-      accountId: 'acct_1',
     });
     expect(body.tier).toBe('enterprise');
     expect(body.features).toEqual({ ai: true });
+  });
+
+  it('does not fail the request when the operator grant throws', async () => {
+    vi.mocked(isPlatformOperatorUser).mockReturnValue(true);
+    vi.mocked(ensurePlatformOperatorEntitlement).mockRejectedValue(new Error('db down'));
+    selectResults = [
+      [{ accountId: 'acct_1', role: 'owner' }],
+      [
+        {
+          tier: 'free',
+          status: 'active',
+          features: { ai: false },
+          limits: {},
+        },
+      ],
+    ];
+
+    const app = createApp({ id: 'user-1' });
+    const res = await app.request('/test');
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.tier).toBe('free');
   });
 });

--- a/apps/server/src/middleware/entitlements.ts
+++ b/apps/server/src/middleware/entitlements.ts
@@ -13,6 +13,7 @@ import {
 } from '@revealui/auth/platform-operator';
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
+import { logger } from '@revealui/core/observability/logger';
 import { getClient } from '@revealui/db';
 import { accountEntitlements } from '@revealui/db/schema';
 import { and, eq } from 'drizzle-orm';
@@ -105,10 +106,17 @@ export const entitlementMiddleware = (): MiddlewareHandler => {
     }
 
     if (isPlatformOperatorUser(user)) {
-      await ensurePlatformOperatorEntitlement({
-        userId,
-        accountId: membership.accountId,
-      });
+      // Resolve the operator's owner workspace inside the helper. Never pass
+      // the request tenant (X-Tenant-ID / member membership) — that would
+      // grant Enterprise onto a customer account.
+      try {
+        await ensurePlatformOperatorEntitlement({ userId });
+      } catch (err) {
+        logger.error('[entitlements] platform operator grant failed (non-fatal)', {
+          userId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     const [entitlement] = await db

--- a/apps/server/src/middleware/entitlements.ts
+++ b/apps/server/src/middleware/entitlements.ts
@@ -6,7 +6,11 @@
  * account, membership, and entitlement context to the request.
  */
 
-import { ensurePlatformOperatorEntitlement, isPlatformOperatorUser } from '@revealui/auth/server';
+import {
+  ensurePlatformOperatorEntitlement,
+  isPlatformOperatorUser,
+  type PlatformOperatorUserView,
+} from '@revealui/auth/server';
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import { getClient } from '@revealui/db';
@@ -73,7 +77,7 @@ function isHealthyStatus(status: string | null): boolean {
 
 export const entitlementMiddleware = (): MiddlewareHandler => {
   return async (c, next) => {
-    const user = c.get('user') as { id?: string } | undefined;
+    const user = c.get('user') as PlatformOperatorUserView | undefined;
     const userId = user?.id ?? null;
 
     if (!userId) {

--- a/apps/server/src/middleware/entitlements.ts
+++ b/apps/server/src/middleware/entitlements.ts
@@ -6,6 +6,7 @@
  * account, membership, and entitlement context to the request.
  */
 
+import { ensurePlatformOperatorEntitlement, isPlatformOperatorUser } from '@revealui/auth/server';
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import { getClient } from '@revealui/db';
@@ -97,6 +98,13 @@ export const entitlementMiddleware = (): MiddlewareHandler => {
       c.set('entitlements', createFreeEntitlements(userId));
       await next();
       return;
+    }
+
+    if (isPlatformOperatorUser(user)) {
+      await ensurePlatformOperatorEntitlement({
+        userId,
+        accountId: membership.accountId,
+      });
     }
 
     const [entitlement] = await db

--- a/apps/server/src/middleware/entitlements.ts
+++ b/apps/server/src/middleware/entitlements.ts
@@ -10,7 +10,7 @@ import {
   ensurePlatformOperatorEntitlement,
   isPlatformOperatorUser,
   type PlatformOperatorUserView,
-} from '@revealui/auth/server';
+} from '@revealui/auth/platform-operator';
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
 import { getFeaturesForTier } from '@revealui/core/features';
 import { getClient } from '@revealui/db';

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -60,6 +60,11 @@
       "import": "./dist/server/audit-storage.js",
       "default": "./dist/server/audit-storage.js"
     },
+    "./platform-operator": {
+      "types": "./dist/server/platform-operator.d.ts",
+      "import": "./dist/server/platform-operator.js",
+      "default": "./dist/server/platform-operator.js"
+    },
     "./react": {
       "types": "./dist/react/index.d.ts",
       "import": "./dist/react/index.js",

--- a/packages/auth/src/server/__tests__/platform-operator.test.ts
+++ b/packages/auth/src/server/__tests__/platform-operator.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockLimit = vi.fn();
+const mockWhere = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockValues = vi.fn();
+const mockSet = vi.fn();
+
+const mockDb = {
+  select: mockSelect,
+  insert: mockInsert,
+  update: mockUpdate,
+};
+
+vi.mock('@revealui/db', () => ({
+  getClient: vi.fn(() => mockDb),
+}));
+
+vi.mock('@revealui/config/stripe-mode', () => ({
+  getConfiguredStripeMode: vi.fn(() => 'live'),
+}));
+
+vi.mock('@revealui/core/features', () => ({
+  getFeaturesForTier: vi.fn((tier: string) => ({
+    ai: tier === 'pro' || tier === 'max' || tier === 'enterprise',
+    sso: tier === 'enterprise',
+  })),
+}));
+
+vi.mock('@revealui/core/observability/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  ensurePlatformOperatorEntitlement,
+  isPlatformOperatorUser,
+  PLATFORM_OPERATOR_LIMITS,
+  rolesFromUserJson,
+} from '../platform-operator.js';
+
+describe('rolesFromUserJson', () => {
+  it('reads roles from an object', () => {
+    expect(rolesFromUserJson({ roles: ['super-admin'] })).toEqual(['super-admin']);
+  });
+
+  it('reads roles from a JSON string', () => {
+    expect(rolesFromUserJson(JSON.stringify({ roles: ['admin', 'super-admin'] }))).toEqual([
+      'admin',
+      'super-admin',
+    ]);
+  });
+
+  it('returns empty for junk', () => {
+    expect(rolesFromUserJson(null)).toEqual([]);
+    expect(rolesFromUserJson('not-json')).toEqual([]);
+    expect(rolesFromUserJson({ roles: 'super-admin' })).toEqual([]);
+  });
+});
+
+describe('isPlatformOperatorUser', () => {
+  it('is true for engine roles super-admin', () => {
+    expect(isPlatformOperatorUser({ roles: ['super-admin'] })).toBe(true);
+  });
+
+  it('is true for session _json.roles super-admin', () => {
+    expect(isPlatformOperatorUser({ _json: { roles: ['super-admin'] } })).toBe(true);
+  });
+
+  it('is false for hosted account owners (shell admin only)', () => {
+    expect(isPlatformOperatorUser({ roles: ['admin'] })).toBe(false);
+    expect(isPlatformOperatorUser({ _json: { roles: ['admin'] } })).toBe(false);
+    expect(isPlatformOperatorUser({ role: 'owner' } as { role: string })).toBe(false);
+  });
+
+  it('is false for null', () => {
+    expect(isPlatformOperatorUser(null)).toBe(false);
+    expect(isPlatformOperatorUser(undefined)).toBe(false);
+  });
+});
+
+describe('PLATFORM_OPERATOR_LIMITS', () => {
+  it('matches hosted enterprise task budget (unlimited)', () => {
+    expect(PLATFORM_OPERATOR_LIMITS).toEqual({ maxAgentTasks: Number.MAX_SAFE_INTEGER });
+  });
+});
+
+describe('ensurePlatformOperatorEntitlement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockInsert.mockReturnValue({ values: mockValues });
+    mockUpdate.mockReturnValue({ set: mockSet });
+    mockSet.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    mockValues.mockResolvedValue(undefined);
+  });
+
+  it('skips users who are not super-admin', async () => {
+    mockLimit.mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['admin'] } }]);
+
+    const result = await ensurePlatformOperatorEntitlement({ userId: 'user-1' });
+
+    expect(result).toEqual({ skipped: true, reason: 'not_platform_operator' });
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('skips when there is no owner membership', async () => {
+    mockLimit
+      .mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['super-admin'] } }])
+      .mockResolvedValueOnce([]);
+
+    const result = await ensurePlatformOperatorEntitlement({ userId: 'user-1' });
+
+    expect(result).toEqual({ skipped: true, reason: 'no_owner_membership' });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('inserts an enterprise grant for a first-time operator', async () => {
+    mockLimit
+      .mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['super-admin'] } }])
+      .mockResolvedValueOnce([{ accountId: 'acct-1' }])
+      .mockResolvedValueOnce([]);
+
+    const result = await ensurePlatformOperatorEntitlement({
+      userId: 'user-1',
+      now: new Date('2026-08-14T00:00:00.000Z'),
+    });
+
+    expect(result).toEqual({ accountId: 'acct-1', wrote: true });
+    expect(mockInsert).toHaveBeenCalled();
+    const inserted = mockValues.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(inserted.accountId).toBe('acct-1');
+    expect(inserted.tier).toBe('enterprise');
+    expect(inserted.source).toBe('grant');
+    expect(inserted.mode).toBe('live');
+    expect((inserted.features as { ai?: boolean }).ai).toBe(true);
+    expect((inserted.features as { sso?: boolean }).sso).toBe(true);
+    expect(inserted.limits).toEqual(PLATFORM_OPERATOR_LIMITS);
+  });
+
+  it('upgrades a free signup row instead of leaving the operator on Free', async () => {
+    mockLimit
+      .mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['super-admin'] } }])
+      .mockResolvedValueOnce([{ accountId: 'acct-1' }])
+      .mockResolvedValueOnce([
+        {
+          tier: 'free',
+          status: 'active',
+          features: { ai: false },
+          lastEventAt: null,
+        },
+      ]);
+
+    const result = await ensurePlatformOperatorEntitlement({ userId: 'user-1' });
+
+    expect(result).toEqual({ accountId: 'acct-1', wrote: true });
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+    const updated = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updated.tier).toBe('enterprise');
+    expect(updated.source).toBe('grant');
+    expect((updated.features as { ai?: boolean }).ai).toBe(true);
+  });
+
+  it('is a no-op when enterprise with ai is already granted', async () => {
+    mockLimit
+      .mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['super-admin'] } }])
+      .mockResolvedValueOnce([{ accountId: 'acct-1' }])
+      .mockResolvedValueOnce([
+        {
+          tier: 'enterprise',
+          status: 'active',
+          features: { ai: true },
+          lastEventAt: new Date(),
+        },
+      ]);
+
+    const result = await ensurePlatformOperatorEntitlement({ userId: 'user-1' });
+
+    expect(result).toEqual({ accountId: 'acct-1', wrote: false });
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/auth/src/server/__tests__/platform-operator.test.ts
+++ b/packages/auth/src/server/__tests__/platform-operator.test.ts
@@ -75,6 +75,10 @@ describe('isPlatformOperatorUser', () => {
     expect(isPlatformOperatorUser({ role: 'owner' } as { role: string })).toBe(false);
   });
 
+  it('accepts a session user that only has id (middleware shape)', () => {
+    expect(isPlatformOperatorUser({ id: 'user-1' })).toBe(false);
+  });
+
   it('is false for null', () => {
     expect(isPlatformOperatorUser(null)).toBe(false);
     expect(isPlatformOperatorUser(undefined)).toBe(false);

--- a/packages/auth/src/server/__tests__/platform-operator.test.ts
+++ b/packages/auth/src/server/__tests__/platform-operator.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockLimit = vi.fn();
 const mockWhere = vi.fn();
 const mockFrom = vi.fn();
 const mockSelect = vi.fn();
@@ -92,10 +91,21 @@ describe('PLATFORM_OPERATOR_LIMITS', () => {
 });
 
 describe('ensurePlatformOperatorEntitlement', () => {
+  let selectQueue: unknown[][] = [];
+
+  function enqueue(...batches: unknown[][]): void {
+    selectQueue.push(...batches);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    selectQueue = [];
     mockFrom.mockReturnValue({ where: mockWhere });
-    mockWhere.mockReturnValue({ limit: mockLimit });
+    mockWhere.mockImplementation(() => {
+      const rows = selectQueue.shift() ?? [];
+      const pending = Promise.resolve(rows);
+      return Object.assign(pending, { limit: () => pending });
+    });
     mockSelect.mockReturnValue({ from: mockFrom });
     mockInsert.mockReturnValue({ values: mockValues });
     mockUpdate.mockReturnValue({ set: mockSet });
@@ -104,7 +114,7 @@ describe('ensurePlatformOperatorEntitlement', () => {
   });
 
   it('skips users who are not super-admin', async () => {
-    mockLimit.mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['admin'] } }]);
+    enqueue([{ id: 'user-1', json: { roles: ['admin'] } }]);
 
     const result = await ensurePlatformOperatorEntitlement({ userId: 'user-1' });
 
@@ -114,9 +124,7 @@ describe('ensurePlatformOperatorEntitlement', () => {
   });
 
   it('skips when there is no owner membership', async () => {
-    mockLimit
-      .mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['super-admin'] } }])
-      .mockResolvedValueOnce([]);
+    enqueue([{ id: 'user-1', json: { roles: ['super-admin'] } }], []);
 
     const result = await ensurePlatformOperatorEntitlement({ userId: 'user-1' });
 
@@ -124,11 +132,21 @@ describe('ensurePlatformOperatorEntitlement', () => {
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
+  it('refuses a requested account the operator does not own', async () => {
+    enqueue([{ id: 'user-1', json: { roles: ['super-admin'] } }], [{ accountId: 'acct-1' }]);
+
+    const result = await ensurePlatformOperatorEntitlement({
+      userId: 'user-1',
+      accountId: 'customer-acct',
+    });
+
+    expect(result).toEqual({ skipped: true, reason: 'not_owner_workspace' });
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it('inserts an enterprise grant for a first-time operator', async () => {
-    mockLimit
-      .mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['super-admin'] } }])
-      .mockResolvedValueOnce([{ accountId: 'acct-1' }])
-      .mockResolvedValueOnce([]);
+    enqueue([{ id: 'user-1', json: { roles: ['super-admin'] } }], [{ accountId: 'acct-1' }], []);
 
     const result = await ensurePlatformOperatorEntitlement({
       userId: 'user-1',
@@ -148,17 +166,18 @@ describe('ensurePlatformOperatorEntitlement', () => {
   });
 
   it('upgrades a free signup row instead of leaving the operator on Free', async () => {
-    mockLimit
-      .mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['super-admin'] } }])
-      .mockResolvedValueOnce([{ accountId: 'acct-1' }])
-      .mockResolvedValueOnce([
+    enqueue(
+      [{ id: 'user-1', json: { roles: ['super-admin'] } }],
+      [{ accountId: 'acct-1' }],
+      [
         {
           tier: 'free',
           status: 'active',
           features: { ai: false },
           lastEventAt: null,
         },
-      ]);
+      ],
+    );
 
     const result = await ensurePlatformOperatorEntitlement({ userId: 'user-1' });
 
@@ -171,18 +190,31 @@ describe('ensurePlatformOperatorEntitlement', () => {
     expect((updated.features as { ai?: boolean }).ai).toBe(true);
   });
 
+  it('grants when the requested accountId is an owner workspace', async () => {
+    enqueue([{ id: 'user-1', json: { roles: ['super-admin'] } }], [{ accountId: 'acct-1' }], []);
+
+    const result = await ensurePlatformOperatorEntitlement({
+      userId: 'user-1',
+      accountId: 'acct-1',
+    });
+
+    expect(result).toEqual({ accountId: 'acct-1', wrote: true });
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
   it('is a no-op when enterprise with ai is already granted', async () => {
-    mockLimit
-      .mockResolvedValueOnce([{ id: 'user-1', json: { roles: ['super-admin'] } }])
-      .mockResolvedValueOnce([{ accountId: 'acct-1' }])
-      .mockResolvedValueOnce([
+    enqueue(
+      [{ id: 'user-1', json: { roles: ['super-admin'] } }],
+      [{ accountId: 'acct-1' }],
+      [
         {
           tier: 'enterprise',
           status: 'active',
           features: { ai: true },
           lastEventAt: new Date(),
         },
-      ]);
+      ],
+    );
 
     const result = await ensurePlatformOperatorEntitlement({ userId: 'user-1' });
 

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -137,6 +137,12 @@ export {
   validatePasswordStrength,
 } from './password-validation.js';
 export {
+  ensurePlatformOperatorEntitlement,
+  isPlatformOperatorUser,
+  PLATFORM_OPERATOR_LIMITS,
+  rolesFromUserJson,
+} from './platform-operator.js';
+export {
   ensureAccountOwnerPlatformAdmin,
   ensureShellAdminIfAccountOwner,
   isPlatformShellAdminRole,

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -140,6 +140,7 @@ export {
   ensurePlatformOperatorEntitlement,
   isPlatformOperatorUser,
   PLATFORM_OPERATOR_LIMITS,
+  type PlatformOperatorUserView,
   rolesFromUserJson,
 } from './platform-operator.js';
 export {

--- a/packages/auth/src/server/platform-operator.ts
+++ b/packages/auth/src/server/platform-operator.ts
@@ -41,13 +41,18 @@ export function rolesFromUserJson(json: unknown): string[] {
   return roles.filter((role): role is string => typeof role === 'string');
 }
 
+/** Session/engine user fields this check reads. Extra keys (id, email) are fine. */
+export interface PlatformOperatorUserView {
+  id?: string;
+  _json?: unknown;
+  roles?: unknown;
+}
+
 /**
  * True when this user is the instance operator (engine super-admin).
  * Accepts session `_json.roles` and engine `roles`.
  */
-export function isPlatformOperatorUser(
-  user: { _json?: unknown; roles?: unknown } | null | undefined,
-): boolean {
+export function isPlatformOperatorUser(user: PlatformOperatorUserView | null | undefined): boolean {
   if (!user) {
     return false;
   }

--- a/packages/auth/src/server/platform-operator.ts
+++ b/packages/auth/src/server/platform-operator.ts
@@ -123,22 +123,27 @@ export async function ensurePlatformOperatorEntitlement(params: {
     return { skipped: true, reason: 'not_platform_operator' };
   }
 
-  let accountId = params.accountId;
-  if (!accountId) {
-    const [membership] = await db
-      .select({ accountId: accountMemberships.accountId })
-      .from(accountMemberships)
-      .where(
-        and(
-          eq(accountMemberships.userId, params.userId),
-          eq(accountMemberships.role, 'owner'),
-          eq(accountMemberships.status, 'active'),
-        ),
-      )
-      .limit(1);
-    accountId = membership?.accountId;
+  const ownerMemberships = await db
+    .select({ accountId: accountMemberships.accountId })
+    .from(accountMemberships)
+    .where(
+      and(
+        eq(accountMemberships.userId, params.userId),
+        eq(accountMemberships.role, 'owner'),
+        eq(accountMemberships.status, 'active'),
+      ),
+    );
+
+  const ownerIds = ownerMemberships.map((row) => row.accountId);
+  if (params.accountId && !ownerIds.includes(params.accountId)) {
+    logger.warn('[platform-operator-entitlement] refused non-owner workspace', {
+      userId: params.userId,
+      accountId: params.accountId,
+    });
+    return { skipped: true, reason: 'not_owner_workspace' };
   }
 
+  const accountId = params.accountId ?? ownerIds[0];
   if (!accountId) {
     logger.warn('[platform-operator-entitlement] no owner membership; skip', {
       userId: params.userId,

--- a/packages/auth/src/server/platform-operator.ts
+++ b/packages/auth/src/server/platform-operator.ts
@@ -1,0 +1,191 @@
+/**
+ * Platform-operator entitlement.
+ *
+ * Super-admin (`_json.roles`) is the instance operator (first signup / bootstrap).
+ * Hosted account owners are shell admins, not super-admin.
+ *
+ * Operators receive a real Enterprise `account_entitlements` row (source=grant).
+ * Gates stay fail-closed. This is not an identity bypass.
+ */
+
+import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';
+import { getFeaturesForTier } from '@revealui/core/features';
+import { logger } from '@revealui/core/observability/logger';
+import { getClient } from '@revealui/db';
+import { accountEntitlements, accountMemberships, users } from '@revealui/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+/** Lockstep with `getHostedLimitsForTier('enterprise')` in apps/server. */
+export const PLATFORM_OPERATOR_LIMITS = {
+  maxAgentTasks: Number.MAX_SAFE_INTEGER,
+} as const;
+
+const SUPER_ADMIN_ROLE = 'super-admin';
+
+export function rolesFromUserJson(json: unknown): string[] {
+  let value: unknown = json;
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value) as unknown;
+    } catch {
+      return [];
+    }
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return [];
+  }
+  const roles = (value as { roles?: unknown }).roles;
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+  return roles.filter((role): role is string => typeof role === 'string');
+}
+
+/**
+ * True when this user is the instance operator (engine super-admin).
+ * Accepts session `_json.roles` and engine `roles`.
+ */
+export function isPlatformOperatorUser(
+  user: { _json?: unknown; roles?: unknown } | null | undefined,
+): boolean {
+  if (!user) {
+    return false;
+  }
+  if (Array.isArray(user.roles) && user.roles.includes(SUPER_ADMIN_ROLE)) {
+    return true;
+  }
+  return rolesFromUserJson(user._json).includes(SUPER_ADMIN_ROLE);
+}
+
+export interface EnsurePlatformOperatorEntitlementResult {
+  accountId: string;
+  wrote: boolean;
+}
+
+export interface EnsurePlatformOperatorSkipped {
+  skipped: true;
+  reason: string;
+}
+
+function featureRecord(features: object): Record<string, boolean> {
+  return Object.fromEntries(
+    Object.entries(features).filter(
+      (entry): entry is [string, boolean] => typeof entry[1] === 'boolean',
+    ),
+  );
+}
+
+function enterpriseRowComplete(row: {
+  tier?: string | null;
+  status?: string | null;
+  features?: unknown;
+}): boolean {
+  if (row.tier !== 'enterprise') {
+    return false;
+  }
+  if (row.status !== 'active' && row.status !== 'trialing') {
+    return false;
+  }
+  const features =
+    row.features && typeof row.features === 'object' && !Array.isArray(row.features)
+      ? (row.features as Record<string, unknown>)
+      : {};
+  return features.ai === true;
+}
+
+/**
+ * Upsert Enterprise (source=grant) for a platform operator's billing account.
+ *
+ * Skips users who are not super-admin. Idempotent when the row is already
+ * a healthy Enterprise grant with `ai`.
+ */
+export async function ensurePlatformOperatorEntitlement(params: {
+  userId: string;
+  accountId?: string;
+  now?: Date;
+}): Promise<EnsurePlatformOperatorEntitlementResult | EnsurePlatformOperatorSkipped> {
+  const db = getClient();
+  const [user] = await db
+    .select({ id: users.id, json: users._json })
+    .from(users)
+    .where(eq(users.id, params.userId))
+    .limit(1);
+
+  if (!(user && isPlatformOperatorUser({ _json: user.json }))) {
+    return { skipped: true, reason: 'not_platform_operator' };
+  }
+
+  let accountId = params.accountId;
+  if (!accountId) {
+    const [membership] = await db
+      .select({ accountId: accountMemberships.accountId })
+      .from(accountMemberships)
+      .where(
+        and(
+          eq(accountMemberships.userId, params.userId),
+          eq(accountMemberships.role, 'owner'),
+          eq(accountMemberships.status, 'active'),
+        ),
+      )
+      .limit(1);
+    accountId = membership?.accountId;
+  }
+
+  if (!accountId) {
+    logger.warn('[platform-operator-entitlement] no owner membership; skip', {
+      userId: params.userId,
+    });
+    return { skipped: true, reason: 'no_owner_membership' };
+  }
+
+  const mode = getConfiguredStripeMode();
+  const [existing] = await db
+    .select({
+      tier: accountEntitlements.tier,
+      status: accountEntitlements.status,
+      features: accountEntitlements.features,
+      lastEventAt: accountEntitlements.lastEventAt,
+    })
+    .from(accountEntitlements)
+    .where(and(eq(accountEntitlements.accountId, accountId), eq(accountEntitlements.mode, mode)))
+    .limit(1);
+
+  if (existing && enterpriseRowComplete(existing)) {
+    return { accountId, wrote: false };
+  }
+
+  const now = params.now ?? new Date();
+  const values = {
+    planId: 'enterprise' as const,
+    tier: 'enterprise' as const,
+    status: 'active',
+    features: featureRecord(getFeaturesForTier('enterprise')),
+    limits: { ...PLATFORM_OPERATOR_LIMITS },
+    meteringStatus: 'active',
+    mode,
+    source: 'grant' as const,
+    graceUntil: null,
+    lastEventAt: existing ? (existing.lastEventAt ?? null) : null,
+    updatedAt: now,
+    cogsBreakerTrippedAt: null,
+    cogsBreakerReason: null,
+  };
+
+  if (existing) {
+    await db
+      .update(accountEntitlements)
+      .set(values)
+      .where(and(eq(accountEntitlements.accountId, accountId), eq(accountEntitlements.mode, mode)));
+  } else {
+    await db.insert(accountEntitlements).values({ accountId, ...values });
+  }
+
+  logger.info('[platform-operator-entitlement] granted enterprise', {
+    accountId,
+    userId: params.userId,
+    mode,
+    previousTier: existing?.tier ?? null,
+  });
+
+  return { accountId, wrote: true };
+}

--- a/packages/auth/src/server/platform-operator.ts
+++ b/packages/auth/src/server/platform-operator.ts
@@ -6,6 +6,9 @@
  *
  * Operators receive a real Enterprise `account_entitlements` row (source=grant).
  * Gates stay fail-closed. This is not an identity bypass.
+ *
+ * Live on `@revealui/auth/platform-operator`, not the `/server` barrel.
+ * Route tests bare-mock that barrel for getSession (same reason as audit-storage).
  */
 
 import { getConfiguredStripeMode } from '@revealui/config/stripe-mode';

--- a/scripts/admin/bootstrap.ts
+++ b/scripts/admin/bootstrap.ts
@@ -143,7 +143,9 @@ async function main(): Promise<void> {
     }
     if (result.user.id) {
       try {
-        const { ensurePlatformOperatorEntitlement } = await import('@revealui/auth/server');
+        const { ensurePlatformOperatorEntitlement } = await import(
+          '@revealui/auth/platform-operator'
+        );
         await ensurePlatformOperatorEntitlement({ userId: result.user.id });
         console.log('[bootstrap] platform operator enterprise entitlement ensured');
       } catch (err) {

--- a/scripts/admin/bootstrap.ts
+++ b/scripts/admin/bootstrap.ts
@@ -141,6 +141,17 @@ async function main(): Promise<void> {
         `[bootstrap] failed to record TOS acceptance: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+    if (result.user.id) {
+      try {
+        const { ensurePlatformOperatorEntitlement } = await import('@revealui/auth/server');
+        await ensurePlatformOperatorEntitlement({ userId: result.user.id });
+        console.log('[bootstrap] platform operator enterprise entitlement ensured');
+      } catch (err) {
+        console.warn(
+          `[bootstrap] failed to grant operator enterprise entitlement: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   }
 
   // Set mustRotatePassword flag if requested


### PR DESCRIPTION
## Summary

The GAP-360 hosted walk failed at Task Tester with `Feature 'ai' requires a Pro or Enterprise license` even though Groq was saved. The instance operator (first user / bootstrap super-admin) was written a **free@t0** `account_entitlements` row. Gates were correct. The row was wrong.

This does **not** add a founder identity bypass. Super-admin already means instance operator (`_json.roles`, never `users.role`). That user now gets a real **Enterprise grant** (`source=grant`), the same shape `pnpm admin:grant-entitlement --tier=enterprise` writes. Every feature gate, including A2A `tasks/send`, stays fail-closed.

## What changed

- `ensurePlatformOperatorEntitlement` upserts enterprise + unlimited `maxAgentTasks` for super-admin only.
- First-user signup promotes, then grants (after free@t0, so the operator is not left on Free).
- `pnpm admin:bootstrap` grants after the operator user exists.
- `entitlementMiddleware` heals an existing operator on the next authenticated request (covers today's founder account after deploy).
- Hosted account owners stay Free/Pro/Max as billed. They are shell admin, not super-admin.

## Tests

- `packages/auth` `platform-operator.test.ts` (13): skip non-operator, insert, upgrade free row, no-op when already enterprise.
- Server middleware: operator heal before attach.
- Lockstep: enterprise limits stay `{ maxAgentTasks: MAX_SAFE_INTEGER }`.

## Walk residual

After this is on the hosted API you used for the walk, send `List my open tickets.` again. The same session should heal the row and run Groq. If the admin UI still shows the old 403 without a new request to the API, refresh once.

## Security

Entitlements / license surface. Non-author guardrail-2 verdict required. Do not merge until that lands.