### PR TITLE
ci(ds): gate marketing lighthouse a11y at 0.95

### DIFF
--- a/.github/workflows/ds.yml
+++ b/.github/workflows/ds.yml
@@ -19,6 +19,10 @@
 #                             themes. Before this, a one-pixel visual diff
 #                             hard-failed the build while a serious axe
 #                             violation shipped silently.
+#   6. marketing-a11y       — frontend-excellence lane: axe WCAG 2.2 AA plus
+#                             Lighthouse accessibility ≥ 0.95 on marketing
+#                             homepage + /pricing. Agency (revealuistudio.com)
+#                             is gated in the agency repo.
 #
 # Conventions match ci.yml (pinned action SHAs, pnpm action-setup @
 # PNPM_VERSION, node 24, persist-credentials:false).
@@ -34,6 +38,7 @@ on:
       - 'packages/presentation/**'
       - 'e2e/showcase-visual.e2e.ts'
       - 'e2e/showcase-a11y.e2e.ts'
+      - 'e2e/marketing-a11y.e2e.ts'
       - '.github/workflows/ds.yml'
   push:
     branches: [main]
@@ -333,4 +338,74 @@ jobs:
           path: |
             playwright-report/
             test-results/
+          retention-days: 30
+
+  marketing-a11y:
+    name: Marketing accessibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Ensure git SSL CA bundle
+        run: |
+          set -euo pipefail
+          CA=/etc/ssl/certs/ca-certificates.crt
+          if [ ! -s "$CA" ]; then
+            sudo apt-get update -qq
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates
+            sudo update-ca-certificates
+          fi
+          test -s "$CA"
+          {
+            echo "SSL_CERT_FILE=$CA"
+            echo "GIT_SSL_CAINFO=$CA"
+            echo "CURL_CA_BUNDLE=$CA"
+            echo "REQUESTS_CA_BUNDLE=$CA"
+          } >> "$GITHUB_ENV"
+          git config --global http.sslCAInfo "$CA"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright (chromium only)
+        run: npx playwright install --with-deps chromium
+      - name: Build marketing app
+        run: pnpm --filter marketing... build
+      - name: Start marketing preview
+        run: pnpm --filter marketing start &
+      - name: Wait for marketing
+        run: |
+          for i in $(seq 1 40); do
+            curl -sf http://localhost:3000 > /dev/null 2>&1 && echo "Marketing ready" && break || \
+            echo "Waiting for marketing... ($i/40)" && sleep 3
+          done
+          curl -sf http://localhost:3000 > /dev/null 2>&1 || \
+            (echo "::error::Marketing app failed to start within 120s" && exit 1)
+      - name: Run marketing axe
+        run: npx playwright test --project=chromium e2e/marketing-a11y.e2e.ts
+        env:
+          CI: "true"
+          MARKETING_BASE_URL: "http://localhost:3000"
+      - name: Run marketing Lighthouse a11y
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12.6.2
+        with:
+          configPath: ./apps/marketing/lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+      - name: Upload marketing a11y artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: marketing-a11y-results
+          path: |
+            playwright-report/
+            test-results/
+            .lighthouseci/
           retention-days: 30

--- a/apps/marketing/lighthouserc.json
+++ b/apps/marketing/lighthouserc.json
@@ -1,0 +1,21 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 1,
+      "url": ["http://localhost:3000/", "http://localhost:3000/pricing"],
+      "settings": {
+        "onlyCategories": ["accessibility"],
+        "preset": "desktop",
+        "chromeFlags": "--no-sandbox --headless=new --disable-gpu"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 0.95 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/e2e/accessibility.e2e.ts
+++ b/e2e/accessibility.e2e.ts
@@ -94,11 +94,11 @@ test.describe('Accessibility', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Marketing Pages (apps/marketing  -  port 3002)
+  // Marketing Pages (apps/marketing  -  port 3000)
   // ---------------------------------------------------------------------------
 
   test.describe('Marketing pages', () => {
-    const MarketingBase = process.env.MARKETING_BASE_URL || 'http://localhost:3002';
+    const MarketingBase = process.env.MARKETING_BASE_URL || 'http://localhost:3000';
 
     test('homepage meets WCAG 2.1 AA standards', async ({ page }) => {
       await page.goto(MarketingBase, { waitUntil: 'domcontentloaded' });

--- a/e2e/marketing-a11y.e2e.ts
+++ b/e2e/marketing-a11y.e2e.ts
@@ -1,0 +1,34 @@
+/**
+ * Marketing accessibility (frontend-excellence lane acceptance).
+ *
+ * axe-core WCAG 2.2 AA over the public marketing homepage and pricing page.
+ * Companion to apps/marketing/lighthouserc.json (Lighthouse a11y ≥ 0.95).
+ *
+ * Defaults to the Vite marketing preview port (3000). CI sets
+ * MARKETING_BASE_URL explicitly. The older e2e/accessibility.e2e.ts default
+ * of :3002 was the docs port.
+ *
+ *   pnpm --filter marketing... build && pnpm --filter marketing start &
+ *   MARKETING_BASE_URL=http://localhost:3000 \
+ *     pnpm exec playwright test --project=chromium e2e/marketing-a11y.e2e.ts
+ */
+
+import { test } from '@playwright/test';
+import { checkAccessibility } from './utils/a11y-helper';
+
+const MarketingBase = process.env.MARKETING_BASE_URL || 'http://localhost:3000';
+
+test.describe('Marketing accessibility', () => {
+  // Full-page axe on the homepage is heavier than a component scan.
+  test.setTimeout(90_000);
+
+  test('homepage meets WCAG 2.2 AA', async ({ page }) => {
+    await page.goto(MarketingBase, { waitUntil: 'domcontentloaded' });
+    await checkAccessibility(page);
+  });
+
+  test('pricing page meets WCAG 2.2 AA', async ({ page }) => {
+    await page.goto(`${MarketingBase}/pricing`, { waitUntil: 'domcontentloaded' });
+    await checkAccessibility(page);
+  });
+});

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -107,11 +107,11 @@ test.describe('Admin basic render', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Marketing Page (apps/marketing  -  port 3002)
+// Marketing Page (apps/marketing  -  port 3000)
 // ---------------------------------------------------------------------------
 
 test.describe('Marketing page', () => {
-  const MarketingBase = process.env.MARKETING_BASE_URL || 'http://localhost:3002';
+  const MarketingBase = process.env.MARKETING_BASE_URL || 'http://localhost:3000';
 
   test('Marketing root responds', async ({ page }) => {
     const response = await page.goto(MarketingBase, { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
## Summary

Frontend-excellence lane acceptance is Lighthouse a11y ≥ 95 on marketing and agency. Showcase axe already runs on PRs. Marketing axe only ran on `main`, and e2e defaults still pointed at the docs port (`3002`).

This adds a design-system job that:

- builds and previews marketing on `:3000`
- fails on any WCAG 2.2 AA axe violation (`e2e/marketing-a11y.e2e.ts`)
- fails if Lighthouse accessibility is below 0.95 (`apps/marketing/lighthouserc.json`)

Agency is gated in a sibling PR on `RevealUIStudio/agency`.

## Test plan

- [x] `CI=true` Playwright axe against local marketing preview (homepage + /pricing)
- [ ] CI job green on this PR (Lighthouse runs there; local Chrome attach is unreliable)