### PR TITLE
fix(docs): record GHCR fleet images as published

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -52,6 +52,6 @@
 
 - 0 paying customers; A- (8.7/10) on internal honest grading
 - **Stripe** runs in TEST mode in production; live mode gated on billing-readiness audit (see `WHAT_WORKS_TODAY`)
-- **RevealUI Fleet** (formerly RevealUI Forge) Docker images not yet on GHCR (preview status — runs from source today)
+- **RevealUI Fleet** runtime images are on GHCR (`revealui-api`, `revealui-admin`, `revealui-migrate`) and pull anonymously. A license JWT is still required to run a stamped kit.
 - **Ubuntu Inference Snaps** integration in progress; **Ollama** is the shipped open-model path
 - **Supabase** being phased out in favor of NeonDB + ElectricSQL (vector store consolidation in flight)

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -46,7 +46,7 @@ Five primitives make up the runtime: People, Content, Offers, Payments, Agents.
 
 - Zero paying customers. Used in production by the team that maintains it.
 - Stripe live mode is on for product billing; no paid customer base yet.
-- RevealUI Fleet Docker images are not yet published to GHCR; self-host from source today.
+- RevealUI Fleet runtime images (`revealui-api`, `revealui-admin`, `revealui-migrate`) are published on GHCR and pull anonymously. A license JWT is still required to run a stamped kit.
 - Default inference is open-weight on infrastructure you own (Inference Snaps or Ollama). Frontier providers are opt-in adapters.
 - NeonDB is the primary database. Supabase is not an internal datastore.
 - Professional services and fixed-bid delivery: [revealuistudio.com](https://revealuistudio.com)

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -17,6 +17,7 @@ RevealUI Fleet is a deployment-level commercial product, distinct from the hoste
 |---|---|---|
 | API (Hono) | `ghcr.io/revealuistudio/revealui-api` | 3004 |
 | Admin (Next.js) | `ghcr.io/revealuistudio/revealui-admin` | 4000 |
+| Migrate (one-shot) | `ghcr.io/revealuistudio/revealui-migrate` | (exits) |
 | PostgreSQL 16 | `postgres:16-alpine` | 5432 (internal) |
 
 All three services are wired together in `docker-compose.forge.yml` at the root of the repository.
@@ -46,16 +47,13 @@ Fleet sits beside, not underneath, the hosted pricing model:
 ### 1. Pull the stack
 
 ```bash
-# Preview — images publish post-launch; commands below will fail with `manifest unknown` until then.
+# Public today. No GHCR login. Verified 2026-08-16 (anonymous manifest HTTP 200).
 docker pull ghcr.io/revealuistudio/revealui-api:latest
 docker pull ghcr.io/revealuistudio/revealui-admin:latest
+docker pull ghcr.io/revealuistudio/revealui-migrate:latest
 ```
 
-> Once Fleet launches, GHCR access will be gated by your license key. You'll log in with the token provided in your Fleet welcome email:
->
-> ```bash
-> echo "$GHCR_TOKEN" | docker login ghcr.io -u revealuistudio --password-stdin
-> ```
+The images pull without a token. A Fleet license JWT is still required to *run* the kit.
 
 ### 2. Create your `.env.forge`
 

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -1319,10 +1319,10 @@ See **[FLEET.md](./FLEET.md)** for the complete deployment guide, including:
 ### Quick reference
 
 ```bash
-# Pull images (requires GHCR token from Fleet welcome email)
-echo "$GHCR_TOKEN" | docker login ghcr.io -u revealuistudio --password-stdin
+# Public images. No GHCR login. A Fleet license JWT is still required to run the kit.
 docker pull ghcr.io/revealuistudio/revealui-api:latest
 docker pull ghcr.io/revealuistudio/revealui-admin:latest
+docker pull ghcr.io/revealuistudio/revealui-migrate:latest
 
 # Start the stack
 docker compose -f docker-compose.forge.yml --env-file .env.forge up -d

--- a/docs/REVFLEET.md
+++ b/docs/REVFLEET.md
@@ -49,7 +49,7 @@ Status: pre-launch (0 paying customers). Enterprise tier at $1,499/mo hosted; Re
 
 RevForge is what an operator runs to produce a customer Fleet kit. It generates the per-customer Docker Compose stack with domain lock, branding, and license configuration. The operator is RevealUI Studio; the customer is the enterprise organization deploying the kit.
 
-Status: pre-launch (Docker images not yet on GHCR — stack runs from source today).
+Status: pre-launch. Runtime images are on GHCR and pull anonymously. A stamped kit still needs a license JWT.
 
 ### RevealUI Fleet (the self-hosted kit)
 

--- a/docs/WHAT_WORKS_TODAY.md
+++ b/docs/WHAT_WORKS_TODAY.md
@@ -74,6 +74,9 @@ Content Security Policy headers, CORS, HSTS, rate limiting, webhook rate limitin
 JWT-based licensing (EdDSA/Ed25519, server-side only — distinct from user-facing auth which is session-only) with tier checks (free / pro / max / enterprise), feature gating, grace periods (3-day subscription, 30-day perpetual, 7-day infrastructure), and revocation via DB status checks. Perpetual and subscription models supported.
 **License generation and enforcement work in tests. Not yet tested with paying customers.**
 
+### Fleet runtime images (GHCR)
+`ghcr.io/revealuistudio/revealui-api:latest`, `revealui-admin:latest`, and `revealui-migrate:latest` are published and pull anonymously. Verified 2026-08-16: unauthenticated OCI manifest GET returned HTTP 200 for all three tags (multi-arch indexes). RevForge stamps those tags. A stamped kit still needs a license JWT and operator env. This is not a sold customer walk.
+
 ---
 
 ## What doesn't work yet
@@ -83,8 +86,7 @@ Honest list of things that are not done, not deployed, or not verified.
 - **Zero paying customers.** Pre-launch posture. The admin account exists for the studio's own use.
 - **Marketing site is live but external traffic is near-zero.** Deployed at [revealui.com](https://revealui.com); near-zero outside-the-team traffic to date.
 - **Docs site is live but external traffic is near-zero.** Deployed at [docs.revealui.com](https://docs.revealui.com); same caveat.
-- **No managed hosting service.** RevealUI Studio's own marketing site runs on Vercel; we do not (today) offer to host customer instances. Self-host (Vercel, Cloudflare, Fly, Hetzner, Docker, Fleet kit when GHCR images publish) is the path. Vercel and Cloudflare are friendly deploy targets, not competitors.
-- **Fleet Docker images not yet published to GHCR.** The `docker/` stack and stamp scripts are production-ready, but the images at `ghcr.io/revealuistudio/revealui-{api,admin}` have not yet been published. Until then, Fleet customers build from source.
+- **No managed hosting service.** RevealUI Studio's own marketing site runs on Vercel; we do not (today) offer to host customer instances. Self-host (Vercel, Cloudflare, Fly, Hetzner, Docker, Fleet kit) is the path. Vercel and Cloudflare are friendly deploy targets, not competitors.
 - **Stripe live mode is ON in production** (flipped 2026-06-26 after the billing-readiness audit closed).
 - **REVEALUI_KEK rotation tooling ships** (`scripts/security/rotate-kek.ts`) — zero-downtime dual-key rotation; see the credential-rotation runbook.
 - **No status page publicly advertised.** Uptime monitoring is configured.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -87,7 +87,7 @@ A RevealUI agent's permanent named identity, formatted as **`Rev [Surname]`** (e
 
 ## RevealUI Fleet
 
-The white-label self-hosted runtime kit — Docker Compose stack + domain lock + unlimited users. Customers on the [Enterprise](#enterprise-tier) tier typically deploy a RevealUI Fleet instance on their own infrastructure. Produced by the [RevForge](#revforge) stamping tool, which yields per-customer instances. Formerly *RevealUI Forge* per ADR [`2026-05-03-revfleet-rename.md`](./REVFLEET.md) Tier 4. **Status:** preview — Docker images not yet on GHCR; stack runs from source today. See [`./FORGE`](./FORGE.md) (page name preserved as redirect; content reflects "RevealUI Fleet" terminology).
+The white-label self-hosted runtime kit — Docker Compose stack + domain lock + unlimited users. Customers on the [Enterprise](#enterprise-tier) tier typically deploy a RevealUI Fleet instance on their own infrastructure. Produced by the [RevForge](#revforge) stamping tool, which yields per-customer instances. Formerly *RevealUI Forge* per ADR [`2026-05-03-revfleet-rename.md`](./REVFLEET.md) Tier 4. **Status:** preview. Runtime images are on GHCR and pull anonymously. A stamped kit still needs a license JWT. See [`./FORGE`](./FORGE.md) (page name preserved as redirect; content reflects "RevealUI Fleet" terminology).
 
 ## RevForge
 

--- a/packages/claim-gates/src/claim-drift/prose-future.ts
+++ b/packages/claim-gates/src/claim-drift/prose-future.ts
@@ -317,7 +317,7 @@ export const ASPIRATIONAL_BLOCKLIST: AspirationalBlocklistEntry[] = [
       },
     ],
     label: 'on-prem',
-    why: 'forge docker images not yet published to GHCR',
+    why: 'on-prem is not a supported product claim; Fleet is a self-hosted Docker kit',
   },
   {
     rules: [


### PR DESCRIPTION
## Why

Phase 0 fleet assessment found a contradiction: RevForge stamps
`ghcr.io/revealuistudio/revealui-{api,admin,migrate}:latest` while
`docs/WHAT_WORKS_TODAY.md` said those images were unpublished.

## Proof (2026-08-16)

Unauthenticated registry token + manifest GET:

- `ghcr.io/revealuistudio/revealui-api:latest` → HTTP 200 (OCI index)
- `ghcr.io/revealuistudio/revealui-admin:latest` → HTTP 200
- `ghcr.io/revealuistudio/revealui-migrate:latest` → HTTP 200

RevForge README was already correct. This PR fixes the stale public docs.

## What

- Move GHCR from "does not work" to medium-confidence "works" on What Works Today
- Drop "build from source / login required / will fail until launch" copy in FLEET, PRO, REVFLEET, glossary, both `llms.txt` files
- Update the on-prem claim-drift `why` string (ban stays; images are not the reason)

`pnpm validate:claims` passes. `@revealui/claim-gates` `claim-drift.test.ts` 69/69.

## Not this PR

A sold Fleet customer walk. License JWT is still required to run a kit.