### PR TITLE
fix(e2e): dismiss cookie banner after visual snapshot navigation

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -20,9 +20,12 @@
 
 import { mkdir, writeFile } from 'node:fs/promises';
 import type { FullConfig } from '@playwright/test';
+import { consentStorageState } from './utils/consent';
 import { createTestDb } from './utils/db-helpers';
 
-const EMPTY_AUTH_STATE = JSON.stringify({ cookies: [], origins: [] });
+function emptyAuthState(baseURL: string): string {
+  return JSON.stringify(consentStorageState(baseURL));
+}
 
 /**
  * Sign in via the admin API and build a Playwright storageState JSON.
@@ -107,7 +110,11 @@ async function signInViaAPI(baseURL: string, email: string, password: string): P
     throw new Error('Sign-in succeeded but no cookies could be parsed from Set-Cookie headers');
   }
 
-  return JSON.stringify({ cookies, origins: [] });
+  const consent = consentStorageState(baseURL);
+  return JSON.stringify({
+    cookies: [...cookies, ...consent.cookies],
+    origins: consent.origins,
+  });
 }
 
 async function globalSetup(config: FullConfig) {
@@ -185,24 +192,25 @@ async function globalSetup(config: FullConfig) {
         if (Array.isArray(existing?.cookies) && existing.cookies.length > 0) {
           console.log('   ℹ️  Preserving existing auth state (has valid cookies)');
         } else {
-          await writeFile('e2e/.auth/user.json', EMPTY_AUTH_STATE).catch(() => undefined);
+          await writeFile('e2e/.auth/user.json', emptyAuthState(baseURL)).catch(() => undefined);
         }
       } catch {
-        await writeFile('e2e/.auth/user.json', EMPTY_AUTH_STATE).catch(() => undefined);
+        await writeFile('e2e/.auth/user.json', emptyAuthState(baseURL)).catch(() => undefined);
       }
     }
   } else {
     console.log('ℹ️  ADMIN_EMAIL/ADMIN_PASSWORD not set  -  skipping auth state creation');
-    // Same preservation logic: keep existing cookies if present
+    const baseURL = config.projects[0].use.baseURL || 'http://localhost:4000';
+    // Same preservation logic: keep existing session cookies if present
     try {
       const existing = JSON.parse(
         await (await import('node:fs/promises')).readFile('e2e/.auth/user.json', 'utf8'),
       );
       if (!(Array.isArray(existing?.cookies) && existing.cookies.length > 0)) {
-        await writeFile('e2e/.auth/user.json', EMPTY_AUTH_STATE).catch(() => undefined);
+        await writeFile('e2e/.auth/user.json', emptyAuthState(baseURL)).catch(() => undefined);
       }
     } catch {
-      await writeFile('e2e/.auth/user.json', EMPTY_AUTH_STATE).catch(() => undefined);
+      await writeFile('e2e/.auth/user.json', emptyAuthState(baseURL)).catch(() => undefined);
     }
   }
 

--- a/e2e/utils/consent.ts
+++ b/e2e/utils/consent.ts
@@ -1,0 +1,77 @@
+import { expect, type Page } from '@playwright/test';
+
+/** Decided reject-optional record. Same shape CookieConsentManager persists. */
+export const DECIDED_CONSENT = {
+  necessary: true,
+  functional: false,
+  analytics: false,
+  marketing: false,
+  version: 1,
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  source: 'explicit',
+} as const;
+
+export function decidedConsentSerialized(): string {
+  return JSON.stringify(DECIDED_CONSENT);
+}
+
+/**
+ * storageState fragment so contexts created with e2e/.auth/user.json already
+ * have a decided consent record. storageState restore runs after init scripts
+ * and would otherwise wipe a beforeEach seed.
+ */
+export function consentStorageState(origin: string): {
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: 'Lax';
+  }>;
+  origins: Array<{
+    origin: string;
+    localStorage: Array<{ name: string; value: string }>;
+  }>;
+} {
+  const serialized = decidedConsentSerialized();
+  const hostname = new URL(origin).hostname;
+  return {
+    cookies: [
+      {
+        name: 'revealui-cookie-consent',
+        value: encodeURIComponent(serialized),
+        domain: hostname,
+        path: '/',
+        expires: -1,
+        httpOnly: false,
+        secure: origin.startsWith('https:'),
+        sameSite: 'Lax',
+      },
+    ],
+    origins: [
+      {
+        origin,
+        localStorage: [{ name: 'cookie-consent', value: serialized }],
+      },
+    ],
+  };
+}
+
+/** If the first-visit banner is up, reject it so page goldens stay banner-free. */
+export async function dismissCookieBannerIfPresent(page: Page): Promise<void> {
+  const dialog = page.getByRole('dialog', { name: /Cookies|Necessary cookies only/ });
+  if (!(await dialog.isVisible().catch(() => false))) {
+    return;
+  }
+  const reject = page.getByRole('button', { name: 'Reject all' });
+  const ok = page.getByRole('button', { name: 'OK' });
+  if (await reject.isVisible().catch(() => false)) {
+    await reject.click();
+  } else if (await ok.isVisible().catch(() => false)) {
+    await ok.click();
+  }
+  await expect(dialog).toBeHidden();
+}

--- a/e2e/visual-snapshots.e2e.ts
+++ b/e2e/visual-snapshots.e2e.ts
@@ -10,13 +10,11 @@
  * use the storageState written by global-setup.ts (e2e/.auth/user.json) so
  * each route renders its actual content rather than the /login redirect.
  *
- * If ADMIN_EMAIL/ADMIN_PASSWORD were not set during setup, e2e/.auth/user.json
- * will contain an empty cookie list and the authenticated tests will redirect
- * to /login — run global-setup again with credentials to populate the state.
- *
- * Every snapshot seeds a decided consent record before navigation so the
- * first-visit cookie banner cannot cover the page under test. Banner chrome
- * is locked by the presentation unit tests, not these goldens.
+ * If ADMIN_EMAIL/ADMIN_PASSWORD were not set during setup, authenticated tests
+ * redirect to /login. Global setup still writes a decided consent record into
+ * that storageState. After each goto we also dismiss the banner if it appears
+ * (storageState restore can wipe an init-script seed). Banner chrome is locked
+ * by presentation unit tests, not these goldens.
  *
  * Usage:
  * - Run tests: pnpm test:e2e:visual
@@ -25,29 +23,23 @@
  */
 
 import { expect, type Page, test } from '@playwright/test';
+import { decidedConsentSerialized, dismissCookieBannerIfPresent } from './utils/consent';
 import { waitForNetworkIdle } from './utils/test-helpers';
 
 const AUTH_STATE = 'e2e/.auth/user.json';
 
-/** Decided consent so page snapshots are not coupled to the first-visit banner. */
-const DECIDED_CONSENT = JSON.stringify({
-  necessary: true,
-  functional: false,
-  analytics: false,
-  marketing: false,
-  version: 1,
-  updatedAt: '2026-08-01T00:00:00.000Z',
-  source: 'explicit',
-});
-
 async function seedDecidedConsent(page: Page): Promise<void> {
   await page.addInitScript((serialized) => {
     // Same write as CookieConsentManager.writeConsentCookie: encoded value, Path=/.
-    // Origin-independent so PLAYWRIGHT_BASE_URL / storageState cannot drop it.
     // biome-ignore lint/suspicious/noDocumentCookie: e2e seeds the first-party consent cookie the manager reads
     document.cookie = `revealui-cookie-consent=${encodeURIComponent(serialized)}; Path=/; Max-Age=15552000; SameSite=Lax`;
     window.localStorage.setItem('cookie-consent', serialized);
-  }, DECIDED_CONSENT);
+  }, decidedConsentSerialized());
+}
+
+async function settleVisualPage(page: Page): Promise<void> {
+  await waitForNetworkIdle(page);
+  await dismissCookieBannerIfPresent(page);
 }
 
 test.describe('Visual Snapshots - Admin Application', () => {
@@ -58,8 +50,8 @@ test.describe('Visual Snapshots - Admin Application', () => {
   test.describe('Unauthenticated States', () => {
     test('login page should match snapshot', async ({ page }) => {
       await page.goto('/login');
-      await waitForNetworkIdle(page);
       await page.waitForLoadState('networkidle');
+      await settleVisualPage(page);
 
       await expect(page).toHaveScreenshot('admin-login-page.png', {
         fullPage: true,
@@ -70,7 +62,7 @@ test.describe('Visual Snapshots - Admin Application', () => {
   test.describe('Error States', () => {
     test('404 page should match snapshot', async ({ page }) => {
       await page.goto('/non-existent-page-that-should-404');
-      await waitForNetworkIdle(page);
+      await settleVisualPage(page);
 
       await expect(page).toHaveScreenshot('404-page.png', {
         fullPage: true,
@@ -83,8 +75,8 @@ test.describe('Visual Snapshots - Admin Application', () => {
 
     test('collections page should match snapshot', async ({ page }) => {
       await page.goto('/collections');
-      await waitForNetworkIdle(page);
       await page.waitForLoadState('networkidle');
+      await settleVisualPage(page);
 
       await expect(page).toHaveScreenshot('admin-collections.png', {
         fullPage: true,
@@ -93,8 +85,8 @@ test.describe('Visual Snapshots - Admin Application', () => {
 
     test('globals page should match snapshot', async ({ page }) => {
       await page.goto('/globals');
-      await waitForNetworkIdle(page);
       await page.waitForLoadState('networkidle');
+      await settleVisualPage(page);
 
       await expect(page).toHaveScreenshot('admin-globals.png', {
         fullPage: true,
@@ -108,7 +100,7 @@ test.describe('Visual Snapshots - Admin Application', () => {
     test('collections page on mobile viewport should match snapshot', async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 667 });
       await page.goto('/collections');
-      await waitForNetworkIdle(page);
+      await settleVisualPage(page);
 
       await expect(page).toHaveScreenshot('admin-collections-mobile.png', {
         fullPage: true,
@@ -122,7 +114,7 @@ test.describe('Visual Snapshots - Admin Application', () => {
     test('collections page with dark color scheme should match snapshot', async ({ page }) => {
       await page.emulateMedia({ colorScheme: 'dark' });
       await page.goto('/collections');
-      await waitForNetworkIdle(page);
+      await settleVisualPage(page);
 
       await expect(page).toHaveScreenshot('admin-collections-dark-mode.png', {
         fullPage: true,
@@ -135,7 +127,7 @@ test.describe('Visual Snapshots - Admin Application', () => {
 
     test('collections page should be visually consistent across browsers', async ({ page }) => {
       await page.goto('/collections');
-      await waitForNetworkIdle(page);
+      await settleVisualPage(page);
 
       await expect(page).toHaveScreenshot('cross-browser-admin-collections.png', {
         fullPage: true,


### PR DESCRIPTION
## Summary

#2632 made login and 404 goldens green. Mobile collections is still red (same 11k pixels) because those tests use `storageState: e2e/.auth/user.json`. Playwright restores that file **after** init scripts, so the consent seed is wiped and the banner covers the 375px login form again.

This PR:

- Writes a decided consent record into the empty (and signed-in) storageState
- After every visual `goto`, dismisses the banner if it is still up (`Reject all` / `OK`)

Page goldens stay banner-free. Banner behavior stays in presentation unit tests.

## After merge

#2629 re-runs Visual Regression from the new `test` tip.