### PR TITLE
fix(presentation): keep cookie banner from covering mobile login

### DIFF
--- a/e2e/visual-snapshots.e2e.ts
+++ b/e2e/visual-snapshots.e2e.ts
@@ -20,10 +20,34 @@
  * - View report: pnpm test:e2e:report
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import { waitForNetworkIdle } from './utils/test-helpers';
 
 const AUTH_STATE = 'e2e/.auth/user.json';
+
+/** Decided consent so page snapshots are not coupled to the first-visit banner. */
+const DECIDED_CONSENT = JSON.stringify({
+  necessary: true,
+  functional: false,
+  analytics: false,
+  marketing: false,
+  version: 1,
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  source: 'explicit',
+});
+
+async function seedDecidedConsent(page: Page): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: 'revealui-cookie-consent',
+      value: encodeURIComponent(DECIDED_CONSENT),
+      url: 'http://localhost:4000/',
+    },
+  ]);
+  await page.addInitScript((serialized) => {
+    window.localStorage.setItem('cookie-consent', serialized);
+  }, DECIDED_CONSENT);
+}
 
 test.describe('Visual Snapshots - Admin Application', () => {
   test.describe('Unauthenticated States', () => {
@@ -52,6 +76,10 @@ test.describe('Visual Snapshots - Admin Application', () => {
   test.describe('Authenticated Admin Pages', () => {
     test.use({ storageState: AUTH_STATE });
 
+    test.beforeEach(async ({ page }) => {
+      await seedDecidedConsent(page);
+    });
+
     test('collections page should match snapshot', async ({ page }) => {
       await page.goto('/collections');
       await waitForNetworkIdle(page);
@@ -76,6 +104,10 @@ test.describe('Visual Snapshots - Admin Application', () => {
   test.describe('Responsive Snapshots', () => {
     test.use({ storageState: AUTH_STATE });
 
+    test.beforeEach(async ({ page }) => {
+      await seedDecidedConsent(page);
+    });
+
     test('collections page on mobile viewport should match snapshot', async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 667 });
       await page.goto('/collections');
@@ -90,6 +122,10 @@ test.describe('Visual Snapshots - Admin Application', () => {
   test.describe('Theme Snapshots', () => {
     test.use({ storageState: AUTH_STATE });
 
+    test.beforeEach(async ({ page }) => {
+      await seedDecidedConsent(page);
+    });
+
     test('collections page with dark color scheme should match snapshot', async ({ page }) => {
       await page.emulateMedia({ colorScheme: 'dark' });
       await page.goto('/collections');
@@ -103,6 +139,10 @@ test.describe('Visual Snapshots - Admin Application', () => {
 
   test.describe('Cross-Browser Consistency', () => {
     test.use({ storageState: AUTH_STATE });
+
+    test.beforeEach(async ({ page }) => {
+      await seedDecidedConsent(page);
+    });
 
     test('collections page should be visually consistent across browsers', async ({ page }) => {
       await page.goto('/collections');

--- a/packages/presentation/src/__tests__/components/cookie-consent-banner.test.tsx
+++ b/packages/presentation/src/__tests__/components/cookie-consent-banner.test.tsx
@@ -56,6 +56,15 @@ describe('CookieConsentBanner', () => {
     expect(screen.getByTestId('analytics')).toHaveTextContent('false');
   });
 
+  it('caps height so a phone login form stays reachable', () => {
+    renderBanner();
+    const dialog = screen.getByRole('dialog', { name: 'Cookies' });
+    expect(dialog.className).toContain('max-h-[min(42vh,22rem)]');
+    expect(dialog.className).toContain('overflow-y-auto');
+    expect(dialog.className).toContain('bottom-0');
+    expect(dialog.className).not.toContain('inset-0');
+  });
+
   it('accept all grants analytics and hides the banner', async () => {
     const user = userEvent.setup();
     renderBanner();

--- a/packages/presentation/src/cookie-consent/banner.tsx
+++ b/packages/presentation/src/cookie-consent/banner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useId, useState } from 'react';
+import { type ReactNode, useId, useLayoutEffect, useRef, useState } from 'react';
 import { Button } from '../components/Button.js';
 import { Description, Label } from '../components/fieldset.js';
 import { Switch, SwitchField } from '../components/switch.js';
@@ -57,22 +57,50 @@ export function CookieConsentBanner({ className }: CookieConsentBannerProps): Re
     closePreferences,
   } = useCookieConsent();
   const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
   const [draft, setDraft] = useState<CookieConsentConfig>(consent);
 
   const showBanner = !decided || preferencesOpen;
+  const showCustomize = allowOptionalCookies && (preferencesOpen || decided);
+
+  useLayoutEffect(() => {
+    if (!showBanner) {
+      return;
+    }
+    const root = document.documentElement;
+    const panel = panelRef.current;
+    if (!panel) {
+      return;
+    }
+    const applyPad = () => {
+      root.style.paddingBottom = `${panel.offsetHeight}px`;
+    };
+    applyPad();
+    if (typeof ResizeObserver === 'undefined') {
+      return () => {
+        root.style.paddingBottom = '';
+      };
+    }
+    const observer = new ResizeObserver(applyPad);
+    observer.observe(panel);
+    return () => {
+      observer.disconnect();
+      root.style.paddingBottom = '';
+    };
+  }, [showBanner]);
+
   if (!showBanner) {
     return null;
   }
 
-  const showCustomize = allowOptionalCookies && (preferencesOpen || decided);
-
   return (
     <div
+      ref={panelRef}
       role="dialog"
       aria-modal="false"
       aria-labelledby={titleId}
       className={cn(
-        'fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background/95 p-4 shadow-lg backdrop-blur-sm sm:p-6',
+        'fixed inset-x-0 bottom-0 z-50 max-h-[min(42vh,22rem)] overflow-y-auto border-t border-border bg-background/95 p-3 shadow-lg backdrop-blur-sm sm:p-6',
         className,
       )}
     >


### PR DESCRIPTION
## Summary

#2629 Visual Regression failed on `admin-collections-mobile` (8% pixels). The actual screenshot is the **login page at 375px** (CI has no admin credentials) with the new cookie banner covering Email / Password / Sign in.

That is a real mobile bug, not a stale snapshot. This PR:

- Caps the banner at `max-h-[min(42vh,22rem)]` with scroll
- Pads `documentElement` by the banner height so the form stays reachable
- Seeds a decided consent cookie on page-chrome visual snapshots so they do not couple to the first-visit banner
- Locks the height cap in the banner unit test

Login and 404 snapshots still render the banner (desktop login already passed).

## Proof

- `pnpm --filter @revealui/presentation exec vitest run src/__tests__/components/cookie-consent-banner.test.tsx` — 8/8
- Phase 1 local gate — PASS

## After merge

This lands on `test`, then #2629 (`test` → `main`) re-runs Visual Regression.