### PR TITLE
fix(core): block local license mint on hosted mode

### DIFF
--- a/packages/core/src/__tests__/license-mint-client.test.ts
+++ b/packages/core/src/__tests__/license-mint-client.test.ts
@@ -59,6 +59,26 @@ describe('isSignViaSigner / canMintLicense', () => {
       }),
     ).toBe(true);
   });
+
+  it('canMintLicense hosted with private key only is false', () => {
+    expect(
+      canMintLicense({
+        REVEALUI_DEPLOYMENT_MODE: 'hosted',
+        REVEALUI_LICENSE_PRIVATE_KEY: privateKeyPem,
+      }),
+    ).toBe(false);
+  });
+
+  it('canMintLicense hosted with SIGN_VIA + url + secret is true', () => {
+    expect(
+      canMintLicense({
+        REVEALUI_DEPLOYMENT_MODE: 'hosted',
+        REVEALUI_LICENSE_SIGN_VIA_SIGNER: '1',
+        REVEALUI_LICENSE_SIGNER_URL: 'http://127.0.0.1:8791',
+        REVEALUI_SIGNER_INVOKE_SECRET: 'sec',
+      }),
+    ).toBe(true);
+  });
 });
 
 describe('mintLicenseKey local path', () => {
@@ -92,6 +112,76 @@ describe('mintLicenseKey local path', () => {
     const payload = await validateLicenseKey(jwt, publicKeyPem);
     expect(payload?.perpetual).toBe(true);
     expect(payload?.exp).toBeUndefined();
+  });
+});
+
+describe('mintLicenseKey hosted mode (GAP-260 residual)', () => {
+  it('MODE=hosted + private key + SIGN_VIA unset never mints local or remote', async () => {
+    const fetchMock = vi.fn(async () => new Response('should-not-call', { status: 500 }));
+    await expect(
+      mintLicenseKey(
+        { tier: 'pro', customerId: 'cus_hosted_local_forbidden' },
+        {
+          env: {
+            REVEALUI_DEPLOYMENT_MODE: 'hosted',
+            REVEALUI_LICENSE_PRIVATE_KEY: privateKeyPem,
+            REVEALUI_LICENSE_PUBLIC_KEY: publicKeyPem,
+          },
+          fetch: fetchMock as unknown as typeof fetch,
+        },
+      ),
+    ).rejects.toBeInstanceOf(LicenseMintConfigError);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mintConfigMissingMessage({ REVEALUI_DEPLOYMENT_MODE: 'hosted' })).toMatch(
+      /SIGN_VIA|signer/i,
+    );
+  });
+
+  it('MODE=hosted + SIGN_VIA + missing URL/secret throws', async () => {
+    await expect(
+      mintLicenseKey(
+        { tier: 'pro', customerId: 'cus_hosted_incomplete' },
+        {
+          env: {
+            REVEALUI_DEPLOYMENT_MODE: 'hosted',
+            REVEALUI_LICENSE_SIGN_VIA_SIGNER: '1',
+            REVEALUI_LICENSE_PRIVATE_KEY: privateKeyPem,
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(LicenseMintConfigError);
+  });
+
+  it('MODE=hosted + SIGN_VIA + url + secret uses remote path', async () => {
+    const secret = 'hosted-invoke-secret';
+    const expectedJwt = 'hosted.remote.jwt';
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      expect(String(url)).toBe('http://signer.example/internal/mint');
+      expect(init?.method).toBe('POST');
+      const headers = new Headers(init?.headers);
+      const ts = headers.get(SIGNER_TIMESTAMP_HEADER);
+      const sig = headers.get(SIGNER_SIGNATURE_HEADER);
+      const body = String(init?.body ?? '');
+      expect(sig).toBe(signMintRequest(secret, 'POST', SIGNER_MINT_PATH, body, Number(ts)));
+      return new Response(JSON.stringify({ licenseKey: expectedJwt }), { status: 200 });
+    });
+
+    const jwt = await mintLicenseKey(
+      { tier: 'pro', customerId: 'cus_hosted_remote', expiresInSeconds: 3600 },
+      {
+        env: {
+          REVEALUI_DEPLOYMENT_MODE: '  HOSTED  ',
+          REVEALUI_LICENSE_SIGN_VIA_SIGNER: 'true',
+          REVEALUI_LICENSE_SIGNER_URL: 'http://signer.example/',
+          REVEALUI_SIGNER_INVOKE_SECRET: secret,
+          // Present but must not divert to local mint.
+          REVEALUI_LICENSE_PRIVATE_KEY: privateKeyPem,
+        },
+        fetch: fetchMock as unknown as typeof fetch,
+      },
+    );
+    expect(jwt).toBe(expectedJwt);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/core/src/license/mint-client.ts
+++ b/packages/core/src/license/mint-client.ts
@@ -1,12 +1,13 @@
 /**
- * License mint client (GAP-260 P4-3).
+ * License mint client (GAP-260 P4-3 + residual hosted gate).
  *
  * Single entry for online mint surfaces (Stripe webhooks, admin generate).
  * Routes to either:
  *   - remote `apps/license-signer` POST /internal/mint when
- *     REVEALUI_LICENSE_SIGN_VIA_SIGNER is truthy, or
+ *     REVEALUI_LICENSE_SIGN_VIA_SIGNER is truthy, or when
+ *     REVEALUI_DEPLOYMENT_MODE=hosted (explicit; never local private-key mint), or
  *   - local {@link generateLicenseKey} with REVEALUI_LICENSE_PRIVATE_KEY
- *     (default / fallback until P4-4 drops the private key from api).
+ *     only when MODE is not hosted and SIGN_VIA is off (tests / dogfood).
  *
  * Offline stamper (revforge) keeps calling generateLicenseKey directly.
  *
@@ -14,6 +15,7 @@
  *   REVEALUI_LICENSE_SIGN_VIA_SIGNER=1|true|yes|on
  *   REVEALUI_LICENSE_SIGNER_URL      base URL (e.g. http://127.0.0.1:8791)
  *   REVEALUI_SIGNER_INVOKE_SECRET    HMAC secret (no REVEALUI_SECRET fallback)
+ *   REVEALUI_DEPLOYMENT_MODE=hosted  forces remote-only (SIGN_VIA required)
  *
  * Env (local path):
  *   REVEALUI_LICENSE_PRIVATE_KEY     PKCS#8 Ed25519 PEM (required)
@@ -73,22 +75,47 @@ export function isSignViaSigner(env: MintEnv = process.env): boolean {
 }
 
 /**
+ * Explicit hosted SaaS posture only. Does not use private-key inference
+ * (that belongs to detectDeploymentMode). Hosted online mint must never
+ * fall through to mintLocal.
+ */
+export function isExplicitHostedMintMode(env: MintEnv = process.env): boolean {
+  return (env.REVEALUI_DEPLOYMENT_MODE ?? '').trim().toLowerCase() === 'hosted';
+}
+
+function hasRemoteMintConfig(env: MintEnv): boolean {
+  const url = env.REVEALUI_LICENSE_SIGNER_URL?.trim() ?? '';
+  const secret = env.REVEALUI_SIGNER_INVOKE_SECRET?.trim() ?? '';
+  return url.length > 0 && secret.length > 0;
+}
+
+/**
  * Whether this process can mint a license key (local private key OR remote
  * signer fully configured). Used by call sites that used to gate only on
  * REVEALUI_LICENSE_PRIVATE_KEY presence.
+ *
+ * Explicit MODE=hosted never treats a local private key as sufficient.
  */
 export function canMintLicense(env: MintEnv = process.env): boolean {
+  if (isExplicitHostedMintMode(env)) {
+    return isSignViaSigner(env) && hasRemoteMintConfig(env);
+  }
   if (isSignViaSigner(env)) {
-    const url = env.REVEALUI_LICENSE_SIGNER_URL?.trim() ?? '';
-    const secret = env.REVEALUI_SIGNER_INVOKE_SECRET?.trim() ?? '';
-    return url.length > 0 && secret.length > 0;
+    return hasRemoteMintConfig(env);
   }
   return Boolean(env.REVEALUI_LICENSE_PRIVATE_KEY?.trim());
 }
 
 /** Human-readable reason mint is unavailable (for CRITICAL logs). */
 export function mintConfigMissingMessage(env: MintEnv = process.env): string {
-  if (isSignViaSigner(env)) {
+  if (isExplicitHostedMintMode(env) && !isSignViaSigner(env)) {
+    return (
+      'REVEALUI_DEPLOYMENT_MODE=hosted requires REVEALUI_LICENSE_SIGN_VIA_SIGNER ' +
+      'with REVEALUI_LICENSE_SIGNER_URL and REVEALUI_SIGNER_INVOKE_SECRET ' +
+      '(local private-key mint is disabled on hosted)'
+    );
+  }
+  if (isSignViaSigner(env) || isExplicitHostedMintMode(env)) {
     return (
       'REVEALUI_LICENSE_SIGN_VIA_SIGNER is set but REVEALUI_LICENSE_SIGNER_URL ' +
       'and/or REVEALUI_SIGNER_INVOKE_SECRET are missing'
@@ -235,7 +262,8 @@ export type MintLicenseKeyOptions = {
 };
 
 /**
- * Mint a signed license JWT — remote signer when flagged, else local private key.
+ * Mint a signed license JWT — remote signer when SIGN_VIA is on or MODE is
+ * explicitly hosted; else local private key (tests / dogfood only).
  */
 export async function mintLicenseKey(
   input: MintLicensePayload,
@@ -245,7 +273,12 @@ export async function mintLicenseKey(
   const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
   const normalized = withPerpetualSiteCaps(input);
 
-  if (isSignViaSigner(env)) {
+  // Hosted online mint never uses the local private-key path, even when the
+  // key is still present in env during migration.
+  if (isExplicitHostedMintMode(env) && !isSignViaSigner(env)) {
+    throw new LicenseMintConfigError(mintConfigMissingMessage(env));
+  }
+  if (isSignViaSigner(env) || isExplicitHostedMintMode(env)) {
     return mintViaSigner(normalized, env, fetchImpl);
   }
   return mintLocal(normalized, env);


### PR DESCRIPTION
## Summary

GAP-260 residual: hosted online mint must never use the local private-key fallback.

After P4-4, admin/api/worker no longer carry `REVEALUI_LICENSE_PRIVATE_KEY`, but `mintLicenseKey` still defaulted to `mintLocal` whenever `REVEALUI_LICENSE_SIGN_VIA_SIGNER` was unset. That left a residual attack surface if the private key ever reappeared in a hosted process env.

This change gates mint routing on **explicit** `REVEALUI_DEPLOYMENT_MODE=hosted` (case-insensitive trim) plus the existing SIGN_VIA flag:

- Explicit hosted **never** calls `mintLocal`, even when a private key is present
- Hosted without SIGN_VIA throws `LicenseMintConfigError` (no fall-through)
- Hosted + SIGN_VIA requires signer URL + invoke secret (remote path only)
- Without explicit hosted and without SIGN_VIA, local mint remains for tests / dogfood / offline-adjacent use
- `generateLicenseKey` export and revforge / `apps/license-signer` callers unchanged
- `canMintLicense` / `mintConfigMissingMessage` updated to match

Boot list: no change. `validateStartup` already drops `REVEALUI_LICENSE_PRIVATE_KEY` when MODE is explicitly hosted. Did not add signer URL / invoke secret to `REQUIRED_IN_PRODUCTION_HOSTED` (shared list shape; mint-time fail-closed is the durable gate for online mint).

## Security classification

**Security-classed (license mint).** Review-pending. Do **not** merge until the guardrail-2 verdict lands. Do not apply `sec-review:approved` without a recorded review.

## Test plan

- [x] `pnpm --filter @revealui/core exec vitest run src/__tests__/license-mint-client.test.ts` (20 passed)
- [x] Biome on touched files
- [x] TDD: hosted + private key only failed red before implementation
- [ ] CI green on PR
- [ ] Guardrail-2 security review (non-author)

## Files

- `packages/core/src/license/mint-client.ts`
- `packages/core/src/__tests__/license-mint-client.test.ts`