### PR TITLE
docs(sync): point operators at private ops/sync manifests

### DIFF
--- a/.github/workflows/secret-path-drift.yml
+++ b/.github/workflows/secret-path-drift.yml
@@ -1,7 +1,8 @@
 name: Secret Path Drift
 
-# Read-only Vercel env NAME-diff vs scripts/sync/revvault-vercel.toml (GAP-258 P0-8).
-# NOT a per-PR gate (live API + tokens are a PR-gate anti-pattern) — schedule +
+# Read-only Vercel env NAME-diff vs the private ops/sync Vercel manifest
+# (GAP-258 P0-8; resolved on operator machines via print-manifest-path).
+# NOT a per-PR gate (live API + tokens are a PR-gate anti-pattern); schedule +
 # workflow_dispatch only. Orphan / missing only; shape-violation stays local
 # (`pnpm vercel:drift-check` + revvault, age identity never in Actions).
 #

--- a/apps/server/fly.toml
+++ b/apps/server/fly.toml
@@ -27,7 +27,7 @@ primary_region = 'iad'
   # GAP-355 Stage 4 / GAP-427: per-tenant Merkle anchor sweep. The worker
   # boot calls startAuditAnchorSweep(), which no-ops without this flag.
   # Inserting anchors also requires REVEALUI_AUDIT_SIGNING_KEY (synced from
-  # revvault via scripts/sync/revvault-fly.toml). The legacy floor (merged
+  # revvault via private ops/sync/revvault-fly.toml). The legacy floor (merged
   # 2026-07-26) makes the first prod sweep start above the pre-enforcement
   # unsigned era instead of gap-stalling.
   AUDIT_ANCHOR_SWEEP_ENABLED = 'true'

--- a/apps/server/src/lib/required-env.ts
+++ b/apps/server/src/lib/required-env.ts
@@ -79,7 +79,7 @@ export const REQUIRED_IN_PRODUCTION_HOSTED = [
 // opposite of the fail-open posture the flag needs. It is still registered
 // (so "where does this get set" has one answer, not zero): the documented
 // env matrix (docs/ENVIRONMENT-VARIABLES-GUIDE.md, Stripe Payments section),
-// the Fly sync manifest skip-list (scripts/sync/revvault-fly.toml — a plain
+// the Fly sync manifest skip-list (private ops/sync/revvault-fly.toml; a plain
 // boolean, not a secret, so it has no vault path), and validated for
 // live-mode drift by the daily billing-readiness cron
 // (apps/server/src/routes/cron/billing-readiness.ts) plus a secondary

--- a/apps/server/src/lib/self-api-url.ts
+++ b/apps/server/src/lib/self-api-url.ts
@@ -31,4 +31,4 @@ export function resolveSelfApiBaseUrl(
 export const MISSING_SELF_API_URL_MESSAGE =
   'governed MCP endpoint: REVEALUI_API_URL is not configured ' +
   '(set REVEALUI_API_URL to this API public origin; vault path ' +
-  'revealui/prod/public/api-url; sync via scripts/sync/revvault-vercel.toml → revealui-api)';
+  'revealui/prod/public/api-url; sync via pnpm vercel:sync → revealui-api)';

--- a/deployment/fly/electric/README.md
+++ b/deployment/fly/electric/README.md
@@ -65,11 +65,10 @@ curl -sS "https://revealui-electric.fly.dev/v1/health"
 Prefer dry-run then apply, or single-key push after vault is clean. Full `vercel:sync:apply` can rewrite every sensitive var (GAP-339). After vault is good:
 
 ```bash
-revvault run --env VERCEL_TOKEN=revealui/prod/api-keys/vercel-token -- \
-  revvault sync vercel --manifest scripts/sync/revvault-vercel.toml
+# Prefer wrappers (resolve private ops/sync via print-manifest-path):
+pnpm vercel:sync
 # inspect electric rows only, then:
-revvault run --env VERCEL_TOKEN=revealui/prod/api-keys/vercel-token -- \
-  revvault sync vercel --manifest scripts/sync/revvault-vercel.toml --apply
+pnpm vercel:sync:apply
 ```
 
 Redeploy **revealui-admin** so runtime picks up env. Probe:

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -84,10 +84,12 @@ CI secret mirrors. The table below is a DERIVED VIEW of the machine spec at
 `scripts/sync/secret-paths.ts` - do not hand-edit it (see the marker note).
 
 The `revealui/staging/*` rows below (GAP-343) are synced by a SEPARATE
-manifest, `scripts/sync/revvault-vercel-staging.toml`, deliberately never the
-prod one - see that file's header for the `git_branch` preview-scoping
+private-ops manifest (`ops/sync/revvault-vercel-staging.toml`, resolved by
+`tsx scripts/sync/print-manifest-path.ts staging`), deliberately never the
+prod one. See that file's header for the `git_branch` preview-scoping
 mechanics and `scripts/setup/gen-staging-secrets.ts` for the owner-run
-generator that fills the "fresh value" paths.
+generator that fills the "fresh value" paths. Sync with
+`pnpm vercel:sync:staging` / `pnpm vercel:sync:staging:apply`.
 
 <!-- BEGIN GENERATED:secret-paths -->
 
@@ -435,8 +437,8 @@ Env vars are populated from revvault at deploy time via a mirror step,
 not hand-typed in the Vercel UI:
 
 ```bash
-# Driven by the Vercel sync manifest (scripts/sync/revvault-vercel.toml):
-pnpm vercel:sync          # dry-run — review diffs
+# Driven by the private ops/sync Vercel manifest (print-manifest-path):
+pnpm vercel:sync          # dry-run; review diffs
 pnpm vercel:sync:apply    # apply to Vercel production
 ```
 

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -13,8 +13,9 @@ rotates the **production runtime + CI** secret set end-to-end — e.g. after a s
 incident (npm token compromise, a dependency exfiltrating build env, a platform incident).
 For routine single-secret changes, use [`vercel-env-sync.md`](./vercel-env-sync.md) instead.
 
-> Scope: this rotates the **revealui prod runtime** secrets (the Vercel sync manifest,
-> `scripts/sync/revvault-vercel.toml`) plus the **CI** secrets that mirror them. The vault
+> Scope: this rotates the **revealui prod runtime** secrets (the private planning-repo
+> Vercel sync manifest at `ops/sync/revvault-vercel.toml`, resolved via
+> `scripts/sync/print-manifest-path.ts`) plus the **CI** secrets that mirror them. The vault
 > holds other entries (other projects, personal credentials) that are out of scope unless
 > they were independently exposed.
 
@@ -39,7 +40,8 @@ updating revvault **and** the GitHub secret, or CI and runtime drift apart.
 - **Unlock revvault first.** Confirm it's alive:
   ```bash
   revvault --version
-  revvault doctor --manifest scripts/sync/revvault-vercel.toml   # reads every manifest entry, validates shape
+  revvault doctor --manifest "$(tsx scripts/sync/print-manifest-path.ts vercel)"
+  # reads every private-ops manifest entry, validates shape
   ```
 
 ## Order matters — follow top to bottom
@@ -139,8 +141,8 @@ vercel redeploy <latest-prod-url> --token=$VERCEL_TOKEN
 ### Phase 7 — Verify E2E
 
 ```bash
-revvault doctor --manifest scripts/sync/revvault-vercel.toml   # vault shape OK
-pnpm vercel:drift-check                                        # every var Skip/Update-clean — no Orphan/Add surprises
+revvault doctor --manifest "$(tsx scripts/sync/print-manifest-path.ts vercel)"  # vault shape OK
+pnpm vercel:drift-check  # every var Skip/Update-clean; no Orphan/Add surprises
 ```
 Then smoke prod: log in (rotated session secret → fresh login works), exercise a Stripe-backed
 path, confirm DB connectivity (Neon rotated), check apps healthy post-redeploy, and watch the
@@ -158,6 +160,8 @@ all `NEXT_PUBLIC_*` + `public/server-url` + `public/api-url` + `public/is-live` 
 `VERCEL_ORG_ID`.
 
 ## See also
-- [`vercel-env-sync.md`](./vercel-env-sync.md) — day-to-day single-secret sync workflow
-- [`../SECRETS.md`](../SECRETS.md) — canonical secret index + paths
-- Manifest: [`../../scripts/sync/revvault-vercel.toml`](../../scripts/sync/revvault-vercel.toml)
+- [`vercel-env-sync.md`](./vercel-env-sync.md) day-to-day single-secret sync workflow
+- [`../SECRETS.md`](../SECRETS.md) canonical secret index + paths
+- Manifest location: private planning repo `ops/sync/` (resolve with
+  `tsx scripts/sync/print-manifest-path.ts vercel`; see
+  [`../../scripts/sync/README.md`](../../scripts/sync/README.md))

--- a/docs/runbooks/stripe-go-live-cutover.md
+++ b/docs/runbooks/stripe-go-live-cutover.md
@@ -64,7 +64,8 @@ Use the canonical sync — this overwrites the Gate-5 Vercel-direct test values 
 
 ```bash
 cd ~/revfleet/revealui
-revvault sync vercel --manifest scripts/sync/revvault-vercel.toml   # or the pnpm wrapper
+pnpm vercel:sync          # dry-run via print-manifest-path (private ops/sync)
+pnpm vercel:sync:apply    # after reviewing diffs
 ```
 
 `STRIPE_LIVE_MODE` is in the manifest `skip` list, so the sync does **not** touch it — you flip it explicitly in step 4. Confirm the secret-key + webhook vars now resolve to live (the sync reports each var).

--- a/docs/runbooks/vercel-env-sync.md
+++ b/docs/runbooks/vercel-env-sync.md
@@ -38,7 +38,8 @@ audience: maintainer
 # 1. Add the value to revvault at its canonical path
 revvault set revealui/prod/<subsystem>/<name-kebab>
 
-# 2. Map it in the manifest (scripts/sync/revvault-vercel.toml)
+# 2. Map it in the private ops/sync manifest (ops/sync/revvault-vercel.toml;
+#    resolve with: tsx scripts/sync/print-manifest-path.ts vercel)
 #    Add a [projects.<slug>.vars] entry: VERCEL_VAR_NAME = "revealui/prod/..."
 
 # 3. Dry-run first to see what'd change

--- a/docs/security/REVVAULT-VERCEL-SCOPED-SYNC.md
+++ b/docs/security/REVVAULT-VERCEL-SCOPED-SYNC.md
@@ -13,15 +13,21 @@ brick hosted license verification.
 ```bash
 cd ~/revfleet/revealui
 
+# Manifest resolves from private planning-repo ops/sync/ (or
+# REVEALUI_SYNC_MANIFEST_DIR / JV_REPO). Prefer stream-safe token inject.
+MANIFEST="$(tsx scripts/sync/print-manifest-path.ts vercel)"
+
 # Dry-run one project + one key (no writes)
-revvault sync vercel \
-  --manifest scripts/sync/revvault-vercel.toml \
+revvault run --env VERCEL_TOKEN=revealui/prod/api-keys/vercel-token -- \
+  revvault sync vercel \
+  --manifest "$MANIFEST" \
   --project revealui-admin \
   --key REVEALUI_SIGNUP_OPEN
 
 # Apply only that key after the vault value is verified correct
-revvault sync vercel \
-  --manifest scripts/sync/revvault-vercel.toml \
+revvault run --env VERCEL_TOKEN=revealui/prod/api-keys/vercel-token -- \
+  revvault sync vercel \
+  --manifest "$MANIFEST" \
   --project revealui-admin \
   --key REVEALUI_SIGNUP_OPEN \
   --apply
@@ -63,4 +69,7 @@ Then scoped sync as above. Agents do **not** run `--apply` without named owner a
 
 - GAP-260 P4-4 license private key drop (separate owner cutover)
 - GAP-230 / GAP-231 Electric corrupt rows
-- `scripts/sync/revvault-vercel.toml` — manifest SSOT
+- Manifest SSOT: private planning repo `ops/sync/revvault-vercel.toml`
+  (public resolver: [`scripts/sync/README.md`](../../scripts/sync/README.md),
+  `print-manifest-path.ts`)
+- Unscoped day-to-day: `pnpm vercel:sync` / `pnpm vercel:sync:apply`

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -47,8 +47,9 @@ phase-out. Test-database utilities live in `scripts/dev-tools/`.
 | `credentials.ts`      | `pnpm tsx scripts/setup/credentials.ts` | Bootstrap machine credentials: read from revvault and write `~/.npmrc` etc. |
 | `gen-staging-secrets.ts` | `pnpm setup:staging-secrets`        | Owner-run generator for the staging secret bucket (writes to revvault) |
 
-The staging manifest at `scripts/sync/revvault-vercel-staging.toml` then syncs
-those vault values into Vercel via `pnpm vercel:sync:staging:apply`.
+The private staging manifest (`ops/sync/revvault-vercel-staging.toml`, via
+`print-manifest-path.ts staging`) then syncs those vault values into Vercel via
+`pnpm vercel:sync:staging:apply`.
 
 ## MCP Server Setup
 

--- a/scripts/setup/gen-staging-secrets.ts
+++ b/scripts/setup/gen-staging-secrets.ts
@@ -2,9 +2,9 @@
 /**
  * Owner-run generator for the staging environment's "generate fresh" secret
  * bucket (GAP-343 Phase 3, docs/lanes/staging-environment/plan.md). Writes
- * directly to revvault under revealui/staging/* - the manifest
- * (scripts/sync/revvault-vercel-staging.toml) then syncs these vault values
- * into Vercel via `pnpm vercel:sync:staging:apply`.
+ * directly to revvault under revealui/staging/* - the private ops/sync
+ * staging manifest (print-manifest-path.ts staging) then syncs these vault
+ * values into Vercel via `pnpm vercel:sync:staging:apply`.
  *
  * What this writes:
  *   - A fresh Ed25519 license-signing keypair, self-verified at generation

--- a/scripts/setup/stripe-revvault-sync.ts
+++ b/scripts/setup/stripe-revvault-sync.ts
@@ -74,7 +74,7 @@ export function loadManifestEnvKeyToVaultPath(manifestPath: string): Map<string,
 }
 
 export interface SyncToRevvaultOptions {
-  /** Path to scripts/sync/revvault-vercel.toml */
+  /** Absolute path to private ops/sync revvault-vercel.toml (requireManifestPath). */
   manifestPath: string;
   dryRun?: boolean;
   /** Injectable for tests; defaults to a real `revvault set` over stdin. */

--- a/scripts/sync/secret-paths.ts
+++ b/scripts/sync/secret-paths.ts
@@ -20,8 +20,9 @@
  * docs/SECRETS.md OUTSIDE the generated markers. The SecretTier union carries
  * them for forward-compatibility as later phases fold them in.
  *
- * NO SECRET VALUES live here - paths + structure only. Every path is already
- * public in the sync manifests in this same repo; this file adds no exposure.
+ * NO SECRET VALUES live here - paths + structure only. Path names are not
+ * secret; the private ops/sync TOML inventories (vault-path maps and platform
+ * IDs) live outside this public tree.
  *
  * The rendered derived view (docs/SECRETS.md §Production runtime, between the
  * BEGIN/END GENERATED:secret-paths markers) is produced by
@@ -564,8 +565,9 @@ export const SECRET_PATHS: SecretPathDef[] = [
     note: 'NEXT_PUBLIC_IS_LIVE - Stripe live-mode feature flag',
   },
   // ── STAGING (GAP-343 Phase 3) ──────────────────────────────────────────────
-  // The revealui/staging/* surface synced by scripts/sync/revvault-vercel-staging.toml
-  // (a SEPARATE manifest from the prod one - see its header). Same subsystem
+  // The revealui/staging/* surface synced by private ops/sync
+  // revvault-vercel-staging.toml (a SEPARATE manifest from the prod one -
+  // see its header). Same subsystem
   // grouping as the prod entries above; consumers use the *-staging tokens
   // (vercel:api-staging / vercel:admin-staging / vercel:marketing-staging) so
   // "which manifest reads this" stays visible without inventing a new field.


### PR DESCRIPTION
## Summary

GAP-265 residual after #2641: public operator docs and comments still taught
`scripts/sync/revvault-*.toml` as if the vault-path inventories still lived in
this public tree. They do not; inventories live in the private planning repo
`ops/sync/`.

This PR rewires the leftover public recipes to:

- `pnpm vercel:sync` / `pnpm vercel:sync:apply` / `pnpm vercel:drift-check`
- `tsx scripts/sync/print-manifest-path.ts vercel|fly|staging`
- private planning-repo `ops/sync/` (or `REVEALUI_SYNC_MANIFEST_DIR` / `JV_REPO`)

Does **not** re-add TOML inventories to the public repo.

## Files

- `docs/runbooks/secret-rotation.md`
- `docs/runbooks/stripe-go-live-cutover.md`
- `docs/runbooks/vercel-env-sync.md`
- `docs/security/REVVAULT-VERCEL-SCOPED-SYNC.md`
- `docs/SECRETS.md`
- `deployment/fly/electric/README.md`
- `scripts/setup/README.md`
- `scripts/setup/gen-staging-secrets.ts`
- `scripts/setup/stripe-revvault-sync.ts`
- `scripts/sync/secret-paths.ts`
- `apps/server/src/lib/required-env.ts`
- `apps/server/src/lib/self-api-url.ts`
- `apps/server/fly.toml`
- `.github/workflows/secret-path-drift.yml`

## Prove-grep

No remaining `scripts/sync/revvault-vercel.toml` / `revvault-fly.toml` /
`revvault-vercel-staging.toml` operator recipes. Filename constants in
`resolve-manifest-dir.ts` and fixture writes in tests are intentional.

## Residuals (out of scope)

- **`.github/vercel-projects.json` exposure** (if still present) is a separate
  surface; not moved or redacted in this PR.
- Stream-safe rewrite of older `$(revvault get …)` / `--json get` shell recipes
  outside the manifest-path residual (for example Phase 0 token export in
  secret-rotation) is not expanded here.
- Private coordination-repo inventory content itself lives in `.jv` (jv#1387).

## Test plan

- [x] Grep: zero `scripts/sync/revvault-*.toml` path recipes left in public tree
- [ ] Skim PR: every operator sync recipe uses wrappers or `print-manifest-path`
- [ ] Confirm CI green on docs-only changes