### PR TITLE
promote: test → main

### DIFF
--- a/.changeset/gap-484-ai-artifact-cscrm.md
+++ b/.changeset/gap-484-ai-artifact-cscrm.md
@@ -1,0 +1,6 @@
+---
+'@revealui/ai': minor
+'@revealui/claim-gates': minor
+---
+
+Add the model-artifact C-SCRM door (URL plus sha256, refuse pickle-class formats) and claim-gates holds that block C-SCRM, trustworthy-AI, AML-hardened, and weight-scan product claims.

--- a/apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/__tests__/api-keys-client.test.tsx
@@ -32,10 +32,10 @@ describe('ApiKeysPageClient', () => {
     vi.stubGlobal('fetch', mockFetchOnce(null));
     render(<ApiKeysPageClient providers={ALL_PROVIDERS} isHosted={false} />);
 
-    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Ollama/ })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Inference Snaps/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · OpenAI' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /local · Ollama/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /local · Inference Snaps/ })).toBeInTheDocument();
     expect(screen.queryByText(/hosted deployment/)).not.toBeInTheDocument();
   });
 
@@ -52,8 +52,8 @@ describe('ApiKeysPageClient', () => {
     });
     render(<ApiKeysPageClient providers={hostedProviders} isHosted={true} />);
 
-    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · OpenAI' })).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /Ollama/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /Inference Snaps/ })).not.toBeInTheDocument();
     expect(screen.getByText(/hosted deployment/)).toBeInTheDocument();
@@ -66,7 +66,7 @@ describe('ApiKeysPageClient', () => {
     const link = screen.getByRole('link', { name: /Get key/ });
     expect(link).toHaveAttribute('href', 'https://console.anthropic.com/settings/keys');
 
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    fireEvent.change(screen.getByLabelText('Adapter'), { target: { value: 'openai' } });
     expect(screen.getByRole('link', { name: /Get key/ })).toHaveAttribute(
       'href',
       'https://platform.openai.com/api-keys',
@@ -80,7 +80,9 @@ describe('ApiKeysPageClient', () => {
     await waitFor(() => {
       expect(screen.getByText(/Agent tasks will use it\./)).toBeInTheDocument();
     });
-    expect(screen.getByText(/Anthropic key configured \(sk-ant-...abcd\)/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/frontier · Anthropic key configured \(sk-ant-...abcd\)/),
+    ).toBeInTheDocument();
   });
 
   it('selects the saved provider instead of defaulting to Anthropic', async () => {
@@ -88,9 +90,9 @@ describe('ApiKeysPageClient', () => {
     render(<ApiKeysPageClient providers={ALL_PROVIDERS} isHosted={false} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Provider')).toHaveValue('groq');
+      expect(screen.getByLabelText('Adapter')).toHaveValue('groq');
     });
-    expect(screen.getByRole('option', { name: 'Groq' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'mechanical · Groq' })).toBeInTheDocument();
     expect(screen.queryByText(/LPU silicon/)).not.toBeInTheDocument();
   });
 
@@ -102,7 +104,7 @@ describe('ApiKeysPageClient', () => {
     fireEvent.change(input, { target: { value: 'sk-ant-typed' } });
     expect(input).toHaveValue('sk-ant-typed');
 
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    fireEvent.change(screen.getByLabelText('Adapter'), { target: { value: 'openai' } });
     expect(screen.getByPlaceholderText('sk-...')).toHaveValue('');
   });
 

--- a/apps/admin/src/app/(backend)/settings/api-keys/__tests__/page.test.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/__tests__/page.test.tsx
@@ -42,7 +42,7 @@ describe('ApiKeysPage (server shell)', () => {
 
     expect(screen.getByRole('option', { name: /Ollama/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Inference Snaps/ })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · Anthropic' })).toBeInTheDocument();
   });
 
   it('hides localhost-only providers when REVEALUI_LICENSE_PRIVATE_KEY is set (hosted)', async () => {
@@ -53,7 +53,7 @@ describe('ApiKeysPage (server shell)', () => {
 
     expect(screen.queryByRole('option', { name: /Ollama/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /Inference Snaps/ })).not.toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Anthropic' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'OpenAI' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · Anthropic' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'frontier · OpenAI' })).toBeInTheDocument();
   });
 });

--- a/apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx
+++ b/apps/admin/src/app/(backend)/settings/api-keys/api-keys-client.tsx
@@ -6,7 +6,12 @@ import { Button, IconCheck, Input, Select, TextLink } from '@revealui/presentati
 import { Field, Label } from '@revealui/presentation/client';
 import { useEffect, useState } from 'react';
 import { LicenseGate } from '@/lib/components/LicenseGate';
-import type { Provider, ProviderInfo } from '@/lib/settings/api-key-providers';
+import {
+  CAPABILITY_CLASS_ORDER,
+  formatAdapterLabel,
+  type Provider,
+  type ProviderInfo,
+} from '@/lib/settings/api-key-providers';
 import { apiFetch } from '@/lib/utils/csrf';
 
 interface ApiKeysPageClientProps {
@@ -85,6 +90,7 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
   }
 
   const activeProviderInfo = providers.find((p) => p.id === provider);
+  const configuredProvider = providers.find((p) => p.id === currentProvider);
 
   return (
     <LicenseGate feature="ai">
@@ -94,7 +100,7 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
           {currentProvider && (
             <div className="mb-6 flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
               <span className="h-2 w-2 rounded-full bg-success" />
-              {providers.find((p) => p.id === currentProvider)?.label ?? currentProvider} key
+              {configuredProvider ? formatAdapterLabel(configuredProvider) : currentProvider} key
               configured{currentKeyHint ? ` (${currentKeyHint})` : ''}. Agent tasks will use it.
             </div>
           )}
@@ -116,15 +122,15 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
           )}
 
           <div className="rounded-xl border border-border bg-card p-5">
-            <h1 className="text-base font-semibold text-foreground">AI Provider</h1>
+            <h1 className="text-base font-semibold text-foreground">Inference</h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              Connect the AI provider your agents run on. We store your key encrypted on RevealUI's
-              servers and only use it server-side when an agent task runs.
+              The class is the kind of model. The name is the adapter we use to reach it. We store
+              your key encrypted and only use it on the server when an agent task runs.
             </p>
             {isHosted && (
               <p className="mt-1 text-xs text-muted-foreground">
-                This is a hosted deployment, so local-only providers like Ollama and Inference Snaps
-                aren't listed below.
+                This is a hosted deployment, so local adapters (custom on-box setups) are not
+                listed.
               </p>
             )}
 
@@ -132,7 +138,7 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
               {/* Provider selector */}
               <Field>
                 <Label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                  Provider
+                  Adapter
                 </Label>
                 <Select
                   value={provider}
@@ -142,11 +148,19 @@ export default function ApiKeysPageClient({ providers, isHosted }: ApiKeysPageCl
                     setShowKey(false);
                   }}
                 >
-                  {providers.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.label}
-                    </option>
-                  ))}
+                  {CAPABILITY_CLASS_ORDER.map((capability) => {
+                    const group = providers.filter((entry) => entry.capability === capability);
+                    if (group.length === 0) return null;
+                    return (
+                      <optgroup key={capability} label={capability}>
+                        {group.map((entry) => (
+                          <option key={entry.id} value={entry.id}>
+                            {formatAdapterLabel(entry)}
+                          </option>
+                        ))}
+                      </optgroup>
+                    );
+                  })}
                 </Select>
               </Field>
 

--- a/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
+++ b/apps/admin/src/lib/settings/__tests__/api-key-providers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Provider } from '../api-key-providers';
-import { ALL_PROVIDERS, visibleProviders } from '../api-key-providers';
+import { ALL_PROVIDERS, formatAdapterLabel, visibleProviders } from '../api-key-providers';
 
 /**
  * Loads the real `hostedViable` map from `@revealui/ai/llm/client` so this
@@ -30,6 +30,15 @@ describe('visibleProviders', () => {
     expect(ids).toEqual(['anthropic', 'openai', 'xai', 'groq', 'huggingface']);
     expect(ids).not.toContain('ollama');
     expect(ids).not.toContain('inference-snaps');
+  });
+
+  it('maps adapters onto capability classes (GAP-483 2026-08-15)', () => {
+    expect(ALL_PROVIDERS.find((p) => p.id === 'groq')?.capability).toBe('mechanical');
+    expect(ALL_PROVIDERS.find((p) => p.id === 'xai')?.capability).toBe('frontier');
+    expect(ALL_PROVIDERS.find((p) => p.id === 'ollama')?.capability).toBe('local');
+    expect(formatAdapterLabel(ALL_PROVIDERS.find((p) => p.id === 'groq')!)).toBe(
+      'mechanical · Groq',
+    );
   });
 
   it('fails open to the full list on hosted when the hosted map is unavailable', () => {

--- a/apps/admin/src/lib/settings/api-key-providers.ts
+++ b/apps/admin/src/lib/settings/api-key-providers.ts
@@ -19,11 +19,23 @@ export type Provider =
   | 'inference-snaps'
   | 'xai';
 
+/** GAP-483 dated map. Remap here when a release moves the band. */
+export type CapabilityClass = 'local' | 'mechanical' | 'frontier' | 'reasoning';
+
+export const CAPABILITY_CLASS_ORDER: readonly CapabilityClass[] = [
+  'local',
+  'mechanical',
+  'frontier',
+  'reasoning',
+];
+
 export interface ProviderInfo {
   id: Provider;
   label: string;
   placeholder: string;
   docsUrl: string;
+  /** Capability class (2026-08-15 map). Not a vendor name. */
+  capability: CapabilityClass;
 }
 
 /** All seven providers, hosted-viable and localhost-only alike. */
@@ -33,44 +45,55 @@ export const ALL_PROVIDERS: ProviderInfo[] = [
     label: 'Anthropic',
     placeholder: 'sk-ant-...',
     docsUrl: 'https://console.anthropic.com/settings/keys',
+    capability: 'frontier',
   },
   {
     id: 'openai',
     label: 'OpenAI',
     placeholder: 'sk-...',
     docsUrl: 'https://platform.openai.com/api-keys',
+    capability: 'frontier',
   },
   {
     id: 'xai',
     label: 'xAI (Grok)',
     placeholder: 'xai-...',
     docsUrl: 'https://console.x.ai',
+    capability: 'frontier',
   },
   {
     id: 'groq',
     label: 'Groq',
     placeholder: 'gsk_...',
     docsUrl: 'https://console.groq.com/keys',
+    capability: 'mechanical',
   },
   {
     id: 'huggingface',
     label: 'Hugging Face',
     placeholder: 'hf_...',
     docsUrl: 'https://huggingface.co/settings/tokens',
+    capability: 'mechanical',
   },
   {
     id: 'inference-snaps',
     label: 'Inference Snaps',
-    placeholder: 'leave blank — runs locally',
+    placeholder: 'leave blank, runs locally',
     docsUrl: 'https://snapcraft.io/search?q=inference',
+    capability: 'local',
   },
   {
     id: 'ollama',
     label: 'Ollama',
-    placeholder: 'leave blank — runs locally',
+    placeholder: 'leave blank, runs locally',
     docsUrl: 'https://ollama.com/docs',
+    capability: 'local',
   },
 ];
+
+export function formatAdapterLabel(provider: ProviderInfo): string {
+  return `${provider.capability} · ${provider.label}`;
+}
 
 /**
  * Resolve which providers the Settings, API Keys page should offer.

--- a/apps/marketing/app/content/claims-evidence/blog-body-claims.ts
+++ b/apps/marketing/app/content/claims-evidence/blog-body-claims.ts
@@ -1134,7 +1134,7 @@ export const blogBodyClaims: readonly ClaimEntry[] = [
   {
     file: 'blog/ui-of-the-future',
     exportPath: 'body.23',
-    text: 'Today, RevealUI is the runtime layer of that thesis. Five primitives that every business needs: People, Content, Offers, Payments, Agents. One permission model that covers humans and agents alike. A tamper-evident audit log. Local-first AI that runs on models you own, with any provider you choose as an option rather than a dependency. It is open source, and you can read every line.',
+    text: 'Today, RevealUI is the runtime layer of that thesis. Five primitives that every business needs: People, Content, Offers, Payments, Agents. One permission model that covers humans and agents alike. A tamper-evident audit log. Local-first AI that runs on models you host, with any provider you choose as an option rather than a dependency. It is open source, and you can read every line.',
     evidence: [
       { kind: 'code', ref: 'docs/blog/16-ui-of-the-future.md', note: 'body source paragraph 23' },
       {

--- a/apps/marketing/app/content/claims-evidence/claims-part-3.ts
+++ b/apps/marketing/app/content/claims-evidence/claims-part-3.ts
@@ -451,7 +451,7 @@ export const claimsPart3: readonly ClaimEntry[] = [
     file: 'local-ai.ts',
     exportPath: 'LOCAL_AI_SECTION.heading',
     proofGrade: 'outcome',
-    text: 'Your agents run on models you own.',
+    text: 'Your agents run on models you host.',
     evidence: [OPEN_WEIGHT],
   },
   {

--- a/apps/marketing/app/content/local-ai.ts
+++ b/apps/marketing/app/content/local-ai.ts
@@ -34,7 +34,7 @@ export interface LocalAiBeat {
 // Shared home-section content. Four beats per the corpus §4.12 lead.
 export const LOCAL_AI_SECTION = {
   eyebrow: 'Local-first AI',
-  heading: 'Your agents run on models you own.',
+  heading: 'Your agents run on models you host.',
   body: 'By default, agents run on open-weight models on infrastructure you control. Their work stays in your boundary. Your AI bill is your own inference cost.',
   beats: [
     {

--- a/docs/blog/16-ui-of-the-future.md
+++ b/docs/blog/16-ui-of-the-future.md
@@ -55,7 +55,7 @@ And because it all runs on infrastructure you own, it compounds. The memory your
 
 I want to be precise about the present tense, because this industry has a lying problem and I refuse to add to it.
 
-Today, RevealUI is the runtime layer of that thesis. Five primitives that every business needs: People, Content, Offers, Payments, Agents. One permission model that covers humans and agents alike. A tamper-evident audit log. Local-first AI that runs on models you own, with any provider you choose as an option rather than a dependency. It is open source, and you can read every line.
+Today, RevealUI is the runtime layer of that thesis. Five primitives that every business needs: People, Content, Offers, Payments, Agents. One permission model that covers humans and agents alike. A tamper-evident audit log. Local-first AI that runs on models you host, with any provider you choose as an option rather than a dependency. It is open source, and you can read every line.
 
 Today, you still need to be the kind of person who can run your own infrastructure. The owner-operators come first: the founders and small teams who run their business on their own AI and want the receipts to prove what it did. They are who this is built with, right now, in production, by the one engineer in Tennessee writing this.
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -61,6 +61,7 @@ export * from './audit/index.js';
 export * from './embeddings/index.js';
 // Re-export ingestion pipeline (RAG document indexing + hybrid search)
 export * from './ingestion/index.js';
+export * from './llm/artifact-provenance.js';
 // Re-export LLM providers and client
 export * from './llm/client.js';
 export * from './llm/local-ai-profile.js';

--- a/packages/ai/src/llm/__tests__/artifact-provenance.test.ts
+++ b/packages/ai/src/llm/__tests__/artifact-provenance.test.ts
@@ -1,0 +1,153 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  AceModelArtifactError,
+  ArtifactHashMismatchError,
+  ArtifactProvenanceError,
+  assertArtifactProvenance,
+  assertOllamaPullRef,
+  assertSafeModelArtifactName,
+  assertSnapInstallName,
+  fetchProvenancedArtifact,
+  isAceDeserializeArtifact,
+  isSafeModelArtifactName,
+  sha256Hex,
+  verifyBytesSha256,
+} from '../artifact-provenance.js';
+
+describe('isAceDeserializeArtifact', () => {
+  it.each([
+    'model.pkl',
+    'weights.pickle',
+    'clf.joblib',
+    'net.pth',
+    'net.pt',
+    'x.ckpt',
+    'pytorch.bin',
+  ])('flags %s', (name) => {
+    expect(isAceDeserializeArtifact(name)).toBe(true);
+  });
+
+  it('does not flag safetensors or gguf', () => {
+    expect(isAceDeserializeArtifact('model.safetensors')).toBe(false);
+    expect(isAceDeserializeArtifact('gemma3.gguf')).toBe(false);
+  });
+});
+
+describe('assertSafeModelArtifactName', () => {
+  it('allows safetensors, gguf, onnx', () => {
+    expect(assertSafeModelArtifactName('weights.safetensors')).toBe('weights.safetensors');
+    expect(assertSafeModelArtifactName('/tmp/a.gguf')).toBe('a.gguf');
+    expect(assertSafeModelArtifactName('model.ONNX')).toBe('model.ONNX');
+  });
+
+  it('refuses pickle-class names', () => {
+    expect(() => assertSafeModelArtifactName('evil.pkl')).toThrow(AceModelArtifactError);
+    expect(() => assertSafeModelArtifactName('pytorch.bin')).toThrow(AceModelArtifactError);
+  });
+
+  it('refuses unknown extensions instead of scanning weights', () => {
+    expect(() => assertSafeModelArtifactName('mystery.dat')).toThrow(AceModelArtifactError);
+  });
+});
+
+describe('assertArtifactProvenance', () => {
+  const sha = 'a'.repeat(64);
+
+  it('accepts https + sha256 + safe name', () => {
+    const out = assertArtifactProvenance({
+      url: 'https://example.com/models/gemma.safetensors',
+      sha256: sha,
+    });
+    expect(out.filename).toBe('gemma.safetensors');
+    expect(out.sha256).toBe(sha);
+  });
+
+  it('accepts http localhost for operator/dev', () => {
+    const out = assertArtifactProvenance({
+      url: 'http://127.0.0.1:8080/a.gguf',
+      sha256: sha,
+    });
+    expect(out.filename).toBe('a.gguf');
+  });
+
+  it('rejects http remote and missing hash', () => {
+    expect(() =>
+      assertArtifactProvenance({
+        url: 'http://evil.example/a.gguf',
+        sha256: sha,
+      }),
+    ).toThrow(ArtifactProvenanceError);
+    expect(() =>
+      assertArtifactProvenance({
+        url: 'https://example.com/a.gguf',
+        sha256: 'not-a-hash',
+      }),
+    ).toThrow(ArtifactProvenanceError);
+  });
+
+  it('rejects pickle URLs even with a hash', () => {
+    expect(() =>
+      assertArtifactProvenance({
+        url: 'https://example.com/model.pkl',
+        sha256: sha,
+      }),
+    ).toThrow(AceModelArtifactError);
+  });
+});
+
+describe('verifyBytesSha256 / fetchProvenancedArtifact', () => {
+  it('verifies matching bytes and rejects a mismatch', () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const hex = sha256Hex(bytes);
+    verifyBytesSha256(bytes, hex);
+    expect(() => verifyBytesSha256(bytes, 'b'.repeat(64))).toThrow(ArtifactHashMismatchError);
+  });
+
+  it('fetches only after provenance passes and checks the hash', async () => {
+    const payload = new Uint8Array([9, 8, 7]);
+    const hex = createHash('sha256').update(payload).digest('hex');
+    const fetchFn: typeof fetch = async () =>
+      new Response(payload, { status: 200, statusText: 'OK' });
+    const got = await fetchProvenancedArtifact(
+      { url: 'https://example.com/m.safetensors', sha256: hex },
+      { fetch: fetchFn },
+    );
+    expect(got).toEqual(payload);
+  });
+
+  it('does not fetch when the filename is pickle-class', async () => {
+    let called = false;
+    const fetchFn: typeof fetch = async () => {
+      called = true;
+      return new Response(new Uint8Array(), { status: 200 });
+    };
+    await expect(
+      fetchProvenancedArtifact(
+        { url: 'https://example.com/m.pkl', sha256: 'c'.repeat(64) },
+        { fetch: fetchFn },
+      ),
+    ).rejects.toBeInstanceOf(AceModelArtifactError);
+    expect(called).toBe(false);
+  });
+});
+
+describe('registry names', () => {
+  it('allows ollama registry refs and refuses file-like refs', () => {
+    expect(assertOllamaPullRef('gemma3:latest')).toBe('gemma3:latest');
+    expect(() => assertOllamaPullRef('model.pkl')).toThrow(ArtifactProvenanceError);
+    expect(() => assertOllamaPullRef('weights.gguf')).toThrow(ArtifactProvenanceError);
+  });
+
+  it('reuses the US-origin snap allowlist', () => {
+    expect(assertSnapInstallName('gemma3')).toBe('gemma3');
+    expect(() => assertSnapInstallName('deepseek-r1')).toThrow();
+  });
+});
+
+describe('isSafeModelArtifactName', () => {
+  it('is false for empty names', () => {
+    expect(isSafeModelArtifactName('')).toBe(false);
+    expect(isSafeModelArtifactName('/')).toBe(false);
+  });
+});

--- a/packages/ai/src/llm/artifact-provenance.ts
+++ b/packages/ai/src/llm/artifact-provenance.ts
@@ -1,0 +1,237 @@
+/**
+ * Model/data artifact C-SCRM door (GAP-484).
+ *
+ * NIST C-SCRM + AI 100-2 (Vassilev, SSCA 2024): hash + URL provenance, refuse
+ * pickle-class deserialize-to-ACE formats. Do not scan weights for behavior.
+ *
+ * This is the only supported fetch path for fleet-fetched weight artifacts.
+ * Inference Snaps stay on the US-origin snap allowlist (us-origin-snaps.ts).
+ * Snap store / Ollama registry names are not weight files.
+ */
+
+import { createHash } from 'node:crypto';
+import { assertUsOriginInferenceSnap } from './providers/us-origin-snaps.js';
+
+/** Formats that deserialize to arbitrary code (pickle protocol family). */
+export const ACE_MODEL_SUFFIXES = [
+  '.pickle',
+  '.pkl',
+  '.joblib',
+  '.dill',
+  '.pth',
+  '.pt',
+  '.ckpt',
+  '.bin',
+] as const;
+
+/** Formats that do not use pickle deserialize. */
+export const SAFE_MODEL_SUFFIXES = ['.safetensors', '.gguf', '.onnx'] as const;
+
+export class AceModelArtifactError extends Error {
+  readonly code = 'ACE_MODEL_ARTIFACT' as const;
+  readonly filename: string;
+
+  constructor(filename: string) {
+    super(
+      `Refusing model artifact "${filename}": pickle-class formats can deserialize ` +
+        'to arbitrary code (NIST AI 100-2 / GAP-484). Use .safetensors, .gguf, or .onnx. ' +
+        'We do not scan weights for behavior.',
+    );
+    this.name = 'AceModelArtifactError';
+    this.filename = filename;
+  }
+}
+
+export class ArtifactProvenanceError extends Error {
+  readonly code = 'ARTIFACT_PROVENANCE' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArtifactProvenanceError';
+  }
+}
+
+export class ArtifactHashMismatchError extends Error {
+  readonly code = 'ARTIFACT_HASH_MISMATCH' as const;
+  readonly expected: string;
+  readonly actual: string;
+
+  constructor(expected: string, actual: string) {
+    super(
+      `Artifact sha256 mismatch (GAP-484). expected=${expected} actual=${actual}. ` +
+        'This is an integrity check, not a capability scan of the weights.',
+    );
+    this.name = 'ArtifactHashMismatchError';
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+export interface ArtifactProvenance {
+  readonly url: string;
+  readonly sha256: string;
+  readonly filename: string;
+}
+
+function lastPathSegment(value: string): string {
+  const trimmed = value.trim();
+  const slash = trimmed.lastIndexOf('/');
+  const raw = slash === -1 ? trimmed : trimmed.slice(slash + 1);
+  const query = raw.indexOf('?');
+  return query === -1 ? raw : raw.slice(0, query);
+}
+
+function lowerName(value: string): string {
+  return lastPathSegment(value).toLowerCase();
+}
+
+function hasSuffix(name: string, suffix: string): boolean {
+  return name.length > suffix.length && name.endsWith(suffix);
+}
+
+/** True when the path looks like a pickle-class deserialize format. */
+export function isAceDeserializeArtifact(name: string): boolean {
+  const n = lowerName(name);
+  return ACE_MODEL_SUFFIXES.some((suffix) => hasSuffix(n, suffix));
+}
+
+/** True when the path is an allowlisted non-pickle weight format. */
+export function isSafeModelArtifactName(name: string): boolean {
+  const n = lowerName(name);
+  if (n.length === 0) return false;
+  return SAFE_MODEL_SUFFIXES.some((suffix) => hasSuffix(n, suffix));
+}
+
+/**
+ * Refuse pickle-class filenames. Allow only safetensors / gguf / onnx.
+ */
+export function assertSafeModelArtifactName(name: string): string {
+  const filename = lastPathSegment(name);
+  if (filename.length === 0) {
+    throw new AceModelArtifactError(name);
+  }
+  if (isAceDeserializeArtifact(filename) || !isSafeModelArtifactName(filename)) {
+    throw new AceModelArtifactError(filename);
+  }
+  return filename;
+}
+
+function isSha256Hex(value: string): boolean {
+  if (value.length !== 64) return false;
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i);
+    const isDigit = c >= 48 && c <= 57;
+    const isAf = c >= 97 && c <= 102;
+    const isAF = c >= 65 && c <= 70;
+    if (!(isDigit || isAf || isAF)) return false;
+  }
+  return true;
+}
+
+function isAllowedProvenanceUrl(url: URL): boolean {
+  if (url.protocol === 'https:') return true;
+  if (url.protocol !== 'http:') return false;
+  const host = url.hostname.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1';
+}
+
+/**
+ * Validate URL + sha256 + safe filename. Does not fetch and does not scan weights.
+ */
+export function assertArtifactProvenance(spec: {
+  readonly url: string;
+  readonly sha256: string;
+  readonly filename?: string;
+}): ArtifactProvenance {
+  let parsed: URL;
+  try {
+    parsed = new URL(spec.url);
+  } catch {
+    throw new ArtifactProvenanceError(`Invalid artifact URL: ${spec.url}`);
+  }
+  if (!isAllowedProvenanceUrl(parsed)) {
+    throw new ArtifactProvenanceError(
+      `Artifact URL must be https (or http localhost for operator/dev): ${spec.url}`,
+    );
+  }
+  if (!isSha256Hex(spec.sha256)) {
+    throw new ArtifactProvenanceError('Artifact sha256 must be 64 hex characters (GAP-484).');
+  }
+  const filename = assertSafeModelArtifactName(spec.filename ?? lastPathSegment(parsed.pathname));
+  return {
+    url: parsed.href,
+    sha256: spec.sha256.toLowerCase(),
+    filename,
+  };
+}
+
+export function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/** Integrity check only. Not a capability or safety scan of the weights. */
+export function verifyBytesSha256(bytes: Uint8Array, expectedHex: string): void {
+  if (!isSha256Hex(expectedHex)) {
+    throw new ArtifactProvenanceError('Artifact sha256 must be 64 hex characters (GAP-484).');
+  }
+  const actual = sha256Hex(bytes);
+  const expected = expectedHex.toLowerCase();
+  if (actual !== expected) {
+    throw new ArtifactHashMismatchError(expected, actual);
+  }
+}
+
+export interface FetchProvenancedArtifactOptions {
+  readonly fetch?: typeof fetch;
+}
+
+/**
+ * The fleet fetch door for weight artifacts: URL + sha256, then hash-verify.
+ * Fails closed on ACE formats, bad URLs, missing hash, or mismatch.
+ */
+export async function fetchProvenancedArtifact(
+  spec: {
+    readonly url: string;
+    readonly sha256: string;
+    readonly filename?: string;
+  },
+  options?: FetchProvenancedArtifactOptions,
+): Promise<Uint8Array> {
+  const provenanced = assertArtifactProvenance(spec);
+  const fetchImpl = options?.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new ArtifactProvenanceError('fetch is not available');
+  }
+  const response = await fetchImpl(provenanced.url);
+  if (!response.ok) {
+    throw new ArtifactProvenanceError(
+      `Artifact fetch failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  verifyBytesSha256(bytes, provenanced.sha256);
+  return bytes;
+}
+
+/**
+ * Ollama pull refs are registry names (`gemma3:latest`), not files.
+ * Refuse refs that look like local pickle/ACE paths.
+ */
+export function assertOllamaPullRef(modelName: string): string {
+  const name = modelName.trim();
+  if (name.length === 0) {
+    throw new ArtifactProvenanceError('Ollama pull ref is empty');
+  }
+  if (isAceDeserializeArtifact(name) || isSafeModelArtifactName(name)) {
+    throw new ArtifactProvenanceError(
+      `Ollama pull ref "${name}" looks like a weight file. Pull a registry name, ` +
+        'not a pickle or local artifact path (GAP-484).',
+    );
+  }
+  return name;
+}
+
+/** Snap install names stay on the US-origin product allowlist. */
+export function assertSnapInstallName(snapName: string): string {
+  return assertUsOriginInferenceSnap(snapName);
+}

--- a/packages/ai/src/llm/providers/us-origin-snaps.ts
+++ b/packages/ai/src/llm/providers/us-origin-snaps.ts
@@ -15,6 +15,9 @@
  *   REVEALUI_ALLOW_NON_US_MODELS=1
  *
  * Companion ADR: .jv docs/decisions/2026-07-24-us-origin-inference-snaps.md
+ *
+ * Weight-file fetches (URL + sha256, pickle refuse) live in
+ * `../artifact-provenance.ts` (GAP-484). This module is snap-id origin only.
  */
 
 /**

--- a/packages/claim-gates/README.md
+++ b/packages/claim-gates/README.md
@@ -71,6 +71,11 @@ IDs match the private planning registry (`.jv` `docs/marketing/copy-dependents.y
 When a feature ships: set hold `status: released` in the same PR as the product
 work, then cue private COPY-DEP work for any remaining copy package.
 
+GAP-484 honesty holds (stay `waiting`; they are bans, not roadmap cues):
+`COPY-DEP-C-SCRM-CERT`, `COPY-DEP-AML-HARDENED`, `COPY-DEP-TRUSTWORTHY-AI`,
+`COPY-DEP-MODEL-PROVENANCE` (weight *scan* claims; hash-plus-URL provenance is
+the allowed control language).
+
 ## Development
 
 ```bash

--- a/packages/claim-gates/src/__tests__/copy-dependents.test.ts
+++ b/packages/claim-gates/src/__tests__/copy-dependents.test.ts
@@ -68,4 +68,53 @@ describe('copy-dependent holds', () => {
     const h = hits('Official Docker images are available on GHCR today.');
     expect(h.some((x) => x.holdId === 'COPY-DEP-FLEET-DOCKER-IMAGES')).toBe(true);
   });
+
+  it('flags C-SCRM and NIST 800-161 certification claims', () => {
+    expect(
+      hits('C-SCRM is certified for every tenant.').some(
+        (x) => x.holdId === 'COPY-DEP-C-SCRM-CERT',
+      ),
+    ).toBe(true);
+    expect(
+      hits('RevealUI is NIST 800-161 compliant today.').some(
+        (x) => x.holdId === 'COPY-DEP-C-SCRM-CERT',
+      ),
+    ).toBe(true);
+    expect(
+      hits('Supply chain risk is a buyer concern.').some(
+        (x) => x.holdId === 'COPY-DEP-C-SCRM-CERT',
+      ),
+    ).toBe(false);
+  });
+
+  it('flags trustworthy-AI badges but not a bare NIST attribute mention', () => {
+    expect(
+      hits('Our trustworthy AI is certified for operators.').some(
+        (x) => x.holdId === 'COPY-DEP-TRUSTWORTHY-AI',
+      ),
+    ).toBe(true);
+    expect(
+      hits('Fairness is one trustworthy AI attribute.').some(
+        (x) => x.holdId === 'COPY-DEP-TRUSTWORTHY-AI',
+      ),
+    ).toBe(false);
+  });
+
+  it('flags AML-hardened and weight-scan claims', () => {
+    expect(
+      hits('The runtime is adversarially robust.').some(
+        (x) => x.holdId === 'COPY-DEP-AML-HARDENED',
+      ),
+    ).toBe(true);
+    expect(
+      hits('We scan model weights before load.').some(
+        (x) => x.holdId === 'COPY-DEP-MODEL-PROVENANCE',
+      ),
+    ).toBe(true);
+    expect(
+      hits('Hash plus URL is provenance, not a scan.').some(
+        (x) => x.holdId === 'COPY-DEP-MODEL-PROVENANCE',
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/claim-gates/src/copy-dependents.ts
+++ b/packages/claim-gates/src/copy-dependents.ts
@@ -23,7 +23,11 @@ export type CopyDependentDetector =
   | 'sso-live'
   | 'visual-builder-live'
   | 'ghcr-fleet-images-live'
-  | 'saml-live';
+  | 'saml-live'
+  | 'cscrm-certified'
+  | 'trustworthy-ai-badge'
+  | 'aml-hardened'
+  | 'weight-scan';
 
 export interface CopyDependentHold {
   readonly id: string;
@@ -85,6 +89,34 @@ export const COPY_DEPENDENT_HOLDS: readonly CopyDependentHold[] = [
     title: 'Self-hosted Docker / GHCR Fleet kit copy',
     detector: 'ghcr-fleet-images-live',
     why: 'Official GHCR Docker images for Fleet are Planned; no "images published" live claim',
+  },
+  {
+    id: 'COPY-DEP-C-SCRM-CERT',
+    status: 'waiting',
+    title: 'C-SCRM / NIST SP 800-161 certification copy',
+    detector: 'cscrm-certified',
+    why: 'No C-SCRM or NIST SP 800-161 product badge. npm/CI hardening is a different class (GAP-484)',
+  },
+  {
+    id: 'COPY-DEP-AML-HARDENED',
+    status: 'waiting',
+    title: 'Adversarial-ML / poisoning-resistant copy',
+    detector: 'aml-hardened',
+    why: 'NIST AI 100-2: no information-theoretic AML guarantees; do not claim hardened or poisoning-resistant (GAP-484)',
+  },
+  {
+    id: 'COPY-DEP-TRUSTWORTHY-AI',
+    status: 'waiting',
+    title: 'Trustworthy AI product-badge copy',
+    detector: 'trustworthy-ai-badge',
+    why: 'NIST trustworthiness attributes are a framework with tradeoffs, not a RevealUI badge (GAP-484)',
+  },
+  {
+    id: 'COPY-DEP-MODEL-PROVENANCE',
+    status: 'waiting',
+    title: 'Model-weight scan copy',
+    detector: 'weight-scan',
+    why: 'Weights are not scanned for behavior. Provenance is hash plus URL, not a capability scan (GAP-484)',
   },
 ] as const;
 
@@ -226,6 +258,91 @@ function detectGhcrFleetImagesLive(words: string[]): boolean {
   return false;
 }
 
+const CERT_WORDS = new Set(['certified', 'compliant', 'aligned', 'assured', 'badge', 'standard']);
+
+const WEIGHT_WORDS = new Set(['weights', 'weight']);
+
+function hasNearby(words: string[], from: number, window: number, needles: Set<string>): boolean {
+  const lo = Math.max(0, from - window);
+  const hi = Math.min(words.length, from + window);
+  for (let j = lo; j < hi; j++) {
+    if (needles.has(words[j] ?? '')) return true;
+  }
+  return false;
+}
+
+/** "C-SCRM certified" / "NIST 800-161 compliant" — not a glossary mention. */
+function detectCscrmCertified(words: string[]): boolean {
+  for (let i = 0; i < words.length; i++) {
+    if (words[i] === 'c' && words[i + 1] === 'scrm') {
+      if (hasNearby(words, i, 8, CERT_WORDS)) return true;
+    }
+    if (words[i] === 'cscrm' && hasNearby(words, i, 8, CERT_WORDS)) return true;
+    if (
+      words[i] === 'nist' &&
+      words[i + 1] === '800' &&
+      words[i + 2] === '161' &&
+      hasNearby(words, i, 8, CERT_WORDS)
+    ) {
+      return true;
+    }
+    if (
+      words[i] === 'sp' &&
+      words[i + 1] === '800' &&
+      words[i + 2] === '161' &&
+      hasNearby(words, i, 8, CERT_WORDS)
+    ) {
+      return true;
+    }
+    if (
+      words[i] === 'supply' &&
+      words[i + 1] === 'chain' &&
+      (words[i + 2] === 'assured' || words[i + 2] === 'certified' || words[i + 2] === 'compliant')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** "trustworthy AI certified" / "our trustworthy AI" as a product badge. */
+function detectTrustworthyAiBadge(words: string[]): boolean {
+  for (let i = 0; i < words.length; i++) {
+    if (words[i] !== 'trustworthy' || words[i + 1] !== 'ai') continue;
+    if (hasNearby(words, i, 6, CERT_WORDS)) return true;
+    if (i > 0 && (words[i - 1] === 'our' || words[i - 1] === 'revealui')) return true;
+  }
+  return false;
+}
+
+function detectAmlHardened(words: string[]): boolean {
+  for (let i = 0; i < words.length; i++) {
+    if (words[i] === 'adversarially' && words[i + 1] === 'robust') return true;
+    if (words[i] === 'aml' && words[i + 1] === 'hardened') return true;
+    if (words[i] === 'poisoning' && words[i + 1] === 'resistant') return true;
+    if (
+      words[i] === 'prompt' &&
+      words[i + 1] === 'injection' &&
+      (words[i + 2] === 'proof' || words[i + 2] === 'proofed')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** "we scan model weights" / "scanned weights" as a capability claim. */
+function detectWeightScan(words: string[]): boolean {
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i];
+    if (w !== 'scan' && w !== 'scans' && w !== 'scanned' && w !== 'sanitize' && w !== 'sanitized') {
+      continue;
+    }
+    if (hasNearby(words, i, 6, WEIGHT_WORDS)) return true;
+  }
+  return false;
+}
+
 function runDetector(detector: CopyDependentDetector, words: string[]): boolean {
   switch (detector) {
     case 'marketplace-live':
@@ -240,6 +357,14 @@ function runDetector(detector: CopyDependentDetector, words: string[]): boolean 
       return detectVisualBuilderLive(words);
     case 'ghcr-fleet-images-live':
       return detectGhcrFleetImagesLive(words);
+    case 'cscrm-certified':
+      return detectCscrmCertified(words);
+    case 'trustworthy-ai-badge':
+      return detectTrustworthyAiBadge(words);
+    case 'aml-hardened':
+      return detectAmlHardened(words);
+    case 'weight-scan':
+      return detectWeightScan(words);
     default:
       return false;
   }


### PR DESCRIPTION
## Why

GAP-466 deploy lockstep. Customer-visible honesty from revealui#2637 (host-not-own, artifact-provenance door, claim-gates C-SCRM/AML holds) is on `test` and not on `main`. Last production honesty promote was #2629.

Also includes #2636 (Settings inference class before adapter name).

## Merge

**Create a merge commit only.** Do not squash or rebase.

```bash
gh pr merge <N> -R RevealUIStudio/revealui --merge
```

## After merge (GAP-466 checklist)

```bash
gh run list -R RevealUIStudio/revealui --workflow=deploy.yml --branch main --limit 1
# expect success including Deploy marketing

# SPA: grep production JS, not only HTML
curl -sS https://revealui.com/ -o /tmp/idx.html
js=$(grep -oE '/assets/[^"]+\.js' /tmp/idx.html | head -1)
curl -sS "https://revealui.com$js" | grep -F 'models you host'
```

Do not claim validated on production until that grep hits.