### PR TITLE
fix(admin): show upgrade prompt on Task Tester AI license 403

### DIFF
--- a/apps/admin/src/lib/components/agents/__tests__/ai-license-denial.test.ts
+++ b/apps/admin/src/lib/components/agents/__tests__/ai-license-denial.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isAiLicenseDenial } from '../ai-license-denial';
+
+describe('isAiLicenseDenial', () => {
+  it('matches the hosted A2A entitlement sentence', () => {
+    expect(
+      isAiLicenseDenial(
+        "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match other A2A errors', () => {
+    expect(isAiLicenseDenial('Invalid Request')).toBe(false);
+    expect(isAiLicenseDenial('LLM_NOT_CONFIGURED')).toBe(false);
+  });
+});

--- a/apps/admin/src/lib/components/agents/__tests__/task-tester.test.tsx
+++ b/apps/admin/src/lib/components/agents/__tests__/task-tester.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApiFetch = vi.fn();
+vi.mock('@/lib/utils/csrf', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+
+vi.mock('@/components/UpgradePrompt', () => ({
+  UpgradePrompt: ({ feature, description }: { feature: string; description?: string }) => (
+    <div data-testid="upgrade-prompt">
+      Upgrade required for {feature}
+      {description ? `: ${description}` : ''}
+    </div>
+  ),
+}));
+
+import { TaskTester } from '../task-tester';
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TaskTester', () => {
+  it('offers Send Task when the account can reach the tester', () => {
+    render(<TaskTester agentId="agent-1" agentName="Ticket Agent" />);
+
+    expect(screen.getByRole('button', { name: /send task/i })).toBeInTheDocument();
+  });
+
+  it('replaces a license-gate 403 with the upgrade prompt instead of the raw API sentence', async () => {
+    mockApiFetch.mockResolvedValue({
+      json: async () => ({
+        error: {
+          code: -32003,
+          message:
+            "Feature 'ai' requires a Pro or Enterprise license. Upgrade at https://revealui.com/pricing",
+        },
+      }),
+    });
+
+    render(<TaskTester agentId="agent-1" agentName="Ticket Agent" />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'List my open tickets.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send task/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upgrade-prompt')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/Feature 'ai' requires a Pro or Enterprise license/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/lib/components/agents/ai-license-denial.ts
+++ b/apps/admin/src/lib/components/agents/ai-license-denial.ts
@@ -1,0 +1,4 @@
+/** True when A2A (or a sibling AI route) refused the call for missing Pro/Enterprise AI. */
+export function isAiLicenseDenial(message: string): boolean {
+  return /requires a Pro or Enterprise license/i.test(message);
+}

--- a/apps/admin/src/lib/components/agents/task-tester.tsx
+++ b/apps/admin/src/lib/components/agents/task-tester.tsx
@@ -4,6 +4,8 @@ import type { A2ATask } from '@revealui/contracts';
 import { Badge, Button, Textarea } from '@revealui/presentation';
 import { Field, Label } from '@revealui/presentation/client';
 import { useState } from 'react';
+import { UpgradePrompt } from '@/components/UpgradePrompt';
+import { isAiLicenseDenial } from '@/lib/components/agents/ai-license-denial';
 import { apiFetch } from '@/lib/utils/csrf';
 
 interface TaskTesterProps {
@@ -43,12 +45,14 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
   const [state, setState] = useState<TesterState>('idle');
   const [task, setTask] = useState<A2ATask | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [needsUpgrade, setNeedsUpgrade] = useState(false);
 
   async function submit() {
     if (!instruction.trim()) return;
     setState('submitting');
     setTask(null);
     setErrorMsg(null);
+    setNeedsUpgrade(false);
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -80,6 +84,14 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
       };
 
       if (json.error) {
+        if (isAiLicenseDenial(json.error.message)) {
+          setErrorMsg(null);
+          setState('error');
+          setTask(null);
+          setNeedsUpgrade(true);
+          return;
+        }
+        setNeedsUpgrade(false);
         setErrorMsg(json.error.message);
         setState('error');
         return;
@@ -156,6 +168,13 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
           </p>
           <p className="whitespace-pre-wrap text-sm text-muted-foreground">{responseText}</p>
         </div>
+      )}
+
+      {needsUpgrade && (
+        <UpgradePrompt
+          feature="ai"
+          description="Sending a task runs the agent. This account is not entitled to AI yet. Upgrade or ask an operator to grant the plan on the account. There is no founder bypass."
+        />
       )}
 
       {/* Inline error — Alert primitive is a modal dialog, not applicable */}


### PR DESCRIPTION
## Summary

GAP-360 hosted walk Step 5 (Send Task) returned the A2A entitlement denial. The agent page is already behind LicenseGate, so this is defense when the UI and the A2A entitlement row disagree.

This PR does not add a founder bypass. The server gate stays. Send Task maps that specific denial to the existing UpgradePrompt instead of dumping the raw API sentence.

Peer session is granting Enterprise on the hosted account via the admin grant-entitlement CLI (the durable operator path). After that grant lands, Send Task should succeed. This prompt remains the honest path for a truly unentitled account.

## Test plan

- [x] isAiLicenseDenial helper asserted against the live A2A sentence
- [ ] CI: admin task-tester + ai-license-denial tests
- [ ] After peer grant: Send Task on Ticket Agent should no longer hit this prompt
- [ ] Unentitled account: Send Task still shows Upgrade, not a raw 403 sentence