### PR TITLE
feat(presentation): re-author Badge onto semantic intent

### DIFF
--- a/.changeset/presentation-badge-sovereignty.md
+++ b/.changeset/presentation-badge-sovereignty.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': minor
+---
+
+Re-author Badge onto semantic `intent` and retire the Catalyst 20-swatch `color` palette.

--- a/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/page.tsx
@@ -268,7 +268,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                       <div className="flex items-start justify-between gap-3">
                         <h1 className="text-xl font-semibold text-foreground">{card.name}</h1>
                         <div className="flex shrink-0 items-center gap-2">
-                          <Badge color="success">v{card.version}</Badge>
+                          <Badge intent="success">v{card.version}</Badge>
                           <Button
                             type="button"
                             onClick={handleEditStart}
@@ -350,7 +350,7 @@ export default function AgentDetailPage({ params }: PageProps) {
                         {skill.tags && skill.tags.length > 0 && (
                           <div className="mt-1.5 flex flex-wrap gap-1">
                             {skill.tags.map((tag) => (
-                              <Badge key={tag} color="muted">
+                              <Badge key={tag} intent="muted">
                                 {tag}
                               </Badge>
                             ))}

--- a/apps/admin/src/app/(backend)/agents/new/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/new/page.tsx
@@ -318,12 +318,12 @@ export default function NewAgentPage() {
                     <p className="text-xs text-muted-foreground leading-relaxed">{t.description}</p>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {t.capabilities.slice(0, 2).map((cap) => (
-                        <Badge key={cap} color="muted">
+                        <Badge key={cap} intent="muted">
                           {cap}
                         </Badge>
                       ))}
                       {t.capabilities.length > 2 && (
-                        <Badge color="muted">+{t.capabilities.length - 2}</Badge>
+                        <Badge intent="muted">+{t.capabilities.length - 2}</Badge>
                       )}
                     </div>
                   </Button>

--- a/apps/admin/src/app/(backend)/audit/page.tsx
+++ b/apps/admin/src/app/(backend)/audit/page.tsx
@@ -312,7 +312,7 @@ function AuditDashboard() {
                         {formatTime(new Date(row.timestamp))}
                       </TableCell>
                       <TableCell>
-                        <Badge color={SEVERITY_BADGE_COLOR[row.severity] ?? 'muted'}>
+                        <Badge intent={SEVERITY_BADGE_COLOR[row.severity] ?? 'muted'}>
                           {row.severity}
                         </Badge>
                       </TableCell>

--- a/apps/admin/src/app/(backend)/coordination/page.tsx
+++ b/apps/admin/src/app/(backend)/coordination/page.tsx
@@ -253,7 +253,7 @@ function SessionRow({
         aria-expanded={expanded}
       >
         <div className="flex w-full items-center gap-3">
-          <Badge color={statusColor(session.status)}>{session.status}</Badge>
+          <Badge intent={statusColor(session.status)}>{session.status}</Badge>
           <span className="truncate font-mono text-sm text-muted-foreground">
             {session.agent_id}
           </span>
@@ -264,7 +264,10 @@ function SessionRow({
             {formatAge(age)}
           </span>
           {stale && (
-            <Badge color="warning" title="Session has not ended after 7+ days — likely a stale row">
+            <Badge
+              intent="warning"
+              title="Session has not ended after 7+ days — likely a stale row"
+            >
               stale
             </Badge>
           )}
@@ -292,7 +295,7 @@ function SessionRow({
                 <h4 className="mb-1 text-xs font-medium text-muted-foreground">Tool counters</h4>
                 <div className="flex flex-wrap gap-2">
                   {Object.entries(session.tools).map(([tool, n]) => (
-                    <Badge key={tool} color="muted">
+                    <Badge key={tool} intent="muted">
                       <span className="font-mono">
                         {tool}: {n}
                       </span>

--- a/apps/admin/src/app/(backend)/knowledge-graph/page.tsx
+++ b/apps/admin/src/app/(backend)/knowledge-graph/page.tsx
@@ -235,7 +235,7 @@ function KnowledgeGraphExplorer() {
                   >
                     <div className="flex w-full flex-col gap-0.5">
                       <div className="flex items-center gap-2">
-                        <Badge color="muted">{node.kind}</Badge>
+                        <Badge intent="muted">{node.kind}</Badge>
                         <span className="truncate text-sm text-foreground">{node.name}</span>
                       </div>
                       <div className="truncate font-mono text-xs text-muted-foreground">
@@ -368,9 +368,9 @@ function NodeDetailPane({
       <Card>
         <div className="p-4">
           <div className="flex items-center gap-2">
-            <Badge color="muted">{node.kind}</Badge>
+            <Badge intent="muted">{node.kind}</Badge>
             <h2 className="text-lg font-semibold text-foreground">{node.name}</h2>
-            {isPinned && <Badge color="warning">pinned</Badge>}
+            {isPinned && <Badge intent="warning">pinned</Badge>}
           </div>
           <div className="mt-1 font-mono text-xs text-muted-foreground">{node.natural_key}</div>
           {node.repo && <div className="mt-1 text-xs text-muted-foreground">repo: {node.repo}</div>}
@@ -407,7 +407,7 @@ function NodeDetailPane({
               {facts.map(({ edge, other, provenance }) => (
                 <li key={edge.id} className="rounded-lg border border-border p-2 text-sm">
                   <div>
-                    <Badge color="muted">{edge.relation}</Badge>{' '}
+                    <Badge intent="muted">{edge.relation}</Badge>{' '}
                     <span className="text-foreground">{edge.fact}</span>
                   </div>
                   <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">

--- a/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/[agentId]/page.tsx
@@ -147,7 +147,7 @@ export default function MarketplaceAgentDetailPage() {
                   {agent.rating.toFixed(1)} ({agent.reviewCount} reviews)
                 </span>
                 <span>{agent.taskCount} tasks completed</span>
-                <Badge color="muted">{agent.category}</Badge>
+                <Badge intent="muted">{agent.category}</Badge>
                 <span className="text-muted-foreground">v{agent.version}</span>
               </div>
             </div>
@@ -376,7 +376,7 @@ function ReviewsPanel({
                     </span>
                   ))}
                 </div>
-                {review.verified === 1 && <Badge color="success">Verified</Badge>}
+                {review.verified === 1 && <Badge intent="success">Verified</Badge>}
                 <span className="text-xs text-muted-foreground">
                   {new Date(review.createdAt).toLocaleDateString()}
                 </span>

--- a/apps/admin/src/app/(backend)/marketplace/analytics/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/analytics/page.tsx
@@ -161,7 +161,7 @@ export default function AnalyticsPage() {
                           </TableCell>
                           <TableCell>
                             <Badge
-                              color={
+                              intent={
                                 agent.status === 'published'
                                   ? 'success'
                                   : agent.status === 'draft'

--- a/apps/admin/src/app/(backend)/marketplace/earnings/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/earnings/page.tsx
@@ -133,7 +133,7 @@ export default function EarningsDashboardPage() {
                               ★ {agent.rating.toFixed(1)} ({agent.reviewCount})
                             </span>
                             <span>{agent.taskCount} tasks</span>
-                            <Badge color={agent.status === 'published' ? 'success' : 'muted'}>
+                            <Badge intent={agent.status === 'published' ? 'success' : 'muted'}>
                               {agent.status}
                             </Badge>
                           </div>

--- a/apps/admin/src/app/(backend)/marketplace/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/page.tsx
@@ -196,14 +196,14 @@ function MarketplaceAgentCard({ agent }: { agent: MarketplaceAgent }) {
           </h3>
           <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{agent.description}</p>
         </div>
-        <Badge color="muted">{agent.category}</Badge>
+        <Badge intent="muted">{agent.category}</Badge>
       </div>
 
       {/* Tags */}
       {agent.tags.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-1">
           {agent.tags.slice(0, 4).map((tag) => (
-            <Badge key={tag} color="muted">
+            <Badge key={tag} intent="muted">
               {tag}
             </Badge>
           ))}

--- a/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
+++ b/apps/admin/src/app/(backend)/marketplace/tasks/page.tsx
@@ -203,7 +203,7 @@ function TaskRow({
         onClick={onToggle}
         className="flex h-auto w-full items-center gap-4 rounded-none px-4 py-3 text-left hover:bg-muted"
       >
-        <Badge color={STATUS_BADGE_COLORS[task.status] ?? 'muted'}>{task.status}</Badge>
+        <Badge intent={STATUS_BADGE_COLORS[task.status] ?? 'muted'}>{task.status}</Badge>
         <span className="flex-1 truncate text-sm text-foreground">{task.skill_name}</span>
         <span className="text-xs text-muted-foreground">P{task.priority}</span>
         {task.cost_usdc && <span className="text-xs text-muted-foreground">${task.cost_usdc}</span>}

--- a/apps/admin/src/app/(backend)/mcp/page.tsx
+++ b/apps/admin/src/app/(backend)/mcp/page.tsx
@@ -270,7 +270,7 @@ export default function McpCatalogPage() {
                             {r.tenant}
                           </TableCell>
                           <TableCell>
-                            <Badge color="success">{r.connectionState}</Badge>
+                            <Badge intent="success">{r.connectionState}</Badge>
                           </TableCell>
                           <TableCell className="text-right">
                             <div className="flex items-center justify-end gap-3">
@@ -340,9 +340,9 @@ export default function McpCatalogPage() {
                           </TableCell>
                           <TableCell>
                             {c.mcpResource ? (
-                              <Badge color="success">exposed</Badge>
+                              <Badge intent="success">exposed</Badge>
                             ) : (
-                              <Badge color="muted">hidden</Badge>
+                              <Badge intent="muted">hidden</Badge>
                             )}
                           </TableCell>
                         </TableRow>

--- a/apps/admin/src/app/(backend)/refunds/page.tsx
+++ b/apps/admin/src/app/(backend)/refunds/page.tsx
@@ -421,7 +421,7 @@ function RefundsDashboard() {
                       {record.id}
                     </TableCell>
                     <TableCell>
-                      <Badge color={REFUND_STATUS_COLORS[record.status] ?? 'muted'}>
+                      <Badge intent={REFUND_STATUS_COLORS[record.status] ?? 'muted'}>
                         {record.status}
                       </Badge>
                     </TableCell>

--- a/apps/admin/src/app/(frontend)/welcome/page.tsx
+++ b/apps/admin/src/app/(frontend)/welcome/page.tsx
@@ -76,7 +76,7 @@ export default function WelcomePage() {
       <div className="text-center mb-12">
         {isPostPurchase && isPaidTier && (
           <div className="mb-6 flex justify-center">
-            <Badge color="success">
+            <Badge intent="success">
               <span role="img" aria-label="Checkmark">
                 &#10003;
               </span>

--- a/apps/admin/src/lib/components/agents/agent-card.tsx
+++ b/apps/admin/src/lib/components/agents/agent-card.tsx
@@ -22,7 +22,7 @@ export function AgentCard({ card, agentId }: AgentCardProps) {
           <h3 className="truncate font-semibold text-foreground">{card.name}</h3>
           <p className="mt-0.5 text-xs text-muted-foreground">v{card.version}</p>
         </div>
-        <Badge color="success">active</Badge>
+        <Badge intent="success">active</Badge>
       </div>
 
       {/* Description */}
@@ -30,10 +30,10 @@ export function AgentCard({ card, agentId }: AgentCardProps) {
 
       {/* Capabilities */}
       <div className="flex flex-wrap gap-1.5">
-        {card.capabilities.streaming && <Badge color="blue">streaming</Badge>}
-        {card.capabilities.pushNotifications && <Badge color="purple">push</Badge>}
+        {card.capabilities.streaming && <Badge intent="brand">streaming</Badge>}
+        {card.capabilities.pushNotifications && <Badge intent="brand">push</Badge>}
         {card.authentication.schemes.map((scheme) => (
-          <Badge key={scheme} color="zinc">
+          <Badge key={scheme} intent="neutral">
             {scheme}
           </Badge>
         ))}

--- a/apps/admin/src/lib/components/agents/agent-contexts.tsx
+++ b/apps/admin/src/lib/components/agents/agent-contexts.tsx
@@ -70,7 +70,7 @@ function AgentContextsInner({ agentId }: AgentContextsProps) {
       {agentContexts.map((ctx) => (
         <li key={ctx.id} className="rounded-lg border border-border p-3">
           <div className="mb-1.5 flex items-center gap-2">
-            <Badge color="muted">priority {ctx.priority}</Badge>
+            <Badge intent="muted">priority {ctx.priority}</Badge>
             <span className="text-xs text-muted-foreground">
               {formatRelativeTime(ctx.created_at)}
             </span>

--- a/apps/admin/src/lib/components/agents/mcp-server-card.tsx
+++ b/apps/admin/src/lib/components/agents/mcp-server-card.tsx
@@ -46,7 +46,7 @@ export function McpServerCard({ server }: McpServerCardProps) {
             {server.packageName ?? server.remoteUrl ?? server.id}
           </p>
         </div>
-        <Badge color={STATUS_BADGE_COLOR[server.status]}>{server.status}</Badge>
+        <Badge intent={STATUS_BADGE_COLOR[server.status]}>{server.status}</Badge>
       </div>
 
       {/* Description */}
@@ -56,7 +56,7 @@ export function McpServerCard({ server }: McpServerCardProps) {
       {server.envRequired.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-1">
           {server.envRequired.map((envVar) => (
-            <Badge key={envVar} color="muted" className="font-mono">
+            <Badge key={envVar} intent="muted" className="font-mono">
               {envVar}
             </Badge>
           ))}

--- a/apps/admin/src/lib/components/agents/task-history.tsx
+++ b/apps/admin/src/lib/components/agents/task-history.tsx
@@ -119,8 +119,11 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const color = (STATUS_BADGE_COLOR as Record<string, string>)[status] ?? 'muted';
-  return <Badge intent={color}>{status}</Badge>;
+  const intent =
+    status in STATUS_BADGE_COLOR
+      ? STATUS_BADGE_COLOR[status as keyof typeof STATUS_BADGE_COLOR]
+      : 'muted';
+  return <Badge intent={intent}>{status}</Badge>;
 }
 
 /** Pull the user text from the tasks/send params */

--- a/apps/admin/src/lib/components/agents/task-history.tsx
+++ b/apps/admin/src/lib/components/agents/task-history.tsx
@@ -120,7 +120,7 @@ export function TaskHistory({ agentId, refreshKey }: TaskHistoryProps) {
 
 function StatusBadge({ status }: { status: string }) {
   const color = (STATUS_BADGE_COLOR as Record<string, string>)[status] ?? 'muted';
-  return <Badge color={color as 'success' | 'danger' | 'muted'}>{status}</Badge>;
+  return <Badge intent={color}>{status}</Badge>;
 }
 
 /** Pull the user text from the tasks/send params */

--- a/apps/admin/src/lib/components/agents/task-tester.tsx
+++ b/apps/admin/src/lib/components/agents/task-tester.tsx
@@ -190,5 +190,5 @@ export function TaskTester({ agentId, agentName, onComplete }: TaskTesterProps) 
 function TaskStateBadge({ state }: { state: string }) {
   const color = TASK_STATE_BADGE_COLOR[state as keyof typeof TASK_STATE_BADGE_COLOR] ?? 'muted';
   const label = TASK_STATE_LABEL[state] ?? state;
-  return <Badge color={color}>{label}</Badge>;
+  return <Badge intent={color}>{label}</Badge>;
 }

--- a/apps/docs/app/showcase/badge.showcase.tsx
+++ b/apps/docs/app/showcase/badge.showcase.tsx
@@ -1,75 +1,56 @@
 import { Badge } from '@revealui/presentation/client';
 import type { ShowcaseStory } from '@/components/showcase/types.js';
 
-const badgeColors = [
-  'red',
-  'orange',
-  'amber',
-  'yellow',
-  'lime',
-  'green',
-  'emerald',
-  'teal',
-  'cyan',
-  'sky',
-  'blue',
-  'indigo',
-  'violet',
-  'purple',
-  'fuchsia',
-  'pink',
-  'rose',
-  'zinc',
-];
+const badgeIntents = ['brand', 'neutral', 'success', 'warning', 'danger', 'muted'] as const;
 
 const story: ShowcaseStory = {
   slug: 'badge',
   name: 'Badge',
-  description: 'Inline status indicator with 18 color variants. Uses pill-shaped radius token.',
+  description: 'Inline status chip. Semantic intents only; colour never encodes meaning alone.',
   category: 'component',
 
   controls: {
-    color: { type: 'select', options: badgeColors, default: 'zinc' },
+    intent: { type: 'select', options: [...badgeIntents], default: 'neutral' },
     children: { type: 'text', default: 'Badge' },
   },
 
   render: (props: Record<string, unknown>) => (
-    <Badge color={props.color as 'zinc'}>{props.children as string}</Badge>
+    <Badge intent={props.intent as (typeof badgeIntents)[number]}>{props.children as string}</Badge>
   ),
 
   variantGrid: {
-    color: badgeColors,
+    intent: [...badgeIntents],
   },
 
   examples: [
     {
-      name: 'Status Indicators',
+      name: 'Status',
       render: () => (
         <div className="flex flex-wrap gap-2">
-          <Badge color="green">Active</Badge>
-          <Badge color="amber">Pending</Badge>
-          <Badge color="red">Failed</Badge>
-          <Badge color="blue">Info</Badge>
-          <Badge color="zinc">Draft</Badge>
+          <Badge intent="success">Active</Badge>
+          <Badge intent="warning">Pending</Badge>
+          <Badge intent="danger">Failed</Badge>
+          <Badge intent="brand">Info</Badge>
+          <Badge intent="neutral">Draft</Badge>
         </div>
       ),
     },
     {
-      name: 'Feature Tags',
+      name: 'Tags',
       render: () => (
         <div className="flex flex-wrap gap-2">
-          <Badge color="violet">AI</Badge>
-          <Badge color="emerald">OSS</Badge>
-          <Badge color="sky">TypeScript</Badge>
-          <Badge color="fuchsia">Pro</Badge>
+          <Badge intent="brand">AI</Badge>
+          <Badge intent="success">OSS</Badge>
+          <Badge intent="muted">TypeScript</Badge>
+          <Badge intent="brand">Pro</Badge>
         </div>
       ),
     },
   ],
 
   code: (props: Record<string, unknown>) => {
-    const colorAttr = props.color !== 'zinc' ? ` color="${props.color}"` : '';
-    return `<Badge${colorAttr}>${props.children}</Badge>`;
+    const intentAttr = props.intent !== 'neutral' ? ` intent="${props.intent}"` : '';
+    return `<Badge${intentAttr}>${props.children}</Badge>`;
   },
 
   a11y: {

--- a/apps/marketing/app/routes/ClaimsPage.tsx
+++ b/apps/marketing/app/routes/ClaimsPage.tsx
@@ -107,7 +107,7 @@ const LEDGER_SURFACE_COUNT = COVERED_FILES.length + BLOG_POST_METADATA.length;
 function EvidenceRow({ evidence }: { evidence: ClaimEntry['evidence'][number] }) {
   return (
     <li className="flex flex-wrap items-start gap-x-2 gap-y-1 border-t border-dashed border-border py-2 font-mono text-xs">
-      <Badge color={KIND_BADGE_COLOR}>{KIND_LABEL[evidence.kind] ?? evidence.kind}</Badge>
+      <Badge intent={KIND_BADGE_COLOR}>{KIND_LABEL[evidence.kind] ?? evidence.kind}</Badge>
       {evidence.kind === 'command' ? (
         <div className="w-full pt-1">
           <CodeBlock code={evidence.ref} language="bash" />
@@ -223,7 +223,7 @@ export function ClaimsPage() {
         <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {CLAIMS_KIND_LEGEND.map((entry) => (
             <div key={entry.kind} className="flex items-start gap-3">
-              <Badge color={KIND_BADGE_COLOR} className="mt-0.5 shrink-0">
+              <Badge intent={KIND_BADGE_COLOR} className="mt-0.5 shrink-0">
                 {entry.label}
               </Badge>
               <dd className="text-sm text-body">{entry.description}</dd>

--- a/packages/presentation/CHANGELOG.md
+++ b/packages/presentation/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @revealui/presentation
 
+## 0.14.0
+
+### Minor Changes
+
+- Re-author Badge as an owned RevealUI chip (component sovereignty PR-3).
+
+  **Breaking (0.x minor):** `Badge` / `BadgeButton` drop the Catalyst 20-swatch
+  `color` palette for semantic `intent`:
+  `'brand' | 'neutral' | 'success' | 'warning' | 'danger' | 'muted'`.
+
+  **Default change:** an unstyled `<Badge>` was palette zinc and is now
+  `neutral` (muted surface + muted ink).
+
+  Migration: `color="blue"|"indigo"|"violet"|…` → `intent="brand"`;
+  `color="zinc"` → `intent="neutral"`; green family → `success`;
+  amber/yellow → `warning`; red family → `danger`. The legacy `color` prop
+  remains as a deprecated alias through 0.15 with a one-shot dev warning.
+
+  First-party admin, marketing, and docs showcase call sites already use
+  `intent`. `presentation-lint` no longer exempts `badge.tsx`.
+
 ## 0.13.1
 
 ### Patch Changes

--- a/packages/presentation/CONTRIBUTING.md
+++ b/packages/presentation/CONTRIBUTING.md
@@ -33,8 +33,8 @@ Every new component goes through five steps. Skipping any of these blocks merge.
 
 Components live under `src/components/`. Two patterns coexist:
 
-- **Headless** (`button-headless.tsx`) — bare functionality with no styling. Useful when consumers need to bring their own visual treatment.
-- **CVA** (`Button.tsx`) — opinionated styled variant powered by CVA (`class-variance-authority` clone in `utils/cn.ts`). Most consumers use this.
+- **Headless** (`checkbox-headless.tsx`, `input-headless.tsx`, …) — behavior and a11y with no visual opinion. Useful when consumers bring their own classes.
+- **Styled** (`Button.tsx`, `Badge.tsx`) — opinionated tokens via CVA (`utils/cn.ts`). Most consumers use this.
 
 The CVA component should accept the same props as the headless one plus a `variant` and `size` (or component-specific equivalents). Re-export both from `src/components/index.ts` and `src/server.ts` (server-safe subset) or `src/client.ts` (client-only).
 

--- a/packages/presentation/docs/anatomy/badge.md
+++ b/packages/presentation/docs/anatomy/badge.md
@@ -1,0 +1,63 @@
+# Badge anatomy (Phase 3 PR-3)
+
+Grounding: product usage (admin status chips, /claims evidence kind, docs
+showcase), WAI-ARIA APG "Status" (text that is not a widget), `@revealui/tokens`
+semantic bridge. Catalyst source was not open while writing this.
+
+## Parts
+
+| Part | Role |
+|---|---|
+| Root | `<span>` (static) or `<button>` / `<a>` wrapper (`BadgeButton`) |
+| Label | Required visible text. Color never encodes meaning alone (WCAG 1.4.1). |
+| Hit target | `TouchTarget` on `BadgeButton` only (WCAG 2.5.5, 44px on coarse pointers). |
+
+Not a live region by default. Callers that need announcements use `role="status"`
+on the page, not on every chip.
+
+## States
+
+| State | How |
+|---|---|
+| Rest | Token fill + ink for the resolved `intent` |
+| Hover | `BadgeButton` only: `group-hover:` steps the fill. Static `Badge` has no hover. |
+| Focus-visible | Native `:focus-visible` ring via `focusRing` (`--ring`). |
+| Disabled | `BadgeButton`: native `disabled` / `aria-disabled` + `opacity-50`. |
+| Press | Native `:active` (no press-scale; chips are not primary actions). |
+
+No Catalyst `data-hover` / `data-focus` class recipes.
+
+## Keyboard (`BadgeButton`)
+
+Native button / link map. Enter and Space activate the button. Disabled
+controls are not in the tab order.
+
+## Token hooks
+
+| Intent | Fill | Ink |
+|---|---|---|
+| `brand` | `bg-primary/10` | `text-primary` |
+| `neutral` (default) | `bg-muted` | `text-muted-foreground` |
+| `muted` | same as `neutral` (metadata tags; named because call sites already use it) |
+| `success` | `bg-success/10` | `text-success` |
+| `warning` | `bg-warning/10` | `text-warning-foreground` |
+| `danger` | `bg-destructive/10` | `text-destructive` |
+
+Radius: `--rvui-radius-full`. Motion: `--rvui-duration-fast` / `--rvui-ease`.
+No raw Tailwind palette steps.
+
+## API
+
+```ts
+intent?: 'brand' | 'neutral' | 'success' | 'warning' | 'danger' | 'muted'
+color?: LegacyColorway | BadgeIntent  // deprecated through 0.15
+```
+
+`color` maps through `LEGACY_COLOR_TO_INTENT` (or the six intents if already
+semantic) and warns once in development. The 20-swatch product-tag palette
+does not survive.
+
+## Do-not-redo
+
+Visual weight stays a small pill. This is the API / provenance pass from the
+sovereignty spec §3.5, not a new chip design.

--- a/packages/presentation/src/__tests__/components/badge.test.tsx
+++ b/packages/presentation/src/__tests__/components/badge.test.tsx
@@ -1,80 +1,104 @@
 /**
  * Badge Component Tests
  *
- * Tests the Badge and BadgeButton components for rendering,
- * color variants, and interactive behavior.
+ * Semantic-intent API (Phase 3 PR-3). Palette `color` remains as a deprecated
+ * alias through 0.15 and is covered only as a mapping contract.
  */
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Badge, BadgeButton } from '../../components/badge';
+import { Badge, BadgeButton } from '../../components/badge.js';
 
 describe('Badge', () => {
   describe('Rendering', () => {
-    it('should render with text content', () => {
+    it('renders a span with its text', () => {
       render(<Badge>Active</Badge>);
-      expect(screen.getByText('Active')).toBeInTheDocument();
-    });
-
-    it('should render as a span element', () => {
-      render(<Badge>Status</Badge>);
-      const badge = screen.getByText('Status');
+      const badge = screen.getByText('Active');
       expect(badge.tagName).toBe('SPAN');
     });
 
-    it('should apply custom className', () => {
+    it('applies a custom className after the intent classes', () => {
       render(<Badge className="custom-class">Test</Badge>);
       expect(screen.getByText('Test')).toHaveClass('custom-class');
     });
 
-    it('should apply base styles', () => {
+    it('applies the chip base styles', () => {
       render(<Badge>Base</Badge>);
       const badge = screen.getByText('Base');
       expect(badge).toHaveClass('inline-flex');
-      expect(badge).toHaveClass('rounded-md');
       expect(badge).toHaveClass('font-medium');
+      expect(badge).toHaveClass('rounded-[var(--rvui-radius-full,9999px)]');
     });
   });
 
-  describe('Color Variants', () => {
-    it('should default to zinc color', () => {
+  describe('Intents', () => {
+    it('defaults to the neutral (muted) fill', () => {
       render(<Badge>Default</Badge>);
-      const badge = screen.getByText('Default');
-      expect(badge.className).toContain('bg-zinc');
+      expect(screen.getByText('Default')).toHaveClass('bg-muted');
+      expect(screen.getByText('Default')).toHaveClass('text-muted-foreground');
     });
 
-    it('should apply red color variant', () => {
-      render(<Badge color="red">Error</Badge>);
-      const badge = screen.getByText('Error');
-      expect(badge.className).toContain('bg-red');
-      expect(badge.className).toContain('text-red');
+    it('applies brand', () => {
+      render(<Badge intent="brand">Info</Badge>);
+      expect(screen.getByText('Info')).toHaveClass('bg-primary/10');
+      expect(screen.getByText('Info')).toHaveClass('text-primary');
     });
 
-    it('should apply green color variant', () => {
-      render(<Badge color="green">Success</Badge>);
-      const badge = screen.getByText('Success');
-      expect(badge.className).toContain('bg-green');
-      expect(badge.className).toContain('text-green');
+    it('applies success', () => {
+      render(<Badge intent="success">Ok</Badge>);
+      expect(screen.getByText('Ok')).toHaveClass('bg-success/10');
+      expect(screen.getByText('Ok')).toHaveClass('text-success');
     });
 
-    it('should apply blue color variant', () => {
-      render(<Badge color="blue">Info</Badge>);
-      const badge = screen.getByText('Info');
-      expect(badge.className).toContain('bg-blue');
-      expect(badge.className).toContain('text-blue');
+    it('applies warning', () => {
+      render(<Badge intent="warning">Hold</Badge>);
+      expect(screen.getByText('Hold')).toHaveClass('bg-warning/10');
     });
 
-    it('should apply amber color variant', () => {
-      render(<Badge color="amber">Warning</Badge>);
-      const badge = screen.getByText('Warning');
-      expect(badge.className).toContain('bg-amber');
-      expect(badge.className).toContain('text-amber');
+    it('applies danger', () => {
+      render(<Badge intent="danger">Failed</Badge>);
+      expect(screen.getByText('Failed')).toHaveClass('bg-destructive/10');
+      expect(screen.getByText('Failed')).toHaveClass('text-destructive');
+    });
+
+    it('does not emit raw Tailwind palette steps', () => {
+      render(<Badge intent="danger">Failed</Badge>);
+      expect(screen.getByText('Failed').className).not.toMatch(
+        /\b(?:red|green|blue|amber|zinc|purple)-\d{2,3}\b/,
+      );
     });
   });
 
-  describe('Props Spreading', () => {
-    it('should pass through HTML span attributes', () => {
+  describe('Deprecated color alias', () => {
+    it('maps palette red to danger', () => {
+      render(<Badge color="red">Error</Badge>);
+      expect(screen.getByText('Error')).toHaveClass('bg-destructive/10');
+    });
+
+    it('maps palette green to success', () => {
+      render(<Badge color="green">Saved</Badge>);
+      expect(screen.getByText('Saved')).toHaveClass('bg-success/10');
+    });
+
+    it('maps palette blue to brand', () => {
+      render(<Badge color="blue">Info</Badge>);
+      expect(screen.getByText('Info')).toHaveClass('bg-primary/10');
+    });
+
+    it('accepts an already-semantic color name as a migration shim', () => {
+      render(<Badge color="muted">Tag</Badge>);
+      expect(screen.getByText('Tag')).toHaveClass('bg-muted');
+    });
+
+    it('does not leak the color prop onto the DOM', () => {
+      render(<Badge color="red">Error</Badge>);
+      expect(screen.getByText('Error')).not.toHaveAttribute('color');
+    });
+  });
+
+  describe('Props spreading', () => {
+    it('passes through HTML span attributes', () => {
       render(
         <Badge data-testid="my-badge" id="badge-1">
           Test
@@ -88,19 +112,25 @@ describe('Badge', () => {
 
 describe('BadgeButton', () => {
   describe('Rendering as button', () => {
-    it('should render as a button by default', () => {
+    it('renders a button by default', () => {
       render(<BadgeButton>Click</BadgeButton>);
       expect(screen.getByRole('button', { name: /click/i })).toBeInTheDocument();
     });
 
-    it('should render with badge styling inside', () => {
-      render(<BadgeButton color="red">Alert</BadgeButton>);
-      expect(screen.getByText('Alert')).toBeInTheDocument();
+    it('forwards intent to the inner Badge', () => {
+      render(<BadgeButton intent="danger">Alert</BadgeButton>);
+      expect(screen.getByText('Alert')).toHaveClass('bg-destructive/10');
+    });
+
+    it('uses the native focus-visible ring, not data-focus', () => {
+      render(<BadgeButton>Focus</BadgeButton>);
+      expect(screen.getByRole('button')).toHaveClass('focus-visible:outline-ring');
+      expect(screen.getByRole('button').className).not.toContain('data-focus:outline');
     });
   });
 
-  describe('User Interaction', () => {
-    it('should handle click events', async () => {
+  describe('User interaction', () => {
+    it('fires onClick', async () => {
       const user = userEvent.setup();
       const onClick = vi.fn();
 
@@ -110,7 +140,7 @@ describe('BadgeButton', () => {
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should not fire click when disabled', async () => {
+    it('does not fire onClick when disabled', async () => {
       const user = userEvent.setup();
       const onClick = vi.fn();
 
@@ -122,14 +152,6 @@ describe('BadgeButton', () => {
       await user.click(screen.getByRole('button', { name: /disabled/i }));
 
       expect(onClick).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Color Variants', () => {
-    it('should pass color to inner Badge', () => {
-      render(<BadgeButton color="purple">Purple</BadgeButton>);
-      const badgeSpan = screen.getByText('Purple');
-      expect(badgeSpan.className).toContain('bg-purple');
     });
   });
 });

--- a/packages/presentation/src/client.ts
+++ b/packages/presentation/src/client.ts
@@ -31,7 +31,7 @@ export {
   type ButtonProps,
   buttonVariants,
 } from './components/Button.js';
-export { Badge } from './components/badge.js';
+export { Badge, type BadgeIntent, type BadgeProps } from './components/badge.js';
 // Brand marks + form-field composition — client-safe presentation components that
 // were absent from this barrel though their peers (Label, StatusDot) are here.
 export { RevealUIMark, type RevealUIMarkProps } from './components/brand-mark.js';

--- a/packages/presentation/src/components/badge.tsx
+++ b/packages/presentation/src/components/badge.tsx
@@ -1,56 +1,90 @@
 import type React from 'react';
-import { useDataInteractive } from '../hooks/use-data-interactive.js';
 import { cn } from '../utils/cn.js';
+import { focusRing } from '../utils/focus.js';
+import { type Intent, LEGACY_COLOR_TO_INTENT, type LegacyColorway } from '../utils/intent.js';
 import { TouchTarget } from './_button-shared.js';
 import { Link } from './link.js';
 
-const colors = {
-  red: 'bg-red-500/15 text-red-700 group-data-hover:bg-red-500/25',
-  orange: 'bg-orange-500/15 text-orange-700 group-data-hover:bg-orange-500/25',
-  amber: 'bg-amber-400/20 text-amber-700 group-data-hover:bg-amber-400/30',
-  yellow: 'bg-yellow-400/20 text-yellow-700 group-data-hover:bg-yellow-400/30',
-  lime: 'bg-lime-400/20 text-lime-700 group-data-hover:bg-lime-400/30',
-  green: 'bg-green-500/15 text-green-700 group-data-hover:bg-green-500/25',
-  emerald: 'bg-emerald-500/15 text-emerald-700 group-data-hover:bg-emerald-500/25',
-  teal: 'bg-teal-500/15 text-teal-700 group-data-hover:bg-teal-500/25',
-  cyan: 'bg-cyan-400/20 text-cyan-700 group-data-hover:bg-cyan-400/30',
-  sky: 'bg-sky-500/15 text-sky-700 group-data-hover:bg-sky-500/25',
-  blue: 'bg-blue-500/15 text-blue-700 group-data-hover:bg-blue-500/25',
-  indigo: 'bg-indigo-500/15 text-indigo-700 group-data-hover:bg-indigo-500/25',
-  violet: 'bg-violet-500/15 text-violet-700 group-data-hover:bg-violet-500/25',
-  purple: 'bg-purple-500/15 text-purple-700 group-data-hover:bg-purple-500/25',
-  fuchsia: 'bg-fuchsia-400/15 text-fuchsia-700 group-data-hover:bg-fuchsia-400/25',
-  pink: 'bg-pink-400/15 text-pink-700 group-data-hover:bg-pink-400/25',
-  rose: 'bg-rose-400/15 text-rose-700 group-data-hover:bg-rose-400/25',
-  zinc: 'bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20',
-  // Cobalt semantic variants (token-driven; auto-adapt to light/dark via the --rvui-*
-  // bridge, so no `dark:` pair is needed). Added so admin/dashboard status badges can
-  // track the semantic token system instead of the raw-palette swatches above. The raw
-  // palette stays intact (it is the allowlisted product surface per ds-catalyst-reskin).
-  brand: 'bg-primary/10 text-primary group-data-hover:bg-primary/20',
-  success: 'bg-success/10 text-success group-data-hover:bg-success/20',
-  warning: 'bg-warning/10 text-warning-foreground group-data-hover:bg-warning/20',
-  danger: 'bg-destructive/10 text-destructive group-data-hover:bg-destructive/20',
-  muted: 'bg-muted text-muted-foreground group-data-hover:bg-muted/80',
+/**
+ * Badge — owned RevealUI status chip.
+ *
+ * `intent` is the semantic colour (brand, neutral, success, warning, danger,
+ * plus `muted` for metadata tags). Styles come from the `--rvui-*` / `@theme`
+ * bridge only. The Catalyst 20-swatch `color` palette is gone; `color` remains
+ * as a deprecated alias through 0.15.
+ */
+
+export type BadgeIntent = Intent | 'muted';
+
+const INTENT_STYLES: Record<BadgeIntent, string> = {
+  brand: 'bg-primary/10 text-primary group-hover:bg-primary/20',
+  danger: 'bg-destructive/10 text-destructive group-hover:bg-destructive/20',
+  muted: 'bg-muted text-muted-foreground group-hover:bg-muted/80',
+  neutral: 'bg-muted text-muted-foreground group-hover:bg-muted/80',
+  success: 'bg-success/10 text-success group-hover:bg-success/20',
+  warning: 'bg-warning/10 text-warning-foreground group-hover:bg-warning/20',
 };
 
-type BadgeProps = { color?: keyof typeof colors };
+const BADGE_INTENTS = new Set<string>(Object.keys(INTENT_STYLES));
 
-export function Badge({
-  color = 'zinc',
-  className,
-  ...props
-}: BadgeProps & React.ComponentPropsWithoutRef<'span'>) {
+const warned = new Set<string>();
+
+function isBadgeIntent(value: string): value is BadgeIntent {
+  return BADGE_INTENTS.has(value);
+}
+
+/**
+ * Resolve the chip intent. `intent` wins. Deprecated `color` maps either an
+ * already-semantic name or a Catalyst colorway, then warns once per pair.
+ */
+export function resolveBadgeIntent(opts: {
+  intent?: BadgeIntent;
+  color?: string;
+  component?: string;
+}): BadgeIntent {
+  if (opts.intent) return opts.intent;
+  if (!opts.color) return 'neutral';
+
+  const next = isBadgeIntent(opts.color)
+    ? opts.color
+    : (LEGACY_COLOR_TO_INTENT[opts.color as LegacyColorway] ?? 'neutral');
+
+  if (process.env.NODE_ENV !== 'production') {
+    const component = opts.component ?? 'Badge';
+    const key = `${component}:${opts.color}`;
+    if (!warned.has(key)) {
+      warned.add(key);
+      const msg =
+        `[RevealUI] ${component}: the \`color\` prop is deprecated and will be removed in 0.15. ` +
+        `Use \`intent\` instead: color="${opts.color}" → intent="${next}".`;
+      // biome-ignore lint/suspicious/noConsole: one-shot deprecation surface through 0.15
+      console.warn(msg); // console-allowed
+    }
+  }
+
+  return next;
+}
+
+export interface BadgeProps extends React.ComponentPropsWithoutRef<'span'> {
+  /** Semantic fill. Default `neutral` (was palette `zinc`). */
+  intent?: BadgeIntent;
+  /**
+   * @deprecated Use `intent`. Mapped for two minors (through 0.15).
+   */
+  color?: BadgeIntent | LegacyColorway;
+}
+
+export function Badge({ intent, color, className, ...props }: BadgeProps): React.ReactElement {
+  const resolved = resolveBadgeIntent({ intent, color, component: 'Badge' });
   return (
     <span
       {...props}
       className={cn(
+        'inline-flex items-center gap-x-1.5 rounded-[var(--rvui-radius-full,9999px)] px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline',
+        INTENT_STYLES[resolved],
         className,
-        'inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline',
-        colors[color],
       )}
       style={{
-        borderRadius: 'var(--rvui-radius-full, 9999px)',
         transition:
           'background-color var(--rvui-duration-fast, 120ms) var(--rvui-ease, cubic-bezier(0.22, 1, 0.36, 1))',
       }}
@@ -58,43 +92,46 @@ export function Badge({
   );
 }
 
+export type BadgeButtonProps = {
+  intent?: BadgeIntent;
+  /** @deprecated Use `intent`. Mapped through 0.15. */
+  color?: BadgeIntent | LegacyColorway;
+  className?: string;
+  children: React.ReactNode;
+  ref?: React.Ref<HTMLElement>;
+} & (
+  | ({
+      href?: never;
+      disabled?: boolean;
+    } & Omit<React.ComponentPropsWithoutRef<'button'>, 'className' | 'color'>)
+  | ({ href: string } & Omit<React.ComponentPropsWithoutRef<typeof Link>, 'className' | 'color'>)
+);
+
 export function BadgeButton({
-  color = 'zinc',
+  intent,
+  color,
   className,
   children,
   ref,
   ...props
-}: BadgeProps & { className?: string; children: React.ReactNode; ref?: React.Ref<HTMLElement> } & (
-    | ({
-        href?: never;
-        disabled?: boolean;
-      } & Omit<React.ComponentPropsWithoutRef<'button'>, 'className'>)
-    | ({ href: string } & Omit<React.ComponentPropsWithoutRef<typeof Link>, 'className'>)
-  )) {
-  const disabled = 'disabled' in props ? props.disabled : false;
-  const interactiveProps = useDataInteractive({ disabled: disabled ?? false });
-
+}: BadgeButtonProps): React.ReactElement {
+  const resolved = resolveBadgeIntent({ intent, color, component: 'BadgeButton' });
   const classes = cn(
+    'group relative inline-flex rounded-[var(--rvui-radius-full,9999px)]',
+    focusRing,
     className,
-    'group relative inline-flex rounded-md focus:not-data-focus:outline-hidden data-focus:outline-2 data-focus:outline-offset-2 data-focus:outline-ring',
   );
 
   return typeof props.href === 'string' ? (
     <Link {...props} className={classes} ref={ref as React.Ref<HTMLAnchorElement>}>
       <TouchTarget>
-        <Badge color={color}>{children}</Badge>
+        <Badge intent={resolved}>{children}</Badge>
       </TouchTarget>
     </Link>
   ) : (
-    <button
-      type="button"
-      {...props}
-      {...interactiveProps}
-      className={classes}
-      ref={ref as React.Ref<HTMLButtonElement>}
-    >
+    <button type="button" {...props} className={classes} ref={ref as React.Ref<HTMLButtonElement>}>
       <TouchTarget>
-        <Badge color={color}>{children}</Badge>
+        <Badge intent={resolved}>{children}</Badge>
       </TouchTarget>
     </button>
   );

--- a/packages/presentation/src/components/index.ts
+++ b/packages/presentation/src/components/index.ts
@@ -27,7 +27,13 @@ export {
   type ButtonProps,
   buttonVariants,
 } from './Button.js';
-export { Badge, BadgeButton } from './badge.js';
+export {
+  Badge,
+  BadgeButton,
+  type BadgeButtonProps,
+  type BadgeIntent,
+  type BadgeProps,
+} from './badge.js';
 export { RevealUIMark, type RevealUIMarkProps } from './brand-mark.js';
 export { Breadcrumb, type BreadcrumbItem } from './breadcrumb.js';
 export {

--- a/packages/presentation/src/utils/focus.ts
+++ b/packages/presentation/src/utils/focus.ts
@@ -32,8 +32,8 @@ export const focusRing =
  * than relying on `:focus-visible`. `focus:not-data-focus:outline-hidden`
  * suppresses the native ring so the two mechanisms don't double up.
  *
- * Use in: badge (BadgeButton), avatar (AvatarButton), switch, dropdown items,
- * listbox / combobox options.
+ * Use in: avatar (AvatarButton), switch, dropdown items,
+ * listbox / combobox options. BadgeButton uses {@link focusRing}.
  *
  * Replaces: `focus:not-data-focus:outline-hidden data-focus:outline-2
  * data-focus:outline-offset-2 data-focus:outline-blue-500`

--- a/packages/presentation/src/utils/intent.ts
+++ b/packages/presentation/src/utils/intent.ts
@@ -1,5 +1,5 @@
 /**
- * Semantic intent — shared by Button, Switch, Radio, Checkbox, Progress.
+ * Semantic intent — shared by Button, Switch, Radio, Checkbox, Progress, Badge.
  *
  * Gate 0 collapses the Catalyst 11-colorway `color` prop onto these five
  * values so form controls theme with `--rvui-*` instead of Tailwind swatches.

--- a/packages/tokens/scripts/presentation-lint.cjs
+++ b/packages/tokens/scripts/presentation-lint.cjs
@@ -71,14 +71,10 @@ const SKIP_FILE = /(?:\.test\.tsx?|\.spec\.tsx?)$/;
 const EXEMPT = {
   // focus.ts documents the classes it replaces ("Replaces: outline-blue-500").
   // Without this, the fix for blocker 2 permanently fails the rule that checks it.
-  'raw-palette': [/utils\/focus\.ts$/, /components\/badge\.tsx$/],
+  'raw-palette': [/utils\/focus\.ts$/],
   'palette-css-var': [/utils\/focus\.ts$/],
   'literal-ring-colour': [/utils\/focus\.ts$/],
   'bare-white-black': [/utils\/focus\.ts$/],
-  // Badge keeps a 20-swatch product-tag palette on purpose (SEMANTIC-INTENTS.md):
-  // the colour carries user meaning, not system semantics. Gate 0 still removes
-  // its theme-lock `dark:` pairs; the remaining palette is the intentional API.
-  'dark-variant': [/components\/badge\.tsx$/],
   // The brand marks carry the brand's own geometry and fixed colours — cobalt
   // #003d94 and amber #eeb300 ARE the mark, and a themed logo is not a logo.
   'hex-literal': [/brand-mark\.tsx$/, /wordmark\.tsx$/],


### PR DESCRIPTION
## Summary

Frontend-excellence Phase 3 **PR-3** (component sovereignty). §2 is already ratified. PR-0/1/2 and the 0.13.0 fields family are on `test`. Badge was the last Catalyst 20-swatch `color` holdout (`presentation-lint` even exempted it).

- `Badge` / `BadgeButton` now take `intent`: `brand | neutral | success | warning | danger | muted`
- Styles come from the token / `@theme` bridge only. Native `:focus-visible` ring on `BadgeButton`.
- Deprecated `color` alias maps through `LEGACY_COLOR_TO_INTENT` (and already-semantic names) until 0.15
- Default unstyled badge is `neutral` (was palette zinc)
- Anatomy spec: `packages/presentation/docs/anatomy/badge.md` (APG status chip; Catalyst source not used)
- First-party admin, marketing `/claims`, and docs showcase migrated
- Lint exemption for `badge.tsx` removed

Local gate: `pnpm gate --phase=1 --changed` PASS after building worktree deps.

## Test plan

- [x] `pnpm --filter @revealui/presentation test src/__tests__/components/badge.test.tsx` (20 pass)
- [x] `node packages/tokens/scripts/presentation-lint.cjs packages/presentation/src` (0 errors)
- [x] Pre-push phase 1
- [ ] CI typecheck / remaining phases
- [ ] Docs showcase `/showcase/badge` after preview: six intents, no rainbow grid

## Migration

`color="blue"|"violet"|…` → `intent="brand"`
`color="zinc"` → `intent="neutral"`
green family → `success`; amber/yellow → `warning`; red family → `danger`

## Owner

```bash
gh pr merge <N> --squash -R RevealUIStudio/revealui
```

Replace `<N>` after open. Merge when CI is green. Not security-classed.