### PR TITLE
fix(admin): show inference class before the adapter name

### DIFF
--- a/apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx
@@ -32,10 +32,10 @@ describe('ApiKeysPageClient', () => {
     vi.stubGlobal('fetch', mockFetchOnce(null));
     render(<ApiKeysPageClient providers={ALL_PROVIDERS} isHosted={false} />);
 
-    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Ollama/ })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Inference Snaps/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · OpenAI' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /local · Ollama/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /local · Inference Snaps/ })).toBeInTheDocument();
     expect(screen.queryByText(/hosted deployment/)).not.toBeInTheDocument();
   });
 
@@ -52,8 +52,8 @@ describe('ApiKeysPageClient', () => {
     });
     render(<ApiKeysPageClient providers={hostedProviders} isHosted={true} />);
 
-    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · OpenAI' })).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /Ollama/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /Inference Snaps/ })).not.toBeInTheDocument();
     expect(screen.getByText(/hosted deployment/)).toBeInTheDocument();
@@ -66,7 +66,7 @@ describe('ApiKeysPageClient', () => {
     const link = screen.getByRole('link', { name: /Get key/ });
     expect(link).toHaveAttribute('href', 'https://console.anthropic.com/settings/keys');
 
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    fireEvent.change(screen.getByLabelText('Adapter'), { target: { value: 'openai' } });
     expect(screen.getByRole('link', { name: /Get key/ })).toHaveAttribute(
       'href',
       'https://platform.openai.com/api-keys',
@@ -80,7 +80,9 @@ describe('ApiKeysPageClient', () => {
     await waitFor(() => {
       expect(screen.getByText(/Agent tasks will use it\./)).toBeInTheDocument();
     });
-    expect(screen.getByText(/Anthropic key configured \(sk-ant-...abcd\)/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/frontier · Anthropic key configured \(sk-ant-...abcd\)/),
+    ).toBeInTheDocument();
   });
 
   it('selects the saved provider instead of defaulting to Anthropic', async () => {
@@ -88,9 +90,9 @@ describe('ApiKeysPageClient', () => {
     render(<ApiKeysPageClient providers={ALL_PROVIDERS} isHosted={false} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Provider')).toHaveValue('groq');
+      expect(screen.getByLabelText('Adapter')).toHaveValue('groq');
     });
-    expect(screen.getByRole('option', { name: 'Groq' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'mechanical · Groq' })).toBeInTheDocument();
     expect(screen.queryByText(/LPU silicon/)).not.toBeInTheDocument();
   });
 
@@ -102,7 +104,7 @@ describe('ApiKeysPageClient', () => {
     fireEvent.change(input, { target: { value: 'sk-ant-typed' } });
     expect(input).toHaveValue('sk-ant-typed');
 
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    fireEvent.change(screen.getByLabelText('Adapter'), { target: { value: 'openai' } });
     expect(screen.getByPlaceholderText('sk-...')).toHaveValue('');
   });
 

--- a/apps/admin/src/app/(backend)/settings/api-keys/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/__tests__/page.test.tsx
@@ -42,7 +42,7 @@ describe('ApiKeysPage (server shell)', () => {
 
     expect(screen.getByRole('option', { name: /Ollama/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Inference Snaps/ })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · Anthropic' })).toBeInTheDocument();
   });
 
   it('hides localhost-only providers when REVEALUI_LICENSE_PRIVATE_KEY is set (hosted)', async () => {
@@ -53,7 +53,7 @@ describe('ApiKeysPage (server shell)', () => {
 
     expect(screen.queryByRole('option', { name: /Ollama/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /Inference Snaps/ })).not.toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · OpenAI' })).toBeInTheDocument();
   });
 });

--- a/apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx
@@ -6,7 +6,12 @@ import { Button, IconCheck, Input, Select, TextLink } from '@revealui/presentati
 import { Field, Label } from '@revealui/presentation/client';
 import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
-import type { Provider, ProviderInfo } from '@/lib/settings/api-key-providers';
+import {
+  CAPABILITY_CLASS_ORDER,
+  formatAdapterLabel,
+  type Provider,
+  type ProviderInfo,
+} from '@/lib/settings/api-key-providers';
 import { apiFetch } from '@/lib/utils/csrf';
 
 interface ApiKeysPageClientProps {
@@ -85,6 +90,7 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
   }
 
   const activeProviderInfo = providers.find((p) => p.id === provider);
+  const configuredProvider = providers.find((p) => p.id === currentProvider);
 
   return (
     <LicenseGate feature="ai">
@@ -94,7 +100,7 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
           {currentProvider && (
             <div className="mb-6 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
               <span className="h-2 w-2 rounded-full bg-success" />
-              {providers.find((p) => p.id === currentProvider)?.label ?? currentProvider} key
+              {configuredProvider ? formatAdapterLabel(configuredProvider) : currentProvider} key
               configured{currentKeyHint ? ` (${currentKeyHint})` : ''}. Agent tasks will use it.
             </div>
           )}
@@ -116,15 +122,15 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
           )}
 
           <div className="rounded-xl border border-border bg-card p-5">
-            <h1 className="text-base font-semibold text-foreground">AI Provider</h1>
+            <h1 className="text-base font-semibold text-foreground">Inference</h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              Connect the AI provider your agents run on. We store your key encrypted on RevealUI's
-              servers and only use it server-side when an agent task runs.
+              The class is the kind of model. The name is the adapter we use to reach it. We store
+              your key encrypted and only use it on the server when an agent task runs.
             </p>
             {isHosted && (
               <p className="mt-1 text-xs text-muted-foreground">
-                This is a hosted deployment, so local-only providers like Ollama and Inference Snaps
-                aren't listed below.
+                This is a hosted deployment, so local adapters (custom on-box setups) are not
+                listed.
               </p>
             )}
 
@@ -132,7 +138,7 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
               {/* Provider selector */}
               <Field>
                 <Label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                  Provider
+                  Adapter
                 </Label>
                 <Select
                   value={provider}
@@ -142,11 +148,19 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
                     setShowKey(false);
                   }}
                 >
-                  {providers.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.label}
-                    </option>
-                  ))}
+                  {CAPABILITY_CLASS_ORDER.map((capability) => {
+                    const group = providers.filter((entry) => entry.capability === capability);
+                    if (group.length === 0) return null;
+                    return (
+                      <optgroup key={capability} label={capability}>
+                        {group.map((entry) => (
+                          <option key={entry.id} value={entry.id}>
+                            {formatAdapterLabel(entry)}
+                          </option>
+                        ))}
+                      </optgroup>
+                    );
+                  })}
                 </Select>
               </Field>
 

--- a/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
+++ b/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Provider } from '../api-key-providers';
-import { ALL_PROVIDERS, visibleProviders } from '../api-key-providers';
+import { ALL_PROVIDERS, formatAdapterLabel, visibleProviders } from '../api-key-providers';
 
 /**
  * Loads the real `hostedViable` map from `@revealui/ai/llm/client` so this
@@ -30,6 +30,15 @@ describe('visibleProviders', () => {
     expect(ids).toEqual(['anthropic', 'openai', 'xai', 'groq', 'huggingface']);
     expect(ids).not.toContain('ollama');
     expect(ids).not.toContain('inference-snaps');
+  });
+
+  it('maps adapters onto capability classes (GAP-483 2026-08-15)', () => {
+    expect(ALL_PROVIDERS.find((p) => p.id === 'groq')?.capability).toBe('mechanical');
+    expect(ALL_PROVIDERS.find((p) => p.id === 'xai')?.capability).toBe('frontier');
+    expect(ALL_PROVIDERS.find((p) => p.id === 'ollama')?.capability).toBe('local');
+    expect(formatAdapterLabel(ALL_PROVIDERS.find((p) => p.id === 'groq')!)).toBe(
+      'mechanical · Groq',
+    );
   });
 
   it('fails open to the full list on hosted when the hosted map is unavailable', () => {

--- a/apps/admin/src/lib/settings/api-key-providers.ts
+++ b/apps/admin/src/lib/settings/api-key-providers.ts
@@ -19,11 +19,23 @@ export type Provider =
   | 'inference-snaps'
   | 'xai';
 
+/** GAP-483 dated map. Remap here when a release moves the band. */
+export type CapabilityClass = 'local' | 'mechanical' | 'frontier' | 'reasoning';
+
+export const CAPABILITY_CLASS_ORDER: readonly CapabilityClass[] = [
+  'local',
+  'mechanical',
+  'frontier',
+  'reasoning',
+];
+
 export interface ProviderInfo {
   id: Provider;
   label: string;
   placeholder: string;
   docsUrl: string;
+  /** Capability class (2026-08-15 map). Not a vendor name. */
+  capability: CapabilityClass;
 }
 
 /** All seven providers, hosted-viable and localhost-only alike. */
@@ -33,44 +45,55 @@ export const ALL_PROVIDERS: ProviderInfo[] = [
     label: 'Anthropic',
     placeholder: 'sk-ant-...',
     docsUrl: 'https://console.anthropic.com/settings/keys',
+    capability: 'frontier',
   },
   {
     id: 'openai',
     label: 'OpenAI',
     placeholder: 'sk-...',
     docsUrl: 'https://platform.openai.com/api-keys',
+    capability: 'frontier',
   },
   {
     id: 'xai',
     label: 'xAI (Grok)',
     placeholder: 'xai-...',
     docsUrl: 'https://console.x.ai',
+    capability: 'frontier',
   },
   {
     id: 'groq',
     label: 'Groq',
     placeholder: 'gsk_...',
     docsUrl: 'https://console.groq.com/keys',
+    capability: 'mechanical',
   },
   {
     id: 'huggingface',
     label: 'Hugging Face',
     placeholder: 'hf_...',
     docsUrl: 'https://huggingface.co/settings/tokens',
+    capability: 'mechanical',
   },
   {
     id: 'inference-snaps',
     label: 'Inference Snaps',
-    placeholder: 'leave blank — runs locally',
+    placeholder: 'leave blank, runs locally',
     docsUrl: 'https://snapcraft.io/search?q=inference',
+    capability: 'local',
   },
   {
     id: 'ollama',
     label: 'Ollama',
-    placeholder: 'leave blank — runs locally',
+    placeholder: 'leave blank, runs locally',
     docsUrl: 'https://ollama.com/docs',
+    capability: 'local',
   },
 ];
+
+export function formatAdapterLabel(provider: ProviderInfo): string {
+  return `${provider.capability} · ${provider.label}`;
+}
 
 /**
  * Resolve which providers the Settings, API Keys page should offer.


### PR DESCRIPTION
Follow-through for accepted GAP-483. Settings groups adapters by class. Provider ids unchanged. Groq or Grok is enough for the hosted walk.