### PR TITLE
fix(presentation): keep ghost button labels visible on hover

### DIFF
--- a/.changeset/ghost-hover-contrast.md
+++ b/.changeset/ghost-hover-contrast.md
@@ -1,0 +1,5 @@
+---
+'@revealui/presentation': patch
+---
+
+Keep ghost and outline neutral button labels readable on hover. Hover now uses body ink on a muted fill instead of ink-on-amber (`accent-foreground`) over a dark card.

--- a/packages/presentation/src/__tests__/components/Button.test.tsx
+++ b/packages/presentation/src/__tests__/components/Button.test.tsx
@@ -156,6 +156,28 @@ describe('Button', () => {
       expect(btn).not.toHaveClass('bg-secondary');
     });
 
+    it('keeps ghost+neutral label readable on hover (body ink, not ink-on-accent)', () => {
+      render(
+        <Button appearance="ghost" variant="neutral">
+          Skip
+        </Button>,
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('hover:text-foreground');
+      expect(btn.className).not.toContain('hover:text-accent-foreground');
+    });
+
+    it('keeps outline+neutral label readable on hover', () => {
+      render(
+        <Button appearance="outline" variant="neutral">
+          Cancel
+        </Button>,
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.className).toContain('hover:text-foreground');
+      expect(btn.className).not.toContain('hover:text-accent-foreground');
+    });
+
     it('applies the link appearance', () => {
       render(<Button appearance="link">Link</Button>);
       expect(screen.getByRole('button')).toHaveClass('underline-offset-4');

--- a/packages/presentation/src/components/Button.tsx
+++ b/packages/presentation/src/components/Button.tsx
@@ -98,7 +98,7 @@ const buttonVariants = cva(
         appearance: 'outline',
         variant: 'neutral',
         class:
-          'border border-[var(--border)] bg-background text-foreground shadow-sm hover:bg-card hover:text-accent-foreground',
+          'border border-[var(--border)] bg-background text-foreground shadow-sm hover:bg-muted hover:text-foreground',
       },
       {
         appearance: 'outline',
@@ -122,7 +122,9 @@ const buttonVariants = cva(
       {
         appearance: 'ghost',
         variant: 'neutral',
-        class: 'hover:bg-card hover:text-accent-foreground',
+        // Body ink on a muted fill. `accent-foreground` is ink-on-amber
+        // (`--rvui-text-on-accent`) and disappears on `--card` in dark theme.
+        class: 'text-foreground hover:bg-muted hover:text-foreground',
       },
       {
         appearance: 'ghost',


### PR DESCRIPTION
## What

Neutral ghost and outline buttons hovered to `accent-foreground` (ink on amber, `--rvui-text-on-accent`) over a card fill. On dark surfaces that pair is dark-on-dark and the label disappears. Studio Setup **Skip** is the dogfood report.

Hover now keeps body ink on a muted fill: `text-foreground hover:bg-muted hover:text-foreground`.

`accent-foreground` stays correct for real accent fills (Select focus). This only changes the ghost/outline pairing that used it without an accent background.

## Test

`pnpm --filter @revealui/presentation exec vitest run src/__tests__/components/Button.test.tsx` (57 pass)

## Consumers

Studio still pins ghost chrome to `text-fg` until it depends on a presentation release that includes this (revdev#414). After publish + bump, that adapter override can drop.