### PR TITLE
fix(sync): drop api license private key after signer soak

### DIFF
--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -97,12 +97,12 @@ _Machine-generated from [`scripts/sync/secret-paths.ts`](../scripts/sync/secret-
 spec, the Vercel/Fly sync manifests, or their sensitivity markers. Change `secret-paths.ts`
 and re-run the renderer._
 
-Production runtime paths synced to Vercel + Fly (111 paths). `sensitive` = the
+Production runtime paths synced to Vercel + Fly (113 paths). `sensitive` = the
 value is never UI/API-revealable after write (credentials + private signing keys).
 
 | Path | Kind | Sensitive | Consumers | Notes |
 | --- | --- | --- | --- | --- |
-| `revdev/license-signing-private-key` | signing-private | yes | vercel:api, fly:worker, fly:license-signer, with-secrets:license-signing | → migrating to `revealui/prod/license/private-key` (since 2026-06-28); Ed25519 license-signing key. Admin dropped P4-4. Online mint target is fly:license-signer; api/worker keep a copy until SIGN_VIA_SIGNER is sole path. |
+| `revdev/license-signing-private-key` | signing-private | yes | fly:worker, fly:license-signer, with-secrets:license-signing | → migrating to `revealui/prod/license/private-key` (since 2026-06-28); Ed25519 license-signing key. Admin + api dropped P4-4 (signer is mint path). Fly worker last until executor-off digest. Offline stamper keeps with-secrets:license-signing. |
 | `revdev/license-signing-public-key` | signing-public | no | vercel:api, vercel:admin, fly:worker, fly:license-signer, with-secrets:license | → migrating to `revealui/prod/license/public-key` (since 2026-06-28); Ed25519 verification key - rotating invalidates all issued customer licenses |
 | `revealui/prod/admin/api-key` | credential | yes | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/admin/email` | public-config | no | vercel:admin |  |
@@ -124,6 +124,8 @@ value is never UI/API-revealable after write (credentials + private signing keys
 | `revealui/prod/google/private-key` | credential | yes | vercel:api, vercel:admin, fly:worker, vercel:api-staging, vercel:admin-staging | PKCS8 PEM - Gmail SA domain-wide delegation; also read by staging (GAP-343) |
 | `revealui/prod/google/service-account-email` | public-config | no | vercel:api, vercel:admin, fly:worker, vercel:api-staging, vercel:admin-staging |  |
 | `revealui/prod/kek` | credential | yes | vercel:api, vercel:admin, fly:worker | REVEALUI_KEK - AES-256-GCM envelope key; has a NEXT dual-slot rotation story |
+| `revealui/prod/license/signer-invoke-secret` | credential | yes | app:license-signer, vercel:api | HMAC-SHA256 per-call auth for POST /internal/mint. Consumed by license-signer AND mint-client when REVEALUI_LICENSE_SIGN_VIA_SIGNER is on. No REVEALUI_SECRET fallback. Fly signer sets this Fly-direct (skip). |
+| `revealui/prod/license/signer-url` | public-config | no | vercel:api | Base URL for apps/license-signer (GAP-260 P4-3 mint-client). Not a secret. Flag REVEALUI_LICENSE_SIGN_VIA_SIGNER is a plain env toggle (not vaulted). |
 | `revealui/prod/marketplace-connect-return-url` | public-config | no | vercel:api, fly:worker |  |
 | `revealui/prod/passkey/origin` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
 | `revealui/prod/passkey/rp-id` | public-config | no | vercel:api, vercel:admin, fly:worker |  |
@@ -311,7 +313,7 @@ revealui/env/license-signing  # PRIVATE: REVEALUI_LICENSE_PRIVATE_KEY
 # It previously held a pre-cutover RSA/RS256 pair. The target is UNVERIFIED: a stale RSA-era value
 # may still occupy this path (RSA is incompatible with the Ed25519 runtime verifier), so the P3-4
 # value-move is gated on a computeKeyId readback. Adversarial verification of the target is in flight.
-# GAP-260 P4-2/P4-3 (apps/license-signer + mint-client), not platform-synced until deploy:
+# GAP-260 P4-4: api now syncs these (signer soak landed). Fly signer still Fly-direct.
 revealui/prod/license/signer-invoke-secret  # REVEALUI_SIGNER_INVOKE_SECRET
                                             # HMAC for POST /internal/mint; NEVER reuse REVEALUI_SECRET
 revealui/prod/license/signer-url            # REVEALUI_LICENSE_SIGNER_URL (public base URL)
@@ -338,16 +340,17 @@ back to "private key present → hosted". `MODE=forge` with a private key presen
 requires `REVEALUI_LICENSE_PRIVATE_KEY` + `REVEALUI_SIGNER_INVOKE_SECRET` at boot (fail-loud).
 
 **Mint cutover (GAP-260 P4-3):** online mint surfaces (`apps/server` webhooks +
-`POST /api/license/generate`) call `@revealui/core/license/mint-client`. Default remains
-local private-key mint. Set `REVEALUI_LICENSE_SIGN_VIA_SIGNER=1` plus
-`REVEALUI_LICENSE_SIGNER_URL` and `REVEALUI_SIGNER_INVOKE_SECRET` on api (and worker if
-it mints) to route mints to the signer.
+`POST /api/license/generate`) call `@revealui/core/license/mint-client`. Hosted
+api routes mints to the signer when `REVEALUI_LICENSE_SIGN_VIA_SIGNER=1` plus
+`REVEALUI_LICENSE_SIGNER_URL` and `REVEALUI_SIGNER_INVOKE_SECRET` are set.
 
-**P4-4 admin drop:** prod and staging admin manifests no longer sync
-`REVEALUI_LICENSE_PRIVATE_KEY`. Set `REVEALUI_DEPLOYMENT_MODE=hosted` on admin
-preview, prove boot GREEN, then owner-apply `revvault sync vercel` so the
-private key is not re-pushed. Fly worker still lists the private key until
-executor-off is proven live. Do not apply this train without that MODE set.
+**P4-4 api drop:** prod and staging admin, and now prod api, no longer sync
+`REVEALUI_LICENSE_PRIVATE_KEY`. Set `REVEALUI_DEPLOYMENT_MODE=hosted` on api
+Production BEFORE owner-apply `revvault sync vercel --project revealui-api`
+(or scoped `--key`). Without MODE, dropping the private key makes
+`detectDeploymentMode` fall back to forge and bricks hosted boot. Fly worker
+still lists the private key until executor-off is proven live. Do not unscoped
+`--apply`.
 
 ### LLM / AI providers
 

--- a/scripts/sync/__tests__/secret-paths-lockstep.test.ts
+++ b/scripts/sync/__tests__/secret-paths-lockstep.test.ts
@@ -100,11 +100,15 @@ describe('manifest ↔ spec lockstep', () => {
     expect(findSensitivityGaps(stagingVars)).toEqual([]);
   });
 
-  it('the license private key is sensitive and the public key is bare in the Vercel manifest', () => {
+  it('Vercel prod no longer syncs the license private key; public key stays bare', () => {
     const priv = vercelVars.find((v) => v.name === 'REVEALUI_LICENSE_PRIVATE_KEY');
     const pub = vercelVars.find((v) => v.name === 'REVEALUI_LICENSE_PUBLIC_KEY');
-    expect(priv?.sensitive).toBe(true);
+    expect(priv).toBeUndefined();
     expect(pub?.sensitive).toBe(false);
+    const workerPriv = flyVars.find(
+      (v) => v.name === 'REVEALUI_LICENSE_PRIVATE_KEY' && v.source === 'fly:revealui-worker',
+    );
+    expect(workerPriv?.path).toBe('revdev/license-signing-private-key');
   });
 
   it('admin (prod + staging) does not sync the license private key (GAP-260 P4-4)', () => {
@@ -122,7 +126,16 @@ describe('manifest ↔ spec lockstep', () => {
     const apiPriv = vercelVars.find(
       (v) => v.name === 'REVEALUI_LICENSE_PRIVATE_KEY' && v.source === 'vercel:revealui-api',
     );
-    expect(apiPriv?.path).toBe('revdev/license-signing-private-key');
+    expect(apiPriv).toBeUndefined();
+    const apiSignerUrl = vercelVars.find(
+      (v) => v.name === 'REVEALUI_LICENSE_SIGNER_URL' && v.source === 'vercel:revealui-api',
+    );
+    const apiInvoke = vercelVars.find(
+      (v) => v.name === 'REVEALUI_SIGNER_INVOKE_SECRET' && v.source === 'vercel:revealui-api',
+    );
+    expect(apiSignerUrl?.path).toBe('revealui/prod/license/signer-url');
+    expect(apiInvoke?.path).toBe('revealui/prod/license/signer-invoke-secret');
+    expect(apiInvoke?.sensitive).toBe(true);
   });
 
   it('the staging license private key is sensitive and the public key is bare', () => {

--- a/scripts/sync/revvault-fly.toml
+++ b/scripts/sync/revvault-fly.toml
@@ -64,7 +64,16 @@ app = "revealui-worker"
 # diverged between the Vercel `api` project and this worker app. When you flip
 # it on one, flip it on the other in the SAME change — this manifest is the
 # checklist that makes that explicit instead of implicit.
-skip = ["STRIPE_LIVE_MODE", "STRIPE_SECRET_KEY", "STRIPE_TAX_ENABLED"]
+skip = [
+  "STRIPE_LIVE_MODE",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_TAX_ENABLED",
+  # GAP-260 P4-4: owner-set posture / mint toggle. Do not orphan on apply.
+  # Worker still holds the private key (Fly last). Set MODE=hosted here before
+  # any later private-key drop.
+  "REVEALUI_DEPLOYMENT_MODE",
+  "REVEALUI_LICENSE_SIGN_VIA_SIGNER",
+]
 
 [fly-apps.revealui-worker.vars]
 # Database (Neon)

--- a/scripts/sync/revvault-vercel.toml
+++ b/scripts/sync/revvault-vercel.toml
@@ -54,6 +54,12 @@ skip = [
   # never hardcoded or vault-mirrored — this is a public repo and the value
   # discloses the Fly worker's hostname.
   "REVEALUI_WORKER_HEALTH_URL",
+  # GAP-260 P4-4: plain hosted|forge flag. Owner must set MODE=hosted on api
+  # Production BEFORE applying a sync that drops the private key, or detectDeploymentMode
+  # falls back to forge and bricks hosted boot.
+  "REVEALUI_DEPLOYMENT_MODE",
+  # Mint-path toggle (not vaulted). Already live on api; skip so apply cannot orphan it.
+  "REVEALUI_LICENSE_SIGN_VIA_SIGNER",
 ]
 
 [projects.revealui-api.vars]
@@ -98,10 +104,12 @@ DATABASE_URL = { path = "revealui/prod/db/postgres-url", sensitive = true }
 REVEALUI_KEK                = { path = "revealui/prod/kek", sensitive = true }
 # REVEALUI_KEK_NEXT deferred — rotation slot, populated only during KEK
 # rotation. Re-add to manifest at that time.
-# Canonical license-signing keypair (Ed25519). The retired
-# revealui/prod/license/* path held the stale pre-cutover RSA pair.
-REVEALUI_LICENSE_PRIVATE_KEY = { path = "revdev/license-signing-private-key", sensitive = true }
+# GAP-260 P4-4: api mints via license-signer (SIGN_VIA_SIGNER already live).
+# Do not sync the signing private key here. Public key remains so api can
+# verify JWTs. Owner must set REVEALUI_DEPLOYMENT_MODE=hosted before apply.
 REVEALUI_LICENSE_PUBLIC_KEY  = "revdev/license-signing-public-key"
+REVEALUI_LICENSE_SIGNER_URL  = "revealui/prod/license/signer-url"
+REVEALUI_SIGNER_INVOKE_SECRET = { path = "revealui/prod/license/signer-invoke-secret", sensitive = true }
 REVEALUI_AUDIT_SIGNING_KEY   = { path = "revealui/prod/audit/signing-private-key", sensitive = true }
 REVEALUI_AUDIT_PUBLIC_KEY    = "revealui/prod/audit/signing-public-key"
 REVEALUI_SECRET              = { path = "revealui/prod/secret", sensitive = true }
@@ -220,8 +228,8 @@ NEON_API_KEY  = { path = "revealui/prod/db/neon-api-key", sensitive = true }
 # leaving it untracked here is what let it go missing when the prod env was rebuilt (regression #928).
 REVEALUI_KEK                 = { path = "revealui/prod/kek", sensitive = true }
 # GAP-260 P4-4: admin is verify-only. Do not sync the signing private key here.
-# Mint stays on api (local fallback) until SIGN_VIA_SIGNER is the sole path,
-# then apps/license-signer. Public key remains so admin can verify JWTs.
+# Online mint is apps/license-signer via api SIGN_VIA_SIGNER. Public key remains
+# so admin can verify JWTs.
 REVEALUI_LICENSE_PUBLIC_KEY  = "revdev/license-signing-public-key"
 REVEALUI_AUDIT_SIGNING_KEY   = { path = "revealui/prod/audit/signing-private-key", sensitive = true }
 REVEALUI_AUDIT_PUBLIC_KEY    = "revealui/prod/audit/signing-public-key"

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -258,10 +258,10 @@ export const SECRET_PATHS: SecretPathDef[] = [
     kind: 'signing-private',
     sensitive: true,
     tier: 'prod',
-    consumers: ['vercel:api', 'fly:worker', 'fly:license-signer', 'with-secrets:license-signing'],
+    consumers: ['fly:worker', 'fly:license-signer', 'with-secrets:license-signing'],
     migratingTo: 'revealui/prod/license/private-key',
     migratingSince: '2026-06-28',
-    note: 'Ed25519 license-signing key. Admin dropped P4-4. Online mint target is fly:license-signer; api/worker keep a copy until SIGN_VIA_SIGNER is sole path.',
+    note: 'Ed25519 license-signing key. Admin + api dropped P4-4 (signer is mint path). Fly worker last until executor-off digest. Offline stamper keeps with-secrets:license-signing.',
   },
   {
     path: 'revdev/license-signing-public-key',
@@ -875,24 +875,23 @@ export const SECRET_PATHS: SecretPathDef[] = [
     note: 'export-env signing bundle: REVEALUI_LICENSE_PRIVATE_KEY (+ public if needed for self-check). with-secrets license-signing requires REVVAULT_ALLOW_PRIVATE=1',
   },
   // GAP-260 P4-2/P4-3: dedicated HMAC for apps/license-signer mint API.
-  // NOT REVEALUI_SECRET. Not platform-synced until the signer deploy lands (P4-4).
+  // NOT REVEALUI_SECRET. Synced to api after signer soak (P4-4). Fly signer
+  // still sets it Fly-direct (skip list).
   {
     path: 'revealui/prod/license/signer-invoke-secret',
     kind: 'credential',
     sensitive: true,
     tier: 'prod',
-    consumers: ['app:license-signer', 'vercel:api', 'fly:worker'],
-    intentionallyUnsynced: true,
+    consumers: ['app:license-signer', 'vercel:api'],
     envVars: ['REVEALUI_SIGNER_INVOKE_SECRET'],
-    note: 'HMAC-SHA256 per-call auth for POST /internal/mint. Consumed by license-signer AND mint-client (api/worker) when REVEALUI_LICENSE_SIGN_VIA_SIGNER is on. No REVEALUI_SECRET fallback.',
+    note: 'HMAC-SHA256 per-call auth for POST /internal/mint. Consumed by license-signer AND mint-client when REVEALUI_LICENSE_SIGN_VIA_SIGNER is on. No REVEALUI_SECRET fallback. Fly signer sets this Fly-direct (skip).',
   },
   {
     path: 'revealui/prod/license/signer-url',
     kind: 'public-config',
     sensitive: false,
     tier: 'prod',
-    consumers: ['vercel:api', 'fly:worker'],
-    intentionallyUnsynced: true,
+    consumers: ['vercel:api'],
     envVars: ['REVEALUI_LICENSE_SIGNER_URL'],
     note: 'Base URL for apps/license-signer (GAP-260 P4-3 mint-client). Not a secret. Flag REVEALUI_LICENSE_SIGN_VIA_SIGNER is a plain env toggle (not vaulted).',
   },


### PR DESCRIPTION
## Summary

GAP-260 P4-4 next slice. Hosted api already mints via `revealui-license-signer`. This PR stops syncing `REVEALUI_LICENSE_PRIVATE_KEY` to `vercel:api`, starts syncing signer URL + invoke secret, and skips `REVEALUI_DEPLOYMENT_MODE` / `REVEALUI_LICENSE_SIGN_VIA_SIGNER` so apply cannot orphan them.

Fly worker still lists the private key (last surface).

## Review-pending

Security-classed (license signing). Do not merge until a non-author guardrail-2 verdict is recorded.

## Owner apply after merge (strict order)

Do not run unscoped `revvault sync vercel --apply`.

This machine is Vercel CLI 50.37.3. `vercel env` has **no** `--project` flag. `--scope` is the team, not the environment. The monorepo `.vercel` link is the `revealui` project, not `revealui-api`. Do not `vercel link` inside `~/revfleet/revealui` (that overwrites the existing link).

1. Set MODE on api Production before unsetting the private key.

Dashboard (simplest):
https://vercel.com/revealuistudio/revealui-api/settings/environment-variables
Add `REVEALUI_DEPLOYMENT_MODE` = `hosted`, Production only.

CLI (scratch link, leave the repo link alone):

```bash
mkdir -p /tmp/vercel-revealui-api
vercel link --cwd /tmp/vercel-revealui-api --yes \
  --project prj_zk6EQijYXwd9L7BccuBssi436ktM \
  --team revealuistudio
vercel env ls production --cwd /tmp/vercel-revealui-api
vercel env add REVEALUI_DEPLOYMENT_MODE production \
  --cwd /tmp/vercel-revealui-api --value hosted --yes
```

If the name already exists, `vercel env rm REVEALUI_DEPLOYMENT_MODE production --cwd /tmp/vercel-revealui-api --yes` then add again.

Without MODE, dropping the private key makes `detectDeploymentMode` fall back to forge and bricks hosted boot.

2. Confirm signer URL + invoke secret on api (already live from the earlier signer cutover), or scoped-apply those two keys only.
3. Unset the private key on api Production only (after this PR is on `test`):

```bash
vercel env rm REVEALUI_LICENSE_PRIVATE_KEY production \
  --cwd /tmp/vercel-revealui-api --yes
```

4. Prove `api.revealui.com/health` is 200 and one mint still verifies against the unchanged public key.
5. Fly worker last, after executor-off digest. Not this PR.

## Tests

`vitest run scripts/sync/__tests__/secret-paths-lockstep.test.ts scripts/sync/__tests__/license-public-only-mint-boundary.test.ts` (26 passed).

Pairs with jv#1348.