### PR TITLE
fix(ai): GAP-360 walk residuals — A2A entitlements, tool schema, agent tools

### DIFF
--- a/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
+++ b/apps/admin/src/app/(backend)/agents/[agentId]/run/page.tsx
@@ -36,7 +36,7 @@ export default function AgentRunPage({ params }: PageProps) {
     e.preventDefault();
     const trimmed = instruction.trim();
     if (!trimmed) return;
-    void stream.start({ instruction: trimmed, mode });
+    void stream.start({ instruction: trimmed, mode, agentId });
   };
 
   return (

--- a/apps/admin/src/lib/hooks/useAgentStream.ts
+++ b/apps/admin/src/lib/hooks/useAgentStream.ts
@@ -79,6 +79,8 @@ export interface AgentStreamRequest {
    * request schema.
    */
   mode?: 'admin' | 'coding';
+  /** Built-in agent id. Scopes admin tools on /api/agent-stream. */
+  agentId?: string;
 }
 
 export interface PendingElicitation {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -763,11 +763,21 @@ const supportExpiryCheck = checkSupportExpiry(async (customerId) => {
 app.use('/api/*', supportExpiryCheck);
 app.use('/api/v1/*', supportExpiryCheck);
 
-// A2A routes live outside /api/* so they need their own entitlement + license status check.
-// Without this, a revoked license retains A2A task execution access until the
-// 5-minute in-memory feature-flag cache expires.
+// A2A lives outside /api/*. Auth must run before entitlements so
+// platform-operator / membership resolve sees the session. Mounting only
+// entitlements on `/a2a/*` (after the route's own auth) left Task Tester
+// with free features.ai. GAP-360 walk.
+app.use('/a2a', optionalAuth);
+app.use('/a2a/*', optionalAuth);
+app.use('/a2a', optionalTenant);
+app.use('/a2a/*', optionalTenant);
+app.use('/a2a', entitlementMiddleware());
 app.use('/a2a/*', entitlementMiddleware());
+app.use('/a2a', csrfMiddleware());
+app.use('/a2a/*', csrfMiddleware());
+app.use('/a2a', licenseStatusCheck);
 app.use('/a2a/*', licenseStatusCheck);
+app.use('/a2a', supportExpiryCheck);
 app.use('/a2a/*', supportExpiryCheck);
 
 // GAP-310: block writes for lapsed-perpetual (read-only) licenses. Runs after
@@ -776,6 +786,7 @@ app.use('/a2a/*', supportExpiryCheck);
 // (off default / shadow / enforce); inert unless a license is in read-only mode.
 app.use('/api/*', enforceReadOnlyWrites());
 app.use('/api/v1/*', enforceReadOnlyWrites());
+app.use('/a2a', enforceReadOnlyWrites());
 app.use('/a2a/*', enforceReadOnlyWrites());
 
 // License enforcement  -  gate premium routes by feature

--- a/apps/server/src/lib/__tests__/agent-tool-access.test.ts
+++ b/apps/server/src/lib/__tests__/agent-tool-access.test.ts
@@ -9,6 +9,7 @@ import {
   resolveStreamPrincipal,
 } from '../agent-principal.js';
 import {
+  adminToolIncludeForAgent,
   agentToolPermissionKey,
   authorizeAgentTool,
   getAgentToolMeta,
@@ -190,5 +191,20 @@ describe('authorizeAgentTool — dispatch principal', () => {
       allowed: false,
       reason: 'user_role_denied',
     });
+  });
+});
+
+describe('adminToolIncludeForAgent', () => {
+  it('scopes Ticket Agent away from user-PII tools', () => {
+    const include = adminToolIncludeForAgent('revealui-ticket-agent');
+    expect(include).toBeDefined();
+    expect(include).toContain('find_documents');
+    expect(include).not.toContain('create_user');
+    expect(include).not.toContain('list_users');
+  });
+
+  it('leaves generic admin streams unscoped', () => {
+    expect(adminToolIncludeForAgent(undefined)).toBeUndefined();
+    expect(adminToolIncludeForAgent('custom-agent')).toBeUndefined();
   });
 });

--- a/apps/server/src/lib/agent-tool-access.ts
+++ b/apps/server/src/lib/agent-tool-access.ts
@@ -260,3 +260,38 @@ export function authorizeAgentTool(
 export function listExecToolNames(): readonly string[] {
   return CODING_EXEC;
 }
+
+/** Ticket Agent card skills: create / search / update tickets. No user PII. */
+export const TICKET_AGENT_ADMIN_TOOLS: readonly string[] = [
+  'list_collections',
+  'find_documents',
+  'get_document',
+  'create_document',
+  'update_document',
+];
+
+/** Creator scaffolds agents. No user-PII tools. */
+export const CREATOR_AGENT_ADMIN_TOOLS: readonly string[] = [
+  'list_collections',
+  'find_documents',
+  'get_document',
+  'create_document',
+  'update_document',
+  'get_current_user',
+];
+
+/**
+ * Allowlist for Watch live / agent-stream admin tools.
+ * `undefined` means the full admin catalog (generic admin mode).
+ */
+export function adminToolIncludeForAgent(
+  agentId: string | undefined,
+): readonly string[] | undefined {
+  if (agentId === 'revealui-ticket-agent') {
+    return TICKET_AGENT_ADMIN_TOOLS;
+  }
+  if (agentId === 'revealui-creator') {
+    return CREATOR_AGENT_ADMIN_TOOLS;
+  }
+  return undefined;
+}

--- a/apps/server/src/middleware/__tests__/a2a-path-match.test.ts
+++ b/apps/server/src/middleware/__tests__/a2a-path-match.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Task Tester POSTs `/a2a`. Entitlements used to run before optional auth, so
+ * `c.get('user')` was empty and features.ai defaulted to false — a fake
+ * "not entitled" 403 for the founder Pro account (GAP-360 walk).
+ */
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+interface Vars {
+  user?: { id: string };
+  entitlements?: { features: { ai: boolean } };
+}
+
+describe('A2A entitlement middleware order', () => {
+  it('Hono /a2a/* matches POST /a2a', async () => {
+    const app = new Hono();
+    const seen: string[] = [];
+    app.use('/a2a/*', async (_c, next) => {
+      seen.push('star');
+      await next();
+    });
+    app.post('/a2a', (c) => c.json({ ok: true }));
+
+    const res = await app.request('http://localhost/a2a', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(seen).toEqual(['star']);
+  });
+
+  it('entitlements-before-auth attach free features even after the route sets user', async () => {
+    const app = new Hono<{ Variables: Vars }>();
+    app.use('/a2a/*', async (c, next) => {
+      const user = c.get('user');
+      c.set('entitlements', { features: { ai: Boolean(user) } });
+      await next();
+    });
+    app.use('/a2a/*', async (c, next) => {
+      c.set('user', { id: 'founder' });
+      await next();
+    });
+    app.post('/a2a', (c) =>
+      c.json({
+        ai: c.get('entitlements')?.features.ai ?? false,
+        user: c.get('user')?.id ?? null,
+      }),
+    );
+
+    const body = (await (await app.request('http://localhost/a2a', { method: 'POST' })).json()) as {
+      ai: boolean;
+      user: string | null;
+    };
+    expect(body.user).toBe('founder');
+    expect(body.ai).toBe(false);
+  });
+
+  it('auth-then-entitlements attach ai for the session user', async () => {
+    const app = new Hono<{ Variables: Vars }>();
+    app.use('/a2a/*', async (c, next) => {
+      c.set('user', { id: 'founder' });
+      await next();
+    });
+    app.use('/a2a/*', async (c, next) => {
+      const user = c.get('user');
+      c.set('entitlements', { features: { ai: Boolean(user) } });
+      await next();
+    });
+    app.post('/a2a', (c) =>
+      c.json({
+        ai: c.get('entitlements')?.features.ai ?? false,
+        user: c.get('user')?.id ?? null,
+      }),
+    );
+
+    const body = (await (await app.request('http://localhost/a2a', { method: 'POST' })).json()) as {
+      ai: boolean;
+      user: string | null;
+    };
+    expect(body.user).toBe('founder');
+    expect(body.ai).toBe(true);
+  });
+});

--- a/apps/server/src/routes/__tests__/a2a-edge.test.ts
+++ b/apps/server/src/routes/__tests__/a2a-edge.test.ts
@@ -599,6 +599,20 @@ describe('POST /a2a  -  JSON-RPC validation edge cases', () => {
     expect(body.id).toBeNull();
   });
 
+  it('does not license-deny tasks/send when entitlements.features.ai is true', async () => {
+    const app = makeA2AApp({ id: 'user-1' }, { features: { ai: true } });
+    const res = await app.request(
+      post('/', {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tasks/send',
+        params: { id: 'test-agent', message: { role: 'user', parts: [{ text: 'hi' }] } },
+      }),
+    );
+    const body = (await res.json()) as { error?: { message?: string } };
+    expect(body.error?.message ?? '').not.toMatch(/Pro or Enterprise license/i);
+  });
+
   it('returns 403 for tasks/send when ai feature is disabled', async () => {
     mockIsFeatureEnabled.mockReturnValue(false);
 

--- a/apps/server/src/routes/__tests__/agent-stream.test.ts
+++ b/apps/server/src/routes/__tests__/agent-stream.test.ts
@@ -146,6 +146,18 @@ describe('agent-stream route  -  mode parameter', () => {
     expect(res.status).toBe(400);
   });
 
+  it('accepts agentId for built-in agents', async () => {
+    const app = createApp();
+
+    const res = await jsonPost(app, '/agent-stream', {
+      instruction: 'List all tickets',
+      mode: 'admin',
+      agentId: 'revealui-ticket-agent',
+    });
+
+    expect(res.status).toBe(503);
+  });
+
   it('accepts mode alongside all other optional fields', async () => {
     const app = createApp();
 

--- a/apps/server/src/routes/agent-stream.ts
+++ b/apps/server/src/routes/agent-stream.ts
@@ -28,6 +28,7 @@ import {
   createAgentRunSession,
   deleteAgentRunSession,
 } from '../lib/agent-run-sessions.js';
+import { adminToolIncludeForAgent } from '../lib/agent-tool-access.js';
 import { recordAgentMcpToolAudit } from '../lib/agent-tool-audit.js';
 import { applyAgentToolGovernance } from '../lib/agent-tool-governance.js';
 import {
@@ -70,6 +71,8 @@ const agentStreamRoute = createRoute({
             provider: z.string().optional(),
             model: z.string().optional(),
             mode: z.enum(['admin', 'coding']).default('admin').optional(),
+            /** Built-in agent id (e.g. revealui-ticket-agent). Scopes the admin tool catalog. */
+            agentId: z.string().min(1).max(128).optional(),
           }),
         },
       },
@@ -274,9 +277,11 @@ app.openapi(agentStreamRoute, async (c) => {
 
       // Integrity (S5) inside factory; governance (S6) wraps outside so deny
       // never executes the tool.
+      const include = adminToolIncludeForAgent(body.agentId);
       const rawAdmin = cmsToolsMod.createAdminTools({
         apiClient,
         onToolAudit: streamToolAudit('admin-cms'),
+        ...(include ? { include } : {}),
       });
       cmsTools = applyAgentToolGovernance(rawAdmin, governanceCtx('admin-cms'));
     }
@@ -361,7 +366,9 @@ app.openapi(agentStreamRoute, async (c) => {
       }
     : loggerSink;
 
-  if (tenant) {
+  const scopedBuiltin = adminToolIncludeForAgent(body.agentId) !== undefined;
+
+  if (tenant && !scopedBuiltin) {
     let serverIds: string[] = [];
     try {
       serverIds = await listConnectedMcpServers(createRevvaultVault(), tenant);
@@ -531,19 +538,42 @@ app.openapi(agentStreamRoute, async (c) => {
 Always confirm before making destructive changes. Explain what you're doing as you work.`
       : '';
 
-  const agent = {
-    id: mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent',
-    name: mode === 'coding' ? 'Coding Agent' : 'Admin Stream Agent',
-    instructions: `You are an AI-powered ${mode === 'coding' ? 'coding and admin' : 'admin management'} assistant for RevealUI. You can help users manage their content, media, users, and settings through natural conversation.
+  const streamIdentity =
+    body.agentId === 'revealui-ticket-agent'
+      ? {
+          id: 'revealui-ticket-agent',
+          name: 'Ticket Agent',
+          instructions: `You are the RevealUI Ticket Agent. Help with support tickets: search, create, and update them using the ticket tools. Do not manage users or unrelated CMS records.
+
+Workspace: ${workspaceId}`,
+        }
+      : body.agentId === 'revealui-creator'
+        ? {
+            id: 'revealui-creator',
+            name: 'The Creator',
+            instructions: `You are the RevealUI platform agent. Scaffold agents, inspect collections, and orchestrate workflows. Do not create or delete user accounts.
+
+Workspace: ${workspaceId}`,
+          }
+        : {
+            id: mode === 'coding' ? 'coding-stream-agent' : 'admin-stream-agent',
+            name: mode === 'coding' ? 'Coding Agent' : 'Admin Stream Agent',
+            instructions: `You are an AI-powered ${mode === 'coding' ? 'coding and admin' : 'admin management'} assistant for RevealUI. You can help users manage their content, media, users, and settings through natural conversation.
 
 When asked to modify the admin, use the available tools. Be conversational and explain what you're doing. For destructive operations (delete), confirm the user's intent first.${codingInstructions}
 
 Workspace: ${workspaceId}`,
+          };
+
+  const agent = {
+    id: streamIdentity.id,
+    name: streamIdentity.name,
+    instructions: streamIdentity.instructions,
     tools: allTools as Parameters<
       typeof streamingRuntimeMod.StreamingAgentRuntime.prototype.streamTask
     >[0]['tools'],
     memory: undefined,
-    getContext: () => ({ agentId: 'admin-stream-agent' }),
+    getContext: () => ({ agentId: streamIdentity.id }),
   };
 
   const task = {

--- a/packages/ai/src/client/hooks/useAgentStream.ts
+++ b/packages/ai/src/client/hooks/useAgentStream.ts
@@ -77,6 +77,8 @@ export interface AgentStreamRequest {
    * request schema.
    */
   mode?: 'admin' | 'coding';
+  /** Built-in agent id. Scopes admin tools on /api/agent-stream. */
+  agentId?: string;
 }
 
 /**

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -72,6 +72,7 @@ export * from './llm/providers/openai-compat.js';
 export * from './llm/providers/us-origin-snaps.js';
 export * from './llm/resolve.js';
 export * from './llm/token-counter.js';
+export { sanitizeProviderToolSchema, toolParametersToJsonSchema } from './llm/tool-json-schema.js';
 export * from './llm/workspace-provider-config.js';
 // Re-export memory system
 export * from './memory/index.js';
@@ -88,7 +89,6 @@ export * from './skills/index.js';
 // Re-export specification templates
 export * from './templates/index.js';
 // Re-export tools
-export { sanitizeProviderToolSchema, toolParametersToJsonSchema } from './llm/tool-json-schema.js';
 export * from './tools/base.js';
 export * from './tools/deduplicator.js';
 export * from './tools/document-summarizer.js';

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -88,6 +88,7 @@ export * from './skills/index.js';
 // Re-export specification templates
 export * from './templates/index.js';
 // Re-export tools
+export { sanitizeProviderToolSchema, toolParametersToJsonSchema } from './llm/tool-json-schema.js';
 export * from './tools/base.js';
 export * from './tools/deduplicator.js';
 export * from './tools/document-summarizer.js';

--- a/packages/ai/src/llm/__tests__/tool-json-schema.test.ts
+++ b/packages/ai/src/llm/__tests__/tool-json-schema.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { sanitizeProviderToolSchema, toolParametersToJsonSchema } from '../tool-json-schema.js';
+
+describe('toolParametersToJsonSchema', () => {
+  it('rewrites z.string().email() lookaround patterns to format: email', () => {
+    const schema = z.object({
+      email: z.string().email().describe('User email address'),
+    });
+
+    const raw = z.toJSONSchema(schema) as {
+      properties?: { email?: { pattern?: string; format?: string } };
+    };
+    expect(raw.properties?.email?.pattern).toMatch(/\(\?/);
+
+    const safe = toolParametersToJsonSchema(schema);
+    const email = (safe.properties as Record<string, { pattern?: string; format?: string }>).email;
+    expect(email.pattern).toBeUndefined();
+    expect(email.format).toBe('email');
+  });
+
+  it('leaves lookaround-free patterns intact', () => {
+    const schema = z.object({
+      slug: z.string().regex(/^[a-z0-9-]+$/),
+    });
+    const safe = toolParametersToJsonSchema(schema);
+    const slug = (safe.properties as Record<string, { pattern?: string }>).slug;
+    expect(slug.pattern).toBeDefined();
+    expect(slug.pattern).not.toMatch(/\(\?/);
+  });
+});
+
+describe('sanitizeProviderToolSchema', () => {
+  it('rewrites nested $defs lookaround email patterns', () => {
+    const raw = {
+      type: 'object',
+      $defs: {
+        User: {
+          type: 'object',
+          properties: {
+            email: {
+              type: 'string',
+              pattern: '^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9]+)@example.com$',
+              description: 'User email address',
+            },
+          },
+        },
+      },
+    };
+
+    const safe = sanitizeProviderToolSchema(raw);
+    const email = (
+      safe.$defs as Record<
+        string,
+        { properties: Record<string, { pattern?: string; format?: string }> }
+      >
+    ).User.properties.email;
+    expect(email.pattern).toBeUndefined();
+    expect(email.format).toBe('email');
+  });
+});

--- a/packages/ai/src/llm/tool-json-schema.ts
+++ b/packages/ai/src/llm/tool-json-schema.ts
@@ -1,0 +1,75 @@
+/**
+ * Convert a Zod tool-parameter schema into JSON Schema that OpenAI-compatible
+ * providers will accept.
+ *
+ * Zod v4 `z.string().email()` emits an ECMA-262 pattern with lookarounds.
+ * JSON Schema 2020-12 `pattern` / OpenAI / Groq reject lookarounds, so the
+ * entire tools[] payload 400s before the model runs (GAP-360 walk, create_user).
+ *
+ * `z.email()` already emits `{ format: "email" }`. This helper is the
+ * conversion chokepoint so every future `.email()` / lookaround pattern is
+ * rewritten here, not per-tool.
+ */
+
+import { z } from 'zod/v4';
+
+const LOOKAROUND_PATTERN = /\(\?<?[=!]/;
+
+export function toolParametersToJsonSchema(parameters: z.ZodType): Record<string, unknown> {
+  return sanitizeProviderToolSchema(z.toJSONSchema(parameters));
+}
+
+export function sanitizeProviderToolSchema(value: unknown): Record<string, unknown> {
+  const sanitized = sanitizeNode(value, undefined);
+  if (typeof sanitized !== 'object' || sanitized === null || Array.isArray(sanitized)) {
+    return { type: 'object', properties: {} };
+  }
+  return sanitized as Record<string, unknown>;
+}
+
+function sanitizeNode(value: unknown, parentKey: string | undefined): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeNode(entry, parentKey));
+  }
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  const obj: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+
+  for (const nestKey of ['$defs', 'definitions', 'properties'] as const) {
+    const nested = obj[nestKey];
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      const next: Record<string, unknown> = {};
+      for (const [key, child] of Object.entries(nested as Record<string, unknown>)) {
+        next[key] = sanitizeNode(child, key);
+      }
+      obj[nestKey] = next;
+    }
+  }
+
+  for (const nestKey of ['items', 'additionalProperties', 'not'] as const) {
+    if (obj[nestKey] !== undefined) {
+      obj[nestKey] = sanitizeNode(obj[nestKey], parentKey);
+    }
+  }
+
+  for (const nestKey of ['anyOf', 'oneOf', 'allOf'] as const) {
+    if (Array.isArray(obj[nestKey])) {
+      obj[nestKey] = (obj[nestKey] as unknown[]).map((entry) => sanitizeNode(entry, parentKey));
+    }
+  }
+
+  if (typeof obj.pattern === 'string' && LOOKAROUND_PATTERN.test(obj.pattern)) {
+    const emailShaped =
+      obj.format === 'email' ||
+      parentKey === 'email' ||
+      (typeof obj.description === 'string' && /email/i.test(obj.description));
+    delete obj.pattern;
+    if (emailShaped) {
+      obj.format = 'email';
+    }
+  }
+
+  return obj;
+}

--- a/packages/ai/src/llm/tool-json-schema.ts
+++ b/packages/ai/src/llm/tool-json-schema.ts
@@ -65,10 +65,13 @@ function sanitizeNode(value: unknown, parentKey: string | undefined): unknown {
       obj.format === 'email' ||
       parentKey === 'email' ||
       (typeof obj.description === 'string' && /email/i.test(obj.description));
-    delete obj.pattern;
+    const withoutPattern = Object.fromEntries(
+      Object.entries(obj).filter(([key]) => key !== 'pattern'),
+    );
     if (emailShaped) {
-      obj.format = 'email';
+      return { ...withoutPattern, format: 'email' };
     }
+    return withoutPattern;
   }
 
   return obj;

--- a/packages/ai/src/orchestration/runtime.ts
+++ b/packages/ai/src/orchestration/runtime.ts
@@ -5,8 +5,8 @@
  */
 
 import { registerCleanupHandler } from '@revealui/core/monitoring';
-import { z } from 'zod/v4';
 import type { LLMClient } from '../llm/client.js';
+import { toolParametersToJsonSchema } from '../llm/tool-json-schema.js';
 import type { Message, ReasoningEffort } from '../llm/providers/base.js';
 import { estimateCost } from '../llm/token-counter.js';
 import type { AgentSkillProvider } from '../skills/integration/agent-skill-provider.js';
@@ -272,7 +272,7 @@ export class AgentRuntime {
             function: {
               name: tool.name,
               description: tool.description,
-              parameters: z.toJSONSchema(tool.parameters) as Record<string, unknown>,
+              parameters: toolParametersToJsonSchema(tool.parameters),
             },
           })),
           cacheHint: this.config.enableCache,

--- a/packages/ai/src/orchestration/runtime.ts
+++ b/packages/ai/src/orchestration/runtime.ts
@@ -6,9 +6,9 @@
 
 import { registerCleanupHandler } from '@revealui/core/monitoring';
 import type { LLMClient } from '../llm/client.js';
-import { toolParametersToJsonSchema } from '../llm/tool-json-schema.js';
 import type { Message, ReasoningEffort } from '../llm/providers/base.js';
 import { estimateCost } from '../llm/token-counter.js';
+import { toolParametersToJsonSchema } from '../llm/tool-json-schema.js';
 import type { AgentSkillProvider } from '../skills/integration/agent-skill-provider.js';
 import type { ApprovalCallback, Tool, ToolResult } from '../tools/base.js';
 import { ToolCallDeduplicator } from '../tools/deduplicator.js';

--- a/packages/ai/src/orchestration/streaming-runtime.ts
+++ b/packages/ai/src/orchestration/streaming-runtime.ts
@@ -9,9 +9,9 @@
  */
 
 import type { ModelTier } from '../inference/context-budget.js';
-import { toolParametersToJsonSchema } from '../llm/tool-json-schema.js';
 import { compressToolResult } from '../inference/tool-result-compressor.js';
 import type { LLMClient } from '../llm/client.js';
+import { toolParametersToJsonSchema } from '../llm/tool-json-schema.js';
 import type { ToolResult } from '../tools/base.js';
 import { ToolCallDeduplicator } from '../tools/deduplicator.js';
 import type { Agent, Task } from './agent.js';

--- a/packages/ai/src/orchestration/streaming-runtime.ts
+++ b/packages/ai/src/orchestration/streaming-runtime.ts
@@ -8,8 +8,8 @@
  * EventSource is not used client-side because it doesn't support POST  -  use fetch + ReadableStream.
  */
 
-import { z } from 'zod/v4';
 import type { ModelTier } from '../inference/context-budget.js';
+import { toolParametersToJsonSchema } from '../llm/tool-json-schema.js';
 import { compressToolResult } from '../inference/tool-result-compressor.js';
 import type { LLMClient } from '../llm/client.js';
 import type { ToolResult } from '../tools/base.js';
@@ -158,7 +158,7 @@ export class StreamingAgentRuntime extends AgentRuntime {
                 function: {
                   name: tool.name,
                   description: tool.description,
-                  parameters: z.toJSONSchema(tool.parameters) as Record<string, unknown>,
+                  parameters: toolParametersToJsonSchema(tool.parameters),
                 },
               })),
             },

--- a/packages/ai/src/tools/admin/__tests__/factory-include.test.ts
+++ b/packages/ai/src/tools/admin/__tests__/factory-include.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type AdminAPIClient, createAdminTools } from '../factory.js';
+
+function fakeClient(): AdminAPIClient {
+  return {
+    find: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    findGlobal: vi.fn(),
+    updateGlobal: vi.fn(),
+  };
+}
+
+describe('createAdminTools include', () => {
+  it('returns the full catalog when include is omitted', () => {
+    const tools = createAdminTools({ apiClient: fakeClient() });
+    expect(tools.map((t) => t.name)).toContain('create_user');
+    expect(tools.map((t) => t.name)).toContain('find_documents');
+  });
+
+  it('returns only named tools when include is set', () => {
+    const tools = createAdminTools({
+      apiClient: fakeClient(),
+      include: ['find_documents', 'create_document'],
+    });
+    expect(tools.map((t) => t.name).sort()).toEqual(['create_document', 'find_documents']);
+    expect(tools.some((t) => t.name === 'create_user')).toBe(false);
+  });
+});

--- a/packages/ai/src/tools/admin/factory.ts
+++ b/packages/ai/src/tools/admin/factory.ts
@@ -116,6 +116,13 @@ export interface AdminToolsConfig {
    * successful results fail closed if the audit write throws.
    */
   onToolAudit?: ToolIntegrityAuditHandler;
+
+  /**
+   * When set, only these tool names are returned. Built-in agents (ticket,
+   * creator) pass a profile so Watch live does not ship create_user to Groq
+   * for a "list tickets" run.
+   */
+  include?: readonly string[];
 }
 
 /**
@@ -633,5 +640,10 @@ export function createAdminTools(config: AdminToolsConfig): Tool[] {
     },
   });
 
-  return maybeWrapToolsWithIntegrityAudit(tools, onToolAudit);
+  const wrapped = maybeWrapToolsWithIntegrityAudit(tools, onToolAudit);
+  if (!config.include) {
+    return wrapped;
+  }
+  const allowed = new Set(config.include);
+  return wrapped.filter((tool) => allowed.has(tool.name));
 }

--- a/packages/ai/src/tools/admin/user-tools.ts
+++ b/packages/ai/src/tools/admin/user-tools.ts
@@ -79,7 +79,7 @@ export const createUserTool: Tool = {
   name: 'create_user',
   description: 'Create a new user account. Typically requires admin permissions.',
   parameters: z.object({
-    email: z.string().email().describe('User email address'),
+    email: z.email().describe('User email address'),
     password: z.string().min(8).describe('User password (minimum 8 characters)'),
     name: z.string().optional().describe('User full name'),
     role: z
@@ -124,7 +124,7 @@ export const updateUserTool: Tool = {
   description: 'Update a user account. Users can update their own account, admins can update any.',
   parameters: z.object({
     id: z.string().describe('User ID to update'),
-    email: z.string().email().optional().describe('New email address'),
+    email: z.email().optional().describe('New email address'),
     name: z.string().optional().describe('New full name'),
     role: z.string().optional().describe('New role (admin only)'),
     password: z.string().min(8).optional().describe('New password'),

--- a/packages/ai/src/tools/registry.ts
+++ b/packages/ai/src/tools/registry.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from '../llm/providers/base.js';
+import { toolParametersToJsonSchema } from '../llm/tool-json-schema.js';
 import type { Tool, ToolResult } from './base.js';
 
 export class ToolRegistry {
@@ -33,7 +34,7 @@ export class ToolRegistry {
       function: {
         name: tool.name,
         description: tool.description,
-        parameters: tool.parameters.toJSONSchema(), // Native Zod v4 method
+        parameters: toolParametersToJsonSchema(tool.parameters),
       },
     }));
   }

--- a/packages/apify-actor-governed-run/src/agent/run-governed-task.ts
+++ b/packages/apify-actor-governed-run/src/agent/run-governed-task.ts
@@ -1,5 +1,11 @@
-import type { LLMChatOptions, LLMResponse, Message, Tool, ToolDefinition } from '@revealui/ai';
-import { toJSONSchema } from 'zod/v4';
+import {
+  type LLMChatOptions,
+  type LLMResponse,
+  type Message,
+  type Tool,
+  type ToolDefinition,
+  toolParametersToJsonSchema,
+} from '@revealui/ai';
 import type { ActionLogEntry } from '../types.js';
 
 export const DEFAULT_MAX_STEPS = 10;
@@ -38,9 +44,8 @@ function toolToDefinition(tool: Tool): ToolDefinition {
       name: tool.name,
       description: tool.description,
       // Tool.parameters is a Zod schema; providers need JSON Schema-shaped
-      // params. zod/v4 ships a native converter (toJSONSchema) -- no second
-      // schema-conversion dependency needed.
-      parameters: toJSONSchema(tool.parameters) as Record<string, unknown>,
+      // params. Conversion strips lookaround email patterns Groq/OpenAI reject.
+      parameters: toolParametersToJsonSchema(tool.parameters),
     },
   };
 }


### PR DESCRIPTION
## Why

GAP-360 hosted walk (founder Pro on prod):

1. **Send Task** showed "This account is not entitled to AI" with no founder bypass. The Agents page already had `features.ai`. Cause: `/a2a` entitlements ran **before** session auth, so `features.ai` was free.
2. **Watch live** reached Groq, then 400ed: Zod v4 `z.string().email()` on `create_user` emits a lookaround `pattern`. OpenAI-compatible validators reject it. Ticket Agent did not need that tool.

Stay on Hono. These are mount-order and schema-export defects, not a router rewrite.

## What

1. Auth → tenant → entitlements → CSRF → license status on `/a2a` and `/a2a/*` (same chain as `/api/*`).
2. `toolParametersToJsonSchema` at the LLM conversion chokepoints. Lookaround patterns become `format: "email"` (or drop the pattern). `create_user` uses `z.email()`.
3. Run page sends `agentId`. Ticket Agent / Creator get allowlisted admin tools. Scoped agents do not attach the tenant MCP dump.

## Tests

- Entitlement order on POST `/a2a`
- `z.string().email()` lookaround rewrite
- `createAdminTools({ include })`
- Ticket Agent allowlist excludes `create_user`
- `agentId` accepted on `/api/agent-stream`

## Security

Auth/entitlements path. Guardrail-2 review required. Do not merge until the verdict lands. Do not `--admin` merge.

## Walk after this is on prod

Settings → Groq or Grok still saved. Ticket Agent → Send Task **and** Watch live → `List all tickets`.