### PR TITLE
feat(presentation): route overlay focus through shared recipes

### DIFF
--- a/.changeset/presentation-overlay-sovereignty.md
+++ b/.changeset/presentation-overlay-sovereignty.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': patch
+---
+
+Route Dropdown, Listbox, and Combobox focus/active-option styles through the shared focus recipes.

--- a/packages/presentation/CHANGELOG.md
+++ b/packages/presentation/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @revealui/presentation
 
+## 0.14.1
+
+### Patch Changes
+
+- Overlay family (Dropdown, Listbox, Combobox) consumes the shared `focus.ts`
+  recipes for rings and active-option fill. Listbox trigger ring is native
+  `:focus-visible` (the previous `data-focus:` after-ring never fired). Anatomy
+  spec: `docs/anatomy/overlays.md`.
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/presentation/docs/anatomy/overlays.md
+++ b/packages/presentation/docs/anatomy/overlays.md
@@ -1,0 +1,65 @@
+# Overlay family anatomy (Phase 3 PR-4)
+
+Dropdown (menu), Listbox, Combobox. Grounded in product usage (admin pickers,
+docs showcase), WAI-ARIA APG Menu / Listbox / Combobox, and `@revealui/tokens`.
+Catalyst source was not open while writing this. Existing package tests define
+behavioral compatibility.
+
+## Shared contract
+
+| Concern | Rule |
+|---|---|
+| Focus ring | `focus.ts` only. Same `--ring` token as Button. |
+| Active option | `activeOption` (`bg-primary` / `text-primary-foreground`). Never a palette step. |
+| Keyboard | APG maps below. `useRovingTabindex` / `usePopover` / `useEscapeKey` stay the behavior layer. |
+| Motion | Overlay enter/leave already honour reduced motion in `useTransition`. |
+
+`data-focus` on options is our roving-tabindex marker (set by the hook), not a
+vendor attribute. Class recipes for that marker live in `focus.ts`.
+
+## Dropdown (APG Menu)
+
+| Part | Role |
+|---|---|
+| Trigger | `DropdownButton` → real `<button>` (`aria-haspopup="menu"`, `aria-expanded`) |
+| Menu | `role="menu"` portaled popover |
+| Item | `role="menuitem"` (button or link) |
+
+Keyboard: Enter / Space / ArrowDown open. ArrowUp/Down move. Escape closes and
+returns focus to the trigger. Type-ahead is `useTypeAhead`.
+
+Trigger ring: `focusRingData` (the trigger also carries `useDataInteractive`).
+Item highlight: `activeOption` + `activeOptionForced`.
+
+## Listbox (APG Select-Only Combobox)
+
+| Part | Role |
+|---|---|
+| Trigger | real `<button role="combobox">` |
+| Popup | `role="listbox"` |
+| Option | `role="option"` (`aria-selected`) |
+
+Keyboard: Enter / Space / ArrowDown open. Arrows move `aria-activedescendant`
+equivalent via `data-focus`. Escape closes.
+
+Trigger ring: native `:focus-visible` via `focusRingAfterVisible`. The trigger
+is a real button; a `data-focus:` ring that nothing sets is a dead recipe.
+Option highlight: `activeOption` + `activeOptionForced`.
+
+## Combobox (APG Editable Combobox)
+
+| Part | Role |
+|---|---|
+| Input | `<input role="combobox" aria-autocomplete="list">` |
+| Popup | `role="listbox"` |
+| Option | `role="option"` |
+
+Keyboard: typing filters. ArrowDown/Up move. Enter selects. Escape closes.
+
+Trigger/input ring: `focusRingAfterWithin` (`:focus-within` on the control
+shell). Option highlight: same as Listbox.
+
+## Do-not-redo
+
+Layout grid (icon / label / shortcut columns) stays. This pass authors the
+focus and active-option recipes. It does not redesign the menus.

--- a/packages/presentation/src/__tests__/api-surface.test.ts
+++ b/packages/presentation/src/__tests__/api-surface.test.ts
@@ -115,7 +115,7 @@ describe('public API surface', () => {
     const current = await readSurface();
     const leaked = Object.entries(current).flatMap(([entry, names]) =>
       names
-        .filter((n) => n.startsWith('focusRing') || n === 'activeOption')
+        .filter((n) => n.startsWith('focusRing') || n.startsWith('activeOption'))
         .map((n) => `${entry} → ${n}`),
     );
 
@@ -131,7 +131,7 @@ describe('public API surface', () => {
   it('covers every entry point declared in package.json', () => {
     const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8'));
     const declared = Object.keys(pkg.exports).filter(
-      (k) => !k.endsWith('.css') && !k.includes('design-context'),
+      (k) => !(k.endsWith('.css') || k.includes('design-context')),
     );
     const tested = Object.keys(ENTRY_POINTS);
     const untested = declared.filter((e) => !tested.includes(e));

--- a/packages/presentation/src/__tests__/components/combobox.test.tsx
+++ b/packages/presentation/src/__tests__/components/combobox.test.tsx
@@ -66,6 +66,12 @@ describe('Combobox', () => {
     expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
+  it('paints the control ring on :focus-within from the --ring token', () => {
+    render(<BasicCombobox />);
+    const shell = screen.getByRole('combobox').parentElement;
+    expect(shell?.className).toContain('focus-within:after:ring-ring');
+  });
+
   it('should display placeholder text', () => {
     render(<BasicCombobox />);
     expect(screen.getByPlaceholderText('Select a fruit')).toBeInTheDocument();

--- a/packages/presentation/src/__tests__/components/dropdown-trigger.test.tsx
+++ b/packages/presentation/src/__tests__/components/dropdown-trigger.test.tsx
@@ -65,10 +65,10 @@ describe('DropdownTriggerButton', () => {
     expect(screen.getByRole('button')).toHaveClass('my-custom-class');
   });
 
-  it('styles the focus ring from the --ring token, not a fixed palette', () => {
+  it('styles the focus ring from the shared --ring token, not a fixed palette', () => {
     render(<DropdownTriggerButton>Focus</DropdownTriggerButton>);
     const button = screen.getByRole('button');
-    expect(button.className).toContain('data-focus:outline-[var(--ring)]');
+    expect(button).toHaveClass('data-focus:outline-ring');
     expect(button.className).not.toContain('outline-blue-500');
   });
 });

--- a/packages/presentation/src/__tests__/components/dropdown.test.tsx
+++ b/packages/presentation/src/__tests__/components/dropdown.test.tsx
@@ -94,6 +94,19 @@ describe('Dropdown', () => {
     expect(items).toHaveLength(2);
   });
 
+  it('highlights the active menuitem from brand tokens, not a palette step', async () => {
+    const user = userEvent.setup();
+    render(<BasicDropdown />);
+
+    await user.click(screen.getByText('Actions'));
+    const items = screen.getAllByRole('menuitem');
+    for (const item of items) {
+      expect(item).toHaveClass('data-focus:bg-primary');
+      expect(item).toHaveClass('data-focus:text-primary-foreground');
+      expect(item.className).not.toMatch(/\b(?:blue|zinc|indigo)-\d{2,3}\b/);
+    }
+  });
+
   it('should call onClick handler and close menu when item is clicked', async () => {
     const user = userEvent.setup();
     const onItemClick = vi.fn();

--- a/packages/presentation/src/__tests__/components/listbox.test.tsx
+++ b/packages/presentation/src/__tests__/components/listbox.test.tsx
@@ -53,6 +53,13 @@ describe('Listbox', () => {
     expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
+  it('paints the trigger ring on :focus-visible, not a dead data-focus recipe', () => {
+    render(<BasicListbox />);
+    const trigger = screen.getByRole('combobox');
+    expect(trigger.className).toContain('focus-visible:after:ring-ring');
+    expect(trigger.className).not.toContain('data-focus:after:ring-ring');
+  });
+
   it('should display placeholder when no value is selected', () => {
     render(<BasicListbox />);
     expect(screen.getByText('Select a color')).toBeInTheDocument();
@@ -78,6 +85,17 @@ describe('Listbox', () => {
     await user.click(screen.getByRole('combobox'));
     const options = screen.getAllByRole('option');
     expect(options).toHaveLength(3);
+  });
+
+  it('highlights options from brand tokens, not a palette step', async () => {
+    const user = userEvent.setup();
+    render(<BasicListbox />);
+
+    await user.click(screen.getByRole('combobox'));
+    for (const option of screen.getAllByRole('option')) {
+      expect(option).toHaveClass('data-focus:bg-primary');
+      expect(option.className).not.toMatch(/\b(?:blue|zinc|indigo)-\d{2,3}\b/);
+    }
   });
 
   it('should display selected value text in trigger', () => {

--- a/packages/presentation/src/components/combobox.tsx
+++ b/packages/presentation/src/components/combobox.tsx
@@ -9,6 +9,7 @@ import { useEscapeKey } from '../hooks/use-escape-key.js';
 import { usePopover } from '../hooks/use-popover.js';
 import { useTransition } from '../hooks/use-transition.js';
 import { cn } from '../utils/cn.js';
+import { activeOption, activeOptionForced, focusRingAfterWithin } from '../utils/focus.js';
 
 // ---------------------------------------------------------------------------
 // Context
@@ -237,7 +238,8 @@ export function Combobox<T>({
           'relative block w-full',
           'before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-card before:shadow-sm',
 
-          'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-ring',
+          'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset',
+          focusRingAfterWithin,
           'has-data-disabled:opacity-50 has-data-disabled:before:bg-border has-data-disabled:before:shadow-none',
           'has-data-invalid:before:shadow-destructive/10',
         ])}
@@ -431,8 +433,9 @@ export function ComboboxOption<T>({
       className={cn(
         'group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3',
         'text-base/6 text-foreground sm:text-sm/6 forced-colors:text-[CanvasText]',
-        'outline-hidden data-focus:bg-primary data-focus:text-primary-foreground',
-        'forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]',
+        'outline-hidden',
+        activeOption,
+        activeOptionForced,
         'data-disabled:opacity-50',
       )}
     >

--- a/packages/presentation/src/components/dropdown-trigger.tsx
+++ b/packages/presentation/src/components/dropdown-trigger.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { useDataInteractive } from '../hooks/use-data-interactive.js';
 import { cn } from '../utils/cn.js';
+import { focusRingData } from '../utils/focus.js';
 import { TouchTarget } from './_button-shared.js';
 import { Link } from './link.js';
 
@@ -24,8 +25,7 @@ const triggerClasses = [
   'px-3.5 py-2.5 sm:px-3 sm:py-1.5',
   // Neutral token surface + interaction states via the data-* contract
   'bg-secondary text-secondary-foreground shadow-sm data-hover:bg-secondary/80 data-active:bg-secondary/70',
-  // Focus ring — the shared --ring token, replacing the old fixed blue outline
-  'focus:not-data-focus:outline-hidden data-focus:outline-2 data-focus:outline-offset-2 data-focus:outline-[var(--ring)]',
+  focusRingData,
   // Disabled
   'data-disabled:opacity-50',
   // Icon slot

--- a/packages/presentation/src/components/dropdown.tsx
+++ b/packages/presentation/src/components/dropdown.tsx
@@ -11,6 +11,7 @@ import { useRovingTabindex } from '../hooks/use-roving-tabindex.js';
 import { useTransition } from '../hooks/use-transition.js';
 import { useTypeAhead } from '../hooks/use-type-ahead.js';
 import { cn } from '../utils/cn.js';
+import { activeOption, activeOptionForced } from '../utils/focus.js';
 import { DropdownTriggerButton } from './dropdown-trigger.js';
 import { Link } from './link.js';
 
@@ -348,12 +349,10 @@ export function DropdownItem({
     'group cursor-default rounded-lg px-3.5 py-2.5 focus:outline-hidden sm:px-3 sm:py-1.5',
     // Text styles
     'text-left text-base/6 text-foreground sm:text-sm/6 forced-colors:text-[CanvasText]',
-    // Focus
-    'data-focus:bg-primary data-focus:text-primary-foreground',
-    // Disabled state
+    activeOption,
+    activeOptionForced,
     'data-disabled:opacity-50',
-    // Forced colors mode
-    'forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText] forced-colors:data-focus:*:data-[slot=icon]:text-[HighlightText]',
+    'forced-colors:data-focus:*:data-[slot=icon]:text-[HighlightText]',
     // Use subgrid when available but fallback to an explicit grid layout if not
     'col-span-full grid grid-cols-[auto_1fr_1.5rem_0.5rem_auto] items-center supports-[grid-template-columns:subgrid]:grid-cols-subgrid',
     // Icons

--- a/packages/presentation/src/components/listbox.tsx
+++ b/packages/presentation/src/components/listbox.tsx
@@ -21,6 +21,7 @@ import { useEscapeKey } from '../hooks/use-escape-key.js';
 import { usePopover } from '../hooks/use-popover.js';
 import { useTransition } from '../hooks/use-transition.js';
 import { cn } from '../utils/cn.js';
+import { activeOption, activeOptionForced, focusRingAfterVisible } from '../utils/focus.js';
 
 // ---------------------------------------------------------------------------
 // Context
@@ -332,7 +333,8 @@ export function Listbox<T>({
           'before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-card before:shadow-sm',
 
           'focus:outline-hidden',
-          'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset data-focus:after:ring-2 data-focus:after:ring-ring',
+          'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset',
+          focusRingAfterVisible,
           'data-disabled:opacity-50 data-disabled:before:bg-border data-disabled:before:shadow-none',
         ])}
       >
@@ -473,8 +475,9 @@ export function ListboxOption<T>({
       className={cn(
         'group/option grid cursor-default grid-cols-[--spacing(5)_1fr] items-baseline gap-x-2 rounded-lg py-2.5 pr-3.5 pl-2 sm:grid-cols-[--spacing(4)_1fr] sm:py-1.5 sm:pr-3 sm:pl-1.5',
         'text-base/6 text-foreground sm:text-sm/6 forced-colors:text-[CanvasText]',
-        'outline-hidden data-focus:bg-primary data-focus:text-primary-foreground',
-        'forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]',
+        'outline-hidden',
+        activeOption,
+        activeOptionForced,
         'data-disabled:opacity-50',
       )}
     >

--- a/packages/presentation/src/utils/focus.ts
+++ b/packages/presentation/src/utils/focus.ts
@@ -61,12 +61,31 @@ export const focusRingGroup =
 export const focusRingAfter = 'data-focus:after:ring-2 data-focus:after:ring-ring';
 
 /**
+ * Native-focusable overlay trigger (Listbox button). The ring paints on
+ * `::after` so the control can keep its own border. Use this when the host is
+ * a real `<button>` / `<input>` — a `data-focus:` after-ring that nothing sets
+ * is a dead recipe.
+ */
+export const focusRingAfterVisible = 'focus-visible:after:ring-2 focus-visible:after:ring-ring';
+
+/**
+ * Combobox control shell: ring when the inner input is focused.
+ */
+export const focusRingAfterWithin = 'sm:focus-within:after:ring-2 sm:focus-within:after:ring-ring';
+
+/**
  * Active-option highlight inside menus and listboxes. Not a focus *ring* — the
  * filled row that follows keyboard navigation in Dropdown, Listbox and
- * Combobox. It was `data-focus:bg-primary data-focus:text-primary-foreground`, which is
- * both off-brand and unthemeable; the ink token guarantees AA on the fill.
+ * Combobox. Token fill + on-fill ink so a brand replacement stays AA.
  */
 export const activeOption = 'data-focus:bg-primary data-focus:text-primary-foreground';
+
+/**
+ * Forced-colors companion for {@link activeOption}. Highlight system colours,
+ * not a palette step.
+ */
+export const activeOptionForced =
+  'forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]';
 
 /**
  * Range-input thumb ring (Slider). Vendor pseudo-elements can't inherit the


### PR DESCRIPTION
## Summary

Frontend-excellence Phase 3 overlay family (Dropdown, Listbox, Combobox).

These widgets already used our hooks. This pass authors the **focus and active-option recipes** from `focus.ts` instead of duplicated inline strings:

- Dropdown trigger → `focusRingData`
- Dropdown / Listbox / Combobox options → `activeOption` + `activeOptionForced` (brand tokens, not palette)
- Listbox trigger → `focusRingAfterVisible` (`:focus-visible`). The old `data-focus:` after-ring never fired because nothing set `data-focus` on the button.
- Combobox shell → `focusRingAfterWithin`

Anatomy spec: `packages/presentation/docs/anatomy/overlays.md` (APG Menu / Listbox / Combobox). Catalyst source was not used.

48 overlay tests pass locally. Phase 1 gate passed.

## Test plan

- [x] dropdown / dropdown-trigger / listbox / combobox unit tests (48)
- [x] `pnpm gate --phase=1 --changed`
- [ ] CI typecheck + showcase visual

## Owner

```bash
gh pr merge <N> --squash -R RevealUIStudio/revealui
```

Replace `<N>` after open. Merge when CI is green. Not security-classed.